### PR TITLE
fix(compliance): default governance_agent_url to seller-local stub (#5665) [Option B — alternative]

### DIFF
--- a/.changeset/5665-governance-agent-url-seller-stub.md
+++ b/.changeset/5665-governance-agent-url-seller-stub.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset: Default `governance_agent_url` in the `governance_denied` / `governance_denied_recovery` storyboards to a seller-local stub served by the seller's `comply_test_controller`, removing the counterparty-supplied-URL egress/SSRF surface. Alternative to #5665 Option A; depends on runner support for a controller-self-URL placeholder. Addresses #5665 (Option B).

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -23,7 +23,15 @@ narrative: |
   (e.g., via `--context` on `adcp storyboard run` once the CLI supports it).
 
 context:
-  governance_agent_url: "https://test-agent.adcontextprotocol.org"
+  # Option B (#5665): default the governance agent to a seller-local stub served
+  # by the seller's own comply_test_controller, instead of the external training
+  # agent. This removes the counterparty-supplied-URL egress/SSRF surface (the
+  # seller calls its own controller) and lets sellers without an external
+  # governance agent still exercise the denial path. NOTE: depends on the runner
+  # exposing a controller-self-URL placeholder (cf. {{runner.webhook_url:...}});
+  # {{runner.controller_url}} does not exist yet — adcp-client support required.
+  # An explicit --context governance_agent_url still overrides this default.
+  governance_agent_url: "{{runner.controller_url}}/stub-governance-agent"
 
 agent:
   interaction_model: media_buy_seller

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
@@ -24,7 +24,15 @@ narrative: |
   (e.g., via `--context` on `adcp storyboard run` once the CLI supports it).
 
 context:
-  governance_agent_url: "https://test-agent.adcontextprotocol.org"
+  # Option B (#5665): default the governance agent to a seller-local stub served
+  # by the seller's own comply_test_controller, instead of the external training
+  # agent. This removes the counterparty-supplied-URL egress/SSRF surface (the
+  # seller calls its own controller) and lets sellers without an external
+  # governance agent still exercise the denial path. NOTE: depends on the runner
+  # exposing a controller-self-URL placeholder (cf. {{runner.webhook_url:...}});
+  # {{runner.controller_url}} does not exist yet — adcp-client support required.
+  # An explicit --context governance_agent_url still overrides this default.
+  governance_agent_url: "{{runner.controller_url}}/stub-governance-agent"
 
 agent:
   interaction_model: media_buy_seller


### PR DESCRIPTION
Alternative to the Option A PR for #5665, per the triage's Option B. Opened for completeness so the A-vs-B call can be made against concrete diffs.

Defaults `governance_agent_url` to a seller-served stub (the seller's own `comply_test_controller`), removing the counterparty-supplied-URL egress/SSRF surface.

**Two caveats vs Option A:**
1. It keeps the scenario **mandatory** — it does **not** create the `not_applicable` opt-out the issue title asks for. Sellers still must implement outbound governance consultation (now against a local stub instead of an external agent).
2. It depends on the runner exposing a controller-self-URL placeholder — `{{runner.controller_url}}` doesn't exist yet (only `{{runner.webhook_url:…}}` and `{{prior_step.…}}` are runner-managed today), so this spans **adcp-client** too, not just scenario YAML.

We'd lean Option A — self-contained, and it actually creates the opt-out.
