### PR TITLE
fix(schemas): resolve pinned schema version paths with no published dir

### DIFF
--- a/server/src/schemas-middleware.ts
+++ b/server/src/schemas-middleware.ts
@@ -71,6 +71,52 @@ export function findMatchingVersion(
 }
 
 /**
+ * Resolve a pinned semver path whose exact version directory does NOT exist to
+ * the nearest published release it should map to.
+ *
+ * This covers docs-only version bumps: when a docs snapshot is cut at a version
+ * whose schema content was unchanged from the last published release on the
+ * same line (e.g. a 3.0.19 docs snapshot built against the existing 3.0.18
+ * schemas), no 3.0.19 schema directory is ever produced. The snapshot's link
+ * rewrite still pins schema URLs to /schemas/3.0.19/..., which would 404
+ * without this fallback.
+ *
+ * Resolution prefers the highest release at-or-below the requested version
+ * within the SAME major.minor line, falling back to the highest at-or-below
+ * release in the same major. Staying at-or-below keeps a frozen 3.0.x doc
+ * pointing at 3.0.x schemas rather than jumping forward to a newer minor.
+ *
+ * When the requested version is stable, prerelease candidates are excluded so
+ * a missing stable pin (e.g. /schemas/3.0.0/...) never silently resolves to a
+ * release candidate; when the requested version is itself a prerelease, lower
+ * prereleases (and stables) on the line are eligible. Returns undefined when
+ * nothing in the same major qualifies.
+ */
+export function resolvePinnedFallback(
+  versions: string[],
+  requested: string,
+): string | undefined {
+  const parsed = semver.parse(requested);
+  if (!parsed) return undefined;
+
+  const wantStable = parsed.prerelease.length === 0;
+  const eligible = (v: string): boolean => {
+    const p = semver.parse(v);
+    if (!p || p.major !== parsed.major) return false;
+    if (wantStable && p.prerelease.length > 0) return false;
+    return semver.lte(v, requested);
+  };
+
+  const sameMinor = versions
+    .filter((v) => eligible(v) && semver.parse(v)!.minor === parsed.minor)
+    .sort(semver.rcompare);
+  if (sameMinor[0]) return sameMinor[0];
+
+  const sameMajor = versions.filter(eligible).sort(semver.rcompare);
+  return sameMajor[0];
+}
+
+/**
  * Mount /schemas routes on the given Express app:
  *  - rewrites version-alias paths (/v2, /v2.5, /v3, /v12, ...) to a concrete version directory
  *  - redirects bare version directories (/2.5.3/, /3.0.0-rc.3/, /latest/) to index.json
@@ -267,20 +313,47 @@ function mountVersionedStaticRoutes(
       }
     }
 
-    // 2. Set cache-control based on the original request path:
-    //    - Pinned semver (client asked for an immutable version): 1-year immutable.
-    //    - /latest/ and aliases (/v2, /v2.5, ...): no-cache + ETag, so shared
-    //      caches revalidate on every request and pick up retargeting immediately.
-    //      Without this, edge caches can serve different versions from different
-    //      POPs within their TTL window and cause drift for consumers generating
-    //      types from the schemas.
+    // 2. Pinned semver path whose exact version directory is missing: resolve
+    //    to the nearest published release on the same line (e.g. a 3.0.19 docs
+    //    snapshot's links to /schemas/3.0.19/... resolve to the 3.0.18 schemas
+    //    they were built against). Without this, frozen doc snapshots that pin
+    //    schema links to a docs-only version bump 404. Tracks whether the exact
+    //    directory was hit so the cache policy below stays correct.
+    let exactPinnedHit = false;
     if (!isAlias && isPinnedVersionPath(originalPath)) {
+      const requestedVersion = originalPath.split("/")[1];
+      try {
+        const versions = await getSchemaVersions();
+        if (versions.includes(requestedVersion)) {
+          exactPinnedHit = true;
+        } else {
+          const fallback = resolvePinnedFallback(versions, requestedVersion);
+          if (fallback) {
+            req.url = "/" + fallback + originalPath.slice(requestedVersion.length + 1);
+          }
+        }
+      } catch {
+        // Fall through; static handler below will produce the 404.
+      }
+    }
+
+    // 3. Set cache-control based on the original request path:
+    //    - Exact pinned semver hit (client asked for an immutable version that
+    //      exists): 1-year immutable.
+    //    - /latest/, aliases (/v2, /v2.5, ...) and resolved pinned fallbacks:
+    //      no-cache + ETag, so shared caches revalidate on every request and
+    //      pick up retargeting immediately. Without this, edge caches can serve
+    //      different versions from different POPs within their TTL window and
+    //      cause drift for consumers generating types from the schemas. A
+    //      resolved fallback is treated like an alias because what it points at
+    //      can change as new patches land on the line.
+    if (exactPinnedHit) {
       res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
     } else {
       res.setHeader("Cache-Control", "public, no-cache, must-revalidate");
     }
 
-    // 3. Redirect bare version directories to their index.json.
+    // 4. Redirect bare version directories to their index.json.
     if (matchVersionedDir(req.path)) {
       return res.redirect(mountPath + req.path + "index.json");
     }

--- a/server/tests/integration/schema-routing.test.ts
+++ b/server/tests/integration/schema-routing.test.ts
@@ -116,6 +116,64 @@ describe("/schemas HTTP routing", () => {
     });
   });
 
+  describe("missing pinned version fallback (docs-only version bumps)", () => {
+    // A docs snapshot can be cut at a version whose schema content was
+    // unchanged from the last published release on the same line (e.g. a
+    // 3.0.19 docs snapshot built against the existing 3.0.18 schemas), so no
+    // matching schema directory is ever produced. The snapshot's link rewrite
+    // still pins schema URLs to /schemas/<docs-version>/..., which must resolve
+    // rather than 404.
+    let missingPatch: string | undefined;
+    let resolvedTarget: string | undefined;
+
+    beforeAll(() => {
+      // Synthesize a "one patch above the latest published 3.0.x" version that
+      // is guaranteed not to have a directory, and compute what it should
+      // resolve to (the latest published 3.0.x).
+      const latest30 = versions
+        .filter((v) => v.startsWith("3.0.") && !v.includes("-"))
+        .sort((a, b) => semver.rcompare(a, b))[0];
+      if (latest30) {
+        resolvedTarget = latest30;
+        const p = semver.parse(latest30)!;
+        missingPatch = `${p.major}.${p.minor}.${p.patch + 1}`;
+        // Guard: the synthesized version must genuinely be absent.
+        if (versions.includes(missingPatch)) missingPatch = undefined;
+      }
+    });
+
+    it("serves a missing pinned patch from the nearest published release on the same line", async () => {
+      if (!missingPatch) return;
+      const res = await request(app).get(
+        `/schemas/${missingPatch}/media-buy/get-media-buy-delivery-request.json`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+    });
+
+    it("marks resolved-fallback responses no-cache (the target can change as patches land)", async () => {
+      if (!missingPatch) return;
+      const res = await request(app).get(
+        `/schemas/${missingPatch}/media-buy/get-media-buy-delivery-request.json`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers["cache-control"] ?? "").not.toContain("immutable");
+      expect(res.headers["cache-control"] ?? "").toContain("no-cache");
+    });
+
+    it("redirects a missing bare pinned directory to the resolved index.json", async () => {
+      if (!missingPatch || !resolvedTarget) return;
+      const res = await request(app).get(`/schemas/${missingPatch}/`);
+      expect(res.status).toBe(302);
+      expect(res.headers["location"]).toBe(`/schemas/${resolvedTarget}/index.json`);
+    });
+
+    it("still 404s a pinned version with no published release in its major line", async () => {
+      const res = await request(app).get("/schemas/99.9.9/adagents.json");
+      expect(res.status).toBe(404);
+    });
+  });
+
   describe("cache-control policy", () => {
     // Aliases and /latest/ must force revalidation — they retarget over time,
     // and edge caches serving stale copies cause version drift for consumers


### PR DESCRIPTION
## Problem

Docs links like `https://adcontextprotocol.org/schemas/3.0.19/media-buy/get-media-buy-delivery-request.json` return **Not Found**.

Root cause: the docs snapshot for **v3.0.19** (cut by the release bot in #5575) was a docs-only version bump — the schema *content* was unchanged from 3.0.18, so the schema build never produced a `dist/schemas/3.0.19/` directory (the 3.0.x line stops at 3.0.18, then jumps to 3.1.0). The snapshot's link-rewriter still pins every schema link to `/schemas/3.0.19/...`, and the `/schemas` middleware serves pinned semver paths as static directories with **no fallback** — so those links 404.

## Fix

Server-side fallback resolution in `server/src/schemas-middleware.ts`: when a pinned `/schemas/X.Y.Z/...` path has no exact directory, resolve to the nearest published release **at-or-below** `X.Y.Z` on the same minor line (then same major). So `3.0.19` → `3.0.18` — the schemas those docs were actually built against.

- Exact version hits keep `immutable` caching; resolved fallbacks get `no-cache`/revalidate (like aliases), since the target can shift as new patches land.
- A missing **stable** pin never silently resolves to a release candidate (prereleases excluded when the requested version is stable).
- Gated by `semver.valid`, so no path-traversal vector via the version segment.

This fixes the entire class of docs-only version bumps — present and future — without regenerating the 128 committed snapshot files.

## Testing

- `server/tests/integration/schema-routing.test.ts`: **20/20 pass**, including 4 new tests — fallback serves the file, `no-cache` on resolved fallbacks, bare-dir redirect to the resolved `index.json`, and a no-matching-major version still 404s.
- `tsc` clean; `npm run build` clean; `lint:schema-links` clean.