### PR TITLE
fix(cdn-worker): resolve pinned schema versions with no published dir

### DIFF
--- a/tests/artifact-cdn-worker.test.cjs
+++ b/tests/artifact-cdn-worker.test.cjs
@@ -226,6 +226,60 @@ describe('artifact CDN Worker', () => {
     assert.equal(response.headers.get('cache-control'), 'public, max-age=31536000, immutable');
   });
 
+  it('resolves a pinned docs-only version bump to the nearest published release', async () => {
+    const response = await fetchPath('/schemas/3.0.19/foo.json');
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { version: '3.0.12' });
+    assert.equal(response.headers.get('cache-control'), 'public, no-cache, must-revalidate');
+    assert.equal(response.headers.get('access-control-allow-origin'), '*');
+  });
+
+  it('redirects a bare pinned-fallback version directory to the resolved index.json', async () => {
+    const response = await fetchPath('/schemas/3.0.19/');
+
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.get('location'), '/schemas/3.0.12/index.json');
+  });
+
+  it('never resolves a stable pin to a prerelease on the same line', async () => {
+    // 3.1.x has only a prerelease published (3.1.0-beta.3); a stable 3.1.5 pin
+    // must fall back to the highest stable in the major (3.0.12), not the beta.
+    const response = await fetchPath('/schemas/3.1.5/foo.json');
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { version: '3.0.12' });
+    assert.equal(response.headers.get('cache-control'), 'public, no-cache, must-revalidate');
+  });
+
+  it('does not edge-cache resolved pinned fallbacks', async () => {
+    const { clearVersionCacheForTests, handleRequest } = await loadWorker();
+    const testEnv = env();
+    const edgeCache = new MockEdgeCache();
+    const ctx = { waitUntil: () => assert.fail('resolved fallbacks should not write to edge cache') };
+    clearVersionCacheForTests();
+
+    await withMockEdgeCache(edgeCache, async () => {
+      const response = await handleRequest(
+        new Request('https://artifacts.example/schemas/3.0.19/foo.json'),
+        testEnv,
+        ctx,
+      );
+      assert.equal(response.status, 200);
+      assert.deepEqual(await response.json(), { version: '3.0.12' });
+    });
+
+    assert.equal(edgeCache.matches, 0);
+    assert.equal(edgeCache.puts, 0);
+  });
+
+  it('404s a pinned version with no resolvable release in its major', async () => {
+    const response = await fetchPath('/schemas/4.0.0/foo.json');
+
+    assert.equal(response.status, 404);
+    assert.equal(await response.text(), 'Not Found');
+  });
+
   it('uses edge cache for immutable versioned schema objects', async () => {
     const { clearVersionCacheForTests, handleRequest } = await loadWorker();
     const testEnv = env();

--- a/workers/artifact-cdn/src/index.js
+++ b/workers/artifact-cdn/src/index.js
@@ -84,6 +84,29 @@ async function versionedArtifactResponse(request, env, ctx, mount, pathname) {
     }
   }
 
+  // Pinned semver path whose exact version directory is absent from R2: resolve
+  // to the nearest published release on the same line (e.g. a 3.0.19 docs
+  // snapshot's links to /schemas/3.0.19/... resolve to the 3.0.18 artifacts it
+  // was built against). Mirrors the Fly schemas middleware so docs-only version
+  // bumps don't 404 when no schema directory is published for them. Tracks
+  // whether the exact directory exists so the cache policy below stays correct.
+  let exactPinnedHit = false;
+  if (!isAlias) {
+    const semverMatch = requestPath.match(SEMVER_PATH);
+    if (semverMatch) {
+      const requestedVersion = semverMatch[1];
+      const versions = await getVersions(env.ARTIFACTS, mount);
+      if (versions.includes(requestedVersion)) {
+        exactPinnedHit = true;
+      } else {
+        const fallback = resolvePinnedFallback(versions, requestedVersion);
+        if (fallback) {
+          resolvedPath = `/${fallback}${requestPath.slice(requestedVersion.length + 1)}`;
+        }
+      }
+    }
+  }
+
   const bareVersionMatch = resolvedPath.match(/^\/([^/]+)$/);
   if (bareVersionMatch && (bareVersionMatch[1] === "latest" || parseSemver(bareVersionMatch[1]))) {
     return redirect(`/${mount}${resolvedPath}/`, 301);
@@ -94,7 +117,10 @@ async function versionedArtifactResponse(request, env, ctx, mount, pathname) {
     return redirect(`/${mount}${resolvedPath}index.json`, 302);
   }
 
-  const isImmutableArtifact = !isAlias && SEMVER_PATH.test(requestPath);
+  // Only an exact pinned directory hit is immutable. Resolved fallbacks (like
+  // aliases) revalidate, since the version they point at can shift as patches
+  // land on the line.
+  const isImmutableArtifact = exactPinnedHit;
   const cacheControl = isImmutableArtifact
     ? IMMUTABLE_CACHE_CONTROL
     : REVALIDATE_CACHE_CONTROL;
@@ -286,6 +312,39 @@ export function findMatchingVersion(versions, requestedMajor, requestedMinor) {
     if (!parsed || parsed.major !== requestedMajor) return false;
     return requestedMinor === undefined || parsed.minor === requestedMinor;
   });
+}
+
+/**
+ * Resolve a pinned semver whose exact version directory is not published to the
+ * nearest release it should map to: the highest release at-or-below the request
+ * on the same major.minor line, falling back to the highest at-or-below release
+ * in the same major. Staying at-or-below keeps a frozen 3.0.x doc pointing at
+ * 3.0.x artifacts rather than jumping forward to a newer minor.
+ *
+ * A stable request excludes prerelease candidates so a missing stable pin never
+ * silently resolves to a release candidate; a prerelease request also accepts
+ * lower prereleases (and stables) on the line. Returns undefined when nothing in
+ * the same major qualifies.
+ */
+export function resolvePinnedFallback(versions, requested) {
+  const parsed = parseSemver(requested);
+  if (!parsed) return undefined;
+
+  const wantStable = parsed.prerelease.length === 0;
+  const eligible = (candidate) => {
+    const p = parseSemver(candidate);
+    if (!p || p.major !== parsed.major) return false;
+    if (wantStable && p.prerelease.length > 0) return false;
+    return compareVersions(candidate, requested) <= 0;
+  };
+
+  const sameMinor = versions
+    .filter((candidate) => eligible(candidate) && parseSemver(candidate).minor === parsed.minor)
+    .sort((a, b) => compareVersions(b, a));
+  if (sameMinor[0]) return sameMinor[0];
+
+  const sameMajor = versions.filter(eligible).sort((a, b) => compareVersions(b, a));
+  return sameMajor[0];
 }
 
 export function clearVersionCacheForTests() {


### PR DESCRIPTION
## Problem

`https://adcontextprotocol.org/schemas/3.0.19/media-buy/create-media-buy-request.json` (and every other pinned schema version with no published directory) returns **404 Not Found** in production.

The docs site rewrites schema links to the docs snapshot's version (e.g. `3.0.19`). When a version is a docs-only bump — schema content unchanged from the prior release, so no `3.0.19` schema directory is ever published — those links 404.

## Root cause

#5690 added a "resolve pinned version with no published dir" fallback to **`server/src/schemas-middleware.ts`** (the Express/Fly app). But production `adcontextprotocol.org/schemas/*`, `/compliance/*` and `/protocol/*` are served by the **`adcp-artifacts-cdn` Cloudflare Worker** (`workers/artifact-cdn/`) reading from R2 — see `wrangler.cutover.toml` routes. The Worker handled aliases (`/v3`) and bare-dir redirects but had **no pinned-fallback**, so a pinned semver with no R2 directory missed and hit the Worker's hardcoded `Not Found`. #5690 fixed a path that production never executes.

Confirmed live: `/schemas/v3/...` → 200 and `/schemas/3.0.18/` → 302 (Worker alias/redirect work), but `/schemas/3.0.19/...` → 404 with the Worker's `access-control-allow-origin: *` / `Not Found` signature (a cache-buster query still 404s — origin, not stale edge cache).

## Fix

Port the same fallback into the Worker, matching #5690's semantics:

- Pinned semver with no R2 directory → resolve to the highest published release **at-or-below** it on the same minor line, then the same major.
- Exact directory hit → keeps `immutable` cache header + edge caching.
- Resolved fallback → `no-cache, must-revalidate`, **not** edge-cached (target shifts as patches land), like aliases.
- Stable pins never resolve to a prerelease; an unresolvable major still 404s.

Verified against the real prod version list: `3.0.19 → 3.0.18`, `3.1.1 → 3.1.0`, `4.0.0 → 404`, `3.0.18 → 3.0.18` (exact, immutable).

## Tests

Added 5 Worker tests (docs-only bump resolution, bare-dir redirect to resolved version, stable-never-prerelease, no edge-cache on fallbacks, unresolvable-major 404). All 23 Worker tests pass; precommit unit suite + typecheck pass.

## Deploy note

This ships via the **Worker cutover deploy** (`npm run deploy:cdn-artifacts-cutover`), not the Fly deploy — the Fly path already had the fix and isn't what's live for these routes.