### PR TITLE
docs(creative): clarify click tracker insertion model (#5692)

### DIFF
--- a/docs/creative/universal-macros.mdx
+++ b/docs/creative/universal-macros.mdx
@@ -689,7 +689,16 @@ Sales agents must translate universal macros to their ad server's native syntax.
 
 ### Click Tracker Insertion
 
-Sales agents must automatically insert click tracking macros into clickable elements:
+A click on a creative produces two distinct signals, and AdCP models them as **separate asset slots**:
+
+| Slot | Asset | Role | OpenRTB Native parallel |
+|------|-------|------|--------------------------|
+| `landing_page_url` | `url` | The single terminal destination the user navigates to. | `link.url` |
+| `click_tracker` | `pixel_tracker` (`event: click`) | A measurement hop that fires on click **without** navigating the user there. Any number may be present. | `link.clicktrackers[]` |
+
+This separation is inherited from IAB OpenRTB Native: a click has **exactly one destination** and **N fire-and-forget click trackers** (the `link.fallback` deeplink is an alternative form of that one destination, not a second one). At serve time the sales agent fires every `click_tracker` as a count beacon and navigates the user to the one `landing_page_url`. Both slots are defined in [Asset Types](/docs/creative/asset-types).
+
+**Macro insertion.** Sales agents insert their ad server's click-tracking macro ahead of the destination so the platform records the click and forwards the user. The destination encoding is ad-server-specific (GAM uses append-style `%%CLICK_URL_UNESC%%<landing>`; other servers ship a self-contained `?...&rurl=<encoded-landing>` form):
 
 **Original creative**:
 ```html
@@ -700,6 +709,12 @@ Sales agents must automatically insert click tracking macros into clickable elem
 ```html
 <a href="%%CLICK_URL_UNESC%%https://brand.com/product">Click here</a>
 ```
+
+**Preserving the buyer's clickthrough parameters.** Inserting a click macro can strip query parameters already present on the buyer-supplied clickthrough URL — including ones the agent does not recognize, such as a buyer-side vendor's click identifier — which silently breaks downstream attribution. An agent that forwards these parameters applies the encoding discipline [Substitution safety](#substitution-safety-catalog-item-macros) defines for catalog-item values (Unicode NFC normalization, then percent-encoding to the RFC 3986 `unreserved` set) to any value derived from buyer- or third-party-supplied data, so preservation does not reopen URL-context breakout, CRLF injection, or bidi spoofing. Whether to make parameter preservation a normative requirement is part of the click-tracking proposal under working-group review ([#5693](https://github.com/adcontextprotocol/adcp/issues/5693)).
+
+**Getting a buyer's click identifier onto the landing.** A `click_tracker` is a count beacon: it records the click but does not place its identifier into the user's landing session, because only `landing_page_url` is navigated. When a buyer needs its click identifier to reach the landing (for click-level conversion attribution), the reliable, redirect-free pattern is to put that identifier directly on the `landing_page_url` it supplies — either as a literal value (`&buyer_click_id=abc123`) or composed from an AdCP macro the buyer controls (`&buyer_click_id={CREATIVE_ID}`, expanded by the sales agent at serve time). `{buyer_click_id}` is not itself an AdCP macro — the macro set is a closed registry (see [Available Macros](#available-macros-by-format)), so the buyer supplies the value, not a new token. Because the identifier rides on the one navigated URL, no party's redirect has to be the terminal hop. This works for any identifier the buyer can supply or derive ahead of serve time, and avoids multi-party redirect chaining entirely.
+
+Identifiers that can only be minted at click time (inside a vendor's own redirect) cannot survive on a count beacon, and routing the user *through* the vendor's redirect so its identifier lands requires a chaining contract AdCP does not define. A buyer-declarable "this tracker must be in the navigation path" slot semantic is under working-group discussion ([#5693](https://github.com/adcontextprotocol/adcp/issues/5693)); until it lands, the count beacon is the default and in-path identifier survival is out of scope.
 
 ### Mapping Storage
 


### PR DESCRIPTION
## What

Rewrites the **Click Tracker Insertion** section of `docs/creative/universal-macros.mdx` to connect the prose to the asset model that already exists, so the two stop drifting.

Addresses the documentation-drift core of #5692. The normative pieces (a param-preservation `MUST`, a buyer-declarable attribution-redirect slot) are **deferred to an RFC** per `docs/governance/rfc-process.mdx` — this PR is non-normative clarification only.

## Why

#5692 frames multi-party click-ID survival as a missing capability ("only one party can own the final hop"). That rule is not a gap — it's the inherited **OpenRTB Native invariant**, and AdCP already encodes it:

- `pixel_tracker {event: click}` ≅ `link.clicktrackers[]` — N renderer-fired **count beacons** (`asset-group-vocabulary.json`: *"a measurement hop that fires when the user clicks but doesn't navigate the user there"*).
- `landing_page_url` (the `url` asset) ≅ `link.url` — exactly **one** terminal destination.

The actual defect was that the "Click Tracker Insertion" section was a two-line GAM `%%CLICK_URL_UNESC%%` snippet that never referenced any of this.

## Changes

- Documents the **count-beacon + single-destination** model with the OpenRTB parallel.
- Documents the **redirect-free** way to get a buyer's click identifier onto the landing — a literal value or buyer-controlled registry macro on `landing_page_url` (no chaining, no terminal-hop contest) — and is explicit that `{buyer_click_id}` is *not* an AdCP macro (the registry is closed).
- Notes the **param-stripping interop hazard** descriptively (the normative `MUST` is deferred to the RFC).

## Scope / process

- **Non-normative** (doc clarification of already-shipped schema). No schema change, no changeset (the policy correctly classifies docs-only as non-protocol scope).
- Reviewed by protocol + docs subagents; both should-fixes addressed (a `{buyer_click_id}` phrasing that implied a nonexistent macro; a cross-ref that implied the catalog-scoped encoding `MUST` extended — now borrows only the *technique*). Anchors verified; broken-links check passes.

## Follow-ups (separate)

- **RFC** for the normative click-tracking model (param-preservation `MUST` + the count-beacon vs attribution-redirect `click_redirects[]` slot, with satisfy-or-reject-at-sync, opt-in/consent-gated, and `allowed_domains` guardrails). Refs #5693.

Refs #5692, #5693