### PR TITLE
docs(content-standards): stop showing inline credentials in asset_access examples

### DIFF
--- a/docs/governance/content-standards/artifacts.mdx
+++ b/docs/governance/content-standards/artifacts.mdx
@@ -223,7 +223,7 @@ This happens during the activation phase when the seller first receives content 
 
 ### Per-Asset Authentication
 
-When pre-configuration isn't possible, include access credentials with individual assets:
+When pre-configured identity access isn't possible, attach a short-lived, asset-scoped token to individual assets:
 
 ```json
 {
@@ -248,11 +248,13 @@ The `url` field is the access URL - it may differ from the artifact's canonical/
 
 | Method | Use Case |
 |--------|----------|
-| `bearer_token` | OAuth2 bearer token in Authorization header |
-| `service_account` | GCP/AWS service account credentials |
-| `signed_url` | Pre-signed URL with embedded credentials (URL itself is the credential) |
+| `bearer_token` | Short-lived, asset-scoped OAuth2 token in the Authorization header. The only method that carries a live secret in the payload — treat it as a secret (never log it or place it in model context). |
+| `service_account` | Identity-based access. The seller pre-authorizes the caller's own service account; **no credentials are transmitted**. |
+| `signed_url` | Pre-signed URL — the URL itself is the (time-limited) credential. |
 
-### Service Account Setup
+### Service Account Access
+
+`service_account` is **identity-based** — no credentials are sent in the response. During onboarding the seller grants the buyer's (or verification agent's) own service account read access to the asset store; at fetch time the client authenticates with that identity using the cloud provider's normal credential chain (GCP Application Default Credentials, AWS SigV4).
 
 For GCP:
 
@@ -260,14 +262,7 @@ For GCP:
 {
   "access": {
     "method": "service_account",
-    "provider": "gcp",
-    "credentials": {
-      "type": "service_account",
-      "project_id": "my-project",
-      "private_key_id": "...",
-      "private_key": "-----BEGIN PRIVATE KEY-----\n...",
-      "client_email": "verification-agent@my-project.iam.gserviceaccount.com"
-    }
+    "provider": "gcp"
   }
 }
 ```
@@ -278,15 +273,12 @@ For AWS:
 {
   "access": {
     "method": "service_account",
-    "provider": "aws",
-    "credentials": {
-      "access_key_id": "AKIAIOSFODNN7EXAMPLE",
-      "secret_access_key": "...",
-      "region": "us-east-1"
-    }
+    "provider": "aws"
   }
 }
 ```
+
+**Never place service-account keys, private keys, or access secrets in a response payload** — they would travel across agent transport, logs, and model context. Identity-based access keeps secrets off the wire entirely.
 
 ### Pre-Signed URLs
 


### PR DESCRIPTION
## What

Removes the inline-credential examples from the `asset_access` docs (`docs/governance/content-standards/artifacts.mdx`). The `service_account` "setup" examples currently instruct sellers to paste a **GCP private key** / **AWS secret key** into a response payload — which then flows Seller → Buyer → Verifier through agent transport, logs, and LLM context. They are rewritten to document **identity-based access** (the seller pre-authorizes the caller's own service account out-of-band; no credentials cross the wire), and the access-methods table now flags `bearer_token` as the only method carrying a live secret (must be short-lived, asset-scoped, and treated as a secret).

## Scope

Docs-only correction — **no schema change, no version bump**. `docs/governance/` is not a protocol-scoped path, so no changeset is added (per `scripts/check-changeset-protocol-scope.cjs`). The schema still permits `credentials`; this only stops the docs from *teaching* the dangerous pattern.

## Why the schema isn't touched here

Per `versioning.mdx` (lines 136-137, 142), removing a field and changing a core security requirement are version-level (4.0) changes, and removal requires a prior deprecation release. The schema work is therefore staged:

- **3.2** — deprecate `credentials`, add optional non-secret `authorized_principal`: #5698
- **4.0** — remove `credentials`, set `additionalProperties: false`: #5699
- **Security baseline** (normative URL-handoff contract: principal-binding, no-forwarded-auth, SSRF MUSTs): #5669
- **Epic**: #5666
