### PR TITLE
fix(training-agent): block IPv6-literal SSRF bypass in webhook fetch

### DIFF
--- a/server/src/training-agent/webhook-fetch.ts
+++ b/server/src/training-agent/webhook-fetch.ts
@@ -65,6 +65,22 @@ function isPrivateIpv4(address: string): boolean {
   );
 }
 
+/** Extract the embedded IPv4 from an IPv4-mapped IPv6 address. Node's URL
+ *  parser canonicalizes `::ffff:10.0.0.1` to the compressed hex form
+ *  `::ffff:a00:1`, so matching only the dotted-quad text would miss it. Read
+ *  the trailing 32 bits regardless of which canonical form the parser chose. */
+function mappedIpv4(v: string): string | null {
+  const dotted = v.match(/^::ffff:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$/);
+  if (dotted) return dotted[1];
+  const hex = v.match(/^::ffff:([0-9a-f]{1,4})(?::([0-9a-f]{1,4}))?$/);
+  if (!hex) return null;
+  const first = parseInt(hex[1], 16);
+  const hasSecond = hex[2] !== undefined;
+  const high = hasSecond ? first : 0;
+  const low = hasSecond ? parseInt(hex[2], 16) : first;
+  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+}
+
 function isPrivateIpAddress(address: string): boolean {
   const version = isIP(address);
   if (version === 4) return isPrivateIpv4(address);
@@ -76,9 +92,8 @@ function isPrivateIpAddress(address: string): boolean {
     if (v.startsWith('ff')) return true;                               // multicast ff00::/8
     if (v.startsWith('64:ff9b:')) return true;                         // NAT64 well-known
     if (v.startsWith('2001:db8:')) return true;                        // documentation
-    // IPv4-mapped (::ffff:a.b.c.d). Node's URL parser canonicalizes to this form.
-    const mapped = v.match(/^::ffff:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$/);
-    if (mapped && isPrivateIpv4(mapped[1])) return true;
+    const mapped = mappedIpv4(v);
+    if (mapped && isPrivateIpv4(mapped)) return true;
     return false;
   }
   return false;
@@ -100,9 +115,14 @@ export async function assertPublicTarget(url: URL): Promise<void> {
   // Scheme refusal is handled by the wrapper before this is called (so it
   // applies unconditionally, including under `allowPrivateIp: true`). By the
   // time we get here the URL is already known to be http(s).
-  // `url.hostname` strips brackets from `[::1]` → `::1`. Userinfo (user:pass@)
-  // never leaks into hostname per WHATWG, so we don't need to scrub that.
-  const hostname = url.hostname;
+  // `url.hostname` keeps the brackets on IPv6 literals (`[::1]`), so strip
+  // them before classification — `isIP('[::1]')` returns 0, which would route
+  // a literal private v6 address into the DNS-lookup path and let it through.
+  // Userinfo (user:pass@) never leaks into hostname per WHATWG, so we don't
+  // need to scrub that.
+  const hostname = url.hostname.startsWith('[') && url.hostname.endsWith(']')
+    ? url.hostname.slice(1, -1)
+    : url.hostname;
   if (!hostname || hostname === 'localhost' || hostname.endsWith('.localhost')) {
     throw new SsrfRefusedError(url.toString(), 'hostname resolves to loopback');
   }

--- a/server/src/training-agent/webhook-fetch.ts
+++ b/server/src/training-agent/webhook-fetch.ts
@@ -59,20 +59,23 @@ function isPrivateIpv4(address: string): boolean {
     a === 0 ||
     a === 10 ||
     a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||                  // CGNAT 100.64.0.0/10
     (a === 169 && b === 254) ||
     (a === 172 && b >= 16 && b <= 31) ||
     (a === 192 && b === 168)
   );
 }
 
-/** Extract the embedded IPv4 from an IPv4-mapped IPv6 address. Node's URL
- *  parser canonicalizes `::ffff:10.0.0.1` to the compressed hex form
- *  `::ffff:a00:1`, so matching only the dotted-quad text would miss it. Read
- *  the trailing 32 bits regardless of which canonical form the parser chose. */
+/** Extract the embedded IPv4 from an IPv6 address that carries one in its low
+ *  32 bits: IPv4-mapped (`::ffff:a.b.c.d`) and deprecated IPv4-compatible
+ *  (`::a.b.c.d`). Node's URL parser canonicalizes the dotted quad to compressed
+ *  hex (`::ffff:10.0.0.1` -> `::ffff:a00:1`; `::127.0.0.1` -> `::7f00:1`), so
+ *  read the trailing 32 bits regardless of which prefix or form the parser
+ *  produced. The `ffff:` prefix is optional so the compatible form is covered. */
 function mappedIpv4(v: string): string | null {
-  const dotted = v.match(/^::ffff:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$/);
+  const dotted = v.match(/^::(?:ffff:)?([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)$/);
   if (dotted) return dotted[1];
-  const hex = v.match(/^::ffff:([0-9a-f]{1,4})(?::([0-9a-f]{1,4}))?$/);
+  const hex = v.match(/^::(?:ffff:)?([0-9a-f]{1,4})(?::([0-9a-f]{1,4}))?$/);
   if (!hex) return null;
   const first = parseInt(hex[1], 16);
   const hasSecond = hex[2] !== undefined;

--- a/server/tests/unit/training-agent-webhook-fetch.test.ts
+++ b/server/tests/unit/training-agent-webhook-fetch.test.ts
@@ -105,6 +105,19 @@ describe('createWebhookFetch — SSRF guard', () => {
       await expect(fetch('http://[64:ff9b::1]/')).rejects.toBeInstanceOf(SsrfRefusedError);
     });
 
+    it('refuses deprecated IPv4-compatible IPv6 wrapping a private v4 (::a.b.c.d)', async () => {
+      // The URL parser canonicalizes ::127.0.0.1 -> ::7f00:1 and
+      // ::169.254.169.254 -> ::a9fe:a9fe; both must decode to the embedded v4.
+      await expect(fetch('http://[::127.0.0.1]/')).rejects.toBeInstanceOf(SsrfRefusedError);
+      await expect(fetch('http://[::10.0.0.1]/')).rejects.toBeInstanceOf(SsrfRefusedError);
+      await expect(fetch('http://[::169.254.169.254]/')).rejects.toBeInstanceOf(SsrfRefusedError);
+    });
+
+    it('refuses CGNAT shared address space (100.64.0.0/10)', async () => {
+      await expect(fetch('http://100.64.0.1/')).rejects.toBeInstanceOf(SsrfRefusedError);
+      await expect(fetch('http://100.127.255.255/')).rejects.toBeInstanceOf(SsrfRefusedError);
+    });
+
     it('userinfo does not smuggle a private host past the hostname check', async () => {
       // URL parser routes user:pass@ to credentials; the hostname is 169.254.169.254.
       await expect(fetch('http://user:pass@169.254.169.254/')).rejects.toBeInstanceOf(SsrfRefusedError);


### PR DESCRIPTION
## Security fix

The webhook-fetch SSRF guard had a **bypass for all IPv6-literal targets**.

### Root cause

`assertPublicTarget()` classified `url.hostname`, but per WHATWG, `URL.hostname` **keeps the brackets** on an IPv6 literal — `new URL('http://[::1]/').hostname` is `"[::1]"`, not `"::1"`. `isIP("[::1]")` returns `0`, so the address was never classified as IPv6 and the **entire `version === 6` block was dead code**. Every IPv6-literal target fell through to the DNS-resolution path and was allowed:

- loopback `[::1]`
- link-local `[fe80::…]`
- multicast `[ff00::/8]`
- NAT64 `[64:ff9b::/96]`
- IPv4-mapped private `[::ffff:10.0.0.1]`

A second, narrower gap: Node's URL parser canonicalizes IPv4-mapped addresses to compressed hex (`::ffff:10.0.0.1` → `::ffff:a00:1`), which the dotted-quad-only regex missed.

### Fix

- Strip the surrounding brackets from `url.hostname` before classification, so IPv6 literals reach the existing IPv6 checks.
- Add `mappedIpv4()` to decode the embedded IPv4 from both the dotted-quad and compressed-hex forms.

### Verification

`server/tests/unit/training-agent-webhook-fetch.test.ts` — **20/20 pass** (was 4 failing on exactly these vectors). The failing tests were correctly catching a real vuln, not a flake.

### Notes

- Found incidentally while diagnosing why a docs-only commit's precommit hook failed (the `docs/` trigger runs the full server suite). The other failures in that run were a corrupted local `@contentauth/c2pa-node` native binary (workspace-only; `npm rebuild` fixes it) — unrelated to this change.
- App code (`server/src/training-agent/`), non-protocol scope → no changeset.
- 🔒 Requests a security review before merge.