### PR TITLE
fix(compliance): wire propagation_surfaces gate on dependency_impairment scenarios

### DIFF
--- a/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml
@@ -12,6 +12,10 @@ required_tools:
   - update_media_buy
   - comply_test_controller
 
+requires_capability:
+  path: media_buy.propagation_surfaces
+  contains: "snapshot"
+
 narrative: |
   Per the dependency-impairment surface ([adcp#2855](https://github.com/adcontextprotocol/adcp/issues/2855)
   and `core/impairment.json`), sellers MUST propagate resource-state transitions

--- a/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_cardinality.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_cardinality.yaml
@@ -12,6 +12,10 @@ required_tools:
   - update_media_buy
   - comply_test_controller
 
+requires_capability:
+  path: media_buy.propagation_surfaces
+  contains: "snapshot"
+
 narrative: |
   The base dependency_impairment scenario tests forward + inverse + health-iff
   with one creative on one package — a malicious or buggy seller can pass the


### PR DESCRIPTION
## Summary

Refs #5664 (facet 1 only — capability gate).

`dependency_impairment.yaml` and `dependency_impairment_cardinality.yaml` both document in their narrative that sellers whose `propagation_surfaces` does not include `"snapshot"` should grade `not_applicable` — but the actual `requires_capability` block was never wired, so the runner executed them unconditionally. Webhook-only sellers got a failing compliance run for a scenario they should never have entered.

**Fix:** Adds `requires_capability: { path: media_buy.propagation_surfaces, contains: "snapshot" }` to both scenarios, matching the existing pattern used by `proposal_finalize.yaml` (which uses `{ path: media_buy.supports_proposals, equals: true }` and works correctly).

**Scope note:** This PR addresses facet 1 (the capability gate for webhook-only sellers) but not facet 2 (the `list_creatives` re-read needed for `impairment.coherence` on default/snapshot sellers). #5675 carries both facets and is the better candidate to close #5664 in full.

## Changes

- `static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml` — add `requires_capability` block
- `static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_cardinality.yaml` — add matching `requires_capability` block

No schema changes. No protocol changes. The narratives already describe this exact gating — this just wires it into the runner.

## Test plan

- [ ] Verify a seller declaring `propagation_surfaces: ["webhook"]` now gets `not_applicable` for both scenarios
- [ ] Verify a seller declaring `propagation_surfaces: ["snapshot"]` or `["snapshot", "webhook"]` still runs the full scenario
- [ ] Verify a seller omitting `propagation_surfaces` entirely still runs (omission defaults to `snapshot` per the schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)