### PR TITLE
fix(server): close IPv6-encoded private-v4 SSRF gaps in shared classifier

### DIFF
--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -130,6 +130,29 @@ export function isPrivateHostname(hostname: string): boolean {
     if ((groups[0] & 0xfe00) === 0xfc00) return true;
     // fec0::/10 deprecated site-local (RFC 3879) — first group is fec0..feff
     if ((groups[0] & 0xffc0) === 0xfec0) return true;
+    // Deprecated IPv4-compatible ::a.b.c.d (RFC 4291 §2.5.5.1) — high 96 bits
+    // zero (and not ::ffff:, handled above); classify the embedded v4 so a
+    // private v4 tunneled through the compatible form is rejected.
+    if (groups.slice(0, 6).every((n) => n === 0)) {
+      const v4 = `${(groups[6] >> 8) & 0xff}.${groups[6] & 0xff}.${(groups[7] >> 8) & 0xff}.${groups[7] & 0xff}`;
+      if (isPrivateHostname(v4)) return true;
+    }
+    // 6to4 2002:V4::/16 (RFC 3056) — the embedded v4 is groups[1:2].
+    if (groups[0] === 0x2002) {
+      const v4 = `${(groups[1] >> 8) & 0xff}.${groups[1] & 0xff}.${(groups[2] >> 8) & 0xff}.${groups[2] & 0xff}`;
+      if (isPrivateHostname(v4)) return true;
+    }
+    // NAT64 well-known 64:ff9b::/96 (RFC 6052) — embedded v4 in groups[6:7];
+    // classify it so a NAT64-wrapped private v4 is rejected while a wrapped
+    // public v4 stays reachable.
+    if (groups[0] === 0x0064 && groups[1] === 0xff9b && groups.slice(2, 6).every((n) => n === 0)) {
+      const v4 = `${(groups[6] >> 8) & 0xff}.${groups[6] & 0xff}.${(groups[7] >> 8) & 0xff}.${groups[7] & 0xff}`;
+      if (isPrivateHostname(v4)) return true;
+    }
+    // Scope: this classifier covers private/internal *reachability*. Multicast
+    // (ff00::/8) and documentation (2001:db8::/32) are intentionally NOT flagged
+    // here — they aren't reachable internal targets, and the dns-rebind suite
+    // asserts ff00::1 is allowed. Don't add them without updating that test.
   }
 
   return false;

--- a/server/tests/unit/url-security-dns-rebind.test.ts
+++ b/server/tests/unit/url-security-dns-rebind.test.ts
@@ -178,6 +178,11 @@ describe('isPrivateHostname (regression coverage for the surfaces ssrfSafeLookup
     ['fec0::1'],                  // fec0::/10 deprecated site-local
     ['feff::1'],                  // fec0::/10 last address
     ['fe80::1%eth0'],             // zone-id stripped before classification
+    ['::7f00:1'],                 // deprecated IPv4-compatible ::127.0.0.1
+    ['::a00:1'],                  // deprecated IPv4-compatible ::10.0.0.1
+    ['2002:7f00:1::'],            // 6to4 wrapping 127.0.0.1
+    ['2002:a9fe:a9fe::'],         // 6to4 wrapping 169.254.169.254 (link-local/metadata)
+    ['64:ff9b::a00:1'],           // NAT64 well-known wrapping 10.0.0.1
   ])('flags %s as private (IPv6 canonicalization)', (host) => {
     expect(isPrivateHostname(host)).toBe(true);
   });
@@ -189,6 +194,8 @@ describe('isPrivateHostname (regression coverage for the surfaces ssrfSafeLookup
     ['example.com'],
     ['2001:4860:4860::8888'],     // public IPv6 (Google DNS) — must not match private blocks
     ['ff00::1'],                  // multicast — not private, separate concern
+    ['2002:808:808::'],           // 6to4 wrapping public 8.8.8.8 — embedded v4 is public
+    ['64:ff9b::808:808'],         // NAT64 wrapping public 8.8.8.8 — embedded v4 is public
   ])('does not flag %s as private', (host) => {
     expect(isPrivateHostname(host)).toBe(false);
   });


### PR DESCRIPTION
## Why

`isPrivateHostname` in `server/src/utils/url-security.ts` is the shared SSRF backstop behind `safeFetch`, `validateCrawlDomain`, `validateRedirectTarget`, and the connect-time `ssrfSafeLookup` dispatcher. It classified three IPv6 encodings of a private v4 as **public**, so an outbound fetch could reach an internal/metadata target through them:

| input | maps to | before |
|---|---|---|
| `::7f00:1` (IPv4-compatible `::127.0.0.1`) | 127.0.0.1 | ❌ allowed |
| `2002:a9fe:a9fe::` (6to4) | 169.254.169.254 (cloud metadata) | ❌ allowed |
| `64:ff9b::a00:1` (NAT64 well-known) | 10.0.0.1 | ❌ allowed |

`#5696` closed the IPv6-literal **bracket** bug in webhook-fetch's *local* classifier, but not these encodings, and not in the *shared* backstop — so every other server fetch path (adagents/brand validators via `safeFetch`, crawl-domain validation, redirect validation) was still exposed.

## What

Three checks added to the canonicalized-groups block of `isPrivateHostname`:
- **IPv4-compatible** `::a.b.c.d` (RFC 4291 §2.5.5.1) — high 96 bits zero, not `::ffff:`; classify embedded v4 in `groups[6:7]`.
- **6to4** `2002:V4::/16` (RFC 3056) — embedded v4 in `groups[1:2]`.
- **NAT64** well-known `64:ff9b::/96` (RFC 6052) — embedded v4 in `groups[6:7]`.

Each extracts the embedded v4 and recurses into `isPrivateHostname`, so a wrapped **private** v4 is refused while a wrapped **public** v4 (`2002:808:808::`, `64:ff9b::808:808`) stays reachable. Uses the existing `canonicalizeIPv6` 8-group form, so compressed/padded variants are handled robustly.

Scoped to private-network *reachability*: multicast (`ff00::/8`) and documentation (`2001:db8::/32`) are deliberately **not** flagged — they aren't reachable internal targets and the `dns-rebind` suite asserts `ff00::1` is allowed (a code comment notes this so it isn't "fixed" into a test break).

## Review

code-reviewer + security-reviewer (parallel, adversarial) → **ship**, zero must-fix. Verified: bit-math/byte-order correct and round-trips with `canonicalizeIPv6`'s encoder; no collision between the IPv4-compatible all-zero check and IPv4-mapped (`groups[5]==0xffff`) or loopback (caught earlier); recursion always terminates (embedded value is a dotted quad → IPv4 path, never re-enters IPv6); Teredo/ISATAP/SIIT probed and confirmed non-routable look-alikes (not reachable, classified identically by the connect-time backstop). 65 url-security tests + dns-rebind suite pass; server typecheck clean.

No changeset: `server/**` is not a `PROTOCOL_SCOPED_PATH`, so this is a non-protocol change (the gate requires none; an empty one would trip it).

## Known residual (separate scope, follow-up)

`webhook-fetch.ts`'s **local** classifier still has no `2002:` branch, so a 6to4 **IP-literal** webhook URL (e.g. `[2002:a9fe:a9fe::]`) passes its pre-flight — reachable only on a host that actually routes 6to4 (not stock Fly), and undici skips the connect-time lookup for IP literals so the hardened backstop doesn't cover that one path. The clean fix is to have webhook-fetch delegate to this shared classifier rather than maintain a divergent copy (which also means reconciling webhook's wholesale `64:ff9b:`/multicast/doc blocks against this classifier's narrower private-reachability scope). Tracking as a follow-up rather than piling onto the just-merged #5696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
