### PR TITLE
fix(compliance): assert governance_context echo + gate governance_approved/conditions (#5716)

### DIFF
--- a/.changeset/5716-governance-handshake-assertions.md
+++ b/.changeset/5716-governance-handshake-assertions.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Strengthen the `governance_approved` and `governance_conditions` storyboards so they actually verify the governance handshake. Both previously asserted only `response_schema`, so a seller that never consulted its registered governance agent still passed. Each terminal `create_media_buy` step now asserts `envelope_field_present: governance_context` — a token only a seller that called `check_governance` can echo — and both scenarios are gated on `media_buy.governance_aware` (mirroring `governance_denied` / `governance_denied_recovery`), so sellers without outbound governance consultation grade `not_applicable` instead of false-failing. Addresses #5716.

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
@@ -9,6 +9,16 @@ required_tools:
   - get_products
   - create_media_buy
 
+# Capability gate: this scenario asserts the seller consults a registered
+# governance agent (check_governance) and echoes the governance_context token
+# on the buy, so it runs only for sellers that declare
+# media_buy.governance_aware: true. Sellers without outbound governance
+# consultation grade not_applicable rather than false-failing on a handshake
+# they do not implement.
+requires_capability:
+  path: media_buy.governance_aware
+  equals: true
+
 narrative: |
   This is a multi-agent test. The test harness sets up a permissive governance plan on
   a governance agent with a $100K budget, then registers that agent with the seller.
@@ -221,3 +231,6 @@ phases:
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
+          - check: envelope_field_present
+            path: governance_context
+            description: "Seller echoes the governance_context token issued by check_governance, proving it consulted the registered governance agent before confirming the buy"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
@@ -9,6 +9,16 @@ required_tools:
   - get_products
   - create_media_buy
 
+# Capability gate: this scenario asserts the seller consults a registered
+# governance agent (check_governance) and echoes the governance_context token
+# on the buy, so it runs only for sellers that declare
+# media_buy.governance_aware: true. Sellers without outbound governance
+# consultation grade not_applicable rather than false-failing on a handshake
+# they do not implement.
+requires_capability:
+  path: media_buy.governance_aware
+  equals: true
+
 narrative: |
   This is a multi-agent test. The test harness sets up a governance plan on a governance
   agent with custom policies that trigger conditions (e.g., "CTV buys require weekly
@@ -202,3 +212,6 @@ phases:
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
+          - check: envelope_field_present
+            path: governance_context
+            description: "Seller echoes the governance_context token issued by check_governance, proving it consulted the registered governance agent before attaching conditions"


### PR DESCRIPTION
Closes #5716.

## Problem

`governance_approved` and `governance_conditions` asserted **only** `response_schema` on their terminal `create_media_buy` step. Since storyboard grading is deterministic `validations[]` only (the `expected:` prose is documentation, not graded), a seller that registers a governance agent but **never calls `check_governance`** creates a schema-valid buy and *passes both* — the governance handshake those scenarios are named for went untested.

(`governance_denied` / `governance_denied_recovery` were already safe — they carry hard `expect_error` + `error_code: GOVERNANCE_DENIED` assertions a non-consulting seller can't fake, and #5676 gated them.)

## Fix

For both scenarios:
1. **Assert the handshake** — add `check: envelope_field_present, path: governance_context` to the terminal step. `governance_context` is the token issued by `check_governance` (`protocol-envelope.json`), so only a seller that actually consulted the registered governance agent can echo it. (`envelope_field_present` is implemented in `@adcp/sdk@9.0.0-beta.31`, added per #3429.)
2. **Gate on the capability** — add `requires_capability: { path: media_buy.governance_aware, equals: true }`, mirroring #5676, so sellers without outbound governance consultation grade `not_applicable` instead of newly false-failing.

## On the "conditions" half of the issue

The issue asked to also assert conditions propagation. There is **no dedicated wire field for governance conditions** on the buy (`create-media-buy-response.json`, `core/media-buy.json`, and `core/package.json` have none). The `governance_context` token *is* the propagation/correlation mechanism (`protocol-envelope.json`: "primary correlation key for audit and reporting across the governance lifecycle"), with conditions retrievable at the governance agent. So the token echo is the correct assertable handshake signal. If the WG wants an explicit conditions field on the buy, that's a separate schema-modeling decision.

## Validation

Targeted storyboard lints pass: `lint-storyboard-check-enum` (✓ `envelope_field_present`), `lint-storyboard-validations-paths` (✓ `governance_context` path), `sdk-runner-capability-gates` (✓ gate resolves). Full pre-commit suite green.

Note: the gate keys `equals: true` while the schema default is `false`, so the only sellers skipped are those that don't declare governance support — the intended skip, not the gated-value-equals-default trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)