### PR TITLE
fix(compliance): fix hosted governance routing

### DIFF
--- a/.changeset/fix-hosted-compliance-governance.md
+++ b/.changeset/fix-hosted-compliance-governance.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix hosted compliance auth defaults so static fixture API keys are only inferred for fixture-backed runs, align the async media-buy submitted-state fixture account with the create request, and mark governance-denial storyboards as multi-agent scenarios routed through seller and governance agents.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.1.0",
       "dependencies": {
-        "@adcp/sdk": "9.0.0-beta.31",
+        "@adcp/sdk": "9.2.0",
         "@anthropic-ai/sdk": "^0.104.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "9.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.0.0-beta.31.tgz",
-      "integrity": "sha512-pzGwW/wf346LPqzZ2e1yd5p4tDJxba6X7jd3296fk8oFDV3pTI+HUPty3ZYrkmVep4W1jPVk6Uw39JYCCQBGFw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.2.0.tgz",
+      "integrity": "sha512-cOqJaTLpgNvBGcBI8MqY0mua8PWzr9Tr4XTXwxyIMj3e3N9ka2GsBaYIdNHoCFj+lSc9O3QGmcGudqObX04aPw==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -141,7 +141,7 @@
         "secure-json-parse": "^4.1.0",
         "structured-headers": "^2.0.2",
         "tldts": "^7.0.29",
-        "undici": "^6.25.0",
+        "undici": "^6.27.0",
         "ws": "^8.21.0",
         "yaml": "^2.7.1"
       },
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@adcp/sdk/node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "9.0.0-beta.31",
+    "@adcp/sdk": "9.2.0",
     "@anthropic-ai/sdk": "^0.104.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -94,7 +94,9 @@ async function hostedAuthDefaultsForRun(
   agentUrl: string,
   options: ComplyOptions,
 ): Promise<{ probeTask?: string; apiKey?: string }> {
-  const shouldInferStaticFixture = !options.test_kit?.auth?.api_key && !options.test_kit?.auth?.basic;
+  const hasOperatorTransportAuth = options.auth?.type === 'bearer' || options.auth?.type === 'basic';
+  const shouldInferStaticFixture =
+    !hasOperatorTransportAuth && !options.test_kit?.auth?.api_key && !options.test_kit?.auth?.basic;
   if (options.test_kit?.auth?.probe_task && !shouldInferStaticFixture) {
     return { probeTask: options.test_kit.auth.probe_task };
   }

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -23,6 +23,7 @@ import {
 import {
   hostedComplianceTarget,
   hostedAuthProbeTaskForProfile,
+  hostedStaticApiKeyForProfile,
   agentAdvertisesBadgeEligibleHostedComplianceTarget,
   badgeEligibleVersionsForHostedComplianceTarget,
   selectCanonicalHostedComplianceTargetForProfile,
@@ -89,20 +90,27 @@ export type {
   SampleBrief,
 };
 
-async function hostedAuthProbeTaskForRun(
+async function hostedAuthDefaultsForRun(
   agentUrl: string,
   options: ComplyOptions,
-): Promise<string | undefined> {
-  const auth = options.auth;
-  if (auth?.type !== 'bearer' && auth?.type !== 'basic') return undefined;
-  if (options.test_kit?.auth?.probe_task) return options.test_kit.auth.probe_task;
+): Promise<{ probeTask?: string; apiKey?: string }> {
+  const shouldInferStaticFixture = !options.test_kit?.auth?.api_key && !options.test_kit?.auth?.basic;
+  if (options.test_kit?.auth?.probe_task && !shouldInferStaticFixture) {
+    return { probeTask: options.test_kit.auth.probe_task };
+  }
 
   try {
     const discovery = await testCapabilityDiscovery(agentUrl, options);
-    return hostedAuthProbeTaskForProfile(discovery.profile);
+    const apiKey = shouldInferStaticFixture
+      ? hostedStaticApiKeyForProfile(discovery.profile)
+      : undefined;
+    return {
+      probeTask: options.test_kit?.auth?.probe_task ?? hostedAuthProbeTaskForProfile(discovery.profile),
+      ...(apiKey ? { apiKey } : {}),
+    };
   } catch (err) {
-    logger.warn({ err, agentUrl }, 'Could not pre-discover hosted auth probe task; using default');
-    return undefined;
+    logger.warn({ err, agentUrl }, 'Could not pre-discover hosted auth defaults; using default probe task only');
+    return {};
   }
 }
 
@@ -111,8 +119,11 @@ export async function comply(
   options: ComplyOptions,
   target: HostedComplianceTarget,
 ): Promise<ComplianceResult> {
-  const authProbeTask = await hostedAuthProbeTaskForRun(agentUrl, options);
-  const result = await sdkComply(agentUrl, withHostedComplianceRunOptions(options, target, authProbeTask));
+  const authDefaults = await hostedAuthDefaultsForRun(agentUrl, options);
+  const result = await sdkComply(
+    agentUrl,
+    withHostedComplianceRunOptions(options, target, authDefaults.probeTask, authDefaults.apiKey),
+  );
   result.adcp_version ??= target.version;
   (result as ComplianceResult & { requested_compliance_target?: string }).requested_compliance_target = target.requested;
   return result;

--- a/server/src/services/hosted-compliance-version.ts
+++ b/server/src/services/hosted-compliance-version.ts
@@ -516,14 +516,14 @@ export function withHostedAuthTestKit<T extends Partial<TestOptions> | undefined
   const nextAuth: RuntimeTestKitAuth = { ...currentAuth };
   let changed = false;
 
-  if (defaultApiKey && !nextAuth.api_key && !nextAuth.basic) {
-    nextAuth.api_key = defaultApiKey;
-    changed = true;
-  } else if (auth?.type === 'bearer' && !nextAuth.api_key) {
+  if (auth?.type === 'bearer' && !nextAuth.api_key) {
     nextAuth.api_key = auth.token;
     changed = true;
   } else if (auth?.type === 'basic' && !nextAuth.basic) {
     nextAuth.basic = { username: auth.username, password: auth.password };
+    changed = true;
+  } else if (defaultApiKey && !nextAuth.api_key && !nextAuth.basic) {
+    nextAuth.api_key = defaultApiKey;
     changed = true;
   }
 

--- a/server/src/services/hosted-compliance-version.ts
+++ b/server/src/services/hosted-compliance-version.ts
@@ -52,6 +52,7 @@ type HostedComplianceProfile = {
 
 const DEFAULT_HOSTED_AUTH_PROBE_TASK = 'list_creatives';
 const HOSTED_AUTH_PROBE_TASKS_BY_PROTOCOL: Readonly<Record<string, readonly string[]>> = {
+  media_buy: ['list_creatives', 'get_media_buy_delivery'],
   'media-buy': ['list_creatives', 'get_media_buy_delivery'],
   creative: ['list_creatives'],
   signals: ['get_signals'],
@@ -70,6 +71,19 @@ const HOSTED_AUTH_PROBE_TASK_FALLBACKS = [
   'list_authorized_properties',
   'list_si_sessions',
 ] as const;
+const HOSTED_STATIC_API_KEY_BY_PROTOCOL: ReadonlyArray<{
+  protocols: readonly string[];
+  apiKey: string;
+}> = [
+  {
+    protocols: ['media_buy', 'media-buy', 'creative', 'governance'],
+    apiKey: 'demo-acme-outdoor-v1',
+  },
+  {
+    protocols: ['signals', 'brand', 'sponsored_intelligence', 'sponsored-intelligence'],
+    apiKey: 'demo-nova-motors-v1',
+  },
+];
 
 function repoPath(...parts: string[]): string {
   return resolve(process.cwd(), ...parts);
@@ -478,9 +492,22 @@ export function hostedAuthProbeTaskForProfile(
   return HOSTED_AUTH_PROBE_TASK_FALLBACKS.find(task => tools.has(task)) ?? DEFAULT_HOSTED_AUTH_PROBE_TASK;
 }
 
+export function hostedStaticApiKeyForProfile(
+  profile: HostedAuthProbeProfile | undefined,
+): string | undefined {
+  const protocols = new Set(profile?.supported_protocols ?? []);
+  for (const entry of HOSTED_STATIC_API_KEY_BY_PROTOCOL) {
+    if (entry.protocols.some(protocol => protocols.has(protocol))) {
+      return entry.apiKey;
+    }
+  }
+  return undefined;
+}
+
 export function withHostedAuthTestKit<T extends Partial<TestOptions> | undefined>(
   options: T,
   defaultProbeTask = DEFAULT_HOSTED_AUTH_PROBE_TASK,
+  defaultApiKey?: string,
 ): (T extends undefined ? TestOptions : NonNullable<T> & TestOptions) {
   const input = (options ?? {}) as Partial<TestOptions>;
   const auth = input.auth;
@@ -489,7 +516,10 @@ export function withHostedAuthTestKit<T extends Partial<TestOptions> | undefined
   const nextAuth: RuntimeTestKitAuth = { ...currentAuth };
   let changed = false;
 
-  if (auth?.type === 'bearer' && !nextAuth.api_key) {
+  if (defaultApiKey && !nextAuth.api_key && !nextAuth.basic) {
+    nextAuth.api_key = defaultApiKey;
+    changed = true;
+  } else if (auth?.type === 'bearer' && !nextAuth.api_key) {
     nextAuth.api_key = auth.token;
     changed = true;
   } else if (auth?.type === 'basic' && !nextAuth.basic) {
@@ -520,8 +550,9 @@ export function withHostedComplianceRunOptions<T extends Partial<ComplyOptions> 
   options: T,
   target: HostedComplianceTarget,
   defaultAuthProbeTask?: string,
+  defaultApiKey?: string,
 ): (T extends undefined ? ComplyOptions : NonNullable<T> & ComplyOptions) {
-  const input = withHostedAuthTestKit(options, defaultAuthProbeTask) as Partial<ComplyOptions>;
+  const input = withHostedAuthTestKit(options, defaultAuthProbeTask, defaultApiKey) as Partial<ComplyOptions>;
   return withHostedComplianceOptions(input, target) as T extends undefined
     ? ComplyOptions
     : NonNullable<T> & ComplyOptions;
@@ -531,8 +562,9 @@ export function withHostedStoryboardRunOptions<T extends Partial<StoryboardRunOp
   options: T,
   target: HostedComplianceTarget,
   defaultAuthProbeTask?: string,
+  defaultApiKey?: string,
 ): (T extends undefined ? StoryboardRunOptions : NonNullable<T> & StoryboardRunOptions) {
-  const input = withHostedAuthTestKit(options, defaultAuthProbeTask) as Partial<StoryboardRunOptions>;
+  const input = withHostedAuthTestKit(options, defaultAuthProbeTask, defaultApiKey) as Partial<StoryboardRunOptions>;
   const version = resolveHostedComplianceVersion(input.adcpVersion ?? target.version);
   assertHostedArtifacts(version);
   const hostedStableLineAlias = hostedStableLineAliasForVersion(target, version);
@@ -549,8 +581,9 @@ export function withHostedTestOptions<T extends Partial<TestOptions> | undefined
   options: T,
   target: HostedComplianceTarget,
   defaultAuthProbeTask?: string,
+  defaultApiKey?: string,
 ): (T extends undefined ? TestOptions : NonNullable<T> & TestOptions) {
-  const input = withHostedAuthTestKit(options, defaultAuthProbeTask);
+  const input = withHostedAuthTestKit(options, defaultAuthProbeTask, defaultApiKey);
   const version = resolveHostedComplianceVersion(input.adcpVersion ?? target.version);
   assertHostedArtifacts(version);
   const hostedStableLineAlias = hostedStableLineAliasForVersion(target, version);

--- a/server/tests/unit/storyboards.test.ts
+++ b/server/tests/unit/storyboards.test.ts
@@ -17,6 +17,7 @@ import {
   HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
   badgeEligibleVersionsForHostedComplianceTarget,
   hostedAuthProbeTaskForProfile,
+  hostedStaticApiKeyForProfile,
   hostedComplianceOptions,
   hostedComplianceTargetPreference,
   hostedComplianceTarget,
@@ -293,6 +294,38 @@ describe('wrapper contract', () => {
     expect(options.test_kit?.auth?.probe_task).toBe('list_creatives');
   });
 
+  it('threads hosted static fixture auth into the runtime test kit when no operator auth is supplied', () => {
+    const apiKey = hostedStaticApiKeyForProfile({
+      tools: ['get_adcp_capabilities', 'get_products'],
+      supported_protocols: ['media_buy'],
+    });
+    const options = withHostedAuthTestKit({}, 'list_creatives', apiKey);
+
+    expect(options.test_kit?.auth?.api_key).toBe('demo-acme-outdoor-v1');
+    expect(options.test_kit?.auth?.probe_task).toBe('list_creatives');
+  });
+
+  it('keeps hosted static fixture auth distinct from operator transport auth', () => {
+    const options = withHostedAuthTestKit({
+      auth: { type: 'bearer', token: 'secret-token' },
+    }, 'list_creatives', 'demo-acme-outdoor-v1');
+
+    expect(options.auth).toEqual({ type: 'bearer', token: 'secret-token' });
+    expect(options.test_kit?.auth?.api_key).toBe('demo-acme-outdoor-v1');
+  });
+
+  it('selects hosted static fixture auth from the discovered protocol profile', () => {
+    expect(hostedStaticApiKeyForProfile({
+      supported_protocols: ['media_buy'],
+    })).toBe('demo-acme-outdoor-v1');
+    expect(hostedStaticApiKeyForProfile({
+      supported_protocols: ['signals'],
+    })).toBe('demo-nova-motors-v1');
+    expect(hostedStaticApiKeyForProfile({
+      supported_protocols: ['unknown'],
+    })).toBeUndefined();
+  });
+
   it('threads Basic auth into the hosted runtime test kit', () => {
     const options = withHostedAuthTestKit({
       auth: { type: 'basic', username: 'agent-user', password: 'agent-pass' },
@@ -306,6 +339,11 @@ describe('wrapper contract', () => {
   });
 
   it('selects a hosted auth probe task from the discovered agent profile', () => {
+    expect(hostedAuthProbeTaskForProfile({
+      tools: ['get_adcp_capabilities', 'get_media_buy_delivery'],
+      supported_protocols: ['media_buy'],
+    })).toBe('get_media_buy_delivery');
+
     expect(hostedAuthProbeTaskForProfile({
       tools: ['get_adcp_capabilities', 'get_signals'],
       supported_protocols: ['signals'],

--- a/server/tests/unit/storyboards.test.ts
+++ b/server/tests/unit/storyboards.test.ts
@@ -305,13 +305,25 @@ describe('wrapper contract', () => {
     expect(options.test_kit?.auth?.probe_task).toBe('list_creatives');
   });
 
-  it('keeps hosted static fixture auth distinct from operator transport auth', () => {
+  it('does not override operator bearer auth with hosted static fixture auth', () => {
     const options = withHostedAuthTestKit({
       auth: { type: 'bearer', token: 'secret-token' },
     }, 'list_creatives', 'demo-acme-outdoor-v1');
 
     expect(options.auth).toEqual({ type: 'bearer', token: 'secret-token' });
-    expect(options.test_kit?.auth?.api_key).toBe('demo-acme-outdoor-v1');
+    expect(options.test_kit?.auth?.api_key).toBe('secret-token');
+  });
+
+  it('does not override operator basic auth with hosted static fixture auth', () => {
+    const options = withHostedAuthTestKit({
+      auth: { type: 'basic', username: 'agent-user', password: 'agent-pass' },
+    }, 'list_creatives', 'demo-acme-outdoor-v1');
+
+    expect((options.test_kit?.auth as any)?.basic).toEqual({
+      username: 'agent-user',
+      password: 'agent-pass',
+    });
+    expect(options.test_kit?.auth?.api_key).toBeUndefined();
   });
 
   it('selects hosted static fixture auth from the discovered protocol profile', () => {

--- a/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async.yaml
@@ -125,6 +125,9 @@ phases:
 
         sample_request:
           account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
             sandbox: true
           scenario: "force_create_media_buy_arm"
           params:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -4,6 +4,9 @@ title: "Seller rejects buy when governance denies"
 category: media_buy_seller
 summary: "Verifies that the seller rejects a media buy and propagates the denial when governance denies the transaction."
 track: media_buy
+requires:
+  - multi_agent
+default_agent: sales
 required_tools:
   - sync_governance
   - get_products
@@ -17,6 +20,13 @@ narrative: |
   When the seller calls check_governance, the governance agent denies because the
   requested budget exceeds the plan total. The seller must reject the buy and propagate
   the denial back to the buyer.
+
+  This scenario requires a runner that can route calls to at least two logical
+  agents: `sales` for the seller under test and `governance` for the governance
+  plan setup. Single-agent runners should only include this storyboard when the
+  endpoint under test deliberately combines seller and governance behavior in
+  one tenant; otherwise it belongs in the governance-aware-seller multi-agent
+  suite.
 
   By default, the governance agent is the training agent at test-agent.adcontextprotocol.org.
   Override by supplying a different `governance_agent_url` in the run's initial context
@@ -39,7 +49,9 @@ caller:
 
 prerequisites:
   description: |
-    A governance agent that supports sync_plans and check_governance.
+    A multi-agent runner with `sales` and `governance` agents. The governance
+    agent supports sync_plans and check_governance; the sales agent supports
+    sync_governance and create_media_buy.
   test_kit: "test-kits/acme-outdoor.yaml"
 
 phases:
@@ -53,6 +65,7 @@ phases:
     steps:
       - id: sync_plans
         title: "Create strict governance plan"
+        agent: governance
         task: sync_plans
         schema_ref: "governance/sync-plans-request.json"
         response_schema_ref: "governance/sync-plans-response.json"
@@ -84,6 +97,7 @@ phases:
     steps:
       - id: sync_accounts
         title: "Establish account with seller"
+        agent: sales
         task: sync_accounts
         schema_ref: "account/sync-accounts-request.json"
         response_schema_ref: "account/sync-accounts-response.json"
@@ -108,6 +122,7 @@ phases:
 
       - id: sync_governance
         title: "Register governance agent with seller"
+        agent: sales
         task: sync_governance
         schema_ref: "account/sync-governance-request.json"
         response_schema_ref: "account/sync-governance-response.json"
@@ -136,6 +151,7 @@ phases:
     steps:
       - id: get_products_brief
         title: "Discover products"
+        agent: sales
         task: get_products
         schema_ref: "media-buy/get-products-request.json"
         response_schema_ref: "media-buy/get-products-response.json"
@@ -169,6 +185,7 @@ phases:
 
       - id: create_media_buy_denied
         title: "Create buy (governance denies — should fail)"
+        agent: sales
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
@@ -4,6 +4,9 @@ title: "Seller accepts corrected buy after governance denial"
 category: media_buy_seller
 summary: "Verifies that a buyer can recover from GOVERNANCE_DENIED by shrinking the buy to within plan limits and retrying."
 track: media_buy
+requires:
+  - multi_agent
+default_agent: sales
 required_tools:
   - sync_governance
   - get_products
@@ -18,6 +21,13 @@ narrative: |
   The seller must propagate the governance findings unchanged so the buyer can identify
   exactly which constraint was violated (budget authority, brand policy, etc.) and
   correct it.
+
+  This scenario requires a runner that can route calls to at least two logical
+  agents: `sales` for the seller under test and `governance` for the governance
+  plan setup. Single-agent runners should only include this storyboard when the
+  endpoint under test deliberately combines seller and governance behavior in
+  one tenant; otherwise it belongs in the governance-aware-seller multi-agent
+  suite.
 
   By default, the governance agent is the training agent at test-agent.adcontextprotocol.org.
   Override by supplying a different `governance_agent_url` in the run's initial context
@@ -40,7 +50,9 @@ caller:
 
 prerequisites:
   description: |
-    A governance agent that supports sync_plans and check_governance.
+    A multi-agent runner with `sales` and `governance` agents. The governance
+    agent supports sync_plans and check_governance; the sales agent supports
+    sync_governance and create_media_buy.
   test_kit: "test-kits/acme-outdoor.yaml"
 
 phases:
@@ -53,6 +65,7 @@ phases:
     steps:
       - id: sync_plans
         title: "Create strict governance plan"
+        agent: governance
         task: sync_plans
         schema_ref: "governance/sync-plans-request.json"
         response_schema_ref: "governance/sync-plans-response.json"
@@ -84,6 +97,7 @@ phases:
     steps:
       - id: sync_accounts
         title: "Establish account with seller"
+        agent: sales
         task: sync_accounts
         schema_ref: "account/sync-accounts-request.json"
         response_schema_ref: "account/sync-accounts-response.json"
@@ -108,6 +122,7 @@ phases:
 
       - id: sync_governance
         title: "Register governance agent with seller"
+        agent: sales
         task: sync_governance
         schema_ref: "account/sync-governance-request.json"
         response_schema_ref: "account/sync-governance-response.json"
@@ -136,6 +151,7 @@ phases:
     steps:
       - id: get_products_brief
         title: "Discover products"
+        agent: sales
         task: get_products
         schema_ref: "media-buy/get-products-request.json"
         response_schema_ref: "media-buy/get-products-response.json"
@@ -170,6 +186,7 @@ phases:
 
       - id: create_media_buy_denied
         title: "Attempt $50K buy — denied"
+        agent: sales
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
@@ -217,6 +234,7 @@ phases:
     steps:
       - id: create_media_buy_retry
         title: "Retry with $8K — approved"
+        agent: sales
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -140,7 +140,7 @@
 #   different topologies.)
 #
 # requires: string[] (optional — storyboard-level runtime requirement gate.
-#   Known values: controller | seeded_state | real_wire | webhook_receiver (forward-compat:
+#   Known values: controller | seeded_state | real_wire | webhook_receiver | multi_agent (forward-compat:
 #   unrecognized values are NOT schema violations — runners emit
 #   requirement_unmet at runtime; see Forward compatibility below).
 #   Default when absent: [real_wire] — untagged storyboards run unchanged.
@@ -226,6 +226,19 @@
 #                    This value may be declared explicitly on storyboards such
 #                    as webhook-emission; runners may also infer it from
 #                    webhook URL substitutions in sample_request payloads.
+#
+#     multi_agent  — gate on the runner being configured with every logical
+#                    agent key required by this storyboard's `default_agent`
+#                    and step-level `agent:` declarations. Available when the
+#                    runner receives an `agents` map containing at least two
+#                    logical agents and all authored route keys used by the
+#                    storyboard resolve against that map. When unmet, the
+#                    runner MUST emit skip_result.reason: requirement_unmet
+#                    with detail naming "multi_agent" rather than failing a
+#                    routed step with default_agent_unresolved or unrouted_step.
+#                    Storyboards SHOULD declare this when the scenario's setup
+#                    and execution require distinct logical tenants, such as a
+#                    seller agent plus a governance agent.
 #
 #   Forward compatibility: runners encountering a requires value they do not
 #   recognize MUST emit skip_result.reason: requirement_unmet (not fail-load)


### PR DESCRIPTION
## Summary

Fix the remaining hosted compliance conformance gaps for the training agent:

- apply hosted static fixture API keys to hosted compliance test-kit auth defaults, separate from operator auth
- align the async media-buy arming fixture account with the subsequent create request
- mark governance-denial storyboards as native multi-agent scenarios and route setup/execution steps through `governance` and `sales`
- bump `@adcp/sdk` to `9.2.0` so `requires: [multi_agent]` is recognized and satisfied by authored route keys

## Root Cause

The hosted compliance runner had two separate contract gaps:

- hosted static fixture runs did not provide the same seeded API key through `test_kit.auth.api_key` that the storyboards expected for `from_test_kit` tool-call auth
- governance-denial storyboards were authored as if a governance signal could reach the seller in a single-agent run, but the scenario actually requires a runner that can route calls to both a seller agent and a governance agent

The async submitted-state gap was an authoring mismatch: the force directive armed one account while the following create-media-buy request used another.

## Validation

- `npm run build:compliance`
- `npx tsx .context/probe-multi-agent-governance.ts`
- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-contradictions`
- `npm run test:storyboard-auth-shape`
- `npm run test:compliance-source-authority`
- `npx vitest run server/tests/unit/storyboards.test.ts`
- `npm run typecheck`
- `git diff --check`
