### PR TITLE
chore: bump @adcp/sdk runner to 9.2.0 (honor capability-gate schema defaults)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.1.0",
       "dependencies": {
-        "@adcp/sdk": "9.0.0-beta.31",
+        "@adcp/sdk": "9.2.0",
         "@anthropic-ai/sdk": "^0.104.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "9.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.0.0-beta.31.tgz",
-      "integrity": "sha512-pzGwW/wf346LPqzZ2e1yd5p4tDJxba6X7jd3296fk8oFDV3pTI+HUPty3ZYrkmVep4W1jPVk6Uw39JYCCQBGFw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.2.0.tgz",
+      "integrity": "sha512-cOqJaTLpgNvBGcBI8MqY0mua8PWzr9Tr4XTXwxyIMj3e3N9ka2GsBaYIdNHoCFj+lSc9O3QGmcGudqObX04aPw==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -141,7 +141,7 @@
         "secure-json-parse": "^4.1.0",
         "structured-headers": "^2.0.2",
         "tldts": "^7.0.29",
-        "undici": "^6.25.0",
+        "undici": "^6.27.0",
         "ws": "^8.21.0",
         "yaml": "^2.7.1"
       },
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@adcp/sdk/node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "9.0.0-beta.31",
+    "@adcp/sdk": "9.2.0",
     "@anthropic-ai/sdk": "^0.104.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",


### PR DESCRIPTION
## What

Moves the hosted compliance runner off the stale `9.0.0-beta.31` pin to the released **9.2.0** (`latest`).

## Why

`@adcp/sdk@9.2.0` ([adcp-client#2282](https://github.com/adcontextprotocol/adcp-client/pull/2282), closing [#2278](https://github.com/adcontextprotocol/adcp-client/issues/2278)) makes the storyboard runner **materialize `get_adcp_capabilities` schema defaults** when evaluating `equals`/`contains` `requires_capability` gates.

Concretely: the `dependency_impairment` / `dependency_impairment_cardinality` gate added in #5675 is `media_buy.propagation_surfaces contains "snapshot"`. That field is new in 3.1 with default `["snapshot"]`. On the old runner, a snapshot seller that **omits** the field resolved to `undefined` → `not_applicable` skip — a silent coverage cliff for exactly the sellers the default exists to protect. On 9.2.0 they inherit the default and are graded. `present:` gates are unaffected (absence stays the load-bearing signal).

So this is the production half of closing the #5664 / #5675 grading gap: the gate is already on `main`, but grading still runs the pre-fix runner until this lands.

## Verification (local, against 9.2.0)

| Check | Result |
|---|---|
| `typecheck` (server/tsconfig, strict) | 0 errors |
| `test:sdk-runner-capability-gates` | pass |
| `test:sdk-shims`, `test:test-dynamic-imports` | pass |
| `test:server-unit` | 278 files / 4301 pass / 0 fail |
| `test:unit` | 60 files / 999 pass / 0 fail |

No changeset (operational dependency bump — non-protocol, per the pre-push policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)