### PR TITLE
fix(compliance): harden dependency_impairment re-reads (follow-up to #5675)

### DIFF
--- a/.changeset/dependency-impairment-reread-hardening.md
+++ b/.changeset/dependency-impairment-reread-hardening.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset: Harden the `dependency_impairment` / `dependency_impairment_cardinality` storyboards (follow-up to #5675). Declare `list_creatives` in `required_tools` (the re-read steps invoke it, so a seller without it is screened at the applicability layer instead of hard-failing the step); assert each re-read returned the intended creative via `creatives[0].creative_id` (so the cardinality re-reads prove they observed the right creative, not any rejected library entry); and update the capability-gate comment to note that default-`snapshot` sellers (those omitting `propagation_surfaces`) are graded only on `@adcp/sdk >= 9.2.0`, which materializes capability-gate schema defaults (adcp-client#2278).

--- a/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml
@@ -9,6 +9,7 @@ required_tools:
   - create_media_buy
   - get_media_buys
   - sync_creatives
+  - list_creatives
   - update_media_buy
   - comply_test_controller
 
@@ -17,8 +18,11 @@ required_tools:
 # "snapshot". Webhook-only or out_of_band sellers grade not_applicable instead
 # of false-failing on a contract that does not apply to them — the opt-out the
 # propagation_surfaces schema already documents (get-adcp-capabilities-response.json)
-# but that was never wired into this scenario. Requires runner support for the
-# `contains:` matcher (adcp-client >= 7.70).
+# but that was never wired into this scenario. Requires the `contains:` matcher
+# (@adcp/sdk >= 7.70). Sellers that OMIT propagation_surfaces inherit the
+# ["snapshot"] default and are graded here only on @adcp/sdk >= 9.2.0, which
+# materializes capability-gate schema defaults; earlier runners skip them as
+# not_applicable (adcp-client#2278).
 requires_capability:
   path: media_buy.propagation_surfaces
   contains: "snapshot"
@@ -461,6 +465,10 @@ phases:
         validations:
           - check: response_schema
             description: "Response matches list-creatives-response.json schema"
+          - check: field_value
+            path: "creatives[0].creative_id"
+            value: "acme_dep_banner_001"
+            description: "Filter returned the rejected creative specifically — the status assertion below is grounded on this creative, not another library entry"
           - check: field_value
             path: "creatives[0].status"
             value: "rejected"

--- a/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_cardinality.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_cardinality.yaml
@@ -9,6 +9,7 @@ required_tools:
   - create_media_buy
   - get_media_buys
   - sync_creatives
+  - list_creatives
   - update_media_buy
   - comply_test_controller
 
@@ -17,8 +18,11 @@ required_tools:
 # "snapshot". Webhook-only or out_of_band sellers grade not_applicable instead
 # of false-failing on a contract that does not apply to them — the opt-out the
 # propagation_surfaces schema already documents (get-adcp-capabilities-response.json)
-# but that was never wired into this scenario. Requires runner support for the
-# `contains:` matcher (adcp-client >= 7.70).
+# but that was never wired into this scenario. Requires the `contains:` matcher
+# (@adcp/sdk >= 7.70). Sellers that OMIT propagation_surfaces inherit the
+# ["snapshot"] default and are graded here only on @adcp/sdk >= 9.2.0, which
+# materializes capability-gate schema defaults; earlier runners skip them as
+# not_applicable (adcp-client#2278).
 requires_capability:
   path: media_buy.propagation_surfaces
   contains: "snapshot"
@@ -462,6 +466,10 @@ phases:
           - check: response_schema
             description: "Response matches list-creatives-response.json schema"
           - check: field_value
+            path: "creatives[0].creative_id"
+            value: "acme_card_banner_a"
+            description: "Filter returned creative A specifically — proves the rejected status below is A's, not creative B (also rejected by the cardinality-2 point)"
+          - check: field_value
             path: "creatives[0].status"
             value: "rejected"
             description: "Creative observed as rejected on the wire — closes the impairment.coherence ledger for the impaired read that follows"
@@ -586,6 +594,10 @@ phases:
         validations:
           - check: response_schema
             description: "Response matches list-creatives-response.json schema"
+          - check: field_value
+            path: "creatives[0].creative_id"
+            value: "acme_card_banner_b"
+            description: "Filter returned creative B specifically — proves the rejected status below is B's, not creative A (also rejected at this point)"
           - check: field_value
             path: "creatives[0].status"
             value: "rejected"


### PR DESCRIPTION
Follow-up to #5675 — three small hardenings to the `dependency_impairment` / `dependency_impairment_cardinality` storyboards, from review of that PR.

## Changes

1. **Declare `list_creatives` in `required_tools`** (both scenarios). The re-read steps invoke `list_creatives`, but it wasn't in `required_tools` — so a seller that exposes the snapshot impairment surface but not `list_creatives` would hard-fail the re-read step instead of being screened out cleanly at the applicability layer. Matches the `creative_fate_after_cancellation` precedent (the only other media-buy scenario doing a `list_creatives` re-read).

2. **Assert `creatives[0].creative_id` on each re-read.** The re-reads filter by a single `creative_id` and asserted `creatives[0].status == "rejected"` — but at the cardinality-2 point there are *two* rejected creatives in the library, so the status check alone was satisfiable by the *wrong* creative if a seller mis-orders or ignores the filter. Adding the `creative_id` check makes each re-read prove it observed the intended creative (A vs B). Base scenario gets it too for consistency (it's immune today — one creative — but the assertion is strictly better).

3. **Update the capability-gate comment.** The `contains:` matcher floor stays `@adcp/sdk >= 7.70`, but default-`snapshot` sellers (those that *omit* `propagation_surfaces` and inherit the `["snapshot"]` default) are graded here only on **`@adcp/sdk >= 9.2.0`**, which materializes capability-gate schema defaults ([adcp-client#2278](https://github.com/adcontextprotocol/adcp-client/issues/2278)). Earlier runners skip them as `not_applicable`.

## Verification

Full storyboard + compliance lint suite green, including `test:storyboard-validations-paths` (confirms `creatives[0].creative_id` resolves against `list-creatives-response.json`), `test:storyboard-check-enum`, `test:storyboard-doc-parity`, and the `test:storyboards` / `:3.0-compat` runs.

No pass/fail-boundary change for already-conformant snapshot sellers; this only tightens what the re-reads prove and screens non-`list_creatives` sellers at the gate instead of mid-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)