### PR TITLE
compliance(media-buy): available_actions should be runnable by sales-non-guaranteed-only sellers

### DIFF
--- a/.changeset/available-actions-non-guaranteed.md
+++ b/.changeset/available-actions-non-guaranteed.md
@@ -1,0 +1,6 @@
+---
+---
+
+compliance(media-buy): the `available_actions` scenario uses a non-guaranteed product fixture so `sales-non-guaranteed`-only sellers can run it.
+
+`available_actions.yaml` seeded a guaranteed-only product, so its `create_buy_from_product` step (and the whole available-actions enforcement flow that follows) failed with a terminal `DELIVERY_MODE_NOT_SUPPORTED` for sellers that declare only `specialisms: ["sales-non-guaranteed"]`. The `allowed_actions` behavior the scenario actually grades is delivery-type-agnostic, so the fixture is switched to `non_guaranteed` (floor-priced) — the same fix applied to the base `media_buy_seller` flow. The packaged `dist/compliance/` cache is generated from this source.

--- a/static/compliance/source/protocols/media-buy/scenarios/available_actions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/available_actions.yaml
@@ -62,7 +62,12 @@ fixtures:
     - product_id: "available_actions_display"
       name: "Available Actions Display Package"
       description: "Display inventory fixture used to verify product allowed actions become buy available actions."
-      delivery_type: "guaranteed"
+      # Non-guaranteed so this scenario is runnable by sales-non-guaranteed-only
+      # sellers (a guaranteed-only fixture made create_buy_from_product fail with
+      # DELIVERY_MODE_NOT_SUPPORTED, cascading the whole available-actions flow).
+      # The allowed_actions below — what this scenario actually grades — are
+      # delivery-type-agnostic. Mirrors the base media-buy flow fix.
+      delivery_type: "non_guaranteed"
       channels: ["display"]
       format_ids:
         - id: "display_300x250"
@@ -91,7 +96,7 @@ fixtures:
       pricing_option_id: "available_actions_cpm"
       pricing_model: "cpm"
       currency: "USD"
-      fixed_price: 8.0
+      floor_price: 8.0
 
 phases:
   - id: discover_product_action_template


### PR DESCRIPTION
## Problem
Follows the same root cause as the base `media_buy_seller` flow fix (recently merged): `available_actions.yaml` seeds a **guaranteed-only** product fixture (`available_actions_display`, `delivery_type: guaranteed`). A seller declaring only `specialisms: ["sales-non-guaranteed"]` correctly rejects a guaranteed buy with a terminal `DELIVERY_MODE_NOT_SUPPORTED`, so `create_buy_from_product` fails and the whole enforcement flow (`read_persisted_buy_actions`, `enforce_available_actions`) cascades as `prerequisite_failed`.

## Change
Switch the fixture to **`non_guaranteed`** (`fixed_price` → `floor_price`). The `allowed_actions` behavior this scenario actually grades (self-serve vs requires-approval action enforcement) is **delivery-type-agnostic**, so nothing about the test's intent changes. The create steps reference the product/pricing by id, unchanged.

## Reproduction
Against a live `sales-non-guaranteed` seller, `media_buy_seller/available_actions` → `create_buy_from_product` returns `DELIVERY_MODE_NOT_SUPPORTED` (terminal) → downstream steps `prerequisite_failed`.

## Scope note for maintainers
This is the second incidental guaranteed-only fixture (after the base flow). I found **8 other** media-buy scenarios that also seed `delivery_type: guaranteed` (`billing_finality_delivery`, `create_media_buy_async`, `measurement_accountability`, `vendor_metric_accountability`, `delivery_reporting`, `canonical_formats`, `get_products_async`, `governance_approved`). I deliberately did **not** touch those — some likely test guaranteed-specific behavior on purpose (e.g. `governance_approved`'s IO-approval, the async arms) and should stay guaranteed + be capability-gated rather than flipped. Happy to follow up per your guidance on which are incidental vs intentional.

Source-only change; the packaged `dist/compliance/` cache is generated by the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)