### PR TITLE
feat(registry): add SSE feed stream

### DIFF
--- a/.changeset/registry-feed-stream.md
+++ b/.changeset/registry-feed-stream.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Registry: add `GET /api/registry/feed/stream` as the 3.x Server-Sent Events transport for cursor-based registry feed pages, with heartbeat events while caught up and reconnect recovery through the persisted cursor. `GET /api/registry/feed` responses now include required `freshness` metadata (`generated_at`, `latest_event_created_at`, `lag_seconds`, `retention_days`) so consumers can monitor mirror lag for their selected type filter. Freshness and feed queries are bounded to the 90-day retention window; SDKs should treat the SSE endpoint as the preferred transport and fall back to polling `/api/registry/feed`.

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -189,6 +189,7 @@ curl "https://agenticadvertising.org/api/registry/agents?type=measurement&accred
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/api/registry/feed` | Poll cursor-based registry change feed (auth required) |
+| GET | `/api/registry/feed/stream` | Stream cursor-based registry feed pages over Server-Sent Events (auth required) |
 
 
 ### Lookups & Authorization
@@ -483,7 +484,7 @@ result = requests.post(
 
 `GET /api/registry/feed`
 
-Poll a cursor-based feed of registry changes. Use this to keep a local copy of the registry in sync without re-fetching the full dataset. Events are ordered by UUID v7 `event_id`, providing monotonic cursor progression. The feed retains events for 90 days — expired cursors return `410 Gone`.
+Poll a cursor-based feed of registry changes. Use this to keep a local copy of the registry in sync without re-fetching the full dataset. Events are ordered by UUID v7 `event_id`, providing monotonic cursor progression. The feed retains events for 90 days — expired cursors return `410 Gone`. Each response includes `freshness` metadata so consumers can measure feed lag for the requested type filter.
 
 **Schema:** [`core/registry-feed-response.json`](https://adcontextprotocol.org/schemas/v3/core/registry-feed-response.json) wraps [`core/registry-event.json`](https://adcontextprotocol.org/schemas/v3/core/registry-event.json) items.
 
@@ -570,11 +571,21 @@ feed = requests.get(
     }
   ],
   "cursor": "019539a0-1234-7000-8000-000000000001",
-  "has_more": true
+  "has_more": true,
+  "freshness": {
+    "generated_at": "2026-03-31T10:00:15.000Z",
+    "latest_event_created_at": "2026-03-31T10:00:00.000Z",
+    "lag_seconds": 15,
+    "retention_days": 90
+  }
 }
 ```
 
 When `has_more` is `true`, pass the returned `cursor` value in the next request to continue polling. When `false`, you've reached the end of the current feed — poll again later with the same cursor to pick up new events.
+
+`latest_event_created_at` is the newest matching event currently visible to the feed. `lag_seconds` is computed against `generated_at`; alert on it according to your own mirror freshness target.
+
+`GET /api/registry/feed/stream` provides the same feed pages over Server-Sent Events. Reconnect with your last persisted cursor after disconnects. The stream emits `event: feed` with the same JSON shape shown above and `event: heartbeat` while caught up. Cursors are tied to the same logical `types` subscription; changing filters while reusing a cursor can skip events that were filtered out previously. The stream carries the resume cursor in JSON `data.cursor`, not SSE `id`, so browser `EventSource` clients must reconnect with `?cursor=...`.
 
 If the cursor has expired (older than 90 days or not found), the response is `410 Gone`:
 

--- a/server/src/db/catalog-events-db.ts
+++ b/server/src/db/catalog-events-db.ts
@@ -32,6 +32,14 @@ export interface FeedResult {
   events: CatalogEvent[];
   cursor: string | null;
   has_more: boolean;
+  freshness: FeedFreshness;
+}
+
+export interface FeedFreshness {
+  generated_at: string;
+  latest_event_created_at: string | null;
+  lag_seconds: number | null;
+  retention_days: number;
 }
 
 export interface FeedError {
@@ -130,9 +138,9 @@ export class CatalogEventsDatabase {
     }
 
     // Build query
-    const conditions: string[] = [];
-    const params: unknown[] = [];
-    let paramIdx = 1;
+    const conditions: string[] = [`created_at >= NOW() - INTERVAL '1 day' * $1`];
+    const params: unknown[] = [RETENTION_DAYS_DEFAULT];
+    let paramIdx = 2;
 
     if (cursor) {
       conditions.push(`event_id > $${paramIdx}`);
@@ -165,8 +173,41 @@ export class CatalogEventsDatabase {
     const hasMore = result.rows.length > effectiveLimit;
     const events = hasMore ? result.rows.slice(0, effectiveLimit) : result.rows;
     const lastCursor = events.length > 0 ? events[events.length - 1].event_id : cursor;
+    const freshness = await this.getFreshness(types);
 
-    return { events, cursor: lastCursor, has_more: hasMore };
+    return { events, cursor: lastCursor, has_more: hasMore, freshness };
+  }
+
+  private async getFreshness(types: string[] | null): Promise<FeedFreshness> {
+    const generatedAt = new Date();
+    const conditions: string[] = [`created_at >= NOW() - INTERVAL '1 day' * $1`];
+    const params: unknown[] = [RETENTION_DAYS_DEFAULT];
+    let paramIdx = 2;
+
+    if (types && types.length > 0) {
+      const typeConditions = types.map(t => {
+        const pattern = escapeLikePattern(t).replace(/\*/g, '%');
+        params.push(pattern);
+        return `event_type LIKE $${paramIdx++}`;
+      });
+      conditions.push(`(${typeConditions.join(' OR ')})`);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const result = await query<{ latest_event_created_at: Date | null }>(
+      `SELECT MAX(created_at) AS latest_event_created_at
+       FROM catalog_events
+       ${where}`,
+      params
+    );
+    const latest = result.rows[0]?.latest_event_created_at ?? null;
+
+    return {
+      generated_at: generatedAt.toISOString(),
+      latest_event_created_at: latest ? latest.toISOString() : null,
+      lag_seconds: latest ? Math.max(0, Math.floor((generatedAt.getTime() - latest.getTime()) / 1000)) : null,
+      retention_days: RETENTION_DAYS_DEFAULT,
+    };
   }
 
   /**

--- a/server/src/db/migrations/522_catalog_events_type_created_index.sql
+++ b/server/src/db/migrations/522_catalog_events_type_created_index.sql
@@ -1,0 +1,3 @@
+-- Supports type-filtered registry feed freshness lookups and SSE heartbeats.
+CREATE INDEX IF NOT EXISTS idx_catalog_events_type_created
+  ON catalog_events (event_type text_pattern_ops, created_at DESC);

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -6,6 +6,7 @@
  */
 
 import { Router } from "express";
+import { once } from "node:events";
 import type { Request, RequestHandler } from "express";
 import { z } from "zod";
 import escapeHtml from "escape-html";
@@ -1903,13 +1904,43 @@ registry.registerPath({
 });
 
 // Change Feed & Sync
+const RegistryFeedFreshnessSchema = z.object({
+  generated_at: z.string().datetime().openapi({
+    description: "Server timestamp when this feed page was generated.",
+  }),
+  latest_event_created_at: z.string().datetime().nullable().openapi({
+    description: "Newest event creation timestamp currently visible in the feed for the requested type filter. Null when no matching event exists inside retention.",
+  }),
+  lag_seconds: z.number().int().nonnegative().nullable().openapi({
+    description: "Seconds between generated_at and latest_event_created_at. Null when no matching event exists.",
+  }),
+  retention_days: z.number().int().positive().openapi({
+    description: "Number of days the registry retains feed cursors and events.",
+  }),
+});
+
+const RegistryFeedPageSchema = z.object({
+  events: z.array(z.object({
+    event_id: z.string().uuid(),
+    event_type: z.string().openapi({ example: "property.created" }),
+    entity_type: z.string().openapi({ example: "property" }),
+    entity_id: z.string(),
+    payload: z.record(z.string(), z.unknown()),
+    actor: z.string(),
+    created_at: z.string().datetime(),
+  })),
+  cursor: z.string().uuid().nullable().openapi({ description: "Pass as cursor in the next request to continue polling" }),
+  has_more: z.boolean(),
+  freshness: RegistryFeedFreshnessSchema,
+});
+
 registry.registerPath({
   method: "get",
   path: "/api/registry/feed",
   operationId: "getRegistryFeed",
   summary: "Registry change feed",
   description:
-    "Poll a cursor-based feed of registry changes. Events are ordered by UUID v7 event_id for monotonic cursor progression. The feed retains events for 90 days.\n\nType filtering supports glob patterns: `property.*` matches `property.created`, `property.updated`, etc.",
+    "Poll a cursor-based feed of registry changes. Events are ordered by UUID v7 event_id for monotonic cursor progression. The feed retains events for 90 days. The `freshness` object reports when the response was generated, the newest matching event currently visible to the feed, and the resulting feed lag.\n\nType filtering supports glob patterns: `property.*` matches `property.created`, `property.updated`, etc.",
   tags: ["Change Feed"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -1924,19 +1955,7 @@ registry.registerPath({
       description: "Feed page",
       content: {
         "application/json": {
-          schema: z.object({
-            events: z.array(z.object({
-              event_id: z.string().uuid(),
-              event_type: z.string().openapi({ example: "property.created" }),
-              entity_type: z.string().openapi({ example: "property" }),
-              entity_id: z.string(),
-              payload: z.record(z.string(), z.unknown()),
-              actor: z.string(),
-              created_at: z.string().datetime(),
-            })),
-            cursor: z.string().uuid().nullable().openapi({ description: "Pass as cursor in the next request to continue polling" }),
-            has_more: z.boolean(),
-          }),
+          schema: RegistryFeedPageSchema,
         },
       },
     },
@@ -1953,6 +1972,40 @@ registry.registerPath({
         },
       },
     },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/registry/feed/stream",
+  operationId: "streamRegistryFeed",
+  summary: "Registry change feed stream",
+  description:
+    "Subscribe to registry feed pages over Server-Sent Events. This is a push-friendly transport for the same cursor contract as `/api/registry/feed`: clients still persist `cursor`, apply only feed events, and recover from `cursor_expired` by re-bootstrapping. The stream emits `feed` events containing a full feed page, `heartbeat` events while caught up, and `error` before closing when the cursor expires or the server cannot query the feed.",
+  tags: ["Change Feed"],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
+  request: {
+    query: z.object({
+      cursor: z.string().uuid().optional().openapi({ description: "Resume after this event ID" }),
+      types: z.string().optional().openapi({ description: "Comma-separated event type filters with glob support (e.g. property.*)", example: "authorization.*,publisher.adagents_changed" }),
+      limit: z.coerce.number().int().min(1).max(10000).optional().openapi({ description: "Max events per SSE feed page (default 100, max 10,000)" }),
+      poll_interval_seconds: z.coerce.number().int().min(5).max(60).optional().openapi({ description: "Server-side interval while caught up (default 15 seconds). Backlog pages are sent without waiting." }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "SSE stream. `event: feed` data validates as a registry feed page.",
+      content: {
+        "text/event-stream": {
+          schema: z.string().openapi({
+            description: "Server-Sent Events stream. `feed` events carry JSON matching the RegistryFeedPage schema; `heartbeat` events carry `{ generated_at, cursor }`.",
+          }),
+        },
+      },
+    },
+    400: { description: "Invalid cursor format, type filter, limit, or poll interval", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    410: { description: "Initial cursor expired", content: { "application/json": { schema: z.object({ error: z.literal("cursor_expired"), message: z.string() }) } } },
   },
 });
 
@@ -9089,34 +9142,131 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
   if (config.eventsDb) {
     if (!authMiddleware) throw new Error('requireAuth middleware is required when eventsDb is provided');
     const eventsDb = config.eventsDb;
+    const VALID_FEED_TYPE = /^[a-z][a-z0-9_.]*(\*)?$/;
+    const MAX_ACTIVE_FEED_STREAMS = 100;
+    const MAX_BACKLOG_PAGES_PER_TICK = 10;
+    const BACKLOG_YIELD_MS = 100;
+    let activeFeedStreams = 0;
 
-    router.get("/registry/feed", authMiddleware, async (req, res) => {
-      try {
-        const cursor = (req.query.cursor as string) || null;
-        const typesParam = req.query.types as string | undefined;
-        const types = typesParam ? typesParam.split(',').map(t => t.trim()).filter(Boolean) : null;
-        const rawLimit = req.query.limit ? parseInt(req.query.limit as string, 10) : undefined;
+    function getSingleQueryParam(value: unknown, name: string): { value?: string; error?: string } {
+      if (value == null) return {};
+      if (Array.isArray(value)) {
+        return { error: `${name} must be provided only once` };
+      }
+      if (typeof value !== "string") {
+        return { error: `${name} must be a string` };
+      }
+      return { value };
+    }
 
-        // Validate cursor format (should be a UUID if provided)
-        if (cursor && !isUuid(cursor)) {
-          return res.status(400).json({ error: "Invalid cursor format. Must be a UUID." });
-        }
+    function parseIntegerQueryParam(
+      value: unknown,
+      name: string,
+      min: number,
+      max: number,
+    ): { value?: number; error?: string } {
+      const single = getSingleQueryParam(value, name);
+      if (single.error) return { error: single.error };
+      if (single.value == null || single.value === "") return {};
+      if (!/^\d+$/.test(single.value)) {
+        return { error: `${name} must be an integer` };
+      }
+      const parsed = Number(single.value);
+      if (!Number.isSafeInteger(parsed)) {
+        return { error: `${name} must be a safe integer` };
+      }
+      if (parsed < min || parsed > max) {
+        return { error: `${name} must be between ${min} and ${max}` };
+      }
+      return { value: parsed };
+    }
 
-        if (rawLimit !== undefined && isNaN(rawLimit)) {
-          return res.status(400).json({ error: "limit must be a number" });
-        }
+    function parseRegistryFeedQuery(req: Request, options: { parsePollInterval?: boolean } = {}): {
+      cursor: string | null;
+      types: string[] | null;
+      limit?: number;
+      pollIntervalMs: number;
+      error?: string;
+    } {
+      const cursorParam = getSingleQueryParam(req.query.cursor, "cursor");
+      if (cursorParam.error) {
+        return { cursor: null, types: null, pollIntervalMs: 15_000, error: cursorParam.error };
+      }
+      const typesParamResult = getSingleQueryParam(req.query.types, "types");
+      if (typesParamResult.error) {
+        return { cursor: null, types: null, pollIntervalMs: 15_000, error: typesParamResult.error };
+      }
+      const cursor = cursorParam.value || null;
+      const typesParam = typesParamResult.value;
+      const types = typesParam ? typesParam.split(',').map(t => t.trim()).filter(Boolean) : null;
+      const limit = parseIntegerQueryParam(req.query.limit, "limit", 1, 10_000);
+      if (limit.error) {
+        return { cursor, types, pollIntervalMs: 15_000, error: limit.error };
+      }
+      const pollInterval: { value?: number; error?: string } = options.parsePollInterval
+        ? parseIntegerQueryParam(req.query.poll_interval_seconds, "poll_interval_seconds", 5, 60)
+        : {};
+      if (pollInterval.error) {
+        return { cursor, types, limit: limit.value, pollIntervalMs: 15_000, error: pollInterval.error };
+      }
 
-        // Validate type filter values — only allow safe glob patterns
-        const VALID_TYPE = /^[a-z][a-z0-9_.]*(\*)?$/;
-        if (types) {
-          for (const t of types) {
-            if (!VALID_TYPE.test(t)) {
-              return res.status(400).json({ error: `Invalid type filter: ${t}` });
-            }
+      if (cursor && !isUuid(cursor)) {
+        return { cursor, types, limit: limit.value, pollIntervalMs: 15_000, error: "Invalid cursor format. Must be a UUID." };
+      }
+
+      if (types) {
+        for (const t of types) {
+          if (!VALID_FEED_TYPE.test(t)) {
+            return { cursor, types, limit: limit.value, pollIntervalMs: 15_000, error: `Invalid type filter: ${t}` };
           }
         }
+      }
 
-        const result = await eventsDb.queryFeed(cursor, types, rawLimit);
+      return {
+        cursor,
+        types,
+        limit: limit.value,
+        pollIntervalMs: (pollInterval.value ?? 15) * 1000,
+      };
+    }
+
+    async function writeSse(
+      res: import("express").Response,
+      event: string,
+      data: unknown,
+      isClosed: () => boolean,
+    ): Promise<void> {
+      if (isClosed() || res.writableEnded) return;
+      const ok = res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+      if (!ok && !isClosed() && !res.writableEnded) {
+        await Promise.race([once(res, "drain"), once(res, "close")]);
+      }
+    }
+
+    function waitForSseInterval(res: import("express").Response, ms: number, isClosed: () => boolean): Promise<void> {
+      return new Promise(resolve => {
+        if (isClosed()) return resolve();
+        const onClose = () => {
+          clearTimeout(timeout);
+          resolve();
+        };
+        const timeout = setTimeout(() => {
+          res.removeListener("close", onClose);
+          resolve();
+        }, ms);
+        timeout.unref?.();
+        res.once("close", onClose);
+      });
+    }
+
+    router.get("/registry/feed", authMiddleware, registryReadRateLimiter, async (req, res) => {
+      try {
+        const parsed = parseRegistryFeedQuery(req);
+        if (parsed.error) {
+          return res.status(400).json({ error: parsed.error });
+        }
+
+        const result = await eventsDb.queryFeed(parsed.cursor, parsed.types, parsed.limit);
 
         if ('error' in result) {
           return res.status(410).json(result);
@@ -9126,6 +9276,85 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       } catch (error) {
         logger.error({ error }, "Failed to query registry feed");
         return res.status(500).json({ error: "Failed to query registry feed" });
+      }
+    });
+
+    router.get("/registry/feed/stream", authMiddleware, registryReadRateLimiter, async (req, res) => {
+      const parsed = parseRegistryFeedQuery(req, { parsePollInterval: true });
+      if (parsed.error) {
+        return res.status(400).json({ error: parsed.error });
+      }
+      if (activeFeedStreams >= MAX_ACTIVE_FEED_STREAMS) {
+        return res.status(429).json({ error: "Too many active registry feed streams" });
+      }
+      activeFeedStreams++;
+
+      let cursor = parsed.cursor;
+      let closed = false;
+      let streamStarted = false;
+      res.on("close", () => {
+        closed = true;
+      });
+
+      try {
+        const initial = await eventsDb.queryFeed(cursor, parsed.types, parsed.limit);
+        if ('error' in initial) {
+          return res.status(410).json(initial);
+        }
+        if (closed) return;
+
+        res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+        res.setHeader("Cache-Control", "no-cache, no-transform");
+        res.setHeader("Connection", "keep-alive");
+        res.setHeader("X-Accel-Buffering", "no");
+        res.flushHeaders?.();
+        streamStarted = true;
+
+        let pending: import('../db/catalog-events-db.js').FeedResult | null = initial;
+        let backlogPages = 0;
+
+        while (!closed) {
+          const result = pending ?? await eventsDb.queryFeed(cursor, parsed.types, parsed.limit);
+          pending = null;
+
+          if ('error' in result) {
+            await writeSse(res, "error", result, () => closed);
+            break;
+          }
+
+          if (result.events.length > 0) {
+            await writeSse(res, "feed", result, () => closed);
+            cursor = result.cursor;
+          } else {
+            await writeSse(res, "heartbeat", {
+              generated_at: result.freshness.generated_at,
+              cursor: result.cursor,
+              freshness: result.freshness,
+            }, () => closed);
+          }
+
+          if (result.has_more) {
+            backlogPages++;
+            if (backlogPages >= MAX_BACKLOG_PAGES_PER_TICK) {
+              backlogPages = 0;
+              await waitForSseInterval(res, BACKLOG_YIELD_MS, () => closed);
+            }
+            continue;
+          }
+          backlogPages = 0;
+          await waitForSseInterval(res, parsed.pollIntervalMs, () => closed);
+        }
+      } catch (error) {
+        logger.error({ error }, "Failed to stream registry feed");
+        if (!closed && !res.headersSent) {
+          return res.status(500).json({ error: "Failed to query registry feed" });
+        }
+        if (!closed) {
+          await writeSse(res, "error", { error: "feed_stream_error", message: "Failed to query registry feed" }, () => closed);
+        }
+      } finally {
+        activeFeedStreams--;
+        if (streamStarted && !closed && !res.writableEnded) res.end();
       }
     });
   }

--- a/server/tests/integration/registry-feed.test.ts
+++ b/server/tests/integration/registry-feed.test.ts
@@ -65,15 +65,15 @@ describe('Registry Feed Integration Tests', () => {
 
     it('writes multiple events in a transaction', async () => {
       const inputs: WriteEventInput[] = [
-        { event_type: 'agent.discovered', entity_type: 'agent', entity_id: 'url-1', actor: 'test' },
-        { event_type: 'agent.discovered', entity_type: 'agent', entity_id: 'url-2', actor: 'test' },
-        { event_type: 'authorization.granted', entity_type: 'authorization', entity_id: 'a:b', actor: 'test' },
+        { event_type: 'test.multi_agent_discovered', entity_type: 'agent', entity_id: 'url-1', actor: 'test' },
+        { event_type: 'test.multi_agent_discovered', entity_type: 'agent', entity_id: 'url-2', actor: 'test' },
+        { event_type: 'test.multi_authorization_granted', entity_type: 'authorization', entity_id: 'a:b', actor: 'test' },
       ];
 
       const ids = await eventsDb.writeEvents(inputs);
       expect(ids).toHaveLength(3);
 
-      const feed = await eventsDb.queryFeed(null, null);
+      const feed = await eventsDb.queryFeed(null, ['test.multi_*']);
       if ('error' in feed) throw new Error(feed.message);
       const ours = feed.events.filter(e => e.actor === 'test');
       expect(ours).toHaveLength(3);

--- a/server/tests/unit/catalog-events-db.test.ts
+++ b/server/tests/unit/catalog-events-db.test.ts
@@ -33,6 +33,7 @@ describe('CatalogEventsDatabase', () => {
   beforeEach(() => {
     db = new CatalogEventsDatabase();
     vi.clearAllMocks();
+    mockedQuery.mockResolvedValue(EMPTY_RESULT);
     mockedUuidv7.mockReturnValue('019...-event-001');
   });
 
@@ -156,6 +157,7 @@ describe('CatalogEventsDatabase', () => {
       mockedQuery.mockResolvedValueOnce(mockResult([{ status: 'valid' }]));
       // feed query (2 rows, no extra = has_more false)
       mockedQuery.mockResolvedValueOnce(mockResult(events));
+      mockedQuery.mockResolvedValueOnce(mockResult([{ latest_event_created_at: now }]));
 
       const result = await db.queryFeed('cursor-abc', null, 100);
 
@@ -164,6 +166,9 @@ describe('CatalogEventsDatabase', () => {
         expect(result.events).toHaveLength(2);
         expect(result.cursor).toBe('e2');
         expect(result.has_more).toBe(false);
+        expect(result.freshness.latest_event_created_at).toBe(now.toISOString());
+        expect(result.freshness.retention_days).toBe(90);
+        expect(result.freshness.lag_seconds).toEqual(expect.any(Number));
       }
     });
 
@@ -220,6 +225,39 @@ describe('CatalogEventsDatabase', () => {
       const params = mockedQuery.mock.calls[0][1] as unknown[];
       expect(params).toContain('property.%');
       expect(params).toContain('agent.%');
+    });
+
+    it('computes freshness with the same type filters and retention window', async () => {
+      const latest = new Date('2026-03-31T10:00:00.000Z');
+      mockedQuery
+        .mockResolvedValueOnce(mockResult([]))
+        .mockResolvedValueOnce(mockResult([{ latest_event_created_at: latest }]));
+
+      const result = await db.queryFeed(null, ['property.*']);
+
+      expect('error' in result).toBe(false);
+      if (!('error' in result)) {
+        expect(result.freshness.latest_event_created_at).toBe(latest.toISOString());
+      }
+      const freshnessSql = mockedQuery.mock.calls[1][0] as string;
+      const freshnessParams = mockedQuery.mock.calls[1][1] as unknown[];
+      expect(freshnessSql).toContain("created_at >= NOW() - INTERVAL '1 day' * $1");
+      expect(freshnessSql).toContain('event_type LIKE $2');
+      expect(freshnessParams).toEqual([90, 'property.%']);
+    });
+
+    it('returns null freshness when no matching retained event exists', async () => {
+      mockedQuery
+        .mockResolvedValueOnce(mockResult([]))
+        .mockResolvedValueOnce(mockResult([{ latest_event_created_at: null }]));
+
+      const result = await db.queryFeed(null, ['nonexistent.*']);
+
+      expect('error' in result).toBe(false);
+      if (!('error' in result)) {
+        expect(result.freshness.latest_event_created_at).toBeNull();
+        expect(result.freshness.lag_seconds).toBeNull();
+      }
     });
 
     it('caps limit at 10000', async () => {

--- a/server/tests/unit/registry-feed-stream-route.test.ts
+++ b/server/tests/unit/registry-feed-stream-route.test.ts
@@ -1,0 +1,266 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+import type { FeedError, FeedResult } from '../../src/db/catalog-events-db.js';
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'sk_test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+});
+
+vi.mock('../../src/middleware/rate-limit.js', () => {
+  const pass: import('express').RequestHandler = (_req, _res, next) => next();
+  return {
+    bulkResolveRateLimiter: pass,
+    brandCreationRateLimiter: pass,
+    storyboardEvalRateLimiter: pass,
+    storyboardStepRateLimiter: pass,
+    agentReadRateLimiter: pass,
+    registryPublisherRateLimiter: pass,
+    registryReadRateLimiter: pass,
+  };
+});
+
+import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/routes/registry-api.js';
+
+function makeFeed(overrides: Partial<FeedResult> = {}): FeedResult {
+  return {
+    events: [],
+    cursor: '019539a0-1234-7000-8000-000000000001',
+    has_more: false,
+    freshness: {
+      generated_at: '2026-03-31T10:00:15.000Z',
+      latest_event_created_at: '2026-03-31T10:00:00.000Z',
+      lag_seconds: 15,
+      retention_days: 90,
+    },
+    ...overrides,
+  };
+}
+
+function makeApp(queryFeed: RegistryApiConfig['eventsDb']['queryFeed']) {
+  const app = express();
+  const passAuth: import('express').RequestHandler = (_req, _res, next) => next();
+  const config: RegistryApiConfig = {
+    brandManager: {} as RegistryApiConfig['brandManager'],
+    brandDb: {} as RegistryApiConfig['brandDb'],
+    propertyDb: {} as RegistryApiConfig['propertyDb'],
+    adagentsManager: {} as RegistryApiConfig['adagentsManager'],
+    healthChecker: {} as RegistryApiConfig['healthChecker'],
+    crawler: {} as RegistryApiConfig['crawler'],
+    capabilityDiscovery: {} as RegistryApiConfig['capabilityDiscovery'],
+    registryRequestsDb: {
+      trackRequest: async () => {},
+      markResolved: async () => true,
+    },
+    eventsDb: { queryFeed },
+    requireAuth: passAuth,
+    optionalAuth: passAuth,
+  };
+
+  app.use('/api', createRegistryApiRouter(config));
+  return app;
+}
+
+function parseSseFrames(text: string): Array<{ event: string; data: unknown }> {
+  return text.trim().split(/\n\n+/).filter(Boolean).map(frame => {
+    const eventLine = frame.split('\n').find(line => line.startsWith('event: '));
+    const dataLines = frame.split('\n').filter(line => line.startsWith('data: '));
+    if (!eventLine || dataLines.length === 0) {
+      throw new Error(`Invalid SSE frame: ${frame}`);
+    }
+    return {
+      event: eventLine.slice('event: '.length),
+      data: JSON.parse(dataLines.map(line => line.slice('data: '.length)).join('\n')),
+    };
+  });
+}
+
+async function readFirstSseFrame(app: express.Express, path: string): Promise<{
+  statusCode: number;
+  headers: http.IncomingHttpHeaders;
+  text: string;
+}> {
+  const server = http.createServer(app);
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      callback();
+      server.close();
+    };
+
+    const req = http.get({ hostname: '127.0.0.1', port, path }, res => {
+      let text = '';
+      res.setEncoding('utf8');
+      res.on('data', chunk => {
+        text += chunk;
+        if (text.includes('\n\n')) {
+          finish(() => {
+            req.destroy();
+            resolve({ statusCode: res.statusCode ?? 0, headers: res.headers, text });
+          });
+        }
+      });
+      res.on('error', error => finish(() => reject(error)));
+    });
+
+    req.setTimeout(1000, () => {
+      finish(() => {
+        req.destroy();
+        reject(new Error('Timed out waiting for SSE frame'));
+      });
+    });
+    req.on('error', error => {
+      if (!settled) finish(() => reject(error));
+    });
+  });
+}
+
+describe('GET /api/registry/feed/stream', () => {
+  it('rejects invalid stream query params before opening the SSE stream', async () => {
+    const queryFeed = vi.fn<RegistryApiConfig['eventsDb']['queryFeed']>();
+    const app = makeApp(queryFeed);
+
+    const res = await request(app).get('/api/registry/feed/stream?cursor=not-a-uuid');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid cursor format/);
+    expect(queryFeed).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['limit', '0', /limit must be between 1 and 10000/],
+    ['limit', '10001', /limit must be between 1 and 10000/],
+    ['limit', '1abc', /limit must be an integer/],
+    ['poll_interval_seconds', '4', /poll_interval_seconds must be between 5 and 60/],
+    ['poll_interval_seconds', '61', /poll_interval_seconds must be between 5 and 60/],
+    ['poll_interval_seconds', '5abc', /poll_interval_seconds must be an integer/],
+  ])('rejects invalid %s=%s before opening the SSE stream', async (param, value, message) => {
+    const queryFeed = vi.fn<RegistryApiConfig['eventsDb']['queryFeed']>();
+    const app = makeApp(queryFeed);
+
+    const res = await request(app).get(`/api/registry/feed/stream?${param}=${encodeURIComponent(value)}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(message);
+    expect(queryFeed).not.toHaveBeenCalled();
+  });
+
+  it('returns 410 JSON when the initial cursor is expired', async () => {
+    const expired: FeedError = { error: 'cursor_expired', message: 'expired' };
+    const queryFeed = vi.fn<RegistryApiConfig['eventsDb']['queryFeed']>().mockResolvedValue(expired);
+    const app = makeApp(queryFeed);
+
+    const res = await request(app).get('/api/registry/feed/stream?cursor=019539a0-1234-7000-8000-000000000001');
+
+    expect(res.status).toBe(410);
+    expect(res.body).toEqual(expired);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+  });
+
+  it('streams feed pages and emits a terminal SSE error after headers are sent', async () => {
+    const firstPage = makeFeed({
+      events: [{
+        event_id: '019539a0-1234-7000-8000-000000000002',
+        event_type: 'property.created',
+        entity_type: 'property',
+        entity_id: 'property-1',
+        payload: { property_rid: 'property-1' },
+        actor: 'test',
+        created_at: new Date('2026-03-31T10:00:00.000Z'),
+      }],
+      cursor: '019539a0-1234-7000-8000-000000000002',
+      has_more: true,
+    });
+    const expired: FeedError = { error: 'cursor_expired', message: 'expired' };
+    const queryFeed = vi.fn<RegistryApiConfig['eventsDb']['queryFeed']>()
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce(expired);
+    const app = makeApp(queryFeed);
+
+    const res = await request(app).get('/api/registry/feed/stream?types=property.*&limit=1');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/event-stream/);
+    expect(res.headers['cache-control']).toContain('no-cache');
+    const frames = parseSseFrames(res.text);
+    expect(frames).toEqual([
+      expect.objectContaining({
+        event: 'feed',
+        data: expect.objectContaining({
+          events: [expect.objectContaining({ event_type: 'property.created' })],
+          cursor: '019539a0-1234-7000-8000-000000000002',
+          freshness: firstPage.freshness,
+        }),
+      }),
+      { event: 'error', data: expired },
+    ]);
+    expect(queryFeed).toHaveBeenNthCalledWith(1, null, ['property.*'], 1);
+    expect(queryFeed).toHaveBeenNthCalledWith(2, '019539a0-1234-7000-8000-000000000002', ['property.*'], 1);
+  });
+
+  it('emits feed_stream_error when querying throws after headers are sent', async () => {
+    const firstPage = makeFeed({
+      events: [{
+        event_id: '019539a0-1234-7000-8000-000000000003',
+        event_type: 'property.updated',
+        entity_type: 'property',
+        entity_id: 'property-2',
+        payload: { property_rid: 'property-2' },
+        actor: 'test',
+        created_at: new Date('2026-03-31T10:00:00.000Z'),
+      }],
+      cursor: '019539a0-1234-7000-8000-000000000003',
+      has_more: true,
+    });
+    const queryFeed = vi.fn<RegistryApiConfig['eventsDb']['queryFeed']>()
+      .mockResolvedValueOnce(firstPage)
+      .mockRejectedValueOnce(new Error('db down'));
+    const app = makeApp(queryFeed);
+
+    const res = await request(app).get('/api/registry/feed/stream?limit=1');
+
+    expect(res.status).toBe(200);
+    const frames = parseSseFrames(res.text);
+    expect(frames).toEqual([
+      expect.objectContaining({ event: 'feed' }),
+      {
+        event: 'error',
+        data: { error: 'feed_stream_error', message: 'Failed to query registry feed' },
+      },
+    ]);
+  });
+
+  it('emits heartbeat with freshness while caught up and closes without another query', async () => {
+    const caughtUp = makeFeed({
+      events: [],
+      cursor: '019539a0-1234-7000-8000-000000000010',
+      has_more: false,
+    });
+    const queryFeed = vi.fn<RegistryApiConfig['eventsDb']['queryFeed']>().mockResolvedValue(caughtUp);
+    const app = makeApp(queryFeed);
+
+    const res = await readFirstSseFrame(app, '/api/registry/feed/stream?types=property.*&limit=1&poll_interval_seconds=5');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/event-stream/);
+    const [frame] = parseSseFrames(res.text);
+    expect(frame).toEqual({
+      event: 'heartbeat',
+      data: {
+        generated_at: caughtUp.freshness.generated_at,
+        cursor: caughtUp.cursor,
+        freshness: caughtUp.freshness,
+      },
+    });
+    expect(queryFeed).toHaveBeenCalledTimes(1);
+    expect(queryFeed).toHaveBeenCalledWith(null, ['property.*'], 1);
+  });
+});

--- a/specs/registry-change-feed.md
+++ b/specs/registry-change-feed.md
@@ -8,11 +8,11 @@ Buyers have no way to discover new agents or publishers joining the registry, or
 
 1. Buyers can poll a single feed endpoint and maintain a near-real-time local copy of the registry.
 2. Publishers/agents can trigger immediate re-crawl of their domain after updating `adagents.json`.
-3. Optional webhook notifications reduce polling frequency for subscribers.
+3. Consumer-facing push transport lets subscribers receive a prompt wake-up without inventing a second source of truth.
 
 ## Design Principles
 
-- **Polling is the source of truth.** Webhooks are best-effort notifications, not guaranteed delivery.
+- **The feed is the source of truth.** Push transports are delivery mechanisms for feed pages or wake-ups, not a separate event log.
 - **Cursor-based, not timestamp-based.** UUID v7 event IDs are monotonically ordered and avoid clock-skew problems.
 - **Events are denormalized.** Payload contains enough data for consumers to act without additional API calls.
 - **Single unified feed.** Buyers care about downstream effects on property lists, not internal entity taxonomy.
@@ -177,11 +177,20 @@ Poll the change feed.
     }
   ],
   "cursor": "019539a1-...",
-  "has_more": true
+  "has_more": true,
+  "freshness": {
+    "generated_at": "2026-06-26T12:00:00.000Z",
+    "latest_event_created_at": "2026-06-26T11:59:47.000Z",
+    "lag_seconds": 13,
+    "retention_days": 90
+  }
 }
 ```
 
 Consumers save `cursor` and pass it as `cursor` on the next poll. When `has_more` is false, the consumer is caught up.
+Persisted cursors are tied to the same logical `types` subscription. Reusing a
+cursor after broadening or changing `types` can skip matching events that were
+filtered out under the previous subscription.
 
 ### `POST /api/registry/crawl-request`
 
@@ -218,84 +227,91 @@ Publisher or authorized agent requests immediate re-crawl of a domain's `adagent
 
 **Rate limit:** One re-crawl per domain per 10 minutes. Returns 429 if the domain was crawled within that window.
 
-After the re-crawl completes, the crawler diffs previous state against new state and writes events to `catalog_events`. Those events flow to the feed and trigger webhook notifications.
+After the re-crawl completes, the crawler diffs previous state against new state and writes events to `catalog_events`. Those events flow to the feed and any active stream subscribers.
 
-### `POST /api/registry/webhooks`
+### `GET /api/registry/feed/stream`
 
-Register a webhook subscription for change notifications.
+Subscribe to the change feed over Server-Sent Events. This is the shipped
+consumer-facing push surface for 3.x. It uses the same cursor, type filter,
+limit, retention, and recovery rules as `GET /api/registry/feed`.
 
-**Authentication:** Required. One subscription per member (higher tiers may have more).
+**Authentication:** Required. Member-only endpoint.
 
-**Request:**
+**Parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cursor` | UUID | (none) | Last event_id processed. Omit for start of retention window. |
+| `types` | string | all | Comma-separated event types. Supports glob: `authorization.*` |
+| `limit` | integer | 100 | Max events per feed page. Max 10000. |
+| `poll_interval_seconds` | integer | 15 | Server-side interval while caught up. Min 5, max 60. Backlog pages are sent without waiting. |
+
+**Events:**
+
+```text
+event: feed
+data: {"events":[...],"cursor":"019...","has_more":false,"freshness":{...}}
+
+event: heartbeat
+data: {"generated_at":"2026-06-26T12:00:00.000Z","cursor":"019...","freshness":{...}}
+```
+
+`feed` event bodies validate against
+`static/schemas/source/core/registry-feed-response.json`. `heartbeat` events do
+not advance the cursor; they keep intermediaries from closing an idle stream
+and expose current freshness while the client is caught up.
+
+The stream intentionally carries the resume cursor in the JSON `data` payload
+rather than SSE `id:` / `Last-Event-ID`. Generic browser `EventSource` clients
+must persist `data.cursor` and reconnect with `?cursor=...`; native
+`Last-Event-ID` resume is not part of the 3.x contract.
+
+**Recovery:** On disconnect, clients reconnect with their last persisted
+cursor. If the initial cursor is expired, the endpoint returns `410
+cursor_expired`; clients re-bootstrap from the full-state sync endpoints and
+then resume tailing the feed.
+
+### Freshness Contract
+
+Every feed page includes:
+
 ```json
 {
-  "url": "https://buyer.example.com/hooks/registry",
-  "events": ["property.*", "agent.discovered"]
+  "freshness": {
+    "generated_at": "2026-06-26T12:00:00.000Z",
+    "latest_event_created_at": "2026-06-26T11:59:47.000Z",
+    "lag_seconds": 13,
+    "retention_days": 90
+  }
 }
 ```
 
-Default subscriptions do not require a shared webhook secret. The registry signs
-outbound deliveries with its `adcp_use: "webhook-signing"` key using the AdCP
-RFC 9421 webhook profile. This surface does not define a registry-specific
-`secret`, `X-Registry-Signature`, or versioned-HMAC signing mode.
+`latest_event_created_at` is the newest event currently visible in the feed for
+the requested `types` filter. `lag_seconds` is computed against
+`generated_at`. Consumers should alert when lag exceeds their own freshness
+target and should treat a missing `latest_event_created_at` as "no matching
+events inside retention", not as proof that the registry has crawled every
+publisher.
 
-**Response:**
-```json
-{
-  "subscription_id": "sub_...",
-  "status": "active"
-}
-```
+`POST /api/registry/crawl-request` is still asynchronous. Acceptance means the
+domain passed validation and rate limits and has been queued for immediate
+work; convergence is observed by `last_validated` advancing on
+`lookupPublisher`, by a `publisher.adagents_discovered` /
+`publisher.adagents_changed` feed event, or by authorization events. The 3.x
+contract is "request accepted plus observable completion signal", not
+"synchronous validation completed before the 202 response".
 
-Additional CRUD endpoints:
-- `GET /api/registry/webhooks` — list subscriptions
-- `DELETE /api/registry/webhooks/:id` — remove subscription
+### Future Transport: Persistent Webhook Wake-Ups
 
-### Webhook Delivery
+Persistent registry-to-consumer webhooks are not the 3.x push surface. The 3.x
+surface is `GET /api/registry/feed/stream`.
 
-Webhooks are notifications, not event delivery. The payload says "something changed, poll the feed."
-
-```
-POST https://buyer.example.com/hooks/registry
-Signature-Input: sig1=("@method" "@target-uri" "@authority" "content-type" "content-digest");
-                 created=1770044400;expires=1770044700;nonce="...";
-                 keyid="registry-webhook-2026";alg="ed25519";tag="adcp/webhook-signing/v1"
-Signature: sig1=:<base64url-unpadded>:
-Content-Digest: sha-256=:<base64url-unpadded>:
-Content-Type: application/json
-
-{
-  "event_count": 3,
-  "latest_event_id": "019...",
-  "event_types": ["property.created", "property.updated"]
-}
-```
-
-**Signature verification and anti-replay:** Receivers MUST verify registry
-webhooks with the AdCP RFC 9421 webhook profile defined in
-`docs/building/by-layer/L1/security.mdx` §Webhook callbacks. The signed
-`content-digest` binds the body bytes; `created` / `expires` bound the validity
-window; and the receiver's `(keyid, nonce)` replay cache rejects captured
-deliveries replayed inside that window. A registry-specific HMAC signature
-scheme MUST NOT be introduced.
-
-**Receiver dedup:** The webhook is still only a notification. After signature
-verification, receivers poll `GET /api/registry/feed` from their last saved
-cursor and treat the feed as authoritative. The sender MUST NOT provide a
-cursor-bearing feed URL that overrides receiver state; using
-`latest_event_id` as the next request cursor would skip the events the
-notification is announcing. Receivers MAY suppress redundant polls by
-remembering the largest `latest_event_id` observed per subscription, but they
-MUST NOT treat a repeated notification as event replay or recovery.
-
-Implementations that need a simple dispatch header MAY include
-`X-Registry-Event`, but receivers MUST route from the JSON payload's
-`event_types` and the authoritative feed response. The dispatch header is not a
-trust anchor unless it is explicitly covered by a future webhook-signing profile.
-
-**Coalescing:** Events are batched per subscriber per 30-second window. A seed operation that creates 1000 properties produces one webhook notification, not 1000.
-
-**Retries:** 3 attempts with exponential backoff (30s, 5m, 30m). After 3 consecutive failures, subscription marked `degraded`. After 24 hours of failures, marked `suspended` and subscriber notified via email.
+If a later phase adds persisted webhook subscriptions, those callbacks must be
+wake-ups for the feed, not event delivery. Receivers would still persist their
+own cursor and drain `GET /api/registry/feed` or
+`GET /api/registry/feed/stream` as the authoritative event source. Any callback
+signing must reuse the AdCP RFC 9421 webhook profile rather than introducing a
+registry-specific HMAC scheme.
 
 ---
 
@@ -329,7 +345,7 @@ Events are written at the point of change, not reconstructed later:
 ## Consumer Pattern
 
 1. **Bootstrap:** `GET /api/registry/catalog` with cursor pagination for the full property catalog, and `GET /api/registry/catalog/collections/sync` for the full collection catalog.
-2. **Steady state:** Poll `GET /api/registry/feed?cursor={last_event_id}` every 30-60 seconds, or wait for webhook notification and then poll.
+2. **Steady state:** Prefer `GET /api/registry/feed/stream?cursor={last_event_id}` for push delivery. If streaming is unavailable, poll `GET /api/registry/feed?cursor={last_event_id}` every 30-60 seconds.
 3. **Recovery:** If cursor is older than 90 days (retention window), do another full sync via `/catalog` and `/catalog/collections/sync`, then reset the cursor.
 
 ---
@@ -446,7 +462,7 @@ matches := registry.Agents().Search(adcp.AgentSearchQuery{
    - Builds in-memory indexes: properties by rid, properties by identifier, agents by url, agents by profile fields, authorizations by domain
 
 2. **Steady state** (background poller):
-   - Polls `GET /registry/feed?cursor={last_event_id}` every 30 seconds
+   - Streams `GET /registry/feed/stream?cursor={last_event_id}` when available, otherwise polls `GET /registry/feed?cursor={last_event_id}` every 30 seconds
    - Applies events to in-memory indexes incrementally
    - Emits typed events for subscribers (`on('agent.discovered', ...)`)
 
@@ -597,14 +613,14 @@ The change feed keeps all of this live. When a publisher updates their `adagents
 
 | SDK Method | Server Endpoint (bootstrap) | Server Endpoint (updates) |
 |------------|---------------------------|--------------------------|
-| `registry.agents.search(...)` | `GET /registry/agents/search` | `GET /registry/feed` (agent events) |
-| `registry.agents.get(url)` | `GET /registry/agents/search` | `GET /registry/feed` |
-| `registry.properties.getByRid(rid)` | `GET /catalog` | `GET /registry/feed` (property events) |
-| `registry.properties.getByIdentifier(...)` | `GET /catalog` | `GET /registry/feed` |
-| `registry.collections.getByDistributionIdentifier(...)` | `GET /catalog/collections/sync` | `GET /registry/feed` (collection events) |
-| `registry.authorizations.check(...)` | `GET /registry/agents/search` (includes auth data) | `GET /registry/feed` (authorization events) |
-| `registry.authorizations.getSigningKeys(...)` | `GET /registry/agents/search` | `GET /registry/feed` |
-| `registry.on('event', ...)` | — | `GET /registry/feed` |
+| `registry.agents.search(...)` | `GET /registry/agents/search` | `GET /registry/feed/stream`, fallback `GET /registry/feed` (agent events) |
+| `registry.agents.get(url)` | `GET /registry/agents/search` | `GET /registry/feed/stream`, fallback `GET /registry/feed` |
+| `registry.properties.getByRid(rid)` | `GET /catalog` | `GET /registry/feed/stream`, fallback `GET /registry/feed` (property events) |
+| `registry.properties.getByIdentifier(...)` | `GET /catalog` | `GET /registry/feed/stream`, fallback `GET /registry/feed` |
+| `registry.collections.getByDistributionIdentifier(...)` | `GET /catalog/collections/sync` | `GET /registry/feed/stream`, fallback `GET /registry/feed` (collection events) |
+| `registry.authorizations.check(...)` | `GET /registry/agents/search` (includes auth data) | `GET /registry/feed/stream`, fallback `GET /registry/feed` (authorization events) |
+| `registry.authorizations.getSigningKeys(...)` | `GET /registry/agents/search` | `GET /registry/feed/stream`, fallback `GET /registry/feed` |
+| `registry.on('event', ...)` | — | `GET /registry/feed/stream`, fallback `GET /registry/feed` |
 
 ---
 
@@ -617,13 +633,16 @@ Add `catalog_events` table. Instrument `CatalogDatabase` and the crawler to writ
 Add `agent_inventory_profiles` table (see `specs/structured-agent-query.md`). Populate from crawled data. Ship `GET /api/registry/agents/search`. This gives the bootstrap data for `RegistrySync`.
 
 ### Phase 3: SDK `RegistrySync` client
-Ship `RegistrySync` in `@adcp/client` (TypeScript). Bootstrap from search + sync endpoints, poll the feed, maintain in-memory indexes. This is where buyers get the "just works" experience.
+Ship `RegistrySync` in `@adcp/client` (TypeScript). Bootstrap from search + sync endpoints, stream the feed when available, fall back to polling, and maintain in-memory indexes. This is where buyers get the "just works" experience.
 
-### Phase 4: Re-crawl trigger
+### Phase 4: Feed stream endpoint
+Ship `GET /api/registry/feed/stream` as the 3.x consumer-facing push surface. It sends the same cursor-bearing feed pages over SSE, with heartbeat events while caught up and reconnect recovery through the persisted cursor.
+
+### Phase 5: Re-crawl trigger
 Add `POST /api/registry/crawl-request`. Wire to the crawler for single-domain re-crawl. Closes the "publisher changed file → buyer sees it within minutes" loop.
 
-### Phase 5: Go and Python SDKs
+### Phase 6: Go and Python SDKs
 Port `RegistrySync` to the Go and Python clients with idiomatic APIs.
 
-### Phase 6: Webhook subscriptions
-Add subscription CRUD, delivery worker with coalescing, retry/suspension logic. Most operationally complex — ship after the feed endpoint and SDK have proven stable.
+### Future: Persistent webhook wake-ups
+Optional subscription CRUD and delivery workers can be considered after the feed endpoint, SSE stream, and SDK have proven stable. These would remain wake-ups for the cursor feed, not a second event source.

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -6496,7 +6496,7 @@ paths:
       operationId: getRegistryFeed
       summary: Registry change feed
       description: |-
-        Poll a cursor-based feed of registry changes. Events are ordered by UUID v7 event_id for monotonic cursor progression. The feed retains events for 90 days.
+        Poll a cursor-based feed of registry changes. Events are ordered by UUID v7 event_id for monotonic cursor progression. The feed retains events for 90 days. The `freshness` object reports when the response was generated, the newest matching event currently visible to the feed, and the resulting feed lag.
 
         Type filtering supports glob patterns: `property.*` matches `property.created`, `property.updated`, etc.
       tags:
@@ -6578,10 +6578,39 @@ paths:
                     description: Pass as cursor in the next request to continue polling
                   has_more:
                     type: boolean
+                  freshness:
+                    type: object
+                    properties:
+                      generated_at:
+                        type: string
+                        format: date-time
+                        description: Server timestamp when this feed page was generated.
+                      latest_event_created_at:
+                        type:
+                          - string
+                          - "null"
+                        format: date-time
+                        description: Newest event creation timestamp currently visible in the feed for the requested type filter. Null when no matching event exists inside retention.
+                      lag_seconds:
+                        type:
+                          - integer
+                          - "null"
+                        minimum: 0
+                        description: Seconds between generated_at and latest_event_created_at. Null when no matching event exists.
+                      retention_days:
+                        type: integer
+                        exclusiveMinimum: 0
+                        description: Number of days the registry retains feed cursors and events.
+                    required:
+                      - generated_at
+                      - latest_event_created_at
+                      - lag_seconds
+                      - retention_days
                 required:
                   - events
                   - cursor
                   - has_more
+                  - freshness
         "400":
           description: Invalid cursor format or type filter
           content:
@@ -6596,6 +6625,87 @@ paths:
                 $ref: "#/components/schemas/Error"
         "410":
           description: Cursor expired (older than 90-day retention window)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum:
+                      - cursor_expired
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/registry/feed/stream:
+    get:
+      operationId: streamRegistryFeed
+      summary: Registry change feed stream
+      description: "Subscribe to registry feed pages over Server-Sent Events. This is a push-friendly transport for the same cursor contract as `/api/registry/feed`: clients still persist `cursor`, apply only feed events, and recover from `cursor_expired` by re-bootstrapping. The stream emits `feed` events containing a full feed page, `heartbeat` events while caught up, and `error` before closing when the cursor expires or the server cannot query the feed."
+      tags:
+        - Change Feed
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Resume after this event ID
+          required: false
+          description: Resume after this event ID
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated event type filters with glob support (e.g. property.*)
+            example: authorization.*,publisher.adagents_changed
+          required: false
+          description: Comma-separated event type filters with glob support (e.g. property.*)
+          name: types
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+            description: Max events per SSE feed page (default 100, max 10,000)
+          required: false
+          description: Max events per SSE feed page (default 100, max 10,000)
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            minimum: 5
+            maximum: 60
+            description: Server-side interval while caught up (default 15 seconds). Backlog pages are sent without waiting.
+          required: false
+          description: Server-side interval while caught up (default 15 seconds). Backlog pages are sent without waiting.
+          name: poll_interval_seconds
+          in: query
+      responses:
+        "200":
+          description: "SSE stream. `event: feed` data validates as a registry feed page."
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: Server-Sent Events stream. `feed` events carry JSON matching the RegistryFeedPage schema; `heartbeat` events carry `{ generated_at, cursor }`.
+        "400":
+          description: Invalid cursor format, type filter, limit, or poll interval
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "410":
+          description: Initial cursor expired
           content:
             application/json:
               schema:

--- a/static/schemas/source/core/registry-feed-response.json
+++ b/static/schemas/source/core/registry-feed-response.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/registry-feed-response.json",
   "title": "Registry Feed Response",
-  "description": "Response from GET /api/registry/feed. The events array contains cursor-ordered registry events; cursor is the value to pass on the next poll. See specs/registry-change-feed.md.",
+  "description": "Response from GET /api/registry/feed and the `feed` event body from GET /api/registry/feed/stream. The events array contains cursor-ordered registry events; cursor is the value to pass on the next poll or stream reconnect. See specs/registry-change-feed.md.",
   "type": "object",
   "properties": {
     "events": {
@@ -22,12 +22,52 @@
     "has_more": {
       "type": "boolean",
       "description": "True when more events are immediately available after cursor."
+    },
+    "freshness": {
+      "type": "object",
+      "description": "Consumer-visible feed freshness metadata for the requested type filter.",
+      "properties": {
+        "generated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Server timestamp when this feed page was generated."
+        },
+        "latest_event_created_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time",
+          "description": "Newest event creation timestamp currently visible in the feed for the requested type filter. Null when no matching event exists inside retention."
+        },
+        "lag_seconds": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Seconds between generated_at and latest_event_created_at. Null when no matching event exists."
+        },
+        "retention_days": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of days the registry retains feed cursors and events."
+        }
+      },
+      "required": [
+        "generated_at",
+        "latest_event_created_at",
+        "lag_seconds",
+        "retention_days"
+      ],
+      "additionalProperties": false
     }
   },
   "required": [
     "events",
     "cursor",
-    "has_more"
+    "has_more",
+    "freshness"
   ],
   "additionalProperties": true
 }

--- a/tests/composed-schema-validation.test.cjs
+++ b/tests/composed-schema-validation.test.cjs
@@ -1470,7 +1470,13 @@ async function runTests() {
         }
       ],
       cursor: '019539a0-1234-7000-8000-000000000013',
-      has_more: false
+      has_more: false,
+      freshness: {
+        generated_at: '2026-03-31T10:03:15.000Z',
+        latest_event_created_at: '2026-03-31T10:03:00.000Z',
+        lag_seconds: 15,
+        retention_days: 90
+      }
     },
     'Registry feed response validates typed property, collection, authorization, and compliance events'
   );


### PR DESCRIPTION
## Summary

Adds the registry Server-Sent Events feed stream at `GET /api/registry/feed/stream` and documents it as the push transport for keeping registry subscribers in sync.

## What changed

- Adds an SSE endpoint that emits `feed`, `heartbeat`, and terminal `error` events from the existing cursor-based registry feed.
- Adds strict feed query validation, stream lifecycle handling, backpressure awareness, active stream caps, backlog page limits, and proxy-buffering headers.
- Adds feed freshness metadata and retention-bounds both feed pages and freshness queries.
- Adds the `catalog_events(event_type, created_at)` index for filtered feed/freshness reads.
- Updates OpenAPI, JSON Schema, registry docs, protocol spec, and changeset metadata.

## SDK impact

The SDK should regenerate/import the updated registry feed schema because `freshness` is now required on feed responses. The SSE stream itself will still need hand-written transport handling because the endpoint returns `text/event-stream`.

## Validation

- `npx vitest run server/tests/unit/registry-feed-stream-route.test.ts server/tests/unit/catalog-events-db.test.ts`
- `npm run typecheck`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- `npm run build:openapi`
- `npm run test:openapi`
- `npm run test:schemas`
- `node tests/composed-schema-validation.test.cjs`
- `npm run test:migrations`
- `git diff --cached --check`
- `npx --yes @changesets/cli@^2.31.0 status --since=origin/main`
- `DATABASE_URL=postgresql://adcp:localdev@localhost:5432/adcp_test npx vitest run server/tests/integration/registry-feed.test.ts --config server/vitest.config.ts`
- `DATABASE_URL=postgresql://adcp:localdev@localhost:5432/adcp_test npx vitest run server/tests/integration/registry-feed-authorization.test.ts --config server/vitest.config.ts`
- `DATABASE_URL=postgresql://adcp:localdev@localhost:5432/adcp_test npx vitest run server/tests/integration/registry-reader-baseline-public-endpoints.test.ts --config server/vitest.config.ts`

## Notes

- The full pre-commit hook was attempted, but the repo-wide unit suite failed in unrelated `server/tests/unit/admin-stripe-customer-link.test.ts` assertions before commit. This change does not touch those paths.
- `npm run test:schema-utf8` still fails on the existing printable Unicode escape in `protocol/get-adcp-capabilities-response.json`; unrelated to this feed stream change.
