### PR TITLE
feat(schema): add sample render URLs for canonical formats

### DIFF
--- a/.changeset/canonical-format-sample-render-url.md
+++ b/.changeset/canonical-format-sample-render-url.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `sample_render_url` to canonical format declarations and registry summaries so catalogs can link to human-facing sample renders without implying buyer-asset preview, validation, creative approval, or live delivery fidelity.

--- a/.changeset/canonical-format-sample-render-url.md
+++ b/.changeset/canonical-format-sample-render-url.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": minor
 ---
 
-Add `sample_render_url` to canonical format declarations and registry summaries so catalogs can link to human-facing sample renders without implying buyer-asset preview, validation, creative approval, or live delivery fidelity.
+Add `sample_render_url` to canonical format declarations and registry summaries so publisher catalogs retain a human-facing preview path without a creative agent owning the format. Define declaration-scoped authority and safe consumer behavior without implying buyer-asset rendering, validation, creative approval, publisher acceptance, or live-delivery fidelity.

--- a/docs.json
+++ b/docs.json
@@ -594,7 +594,7 @@
               {
                 "group": "Registry API",
                 "openapi": {
-                  "source": "static/openapi/registry.yaml",
+                  "source": "/static/openapi/registry.yaml",
                   "directory": "dist/docs/3.0.21/registry/api-reference"
                 },
                 "pages": [
@@ -1203,7 +1203,7 @@
               {
                 "group": "Registry API",
                 "openapi": {
-                  "source": "static/openapi/registry.yaml",
+                  "source": "/static/openapi/registry.yaml",
                   "directory": "docs/registry/api-reference"
                 },
                 "pages": [
@@ -1786,7 +1786,7 @@
               {
                 "group": "Registry API",
                 "openapi": {
-                  "source": "static/openapi/registry.yaml",
+                  "source": "/static/openapi/registry.yaml",
                   "directory": "docs/registry/api-reference"
                 },
                 "pages": [

--- a/docs.json
+++ b/docs.json
@@ -594,7 +594,7 @@
               {
                 "group": "Registry API",
                 "openapi": {
-                  "source": "/static/openapi/registry.yaml",
+                  "source": "https://agenticadvertising.org/openapi/registry.yaml",
                   "directory": "dist/docs/3.0.21/registry/api-reference"
                 },
                 "pages": [
@@ -1203,7 +1203,7 @@
               {
                 "group": "Registry API",
                 "openapi": {
-                  "source": "/static/openapi/registry.yaml",
+                  "source": "https://agenticadvertising.org/openapi/registry.yaml",
                   "directory": "docs/registry/api-reference"
                 },
                 "pages": [
@@ -1786,7 +1786,7 @@
               {
                 "group": "Registry API",
                 "openapi": {
-                  "source": "/static/openapi/registry.yaml",
+                  "source": "https://agenticadvertising.org/openapi/registry.yaml",
                   "directory": "docs/registry/api-reference"
                 },
                 "pages": [

--- a/docs/creative/canonical-formats.mdx
+++ b/docs/creative/canonical-formats.mdx
@@ -28,7 +28,7 @@ For hands-on authoring practice, use the [S2 creative specialist module](/docs/l
 | **Canonical format** | One of 12 AdCP-defined format archetypes that products narrow (e.g., `image`, `video_vast`, `audio_hosted`, `native_in_feed`). The buyer's stable validation target. |
 | **`format_kind`** | Discriminator value naming a canonical format (e.g., `"image"`). Selects which canonical's parameter schema applies. |
 | **`format_options`** | On a product, an array of full `ProductFormatDeclaration`s. The 90% case is single-element; multi-element declares "accepts any of." Product entries are declarations, not bare references. |
-| **`ProductFormatDeclaration`** | Inline format declaration: required `format_kind` + required `params` + optional `format_option_id` (REQUIRED when entries share `format_kind`; SHOULD be set on every entry per 3.1 so V2 buyers can author against the product via `PackageRequest.format_option_refs[]`) + optional `publisher_domain` for publisher-catalog-backed options + optional `applies_to_channels` + optional `experimental` + optional `v1_format_ref[]` (always array — see below). Even when catalog-backed, the product still carries the full declaration. |
+| **`ProductFormatDeclaration`** | Inline format declaration: required `format_kind` + required `params` + optional `format_option_id` (REQUIRED when entries share `format_kind`; SHOULD be set on every entry per 3.1 so V2 buyers can author against the product via `PackageRequest.format_option_refs[]`) + optional `publisher_domain` for publisher-catalog-backed options + optional human-facing `sample_render_url` + optional `applies_to_channels` + optional `experimental` + optional `v1_format_ref[]` (always array — see below). Even when catalog-backed, the product still carries the full declaration. |
 | **`v1_format_ref`** | Array of `{agent_url, id}` references linking a v2 declaration to one or more v1 named formats. Always array; single-ref is `[{...}]`. Multi-size declarations carry one ref per size (see "Multi-size fan-out" below). |
 | **`canonical:` annotation** | The v1 catalog entry's projection annotation. Always object form — `{ kind: "image" }` minimum, `{ kind, asset_source, slots_override }` rich form for entries whose v1 shape doesn't follow the canonical's defaults (generative, brief-driven). Never bare-string. |
 | **Sibling refinement principle** | Before reaching for a new canonical, check whether `asset_source` + `slots_override` + `applies_to_channels` + event_log surface covers the case. Applied to: generative (image + asset_source: agent_synthesized), published-post references (video_hosted/image/native_in_feed + asset_source: publisher_owned_reference + published_post slot), broadcast TV (video_hosted + applies_to_channels: ["tv"]), DOOH (image + applies_to_channels: ["dooh"]), native (image + slots_override). No new canonical for any of them. |
@@ -336,6 +336,26 @@ Product declarations, buyer selectors, and placement references are intentionall
 `applies_to_property_ids` and `Placement.format_options[]` answer different questions: the first scopes a FORMAT to a subset of properties ("Reels applies to Instagram + Facebook but not WhatsApp"); the second binds a PLACEMENT to one or more formats ("Instagram Reels accepts the `meta_reels` format option"). Property-level format support → `applies_to_property_ids`. Placement-level binding → `placements[].format_options[]`.
 
 **Naming boundary:** `format_option_id` selects a buyable product or publisher-catalog format contract. Creative-agent `capability_id` remains separate: it selects a build path on `creative.supported_formats` when calling `build_creative`. Do not use `capability_id` on media-buy products, placements, package requests, creative manifests, or creative assets.
+
+### Sample renders and declaration authority
+
+Starting in 3.2, `sample_render_url` restores the human-preview path that publisher-owned canonical formats otherwise lose when there is no creative agent owning the format. It answers “what does this declared format look like?” using example assets selected by the declaring party. It does not render buyer assets.
+
+Authority follows the enclosing declaration rather than the shared `ProductFormatDeclaration` type:
+
+| Enclosing surface | Who asserts the sample |
+|---|---|
+| Publisher-hosted `adagents.json` top-level `formats[]` | Publisher |
+| AgenticAdvertising.org community-mirror `adagents.json` top-level `formats[]` | Community mirror, clearly labeled as such |
+| Inline `Placement.format_options[]` declaration | Party publishing that placement catalog |
+| `Product.format_options[]` | Seller publishing the product |
+| `creative.supported_formats[]` | Creative agent demonstrating its production capability; not evidence that a publisher accepts the format |
+
+A bare `{format_option_id}` in `Placement.format_options[]` resolves to the same file's top-level declaration and therefore inherits its `sample_render_url`. A product entry is always a full declaration and does not implicitly inherit presentation metadata. When a product entry carries `{publisher_domain, format_option_id}`, a UI MAY resolve the catalog. A tier-1 publisher-hosted sample SHOULD be preferred when presenting a preview as publisher-authored. A community-mirror result MUST be labeled community-maintained and MUST NOT be presented as publisher-authored. A sample copied directly onto the product remains seller-supplied unless it was verified against the publisher-hosted catalog.
+
+Sample URLs are untrusted external navigation. They SHOULD be public and unauthenticated. Consumers MUST NOT auto-fetch or iframe a sample solely because it appears in a declaration, and MUST NOT attach buyer assets, authorization credentials, source-origin or account context, or user-specific query parameters. Ordinary browser state belonging to the destination origin is outside AdCP's control. Human-facing clients SHOULD open the URL only after explicit user action in a new browsing context with opener and referrer information suppressed.
+
+Dynamic preview is a separate capability. Rendering a buyer's creative manifest requires an authorized renderer and canonical format context for `preview_creative`; `sample_render_url` is neither renderer discovery nor a substitute for that task.
 
 ### Format discovery (resolution order)
 

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -447,6 +447,14 @@
         border-radius: var(--radius-lg);
         background: var(--color-bg-card);
         overflow: hidden;
+        cursor: pointer;
+        transition: var(--transition-all);
+      }
+      .format-card:hover,
+      .format-card:focus {
+        border-color: var(--color-brand);
+        box-shadow: var(--shadow-sm);
+        outline: none;
       }
       .format-preview {
         display: grid;
@@ -547,6 +555,130 @@
         color: var(--color-text-secondary);
         overflow-wrap: anywhere;
       }
+      .format-card__actions {
+        display: flex;
+        gap: var(--space-2);
+        margin-top: var(--space-3);
+      }
+      .format-card__sample-state {
+        font-size: var(--text-xs);
+        font-weight: var(--font-semibold);
+        color: var(--color-brand);
+      }
+      .format-dialog {
+        position: fixed;
+        inset: 0;
+        z-index: 1000;
+        display: grid;
+        place-items: center;
+        padding: var(--space-4);
+        background: var(--modal-backdrop);
+      }
+      .format-dialog__panel {
+        width: min(720px, 100%);
+        max-height: min(760px, calc(100vh - 32px));
+        overflow: auto;
+        border-radius: var(--radius-lg);
+        border: var(--border-1) solid var(--color-border);
+        background: var(--color-bg-card);
+        box-shadow: var(--shadow-xl);
+      }
+      .format-dialog__header {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        display: flex;
+        justify-content: space-between;
+        gap: var(--space-4);
+        align-items: flex-start;
+        padding: var(--space-5);
+        border-bottom: var(--border-1) solid var(--color-border-light);
+        background: var(--color-bg-card);
+      }
+      .format-dialog__title {
+        margin: 0;
+        font-size: var(--text-xl);
+        font-weight: var(--font-bold);
+        color: var(--color-text-heading);
+      }
+      .format-dialog__subtitle {
+        margin-top: 2px;
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--color-text-secondary);
+        overflow-wrap: anywhere;
+      }
+      .format-dialog__close {
+        border: var(--border-1) solid var(--color-border);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-subtle);
+        color: var(--color-text);
+        cursor: pointer;
+        font-size: var(--text-lg);
+        line-height: 1;
+        padding: var(--space-2);
+      }
+      .format-dialog__body {
+        padding: var(--space-5);
+      }
+      .format-dialog__preview {
+        margin-bottom: var(--space-5);
+      }
+      .format-dialog__actions {
+        display: flex;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+        margin-bottom: var(--space-5);
+      }
+      .format-dialog__primary {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 38px;
+        padding: 0 var(--space-4);
+        border-radius: var(--radius-md);
+        background: var(--color-brand);
+        color: var(--color-bg-card);
+        text-decoration: none;
+        font-weight: var(--font-semibold);
+      }
+      .format-dialog__empty {
+        margin: 0;
+        color: var(--color-text-secondary);
+        font-size: var(--text-sm);
+      }
+      .format-dialog__section {
+        margin-top: var(--space-5);
+      }
+      .format-dialog__section h4 {
+        margin: 0 0 var(--space-3);
+        font-size: var(--text-sm);
+        font-weight: var(--font-semibold);
+        color: var(--color-text-heading);
+      }
+      .format-detail-list {
+        display: grid;
+        gap: var(--space-2);
+        margin: 0;
+      }
+      .format-detail-list div {
+        display: grid;
+        grid-template-columns: minmax(120px, 0.35fr) minmax(0, 1fr);
+        gap: var(--space-3);
+        padding: var(--space-2) 0;
+        border-bottom: var(--border-1) solid var(--color-border-light);
+      }
+      .format-detail-list dt {
+        color: var(--color-text-secondary);
+        font-size: var(--text-xs);
+        font-weight: var(--font-semibold);
+      }
+      .format-detail-list dd {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        overflow-wrap: anywhere;
+      }
 
       @media (max-width: 760px) {
         .publisher-profile__grid {
@@ -567,6 +699,10 @@
         }
         .publisher-formats__intro {
           margin-top: var(--space-2);
+        }
+        .format-detail-list div {
+          grid-template-columns: 1fr;
+          gap: var(--space-1);
         }
       }
 
@@ -757,6 +893,16 @@
         String(s ?? '')
           .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
           .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+
+      function safeHttpsUrl(raw) {
+        if (!raw) return '';
+        try {
+          const url = new URL(String(raw));
+          return url.protocol === 'https:' ? url.href : '';
+        } catch (_) {
+          return '';
+        }
+      }
 
       function getDomain() {
         const path = window.location.pathname;
@@ -1297,6 +1443,43 @@
         return chips.slice(0, 5);
       }
 
+      function formatParamValue(value) {
+        if (value === null || value === undefined) return '';
+        if (Array.isArray(value) || typeof value === 'object') {
+          return JSON.stringify(value);
+        }
+        return String(value);
+      }
+
+      function renderFormatParams(params) {
+        const entries = Object.entries(params || {})
+          .filter(([, value]) => value !== undefined && value !== null)
+          .slice(0, 32);
+        if (!entries.length) return '<p class="format-dialog__empty">No canonical parameters published.</p>';
+        return `<dl class="format-detail-list">${
+          entries.map(([key, value]) => `<div>
+            <dt>${escapeHtml(compactIdentifier(key))}</dt>
+            <dd>${escapeHtml(formatParamValue(value))}</dd>
+          </div>`).join('')
+        }</dl>`;
+      }
+
+      function renderFormatDetailList(format, scope) {
+        const rows = [
+          ['Format kind', compactKind(format.format_kind)],
+          ['Format option ID', format.format_option_id || 'not published'],
+          ['Scope', scope],
+          ['Seller preference', format.seller_preference || 'not set'],
+          ['Experimental', format.experimental ? 'yes' : 'no'],
+        ];
+        return `<dl class="format-detail-list">${
+          rows.map(([label, value]) => `<div>
+            <dt>${escapeHtml(label)}</dt>
+            <dd>${escapeHtml(value)}</dd>
+          </div>`).join('')
+        }</dl>`;
+      }
+
       function previewShape(format) {
         const kind = format.format_kind || '';
         const params = format.params || {};
@@ -1336,6 +1519,131 @@
         </div>`;
       }
 
+      function formatScopeLabel(format, props) {
+        const propertyNames = new Map(
+          props
+            .filter((p) => p.id)
+            .map((p) => [p.id, p.name || p.id])
+        );
+        const scopedIds = Array.isArray(format.applies_to_property_ids) ? format.applies_to_property_ids : [];
+        const scopedTags = Array.isArray(format.applies_to_property_tags) ? format.applies_to_property_tags : [];
+        if (scopedIds.length) {
+          return `Applies to ${scopedIds.map((id) => propertyNames.get(id) || compactIdentifier(id)).join(', ')}`;
+        }
+        if (scopedTags.length) {
+          return `Applies to ${scopedTags.map((tag) => compactIdentifier(tag)).join(', ')} properties`;
+        }
+        return 'Applies to all listed properties';
+      }
+
+      let formatDialogTrigger = null;
+
+      function closeFormatDialog(options = {}) {
+        const { restoreFocus = true } = options;
+        const existing = document.getElementById('format-detail-dialog');
+        if (existing) existing.remove();
+        document.removeEventListener('keydown', handleFormatDialogKeydown);
+        if (restoreFocus && formatDialogTrigger instanceof HTMLElement) {
+          formatDialogTrigger.focus();
+        }
+        formatDialogTrigger = null;
+      }
+
+      function handleFormatDialogKeydown(event) {
+        if (event.key === 'Escape') {
+          closeFormatDialog();
+          return;
+        }
+        if (event.key !== 'Tab') return;
+        const dialog = document.getElementById('format-detail-dialog');
+        if (!dialog) return;
+        const focusable = Array.from(dialog.querySelectorAll('a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'))
+          .filter((el) => el instanceof HTMLElement);
+        if (!focusable.length) {
+          event.preventDefault();
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+
+      function showFormatDetails(format, scope, trigger) {
+        closeFormatDialog({ restoreFocus: false });
+        formatDialogTrigger = trigger instanceof HTMLElement ? trigger : null;
+        const sampleRenderUrl = safeHttpsUrl(format.sample_render_url);
+        const title = format.display_name || format.format_option_id || compactKind(format.format_kind);
+        const chips = formatChips(format);
+        const dialog = document.createElement('div');
+        dialog.id = 'format-detail-dialog';
+        dialog.className = 'format-dialog';
+        dialog.innerHTML = `
+          <section class="format-dialog__panel" role="dialog" aria-modal="true" aria-labelledby="format-dialog-title">
+            <header class="format-dialog__header">
+              <div>
+                <h3 class="format-dialog__title" id="format-dialog-title">${escapeHtml(title)}</h3>
+                <div class="format-dialog__subtitle">${escapeHtml(compactKind(format.format_kind))}</div>
+              </div>
+              <button class="format-dialog__close" type="button" aria-label="Close format details">×</button>
+            </header>
+            <div class="format-dialog__body">
+              <div class="format-dialog__preview">${renderFormatPreview(format)}</div>
+              ${chips.length ? `<div class="format-card__chips">${
+                chips.map((chip) => `<span class="format-chip">${escapeHtml(chip)}</span>`).join('')
+              }</div>` : ''}
+              <div class="format-dialog__actions">
+                ${sampleRenderUrl
+                  ? `<a class="format-dialog__primary" href="${escapeHtml(sampleRenderUrl)}" target="_blank" rel="noopener noreferrer">Open sample render</a>`
+                  : '<p class="format-dialog__empty">No sample render is published for this format.</p>'}
+              </div>
+              <div class="format-dialog__section">
+                <h4>Declaration</h4>
+                ${renderFormatDetailList(format, scope)}
+              </div>
+              <div class="format-dialog__section">
+                <h4>Canonical parameters</h4>
+                ${renderFormatParams(format.params || {})}
+              </div>
+            </div>
+          </section>
+        `;
+        dialog.addEventListener('click', (event) => {
+          if (event.target === dialog) closeFormatDialog();
+        });
+        dialog.querySelector('.format-dialog__close').addEventListener('click', closeFormatDialog);
+        document.addEventListener('keydown', handleFormatDialogKeydown);
+        document.body.appendChild(dialog);
+        dialog.querySelector('.format-dialog__close').focus();
+      }
+
+      function bindFormatCards(formats, props) {
+        const grid = document.getElementById('publisher-formats-grid');
+        if (!grid) return;
+        grid.querySelectorAll('.format-card[data-format-index]').forEach((card) => {
+          const open = () => {
+            const index = Number(card.getAttribute('data-format-index'));
+            const format = formats[index];
+            if (!format) return;
+            showFormatDetails(format, formatScopeLabel(format, props), card);
+          };
+          card.addEventListener('click', (event) => {
+            if (event.target instanceof Element && event.target.closest('a')) return;
+            open();
+          });
+          card.addEventListener('keydown', (event) => {
+            if (event.key !== 'Enter' && event.key !== ' ') return;
+            event.preventDefault();
+            open();
+          });
+        });
+      }
+
       function renderFormats(formats, props, agents) {
         const intro = document.getElementById('publisher-formats-intro');
         const grid = document.getElementById('publisher-formats-grid');
@@ -1351,32 +1659,27 @@
           grid.innerHTML = `${note}<div class="on-file__empty">No creative format declarations recorded yet.</div>`;
           return;
         }
-        const propertyNames = new Map(
-          props
-            .filter((p) => p.id)
-            .map((p) => [p.id, p.name || p.id])
-        );
-        grid.innerHTML = note + formats.map((format) => {
+        grid.innerHTML = note + formats.map((format, index) => {
           const chips = formatChips(format);
-          const scopedIds = Array.isArray(format.applies_to_property_ids) ? format.applies_to_property_ids : [];
-          const scopedTags = Array.isArray(format.applies_to_property_tags) ? format.applies_to_property_tags : [];
-          const scope = scopedIds.length
-            ? `Applies to ${scopedIds.map((id) => escapeHtml(propertyNames.get(id) || compactIdentifier(id))).join(', ')}`
-            : scopedTags.length
-              ? `Applies to ${scopedTags.map((tag) => escapeHtml(compactIdentifier(tag))).join(', ')} properties`
-              : 'Applies to all listed properties';
-          return `<article class="format-card">
+          const scope = formatScopeLabel(format, props);
+          const sampleRenderUrl = safeHttpsUrl(format.sample_render_url);
+          const title = format.display_name || format.format_option_id || compactKind(format.format_kind);
+          return `<article class="format-card" role="button" tabindex="0" data-format-index="${index}" aria-label="Open details for ${escapeHtml(title)}">
             <div class="format-preview">${renderFormatPreview(format)}</div>
             <div class="format-card__body">
-              <h3 class="format-card__title">${escapeHtml(format.display_name || format.format_option_id || compactKind(format.format_kind))}</h3>
+              <h3 class="format-card__title">${escapeHtml(title)}</h3>
               <div class="format-card__kind">${format.format_option_id ? `${escapeHtml(compactIdentifier(format.format_option_id))} · ` : ''}${escapeHtml(compactKind(format.format_kind))}</div>
               ${chips.length ? `<div class="format-card__chips">${
                 chips.map((chip) => `<span class="format-chip">${escapeHtml(chip)}</span>`).join('')
               }</div>` : ''}
-              <div class="format-card__scope">${scope}</div>
+              <div class="format-card__scope">${escapeHtml(scope)}</div>
+              ${sampleRenderUrl ? `<div class="format-card__actions">
+                <span class="format-card__sample-state">Sample render available</span>
+              </div>` : ''}
             </div>
           </article>`;
         }).join('');
+        bindFormatCards(formats, props);
       }
 
       // ─── On-file: adagents.json + brand.json file cards ─────────

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -454,6 +454,12 @@
       .format-card:focus {
         border-color: var(--color-brand);
         box-shadow: var(--shadow-sm);
+      }
+      .format-card:focus-visible {
+        outline: 2px solid var(--color-brand);
+        outline-offset: 2px;
+      }
+      .format-card:focus:not(:focus-visible) {
         outline: none;
       }
       .format-preview {
@@ -646,6 +652,11 @@
         margin: 0;
         color: var(--color-text-secondary);
         font-size: var(--text-sm);
+      }
+      .format-dialog__destination {
+        margin: 0;
+        color: var(--color-text-secondary);
+        font-size: var(--text-xs);
       }
       .format-dialog__section {
         margin-top: var(--space-5);
@@ -898,7 +909,7 @@
         if (!raw) return '';
         try {
           const url = new URL(String(raw));
-          return url.protocol === 'https:' ? url.href : '';
+          return url.protocol === 'https:' && !url.username && !url.password ? url.href : '';
         } catch (_) {
           return '';
         }
@@ -1578,6 +1589,7 @@
         closeFormatDialog({ restoreFocus: false });
         formatDialogTrigger = trigger instanceof HTMLElement ? trigger : null;
         const sampleRenderUrl = safeHttpsUrl(format.sample_render_url);
+        const sampleRenderHost = sampleRenderUrl ? new URL(sampleRenderUrl).hostname : '';
         const title = format.display_name || format.format_option_id || compactKind(format.format_kind);
         const chips = formatChips(format);
         const dialog = document.createElement('div');
@@ -1599,7 +1611,8 @@
               }</div>` : ''}
               <div class="format-dialog__actions">
                 ${sampleRenderUrl
-                  ? `<a class="format-dialog__primary" href="${escapeHtml(sampleRenderUrl)}" target="_blank" rel="noopener noreferrer">Open sample render</a>`
+                  ? `<a class="format-dialog__primary" href="${escapeHtml(sampleRenderUrl)}" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">Open sample render</a>
+                    <p class="format-dialog__destination">External sample hosted at <code>${escapeHtml(sampleRenderHost)}</code></p>`
                   : '<p class="format-dialog__empty">No sample render is published for this format.</p>'}
               </div>
               <div class="format-dialog__section">

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -238,7 +238,7 @@ function httpsUrlOrUndefined(value: unknown): string | undefined {
   if (!raw) return undefined;
   try {
     const url = new URL(raw);
-    return url.protocol === "https:" ? url.href : undefined;
+    return url.protocol === "https:" && !url.username && !url.password ? url.href : undefined;
   } catch {
     return undefined;
   }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -215,6 +215,7 @@ type PublisherFormatSummary = {
   format_option_id?: string;
   display_name: string;
   format_kind: string;
+  sample_render_url?: string;
   params?: Record<string, unknown>;
   applies_to_property_ids?: string[];
   applies_to_property_tags?: string[];
@@ -230,6 +231,17 @@ function recordOrNull(value: unknown): Record<string, unknown> | null {
 
 function stringOrUndefined(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function httpsUrlOrUndefined(value: unknown): string | undefined {
+  const raw = stringOrUndefined(value);
+  if (!raw) return undefined;
+  try {
+    const url = new URL(raw);
+    return url.protocol === "https:" ? url.href : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function stringArray(value: unknown, cap = 8): string[] {
@@ -365,6 +377,7 @@ function summarizeFormats(
         format_option_id: optionId,
         display_name: displayName,
         format_kind: formatKind,
+        sample_render_url: httpsUrlOrUndefined(format.sample_render_url),
         params,
         applies_to_property_ids: appliesToPropertyIds,
         applies_to_property_tags: appliesToPropertyTags,

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -1059,7 +1059,7 @@ const PublisherFormatSummarySchema = z.object({
   format_kind: z.string().openapi({ description: "Canonical format discriminator, such as `image`, `video_hosted`, `native_in_feed`, or `custom`." }),
   sample_render_url: HttpsUrlSchema.optional().openapi({
     description:
-      "Optional HTTPS page where a human can inspect a sample render of this catalog format using publisher- or registry-provided example assets. Informational only; this is not a renderer endpoint, buyer-asset preview, validation result, creative approval, or live delivery guarantee.",
+      "Optional public HTTPS page where a human can inspect a sample render of this catalog format using publisher- or community-mirror-provided example assets. Informational only; this is not a renderer endpoint, buyer-asset preview, validation result, creative approval, proof of publisher acceptance, or live delivery guarantee.",
   }),
   params: z.record(z.string(), z.unknown()).optional().openapi({ description: "Canonical format params from the publisher's adagents.json declaration." }),
   applies_to_property_ids: z.array(z.string()).optional().openapi({ description: "Property IDs this format applies to; absent means all properties." }),

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -1057,6 +1057,10 @@ const PublisherFormatSummarySchema = z.object({
   format_option_id: z.string().optional().openapi({ description: "Stable format option identifier from adagents.json `formats[]`." }),
   display_name: z.string().openapi({ description: "Human-readable format label for catalog and publisher UI display." }),
   format_kind: z.string().openapi({ description: "Canonical format discriminator, such as `image`, `video_hosted`, `native_in_feed`, or `custom`." }),
+  sample_render_url: HttpsUrlSchema.optional().openapi({
+    description:
+      "Optional HTTPS page where a human can inspect a sample render of this catalog format using publisher- or registry-provided example assets. Informational only; this is not a renderer endpoint, buyer-asset preview, validation result, creative approval, or live delivery guarantee.",
+  }),
   params: z.record(z.string(), z.unknown()).optional().openapi({ description: "Canonical format params from the publisher's adagents.json declaration." }),
   applies_to_property_ids: z.array(z.string()).optional().openapi({ description: "Property IDs this format applies to; absent means all properties." }),
   applies_to_property_tags: z.array(z.string()).optional().openapi({ description: "Property tags this format applies to; absent means all properties." }),

--- a/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
+++ b/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
@@ -316,6 +316,23 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
             display_name: 'Community Site Square',
             format_kind: 'image',
             params: { width: 1080, height: 1080 },
+            sample_render_url: ' https://samples.community.example/formats/site-square ',
+            applies_to_property_ids: ['community-site'],
+          },
+          {
+            format_option_id: 'community_site_rectangle',
+            display_name: 'Community Site Rectangle',
+            format_kind: 'image',
+            params: { width: 1200, height: 628 },
+            sample_render_url: 'http://samples.community.example/formats/site-rectangle',
+            applies_to_property_ids: ['community-site'],
+          },
+          {
+            format_option_id: 'community_site_banner',
+            display_name: 'Community Site Banner',
+            format_kind: 'image',
+            params: { width: 728, height: 90 },
+            sample_render_url: 'https://user:secret@samples.community.example/formats/site-banner',
             applies_to_property_ids: ['community-site'],
           },
           {
@@ -339,8 +356,13 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     expect(new URL(res.body.files.adagents_json.registry_url).pathname).toBe(`/api/creative-agent/translated/${COMMUNITY_PLATFORM}/adagents.json`);
     expect(res.body.hosting.mode).toBe('none');
     expect(res.body.hosting.last_validated).toBeNull();
-    expect(res.body.formats).toHaveLength(1);
+    expect(res.body.formats).toHaveLength(3);
     expect(res.body.formats[0].format_option_id).toBe('community_site_square');
+    expect(res.body.formats[0].sample_render_url).toBe('https://samples.community.example/formats/site-square');
+    expect(res.body.formats[1].format_option_id).toBe('community_site_rectangle');
+    expect(res.body.formats[1].sample_render_url).toBeUndefined();
+    expect(res.body.formats[2].format_option_id).toBe('community_site_banner');
+    expect(res.body.formats[2].sample_render_url).toBeUndefined();
   });
 
   it('does NOT auto-crawl when validateCrawlDomain rejects (SSRF gate)', async () => {

--- a/server/tests/unit/client-security-wiring.test.ts
+++ b/server/tests/unit/client-security-wiring.test.ts
@@ -45,6 +45,18 @@ describe('browser external URL defenses', () => {
     expect(source).toContain('getSafeHttpsUrl(member.twitter_url)');
   });
 
+  it('opens publisher format samples only as explicit, credential-free external navigation', async () => {
+    const source = await publicSource('publisher-home.html');
+    const safeUrl = extractFunction(source, 'safeHttpsUrl');
+    expect(safeUrl('javascript:alert(1)')).toBe('');
+    expect(safeUrl('https://user:pass@samples.publisher.example/format')).toBe('');
+    expect(safeUrl(' https://samples.publisher.example/format ')).toBe('https://samples.publisher.example/format');
+    expect(source).toContain('target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer"');
+    expect(source).toContain('External sample hosted at');
+    expect(source).toContain("event.key === 'Escape'");
+    expect(source).toContain("event.key !== 'Enter' && event.key !== ' '");
+  });
+
   it('attaches and clears the SI capability without logging the token', async () => {
     const source = await publicSource('chat.html');
     expect(source).toMatch(/headers\['X-SI-Session-Capability'\] = siSessionCapability/);

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -1167,6 +1167,10 @@ components:
               format_kind:
                 type: string
                 description: Canonical format discriminator, such as `image`, `video_hosted`, `native_in_feed`, or `custom`.
+              sample_render_url:
+                type: string
+                pattern: ^https:\/\/
+                description: Optional HTTPS page where a human can inspect a sample render of this catalog format using publisher- or registry-provided example assets. Informational only; this is not a renderer endpoint, buyer-asset preview, validation result, creative approval, or live delivery guarantee.
               params:
                 type: object
                 additionalProperties: {}

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -1170,7 +1170,7 @@ components:
               sample_render_url:
                 type: string
                 pattern: ^https:\/\/
-                description: Optional HTTPS page where a human can inspect a sample render of this catalog format using publisher- or registry-provided example assets. Informational only; this is not a renderer endpoint, buyer-asset preview, validation result, creative approval, or live delivery guarantee.
+                description: Optional public HTTPS page where a human can inspect a sample render of this catalog format using publisher- or community-mirror-provided example assets. Informational only; this is not a renderer endpoint, buyer-asset preview, validation result, creative approval, proof of publisher acceptance, or live delivery guarantee.
               params:
                 type: object
                 additionalProperties: {}

--- a/static/schemas/source/core/product-format-declaration.json
+++ b/static/schemas/source/core/product-format-declaration.json
@@ -20,6 +20,12 @@
       "type": "string",
       "description": "Optional seller-controlled human-readable label for this format declaration. Used by buyer dashboards, catalog UIs, and reporting surfaces to show a seller's own naming ('Homepage Takeover', 'Branded Canvas', 'Reels Premium Video') rather than the raw `format_kind` or `format_option_id`. Has no machine semantics — buyer agents route on `format_kind` and `format_option_id`; `display_name` is purely for human presentation. Freeform; no enumeration. Sellers SHOULD keep it stable once published to avoid dashboard churn."
     },
+    "sample_render_url": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://",
+      "description": "Optional human-facing rendered example for this format declaration. Used by registry/catalog UIs to let buyers inspect the unit shape (for example, an AgenticAdvertising.org-translated Snap unit) before constructing a creative manifest. Uses publisher- or registry-provided sample assets, not buyer-submitted creative assets. Informational only: this URL is not a renderer endpoint, validation oracle, creative approval, or guarantee of how submitted creative will render in live delivery. Sellers SHOULD keep the URL stable while the declaration is active."
+    },
     "applies_to_channels": {
       "type": "array",
       "items": { "$ref": "/schemas/enums/channels.json" },

--- a/static/schemas/source/core/product-format-declaration.json
+++ b/static/schemas/source/core/product-format-declaration.json
@@ -24,7 +24,7 @@
       "type": "string",
       "format": "uri",
       "pattern": "^https://",
-      "description": "Optional human-facing rendered example for this format declaration. Used by registry/catalog UIs to let buyers inspect the unit shape (for example, an AgenticAdvertising.org-translated Snap unit) before constructing a creative manifest. Uses publisher- or registry-provided sample assets, not buyer-submitted creative assets. Informational only: this URL is not a renderer endpoint, validation oracle, creative approval, or guarantee of how submitted creative will render in live delivery. Sellers SHOULD keep the URL stable while the declaration is active."
+      "description": "Optional public HTTPS page where a human can inspect a sample render of this declaration using assets chosen by the party publishing the enclosing declaration. Consumers MUST identify that source correctly: publisher or community mirror for `adagents.json` `formats[]`, seller for product or inline-placement declarations, and creative agent for `creative.supported_formats`. Informational only: this is not a renderer endpoint, buyer-asset preview, validation result, creative approval, proof of publisher acceptance, or guarantee of live delivery. Declaring parties SHOULD keep the URL stable while the declaration is active."
     },
     "applies_to_channels": {
       "type": "array",

--- a/tests/placement-catalog-schema.test.cjs
+++ b/tests/placement-catalog-schema.test.cjs
@@ -413,6 +413,7 @@ test('format options can be referenced by publisher domain or product-local ID',
     validateDeclaration({
       publisher_domain: 'daily-pulse.example',
       format_option_id: 'homepage_image',
+      sample_render_url: 'https://creative.adcontextprotocol.org/translated/snap/samples/story',
       format_kind: 'image',
       params: {
         width: 300,
@@ -421,6 +422,19 @@ test('format options can be referenced by publisher domain or product-local ID',
     }),
     true,
     JSON.stringify(validateDeclaration.errors, null, 2)
+  );
+
+  assert.equal(
+    validateDeclaration({
+      format_option_id: 'homepage_image',
+      sample_render_url: 'http://creative.adcontextprotocol.org/translated/snap/samples/story',
+      format_kind: 'image',
+      params: {
+        width: 300,
+        height: 250
+      }
+    }),
+    false
   );
 
   assert.equal(

--- a/tests/placement-catalog-schema.test.cjs
+++ b/tests/placement-catalog-schema.test.cjs
@@ -317,7 +317,7 @@ test('products can include publisher-scoped referenced placements', async () => 
   assert.equal(validate(product), true, JSON.stringify(validate.errors, null, 2));
 });
 
-test('adagents.json supports catalog_etag for cache/version validation', async () => {
+test('adagents.json supports catalog_etag and publisher-owned format samples', async () => {
   const validate = await compile('/schemas/adagents.json');
   const adagents = {
     catalog_etag: '2026-05-25T18:30:00Z',
@@ -334,6 +334,16 @@ test('adagents.json supports catalog_etag for cache/version validation', async (
         placement_id: 'homepage_banner',
         name: 'Homepage banner',
         property_ids: ['daily_pulse']
+      }
+    ],
+    formats: [
+      {
+        format_option_id: 'homepage_image',
+        display_name: 'Homepage image',
+        sample_render_url: 'https://samples.publisher.example/formats/homepage-image',
+        format_kind: 'image',
+        params: { width: 300, height: 250 },
+        applies_to_property_ids: ['daily_pulse']
       }
     ],
     authorized_agents: [
@@ -413,7 +423,7 @@ test('format options can be referenced by publisher domain or product-local ID',
     validateDeclaration({
       publisher_domain: 'daily-pulse.example',
       format_option_id: 'homepage_image',
-      sample_render_url: 'https://creative.adcontextprotocol.org/translated/snap/samples/story',
+      sample_render_url: 'https://samples.publisher.example/formats/homepage-image',
       format_kind: 'image',
       params: {
         width: 300,
@@ -427,7 +437,7 @@ test('format options can be referenced by publisher domain or product-local ID',
   assert.equal(
     validateDeclaration({
       format_option_id: 'homepage_image',
-      sample_render_url: 'http://creative.adcontextprotocol.org/translated/snap/samples/story',
+      sample_render_url: 'http://samples.publisher.example/formats/homepage-image',
       format_kind: 'image',
       params: {
         width: 300,


### PR DESCRIPTION
## Summary

Ready for working group review.

This PR restores a human-preview path for publisher-owned canonical formats by adding `sample_render_url` to `ProductFormatDeclaration` and consuming it end to end in the registry publisher view. The field points to a static example selected by the party publishing the enclosing declaration; it does not render buyer assets.

The authority rules are explicit:

- Publisher-hosted `adagents.json formats[]` samples are publisher-authored.
- AgenticAdvertising.org community-mirror samples are community-maintained and must not be presented as publisher-authored.
- Product samples are seller-authored; creative capability samples are creative-agent-authored.
- Bare same-file placement references inherit the top-level declaration, while full product declarations do not implicitly inherit presentation metadata.

## Why

Moving canonical format ownership from creative agents to publishers removed the old agent endpoint that buyers could use to understand what a format looks like. `sample_render_url` restores the static discovery experience without conflating it with dynamic preview.

Three concepts remain deliberately separate:

1. `sample_render_url`: static human-facing example implemented here.
2. Future renderer discovery: an authorized agent capable of rendering buyer manifests.
3. Future canonical `preview_creative.format_context`: context for resolving `format_kind` and `format_option_ref`.

## Changes

- Adds optional HTTPS `sample_render_url` to canonical format declarations with a minor protocol changeset.
- Documents declaration-scoped authority, same-file placement inheritance, product behavior, and the boundary from dynamic buyer-asset preview.
- Exposes normalized sample URLs in the registry publisher API and generated OpenAPI schema.
- Loads Mintlify API pages from the project's hosted OpenAPI document, avoiding GitHub's truncated recursive-tree response for this large repository.
- Adds an accessible format-details dialog and explicit user-initiated external navigation.
- Rejects non-HTTPS and credential-bearing URLs in the registry/browser consumers; displays the destination host and suppresses opener/referrer information.
- Adds full `adagents.json`, registry hydration, browser security, and negative URL coverage.

## Validation

- [x] `node --test --test-force-exit --test-timeout=30000 tests/placement-catalog-schema.test.cjs` — 14 passed
- [x] `node tests/schema-validation.test.cjs` — 20 passed
- [x] `vitest run server/tests/unit/client-security-wiring.test.ts` — 7 passed
- [x] `vitest run server/tests/integration/registry-publisher-brand-json-hydration.test.ts` — 27 passed
- [x] TypeScript typecheck
- [x] OpenAPI generation is current
- [x] Schema build
- [x] Docs navigation and schema-link checks
- [x] Changeset protocol-scope checks
- [x] Inline publisher-page script parse
- [x] `git diff --check`
- [x] Fresh GitHub CI — all 32 checks pass, including Mintlify preview deployment

## Follow-ups

- Define renderer discovery separately from this static sample URL.
- Extend `preview_creative` with canonical format context for buyer-asset rendering, especially product-local references.
