### PR TITLE
fix(addie): repair domain split handling

### DIFF
--- a/docs/aao/addie-tools.mdx
+++ b/docs/aao/addie-tools.mdx
@@ -134,13 +134,13 @@ If the brand domain was previously registered by another organization, the tool 
 
 ### `request_brand_domain_challenge`
 
-Issue a DNS TXT challenge so the caller's organization can claim a brand domain currently registered to another org or unregistered. Returns the verification record (Name/Type/Value) for the user to publish at their DNS host. DO NOT use when: the domain is already owned by the caller's org (already linked in their member profile); the user is just asking what their domain is; the user is asking generic 'is my domain set up?' questions. Pair with verify_brand_domain_challenge ONLY after the user confirms they've published the record. Response begins with an HTML comment '&lt;!-- STATUS: &lt;code> -->' for machine parsing (invisible in rendered markdown) — codes: dns_record_issued, already_verified, collision, invalid_domain, workos_error, not_authenticated, no_org, not_admin, missing_domain.
+Issue a DNS TXT challenge so the caller's selected organization can claim a brand domain currently registered to another org or unregistered. Returns the verification record (Name/Type/Value) for the user to publish at their DNS host. DO NOT use when: the domain is already owned by the caller's org (already linked in their member profile); the user is just asking what their domain is; the user is asking generic 'is my domain set up?' questions. If the caller belongs to multiple organizations, or the current org is a personal workspace while the domain matches a company org, STOP and ask them to choose the company organization_id before issuing a challenge. Pair with verify_brand_domain_challenge ONLY after the user confirms they've published the record. Response begins with an HTML comment '&lt;!-- STATUS: &lt;code> -->' for machine parsing (invisible in rendered markdown) — codes: dns_record_issued, already_verified, collision, invalid_domain, workos_error, not_authenticated, no_org, org_selection_required, not_admin, missing_domain.
 
 *Source: `server/src/addie/mcp/member-tools.ts`*
 
 ### `verify_brand_domain_challenge`
 
-Run the WorkOS DNS lookup against a previously-issued challenge and, on success, apply the brand-registry update. ONLY call after request_brand_domain_challenge returned DNS instructions in this same conversation AND the user has explicitly confirmed they published the record. NEVER call speculatively, as a 'check status' tool, or in a retry loop — DNS propagation takes minutes and the server enforces a cooldown that will return still_pending if you call again too soon. If the call returns still_pending, STOP and ask the user to confirm before any retry. Response begins with an HTML comment '&lt;!-- STATUS: &lt;code> -->' (invisible in rendered markdown) — codes: verified, still_pending, no_challenge, workos_error, not_authenticated, no_org, not_admin, missing_domain. After 'verified' the claim is complete; after 'still_pending' STOP and ask the user to confirm before retrying.
+Run the WorkOS DNS lookup against a previously-issued challenge for the selected organization and, on success, apply the brand-registry update. ONLY call after request_brand_domain_challenge returned DNS instructions in this same conversation AND the user has explicitly confirmed they published the record. NEVER call speculatively, as a 'check status' tool, or in a retry loop — DNS propagation takes minutes and the server enforces a cooldown that will return still_pending if you call again too soon. If the call returns still_pending, STOP and ask the user to confirm before any retry. Response begins with an HTML comment '&lt;!-- STATUS: &lt;code> -->' (invisible in rendered markdown) — codes: verified, still_pending, no_challenge, workos_error, not_authenticated, no_org, org_selection_required, not_admin, missing_domain. After 'verified' the claim is complete; after 'still_pending' STOP and ask the user to confirm before retrying.
 
 *Source: `server/src/addie/mcp/member-tools.ts`*
 
@@ -1038,7 +1038,7 @@ Check domain health for data quality issues: orphan domains, conflicts, misalign
 
 ### `manage_organization_domains`
 
-Add, remove, or list verified domains for an organization. Syncs to WorkOS.
+Add, remove, list, set primary, or reconcile verified domains for an organization. Syncs to WorkOS.
 
 *Source: `server/src/addie/mcp/admin-tools.ts`*
 

--- a/docs/building/operating/support-recovery-runbooks.mdx
+++ b/docs/building/operating/support-recovery-runbooks.mdx
@@ -57,6 +57,23 @@ Use admin domain verification recovery when a member has published the WorkOS DN
 
 This is an internal support workflow. Use authenticated admin domain tooling or the private ops runbook; public docs should not expose admin endpoint paths, bearer-token examples, or WorkOS challenge-token handling.
 
+Before closing a registry/domain escalation as resolved, confirm the registry state, not just the AAO UI:
+
+- The target domain has a local `organization_domains` row for the intended org.
+- That row is `verified=true`.
+- The row is not attached to the member's personal workspace when the support request is for a company org.
+- The registry no longer returns `member:null` for the relevant domain.
+- The requested agent hostname is covered by a verified domain row on the registering org.
+
+If WorkOS shows a verified domain but the local rows are missing, stale, or attached to another org, run the WorkOS-domain reconciliation action for the intended org. This replays WorkOS as the source of truth, mirrors domains into `organization_domains`, and re-runs brand-registry sync for verified domains. It does not bypass DNS verification; WorkOS still has to know the domain/challenge first.
+
+For personal-workspace/company-org split incidents, run the read-only admin preview first:
+
+- Use the private domain-split preview from the internal ops runbook or admin UI.
+- The preview reports WorkOS state, local `organization_domains`, member-profile presence, org membership, and the next safe action.
+- Only run the reconciliation action when the preview says WorkOS already verifies the domain for the company org.
+- If billing appears attached to the personal workspace, use the separate Stripe customer preview/confirm workflow after human review; do not move billing in the domain repair path.
+
 Outcomes:
 
 - `success: true`: WorkOS confirmed DNS and local `organization_domains` was reconciled.
@@ -64,6 +81,8 @@ Outcomes:
 - `no_challenge`: issue a new domain challenge from the member domain settings or admin domain tooling.
 
 DNS propagation normally takes minutes, but stale provider caches can last longer. Do not keep retrying every few seconds; fix the DNS record and retry after propagation.
+
+If the request is invalid or suspicious, close it as `wont_do` with notes. Do not mark a registry/domain escalation `resolved` while the local domain row is missing, unverified, or attached to the wrong org.
 
 ## Registry and heartbeat recovery
 

--- a/server/src/addie/jobs/github-filer.ts
+++ b/server/src/addie/jobs/github-filer.ts
@@ -6,6 +6,7 @@
  */
 
 import { createLogger } from '../../logger.js';
+import { redactSupportSecrets } from '../../services/support-redaction.js';
 
 const logger = createLogger('github-filer');
 
@@ -51,8 +52,8 @@ export async function fileGitHubIssue(input: FileIssueInput): Promise<FiledIssue
         'User-Agent': 'aao-escalation-triage/1.0',
       },
       body: JSON.stringify({
-        title: input.title,
-        body: input.body,
+        title: redactSupportSecrets(input.title) ?? '',
+        body: redactSupportSecrets(input.body) ?? '',
         labels: input.labels ?? [],
       }),
     });

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -133,6 +133,7 @@ import {
   buildResolutionNotificationMessage,
   type EscalationStatus,
 } from "../../db/escalation-db.js";
+import { guardEscalationResolution } from "../../services/escalation-resolution-guard.js";
 import { sendDirectMessage } from "../../slack/client.js";
 import { sendEscalationResolutionEmail } from "../../notifications/email.js";
 import {
@@ -1409,14 +1410,14 @@ Actions:
   {
     name: "manage_organization_domains",
     description:
-      "Add, remove, or list verified domains for an organization. Syncs to WorkOS.",
-    usage_hints: 'Use "list" first. Add/remove sync to WorkOS.',
+      "Add, remove, list, set primary, or reconcile verified domains for an organization. Syncs to WorkOS.",
+    usage_hints: 'Use "list" first. Use "reconcile_workos" when WorkOS and local organization_domains are out of sync.',
     input_schema: {
       type: "object" as const,
       properties: {
         action: {
           type: "string",
-          enum: ["list", "add", "remove", "set_primary"],
+          enum: ["list", "add", "remove", "set_primary", "reconcile_workos"],
           description: "Action",
         },
         organization_id: {
@@ -7600,6 +7601,28 @@ Use add_committee_leader to assign a leader.`;
           return response;
         }
 
+        case "reconcile_workos": {
+          const { reconcileWorkosOrganizationDomains } = await import("../../services/workos-domain-reconciliation.js");
+          const result = await reconcileWorkosOrganizationDomains({ workos, orgId: organizationId });
+          const invalidate = await import("../member-context.js").then((m) => m.invalidateMemberContextCache).catch(() => null);
+          invalidate?.();
+
+          let response = `## WorkOS domain reconciliation for ${orgName}\n\n`;
+          response += `WorkOS domains: ${result.workos_domains.length}\n`;
+          response += `Before mismatches: ${result.before_mismatches.length}\n`;
+          response += `After mismatches: ${result.after_mismatches.length}\n`;
+          response += `Changed local state: ${result.changed ? "yes" : "no"}\n`;
+          if (result.after_mismatches.length > 0) {
+            response += `\nRemaining blockers:\n`;
+            for (const mismatch of result.after_mismatches) {
+              response += `- ${mismatch.domain}: ${mismatch.reason} (WorkOS: ${mismatch.workos_state})\n`;
+            }
+          } else {
+            response += `\nLocal organization_domains now mirrors WorkOS for this org's domains.`;
+          }
+          return response;
+        }
+
         case "add": {
           if (!domain) {
             return '❌ domain is required for the "add" action. Example: "acme.com"';
@@ -10074,6 +10097,19 @@ Use add_committee_leader to assign a leader.`;
 
       if (escalation.status === "resolved" || escalation.status === "wont_do") {
         return `ℹ️ Escalation #${escalationId} is already ${escalation.status}.`;
+      }
+
+      const guard = await guardEscalationResolution({ escalation, status });
+      if (!guard.ok) {
+        const blockers = guard.blockers
+          .map((b) => `- ${b.domain ? `${b.domain}: ` : ""}${b.message}`)
+          .join("\n");
+        return (
+          `❌ Escalation #${escalationId} looks like registry/domain propagation work, ` +
+          `but local registry state is not resolved yet.\n\n${blockers}\n\n` +
+          `Use manage_organization_domains with action "reconcile_workos" or the admin domain verify recovery path, then retry. ` +
+          `If the request is invalid or malicious, resolve it as wont_do instead.`
+        );
       }
 
       // Get resolver info

--- a/server/src/addie/mcp/escalation-tools.ts
+++ b/server/src/addie/mcp/escalation-tools.ts
@@ -22,6 +22,7 @@ import {
 import { getThreadService } from '../thread-service.js';
 import { sendChannelMessage } from '../../slack/client.js';
 import { getEscalationChannel } from '../../db/system-settings-db.js';
+import { redactSupportSecrets } from '../../services/support-redaction.js';
 
 const logger = createLogger('addie-escalation-tools');
 
@@ -281,11 +282,11 @@ export function createEscalationToolHandlers(
       throw new ToolError(`priority must be one of: ${validPriorities.join(', ')}`);
     }
 
-    const summary = input.summary as string;
+    const summary = redactSupportSecrets(input.summary as string) ?? '';
     const category = input.category as EscalationCategory;
     const priority = (input.priority as EscalationPriority) || 'normal';
-    const originalRequest = input.original_request as string | undefined;
-    const addieContext = input.addie_context as string | undefined;
+    const originalRequest = redactSupportSecrets(input.original_request as string | undefined);
+    const addieContext = redactSupportSecrets(input.addie_context as string | undefined);
     const userEmail = input.user_email as string | undefined;
     const userSlackHandle = input.user_slack_handle as string | undefined;
     const perspectiveId = input.perspective_id as string | undefined;

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -133,6 +133,10 @@ import { getWorkos } from '../../auth/workos-client.js';
 import { resolveUserRole } from '../../utils/resolve-user-role.js';
 import { recordAgentTestRun } from '../../db/agent-test-db.js';
 import { canonicalizeAgentUrl } from '../../db/publisher-db.js';
+import {
+  guardPersonalWorkspaceDomainSelection,
+  type PersonalWorkspaceDomainSelectionResult,
+} from '../../services/org-selection-guard.js';
 
 const logger = createLogger('addie-member-tools');
 const complianceTarget = hostedComplianceTarget();
@@ -982,8 +986,57 @@ function formatOrgChoice(org: { organizationId: string; name?: string | null }):
 }
 
 type SaveAgentOrgResolution =
-  | { ok: true; organizationId: string; organizationName: string | null }
+  | {
+      ok: true;
+      organizationId: string;
+      organizationName: string | null;
+      organizationIsPersonal?: boolean | null;
+    }
   | { ok: false; message: string };
+
+function memberContextForOrgGuard(
+  memberContext: MemberContext,
+  orgResolution: Extract<SaveAgentOrgResolution, { ok: true }>,
+): MemberContext {
+  if (typeof orgResolution.organizationIsPersonal !== 'boolean') {
+    return memberContext;
+  }
+
+  return {
+    ...memberContext,
+    organization: {
+      ...memberContext.organization,
+      workos_organization_id: orgResolution.organizationId,
+      name: orgResolution.organizationName ?? memberContext.organization?.name ?? '',
+      subscription_status: memberContext.organization?.subscription_status ?? null,
+      is_personal: orgResolution.organizationIsPersonal,
+      membership_tier: memberContext.organization?.membership_tier ?? null,
+    },
+  };
+}
+
+function agentUrlBaseDomain(agentUrl: string): string | null {
+  try {
+    return canonicalizeBrandDomain(new URL(agentUrl).hostname);
+  } catch {
+    return null;
+  }
+}
+
+function formatOrgSelectionRequiredMessage(
+  result: Extract<PersonalWorkspaceDomainSelectionResult, { ok: false }>,
+  action: string,
+): string {
+  const choices = result.companyOrgs.map(formatOrgChoice).join(', ');
+  const selectedName = result.selectedOrg.name
+    ? formatOrgNameForTool(result.selectedOrg.name)
+    : result.selectedOrg.organizationId;
+  return (
+    `I need you to choose the company organization before I ${action}. ` +
+    `Right now the selected organization is your personal workspace (${selectedName}), but ${result.domain} matches company org ${choices}. ` +
+    `Reply with the organization_id for the company org, or select it in the dashboard, and I will continue there. I will not issue domain challenges or save agents against the personal workspace for this company domain.`
+  );
+}
 
 type ActiveSaveAgentMembership = {
   userId: string;
@@ -1037,6 +1090,7 @@ async function listActiveWorkosMembershipsForSaveAgent(
 async function resolveSaveAgentOrganization(
   memberContext: MemberContext,
   input: Record<string, unknown>,
+  actionLabel = 'save to',
 ): Promise<SaveAgentOrgResolution> {
   const workosUserId = memberContext.workos_user?.workos_user_id;
   if (!workosUserId) {
@@ -1052,7 +1106,7 @@ async function resolveSaveAgentOrganization(
   if (requestedOrgId && requestedOrgName) {
     return {
       ok: false,
-      message: 'Use either organization_id or organization_name for save_agent, not both.',
+      message: `Use either organization_id or organization_name to ${actionLabel}, not both.`,
     };
   }
 
@@ -1061,20 +1115,21 @@ async function resolveSaveAgentOrganization(
     if (!contextOrgId) {
       return {
         ok: false,
-        message: 'This feature requires an organization. If you belong to multiple organizations, say which one to save to, or use the organization_id / organization_name field.',
+        message: `This feature requires an organization. If you belong to multiple organizations, say which one to ${actionLabel}, or use the organization_id / organization_name field.`,
       };
     }
     const activeMemberships = await listActiveWorkosMembershipsForSaveAgent(workosUserId, contextOrgId);
     if (activeMemberships.length === 0) {
       return {
         ok: false,
-        message: `I can't save to ${contextOrgId} because your account is not an active member of that organization.`,
+        message: `I can't ${actionLabel} ${contextOrgId} because your account is not an active member of that organization.`,
       };
     }
     return {
       ok: true,
       organizationId: contextOrgId,
       organizationName: memberContext.organization?.name || null,
+      organizationIsPersonal: memberContext.organization?.is_personal ?? null,
     };
   }
 
@@ -1089,7 +1144,7 @@ async function resolveSaveAgentOrganization(
     if (activeOrgIds.length === 0) {
       return {
         ok: false,
-        message: `I can't save to ${requestedOrgId} because your account is not an active member of that organization.`,
+        message: `I can't ${actionLabel} ${requestedOrgId} because your account is not an active member of that organization.`,
       };
     }
     const org = await orgDb.getOrganization(requestedOrgId).catch(() => null);
@@ -1101,6 +1156,7 @@ async function resolveSaveAgentOrganization(
       ok: true,
       organizationId: requestedOrgId,
       organizationName: org?.name || workosOrg?.name || ambientOrgName || null,
+      organizationIsPersonal: org?.is_personal ?? null,
     };
   }
 
@@ -1111,7 +1167,7 @@ async function resolveSaveAgentOrganization(
       const workosOrg = await getWorkos().organizations.getOrganization(organizationId).catch(() => null);
       name = workosOrg?.name ?? null;
     }
-    return { organizationId, name };
+    return { organizationId, name, isPersonal: localOrg?.is_personal ?? null };
   }));
 
   const requestedName = normalizeOrgNameForMatch(requestedOrgName!);
@@ -1125,6 +1181,7 @@ async function resolveSaveAgentOrganization(
       ok: true,
       organizationId: matches[0].organizationId,
       organizationName: matches[0].name ?? null,
+      organizationIsPersonal: matches[0].isPersonal ?? null,
     };
   }
 
@@ -1140,8 +1197,8 @@ async function resolveSaveAgentOrganization(
   return {
     ok: false,
     message: visibleChoices
-      ? `I couldn't find an active organization named "${sanitizeInline(requestedOrgName!)}" for your account. Active organizations I can save to: ${visibleChoices}.`
-      : `I couldn't find any active organizations for your account, so I can't save to "${sanitizeInline(requestedOrgName!)}".`,
+      ? `I couldn't find an active organization named "${sanitizeInline(requestedOrgName!)}" for your account. Active organizations I can ${actionLabel}: ${visibleChoices}.`
+      : `I couldn't find any active organizations for your account, so I can't ${actionLabel} "${sanitizeInline(requestedOrgName!)}".`,
   };
 }
 
@@ -1421,8 +1478,8 @@ export const MEMBER_TOOLS: AddieTool[] = [
   {
     name: 'request_brand_domain_challenge',
     description:
-      "Issue a DNS TXT challenge so the caller's organization can claim a brand domain currently registered to another org or unregistered. Returns the verification record (Name/Type/Value) for the user to publish at their DNS host. DO NOT use when: the domain is already owned by the caller's org (already linked in their member profile); the user is just asking what their domain is; the user is asking generic 'is my domain set up?' questions. Pair with verify_brand_domain_challenge ONLY after the user confirms they've published the record. Response begins with an HTML comment '<!-- STATUS: <code> -->' for machine parsing (invisible in rendered markdown) — codes: dns_record_issued, already_verified, collision, invalid_domain, workos_error, not_authenticated, no_org, not_admin, missing_domain.",
-    usage_hints: 'Use when the user explicitly asks to claim a domain they control but cannot link (cross-org dispute, "claim nike.com for us"). Do NOT call speculatively or as a status check.',
+      "Issue a DNS TXT challenge so the caller's selected organization can claim a brand domain currently registered to another org or unregistered. Returns the verification record (Name/Type/Value) for the user to publish at their DNS host. DO NOT use when: the domain is already owned by the caller's org (already linked in their member profile); the user is just asking what their domain is; the user is asking generic 'is my domain set up?' questions. If the caller belongs to multiple organizations, or the current org is a personal workspace while the domain matches a company org, STOP and ask them to choose the company organization_id before issuing a challenge. Pair with verify_brand_domain_challenge ONLY after the user confirms they've published the record. Response begins with an HTML comment '<!-- STATUS: <code> -->' for machine parsing (invisible in rendered markdown) — codes: dns_record_issued, already_verified, collision, invalid_domain, workos_error, not_authenticated, no_org, org_selection_required, not_admin, missing_domain.",
+    usage_hints: 'Use when the user explicitly asks to claim a domain they control but cannot link (cross-org dispute, "claim nike.com for us"). Do NOT call speculatively or as a status check. Include organization_id when the user has selected a specific org.',
     input_schema: {
       type: 'object',
       properties: {
@@ -1430,6 +1487,8 @@ export const MEMBER_TOOLS: AddieTool[] = [
           type: 'string',
           description: 'The brand domain to claim (e.g., "acme.com"). The caller must control DNS for this domain.',
         },
+        organization_id: { type: 'string', description: 'Optional explicit WorkOS organization ID to issue the challenge under. Required when the caller must choose between a personal workspace and a company org.' },
+        organization_name: { type: 'string', description: 'Optional explicit organization name. Must match exactly one active organization for the caller. Prefer organization_id when available.' },
       },
       required: ['domain'],
     },
@@ -1437,8 +1496,8 @@ export const MEMBER_TOOLS: AddieTool[] = [
   {
     name: 'verify_brand_domain_challenge',
     description:
-      "Run the WorkOS DNS lookup against a previously-issued challenge and, on success, apply the brand-registry update. ONLY call after request_brand_domain_challenge returned DNS instructions in this same conversation AND the user has explicitly confirmed they published the record. NEVER call speculatively, as a 'check status' tool, or in a retry loop — DNS propagation takes minutes and the server enforces a cooldown that will return still_pending if you call again too soon. If the call returns still_pending, STOP and ask the user to confirm before any retry. Response begins with an HTML comment '<!-- STATUS: <code> -->' (invisible in rendered markdown) — codes: verified, still_pending, no_challenge, workos_error, not_authenticated, no_org, not_admin, missing_domain. After 'verified' the claim is complete; after 'still_pending' STOP and ask the user to confirm before retrying.",
-    usage_hints: 'Use only after the user confirms publication. Pass adopt_prior_manifest=true ONLY when the prior request_brand_domain_challenge response indicated prior_manifest_exists=true AND the user explicitly asked to inherit the prior identity (acquisition/handoff case). Default false.',
+      "Run the WorkOS DNS lookup against a previously-issued challenge for the selected organization and, on success, apply the brand-registry update. ONLY call after request_brand_domain_challenge returned DNS instructions in this same conversation AND the user has explicitly confirmed they published the record. NEVER call speculatively, as a 'check status' tool, or in a retry loop — DNS propagation takes minutes and the server enforces a cooldown that will return still_pending if you call again too soon. If the call returns still_pending, STOP and ask the user to confirm before any retry. Response begins with an HTML comment '<!-- STATUS: <code> -->' (invisible in rendered markdown) — codes: verified, still_pending, no_challenge, workos_error, not_authenticated, no_org, org_selection_required, not_admin, missing_domain. After 'verified' the claim is complete; after 'still_pending' STOP and ask the user to confirm before retrying.",
+    usage_hints: 'Use only after the user confirms publication. Include organization_id when the original challenge was issued under a selected org. Pass adopt_prior_manifest=true ONLY when the prior request_brand_domain_challenge response indicated prior_manifest_exists=true AND the user explicitly asked to inherit the prior identity (acquisition/handoff case). Default false.',
     input_schema: {
       type: 'object',
       properties: {
@@ -1446,6 +1505,8 @@ export const MEMBER_TOOLS: AddieTool[] = [
           type: 'string',
           description: 'The brand domain being verified.',
         },
+        organization_id: { type: 'string', description: 'Optional explicit WorkOS organization ID for the challenge to verify. Use the same org that issued the challenge.' },
+        organization_name: { type: 'string', description: 'Optional explicit organization name. Must match exactly one active organization for the caller. Prefer organization_id when available.' },
         adopt_prior_manifest: {
           type: 'boolean',
           description: 'Set true ONLY when the issue response had prior_manifest_exists=true AND the user explicitly asked to keep the existing brand record (logos, colors, agents). Default false starts fresh — this is the right choice for most claims, including reclaiming a domain from a squatter or first-time registration.',
@@ -3070,16 +3131,25 @@ export function createMemberToolHandlers(
     if (!memberContext?.workos_user?.workos_user_id) {
       return '<!-- STATUS: not_authenticated -->\n\nYou need to be logged in to claim a brand domain. Please sign in at https://agenticadvertising.org and try again.';
     }
-    const orgId = memberContext.organization?.workos_organization_id;
-    if (!orgId) {
-      return '<!-- STATUS: no_org -->\n\nYour account isn\'t linked to an organization yet. Set up your company on https://agenticadvertising.org/member-profile first.';
+    const rawDomain = typeof input.domain === 'string' ? input.domain.trim() : '';
+    if (!rawDomain) return '<!-- STATUS: missing_domain -->\n\nTell me the brand domain you want to claim (e.g., "acme.com").';
+
+    const orgResolution = await resolveSaveAgentOrganization(memberContext, input, 'issue a DNS challenge under');
+    if (!orgResolution.ok) {
+      return `<!-- STATUS: no_org -->\n\n${orgResolution.message}`;
+    }
+    const orgId = orgResolution.organizationId;
+    const orgGuard = await guardPersonalWorkspaceDomainSelection({
+      memberContext: memberContextForOrgGuard(memberContext, orgResolution),
+      selectedOrgId: orgId,
+      rawDomain,
+    });
+    if (!orgGuard.ok) {
+      return `<!-- STATUS: org_selection_required -->\n\n${formatOrgSelectionRequiredMessage(orgGuard, `issue a DNS challenge for ${rawDomain}`)}`;
     }
     if (!(await callerIsOrgAdmin(memberContext.workos_user.workos_user_id, orgId))) {
       return '<!-- STATUS: not_admin -->\n\nOnly your organization\'s admin or owner can claim a brand domain. Ask one of them to run this.';
     }
-
-    const rawDomain = typeof input.domain === 'string' ? input.domain.trim() : '';
-    if (!rawDomain) return '<!-- STATUS: missing_domain -->\n\nTell me the brand domain you want to claim (e.g., "acme.com").';
 
     const result = await issueDomainChallenge({ workos: getWorkos(), brandDb, orgId, rawDomain });
 
@@ -3121,6 +3191,8 @@ export function createMemberToolHandlers(
       `- Value: \`${result.verification_token}\``,
       `- TTL: \`300\` (or your registrar's minimum)`,
       ``,
+      `Organization: ${orgResolution.organizationName ? `${formatOrgNameForTool(orgResolution.organizationName)} (${orgId})` : orgId}`,
+      ``,
       `DNS propagation usually takes 5–15 minutes; some registrars take an hour. Once you've published it AND confirmed it's live, tell me and I'll run \`verify_brand_domain_challenge\`. Don't ask me to verify before then — the call will just fail and the server enforces a 60s cooldown between attempts.`,
     ];
     if (result.prior_manifest_exists) {
@@ -3136,17 +3208,26 @@ export function createMemberToolHandlers(
     if (!memberContext?.workos_user?.workos_user_id) {
       return '<!-- STATUS: not_authenticated -->\n\nYou need to be logged in to verify a brand domain claim.';
     }
-    const orgId = memberContext.organization?.workos_organization_id;
-    if (!orgId) {
-      return '<!-- STATUS: no_org -->\n\nYour account isn\'t linked to an organization yet.';
+    const rawDomain = typeof input.domain === 'string' ? input.domain.trim() : '';
+    if (!rawDomain) return '<!-- STATUS: missing_domain -->\n\nWhich domain should I verify? Pass the domain you ran `request_brand_domain_challenge` for.';
+    const adoptPriorManifest = input.adopt_prior_manifest === true;
+
+    const orgResolution = await resolveSaveAgentOrganization(memberContext, input, 'verify a DNS challenge under');
+    if (!orgResolution.ok) {
+      return `<!-- STATUS: no_org -->\n\n${orgResolution.message}`;
+    }
+    const orgId = orgResolution.organizationId;
+    const orgGuard = await guardPersonalWorkspaceDomainSelection({
+      memberContext: memberContextForOrgGuard(memberContext, orgResolution),
+      selectedOrgId: orgId,
+      rawDomain,
+    });
+    if (!orgGuard.ok) {
+      return `<!-- STATUS: org_selection_required -->\n\n${formatOrgSelectionRequiredMessage(orgGuard, `verify ${rawDomain}`)}`;
     }
     if (!(await callerIsOrgAdmin(memberContext.workos_user.workos_user_id, orgId))) {
       return '<!-- STATUS: not_admin -->\n\nOnly your organization\'s admin or owner can verify a brand domain claim.';
     }
-
-    const rawDomain = typeof input.domain === 'string' ? input.domain.trim() : '';
-    if (!rawDomain) return '<!-- STATUS: missing_domain -->\n\nWhich domain should I verify? Pass the domain you ran `request_brand_domain_challenge` for.';
-    const adoptPriorManifest = input.adopt_prior_manifest === true;
 
     const result = await verifyDomainChallenge({
       workos: getWorkos(),
@@ -6727,6 +6808,18 @@ export function createMemberToolHandlers(
     // rather than `string | null` — TS can't carry the narrowing across the
     // function boundary.
     const agentUrl: string = canonical;
+
+    const agentDomain = agentUrlBaseDomain(agentUrl);
+    if (agentDomain) {
+      const orgGuard = await guardPersonalWorkspaceDomainSelection({
+        memberContext: memberContextForOrgGuard(memberContext, saveOrg),
+        selectedOrgId: saveOrgId,
+        rawDomain: agentDomain,
+      });
+      if (!orgGuard.ok) {
+        return formatOrgSelectionRequiredMessage(orgGuard, `save agent ${agentUrl}`);
+      }
+    }
 
     // Hostname ownership check (#4499 MVP). Mirrors the REST POST
     // /api/me/agents gate. See `agent-hostname-verification.ts` for the

--- a/server/src/audit/integrity/invariants/index.ts
+++ b/server/src/audit/integrity/invariants/index.ts
@@ -18,17 +18,21 @@ import { workosMembershipRowExistsInWorkosInvariant } from './workos-membership-
 import { usersHavePrimaryOrganizationInvariant } from './users-have-primary-organization.js';
 import { everyEntitledOrgHasResolvableTierInvariant } from './every-entitled-org-has-resolvable-tier.js';
 import { uniqueOrgPerEmailDomainInvariant } from './unique-org-per-email-domain.js';
+import { workosVerifiedDomainsMirroredInvariant } from './workos-verified-domains-mirrored.js';
+import { personalMemberCompanyOrgSplitInvariant } from './personal-member-company-org-split.js';
 
 export const ALL_INVARIANTS: readonly Invariant[] = [
   // DB-only checks first (no external API calls).
   usersHavePrimaryOrganizationInvariant,
   uniqueOrgPerEmailDomainInvariant,
+  personalMemberCompanyOrgSplitInvariant,
   everyEntitledOrgHasResolvableTierInvariant,
   stripeCustomerOrgMetadataBidirectionalInvariant,
   oneActiveStripeSubPerOrgInvariant,
   stripeCustomerResolvesInvariant,
   orgRowMatchesLiveStripeSubInvariant,
   stripeSubReflectedInOrgRowInvariant,
+  workosVerifiedDomainsMirroredInvariant,
   workosMembershipRowExistsInWorkosInvariant,
 ];
 

--- a/server/src/audit/integrity/invariants/personal-member-company-org-split.ts
+++ b/server/src/audit/integrity/invariants/personal-member-company-org-split.ts
@@ -1,0 +1,101 @@
+/**
+ * Invariant: an active paid personal workspace should not be the place where a
+ * domain is being verified when the same user also belongs to a non-personal
+ * company org for that domain.
+ *
+ * This catches the "paid individual workspace vs. company prospect org" split
+ * that makes UI membership look active while registry/domain operations target
+ * the wrong org.
+ */
+import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
+
+interface SplitRow {
+  personal_org_id: string;
+  personal_org_name: string;
+  company_org_id: string;
+  company_org_name: string;
+  domain: string;
+  domain_verified: boolean;
+  user_email: string;
+  company_member_status: string | null;
+  company_subscription_status: string | null;
+}
+
+export const personalMemberCompanyOrgSplitInvariant: Invariant = {
+  name: 'personal-member-company-org-split',
+  description:
+    'Flags active paid personal workspaces that hold or are verifying a domain for a company org the same user owns/belongs to. Prevents Addie and support from mistaking personal membership for company registry readiness.',
+  severity: 'warning',
+  async check(ctx: InvariantContext): Promise<InvariantResult> {
+    const { pool } = ctx;
+
+    const result = await pool.query<SplitRow>(`
+      WITH live_personal_orgs AS (
+        SELECT workos_organization_id, name
+        FROM organizations
+        WHERE COALESCE(is_personal, false) = true
+          AND (
+            subscription_status IN ('active', 'trialing', 'past_due')
+            OR member_status = 'member'
+          )
+      )
+      SELECT DISTINCT
+        po.workos_organization_id AS personal_org_id,
+        po.name AS personal_org_name,
+        co.workos_organization_id AS company_org_id,
+        co.name AS company_org_name,
+        pod.domain,
+        pod.verified AS domain_verified,
+        pom.email AS user_email,
+        co.member_status AS company_member_status,
+        co.subscription_status AS company_subscription_status
+      FROM live_personal_orgs po
+      JOIN organization_domains pod
+        ON pod.workos_organization_id = po.workos_organization_id
+      JOIN organization_memberships pom
+        ON pom.workos_organization_id = po.workos_organization_id
+       AND pom.email IS NOT NULL
+      JOIN organizations co
+        ON COALESCE(co.is_personal, false) = false
+       AND co.workos_organization_id <> po.workos_organization_id
+       AND (
+         LOWER(co.email_domain) = LOWER(pod.domain)
+         OR EXISTS (
+           SELECT 1
+           FROM organization_domains cod
+           WHERE cod.workos_organization_id = co.workos_organization_id
+             AND LOWER(cod.domain) = LOWER(pod.domain)
+         )
+       )
+      JOIN organization_memberships com
+        ON com.workos_organization_id = co.workos_organization_id
+       AND LOWER(com.email) = LOWER(pom.email)
+    `);
+
+    const violations: Violation[] = result.rows.map((row) => ({
+      invariant: 'personal-member-company-org-split',
+      severity: 'warning',
+      subject_type: 'organization',
+      subject_id: row.company_org_id,
+      message:
+        `User ${row.user_email} has active personal workspace "${row.personal_org_name}" ` +
+        `holding domain ${row.domain}, while also belonging to company org "${row.company_org_name}". ` +
+        'Registry/domain setup may be targeting the personal workspace instead of the company org.',
+      details: {
+        domain: row.domain,
+        domain_verified: row.domain_verified,
+        user_email: row.user_email,
+        personal_org_id: row.personal_org_id,
+        personal_org_name: row.personal_org_name,
+        company_org_id: row.company_org_id,
+        company_org_name: row.company_org_name,
+        company_member_status: row.company_member_status,
+        company_subscription_status: row.company_subscription_status,
+      },
+      remediation_hint:
+        `Decide the canonical org for ${row.domain}. If it is ${row.company_org_id}, move/replace the paid membership and domain claim there before registering agents.`,
+    }));
+
+    return { checked: result.rows.length, violations };
+  },
+};

--- a/server/src/audit/integrity/invariants/workos-verified-domains-mirrored.ts
+++ b/server/src/audit/integrity/invariants/workos-verified-domains-mirrored.ts
@@ -1,0 +1,157 @@
+/**
+ * Invariant (sampled): verified WorkOS organization domains are mirrored into
+ * local organization_domains as verified rows for the same org.
+ *
+ * WorkOS is the DNS proof-of-control source of truth. The local table gates
+ * registry membership, brand sync, and save_agent hostname ownership. If a
+ * WorkOS verified domain is missing locally, attached to a different org, or
+ * still marked unverified, the member sees "member:null" / save_agent blocked
+ * even though WorkOS has already accepted DNS verification.
+ */
+import type { Invariant, InvariantContext, InvariantResult, Violation } from '../types.js';
+
+const DEFAULT_SAMPLE_SIZE = 200;
+
+interface OrgRow {
+  workos_organization_id: string;
+  name: string;
+}
+
+interface LocalDomainRow {
+  domain: string;
+  workos_organization_id: string;
+  org_name: string | null;
+  verified: boolean;
+  is_primary: boolean;
+}
+
+export const workosVerifiedDomainsMirroredInvariant: Invariant = {
+  name: 'workos-verified-domains-mirrored',
+  description:
+    'Sampled organizations with WorkOS-verified domains must have matching verified local organization_domains rows. Catches missed WorkOS domain webhooks and local domain ownership drift that blocks registry membership and save_agent.',
+  severity: 'critical',
+  async check(ctx: InvariantContext): Promise<InvariantResult> {
+    const { pool, workos, logger, options } = ctx;
+    const sampleSize = options?.sampleSize ?? DEFAULT_SAMPLE_SIZE;
+    const violations: Violation[] = [];
+
+    const orgs = await pool.query<OrgRow>(
+      `SELECT workos_organization_id, name
+         FROM organizations
+        WHERE workos_organization_id IS NOT NULL
+        ORDER BY RANDOM()
+        LIMIT $1`,
+      [sampleSize],
+    );
+
+    for (const org of orgs.rows) {
+      try {
+        const workosOrg = await workos.organizations.getOrganization(org.workos_organization_id);
+        const verifiedDomains = workosOrg.domains
+          .filter((d) => String(d.state) === 'verified' || String(d.state) === 'legacy_verified')
+          .map((d) => d.domain.toLowerCase());
+        if (verifiedDomains.length === 0) continue;
+
+        const local = await pool.query<LocalDomainRow>(
+          `SELECT
+             od.domain,
+             od.workos_organization_id,
+             o.name AS org_name,
+             od.verified,
+             od.is_primary
+           FROM organization_domains od
+           LEFT JOIN organizations o ON o.workos_organization_id = od.workos_organization_id
+           WHERE od.domain = ANY($1::text[])`,
+          [verifiedDomains],
+        );
+        const localByDomain = new Map(local.rows.map((row) => [row.domain.toLowerCase(), row]));
+
+        for (const domain of verifiedDomains) {
+          const row = localByDomain.get(domain);
+          if (!row) {
+            violations.push({
+              invariant: 'workos-verified-domains-mirrored',
+              severity: 'critical',
+              subject_type: 'domain',
+              subject_id: domain,
+              message:
+                `WorkOS says ${domain} is verified for "${org.name}" (${org.workos_organization_id}), ` +
+                'but organization_domains has no local row.',
+              details: {
+                domain,
+                workos_organization_id: org.workos_organization_id,
+                organization_name: org.name,
+                local_state: 'missing',
+              },
+              remediation_hint:
+                `Replay WorkOS domain reconciliation for org ${org.workos_organization_id}; this should call upsertWorkosDomain and brand registry sync.`,
+            });
+            continue;
+          }
+
+          if (row.workos_organization_id !== org.workos_organization_id) {
+            violations.push({
+              invariant: 'workos-verified-domains-mirrored',
+              severity: 'critical',
+              subject_type: 'domain',
+              subject_id: domain,
+              message:
+                `WorkOS says ${domain} is verified for "${org.name}" (${org.workos_organization_id}), ` +
+                `but the local row belongs to "${row.org_name ?? 'unknown'}" (${row.workos_organization_id}).`,
+              details: {
+                domain,
+                workos_organization_id: org.workos_organization_id,
+                organization_name: org.name,
+                local_workos_organization_id: row.workos_organization_id,
+                local_organization_name: row.org_name,
+                local_verified: row.verified,
+              },
+              remediation_hint:
+                `Replay WorkOS domain reconciliation for org ${org.workos_organization_id}; WorkOS-sourced upserts are allowed to transfer local domain ownership.`,
+            });
+            continue;
+          }
+
+          if (!row.verified) {
+            violations.push({
+              invariant: 'workos-verified-domains-mirrored',
+              severity: 'critical',
+              subject_type: 'domain',
+              subject_id: domain,
+              message:
+                `WorkOS says ${domain} is verified for "${org.name}" (${org.workos_organization_id}), ` +
+                'but the local organization_domains row is still unverified.',
+              details: {
+                domain,
+                workos_organization_id: org.workos_organization_id,
+                organization_name: org.name,
+                local_verified: row.verified,
+                local_is_primary: row.is_primary,
+              },
+              remediation_hint:
+                `Replay WorkOS domain reconciliation for org ${org.workos_organization_id}; local verified should mirror WorkOS verified.`,
+            });
+          }
+        }
+      } catch (err) {
+        logger.warn(
+          { err, orgId: org.workos_organization_id },
+          'workos-verified-domains-mirrored: WorkOS organization lookup failed',
+        );
+        violations.push({
+          invariant: 'workos-verified-domains-mirrored',
+          severity: 'warning',
+          subject_type: 'organization',
+          subject_id: org.workos_organization_id,
+          message: `WorkOS organization lookup failed for ${org.workos_organization_id}: ${err instanceof Error ? err.message : String(err)}`,
+          details: {
+            workos_organization_id: org.workos_organization_id,
+            organization_name: org.name,
+          },
+        });
+      }
+    }
+
+    return { checked: orgs.rows.length, violations };
+  },
+};

--- a/server/src/audit/integrity/types.ts
+++ b/server/src/audit/integrity/types.ts
@@ -28,6 +28,7 @@ export type Severity = 'critical' | 'warning' | 'info';
 export type SubjectType =
   | 'organization'
   | 'user'
+  | 'domain'
   | 'subscription'
   | 'customer'
   | 'membership'

--- a/server/src/db/escalation-db.ts
+++ b/server/src/db/escalation-db.ts
@@ -5,6 +5,7 @@
 
 import { query } from './client.js';
 import { createLogger } from '../logger.js';
+import { redactSupportSecrets } from '../services/support-redaction.js';
 
 const logger = createLogger('escalation-db');
 
@@ -182,6 +183,10 @@ export async function createEscalation(input: EscalationInput): Promise<Escalati
     if (existing) return existing;
   }
 
+  const summary = redactSupportSecrets(input.summary) ?? input.summary;
+  const originalRequest = redactSupportSecrets(input.original_request);
+  const addieContext = redactSupportSecrets(input.addie_context);
+
   try {
     const result = await query<Escalation>(
       `INSERT INTO addie_escalations (
@@ -201,9 +206,9 @@ export async function createEscalation(input: EscalationInput): Promise<Escalati
         input.user_slack_handle || null,
         input.category,
         input.priority || 'normal',
-        input.summary,
-        input.original_request || null,
-        input.addie_context || null,
+        summary,
+        originalRequest || null,
+        addieContext || null,
         input.perspective_id || null,
         input.perspective_slug || null,
         input.dedup_key || null,

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -57,6 +57,7 @@ import {
   getInsightByWeek,
 } from "../db/conversation-insights-db.js";
 import { runConversationInsightsJob } from "../addie/jobs/conversation-insights.js";
+import { guardEscalationResolution } from "../services/escalation-resolution-guard.js";
 
 const logger = createLogger("addie-admin-routes");
 const addieDb = new AddieDatabase();
@@ -1858,6 +1859,20 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
             });
           }
 
+          const escalation = await getEscalation(suggestion.escalation_id);
+          if (!escalation) {
+            return res.status(404).json({ error: "Escalation not found" });
+          }
+          const guard = await guardEscalationResolution({ escalation, status: 'resolved' });
+          if (!guard.ok) {
+            return res.status(409).json({
+              error: "registry_state_not_resolved",
+              message:
+                "This escalation looks like registry/domain propagation work, but local registry state still has blockers. File a GitHub issue without resolving only after human review, or repair/reconcile the listed state before accepting this suggestion.",
+              blockers: guard.blockers,
+            });
+          }
+
           // Reserve the suggestion atomically before calling GitHub, so
           // two concurrent clicks can't both file an issue. If GitHub
           // fails, release the reservation so a retry can claim it.
@@ -1899,6 +1914,22 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
             escalation: resolvedEsc ?? updatedEsc,
             issue: filed,
           });
+        }
+
+        if (suggestion.suggested_status === 'resolved') {
+          const escalation = await getEscalation(suggestion.escalation_id);
+          if (!escalation) {
+            return res.status(404).json({ error: "Escalation not found" });
+          }
+          const guard = await guardEscalationResolution({ escalation, status: 'resolved' });
+          if (!guard.ok) {
+            return res.status(409).json({
+              error: "registry_state_not_resolved",
+              message:
+                "This escalation looks like registry/domain propagation work, but local registry state still has blockers. Resolve as wont_do if invalid, or repair/reconcile the listed state before accepting this suggestion.",
+              blockers: guard.blockers,
+            });
+          }
         }
 
         const notes = `Triage suggestion #${id}: ${suggestion.reasoning}`;
@@ -2014,6 +2045,16 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
       const escalation = await getEscalation(id);
       if (!escalation) {
         return res.status(404).json({ error: "Not found", message: "Escalation not found" });
+      }
+
+      const guard = await guardEscalationResolution({ escalation, status });
+      if (!guard.ok) {
+        return res.status(409).json({
+          error: "registry_state_not_resolved",
+          message:
+            "This escalation looks like registry/domain propagation work, but local registry state still has blockers. Resolve as wont_do if the request is invalid, or repair/reconcile the listed state before marking resolved.",
+          blockers: guard.blockers,
+        });
       }
 
       const updated = await updateEscalationStatus(id, status, resolvedBy, notes);

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -13,7 +13,7 @@ import {
   unlinkDomainAndReselectPrimary,
 } from "../../db/organization-domains-db.js";
 import { createLogger } from "../../logger.js";
-import { requireAuth, requireAdmin } from "../../middleware/auth.js";
+import { requireAuth, requireAdmin, requireGlobalAdmin } from "../../middleware/auth.js";
 import { SlackDatabase } from "../../db/slack-db.js";
 import { enrichOrganization } from "../../services/enrichment.js";
 import { trackBackground } from "../../services/brand-enrichment.js";
@@ -27,6 +27,7 @@ import { resolveOrgsByDomains } from "../../db/domain-resolution-db.js";
 import { complete, isLLMConfigured } from "../../utils/llm.js";
 import { BrandDatabase } from "../../db/brand-db.js";
 import { verifyDomainChallenge } from "../../services/brand-claim.js";
+import { reconcileWorkosOrganizationDomains } from "../../services/workos-domain-reconciliation.js";
 import {
   FREE_EMAIL_PROVIDER_DOMAINS,
   canonicalizeBrandDomain,
@@ -91,11 +92,281 @@ interface DomainRoutesConfig {
   workos: WorkOS | null;
 }
 
+type RepairActionStatus = "available" | "blocked" | "manual";
+
+interface DomainSplitRepairAction {
+  id: string;
+  status: RepairActionStatus;
+  message: string;
+  endpoint?: string;
+  tool?: string;
+  body?: Record<string, unknown>;
+  blockers?: string[];
+}
+
+function findWorkosDomainState(
+  org: Awaited<ReturnType<WorkOS["organizations"]["getOrganization"]>> | null,
+  domain: string,
+): string | null {
+  return org?.domains?.find((d) => d.domain.toLowerCase() === domain)?.state ?? null;
+}
+
 export function setupDomainRoutes(
   apiRouter: Router,
   config: DomainRoutesConfig
 ): void {
   const { workos } = config;
+
+  // POST /api/admin/domain-split-repair/preview
+  //
+  // Read-only incident helper for the personal-workspace/company-org split
+  // state seen in registry/domain escalations. It intentionally previews
+  // repair actions only: WorkOS-verified domain reconciliation can be
+  // committed through the existing reconcile endpoint; billing relinks still
+  // require their own preview/confirm flow.
+	  apiRouter.post(
+	    "/domain-split-repair/preview",
+	    ...requireGlobalAdmin,
+	    async (req, res) => {
+      try {
+        const rawDomain = typeof req.body?.domain === "string" ? req.body.domain : "";
+        const companyOrgId = typeof req.body?.company_org_id === "string" ? req.body.company_org_id.trim() : "";
+        const personalOrgId = typeof req.body?.personal_org_id === "string" ? req.body.personal_org_id.trim() : "";
+        const workosUserId = typeof req.body?.workos_user_id === "string" ? req.body.workos_user_id.trim() : "";
+
+	        if (!rawDomain || !companyOrgId) {
+	          return res.status(400).json({
+	            error: "domain_and_company_org_required",
+	            message: "Provide domain and company_org_id.",
+	          });
+	        }
+	        if (personalOrgId && personalOrgId === companyOrgId) {
+	          return res.status(400).json({
+	            error: "company_and_personal_org_must_differ",
+	            message: "company_org_id and personal_org_id must be different organizations.",
+	          });
+	        }
+
+        const domain = canonicalizeBrandDomain(rawDomain);
+        const orgIds = [...new Set([companyOrgId, personalOrgId].filter(Boolean))];
+        const pool = getPool();
+
+        const [orgResult, localDomainResult, memberProfileResult, membershipResult] =
+          await Promise.all([
+            pool.query<{
+              workos_organization_id: string;
+              name: string;
+              is_personal: boolean | null;
+              email_domain: string | null;
+              member_status: string | null;
+              subscription_status: string | null;
+              subscription_canceled_at: Date | null;
+              membership_tier: string | null;
+              stripe_customer_id: string | null;
+              stripe_subscription_id: string | null;
+            }>(
+              `SELECT workos_organization_id, name, is_personal, email_domain,
+                      member_status, subscription_status, subscription_canceled_at,
+                      membership_tier, stripe_customer_id, stripe_subscription_id
+                 FROM organizations
+                WHERE workos_organization_id = ANY($1::text[])`,
+              [orgIds],
+            ),
+            pool.query<{
+              domain: string;
+              workos_organization_id: string;
+              organization_name: string | null;
+              is_personal: boolean | null;
+              verified: boolean;
+              is_primary: boolean;
+              source: string;
+            }>(
+              `SELECT od.domain, od.workos_organization_id, o.name AS organization_name,
+                      o.is_personal, od.verified, od.is_primary, od.source
+                 FROM organization_domains od
+                 LEFT JOIN organizations o ON o.workos_organization_id = od.workos_organization_id
+                WHERE od.domain = $1
+                   OR od.workos_organization_id = ANY($2::text[])
+                ORDER BY od.domain ASC, od.workos_organization_id ASC`,
+              [domain, orgIds],
+            ),
+            pool.query<{ workos_organization_id: string; id: string }>(
+              `SELECT workos_organization_id, id
+                 FROM member_profiles
+                WHERE workos_organization_id = ANY($1::text[])`,
+              [orgIds],
+            ),
+            workosUserId
+              ? pool.query<{
+                  workos_organization_id: string;
+                  role: string | null;
+                  joined_at: Date | null;
+                }>(
+                  `SELECT workos_organization_id, role, joined_at
+                     FROM organization_memberships
+                    WHERE workos_user_id = $1
+                      AND workos_organization_id = ANY($2::text[])`,
+                  [workosUserId, orgIds],
+                )
+              : Promise.resolve({ rows: [] }),
+          ]);
+
+        const orgById = new Map(orgResult.rows.map((row) => [row.workos_organization_id, row]));
+        const companyOrg = orgById.get(companyOrgId);
+        const personalOrg = personalOrgId ? orgById.get(personalOrgId) : null;
+
+        if (!companyOrg) {
+          return res.status(404).json({
+            error: "company_org_not_found",
+            message: `Company organization ${companyOrgId} was not found locally.`,
+          });
+        }
+	        if (personalOrgId && !personalOrg) {
+	          return res.status(404).json({
+	            error: "personal_org_not_found",
+	            message: `Personal organization ${personalOrgId} was not found locally.`,
+	          });
+	        }
+	        if (companyOrg.is_personal === true) {
+	          return res.status(400).json({
+	            error: "company_org_is_personal",
+	            message: `${companyOrgId} is marked as a personal workspace. Provide the non-personal company organization as company_org_id.`,
+	          });
+	        }
+	        if (personalOrg && personalOrg.is_personal !== true) {
+	          return res.status(400).json({
+	            error: "personal_org_is_not_personal",
+	            message: `${personalOrgId} is not marked as a personal workspace. Provide the user's personal workspace as personal_org_id, or omit it.`,
+	          });
+	        }
+
+        const workosOrgs = new Map<string, unknown>();
+        const workosFailures = new Map<string, string>();
+        const [companyWorkosOrg, personalWorkosOrg] = workos
+          ? await Promise.all([
+              workos.organizations.getOrganization(companyOrgId).catch((err) => {
+                workosFailures.set(companyOrgId, err instanceof Error ? err.message : "WorkOS lookup failed");
+                return null;
+              }),
+              personalOrgId
+                ? workos.organizations.getOrganization(personalOrgId).catch((err) => {
+                    workosFailures.set(personalOrgId, err instanceof Error ? err.message : "WorkOS lookup failed");
+                    return null;
+                  })
+                : Promise.resolve(null),
+            ])
+          : [null, null];
+
+        for (const org of [companyWorkosOrg, personalWorkosOrg]) {
+          if (org) {
+            workosOrgs.set(org.id, {
+              id: org.id,
+              name: org.name,
+              domains: org.domains.map((d) => ({ domain: d.domain, state: d.state })),
+            });
+          }
+        }
+
+        const companyWorkosState = findWorkosDomainState(companyWorkosOrg, domain);
+        const personalWorkosState = findWorkosDomainState(personalWorkosOrg, domain);
+        const companyHasVerifiedWorkosDomain =
+          companyWorkosState === "verified" || companyWorkosState === "legacy_verified";
+        const companyProfileExists = memberProfileResult.rows.some(
+          (row) => row.workos_organization_id === companyOrgId,
+        );
+        const companyMembership = membershipResult.rows.find(
+          (row) => row.workos_organization_id === companyOrgId,
+        );
+
+        const actions: DomainSplitRepairAction[] = [];
+        if (companyHasVerifiedWorkosDomain) {
+          actions.push({
+            id: "reconcile_company_workos_domains",
+            status: "available",
+            message:
+              "WorkOS already marks this domain verified for the company org. Run reconciliation to mirror WorkOS into organization_domains.",
+            endpoint: `/api/admin/organizations/${companyOrgId}/domains/reconcile`,
+            body: {},
+          });
+        } else {
+          actions.push({
+            id: "prove_company_domain_control",
+            status: "blocked",
+            message:
+              "Do not mark this domain verified manually. Issue and verify a DNS challenge under the company org, then rerun this preview.",
+            blockers: [
+              `WorkOS company-org domain state is ${companyWorkosState ?? "missing"}.`,
+            ],
+          });
+        }
+
+        if (!companyProfileExists) {
+          actions.push({
+            id: "create_member_profile",
+            status: "manual",
+            message:
+              "The company org has no member profile, so registry/operator can still return member:null after domain reconciliation. Create or backfill the profile through the normal member-profile path.",
+          });
+        }
+
+	        if (workosUserId && !companyMembership) {
+	          actions.push({
+	            id: "confirm_company_org_membership",
+            status: "blocked",
+            message:
+              "The supplied user is not a local member of the company org. Stop and ask for org selection/invite before repairing state for this user.",
+	          });
+	        }
+	        const blockers = actions.filter((action) => action.status === "blocked");
+	        const safeToReconcile = companyHasVerifiedWorkosDomain && blockers.length === 0;
+
+	        if (personalOrg?.stripe_customer_id && personalOrg.stripe_customer_id !== companyOrg.stripe_customer_id) {
+	          actions.push({
+            id: "billing_relink_requires_separate_preview",
+            status: "manual",
+            message:
+              "Billing appears attached to the personal workspace. Do not move it in this domain repair path. Use the Stripe customer relink preview/confirm flow after deciding whether the customer really belongs on the company org.",
+            tool: "preview_org_stripe_customer_update",
+            body: {
+              org_id: companyOrgId,
+              new_customer_id: personalOrg.stripe_customer_id,
+            },
+            blockers: [
+              "If the Stripe customer is still linked to the personal org locally, the relink preview will refuse it until an operator safely unlinks or merges duplicate account state.",
+            ],
+          });
+        }
+
+        res.json({
+          success: true,
+          domain,
+          company_org: companyOrg,
+          personal_org: personalOrg,
+          local_domains: localDomainResult.rows,
+	          member_profiles: memberProfileResult.rows,
+	          memberships: membershipResult.rows,
+	          safe_to_reconcile: safeToReconcile,
+	          next_safe_action: safeToReconcile
+	            ? "Run the company WorkOS-domain reconciliation endpoint."
+	            : blockers[0]?.message ?? "Review manual actions before making production changes.",
+	          workos: {
+	            configured: Boolean(workos),
+	            orgs: Object.fromEntries(workosOrgs),
+	            failures: Object.fromEntries(workosFailures),
+            company_domain_state: companyWorkosState,
+            personal_domain_state: personalWorkosState,
+          },
+          actions,
+        });
+      } catch (error) {
+        logger.error({ err: error }, "Failed to preview domain split repair");
+	        res.status(500).json({
+	          error: "domain_split_repair_preview_failed",
+	          message: "Unable to preview repair.",
+	        });
+      }
+    },
+  );
 
   // =========================================================================
   // SLACK DOMAIN DISCOVERY FOR PROSPECT IDENTIFICATION
@@ -1256,6 +1527,48 @@ export function setupDomainRoutes(
         return res.status(500).json({ error: "Internal server error" });
       }
     }
+  );
+
+  // POST /api/admin/organizations/:orgId/domains/reconcile
+  // Replay WorkOS as the source of truth for this org's domain list. This is
+  // the recovery path for missed organization_domain.* webhooks: it mirrors
+  // WorkOS domains into organization_domains and re-runs verified-domain brand
+  // registry sync without inventing verification locally.
+  apiRouter.post(
+    "/organizations/:orgId/domains/reconcile",
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      const { orgId } = req.params;
+      if (!workos) {
+        return res.status(503).json({ error: "WorkOS not configured" });
+      }
+
+      try {
+        const result = await reconcileWorkosOrganizationDomains({ workos, orgId });
+        invalidateMemberContextCache();
+        logger.info(
+          {
+            orgId,
+            actor: req.user?.id,
+            beforeMismatches: result.before_mismatches.length,
+            afterMismatches: result.after_mismatches.length,
+            changed: result.changed,
+          },
+          "Admin reconciled organization domains from WorkOS",
+        );
+        return res.json({
+          success: result.after_mismatches.length === 0,
+          ...result,
+        });
+      } catch (error) {
+        logger.error({ err: error, orgId }, "Admin WorkOS domain reconciliation failed");
+        return res.status(502).json({
+          error: "workos_error",
+          message: "Failed to reconcile organization domains from WorkOS.",
+        });
+      }
+    },
   );
 
   // POST /api/admin/organizations/:orgId/domains/:domain/verify

--- a/server/src/routes/workos-webhooks.ts
+++ b/server/src/routes/workos-webhooks.ts
@@ -96,7 +96,7 @@ export interface OrganizationDomainEventData {
   state: 'verified' | 'pending' | 'failed';
 }
 
-interface OrganizationData {
+export interface OrganizationData {
   id: string;
   name: string;
   domains: OrganizationDomainData[];

--- a/server/src/services/escalation-resolution-guard.ts
+++ b/server/src/services/escalation-resolution-guard.ts
@@ -1,0 +1,242 @@
+import type { Pool } from 'pg';
+import { getDomain } from 'tldts';
+import { getPool } from '../db/client.js';
+import type { Escalation, EscalationStatus } from '../db/escalation-db.js';
+import { checkAgentHostnameAgainstDomains } from './agent-hostname-verification.js';
+
+export interface EscalationResolutionBlocker {
+  type:
+    | 'missing_local_domain'
+    | 'unverified_local_domain'
+    | 'personal_workspace_domain'
+    | 'missing_member_profile'
+    | 'agent_hostname_not_verified'
+    | 'member_null_unchecked';
+  domain?: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export type EscalationResolutionGuardResult =
+  | { ok: true; checked: boolean }
+  | { ok: false; checked: true; blockers: EscalationResolutionBlocker[] };
+
+interface DomainRow {
+  domain: string;
+  workos_organization_id: string;
+  organization_name: string | null;
+  is_personal: boolean | null;
+  verified: boolean;
+  member_status: string | null;
+  subscription_status: string | null;
+}
+
+const REGISTRY_SETUP_RE = /\b(registry|member:\s*null|domain verification|verify_brand_domain_challenge|save_agent|brand manifest|adagents|agent registration|pending sync|propagation)\b/i;
+const DOMAIN_RE = /\b(?:https?:\/\/)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}\b/gi;
+const URL_RE = /\bhttps?:\/\/[^\s)>'"]+/gi;
+const IGNORED_DOMAINS = new Set([
+  'agenticadvertising.org',
+  'adcontextprotocol.org',
+  'github.com',
+  'slack.com',
+  'workos.com',
+]);
+
+function escalationText(escalation: Escalation): string {
+  return [
+    escalation.summary,
+    escalation.original_request ?? '',
+    escalation.addie_context ?? '',
+    escalation.resolution_notes ?? '',
+  ].join('\n');
+}
+
+export function isRegistrySetupEscalation(escalation: Escalation): boolean {
+  return REGISTRY_SETUP_RE.test(escalationText(escalation));
+}
+
+function toBaseDomain(hostname: string): string | null {
+  const withoutProtocol = hostname.replace(/^https?:\/\//i, '');
+  const normalized = withoutProtocol
+    .split('/')[0]
+    .split(':')[0]
+    .toLowerCase();
+  return getDomain(normalized, { allowPrivateDomains: true });
+}
+
+export function extractEscalationDomains(escalation: Escalation): string[] {
+  const text = escalationText(escalation);
+  const domains = new Set<string>();
+  for (const match of text.matchAll(DOMAIN_RE)) {
+    const raw = match[0];
+    if (raw.includes('@')) continue;
+    const base = toBaseDomain(raw);
+    if (base && !IGNORED_DOMAINS.has(base)) domains.add(base);
+  }
+  return [...domains].sort();
+}
+
+export function extractEscalationAgentUrls(escalation: Escalation): string[] {
+  const text = escalationText(escalation);
+  const urls = new Set<string>();
+  for (const match of text.matchAll(URL_RE)) {
+    try {
+      const url = new URL(match[0]);
+      const base = toBaseDomain(url.hostname);
+      if (!base || IGNORED_DOMAINS.has(base)) continue;
+      urls.add(url.toString());
+    } catch {
+      // Ignore malformed free-text URL fragments.
+    }
+  }
+  return [...urls].sort();
+}
+
+export async function guardEscalationResolution(input: {
+  escalation: Escalation;
+  status: EscalationStatus;
+  pool?: Pool;
+}): Promise<EscalationResolutionGuardResult> {
+  if (input.status !== 'resolved') {
+    return { ok: true, checked: false };
+  }
+  if (!isRegistrySetupEscalation(input.escalation)) {
+    return { ok: true, checked: false };
+  }
+
+  const domains = extractEscalationDomains(input.escalation);
+  const blockers: EscalationResolutionBlocker[] = [];
+  if (domains.length === 0) {
+    blockers.push({
+      type: 'member_null_unchecked',
+      message:
+        'This looks like a registry/domain propagation escalation, but no domain could be extracted for a local state check. Resolve as wont_do if invalid, or add domain evidence before marking resolved.',
+    });
+    return { ok: false, checked: true, blockers };
+  }
+
+  const pool = input.pool ?? getPool();
+  const result = await pool.query<DomainRow>(
+    `SELECT
+       od.domain,
+       od.workos_organization_id,
+       o.name AS organization_name,
+       o.is_personal,
+       od.verified,
+       o.member_status,
+       o.subscription_status
+     FROM organization_domains od
+     LEFT JOIN organizations o ON o.workos_organization_id = od.workos_organization_id
+     WHERE od.domain = ANY($1::text[])`,
+    [domains],
+  );
+  const rowsByDomain = new Map(result.rows.map((row) => [row.domain.toLowerCase(), row]));
+  const orgIdsForAgentCheck = new Set<string>();
+
+  for (const domain of domains) {
+    const row = rowsByDomain.get(domain);
+    if (!row) {
+      blockers.push({
+        type: 'missing_local_domain',
+        domain,
+        message: `Cannot mark resolved: ${domain} has no local organization_domains row.`,
+      });
+      continue;
+    }
+
+    if (!row.verified) {
+      blockers.push({
+        type: 'unverified_local_domain',
+        domain,
+        message: `Cannot mark resolved: ${domain} is still unverified locally.`,
+        details: {
+          workos_organization_id: row.workos_organization_id,
+          organization_name: row.organization_name,
+        },
+      });
+    }
+
+    if (row.is_personal) {
+      blockers.push({
+        type: 'personal_workspace_domain',
+        domain,
+        message:
+          `Cannot mark resolved: ${domain} is attached to personal workspace ` +
+          `"${row.organization_name ?? row.workos_organization_id}", not a company org.`,
+        details: {
+          workos_organization_id: row.workos_organization_id,
+          organization_name: row.organization_name,
+          member_status: row.member_status,
+          subscription_status: row.subscription_status,
+        },
+      });
+    }
+
+    if (row && row.verified && !row.is_personal) {
+      orgIdsForAgentCheck.add(row.workos_organization_id);
+      const profileResult = await pool.query<{ id: string }>(
+        `SELECT mp.id
+         FROM member_profiles mp
+         WHERE mp.workos_organization_id = $1
+         LIMIT 1`,
+        [row.workos_organization_id],
+      );
+      if (profileResult.rows.length === 0) {
+        blockers.push({
+          type: 'missing_member_profile',
+          domain,
+          message: `Cannot mark resolved: ${domain} is verified locally but has no member profile, so /api/registry/operator still returns member:null.`,
+          details: {
+            workos_organization_id: row.workos_organization_id,
+            organization_name: row.organization_name,
+          },
+        });
+      }
+    }
+  }
+
+  const agentUrls = extractEscalationAgentUrls(input.escalation);
+  if (agentUrls.length > 0 && orgIdsForAgentCheck.size > 0) {
+    const verifiedDomains = await pool.query<{ workos_organization_id: string; domain: string }>(
+      `SELECT workos_organization_id, domain
+       FROM organization_domains
+       WHERE workos_organization_id = ANY($1::text[])
+         AND verified = true`,
+      [[...orgIdsForAgentCheck]],
+    );
+    const domainsByOrg = new Map<string, string[]>();
+    for (const row of verifiedDomains.rows) {
+      const existing = domainsByOrg.get(row.workos_organization_id) ?? [];
+      existing.push(row.domain.toLowerCase());
+      domainsByOrg.set(row.workos_organization_id, existing);
+    }
+
+    for (const agentUrl of agentUrls) {
+      let covered = false;
+      const failures: unknown[] = [];
+      for (const orgId of orgIdsForAgentCheck) {
+        const verification = checkAgentHostnameAgainstDomains(agentUrl, domainsByOrg.get(orgId) ?? [], orgId);
+        if (verification.ok) {
+          covered = true;
+          break;
+        }
+        failures.push({ orgId, verification });
+      }
+      if (!covered) {
+        blockers.push({
+          type: 'agent_hostname_not_verified',
+          message: `Cannot mark resolved: agent URL ${agentUrl} is not covered by any verified company-domain row referenced in this escalation.`,
+          details: {
+            agent_url: agentUrl,
+            failures,
+          },
+        });
+      }
+    }
+  }
+
+  if (blockers.length > 0) {
+    return { ok: false, checked: true, blockers };
+  }
+  return { ok: true, checked: true };
+}

--- a/server/src/services/org-selection-guard.ts
+++ b/server/src/services/org-selection-guard.ts
@@ -1,0 +1,151 @@
+import type { Pool } from 'pg';
+import { getDomain } from 'tldts';
+import { getPool } from '../db/client.js';
+import { canonicalizeBrandDomain } from './identifier-normalization.js';
+
+export interface OrgSelectionMemberContext {
+  workos_user?: {
+    workos_user_id?: string | null;
+  } | null;
+  organization?: {
+    workos_organization_id?: string | null;
+    name?: string | null;
+    is_personal?: boolean | null;
+  } | null;
+}
+
+export interface CompanyOrgChoice {
+  organizationId: string;
+  name: string | null;
+}
+
+export type PersonalWorkspaceDomainSelectionResult =
+  | { ok: true; checked: boolean; domain?: string }
+  | {
+      ok: false;
+      status: 'org_selection_required';
+      domain: string;
+      selectedOrg: {
+        organizationId: string;
+        name: string | null;
+      };
+      companyOrgs: CompanyOrgChoice[];
+    };
+
+export async function guardPersonalWorkspaceDomainSelection(input: {
+  memberContext: OrgSelectionMemberContext;
+  selectedOrgId: string;
+  rawDomain: string;
+  pool?: Pool;
+}): Promise<PersonalWorkspaceDomainSelectionResult> {
+  const workosUserId = input.memberContext.workos_user?.workos_user_id;
+  if (!workosUserId) {
+    return { ok: true, checked: false };
+  }
+
+  let domain: string;
+  try {
+    const canonical = canonicalizeBrandDomain(input.rawDomain);
+    domain = getDomain(canonical, { allowPrivateDomains: true }) ?? canonical;
+  } catch {
+    return { ok: true, checked: false };
+  }
+
+  const ambientOrg = input.memberContext.organization;
+  const selectedOrg = ambientOrg?.workos_organization_id === input.selectedOrgId
+    ? ambientOrg
+    : null;
+
+  if (selectedOrg?.is_personal !== true) {
+    if (selectedOrg) {
+      return { ok: true, checked: false };
+    }
+
+    const lookupPool = input.pool ?? getPool();
+    const selectedOrgLookup = (await lookupPool.query<{
+      workos_organization_id: string;
+      name: string | null;
+      is_personal: boolean | null;
+    }>(
+      `SELECT workos_organization_id, name, is_personal
+         FROM organizations
+        WHERE workos_organization_id = $1`,
+      [input.selectedOrgId],
+    )).rows[0] ?? null;
+
+    if (selectedOrgLookup?.is_personal !== true) {
+      return { ok: true, checked: false };
+    }
+
+    return checkPersonalWorkspaceDomain({
+      pool: lookupPool,
+      selectedOrg: selectedOrgLookup,
+      selectedOrgId: input.selectedOrgId,
+      workosUserId,
+      domain,
+    });
+  }
+
+  const pool = input.pool ?? getPool();
+  return checkPersonalWorkspaceDomain({
+    pool,
+    selectedOrg,
+    selectedOrgId: input.selectedOrgId,
+    workosUserId,
+    domain,
+  });
+}
+
+async function checkPersonalWorkspaceDomain(input: {
+  pool: Pool;
+  selectedOrg: {
+    workos_organization_id?: string | null;
+    name?: string | null;
+  };
+  selectedOrgId: string;
+  workosUserId: string;
+  domain: string;
+}): Promise<PersonalWorkspaceDomainSelectionResult> {
+  const result = await input.pool.query<{
+    workos_organization_id: string;
+    name: string | null;
+  }>(
+    `SELECT DISTINCT
+       o.workos_organization_id,
+       o.name
+     FROM organizations o
+     JOIN organization_memberships om
+       ON om.workos_organization_id = o.workos_organization_id
+      AND om.workos_user_id = $2
+     LEFT JOIN organization_domains od
+       ON od.workos_organization_id = o.workos_organization_id
+     WHERE COALESCE(o.is_personal, false) = false
+       AND o.workos_organization_id <> $3
+       AND (
+         LOWER(o.email_domain) = LOWER($1)
+         OR LOWER(od.domain) = LOWER($1)
+       )
+     ORDER BY o.name ASC NULLS LAST
+     LIMIT 5`,
+    [input.domain, input.workosUserId, input.selectedOrgId],
+  );
+
+  if (result.rows.length === 0) {
+    return { ok: true, checked: true, domain: input.domain };
+  }
+
+  return {
+    ok: false,
+    status: 'org_selection_required',
+    domain: input.domain,
+    selectedOrg: {
+      organizationId:
+        input.selectedOrg.workos_organization_id ?? input.selectedOrgId,
+      name: input.selectedOrg.name ?? null,
+    },
+    companyOrgs: result.rows.map((row) => ({
+      organizationId: row.workos_organization_id,
+      name: row.name,
+    })),
+  };
+}

--- a/server/src/services/support-redaction.ts
+++ b/server/src/services/support-redaction.ts
@@ -1,0 +1,27 @@
+const SECRET_MARKER = '[redacted-verification-token]';
+
+const TOKEN_ASSIGNMENT_RE =
+  /\b((?:verification[_ -]?token|dns[_ -]?txt[_ -]?value|txt[_ -]?value|secret|api[_ -]?key|access[_ -]?token|refresh[_ -]?token)\s*[:=]\s*)(`?)[^\s`'"]{12,}(\2)/gi;
+const MARKDOWN_VALUE_RE =
+  /^(\s*[-*]?\s*(?:Value|TXT value|Verification token)\s*:\s*)`?[^`\r\n]{12,}`?/gim;
+const WORKOS_DOMAIN_TOKEN_RE =
+  /\b(?:wos|workos)[a-z0-9._=-]{8,}(?:verification|verify|domain)[a-z0-9._=-]*\b/gi;
+const COMMON_SECRET_RE =
+  /\b(?:sk_(?:live|test)_[A-Za-z0-9_]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{12,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b/g;
+const AUTH_HEADER_RE = /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{12,}/gi;
+const MAX_REDACTION_INPUT_LENGTH = 20_000;
+
+export function redactSupportSecrets(value: string | null | undefined): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  const bounded = value.length > MAX_REDACTION_INPUT_LENGTH
+    ? value.slice(0, MAX_REDACTION_INPUT_LENGTH)
+    : value;
+  return bounded
+    .replace(MARKDOWN_VALUE_RE, `$1\`${SECRET_MARKER}\``)
+    .replace(TOKEN_ASSIGNMENT_RE, (_match, prefix: string, quote: string) =>
+      `${prefix}${quote || ''}${SECRET_MARKER}${quote || ''}`,
+    )
+    .replace(WORKOS_DOMAIN_TOKEN_RE, SECRET_MARKER)
+    .replace(COMMON_SECRET_RE, '[redacted-secret]')
+    .replace(AUTH_HEADER_RE, (_match, scheme: string) => `${scheme} [redacted-secret]`);
+}

--- a/server/src/services/workos-domain-reconciliation.ts
+++ b/server/src/services/workos-domain-reconciliation.ts
@@ -1,0 +1,151 @@
+import type { WorkOS } from '@workos-inc/node';
+import type { Pool } from 'pg';
+import { getPool } from '../db/client.js';
+import {
+  syncOrganizationDomains,
+  type OrganizationData,
+} from '../routes/workos-webhooks.js';
+
+interface LocalDomainSnapshot {
+  domain: string;
+  workos_organization_id: string;
+  organization_name: string | null;
+  verified: boolean;
+  is_primary: boolean;
+  source: string;
+}
+
+interface WorkosDomainSnapshot {
+  domain: string;
+  state: string;
+}
+
+export interface DomainReconciliationMismatch {
+  domain: string;
+  reason: 'missing_local_row' | 'wrong_local_org' | 'verified_mismatch';
+  workos_state: string;
+  local?: LocalDomainSnapshot;
+}
+
+export interface WorkosDomainReconciliationResult {
+  organization_id: string;
+  organization_name: string;
+  workos_domains: WorkosDomainSnapshot[];
+  before: LocalDomainSnapshot[];
+  after: LocalDomainSnapshot[];
+  before_mismatches: DomainReconciliationMismatch[];
+  after_mismatches: DomainReconciliationMismatch[];
+  changed: boolean;
+}
+
+async function loadLocalRowsForDomains(
+  pool: Pool,
+  domains: string[],
+): Promise<LocalDomainSnapshot[]> {
+  if (domains.length === 0) return [];
+  const result = await pool.query<LocalDomainSnapshot>(
+    `SELECT
+       od.domain,
+       od.workos_organization_id,
+       o.name AS organization_name,
+       od.verified,
+       od.is_primary,
+       od.source
+     FROM organization_domains od
+     LEFT JOIN organizations o ON o.workos_organization_id = od.workos_organization_id
+     WHERE od.domain = ANY($1::text[])
+     ORDER BY od.domain ASC`,
+    [domains],
+  );
+  return result.rows;
+}
+
+function findMismatches(
+  orgId: string,
+  workosDomains: WorkosDomainSnapshot[],
+  localRows: LocalDomainSnapshot[],
+): DomainReconciliationMismatch[] {
+  const byDomain = new Map(localRows.map((row) => [row.domain.toLowerCase(), row]));
+  const mismatches: DomainReconciliationMismatch[] = [];
+
+  for (const workosDomain of workosDomains) {
+    const state = String(workosDomain.state);
+    const expectsVerified = state === 'verified' || state === 'legacy_verified';
+    const domain = workosDomain.domain.toLowerCase();
+    const local = byDomain.get(domain);
+
+    if (!local) {
+      mismatches.push({
+        domain,
+        reason: 'missing_local_row',
+        workos_state: state,
+      });
+      continue;
+    }
+
+    if (local.workos_organization_id !== orgId) {
+      mismatches.push({
+        domain,
+        reason: 'wrong_local_org',
+        workos_state: state,
+        local,
+      });
+      continue;
+    }
+
+    if (expectsVerified && !local.verified) {
+      mismatches.push({
+        domain,
+        reason: 'verified_mismatch',
+        workos_state: state,
+        local,
+      });
+    }
+  }
+
+  return mismatches;
+}
+
+export async function reconcileWorkosOrganizationDomains(input: {
+  workos: WorkOS;
+  orgId: string;
+  pool?: Pool;
+}): Promise<WorkosDomainReconciliationResult> {
+  const pool = input.pool ?? getPool();
+  const workosOrg = await input.workos.organizations.getOrganization(input.orgId);
+  const workosDomains = workosOrg.domains.map((d) => ({
+    domain: d.domain.toLowerCase(),
+    state: String(d.state),
+  }));
+  const domainNames = workosDomains.map((d) => d.domain);
+
+  const before = await loadLocalRowsForDomains(pool, domainNames);
+  const beforeMismatches = findMismatches(workosOrg.id, workosDomains, before);
+
+  const orgData: OrganizationData = {
+    id: workosOrg.id,
+    name: workosOrg.name,
+    domains: workosDomains.map((d) => ({
+      domain: d.domain,
+      state: d.state === 'verified' || d.state === 'legacy_verified' ? 'verified' : 'pending',
+    })),
+    created_at: workosOrg.createdAt ?? new Date().toISOString(),
+    updated_at: workosOrg.updatedAt ?? new Date().toISOString(),
+  };
+
+  await syncOrganizationDomains(orgData);
+
+  const after = await loadLocalRowsForDomains(pool, domainNames);
+  const afterMismatches = findMismatches(workosOrg.id, workosDomains, after);
+
+  return {
+    organization_id: workosOrg.id,
+    organization_name: workosOrg.name,
+    workos_domains: workosDomains,
+    before,
+    after,
+    before_mismatches: beforeMismatches,
+    after_mismatches: afterMismatches,
+    changed: JSON.stringify(before) !== JSON.stringify(after),
+  };
+}

--- a/server/tests/unit/domain-split-repair-preview.test.ts
+++ b/server/tests/unit/domain-split-repair-preview.test.ts
@@ -1,0 +1,92 @@
+import express from 'express';
+import type { NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupDomainRoutes } from '../../src/routes/admin/domains.js';
+
+const queryMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/db/client.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/db/client.js')>()),
+  getPool: () => ({ query: queryMock }),
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  requireAuth: (_req: Request, _res: Response, next: NextFunction) => next(),
+  requireAdmin: (_req: Request, _res: Response, next: NextFunction) => next(),
+  requireGlobalAdmin: [
+    (_req: Request, _res: Response, next: NextFunction) => next(),
+    (_req: Request, _res: Response, next: NextFunction) => next(),
+  ],
+}));
+
+function app() {
+  const app = express();
+  const router = express.Router();
+  app.use(express.json());
+  setupDomainRoutes(router, { workos: null });
+  app.use('/api/admin', router);
+  return app;
+}
+
+function mockPreviewQueries(orgRows: Array<{ workos_organization_id: string; name: string; is_personal: boolean }>) {
+  queryMock
+    .mockResolvedValueOnce({ rows: orgRows })
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [] });
+}
+
+describe('domain split repair preview', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it('rejects identical company and personal org ids', async () => {
+    const res = await request(app())
+      .post('/api/admin/domain-split-repair/preview')
+      .send({
+        domain: 'example.com',
+        company_org_id: 'org_same',
+        personal_org_id: 'org_same',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('company_and_personal_org_must_differ');
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a company org that is marked personal', async () => {
+    mockPreviewQueries([
+      { workos_organization_id: 'org_personal', name: 'Personal', is_personal: true },
+    ]);
+
+    const res = await request(app())
+      .post('/api/admin/domain-split-repair/preview')
+      .send({
+        domain: 'example.com',
+        company_org_id: 'org_personal',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('company_org_is_personal');
+  });
+
+  it('rejects a personal org that is not marked personal', async () => {
+    mockPreviewQueries([
+      { workos_organization_id: 'org_company', name: 'Company', is_personal: false },
+      { workos_organization_id: 'org_other_company', name: 'Other Company', is_personal: false },
+    ]);
+
+    const res = await request(app())
+      .post('/api/admin/domain-split-repair/preview')
+      .send({
+        domain: 'example.com',
+        company_org_id: 'org_company',
+        personal_org_id: 'org_other_company',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('personal_org_is_not_personal');
+  });
+});

--- a/server/tests/unit/escalation-resolution-guard.test.ts
+++ b/server/tests/unit/escalation-resolution-guard.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  extractEscalationDomains,
+  extractEscalationAgentUrls,
+  guardEscalationResolution,
+  isRegistrySetupEscalation,
+} from '../../src/services/escalation-resolution-guard.js';
+import type { Escalation } from '../../src/db/escalation-db.js';
+
+function escalation(overrides: Partial<Escalation>): Escalation {
+  return {
+    id: 1,
+    thread_id: null,
+    message_id: null,
+    slack_user_id: null,
+    workos_user_id: null,
+    user_display_name: null,
+    user_email: null,
+    user_slack_handle: null,
+    category: 'needs_human_action',
+    priority: 'normal',
+    summary: 'Registry propagation failure for latinxctv.com',
+    original_request: null,
+    addie_context: null,
+    notification_channel_id: null,
+    notification_sent_at: null,
+    notification_message_ts: null,
+    status: 'open',
+    resolved_by: null,
+    resolved_at: null,
+    resolution_notes: null,
+    perspective_id: null,
+    perspective_slug: null,
+    github_issue_url: null,
+    github_issue_number: null,
+    github_issue_repo: null,
+    dedup_key: null,
+    sla_admin_last_notified_at: null,
+    sla_requester_last_notified_at: null,
+    sla_follow_up_count: 0,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+describe('escalation-resolution-guard', () => {
+  it('identifies registry setup escalations and extracts base domains from agent URLs', () => {
+    const esc = escalation({
+      summary: 'save_agent blocked for https://sales.latinxctv.com/mcp',
+      addie_context: 'registry still returns member:null for latinxctv.com; tracked at https://github.com/adcontextprotocol/adcp/issues/5709',
+    });
+
+    expect(isRegistrySetupEscalation(esc)).toBe(true);
+    expect(extractEscalationDomains(esc)).toEqual(['latinxctv.com']);
+    expect(extractEscalationAgentUrls(esc)).toEqual(['https://sales.latinxctv.com/mcp']);
+  });
+
+  it('does not guard non-registry escalations', async () => {
+    const pool = { query: vi.fn() };
+    const result = await guardEscalationResolution({
+      escalation: escalation({ summary: 'Please update event title', addie_context: null }),
+      status: 'resolved',
+      pool: pool as any,
+    });
+
+    expect(result).toEqual({ ok: true, checked: false });
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it('blocks resolved when a referenced domain is missing locally', async () => {
+    const pool = { query: vi.fn().mockResolvedValueOnce({ rows: [] }) };
+
+    const result = await guardEscalationResolution({
+      escalation: escalation({
+        summary: 'Registry propagation failure for latinxctv.com',
+        addie_context: 'member:null and save_agent blocked',
+      }),
+      status: 'resolved',
+      pool: pool as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.blockers[0].type).toBe('missing_local_domain');
+      expect(result.blockers[0].domain).toBe('latinxctv.com');
+    }
+  });
+
+  it('blocks resolved when the domain is attached to an unverified personal workspace', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValueOnce({
+        rows: [
+          {
+            domain: 'latinxctv.com',
+            workos_organization_id: 'org_personal',
+            organization_name: 'Gustavo Workspace',
+            is_personal: true,
+            verified: false,
+            member_status: 'member',
+            subscription_status: 'active',
+          },
+        ],
+      }),
+    };
+
+    const result = await guardEscalationResolution({
+      escalation: escalation({
+        summary: 'Domain verification and save_agent blocked for latinxctv.com',
+        addie_context: 'registry returns member:null',
+      }),
+      status: 'resolved',
+      pool: pool as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.blockers.map((b) => b.type).sort()).toEqual([
+        'personal_workspace_domain',
+        'unverified_local_domain',
+      ]);
+    }
+  });
+
+  it('blocks resolved when verified local domain has no member profile', async () => {
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              domain: 'latinxctv.com',
+              workos_organization_id: 'org_company',
+              organization_name: 'LatinxCTV',
+              is_personal: false,
+              verified: true,
+              member_status: 'member',
+              subscription_status: 'active',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [] }),
+    };
+
+    const result = await guardEscalationResolution({
+      escalation: escalation({
+        summary: 'Registry member:null for latinxctv.com',
+      }),
+      status: 'resolved',
+      pool: pool as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.blockers[0].type).toBe('missing_member_profile');
+      expect(result.blockers[0].message).toContain('member:null');
+    }
+  });
+
+  it('allows resolved when verified company domain has member profile and agent hostname is covered', async () => {
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              domain: 'latinxctv.com',
+              workos_organization_id: 'org_company',
+              organization_name: 'LatinxCTV',
+              is_personal: false,
+              verified: true,
+              member_status: 'member',
+              subscription_status: 'active',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [{ id: 'profile_1' }] })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              workos_organization_id: 'org_company',
+              domain: 'latinxctv.com',
+            },
+          ],
+        }),
+    };
+
+    const result = await guardEscalationResolution({
+      escalation: escalation({
+        summary: 'save_agent now unblocked for https://sales.latinxctv.com/mcp',
+        addie_context: 'registry no longer returns member:null for latinxctv.com',
+      }),
+      status: 'resolved',
+      pool: pool as any,
+    });
+
+    expect(result).toEqual({ ok: true, checked: true });
+  });
+
+  it('blocks resolved when agent hostname is not covered by the verified company domain', async () => {
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              domain: 'latinxctv.com',
+              workos_organization_id: 'org_company',
+              organization_name: 'LatinxCTV',
+              is_personal: false,
+              verified: true,
+              member_status: 'member',
+              subscription_status: 'active',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [{ id: 'profile_1' }] })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              workos_organization_id: 'org_company',
+              domain: 'latinxctv.com',
+            },
+          ],
+        }),
+    };
+
+    const result = await guardEscalationResolution({
+      escalation: escalation({
+        summary: 'save_agent blocked for https://sales.other-domain.com/mcp',
+        addie_context: 'registry member:null for latinxctv.com',
+      }),
+      status: 'resolved',
+      pool: pool as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.blockers.map((b) => b.type)).toContain('agent_hostname_not_verified');
+    }
+  });
+
+  it('allows wont_do for suspicious registry requests', async () => {
+    const pool = { query: vi.fn() };
+    const result = await guardEscalationResolution({
+      escalation: escalation({ summary: 'Registry propagation failure for latinxctv.com' }),
+      status: 'wont_do',
+      pool: pool as any,
+    });
+
+    expect(result).toEqual({ ok: true, checked: false });
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/integrity/invariants.test.ts
+++ b/server/tests/unit/integrity/invariants.test.ts
@@ -14,10 +14,12 @@ import { stripeSubReflectedInOrgRowInvariant } from '../../../src/audit/integrit
 import { workosMembershipRowExistsInWorkosInvariant } from '../../../src/audit/integrity/invariants/workos-membership-row-exists-in-workos.js';
 import { everyEntitledOrgHasResolvableTierInvariant } from '../../../src/audit/integrity/invariants/every-entitled-org-has-resolvable-tier.js';
 import { uniqueOrgPerEmailDomainInvariant } from '../../../src/audit/integrity/invariants/unique-org-per-email-domain.js';
+import { workosVerifiedDomainsMirroredInvariant } from '../../../src/audit/integrity/invariants/workos-verified-domains-mirrored.js';
+import { personalMemberCompanyOrgSplitInvariant } from '../../../src/audit/integrity/invariants/personal-member-company-org-split.js';
 import { ALL_INVARIANTS, getInvariantByName } from '../../../src/audit/integrity/invariants/index.js';
 import type { InvariantContext } from '../../../src/audit/integrity/types.js';
 
-const EXPECTED_INVARIANT_COUNT = 9;
+const EXPECTED_INVARIANT_COUNT = 11;
 
 const mockPoolQuery = vi.fn();
 const mockStripeCustomersRetrieve = vi.fn();
@@ -25,6 +27,7 @@ const mockStripeSubsList = vi.fn();
 const mockStripeSubsRetrieve = vi.fn();
 const mockStripeProductsRetrieve = vi.fn();
 const mockWorkosListMemberships = vi.fn();
+const mockWorkosGetOrganization = vi.fn();
 
 function makeCtx(): InvariantContext {
   return {
@@ -35,6 +38,7 @@ function makeCtx(): InvariantContext {
       products: { retrieve: mockStripeProductsRetrieve },
     } as unknown as InvariantContext['stripe'],
     workos: {
+      organizations: { getOrganization: mockWorkosGetOrganization },
       userManagement: { listOrganizationMemberships: mockWorkosListMemberships },
     } as unknown as InvariantContext['workos'],
     logger: {
@@ -52,6 +56,7 @@ beforeEach(() => {
   mockStripeSubsRetrieve.mockReset();
   mockStripeProductsRetrieve.mockReset();
   mockWorkosListMemberships.mockReset();
+  mockWorkosGetOrganization.mockReset();
 });
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -67,6 +72,7 @@ describe('invariants registry', () => {
 
   it('resolves invariants by name', () => {
     expect(getInvariantByName('one-active-stripe-sub-per-org')).toBe(oneActiveStripeSubPerOrgInvariant);
+    expect(getInvariantByName('workos-verified-domains-mirrored')).toBe(workosVerifiedDomainsMirroredInvariant);
     expect(getInvariantByName('does-not-exist')).toBeUndefined();
   });
 
@@ -75,6 +81,130 @@ describe('invariants registry', () => {
       expect(inv.description.length).toBeGreaterThan(20);
       expect(['critical', 'warning', 'info']).toContain(inv.severity);
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// workos-verified-domains-mirrored
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('workos-verified-domains-mirrored', () => {
+  it('passes when every WorkOS verified domain has a matching verified local row', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({
+        rows: [{ workos_organization_id: 'org_acme', name: 'Acme' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            domain: 'acme.test',
+            workos_organization_id: 'org_acme',
+            org_name: 'Acme',
+            verified: true,
+            is_primary: true,
+          },
+        ],
+      });
+    mockWorkosGetOrganization.mockResolvedValueOnce({
+      id: 'org_acme',
+      name: 'Acme',
+      domains: [{ domain: 'acme.test', state: 'verified' }],
+    });
+
+    const result = await workosVerifiedDomainsMirroredInvariant.check(makeCtx());
+
+    expect(result.checked).toBe(1);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags a verified WorkOS domain that is missing locally', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({
+        rows: [{ workos_organization_id: 'org_spanglish', name: 'Spanglish Movies' }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+    mockWorkosGetOrganization.mockResolvedValueOnce({
+      id: 'org_spanglish',
+      name: 'Spanglish Movies',
+      domains: [{ domain: 'spanglishmovies.com', state: 'verified' }],
+    });
+
+    const result = await workosVerifiedDomainsMirroredInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].severity).toBe('critical');
+    expect(result.violations[0].subject_type).toBe('domain');
+    expect(result.violations[0].subject_id).toBe('spanglishmovies.com');
+    expect(result.violations[0].message).toContain('no local row');
+  });
+
+  it('flags a verified WorkOS domain whose local row belongs to another org', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({
+        rows: [{ workos_organization_id: 'org_spanglish', name: 'Spanglish Movies' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            domain: 'spanglishmovies.com',
+            workos_organization_id: 'org_personal',
+            org_name: 'Gustavo Workspace',
+            verified: false,
+            is_primary: false,
+          },
+        ],
+      });
+    mockWorkosGetOrganization.mockResolvedValueOnce({
+      id: 'org_spanglish',
+      name: 'Spanglish Movies',
+      domains: [{ domain: 'spanglishmovies.com', state: 'verified' }],
+    });
+
+    const result = await workosVerifiedDomainsMirroredInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].message).toContain('local row belongs');
+    expect(result.violations[0].details?.local_workos_organization_id).toBe('org_personal');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// personal-member-company-org-split
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('personal-member-company-org-split', () => {
+  it('passes when no split rows are returned', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await personalMemberCompanyOrgSplitInvariant.check(makeCtx());
+
+    expect(result.checked).toBe(0);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags an active personal workspace holding a company domain for the same user', async () => {
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          personal_org_id: 'org_personal',
+          personal_org_name: 'Gustavo Workspace',
+          company_org_id: 'org_spanglish',
+          company_org_name: 'Spanglish Movies',
+          domain: 'latinxctv.com',
+          domain_verified: false,
+          user_email: 'gustavo@spanglishmovies.com',
+          company_member_status: 'prospect',
+          company_subscription_status: null,
+        },
+      ],
+    });
+
+    const result = await personalMemberCompanyOrgSplitInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].subject_id).toBe('org_spanglish');
+    expect(result.violations[0].message).toContain('active personal workspace');
+    expect(result.violations[0].details?.personal_org_id).toBe('org_personal');
   });
 });
 

--- a/server/tests/unit/mcp-eval-tools.test.ts
+++ b/server/tests/unit/mcp-eval-tools.test.ts
@@ -382,7 +382,7 @@ describe('createMemberToolHandler', () => {
       organization_name: 'Example Org',
     });
 
-    expect(result).toContain('Use either organization_id or organization_name for save_agent, not both.');
+    expect(result).toContain('Use either organization_id or organization_name to save to, not both.');
     expect(createSpy).not.toHaveBeenCalled();
   });
 

--- a/server/tests/unit/org-selection-guard.test.ts
+++ b/server/tests/unit/org-selection-guard.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest';
+import { guardPersonalWorkspaceDomainSelection } from '../../src/services/org-selection-guard.js';
+
+function makePool(rows: Array<{ workos_organization_id: string; name: string | null }>) {
+  return {
+    query: vi.fn().mockResolvedValue({ rows }),
+  };
+}
+
+describe('guardPersonalWorkspaceDomainSelection', () => {
+  it('does not query when the selected org is not personal', async () => {
+    const pool = makePool([]);
+    const result = await guardPersonalWorkspaceDomainSelection({
+      memberContext: {
+        workos_user: { workos_user_id: 'user_123' },
+        organization: {
+          workos_organization_id: 'org_company',
+          name: 'Company',
+          is_personal: false,
+        },
+      },
+      selectedOrgId: 'org_company',
+      rawDomain: 'example.com',
+      pool: pool as any,
+    });
+
+    expect(result).toEqual({ ok: true, checked: false });
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it('stops before mutation when a personal workspace domain maps to a company org for the same user', async () => {
+    const pool = makePool([
+      { workos_organization_id: 'org_company', name: 'Example Co' },
+    ]);
+
+    const result = await guardPersonalWorkspaceDomainSelection({
+      memberContext: {
+        workos_user: { workos_user_id: 'user_123' },
+        organization: {
+          workos_organization_id: 'org_personal',
+          name: "User's Workspace",
+          is_personal: true,
+        },
+      },
+      selectedOrgId: 'org_personal',
+      rawDomain: 'https://agent.example.com/path',
+      pool: pool as any,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 'org_selection_required',
+      domain: 'example.com',
+      selectedOrg: {
+        organizationId: 'org_personal',
+        name: "User's Workspace",
+      },
+      companyOrgs: [
+        {
+          organizationId: 'org_company',
+          name: 'Example Co',
+        },
+      ],
+    });
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('organization_memberships'), [
+      'example.com',
+      'user_123',
+      'org_personal',
+    ]);
+  });
+
+  it('checks the explicit selected org, not just ambient context', async () => {
+    const pool = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              workos_organization_id: 'org_personal',
+              name: "User's Workspace",
+              is_personal: true,
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ workos_organization_id: 'org_company', name: 'Example Co' }],
+        }),
+    };
+
+    const result = await guardPersonalWorkspaceDomainSelection({
+      memberContext: {
+        workos_user: { workos_user_id: 'user_123' },
+        organization: {
+          workos_organization_id: 'org_ambient_company',
+          name: 'Ambient Company',
+          is_personal: false,
+        },
+      },
+      selectedOrgId: 'org_personal',
+      rawDomain: 'agent.example.com',
+      pool: pool as any,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.selectedOrg).toEqual({
+        organizationId: 'org_personal',
+        name: "User's Workspace",
+      });
+      expect(result.companyOrgs).toEqual([
+        { organizationId: 'org_company', name: 'Example Co' },
+      ]);
+    }
+    expect(pool.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('WHERE workos_organization_id = $1'),
+      ['org_personal'],
+    );
+    expect(pool.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('organization_memberships'),
+      ['example.com', 'user_123', 'org_personal'],
+    );
+  });
+
+  it('allows the action when no matching company org exists', async () => {
+    const pool = makePool([]);
+    const result = await guardPersonalWorkspaceDomainSelection({
+      memberContext: {
+        workos_user: { workos_user_id: 'user_123' },
+        organization: {
+          workos_organization_id: 'org_personal',
+          name: "User's Workspace",
+          is_personal: true,
+        },
+      },
+      selectedOrgId: 'org_personal',
+      rawDomain: 'example.com',
+      pool: pool as any,
+    });
+
+    expect(result).toEqual({ ok: true, checked: true, domain: 'example.com' });
+  });
+});

--- a/server/tests/unit/support-redaction-call-sites.test.ts
+++ b/server/tests/unit/support-redaction-call-sites.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  query: mocks.query,
+}));
+
+import { createEscalation } from '../../src/db/escalation-db.js';
+import { fileGitHubIssue } from '../../src/addie/jobs/github-filer.js';
+
+describe('support redaction call sites', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GITHUB_TOKEN = 'unit-test-github-token';
+  });
+
+  it('redacts GitHub issue title and body before posting', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        html_url: 'https://github.com/adcontextprotocol/adcp/issues/1',
+        number: 1,
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fileGitHubIssue({
+      title: 'Domain stuck verification_token: super-secret-token-1234567890',
+      body: '- Value: `wos-domain-verification=abcdef1234567890abcdef`',
+      repo: 'adcontextprotocol/adcp',
+    });
+
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(payload.title).toContain('[redacted-verification-token]');
+    expect(payload.body).toContain('[redacted-verification-token]');
+    expect(JSON.stringify(payload)).not.toContain('super-secret-token-1234567890');
+    expect(JSON.stringify(payload)).not.toContain('abcdef1234567890abcdef');
+  });
+
+  it('redacts escalation fields before persistence', async () => {
+    mocks.query.mockResolvedValue({
+      rows: [{
+        id: 123,
+        summary: 'redacted row',
+      }],
+    });
+
+    const bearerToken = ['abcdefgh', 'ijklmnop'].join('');
+    await createEscalation({
+      category: 'needs_human_action',
+      priority: 'high',
+      summary: 'Domain stuck verification_token: super-secret-token-1234567890',
+      original_request: '- Value: `wos-domain-verification=abcdef1234567890abcdef`',
+      addie_context: `Bearer ${bearerToken}`,
+    });
+
+    const params = mocks.query.mock.calls[0][1];
+    expect(params[9]).toContain('[redacted-verification-token]');
+    expect(params[10]).toContain('[redacted-verification-token]');
+    expect(params[11]).toContain('Bearer [redacted-secret]');
+    expect(JSON.stringify(params)).not.toContain('super-secret-token-1234567890');
+    expect(JSON.stringify(params)).not.toContain('abcdef1234567890abcdef');
+    expect(JSON.stringify(params)).not.toContain(bearerToken);
+  });
+});

--- a/server/tests/unit/support-redaction.test.ts
+++ b/server/tests/unit/support-redaction.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { redactSupportSecrets } from '../../src/services/support-redaction.js';
+
+describe('redactSupportSecrets', () => {
+  it('redacts DNS TXT values from support text', () => {
+    const text = [
+      'Publish this DNS TXT record:',
+      '- Name: `_workos.example.com`',
+      '- Type: `TXT`',
+      '- Value: `wos-domain-verification=abcdef1234567890abcdef`',
+    ].join('\n');
+
+    const redacted = redactSupportSecrets(text);
+
+    expect(redacted).toContain('- Value: `[redacted-verification-token]`');
+    expect(redacted).not.toContain('abcdef1234567890abcdef');
+  });
+
+  it('redacts explicit verification token assignments', () => {
+    const redacted = redactSupportSecrets(
+      'verification_token: super-secret-token-1234567890 should not leak',
+    );
+
+    expect(redacted).toBe(
+      'verification_token: [redacted-verification-token] should not leak',
+    );
+  });
+
+  it('redacts common API credentials', () => {
+    const githubToken = ['ghp', 'abcdefghijklmnopqrstuvwxyz123456'].join('_');
+    const bearerToken = ['abcdefgh', 'ijklmnop'].join('');
+    const redacted = redactSupportSecrets(
+      `GitHub token ${githubToken} and Authorization: Bearer ${bearerToken}`,
+    );
+
+    expect(redacted).toContain('[redacted-secret]');
+    expect(redacted).not.toContain(githubToken);
+    expect(redacted).not.toContain(bearerToken);
+  });
+});

--- a/server/tests/unit/workos-domain-reconciliation.test.ts
+++ b/server/tests/unit/workos-domain-reconciliation.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  syncOrganizationDomains: vi.fn(),
+}));
+
+vi.mock('../../src/routes/workos-webhooks.js', () => ({
+  syncOrganizationDomains: mocks.syncOrganizationDomains,
+}));
+
+import { reconcileWorkosOrganizationDomains } from '../../src/services/workos-domain-reconciliation.js';
+
+function makeWorkos(domains: Array<{ domain: string; state: string }>) {
+  return {
+    organizations: {
+      getOrganization: vi.fn().mockResolvedValue({
+        id: 'org_company',
+        name: 'Company',
+        domains,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      }),
+    },
+  };
+}
+
+function makePool(rowsByCall: unknown[][]) {
+  return {
+    query: vi.fn().mockImplementation(async () => ({
+      rows: rowsByCall.shift() ?? [],
+    })),
+  };
+}
+
+describe('reconcileWorkosOrganizationDomains', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps verified and legacy_verified WorkOS states into verified sync data', async () => {
+    const workos = makeWorkos([
+      { domain: 'example.com', state: 'verified' },
+      { domain: 'legacy.example', state: 'legacy_verified' },
+    ]);
+    const pool = makePool([
+      [],
+      [
+        {
+          domain: 'example.com',
+          workos_organization_id: 'org_company',
+          organization_name: 'Company',
+          verified: true,
+          is_primary: false,
+          source: 'workos',
+        },
+        {
+          domain: 'legacy.example',
+          workos_organization_id: 'org_company',
+          organization_name: 'Company',
+          verified: true,
+          is_primary: false,
+          source: 'workos',
+        },
+      ],
+    ]);
+
+    const result = await reconcileWorkosOrganizationDomains({
+      workos: workos as any,
+      orgId: 'org_company',
+      pool: pool as any,
+    });
+
+    expect(mocks.syncOrganizationDomains).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'org_company',
+        domains: [
+          { domain: 'example.com', state: 'verified' },
+          { domain: 'legacy.example', state: 'verified' },
+        ],
+      }),
+    );
+    expect(result.before_mismatches.map((m) => m.reason)).toEqual([
+      'missing_local_row',
+      'missing_local_row',
+    ]);
+    expect(result.after_mismatches).toEqual([]);
+  });
+
+  it('reports remaining mismatches after sync', async () => {
+    const workos = makeWorkos([{ domain: 'example.com', state: 'verified' }]);
+    const wrongLocalRow = {
+      domain: 'example.com',
+      workos_organization_id: 'org_wrong',
+      organization_name: 'Wrong Org',
+      verified: true,
+      is_primary: false,
+      source: 'workos',
+    };
+    const pool = makePool([[wrongLocalRow], [wrongLocalRow]]);
+
+    const result = await reconcileWorkosOrganizationDomains({
+      workos: workos as any,
+      orgId: 'org_company',
+      pool: pool as any,
+    });
+
+    expect(result.before_mismatches).toEqual([
+      expect.objectContaining({ reason: 'wrong_local_org', domain: 'example.com' }),
+    ]);
+    expect(result.after_mismatches).toEqual([
+      expect.objectContaining({ reason: 'wrong_local_org', domain: 'example.com' }),
+    ]);
+  });
+
+  it('passes zero WorkOS domains through to the canonical sync path', async () => {
+    const workos = makeWorkos([]);
+    const pool = makePool([]);
+
+    const result = await reconcileWorkosOrganizationDomains({
+      workos: workos as any,
+      orgId: 'org_company',
+      pool: pool as any,
+    });
+
+    expect(mocks.syncOrganizationDomains).toHaveBeenCalledWith(
+      expect.objectContaining({ domains: [] }),
+    );
+    expect(result.workos_domains).toEqual([]);
+    expect(result.before_mismatches).toEqual([]);
+    expect(result.after_mismatches).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the Addie/registry domain split failure mode by adding explicit org-selection guardrails, WorkOS domain reconciliation, admin preview safety checks, integrity invariants, escalation resolution guards, and support redaction.

## What changed

- Addie now stops and asks for company org selection before issuing domain challenges or saving agents against a personal workspace when the domain maps to a company org.
- Added admin-only WorkOS domain reconciliation and a read-only domain-split repair preview with org-role validation and explicit `safe_to_reconcile` output.
- Added integrity invariants for WorkOS domain mirroring and personal/company org split drift.
- Added escalation resolution guardrails so tickets cannot be resolved while registry/domain state still looks broken.
- Redacts support secrets at escalation storage and GitHub issue title/body boundaries.
- Updated recovery runbook and Addie tool catalog.

## Validation

- `npx vitest run server/tests/unit/org-selection-guard.test.ts server/tests/unit/support-redaction.test.ts server/tests/unit/support-redaction-call-sites.test.ts server/tests/unit/workos-domain-reconciliation.test.ts server/tests/unit/mcp-eval-tools.test.ts server/tests/unit/domain-split-repair-preview.test.ts --pool=threads`
- `npm run typecheck`
- `npm run test:addie-tools`
- `git diff --check`
- pre-push checks passed, including Mintlify broken-link validation

## Expert review follow-up

Addressed security/test/internal-tools blockers: explicit selected org lookup, no public exposure of private admin endpoint details in docs, title/body redaction, preview org-role validation, whitespace hygiene, and direct tests for the new safety paths.