### PR TITLE
fix(admin): derive domain preview member status

### DIFF
--- a/server/src/audit/integrity/invariants/personal-member-company-org-split.ts
+++ b/server/src/audit/integrity/invariants/personal-member-company-org-split.ts
@@ -34,10 +34,8 @@ export const personalMemberCompanyOrgSplitInvariant: Invariant = {
         SELECT workos_organization_id, name
         FROM organizations
         WHERE COALESCE(is_personal, false) = true
-          AND (
-            subscription_status IN ('active', 'trialing', 'past_due')
-            OR member_status = 'member'
-          )
+          AND subscription_status = 'active'
+          AND subscription_canceled_at IS NULL
       )
       SELECT DISTINCT
         po.workos_organization_id AS personal_org_id,
@@ -47,7 +45,11 @@ export const personalMemberCompanyOrgSplitInvariant: Invariant = {
         pod.domain,
         pod.verified AS domain_verified,
         pom.email AS user_email,
-        co.member_status AS company_member_status,
+        CASE
+          WHEN co.subscription_status = 'active' AND co.subscription_canceled_at IS NULL THEN 'member'
+          WHEN co.subscription_status = 'canceled' OR co.subscription_canceled_at IS NOT NULL THEN 'churned'
+          ELSE 'prospect'
+        END AS company_member_status,
         co.subscription_status AS company_subscription_status
       FROM live_personal_orgs po
       JOIN organization_domains pod

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -166,7 +166,12 @@ export function setupDomainRoutes(
               stripe_subscription_id: string | null;
             }>(
               `SELECT workos_organization_id, name, is_personal, email_domain,
-                      member_status, subscription_status, subscription_canceled_at,
+                      CASE
+                        WHEN subscription_status = 'active' AND subscription_canceled_at IS NULL THEN 'member'
+                        WHEN subscription_status = 'canceled' OR subscription_canceled_at IS NOT NULL THEN 'churned'
+                        ELSE 'prospect'
+                      END AS member_status,
+                      subscription_status, subscription_canceled_at,
                       membership_tier, stripe_customer_id, stripe_subscription_id
                  FROM organizations
                 WHERE workos_organization_id = ANY($1::text[])`,

--- a/server/src/services/escalation-resolution-guard.ts
+++ b/server/src/services/escalation-resolution-guard.ts
@@ -123,7 +123,11 @@ export async function guardEscalationResolution(input: {
        o.name AS organization_name,
        o.is_personal,
        od.verified,
-       o.member_status,
+       CASE
+         WHEN o.subscription_status = 'active' AND o.subscription_canceled_at IS NULL THEN 'member'
+         WHEN o.subscription_status = 'canceled' OR o.subscription_canceled_at IS NOT NULL THEN 'churned'
+         ELSE 'prospect'
+       END AS member_status,
        o.subscription_status
      FROM organization_domains od
      LEFT JOIN organizations o ON o.workos_organization_id = od.workos_organization_id


### PR DESCRIPTION
## Summary
- derive organization member status from `subscription_status` in the domain split preview query
- apply the same derived status in the escalation resolution guard and split invariant audit
- unblock the production domain split repair preview that failed on missing `organizations.member_status`

## Root cause
The repair PR treated `member_status` as a physical `organizations` column in a few new production paths. In this schema, AAO member/prospect/churned state is derived from `subscription_status`, matching the existing integrity invariant pattern.

## Validation
- `npx vitest run server/tests/unit/domain-split-repair-preview.test.ts server/tests/unit/escalation-resolution-guard.test.ts server/tests/unit/integrity/invariants.test.ts --pool=threads`
- `npm run typecheck`
- `git diff --check`