### PR TITLE
Fix domain and agent repair workflows

### DIFF
--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -3176,9 +3176,6 @@ export function createMemberToolHandlers(
       return `<!-- STATUS: workos_error -->\n\nIssued a challenge for ${result.domain}, but WorkOS did not return a DNS TXT value. Ask the AgenticAdvertising.org team to verify ${result.domain} manually for you.`;
     }
 
-    const recordName = result.verification_prefix
-      ? `${result.verification_prefix}.${result.domain}`
-      : result.domain;
     const lines = [
       `<!-- STATUS: dns_record_issued -->`,
       ``,
@@ -3186,9 +3183,9 @@ export function createMemberToolHandlers(
       ``,
       `**Publish this DNS TXT record:**`,
       ``,
-      `- Name: \`${recordName}\``,
-      `- Type: \`TXT\``,
-      `- Value: \`${result.verification_token}\``,
+      `- Name: \`${result.dns_record_name}\``,
+      `- Type: \`${result.dns_record_type}\``,
+      `- Value: \`${result.dns_record_value}\``,
       `- TTL: \`300\` (or your registrar's minimum)`,
       ``,
       `Organization: ${orgResolution.organizationName ? `${formatOrgNameForTool(orgResolution.organizationName)} (${orgId})` : orgId}`,

--- a/server/src/db/member-db.ts
+++ b/server/src/db/member-db.ts
@@ -130,12 +130,26 @@ export class MemberDatabase {
    * return `member: null` for legitimate members.
    */
   async getProfileByDomain(domain: string): Promise<MemberProfile | null> {
+    const exactDomain = await query<{ workos_organization_id: string }>(
+      `SELECT workos_organization_id
+         FROM organization_domains
+        WHERE LOWER(domain) = LOWER($1)
+          AND verified = true
+        LIMIT 1`,
+      [domain],
+    );
+    if (exactDomain.rows[0]) {
+      return this.getProfileByOrgId(exactDomain.rows[0].workos_organization_id);
+    }
+
     const result = await query<MemberProfile>(
       `SELECT mp.*
          FROM member_profiles mp
          JOIN organization_domains od
            ON od.workos_organization_id = mp.workos_organization_id
-        WHERE LOWER(od.domain) = LOWER($1)
+        WHERE od.verified = true
+          AND LOWER($1) LIKE '%.' || LOWER(od.domain)
+        ORDER BY LENGTH(od.domain) DESC
         LIMIT 1`,
       [domain]
     );

--- a/server/src/routes/admin/agents.ts
+++ b/server/src/routes/admin/agents.ts
@@ -16,12 +16,30 @@
 
 import { Router } from 'express';
 import { getPool } from '../../db/client.js';
+import { canonicalizeAgentUrl } from '../../db/publisher-db.js';
+import {
+  hasApiAccess,
+  OrganizationDatabase,
+  resolveMembershipTier,
+} from '../../db/organization-db.js';
 import { createLogger } from '../../logger.js';
 import { requireAuth, requireAdmin } from '../../middleware/auth.js';
 import { invalidateMemberContextCache } from '../../addie/index.js';
+import {
+  gateAgentVisibilityForCaller,
+  type VisibilityWarning,
+} from '../../services/agent-visibility-gate.js';
+import {
+  buildUnverifiedHostnameMessage,
+  isHostnameOwnershipRejection,
+  verifyAgentHostname,
+} from '../../services/agent-hostname-verification.js';
+import { logResolvedTypeChanges, resolveAgentTypes } from '../member-profiles.js';
 import type { AgentConfig } from '../../types.js';
+import { isValidAgentType, isValidAgentVisibility } from '../../types.js';
 
 const logger = createLogger('admin-agents');
+const orgDb = new OrganizationDatabase();
 
 const MIN_REASON_LENGTH = 5;
 const MAX_REASON_LENGTH = 500;
@@ -56,6 +74,34 @@ function parseAgents(raw: unknown): AgentConfig[] {
     throw new CorruptAgentsColumnError();
   }
   throw new CorruptAgentsColumnError();
+}
+
+function isParseableUrl(value: string): boolean {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pickAgent(agents: AgentConfig[], url: string): AgentConfig | undefined {
+  return agents.find((a) => a.url === url);
+}
+
+function redactAgentForAudit<T extends { health_check_url?: string } | undefined>(agent: T): T {
+  if (!agent?.health_check_url) return agent;
+  try {
+    const url = new URL(agent.health_check_url);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return { ...agent, health_check_url: url.toString() };
+  } catch {
+    return { ...agent, health_check_url: '[redacted-invalid-url]' };
+  }
 }
 
 export function setupAdminAgentsRoutes(apiRouter: Router): void {
@@ -96,6 +142,227 @@ export function setupAdminAgentsRoutes(apiRouter: Router): void {
           error: 'internal_error',
           message: 'Failed to list agents',
         });
+      }
+    },
+  );
+
+  // POST /api/admin/accounts/:orgId/agents
+  //
+  // Audited repair path for registering or updating a single agent under an
+  // existing member profile. Mirrors the member POST's identity protections:
+  // canonical URL matching, declared type requirement, hostname ownership
+  // verification, visibility gating, type-resolution smuggle protection, and
+  // metadata seeding.
+  apiRouter.post(
+    '/accounts/:orgId/agents',
+    requireAuth,
+    requireAdmin,
+    async (req, res) => {
+      const { orgId } = req.params;
+      const body = (req.body ?? {}) as Record<string, unknown>;
+
+      const reason = typeof body.reason === 'string' ? body.reason.trim() : '';
+      if (reason.length < MIN_REASON_LENGTH) {
+        return res.status(400).json({
+          error: 'reason_required',
+          message: `reason is required in the request body (min ${MIN_REASON_LENGTH} chars)`,
+        });
+      }
+      if (reason.length > MAX_REASON_LENGTH) {
+        return res.status(400).json({
+          error: 'reason_too_long',
+          message: `reason exceeds ${MAX_REASON_LENGTH} chars`,
+        });
+      }
+
+      const rawUrl = typeof body.url === 'string' ? body.url : '';
+      if (rawUrl.length === 0) {
+        return res.status(400).json({ error: 'url_required', message: 'url is required' });
+      }
+      if (!isParseableUrl(rawUrl)) {
+        return res.status(400).json({ error: 'invalid_url', message: 'url must be a valid URL' });
+      }
+      if (rawUrl.includes('?') || rawUrl.includes('#')) {
+        return res.status(400).json({
+          error: 'invalid_url',
+          message: 'url must not contain query strings or fragments',
+        });
+      }
+      const canonicalUrl = canonicalizeAgentUrl(rawUrl);
+      if (!canonicalUrl) {
+        return res.status(400).json({ error: 'invalid_url', message: 'url is not a valid agent URL' });
+      }
+
+      const type = body.type;
+      if (typeof type !== 'string' || !isValidAgentType(type) || type === 'unknown') {
+        return res.status(400).json({
+          error: 'type_required',
+          message: 'Specify one of: brand, rights, measurement, governance, creative, sales, buying, signals.',
+        });
+      }
+
+      const requestedVisibility = body.visibility;
+      if (requestedVisibility !== undefined && !isValidAgentVisibility(requestedVisibility)) {
+        return res.status(400).json({
+          error: 'invalid_visibility',
+          message: 'visibility must be one of: private, members_only, public.',
+        });
+      }
+      if (requestedVisibility === 'public') {
+        return res.status(400).json({
+          error: 'public_visibility_not_supported',
+          message: 'Admin agent repair can register private or members_only agents only. Use the normal publish flow to list an agent publicly.',
+        });
+      }
+
+      const verification = await verifyAgentHostname(orgId, canonicalUrl);
+      if (isHostnameOwnershipRejection(verification)) {
+        return res.status(400).json({
+          error: 'unverified_hostname',
+          message: buildUnverifiedHostnameMessage(verification),
+          agent_hostname: verification.agent_hostname,
+          verified_domains: verification.verified_domains,
+          reason: verification.reason,
+        });
+      }
+
+      const escalationId =
+        typeof body.escalation_id === 'string' && body.escalation_id.length > 0
+          ? body.escalation_id
+          : null;
+      const agentPatch: Partial<AgentConfig> & { url: string } = {
+        url: canonicalUrl,
+        type,
+        ...(requestedVisibility !== undefined ? { visibility: requestedVisibility } : {}),
+        ...(typeof body.name === 'string' && body.name.trim().length > 0
+          ? { name: body.name.trim() }
+          : {}),
+        ...(typeof body.health_check_url === 'string' && body.health_check_url.length > 0
+          ? { health_check_url: body.health_check_url }
+          : {}),
+      };
+
+      const pool = getPool();
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+
+        const row = await client.query<{ id: string; agents: unknown }>(
+          `SELECT id, agents
+           FROM member_profiles
+           WHERE workos_organization_id = $1
+           FOR UPDATE`,
+          [orgId],
+        );
+        if (row.rowCount === 0) {
+          await client.query('ROLLBACK');
+          return res.status(404).json({
+            error: 'profile_not_found',
+            message: `No member profile exists for org ${orgId}`,
+          });
+        }
+
+        const profileId = row.rows[0].id;
+        const existing = parseAgents(row.rows[0].agents);
+        const idx = existing.findIndex((a) => (canonicalizeAgentUrl(a.url) ?? a.url) === canonicalUrl);
+        const wasUpdate = idx !== -1;
+        const newAgent: AgentConfig = {
+          ...agentPatch,
+          visibility: requestedVisibility ?? 'members_only',
+        } as AgentConfig;
+        const next = wasUpdate
+          ? existing.map((a, i) => (i === idx ? { ...a, ...agentPatch } : a))
+          : [...existing, newAgent];
+
+        const org = await orgDb.getOrganization(orgId);
+        const callerHasApi = hasApiAccess(resolveMembershipTier(org));
+        const { agents: gated, warnings } = gateAgentVisibilityForCaller(next, callerHasApi);
+        const typed = (await resolveAgentTypes(gated)) as AgentConfig[];
+        await logResolvedTypeChanges(gated, typed, orgId);
+
+        await client.query(
+          `UPDATE member_profiles
+           SET agents = $1::jsonb, updated_at = NOW()
+           WHERE id = $2`,
+          [JSON.stringify(typed), profileId],
+        );
+
+        const urls = typed
+          .map((a) => (a && typeof a.url === 'string' ? canonicalizeAgentUrl(a.url) : null))
+          .filter((u): u is string => u !== null);
+        if (urls.length > 0) {
+          await client.query(
+            `INSERT INTO agent_registry_metadata (agent_url)
+             SELECT unnest($1::text[])
+             ON CONFLICT (agent_url) DO NOTHING`,
+            [urls],
+          );
+        }
+
+        const upsertedAgent = pickAgent(typed, canonicalUrl);
+        await client.query(
+          `INSERT INTO registry_audit_log
+             (workos_organization_id, workos_user_id, action, resource_type, resource_id, details)
+           VALUES ($1, $2, 'admin_add_agent', 'agent', $3, $4)`,
+          [
+            orgId,
+            req.user!.id,
+            canonicalUrl,
+            JSON.stringify({
+              reason,
+              escalation_id: escalationId,
+              admin_email: req.user!.email,
+              was_update: wasUpdate,
+              requested_agent: redactAgentForAudit(wasUpdate ? agentPatch : newAgent),
+              upserted_agent: redactAgentForAudit(upsertedAgent),
+            }),
+          ],
+        );
+
+        await client.query('COMMIT');
+        invalidateMemberContextCache();
+
+        logger.warn(
+          {
+            orgId,
+            agentUrl: canonicalUrl,
+            adminUserId: req.user!.id,
+            adminEmail: req.user!.email,
+            escalationId,
+            wasUpdate,
+          },
+          'Admin registered agent on org member profile',
+        );
+
+        return res.status(wasUpdate ? 200 : 201).json({
+          agent: upsertedAgent,
+          org_id: orgId,
+          reason,
+          escalation_id: escalationId,
+          was_update: wasUpdate,
+          agents_count: typed.length,
+          ...(warnings.length ? { warnings: warnings as VisibilityWarning[] } : {}),
+        });
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {});
+        if (err instanceof CorruptAgentsColumnError) {
+          logger.error({ orgId }, 'member_profiles.agents column is corrupt');
+          return res.status(500).json({
+            error: 'corrupt_agents_column',
+            message: `member_profiles.agents for org ${orgId} is not a JSON array`,
+          });
+        }
+        logger.error({ err, orgId, agentUrl: canonicalUrl }, 'Admin agent registration failed');
+        return res.status(500).json({
+          error: 'internal_error',
+          message: 'Failed to register agent',
+        });
+      } finally {
+        try {
+          client.release();
+        } catch (releaseErr) {
+          logger.warn({ err: releaseErr, orgId }, 'pg client release failed');
+        }
       }
     },
   );

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -2167,9 +2167,6 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         }
         return res.status(500).json({ error: 'Failed to issue domain verification challenge', code: 'workos_error' });
       }
-      const dnsRecordName = result.verification_prefix
-        ? `${result.verification_prefix}.${result.domain}`
-        : result.domain;
       const requestedOrgId = typeof req.query.org === 'string' && req.query.org.length > 0
         ? req.query.org
         : null;
@@ -2182,12 +2179,14 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         verification_strategy: result.verification_strategy,
         verification_token: result.verification_token,
         verification_prefix: result.verification_prefix,
-        dns_record_name: dnsRecordName,
+        dns_record_name: result.dns_record_name,
+        dns_record_type: result.dns_record_type,
+        dns_record_value: result.dns_record_value,
         prior_manifest_exists: result.prior_manifest_exists,
         instructions: result.already_verified
           ? `Domain is already verified. Run POST ${verifyPath} to sync the brand registry, or call PUT /brand-identity directly.`
-          : dnsRecordName
-            ? `Publish a DNS TXT record at ${dnsRecordName} with the value ${result.verification_token}, then call POST ${verifyPath}.`
+          : result.dns_record_name
+            ? `Publish a DNS TXT record at ${result.dns_record_name} with the value ${result.dns_record_value}, then call POST ${verifyPath}.`
             : `Publish a DNS TXT record at ${result.domain} with the value <verification_token>, then call POST ${verifyPath}.`,
       });
     } catch (error) {

--- a/server/src/services/brand-claim.ts
+++ b/server/src/services/brand-claim.ts
@@ -27,6 +27,9 @@ export type IssueChallengeResult =
       verification_strategy: string | null;
       verification_token: string | null;
       verification_prefix: string | null;
+      dns_record_name: string;
+      dns_record_type: 'TXT';
+      dns_record_value: string | null;
       already_verified: boolean;
       // True when a brand row exists for this domain with an orphaned manifest
       // (a prior owner relinquished). Tells callers whether to surface the
@@ -169,6 +172,9 @@ export async function issueDomainChallenge(input: {
           verification_strategy: existingDomain.verificationStrategy ?? null,
           verification_token: existingDomain.verificationToken ?? null,
           verification_prefix: existingDomain.verificationPrefix ?? null,
+          dns_record_name: dnsRecordName(domain, existingDomain.verificationPrefix),
+          dns_record_type: 'TXT',
+          dns_record_value: existingDomain.verificationToken ?? null,
           already_verified: verified,
           prior_manifest_exists: priorManifestExists,
         };
@@ -188,6 +194,9 @@ export async function issueDomainChallenge(input: {
       verification_strategy: created.verificationStrategy ?? 'dns',
       verification_token: created.verificationToken ?? null,
       verification_prefix: created.verificationPrefix ?? null,
+      dns_record_name: dnsRecordName(domain, created.verificationPrefix),
+      dns_record_type: 'TXT',
+      dns_record_value: created.verificationToken ?? null,
       already_verified: isVerifiedState(created.state),
       prior_manifest_exists: priorManifestExists,
     };

--- a/server/tests/integration/admin-agent-removal.test.ts
+++ b/server/tests/integration/admin-agent-removal.test.ts
@@ -1,9 +1,9 @@
 /**
- * Integration tests for admin cross-org agent removal.
+ * Integration tests for admin cross-org agent management.
  *
- * Covers the DELETE /api/admin/accounts/:orgId/agents/:url endpoint —
- * the path that resolves rogue / disputed agent entries the owning org
- * cannot or will not self-serve clean up (see escalation #340).
+ * Covers the GET/POST/DELETE /api/admin/accounts/:orgId/agents endpoints:
+ * audited repair paths for registering or removing agent entries when the
+ * owning org cannot self-serve cleanly.
  */
 import {
   describe,
@@ -14,6 +14,14 @@ import {
   beforeEach,
   vi,
 } from 'vitest';
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+  process.env.WORKOS_COOKIE_PASSWORD =
+    process.env.WORKOS_COOKIE_PASSWORD ??
+    'test-cookie-password-at-least-32-chars-long';
+});
 
 vi.mock('../../src/middleware/auth.js', async () => {
   const actual = await vi.importActual<typeof import('../../src/middleware/auth.js')>(
@@ -57,8 +65,9 @@ import { MemberDatabase } from '../../src/db/member-db.js';
 import { setupAdminAgentsRoutes } from '../../src/routes/admin/agents.js';
 
 const TEST_PREFIX = 'org_admin_agent_remove';
+const TEST_DOMAIN_SUFFIX = 'admin-agent.test';
 
-describe('Admin cross-org agent removal (DELETE /api/admin/accounts/:orgId/agents/:url)', () => {
+describe('Admin cross-org agent management (/api/admin/accounts/:orgId/agents)', () => {
   let pool: Pool;
   let app: express.Application;
   let memberDb: MemberDatabase;
@@ -83,6 +92,14 @@ describe('Admin cross-org agent removal (DELETE /api/admin/accounts/:orgId/agent
 
   afterAll(async () => {
     await pool.query(
+      `DELETE FROM agent_registry_metadata WHERE agent_url LIKE $1`,
+      [`%${TEST_DOMAIN_SUFFIX}%`],
+    );
+    await pool.query(
+      `DELETE FROM organization_domains WHERE workos_organization_id LIKE $1 OR domain LIKE $2`,
+      [`${TEST_PREFIX}%`, `%${TEST_DOMAIN_SUFFIX}`],
+    );
+    await pool.query(
       `DELETE FROM registry_audit_log WHERE workos_organization_id LIKE $1`,
       [`${TEST_PREFIX}%`],
     );
@@ -103,6 +120,14 @@ describe('Admin cross-org agent removal (DELETE /api/admin/accounts/:orgId/agent
     };
     mod.__setAdmin(true);
 
+    await pool.query(
+      `DELETE FROM agent_registry_metadata WHERE agent_url LIKE $1`,
+      [`%${TEST_DOMAIN_SUFFIX}%`],
+    );
+    await pool.query(
+      `DELETE FROM organization_domains WHERE workos_organization_id LIKE $1 OR domain LIKE $2`,
+      [`${TEST_PREFIX}%`, `%${TEST_DOMAIN_SUFFIX}`],
+    );
     await pool.query(
       `DELETE FROM registry_audit_log WHERE workos_organization_id LIKE $1`,
       [`${TEST_PREFIX}%`],
@@ -136,6 +161,241 @@ describe('Admin cross-org agent removal (DELETE /api/admin/accounts/:orgId/agent
       agents: agents as any,
     });
   }
+
+  async function seedVerifiedDomain(orgId: string, domain: string) {
+    await pool.query(
+      `INSERT INTO organization_domains
+         (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+       VALUES ($1, $2, true, false, 'test', NOW(), NOW())
+       ON CONFLICT (domain) DO UPDATE SET
+         workos_organization_id = EXCLUDED.workos_organization_id,
+         verified = true,
+         source = 'test',
+         updated_at = NOW()`,
+      [orgId, domain],
+    );
+  }
+
+  it('POST registers a canonicalized agent, seeds metadata, and writes an audit row', async () => {
+    const orgId = `${TEST_PREFIX}_post_create`;
+    const domain = `create.${TEST_DOMAIN_SUFFIX}`;
+    const agentUrl = `https://sales.${domain}/mcp/`;
+    const canonicalUrl = `https://sales.${domain}/mcp`;
+    await seedOrgWithAgents(orgId, 'repair-post-create', []);
+    await seedVerifiedDomain(orgId, domain);
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${orgId}/agents`)
+      .send({
+        url: agentUrl,
+        type: 'sales',
+        name: 'Endpoint Sales Agent',
+        health_check_url: `https://user:secret@sales.${domain}/health?token=hidden#frag`,
+        reason: 'escalation 5709: customer DNS ownership established',
+        escalation_id: '5709',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      org_id: orgId,
+      escalation_id: '5709',
+      was_update: false,
+      agents_count: 1,
+      agent: {
+        url: canonicalUrl,
+        type: 'sales',
+        visibility: 'members_only',
+        name: 'Endpoint Sales Agent',
+      },
+    });
+
+    const profile = await memberDb.getProfileByOrgId(orgId);
+    expect(profile?.agents).toEqual([
+      expect.objectContaining({ url: canonicalUrl, type: 'sales', visibility: 'members_only' }),
+    ]);
+
+    const metadata = await pool.query(
+      `SELECT agent_url FROM agent_registry_metadata WHERE agent_url = $1`,
+      [canonicalUrl],
+    );
+    expect(metadata.rowCount).toBe(1);
+
+    const audit = await pool.query(
+      `SELECT action, resource_type, resource_id, details, workos_user_id
+       FROM registry_audit_log
+       WHERE workos_organization_id = $1 AND resource_id = $2`,
+      [orgId, canonicalUrl],
+    );
+    expect(audit.rowCount).toBe(1);
+    expect(audit.rows[0]).toMatchObject({
+      action: 'admin_add_agent',
+      resource_type: 'agent',
+      resource_id: canonicalUrl,
+      workos_user_id: 'admin_api_key',
+    });
+    expect(audit.rows[0].details).toMatchObject({
+      reason: 'escalation 5709: customer DNS ownership established',
+      escalation_id: '5709',
+      was_update: false,
+      admin_email: 'admin-api-key@internal',
+      upserted_agent: { url: canonicalUrl, type: 'sales', visibility: 'members_only' },
+    });
+    expect(audit.rows[0].details.requested_agent.health_check_url).toBe(
+      `https://sales.${domain}/health`,
+    );
+    expect(JSON.stringify(audit.rows[0].details)).not.toContain('secret');
+    expect(JSON.stringify(audit.rows[0].details)).not.toContain('token=hidden');
+  });
+
+  it('POST upserts an existing canonical agent instead of duplicating it', async () => {
+    const orgId = `${TEST_PREFIX}_post_update`;
+    const domain = `update.${TEST_DOMAIN_SUFFIX}`;
+    const canonicalUrl = `https://sales.${domain}/mcp`;
+    await seedOrgWithAgents(orgId, 'repair-post-update', [
+      { url: canonicalUrl, type: 'sales', visibility: 'members_only', name: 'Old name' },
+    ]);
+    await seedVerifiedDomain(orgId, domain);
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${orgId}/agents`)
+      .send({
+        url: `HTTPS://SALES.${domain.toUpperCase()}/mcp/`,
+        type: 'creative',
+        name: 'Updated agent',
+        visibility: 'private',
+        reason: 'correcting previously inserted agent metadata',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      was_update: true,
+      agents_count: 1,
+      agent: {
+        url: canonicalUrl,
+        type: 'creative',
+        visibility: 'private',
+        name: 'Updated agent',
+      },
+    });
+
+    const profile = await memberDb.getProfileByOrgId(orgId);
+    expect(profile?.agents).toHaveLength(1);
+    expect(profile?.agents?.[0]).toMatchObject({
+      url: canonicalUrl,
+      type: 'creative',
+      visibility: 'private',
+      name: 'Updated agent',
+    });
+  });
+
+  it('POST preserves existing visibility when an update omits visibility', async () => {
+    const orgId = `${TEST_PREFIX}_post_preserve_visibility`;
+    const domain = `preserve.${TEST_DOMAIN_SUFFIX}`;
+    const canonicalUrl = `https://sales.${domain}/mcp`;
+    await seedOrgWithAgents(orgId, 'repair-post-preserve-visibility', [
+      { url: canonicalUrl, type: 'sales', visibility: 'private', name: 'Old name' },
+    ]);
+    await seedVerifiedDomain(orgId, domain);
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${orgId}/agents`)
+      .send({
+        url: canonicalUrl,
+        type: 'creative',
+        name: 'Updated private agent',
+        reason: 'update metadata without changing visibility',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.agent).toMatchObject({
+      url: canonicalUrl,
+      type: 'creative',
+      visibility: 'private',
+      name: 'Updated private agent',
+    });
+
+    const profile = await memberDb.getProfileByOrgId(orgId);
+    expect(profile?.agents?.[0]).toMatchObject({ visibility: 'private' });
+  });
+
+  it('POST rejects agents outside the org verified domain set', async () => {
+    const orgId = `${TEST_PREFIX}_post_wrong_host`;
+    await seedOrgWithAgents(orgId, 'repair-post-wrong-host', []);
+    await seedVerifiedDomain(orgId, `owned.${TEST_DOMAIN_SUFFIX}`);
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${orgId}/agents`)
+      .send({
+        url: 'https://sales.someone-else.example/mcp',
+        type: 'sales',
+        reason: 'should reject wrong host',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('unverified_hostname');
+
+    const profile = await memberDb.getProfileByOrgId(orgId);
+    expect(profile?.agents).toEqual([]);
+    const audit = await pool.query(
+      `SELECT 1 FROM registry_audit_log WHERE workos_organization_id = $1`,
+      [orgId],
+    );
+    expect(audit.rowCount).toBe(0);
+  });
+
+  it('POST rejects public visibility because repair does not update brand.json', async () => {
+    const orgId = `${TEST_PREFIX}_post_public_reject`;
+    const domain = `downgrade.${TEST_DOMAIN_SUFFIX}`;
+    await seedOrgWithAgents(orgId, 'repair-post-public-reject', []);
+    await seedVerifiedDomain(orgId, domain);
+
+    const res = await request(app)
+      .post(`/api/admin/accounts/${orgId}/agents`)
+      .send({
+        url: `https://sales.${domain}/mcp`,
+        type: 'sales',
+        visibility: 'public',
+        reason: 'register as repair but do not bypass tier visibility',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('public_visibility_not_supported');
+    const profile = await memberDb.getProfileByOrgId(orgId);
+    expect(profile?.agents).toEqual([]);
+  });
+
+  it('POST requires reason and a declared non-unknown type', async () => {
+    const orgId = `${TEST_PREFIX}_post_validations`;
+    const domain = `validations.${TEST_DOMAIN_SUFFIX}`;
+    await seedOrgWithAgents(orgId, 'repair-post-validations', []);
+    await seedVerifiedDomain(orgId, domain);
+
+    const noReason = await request(app)
+      .post(`/api/admin/accounts/${orgId}/agents`)
+      .send({ url: `https://sales.${domain}/mcp`, type: 'sales' });
+    expect(noReason.status).toBe(400);
+    expect(noReason.body.error).toBe('reason_required');
+
+    const unknownType = await request(app)
+      .post(`/api/admin/accounts/${orgId}/agents`)
+      .send({
+        url: `https://sales.${domain}/mcp`,
+        type: 'unknown',
+        reason: 'unknown type should not be accepted',
+      });
+    expect(unknownType.status).toBe(400);
+    expect(unknownType.body.error).toBe('type_required');
+
+    const queryString = await request(app)
+      .post(`/api/admin/accounts/${orgId}/agents`)
+      .send({
+        url: `https://sales.${domain}/mcp?x=1`,
+        type: 'sales',
+        reason: 'query strings should not be accepted',
+      });
+    expect(queryString.status).toBe(400);
+    expect(queryString.body.error).toBe('invalid_url');
+  });
 
   it('removes the targeted agent from the org JSONB and writes an audit row', async () => {
     const orgId = `${TEST_PREFIX}_basic`;

--- a/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
+++ b/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
@@ -108,7 +108,9 @@ const PUB_B = `${DOMAIN_PREFIX}pinnacle${DOMAIN_SUFFIX}`;
 const AGENT_X = `${AGENT_PREFIX}sales-x.registry-baseline.example`;
 const AGENT_Y = `${AGENT_PREFIX}sales-y.registry-baseline.example`;
 const ORG_ID = 'org_endpoint_registry_baseline';
+const ORG_ID_EXACT = 'org_endpoint_registry_baseline_exact';
 const MEMBER_SLUG = 'endpoint-acme-baseline';
+const MEMBER_SLUG_EXACT = 'endpoint-acme-exact-baseline';
 
 describe('Registry reader baseline — public endpoints', () => {
   let server: HTTPServer;
@@ -146,9 +148,9 @@ describe('Registry reader baseline — public endpoints', () => {
       'DELETE FROM discovered_agents WHERE agent_url LIKE $1',
       [AGENT_LIKE]
     );
-    await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = $1 OR domain LIKE $2', [ORG_ID, DOMAIN_LIKE]);
-    await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = $1', [ORG_ID]);
-    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [ORG_ID]);
+    await pool.query('DELETE FROM organization_domains WHERE workos_organization_id LIKE $1 OR domain LIKE $2', [`${ORG_ID}%`, DOMAIN_LIKE]);
+    await pool.query('DELETE FROM member_profiles WHERE workos_organization_id LIKE $1', [`${ORG_ID}%`]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id LIKE $1', [`${ORG_ID}%`]);
   }
 
   async function seedBrandPrimary(orgId: string, domain: string) {
@@ -538,6 +540,142 @@ describe('Registry reader baseline — public endpoints', () => {
         publisher_domain: PUB_A,
         authorized_for: 'all',
         source: 'adagents_json',
+      });
+    });
+
+    it('GET /api/registry/operator falls back from subdomain to verified parent domain', async () => {
+      await pool.query(
+        `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+         VALUES ($1, 'Endpoint Parent Org', NOW(), NOW())
+         ON CONFLICT (workos_organization_id) DO NOTHING`,
+        [ORG_ID],
+      );
+      await pool.query(
+        `INSERT INTO member_profiles (
+           workos_organization_id, display_name, slug,
+           agents, is_public, created_at, updated_at
+         ) VALUES ($1, 'Endpoint Parent Org', $2, $3::jsonb, true, NOW(), NOW())`,
+        [
+          ORG_ID,
+          MEMBER_SLUG,
+          JSON.stringify([
+            { url: AGENT_X, name: 'Endpoint Sales X', type: 'sales', visibility: 'public' },
+          ]),
+        ],
+      );
+      await seedBrandPrimary(ORG_ID, PUB_A);
+
+      const subdomain = `sales.${PUB_A}`;
+      const res = await request(app).get(
+        `/api/registry/operator?domain=${encodeURIComponent(subdomain)}`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.domain).toBe(subdomain);
+      expect(res.body.member).toMatchObject({
+        slug: MEMBER_SLUG,
+        display_name: 'Endpoint Parent Org',
+      });
+      expect(res.body.agents[0]).toMatchObject({ url: AGENT_X });
+    });
+
+    it('GET /api/registry/operator does not fall back through an unverified parent domain', async () => {
+      await pool.query(
+        `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+         VALUES ($1, 'Endpoint Unverified Org', NOW(), NOW())
+         ON CONFLICT (workos_organization_id) DO NOTHING`,
+        [ORG_ID],
+      );
+      await pool.query(
+        `INSERT INTO member_profiles (
+           workos_organization_id, display_name, slug,
+           agents, is_public, created_at, updated_at
+         ) VALUES ($1, 'Endpoint Unverified Org', $2, '[]'::jsonb, true, NOW(), NOW())`,
+        [ORG_ID, MEMBER_SLUG],
+      );
+      await pool.query(
+        `INSERT INTO organization_domains
+           (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+         VALUES ($1, $2, false, true, 'test', NOW(), NOW())`,
+        [ORG_ID, PUB_A],
+      );
+
+      const res = await request(app).get(
+        `/api/registry/operator?domain=${encodeURIComponent(`sales.${PUB_A}`)}`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.member).toBeNull();
+      expect(res.body.agents).toEqual([]);
+    });
+
+    it('GET /api/registry/operator prefers a verified exact linked subdomain over a verified parent domain', async () => {
+      const exactDomain = `sales.${PUB_A}`;
+      await pool.query(
+        `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+         VALUES
+           ($1, 'Endpoint Parent Org', NOW(), NOW()),
+           ($2, 'Endpoint Exact Org', NOW(), NOW())
+         ON CONFLICT (workos_organization_id) DO NOTHING`,
+        [ORG_ID, ORG_ID_EXACT],
+      );
+      await pool.query(
+        `INSERT INTO member_profiles (
+           workos_organization_id, display_name, slug,
+           agents, is_public, created_at, updated_at
+         ) VALUES
+           ($1, 'Endpoint Parent Org', $2, '[]'::jsonb, true, NOW(), NOW()),
+           ($3, 'Endpoint Exact Org', $4, '[]'::jsonb, true, NOW(), NOW())`,
+        [ORG_ID, MEMBER_SLUG, ORG_ID_EXACT, MEMBER_SLUG_EXACT],
+      );
+      await seedBrandPrimary(ORG_ID, PUB_A);
+      await pool.query(
+        `INSERT INTO organization_domains
+           (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+         VALUES ($1, $2, true, true, 'test', NOW(), NOW())`,
+        [ORG_ID_EXACT, exactDomain],
+      );
+
+      const res = await request(app).get(
+        `/api/registry/operator?domain=${encodeURIComponent(exactDomain)}`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.member).toMatchObject({
+        slug: MEMBER_SLUG_EXACT,
+        display_name: 'Endpoint Exact Org',
+      });
+    });
+
+    it('GET /api/registry/operator ignores an unverified exact linked domain and falls back to a verified parent', async () => {
+      const exactDomain = `sales.${PUB_A}`;
+      await pool.query(
+        `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+         VALUES
+           ($1, 'Endpoint Parent Org', NOW(), NOW()),
+           ($2, 'Endpoint Exact Org', NOW(), NOW())
+         ON CONFLICT (workos_organization_id) DO NOTHING`,
+        [ORG_ID, ORG_ID_EXACT],
+      );
+      await pool.query(
+        `INSERT INTO member_profiles (
+           workos_organization_id, display_name, slug,
+           agents, is_public, created_at, updated_at
+         ) VALUES ($1, 'Endpoint Parent Org', $2, '[]'::jsonb, true, NOW(), NOW())`,
+        [ORG_ID, MEMBER_SLUG],
+      );
+      await seedBrandPrimary(ORG_ID, PUB_A);
+      await pool.query(
+        `INSERT INTO organization_domains
+           (workos_organization_id, domain, verified, is_primary, source, created_at, updated_at)
+         VALUES ($1, $2, false, true, 'test', NOW(), NOW())`,
+        [ORG_ID_EXACT, exactDomain],
+      );
+
+      const res = await request(app).get(
+        `/api/registry/operator?domain=${encodeURIComponent(exactDomain)}`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.member).toMatchObject({
+        slug: MEMBER_SLUG,
+        display_name: 'Endpoint Parent Org',
       });
     });
 

--- a/server/tests/unit/brand-claim-service.test.ts
+++ b/server/tests/unit/brand-claim-service.test.ts
@@ -112,6 +112,9 @@ describe('issueDomainChallenge', () => {
     if (result.ok) {
       expect(result.workos_domain_id).toBe('dom_123');
       expect(result.verification_token).toBe('tok_abc');
+      expect(result.dns_record_name).toBe(`_workos-challenge.${DOMAIN}`);
+      expect(result.dns_record_type).toBe('TXT');
+      expect(result.dns_record_value).toBe('tok_abc');
       expect(result.already_verified).toBe(false);
     }
     expect(workos.organizationDomains.createOrganizationDomain).not.toHaveBeenCalled();
@@ -151,6 +154,8 @@ describe('issueDomainChallenge', () => {
       expect(result.workos_domain_id).toBe('dom_fresh');
       expect(result.verification_token).toBe('tok_fresh');
       expect(result.verification_prefix).toBe('_workos-challenge');
+      expect(result.dns_record_name).toBe(`_workos-challenge.${DOMAIN}`);
+      expect(result.dns_record_value).toBe('tok_fresh');
     }
     expect(deleteFn).toHaveBeenCalledWith('dom_broken');
     expect(createFn).toHaveBeenCalledTimes(1);
@@ -211,6 +216,8 @@ describe('issueDomainChallenge', () => {
       expect(result.workos_domain_id).toBe('dom_no_prefix');
       expect(result.verification_token).toBe('tok_present');
       expect(result.verification_prefix).toBeNull();
+      expect(result.dns_record_name).toBe(DOMAIN);
+      expect(result.dns_record_value).toBe('tok_present');
     }
     expect(deleteFn).not.toHaveBeenCalled();
     expect(createFn).not.toHaveBeenCalled();
@@ -240,6 +247,8 @@ describe('issueDomainChallenge', () => {
       expect(result.workos_domain_id).toBe('dom_new_no_prefix');
       expect(result.verification_token).toBe('tok_new');
       expect(result.verification_prefix).toBeNull();
+      expect(result.dns_record_name).toBe(DOMAIN);
+      expect(result.dns_record_value).toBe('tok_new');
     }
     expect(createFn).toHaveBeenCalledTimes(1);
   });

--- a/server/tests/unit/require-admin-cross-tenant.test.ts
+++ b/server/tests/unit/require-admin-cross-tenant.test.ts
@@ -74,6 +74,14 @@ describe('requireAdmin cross-tenant API key defense', () => {
       },
     );
 
+    app.post(
+      '/api/admin/accounts/:orgId/agents',
+      requireAdmin,
+      (_req, res) => {
+        res.json({ ok: true });
+      },
+    );
+
     // Route without :orgId — gate should NOT engage even with a
     // tenant-scoped API key; this proves the check is opt-in by path
     // convention rather than blanket-deny.
@@ -110,6 +118,15 @@ describe('requireAdmin cross-tenant API key defense', () => {
     expect(res.body.error).toBe('cross_tenant_api_key');
   });
 
+  it('refuses cross-tenant on POST the same way as GET', async () => {
+    const res = await request(app)
+      .post('/api/admin/accounts/org_target/agents')
+      .set('x-test-api-key-org-id', 'org_caller');
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('cross_tenant_api_key');
+  });
+
   it('does NOT engage on routes without a :orgId path param', async () => {
     // A tenant-scoped key with admin:* hitting a non-tenant-scoped admin
     // route should still pass — the check is convention-based on the
@@ -135,6 +152,16 @@ describe('requireAdmin cross-tenant API key defense', () => {
     // not sufficient for writes.
     const res = await request(app)
       .delete('/api/admin/accounts/org_same/agents/some_url')
+      .set('x-test-api-key-org-id', 'org_same')
+      .set('x-test-api-key-perms', 'admin:read');
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Insufficient permissions');
+  });
+
+  it('still rejects admin:read for same-tenant POST operations', async () => {
+    const res = await request(app)
+      .post('/api/admin/accounts/org_same/agents')
       .set('x-test-api-key-org-id', 'org_same')
       .set('x-test-api-key-perms', 'admin:read');
 


### PR DESCRIPTION
## Summary
- make registry operator lookup fall back from subdomains to verified parent org domains, while requiring verified exact-domain ownership
- add audited admin agent create/update repair endpoint with hostname ownership checks, metadata seeding, audit redaction, and no public publish bypass
- return explicit WorkOS DNS TXT record name/type/value from brand-domain challenge issuance for Addie and dashboard callers

## Expert review
- ran code-review and security-review agents on the diff
- addressed findings: unverified domains no longer claim operator ownership, audit logs redact health-check secrets, omitted visibility preserves existing value, and public visibility is rejected from the repair endpoint

## Tests
- npx vitest run server/tests/unit/brand-claim-service.test.ts server/tests/unit/require-admin-cross-tenant.test.ts
- DATABASE_URL=postgresql://adcp:localdev@localhost:5432/adcp_test npx vitest run server/tests/integration/admin-agent-removal.test.ts server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
- npm run typecheck
- git diff --check
- precommit hook on commit: npm run test:unit, test:test-dynamic-imports, test:callapi-state-change, precommit:server-unit, typecheck
