### PR TITLE
fix(registry): enforce identity-not-authorization on property-save (#5749 gap #2)

### DIFF
--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -395,14 +395,13 @@ result = requests.post(
 
 Save or update a hosted property in the registry. For existing properties, creates a revision-tracked edit. Cannot edit authoritative properties managed via `adagents.json` — those return `409 Conflict`.
 
+This is an identity-only write surface: the stored document always carries `authorized_agents: []`. Sales authorization lives solely in the publisher's own origin `adagents.json` — the community registry cannot mint or carry it — so any `authorized_agents` sent in the request body is ignored.
+
 **Request body:**
 
 ```json
 {
   "publisher_domain": "examplepub.com",
-  "authorized_agents": [
-    { "url": "https://agent.example.com", "authorized_for": "sell" }
-  ],
   "properties": [
     { "type": "website", "name": "Example Publisher" }
   ],
@@ -413,7 +412,7 @@ Save or update a hosted property in the registry. For existing properties, creat
 }
 ```
 
-`publisher_domain` and `authorized_agents` (each with a required `url` and optional `authorized_for`) are required. `properties` (each requiring `type` and `name`) and `contact` are optional. Domains are normalized (protocol stripped, lowercased).
+`publisher_domain` is required. `properties` (each requiring `type` and `name`) and `contact` are optional. Domains are normalized (protocol stripped, lowercased).
 
 <CodeGroup>
 
@@ -423,7 +422,6 @@ curl -X POST "https://agenticadvertising.org/api/properties/save" \
   -H "Content-Type: application/json" \
   -d '{
     "publisher_domain": "examplepub.com",
-    "authorized_agents": [{"url": "https://agent.example.com", "authorized_for": "sell"}],
     "properties": [{"type": "website", "name": "Example Publisher"}]
   }'
 ```
@@ -439,7 +437,6 @@ const res = await fetch(
     },
     body: JSON.stringify({
       publisher_domain: "examplepub.com",
-      authorized_agents: [{ url: "https://agent.example.com", authorized_for: "sell" }],
       properties: [{ type: "website", name: "Example Publisher" }],
     }),
   }
@@ -455,7 +452,6 @@ result = requests.post(
     headers={"Authorization": "Bearer YOUR_API_KEY"},
     json={
         "publisher_domain": "examplepub.com",
-        "authorized_agents": [{"url": "https://agent.example.com", "authorized_for": "sell"}],
         "properties": [{"type": "website", "name": "Example Publisher"}],
     },
 ).json()

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -843,7 +843,7 @@ registry.registerPath({
   operationId: "saveProperty",
   summary: "Save property",
   description:
-    "Save or update a hosted property in the registry. Requires authentication. For existing properties, creates a revision-tracked edit. For new properties, creates the property directly. Cannot edit authoritative properties managed via adagents.json.",
+    "Save or update a hosted property in the registry. Requires authentication. For existing properties, creates a revision-tracked edit. For new properties, creates the property directly. Cannot edit authoritative properties managed via adagents.json.\n\nThis is an identity-only write surface: the stored document always carries `authorized_agents: []`. Sales authorization lives solely in the publisher's own origin `adagents.json`; the community registry cannot mint or carry it. Any `authorized_agents` sent in the request body is ignored.",
   tags: ["Property Resolution"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -852,7 +852,11 @@ registry.registerPath({
         "application/json": {
           schema: z.object({
             publisher_domain: z.string().openapi({ example: "examplepub.com" }),
-            authorized_agents: z.array(z.object({ url: z.string(), authorized_for: z.string().optional() })).openapi({ example: [{ url: "https://agent.example.com" }] }),
+            authorized_agents: z.array(z.object({ url: z.string(), authorized_for: z.string().optional() })).optional().openapi({
+              description:
+                "Ignored. Community-registry rows never assert sales authorization — the owner's origin adagents.json is the sole authorization source — so any value here is dropped and the stored document carries authorized_agents:[].",
+              example: [],
+            }),
             properties: z.array(z.object({ type: z.string(), name: z.string() })).optional().openapi({ example: [{ type: "website", name: "Example Publisher" }] }),
             contact: z.object({ name: z.string().optional(), email: z.string().optional() }).optional(),
           }),
@@ -4455,14 +4459,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
   router.post("/properties/save", ...saveMiddleware, async (req, res) => {
     try {
-      const { authorized_agents, properties, contact } = req.body;
+      const { properties, contact } = req.body;
       const rawDomain = req.body.publisher_domain as string;
 
       if (!rawDomain || typeof rawDomain !== "string") {
         return res.status(400).json({ error: "publisher_domain is required" });
-      }
-      if (!Array.isArray(authorized_agents)) {
-        return res.status(400).json({ error: "authorized_agents array is required" });
       }
 
       const publisher_domain = extractDomain(rawDomain);
@@ -4471,9 +4472,15 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         return res.status(400).json({ error: "Invalid domain format" });
       }
 
+      // Identity, not authorization: a community-registry row never asserts
+      // sales authorization. The owner's origin adagents.json is the sole
+      // authorization source, so caller-supplied authorized_agents is dropped
+      // and the stored document always carries authorized_agents:[] — matching
+      // the community-mirror write path (community-mirrors.ts) and the
+      // adagents.json spec, where an empty array asserts "no sales authorization".
       const adagentsJson: Record<string, unknown> = {
         $schema: "https://adcontextprotocol.org/schemas/latest/adagents.json",
-        authorized_agents,
+        authorized_agents: [],
         properties: properties || [],
       };
       if (contact) {

--- a/server/tests/integration/registry-property-save-identity.test.ts
+++ b/server/tests/integration/registry-property-save-identity.test.ts
@@ -1,0 +1,158 @@
+/**
+ * `/api/properties/save` is an identity-only write surface: the stored
+ * community-registry document must never assert sales authorization. The
+ * owner's origin `adagents.json` is the sole authorization source, so the
+ * handler drops any caller-supplied `authorized_agents` and persists
+ * `authorized_agents: []` — matching the community-mirror write path
+ * (`community-mirrors.ts`) and the adagents.json spec, where an empty array
+ * asserts "no sales authorization".
+ *
+ * These tests exercise the handler end-to-end with an authenticated non-admin
+ * caller and assert the persisted document, not the response shape.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import type { Pool } from 'pg';
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+});
+
+vi.mock('../../src/middleware/auth.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/middleware/auth.js');
+  const pass = (req: { user: unknown }, _res: unknown, next: () => void) => {
+    req.user = { id: 'user_save_test', email: 'save@test.com', isAdmin: false };
+    next();
+  };
+  return { ...actual, requireAuth: pass, requireAdmin: (_r: unknown, _s: unknown, n: () => void) => n() };
+});
+
+vi.mock('../../src/middleware/csrf.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/middleware/csrf.js');
+  return { ...actual, csrfProtection: (_r: unknown, _s: unknown, n: () => void) => n() };
+});
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  stripe: null,
+  getSubscriptionInfo: vi.fn().mockResolvedValue(null),
+  createStripeCustomer: vi.fn().mockResolvedValue(null),
+  createCustomerSession: vi.fn().mockResolvedValue(null),
+  createBillingPortalSession: vi.fn().mockResolvedValue(null),
+}));
+
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { PropertyDatabase } from '../../src/db/property-db.js';
+import { HTTPServer } from '../../src/http.js';
+
+const DOMAIN_PREFIX = 'save-identity';
+const DOMAIN_LIKE = `${DOMAIN_PREFIX}-%`;
+const WITH_AGENTS = `${DOMAIN_PREFIX}-with-agents.registry-baseline.example`;
+const NO_AGENTS = `${DOMAIN_PREFIX}-no-agents.registry-baseline.example`;
+const EDIT_DOMAIN = `${DOMAIN_PREFIX}-edit.registry-baseline.example`;
+
+describe('POST /api/properties/save — identity, not authorization', () => {
+  let server: HTTPServer;
+  let app: unknown;
+  let pool: Pool;
+  let propertyDb: PropertyDatabase;
+
+  async function clearFixtures() {
+    await pool.query('DELETE FROM hosted_properties WHERE publisher_domain LIKE $1', [DOMAIN_LIKE]);
+  }
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    propertyDb = new PropertyDatabase();
+    server = new HTTPServer();
+    await server.start(0);
+    app = (server as unknown as { app: unknown }).app;
+  });
+
+  afterAll(async () => {
+    await clearFixtures();
+    await server?.stop();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearFixtures();
+  });
+
+  it('drops caller-supplied authorized_agents and stores authorized_agents:[]', async () => {
+    const res = await request(app)
+      .post('/api/properties/save')
+      .send({
+        publisher_domain: WITH_AGENTS,
+        // A caller asserting a sales agent for a domain it does not own — the
+        // exact spoof surface this endpoint must refuse to carry.
+        authorized_agents: [{ url: 'https://agent.attacker.example' }],
+        properties: [{ type: 'website', name: 'Save Identity Test' }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const stored = await propertyDb.getHostedPropertyByDomain(WITH_AGENTS);
+    expect(stored).not.toBeNull();
+    const adagents = stored!.adagents_json as { authorized_agents: unknown[]; properties: unknown[] };
+    expect(adagents.authorized_agents).toEqual([]);
+    // Identity content (properties) is preserved — only authorization is dropped.
+    expect(adagents.properties).toHaveLength(1);
+  });
+
+  it('accepts a save with no authorized_agents (the field is optional, not required)', async () => {
+    const res = await request(app)
+      .post('/api/properties/save')
+      .send({
+        publisher_domain: NO_AGENTS,
+        properties: [{ type: 'website', name: 'No Agents Test' }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const stored = await propertyDb.getHostedPropertyByDomain(NO_AGENTS);
+    expect(stored).not.toBeNull();
+    const adagents = stored!.adagents_json as { authorized_agents: unknown[] };
+    expect(adagents.authorized_agents).toEqual([]);
+  });
+
+  it('overwrites a previously-stored non-empty authorized_agents to [] on edit (heals a prior spoof)', async () => {
+    // Seed an existing community row that already holds a (spoofed) sales
+    // authorization. review_status:'approved' so the edit path is reachable
+    // (pending rows 409). This is the state a pre-fix write could have left.
+    await propertyDb.createHostedProperty({
+      publisher_domain: EDIT_DOMAIN,
+      adagents_json: {
+        $schema: 'https://adcontextprotocol.org/schemas/latest/adagents.json',
+        authorized_agents: [{ url: 'https://stale.attacker.example' }],
+        properties: [],
+      },
+      source_type: 'community',
+      review_status: 'approved',
+      is_public: true,
+    });
+
+    const res = await request(app)
+      .post('/api/properties/save')
+      .send({
+        publisher_domain: EDIT_DOMAIN,
+        properties: [{ type: 'website', name: 'Edit Path Test' }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    // revision_number is only present on the edit branch — proves we took it.
+    expect(typeof res.body.revision_number).toBe('number');
+
+    const stored = await propertyDb.getHostedPropertyByDomain(EDIT_DOMAIN);
+    expect(stored).not.toBeNull();
+    const adagents = stored!.adagents_json as { authorized_agents: unknown[] };
+    expect(adagents.authorized_agents).toEqual([]);
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -4017,7 +4017,10 @@ paths:
     post:
       operationId: saveProperty
       summary: Save property
-      description: Save or update a hosted property in the registry. Requires authentication. For existing properties, creates a revision-tracked edit. For new properties, creates the property directly. Cannot edit authoritative properties managed via adagents.json.
+      description: |-
+        Save or update a hosted property in the registry. Requires authentication. For existing properties, creates a revision-tracked edit. For new properties, creates the property directly. Cannot edit authoritative properties managed via adagents.json.
+
+        This is an identity-only write surface: the stored document always carries `authorized_agents: []`. Sales authorization lives solely in the publisher's own origin `adagents.json`; the community registry cannot mint or carry it. Any `authorized_agents` sent in the request body is ignored.
       tags:
         - Property Resolution
       security:
@@ -4043,8 +4046,8 @@ paths:
                         type: string
                     required:
                       - url
-                  example:
-                    - url: https://agent.example.com
+                  description: Ignored. Community-registry rows never assert sales authorization — the owner's origin adagents.json is the sole authorization source — so any value here is dropped and the stored document carries authorized_agents:[].
+                  example: []
                 properties:
                   type: array
                   items:
@@ -4069,7 +4072,6 @@ paths:
                       type: string
               required:
                 - publisher_domain
-                - authorized_agents
       responses:
         "200":
           description: Property saved or updated


### PR DESCRIPTION
Closes gap #2 of RFC #5749.

## Problem

`POST /api/properties/save` (`saveProperty`) is the community-registry property write surface. It **required** a caller-supplied `authorized_agents` array (400 if absent) and stored it **verbatim** into the persisted community-mirror `adagents.json` document. That let any authenticated registry caller assert *sales authorization* (which agent may sell a domain's inventory) for a domain they may not own.

AdCP's invariant: the owner's **origin** `/.well-known/adagents.json` is the **sole** authorization source. Community-registry rows never assert authorization and must carry `authorized_agents: []` — `docs/governance/property/adagents.mdx:296`: a community/catalog mirror "Sets `authorized_agents: []` … the mirror **MUST NOT fabricate one**." The sibling community-mirror write path (`server/src/routes/community-mirrors.ts:190-200`) already drops caller authorization and forces `[]`. This brings `saveProperty` in line.

## Why it matters

The registry's authorization view is normally re-derived from a live origin crawl — but for an **un-crawled** brand-new domain (exactly the population this endpoint creates rows for) there is nothing to overwrite a phantom write, and the SDK's `lookupDomain` returns `authorized_agents` to consumers. Combined with the documented TS/Python resolver divergence (adcontextprotocol/adcp-client#2301, where the TS resolver doesn't honor revocation), an un-scrubbed write is a latent sales-authorization spoof. The scrub is now **unconditional and structurally guaranteed** — the persisted object hard-codes `authorized_agents: []` and never spreads the request body.

## Change

- Drop caller-supplied `authorized_agents`; always persist `[]`. The single `adagentsJson` object flows into **both** the create and edit paths, so a previously-stored non-empty array is overwritten to `[]` on the next save (heals a prior spoof).
- Stop requiring `authorized_agents`; mark it optional + documented-as-ignored in the OpenAPI spec; regenerate `static/openapi/registry.yaml`.
- Update the registry save-property docs (request body + cURL/JS/Python samples no longer carry authorization).
- New integration test (`registry-property-save-identity.test.ts`): caller-supplied authorization is dropped → stored `[]`; omitting the field no longer 400s; the edit path heals a prior non-empty array.

## Scope

Scoped to the public REST write surface the RFC names. Both a code review and a security review ran on the diff and came back clean.

The security review surfaced that **other caller-supplied writers of `hosted_properties.adagents_json`** carry the same gap — notably the Addie `save_property` MCP tool (`server/src/addie/mcp/property-tools.ts`), which auto-publishes (`is_public:true`, `review_status:'approved'`) and syncs caller-supplied agents into the federated authorization index — plus admin save endpoints in `http.ts` and `mcp-tools.ts`. These need per-path review to distinguish caller-supplied from origin-crawl-derived authorization (the latter must **not** be scrubbed), so they're deliberately **not** bundled here. Follow-up: #5751.

Gap #1 of the RFC (an authority model / domain-control challenge on the write — already specced at `docs/registry/index.mdx:267` but unimplemented) is a separate issue.

## Test plan

- `tsc -p server/tsconfig.json --noEmit` — clean
- `vitest run server/tests/integration/registry-property-save-identity.test.ts` — 3/3 pass
- `npm run build:openapi` — `static/openapi/registry.yaml` regenerated and committed
- pre-commit (unit + typecheck) and pre-push (broken-links) hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
