### PR TITLE
fix(training-agent): acquire_rights end_date is inclusive (repo-wide CI time-bomb)

### DIFF
--- a/server/src/training-agent/brand-handlers.ts
+++ b/server/src/training-agent/brand-handlers.ts
@@ -938,8 +938,15 @@ export async function handleAcquireRights(
   }
 
   if (campaign.end_date) {
+    // end_date is inclusive through the end of that UTC day — the success path
+    // sets valid_until to 23:59:59Z. Reject only once that whole day is past, so
+    // a campaign ending today (new Date('YYYY-MM-DD') parses to 00:00:00Z) stays
+    // licensable rather than going spuriously "expired" the instant midnight UTC
+    // ticks over.
     const endMs = new Date(campaign.end_date).getTime();
-    if (!Number.isNaN(endMs) && endMs < Date.now()) {
+    const now = new Date(Date.now());
+    const startOfTodayMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+    if (!Number.isNaN(endMs) && endMs < startOfTodayMs) {
       return {
         errors: [{
           code: 'INVALID_REQUEST',

--- a/tests/addie/brand-sandbox-tools.test.ts
+++ b/tests/addie/brand-sandbox-tools.test.ts
@@ -317,6 +317,12 @@ describe('brand protocol tools (training agent)', () => {
     });
 
     it('rights_constraint uses date-time format', async () => {
+      // Use a window in the next calendar year so this exercises the success
+      // path durably. A hardcoded past end_date is (correctly) rejected as
+      // expired, and a hardcoded "today" date is a calendar time-bomb.
+      const year = new Date(Date.now()).getUTCFullYear() + 1;
+      const startDate = `${year}-04-01`;
+      const endDate = `${year}-06-30`;
       const result = await call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
@@ -324,13 +330,13 @@ describe('brand protocol tools (training agent)', () => {
         campaign: {
           description: 'Restaurant food campaign',
           uses: ['likeness'],
-          start_date: '2026-04-01',
-          end_date: '2026-06-30',
+          start_date: startDate,
+          end_date: endDate,
         },
       });
       const constraint = result.rights_constraint as { valid_from: string; valid_until: string };
-      expect(constraint.valid_from).toBe('2026-04-01T00:00:00Z');
-      expect(constraint.valid_until).toBe('2026-06-30T23:59:59Z');
+      expect(constraint.valid_from).toBe(`${startDate}T00:00:00Z`);
+      expect(constraint.valid_until).toBe(`${endDate}T23:59:59Z`);
     });
 
     it('returns error for unknown rights_id', async () => {


### PR DESCRIPTION
## Repo-wide CI blocker — fast-track

As of **2026-06-30**, `tests/addie/brand-sandbox-tools.test.ts > rights_constraint uses date-time format` fails on `main`, which red-lights the precommit hook and the `test:unit` CI job for **every** branch/PR today.

## Root cause — calendar time-bomb

`acquire_rights` (`brand-handlers.ts`) rejected a campaign when:

```js
new Date(campaign.end_date).getTime() < Date.now()
```

`new Date('2026-06-30')` parses to `2026-06-30T00:00:00Z`, so the instant midnight UTC passes on the end date, a campaign ending **today** is wrongly judged "in the past" and rejected — even though the success path sets `valid_until` to that day's `23:59:59Z`. `end_date` is meant to be **inclusive**; the guard was off by up to a day.

## Fix

- Reject only once the **whole end day** is past — compare against the start of today (UTC). A campaign ending today stays licensable, matching the inclusive `valid_until` semantics.
- Make the test use a **next-calendar-year** window instead of a hardcoded date, so it exercises the success path durably instead of rotting into the same time-bomb tomorrow.

All 38 tests in the file pass; typecheck clean.

## Note (follow-up, not fixed here)
The hardcoded default `campaign.end_date || '2026-06-30'` in `brand-handlers.ts` is stale (a no-`end_date` acquisition gets a past expiry), but it's applied *after* the guard so it can't cause a rejection or break a test. Replacing it needs a product call on the default window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)