### PR TITLE
docs(specs): four-layer property-alignment framing + catalog-graduation RFC

### DIFF
--- a/server/src/training-agent/brand-handlers.ts
+++ b/server/src/training-agent/brand-handlers.ts
@@ -938,8 +938,15 @@ export async function handleAcquireRights(
   }
 
   if (campaign.end_date) {
+    // end_date is inclusive through the end of that UTC day — the success path
+    // sets valid_until to 23:59:59Z. Reject only once that whole day is past, so
+    // a campaign ending today (new Date('YYYY-MM-DD') parses to 00:00:00Z) stays
+    // licensable rather than going spuriously "expired" the instant midnight UTC
+    // ticks over.
     const endMs = new Date(campaign.end_date).getTime();
-    if (!Number.isNaN(endMs) && endMs < Date.now()) {
+    const now = new Date(Date.now());
+    const startOfTodayMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+    if (!Number.isNaN(endMs) && endMs < startOfTodayMs) {
       return {
         errors: [{
           code: 'INVALID_REQUEST',

--- a/specs/property-catalog-graduation.md
+++ b/specs/property-catalog-graduation.md
@@ -1,0 +1,201 @@
+# RFC: Graduate the Property Catalog (Draft → normative, non-authoritative)
+
+**Status**: Draft (RFC)
+
+## Summary
+
+`specs/property-registry-catalog.md` describes a fact-graph catalog that already
+embodies the right answer for referential identity (layer 2) and boundary
+(layer 4) of [property-definition alignment](./property-definition-alignment.md).
+It is marked **Draft** and several pieces live only in prose. This RFC proposes
+**graduating it to normative-but-non-authoritative**: making `property_rid` a
+real protocol type, pinning the claims/rank/alias fact model, writing the
+boundary rubric as a normative-but-fallback-only rule, and adding the missing
+ontology-evolution process. It resolves the catalog spec's open questions #3 and
+#4.
+
+It changes **no authoritative wire surface**: adagents.json / brand.json remain
+the origin-rooted authority for what exists and who may sell it. Everything here
+is the non-authoritative convergence layer that sits *beside* the origin.
+
+## Motivation
+
+- Layer 2 (is X the same as Y?) and layer 4 (is ESPN one property or four?) have
+  no normative home today — they live in a Draft doc and in Scope3's internal
+  graph. TMP context-match needs a stable shared join key (`property_rid`).
+- The one genuine layer-1 (ontology) gap is process: there is no documented gate
+  for extending `property_type` / `identifier-types` (closed enums consumers
+  branch on). Without it, the enums either freeze or fragment.
+- #5750/#5752 closed the authority layer; this is the next layer down.
+
+## Proposal
+
+### 1. `property_rid` becomes a protocol type — non-authoritative by construction
+
+- UUID v7, globally unique, **forever-stable**, alias-on-error (never reused).
+- **A non-authoritative surrogate.** `property_rid` is a join/scope key — and
+  today it *is* the per-property scope key in `catalog_agent_authorizations`
+  (`specs/registry-authorization-model.md`) — but it **confers no authority**.
+  Whether an authorization is real is carried by its `evidence` value
+  (`adagents_json` = origin-rooted), never by the rid. The normative rule: a rid
+  never *upgrades* trust — a `community`/`agent_claim` row keyed to a rid is no
+  more authoritative for it. Authority is anchored to origin domain control, not
+  the catalog surrogate. (The risk to guard is the rid being *read* as an
+  authority handle — the same way the AAO mirror could be mistaken for a
+  registrar.)
+- On the wire, `property_id` stays publisher-scoped; `property_rid` is the
+  catalog's surrogate, surfaced for discovery and matching.
+
+### 2. The fact model is normative
+
+- Every catalog assertion is a **claim** carrying its source/trust signal,
+  `actor`, `provenance`, `timestamp`, and **a citable reference** — never a bare
+  assertion (this is what keeps the `community` tier auditable).
+- **Two trust axes, not one ladder** (`specs/registry-authorization-model.md`):
+  authorization rows carry `evidence ∈ {adagents_json, agent_claim, community}` —
+  there is **no separate confidence column**; `evidence` *is* the trust signal
+  (`adagents_json` authoritative-by-definition, the other two non-authoritative,
+  snapshot defaults to `adagents_json`-only). Identifier *linking* carries the
+  separate `confidence ∈ {authoritative, strong, medium, weak}` scale. A
+  non-authoritative signal may corroborate or dispute an authoritative one but
+  **never override** it. Origin-verification (the adagents.json crawl, and the
+  #5752 claim-bind) is the only automatic contributed→authoritative promotion
+  path. A new trust tier (e.g. signed cross-attestation, §5) is added as a **new
+  `evidence` value**, per that spec's extension guidance — not by inserting a
+  rung into a fabricated single ranking.
+- **Contested records coexist, not edit-warred.** Today this is a binary
+  `disputed` boolean on authorization rows. This RFC *proposes moving toward* a
+  graded rank for the catalog's identifier-linking layer (Wikidata
+  preferred/normal/deprecated) so contradictory links coexist with an ordering
+  rather than overwriting — a proposal, not current state.
+- **Auto-link only** on authoritative evidence (a publisher's own adagents.json
+  declaring multiple identifiers under one `property_id`) or same-app app-store
+  evidence. Everything weaker (dns, member_assertion, addie_analysis) requires
+  corroboration or human review.
+- **Reversible by alias.** Merges leave the old rid as an alias that keeps
+  resolving; splits create new rids and preserve the original. No destructive
+  deletes.
+
+### 3. Boundary is owner-declared (declare-don't-derive)
+
+- The partition of identifiers into properties is **whatever the domain
+  controller declares** in its own adagents.json. CNN declaring `cnn_web` and
+  `cnn_ctv_app` is two properties, full stop; same developer ≠ same property.
+- Promote the catalog's one-sentence rubric to **normative but fallback-only**:
+  "a property is a single addressable surface where content lives and ads can
+  appear; one property, one rid, many identifiers." The graph applies this
+  heuristic **only in the absence** of an origin declaration, mints a single
+  **provisional** rid (flagged), and **splits** it losslessly when an origin
+  declaration is later discovered (the original rid persists; declared
+  sub-properties get new rids with a `part_of` edge).
+- **ESPN is a tree, not a node:** a parent network rid with child surface rids
+  joined by `part_of`. Buyers target the parent (whole tree) or a leaf.
+- Boundary disputes resolve through the same evidence/rank/disavow machinery as
+  referential identity — **never** a registry adjudication. A domain controller
+  may always SPLIT/DISAVOW unilaterally; no party may MERGE across a declared
+  boundary or CLAIM another's property.
+
+### 4. Ontology evolution (the layer-1 gap)
+
+Keep `property_type` (10 values) and `identifier-types` (21 values) as **closed**
+leaf enums — consumers branch on them. Add a documented lifecycle:
+
+- A new value enters via a **low-ceremony additive RFC PR** (schema.org / W3C
+  community-group style), ships on a versioned minor with a **crosswalk note**.
+- **Graduation gate (new WG policy — there is no documented enum-evolution gate
+  today):** a candidate must show running-code demand — at least N independent
+  implementers already expressing the concept via `tags` + `supported_channels`
+  before it earns an enum slot. (Proposed N = 3.)
+- **Deprecate, never delete** retired values.
+- `tags` stay **publisher-local** (not a global taxonomy) and `supported_channels`
+  is the soft-typing escape valve — an emerging type a publisher needs but the
+  enum lacks is expressed via channels+tags, and a recurring pattern is the
+  signal to graduate it. Resist "enum the corpus."
+
+### 5. Cross-publisher sameness via signed attestation
+
+This is **not a new mechanism** — it is the realization of the path already
+identified-and-deferred in `specs/registry-authorization-model.md` ("the v3 fix
+for the cross-publisher case requires either signed cross-attestation or a
+corroborating publisher-side claim; deferred"). For the cross-publisher case the
+writer refuses today (agent X claims it may speak for publisher Y), publisher Y
+issues a **signed cross-attestation**: a VC-style credential chained to Y's
+`jwks_uri` / `did:web` key. The verifier accepts it on the strength of the
+signature (domain-rooted) and records it as a **new `evidence` value**
+(`signed_attestation`) — exactly the extension path that spec prescribes ("if a
+future evidence source needs a separate trust gradation, add it as a new
+`evidence` value"), not a parallel scale. This generalizes the established
+seller-publishes / buyer-represents / seller-confirms provenance-verifier pattern
+from authorization to identity. Verifier trust policy stays explicit (snapshot
+defaults to `evidence=adagents_json`); the attestation never overrides a
+conflicting origin declaration.
+
+## Resolved open questions (from the catalog spec)
+
+- **#3 (linking without adagents.json):** introduce a `candidate_edges` table for
+  proposed-but-unexecuted sameness (`said_to_be_same_as`) that lacks ≥ strong
+  evidence. Resolution ignores candidates; a second corroborating source or a
+  signed attestation auto-promotes; genuinely-contested cross-publisher claims
+  route to human review. Never auto-merge below `strong`.
+- **#4 (domain re-registration / staleness):** time-limited *catalog facts*
+  carry an `expires_at`; authoritative *authorization* rows instead refresh on
+  every successful crawl and **soft-delete** when the manifest stops declaring
+  them (`registry-authorization-model.md` — `adagents_json` rows have no TTL).
+  Either way, a domain that stops serving its file, or changes hands, lets its
+  authoritative state **lapse to next-best** (never delete — the rid is forever;
+  deactivate via `classification_changed`/`ownership_changed`, mint a new rid,
+  alias the old). This is the same re-verify-and-lapse mechanism the
+  bind-on-verify ownership model needs (#5752 follow-up) — one shared contract.
+
+## Non-goals / out of scope
+
+- No change to authoritative authorization (adagents.json stays sole source;
+  scores stay private; property lists stay buyer-private).
+- No central registrar. The graph is non-authoritative; the operator is
+  load-bearing only for *materialization*, and the math (append-only facts +
+  rank ordering + UNIQUE constraint + alias chain) is independently recomputable.
+- Full append-only Merkle-provability of the change-feed is a later major; ship
+  monitorability first (see the alignment framing doc).
+
+## Amends to the catalog spec
+
+- **Design Principle #6** (`property-registry-catalog.md` — "the registry IS the
+  authoritative declaration" for fileless properties) is **restated**: the
+  registry may be the *identity* record-of-last-resort for a fileless property
+  (community tier), but it is **not** authoritative for sales authorization
+  (`authorized_agents` stays `[]`) and is instantly superseded by an origin file.
+  "Authoritative" in Principle #6 means identity/listing-of-last-resort, never
+  authority-to-sell.
+- Open questions #3 and #4 are resolved above and should be struck from the
+  catalog spec when this RFC lands.
+
+## Migration & versioning impact
+
+- **Target: a 3.2 minor — additive, no breaking wire change.**
+- **Already on the wire:** `property_rid` is already required on TMP
+  context-match requests (`property-registry-catalog.md`), so part of "make it a
+  protocol type" ships today. **Net-new:** a `$id`'d schema type for
+  `property_rid`, the normative non-authoritative-surrogate language, and the
+  `evidence`/`confidence` two-axis statement.
+- **Registry-internal (not wire-visible):** `candidate_edges`, the `part_of`
+  edge, and the anchor/hint identifier tiering are catalog-internal — no wire
+  schema. They need migrations, not protocol-version bumps.
+- **Governance, not schema:** the enum-evolution gate (§4) is a process doc in
+  `docs/governance/property/`, not a schema artifact.
+- **Deferred to a later major:** signed `signed_attestation` evidence value (§5)
+  and full append-only Merkle-provability of the change-feed.
+
+## Sequencing
+
+1. This RFC + the [alignment framing](./property-definition-alignment.md).
+2. Graduate the catalog data model (property_rid type, fact/rank/alias,
+   `candidate_edges`, anchor/hint identifier tiering) — resolve #3/#4 here.
+3. Ontology-evolution governance section in `docs/governance/property/`.
+4. Signed cross-attestation envelope (reuse request-signing L1 / jwks).
+5. TTL re-verify + lapse (shared with #5752 follow-up).
+
+Related: `specs/registry-authorization-model.md` (the shipped `evidence`/`disputed`/
+`seq_no` model and the deferred cross-attestation decision),
+`specs/property-registry-catalog.md`, `specs/property-definition-alignment.md`
+(the four-layer framing), `specs/registry-change-feed.md` (#5732),
+`docs/governance/property/`, #5750 / #5752 (authority spine).

--- a/specs/property-definition-alignment.md
+++ b/specs/property-definition-alignment.md
@@ -1,0 +1,125 @@
+# How the Community Aligns on Property Definitions
+
+**Status**: Draft (WG framing)
+
+## The reframe
+
+A healthy decentralized registry does **not** align by getting everyone to agree
+on one definition. It **converges on evidence**, with a domain-rooted spine and
+reversible mistakes. Every durable decentralized-naming system works this way —
+DNS, Certificate Transparency, Wikidata, ads.txt/sellers.json, schema.org. The
+ones that tried to mint a single canonical truth by committee either failed or
+re-centralized into a registrar.
+
+So the community's job is not to ratify definitions. It is to **contribute
+attributable claims into a graph where the domain owner always wins and mistakes
+are never destructive**. AdCP already made this bet: the property catalog is a
+*fact graph*, not a declaration store (`specs/property-registry-catalog.md` —
+"facts, not declarations"; "the rid is forever"; "aliases, not deletions").
+
+## The trap: four problems wearing one coat
+
+"Align on property definitions" is **four problems with four different trust
+roots**. Collapsing them is the recurring failure mode — it is how you end up
+reflexively wanting to "just build a property registry," the GS1 move that
+ad-tech rejected for inventory.
+
+| Layer | Question | Trust root | Precedent |
+|---|---|---|---|
+| **1. Ontology** | What *types / identifiers* exist? | **WG rough consensus**, versioned, additive. Central curation is correct *here only*. | schema.org / IAB taxonomy |
+| **2. Referential identity** | Is *this* the same thing as *that*? | **Non-authoritative fact graph** — emergent, ranked, reversible. | Wikidata (rank + reversible merge) |
+| **3. Authority / provenance** | Who may *assert* the canonical record? | **Domain control at the origin** (adagents.json / brand.json over TLS). Never a registrar. | ads.txt / sellers.json + DNS |
+| **4. Boundary / granularity** | Is ESPN one property or four? | **The owner declares** in their own file; never registry-adjudicated, never algorithm-derived. | npm (ownership-convention + dispute) |
+
+AdCP has **layer 3 right and layer 1 mostly right**; layers 2 and 4 are the open
+work, and they deliberately live in the (still-Draft) catalog, *beside* the
+origin, never above it. That separation is correct — do not promote referential
+identity or boundary into the authoritative wire (adagents.json / brand.json).
+
+## The two invariants that make an open write surface safe
+
+1. **Origin always wins; mistakes alias, never delete.** A contributed claim may
+   corroborate or dispute a domain-controlled fact, but can **never** override
+   it. Concretely, two axes carry this (`specs/registry-authorization-model.md`):
+   authorization rows carry an `evidence` value — `adagents_json` (the
+   publisher's own origin file under HTTPS, authoritative-by-definition) vs the
+   non-authoritative `agent_claim` / `community` — and the snapshot endpoint
+   defaults to `adagents_json`-only so a consumer never treats an unverified
+   claim as authority. Identifier *linking* uses a separate `confidence` scale
+   (`authoritative` / `strong` / `medium` / `weak`). The invariant is
+   schema-enforced (`evidence` CHECK + snapshot default), not caller discipline.
+2. **You can unilaterally DISAVOW, never unilaterally CLAIM.** Removing your
+   origin file or marking `not_ours` is zero-burden, immediate, authoritative.
+   Asserting authority over inventory you do not domain-control is structurally
+   impossible.
+
+## Where the shipped work sits on this spine
+
+The two registry fixes are **two points on the layer-3 authority spine**, not
+separate features:
+
+- **#5750 (gap #2)** — the **property-save** community write surface cannot mint
+  authorization: `authorized_agents` is forced to `[]` on `POST /properties/save`;
+  the origin adagents.json is the sole authorization source. (Invariant 1.) The
+  remaining caller-supplied writers of the same column (Addie `save_property`,
+  admin save, mcp-tools) carry the same gap and are a tracked follow-up (#5751).
+- **#5752 (gap #1)** — the authority model is **claim → origin-verify → bind**,
+  not a write-time gate. Anyone may stage a non-authoritative row; ownership is
+  bound only when the publisher places a claim-token pointer at their own origin
+  and verification confirms it. Binding is token-driven (never caller-driven),
+  so a squatter cannot bind a domain they do not control, and an existing owner
+  is never overwritten. (Invariant 2.)
+
+Read together: the registry never mints authority and never gatekeeps writes —
+it accepts attributable claims that **converge to origin-verified facts**.
+
+## What AAO is (and is NOT)
+
+To hold the line against the "just build a property registry" reflex, AAO's role
+is fenced by construction:
+
+- **NOT a registrar.** AAO holds no minting authority. `workos_organization_id`
+  is set only by a verified-origin claim bind; `authorized_agents` is forced `[]`
+  on community writes; authoritative records are refused edits (409).
+- **A neutral index** of origin-verified facts.
+- **Registrar-of-last-resort only** for the long tail with no self-hosted file —
+  those rows are community-tier, non-authoritative for *authorization*, and
+  instantly superseded the moment the publisher deploys their own origin file.
+  (This **amends** catalog Design Principle #6, which today reads "the registry
+  IS the authoritative declaration" for fileless properties: the registry may be
+  the *identity* record-of-last-resort for such a property, but it is **not**
+  authoritative for sales authorization — `authorized_agents` stays `[]` — and
+  the bridge is that "authoritative" there means identity/listing, never
+  authority-to-sell. The graduation RFC restates Principle #6 accordingly.)
+- **A dispute desk**, not a truth oracle — it records, ranks, and routes
+  conflicts; it does not adjudicate boundary or sameness.
+
+## Detect-not-prevent
+
+You cannot *prevent* a false claim in a decentralized system; you make it
+**undeniable and fast to catch** (Certificate Transparency's lesson). The
+registry change-feed (`specs/registry-change-feed.md`, #5732) is most of the way
+there — it already emits `publisher.adagents_changed` / `authorization.granted` /
+`authorization.revoked` over SSE. The high-leverage, low-cost next step is a
+**publisher-domain-scoped subscription filter** so an owner can watch for any
+claim naming their domain they did not make; defer full append-only
+Merkle-provability to a later major. (Revocation *propagation* is already handled
+by `seq_no` rotation-on-tombstone — `specs/registry-authorization-model.md`.)
+
+## What this framing asks of the WG
+
+1. Treat the four layers as separate, with separate trust roots. Resist
+   collapsing them.
+2. Govern the **ontology** (property_type / identifier-types enums) as an
+   additive, versioned vocabulary — see the catalog-graduation RFC for the
+   enum-evolution process (the one genuine layer-1 gap today).
+3. Graduate the **catalog** from Draft to normative-but-non-authoritative so
+   layers 2 and 4 have a real home — see `specs/property-catalog-graduation.md`.
+4. Keep **authority** rooted in domain control. Never a registrar.
+
+Related: `specs/registry-authorization-model.md` (the shipped authorization data
+model — `evidence` enum, `disputed` layer, `seq_no` revocation, the deferred
+cross-publisher / signed-attestation decision), `specs/property-registry-catalog.md`
+(the fact graph), `specs/registry-change-feed.md` (freshness/notifications, #5732),
+`docs/governance/property/` (adagents.json / brand.json trust model),
+#5750 and #5752 (the authority-spine implementations).

--- a/tests/addie/brand-sandbox-tools.test.ts
+++ b/tests/addie/brand-sandbox-tools.test.ts
@@ -317,6 +317,12 @@ describe('brand protocol tools (training agent)', () => {
     });
 
     it('rights_constraint uses date-time format', async () => {
+      // Use a window in the next calendar year so this exercises the success
+      // path durably. A hardcoded past end_date is (correctly) rejected as
+      // expired, and a hardcoded "today" date is a calendar time-bomb.
+      const year = new Date(Date.now()).getUTCFullYear() + 1;
+      const startDate = `${year}-04-01`;
+      const endDate = `${year}-06-30`;
       const result = await call('acquire_rights', {
         rights_id: 'janssen_likeness_voice',
         pricing_option_id: 'monthly_exclusive',
@@ -324,13 +330,13 @@ describe('brand protocol tools (training agent)', () => {
         campaign: {
           description: 'Restaurant food campaign',
           uses: ['likeness'],
-          start_date: '2026-04-01',
-          end_date: '2026-06-30',
+          start_date: startDate,
+          end_date: endDate,
         },
       });
       const constraint = result.rights_constraint as { valid_from: string; valid_until: string };
-      expect(constraint.valid_from).toBe('2026-04-01T00:00:00Z');
-      expect(constraint.valid_until).toBe('2026-06-30T23:59:59Z');
+      expect(constraint.valid_from).toBe(`${startDate}T00:00:00Z`);
+      expect(constraint.valid_until).toBe(`${endDate}T23:59:59Z`);
     });
 
     it('returns error for unknown rights_id', async () => {


### PR DESCRIPTION
Two WG design docs that turn this work's thinking into something the working group can act on, and frame #5750/#5752 as two points on one authority spine.

> **Stacked on #5760** (the repo-wide CI time-bomb fix). The first commit here is that fix; it drops out of this PR's diff automatically once #5760 merges to `main`.

## Docs
- **`specs/property-definition-alignment.md`** — the reframe (alignment = convergence on evidence with a domain-rooted spine + reversible mistakes, not consensus on a value), the four layers and their distinct trust roots (ontology / referential identity / authority / boundary), the two invariants (origin wins + alias-not-delete; unilateral disavow, never unilateral claim), where #5750/#5752 sit, what AAO is NOT (registrar-of-last-resort, not a registrar), and detect-not-prevent.
- **`specs/property-catalog-graduation.md`** — RFC to graduate the catalog from Draft to normative-but-non-authoritative: `property_rid` as a non-authoritative surrogate, the two-axis `evidence`/`confidence` model, owner-declared boundary (declare-don't-derive; ESPN as a tree), ontology-evolution governance (the one genuine layer-1 gap), signed cross-attestation as the already-deferred cross-publisher path, and resolutions for catalog open questions #3/#4.

## Review
Reviewed by the protocol expert against `specs/registry-authorization-model.md` (the shipped `evidence`/`disputed`/`seq_no` model). It caught two factual errors I'd have shipped — a fabricated single `evidence` ladder (the real model is two axes: authorization `evidence ∈ {adagents_json, agent_claim, community}` + separate identifier `confidence`) and over-scoping #5750 — both corrected. The RFC explicitly restates catalog Design Principle #6 (registry is identity-of-last-resort, never authority-to-sell) and includes a 3.2 migration/versioning impact statement.

These are **proposals for WG discussion**, not normative changes — no wire/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)