### PR TITLE
feat(registry): periodic hosted-origin re-verify + lapse→re-claim (#5749 gap #1 follow-up)

### DIFF
--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -19,6 +19,8 @@ import { createLogger } from "./logger.js";
 import type { CatalogEventsDatabase, WriteEventInput } from "./db/catalog-events-db.js";
 import type { AgentInventoryProfilesDatabase, ProfileUpsertInput } from "./db/agent-inventory-profiles-db.js";
 import { query } from "./db/client.js";
+import { PropertyDatabase } from "./db/property-db.js";
+import { verifyHostedPropertyOrigin } from "./services/hosted-property-origin-verifier.js";
 import { insertTypeReclassification } from "./db/type-reclassification-log-db.js";
 import { resolveUserAgentAuth } from "./routes/helpers/resolve-user-agent-auth.js";
 import { adaptAuthForSdk, type SdkAuth } from "./services/sdk-auth-adapter.js";
@@ -2209,6 +2211,71 @@ export class CrawlerService {
       return { processed: rows.length, succeeded, failed };
     } finally {
       this.managerRevalidationProcessing = false;
+    }
+  }
+
+  // ── Hosted-origin Re-verification (bind-on-verify lapse) ──────────
+  //
+  // An AAO-hosted property is bound to its owner only while its origin
+  // pointer still points at AAO (bind-on-verify, #5752). Domains change
+  // hands and publishers remove pointers, so a verified row must be
+  // re-checked on a TTL: when the origin no longer points at us, the
+  // verifier clears origin_verified_at — releasing the owner lock and
+  // making the domain re-claimable (bindOwnerFromVerifiedClaim allows a new
+  // owner once origin_verified_at IS NULL). The row itself is never deleted.
+
+  private hostedReverifyDb = new PropertyDatabase();
+  private hostedReverifyIntervalId: NodeJS.Timeout | null = null;
+  private hostedReverifyProcessing = false;
+
+  startPeriodicHostedOriginReverification(intervalMinutes: number = 60) {
+    this.hostedReverifyIntervalId = setInterval(() => {
+      this.processHostedOriginReverification().catch((err) => {
+        log.error({ err }, 'Hosted-origin re-verification tick failed');
+      });
+    }, intervalMinutes * 60 * 1000);
+    this.hostedReverifyIntervalId?.unref();
+    log.info({ intervalMinutes }, 'Periodic hosted-origin re-verification started');
+  }
+
+  stopPeriodicHostedOriginReverification() {
+    if (this.hostedReverifyIntervalId) {
+      clearInterval(this.hostedReverifyIntervalId);
+      this.hostedReverifyIntervalId = null;
+    }
+  }
+
+  async processHostedOriginReverification(): Promise<{ processed: number; lapsed: number }> {
+    if (this.hostedReverifyProcessing) {
+      log.debug('Hosted-origin re-verification already in progress, skipping tick');
+      return { processed: 0, lapsed: 0 };
+    }
+    this.hostedReverifyProcessing = true;
+    // Re-check each verified origin at most once per TTL; bounded batch per tick
+    // so background re-verification leaves DB/network headroom for foreground.
+    const BATCH_SIZE = 50;
+    const CONCURRENCY = 4;
+    const TTL_HOURS = 24;
+    try {
+      const staleBefore = new Date(Date.now() - TTL_HOURS * 60 * 60 * 1000);
+      const due = await this.hostedReverifyDb.getHostedPropertiesDueForReverification(staleBefore, BATCH_SIZE);
+      if (due.length === 0) {
+        return { processed: 0, lapsed: 0 };
+      }
+
+      const outcomes = await this.processWithConcurrency(due, CONCURRENCY, async (hosted) => {
+        const outcome = await verifyHostedPropertyOrigin({ hosted });
+        // A permanent failure on a previously-verified row clears
+        // origin_verified_at inside the verifier — the owner lock lapses.
+        // Transient failures (5xx / 429 / timeout) leave verified state intact.
+        return !outcome.verified && outcome.reason !== 'transient';
+      });
+      const lapsed = outcomes.filter(Boolean).length;
+
+      log.info({ processed: due.length, lapsed }, 'Hosted-origin re-verification batch complete');
+      return { processed: due.length, lapsed };
+    } finally {
+      this.hostedReverifyProcessing = false;
     }
   }
 

--- a/server/src/db/property-db.ts
+++ b/server/src/db/property-db.ts
@@ -957,9 +957,14 @@ export class PropertyDatabase {
   /**
    * Bind the owner from a verified claim. Sets `workos_organization_id` to the
    * pending `claimant_org_id` and consumes the token — but ONLY when `token`
-   * matches the pending `claim_token` and the row is not already locked to a
-   * different org. Binding is therefore driven by which token the origin
-   * pointer carries, never by who triggers verification.
+   * matches the pending `claim_token` and the row is not currently
+   * verified-locked to a different org. Binding is therefore driven by which
+   * token the origin pointer carries, never by who triggers verification.
+   *
+   * "Verified-locked" means `origin_verified_at IS NOT NULL`. A domain whose
+   * verification has lapsed (origin pointer removed / domain transferred → the
+   * periodic re-verify cleared `origin_verified_at`) is re-claimable: the stale
+   * `workos_organization_id` no longer blocks a new owner from re-binding.
    *
    * Returns the bound org id, or null when no matching pending claim binds.
    */
@@ -978,12 +983,35 @@ export class PropertyDatabase {
         WHERE publisher_domain = $1
           AND claim_token = $2
           AND claimant_org_id IS NOT NULL
-          AND (workos_organization_id IS NULL OR workos_organization_id = claimant_org_id)
+          AND (workos_organization_id IS NULL
+               OR workos_organization_id = claimant_org_id
+               OR origin_verified_at IS NULL)
         RETURNING workos_organization_id`,
       [publisherDomain.toLowerCase(), token],
     );
     const bound = result.rows[0]?.workos_organization_id;
     return bound ? { boundOrgId: bound } : null;
+  }
+
+  /**
+   * Fetch verified hosted properties whose origin hasn't been re-checked since
+   * `staleBefore` — the work-list for the periodic origin re-verification job.
+   * Only rows that are currently verified (`origin_verified_at IS NOT NULL`)
+   * are candidates; an unverified row has no verification state to lapse.
+   */
+  async getHostedPropertiesDueForReverification(
+    staleBefore: Date,
+    limit: number,
+  ): Promise<HostedProperty[]> {
+    const result = await query<HostedProperty>(
+      `SELECT * FROM hosted_properties
+        WHERE origin_verified_at IS NOT NULL
+          AND (origin_last_checked_at IS NULL OR origin_last_checked_at < $1)
+        ORDER BY origin_last_checked_at ASC NULLS FIRST
+        LIMIT $2`,
+      [staleBefore.toISOString(), limit],
+    );
+    return result.rows.map((row) => this.deserializeHostedProperty(row));
   }
 }
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -9580,6 +9580,11 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
       // re-validation when a manager rotates its adagents.json.
       this.crawler.startPeriodicManagerRevalidation(5); // 5-minute tick
 
+      // Re-verify AAO-hosted origins on a TTL so a transferred domain or a
+      // removed origin pointer lapses the owner lock (bind-on-verify, #5752),
+      // releasing the domain for re-claim.
+      this.crawler.startPeriodicHostedOriginReverification(60); // hourly tick
+
       // Register and start all scheduled jobs
       registerAllJobs();
 

--- a/server/src/services/hosted-property-origin-verifier.ts
+++ b/server/src/services/hosted-property-origin-verifier.ts
@@ -134,22 +134,41 @@ function canonicalize(url: string): string | null {
  * The verifier classifies these so the caller can decide whether to
  * demote (permanent) or leave state alone (transient).
  */
+function collectErrorText(err: Error): string {
+  const parts: string[] = [];
+  const seen = new Set<object>();
+  let current: unknown = err;
+
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const value = current as { message?: unknown; code?: unknown; codes?: unknown; cause?: unknown };
+    if (typeof value.message === 'string') parts.push(value.message);
+    if (typeof value.code === 'string') parts.push(value.code);
+    if (Array.isArray(value.codes)) {
+      for (const code of value.codes) {
+        if (typeof code === 'string') parts.push(code);
+      }
+    }
+    current = value.cause;
+  }
+
+  return parts.join(' ');
+}
+
 function classifyFetchError(err: unknown): 'unresolvable' | 'transient' {
   if (!(err instanceof Error)) return 'transient';
-  const msg = err.message || '';
-  // EAI_AGAIN is a *temporary* resolver failure — always transient, never a
-  // lapse. (Today url-security collapses DNS failures into "Could not resolve
-  // hostname" so this rarely surfaces, but classify it correctly regardless.)
-  if (/EAI_AGAIN/i.test(msg)) return 'transient';
-  // Permanent: SSRF/validation rejections and genuine NXDOMAIN. safeFetch
-  // surfaces NXDOMAIN as "Could not resolve hostname" (utils/url-security.ts),
-  // so a dropped/expired domain lapses its verification and releases the owner
-  // lock for re-claim. A transient DNS blip that slips through here self-heals:
-  // the lapse clears only origin_verified_at (not workos_organization_id), so
-  // the next successful re-verify of the owner's still-present pointer re-stamps
-  // it and re-arms the lock.
+  const text = collectErrorText(err);
+  // Temporary resolver failures may be wrapped in `cause` by safeFetch's DNS
+  // preflight. Preserve the verified state whenever any resolver result was
+  // transient; a later successful re-verify will refresh the stamp.
+  if (/\b(EAI_AGAIN|ESERVFAIL|ETIMEOUT|ECONNREFUSED)\b/i.test(text)) return 'transient';
+  // Permanent: SSRF/validation rejections and genuine NXDOMAIN/no-address DNS.
+  // A generic "Could not resolve hostname" without a DNS code is deliberately
+  // not enough to lapse the lock, because validateHostResolution can collapse
+  // transient resolver failures into that same top-level message.
   if (
-    /private|loopback|link-local|metadata|invalid host|invalid url|invalid scheme|unresolvable|could not resolve hostname|ENOTFOUND|EAI_NONAME/i.test(msg)
+    /private|loopback|link-local|metadata|invalid host|invalid url|invalid scheme|unresolvable/i.test(text) ||
+    /\b(ENOTFOUND|EAI_NONAME|ENODATA|ENONAME|EAI_NODATA)\b/i.test(text)
   ) {
     return 'unresolvable';
   }

--- a/server/src/services/hosted-property-origin-verifier.ts
+++ b/server/src/services/hosted-property-origin-verifier.ts
@@ -137,9 +137,19 @@ function canonicalize(url: string): string | null {
 function classifyFetchError(err: unknown): 'unresolvable' | 'transient' {
   if (!(err instanceof Error)) return 'transient';
   const msg = err.message || '';
-  // safeFetch / validateFetchUrl signatures (see utils/url-security.ts)
+  // EAI_AGAIN is a *temporary* resolver failure — always transient, never a
+  // lapse. (Today url-security collapses DNS failures into "Could not resolve
+  // hostname" so this rarely surfaces, but classify it correctly regardless.)
+  if (/EAI_AGAIN/i.test(msg)) return 'transient';
+  // Permanent: SSRF/validation rejections and genuine NXDOMAIN. safeFetch
+  // surfaces NXDOMAIN as "Could not resolve hostname" (utils/url-security.ts),
+  // so a dropped/expired domain lapses its verification and releases the owner
+  // lock for re-claim. A transient DNS blip that slips through here self-heals:
+  // the lapse clears only origin_verified_at (not workos_organization_id), so
+  // the next successful re-verify of the owner's still-present pointer re-stamps
+  // it and re-arms the lock.
   if (
-    /private|loopback|link-local|metadata|invalid host|invalid url|invalid scheme|unresolvable|ENOTFOUND|EAI_/i.test(msg)
+    /private|loopback|link-local|metadata|invalid host|invalid url|invalid scheme|unresolvable|could not resolve hostname|ENOTFOUND|EAI_NONAME/i.test(msg)
   ) {
     return 'unresolvable';
   }
@@ -237,9 +247,9 @@ export async function verifyHostedPropertyOrigin(
 
   // Spec-conformant cache rules (see managed-networks.mdx §security):
   // 5xx and 429 MUST NOT shorten the verified lifetime. Treat as transient.
-  // 3xx — we requested with `redirect: 'manual'`, so a redirect lands
-  // here too. Treat as transient (publisher may have a redirect chain
-  // we don't follow yet) rather than as a hard demote.
+  // 3xx — safeFetch follows up to 5 redirects with per-hop SSRF re-validation,
+  // so a residual 3xx here means the hop budget was exhausted. Treat that as
+  // transient rather than a hard demote.
   if (response.status >= 500 || response.status === 429 || (response.status >= 300 && response.status < 400)) {
     await stampChecked('preserve');
     return {
@@ -300,11 +310,14 @@ export async function verifyHostedPropertyOrigin(
   }
 
   // Verified.
-  await stampChecked(true);
   // Bind-on-verify: if the pointer carried a claim token, bind the domain to
   // the org that requested THAT claim — never the caller who triggered this.
   // bindOwnerFromVerifiedClaim is a no-op unless the token matches the pending
-  // claim and the row isn't already locked to a different org.
+  // claim and the row isn't already verified-locked to a different org. This
+  // runs BEFORE stampChecked(true) so the bind guard sees the pre-verification
+  // `origin_verified_at` state: a lapsed row (origin_verified_at IS NULL) is
+  // re-bindable by a new owner, whereas stamping verified first would re-arm the
+  // lock and block the legitimate re-bind.
   let bound_org_id: string | undefined;
   if (claimToken && propertyDb.bindOwnerFromVerifiedClaim) {
     try {
@@ -315,6 +328,7 @@ export async function verifyHostedPropertyOrigin(
       logger.warn({ err, domain }, 'Origin verified but owner binding failed');
     }
   }
+  await stampChecked(true);
   const manifestAgents = readManifestAgentUrls(hosted.adagents_json || {});
   const promotion = await promoteVerifiedAuthorizations(domain, manifestAgents);
   logger.info({ domain, promoted: promotion.promoted }, 'Origin verified via authoritative_location pointer');

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -7,6 +7,16 @@ import { createLogger } from '../logger.js';
 
 const logger = createLogger('url-security');
 
+const TRANSIENT_DNS_CODES = new Set(['EAI_AGAIN', 'ESERVFAIL', 'ETIMEOUT', 'ECONNREFUSED']);
+const PERMANENT_DNS_CODES = new Set(['ENOTFOUND', 'EAI_NONAME', 'ENODATA', 'ENONAME', 'EAI_NODATA']);
+const DNS_CODE_RE = /\b(EAI_AGAIN|ESERVFAIL|ETIMEOUT|ECONNREFUSED|ENOTFOUND|EAI_NONAME|ENODATA|ENONAME|EAI_NODATA)\b/i;
+
+interface DnsResolutionFailureCause {
+  code?: string;
+  codes: string[];
+  hostname: string;
+}
+
 const fetchWithDispatcher = undiciFetch as unknown as (
   input: string | URL,
   init?: RequestInit & { dispatcher: Dispatcher },
@@ -158,6 +168,45 @@ export function isPrivateHostname(hostname: string): boolean {
   return false;
 }
 
+function extractDnsErrorCode(reason: unknown): string | undefined {
+  if (!reason || typeof reason !== 'object') return undefined;
+  const err = reason as { code?: unknown; message?: unknown };
+  if (typeof err.code === 'string') return err.code.toUpperCase();
+  if (typeof err.message === 'string') {
+    const match = err.message.match(DNS_CODE_RE);
+    if (match) return match[1].toUpperCase();
+  }
+  return undefined;
+}
+
+function dnsResolutionFailureCause(
+  hostname: string,
+  results: readonly PromiseSettledResult<string[]>[],
+): DnsResolutionFailureCause | undefined {
+  const codes = results
+    .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+    .map((result) => extractDnsErrorCode(result.reason))
+    .filter((code): code is string => !!code);
+
+  if (codes.length === 0) return undefined;
+
+  return {
+    hostname,
+    codes,
+    code:
+      codes.find((code) => TRANSIENT_DNS_CODES.has(code)) ??
+      codes.find((code) => PERMANENT_DNS_CODES.has(code)) ??
+      codes[0],
+  };
+}
+
+function unresolvedHostnameError(hostname: string, results: readonly PromiseSettledResult<string[]>[]): Error {
+  const err = new Error('Could not resolve hostname') as Error & { cause?: DnsResolutionFailureCause };
+  const cause = dnsResolutionFailureCause(hostname, results);
+  if (cause) err.cause = cause;
+  return err;
+}
+
 /**
  * Resolve a hostname and verify none of its addresses point to a private network.
  * Checks all A and AAAA records to prevent multi-record bypass attacks.
@@ -182,7 +231,7 @@ export async function validateHostResolution(hostname: string): Promise<void> {
   ];
 
   if (allAddresses.length === 0) {
-    throw new Error('Could not resolve hostname');
+    throw unresolvedHostnameError(hostname, [ipv4Result, ipv6Result]);
   }
 
   for (const address of allAddresses) {

--- a/server/tests/integration/hosted-property-origin-verifier.test.ts
+++ b/server/tests/integration/hosted-property-origin-verifier.test.ts
@@ -299,6 +299,43 @@ describe('hosted-property origin verifier', () => {
     }
   });
 
+  it('treats temporary DNS resolver failures as transient even with a collapsed top-level message', async () => {
+    const hosted = await propertyDb.createHostedProperty({
+      publisher_domain: PUB,
+      adagents_json: { authorized_agents: [{ url: AGENT }], properties: [] },
+      is_public: true,
+      source_type: 'community',
+    });
+    await syncHostedPropertyToFederatedIndex(hosted);
+
+    const ok = vi.fn().mockResolvedValue({
+      status: 200,
+      body: JSON.stringify({ authoritative_location: aaoHostedAdagentsJsonUrl(PUB) }),
+    });
+    await verifyHostedPropertyOrigin({ hosted: (await propertyDb.getHostedPropertyByDomain(PUB))!, fetchImpl: ok });
+
+    const before = await propertyDb.getHostedPropertyByDomain(PUB);
+    expect(before?.origin_verified_at).toBeTruthy();
+
+    const transientDns = Object.assign(new Error('Could not resolve hostname'), {
+      cause: { code: 'EAI_AGAIN', codes: ['EAI_AGAIN', 'ENOTFOUND'], hostname: PUB },
+    });
+    const fetchImpl = vi.fn().mockRejectedValue(transientDns);
+    const outcome = await verifyHostedPropertyOrigin({
+      hosted: before!,
+      fetchImpl,
+    });
+    expect(outcome.verified).toBe(false);
+    if (!outcome.verified) expect(outcome.reason).toBe('transient');
+
+    const after = await propertyDb.getHostedPropertyByDomain(PUB);
+    expect(after?.origin_verified_at?.getTime()).toBe(before?.origin_verified_at?.getTime());
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(PUB)}`);
+    expect(res.body.authorized_agents[0].source).toBe('adagents_json');
+    expect(res.body.hosting.origin_verified_at).toBeTruthy();
+  });
+
   it('classifies DNS NXDOMAIN as permanent unresolvable, demotes if previously verified', async () => {
     const hosted = await propertyDb.createHostedProperty({
       publisher_domain: PUB,
@@ -354,9 +391,9 @@ describe('hosted-property origin verifier', () => {
     expect(res.body).toHaveProperty('verified');
     expect(res.body).toHaveProperty('reason');
     expect(res.body).toHaveProperty('checked_at');
-    // The endpoint should have stamped checked_at OR returned 'transient'
-    // (we can't actually reach the publisher origin in tests).
-    expect(['fetch_failed', 'non_200_response', 'transient', 'invalid_json', 'authoritative_location_mismatch', 'no_authoritative_location']).toContain(res.body.reason);
+    // The endpoint should have stamped checked_at and returned one of the
+    // structured failure reasons from the real safeFetch path.
+    expect(['fetch_failed', 'non_200_response', 'transient', 'unresolvable', 'invalid_json', 'authoritative_location_mismatch', 'no_authoritative_location']).toContain(res.body.reason);
   });
 
   it('POST /api/properties/hosted/:domain/verify-origin returns 404 when no hosted property exists', async () => {

--- a/server/tests/integration/registry-domain-claim-bind.test.ts
+++ b/server/tests/integration/registry-domain-claim-bind.test.ts
@@ -176,4 +176,77 @@ describe('bind-on-verify domain claims', () => {
     expect(bind).toBeNull();
     expect((await propertyDb.getHostedPropertyByDomain(PUB))!.workos_organization_id).toBe(ORG_A);
   });
+
+  it('lapses the lock when the origin pointer disappears, letting a NEW owner re-claim and re-bind', async () => {
+    // ORG_A claims, verifies, and is locked.
+    const { token: tokenA } = await propertyDb.issueDomainClaim(PUB, ORG_A);
+    await verifyHostedPropertyOrigin({
+      hosted: (await propertyDb.getHostedPropertyByDomain(PUB))!,
+      fetchImpl: pointerFetch(PUB, tokenA!),
+    });
+    expect((await propertyDb.getHostedPropertyByDomain(PUB))!.origin_verified_at).toBeTruthy();
+
+    // The domain changes hands / the pointer is removed: re-verification now
+    // gets a 404. A permanent failure clears origin_verified_at (lapse).
+    const lapse = await verifyHostedPropertyOrigin({
+      hosted: (await propertyDb.getHostedPropertyByDomain(PUB))!,
+      fetchImpl: vi.fn().mockResolvedValue({ status: 404, body: '' }),
+    });
+    expect(lapse.verified).toBe(false);
+    const lapsed = await propertyDb.getHostedPropertyByDomain(PUB);
+    expect(lapsed!.origin_verified_at).toBeNull(); // lock released
+
+    // ORG_B can now claim (no longer refused — origin_verified_at is null)...
+    const { token: tokenB } = await propertyDb.issueDomainClaim(PUB, ORG_B);
+    expect(tokenB).toBeTruthy();
+    // ...and re-bind, even though the stale workos_organization_id is still ORG_A.
+    const outcome = await verifyHostedPropertyOrigin({
+      hosted: (await propertyDb.getHostedPropertyByDomain(PUB))!,
+      fetchImpl: pointerFetch(PUB, tokenB!),
+    });
+    expect(outcome.verified).toBe(true);
+    if (outcome.verified) expect(outcome.bound_org_id).toBe(ORG_B);
+    expect((await propertyDb.getHostedPropertyByDomain(PUB))!.workos_organization_id).toBe(ORG_B);
+  });
+
+  it('lapses on NXDOMAIN — an expired domain ("Could not resolve hostname") is a permanent failure', async () => {
+    const { token } = await propertyDb.issueDomainClaim(PUB, ORG_A);
+    await verifyHostedPropertyOrigin({
+      hosted: (await propertyDb.getHostedPropertyByDomain(PUB))!,
+      fetchImpl: pointerFetch(PUB, token!),
+    });
+    expect((await propertyDb.getHostedPropertyByDomain(PUB))!.origin_verified_at).toBeTruthy();
+
+    // Domain expired → DNS NXDOMAIN → safeFetch throws "Could not resolve hostname".
+    const outcome = await verifyHostedPropertyOrigin({
+      hosted: (await propertyDb.getHostedPropertyByDomain(PUB))!,
+      fetchImpl: vi.fn().mockRejectedValue(new Error(`Could not resolve hostname: ${PUB}`)),
+    });
+    expect(outcome.verified).toBe(false);
+    if (!outcome.verified) expect(outcome.reason).toBe('unresolvable');
+    // Permanent failure lapses the lock (vs a transient DNS blip, which would not).
+    expect((await propertyDb.getHostedPropertyByDomain(PUB))!.origin_verified_at).toBeNull();
+  });
+
+  it('getHostedPropertiesDueForReverification returns verified rows past the TTL, not fresh or unverified ones', async () => {
+    // Verified + locked, with origin_last_checked_at well in the past.
+    const { token } = await propertyDb.issueDomainClaim(PUB, ORG_A);
+    await verifyHostedPropertyOrigin({
+      hosted: (await propertyDb.getHostedPropertyByDomain(PUB))!,
+      fetchImpl: pointerFetch(PUB, token!),
+    });
+    await pool.query(
+      `UPDATE hosted_properties SET origin_last_checked_at = NOW() - INTERVAL '2 days' WHERE publisher_domain = $1`,
+      [PUB],
+    );
+
+    // A second, unverified community row — must never be a candidate.
+    const UNVERIFIED = `claim-bind-unverified.registry-baseline.example`;
+    await propertyDb.issueDomainClaim(UNVERIFIED, ORG_B);
+
+    const due = await propertyDb.getHostedPropertiesDueForReverification(new Date(Date.now() - 24 * 60 * 60 * 1000), 50);
+    const domains = due.map((r) => r.publisher_domain);
+    expect(domains).toContain(PUB);
+    expect(domains).not.toContain(UNVERIFIED); // origin_verified_at IS NULL → excluded
+  });
 });

--- a/server/tests/integration/registry-domain-claim-bind.test.ts
+++ b/server/tests/integration/registry-domain-claim-bind.test.ts
@@ -209,7 +209,7 @@ describe('bind-on-verify domain claims', () => {
     expect((await propertyDb.getHostedPropertyByDomain(PUB))!.workos_organization_id).toBe(ORG_B);
   });
 
-  it('lapses on NXDOMAIN — an expired domain ("Could not resolve hostname") is a permanent failure', async () => {
+  it('lapses on NXDOMAIN — an expired domain is a permanent DNS failure', async () => {
     const { token } = await propertyDb.issueDomainClaim(PUB, ORG_A);
     await verifyHostedPropertyOrigin({
       hosted: (await propertyDb.getHostedPropertyByDomain(PUB))!,
@@ -217,10 +217,14 @@ describe('bind-on-verify domain claims', () => {
     });
     expect((await propertyDb.getHostedPropertyByDomain(PUB))!.origin_verified_at).toBeTruthy();
 
-    // Domain expired → DNS NXDOMAIN → safeFetch throws "Could not resolve hostname".
+    // Domain expired → DNS NXDOMAIN. safeFetch's top-level message is generic,
+    // but validateHostResolution preserves the DNS code in the cause.
+    const nxdomain = Object.assign(new Error(`Could not resolve hostname: ${PUB}`), {
+      cause: { code: 'ENOTFOUND', codes: ['ENOTFOUND'], hostname: PUB },
+    });
     const outcome = await verifyHostedPropertyOrigin({
       hosted: (await propertyDb.getHostedPropertyByDomain(PUB))!,
-      fetchImpl: vi.fn().mockRejectedValue(new Error(`Could not resolve hostname: ${PUB}`)),
+      fetchImpl: vi.fn().mockRejectedValue(nxdomain),
     });
     expect(outcome.verified).toBe(false);
     if (!outcome.verified) expect(outcome.reason).toBe('unresolvable');

--- a/server/tests/unit/url-security-dns-rebind.test.ts
+++ b/server/tests/unit/url-security-dns-rebind.test.ts
@@ -12,11 +12,60 @@ vi.mock('dns', async () => {
   };
 });
 
+vi.mock('dns/promises', () => {
+  const resolve4 = vi.fn();
+  const resolve6 = vi.fn();
+  return {
+    default: { resolve4, resolve6 },
+    resolve4,
+    resolve6,
+  };
+});
+
 import { lookup as dnsLookup } from 'dns';
-import { ssrfSafeLookup, isPrivateHostname } from '../../src/utils/url-security.js';
+import dnsPromises from 'dns/promises';
+import { ssrfSafeLookup, isPrivateHostname, validateHostResolution } from '../../src/utils/url-security.js';
 
 type LookupCallback = (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void;
 type LookupSingleCallback = (err: NodeJS.ErrnoException | null, address: string, family: number) => void;
+
+describe('validateHostResolution', () => {
+  const resolve4Mock = dnsPromises.resolve4 as unknown as ReturnType<typeof vi.fn>;
+  const resolve6Mock = dnsPromises.resolve6 as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    resolve4Mock.mockReset();
+    resolve6Mock.mockReset();
+  });
+
+  it('preserves transient DNS failure codes when hostname resolution collapses to no addresses', async () => {
+    resolve4Mock.mockRejectedValue(Object.assign(new Error('queryA EAI_AGAIN example.com'), { code: 'EAI_AGAIN' }));
+    resolve6Mock.mockRejectedValue(Object.assign(new Error('queryAaaa ENOTFOUND example.com'), { code: 'ENOTFOUND' }));
+
+    await expect(validateHostResolution('example.com')).rejects.toMatchObject({
+      message: 'Could not resolve hostname',
+      cause: {
+        code: 'EAI_AGAIN',
+        codes: ['EAI_AGAIN', 'ENOTFOUND'],
+        hostname: 'example.com',
+      },
+    });
+  });
+
+  it('preserves permanent DNS failure codes for NXDOMAIN/no-address results', async () => {
+    resolve4Mock.mockRejectedValue(Object.assign(new Error('queryA ENOTFOUND missing.example'), { code: 'ENOTFOUND' }));
+    resolve6Mock.mockRejectedValue(Object.assign(new Error('queryAaaa ENODATA missing.example'), { code: 'ENODATA' }));
+
+    await expect(validateHostResolution('missing.example')).rejects.toMatchObject({
+      message: 'Could not resolve hostname',
+      cause: {
+        code: 'ENOTFOUND',
+        codes: ['ENOTFOUND', 'ENODATA'],
+        hostname: 'missing.example',
+      },
+    });
+  });
+});
 
 describe('ssrfSafeLookup', () => {
   const lookupMock = dnsLookup as unknown as ReturnType<typeof vi.fn>;


### PR DESCRIPTION
Follow-up to #5752 (bind-on-verify). Closes the domain-transfer / stale-pointer window the security review flagged.

> **Stacked on #5760** (the time-bomb fix). That commit drops out of this diff once #5760 merges.

## Problem
Bind-on-verify binds a domain to its owner while the origin pointer points at AAO. But domains change hands and publishers remove pointers — without re-checking, a transferred domain keeps its **stale owner forever** and can never be re-claimed (the stale `workos_organization_id` would block a new owner's bind).

## Change
- **Periodic re-verify job** (`crawler.ts`): `startPeriodicHostedOriginReverification` re-runs `verifyHostedPropertyOrigin` over verified rows past a 24h TTL (bounded batch + concurrency, mirroring manager-revalidation), wired into startup as an hourly tick. A **permanent** failure (origin no longer points at AAO) clears `origin_verified_at` via the existing verifier path — the owner lock **lapses**. Transient failures (5xx/429/timeout) leave verified state intact by design.
- **Lapse → re-claim** (`property-db.ts`): `bindOwnerFromVerifiedClaim` now also binds when `origin_verified_at IS NULL`, so a lapsed domain's stale `workos_organization_id` no longer blocks a new owner. `issueDomainClaim` already keys its refusal on `origin_verified_at`, so a lapsed domain is re-claimable.
- **Verifier ordering fix**: bind **before** stamping `origin_verified_at`, so the bind guard sees the pre-verification (lapsed) state instead of the lock it's about to re-arm. (Caught by the re-bind test.)
- `getHostedPropertiesDueForReverification`: the work-list query — verified rows past the TTL; unverified rows are never candidates.
- **Never deletes** on lapse — the rid is forever; only verification + the owner binding lapse, content stays.

## Why it's not a takeover vector
A lapse only happens when the **real origin** stops pointing at AAO (404/mismatch) — an attacker can't force it (no origin control). After a legit lapse, re-binding still requires making the origin point at the new claimant's token — which still requires origin control. The `origin_verified_at IS NULL` guard clause only widens re-claim for genuinely-lapsed domains.

## Tests
New: lapse releases the lock and lets a new owner re-claim + re-bind; due-for-reverification excludes unverified rows. Existing bind (now 7/7) + verifier (10/10) suites green; typecheck clean.

## Follow-ups
DNS-TXT pointer flavor; multi-pending-claim griefing table; owner-confirmation of staged `properties[]` on bind; extend owner-lock to Addie/admin write paths (#5751).

🤖 Generated with [Claude Code](https://claude.com/claude-code)