### PR TITLE
fix(addie): surface compliance diagnostics and bump SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.1.0",
       "dependencies": {
-        "@adcp/sdk": "9.2.0",
+        "@adcp/sdk": "9.3.0",
         "@anthropic-ai/sdk": "^0.104.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.4",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.2.0.tgz",
-      "integrity": "sha512-cOqJaTLpgNvBGcBI8MqY0mua8PWzr9Tr4XTXwxyIMj3e3N9ka2GsBaYIdNHoCFj+lSc9O3QGmcGudqObX04aPw==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.3.0.tgz",
+      "integrity": "sha512-bTWOe/Hcq9mgQfxuV9Fmhg0VuC1YzLuxvkIGHvqVSe8uOoybUF4mksupBBeH5LfkuEH9qIxWeS8bEwLGJy9huA==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "test:substitution-vector-names": "node scripts/lint-substitution-vector-names.cjs",
     "test:unit": "vitest run --dir tests/ --pool=threads",
     "test:redteam": "tsx server/src/addie/testing/redteam-cli.ts",
-    "test:server-unit": "vitest run server/tests/unit/",
+    "test:server-unit": "vitest run --config server/vitest.config.ts tests/unit/",
     "test:server-integration": "vitest run server/tests/integration --config server/vitest.config.ts",
     "test:openapi": "tsx scripts/generate-openapi.ts && git diff --exit-code static/openapi/registry.yaml || (echo 'OpenAPI spec is out of date. Run: npm run build:openapi' && exit 1)",
     "test:registry": "vitest run server/tests --exclude 'server/tests/simulation/**'",
@@ -133,7 +133,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "9.2.0",
+    "@adcp/sdk": "9.3.0",
     "@anthropic-ai/sdk": "^0.104.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.4",

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1723,6 +1723,15 @@
         if (statusInfo.first_failure_message) {
           html += '<div class="storyboard-map-detail-message">' + escapeHtml(statusInfo.first_failure_message) + '</div>';
         }
+        const validations = Array.isArray(statusInfo.first_failure_validations)
+          ? statusInfo.first_failure_validations
+          : [];
+        for (const validation of validations.slice(0, 3)) {
+          html += renderDiagnosticValidation(validation);
+        }
+        if (validations.length > 3) {
+          html += '<div class="storyboard-map-detail-message">Showing 3 validation details; ' + escapeHtml(pluralizeCount(validations.length - 3, 'more validation')) + ' remain.</div>';
+        }
         const additionalFailures = Math.max(0, failures - 1);
         if (additionalFailures > 0) {
           html += '<div class="storyboard-map-detail-message">Showing the first failing step; ' + escapeHtml(pluralizeCount(additionalFailures, 'more failure')) + ' remain.</div>';

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -48,6 +48,7 @@ import {
   selectComplianceTargetForAgent,
   selectComplianceTargetForAgentSelection,
   type ComplyOptions,
+  type CapabilityResolutionErrorInfo,
   type ComplianceTargetSelection,
   type ComplianceTrack,
 } from '../services/compliance-testing.js';
@@ -573,6 +574,25 @@ async function inferHostedAuthProbeTask(
   } catch (error) {
     logger.warn({ error, agentUrl }, 'Addie: could not infer hosted auth probe task; using default');
     return undefined;
+  }
+}
+
+async function classifyCapabilityResolutionErrorWithDeclaredProtocols(
+  error: unknown,
+  agentUrl: string,
+  auth: ReturnType<typeof buildAuthOption>,
+): Promise<CapabilityResolutionErrorInfo | undefined> {
+  const initial = classifyCapabilityResolutionError(error);
+  if (initial?.kind !== 'specialism_parent_protocol_missing') return initial;
+
+  try {
+    const caps = await testCapabilityDiscovery(agentUrl, {
+      ...(auth && { auth }),
+    });
+    return classifyCapabilityResolutionError(error, caps.profile?.supported_protocols ?? []) ?? initial;
+  } catch (probeError) {
+    logger.warn({ probeError, agentUrl }, 'evaluate_agent_quality: could not reprobe capabilities after resolver error');
+    return initial;
   }
 }
 
@@ -4736,7 +4756,11 @@ export function createMemberToolHandlers(
       return output;
     } catch (error) {
       const msg = error instanceof Error ? error.message : 'Unknown error';
-      const capsError = classifyCapabilityResolutionError(error);
+      const capsError = await classifyCapabilityResolutionErrorWithDeclaredProtocols(
+        error,
+        resolved.resolvedUrl,
+        authOption,
+      );
 
       // Agent-declared strings (specialism id, parent protocol name) reach
       // the LLM via this tool result, so fence them to neutralise markdown /
@@ -4762,6 +4786,18 @@ export function createMemberToolHandlers(
           );
         }
         const safeSpec = fenceAgentValue(capsError.specialism ?? '', 80);
+        if (capsError.kind === 'unrecognized_supported_protocol') {
+          const safeDeclared = fenceAgentValue(capsError.declaredProtocol ?? '', 80);
+          const safeExpected = fenceAgentValue(capsError.expectedProtocol ?? capsError.parentProtocol ?? '', 80);
+          return (
+            `**Capabilities misconfigured.** The agent at ${resolved.resolvedUrl} declares the ` +
+            `${safeSpec} specialism, but \`supported_protocols\` contains the unrecognized ` +
+            `value ${safeDeclared}.\n\n` +
+            `Use the canonical protocol id ${safeExpected} instead. Protocol ids use underscores, ` +
+            `not hyphens. Update the agent's \`get_adcp_capabilities\` response, redeploy, then ` +
+            `re-run \`evaluate_agent_quality\`.`
+          );
+        }
         if (capsError.kind === 'specialism_parent_protocol_missing') {
           const safeParent = fenceAgentValue(capsError.parentProtocol ?? '', 80);
           return (
@@ -4982,7 +5018,7 @@ export function createMemberToolHandlers(
       const res = resolveStoryboardsForCapabilities(caps, runOptions);
       resolvedBundles = res.bundles;
     } catch (error) {
-      const capsError = classifyCapabilityResolutionError(error);
+      const capsError = classifyCapabilityResolutionError(error, supportedProtocols);
       // specialism ids came from the untrusted agent — fence them so a hostile
       // id string can't break out of the markdown fence.
       const safeDeclared = specialisms.map(s => fenceAgentValue(s, 80)).filter(Boolean).join(', ');
@@ -4999,6 +5035,17 @@ export function createMemberToolHandlers(
             .join(', ');
           output += `**Unsupported compliance target.** The selected compliance target resolves to ${safeVersion}, but the agent advertises \`adcp.supported_versions\`: ${safeSupported || '`(none advertised)`'}.\n\n`;
           output += `Select a compatible compliance target, then re-run \`recommend_storyboards\`.\n`;
+          return output;
+        }
+        if (capsError.kind === 'unrecognized_supported_protocol') {
+          const safeSpec = fenceAgentValue(capsError.specialism ?? '', 80);
+          const safeDeclaredProtocol = fenceAgentValue(capsError.declaredProtocol ?? '', 80);
+          const safeExpectedProtocol = fenceAgentValue(capsError.expectedProtocol ?? capsError.parentProtocol ?? '', 80);
+          output += `**Capabilities misconfigured.** The agent declares the ${safeSpec} specialism, but \`supported_protocols\` contains the unrecognized value ${safeDeclaredProtocol}.\n\n`;
+          if (safeProtocolsDeclared) {
+            output += `Currently declared protocols: ${safeProtocolsDeclared}.\n\n`;
+          }
+          output += `Use the canonical protocol id ${safeExpectedProtocol} instead. Protocol ids use underscores, not hyphens. Update \`get_adcp_capabilities\`, redeploy, then re-run \`recommend_storyboards\`.\n`;
           return output;
         }
         if (capsError.kind === 'specialism_parent_protocol_missing') {

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -220,12 +220,15 @@ export function badgeEligibleVersionsForTargetSelection(
 export type CapabilityResolutionErrorKind =
   | 'specialism_parent_protocol_missing'
   | 'unknown_specialism'
-  | 'unsupported_adcp_version';
+  | 'unsupported_adcp_version'
+  | 'unrecognized_supported_protocol';
 
 export interface CapabilityResolutionErrorInfo {
   kind: CapabilityResolutionErrorKind;
   specialism?: string;
   parentProtocol?: string;
+  declaredProtocol?: string;
+  expectedProtocol?: string;
   complianceVersion?: string;
   supportedVersions?: string[];
 }
@@ -266,7 +269,16 @@ function parseSupportedVersionList(value: string): string[] {
 function knownProtocolsFromIndex(): Set<string> {
   try {
     const index = loadComplianceIndex(defaultComplianceTarget());
-    return new Set(index.specialisms.map(s => s.protocol).filter(Boolean));
+    const protocols = new Set<string>();
+    for (const protocol of index.specialisms.map(s => s.protocol).filter(Boolean)) {
+      protocols.add(protocol);
+      protocols.add(protocol.replace(/-/g, '_'));
+    }
+    for (const protocol of index.protocols?.map(p => p.id).filter(Boolean) ?? []) {
+      protocols.add(protocol);
+      protocols.add(protocol.replace(/-/g, '_'));
+    }
+    return protocols;
   } catch {
     // Cache unavailable — accept the extracted value without cross-check.
     // The anchored regex + sanitizer still bound what can reach downstream.
@@ -274,8 +286,27 @@ function knownProtocolsFromIndex(): Set<string> {
   }
 }
 
+function nearMissProtocolDeclaration(
+  parentProtocol: string,
+  declaredProtocols: readonly unknown[] | undefined,
+): { declaredProtocol: string; expectedProtocol: string } | undefined {
+  if (!declaredProtocols?.length) return undefined;
+
+  for (const raw of declaredProtocols) {
+    if (typeof raw !== 'string') continue;
+    const declaredProtocol = sanitizeClassifiedValue(raw, 80);
+    if (!declaredProtocol || declaredProtocol === parentProtocol) continue;
+    if (declaredProtocol.replace(/-/g, '_') === parentProtocol) {
+      return { declaredProtocol, expectedProtocol: parentProtocol };
+    }
+  }
+
+  return undefined;
+}
+
 export function classifyCapabilityResolutionError(
   err: unknown,
+  declaredProtocols?: readonly unknown[],
 ): CapabilityResolutionErrorInfo | undefined {
   const msg = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
   if (!msg) return undefined;
@@ -302,6 +333,17 @@ export function classifyCapabilityResolutionError(
   if (parentMatch) {
     const specialism = sanitizeClassifiedValue(parentMatch[1]);
     const parentProtocol = sanitizeClassifiedValue(parentMatch[2]);
+    const nearMiss = nearMissProtocolDeclaration(parentProtocol, declaredProtocols);
+    if (nearMiss) {
+      return {
+        kind: 'unrecognized_supported_protocol',
+        specialism,
+        parentProtocol,
+        declaredProtocol: nearMiss.declaredProtocol,
+        expectedProtocol: nearMiss.expectedProtocol,
+      };
+    }
+
     // Defense in depth: the upstream resolver only throws this variant when
     // the specialism exists in the local index, so its parent is a known
     // protocol. If the extracted parent isn't known, the attacker smuggled
@@ -351,6 +393,8 @@ export function presentCapabilityResolutionError(
 ): CapabilityResolutionErrorPresentation {
   const specialism = info.specialism ?? '';
   const parentProtocol = info.parentProtocol ?? '';
+  const declaredProtocol = info.declaredProtocol ?? '';
+  const expectedProtocol = info.expectedProtocol ?? '';
   const complianceVersion = info.complianceVersion ?? '';
   const supportedVersions = info.supportedVersions ?? [];
   const supportedVersionsText = supportedVersions.length > 0 ? supportedVersions.join(', ') : '(none advertised)';
@@ -381,6 +425,23 @@ export function presentCapabilityResolutionError(
         error_kind: 'unsupported_adcp_version',
         compliance_version: complianceVersion,
         supported_versions: supportedVersionsText,
+      },
+    };
+  }
+
+  if (info.kind === 'unrecognized_supported_protocol') {
+    return {
+      headline:
+        `Agent capabilities misconfigured: supported_protocols contains unrecognized ` +
+        `"${declaredProtocol}"; use "${expectedProtocol}" for specialism "${specialism}".`,
+      logMsg: 'Agent declared unrecognized supported_protocols value',
+      logFields: { specialism, parentProtocol, declaredProtocol, expectedProtocol },
+      restBody: {
+        error_kind: 'unrecognized_supported_protocol',
+        specialism,
+        parent_protocol: parentProtocol,
+        declared_protocol: declaredProtocol,
+        expected_protocol: expectedProtocol,
       },
     };
   }

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -212,6 +212,7 @@ export interface StoryboardStatusEntry {
   first_failed_step_title?: string | null;
   first_failed_step_task?: string | null;
   first_failure_message?: string | null;
+  first_failure_validations_jsonb?: unknown;
 }
 
 /**
@@ -1054,6 +1055,7 @@ export class ComplianceDatabase {
     first_failed_step_title: string | null;
     first_failed_step_task: string | null;
     first_failure_message: string | null;
+    first_failure_validations_jsonb: unknown;
     triggered_by: string | null;
   }>> {
     const result = await query(
@@ -1068,8 +1070,23 @@ export class ComplianceDatabase {
        SELECT storyboard_id, requested_compliance_target, adcp_version, status, last_tested_at, last_passed_at, last_failed_at,
               steps_passed, steps_total, failure_count, skipped_count,
               first_failed_step_id, first_failed_step_title, first_failed_step_task, first_failure_message,
+              first_failure_diag.failed_validations_jsonb AS first_failure_validations_jsonb,
               triggered_by
        FROM agent_storyboard_status s
+       LEFT JOIN LATERAL (
+         SELECT d.failed_validations_jsonb
+         FROM agent_compliance_step_diagnostics d
+         WHERE d.agent_url = s.agent_url
+           AND d.run_id = s.run_id
+           AND d.storyboard_id = s.storyboard_id
+           AND d.failed_validations_jsonb IS NOT NULL
+           AND (
+             s.first_failed_step_id IS NULL
+             OR d.step_id = s.first_failed_step_id
+           )
+         ORDER BY d.captured_at DESC, d.id DESC
+         LIMIT 1
+       ) first_failure_diag ON true
        WHERE s.agent_url = $1
          AND ($2::uuid IS NULL OR s.run_id = $2::uuid)
          AND (
@@ -1151,6 +1168,7 @@ export class ComplianceDatabase {
     first_failed_step_title: string | null;
     first_failed_step_task: string | null;
     first_failure_message: string | null;
+    first_failure_validations_jsonb: unknown;
   }>>> {
     if (agentUrls.length === 0) return new Map();
 
@@ -1174,9 +1192,24 @@ export class ComplianceDatabase {
        )
        SELECT s.agent_url, s.storyboard_id, s.requested_compliance_target, s.adcp_version, s.status, s.last_tested_at, s.last_passed_at,
               s.steps_passed, s.steps_total, s.failure_count, s.skipped_count,
-              s.first_failed_step_id, s.first_failed_step_title, s.first_failed_step_task, s.first_failure_message
+              s.first_failed_step_id, s.first_failed_step_title, s.first_failed_step_task, s.first_failure_message,
+              first_failure_diag.failed_validations_jsonb AS first_failure_validations_jsonb
        FROM agent_storyboard_status s
        LEFT JOIN latest_run_flags lf ON lf.agent_url = s.agent_url
+       LEFT JOIN LATERAL (
+         SELECT d.failed_validations_jsonb
+         FROM agent_compliance_step_diagnostics d
+         WHERE d.agent_url = s.agent_url
+           AND d.run_id = s.run_id
+           AND d.storyboard_id = s.storyboard_id
+           AND d.failed_validations_jsonb IS NOT NULL
+           AND (
+             s.first_failed_step_id IS NULL
+             OR d.step_id = s.first_failed_step_id
+           )
+         ORDER BY d.captured_at DESC, d.id DESC
+         LIMIT 1
+       ) first_failure_diag ON true
        WHERE s.agent_url = ANY($1)
          AND COALESCE(lf.has_rows, true) = true
        ORDER BY s.agent_url, s.storyboard_id`,
@@ -1190,6 +1223,7 @@ export class ComplianceDatabase {
       failure_count: number; skipped_count: number;
       first_failed_step_id: string | null; first_failed_step_title: string | null;
       first_failed_step_task: string | null; first_failure_message: string | null;
+      first_failure_validations_jsonb: unknown;
     }>>();
     for (const row of result.rows) {
       if (!map.has(row.agent_url)) map.set(row.agent_url, []);

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -381,6 +381,7 @@ type StoryboardStatusLike = {
   first_failed_step_title?: string | null;
   first_failed_step_task?: string | null;
   first_failure_message?: string | null;
+  first_failure_validations_jsonb?: unknown;
   last_tested_at?: Date | string | null;
   last_passed_at?: Date | string | null;
 };
@@ -388,6 +389,11 @@ type StoryboardStatusLike = {
 function serializeDate(value: Date | string | null | undefined): string | null {
   if (!value) return null;
   return value instanceof Date ? value.toISOString() : value;
+}
+
+function normalizeValidationList(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  return value === null || value === undefined ? [] : [value];
 }
 
 function serializeStoryboardRunStatus(
@@ -406,6 +412,9 @@ function serializeStoryboardRunStatus(
     first_failed_step_title: includeDiagnostics ? s.first_failed_step_title ?? null : null,
     first_failed_step_task: includeDiagnostics ? s.first_failed_step_task ?? null : null,
     first_failure_message: includeDiagnostics ? s.first_failure_message ?? null : null,
+    first_failure_validations: includeDiagnostics
+      ? normalizeValidationList(s.first_failure_validations_jsonb)
+      : [],
   };
 }
 
@@ -3580,6 +3589,7 @@ const StoryboardRunStatusResponseSchema = z.object({
   first_failed_step_title: z.string().nullable(),
   first_failed_step_task: z.string().nullable(),
   first_failure_message: z.string().nullable(),
+  first_failure_validations: z.array(z.any()),
 });
 
 const StoryboardRunDiagnosticResponseSchema = z.object({

--- a/server/tests/unit/capability-resolution-error-classifier.test.ts
+++ b/server/tests/unit/capability-resolution-error-classifier.test.ts
@@ -94,6 +94,22 @@ describe('classifyCapabilityResolutionError', () => {
     expect(info?.kind).toBe('specialism_parent_protocol_missing');
   });
 
+  it('classifies hyphenated supported_protocols near-misses as unrecognized protocol values', () => {
+    const err = new Error(
+      'Agent declared specialism "sales-guaranteed" (parent protocol: media_buy) ' +
+      'but did not include "media_buy" in supported_protocols. ' +
+      'Every specialism must roll up to a declared protocol per the AdCP spec.',
+    );
+
+    expect(classifyCapabilityResolutionError(err, ['media-buy'])).toEqual({
+      kind: 'unrecognized_supported_protocol',
+      specialism: 'sales-guaranteed',
+      parentProtocol: 'media_buy',
+      declaredProtocol: 'media-buy',
+      expectedProtocol: 'media_buy',
+    });
+  });
+
   it('requires the match to be anchored at the start (no smuggling via prefix)', () => {
     // An attacker-crafted error that embeds the structure later in the
     // message should not match — otherwise a hostile specialism id could
@@ -222,6 +238,33 @@ describe('presentCapabilityResolutionError', () => {
       error_kind: 'unsupported_adcp_version',
       compliance_version: '3.1.0-beta.5',
       supported_versions: '3.0, 3.1',
+    });
+  });
+
+  it('formats unrecognized supported protocol values for all sinks', () => {
+    const presentation = presentCapabilityResolutionError({
+      kind: 'unrecognized_supported_protocol',
+      specialism: 'sales-guaranteed',
+      parentProtocol: 'media_buy',
+      declaredProtocol: 'media-buy',
+      expectedProtocol: 'media_buy',
+    });
+    expect(presentation.headline).toContain('media-buy');
+    expect(presentation.headline).toContain('media_buy');
+    expect(presentation.headline).not.toMatch(/[\r\n]/);
+    expect(presentation.logMsg).toBe('Agent declared unrecognized supported_protocols value');
+    expect(presentation.logFields).toEqual({
+      specialism: 'sales-guaranteed',
+      parentProtocol: 'media_buy',
+      declaredProtocol: 'media-buy',
+      expectedProtocol: 'media_buy',
+    });
+    expect(presentation.restBody).toEqual({
+      error_kind: 'unrecognized_supported_protocol',
+      specialism: 'sales-guaranteed',
+      parent_protocol: 'media_buy',
+      declared_protocol: 'media-buy',
+      expected_protocol: 'media_buy',
     });
   });
 });

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -9809,6 +9809,9 @@ paths:
                         type:
                           - string
                           - "null"
+                      first_failure_validations:
+                        type: array
+                        items: {}
                     required:
                       - storyboard_id
                       - status
@@ -9820,6 +9823,7 @@ paths:
                       - first_failed_step_title
                       - first_failed_step_task
                       - first_failure_message
+                      - first_failure_validations
                     description: Persisted storyboard verdict for this run, using the same executable-step semantics as agent_storyboard_status.
                   phases: {}
                   summary: {}


### PR DESCRIPTION
## Summary
- Bump `@adcp/sdk` to `9.3.0` so `seed_account` routes through the SDK fix for `seed.account`.
- Classify malformed `supported_protocols` near-misses distinctly in Addie compliance tools, e.g. `media-buy` vs `media_buy`.
- Surface first-failure validation details in the registry API and dashboard storyboard drilldown for owner/debug views.
- Fix date-only brand rights end-date validation to match the emitted end-of-day `rights_constraint.valid_until`.
- Run server unit tests through the existing server Vitest config so shared server singletons are not tested with file parallelism.

## Validation
- `npx vitest run server/tests/unit/capability-resolution-error-classifier.test.ts tests/addie/member-tools.test.ts server/tests/unit/compliance-db-last-write-wins.test.ts`
- `npx vitest run tests/addie/brand-sandbox-tools.test.ts -t "rights_constraint uses date-time format" --pool=threads`
- `npm run test:server-unit`
- `npm run typecheck`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- `git diff --check`
- pre-commit hook during commit
- pre-push hook during push, including current and 3.0 compatibility storyboard matrices

No changeset: no protocol release-surface changes detected; scope check passes.