### PR TITLE
fix(release): make hosted compliance version test patch-aware

### DIFF
--- a/tests/hosted-compliance-version.test.ts
+++ b/tests/hosted-compliance-version.test.ts
@@ -8,17 +8,19 @@ import {
 
 describe('hosted compliance target selection', () => {
   it('selects the 3.1 GA target when an agent advertises both 3.0 and 3.1', () => {
+    const stable31Target = hostedComplianceTarget('3.1');
     const target = selectCanonicalHostedComplianceTargetForSupportedVersions(['3.0', '3.1']);
 
     expect(target.requested).toBe('3.1');
-    expect(target.version).toBe('3.1.0');
+    expect(target.version).toBe(stable31Target.version);
   });
 
   it('selects the 3.1 GA target when an agent advertises patch-form 3.1.0', () => {
+    const stable31Target = hostedComplianceTarget('3.1');
     const target = selectCanonicalHostedComplianceTargetForSupportedVersions(['3.0', '3.1.0']);
 
     expect(target.requested).toBe('3.1');
-    expect(target.version).toBe('3.1.0');
+    expect(target.version).toBe(stable31Target.version);
   });
 
   it('keeps 3.0-only agents on the 3.0 public target', () => {


### PR DESCRIPTION
## Summary

- Make hosted compliance target-selection tests patch-aware for the 3.1 line
- Assert selected versions against `hostedComplianceTarget('3.1')` instead of hard-coding `3.1.0`

## Why

The main Release workflow correctly generated `3.1.1` artifacts, but the release PR commit failed its pre-commit hook because `tests/hosted-compliance-version.test.ts` still expected the previous 3.1 patch version.

## Validation

- `npx vitest run tests/hosted-compliance-version.test.ts`
- precommit hook during commit:
  - `npm run test:unit`
  - `npm run test:test-dynamic-imports`
  - `npm run test:callapi-state-change`
  - `npm run precommit:server-unit`
  - `npm run typecheck`
- pre-push hook:
  - `npm run verify-version-sync`
  - changeset protocol scope check
