### PR TITLE
chore(deps): bump adcp sdk to 9.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.1.1",
       "dependencies": {
-        "@adcp/sdk": "9.3.0",
+        "@adcp/sdk": "9.6.2",
         "@anthropic-ai/sdk": "^0.107.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.5.5",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.3.0.tgz",
-      "integrity": "sha512-bTWOe/Hcq9mgQfxuV9Fmhg0VuC1YzLuxvkIGHvqVSe8uOoybUF4mksupBBeH5LfkuEH9qIxWeS8bEwLGJy9huA==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.6.2.tgz",
+      "integrity": "sha512-dz62Ff343kMLJWFJ+oux6aeXEoWjA6QW0MF5W0oYtIWaBVjNk56j16F7US1nUs8cwCjusLD8PKJUs+A2d+ehWw==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "9.3.0",
+    "@adcp/sdk": "9.6.2",
     "@anthropic-ai/sdk": "^0.107.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.5.5",

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -185,6 +185,14 @@ const THREE_ZERO_COMPAT_KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new M
     'brand_rights/acquire_rights',
     '3.0.13 compatibility run under @adcp/sdk 8.1 beta.13: frozen brand-rights response schema rejects the current training-agent rights envelope. Current-source brand coverage remains graded by the current matrix.',
   ],
+  [
+    'signal_marketplace/governance_denied/activate_signal_denied',
+    '3.0.19 compatibility run under @adcp/sdk 9.6.2: the frozen linked governance-denial storyboard skips governance setup on the signals tenant because sync_plans is not advertised, but still grades activate_signal_denied, where the current signals tenant no longer emits the frozen GOVERNANCE_DENIED shape. Current-source signal governance-denial coverage remains graded by the current matrix.',
+  ],
+  [
+    'media_buy_seller/measurement_terms_rejected/create_media_buy_aggressive_terms',
+    '3.0.19 compatibility run under @adcp/sdk 9.6.2: the frozen measurement-terms storyboard expects TERMS_REJECTED, while the current training-agent 3.0 compatibility handler returns INVALID_REQUEST for that legacy aggressive payload. Current-source media-buy rejection coverage remains graded by the current matrix.',
+  ],
 ]);
 
 const THREE_ZERO_SIGNED_POSITIVE_VECTOR_IDS = [


### PR DESCRIPTION
## Summary
- Bump the root `@adcp/sdk` dependency from `9.3.0` to published `9.6.2`.
- Update the npm lockfile to the 9.6.2 tarball/integrity.
- Add two narrow frozen-3.0 storyboard compatibility step skips for SDK 9.6.2 runner behavior while keeping current-source coverage intact.

## Validation
- Remote expert code review: ready to push.
- Remote expert security review: ready; pre-existing audit findings only.
- `npm run typecheck`
- `npm run test:sdk-shims`
- `npm run test:sdk-runner-capability-gates`
- `npm run test:patch-3-0-compat-bundle`
- `npm run test:run-storyboards-schema-root`
- `npm run test:storyboards:3.0-compat`
- precommit hook: unit suite + dynamic imports + callapi state change + server-unit + typecheck
- pre-push hook: version sync, changeset scope check, current storyboard matrix, 3.0 compatibility storyboard matrix
- `npm audit signatures --json` returned no invalid or missing signatures

## Risk
- Scope is dependency/runner-maintenance only; no protocol release changeset expected.