### PR TITLE
Fix stale compliance fixture dates

### DIFF
--- a/.changeset/fix-compat-fixed-dates.md
+++ b/.changeset/fix-compat-fixed-dates.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Move stale active-window dates in compliance fixtures and 3.0 compatibility bundles forward so storyboard runs continue to exercise protocol behavior instead of calendar drift.

--- a/scripts/patch-3-0-compat-bundle.cjs
+++ b/scripts/patch-3-0-compat-bundle.cjs
@@ -20,70 +20,52 @@ if (!/^3\.0\.\d+$/.test(version)) {
   process.exit(0);
 }
 
-const idempotencyPath = path.join(bundleDir, 'universal', 'idempotency.yaml');
-let idempotencyFd;
-try {
-  idempotencyFd = fs.openSync(idempotencyPath, 'r+');
-} catch (err) {
-  if (err && err.code === 'ENOENT') {
-    process.exit(0);
+function walkYamlFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkYamlFiles(fullPath));
+    } else if (entry.isFile() && /\.ya?ml$/i.test(entry.name)) {
+      out.push(fullPath);
+    }
   }
-  throw err;
+  return out;
 }
 
-// The frozen 3.0.15 idempotency storyboard authored fixed 2026 flight dates.
-// Once those dates became stale, @adcp/sdk's fixture-aware create_media_buy
-// enricher replaced them with per-step dynamic defaults. That makes the
-// initial/replay payloads differ before they reach the agent and turns the
-// compatibility check into a runner-fixture failure instead of an idempotency
-// regression check. Patch only the temp compatibility bundle so the old
-// storyboard keeps exercising stable same-payload replay semantics.
-try {
-  const before = fs.readFileSync(idempotencyFd, 'utf8');
-  const after = before.replace(/\b2026-/g, '2099-');
-
-  if (after !== before) {
-    fs.ftruncateSync(idempotencyFd, 0);
-    fs.writeSync(idempotencyFd, after, 0, 'utf8');
-    console.log(`Patched stale 3.0 compatibility dates in ${idempotencyPath}`);
-  }
-} finally {
-  fs.closeSync(idempotencyFd);
-}
-
-for (const rel of [
-  path.join('protocols', 'media-buy', 'scenarios', 'measurement_terms_rejected.yaml'),
-  path.join('domains', 'media-buy', 'scenarios', 'measurement_terms_rejected.yaml'),
-]) {
-  const measurementTermsPath = path.join(bundleDir, rel);
-  let measurementTermsFd;
+function patchFile(filePath, transform, label) {
+  let before;
   try {
-    measurementTermsFd = fs.openSync(measurementTermsPath, 'r+');
+    before = fs.readFileSync(filePath, 'utf8');
   } catch (err) {
-    if (err && err.code === 'ENOENT') continue;
+    if (err && err.code === 'ENOENT') return false;
     throw err;
   }
+  const after = transform(before);
+  if (after === before) return false;
+  fs.writeFileSync(filePath, after, 'utf8');
+  if (label) console.log(label);
+  return true;
+}
 
-  // The frozen 3.0.19 measurement_terms_rejected storyboard hard-codes a
-  // 2026-07-01 flight start. Once that date became stale, create_media_buy
-  // correctly rejected the past start_time with INVALID_REQUEST before it
-  // could exercise the intended TERMS_REJECTED branch. Patch only the temp
-  // compatibility bundle so this legacy fixture keeps testing measurement
-  // term negotiation instead of calendar drift.
-  try {
-    const before = fs.readFileSync(measurementTermsFd, 'utf8');
-    const after = before
-      .replace(/\bstart_time: "2026-07-01T00:00:00Z"/g, 'start_time: "2099-07-01T00:00:00Z"')
-      .replace(/\bend_time: "2026-09-30T23:59:59Z"/g, 'end_time: "2099-09-30T23:59:59Z"');
-
-    if (after !== before) {
-      fs.ftruncateSync(measurementTermsFd, 0);
-      fs.writeSync(measurementTermsFd, after, 0, 'utf8');
-      console.log(`Patched stale 3.0 compatibility dates in ${measurementTermsPath}`);
-    }
-  } finally {
-    fs.closeSync(measurementTermsFd);
+// Frozen 3.0.x storyboards authored concrete 2026/2027 active-window dates.
+// As wall-clock time advances those fixtures start failing calendar guards
+// before they can exercise the protocol behavior they were written for
+// (TERMS_REJECTED, GOVERNANCE_DENIED, idempotency replay, etc.). Patch only
+// window/validity keys in the temp compatibility bundle so legacy storyboards
+// keep testing behavior rather than date drift. Historical/event timestamps
+// such as accepted_at, finalized_at, and event_time are intentionally left
+// alone, and JSON test vectors are excluded because some fixed dates are
+// canonicalization preimages.
+const staleDateLineRe = /^(\s*(?:start_time|end_time|start|end|start_date|end_date|valid_from|valid_until|expires_at):\s*["']?)(?:2026|2027)-(?=\d{2}-\d{2}(?:T|\b))/gm;
+let staleDateFiles = 0;
+for (const yamlPath of walkYamlFiles(bundleDir)) {
+  if (patchFile(yamlPath, text => text.replace(staleDateLineRe, (_match, prefix) => `${prefix}2099-`))) {
+    staleDateFiles += 1;
   }
+}
+if (staleDateFiles > 0) {
+  console.log(`Patched stale 3.0 compatibility dates in ${staleDateFiles} YAML file(s)`);
 }
 
 const schemaValidationPath = path.join(bundleDir, 'universal', 'schema-validation.yaml');
@@ -181,7 +163,9 @@ for (const rel of [
   // the lifecycle field, matching current source without rewriting dist.
   try {
     const before = fs.readFileSync(stateMachineFd, 'utf8');
-    const after = before.replace(/\n            path: "status"\n/g, '\n            path: "media_buy_status"\n');
+    const after = before
+      .replace(/\n          start_time: "2099-05-01T00:00:00Z"\n          end_time: "2099-05-31T23:59:59Z"\n/g, '\n          start_time: "asap"\n          end_time: "2099-05-31T23:59:59Z"\n')
+      .replace(/\n            path: "status"\n/g, '\n            path: "media_buy_status"\n');
 
     if (after !== before) {
       fs.ftruncateSync(stateMachineFd, 0);

--- a/server/src/training-agent/brand-handlers.ts
+++ b/server/src/training-agent/brand-handlers.ts
@@ -188,7 +188,7 @@ const TALENT: TalentEntry[] = [
         right_type: 'talent',
         available_uses: ['likeness', 'voice', 'name', 'endorsement', 'commercial', 'ai_generated_image'],
         countries: ['NL', 'BE', 'DE'],
-        exclusivity_status: { available: true, existing_exclusives: ['sportswear (NL) — through 2026-12-31'] },
+        exclusivity_status: { available: true, existing_exclusives: ['sportswear (NL) — through 2099-12-31'] },
         pricing_options: [
           {
             pricing_option_id: 'cpm_endorsement',
@@ -221,8 +221,8 @@ const TALENT: TalentEntry[] = [
       pending_approval: ['alcohol', 'gambling', 'pharmaceutical'],
       rejected: {
         sportswear: {
-          reason: 'Active exclusivity with another brand for sportswear in NL through 2026-12-31',
-          suggestions: ['Available for sportswear in BE and DE markets', 'Available in NL after 2027-01-01'],
+          reason: 'Active exclusivity with another brand for sportswear in NL through 2099-12-31',
+          suggestions: ['Available for sportswear in BE and DE markets', 'Available in NL after 2100-01-01'],
         },
       },
     },
@@ -319,7 +319,7 @@ const TALENT: TalentEntry[] = [
         right_type: 'talent',
         available_uses: ['likeness', 'name', 'endorsement', 'commercial', 'ai_generated_image'],
         countries: ['NL', 'BE', 'DE', 'FR'],
-        exclusivity_status: { available: true, existing_exclusives: ['cycling equipment (EU) — through 2027-03-31'] },
+        exclusivity_status: { available: true, existing_exclusives: ['cycling equipment (EU) — through 2099-03-31'] },
         pricing_options: [
           {
             pricing_option_id: 'cpm_likeness',
@@ -355,8 +355,8 @@ const TALENT: TalentEntry[] = [
         dairy: 'This conflicts with our talent lifestyle guidelines',
         fast_food: 'This conflicts with our talent lifestyle guidelines',
         cycling_equipment: {
-          reason: 'Active exclusivity with another brand for cycling equipment in EU through 2027-03-31',
-          suggestions: ['Available for cycling equipment outside EU', 'Available in EU after 2027-04-01'],
+          reason: 'Active exclusivity with another brand for cycling equipment in EU through 2099-03-31',
+          suggestions: ['Available for cycling equipment outside EU', 'Available in EU after 2099-04-01'],
         },
       },
     },
@@ -404,7 +404,7 @@ const TALENT: TalentEntry[] = [
         countries: ['JP', 'KR', 'US'],
         exclusivity_status: {
           available: false,
-          existing_exclusives: ['cosmetics (JP) — through 2027-06-30'],
+          existing_exclusives: ['cosmetics (JP) — through 2099-06-30'],
         },
         pricing_options: [
           {
@@ -438,8 +438,8 @@ const TALENT: TalentEntry[] = [
       pending_approval: ['fashion', 'technology', 'entertainment'],
       rejected: {
         cosmetics: {
-          reason: 'Active exclusivity with another brand for cosmetics in JP through 2027-06-30',
-          suggestions: ['Available for cosmetics outside JP', 'Available in JP after 2027-07-01'],
+          reason: 'Active exclusivity with another brand for cosmetics in JP through 2099-06-30',
+          suggestions: ['Available for cosmetics outside JP', 'Available in JP after 2099-07-01'],
         },
       },
     },
@@ -899,6 +899,14 @@ interface AcquireRightsArgs {
   };
 }
 
+function defaultRightsWindow() {
+  const year = new Date(Date.now()).getUTCFullYear() + 1;
+  return {
+    startDate: `${year}-04-01`,
+    endDate: `${year}-06-30`,
+  };
+}
+
 export async function handleAcquireRights(
   args: ToolArgs,
   ctx: TrainingContext,
@@ -1045,8 +1053,9 @@ export async function handleAcquireRights(
   }
 
   const talentName = getTalentName(talent);
-  const startDate = campaign.start_date || '2026-04-01';
-  const endDate = campaign.end_date || '2026-06-30';
+  const defaultWindow = defaultRightsWindow();
+  const startDate = campaign.start_date || defaultWindow.startDate;
+  const endDate = campaign.end_date || defaultWindow.endDate;
 
   const generationCredentials: GenerationCredential[] = [];
   const campaignUses = campaign.uses || pricingOption.uses;
@@ -1146,8 +1155,9 @@ export function handleUpdateRights(
     return { errors: [{ code: 'REFERENCE_NOT_FOUND', message: `No active grant with id '${rightsId}'` }] };
   }
 
-  const currentEndDate = '2026-06-30';
-  const currentStartDate = '2026-04-01';
+  const defaultWindow = defaultRightsWindow();
+  const currentEndDate = defaultWindow.endDate;
+  const currentStartDate = defaultWindow.startDate;
   if (endDate && endDate < currentEndDate) {
     return { errors: [{ code: 'INVALID_REQUEST', message: 'New end_date must be >= current end_date' }] };
   }

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -187,11 +187,7 @@ const THREE_ZERO_COMPAT_KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new M
   ],
   [
     'signal_marketplace/governance_denied/activate_signal_denied',
-    '3.0.19 compatibility run under @adcp/sdk 9.6.2: the frozen linked governance-denial storyboard skips governance setup on the signals tenant because sync_plans is not advertised, but still grades activate_signal_denied, where the current signals tenant no longer emits the frozen GOVERNANCE_DENIED shape. Current-source signal governance-denial coverage remains graded by the current matrix.',
-  ],
-  [
-    'media_buy_seller/measurement_terms_rejected/create_media_buy_aggressive_terms',
-    '3.0.19 compatibility run under @adcp/sdk 9.6.2: the frozen measurement-terms storyboard expects TERMS_REJECTED, while the current training-agent 3.0 compatibility handler returns INVALID_REQUEST for that legacy aggressive payload. Current-source media-buy rejection coverage remains graded by the current matrix.',
+    'latest 3.0.x compatibility run under @adcp/sdk 9.6.2: the frozen linked governance-denial storyboard skips governance setup on the signals tenant because sync_plans is not advertised, but still grades activate_signal_denied, where the current signals tenant no longer emits the frozen GOVERNANCE_DENIED shape. Current-source signal governance-denial coverage remains graded by the current matrix.',
   ],
 ]);
 
@@ -246,41 +242,36 @@ function skipThreeZeroSignedVectorsExcept(allowed: string[]): string[] {
     .filter(id => !allowedSet.has(id));
 }
 
-function normalizeThreeZeroCompatFlightDates(value: unknown): void {
+const THREE_ZERO_STALE_STORYBOARD_DATE_RE = /\b(?:2026|2027)-(?=\d{2}-\d{2}(?:T|\b))/g;
+const THREE_ZERO_STALE_DATE_WINDOW_KEYS = new Set([
+  'start_time',
+  'end_time',
+  'start',
+  'end',
+  'start_date',
+  'end_date',
+  'valid_from',
+  'valid_until',
+  'expires_at',
+]);
+
+function normalizeThreeZeroStaleStoryboardDates(value: unknown): void {
   if (!value || typeof value !== 'object') return;
   if (Array.isArray(value)) {
-    for (const item of value) normalizeThreeZeroCompatFlightDates(item);
+    for (let i = 0; i < value.length; i += 1) {
+      normalizeThreeZeroStaleStoryboardDates(value[i]);
+    }
     return;
   }
 
   const obj = value as Record<string, unknown>;
-  if (
-    obj.start_time === '2026-05-01T00:00:00Z'
-    && obj.end_time === '2026-05-31T23:59:59Z'
-  ) {
-    obj.start_time = 'asap';
-    obj.end_time = '2099-05-31T23:59:59Z';
+  for (const [key, child] of Object.entries(obj)) {
+    if (typeof child === 'string' && THREE_ZERO_STALE_DATE_WINDOW_KEYS.has(key)) {
+      obj[key] = child.replace(THREE_ZERO_STALE_STORYBOARD_DATE_RE, '2099-');
+    } else {
+      normalizeThreeZeroStaleStoryboardDates(child);
+    }
   }
-  for (const child of Object.values(obj)) normalizeThreeZeroCompatFlightDates(child);
-}
-
-function normalizeThreeZeroIdempotencyDates(value: unknown): void {
-  if (!value || typeof value !== 'object') return;
-  if (Array.isArray(value)) {
-    for (const item of value) normalizeThreeZeroIdempotencyDates(item);
-    return;
-  }
-
-  const obj = value as Record<string, unknown>;
-  if (obj.start_time === '2026-06-01T00:00:00Z') {
-    obj.start_time = '2099-06-01T00:00:00Z';
-  }
-  if (obj.end_time === '2026-06-30T23:59:59Z') {
-    obj.end_time = '2099-06-30T23:59:59Z';
-  } else if (obj.end_time === '2026-09-30T23:59:59Z') {
-    obj.end_time = '2099-09-30T23:59:59Z';
-  }
-  for (const child of Object.values(obj)) normalizeThreeZeroIdempotencyDates(child);
 }
 
 function patchThreeZeroStoryboard(sb: Storyboard): Storyboard {
@@ -305,9 +296,8 @@ function patchThreeZeroStoryboard(sb: Storyboard): Storyboard {
 
   if (!isThreeZeroCompatRun) return patched;
   patched = structuredClone(patched) as Storyboard;
-  normalizeThreeZeroCompatFlightDates(patched);
+  normalizeThreeZeroStaleStoryboardDates(patched);
   if (sb.id === 'idempotency') {
-    normalizeThreeZeroIdempotencyDates(patched);
     return patched;
   }
   if (sb.id === 'media_buy_seller/pending_creatives_to_start') {

--- a/static/compliance/source/protocols/creative/scenarios/billing_out_of_band.yaml
+++ b/static/compliance/source/protocols/creative/scenarios/billing_out_of_band.yaml
@@ -117,8 +117,8 @@ phases:
             operator: "pinnacle-agency.example"
           idempotency_key: "$generate:uuid_v4#creative_billing_out_of_band_report_usage"
           reporting_period:
-            start: "2026-07-01T00:00:00Z"
-            end: "2026-07-31T23:59:59Z"
+            start: "2099-07-01T00:00:00Z"
+            end: "2099-07-31T23:59:59Z"
           usage:
             - account:
                 account_id: "acct_acme_creative"

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -79,8 +79,8 @@ fixtures:
         currency: "USD"
         reallocation_threshold: 20000
       flight:
-        start: "2027-04-01T00:00:00Z"
-        end: "2027-06-30T23:59:59Z"
+        start: "2020-01-01T00:00:00Z"
+        end: "2099-06-30T23:59:59Z"
       countries: ["US"]
       custom_policies:
         - policy_id: "weekly_reporting_over_10k"
@@ -260,8 +260,8 @@ phases:
                 currency: "USD"
                 reallocation_threshold: 20000
               flight:
-                start: "2027-04-01T00:00:00Z"
-                end: "2027-06-30T23:59:59Z"
+                start: "2020-01-01T00:00:00Z"
+                end: "2099-06-30T23:59:59Z"
               countries: ["US"]
               custom_policies:
                 - policy_id: "weekly_reporting_over_10k"
@@ -405,8 +405,8 @@ phases:
               operator: "pinnacle-agency.example"
             brand:
               domain: "acmeoutdoor.example"
-            start_time: "2027-01-01T00:00:00Z"
-            end_time: "2027-03-31T23:59:59Z"
+            start_time: "2099-01-01T00:00:00Z"
+            end_time: "2099-03-31T23:59:59Z"
             packages:
               - product_id: "$context.product_1_id"
                 budget: 30000
@@ -480,8 +480,8 @@ phases:
               operator: "pinnacle-agency.example"
             brand:
               domain: "acmeoutdoor.example"
-            start_time: "2027-01-01T00:00:00Z"
-            end_time: "2027-03-31T23:59:59Z"
+            start_time: "2099-01-01T00:00:00Z"
+            end_time: "2099-03-31T23:59:59Z"
             packages:
               - product_id: "$context.product_1_id"
                 budget: 30000

--- a/static/compliance/source/protocols/media-buy/scenarios/billing_finality_delivery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/billing_finality_delivery.yaml
@@ -250,7 +250,7 @@ phases:
               amount: 180.00
               currency: "USD"
             is_final: true
-            finalized_at: "2026-08-03T12:00:00Z"
+            finalized_at: "2099-08-03T12:00:00Z"
             measurement_window: "post_sivt"
         validations:
           - check: field_value
@@ -324,8 +324,8 @@ phases:
             operator: "pinnacle-agency.example"
           idempotency_key: "$generate:uuid_v4#billing_finality_delivery_report_final_usage"
           reporting_period:
-            start: "2026-07-01T00:00:00Z"
-            end: "2026-07-31T23:59:59Z"
+            start: "2099-07-01T00:00:00Z"
+            end: "2099-07-31T23:59:59Z"
           usage:
             - account:
                 brand:
@@ -337,7 +337,7 @@ phases:
               vendor_cost: 1800.00
               currency: "USD"
               final: true
-              finalized_at: "2026-08-03T12:00:00Z"
+              finalized_at: "2099-08-03T12:00:00Z"
               measurement_window: "post_sivt"
           context:
             correlation_id: "billing_finality_delivery--report_usage"

--- a/static/compliance/source/protocols/media-buy/scenarios/canonical_formats.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/canonical_formats.yaml
@@ -793,8 +793,8 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
             sandbox: true
-          start_time: "2027-06-01T00:00:00Z"
-          end_time: "2027-06-30T23:59:59Z"
+          start_time: "2099-06-01T00:00:00Z"
+          end_time: "2099-06-30T23:59:59Z"
           packages:
             - product_id: "canonical_formats_mrec_display"
               budget: 1000
@@ -839,8 +839,8 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
             sandbox: true
-          start_time: "2027-06-01T00:00:00Z"
-          end_time: "2027-06-30T23:59:59Z"
+          start_time: "2099-06-01T00:00:00Z"
+          end_time: "2099-06-30T23:59:59Z"
           packages:
             - product_id: "canonical_formats_mrec_display"
               budget: 1000

--- a/static/compliance/source/protocols/media-buy/scenarios/event_dedup_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/event_dedup_flow.yaml
@@ -290,7 +290,7 @@ phases:
           events:
             - event_type: "purchase"
               event_id: "evt_dedup_001"
-              event_time: "2026-06-05T14:30:00Z"
+              event_time: "2099-06-05T14:30:00Z"
               user_match:
                 hashed_email: "a000000000000000000000000000000000000000000000000000000000000010"
               custom_data:
@@ -322,7 +322,7 @@ phases:
           events:
             - event_type: "purchase"
               event_id: "evt_dedup_001"
-              event_time: "2026-06-05T14:30:00Z"
+              event_time: "2099-06-05T14:30:00Z"
               user_match:
                 hashed_email: "a000000000000000000000000000000000000000000000000000000000000010"
               custom_data:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
@@ -95,7 +95,7 @@ phases:
                 currency: "USD"
                 reallocation_threshold: 100000
               flight:
-                start: "2026-04-01T00:00:00Z"
+                start: "2020-01-01T00:00:00Z"
                 end: "2099-06-30T23:59:59Z"
               countries: ["US", "CA"]
         validations:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_conditions.yaml
@@ -72,7 +72,7 @@ phases:
                 currency: "USD"
                 reallocation_threshold: 100000
               flight:
-                start: "2026-04-01T00:00:00Z"
+                start: "2020-01-01T00:00:00Z"
                 end: "2099-06-30T23:59:59Z"
               countries: ["US", "CA"]
               custom_policies:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied.yaml
@@ -94,7 +94,7 @@ phases:
                 currency: "USD"
                 reallocation_threshold: 5000
               flight:
-                start: "2026-04-01T00:00:00Z"
+                start: "2020-01-01T00:00:00Z"
                 end: "2099-06-30T23:59:59Z"
               countries: ["US"]
         validations:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_denied_recovery.yaml
@@ -94,7 +94,7 @@ phases:
                 currency: "USD"
                 reallocation_threshold: 5000
               flight:
-                start: "2026-04-01T00:00:00Z"
+                start: "2020-01-01T00:00:00Z"
                 end: "2099-06-30T23:59:59Z"
               countries: ["US"]
         validations:

--- a/static/compliance/source/protocols/media-buy/scenarios/per_creative_conversion_attribution.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/per_creative_conversion_attribution.yaml
@@ -369,7 +369,7 @@ phases:
           events:
             - event_type: "purchase"
               event_id: "evt_per_creative_001"
-              event_time: "2026-06-05T14:30:00Z"
+              event_time: "2099-06-05T14:30:00Z"
               user_match:
                 hashed_email: "a000000000000000000000000000000000000000000000000000000000000030"
               custom_data:
@@ -402,7 +402,7 @@ phases:
           events:
             - event_type: "purchase"
               event_id: "evt_per_creative_002"
-              event_time: "2026-06-06T10:15:00Z"
+              event_time: "2099-06-06T10:15:00Z"
               user_match:
                 hashed_email: "a000000000000000000000000000000000000000000000000000000000000031"
               custom_data:

--- a/static/compliance/source/protocols/media-buy/scenarios/performance_buy_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/performance_buy_flow.yaml
@@ -326,7 +326,7 @@ phases:
           events:
             - event_type: "purchase"
               event_id: "evt_perf_buy_flow_001"
-              event_time: "2026-06-05T14:30:00Z"
+              event_time: "2099-06-05T14:30:00Z"
               user_match:
                 hashed_email: "a000000000000000000000000000000000000000000000000000000000000001"
               custom_data:

--- a/static/compliance/source/protocols/media-buy/scenarios/performance_buy_flow_roas.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/performance_buy_flow_roas.yaml
@@ -364,7 +364,7 @@ phases:
           events:
             - event_type: "purchase"
               event_id: "evt_perf_buy_flow_roas_001"
-              event_time: "2026-06-05T14:30:00Z"
+              event_time: "2099-06-05T14:30:00Z"
               user_match:
                 hashed_email: "a000000000000000000000000000000000000000000000000000000000000020"
               custom_data:

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_finalize.yaml
@@ -294,7 +294,7 @@ phases:
             amount: 50000
             currency: "USD"
           start_time: "asap"
-          end_time: "2027-06-30T23:59:59Z"
+          end_time: "2099-06-30T23:59:59Z"
           io_acceptance:
             io_id: "$context.io_id"
             accepted_at: "2026-03-15T14:30:00Z"
@@ -382,7 +382,7 @@ phases:
             amount: 50000
             currency: "USD"
           start_time: "asap"
-          end_time: "2027-06-30T23:59:59Z"
+          end_time: "2099-06-30T23:59:59Z"
 
           idempotency_key: "$generate:uuid_v4#media_buy_seller_proposal_finalize_unknown_proposal_create_media_buy"
         validations:

--- a/static/compliance/source/protocols/media-buy/scenarios/proposal_not_found_errors.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/proposal_not_found_errors.yaml
@@ -173,7 +173,7 @@ phases:
             amount: 50000
             currency: "USD"
           start_time: "asap"
-          end_time: "2027-06-30T23:59:59Z"
+          end_time: "2099-06-30T23:59:59Z"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_proposal_not_found_errors_unknown_proposal_create_create_media_buy_unknown_proposal"
           context:
             correlation_id: "proposal_not_found_errors--create_media_buy_unknown"
@@ -238,7 +238,7 @@ phases:
             amount: 50000
             currency: "USD"
           start_time: "asap"
-          end_time: "2027-06-30T23:59:59Z"
+          end_time: "2099-06-30T23:59:59Z"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_proposal_not_found_errors_expired_proposal_create_create_media_buy_expired_proposal"
           context:
             correlation_id: "proposal_not_found_errors--create_media_buy_expired"

--- a/static/compliance/source/specialisms/brand-rights/index.yaml
+++ b/static/compliance/source/specialisms/brand-rights/index.yaml
@@ -265,8 +265,8 @@ phases:
             uses:
               - "likeness"
               - "commercial"
-            start_date: "2026-04-01"
-            end_date: "2026-06-30"
+            start_date: "2099-04-01"
+            end_date: "2099-06-30"
           revocation_webhook:
             url: "https://pinnacle-agency.example/webhooks/revocation"
             authentication:

--- a/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/brand-rights/scenarios/governance_denied.yaml
@@ -76,8 +76,8 @@ phases:
                 currency: "USD"
                 reallocation_threshold: 25
               flight:
-                start: "2026-04-01T00:00:00Z"
-                end: "2026-06-30T23:59:59Z"
+                start: "2099-04-01T00:00:00Z"
+                end: "2099-06-30T23:59:59Z"
               countries: ["US"]
           idempotency_key: "$generate:uuid_v4#brand_rights_governance_denied_governance_plan_setup_sync_plans"
         validations:
@@ -195,8 +195,8 @@ phases:
             uses:
               - "likeness"
               - "commercial"
-            start_date: "2026-04-01"
-            end_date: "2026-06-30"
+            start_date: "2099-04-01"
+            end_date: "2099-06-30"
           revocation_webhook:
             url: "https://pinnacle-agency.example/webhooks/revocation"
             authentication:

--- a/static/compliance/source/specialisms/creative-ad-server/index.yaml
+++ b/static/compliance/source/specialisms/creative-ad-server/index.yaml
@@ -391,8 +391,8 @@ phases:
             operator: "pinnacle-agency.example"
           idempotency_key: "$generate:uuid_v4#creative-ad-server-report-usage"
           reporting_period:
-            start: "2026-03-01T00:00:00Z"
-            end: "2026-03-31T23:59:59Z"
+            start: "2099-03-01T00:00:00Z"
+            end: "2099-03-31T23:59:59Z"
           usage:
             - account:
                 account_id: "acct_acme_creative"

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -84,8 +84,8 @@ fixtures:
         currency: "USD"
         reallocation_threshold: 8000
       flight:
-        start: "2027-01-01T00:00:00Z"
-        end: "2027-12-31T23:59:59Z"
+        start: "2020-01-01T00:00:00Z"
+        end: "2099-12-31T23:59:59Z"
       countries: ["US"]
       custom_policies:
         - policy_id: "drift_reevaluation"
@@ -98,8 +98,8 @@ fixtures:
         total: 40000
         currency: "USD"
       flight:
-        start: "2026-04-01T00:00:00Z"
-        end: "2026-06-30T23:59:59Z"
+        start: "2020-01-01T00:00:00Z"
+        end: "2099-06-30T23:59:59Z"
 
 phases:
   - id: capability_discovery
@@ -183,8 +183,8 @@ phases:
                 currency: "USD"
                 reallocation_threshold: 8000
               flight:
-                start: "2027-01-01T00:00:00Z"
-                end: "2027-12-31T23:59:59Z"
+                start: "2020-01-01T00:00:00Z"
+                end: "2099-12-31T23:59:59Z"
               countries: ["US"]
               custom_policies:
                 - policy_id: "drift_reevaluation"
@@ -419,8 +419,8 @@ phases:
           governance_context: "gov_ctx_acme_delivery_approved"
           delivery_metrics:
             reporting_period:
-              start: "2026-05-01T00:00:00Z"
-              end: "2026-05-15T00:00:00Z"
+              start: "2099-05-01T00:00:00Z"
+              end: "2099-05-15T00:00:00Z"
             spend: 20000
             cumulative_spend: 20000
             channel_distribution:

--- a/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/denied.yaml
@@ -121,8 +121,8 @@ phases:
                 currency: "USD"
                 reallocation_threshold: 0
               flight:
-                start: "2027-01-01T00:00:00Z"
-                end: "2027-12-31T23:59:59Z"
+                start: "2099-01-01T00:00:00Z"
+                end: "2099-12-31T23:59:59Z"
               countries: ["US"]
 
           context:
@@ -186,8 +186,8 @@ phases:
               operator: "pinnacle-agency.example"
             brand:
               domain: "acmeoutdoor.example"
-            start_time: "2027-01-01T00:00:00Z"
-            end_time: "2027-03-31T23:59:59Z"
+            start_time: "2099-01-01T00:00:00Z"
+            end_time: "2099-03-31T23:59:59Z"
             packages:
               - product_id: "sports_ctv_q2"
                 budget: 30000

--- a/static/compliance/source/specialisms/governance-spend-authority/index.yaml
+++ b/static/compliance/source/specialisms/governance-spend-authority/index.yaml
@@ -85,8 +85,8 @@ fixtures:
         currency: "USD"
         reallocation_unlimited: true
       flight:
-        start: "2027-01-01T00:00:00Z"
-        end: "2027-12-31T23:59:59Z"
+        start: "2020-01-01T00:00:00Z"
+        end: "2099-12-31T23:59:59Z"
       countries: ["US"]
       custom_policies:
         - policy_id: "ctv_weekly_reporting"
@@ -178,8 +178,8 @@ phases:
                 currency: "USD"
                 reallocation_unlimited: true
               flight:
-                start: "2027-01-01T00:00:00Z"
-                end: "2027-12-31T23:59:59Z"
+                start: "2020-01-01T00:00:00Z"
+                end: "2099-12-31T23:59:59Z"
               countries: ["US"]
               custom_policies:
                 - policy_id: "ctv_weekly_reporting"

--- a/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
+++ b/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
@@ -715,19 +715,19 @@ phases:
           events:
             - event_id: "evt_001"
               event_type: "purchase"
-              event_time: "2026-04-15T19:30:00Z"
+              event_time: "2099-04-15T19:30:00Z"
               content_ids: ["ribeye_36oz"]
               value: 89.00
               currency: "USD"
             - event_id: "evt_002"
               event_type: "lead"
-              event_time: "2026-04-15T20:15:00Z"
+              event_time: "2099-04-15T20:15:00Z"
               content_ids: ["wagyu_flight"]
               value: 195.00
               currency: "USD"
             - event_id: "evt_003"
               event_type: "page_view"
-              event_time: "2026-04-15T20:45:00Z"
+              event_time: "2099-04-15T20:45:00Z"
               content_ids: ["seafood_tower"]
 
           idempotency_key: "$generate:uuid_v4#sales_catalog_driven_conversion_tracking_log_events"
@@ -782,8 +782,8 @@ phases:
             operator: "pinnacle-agency.example"
           media_buy_id: "$context.media_buy_id"
           measurement_period:
-            start: "2026-04-07T00:00:00Z"
-            end: "2026-04-14T23:59:59Z"
+            start: "2099-04-07T00:00:00Z"
+            end: "2099-04-14T23:59:59Z"
           performance_index: 1.4
           metric_type: "conversion_rate"
           feedback_source: "buyer_attribution"

--- a/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
+++ b/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
@@ -401,7 +401,7 @@ phases:
             amount: 50000
             currency: "USD"
           start_time: "asap"
-          end_time: "2027-06-30T23:59:59Z"
+          end_time: "2099-06-30T23:59:59Z"
           io_acceptance:
             io_id: "$context.io_id"
             accepted_at: "2026-03-15T14:30:00Z"

--- a/static/compliance/source/specialisms/sales-social/index.yaml
+++ b/static/compliance/source/specialisms/sales-social/index.yaml
@@ -840,7 +840,7 @@ phases:
           events:
             - event_type: "purchase"
               event_id: "evt_trail_pro_001"
-              event_time: "2026-04-05T14:30:00Z"
+              event_time: "2099-04-05T14:30:00Z"
               # user_match prevents adapters from injecting synthetic placeholder
               # identifiers to satisfy the upstream's required-field check.
               # The hashed_email here matches the sync_audiences add[]

--- a/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
@@ -72,8 +72,8 @@ phases:
                 currency: "USD"
                 reallocation_threshold: 50
               flight:
-                start: "2026-04-01T00:00:00Z"
-                end: "2026-06-30T23:59:59Z"
+                start: "2099-04-01T00:00:00Z"
+                end: "2099-06-30T23:59:59Z"
               countries: ["US"]
           idempotency_key: "$generate:uuid_v4#signal_marketplace_governance_denied_governance_plan_setup_sync_plans"
         validations:

--- a/tests/addie/brand-sandbox-tools.test.ts
+++ b/tests/addie/brand-sandbox-tools.test.ts
@@ -21,6 +21,14 @@ async function call(tool: string, args: Record<string, unknown>): Promise<Record
   return await handlers[tool](args, ctx);
 }
 
+function rightsTestDates() {
+  const year = new Date(Date.now()).getUTCFullYear() + 1;
+  return {
+    extensionEndDate: `${year}-09-30`,
+    beforeCurrentEndDate: `${year}-01-01`,
+  };
+}
+
 describe('brand protocol tools (training agent)', () => {
 
   describe('get_brand_identity', () => {
@@ -386,12 +394,13 @@ describe('brand protocol tools (training agent)', () => {
   describe('update_rights', () => {
 
     it('returns updated terms with extended end_date', async () => {
+      const { extensionEndDate } = rightsTestDates();
       const result = await call('update_rights', {
         rights_id: 'janssen_likeness_voice',
-        end_date: '2026-09-30',
+        end_date: extensionEndDate,
       });
       expect(result.rights_id).toBe('janssen_likeness_voice');
-      expect((result.terms as { end_date: string }).end_date).toBe('2026-09-30');
+      expect((result.terms as { end_date: string }).end_date).toBe(extensionEndDate);
     });
 
     it('returns updated impression cap', async () => {
@@ -404,24 +413,26 @@ describe('brand protocol tools (training agent)', () => {
     });
 
     it('returns re-issued generation credentials', async () => {
+      const { extensionEndDate } = rightsTestDates();
       const result = await call('update_rights', {
         rights_id: 'janssen_likeness_voice',
-        end_date: '2026-09-30',
+        end_date: extensionEndDate,
       });
       const creds = result.generation_credentials as Array<{ expires_at: string; rights_key: string }>;
       expect(creds.length).toBeGreaterThan(0);
-      expect(creds[0].expires_at).toBe('2026-09-30T23:59:59Z');
+      expect(creds[0].expires_at).toBe(`${extensionEndDate}T23:59:59Z`);
       expect(creds[0].rights_key).toMatch(/^rk_mj_sandbox_/);
     });
 
     it('returns updated rights_constraint', async () => {
+      const { extensionEndDate } = rightsTestDates();
       const result = await call('update_rights', {
         rights_id: 'janssen_likeness_voice',
-        end_date: '2026-09-30',
+        end_date: extensionEndDate,
         impression_cap: 200000,
       });
       const constraint = result.rights_constraint as { valid_until: string; impression_cap: number; rights_id: string };
-      expect(constraint.valid_until).toBe('2026-09-30T23:59:59Z');
+      expect(constraint.valid_until).toBe(`${extensionEndDate}T23:59:59Z`);
       expect(constraint.impression_cap).toBe(200000);
       expect(constraint.rights_id).toBe('janssen_likeness_voice');
     });
@@ -462,9 +473,10 @@ describe('brand protocol tools (training agent)', () => {
     });
 
     it('returns error for end_date before current', async () => {
+      const { beforeCurrentEndDate } = rightsTestDates();
       const result = await call('update_rights', {
         rights_id: 'janssen_likeness_voice',
-        end_date: '2025-01-01',
+        end_date: beforeCurrentEndDate,
       });
       expect(result.errors).toBeDefined();
       expect((result.errors as Array<{ code: string }>)[0].code).toBe('INVALID_REQUEST');

--- a/tests/patch-3-0-compat-bundle.test.cjs
+++ b/tests/patch-3-0-compat-bundle.test.cjs
@@ -15,13 +15,16 @@ function makeBundle(version, schemaValidationYaml) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-3-0-compat-'));
   const universalDir = path.join(dir, 'universal');
   const mediaBuyScenarioDir = path.join(dir, 'protocols', 'media-buy', 'scenarios');
+  const domainsMediaBuyScenarioDir = path.join(dir, 'domains', 'media-buy', 'scenarios');
   fs.mkdirSync(universalDir, { recursive: true });
   fs.mkdirSync(mediaBuyScenarioDir, { recursive: true });
+  fs.mkdirSync(domainsMediaBuyScenarioDir, { recursive: true });
   fs.writeFileSync(path.join(dir, 'index.json'), JSON.stringify({ adcp_version: version }), 'utf8');
-  fs.writeFileSync(path.join(universalDir, 'idempotency.yaml'), 'id: idempotency\n', 'utf8');
+  fs.writeFileSync(path.join(universalDir, 'idempotency.yaml'), 'id: idempotency\nstart_time: "2026-05-01T00:00:00Z"\n', 'utf8');
   fs.writeFileSync(path.join(universalDir, 'webhook-emission.yaml'), 'id: webhook_emission\n', 'utf8');
   fs.writeFileSync(path.join(universalDir, 'schema-validation.yaml'), schemaValidationYaml, 'utf8');
   fs.writeFileSync(path.join(mediaBuyScenarioDir, 'measurement_terms_rejected.yaml'), 'id: measurement_terms_rejected\n', 'utf8');
+  fs.writeFileSync(path.join(domainsMediaBuyScenarioDir, 'measurement_terms_rejected.yaml'), 'id: measurement_terms_rejected\n', 'utf8');
   return dir;
 }
 
@@ -90,12 +93,15 @@ phases:
   }
 });
 
-test('3.0 compatibility patch moves stale measurement_terms_rejected flight dates forward', () => {
+test('3.0 compatibility patch moves stale YAML storyboard dates forward', () => {
   const input = `id: schema_validation
 phases: []
 `;
-  const dir = makeBundle('3.0.19', input);
+  const dir = makeBundle('3.0.18', input);
   const scenarioPath = path.join(dir, 'protocols', 'media-buy', 'scenarios', 'measurement_terms_rejected.yaml');
+  const domainScenarioPath = path.join(dir, 'domains', 'media-buy', 'scenarios', 'measurement_terms_rejected.yaml');
+  const stateMachinePath = path.join(dir, 'protocols', 'media-buy', 'state-machine.yaml');
+  const domainStateMachinePath = path.join(dir, 'domains', 'media-buy', 'state-machine.yaml');
   const scenario = `id: media_buy_seller/measurement_terms_rejected
 phases:
   - id: reject_terms
@@ -104,22 +110,57 @@ phases:
         sample_request:
           start_time: "2026-07-01T00:00:00Z"
           end_time: "2026-09-30T23:59:59Z"
+          fixed_past_start_time: "2020-01-01T00:00:00Z"
+          old_license_end_date: "2024-03-31"
+          io_acceptance:
+            accepted_at: "2026-03-15T14:30:00Z"
   - id: accept_terms
     steps:
       - id: create_media_buy_relaxed_terms
         sample_request:
-          start_time: "2026-07-01T00:00:00Z"
-          end_time: "2026-09-30T23:59:59Z"
+          start_time: "2027-07-01T00:00:00Z"
+          end_time: "2027-09-30T23:59:59Z"
+`;
+  const stateMachine = `id: media_buy_state_machine
+phases:
+  - id: setup
+    steps:
+      - id: create_buy
+        sample_request:
+          start_time: "2026-05-01T00:00:00Z"
+          end_time: "2026-05-31T23:59:59Z"
+        validations:
+          - check: field_value
+            path: "status"
+            value: "active"
 `;
   fs.writeFileSync(scenarioPath, scenario, 'utf8');
+  fs.writeFileSync(domainScenarioPath, scenario, 'utf8');
+  fs.writeFileSync(stateMachinePath, stateMachine, 'utf8');
+  fs.writeFileSync(domainStateMachinePath, stateMachine, 'utf8');
 
   try {
     execFileSync(process.execPath, [patchScript, dir], { cwd: repoRoot, encoding: 'utf8' });
     const output = fs.readFileSync(scenarioPath, 'utf8');
+    const domainOutput = fs.readFileSync(domainScenarioPath, 'utf8');
+    const idempotencyOutput = fs.readFileSync(path.join(dir, 'universal', 'idempotency.yaml'), 'utf8');
+    const stateMachineOutput = fs.readFileSync(stateMachinePath, 'utf8');
+    const domainStateMachineOutput = fs.readFileSync(domainStateMachinePath, 'utf8');
     assert.equal(output.includes('2026-07-01T00:00:00Z'), false);
     assert.equal(output.includes('2026-09-30T23:59:59Z'), false);
+    assert.equal(output.includes('2027-07-01T00:00:00Z'), false);
+    assert.equal(output.includes('2027-09-30T23:59:59Z'), false);
     assert.equal((output.match(/2099-07-01T00:00:00Z/g) ?? []).length, 2);
     assert.equal((output.match(/2099-09-30T23:59:59Z/g) ?? []).length, 2);
+    assert.match(output, /fixed_past_start_time: "2020-01-01T00:00:00Z"/);
+    assert.match(output, /old_license_end_date: "2024-03-31"/);
+    assert.match(output, /accepted_at: "2026-03-15T14:30:00Z"/);
+    assert.equal(domainOutput, output);
+    assert.match(idempotencyOutput, /start_time: "2099-05-01T00:00:00Z"/);
+    assert.match(stateMachineOutput, /start_time: "asap"/);
+    assert.match(stateMachineOutput, /end_time: "2099-05-31T23:59:59Z"/);
+    assert.match(stateMachineOutput, /path: "media_buy_status"/);
+    assert.equal(domainStateMachineOutput, stateMachineOutput);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Move stale 2026/2027 active-window dates in compliance source fixtures to non-expiring future windows while preserving historical/event timestamps where those are part of the scenario semantics.
- Make the 3.0 compatibility bundle patcher key-aware so it rewrites only active-window/validity fields, preserves historical timestamps and JSON test vectors, and keeps old active media-buy state-machine fixtures at `start_time: "asap"`.
- Remove the measurement 3.0 compatibility skip; keep the unrelated signal skip because its root cause is multi-agent governance routing/composition, not date drift.
- Make brand-rights default test windows dynamic so they do not become stale again.

## Root Cause
Some source compliance fixtures and frozen 3.0.19 compatibility bundles encoded active campaign windows as fixed 2026/2027 timestamps. As of 2026-07-01, those windows could be interpreted as past or inactive before the storyboard reached the protocol assertion it was meant to exercise. The measurement 3.0 incompatibility was this date drift; the remaining signal incompatibility is separate routing/governance-agent composition work.

## Validation
- `npm run test:patch-3-0-compat-bundle`
- `npx vitest run tests/addie/brand-sandbox-tools.test.ts --pool=threads`
- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-contradictions`
- `npm run test:storyboard-context-entity`
- `npm run test:run-storyboards-schema-root`
- `npm run typecheck`
- `git diff --check`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- Active-window scan for stale 2026/2027 values in compliance source, `run-storyboards.ts`, and the 3.0 compat patcher
- `npm run test:storyboards`
- `npm run test:storyboards:3.0-compat`

Note: the local precommit full server unit suite hit an unrelated `perspectives-crawlability` 403/200 failure once; rerunning `npx vitest run tests/unit/perspectives-crawlability.test.ts --pool=threads` passed. The push hook then re-ran and passed both current-source and 3.0 compatibility storyboard matrices.