### PR TITLE
Fix governed signal activation enforcement

### DIFF
--- a/.changeset/fix-signal-governance-context.md
+++ b/.changeset/fix-signal-governance-context.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Clarify and enforce governed signal activation: `activate_signal` now documents `governance_context`, signal agents fail closed on governed accounts without a valid approval context, and signal governance compliance checks no longer require the signals tenant to own `sync_plans`.

--- a/docs/signals/specification.mdx
+++ b/docs/signals/specification.mdx
@@ -157,6 +157,7 @@ Activate a signal for use on a decisioning platform. `activate_signal` is requir
 
 **Requirements:**
 - Orchestrators MUST include `signal_agent_segment_id` and `destinations`
+- For governed accounts, orchestrators MUST pass a valid `governance_context` from `check_governance`; signal agents MUST reject governed activations that omit or fabricate it
 - On success, signal agents MUST return a `deployments` array with `is_live` for each deployment
 - Signal agents MUST return `activation_key` when `is_live: true` AND caller has deployment access
 - On failure, signal agents MUST return an `errors` array (with no `deployments` array)

--- a/docs/signals/tasks/activate_signal.mdx
+++ b/docs/signals/tasks/activate_signal.mdx
@@ -27,6 +27,13 @@ The `activate_signal` task handles the entire activation lifecycle, including:
 | `destinations` | Destination[] | Yes | Target destination(s) for activation (see Destination Object below) |
 | `account` | [AccountRef](/docs/building/integration/accounts-and-agents#account-references) | No | Account for this activation. Associates with a commercial relationship established via `sync_accounts`. |
 | `pricing_option_id` | string | Yes (if signal has pricing options) | The pricing option selected from `pricing_options` in the [`get_signals`](/docs/signals/tasks/get_signals) response. Records the buyer's pricing commitment at activation time. Pass this same value in subsequent `report_usage` calls. |
+| `governance_context` | string | Conditional | Opaque approval context returned by [`check_governance`](/docs/governance/campaign/tasks/check_governance) for this activation. Required when the activation account has a registered governance agent. |
+
+## Governance
+
+Signal activation is a spend-commit event when the selected signal carries activation, usage, or CPM fees. For governed accounts, the buyer-side orchestrator MUST call `check_governance` before `activate_signal` with `purchase_type: "signal_activation"` and a normalized activation payload that includes the spend basis, such as `total_budget` or `budget`.
+
+When `check_governance` approves the activation, pass the returned `governance_context` into `activate_signal`. If the account has a governance agent registered via `sync_governance` and the request omits a valid `governance_context`, the signal agent MUST reject the request with `PERMISSION_DENIED`. If `check_governance` denies the activation, the buyer MUST NOT call `activate_signal`.
 
 ### Destination Object
 

--- a/server/src/training-agent/account-handlers.ts
+++ b/server/src/training-agent/account-handlers.ts
@@ -50,7 +50,7 @@ interface AccountState {
   syncedAt: string;
 }
 
-interface GovernanceAgentEntry {
+export interface GovernanceAgentEntry {
   url: string;
 }
 
@@ -451,6 +451,23 @@ export function resolveAccountIdForRef(
   const account = findAccountByRef(getAccountMap(sessionKey, principal), ref)
     ?? (ref.account_id ? findAccountByIdAcrossSessions(ref.account_id, principal) : undefined);
   return account?.accountId;
+}
+
+export function resolveGovernanceAgentsForAccount(
+  sessionKey: string,
+  principal: string | undefined,
+  ref: AccountRef | undefined,
+): GovernanceAgentEntry[] {
+  if (!ref) return [];
+  for (const accounts of accountMapsForPrincipal(sessionKey, principal)) {
+    const account = findAccountByRef(accounts, ref);
+    if (account) return [...account.governanceAgents];
+  }
+  if (ref.account_id) {
+    const account = findAccountByIdAcrossSessions(ref.account_id, principal);
+    if (account) return [...account.governanceAgents];
+  }
+  return [];
 }
 
 export function seedAccountFixture(

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -691,6 +691,7 @@ import {
   SUPPORTED_BILLINGS,
   handleListAccounts,
   resolveAccountIdForRef,
+  resolveGovernanceAgentsForAccount,
   handleSyncAccounts,
   handleSyncGovernance,
 } from './account-handlers.js';
@@ -6449,7 +6450,10 @@ export async function handleActivateSignal(args: ToolArgs, ctx: TrainingContext)
   const pricingOptionId = req.pricing_option_id;
   const rawGovCtx = (req as unknown as Record<string, unknown>).governance_context;
   const governanceContext = typeof rawGovCtx === 'string' && rawGovCtx.length <= 4096 ? rawGovCtx : undefined;
-  const session = await getSession(sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId));
+  const sessionKey = sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId);
+  const session = await getSession(sessionKey);
+  const registeredGovernanceAgents = resolveGovernanceAgentsForAccount(sessionKey, ctx.principal, req.account);
+  const hasRegisteredGovernanceAgent = registeredGovernanceAgents.length > 0;
 
   if (!segmentId) {
     return { errors: [{ code: 'INVALID_REQUEST', message: 'signal_agent_segment_id is required' }] };
@@ -6470,10 +6474,10 @@ export async function handleActivateSignal(args: ToolArgs, ctx: TrainingContext)
     };
   }
 
-  // Enforce governance: if governance plans or governance agents exist in the session,
-  // the activation requires prior approval via check_governance. Mirrors the
-  // create_media_buy guard — a strict $100 plan (as in the governance_denied storyboard)
-  // should deny activate_signal the same way it denies a media buy.
+  // Enforce governance: if the account has a registered governance agent, the
+  // activation requires a valid approval token from check_governance. Fall back
+  // to session plans for legacy storyboard setup where the governance agent was
+  // called in-process but sync_governance was omitted.
   if (governanceContext) {
     let latestCheck: import('./types.js').GovernanceCheckState | undefined;
     for (const check of session.governanceChecks.values()) {
@@ -6488,27 +6492,38 @@ export async function handleActivateSignal(args: ToolArgs, ctx: TrainingContext)
         }] as TaskError[],
       };
     }
-    if (!latestCheck && session.governancePlans.size > 0) {
+    if (latestCheck?.status === 'conditions') {
       return {
         errors: [{
           code: 'GOVERNANCE_DENIED',
-          message: `governance_context "${governanceContext}" does not match any governance check. Call check_governance first.`,
+          message: latestCheck.explanation || 'Governance check returned conditions; re-call check_governance with an adjusted activation payload before activating this signal.',
+          details: governanceErrorDetails(latestCheck),
         }] as TaskError[],
       };
     }
-  } else if (session.governancePlans.size > 0) {
-    const msg = `Signal activation requires governance approval. Call check_governance first — a governance plan is registered for this account.`;
+    if (!latestCheck && (hasRegisteredGovernanceAgent || session.governancePlans.size > 0)) {
+      return {
+        errors: [{
+          code: 'PERMISSION_DENIED',
+          message: `governance_context "${governanceContext}" does not match any governance approval for this account. Call check_governance first.`,
+        }] as TaskError[],
+      };
+    }
+  } else if (hasRegisteredGovernanceAgent || session.governancePlans.size > 0) {
+    const msg = hasRegisteredGovernanceAgent
+      ? `Signal activation requires governance approval. Call check_governance first — a governance agent is registered for this account.`
+      : `Signal activation requires governance approval. Call check_governance first — a governance plan is registered for this account.`;
     return {
       errors: [{
-        code: 'GOVERNANCE_DENIED',
+        code: hasRegisteredGovernanceAgent ? 'PERMISSION_DENIED' : 'GOVERNANCE_DENIED',
         message: msg,
         details: {
           findings: [{
-            category_id: 'budget_authority',
+            category_id: hasRegisteredGovernanceAgent ? 'governance_context' : 'budget_authority',
             severity: 'critical',
             explanation: msg,
           }],
-          plan_id: [...session.governancePlans.keys()][0],
+          ...(session.governancePlans.size > 0 && { plan_id: [...session.governancePlans.keys()][0] }),
         },
       }] as TaskError[],
     };

--- a/server/src/training-agent/tenants/signals.ts
+++ b/server/src/training-agent/tenants/signals.ts
@@ -8,9 +8,9 @@
  *
  * sync_governance rides opts.customTools (same merge seam as creative_approval
  * on /brand) until the SDK promotes it to a first-class AccountStore method.
- * The tool stores governance agent URLs per-account; activate_signal consults
- * the shared session-level governance plans (keyed by brand.domain, shared
- * with /governance) to enforce the denial check.
+ * The tool stores governance agent URLs per-account; activate_signal requires
+ * a check_governance approval context when the activation account has one of
+ * those registered governance agents.
  */
 
 import { z } from 'zod';

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -3,13 +3,15 @@
  * exposes the tenant key.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import type { TrainingContext } from '../types.js';
+import { clearAccountStore } from '../account-handlers.js';
+import { clearSessions, stopSessionCleanup } from '../state.js';
 
 process.env.PUBLIC_TEST_AGENT_TOKEN = 'test-token';
 
@@ -123,6 +125,17 @@ async function callTenantTool(url: string, id: number, name: string, args: Recor
 }
 
 describe('tenant routing smoke', () => {
+  beforeEach(() => {
+    clearSessions();
+    clearAccountStore();
+  });
+
+  afterEach(() => {
+    clearSessions();
+    clearAccountStore();
+    stopSessionCleanup();
+  });
+
   it('serves brand.json with tenant public keys', async () => {
     const { baseUrl, close } = await bootServer();
     try {
@@ -198,6 +211,65 @@ describe('tenant routing smoke', () => {
       // Tenant should NOT expose mediaBuy / governance tools
       expect(toolNames).not.toContain('create_media_buy');
       expect(toolNames).not.toContain('sync_plans');
+    } finally {
+      await close();
+    }
+  }, 15000);
+
+  it('enforces sync_governance on /signals activations after framework sync_accounts', async () => {
+    const { baseUrl, close } = await bootServer();
+    try {
+      const url = `${baseUrl}/signals/mcp`;
+      await initializeTenant(url);
+
+      const syncAccounts = await callTenantTool(url, 2, 'sync_accounts', {
+        accounts: [{
+          brand: { domain: 'tenant-signal-gov.example' },
+          operator: 'pinnacle-agency.example',
+          billing: 'operator',
+          payment_terms: 'net_30',
+        }],
+        idempotency_key: 'tenant-signal-gov-sync-accounts',
+      }) as {
+        result?: { structuredContent?: { accounts?: Array<{ account_id?: string }> } };
+      };
+      expect(syncAccounts.result?.structuredContent?.accounts?.[0]?.account_id).toBeDefined();
+
+      const syncGovernance = await callTenantTool(url, 3, 'sync_governance', {
+        accounts: [{
+          account: {
+            brand: { domain: 'tenant-signal-gov.example' },
+            operator: 'pinnacle-agency.example',
+          },
+          governance_agents: [{
+            url: 'https://governance.tenant-signal-gov.example/mcp',
+            authentication: {
+              schemes: ['Bearer'],
+              credentials: 'gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+            },
+          }],
+        }],
+        idempotency_key: 'tenant-signal-gov-sync-governance',
+      }) as {
+        result?: { structuredContent?: { accounts?: Array<{ status?: string }> } };
+      };
+      expect(syncGovernance.result?.structuredContent?.accounts?.[0]?.status).toBe('synced');
+
+      const activation = await callTenantTool(url, 4, 'activate_signal', {
+        account: {
+          brand: { domain: 'tenant-signal-gov.example' },
+          operator: 'pinnacle-agency.example',
+        },
+        signal_agent_segment_id: 'trident_likely_ev_buyers',
+        pricing_option_id: 'po_trident_ev_cpm',
+        destinations: [{ type: 'agent', agent_url: 'https://seller.example/mcp' }],
+        idempotency_key: 'tenant-signal-gov-activate',
+      }) as {
+        result?: { structuredContent?: { errors?: Array<{ code?: string; details?: { findings?: Array<{ category_id?: string }> } }> } };
+      };
+      const error = activation.result?.structuredContent?.errors?.[0];
+      expect(error?.code).toBe('PERMISSION_DENIED');
+      expect(error?.details?.findings?.[0]?.category_id).toBe('governance_context');
     } finally {
       await close();
     }

--- a/server/src/training-agent/v6-platform.ts
+++ b/server/src/training-agent/v6-platform.ts
@@ -45,7 +45,12 @@ export interface TrainingMeta {
  */
 const trainingAccounts: AccountStore<TrainingMeta> = {
   resolution: 'explicit',
-  resolve: async (ref, _ctx) => {
+  resolve: async (ref, ctx) => {
+    const principal = ctx?.authInfo?.clientId;
+    const authInfo = {
+      kind: 'api_key' as const,
+      ...(principal && { principal }),
+    };
     if (ref == null) {
       return {
         id: 'public_sandbox',
@@ -54,7 +59,7 @@ const trainingAccounts: AccountStore<TrainingMeta> = {
         mode: 'sandbox',
         ctx_metadata: {},
         sandbox: true,
-        authInfo: { kind: 'public' },
+        authInfo: principal ? authInfo : { kind: 'public' as const },
       };
     }
     const brandDomain =
@@ -73,7 +78,7 @@ const trainingAccounts: AccountStore<TrainingMeta> = {
       ...('operator' in ref && typeof ref.operator === 'string' && { operator: ref.operator }),
       ctx_metadata: { brand_domain: brandDomain },
       sandbox: true,
-      authInfo: { kind: 'api_key' },
+      authInfo,
     };
   },
   upsert: syncAccountsUpsert,
@@ -104,21 +109,22 @@ function translateV5Result<T extends object>(result: unknown): T {
 }
 
 /**
- * Build a TrainingContext from a v6 RequestContext.Account.
+ * Build a TrainingContext from the v6 request context auth bridge.
  *
- * `accounts.resolve` stamps the AuthPrincipal onto the resolved Account's
- * `authInfo` field (training-agent's resolver uses `{ kind: 'api_key' }`
- * — no principal — so this path falls back to `'anonymous'` today). The
- * authoritative principal source for the v6 path is `ctx.authInfo.clientId`
- * on `ResolveContext`, populated by the tenant router's req.auth bridge —
- * see `v6-account-helpers.ts` `trainingCtxFromResolveCtx` for the shape
- * billing gates consume.
+ * `sync_accounts` persists v5 account state under the auth principal via
+ * v6-account-helpers. The synthetic resolver stamps that same value onto
+ * `ctx.account.authInfo.principal`; some SDK callback paths also expose it
+ * as `ctx.authInfo.clientId`, so prefer that when present.
  */
-function buildTrainingCtx(account: { authInfo?: { principal?: string } } | undefined): TrainingContext {
+function buildTrainingCtx(
+  ctx: { account?: { authInfo?: { principal?: string } }; authInfo?: { clientId?: string } } | undefined,
+  storyboardCompat?: TrainingContext['storyboardCompat'],
+): TrainingContext {
   return {
     mode: 'open',
     tenantId: 'signals',
-    principal: account?.authInfo?.principal ?? 'anonymous',
+    principal: ctx?.authInfo?.clientId ?? ctx?.account?.authInfo?.principal ?? 'anonymous',
+    ...(storyboardCompat && { storyboardCompat }),
   };
 }
 
@@ -172,13 +178,13 @@ export class TrainingPlatform implements DecisioningPlatform<TrainingConfig, Tra
 
   signals: SignalsPlatform<TrainingMeta> = {
     getSignals: async (req, ctx) => {
-      const trainingCtx = buildTrainingCtx(ctx.account);
+      const trainingCtx = buildTrainingCtx(ctx, this.storyboardCompat);
       const result = await handleGetSignals(req as ToolArgs, trainingCtx);
       return translateV5Result(result);
     },
 
     activateSignal: async (req, ctx) => {
-      const trainingCtx = buildTrainingCtx(ctx.account);
+      const trainingCtx = buildTrainingCtx(ctx, this.storyboardCompat);
       const result = await handleActivateSignal(req as ToolArgs, trainingCtx);
       const errs = (result as { errors?: unknown[] } | undefined)?.errors;
       if (Array.isArray(errs) && errs.length > 0) {

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -185,10 +185,6 @@ const THREE_ZERO_COMPAT_KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new M
     'brand_rights/acquire_rights',
     '3.0.13 compatibility run under @adcp/sdk 8.1 beta.13: frozen brand-rights response schema rejects the current training-agent rights envelope. Current-source brand coverage remains graded by the current matrix.',
   ],
-  [
-    'signal_marketplace/governance_denied/activate_signal_denied',
-    'latest 3.0.x compatibility run under @adcp/sdk 9.6.2: the frozen linked governance-denial storyboard skips governance setup on the signals tenant because sync_plans is not advertised, but still grades activate_signal_denied, where the current signals tenant no longer emits the frozen GOVERNANCE_DENIED shape. Current-source signal governance-denial coverage remains graded by the current matrix.',
-  ],
 ]);
 
 const THREE_ZERO_SIGNED_POSITIVE_VECTOR_IDS = [
@@ -325,6 +321,46 @@ function patchThreeZeroStoryboard(sb: Storyboard): Storyboard {
       for (const step of phase.steps ?? []) {
         if (step.id === 'acquire_rights') {
           step.validations = (step.validations ?? []).filter(validation => validation.check !== 'response_schema');
+        }
+      }
+    }
+    return patched;
+  }
+
+  if (sb.id === 'signal_marketplace/governance_denied') {
+    patched.context = {
+      ...((patched.context ?? {}) as Record<string, unknown>),
+      governance_agent_url: 'https://test-agent.adcontextprotocol.org',
+    };
+    patched.phases = (patched.phases ?? []).filter(phase => phase.id !== 'governance_plan_setup');
+    for (const phase of patched.phases ?? []) {
+      for (const step of phase.steps ?? []) {
+        if (step.id !== 'activate_signal_denied') continue;
+        step.title = 'activate_signal — missing governance approval';
+        step.expected = [
+          'Signal agent rejects with:',
+          '- code: PERMISSION_DENIED',
+          '- findings explaining that check_governance must run first',
+        ].join('\n');
+        step.sample_response = {
+          status: 'failed',
+          errors: [{
+            code: 'PERMISSION_DENIED',
+            message: 'Signal activation requires governance approval. Call check_governance first — a governance agent is registered for this account.',
+            details: {
+              findings: [{
+                category_id: 'governance_context',
+                severity: 'critical',
+                explanation: 'Signal activation requires governance approval. Call check_governance first — a governance agent is registered for this account.',
+              }],
+            },
+          }],
+        };
+        for (const validation of step.validations ?? []) {
+          if (validation.check === 'error_code') {
+            validation.value = 'PERMISSION_DENIED';
+            validation.description = 'Error code is PERMISSION_DENIED';
+          }
         }
       }
     }

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -33,6 +33,7 @@ import {
   HUMAN_REVIEW_CATEGORIES,
   HUMAN_REVIEW_POLICY_IDS,
 } from '../../src/training-agent/governance-handlers.js';
+import { clearAccountStore } from '../../src/training-agent/account-handlers.js';
 import { TrainingSalesPlatform } from '../../src/training-agent/v6-sales-platform.js';
 
 // Valid channels per the enum schema at static/schemas/source/enums/channels.json
@@ -7634,16 +7635,41 @@ describe('get_signals handler', () => {
 
 describe('activate_signal handler', () => {
   const account = { brand: { domain: 'signal-test.example' }, operator: 'signal-test.example' };
+  const governanceAgentUrl = 'https://governance.signal-test.example/mcp';
+
+  async function syncGovernedAccount(server: ReturnType<typeof createTrainingAgentServer>) {
+    await simulateCallTool(server, 'sync_accounts', {
+      accounts: [{
+        brand: { domain: 'signal-test.example' },
+        operator: 'signal-test.example',
+        billing: 'operator',
+        payment_terms: 'net_30',
+      }],
+    });
+
+    await simulateCallTool(server, 'sync_governance', {
+      accounts: [{
+        account,
+        governance_agents: [{
+          url: governanceAgentUrl,
+          authentication: {
+            schemes: ['Bearer'],
+            credentials: 'test-governance-token',
+          },
+        }],
+      }],
+    });
+  }
 
   beforeEach(() => {
     clearSessions();
+    clearAccountStore();
     invalidateCache();
   });
 
   afterEach(() => {
     clearSessions();
-    stopSessionCleanup();
-
+    clearAccountStore();
     stopSessionCleanup();
   });
 
@@ -7691,6 +7717,87 @@ describe('activate_signal handler', () => {
 
     expect(result.code).toBeDefined();
     expect(result.code).toBe('INVALID_PRICING_MODEL');
+  });
+
+  it('requires governance_context when the account has a registered governance agent', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    await syncGovernedAccount(server);
+
+    const { result } = await simulateCallTool(server, 'activate_signal', {
+      account,
+      signal_agent_segment_id: 'trident_likely_ev_buyers',
+      pricing_option_id: 'po_trident_ev_cpm',
+      destinations: [{ type: 'agent', agent_url: 'https://test.example' }],
+    });
+
+    expect(result.code).toBe('PERMISSION_DENIED');
+    expect(result.message).toContain('governance agent is registered');
+    const details = result.details as Record<string, unknown>;
+    const findings = details.findings as Array<Record<string, unknown>>;
+    expect(findings[0].category_id).toBe('governance_context');
+  });
+
+  it('rejects fabricated governance_context on a governed signal account', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    await syncGovernedAccount(server);
+
+    const { result } = await simulateCallTool(server, 'activate_signal', {
+      account,
+      signal_agent_segment_id: 'trident_likely_ev_buyers',
+      pricing_option_id: 'po_trident_ev_cpm',
+      governance_context: 'fabricated-governance-context',
+      destinations: [{ type: 'agent', agent_url: 'https://test.example' }],
+    });
+
+    expect(result.code).toBe('PERMISSION_DENIED');
+    expect(result.message).toContain('does not match any governance approval');
+  });
+
+  it('accepts an approved governance_context for a governed signal account', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    await syncGovernedAccount(server);
+
+    await simulateCallTool(server, 'sync_plans', {
+      account,
+      plans: [{
+        plan_id: 'plan-signal-activation',
+        brand: { domain: 'signal-test.example' },
+        objectives: 'Approve governed signal activation',
+        budget: { total: 10000, currency: 'USD', reallocation_threshold: 1000 },
+        flight: { start: '2099-01-01T00:00:00Z', end: '2099-12-31T23:59:59Z' },
+      }],
+    });
+
+    const { result: check } = await simulateCallTool(server, 'check_governance', {
+      account,
+      plan_id: 'plan-signal-activation',
+      binding: 'proposed',
+      caller: 'https://buyer.example',
+      purchase_type: 'signal_activation',
+      tool: 'activate_signal',
+      payload: {
+        signal_agent_segment_id: 'trident_likely_ev_buyers',
+        pricing_option_id: 'po_trident_ev_cpm',
+        total_budget: 50,
+        destinations: [{ type: 'agent', agent_url: 'https://test.example' }],
+      },
+    });
+
+    expect(check.status).toBe('approved');
+    expect(check.governance_context).toBeDefined();
+
+    const { result } = await simulateCallTool(server, 'activate_signal', {
+      account,
+      signal_agent_segment_id: 'trident_likely_ev_buyers',
+      pricing_option_id: 'po_trident_ev_cpm',
+      governance_context: check.governance_context,
+      destinations: [{ type: 'agent', agent_url: 'https://test.example' }],
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.governance_context).toBe(check.governance_context);
+    const deployments = result.deployments as Array<Record<string, unknown>>;
+    expect(deployments[0].is_live).toBe(true);
   });
 
   it('returns error when destinations is empty', async () => {

--- a/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
+++ b/static/compliance/source/specialisms/signal-marketplace/scenarios/governance_denied.yaml
@@ -1,8 +1,8 @@
 id: signal_marketplace/governance_denied
 version: "1.0.0"
-title: "Signal agent rejects activation when governance denies"
+title: "Signal agent rejects activation without governance approval"
 category: signal_marketplace
-summary: "Verifies that a signal agent propagates GOVERNANCE_DENIED when the buyer's governance plan denies activation."
+summary: "Verifies that a signal agent requires a governance approval context before activating signals on governed accounts."
 track: signals
 required_tools:
   - sync_governance
@@ -12,13 +12,13 @@ required_tools:
 narrative: |
   Signal activation is a spending event: activating a third-party segment costs per-user
   or per-activation fees that must be authorized against the buyer's governance plan. The
-  signal agent must consult the registered governance agent before activation and deny
-  the request when governance returns denied.
+  buyer-side orchestrator must call check_governance before sending a governed activation
+  request. The signal agent enforces that contract by rejecting activations for governed
+  accounts when the request does not carry a valid governance_context.
 
-  This scenario sets up a strict $100 plan, registers that governance with the signal
-  agent via sync_governance, then attempts to activate a signal whose pricing exceeds
-  the plan. The signal agent must return GOVERNANCE_DENIED with findings propagated
-  from the governance agent.
+  This scenario registers a governance agent with the signal agent via sync_governance,
+  then attempts to activate a signal without the prior check_governance approval context.
+  The signal agent must fail closed with PERMISSION_DENIED.
 
   By default, the governance agent is the training agent at test-agent.adcontextprotocol.org.
   Override by supplying a different `governance_agent_url` in the run's initial context
@@ -40,46 +40,11 @@ caller:
 
 prerequisites:
   description: |
-    A governance agent that supports sync_plans and check_governance, and a signal
-    agent that supports sync_governance + activate_signal.
+    A governance agent URL to register, and a signal agent that supports
+    sync_governance + activate_signal.
   test_kit: "test-kits/acme-outdoor.yaml"
 
 phases:
-  - id: governance_plan_setup
-    title: "Set up strict governance plan"
-    narrative: |
-      Create a governance plan with a $100 budget — enough to block even a single
-      activation at typical CPM-for-segment pricing.
-
-    steps:
-      - id: sync_plans
-        title: "Create strict governance plan"
-        task: sync_plans
-        schema_ref: "governance/sync-plans-request.json"
-        response_schema_ref: "governance/sync-plans-response.json"
-        doc_ref: "/governance/campaign/tasks/sync_plans"
-        stateful: true
-        expected: |
-          The governance agent acknowledges the plan.
-        sample_request:
-          plans:
-            - plan_id: "comply-signal-gov-denied"
-              brand:
-                domain: "acmeoutdoor.example"
-              objectives: "Restricted plan — signals activation test"
-              budget:
-                total: 100
-                currency: "USD"
-                reallocation_threshold: 50
-              flight:
-                start: "2099-04-01T00:00:00Z"
-                end: "2099-06-30T23:59:59Z"
-              countries: ["US"]
-          idempotency_key: "$generate:uuid_v4#signal_marketplace_governance_denied_governance_plan_setup_sync_plans"
-        validations:
-          - check: response_schema
-            description: "Response matches sync-plans-response.json schema"
-
   - id: signal_agent_setup
     title: "Register account and governance with the signal agent"
     steps:
@@ -133,7 +98,7 @@ phases:
             description: "Response matches sync-governance-response.json schema"
 
   - id: activation_denied
-    title: "Attempt activation — governance denies"
+    title: "Attempt activation without governance context"
     steps:
       - id: get_signals_list
         title: "Discover a signal to activate"
@@ -162,7 +127,7 @@ phases:
             description: "Signal has an activation identifier"
 
       - id: activate_signal_denied
-        title: "activate_signal — governance denies"
+        title: "activate_signal — missing governance approval"
         task: activate_signal
         schema_ref: "signals/activate-signal-request.json"
         response_schema_ref: "signals/activate-signal-response.json"
@@ -173,8 +138,8 @@ phases:
         stateful: true
         expected: |
           Signal agent rejects with:
-          - code: GOVERNANCE_DENIED
-          - findings propagated from the governance agent
+          - code: PERMISSION_DENIED
+          - findings explaining that check_governance must run first
 
         sample_request:
           signal_agent_segment_id: "$context.signal_agent_segment_id"
@@ -193,18 +158,17 @@ phases:
         sample_response:
           status: "failed"
           errors:
-            - code: "GOVERNANCE_DENIED"
-              message: "Signal activation requires governance approval. Call check_governance first — a governance plan is registered for this account."
+            - code: "PERMISSION_DENIED"
+              message: "Signal activation requires governance approval. Call check_governance first — a governance agent is registered for this account."
               details:
                 findings:
-                  - category_id: "budget_authority"
+                  - category_id: "governance_context"
                     severity: "critical"
-                    explanation: "Signal activation requires governance approval. Call check_governance first — a governance plan is registered for this account."
-                plan_id: "comply-signal-gov-denied"
+                    explanation: "Signal activation requires governance approval. Call check_governance first — a governance agent is registered for this account."
         validations:
           - check: error_code
-            value: "GOVERNANCE_DENIED"
-            description: "Error code is GOVERNANCE_DENIED"
+            value: "PERMISSION_DENIED"
+            description: "Error code is PERMISSION_DENIED"
           - check: field_present
             path: "context"
             description: "Response echoes back the context object even on errors"

--- a/static/schemas/source/signals/activate-signal-request.json
+++ b/static/schemas/source/signals/activate-signal-request.json
@@ -38,6 +38,13 @@
       "description": "The pricing option selected from the signal's pricing_options in the get_signals response. Required when the signal has pricing options. Records the buyer's pricing commitment at activation time; pass this same value in report_usage for billing verification.",
       "x-entity": "vendor_pricing_option"
     },
+    "governance_context": {
+      "type": "string",
+      "description": "Opaque governance context returned by check_governance for this signal activation. Required when the account has a registered governance agent; signal agents MUST reject governed activations that omit a valid context.",
+      "minLength": 1,
+      "maxLength": 4096,
+      "pattern": "^[\\x20-\\x7E]+$"
+    },
     "account": {
       "$ref": "/schemas/core/account-ref.json",
       "description": "Account for this activation. Associates with a commercial relationship established via sync_accounts."


### PR DESCRIPTION
## Summary

Fix governed signal activation so `/signals` fails closed when an account has a registered governance agent but `activate_signal` does not carry a valid `governance_context`.

## Root Cause

The 3.0.19 incompatibility exposed two separate issues:

- The frozen signal governance storyboard expected `/signals` to own `sync_plans`, but `/signals` only owns signal activation plus account/governance registration. Plan setup belongs to the governance agent path.
- Runtime activation enforcement only looked at session governance plans/checks. It did not resolve governance agents registered through `sync_governance` for the activation account. On the v6 `/signals` tenant, activation also lost the bearer principal at the framework-to-v5 bridge, so it could not see account state created by framework `sync_accounts`.

## Changes

- Resolve registered governance agents from the account store in `activate_signal`.
- Reject governed activations missing or fabricating `governance_context` with `PERMISSION_DENIED`; continue returning `GOVERNANCE_DENIED` when a real governance check denies or conditions the request.
- Bridge the `/signals` tenant auth principal through v6 account resolution so `sync_accounts`, `sync_governance`, and `activate_signal` share the same caller/account state.
- Add `governance_context` to the signal activation request schema and docs.
- Rewrite the current signal governance storyboard around missing approval context instead of fake `sync_plans` ownership.
- Remove the 3.0 skip and patch the frozen 3.0 storyboard in-memory to preserve compatibility without altering 3.0 protocol ownership.

## Validation

- `npx vitest run server/tests/unit/training-agent.test.ts --pool=threads -t "activate_signal handler"`
- `npx vitest run server/src/training-agent/tenants/tenant-smoke.test.ts --pool=threads -t "sync_governance on /signals"`
- `TENANT_PATH=signals npx tsx server/tests/manual/run-storyboards.ts --filter signal_marketplace/governance_denied --verbose`
- `ADCP_RELEASE_BASE_REF=origin/main bash scripts/run-storyboards-3-0-compat.sh`
- `npm run typecheck`
- `npm run test:schemas`
- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-response-schema`
- `npm run test:storyboards`
- Commit hook: `npm run precommit`
- Push hook: version sync, changeset policy, current storyboard matrix, 3.0.19 compatibility matrix, docs link validation

Note: full `server/src/training-agent/tenants/tenant-smoke.test.ts` has an unrelated stale assertion expecting sales `adcp_version` to be `3.0`; the current tenant reports `3.1`. The targeted `/signals` tenant regression added here passes.
