### PR TITLE
Port governance human approval fix to main

### DIFF
--- a/.changeset/governance-human-approval-main.md
+++ b/.changeset/governance-human-approval-main.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Allow governance checks to accept human approval from `ext.human_approval` and use that approval to clear reallocation-threshold human review.

--- a/server/src/training-agent/brand-handlers.ts
+++ b/server/src/training-agent/brand-handlers.ts
@@ -670,10 +670,7 @@ export function handleGetBrandIdentity(
 
   const talent = BRAND_MAP.get(brandId);
   if (!talent) {
-    const code = ctx.storyboardCompat?.version === '3.0'
-      ? 'BRAND_NOT_FOUND'
-      : 'REFERENCE_NOT_FOUND';
-    return { errors: [{ code, message: `No brand with id '${brandId}'`, field: 'brand_id' }] };
+    return { errors: [{ code: 'REFERENCE_NOT_FOUND', message: `No brand with id '${brandId}'`, field: 'brand_id' }] };
   }
 
   const requested = fields ?? [...ALL_FIELDS];

--- a/server/src/training-agent/governance-handlers.ts
+++ b/server/src/training-agent/governance-handlers.ts
@@ -674,6 +674,12 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
   const tool = req.tool;
   const payload = req.payload;
   const governanceContext = req.governance_context;
+  const ext = (req as unknown as { ext?: unknown }).ext;
+  const extHumanApproval = ext && typeof ext === 'object' && !Array.isArray(ext)
+    ? (ext as { human_approval?: unknown }).human_approval
+    : undefined;
+  const humanApproval = req.human_approval ?? extHumanApproval;
+  const hasHumanApproval = typeof humanApproval === 'object' && humanApproval !== null;
   const phase = req.phase || req.governance_phase || 'purchase';
   const plannedDelivery = req.planned_delivery;
   const deliveryMetrics = req.delivery_metrics;
@@ -839,7 +845,7 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
       }
 
       // Commitment exceeds the reallocation threshold — requires human approval.
-      if (payloadBudget > plan.budget.reallocationThreshold) {
+      if (payloadBudget > plan.budget.reallocationThreshold && !hasHumanApproval) {
         humanReviewRequired = true;
         humanReviewReason =
           `Budget commitment exceeds reallocation_threshold of $${plan.budget.reallocationThreshold}.`;
@@ -847,7 +853,7 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
     }
 
     // Plan-level human review (Annex III / Art 22) — every action needs human approval regardless of spend.
-    if (plan.humanReviewRequired) {
+    if (plan.humanReviewRequired && !hasHumanApproval) {
       humanReviewRequired = true;
       humanReviewReason =
         'Plan has human_review_required = true; every action requires human approval.';
@@ -1171,7 +1177,9 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
   // `intent` rather than emit a structurally-valid-but-step-12-rejected
   // token.
   let effectiveContext: string | undefined;
-  if (status === 'approved' || status === 'conditions') {
+  // Human-review denials also need a context so the buyer can bind the
+  // off-protocol approval to the re-check that carries human_approval.
+  if (status === 'approved' || status === 'conditions' || humanReviewRequired) {
     const requestedPhase: GovernancePhase = GOVERNANCE_PHASES.has(phase as GovernancePhase)
       ? (phase as GovernancePhase)
       : 'purchase';

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -11709,6 +11709,51 @@ describe('human_review_required auto-flip and enforcement', () => {
     expect(humanReview?.explanation).toContain('reallocation_threshold');
   });
 
+  it('accepts ext.human_approval after a reallocation-threshold human review denial', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'approval.example' }, operator: 'test.example' };
+    await simulateCallTool(server, 'sync_plans', {
+      account,
+      plans: [{
+        ...PLAN_BASE,
+        brand: { ...PLAN_BASE.brand, domain: 'approval.example' },
+        budget: { total: 100000, currency: 'USD', reallocation_threshold: 10000 },
+      }],
+    });
+
+    const payload = { type: 'media_buy', account, total_budget: 50000 };
+    const { result: denied } = await simulateCallTool(server, 'check_governance', {
+      account,
+      plan_id: PLAN_BASE.plan_id,
+      caller: 'test.example',
+      payload,
+    });
+
+    expect(denied.status).toBe('denied');
+    expect(denied.check_id).toBeDefined();
+    expect(denied.governance_context).toBeDefined();
+
+    const { result: approved } = await simulateCallTool(server, 'check_governance', {
+      account,
+      plan_id: PLAN_BASE.plan_id,
+      caller: 'test.example',
+      governance_context: denied.governance_context,
+      ext: {
+        human_approval: {
+          approved_by: 'human-reviewer-1',
+          approved_at: '2099-03-15T12:00:00Z',
+          approval_reference: denied.check_id,
+        },
+      },
+      payload,
+    });
+
+    expect(approved.status).toBe('approved');
+    expect(approved.governance_context).toBeDefined();
+    const findings = (approved.findings ?? []) as Array<{ category_id: string }>;
+    expect(findings.every(f => f.category_id !== 'human_review')).toBe(true);
+  });
+
   it('emits critical contestation-missing finding when human review + no contestation', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const account = { brand: { domain: 'missing.example' }, operator: 'test.example' };

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -417,6 +417,11 @@ phases:
 
           context:
             correlation_id: "media_buy_governance_escalation--check_governance_denied"
+        context_outputs:
+          - name: check_id
+            path: 'check_id'
+          - name: governance_context
+            path: 'governance_context'
         validations:
           - check: response_schema
             description: "Response matches check-governance-response.json schema"
@@ -470,7 +475,12 @@ phases:
         sample_request:
           plan_id: "$context.plan_id"
           caller: "https://pinnacle-agency.example"
-          governance_context: "gov_ctx_acme_q2_escalated"
+          governance_context: "$context.governance_context"
+          ext:
+            human_approval:
+              approved_by: "human-reviewer-1"
+              approved_at: "2099-03-15T12:00:00Z"
+              approval_reference: "$context.check_id"
           tool: "create_media_buy"
           payload:
             idempotency_key: "$generate:uuid_v4#media_buy_governance_escalation_check_governance_approved_payload"

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -211,18 +211,21 @@ phases:
             path: "plans[0].plan_id"
             description: "Governance agent assigns plan_id — must be echoed in check_governance"
   - id: initial_approval
-    title: "Initial governance check — approved"
+    title: "Initial governance check — human-approved"
     narrative: |
-      The buyer proposes a media buy within authority. The governance agent approves
-      the buy with the delivery monitoring conditions active.
+      The buyer proposes a media buy whose initial commitment exceeds the plan's
+      reallocation threshold. A human reviewer approves that initial commitment
+      off-protocol, and the governance agent returns a context with delivery
+      monitoring conditions active.
 
     steps:
       - id: check_governance_approved
-        title: "Pre-buy governance check (approved)"
+        title: "Pre-buy governance check (approved after human review)"
         narrative: |
-          The buyer calls check_governance with a media buy within authority. The governance
-          agent approves and notes that delivery monitoring is active with the 20% drift
-          threshold.
+          The buyer calls check_governance with a media buy above the plan's
+          reallocation threshold and includes the human approval obtained outside
+          the protocol. The governance agent approves the initial commitment and
+          notes that delivery monitoring is active with the 20% drift threshold.
         task: check_governance
         schema_ref: "governance/check-governance-request.json"
         response_schema_ref: "governance/check-governance-response.json"
@@ -239,6 +242,11 @@ phases:
           plan_id: "$context.plan_id"
           caller: "https://pinnacle-agency.example"
           tool: "create_media_buy"
+          ext:
+            human_approval:
+              approved_by: "human-reviewer-1"
+              approved_at: "2099-03-15T12:00:00Z"
+              approval_reference: "delivery-monitor-initial-commitment"
           payload:
             account:
               brand:


### PR DESCRIPTION
## Summary

Port the 3.0.21 governance human-approval compatibility fix to main/3.1.

- Accept human approval from either top-level `human_approval` or `ext.human_approval` in governance checks.
- Keep the compliance storyboards on the SDK-compatible `ext.human_approval` path and replace dynamic/fixed-near dates with `2099-03-15T12:00:00Z`.
- Preserve signed governance context across human-review denials so rechecks can reference the original `check_id`.
- Add a unit regression for the reallocation-threshold denial followed by an `ext.human_approval` recheck.
- Normalize unknown brand identity lookup failures to the canonical `REFERENCE_NOT_FOUND` code so the 3.0.21 compatibility bundle passes against main.
- Add the required protocol changeset.

## Root Cause

The frozen 3.0 SDK/schema bundle rejects newer top-level request fields. The durable compatibility path is to carry approval metadata through `ext.human_approval`, which existing 3.0 clients can send. Main now accepts both shapes so 3.1 keeps the newer API surface while staying compatible with the released 3.0.21 compliance bundle.

## Validation

- `npm run build:compliance`
- `bash scripts/overlay-compliance-cache.sh`
- `npx vitest run server/tests/unit/training-agent.test.ts --config server/vitest.config.ts`
- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-response-schema`
- `npm run test:storyboard-scoping`
- `npm run typecheck`
- Focused governance storyboards, legacy and framework modes:
  - `media_buy_governance_escalation`
  - `governance_delivery_monitor`
  - `governance_spend_authority`
- `npm run test:unit`
- `npm run test:server-unit`
- Focused brand framework storyboard: `brand_baseline`
- Pre-push current compliance matrix:
  - `/signals`: 113 clean, 137 steps
  - `/sales`: 102 clean, 556 steps
  - `/governance`: 117 clean, 200 steps
  - `/creative`: 106 clean, 234 steps
  - `/creative-builder`: 105 clean, 206 steps
  - `/brand`: 116 clean, 105 steps
- Pre-push released 3.0.21 compatibility matrix:
  - `/signals`: 65 clean, 108 steps
  - `/sales`: 65 clean, 304 steps
  - `/governance`: 65 clean, 164 steps
  - `/creative`: 65 clean, 156 steps
  - `/creative-builder`: 65 clean, 141 steps
  - `/brand`: 65 clean, 87 steps

Note: an unfiltered governance-only local run includes unrelated non-governance storyboards against a governance-only tenant; the affected governance storyboards were validated with focused runs in both modes.
