### PR TITLE
docs(get_media_buy_delivery): correct misleading "Buyer Reference Query" example

### DIFF
--- a/.changeset/fix-delivery-buyer-ref-example.md
+++ b/.changeset/fix-delivery-buyer-ref-example.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix a misleading `get_media_buy_delivery` example that implied buyers can look up delivery by their own reference. `media_buy_ids` are seller-assigned; the top-level `buyer_ref` field was removed in 3.0.0. The example is retitled "Correlating Your Own Reference", uses seller-assigned `mb_...` IDs, and adds a note pointing buyers to reconcile their own reference via `context` echoed on `create_media_buy` / `get_media_buys`.

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -447,7 +447,11 @@ asyncio.run(main())
 
 </CodeGroup>
 
-### Buyer Reference Query
+### Correlating Your Own Reference
+
+<Note>
+**`media_buy_ids` are seller-assigned.** They are the `media_buy_id` values returned by [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy) and [`get_media_buys`](/docs/media-buy/task-reference/get_media_buys) — not buyer-side identifiers. AdCP has no buyer-reference lookup key: the top-level `buyer_ref` field was removed in 3.0.0, making seller-assigned `media_buy_id`/`package_id` canonical. If you hold only your own identifier, include it in the opaque `context` object (commonly `context.buyer_ref`) when you call `create_media_buy`; the seller echoes `context` back on `create_media_buy` and [`get_media_buys`](/docs/media-buy/task-reference/get_media_buys), so you can reconcile your reference to the seller's `media_buy_id` before requesting delivery.
+</Note>
 
 <CodeGroup>
 
@@ -455,9 +459,9 @@ asyncio.run(main())
 import { testAgent } from '@adcp/sdk/testing';
 import { GetMediaBuyDeliveryResponseSchema } from '@adcp/sdk';
 
-// Query by buyer reference instead of media buy ID
+// Compare several media buys by their seller-assigned IDs (from create_media_buy / get_media_buys)
 const result = await testAgent.getMediaBuyDelivery({
-  media_buy_ids: ['acme_q1_campaign_2024', 'acme_q1_retargeting_2024']
+  media_buy_ids: ['mb_q1_campaign_2024', 'mb_q1_retargeting_2024']
 });
 
 if (!result.success) {
@@ -489,10 +493,10 @@ from adcp.testing import test_agent
 from adcp.types import GetMediaBuyDeliveryRequest
 
 async def main():
-    # Query by buyer reference instead of media buy ID
+    # Compare several media buys by their seller-assigned IDs (from create_media_buy / get_media_buys)
     result = await test_agent.get_media_buy_delivery(
         GetMediaBuyDeliveryRequest(
-            media_buy_ids=['acme_q1_campaign_2024', 'acme_q1_retargeting_2024']
+            media_buy_ids=['mb_q1_campaign_2024', 'mb_q1_retargeting_2024']
         )
     )
 


### PR DESCRIPTION
## What

Replaces the "Buyer Reference Query" example on `get_media_buy_delivery` — which passed buyer-side strings into `media_buy_ids` — with a schema-accurate version.

## Why

`media_buy_ids` are seller-assigned (schema items are `x-entity: media_buy`, "Array of media buy IDs"), and the top-level `buyer_ref` field was **removed in 3.0.0** in favor of canonical seller-assigned `media_buy_id` / `package_id`. The example's comment — *"Query by buyer reference instead of media buy ID"* — implies a buyer-reference lookup key that no longer exists.

In practice this can lead an implementer to build a delivery poller keyed on the buyer's own reference and silently receive empty results for an active buy, because that id never matches a seller-assigned `media_buy_id`. The spec already prescribes the correct path (reconcile via the opaque `context` echoed on `create_media_buy` / `get_media_buys`, per the `MEDIA_BUY_NOT_FOUND` recovery guidance), so the docs should match it.

This was the only example in `docs/` still implying buyer-reference lookup; the remaining `buyer_ref` mentions are the (correct) `context.buyer_ref` usage and the deprecation notes.

## How

- Retitle the section → **"Correlating Your Own Reference"**
- Example ids → seller-style `mb_...`; comments corrected (JS + Python)
- Add a `<Note>` pointing buyers to send their reference in the opaque `context` object (echoed back on `create_media_buy` / `get_media_buys`) and reconcile it to the seller's `media_buy_id` before requesting delivery

Docs-only; the page stays `testable: true` and the snippet shape is unchanged. Changeset: `patch`.
