### PR TITLE
feat(addie): add wg-slack-context job distilling WG Slack into .agents/wg/slack-context.md

### DIFF
--- a/server/src/addie/jobs/github-pr.ts
+++ b/server/src/addie/jobs/github-pr.ts
@@ -1,0 +1,189 @@
+/**
+ * GitHub single-file PR helper.
+ *
+ * Creates or refreshes a one-file pull request via the GitHub REST API
+ * using the GITHUB_TOKEN env var (same auth seam as github-filer). The
+ * working branch is force-reset to the base branch head on every call,
+ * so the PR diff is always exactly "base + this file change".
+ */
+
+import { createLogger } from '../../logger.js';
+
+const logger = createLogger('github-pr');
+
+const API_TIMEOUT_MS = 10_000;
+
+export interface UpsertFilePrInput {
+  /** Repo slug `owner/name`. Defaults to `GITHUB_REPO` env or `adcontextprotocol/adcp`. */
+  repo?: string;
+  /** Head branch the PR ships from, e.g. `addie/wg-slack-context`. */
+  branch: string;
+  /** Base branch. Defaults to `main`. */
+  baseBranch?: string;
+  /** Repo-relative file path to create or update. */
+  path: string;
+  content: string;
+  commitMessage: string;
+  prTitle: string;
+  prBody: string;
+}
+
+export interface UpsertFilePrResult {
+  prUrl: string;
+  prNumber: number;
+  /** True when a new PR was opened; false when an open PR was refreshed. */
+  created: boolean;
+}
+
+async function ghFetch(token: string, url: string, init?: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github.v3+json',
+        'Content-Type': 'application/json',
+        'User-Agent': 'aao-wg-secretary/1.0',
+        ...(init?.headers ?? {}),
+      },
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Read the current content of a file at a ref. Returns null when the
+ * file does not exist or the token is missing; throws on other failures
+ * so callers can distinguish "absent" from "unreadable".
+ */
+export async function getFileContent(
+  path: string,
+  ref: string,
+  repo?: string
+): Promise<string | null> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) return null;
+  const repoSlug = repo ?? process.env.GITHUB_REPO ?? 'adcontextprotocol/adcp';
+  const resp = await ghFetch(
+    token,
+    `https://api.github.com/repos/${repoSlug}/contents/${path}?ref=${encodeURIComponent(ref)}`
+  );
+  if (resp.status === 404) return null;
+  if (!resp.ok) {
+    throw new Error(`GitHub contents read failed: ${resp.status}`);
+  }
+  const data = (await resp.json()) as { content?: string };
+  if (!data.content) return null;
+  return Buffer.from(data.content, 'base64').toString('utf8');
+}
+
+/**
+ * Create or refresh a single-file PR. Returns null on any failure so
+ * job callers can record the miss without throwing.
+ */
+export async function upsertFilePr(input: UpsertFilePrInput): Promise<UpsertFilePrResult | null> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    logger.warn('GITHUB_TOKEN not set; cannot open PR');
+    return null;
+  }
+  const repo = input.repo ?? process.env.GITHUB_REPO ?? 'adcontextprotocol/adcp';
+  const base = input.baseBranch ?? 'main';
+  const api = `https://api.github.com/repos/${repo}`;
+
+  try {
+    const refResp = await ghFetch(token, `${api}/git/ref/heads/${base}`);
+    if (!refResp.ok) {
+      logger.error({ status: refResp.status, repo, base }, 'Base ref lookup failed');
+      return null;
+    }
+    const baseSha = ((await refResp.json()) as { object: { sha: string } }).object.sha;
+
+    // Ensure the working branch exists at base head. Force-reset an
+    // existing branch so stale content never leaks into the diff.
+    const createResp = await ghFetch(token, `${api}/git/refs`, {
+      method: 'POST',
+      body: JSON.stringify({ ref: `refs/heads/${input.branch}`, sha: baseSha }),
+    });
+    if (!createResp.ok) {
+      if (createResp.status !== 422) {
+        logger.error({ status: createResp.status, repo }, 'Branch create failed');
+        return null;
+      }
+      const resetResp = await ghFetch(token, `${api}/git/refs/heads/${input.branch}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ sha: baseSha, force: true }),
+      });
+      if (!resetResp.ok) {
+        logger.error({ status: resetResp.status, repo }, 'Branch reset failed');
+        return null;
+      }
+    }
+
+    // Blob sha of the file on the branch (equals base's copy after the
+    // reset); absent for a first-ever refresh.
+    const fileResp = await ghFetch(
+      token,
+      `${api}/contents/${input.path}?ref=${encodeURIComponent(input.branch)}`
+    );
+    let existingSha: string | undefined;
+    if (fileResp.ok) {
+      existingSha = ((await fileResp.json()) as { sha?: string }).sha;
+    } else if (fileResp.status !== 404) {
+      logger.error({ status: fileResp.status, repo }, 'File lookup failed');
+      return null;
+    }
+
+    const putResp = await ghFetch(token, `${api}/contents/${input.path}`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        message: input.commitMessage,
+        content: Buffer.from(input.content, 'utf8').toString('base64'),
+        branch: input.branch,
+        ...(existingSha ? { sha: existingSha } : {}),
+      }),
+    });
+    if (!putResp.ok) {
+      const err = await putResp.text().catch(() => '');
+      logger.error({ status: putResp.status, err, repo }, 'File commit failed');
+      return null;
+    }
+
+    // Reuse the open PR for this branch, or open one.
+    const owner = repo.split('/')[0];
+    const listResp = await ghFetch(
+      token,
+      `${api}/pulls?head=${owner}:${encodeURIComponent(input.branch)}&base=${base}&state=open`
+    );
+    if (listResp.ok) {
+      const open = (await listResp.json()) as Array<{ html_url: string; number: number }>;
+      if (open.length > 0) {
+        return { prUrl: open[0].html_url, prNumber: open[0].number, created: false };
+      }
+    }
+
+    const prResp = await ghFetch(token, `${api}/pulls`, {
+      method: 'POST',
+      body: JSON.stringify({
+        title: input.prTitle,
+        head: input.branch,
+        base,
+        body: input.prBody,
+      }),
+    });
+    if (!prResp.ok) {
+      const err = await prResp.text().catch(() => '');
+      logger.error({ status: prResp.status, err, repo }, 'PR create failed');
+      return null;
+    }
+    const pr = (await prResp.json()) as { html_url: string; number: number };
+    return { prUrl: pr.html_url, prNumber: pr.number, created: true };
+  } catch (err) {
+    logger.error({ err, repo }, 'upsertFilePr threw');
+    return null;
+  }
+}

--- a/server/src/addie/jobs/job-definitions.ts
+++ b/server/src/addie/jobs/job-definitions.ts
@@ -40,6 +40,7 @@ import { runCredentialDigestJob } from './credential-digest.js';
 import { runCertificationRecoveryJob } from './certification-recovery.js';
 import { runBrandLogoDigestJob } from './brand-logo-digest.js';
 import { runWgDigestJob, runWgDigestPrepJob } from './wg-digest.js';
+import { runWgSlackContextJob } from './wg-slack-context.js';
 import { runComplianceHeartbeatJob } from './compliance-heartbeat.js';
 import { runShadowEvaluatorJob } from './shadow-evaluator.js';
 import { runAddieCorrectedCaptureJob } from './shadow-corrected-capture.js';
@@ -380,6 +381,19 @@ export function registerAllJobs(): void {
     runner: runWgDigestPrepJob,
     failureThreshold: 1,
     shouldLogResult: (r) => r.emailsSent > 0,
+  });
+
+  // WG slack-context - distill public WG channel discussion into
+  // .agents/wg/slack-context.md via PR (the Secretariat's Slack input)
+  jobScheduler.register({
+    name: 'wg-slack-context',
+    description: 'Distill WG Slack discussion into .agents/wg/slack-context.md via PR',
+    interval: { value: 24, unit: 'hours' },
+    initialDelay: { value: 14, unit: 'minutes' },
+    runner: runWgSlackContextJob,
+    failureThreshold: 1,
+    businessHours: { startHour: 9, endHour: 17, skipWeekends: true },
+    shouldLogResult: (r) => !!r.prUrl || r.skipped === 'pr-failed',
   });
 
   // Credential digest - weekly summary of certification awards to Slack
@@ -925,6 +939,7 @@ export const JOB_NAMES = {
   WEEKLY_DIGEST: 'weekly-digest',
   WG_DIGEST: 'wg-digest',
   WG_DIGEST_PREP: 'wg-digest-prep',
+  WG_SLACK_CONTEXT: 'wg-slack-context',
   CREDENTIAL_DIGEST: 'credential-digest',
   CERTIFICATION_RECOVERY: 'certification-recovery',
   BRAND_LOGO_DIGEST: 'brand-logo-digest',

--- a/server/src/addie/jobs/wg-slack-context.ts
+++ b/server/src/addie/jobs/wg-slack-context.ts
@@ -1,0 +1,281 @@
+/**
+ * WG Slack context distiller.
+ *
+ * Sweeps public working-group Slack channels, distills spec-relevant
+ * discussion into `.agents/wg/slack-context.md`, and ships the refresh
+ * as a pull request. The distilled file is the only Slack channel into
+ * the Secretariat's review desks (`.agents/wg/constitution.md`
+ * §Information sources and the record): positions are summarized
+ * without attribution, and the refresh PR crosses the sensitive-path
+ * gate so a human sees every version before a desk reads it.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import { createLogger } from '../../logger.js';
+import { ModelConfig } from '../../config/models.js';
+import { WorkingGroupDatabase } from '../../db/working-group-db.js';
+import { getChannelHistory, getChannelInfo } from '../../slack/client.js';
+import type { SlackHistoryMessage } from '../../slack/client.js';
+import { getFileContent, upsertFilePr } from './github-pr.js';
+
+const logger = createLogger('wg-slack-context');
+
+const SLACK_WORKSPACE_URL = process.env.SLACK_WORKSPACE_URL || 'https://agenticads.slack.com';
+export const CONTEXT_FILE_PATH = '.agents/wg/slack-context.md';
+const PR_BRANCH = 'addie/wg-slack-context';
+const NO_CONTENT_SENTINEL = 'NO_SPEC_RELEVANT_DISCUSSION';
+const MAX_THREAD_TEXT_CHARS = 900;
+
+export interface WgSlackContextOptions {
+  /** How far back to sweep. Default 14 days. */
+  windowDays?: number;
+  /** Threads per channel fed to the distiller. Default 8. */
+  maxThreadsPerChannel?: number;
+}
+
+export interface WgSlackContextResult {
+  channelsScanned: number;
+  channelsSkippedPrivate: number;
+  threadsDistilled: number;
+  prUrl?: string;
+  prCreated?: boolean;
+  skipped?:
+    | 'missing-env'
+    | 'no-channels'
+    | 'no-activity'
+    | 'no-spec-content'
+    | 'no-material-change'
+    | 'pr-failed';
+}
+
+interface SourceThread {
+  groupName: string;
+  channelId: string;
+  ts: string;
+  text: string;
+  replyCount: number;
+  permalink: string;
+}
+
+/**
+ * Strip Slack markup that carries identity or noise: user mentions,
+ * channel refs, and link syntax. Exported for tests.
+ */
+export function cleanSlackText(text: string): string {
+  return text
+    .replace(/<@[UW][A-Z0-9]+(\|[^>]*)?>/g, 'a member')
+    .replace(/<#[A-Z0-9]+\|([^>]*)>/g, '#$1')
+    .replace(/<(https?:\/\/[^|>]+)\|([^>]*)>/g, '$2')
+    .replace(/<(https?:\/\/[^>]+)>/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Defense-in-depth on model output: no raw Slack user mentions may
+ * survive into the digest. Exported for tests.
+ */
+export function stripResidualMentions(text: string): string {
+  return text.replace(/<@[UW][A-Z0-9]+(\|[^>]*)?>/g, 'a member');
+}
+
+/** The topic body below the metadata divider; used for change detection. */
+function extractBody(fileContent: string): string {
+  const idx = fileContent.indexOf('\n---\n');
+  return idx === -1 ? fileContent.trim() : fileContent.slice(idx + 5).trim();
+}
+
+function buildDistillerPrompt(threads: SourceThread[]): string {
+  const byChannel = new Map<string, SourceThread[]>();
+  for (const t of threads) {
+    const list = byChannel.get(t.groupName) ?? [];
+    list.push(t);
+    byChannel.set(t.groupName, list);
+  }
+
+  const corpus = [...byChannel.entries()]
+    .map(([group, list]) => {
+      const items = list
+        .map(
+          (t) =>
+            `- [${new Date(Number(t.ts.split('.')[0]) * 1000).toISOString().slice(0, 10)}] ` +
+            `(replies: ${t.replyCount}) ${t.permalink}\n  ${t.text}`
+        )
+        .join('\n');
+      return `## Channel: ${group}\n${items}`;
+    })
+    .join('\n\n');
+
+  return `You are the AAO Secretariat's Slack distiller. Below are recent threads from AdCP working-group Slack channels. Produce a markdown digest of SPEC-RELEVANT discussion for the protocol's review agents.
+
+Hard rules:
+- NEVER name, quote, or otherwise identify a participant: no personal names, no Slack handles, no company names used as attribution. Describe positions by role when useful ("a seller-side member", "an SDK implementer").
+- Never quote a message verbatim. Summarize in third person.
+- Only include discussion relevant to the AdCP specification, schemas, SDKs, conformance, or governance process. Omit social chatter, event logistics, job posts, and admin topics.
+- If an issue or PR number (#NNNN) appears in a thread, carry it into Related.
+
+Output format, one section per topic:
+### <Short topic title>
+- **Status:** active | resolved | parked
+- **Summary:** 2-4 sentences, no quotes, no attribution.
+- **Related:** #NNNN, #NNNN (omit this line if none)
+- **Thread:** <permalink of the source thread(s), copied from the source list>
+
+Order topics by relevance to current spec work. If nothing is spec-relevant, output exactly: ${NO_CONTENT_SENTINEL}
+
+Source threads:
+
+${corpus}`;
+}
+
+function composeFile(body: string, meta: { channels: number; skippedPrivate: number; windowDays: number }): string {
+  return `# WG Slack Context
+
+<!-- Generated by the wg-slack-context job. Do not edit by hand. -->
+
+**Background only.** Summarized from member-visible working-group Slack
+channels per \`.agents/wg/constitution.md\` §Information sources and the
+record: never quote or attribute this content in public output; Slack
+informs, GitHub decides.
+
+- Generated: ${new Date().toISOString().slice(0, 10)}
+- Window: last ${meta.windowDays} days
+- Channels: ${meta.channels} public WG channels swept (${meta.skippedPrivate} private excluded)
+
+---
+
+${body}
+`;
+}
+
+export async function runWgSlackContextJob(
+  options: WgSlackContextOptions = {}
+): Promise<WgSlackContextResult> {
+  const windowDays = options.windowDays ?? 14;
+  const maxThreadsPerChannel = options.maxThreadsPerChannel ?? 8;
+
+  const result: WgSlackContextResult = {
+    channelsScanned: 0,
+    channelsSkippedPrivate: 0,
+    threadsDistilled: 0,
+  };
+
+  if (!process.env.ANTHROPIC_API_KEY || !process.env.GITHUB_TOKEN) {
+    logger.warn('ANTHROPIC_API_KEY or GITHUB_TOKEN not set; skipping');
+    result.skipped = 'missing-env';
+    return result;
+  }
+
+  const wgDb = new WorkingGroupDatabase();
+  const groups = await wgDb.listWorkingGroupsWithSlackChannel();
+  if (groups.length === 0) {
+    result.skipped = 'no-channels';
+    return result;
+  }
+
+  const oldest = String(Math.floor((Date.now() - windowDays * 24 * 60 * 60 * 1000) / 1000));
+  const threads: SourceThread[] = [];
+
+  for (const group of groups) {
+    const channelId = group.slack_channel_id!;
+    // Fail closed on privacy: only channels the Slack API confirms are
+    // public feed a file that lands in a public repo.
+    const info = await getChannelInfo(channelId);
+    if (!info || info.is_private !== false) {
+      result.channelsSkippedPrivate++;
+      continue;
+    }
+    result.channelsScanned++;
+
+    try {
+      const history = await getChannelHistory(channelId, { oldest, limit: 100 });
+      const substantive = history.messages
+        .filter(
+          (m: SlackHistoryMessage) =>
+            m.text && !m.bot_id && !m.subtype && ((m.reply_count ?? 0) >= 2 || m.text.length >= 80)
+        )
+        .sort((a, b) => (b.reply_count ?? 0) - (a.reply_count ?? 0) || Number(b.ts) - Number(a.ts))
+        .slice(0, maxThreadsPerChannel);
+
+      for (const msg of substantive) {
+        threads.push({
+          groupName: group.name,
+          channelId,
+          ts: msg.ts,
+          text: cleanSlackText(msg.text!).slice(0, MAX_THREAD_TEXT_CHARS),
+          replyCount: msg.reply_count ?? 0,
+          permalink: `${SLACK_WORKSPACE_URL}/archives/${channelId}/p${msg.ts.replace('.', '')}`,
+        });
+      }
+    } catch (err) {
+      logger.warn({ err, channelId, group: group.name }, 'Channel sweep failed; continuing');
+    }
+  }
+
+  if (threads.length === 0) {
+    result.skipped = 'no-activity';
+    return result;
+  }
+  result.threadsDistilled = threads.length;
+
+  const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  const response = await client.messages.create({
+    model: ModelConfig.primary,
+    max_tokens: 3000,
+    messages: [{ role: 'user', content: buildDistillerPrompt(threads) }],
+  });
+  const raw = response.content[0]?.type === 'text' ? response.content[0].text.trim() : '';
+
+  if (!raw || raw.includes(NO_CONTENT_SENTINEL)) {
+    result.skipped = 'no-spec-content';
+    return result;
+  }
+
+  const body = stripResidualMentions(raw);
+
+  let currentBody: string | null = null;
+  try {
+    const current = await getFileContent(CONTEXT_FILE_PATH, 'main');
+    currentBody = current === null ? null : extractBody(current);
+  } catch (err) {
+    logger.warn({ err }, 'Could not read current slack-context from main; proceeding');
+  }
+  if (currentBody !== null && currentBody === body.trim()) {
+    result.skipped = 'no-material-change';
+    return result;
+  }
+
+  const content = composeFile(body, {
+    channels: result.channelsScanned,
+    skippedPrivate: result.channelsSkippedPrivate,
+    windowDays,
+  });
+
+  const pr = await upsertFilePr({
+    branch: PR_BRANCH,
+    path: CONTEXT_FILE_PATH,
+    content,
+    commitMessage: 'chore(agents): refresh WG slack-context digest',
+    prTitle: 'chore(agents): refresh WG slack-context digest',
+    prBody:
+      `Automated refresh of \`${CONTEXT_FILE_PATH}\` from the last ${windowDays} days of ` +
+      `public working-group Slack channels (${result.channelsScanned} channels, ` +
+      `${result.threadsDistilled} threads distilled, positions summarized without attribution).\n\n` +
+      `This file is the Secretariat's only Slack input; the sensitive-path gate holds it for ` +
+      `human review by design — merging is the review (see ` +
+      `\`.agents/wg/constitution.md\` §Information sources and the record).`,
+  });
+
+  if (!pr) {
+    result.skipped = 'pr-failed';
+    return result;
+  }
+
+  result.prUrl = pr.prUrl;
+  result.prCreated = pr.created;
+  logger.info(
+    { prUrl: pr.prUrl, created: pr.created, threads: result.threadsDistilled },
+    'WG slack-context refresh PR ready'
+  );
+  return result;
+}

--- a/server/tests/unit/github-pr.test.ts
+++ b/server/tests/unit/github-pr.test.ts
@@ -68,7 +68,7 @@ describe('upsertFilePr', () => {
     expect(result).toEqual({ prUrl: 'https://github.com/acme/spec/pull/7', prNumber: 7, created: false });
 
     const patchCall = fetchMock.mock.calls[2];
-    expect(patchCall[0]).toContain('/git/refs/heads/addie%2Fwg-slack-context'.replace('%2F', '/'));
+    expect(patchCall[0]).toContain('/git/refs/heads/addie/wg-slack-context');
     expect(JSON.parse(patchCall[1].body as string)).toEqual({ sha: 'base-sha', force: true });
 
     const putBody = JSON.parse(fetchMock.mock.calls[4][1].body as string);

--- a/server/tests/unit/github-pr.test.ts
+++ b/server/tests/unit/github-pr.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchMock = vi.fn();
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('upsertFilePr', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('GITHUB_TOKEN', 'test-token');
+    vi.stubEnv('GITHUB_REPO', 'acme/spec');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  const input = {
+    branch: 'addie/wg-slack-context',
+    path: '.agents/wg/slack-context.md',
+    content: '# digest\n',
+    commitMessage: 'chore: refresh',
+    prTitle: 'chore: refresh',
+    prBody: 'body',
+  };
+
+  it('creates branch, commits file, and opens a new PR', async () => {
+    fetchMock
+      .mockResolvedValueOnce(json({ object: { sha: 'base-sha' } })) // GET base ref
+      .mockResolvedValueOnce(json({}, 201)) // POST create branch
+      .mockResolvedValueOnce(json({}, 404)) // GET file on branch (absent)
+      .mockResolvedValueOnce(json({ commit: { sha: 'c1' } })) // PUT contents
+      .mockResolvedValueOnce(json([])) // GET open PRs (none)
+      .mockResolvedValueOnce(json({ html_url: 'https://github.com/acme/spec/pull/9', number: 9 }, 201));
+
+    const { upsertFilePr } = await import('../../src/addie/jobs/github-pr.js');
+    const result = await upsertFilePr(input);
+
+    expect(result).toEqual({ prUrl: 'https://github.com/acme/spec/pull/9', prNumber: 9, created: true });
+
+    const putCall = fetchMock.mock.calls[3];
+    expect(putCall[0]).toContain('/contents/.agents/wg/slack-context.md');
+    const putBody = JSON.parse(putCall[1].body as string);
+    expect(putBody.branch).toBe('addie/wg-slack-context');
+    expect(putBody.sha).toBeUndefined();
+    expect(Buffer.from(putBody.content, 'base64').toString('utf8')).toBe('# digest\n');
+  });
+
+  it('force-resets an existing branch and reuses the open PR', async () => {
+    fetchMock
+      .mockResolvedValueOnce(json({ object: { sha: 'base-sha' } })) // GET base ref
+      .mockResolvedValueOnce(json({ message: 'Reference already exists' }, 422)) // POST create branch
+      .mockResolvedValueOnce(json({}, 200)) // PATCH force-reset
+      .mockResolvedValueOnce(json({ sha: 'blob-sha' })) // GET file on branch
+      .mockResolvedValueOnce(json({ commit: { sha: 'c2' } })) // PUT contents
+      .mockResolvedValueOnce(json([{ html_url: 'https://github.com/acme/spec/pull/7', number: 7 }])); // GET open PRs
+
+    const { upsertFilePr } = await import('../../src/addie/jobs/github-pr.js');
+    const result = await upsertFilePr(input);
+
+    expect(result).toEqual({ prUrl: 'https://github.com/acme/spec/pull/7', prNumber: 7, created: false });
+
+    const patchCall = fetchMock.mock.calls[2];
+    expect(patchCall[0]).toContain('/git/refs/heads/addie%2Fwg-slack-context'.replace('%2F', '/'));
+    expect(JSON.parse(patchCall[1].body as string)).toEqual({ sha: 'base-sha', force: true });
+
+    const putBody = JSON.parse(fetchMock.mock.calls[4][1].body as string);
+    expect(putBody.sha).toBe('blob-sha');
+
+    // No PR creation call after finding the open PR.
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+
+  it('returns null without calling GitHub when the token is missing', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '');
+    const { upsertFilePr } = await import('../../src/addie/jobs/github-pr.js');
+    const result = await upsertFilePr(input);
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('getFileContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('GITHUB_TOKEN', 'test-token');
+    vi.stubEnv('GITHUB_REPO', 'acme/spec');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('decodes base64 content', async () => {
+    fetchMock.mockResolvedValueOnce(
+      json({ content: Buffer.from('hello\n', 'utf8').toString('base64') })
+    );
+    const { getFileContent } = await import('../../src/addie/jobs/github-pr.js');
+    await expect(getFileContent('a.md', 'main')).resolves.toBe('hello\n');
+  });
+
+  it('returns null for a missing file', async () => {
+    fetchMock.mockResolvedValueOnce(json({ message: 'Not Found' }, 404));
+    const { getFileContent } = await import('../../src/addie/jobs/github-pr.js');
+    await expect(getFileContent('missing.md', 'main')).resolves.toBeNull();
+  });
+
+  it('throws on non-404 failures so callers can tell absent from unreadable', async () => {
+    fetchMock.mockResolvedValueOnce(json({ message: 'boom' }, 500));
+    const { getFileContent } = await import('../../src/addie/jobs/github-pr.js');
+    await expect(getFileContent('a.md', 'main')).rejects.toThrow('500');
+  });
+});

--- a/server/tests/unit/wg-slack-context-job.test.ts
+++ b/server/tests/unit/wg-slack-context-job.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listWorkingGroupsWithSlackChannel = vi.fn();
+const getChannelInfo = vi.fn();
+const getChannelHistory = vi.fn();
+const getFileContent = vi.fn();
+const upsertFilePr = vi.fn();
+const messagesCreate = vi.fn();
+
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class {
+    listWorkingGroupsWithSlackChannel = listWorkingGroupsWithSlackChannel;
+  },
+}));
+
+vi.mock('../../src/slack/client.js', () => ({
+  getChannelInfo,
+  getChannelHistory,
+}));
+
+vi.mock('../../src/addie/jobs/github-pr.js', () => ({
+  getFileContent,
+  upsertFilePr,
+}));
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class {
+    messages = { create: messagesCreate };
+  },
+}));
+
+vi.mock('../../src/config/models.js', () => ({
+  ModelConfig: { primary: 'test-model', fast: 'test-model' },
+}));
+
+function wg(name: string, channelId: string) {
+  return { id: `id-${channelId}`, name, slack_channel_id: channelId };
+}
+
+function message(text: string, replyCount = 3, ts = '1700000000.000100') {
+  return { type: 'message', user: 'U1', text, ts, reply_count: replyCount };
+}
+
+function llmText(text: string) {
+  return { content: [{ type: 'text', text }] };
+}
+
+describe('runWgSlackContextJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+    vi.stubEnv('GITHUB_TOKEN', 'test-token');
+    listWorkingGroupsWithSlackChannel.mockResolvedValue([wg('Media Buy WG', 'C001')]);
+    getChannelInfo.mockResolvedValue({ id: 'C001', is_private: false });
+    getChannelHistory.mockResolvedValue({
+      messages: [message('Long discussion about create_media_buy pacing semantics and #1234')],
+      hasMore: false,
+    });
+    messagesCreate.mockResolvedValue(
+      llmText('### Pacing semantics\n- **Status:** active\n- **Summary:** Members discussed pacing.\n- **Related:** #1234')
+    );
+    getFileContent.mockResolvedValue(null);
+    upsertFilePr.mockResolvedValue({ prUrl: 'https://github.com/x/pr/1', prNumber: 1, created: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('skips entirely when env credentials are missing', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '');
+    const { runWgSlackContextJob } = await import('../../src/addie/jobs/wg-slack-context.js');
+    const result = await runWgSlackContextJob();
+    expect(result.skipped).toBe('missing-env');
+    expect(listWorkingGroupsWithSlackChannel).not.toHaveBeenCalled();
+  });
+
+  it('distills public channels and opens a PR', async () => {
+    const { runWgSlackContextJob, CONTEXT_FILE_PATH } = await import(
+      '../../src/addie/jobs/wg-slack-context.js'
+    );
+    const result = await runWgSlackContextJob();
+
+    expect(result.channelsScanned).toBe(1);
+    expect(result.threadsDistilled).toBe(1);
+    expect(result.prUrl).toBe('https://github.com/x/pr/1');
+    expect(upsertFilePr).toHaveBeenCalledTimes(1);
+    const call = upsertFilePr.mock.calls[0][0];
+    expect(call.path).toBe(CONTEXT_FILE_PATH);
+    expect(call.content).toContain('Background only');
+    expect(call.content).toContain('### Pacing semantics');
+  });
+
+  it('excludes private channels and fails closed on unknown privacy', async () => {
+    listWorkingGroupsWithSlackChannel.mockResolvedValue([
+      wg('Public WG', 'C001'),
+      wg('Private WG', 'C002'),
+      wg('Unknown WG', 'C003'),
+    ]);
+    getChannelInfo.mockImplementation(async (id: string) => {
+      if (id === 'C001') return { id, is_private: false };
+      if (id === 'C002') return { id, is_private: true };
+      return null;
+    });
+
+    const { runWgSlackContextJob } = await import('../../src/addie/jobs/wg-slack-context.js');
+    const result = await runWgSlackContextJob();
+
+    expect(result.channelsScanned).toBe(1);
+    expect(result.channelsSkippedPrivate).toBe(2);
+    expect(getChannelHistory).toHaveBeenCalledTimes(1);
+    expect(getChannelHistory).toHaveBeenCalledWith('C001', expect.anything());
+  });
+
+  it('skips without a PR when the distiller finds nothing spec-relevant', async () => {
+    messagesCreate.mockResolvedValue(llmText('NO_SPEC_RELEVANT_DISCUSSION'));
+    const { runWgSlackContextJob } = await import('../../src/addie/jobs/wg-slack-context.js');
+    const result = await runWgSlackContextJob();
+    expect(result.skipped).toBe('no-spec-content');
+    expect(upsertFilePr).not.toHaveBeenCalled();
+  });
+
+  it('skips when the distilled body matches the file already on main', async () => {
+    const body =
+      '### Pacing semantics\n- **Status:** active\n- **Summary:** Members discussed pacing.\n- **Related:** #1234';
+    messagesCreate.mockResolvedValue(llmText(body));
+    getFileContent.mockResolvedValue(`# WG Slack Context\n\nmeta lines\n\n---\n\n${body}\n`);
+
+    const { runWgSlackContextJob } = await import('../../src/addie/jobs/wg-slack-context.js');
+    const result = await runWgSlackContextJob();
+    expect(result.skipped).toBe('no-material-change');
+    expect(upsertFilePr).not.toHaveBeenCalled();
+  });
+
+  it('strips residual Slack mentions from model output before shipping', async () => {
+    messagesCreate.mockResolvedValue(
+      llmText('### Topic\n- **Summary:** <@U12345ABC> proposed a change.')
+    );
+    const { runWgSlackContextJob } = await import('../../src/addie/jobs/wg-slack-context.js');
+    await runWgSlackContextJob();
+    const call = upsertFilePr.mock.calls[0][0];
+    expect(call.content).not.toContain('<@U');
+    expect(call.content).toContain('a member proposed a change');
+  });
+
+  it('reports no-activity when channels have no substantive threads', async () => {
+    getChannelHistory.mockResolvedValue({
+      messages: [{ type: 'message', bot_id: 'B1', text: 'bot noise', ts: '1.0' }],
+      hasMore: false,
+    });
+    const { runWgSlackContextJob } = await import('../../src/addie/jobs/wg-slack-context.js');
+    const result = await runWgSlackContextJob();
+    expect(result.skipped).toBe('no-activity');
+    expect(messagesCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('cleanSlackText', () => {
+  it('replaces mentions, unwraps channel refs and links', async () => {
+    const { cleanSlackText } = await import('../../src/addie/jobs/wg-slack-context.js');
+    expect(cleanSlackText('<@U123ABC> said see <#C1|wg-adcp> and <https://x.test|the doc>')).toBe(
+      'a member said see #wg-adcp and the doc'
+    );
+    expect(cleanSlackText('bare <https://x.test/page>')).toBe('bare https://x.test/page');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Secretariat's knowledge bridge from `specs/spec-guardian.md` (§Knowledge bridge, landed in #5808): a daily Addie job that sweeps **public** working-group Slack channels, distills spec-relevant discussion into `.agents/wg/slack-context.md` — positions summarized, **no attribution, no quotes** — and ships each refresh as a single-file PR. Because `.agents/**` is sensitive-path gated, every refresh is held for human merge: that gate is the reviewability property the constitution's information-sources rules depend on (what the desks read at base SHA is content a human already saw merge).

## Design

- **`server/src/addie/jobs/github-pr.ts`** — single-file PR helper on the same auth seam as `github-filer.ts` (`GITHUB_TOKEN` + raw fetch, 10s timeouts, null-on-failure). Force-resets the rolling branch (`addie/wg-slack-context`) to base head on every run so the PR diff is always exactly "main + this file"; reuses the open PR when one exists.
- **`server/src/addie/jobs/wg-slack-context.ts`** —
  - **Privacy fail-closed:** a channel feeds the file only when `conversations.info` confirms `is_private === false`; null/unknown is skipped. Private WG channels never reach a public repo file.
  - **Identity scrubbing at three layers:** Slack markup cleaned before the LLM (user mentions → "a member"), distiller prompt forbids names/handles/companies-as-attribution and verbatim quotes, and a residual-mention guard strips any surviving `<@U…>` from model output.
  - **Distiller:** `ModelConfig.primary`, per-topic output (status / summary / related #issues / thread permalink), sentinel `NO_SPEC_RELEVANT_DISCUSSION` → no PR.
  - **Material-change gate:** distilled body compared against the copy on `main` (metadata header ignored) — no churn PRs.
- **Registration:** 24h interval, weekday business hours, `failureThreshold: 1`; skip reasons surfaced in the result shape (`missing-env`, `no-activity`, `no-spec-content`, `no-material-change`, `pr-failed`).

## Ops note (action needed before enabling in prod)

The job reuses the existing `GITHUB_TOKEN` env var. Issue-filing (knowledge-gap-closer) only needed `issues:write`; this job additionally needs **contents:write and pull_requests:write** on `adcontextprotocol/adcp`. If the prod token lacks those scopes the job logs `pr-failed` and exits — no crash — but it won't deliver until the token is upgraded (or a dedicated Secretariat token is provisioned, which pairs naturally with the planned "AAO Secretariat" GitHub App).

## Test plan

- [x] 14 unit tests (`server/tests/unit/wg-slack-context-job.test.ts`, `github-pr.test.ts`): private-channel exclusion + fail-closed on unknown privacy, mention scrubbing on both input and output, sentinel/no-activity/material-change skips, branch create vs force-reset paths, PR reuse, missing-token no-op, contents decode/404/500 semantics.
- [x] `tsc --project server/tsconfig.json --noEmit` clean; full precommit suite passed on commit.
- [ ] Manual: first prod run produces a sane digest PR (requires token scopes above; verify no attribution survives before merging that first refresh).

No changeset — Addie server work, not protocol surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)