### PR TITLE
docs(creative): clarify creative-agent role in the sync_creatives flow

### DIFF
--- a/docs/creative/implementing-creative-agents.mdx
+++ b/docs/creative/implementing-creative-agents.mdx
@@ -359,6 +359,21 @@ Accept creative asset uploads into your library. Implement this if your platform
 
 See [sync_creatives task reference](/docs/creative/task-reference/sync_creatives) for complete API specification.
 
+## Integration with the Media Buy Protocol
+
+`sync_creatives` appears in both the Creative Protocol and the Media Buy Protocol, which is a common source of confusion. It is one task with one schema; what changes is the role of the agent receiving it:
+
+- **Sales agents** (Media Buy Protocol) accept `sync_creatives` to traffic creatives: upload into the seller's library, assign to packages in media buys, and run the seller's review pipeline. This is the call a buyer makes when activating a campaign.
+- **Creative agents** (this guide) MAY accept `sync_creatives` as an optional library on-ramp: buyers push assets into your library so `build_creative` and `list_creatives` can reference them later. No packages or media buys are involved unless your platform also manages them.
+
+A typical buyer flow uses both endpoints in sequence:
+
+1. **Build**: the buyer calls your `build_creative` (or assembles a manifest by hand) and checks the result with `preview_creative`.
+2. **Traffic**: the buyer sends the finished manifest to the sales agent's `sync_creatives`, with package assignments for the media buy.
+3. **Deliver**: the sales agent validates the manifest against the format definition your agent published and serves the creative.
+
+Your creative agent is not in the path of step 2; buyers call the sales agent directly. Your format definitions are, because the sales agent validates incoming manifests against the formats you publish via `list_creative_formats`. Sales agents that implement the Creative Protocol alongside the Media Buy Protocol accept both kinds of calls at a single endpoint; see [Creative capabilities on sales agents](/docs/creative/sales-agent-creative-capabilities).
+
 ## Validation best practices
 
 ### Manifest validation


### PR DESCRIPTION
## Summary

Closes #5806 (critical knowledge gap: Integration with Media Buy Protocol).

Users conflate the two receiving roles of `sync_creatives` because the task appears in both the Creative Protocol and the Media Buy Protocol. The issue's auto-proposed text says a buyer's `sync_creatives` call "triggers your Creative Agent to receive creative synchronization requests", which is not how the protocols compose: trafficking calls go to the sales agent, and a creative agent only sees `sync_creatives` if it opted into the library on-ramp. This PR adds the correct clarification instead.

## Change

New "Integration with the Media Buy Protocol" section in `docs/creative/implementing-creative-agents.mdx`, placed after the optional `sync_creatives` task:

- One task, one schema, two receiving roles: sales agents accept it to traffic creatives (library upload, package assignment, review pipeline); creative agents MAY accept it as an optional library on-ramp feeding `build_creative` / `list_creatives`.
- A build, traffic, deliver walkthrough showing that the creative agent is not in the path of the trafficking call, while its published format definitions are what the sales agent validates against.
- Pointer to the existing dual-role page for sales agents that implement both protocols on one endpoint.

Docs only, outside `docs/reference/`; no changeset per the protocol-scope policy.

## Verification

- Content checked against `docs/creative/specification.mdx` (task list and sync_creatives requirements), `docs/creative/task-reference/sync_creatives.mdx`, and `docs/creative/sales-agent-creative-capabilities.mdx`
- Internal links resolve to existing pages
