### PR TITLE
docs(building): explain why bearer tokens are prohibited for financial operations

### DIFF
--- a/docs/building/by-layer/L2/authentication.mdx
+++ b/docs/building/by-layer/L2/authentication.mdx
@@ -53,6 +53,19 @@ AdCP supports three authentication mechanisms for authenticated operations. The 
   **3.0 mutating-operation floor.** Until 3.1 lands, static Authorization-header credentials over TLS are the effective floor for mutating operations. Operators handling spend commitments SHOULD ship RFC 9421 request signing before the 3.1 deprecation date to avoid a forced cutover.
 </Warning>
 
+### Why bearer tokens are prohibited for financial operations
+
+A bearer token authenticates whoever presents it. Any party that obtains the token (a leaked log line, a compromised proxy, a captured request, a misconfigured relay) can originate spend commitments indistinguishable from the legitimate agent's, and the seller cannot tell the difference after the fact. For read and discovery operations that risk is bounded; for operations that move money it is not.
+
+Signed requests replace possession of a string with proof of possession of a private key:
+
+- **Proof of possession.** The signature proves the caller holds the signing key. The key never travels on the wire, so the theft surface shrinks from every system a token passes through to the signer's key storage.
+- **Payload integrity.** The signature binds `@method`, `@target-uri`, `@authority`, `content-type`, and `content-digest`, so tampering with a budget figure, account reference, or target endpoint invalidates the request. TLS protects bytes in transit but not through intermediaries, relays, or logs; the signature protects the transaction end to end.
+- **Replay resistance.** The ±60 s timestamp window and nonce prevent a captured request from being resubmitted as a new transaction.
+- **Accountability.** Both parties can prove after the fact who originated a transaction and exactly what was requested. That audit anchor is what lowers fraud and dispute cost in financial workflows; with a shared secret, origination is unprovable once the token may have leaked.
+
+This is why the 3.1+ conformance floor prohibits static credentials for mutating and financial operations while continuing to permit them for read and discovery. Key discovery, covered components, and the full verifier checklist are defined in the [implementation security reference](/docs/building/by-layer/L1/security#request-signing); build on those (or a reference SDK) rather than hand-rolling the cryptography.
+
 ### Static Authorization credentials (3.0 baseline)
 
 ```


### PR DESCRIPTION
## Summary

Closes #5789 (critical knowledge gap: signed requests vs bearer tokens).

The Authentication Method table in `docs/building/by-layer/L2/authentication.mdx` states that static credentials are prohibited for mutating and financial operations from 3.1, but never says why. The question keeps coming up (the issue captures a Slack thread where a human expert had to supply the rationale). This PR writes the rationale into the doc where the question is asked.

## Change

New "Why bearer tokens are prohibited for financial operations" subsection, placed directly after the mechanism table and the 3.0-floor warning:

- Bearer tokens authenticate whoever presents them; anyone who obtains the token can originate spend commitments indistinguishable from the legitimate agent's.
- What signing buys for spend-bearing calls: proof of possession (key never travels), payload integrity (the signature binds the RFC 9421 covered components already listed later in the page), replay resistance (timestamp window plus nonce), and accountability (provable origination, which is what lowers fraud and dispute cost).
- Points implementers at the L1 verifier checklist and reference SDKs rather than hand-rolled cryptography.

Explanatory only: no new requirements, no changes to the normative table, consistent with the covered components and parameters specified in the L1 security reference. Docs only, outside `docs/reference/`; no changeset per the protocol-scope policy.

## Verification

- Claims cross-checked against the mechanism table in the same file and `docs/building/by-layer/L1/security.mdx` (request-signing section: covered components, ±60 s window, nonce)
- Internal link resolves
