### PR TITLE
[codex] Fix durable OAuth probe auth and feed schema

### DIFF
--- a/server/src/routes/agent-oauth.ts
+++ b/server/src/routes/agent-oauth.ts
@@ -32,16 +32,73 @@ import {
   TokenExchangeError,
   discoverOAuthMetadata,
 } from '@adcp/sdk/auth';
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import {
+  checkResourceAllowed,
+  resourceUrlFromServerUrl,
+} from '@modelcontextprotocol/sdk/shared/auth-utils.js';
 import { createLogger } from '../logger.js';
 import { requireAuth } from '../middleware/auth.js';
 import { AgentContextDatabase } from '../db/agent-context-db.js';
 import { getWorkos } from '../auth/workos-client.js';
 import { createWebOAuthAdapters, AgentOAuthPendingFlowStore } from './helpers/web-oauth-stores.js';
+import { validateExternalUrl } from '../utils/url-security.js';
 
 const logger = createLogger('agent-oauth');
 
 const STATE_COOKIE = 'adcp_oauth_state';
 const STATE_COOKIE_TTL_MS = 10 * 60 * 1000;
+const OFFLINE_ACCESS_SCOPE = 'offline_access';
+const PRM_ABSENT_MARKER = 'does not implement OAuth 2.0 Protected Resource Metadata';
+
+export function buildDurableOAuthScopeHint(
+  scopes: readonly string[] | undefined,
+  allowOfflineAccess = true,
+): string | undefined {
+  const uniqueScopes = new Set<string>();
+  for (const scope of scopes ?? []) {
+    const trimmed = scope.trim();
+    if (trimmed) uniqueScopes.add(trimmed);
+  }
+  if (allowOfflineAccess) uniqueScopes.add(OFFLINE_ACCESS_SCOPE);
+  if (uniqueScopes.size === 0) return undefined;
+  return [...uniqueScopes].join(' ');
+}
+
+async function durableOAuthScopeHintForAgent(agentUrl: string): Promise<string | undefined> {
+  let resourceScopes: readonly string[] | undefined;
+  let authorizationServerUrl: string | undefined;
+  try {
+    const metadata = await discoverOAuthProtectedResourceMetadata(agentUrl);
+    if (
+      metadata.resource &&
+      !checkResourceAllowed({
+        requestedResource: resourceUrlFromServerUrl(agentUrl),
+        configuredResource: metadata.resource,
+      })
+    ) {
+      return undefined;
+    }
+    resourceScopes = metadata.scopes_supported;
+    authorizationServerUrl = metadata.authorization_servers?.[0];
+  } catch (err) {
+    if (!(err instanceof Error) || !err.message.includes(PRM_ABSENT_MARKER)) {
+      // Let startWebOAuthFlow perform canonical discovery and surface the
+      // actionable third-party OAuth error; this preflight only enriches scope.
+      return undefined;
+    }
+  }
+  if (authorizationServerUrl && !validateExternalUrl(authorizationServerUrl)) {
+    return undefined;
+  }
+  const asMetadata = await discoverAuthorizationServerMetadata(authorizationServerUrl ?? agentUrl);
+  const supportedScopes = asMetadata?.scopes_supported;
+  const allowOfflineAccess = !supportedScopes || supportedScopes.includes(OFFLINE_ACCESS_SCOPE);
+  return buildDurableOAuthScopeHint(resourceScopes, allowOfflineAccess);
+}
 
 function isValidUUID(id: string): boolean {
   return uuidValidate(id);
@@ -238,12 +295,15 @@ export function createAgentOAuthRouter(): Router {
         ...(returnTo && { return_to: returnTo }),
       };
 
+      const scopeHint = await durableOAuthScopeHintForAgent(agent.agent_uri);
       const { authorizationUrl, state } = await startWebOAuthFlow({
         agent,
         redirectUri,
         pendingFlowStore,
         agentStorage,
         carry,
+        ...(scopeHint && { scopeHint }),
+        ...(scopeHint && { clientMetadata: { scope: scopeHint } }),
       });
 
       // Browser-binding for CSRF (SEP-835 §state guidance). The cookie

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -1967,16 +1967,213 @@ const RegistryFeedFreshnessSchema = z.object({
   }),
 });
 
-const RegistryFeedPageSchema = z.object({
-  events: z.array(z.object({
+// --- Feed event payloads, typed per event family ---------------------------
+// The change feed carries one `payload` shape per event family. Typing them
+// (rather than an opaque object) lets consumers route on `publisher_domain` /
+// `agent_url` without hand-casting. Fields that appear on only some members of
+// a family (e.g. `*.merged` carries `alias_rid`/`canonical_rid` in place of
+// `identifiers`) are optional on the family schema.
+
+const ComplianceTrackStatusSchema = z.enum(["pass", "fail", "partial", "skip", "silent", "warning", "unknown", "skipped"]);
+
+const ComplianceStoryboardStatusSchema = z
+  .object({
+    storyboard_id: z.string(),
+    status: z.string(),
+    steps_passed: z.number().int().nonnegative().optional(),
+    steps_total: z.number().int().nonnegative().optional(),
+  })
+  .passthrough();
+
+const ChangedFieldsSchema = z.array(z.string()).min(1);
+
+const AgentEventPayloadSchema = z
+  .object({
+    agent_url: z.string().openapi({ description: "Canonical agent URL; the routing key for agent.* events (agents span many publishers)." }),
+    name: z.string().optional(),
+    type: z.string().optional(),
+    channels: z.array(z.string()).optional(),
+    property_types: z.array(z.string()).optional(),
+    markets: z.array(z.string()).optional(),
+    categories: z.array(z.string()).optional(),
+    category_taxonomy: z.string().nullable().optional(),
+    tags: z.array(z.string()).optional(),
+    delivery_types: z.array(z.string()).optional(),
+    format_ids: z.array(z.string()).optional(),
+    property_count: z.number().int().optional(),
+    publisher_count: z.number().int().optional(),
+    has_tmp: z.boolean().optional(),
+    updated_at: z.string().optional(),
+    changed_fields: ChangedFieldsSchema.optional(),
+    inventory_profile: z.record(z.string(), z.unknown()).optional().openapi({ description: "On agent.profile_updated: the agent's refreshed inventory profile." }),
+    compliance_summary: z.record(z.string(), z.unknown()).optional(),
+    previous_status: z.string().optional().openapi({ description: "On agent.compliance_changed: prior compliance/verification status." }),
+    current_status: z.string().optional().openapi({ description: "On agent.compliance_changed: new compliance/verification status." }),
+    headline: z.string().nullable().optional().openapi({ description: "On agent.compliance_changed: human-readable summary of the compliance transition." }),
+    tracks: z.record(z.string(), ComplianceTrackStatusSchema).optional().openapi({ description: "On agent.compliance_changed: map of compliance track id to track status." }),
+    storyboards_passing: z.number().int().nonnegative().optional(),
+    storyboards_total: z.number().int().nonnegative().optional(),
+    storyboards: z.array(ComplianceStoryboardStatusSchema).optional(),
+    role: z.string().optional().openapi({ description: "On agent.verification_earned/lost: verified role affected by the badge transition." }),
+    verified_specialisms: z.array(z.string()).optional().openapi({ description: "On agent.verification_earned: specialisms covered by the earned badge." }),
+    reason: z.string().optional().openapi({ description: "On agent.verification_lost: reason the badge was revoked." }),
+    adcp_version: z.string().optional().openapi({ description: "On agent.verification_earned/lost: AdCP version the badge applies to, when known." }),
+  })
+  .passthrough()
+  .openapi("AgentEventPayload");
+
+const PropertyEventPayloadSchema = z
+  .object({
+    property_rid: z.string().optional(),
+    publisher_domain: z.string().optional().openapi({ description: "Publisher domain that owns the property; the routing key for property.* events." }),
+    identifiers: z.array(PropertyIdentifierSchema).optional(),
+    classification: z.string().optional(),
+    source: z.enum(["authoritative", "enriched", "contributed"]).optional(),
+    property: z.record(z.string(), z.unknown()).optional().openapi({ description: "Optional full post-change property object when available." }),
+    changed_fields: ChangedFieldsSchema.optional(),
+    last_resolved_at: z.string().optional().openapi({ description: "On property.stale: last successful resolution timestamp." }),
+    reactivated_at: z.string().optional().openapi({ description: "On property.reactivated: reactivation timestamp when available." }),
+    reason: z.string().optional().openapi({ description: "On property.stale: reason the property aged out of active resolution." }),
+    alias_rid: z.string().optional().openapi({ description: "On property.merged: the RID merged away." }),
+    canonical_rid: z.string().optional().openapi({ description: "On property.merged: the surviving RID." }),
+    evidence: z.string().optional(),
+  })
+  .passthrough()
+  .openapi("PropertyEventPayload");
+
+const CollectionEventPayloadSchema = z
+  .object({
+    collection_rid: z.string().optional(),
+    publisher_domain: z.string().optional().openapi({ description: "Publisher domain that owns the collection; the routing key for collection.* events." }),
+    collection_id: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    kind: z.string().nullable().optional(),
+    source: z.string().optional(),
+    status: z.string().optional(),
+    identifiers: z
+      .array(z.object({ publisher_domain: z.string(), type: z.string(), value: z.string() }))
+      .optional()
+      .openapi({ description: "Distribution identifiers; the per-identifier publisher_domain (e.g. youtube.com) is the distribution surface, distinct from the owning publisher_domain above." }),
+    collection: z.record(z.string(), z.unknown()).optional(),
+    changed_fields: ChangedFieldsSchema.optional(),
+    alias_rid: z.string().optional().openapi({ description: "On collection.merged: the RID merged away." }),
+    canonical_rid: z.string().optional().openapi({ description: "On collection.merged: the surviving RID." }),
+    evidence: z.string().optional(),
+  })
+  .passthrough()
+  .openapi("CollectionEventPayload");
+
+const AuthorizationEventPayloadSchema = z
+  .object({
+    id: z.string().uuid().optional().openapi({ description: "Registry authorization row id when the event is backed by a materialized effective authorization row." }),
+    agent_url: z.string(),
+    agent_url_canonical: z.string().optional().openapi({ description: "Registry-canonicalized form of agent_url for equality checks." }),
+    publisher_domain: z.string().openapi({ description: "Publisher domain the authorization applies to; the routing key for authorization.* events." }),
+    authorization_type: z.string().optional().openapi({ description: "Present on authorization.granted; authorization.revoked carries only agent_url + publisher_domain." }),
+    authorized_for: z.string().nullable().optional(),
+    property_ids: z.array(z.string()).optional(),
+    property_tags: z.array(z.string()).optional(),
+    properties: z.array(z.record(z.string(), z.unknown())).optional(),
+    publisher_properties: z.array(z.record(z.string(), z.unknown())).optional(),
+    property_rid: z.string().nullable().optional().openapi({ description: "Catalog property_rid for materialized per-property authorization rows. Null for publisher-wide rows." }),
+    property_id_slug: z.string().nullable().optional().openapi({ description: "Publisher-local property id for materialized per-property authorization rows." }),
+    placement_ids: z.array(z.string()).optional(),
+    placement_tags: z.array(z.string()).optional(),
+    collections: z
+      .array(z.object({ publisher_domain: z.string(), collection_ids: z.array(z.string()).min(1) }).passthrough())
+      .optional(),
+    countries: z.array(z.string()).optional(),
+    delegation_type: z.string().optional(),
+    exclusive: z.boolean().optional(),
+    effective_from: z.string().optional(),
+    effective_until: z.string().optional(),
+    signing_keys: z.array(z.record(z.string(), z.unknown())).optional(),
+    evidence: z.string().optional(),
+    disputed: z.boolean().optional(),
+    created_by: z.string().nullable().optional(),
+    expires_at: z.string().nullable().optional(),
+    created_at: z.string().nullable().optional(),
+    updated_at: z.string().nullable().optional(),
+    override_applied: z.boolean().optional(),
+    override_reason: z.string().nullable().optional(),
+  })
+  .passthrough()
+  .openapi("AuthorizationEventPayload");
+
+const PublisherEventPayloadSchema = z
+  .object({
+    publisher_domain: z.string().optional().openapi({ description: "Publisher domain whose adagents.json was discovered/changed; the routing key for publisher.* events." }),
+    domain: z.string().optional().openapi({ description: "Legacy alias for publisher_domain retained for early feed examples." }),
+    properties_added: z.number().int().nonnegative().optional(),
+    properties_removed: z.number().int().nonnegative().optional(),
+    agents_added: z.array(z.string()).optional(),
+    agents_removed: z.array(z.string()).optional(),
+    agent_count: z.number().int().optional(),
+    property_count: z.number().int().optional(),
+    collection_count: z.number().int().optional(),
+    discovery_method: z.string().optional(),
+    manager_domain: z.string().nullable().optional(),
+    source: z.string().optional(),
+  })
+  .passthrough()
+  .openapi("PublisherEventPayload");
+
+registry.register(
+  "BrandEventPayload",
+  z.object({
+    domain: z.string().optional().openapi({
+      description: "Brand domain; brand.* events are identified by entity_id (the brand) and carry hierarchy context here.",
+    }),
+    chain: z
+      .array(z.record(z.string(), z.unknown()))
+      .optional()
+      .openapi({ description: "On brand.resolved/hierarchy_updated: the resolved brand chain (root → leaf)." }),
+    ancestor_domains: z.array(z.string()).optional(),
+    domains: z.array(z.string()).optional(),
+  }),
+);
+
+// One arm per event_type, discriminated on `event_type`. Each arm ties the
+// literal type to its family payload so consumers narrow `payload` by switching
+// on `event_type`.
+const feedEventArm = <T extends string>(eventType: T, payload: z.ZodTypeAny) =>
+  z.object({
     event_id: z.string().uuid(),
-    event_type: z.string().openapi({ example: "property.created" }),
-    entity_type: z.string().openapi({ example: "property" }),
+    event_type: z.literal(eventType),
+    entity_type: z.string(),
     entity_id: z.string(),
-    payload: z.record(z.string(), z.unknown()),
+    payload,
     actor: z.string(),
     created_at: z.string().datetime(),
-  })),
+  });
+
+const RegistryFeedEventSchema = z
+  .discriminatedUnion("event_type", [
+    feedEventArm("agent.discovered", AgentEventPayloadSchema),
+    feedEventArm("agent.removed", AgentEventPayloadSchema),
+    feedEventArm("agent.profile_updated", AgentEventPayloadSchema),
+    feedEventArm("agent.compliance_changed", AgentEventPayloadSchema),
+    feedEventArm("agent.verification_earned", AgentEventPayloadSchema),
+    feedEventArm("agent.verification_lost", AgentEventPayloadSchema),
+    feedEventArm("property.created", PropertyEventPayloadSchema),
+    feedEventArm("property.updated", PropertyEventPayloadSchema),
+    feedEventArm("property.merged", PropertyEventPayloadSchema),
+    feedEventArm("property.stale", PropertyEventPayloadSchema),
+    feedEventArm("property.reactivated", PropertyEventPayloadSchema),
+    feedEventArm("collection.created", CollectionEventPayloadSchema),
+    feedEventArm("collection.updated", CollectionEventPayloadSchema),
+    feedEventArm("collection.merged", CollectionEventPayloadSchema),
+    feedEventArm("collection.removed", CollectionEventPayloadSchema),
+    feedEventArm("authorization.granted", AuthorizationEventPayloadSchema),
+    feedEventArm("authorization.revoked", AuthorizationEventPayloadSchema),
+    feedEventArm("authorization.modified", AuthorizationEventPayloadSchema),
+    feedEventArm("publisher.adagents_changed", PublisherEventPayloadSchema),
+    feedEventArm("publisher.adagents_discovered", PublisherEventPayloadSchema),
+  ])
+  .openapi("RegistryFeedEvent");
+
+const RegistryFeedPageSchema = z.object({
+  events: z.array(RegistryFeedEventSchema),
   cursor: z.string().uuid().nullable().openapi({ description: "Pass as cursor in the next request to continue polling" }),
   has_more: z.boolean(),
   freshness: RegistryFeedFreshnessSchema,
@@ -6217,10 +6414,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
   router.post("/registry/agents/:encodedUrl/refresh", ...complianceWriteMiddleware, async (req, res) => {
     try {
-      const agentUrl = decodeURIComponent(req.params.encodedUrl);
-      if (!validateAgentUrlParam(agentUrl)) {
+      const rawAgentUrl = decodeURIComponent(req.params.encodedUrl);
+      if (!validateAgentUrlParam(rawAgentUrl)) {
         return res.status(400).json({ error: "Invalid agent URL" });
       }
+      const agentUrl = canonicalizeAgentUrl(rawAgentUrl) ?? rawAgentUrl;
       if (!req.user) {
         return res.status(401).json({ error: "Authentication required" });
       }
@@ -6515,10 +6713,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
   router.get("/registry/agents/:encodedUrl/auth-status", ...complianceWriteMiddleware, async (req, res) => {
     try {
-      const agentUrl = decodeURIComponent(req.params.encodedUrl);
-      if (!validateAgentUrlParam(agentUrl)) {
+      const rawAgentUrl = decodeURIComponent(req.params.encodedUrl);
+      if (!validateAgentUrlParam(rawAgentUrl)) {
         return res.status(400).json({ error: "Invalid agent URL" });
       }
+      const agentUrl = canonicalizeAgentUrl(rawAgentUrl) ?? rawAgentUrl;
 
       if (!req.user) {
         return res.status(401).json({ error: "Authentication required" });
@@ -6583,10 +6782,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
   router.put("/registry/agents/:encodedUrl/connect", brandCreationRateLimiter, ...complianceWriteMiddleware, async (req, res) => {
     try {
-      const agentUrl = decodeURIComponent(req.params.encodedUrl);
-      if (!validateAgentUrlParam(agentUrl)) {
+      const rawAgentUrl = decodeURIComponent(req.params.encodedUrl);
+      if (!validateAgentUrlParam(rawAgentUrl)) {
         return res.status(400).json({ error: "Invalid agent URL" });
       }
+      const agentUrl = canonicalizeAgentUrl(rawAgentUrl) ?? rawAgentUrl;
 
       if (!req.user) {
         return res.status(401).json({ error: "Authentication required" });
@@ -6703,10 +6903,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     ...complianceWriteMiddleware,
     async (req, res) => {
       try {
-        const agentUrl = decodeURIComponent(req.params.encodedUrl);
-        if (!validateAgentUrlParam(agentUrl)) {
+        const rawAgentUrl = decodeURIComponent(req.params.encodedUrl);
+        if (!validateAgentUrlParam(rawAgentUrl)) {
           return res.status(400).json({ error: "Invalid agent URL" });
         }
+        const agentUrl = canonicalizeAgentUrl(rawAgentUrl) ?? rawAgentUrl;
         if (!req.user) {
           return res.status(401).json({ error: "Authentication required" });
         }
@@ -6788,10 +6989,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     ...complianceWriteMiddleware,
     async (req, res) => {
       try {
-        const agentUrl = decodeURIComponent(req.params.encodedUrl);
-        if (!validateAgentUrlParam(agentUrl)) {
+        const rawAgentUrl = decodeURIComponent(req.params.encodedUrl);
+        if (!validateAgentUrlParam(rawAgentUrl)) {
           return res.status(400).json({ error: "Invalid agent URL" });
         }
+        const agentUrl = canonicalizeAgentUrl(rawAgentUrl) ?? rawAgentUrl;
         if (!req.user) {
           return res.status(401).json({ error: "Authentication required" });
         }
@@ -6886,10 +7088,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
   });
 
   router.get("/registry/agents/:encodedUrl/applicable-storyboards", storyboardEvalRateLimiter, ...complianceWriteMiddleware, async (req, res) => {
-    const agentUrl = decodeURIComponent(req.params.encodedUrl);
-    if (!validateAgentUrlParam(agentUrl)) {
+    const rawAgentUrl = decodeURIComponent(req.params.encodedUrl);
+    if (!validateAgentUrlParam(rawAgentUrl)) {
       return res.status(400).json({ error: "Invalid agent URL" });
     }
+    const agentUrl = canonicalizeAgentUrl(rawAgentUrl) ?? rawAgentUrl;
 
     if (!req.user) {
       return res.status(401).json({ error: "Authentication required" });

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -39,6 +39,7 @@ const ALL_OWNED_URLS = [
   ownedAgentUrl('paused'),
   ownedAgentUrl('rate-limit'),
   ownedAgentUrl('saved-bearer'),
+  ownedAgentUrl('canonical-saved-bearer'),
   ownedAgentUrl('badge-fanout'),
   ownedAgentUrl('static-admin'),
 ];
@@ -396,17 +397,49 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
     const FAKE_BEARER = 'fake-test-bearer-do-not-use-in-prod';
     await db.saveAuthToken(context.id, FAKE_BEARER, 'bearer');
 
-    const res = await request(app).post(url(agentUrl)).send();
-    expect(res.status).toBe(200);
-    expect(refreshSingleAgentMock).toHaveBeenCalledWith(
-      agentUrl,
-      expect.objectContaining({
-        auth: { type: 'bearer', token: FAKE_BEARER },
-        ownerOrgId: TEST_ORG_ID,
-      }),
-    );
+    try {
+      const res = await request(app).post(url(agentUrl)).send();
+      expect(res.status).toBe(200);
+      expect(refreshSingleAgentMock).toHaveBeenCalledWith(
+        agentUrl,
+        expect.objectContaining({
+          auth: { type: 'bearer', token: FAKE_BEARER },
+          ownerOrgId: TEST_ORG_ID,
+        }),
+      );
+    } finally {
+      await pool.query('DELETE FROM agent_contexts WHERE id = $1', [context.id]);
+    }
+  });
 
-    await pool.query('DELETE FROM agent_contexts WHERE id = $1', [context.id]);
+  it('canonicalizes the requested URL before owner auth lookup and probe', async () => {
+    const agentUrl = ownedAgentUrl('canonical-saved-bearer');
+    const requestedUrl = agentUrl
+      .replace('https://', 'HTTPS://')
+      .replace('.example.com', '.EXAMPLE.COM') + '/';
+    const { AgentContextDatabase } = await import('../../src/db/agent-context-db.js');
+    const db = new AgentContextDatabase();
+    const context = await db.create({
+      organization_id: TEST_ORG_ID,
+      agent_url: agentUrl,
+      created_by: OWNER_USER_ID,
+    });
+    const FAKE_BEARER = 'fake-canonical-bearer-do-not-use-in-prod';
+    await db.saveAuthToken(context.id, FAKE_BEARER, 'bearer');
+
+    try {
+      const res = await request(app).post(url(requestedUrl)).send();
+      expect(res.status).toBe(200);
+      expect(refreshSingleAgentMock).toHaveBeenCalledWith(
+        agentUrl,
+        expect.objectContaining({
+          auth: { type: 'bearer', token: FAKE_BEARER },
+          ownerOrgId: TEST_ORG_ID,
+        }),
+      );
+    } finally {
+      await pool.query('DELETE FROM agent_contexts WHERE id = $1', [context.id]);
+    }
   });
 
   it('fans out badge issuance for an owner refresh with a passing specialism', async () => {

--- a/server/tests/integration/registry-api-oauth.test.ts
+++ b/server/tests/integration/registry-api-oauth.test.ts
@@ -159,6 +159,26 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
       expect(res.body.agent_context_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
     });
 
+    it('canonicalizes the requested URL before ownership and auth-context save', async () => {
+      const requestedUrl = 'HTTPS://AGENT.EXAMPLE.COM/';
+      const res = await request(app)
+        .put(`/api/registry/agents/${encodeURIComponent(requestedUrl)}/connect`)
+        .send({ auth_token: 'test-bearer-123', auth_type: 'bearer' });
+      expect(res.status).toBe(200);
+
+      const stored = await pool.query(
+        `SELECT agent_url, auth_token_hint
+         FROM agent_contexts
+         WHERE organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      expect(stored.rows).toHaveLength(1);
+      expect(stored.rows[0]).toMatchObject({
+        agent_url: TEST_AGENT_URL,
+        auth_token_hint: '****-123',
+      });
+    });
+
     it('normalizes raw Basic credentials before storing', async () => {
       const res = await request(app).put(url).send({ auth_token: 'test-user:test-password', auth_type: 'basic' });
       expect(res.status).toBe(200);
@@ -248,6 +268,26 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
       });
     });
 
+    it('canonicalizes the requested URL before client-credentials save', async () => {
+      const requestedUrl = 'HTTPS://AGENT.EXAMPLE.COM/';
+      const res = await request(app)
+        .put(`/api/registry/agents/${encodeURIComponent(requestedUrl)}/oauth-client-credentials`)
+        .send(validBody);
+      expect(res.status).toBe(200);
+
+      const stored = await pool.query(
+        `SELECT agent_url, oauth_cc_client_id
+         FROM agent_contexts
+         WHERE organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      expect(stored.rows).toHaveLength(1);
+      expect(stored.rows[0]).toMatchObject({
+        agent_url: TEST_AGENT_URL,
+        oauth_cc_client_id: validBody.client_id,
+      });
+    });
+
     it('persists the full config including optional fields', async () => {
       await request(app)
         .put(url)
@@ -323,6 +363,18 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
       expect(typeof res.body.latency_ms).toBe('number');
     });
 
+    it('canonicalizes the requested URL before testing saved client credentials', async () => {
+      await request(app).put(saveUrl).send(validBody).expect(200);
+      exchangeMock.mockResolvedValueOnce({ access_token: 'new-access', token_type: 'Bearer' });
+
+      const requestedUrl = 'HTTPS://AGENT.EXAMPLE.COM/';
+      const res = await request(app)
+        .post(`/api/registry/agents/${encodeURIComponent(requestedUrl)}/oauth-client-credentials/test`)
+        .send({});
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
     it('returns { ok: false, error: { kind: "oauth", ... } } when the AS rejects the client', async () => {
       await request(app).put(saveUrl).send(validBody).expect(200);
 
@@ -375,6 +427,20 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
         .expect(200);
 
       const res = await request(app).get(statusUrl).expect(200);
+      expect(res.body).toMatchObject({ has_auth: true, auth_type: 'bearer' });
+    });
+
+    it('canonicalizes the requested URL before ownership and auth-context lookup', async () => {
+      await request(app)
+        .put(`/api/registry/agents/${encodeURIComponent(TEST_AGENT_URL)}/connect`)
+        .send({ auth_token: 'test-bearer', auth_type: 'bearer' })
+        .expect(200);
+
+      const requestedUrl = 'HTTPS://AGENT.EXAMPLE.COM/';
+      const res = await request(app)
+        .get(`/api/registry/agents/${encodeURIComponent(requestedUrl)}/auth-status`)
+        .expect(200);
+
       expect(res.body).toMatchObject({ has_auth: true, auth_type: 'bearer' });
     });
 

--- a/server/tests/unit/agent-oauth-membership-guard.test.ts
+++ b/server/tests/unit/agent-oauth-membership-guard.test.ts
@@ -1,8 +1,74 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
 import type { PendingWebFlow, PendingWebFlowStore } from '@adcp/sdk/auth';
 
 const workosMocks = vi.hoisted(() => ({
   listOrganizationMemberships: vi.fn(),
+}));
+const sdkMocks = vi.hoisted(() => {
+  class OAuthError extends Error {
+    constructor(message = 'OAuth error', public code = 'oauth_error', public agentId?: string) {
+      super(message);
+      this.name = 'OAuthError';
+    }
+  }
+  return {
+    startWebOAuthFlow: vi.fn(),
+    completeWebOAuthFlow: vi.fn(),
+    discoverOAuthMetadata: vi.fn(),
+    safeReturnTo: vi.fn((value: string) => (value.startsWith('/') ? value : undefined)),
+    OAuthError,
+    AgentVanishedDuringFlowError: class AgentVanishedDuringFlowError extends OAuthError {},
+    ConfidentialClientNotAllowedError: class ConfidentialClientNotAllowedError extends OAuthError {},
+    InvalidOrExpiredFlowError: class InvalidOrExpiredFlowError extends OAuthError {},
+    ProtectedResourceMetadataError: class ProtectedResourceMetadataError extends OAuthError {},
+    StateMismatchError: class StateMismatchError extends OAuthError {},
+    TokenExchangeError: class TokenExchangeError extends OAuthError {
+      oauthErrorCode?: string;
+    },
+  };
+});
+const mcpAuthMocks = vi.hoisted(() => ({
+  discoverAuthorizationServerMetadata: vi.fn(),
+  discoverOAuthProtectedResourceMetadata: vi.fn(),
+}));
+const agentContextDbMocks = vi.hoisted(() => ({
+  instance: {
+    getById: vi.fn(),
+    getOAuthClient: vi.fn(),
+    clearOAuthClient: vi.fn(),
+    removeOAuthTokens: vi.fn(),
+  },
+}));
+const adapterMocks = vi.hoisted(() => ({
+  pendingFlowStore: {
+    put: vi.fn(),
+    consume: vi.fn(),
+  },
+  agentStorage: {
+    loadAgent: vi.fn(),
+  },
+  createWebOAuthAdapters: vi.fn(),
+}));
+
+vi.mock('@adcp/sdk/auth', () => ({
+  startWebOAuthFlow: sdkMocks.startWebOAuthFlow,
+  completeWebOAuthFlow: sdkMocks.completeWebOAuthFlow,
+  safeReturnTo: sdkMocks.safeReturnTo,
+  discoverOAuthMetadata: sdkMocks.discoverOAuthMetadata,
+  OAuthError: sdkMocks.OAuthError,
+  AgentVanishedDuringFlowError: sdkMocks.AgentVanishedDuringFlowError,
+  ConfidentialClientNotAllowedError: sdkMocks.ConfidentialClientNotAllowedError,
+  InvalidOrExpiredFlowError: sdkMocks.InvalidOrExpiredFlowError,
+  ProtectedResourceMetadataError: sdkMocks.ProtectedResourceMetadataError,
+  StateMismatchError: sdkMocks.StateMismatchError,
+  TokenExchangeError: sdkMocks.TokenExchangeError,
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/auth.js', () => ({
+  discoverAuthorizationServerMetadata: mcpAuthMocks.discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata: mcpAuthMocks.discoverOAuthProtectedResourceMetadata,
 }));
 
 vi.mock('../../src/auth/workos-client.js', () => ({
@@ -14,10 +80,95 @@ vi.mock('../../src/auth/workos-client.js', () => ({
 }));
 
 vi.mock('../../src/middleware/auth.js', () => ({
-  requireAuth: (_req: any, _res: any, next: any) => next(),
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: 'user_123', email: 'oauth-unit@test.com' };
+    next();
+  },
 }));
 
-import { createMembershipGuardedPendingFlowStore } from '../../src/routes/agent-oauth.js';
+vi.mock('../../src/db/agent-context-db.js', () => ({
+  AgentContextDatabase: vi.fn(function AgentContextDatabase() {
+    return agentContextDbMocks.instance;
+  }),
+}));
+
+vi.mock('../../src/routes/helpers/web-oauth-stores.js', () => ({
+  AgentOAuthPendingFlowStore: class AgentOAuthPendingFlowStore {
+    cleanupExpired() {
+      return Promise.resolve(0);
+    }
+  },
+  createWebOAuthAdapters: adapterMocks.createWebOAuthAdapters,
+}));
+
+import {
+  buildDurableOAuthScopeHint,
+  createAgentOAuthRouter,
+  createMembershipGuardedPendingFlowStore,
+} from '../../src/routes/agent-oauth.js';
+
+const TEST_USER_ID = 'user_123';
+const TEST_ORG_ID = 'org_123';
+const AGENT_CONTEXT_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_AGENT_URL = 'https://agent.example.com/mcp';
+
+function makeApp() {
+  const app = express();
+  app.use('/api/oauth/agent', createAgentOAuthRouter());
+  return app;
+}
+
+beforeEach(() => {
+  workosMocks.listOrganizationMemberships.mockReset();
+  sdkMocks.startWebOAuthFlow.mockReset();
+  sdkMocks.completeWebOAuthFlow.mockReset();
+  sdkMocks.discoverOAuthMetadata.mockReset();
+  sdkMocks.safeReturnTo.mockClear();
+  mcpAuthMocks.discoverAuthorizationServerMetadata.mockReset();
+  mcpAuthMocks.discoverOAuthProtectedResourceMetadata.mockReset();
+  agentContextDbMocks.instance.getById.mockReset();
+  agentContextDbMocks.instance.getOAuthClient.mockReset();
+  agentContextDbMocks.instance.clearOAuthClient.mockReset();
+  agentContextDbMocks.instance.removeOAuthTokens.mockReset();
+  adapterMocks.pendingFlowStore.put.mockReset();
+  adapterMocks.pendingFlowStore.consume.mockReset();
+  adapterMocks.agentStorage.loadAgent.mockReset();
+  adapterMocks.createWebOAuthAdapters.mockReset();
+
+  workosMocks.listOrganizationMemberships.mockResolvedValue({
+    data: [{ userId: TEST_USER_ID, organizationId: TEST_ORG_ID, status: 'active' }],
+  });
+  agentContextDbMocks.instance.getById.mockResolvedValue({
+    id: AGENT_CONTEXT_ID,
+    organization_id: TEST_ORG_ID,
+    agent_url: TEST_AGENT_URL,
+  });
+  agentContextDbMocks.instance.getOAuthClient.mockResolvedValue(null);
+  adapterMocks.createWebOAuthAdapters.mockReturnValue({
+    pendingFlowStore: adapterMocks.pendingFlowStore,
+    agentStorage: adapterMocks.agentStorage,
+  });
+  adapterMocks.agentStorage.loadAgent.mockResolvedValue({
+    id: AGENT_CONTEXT_ID,
+    name: 'Test Agent',
+    agent_uri: TEST_AGENT_URL,
+    protocol: 'mcp',
+  });
+  sdkMocks.startWebOAuthFlow.mockResolvedValue({
+    authorizationUrl: 'https://auth.example.com/authorize',
+    state: 'state_123',
+  });
+  mcpAuthMocks.discoverOAuthProtectedResourceMetadata.mockResolvedValue({
+    resource: TEST_AGENT_URL,
+    scopes_supported: ['openid', 'profile'],
+    authorization_servers: ['https://auth.example.com'],
+  });
+  mcpAuthMocks.discoverAuthorizationServerMetadata.mockResolvedValue({
+    authorization_endpoint: 'https://auth.example.com/authorize',
+    token_endpoint: 'https://auth.example.com/token',
+    scopes_supported: ['openid', 'profile', 'offline_access'],
+  });
+});
 
 function makeFlow(overrides: Partial<PendingWebFlow> = {}): PendingWebFlow {
   return {
@@ -80,5 +231,105 @@ describe('createMembershipGuardedPendingFlowStore', () => {
     const guarded = createMembershipGuardedPendingFlowStore(store, 'user_123');
 
     await expect(guarded.consume('state_123')).rejects.toThrow('workos unavailable');
+  });
+});
+
+describe('GET /api/oauth/agent/start durable scope hint', () => {
+  it('passes PRM scopes plus offline_access as authorization and registration scope', async () => {
+    const res = await request(makeApp())
+      .get('/api/oauth/agent/start')
+      .query({ agent_context_id: AGENT_CONTEXT_ID });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('https://auth.example.com/authorize');
+    expect(mcpAuthMocks.discoverOAuthProtectedResourceMetadata).toHaveBeenCalledWith(TEST_AGENT_URL);
+    expect(mcpAuthMocks.discoverAuthorizationServerMetadata).toHaveBeenCalledWith('https://auth.example.com');
+    expect(sdkMocks.startWebOAuthFlow).toHaveBeenCalledWith(expect.objectContaining({
+      agent: expect.objectContaining({ id: AGENT_CONTEXT_ID, agent_uri: TEST_AGENT_URL }),
+      scopeHint: 'openid profile offline_access',
+      clientMetadata: { scope: 'openid profile offline_access' },
+      carry: expect.objectContaining({
+        organization_id: TEST_ORG_ID,
+        user_id: TEST_USER_ID,
+      }),
+    }));
+  });
+
+  it('does not request offline_access when the authorization server explicitly omits it', async () => {
+    mcpAuthMocks.discoverOAuthProtectedResourceMetadata.mockResolvedValueOnce({
+      resource: TEST_AGENT_URL,
+      scopes_supported: ['openid'],
+      authorization_servers: ['https://auth.example.com'],
+    });
+    mcpAuthMocks.discoverAuthorizationServerMetadata.mockResolvedValueOnce({
+      authorization_endpoint: 'https://auth.example.com/authorize',
+      token_endpoint: 'https://auth.example.com/token',
+      scopes_supported: ['openid', 'profile'],
+    });
+
+    await request(makeApp())
+      .get('/api/oauth/agent/start')
+      .query({ agent_context_id: AGENT_CONTEXT_ID })
+      .expect(302);
+
+    expect(sdkMocks.startWebOAuthFlow).toHaveBeenCalledWith(expect.objectContaining({
+      scopeHint: 'openid',
+      clientMetadata: { scope: 'openid' },
+    }));
+  });
+
+  it('requests offline_access when PRM is absent and AS metadata does not reject it', async () => {
+    mcpAuthMocks.discoverOAuthProtectedResourceMetadata.mockRejectedValueOnce(
+      new Error('Resource server does not implement OAuth 2.0 Protected Resource Metadata.'),
+    );
+    mcpAuthMocks.discoverAuthorizationServerMetadata.mockResolvedValueOnce(undefined);
+
+    await request(makeApp())
+      .get('/api/oauth/agent/start')
+      .query({ agent_context_id: AGENT_CONTEXT_ID })
+      .expect(302);
+
+    expect(mcpAuthMocks.discoverAuthorizationServerMetadata).toHaveBeenCalledWith(TEST_AGENT_URL);
+    expect(sdkMocks.startWebOAuthFlow).toHaveBeenCalledWith(expect.objectContaining({
+      scopeHint: 'offline_access',
+      clientMetadata: { scope: 'offline_access' },
+    }));
+  });
+
+  it('does not follow PRM authorization_servers when the PRM resource is not allowed', async () => {
+    mcpAuthMocks.discoverOAuthProtectedResourceMetadata.mockResolvedValueOnce({
+      resource: 'https://evil.example.com/mcp',
+      scopes_supported: ['openid'],
+      authorization_servers: ['https://auth.example.com'],
+    });
+
+    await request(makeApp())
+      .get('/api/oauth/agent/start')
+      .query({ agent_context_id: AGENT_CONTEXT_ID })
+      .expect(302);
+
+    expect(mcpAuthMocks.discoverAuthorizationServerMetadata).not.toHaveBeenCalled();
+    const opts = sdkMocks.startWebOAuthFlow.mock.calls[0][0];
+    expect(opts).not.toHaveProperty('scopeHint');
+    expect(opts).not.toHaveProperty('clientMetadata');
+  });
+});
+
+describe('buildDurableOAuthScopeHint', () => {
+  it('preserves advertised scopes and appends offline_access', () => {
+    expect(buildDurableOAuthScopeHint(['openid', 'profile', 'email'])).toBe('openid profile email offline_access');
+  });
+
+  it('deduplicates offline_access when the agent already advertises it', () => {
+    expect(buildDurableOAuthScopeHint(['openid', 'offline_access', 'email', 'offline_access'])).toBe('openid offline_access email');
+  });
+
+  it('requests offline_access even when no scopes are advertised', () => {
+    expect(buildDurableOAuthScopeHint(undefined)).toBe('offline_access');
+  });
+
+  it('preserves advertised scopes without offline_access when the auth server does not allow it', () => {
+    expect(buildDurableOAuthScopeHint(['adcp.read'], false)).toBe('adcp.read');
+    expect(buildDurableOAuthScopeHint(undefined, false)).toBeUndefined();
   });
 });

--- a/server/tests/unit/openapi-feed-components.test.ts
+++ b/server/tests/unit/openapi-feed-components.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import YAML from 'yaml';
+
+const specPath = new URL('../../../static/openapi/registry.yaml', import.meta.url);
+
+function loadSpec(): any {
+  return YAML.parse(readFileSync(specPath, 'utf8'));
+}
+
+describe('OpenAPI feed components', () => {
+  it('keeps registry feed events typed by event family', () => {
+    const spec = loadSpec();
+    const components = spec.components.schemas;
+
+    expect(components.RegistryFeedEvent.oneOf).toBeInstanceOf(Array);
+    expect(components.RegistryFeedEvent.oneOf.length).toBeGreaterThan(0);
+    expect(components.AgentEventPayload).toBeDefined();
+    expect(components.PropertyEventPayload).toBeDefined();
+    expect(components.CollectionEventPayload).toBeDefined();
+    expect(components.AuthorizationEventPayload).toBeDefined();
+    expect(components.PublisherEventPayload).toBeDefined();
+
+    const refs = new Set(
+      components.RegistryFeedEvent.oneOf
+        .map((arm: any) => arm.properties?.payload?.$ref)
+        .filter(Boolean),
+    );
+    expect(refs).toContain('#/components/schemas/AgentEventPayload');
+    expect(refs).toContain('#/components/schemas/AuthorizationEventPayload');
+
+    const feedEventItems = spec.paths['/api/registry/feed'].get.responses['200']
+      .content['application/json'].schema.properties.events.items;
+    expect(feedEventItems).toEqual({ $ref: '#/components/schemas/RegistryFeedEvent' });
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -42,6 +42,26 @@ components:
             profile: User profile information
             email: User email address
   schemas:
+    BrandEventPayload:
+      type: object
+      properties:
+        domain:
+          type: string
+          description: Brand domain; brand.* events are identified by entity_id (the brand) and carry hierarchy context here.
+        chain:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: "On brand.resolved/hierarchy_updated: the resolved brand chain (root → leaf)."
+        ancestor_domains:
+          type: array
+          items:
+            type: string
+        domains:
+          type: array
+          items:
+            type: string
     ResolvedBrand:
       type: object
       properties:
@@ -2170,6 +2190,960 @@ components:
         - policy_id
         - total
         - revisions
+    RegistryFeedEvent:
+      oneOf:
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - agent.discovered
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AgentEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - agent.removed
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AgentEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - agent.profile_updated
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AgentEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - agent.compliance_changed
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AgentEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - agent.verification_earned
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AgentEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - agent.verification_lost
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AgentEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - property.created
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PropertyEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - property.updated
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PropertyEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - property.merged
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PropertyEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - property.stale
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PropertyEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - property.reactivated
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PropertyEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - collection.created
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/CollectionEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - collection.updated
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/CollectionEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - collection.merged
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/CollectionEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - collection.removed
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/CollectionEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - authorization.granted
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AuthorizationEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - authorization.revoked
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AuthorizationEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - authorization.modified
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AuthorizationEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - publisher.adagents_changed
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PublisherEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - publisher.adagents_discovered
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PublisherEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+    AgentEventPayload:
+      type: object
+      properties:
+        agent_url:
+          type: string
+          description: Canonical agent URL; the routing key for agent.* events (agents span many publishers).
+        name:
+          type: string
+        type:
+          type: string
+        channels:
+          type: array
+          items:
+            type: string
+        property_types:
+          type: array
+          items:
+            type: string
+        markets:
+          type: array
+          items:
+            type: string
+        categories:
+          type: array
+          items:
+            type: string
+        category_taxonomy:
+          type:
+            - string
+            - "null"
+        tags:
+          type: array
+          items:
+            type: string
+        delivery_types:
+          type: array
+          items:
+            type: string
+        format_ids:
+          type: array
+          items:
+            type: string
+        property_count:
+          type: integer
+        publisher_count:
+          type: integer
+        has_tmp:
+          type: boolean
+        updated_at:
+          type: string
+        changed_fields:
+          type: array
+          items:
+            type: string
+          minItems: 1
+        inventory_profile:
+          type: object
+          additionalProperties: {}
+          description: "On agent.profile_updated: the agent's refreshed inventory profile."
+        compliance_summary:
+          type: object
+          additionalProperties: {}
+        previous_status:
+          type: string
+          description: "On agent.compliance_changed: prior compliance/verification status."
+        current_status:
+          type: string
+          description: "On agent.compliance_changed: new compliance/verification status."
+        headline:
+          type:
+            - string
+            - "null"
+          description: "On agent.compliance_changed: human-readable summary of the compliance transition."
+        tracks:
+          type: object
+          additionalProperties:
+            type: string
+            enum:
+              - pass
+              - fail
+              - partial
+              - skip
+              - silent
+              - warning
+              - unknown
+              - skipped
+          description: "On agent.compliance_changed: map of compliance track id to track status."
+        storyboards_passing:
+          type: integer
+          minimum: 0
+        storyboards_total:
+          type: integer
+          minimum: 0
+        storyboards:
+          type: array
+          items:
+            type: object
+            properties:
+              storyboard_id:
+                type: string
+              status:
+                type: string
+              steps_passed:
+                type: integer
+                minimum: 0
+              steps_total:
+                type: integer
+                minimum: 0
+            required:
+              - storyboard_id
+              - status
+            additionalProperties: {}
+        role:
+          type: string
+          description: "On agent.verification_earned/lost: verified role affected by the badge transition."
+        verified_specialisms:
+          type: array
+          items:
+            type: string
+          description: "On agent.verification_earned: specialisms covered by the earned badge."
+        reason:
+          type: string
+          description: "On agent.verification_lost: reason the badge was revoked."
+        adcp_version:
+          type: string
+          description: "On agent.verification_earned/lost: AdCP version the badge applies to, when known."
+      required:
+        - agent_url
+      additionalProperties: {}
+    PropertyEventPayload:
+      type: object
+      properties:
+        property_rid:
+          type: string
+        publisher_domain:
+          type: string
+          description: Publisher domain that owns the property; the routing key for property.* events.
+        identifiers:
+          type: array
+          items:
+            $ref: "#/components/schemas/PropertyIdentifier"
+        classification:
+          type: string
+        source:
+          type: string
+          enum:
+            - authoritative
+            - enriched
+            - contributed
+        property:
+          type: object
+          additionalProperties: {}
+          description: Optional full post-change property object when available.
+        changed_fields:
+          type: array
+          items:
+            type: string
+          minItems: 1
+        last_resolved_at:
+          type: string
+          description: "On property.stale: last successful resolution timestamp."
+        reactivated_at:
+          type: string
+          description: "On property.reactivated: reactivation timestamp when available."
+        reason:
+          type: string
+          description: "On property.stale: reason the property aged out of active resolution."
+        alias_rid:
+          type: string
+          description: "On property.merged: the RID merged away."
+        canonical_rid:
+          type: string
+          description: "On property.merged: the surviving RID."
+        evidence:
+          type: string
+      additionalProperties: {}
+    CollectionEventPayload:
+      type: object
+      properties:
+        collection_rid:
+          type: string
+        publisher_domain:
+          type: string
+          description: Publisher domain that owns the collection; the routing key for collection.* events.
+        collection_id:
+          type:
+            - string
+            - "null"
+        name:
+          type:
+            - string
+            - "null"
+        kind:
+          type:
+            - string
+            - "null"
+        source:
+          type: string
+        status:
+          type: string
+        identifiers:
+          type: array
+          items:
+            type: object
+            properties:
+              publisher_domain:
+                type: string
+              type:
+                type: string
+              value:
+                type: string
+            required:
+              - publisher_domain
+              - type
+              - value
+          description: Distribution identifiers; the per-identifier publisher_domain (e.g. youtube.com) is the distribution surface, distinct from the owning publisher_domain above.
+        collection:
+          type: object
+          additionalProperties: {}
+        changed_fields:
+          type: array
+          items:
+            type: string
+          minItems: 1
+        alias_rid:
+          type: string
+          description: "On collection.merged: the RID merged away."
+        canonical_rid:
+          type: string
+          description: "On collection.merged: the surviving RID."
+        evidence:
+          type: string
+      additionalProperties: {}
+    AuthorizationEventPayload:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Registry authorization row id when the event is backed by a materialized effective authorization row.
+        agent_url:
+          type: string
+        agent_url_canonical:
+          type: string
+          description: Registry-canonicalized form of agent_url for equality checks.
+        publisher_domain:
+          type: string
+          description: Publisher domain the authorization applies to; the routing key for authorization.* events.
+        authorization_type:
+          type: string
+          description: Present on authorization.granted; authorization.revoked carries only agent_url + publisher_domain.
+        authorized_for:
+          type:
+            - string
+            - "null"
+        property_ids:
+          type: array
+          items:
+            type: string
+        property_tags:
+          type: array
+          items:
+            type: string
+        properties:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+        publisher_properties:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+        property_rid:
+          type:
+            - string
+            - "null"
+          description: Catalog property_rid for materialized per-property authorization rows. Null for publisher-wide rows.
+        property_id_slug:
+          type:
+            - string
+            - "null"
+          description: Publisher-local property id for materialized per-property authorization rows.
+        placement_ids:
+          type: array
+          items:
+            type: string
+        placement_tags:
+          type: array
+          items:
+            type: string
+        collections:
+          type: array
+          items:
+            type: object
+            properties:
+              publisher_domain:
+                type: string
+              collection_ids:
+                type: array
+                items:
+                  type: string
+                minItems: 1
+            required:
+              - publisher_domain
+              - collection_ids
+            additionalProperties: {}
+        countries:
+          type: array
+          items:
+            type: string
+        delegation_type:
+          type: string
+        exclusive:
+          type: boolean
+        effective_from:
+          type: string
+        effective_until:
+          type: string
+        signing_keys:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+        evidence:
+          type: string
+        disputed:
+          type: boolean
+        created_by:
+          type:
+            - string
+            - "null"
+        expires_at:
+          type:
+            - string
+            - "null"
+        created_at:
+          type:
+            - string
+            - "null"
+        updated_at:
+          type:
+            - string
+            - "null"
+        override_applied:
+          type: boolean
+        override_reason:
+          type:
+            - string
+            - "null"
+      required:
+        - agent_url
+        - publisher_domain
+      additionalProperties: {}
+    PublisherEventPayload:
+      type: object
+      properties:
+        publisher_domain:
+          type: string
+          description: Publisher domain whose adagents.json was discovered/changed; the routing key for publisher.* events.
+        domain:
+          type: string
+          description: Legacy alias for publisher_domain retained for early feed examples.
+        properties_added:
+          type: integer
+          minimum: 0
+        properties_removed:
+          type: integer
+          minimum: 0
+        agents_added:
+          type: array
+          items:
+            type: string
+        agents_removed:
+          type: array
+          items:
+            type: string
+        agent_count:
+          type: integer
+        property_count:
+          type: integer
+        collection_count:
+          type: integer
+        discovery_method:
+          type: string
+        manager_domain:
+          type:
+            - string
+            - "null"
+        source:
+          type: string
+      additionalProperties: {}
     AgentComplianceDetail:
       type: object
       properties:
@@ -6913,35 +7887,7 @@ paths:
                   events:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        event_id:
-                          type: string
-                          format: uuid
-                        event_type:
-                          type: string
-                          example: property.created
-                        entity_type:
-                          type: string
-                          example: property
-                        entity_id:
-                          type: string
-                        payload:
-                          type: object
-                          additionalProperties: {}
-                        actor:
-                          type: string
-                        created_at:
-                          type: string
-                          format: date-time
-                      required:
-                        - event_id
-                        - event_type
-                        - entity_type
-                        - entity_id
-                        - payload
-                        - actor
-                        - created_at
+                      $ref: "#/components/schemas/RegistryFeedEvent"
                   cursor:
                     type:
                       - string


### PR DESCRIPTION
Fixes the OAuth probe durability gap by requesting refresh-token-capable scopes during the web OAuth start flow, while validating PRM resource/AS metadata before adding `offline_access`.

Canonicalizes agent URL route params across refresh, auth status, credential save/test, and applicable-storyboards so saved credentials and probes resolve the same context for URL variants.

Restores typed registry feed OpenAPI payload schemas, preserves `BrandEventPayload`, regenerates `static/openapi/registry.yaml`, and adds regression coverage for the feed components plus OAuth/canonicalization paths.

Checks: OAuth route unit tests, OpenAPI feed unit test, registry OAuth/refresh integration tests against Postgres, `npm run build:openapi`, `npm run typecheck`, and `git diff --check`.