### PR TITLE
fix(addie): run wg-slack-context hourly with daily dedup so business-hours gate cannot starve it

### DIFF
--- a/server/src/addie/jobs/job-definitions.ts
+++ b/server/src/addie/jobs/job-definitions.ts
@@ -384,11 +384,15 @@ export function registerAllJobs(): void {
   });
 
   // WG slack-context - distill public WG channel discussion into
-  // .agents/wg/slack-context.md via PR (the Secretariat's Slack input)
+  // .agents/wg/slack-context.md via PR (the Secretariat's Slack input).
+  // Hourly interval, not 24h: the business-hours gate silently skips
+  // ticks, and setInterval anchors tick time to boot time, so a 24h job
+  // that boots outside the window would never run. The job dedups
+  // itself to one refresh per day via the Generated date in the file.
   jobScheduler.register({
     name: 'wg-slack-context',
     description: 'Distill WG Slack discussion into .agents/wg/slack-context.md via PR',
-    interval: { value: 24, unit: 'hours' },
+    interval: { value: 1, unit: 'hours' },
     initialDelay: { value: 14, unit: 'minutes' },
     runner: runWgSlackContextJob,
     failureThreshold: 1,

--- a/server/src/addie/jobs/wg-slack-context.ts
+++ b/server/src/addie/jobs/wg-slack-context.ts
@@ -41,6 +41,7 @@ export interface WgSlackContextResult {
   prCreated?: boolean;
   skipped?:
     | 'missing-env'
+    | 'already-ran-today'
     | 'no-channels'
     | 'no-activity'
     | 'no-spec-content'
@@ -164,6 +165,24 @@ export async function runWgSlackContextJob(
     logger.warn('ANTHROPIC_API_KEY or GITHUB_TOKEN not set; skipping');
     result.skipped = 'missing-env';
     return result;
+  }
+
+  // The scheduler's business-hours gate silently skips ticks, so this
+  // job runs on an hourly interval and dedups itself to one refresh per
+  // day: if today's digest already exists on the PR branch or on main,
+  // this tick is a no-op.
+  const today = new Date().toISOString().slice(0, 10);
+  for (const ref of [PR_BRANCH, 'main']) {
+    try {
+      const existing = await getFileContent(CONTEXT_FILE_PATH, ref);
+      if (existing?.includes(`- Generated: ${today}`)) {
+        result.skipped = 'already-ran-today';
+        return result;
+      }
+    } catch {
+      // Unreadable ref: fall through — the material-change gate still
+      // prevents duplicate PR content.
+    }
   }
 
   const wgDb = new WorkingGroupDatabase();

--- a/server/tests/unit/wg-slack-context-job.test.ts
+++ b/server/tests/unit/wg-slack-context-job.test.ts
@@ -67,6 +67,24 @@ describe('runWgSlackContextJob', () => {
     vi.unstubAllEnvs();
   });
 
+  it('skips when today\'s digest already exists on the PR branch', async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    getFileContent.mockResolvedValue(`# WG Slack Context\n\n- Generated: ${today}\n\n---\n\nold body\n`);
+    const { runWgSlackContextJob } = await import('../../src/addie/jobs/wg-slack-context.js');
+    const result = await runWgSlackContextJob();
+    expect(result.skipped).toBe('already-ran-today');
+    expect(getChannelHistory).not.toHaveBeenCalled();
+    expect(messagesCreate).not.toHaveBeenCalled();
+  });
+
+  it('proceeds when the existing digest is from an earlier day', async () => {
+    getFileContent.mockResolvedValue('# WG Slack Context\n\n- Generated: 2020-01-01\n\n---\n\nold body\n');
+    const { runWgSlackContextJob } = await import('../../src/addie/jobs/wg-slack-context.js');
+    const result = await runWgSlackContextJob();
+    expect(result.skipped).toBeUndefined();
+    expect(result.prUrl).toBe('https://github.com/x/pr/1');
+  });
+
   it('skips entirely when env credentials are missing', async () => {
     vi.stubEnv('GITHUB_TOKEN', '');
     const { runWgSlackContextJob } = await import('../../src/addie/jobs/wg-slack-context.js');


### PR DESCRIPTION
## Summary

Follow-up to #5811, found while verifying the first prod run after the `GITHUB_TOKEN` upgrade. The scheduler's business-hours gate **silently skips** ticks (`scheduler.ts` `runJob`), and `setInterval` anchors tick time to whenever the app booted. A 24h-interval job registered with a 9–17 ET window therefore never runs if the machines boot outside the window — which is exactly what happened: tonight's secret-set restart anchored the daily tick at ~23:45 ET, permanently outside the gate. (Existing 24h+window jobs like `profile-completion-nudge` survive this only because frequent deploys keep re-anchoring their ticks during working hours.)

## Fix

- Interval 24h → **1h** (the shape `wg-digest` uses: hourly tick, internal cadence logic).
- The job dedups itself to one refresh per day: if a digest with today's `Generated:` date already exists on the PR branch or on `main`, the tick is a no-op (`skipped: 'already-ran-today'`) before any Slack or LLM call.
- Registration comment documents the trap so the next 24h+window job doesn't reintroduce it.

## Test plan

- [x] 2 new unit tests: same-day dedup short-circuits before Slack/LLM calls; prior-day digest proceeds to a refresh.
- [x] All 16 tests in the two suites pass; `tsc --noEmit` clean; precommit on commit.
- [ ] Prod: first digest PR appears on `addie/wg-slack-context` during today's 9–17 ET window after this deploys.

No changeset — Addie server work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)