### PR TITLE
feat(governance): move Argus and server GitHub writes to the AAO Secretariat App identity

### DIFF
--- a/.agents/playbook.md
+++ b/.agents/playbook.md
@@ -514,6 +514,8 @@ Cutting 3.1.0 ends the 3.0.x ↔ main divergence and starts a new 3.0.x → 3.1.
 
 `release.yml`, `release-docs.yml`, and `forward-merge-3.0.yml` mint a GitHub App installation token via `actions/create-github-app-token@v3` (secrets `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) instead of using the default `GITHUB_TOKEN`. App-token-triggered events (push, PR open, release publish) DO fire downstream workflows; `GITHUB_TOKEN`-triggered events don't (GitHub's recursion-blocking rule). Without this swap, the Version Packages PR's required CI never fires, the release-docs snapshot is never created on `release: published`, and the auto-snapshot PR's required CI never fires either.
 
+Two Apps, two trust surfaces: release machinery uses the release App above; the Secretariat (Argus reviews in `ai-review.yml`, server-side GitHub writes from Addie jobs) uses the **AAO Secretariat** App (`aao-secretariat[bot]`, secrets `SECRETARIAT_APP_ID` / `SECRETARIAT_APP_PRIVATE_KEY` — Actions secrets for the workflow, Fly secrets for the server). Server code mints installation tokens through `server/src/addie/jobs/github-app-token.ts`; `resolveGitHubToken()` is the single seam, and a configured-but-failing App fails closed rather than falling back to a PAT.
+
 #### Runbooks
 
 - `.agents/shortcuts/cut-patch.md` — cutting a `3.0.X` patch

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,20 +1,21 @@
 name: AI PR Review (Argus)
 
-# Argus is an LLM PR reviewer that posts an `--approve`, `--comment`, or
-# `--request-changes` review on every non-dependabot PR. It reads the diff,
-# delegates to AdCP subagents when relevant (ad-tech-protocol-expert,
-# security-reviewer, code-reviewer, etc.), and writes the review in
-# bokelley's voice.
+# Argus is the AAO Secretariat's review desk: an LLM PR reviewer that posts
+# an `--approve`, `--comment`, or `--request-changes` review on every
+# non-dependabot PR. It reads the diff, delegates to AdCP subagents when
+# relevant (ad-tech-protocol-expert, security-reviewer, code-reviewer,
+# etc.), and applies the WG constitution (.agents/wg/constitution.md) and
+# decision records (governance/decisions/).
 #
-# Reviews are posted as the AAO release/triage GitHub App, so they count
+# Reviews are posted as the AAO Secretariat GitHub App, so they count
 # toward the "1 review required" branch-protection check the same way a
-# human approval does. The same App is used for changeset releases — its
-# pull_requests:write scope already exists.
+# human approval does. Release machinery (changeset releases, forward
+# merges) stays on the separate release App — distinct trust surfaces.
 #
 # Required secrets:
-#   RELEASE_APP_ID           — GitHub App ID (already configured)
-#   RELEASE_APP_PRIVATE_KEY  — GitHub App private key PEM (already configured)
-#   ANTHROPIC_API_KEY        — Anthropic API key for claude-code-action
+#   SECRETARIAT_APP_ID          — AAO Secretariat GitHub App ID
+#   SECRETARIAT_APP_PRIVATE_KEY — AAO Secretariat App private key PEM
+#   ANTHROPIC_API_KEY           — Anthropic API key for claude-code-action
 #
 # Branch-protection assumption: "Require approval of the most recent
 # reviewable push" MUST be enabled on `main`. The bot's approval is
@@ -41,9 +42,9 @@ on:
 # Bot login that posts Argus reviews. Verifier pins on this to avoid
 # treating reviews from other bots (changesets-release[bot] etc.) as
 # Argus's. The App's user login in `pulls/<n>/reviews` includes the
-# `[bot]` suffix (`user.login: "aao-release-bot[bot]"`, `user.type: "Bot"`).
+# `[bot]` suffix (`user.login: "aao-secretariat[bot]"`, `user.type: "Bot"`).
 env:
-  ARGUS_BOT_LOGIN: aao-release-bot[bot]
+  ARGUS_BOT_LOGIN: aao-secretariat[bot]
 
 jobs:
   code_review:
@@ -76,8 +77,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SECRETARIAT_APP_ID }}
+          private-key: ${{ secrets.SECRETARIAT_APP_PRIVATE_KEY }}
 
       # ─────────────────────────────────────────────────────────────────────
       # Route PR classes Argus should not try to review.

--- a/server/src/addie/jobs/github-app-token.ts
+++ b/server/src/addie/jobs/github-app-token.ts
@@ -1,0 +1,128 @@
+/**
+ * AAO Secretariat GitHub App authentication.
+ *
+ * Mints short-lived installation tokens from the Secretariat GitHub App
+ * credentials (SECRETARIAT_APP_ID + SECRETARIAT_APP_PRIVATE_KEY) so
+ * server-side GitHub writes author as `aao-secretariat[bot]` instead of
+ * a personal PAT. `resolveGitHubToken()` is the single seam callers use:
+ * App token when the App is configured, legacy GITHUB_TOKEN PAT during
+ * migration, null when neither exists. When the App IS configured, a
+ * mint failure fails closed — it never silently degrades to the PAT.
+ */
+
+import { createSign } from 'node:crypto';
+import { createLogger } from '../../logger.js';
+
+const logger = createLogger('github-app-token');
+
+const API_TIMEOUT_MS = 10_000;
+/** Refresh the cached installation token when under 5 minutes remain. */
+const EXPIRY_BUFFER_MS = 5 * 60_000;
+
+let cachedToken: { token: string; expiresAtMs: number } | null = null;
+let cachedInstallationId: number | null = null;
+
+/** Test seam: clear module-level caches between test cases. */
+export function resetGitHubAppTokenCache(): void {
+  cachedToken = null;
+  cachedInstallationId = null;
+}
+
+export function isSecretariatAppConfigured(): boolean {
+  return Boolean(process.env.SECRETARIAT_APP_ID && process.env.SECRETARIAT_APP_PRIVATE_KEY);
+}
+
+function base64url(input: Buffer | string): string {
+  return Buffer.from(input)
+    .toString('base64')
+    .replace(/=+$/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+/**
+ * Short-lived app JWT (RS256, self-signed with the App private key).
+ * iat is backdated 60s per GitHub's clock-drift guidance.
+ */
+function mintAppJwt(appId: string, privateKey: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify({ iat: now - 60, exp: now + 540, iss: appId }));
+  const signer = createSign('RSA-SHA256');
+  signer.update(`${header}.${payload}`);
+  return `${header}.${payload}.${base64url(signer.sign(privateKey))}`;
+}
+
+async function ghFetch(url: string, bearer: string, init?: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${bearer}`,
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'aao-secretariat/1.0',
+      },
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function lookupInstallationId(jwt: string): Promise<number> {
+  if (cachedInstallationId !== null) return cachedInstallationId;
+  const resp = await ghFetch('https://api.github.com/app/installations', jwt);
+  if (!resp.ok) {
+    throw new Error(`Secretariat App installation lookup failed: ${resp.status}`);
+  }
+  const installations = (await resp.json()) as Array<{ id: number }>;
+  if (installations.length === 0) {
+    throw new Error('Secretariat App has no installations');
+  }
+  // The App is installed on exactly one account (the org) by design.
+  cachedInstallationId = installations[0].id;
+  return cachedInstallationId;
+}
+
+async function mintInstallationToken(): Promise<string> {
+  if (cachedToken && cachedToken.expiresAtMs - Date.now() > EXPIRY_BUFFER_MS) {
+    return cachedToken.token;
+  }
+  const appId = process.env.SECRETARIAT_APP_ID!;
+  // Tolerate PEMs stored with escaped newlines (common env-var mangling).
+  const privateKey = process.env.SECRETARIAT_APP_PRIVATE_KEY!.replace(/\\n/g, '\n');
+  const jwt = mintAppJwt(appId, privateKey);
+  const installationId = await lookupInstallationId(jwt);
+  const resp = await ghFetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    jwt,
+    { method: 'POST' }
+  );
+  if (!resp.ok) {
+    const err = await resp.text().catch(() => '');
+    throw new Error(`Secretariat App token mint failed: ${resp.status} ${err}`);
+  }
+  const data = (await resp.json()) as { token: string; expires_at: string };
+  cachedToken = { token: data.token, expiresAtMs: Date.parse(data.expires_at) };
+  return data.token;
+}
+
+/**
+ * The GitHub credential every server-side GitHub write should use.
+ * Returns null when no credential is available or the configured App
+ * fails to mint (fail closed — callers already treat null as "cannot
+ * write to GitHub right now").
+ */
+export async function resolveGitHubToken(): Promise<string | null> {
+  if (isSecretariatAppConfigured()) {
+    try {
+      return await mintInstallationToken();
+    } catch (err) {
+      logger.error({ err }, 'Secretariat App token mint failed; failing closed');
+      return null;
+    }
+  }
+  return process.env.GITHUB_TOKEN || null;
+}

--- a/server/src/addie/jobs/github-filer.ts
+++ b/server/src/addie/jobs/github-filer.ts
@@ -7,6 +7,7 @@
 
 import { createLogger } from '../../logger.js';
 import { redactSupportSecrets } from '../../services/support-redaction.js';
+import { resolveGitHubToken } from './github-app-token.js';
 
 const logger = createLogger('github-filer');
 
@@ -25,14 +26,15 @@ export interface FiledIssue {
 }
 
 /**
- * Create a GitHub issue using the GITHUB_TOKEN env var. Returns null on
- * any failure (missing token, HTTP error, network error) so callers can
- * keep the escalation open without swallowing the exception.
+ * Create a GitHub issue via resolveGitHubToken() (Secretariat App token
+ * when configured, legacy PAT otherwise). Returns null on any failure
+ * (missing credential, HTTP error, network error) so callers can keep
+ * the escalation open without swallowing the exception.
  */
 export async function fileGitHubIssue(input: FileIssueInput): Promise<FiledIssue | null> {
-  const token = process.env.GITHUB_TOKEN;
+  const token = await resolveGitHubToken();
   if (!token) {
-    logger.warn('GITHUB_TOKEN not set; cannot file issue');
+    logger.warn('No GitHub credential available; cannot file issue');
     return null;
   }
 

--- a/server/src/addie/jobs/github-pr.ts
+++ b/server/src/addie/jobs/github-pr.ts
@@ -1,13 +1,15 @@
 /**
  * GitHub single-file PR helper.
  *
- * Creates or refreshes a one-file pull request via the GitHub REST API
- * using the GITHUB_TOKEN env var (same auth seam as github-filer). The
- * working branch is force-reset to the base branch head on every call,
- * so the PR diff is always exactly "base + this file change".
+ * Creates or refreshes a one-file pull request via the GitHub REST API,
+ * authenticated through resolveGitHubToken() (Secretariat App token when
+ * configured, legacy PAT otherwise). The working branch is force-reset
+ * to the base branch head on every call, so the PR diff is always
+ * exactly "base + this file change".
  */
 
 import { createLogger } from '../../logger.js';
+import { resolveGitHubToken } from './github-app-token.js';
 
 const logger = createLogger('github-pr');
 
@@ -65,7 +67,7 @@ export async function getFileContent(
   ref: string,
   repo?: string
 ): Promise<string | null> {
-  const token = process.env.GITHUB_TOKEN;
+  const token = await resolveGitHubToken();
   if (!token) return null;
   const repoSlug = repo ?? process.env.GITHUB_REPO ?? 'adcontextprotocol/adcp';
   const resp = await ghFetch(
@@ -86,9 +88,9 @@ export async function getFileContent(
  * job callers can record the miss without throwing.
  */
 export async function upsertFilePr(input: UpsertFilePrInput): Promise<UpsertFilePrResult | null> {
-  const token = process.env.GITHUB_TOKEN;
+  const token = await resolveGitHubToken();
   if (!token) {
-    logger.warn('GITHUB_TOKEN not set; cannot open PR');
+    logger.warn('No GitHub credential available; cannot open PR');
     return null;
   }
   const repo = input.repo ?? process.env.GITHUB_REPO ?? 'adcontextprotocol/adcp';

--- a/server/tests/unit/github-app-token.test.ts
+++ b/server/tests/unit/github-app-token.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { generateKeyPairSync } from 'node:crypto';
+
+const fetchMock = vi.fn();
+
+const { privateKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function futureIso(minutes: number): string {
+  return new Date(Date.now() + minutes * 60_000).toISOString();
+}
+
+describe('resolveGitHubToken', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('SECRETARIAT_APP_ID', '');
+    vi.stubEnv('SECRETARIAT_APP_PRIVATE_KEY', '');
+    vi.stubEnv('GITHUB_TOKEN', '');
+    const { resetGitHubAppTokenCache } = await import('../../src/addie/jobs/github-app-token.js');
+    resetGitHubAppTokenCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('returns the legacy PAT when the App is not configured', async () => {
+    vi.stubEnv('GITHUB_TOKEN', 'pat-token');
+    const { resolveGitHubToken } = await import('../../src/addie/jobs/github-app-token.js');
+    await expect(resolveGitHubToken()).resolves.toBe('pat-token');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when neither credential exists', async () => {
+    const { resolveGitHubToken } = await import('../../src/addie/jobs/github-app-token.js');
+    await expect(resolveGitHubToken()).resolves.toBeNull();
+  });
+
+  it('mints an installation token when the App is configured', async () => {
+    vi.stubEnv('SECRETARIAT_APP_ID', '4234645');
+    vi.stubEnv('SECRETARIAT_APP_PRIVATE_KEY', privateKey);
+    fetchMock
+      .mockResolvedValueOnce(json([{ id: 77 }])) // GET /app/installations
+      .mockResolvedValueOnce(json({ token: 'ghs_minted', expires_at: futureIso(60) }, 201));
+
+    const { resolveGitHubToken } = await import('../../src/addie/jobs/github-app-token.js');
+    await expect(resolveGitHubToken()).resolves.toBe('ghs_minted');
+
+    // Both calls authenticate with a three-segment app JWT.
+    for (const call of fetchMock.mock.calls) {
+      const auth = (call[1].headers as Record<string, string>).Authorization;
+      expect(auth.replace('Bearer ', '').split('.')).toHaveLength(3);
+    }
+    expect(fetchMock.mock.calls[1][0]).toContain('/app/installations/77/access_tokens');
+  });
+
+  it('caches the installation token until near expiry', async () => {
+    vi.stubEnv('SECRETARIAT_APP_ID', '4234645');
+    vi.stubEnv('SECRETARIAT_APP_PRIVATE_KEY', privateKey);
+    fetchMock
+      .mockResolvedValueOnce(json([{ id: 77 }]))
+      .mockResolvedValueOnce(json({ token: 'ghs_minted', expires_at: futureIso(60) }, 201));
+
+    const { resolveGitHubToken } = await import('../../src/addie/jobs/github-app-token.js');
+    await resolveGitHubToken();
+    await expect(resolveGitHubToken()).resolves.toBe('ghs_minted');
+    expect(fetchMock).toHaveBeenCalledTimes(2); // no extra calls for the second resolve
+  });
+
+  it('re-mints when the cached token is near expiry', async () => {
+    vi.stubEnv('SECRETARIAT_APP_ID', '4234645');
+    vi.stubEnv('SECRETARIAT_APP_PRIVATE_KEY', privateKey);
+    fetchMock
+      .mockResolvedValueOnce(json([{ id: 77 }]))
+      .mockResolvedValueOnce(json({ token: 'ghs_old', expires_at: futureIso(2) }, 201))
+      .mockResolvedValueOnce(json({ token: 'ghs_new', expires_at: futureIso(60) }, 201));
+
+    const { resolveGitHubToken } = await import('../../src/addie/jobs/github-app-token.js');
+    await expect(resolveGitHubToken()).resolves.toBe('ghs_old');
+    await expect(resolveGitHubToken()).resolves.toBe('ghs_new');
+  });
+
+  it('fails closed (null, not PAT) when the configured App cannot mint', async () => {
+    vi.stubEnv('SECRETARIAT_APP_ID', '4234645');
+    vi.stubEnv('SECRETARIAT_APP_PRIVATE_KEY', privateKey);
+    vi.stubEnv('GITHUB_TOKEN', 'pat-token');
+    fetchMock.mockResolvedValueOnce(json({ message: 'nope' }, 401));
+
+    const { resolveGitHubToken } = await import('../../src/addie/jobs/github-app-token.js');
+    await expect(resolveGitHubToken()).resolves.toBeNull();
+  });
+
+  it('tolerates PEMs stored with escaped newlines', async () => {
+    vi.stubEnv('SECRETARIAT_APP_ID', '4234645');
+    vi.stubEnv('SECRETARIAT_APP_PRIVATE_KEY', privateKey.replace(/\n/g, '\\n'));
+    fetchMock
+      .mockResolvedValueOnce(json([{ id: 77 }]))
+      .mockResolvedValueOnce(json({ token: 'ghs_minted', expires_at: futureIso(60) }, 201));
+
+    const { resolveGitHubToken } = await import('../../src/addie/jobs/github-app-token.js');
+    await expect(resolveGitHubToken()).resolves.toBe('ghs_minted');
+  });
+});


### PR DESCRIPTION
## Summary

Completes the personification decision from `specs/spec-guardian.md`: all Secretariat output on GitHub now authors as **`aao-secretariat[bot]`** (App ID 4234645), while `aao-release-bot` returns to being purely release machinery — two Apps, two trust surfaces.

## Changes

- **`.github/workflows/ai-review.yml`** — App-token step mints from `SECRETARIAT_APP_ID` / `SECRETARIAT_APP_PRIVATE_KEY`; `ARGUS_BOT_LOGIN` → `aao-secretariat[bot]` (review verification and re-run-skip pin on it). The release-PR classification at the `PR_AUTHOR == "aao-release-bot[bot]"` check intentionally stays on the release App — that's who authors Version Packages PRs. Header comment updated (it still described Argus as reviewing "in bokelley's voice" — stale since #5808).
- **`server/src/addie/jobs/github-app-token.ts`** (new) — mints hour-lived installation tokens: RS256 app JWT via `node:crypto` (no new dependency), installation lookup + token cache with a 5-minute expiry buffer, escaped-newline PEM tolerance. `resolveGitHubToken()` is the single seam: Secretariat App token when configured, legacy `GITHUB_TOKEN` PAT during migration, **fail-closed (null, never PAT fallback) when a configured App cannot mint**.
- **`github-pr.ts` / `github-filer.ts`** — swap direct `GITHUB_TOKEN` reads for `resolveGitHubToken()`. Digest refresh PRs and knowledge-gap issues author as the bot once Fly secrets land.
- **`.agents/playbook.md`** — §App-token convention documents the two-App split.

## Merge sequencing (important)

**Do not merge until the `SECRETARIAT_APP_*` Actions secrets exist on this repo** — after merge, the next Argus run mints from them, and missing secrets means no reviews. Server-side behavior is safe either way: without Fly secrets it keeps using the PAT; with them it switches to the App.

Retirement path once the first bot-authored digest PR is verified: `fly secrets unset GITHUB_TOKEN -a adcp-docs` — at that point no long-lived GitHub credential exists anywhere in the system.

## Test plan

- [x] 7 new unit tests for the token module (PAT passthrough, null when unconfigured, mint + JWT shape, caching, expiry re-mint, fail-closed on mint failure, escaped-newline PEM). All 23 tests across the three touched suites pass.
- [x] `tsc --noEmit` clean; workflow YAML parse validated; precommit suite on commit.
- [ ] Post-merge: first Argus review posts as `aao-secretariat[bot]` and counts toward required review.
- [ ] Post-Fly-secrets: digest refresh PR authors as `aao-secretariat[bot]`.

No changeset — CI/agent infrastructure and Addie server work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)