### PR TITLE
fix(delivery-metrics): allow null for video-only metrics (quartile_data, completion_rate)

### DIFF
--- a/.changeset/allow-null-video-delivery-metrics.md
+++ b/.changeset/allow-null-video-delivery-metrics.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": minor
+---
+
+Allow `null` for video-only delivery metrics (`quartile_data`, `completion_rate`). Sellers running non-video inventory (display, audio-only, DOOH-without-video) legitimately have no value for these metrics, and returning `null` is the correct "not applicable" signal. The schema previously required `type: "number"` / `type: "object"` and rejected `null`, causing receivers to fail validation on every valid display-inventory delivery report.
+
+`delivery-metrics.json` (`totals` / `by_package[]`) now accepts `["number", "null"]` for `completion_rate` and `["object", "null"]` for `quartile_data`; `get-media-buy-delivery-response.json` `aggregated_totals.completion_rate` gets the same loosening so the aggregate path can't re-trigger the failure. The `minimum`/`maximum` constraints on `completion_rate` still apply to non-null values, and the type stays narrowed to null (no strings/arrays). Every other delivery metric continues to signal "not applicable" by omission, not `null` — this exception is scoped to the two video-only fields. Spec-loosening for the receiver contract: producers already sending numbers/objects remain valid.
+
+The separate inline `completion_rate` in `report-plan-outcome-request.json` (a governance self-report block, not on the `get_media_buy_delivery` path) is intentionally left unchanged.

--- a/docs/creative/task-reference/get_creative_delivery.mdx
+++ b/docs/creative/task-reference/get_creative_delivery.mdx
@@ -64,8 +64,8 @@ Fields available on both `creative.totals` and each `variant` entry. Commonly-us
 | `cost_per_click` | Cost per click (spend/clicks) |
 | `views` | Billable views — threshold varies by format and pricing model |
 | `completed_views` | Video/audio completions |
-| `completion_rate` | Completion rate (completed_views/impressions) |
-| `quartile_data` | Audio/video quartile completion data — object with `q1_views`, `q2_views`, `q3_views`, `q4_views` |
+| `completion_rate` | Completion rate (completed_views/impressions); `null` when not applicable (e.g. a non-video buy) |
+| `quartile_data` | Audio/video quartile completion data — object with `q1_views`, `q2_views`, `q3_views`, `q4_views`; `null` when not applicable (e.g. a non-video buy) |
 | `reach` | Unique reach in units specified by `reach_unit`. Measurement window declared via `reach_window`; without it, do not sum across rows |
 | `reach_unit` | Unit of measurement for `reach`; required when `reach` is present |
 | `reach_window` | Window semantics for reach/frequency — object with `kind` (`cumulative` for uniques since campaign start, `period` for non-overlapping snapshot, `rolling` for trailing window) and `period` (Duration, required for `period` and `rolling`). Optional but strongly recommended whenever `reach` is present |

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -279,7 +279,7 @@ Buyers receive the intersection of both. `impressions` and `spend` are always re
 - **`ctr`**: Click-through rate
 - **`views`**: Views at platform-defined threshold
 - **`completed_views`**: Video/audio completions (or threshold-based completion when an optimization goal sets a custom view duration)
-- **`completion_rate`**: Completion rate (`completed_views` / `impressions`)
+- **`completion_rate`**: Completion rate (`completed_views` / `impressions`); `null` when not applicable (e.g. a non-video buy)
 - **`conversions`**: Post-click or post-view conversions
 - **`conversion_value`**: Monetary value of attributed conversions
 - **`roas`**: Return on ad spend
@@ -296,7 +296,7 @@ Buyers receive the intersection of both. `impressions` and `spend` are always re
 - **`saves`**: Saves, bookmarks, playlist adds attributed to delivery (platforms vary in name — Pinterest "repins", TikTok "video_saves" — all report under this canonical key)
 - **`profile_visits`**: Visits to the brand's in-platform page
 - **`viewability`**: Viewability data (measurable_impressions, viewable_impressions, viewable_rate, viewed_seconds, standard, vendor). Separates MRC and GroupM standards. `viewed_seconds` is the average in-view duration per measurable impression — reporting-side counterpart to the `viewed_seconds` optimization goal, governed by the same `standard` threshold as `viewable_rate`. The optional `vendor` field carries a `BrandRef` so the row is self-describing — buyer agents reading delivery in isolation can attribute the numbers to a measurement vendor without joining back to `package.committed_metrics` or `package.performance_standards`.
-- **`quartile_data`**: Video quartile completion data (q1-q4)
+- **`quartile_data`**: Video quartile completion data (q1-q4); `null` when not applicable (e.g. a non-video buy)
 - **`dooh_metrics`**: DOOH-specific metrics (loop plays, screens, venue breakdown)
 - **`cost_per_click`**: Cost per click (`spend / clicks`)
 - **`cost_per_completed_view`**: Cost per completed view (`spend / completed_views`); CPCV pricing scalar for video/audio inventory
@@ -307,6 +307,8 @@ Buyers receive the intersection of both. `impressions` and `spend` are always re
 - **`plays`**: Raw play count for DOOH/broadcast inventory (mirrors `forecastable-metric.plays`); distinct from `dooh_metrics.loop_plays` (per-screen rotation) and `impressions` (multiplied audience figure)
 
 Buyers can optionally request a subset via `requested_metrics` to reduce payload size and focus on relevant KPIs.
+
+For `completion_rate` and `quartile_data`, sellers MAY return `null` to signal the metric does not apply (e.g. on a non-video buy), and clients MUST accept `null` as a valid value for these two fields. Every other metric signals "not applicable" by omission — sellers omit it rather than sending `null`.
 
 #### Vendor-Defined Metrics
 

--- a/specs/spec-guardian.md
+++ b/specs/spec-guardian.md
@@ -262,7 +262,7 @@ outcome:
 - **Overturn rate per class** = decisions later reversed by a human / total. Editorial
   autonomy is already de facto (Argus approves ~85% of PRs). Normative lazy-consensus
   starts *shadow-mode*: memos posted, but Brian ratifies manually for 4 weeks; if
-  overturn <5%, flip to true lazy consensus.
+  overturn &lt;5%, flip to true lazy consensus.
 - **KPIs on the weekly report**: median time-to-decision, Brian-touches per week
   (target: trending to ~3/week), info-request response rate, decision-record coverage
   (% of merged Normative+ changes with a record).

--- a/static/schemas/source/core/delivery-metrics.json
+++ b/static/schemas/source/core/delivery-metrics.json
@@ -37,8 +37,8 @@
       "minimum": 0
     },
     "completion_rate": {
-      "type": "number",
-      "description": "Completion rate (completed_views/impressions)",
+      "type": ["number", "null"],
+      "description": "Completion rate (completed_views/impressions). Null indicates the metric is not applicable to this package/buy (e.g. completion rate on a non-video buy).",
       "minimum": 0,
       "maximum": 1
     },
@@ -183,8 +183,8 @@
       "minimum": 0
     },
     "quartile_data": {
-      "type": "object",
-      "description": "Audio/video quartile completion data",
+      "type": ["object", "null"],
+      "description": "Audio/video quartile completion data. Null indicates the metric is not applicable to this package/buy (e.g. quartile data on a non-video buy).",
       "properties": {
         "q1_views": {
           "type": "number",

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -129,8 +129,8 @@
           "minimum": 0
         },
         "completion_rate": {
-          "type": "number",
-          "description": "Aggregate completion rate across all media buys (weighted by impressions, not a simple average of per-buy rates)",
+          "type": ["number", "null"],
+          "description": "Aggregate completion rate across all media buys (weighted by impressions, not a simple average of per-buy rates). Null indicates the metric is not applicable to the aggregated buys (e.g. all non-video inventory).",
           "minimum": 0,
           "maximum": 1
         },


### PR DESCRIPTION
## Background

`get_media_buy_delivery` responses from AdCP sellers running non-video (display, audio-only, DOOH-without-video) inventory legitimately return `null` for video-only metrics — the correct "not applicable" signal per the spec's descriptions ("Video quartile completion data (q1–q4)" is meaningless for a non-video buy). But the JSON Schema required `type: "number"` / `type: "object"` and rejected `null`, so the vendored Zod schema in `@adcp/sdk` throws `WebhookPayloadValidationError` on every valid display-inventory poll response.

**Concrete impact (scope3data/agentic-api):**
- Sentry issue **AGENTIC-API-9P**, 87 events over 5 days, `WebhookPayloadValidationError` from `ingestStorefrontRoutePollReport`.
- Multi-seller blast radius: **PubX, BidMachine, Ozone, Vox** — every seller returning `null` for these video metrics on a display buy.
- Observed zod issues:
  - `media_buy_deliveries[0].totals.quartile_data` :: expected object, received null
  - `media_buy_deliveries[0].by_package[N].quartile_data` :: expected object, received null
  - `media_buy_deliveries[0].by_package[N].completion_rate` :: expected number, received null

These two fields are computed columns (`completion_rate = completed_views / impressions`), so on non-video inventory the reporting stack naturally emits `null`, not an absent key — which is why four independent sellers hit it simultaneously.

## Change

- `static/schemas/source/core/delivery-metrics.json`: `completion_rate` → `["number", "null"]`, `quartile_data` → `["object", "null"]`. `minimum`/`maximum` on `completion_rate` still apply to non-null values; the type stays narrowed to `null` (no strings/arrays).
- `static/schemas/source/media-buy/get-media-buy-delivery-response.json`: `aggregated_totals.completion_rate` gets the same loosening so the aggregate path can't re-trigger the failure on a different Zod path.
- Docs (`optimization-reporting.mdx`, `get_creative_delivery.mdx`): scope the null convention to these two fields — omission remains the canonical "not applicable" signal for every other metric.
- Changeset: `minor` (receiver-contract loosening; every existing producer payload stays valid).

The separate inline `completion_rate` in `report-plan-outcome-request.json` (governance self-report, not on the delivery path) is intentionally left unchanged.

Also includes a one-line fix escaping a bare `<` in `specs/spec-guardian.md` (`<5%` → `&lt;5%`) — a pre-existing MDX parse error that blocked the Mintlify broken-links pre-push check on any docs change.

## Tests
schemas 19/19, examples 55/55, json-schema 284/284, composed 113/113. ajv-verified: `null` accepted, valid numbers/objects accepted, out-of-range and strings rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)