### PR TITLE
fix(registry): log resolveUserAgentAuth flag-vs-row divergence instead of silent undefined

### DIFF
--- a/server/src/routes/helpers/resolve-user-agent-auth.ts
+++ b/server/src/routes/helpers/resolve-user-agent-auth.ts
@@ -76,6 +76,19 @@ export async function resolveUserAgentAuth(
         }
         return oauth;
       }
+
+      // The context row advertises a stored OAuth token (has_oauth_token is
+      // derived from `oauth_access_token_encrypted IS NOT NULL`), so GET
+      // /auth-status — which only inspects those flags via hasValidOAuthTokens
+      // — reports `has_valid_oauth: true`. Yet no usable token came back here
+      // (missing IV, a decrypt failure surfacing as null, or a row gap), so the
+      // probe would otherwise run unauthenticated and report a misleading
+      // `oauth_required`. Log the flag-vs-row divergence so the contradiction is
+      // diagnosable instead of silent (mirrors the catch-branch log below).
+      logger.warn(
+        { agentUrl, orgId, contextId: context.id },
+        'resolveUserAgentAuth: has_oauth_token set but no usable token resolved (flag-vs-row divergence)',
+      );
     }
 
     if (context.has_oauth_client_credentials) {

--- a/server/tests/unit/resolve-user-agent-auth.test.ts
+++ b/server/tests/unit/resolve-user-agent-auth.test.ts
@@ -177,6 +177,31 @@ describe('resolveUserAgentAuth', () => {
     expect(db.getOAuthClient).not.toHaveBeenCalled();
   });
 
+  it('logs a divergence warning when has_oauth_token is set but the token row is unreadable', async () => {
+    // Flag-vs-row divergence: the context row reports a stored OAuth token, so
+    // GET /auth-status (which only inspects the has_oauth_token / expiry flags
+    // via hasValidOAuthTokens) shows `has_valid_oauth: true`. But the encrypted
+    // token bytes can't be resolved into a usable credential (missing IV,
+    // decrypt failure, or a row gap), so getOAuthTokensByOrgAndUrl yields null.
+    // Today resolveUserAgentAuth silently returns undefined, so the /refresh
+    // probe runs unauthenticated and reports a misleading `oauth_required`
+    // ("no auth") while auth-status insists auth is valid — with nothing in the
+    // logs to explain the contradiction. Surface the divergence.
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
+    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx_1', has_oauth_token: true });
+    db.getOAuthTokensByOrgAndUrl.mockResolvedValueOnce(null);
+
+    const auth = await call();
+
+    expect(auth).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      // contextId rides in so the server-side row can be correlated (the
+      // maintainer's flag-vs-row SQL keys on agent_context_id).
+      expect.objectContaining({ agentUrl: URL, orgId: ORG, contextId: 'ctx_1' }),
+      expect.stringContaining('has_oauth_token set but no usable token resolved'),
+    );
+  });
+
   it('prefers static token over OAuth when both are present', async () => {
     // Symmetry with resolveOwnerAuth: a connect-form static token shortcircuits
     // the OAuth path entirely.


### PR DESCRIPTION
When an `agent_context` advertises a stored OAuth token (`has_oauth_token`), `GET /auth-status` reports `has_valid_oauth: true` from the flags alone (via `hasValidOAuthTokens`), but `/refresh` → `resolveUserAgentAuth` → `getOAuthTokensByOrgAndUrl` actually reads + decrypts. When that yields nothing usable — missing IV, a decrypt failure surfacing as `null`, or a row gap — `resolveUserAgentAuth` returns `undefined` **silently**, so the probe runs unauthenticated and reports a misleading `oauth_required` with nothing in the logs to explain the contradiction.

This adds a `logger.warn` on that flag-vs-row divergence (symmetric with the existing catch-branch log), carrying `contextId` so the row can be correlated. Observability only — no behavior change.

Repro and root-cause discussion: adcontextprotocol/adcp#5786