### PR TITLE
fix(compliance): replace hardcoded capability_id fixture value with field_present check

### DIFF
--- a/.changeset/fix-canonical-formats-fixture-checks.md
+++ b/.changeset/fix-canonical-formats-fixture-checks.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix `canonical_supported_formats` storyboard: replace hardcoded `capability_id` value assertion with `field_present` check.
+
+`creative.supported_formats[].capability_id` is an agent-local stable identifier — a free-form string that each creative agent defines independently. The storyboard incorrectly used `check: field_value` with the hardcoded value `"training_image_generation"`, causing every creative agent whose capability id differs from the fixture constant to fail this phase. The protocol schema (`get-adcp-capabilities-response.json`) defines `capability_id` as a free-form string with no enum constraint; the storyboard narrative itself states it is "agent-local". Changed to `check: field_present` so the check validates structure rather than a fixture-specific constant.
+
+Also removed a companion `field_absent` check on `creative.supported_formats[1].capability_id` whose own description identified it as a fixture constraint ("only advertises implemented canonical build paths") rather than a protocol requirement. Storyboards must not encode fixture-specific catalog shape as required validations.

--- a/static/compliance/source/protocols/creative/scenarios/canonical_supported_formats.yaml
+++ b/static/compliance/source/protocols/creative/scenarios/canonical_supported_formats.yaml
@@ -77,10 +77,9 @@ phases:
           - check: field_present
             path: "creative.supported_formats"
             description: "Creative canonical supported formats are advertised"
-          - check: field_value
+          - check: field_present
             path: "creative.supported_formats[0].capability_id"
-            value: "training_image_generation"
-            description: "The image build path has a stable local capability_id"
+            description: "The image build path has a stable agent-local capability_id"
           - check: field_value
             path: "creative.supported_formats[0].format.format_kind"
             value: "image"
@@ -91,9 +90,6 @@ phases:
           - check: field_absent
             path: "creative.supported_formats[0].format.format_option_id"
             description: "Creative-agent build routing uses capability_id, not product format_option_id"
-          - check: field_absent
-            path: "creative.supported_formats[1].capability_id"
-            description: "Storyboard fixture only advertises implemented canonical build paths"
           - check: field_value
             path: "context.correlation_id"
             value: "creative_canonical_supported_formats--get_capabilities"


### PR DESCRIPTION
## Summary

Fixes `canonical_supported_formats` storyboard: the `capability_discovery` phase incorrectly asserted a fixture-specific `capability_id` value (`"training_image_generation"`) as a required protocol validation, causing every creative agent with a different — but equally valid — capability identifier to fail compliance.

- Changed `check: field_value` (hardcoded `"training_image_generation"`) to `check: field_present` on `creative.supported_formats[0].capability_id`, so the check validates structure rather than a fixture constant.
- Removed a companion `field_absent` check on `creative.supported_formats[1].capability_id` whose own description identified it as a fixture constraint ("only advertises implemented canonical build paths"), not a protocol requirement.

`creative.supported_formats[].capability_id` is an agent-local stable identifier — a free-form string each creative agent defines independently. The protocol schema (`get-adcp-capabilities-response.json`) defines it with no enum constraint, and the storyboard narrative itself states it is "agent-local". The data flow from `context_outputs` to `$context.image_build_capability_id` in the build phase is unaffected.

Closes #5843

## Test plan

- [ ] `canonical_supported_formats` storyboard passes for a creative agent with any `capability_id` value
- [ ] `canonical_supported_formats` storyboard still correctly validates that a `capability_id` is present (structure check intact)
- [ ] `canonical_supported_formats` storyboard still validates `format.format_kind: "image"` (protocol-level assertion unchanged)
- [ ] Context output `image_build_capability_id` is captured and consumed by the subsequent build phase
- [ ] Changeset scope check passes (`patch` for `adcontextprotocol`)

---
_Generated by [Claude Code](https://claude.ai/code/session_014e3je9QrRgVQPq5VKXwd37)_