### PR TITLE
fix(registry): canonicalize agent ownership lookups

### DIFF
--- a/server/src/services/agent-ownership.ts
+++ b/server/src/services/agent-ownership.ts
@@ -28,6 +28,7 @@
  */
 
 import { query } from '../db/client.js';
+import { canonicalizeAgentUrl } from '../db/publisher-db.js';
 
 /**
  * Find the org id of any org the user is a member of that owns the agent.
@@ -41,6 +42,7 @@ export async function findOwnerOrgForUser(
   agentUrl: string,
 ): Promise<string | null> {
   try {
+    const lookupAgentUrl = canonicalizeAgentUrl(agentUrl) ?? agentUrl;
     const result = await query<{ workos_organization_id: string }>(
       `SELECT mp.workos_organization_id
        FROM member_profiles mp
@@ -49,7 +51,7 @@ export async function findOwnerOrgForUser(
        WHERE mp.agents @> $1::jsonb
          AND om.workos_user_id = $2
        LIMIT 1`,
-      [JSON.stringify([{ url: agentUrl }]), userId],
+      [JSON.stringify([{ url: lookupAgentUrl }]), userId],
     );
     return result.rows[0]?.workos_organization_id ?? null;
   } catch {
@@ -73,6 +75,7 @@ export async function isOrgOwnerOfAgent(
   agentUrl: string,
 ): Promise<boolean> {
   try {
+    const lookupAgentUrl = canonicalizeAgentUrl(agentUrl) ?? agentUrl;
     const result = await query(
       `SELECT 1 FROM member_profiles mp
        JOIN organization_memberships om
@@ -81,7 +84,7 @@ export async function isOrgOwnerOfAgent(
          AND mp.agents @> $2::jsonb
          AND om.workos_user_id = $3
        LIMIT 1`,
-      [orgId, JSON.stringify([{ url: agentUrl }]), userId],
+      [orgId, JSON.stringify([{ url: lookupAgentUrl }]), userId],
     );
     return result.rows.length > 0;
   } catch {

--- a/server/tests/unit/agent-ownership.test.ts
+++ b/server/tests/unit/agent-ownership.test.ts
@@ -53,6 +53,25 @@ describe('agent-ownership', () => {
       const result = await findOwnerOrgForUser('user_123', 'https://agent.example.com/mcp');
       expect(result).toBeNull();
     });
+
+    it('canonicalizes the lookup URL before matching stored member profile agents', async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [{ workos_organization_id: 'org_abc' }],
+        rowCount: 1,
+        command: 'SELECT',
+        oid: 0,
+        fields: [],
+      } as never);
+
+      const result = await findOwnerOrgForUser('user_123', 'HTTPS://Agent.Example.com/MCP///');
+
+      expect(result).toBe('org_abc');
+      const [, params] = queryMock.mock.calls[0];
+      expect(params).toEqual([
+        JSON.stringify([{ url: 'https://agent.example.com/mcp' }]),
+        'user_123',
+      ]);
+    });
   });
 
   describe('isOrgOwnerOfAgent', () => {
@@ -91,6 +110,26 @@ describe('agent-ownership', () => {
       queryMock.mockRejectedValueOnce(new Error('query failed'));
       const result = await isOrgOwnerOfAgent('org_abc', 'user_123', 'https://agent.example.com/mcp');
       expect(result).toBe(false);
+    });
+
+    it('canonicalizes the lookup URL before confirming a specific owning org', async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [{ '?column?': 1 }],
+        rowCount: 1,
+        command: 'SELECT',
+        oid: 0,
+        fields: [],
+      } as never);
+
+      const result = await isOrgOwnerOfAgent('org_abc', 'user_123', 'HTTPS://Agent.Example.com/MCP///');
+
+      expect(result).toBe(true);
+      const [, params] = queryMock.mock.calls[0];
+      expect(params).toEqual([
+        'org_abc',
+        JSON.stringify([{ url: 'https://agent.example.com/mcp' }]),
+        'user_123',
+      ]);
     });
   });
 


### PR DESCRIPTION
Fixes #5786.

This canonicalizes agent URLs inside the shared ownership helpers before JSONB containment lookups, so refresh/auth-gated paths can find stored canonical member-profile agents even when callers send uppercase hosts or trailing slashes. It adds regression coverage for both ownership helper variants.

Validation: `npx vitest run --config server/vitest.config.ts server/tests/unit/agent-ownership.test.ts`, `npm run typecheck`, `npm run precommit:server-unit`, and the normal commit hook passed on retry. Attempted `npx vitest run --config server/vitest.config.ts server/tests/integration/registry-api-agent-refresh.test.ts`, but the local DB port refused connections before tests ran.