### PR TITLE
fix(registry): authenticate OAuth probes during discovery

### DIFF
--- a/server/src/services/sdk-auth-adapter.ts
+++ b/server/src/services/sdk-auth-adapter.ts
@@ -74,7 +74,10 @@ export async function adaptAuthForSdk(
  * authenticated probe / discovery / health calls. Bearer maps to
  * `auth_token`; basic maps to a pre-encoded `Authorization: Basic …`
  * header; oauth maps to the `oauth_tokens` + `oauth_client` shape the
- * SDK refreshes on 401.
+ * SDK refreshes on 401. For oauth, also duplicate the current access token
+ * into `auth_token`: @adcp/sdk runs MCP/A2A endpoint discovery before it
+ * attaches the OAuth provider, and that discovery preflight only reads the
+ * bearer field.
  */
 export type AgentConfigAuthFields = {
   auth_token?: string;
@@ -97,7 +100,10 @@ export function agentConfigAuthFields(auth: SdkAuth | undefined): AgentConfigAut
       return { headers: { Authorization: `Basic ${encoded}` } };
     }
     case 'oauth': {
-      const fields: AgentConfigAuthFields = { oauth_tokens: auth.tokens };
+      const fields: AgentConfigAuthFields = {
+        auth_token: auth.tokens.access_token,
+        oauth_tokens: auth.tokens,
+      };
       if (auth.client) fields.oauth_client = auth.client;
       return fields;
     }

--- a/server/tests/unit/sdk-auth-adapter.test.ts
+++ b/server/tests/unit/sdk-auth-adapter.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { agentConfigAuthFields } from '../../src/services/sdk-auth-adapter.js';
+
+describe('agentConfigAuthFields', () => {
+  it('maps bearer auth to the SDK auth_token field', () => {
+    expect(agentConfigAuthFields({ type: 'bearer', token: 'static-token' })).toEqual({
+      auth_token: 'static-token',
+    });
+  });
+
+  it('maps basic auth to an Authorization header without a competing bearer token', () => {
+    expect(agentConfigAuthFields({ type: 'basic', username: 'user', password: 'pass' })).toEqual({
+      headers: { Authorization: `Basic ${Buffer.from('user:pass').toString('base64')}` },
+    });
+  });
+
+  it('duplicates oauth access_token into auth_token for SDK endpoint discovery', () => {
+    const auth = {
+      type: 'oauth' as const,
+      tokens: {
+        access_token: 'fresh-access-token',
+        refresh_token: 'refresh-token',
+        expires_at: '2030-01-01T00:00:00.000Z',
+      },
+      client: {
+        client_id: 'client-id',
+        client_secret: 'client-secret',
+      },
+    };
+
+    expect(agentConfigAuthFields(auth)).toEqual({
+      auth_token: 'fresh-access-token',
+      oauth_tokens: auth.tokens,
+      oauth_client: auth.client,
+    });
+  });
+
+  it('duplicates oauth access_token even when no OAuth client is saved', () => {
+    const auth = {
+      type: 'oauth' as const,
+      tokens: {
+        access_token: 'fresh-access-token',
+        refresh_token: 'refresh-token',
+      },
+    };
+
+    expect(agentConfigAuthFields(auth)).toEqual({
+      auth_token: 'fresh-access-token',
+      oauth_tokens: auth.tokens,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes OAuth-protected registry probes by copying the saved OAuth access token into the SDK `auth_token` field used during endpoint discovery, while preserving `oauth_tokens` and `oauth_client` for refresh-capable calls. Adds unit coverage for bearer, basic, OAuth with a saved client, and OAuth without a saved client. Validated with targeted Vitest coverage, `npm run typecheck`, and push-time version/changeset policy checks. Fixes #5786.
