### PR TITLE
feat(training-agent): add publisher_domain filter to get_products

### DIFF
--- a/.changeset/training-agent-publisher-domain-filter.md
+++ b/.changeset/training-agent-publisher-domain-filter.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `publisher_domain` filter to `get_products`: buyers can now filter products by publisher domain, returning only products whose `publisher_properties` include an exact match for the specified domain. The training agent enforces this filter at runtime, and the schema documents the expected matching semantics (exact match, no subdomain expansion).

--- a/dist/schemas/3.1.0/core/product-filters.json
+++ b/dist/schemas/3.1.0/core/product-filters.json
@@ -513,6 +513,10 @@
         [{ "vendor": { "domain": "attentionvendor.example" } }, { "vendor": { "domain": "secondattentionvendor.example" } }]
       ]
     },
+    "publisher_domain": {
+      "type": "string",
+      "description": "Filter to products whose publisher_properties include the specified publisher domain. A product matches when at least one publisher_properties entry targets this domain exactly. Use for domain-aware product discovery — 'which products from this seller cover bbc.com?' Buyers receive exactly the products whose declared coverage includes the requested domain; subdomain matching is not applied. For storefront-level domain discovery (which sellers cover a domain at all), use the publisherDomain filter on the storefront list endpoint instead."
+    },
     "keywords": {
       "type": "array",
       "description": "Filter by keyword relevance for search and retail media platforms. Returns products that support keyword targeting for these terms. Allows the sell-side agent to assess keyword availability and recommend appropriate products. Use match_type to indicate the desired precision.",

--- a/dist/schemas/3.1.0/core/product-filters.json
+++ b/dist/schemas/3.1.0/core/product-filters.json
@@ -513,10 +513,6 @@
         [{ "vendor": { "domain": "attentionvendor.example" } }, { "vendor": { "domain": "secondattentionvendor.example" } }]
       ]
     },
-    "publisher_domain": {
-      "type": "string",
-      "description": "Filter to products whose publisher_properties include the specified publisher domain. A product matches when at least one publisher_properties entry targets this domain exactly. Use for domain-aware product discovery — 'which products from this seller cover bbc.com?' Buyers receive exactly the products whose declared coverage includes the requested domain; subdomain matching is not applied. For storefront-level domain discovery (which sellers cover a domain at all), use the publisherDomain filter on the storefront list endpoint instead."
-    },
     "keywords": {
       "type": "array",
       "description": "Filter by keyword relevance for search and retail media platforms. Returns products that support keyword targeting for these terms. Allows the sell-side agent to assess keyword availability and recommend appropriate products. Use match_type to indicate the desired precision.",

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2942,6 +2942,14 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
         );
       });
     }
+    const publisherDomainFilter = (req.filters as { publisher_domain?: string }).publisher_domain;
+    if (publisherDomainFilter) {
+      products = products.filter(p =>
+        p.publisher_properties?.some(
+          (pp: { publisher_domain?: string }) => pp.publisher_domain === publisherDomainFilter,
+        ),
+      );
+    }
   }
   const filteredProducts = products;
 

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -21,6 +21,7 @@ import { mergeSeedProduct } from '@adcp/sdk/testing';
 import { isDatabaseInitialized, getPool } from '../db/client.js';
 import { createLogger } from '../logger.js';
 import { isPrivateHostname, safeFetchAxiosLike } from '../utils/url-security.js';
+import { canonicalizePublisherDomain } from '../services/publisher-domain.js';
 import type { TrainingContext, CatalogProduct, MediaBuyState, MediaBuyAvailableActionState, MediaBuyProductAllowedActionState, PackageState, SignalActivationState, CreativeState, CreativeManifest, ToolArgs, ListReference, PackageTargeting, AccountRef, SessionState } from './types.js';
 import { encodeOffsetCursor, decodeOffsetCursor } from './pagination.js';
 import type {
@@ -2943,11 +2944,20 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
       });
     }
     const publisherDomainFilter = (req.filters as { publisher_domain?: string }).publisher_domain;
-    if (publisherDomainFilter) {
+    if (typeof publisherDomainFilter === 'string' && publisherDomainFilter) {
+      const canonicalDomain = canonicalizePublisherDomain(publisherDomainFilter);
       products = products.filter(p =>
-        p.publisher_properties?.some(
-          (pp: { publisher_domain?: string }) => pp.publisher_domain === publisherDomainFilter,
-        ),
+        p.publisher_properties?.some((pp: { publisher_domain?: string; publisher_domains?: string[] }) => {
+          if (typeof pp.publisher_domain === 'string') {
+            return canonicalizePublisherDomain(pp.publisher_domain) === canonicalDomain;
+          }
+          if (Array.isArray(pp.publisher_domains)) {
+            return pp.publisher_domains.some(
+              (d: unknown) => typeof d === 'string' && canonicalizePublisherDomain(d) === canonicalDomain,
+            );
+          }
+          return false;
+        }),
       );
     }
   }

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1497,6 +1497,31 @@ describe('get_products handler', () => {
     }
   });
 
+  it('filters by publisher_domain', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const targetDomain = PUBLISHERS[0].domain;
+    const { result } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'wholesale',
+      filters: { publisher_domain: targetDomain },
+    });
+
+    const products = result.products as Array<{ publisher_properties: Array<{ publisher_domain: string }> }>;
+    expect(products.length).toBeGreaterThan(0);
+    for (const p of products) {
+      expect(p.publisher_properties.some(pp => pp.publisher_domain === targetDomain)).toBe(true);
+    }
+  });
+
+  it('returns empty list when publisher_domain matches no products', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'wholesale',
+      filters: { publisher_domain: 'no-such-publisher.example' },
+    });
+
+    expect((result.products as unknown[]).length).toBe(0);
+  });
+
   it('keeps fixed-price filtering when brief mode falls back to suggestions', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { result } = await simulateCallTool(server, 'get_products', {

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1505,11 +1505,52 @@ describe('get_products handler', () => {
       filters: { publisher_domain: targetDomain },
     });
 
-    const products = result.products as Array<{ publisher_properties: Array<{ publisher_domain: string }> }>;
+    const products = result.products as Array<{ publisher_properties?: Array<{ publisher_domain?: string; publisher_domains?: string[] }> }>;
     expect(products.length).toBeGreaterThan(0);
-    for (const p of products) {
-      expect(p.publisher_properties.some(pp => pp.publisher_domain === targetDomain)).toBe(true);
-    }
+    expect(products.every(p =>
+      p.publisher_properties?.some(pp =>
+        pp.publisher_domain?.toLowerCase() === targetDomain.toLowerCase() ||
+        pp.publisher_domains?.some(d => d.toLowerCase() === targetDomain.toLowerCase()),
+      ),
+    )).toBe(true);
+  });
+
+  it('matches publisher_domain case-insensitively', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const targetDomain = PUBLISHERS[0].domain;
+    const { result } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'wholesale',
+      filters: { publisher_domain: targetDomain.toUpperCase() },
+    });
+
+    expect((result.products as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it('filters by publisher_domain using plural publisher_domains array form', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'pluraltest.example' } };
+
+    const seed = await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      brand: { domain: 'pluraltest.example' },
+      scenario: 'seed_product',
+      params: {
+        product_id: 'plural_domain_product',
+        fixture: {
+          publisher_properties: [{ publisher_domains: ['plural-publisher.example'], selection_type: 'all' }],
+        },
+      },
+    });
+    expect(seed.result.success).toBe(true);
+
+    const { result } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'wholesale',
+      account,
+      filters: { publisher_domain: 'plural-publisher.example' },
+    });
+
+    const products = result.products as Array<{ product_id: string }>;
+    expect(products.some(p => p.product_id === 'plural_domain_product')).toBe(true);
   });
 
   it('returns empty list when publisher_domain matches no products', async () => {
@@ -1519,6 +1560,7 @@ describe('get_products handler', () => {
       filters: { publisher_domain: 'no-such-publisher.example' },
     });
 
+    expect(Array.isArray(result.products)).toBe(true);
     expect((result.products as unknown[]).length).toBe(0);
   });
 

--- a/static/schemas/source/core/product-filters.json
+++ b/static/schemas/source/core/product-filters.json
@@ -513,6 +513,10 @@
         [{ "vendor": { "domain": "attentionvendor.example" } }, { "vendor": { "domain": "secondattentionvendor.example" } }]
       ]
     },
+    "publisher_domain": {
+      "type": "string",
+      "description": "Filter to products whose publisher_properties include the specified publisher domain. A product matches when at least one publisher_properties entry targets this domain exactly. Use for domain-aware product discovery — 'which products from this seller cover bbc.com?' Buyers receive exactly the products whose declared coverage includes the requested domain; subdomain matching is not applied. For storefront-level domain discovery (which sellers cover a domain at all), use the publisherDomain filter on the storefront list endpoint instead."
+    },
     "keywords": {
       "type": "array",
       "description": "Filter by keyword relevance for search and retail media platforms. Returns products that support keyword targeting for these terms. Allows the sell-side agent to assess keyword availability and recommend appropriate products. Use match_type to indicate the desired precision.",


### PR DESCRIPTION
## Why
Buyers need to discover which products from a given seller cover a specific publisher domain (e.g. \"which products cover bbc.com?\"). Without a filter, they'd have to fetch all products and inspect publisher_properties client-side.

## What Changed
- Added `publisher_domain` to the source schema (`static/schemas/source/core/product-filters.json`) so it survives schema rebuilds
- Handles both the singular `publisher_domain: string` and plural `publisher_domains: string[]` forms of `PublisherPropertySelector` (mirrors `adagents-manager.ts`)
- Canonicalizes both sides via `canonicalizePublisherDomain` so casing and trailing slashes don't cause misses
- Added `typeof` guard so a non-string value doesn't silently return zero products