### PR TITLE
fix(newsletter): render Prompt custom sections

### DIFF
--- a/server/src/addie/jobs/weekly-digest.ts
+++ b/server/src/addie/jobs/weekly-digest.ts
@@ -334,7 +334,11 @@ export async function sendDigest(digest: DigestRecord): Promise<{ sent: number }
     await markSent(digest.id, stats);
 
     // Publish as perspective for SEO/discoverability (non-blocking)
-    publishDigestAsPerspective(digest.id, content, editionDate, subject).catch((err) => {
+    void (async () => {
+      const { thePromptConfig } = await import('../../newsletters/the-prompt/index.js');
+      const markdown = thePromptConfig.buildMarkdown(content);
+      await publishDigestAsPerspective(digest.id, content, editionDate, subject, markdown);
+    })().catch((err) => {
       logger.error({ error: err, digestId: digest.id }, 'Failed to publish digest as perspective');
     });
   } else {

--- a/server/src/addie/services/digest-publisher.ts
+++ b/server/src/addie/services/digest-publisher.ts
@@ -30,13 +30,14 @@ export async function publishDigestAsPerspective(
   content: DigestContent,
   editionDate: string,
   subject: string,
+  markdown: string,
 ): Promise<string | null> {
   try {
     // Create the perspective
     const result = await proposeContentForUser(ADDIE_USER, {
       title: subject,
       content_type: 'article',
-      content: buildFullMarkdown(content),
+      content: markdown,
       excerpt: content.openingTake,
       category: 'The Prompt',
       tags: extractTags(content),
@@ -72,79 +73,6 @@ export async function publishDigestAsPerspective(
     logger.error({ error: err, editionDate }, 'Failed to publish digest as perspective');
     return null;
   }
-}
-
-/**
- * Build the full markdown content of a digest edition (for the perspective body).
- * This is the member-accessible version with all sections.
- */
-function buildFullMarkdown(content: DigestContent): string {
-  const sections: string[] = [];
-
-  // Opening take
-  sections.push(content.openingTake);
-
-  // Editor's note
-  if (content.editorsNote) {
-    sections.push(`> ${content.editorsNote.split('\n').join('\n> ')}`);
-  }
-
-  // New members welcome
-  if (content.newMembers.length > 0) {
-    const names = content.newMembers.map((m) => `**${m.name}**`).join(', ');
-    sections.push(`Welcome to ${names} who joined this week.`);
-  }
-
-  // Worth your time
-  if (content.whatToWatch.length > 0) {
-    sections.push('## Industry intel');
-    for (const item of content.whatToWatch) {
-      sections.push(`### [${item.title}](${item.url})\n\n${item.summary}\n\n*${item.whyItMatters}*`);
-    }
-  }
-
-  // What shipped
-  if (content.whatShipped && content.whatShipped.length > 0) {
-    sections.push('## What shipped');
-    for (const item of content.whatShipped) {
-      sections.push(`- [${item.title}](${item.url})${item.summary ? ` — ${item.summary}` : ''}`);
-    }
-  }
-
-  // From the inside
-  if (content.fromTheInside.length > 0) {
-    sections.push('## From the inside');
-    for (const group of content.fromTheInside) {
-      sections.push(`### ${group.name}\n\n${group.summary}`);
-      if (group.nextMeeting) {
-        sections.push(`*Next: ${group.nextMeeting}*`);
-      }
-      for (const recap of group.meetingRecaps) {
-        sections.push(`- **${recap.title}** (${recap.date})${recap.summary ? `: ${recap.summary}` : ''}`);
-      }
-      for (const thread of group.activeThreads) {
-        sections.push(`- ${thread.starter ? `${thread.starter}: ` : ''}"${thread.summary}" — ${thread.replyCount} replies`);
-      }
-    }
-  }
-
-  // Voices
-  if (content.voices.length > 0) {
-    sections.push('## Voices');
-    for (const item of content.voices) {
-      sections.push(`### [${item.title}](${item.url})\n\nby ${item.authorName}${item.excerpt ? `\n\n${item.excerpt}` : ''}`);
-    }
-  }
-
-  // Shareable take
-  if (content.shareableTake) {
-    sections.push(`> *"${content.shareableTake}"*\n>\n> — Share this take`);
-  }
-
-  // Sign-off
-  sections.push("---\n\nThat's the week. If one thing stuck, share it — this stuff moves faster when more people are paying attention.\n\n— Addie\\\nAgenticAdvertising.org");
-
-  return sections.join('\n\n');
 }
 
 /**

--- a/server/src/addie/templates/weekly-digest.ts
+++ b/server/src/addie/templates/weekly-digest.ts
@@ -145,9 +145,23 @@ function markdownToSlackMrkdwn(md: string): string {
   return escapeSlackMrkdwnPreserveLinks(htmlToSlackMrkdwn(renderMarkdownToEmailHtml(md)));
 }
 
-function renderCustomSectionsEmail(content: DigestContent, trackingId: string): string {
+type CustomSectionPlacement = 'all' | 'before' | 'after';
+
+function matchesCustomSectionPlacement(position: number, placement: CustomSectionPlacement): boolean {
+  if (placement === 'all') return true;
+  if (placement === 'before') return position === 0;
+  return position > 0;
+}
+
+function renderCustomSectionsEmail(
+  content: DigestContent,
+  trackingId: string,
+  placement: CustomSectionPlacement = 'all',
+): string {
   return getCustomSections(content)
-    .map((section, index) => `
+    .map((section, index) => ({ section, index }))
+    .filter(({ section }) => matchesCustomSectionPlacement(section.position, placement))
+    .map(({ section, index }) => `
     <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;">
     ${section.title ? `<h2 style="font-size: 17px; color: #1a1a2e; margin-bottom: 12px;">${escapeHtml(section.title)}</h2>` : ''}
     <div style="font-size: 14px; color: #333; line-height: 1.6;">${markdownToTrackedEmailHtml(section.body, trackingId, `custom_${index + 1}`)}</div>
@@ -155,15 +169,25 @@ function renderCustomSectionsEmail(content: DigestContent, trackingId: string): 
     .join('');
 }
 
-function appendCustomSectionsText(lines: string[], content: DigestContent) {
+function appendCustomSectionsText(
+  lines: string[],
+  content: DigestContent,
+  placement: CustomSectionPlacement = 'all',
+) {
   for (const section of getCustomSections(content)) {
+    if (!matchesCustomSectionPlacement(section.position, placement)) continue;
     if (section.title) lines.push(section.title, '');
     lines.push(markdownToPlainText(section.body), '');
   }
 }
 
-function appendCustomSectionsSlack(blocks: SlackBlock[], content: DigestContent) {
+function appendCustomSectionsSlack(
+  blocks: SlackBlock[],
+  content: DigestContent,
+  placement: CustomSectionPlacement = 'all',
+) {
   for (const section of getCustomSections(content)) {
+    if (!matchesCustomSectionPlacement(section.position, placement)) continue;
     blocks.push({ type: 'divider' });
     const title = section.title ? `*${escapeSlackMrkdwn(section.title)}*\n\n` : '';
     appendSlackMrkdwnSections(blocks, `${title}${markdownToSlackMrkdwn(section.body)}`);
@@ -400,6 +424,8 @@ export function renderDigestEmail(
 
     <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;">
 
+    ${renderCustomSectionsEmail(content, trackingId, 'before')}
+
     <!-- This Edition (official AAO content — no section header, flows from opening take) -->
     ${(() => {
       const official = content.whatToWatch.filter((item) => item.tags?.includes('official'));
@@ -509,6 +535,8 @@ export function renderDigestEmail(
     `).join('')}
     <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;">
     ` : ''}
+
+    ${renderCustomSectionsEmail(content, trackingId, 'after')}
 
     <!-- Sign-off -->
     <p style="font-size: 15px; color: #333; line-height: 1.6; margin-bottom: 4px;">
@@ -679,6 +707,8 @@ function renderDigestText(
     return lines.join('\n');
   }
 
+  appendCustomSectionsText(lines, content, 'before');
+
   if (content.newMembers.length > 0) {
     lines.push(`Welcome to ${content.newMembers.map((m) => m.name).join(', ')} who joined this week.`, '');
   }
@@ -761,6 +791,8 @@ function renderDigestText(
     }
   }
 
+  appendCustomSectionsText(lines, content, 'after');
+
   lines.push('---', '');
   lines.push("We're building this together. If something here resonated, pass it along.", '');
   lines.push("Let's keep building,");
@@ -833,6 +865,8 @@ export function renderDigestSlack(content: DigestContent, editionDate: string): 
   // Official content (with takeaways)
   const officialSlack = content.whatToWatch.filter((item) => item.tags?.includes('official'));
   const externalSlack = content.whatToWatch.filter((item) => !item.tags?.includes('official'));
+
+  appendCustomSectionsSlack(blocks, content, 'before');
 
   if (officialSlack.length > 0) {
     const officialText = officialSlack
@@ -912,6 +946,8 @@ export function renderDigestSlack(content: DigestContent, editionDate: string): 
       text: { type: 'mrkdwn', text: `*Take action*\n\n${actionText}` },
     });
   }
+
+  appendCustomSectionsSlack(blocks, content, 'after');
 
   // Read more
   blocks.push({ type: 'divider' });

--- a/server/src/newsletters/the-prompt/index.ts
+++ b/server/src/newsletters/the-prompt/index.ts
@@ -5,7 +5,7 @@
  * All content-specific logic delegates to existing digest modules.
  */
 
-import type { NewsletterConfig, SectionDescriptor, ItemOperations } from '../config.js';
+import { getCustomSections, getPastedContent, type NewsletterConfig, type SectionDescriptor, type ItemOperations } from '../config.js';
 import DOMPurify from 'isomorphic-dompurify';
 import { registerNewsletter } from '../registry.js';
 import { escapeHtml } from '../email-layout.js';
@@ -176,6 +176,8 @@ function domToMarkdown(node: any): string {
 function buildPromptMarkdown(content: unknown): string {
   const c = content as DigestContent;
   const sections: string[] = [];
+  const customSections = getCustomSections(c);
+  const pasted = getPastedContent(c);
 
   if (c.coverImageUrl) {
     sections.push(`![The Prompt cover](${c.coverImageUrl})`);
@@ -186,6 +188,18 @@ function buildPromptMarkdown(content: unknown): string {
       ? htmlToMarkdown(c.editorsNote)
       : c.editorsNote;
     sections.push(`> ${noteText.split('\n').join('\n> ')}`);
+  }
+  if (pasted) {
+    sections.push(pasted);
+    for (const custom of customSections) {
+      sections.push(custom.title ? `## ${custom.title}\n\n${custom.body}` : custom.body);
+    }
+    sections.push("---\n\nWe're building this together. If something here resonated, pass it along — every share brings in someone new.\n\nLet's keep building,\nAddie\\\nAgenticAdvertising.org");
+    return sections.join('\n\n');
+  }
+  for (const custom of customSections) {
+    if (custom.position !== 0) continue;
+    sections.push(custom.title ? `## ${custom.title}\n\n${custom.body}` : custom.body);
   }
   if (c.newMembers.length > 0) {
     sections.push(`Welcome to ${c.newMembers.map((m) => `**${m.name}**`).join(', ')} who joined this week.`);
@@ -243,6 +257,10 @@ function buildPromptMarkdown(content: unknown): string {
     for (const action of c.takeActions) {
       sections.push(`- **[${action.ctaLabel}](${action.ctaUrl})** — ${action.text}`);
     }
+  }
+  for (const custom of customSections) {
+    if (custom.position <= 0) continue;
+    sections.push(custom.title ? `## ${custom.title}\n\n${custom.body}` : custom.body);
   }
   sections.push("---\n\nWe're building this together. If something here resonated, pass it along — every share brings in someone new.\n\nLet's keep building,\nAddie\\\nAgenticAdvertising.org");
   return sections.join('\n\n');

--- a/server/tests/unit/digest-link-formatting.test.ts
+++ b/server/tests/unit/digest-link-formatting.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../src/utils/markdown.js', async (importOriginal) => {
 
 import { renderDigestEmail, renderDigestSlack } from '../../src/addie/templates/weekly-digest.js';
 import { renderBuildEmail } from '../../src/newsletters/the-build/template.js';
+import { thePromptConfig } from '../../src/newsletters/the-prompt/index.js';
 import type { DigestContent } from '../../src/db/digest-db.js';
 import type { BuildContent } from '../../src/db/build-db.js';
 
@@ -196,12 +197,71 @@ describe('digest editor note link formatting', () => {
       });
       const message = renderDigestSlack(content, '2026-04-01');
       const rendered = JSON.stringify(message.blocks);
+      const markdown = thePromptConfig.buildMarkdown(content);
 
       expect(rendered).toContain('Pasted');
       expect(rendered).toContain('https://example.com/brief');
       expect(rendered).toContain('Extra note');
       expect(rendered).toContain('Custom body');
       expect(rendered).not.toContain('Generated article');
+      expect(markdown).toContain('Pasted **body**');
+      expect(markdown).toContain('Extra note');
+      expect(markdown).toContain('Custom body');
+      expect(markdown).not.toContain('Generated article');
+    });
+  });
+
+  describe('custom sections', () => {
+    const customSections = [
+      { id: 'custom-before', title: 'Before generated', body: 'See [before](https://example.com/before)', position: 0 },
+      { id: 'custom-after', title: 'After generated', body: 'See [after](https://example.com/after)', position: 2 },
+    ];
+
+    it('renders positioned sections in generated email HTML and plain text', () => {
+      const content = makeContent({
+        customSections,
+        whatToWatch: [{
+          title: 'Generated article',
+          url: 'https://example.com/generated',
+          summary: 'Generated summary',
+          whyItMatters: 'Generated rationale',
+          tags: ['official'],
+        }],
+      });
+      const { html, text } = renderDigestEmail(content, 'recipient-1', '2026-04-01', 'both');
+
+      expect(html).toContain('tracked:recipient-1:custom_1_1:https://example.com/before');
+      expect(html).toContain('tracked:recipient-1:custom_2_1:https://example.com/after');
+      expect(html.indexOf('Before generated')).toBeLessThan(html.indexOf('Generated article'));
+      expect(html.indexOf('After generated')).toBeGreaterThan(html.indexOf('Generated article'));
+      expect(text.indexOf('Before generated')).toBeLessThan(text.indexOf('Generated article'));
+      expect(text.indexOf('After generated')).toBeGreaterThan(text.indexOf('Generated article'));
+    });
+
+    it('renders positioned sections in Slack and published markdown', () => {
+      const content = makeContent({
+        customSections,
+        whatToWatch: [{
+          title: 'Generated article',
+          url: 'https://example.com/generated',
+          summary: 'Generated summary',
+          whyItMatters: 'Generated rationale',
+          tags: ['official'],
+        }],
+      });
+      const slack = JSON.stringify(renderDigestSlack(content, '2026-04-01').blocks);
+      const markdown = thePromptConfig.buildMarkdown(content);
+
+      expect(slack).toContain('Before generated');
+      expect(slack).toContain('Generated article');
+      expect(slack).toContain('After generated');
+      expect(slack.indexOf('Before generated')).toBeLessThan(slack.indexOf('Generated article'));
+      expect(slack.indexOf('After generated')).toBeGreaterThan(slack.indexOf('Generated article'));
+      expect(markdown).toContain('Before generated');
+      expect(markdown).toContain('Generated article');
+      expect(markdown).toContain('After generated');
+      expect(markdown.indexOf('Before generated')).toBeLessThan(markdown.indexOf('Generated article'));
+      expect(markdown.indexOf('After generated')).toBeGreaterThan(markdown.indexOf('Generated article'));
     });
   });
 });

--- a/server/tests/unit/weekly-digest-job.test.ts
+++ b/server/tests/unit/weekly-digest-job.test.ts
@@ -7,6 +7,8 @@ const markSent = vi.fn();
 const getDigestEmailRecipients = vi.fn();
 const getUserWorkingGroupMap = vi.fn();
 const sendTrackedBatchMarketingEmails = vi.fn();
+const buildPromptMarkdown = vi.fn(() => 'Rendered Prompt markdown');
+const publishDigestAsPerspective = vi.fn(async () => undefined);
 
 vi.mock('../../src/db/digest-db.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/db/digest-db.js')>();
@@ -33,6 +35,7 @@ vi.mock('../../src/newsletters/the-prompt/index.js', () => ({
       sendHourET: 10,
       shouldRunToday: vi.fn(() => false),
     },
+    buildMarkdown: buildPromptMarkdown,
   },
 }));
 
@@ -63,7 +66,7 @@ vi.mock('../../src/addie/services/digest-builder.js', () => ({
 }));
 
 vi.mock('../../src/addie/services/digest-publisher.js', () => ({
-  publishDigestAsPerspective: vi.fn(async () => undefined),
+  publishDigestAsPerspective,
 }));
 
 vi.mock('../../src/newsletters/cover.js', () => ({
@@ -134,6 +137,16 @@ describe('runWeeklyDigestJob', () => {
     expect(result.sent).toBe(1);
     expect(sendTrackedBatchMarketingEmails).toHaveBeenCalledTimes(1);
     expect(markSent).toHaveBeenCalledWith(123, expect.objectContaining({ email_count: 1 }));
+    await vi.waitFor(() => {
+      expect(buildPromptMarkdown).toHaveBeenCalledWith(expect.objectContaining({ openingTake: 'Opening take' }));
+      expect(publishDigestAsPerspective).toHaveBeenCalledWith(
+        123,
+        expect.objectContaining({ openingTake: 'Opening take' }),
+        '2026-06-05',
+        'The Prompt test subject',
+        'Rendered Prompt markdown',
+      );
+    });
     expect(getDigestByDate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- render The Prompt custom sections in generated email HTML, plain text, and Slack output
- include custom sections and pasted content in published perspective markdown
- route scheduled perspective publishing through the canonical Prompt markdown builder while preserving non-blocking failure handling

## Root cause

The admin editor persisted custom sections, but The Prompt's normal generated-content render paths did not consume them. Scheduled perspective publishing also used a separate legacy markdown builder, so it could diverge from test sends and admin-triggered sends.

## Impact

Custom text blocks saved in the newsletter editor now appear in test sends, scheduled delivery, Slack, web previews, and published perspectives. Position `0` renders before generated sections and positive positions render after them, matching The Build's existing behavior.

Closes #5873.

## Validation

- focused Prompt renderer, cover-image, and weekly-digest job tests
- `npm run typecheck`
- `git diff --check`
- independent code, test, and newsletter-workflow expert reviews

No changeset is required because this is server-side newsletter behavior only.
