### PR TITLE
docs(sync_creatives): document ctx.input.assignments adopter escape hatch

### DIFF
--- a/docs/creative/task-reference/sync_creatives.mdx
+++ b/docs/creative/task-reference/sync_creatives.mdx
@@ -240,6 +240,8 @@ Assignments are at the request level, mapping creative IDs to package IDs. Stand
 }
 ```
 
+**Adopter note (`@adcp/sdk` server-side):** the typed `syncCreatives(creatives, ctx)` signature does not surface `assignments` as a positional argument. The wire envelope lands on `RequestContext.input`, so handlers read `ctx.input.assignments` to fan out package bindings and emit `creatives[i].assigned_to` in the response. The same escape hatch applies to any request field the typed signature intentionally does not model. See [`adcp#5797`](https://github.com/adcontextprotocol/adcp/issues/5797) for the trace that motivated this note (SDK ≥ 11.1.0 threads `params` into `ctx.input`; earlier lines dropped the field at the projector seam).
+
 ## Response
 
 Responses use discriminated unions — a response has exactly one of three shapes, never mixed:


### PR DESCRIPTION
## Summary

- Buyer-facing reference for `sync_creatives` already covers request-level `assignments[]`.
- Implementers repeatedly misread SDK ≥ 11.1.0 as dropping the field at the projector seam and file compliance bugs against the seller side. In fact the typed handler signature intentionally does not surface `assignments` positionally — the wire envelope lands on `RequestContext.input`, and handlers read `ctx.input.assignments` to fan out package bindings and emit `creatives[i].assigned_to` in the response.
- This PR adds a two-sentence adopter callout under **Assignments structure** pointing at `ctx.input.assignments` as the intended escape hatch, and links to [`adcp#5797`](https://github.com/adcontextprotocol/adcp/issues/5797) for the trace that motivated the note.

## Why

Offered on [`adcp#5797`](https://github.com/adcontextprotocol/adcp/issues/5797) on 2026-07-09:

> Happy to also PR a doc note to `docs/creative/task-reference/sync_creatives.mdx` on the `adcp` repo pointing adopters at `ctx.input.assignments` if that helps future implementers avoid the same misread.

@bokelley agreed:

> \[Doc note (`docs/creative/task-reference/sync_creatives.mdx`)\]: @kapoost's offer to PR this is the right call. \`ctx.input.assignments\` is the intended escape hatch for fields the typed signature doesn't model; documenting it prevents this misread for future adopters. Low-entropy, non-breaking, welcome.

## Test plan

- [x] Preview link renders the callout in the correct section (Mintlify broken-links check passed locally on Node 22).
- [x] No schema, storyboard, or code changes — pure MDX addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)