### PR TITLE
fix(perspectives): restore eligibility and re-review edits

### DIFF
--- a/server/public/admin-content.html
+++ b/server/public/admin-content.html
@@ -476,11 +476,18 @@
           <div class="form-group" id="statusGroup">
             <label>Status</label>
             <select id="statusSelect">
-              <option value="pending_review">Submit for Review</option>
-              <option value="draft">Save as Draft</option>
-              <option value="published">Publish Now</option>
+              <option value="pending_review">Submit for review</option>
+              <option value="draft">Save as draft</option>
+              <option value="published">Publish now</option>
             </select>
             <small id="statusHint"></small>
+          </div>
+        </div>
+
+        <div id="publishedEditWarning" class="alert-banner hidden">
+          <div class="alert-banner-content">
+            <h3>Published edits require review</h3>
+            <p>Your changes will be removed from the live site and submitted for review before they are published again.</p>
           </div>
         </div>
 
@@ -1597,8 +1604,15 @@
       const sel = document.getElementById('statusSelect');
       const colHint = document.getElementById('collectionHint');
       const col = collections.find(c => c.slug === slug);
+      const publishedEditRequiresReview = editingContent?.status === 'published' && !isAdmin;
+      document.getElementById('publishedEditWarning').classList.toggle('hidden', !publishedEditRequiresReview);
 
-      if (col?.canPublishDirectly || isAdmin) {
+      if (publishedEditRequiresReview) {
+        hint.textContent = 'Published changes must be reviewed before they go live again.';
+        sel.value = 'pending_review';
+        sel.disabled = true;
+        colHint.textContent = 'Where this perspective will appear on the site';
+      } else if (col?.canPublishDirectly || isAdmin) {
         hint.textContent = col?.type === 'committee' ? 'As a lead, you can publish directly.' : '';
         sel.disabled = false;
         colHint.textContent = 'Where this perspective will appear on the site';
@@ -1621,13 +1635,15 @@
       const isEditing = !!document.getElementById('contentId').value;
 
       if (isEditing) {
-        btn.textContent = 'Save Changes';
+        btn.textContent = editingContent?.status === 'published' && !isAdmin
+          ? 'Submit edits for review'
+          : 'Save changes';
       } else if (statusVal === 'published') {
         btn.textContent = 'Publish';
       } else if (statusVal === 'pending_review') {
-        btn.textContent = 'Submit for Review';
+        btn.textContent = 'Submit for review';
       } else {
-        btn.textContent = 'Save as Draft';
+        btn.textContent = 'Save as draft';
       }
     }
 

--- a/server/src/db/org-filters.ts
+++ b/server/src/db/org-filters.ts
@@ -42,21 +42,6 @@ export function isPayingMembership(row: {
   return row.subscription_status === 'active' && row.subscription_canceled_at === null;
 }
 
-/**
- * Subscription statuses that keep member entitlements available. This is
- * intentionally broader than `isPayingMembership`: `past_due` and `trialing`
- * preserve tiers during Stripe dunning/trial windows.
- */
-function hasEntitledSubscription(row: {
-  subscription_status: string | null;
-  subscription_canceled_at: Date | null;
-}): boolean {
-  return (
-    (TIER_PRESERVING_STATUSES as readonly string[]).includes(row.subscription_status ?? '') &&
-    row.subscription_canceled_at === null
-  );
-}
-
 /** Organization has at least one user (site account or Slack user) */
 export const HAS_USER = `(
   EXISTS (
@@ -202,9 +187,9 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
  * Resolve effective membership for an organization, including inheritance
  * through the brand registry hierarchy (house_domain chain).
  *
- * If the org itself has an entitlement-preserving subscription, returns direct
- * membership. Otherwise, walks up the house_domain chain looking for an
- * entitled/paying ancestor.
+ * If the org itself has an active, non-canceled subscription, returns direct
+ * membership. Otherwise, walks up the house_domain chain looking for a paying
+ * ancestor.
  *
  * Trust gates on inheritance — same shape as findPayingOrgForDomain so the
  * pre-link auto-provisioning path and post-link is_member resolution agree
@@ -213,7 +198,7 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
  *   - cycle protection via visited-domain array
  *   - only edges classified at confidence='high' (LLM classifier output)
  *   - 180-day TTL on the brand classification
- *   - inherited match only counts if the entitled/paying ancestor has opted into
+ *   - inherited match only counts if the paying ancestor has opted into
  *     auto_provision_brand_hierarchy_children (default false). Without
  *     opt-in, the child org's is_member stays false even if the brand
  *     registry says it's a subsidiary.
@@ -304,9 +289,9 @@ export async function resolveEffectiveMembership(orgId: string): Promise<Effecti
     }
 
     // Check the org itself first (depth 1) — opt-in flag does not apply to
-    // self; an org's own entitlement-preserving subscription always counts.
+    // self; an org's own paying subscription always counts.
     const self = rows[0];
-    if (hasEntitledSubscription(self)) {
+    if (isPayingMembership(self)) {
       const directResult: EffectiveMembership = {
         is_member: true,
         is_inherited: false,
@@ -319,11 +304,11 @@ export async function resolveEffectiveMembership(orgId: string): Promise<Effecti
       return directResult;
     }
 
-    // Check ancestors (depth > 1) for an entitled/paying member that has opted into
+    // Check ancestors (depth > 1) for a paying member that has opted into
     // hierarchy inheritance. An ancestor that didn't consent to children
     // auto-joining doesn't grant is_member to those children either.
     for (const row of rows.slice(1)) {
-      if (hasEntitledSubscription(row) && row.auto_provision_hierarchy) {
+      if (isPayingMembership(row) && row.auto_provision_hierarchy) {
         const chain = rows
           .filter(r => r.depth <= row.depth)
           .map(r => r.email_domain)

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -1679,6 +1679,34 @@ export function createMyContentRouter(): Router {
         });
       }
 
+      // Published content has already passed editorial review. Any actual
+      // content change by a non-admin must go through that review again,
+      // regardless of whether the caller omits status or asks to keep it
+      // published. Compare values rather than field presence because the web
+      // editor submits the complete form on every save.
+      const changed = (incoming: unknown, current: unknown): boolean => {
+        if (incoming === undefined) return false;
+        if (Array.isArray(incoming) || Array.isArray(current)) {
+          return JSON.stringify(incoming ?? []) !== JSON.stringify(current ?? []);
+        }
+        return incoming !== current;
+      };
+      const authorNameCanChange = isProposer || contentItem.author_user_id === user.id || userIsAdmin;
+      const hasSubstantiveEdit = [
+        changed(title, contentItem.title),
+        changed(content, contentItem.content),
+        changed(content_type, contentItem.content_type),
+        changed(excerpt, contentItem.excerpt),
+        changed(external_url, contentItem.external_url),
+        changed(external_site_name, contentItem.external_site_name),
+        changed(category, contentItem.category),
+        changed(tags, contentItem.tags),
+        authorNameCanChange && changed(author_name, contentItem.author_name),
+      ].some(Boolean);
+      const requiresRenewedReview = contentItem.status === 'published'
+        && !userIsAdmin
+        && hasSubstantiveEdit;
+
       // Build update query
       const updates: string[] = [];
       const values: (string | string[] | null)[] = [];
@@ -1716,7 +1744,7 @@ export function createMyContentRouter(): Router {
         updates.push(`tags = $${paramIndex++}`);
         values.push(tags);
       }
-      const authorNameUpdated = author_name !== undefined && (isProposer || contentItem.author_user_id === user.id || userIsAdmin);
+      const authorNameUpdated = author_name !== undefined && authorNameCanChange;
       if (authorNameUpdated) {
         updates.push(`author_name = $${paramIndex++}`);
         values.push(author_name);
@@ -1733,7 +1761,16 @@ export function createMyContentRouter(): Router {
       // or archived) is gated to admins or the lead of the item's own
       // committee — otherwise an unrelated co-author could resurrect a
       // rejected item without going through the rejecter (see #2713).
-      if (requestedStatus !== undefined) {
+      if (requiresRenewedReview) {
+        updates.push(`status = 'pending_review'`);
+        updates.push(`published_at = NULL`);
+        updates.push(`proposed_at = NOW()`);
+        updates.push(`reviewed_by_user_id = NULL`);
+        updates.push(`reviewed_at = NULL`);
+        updates.push(`revision_notes = NULL`);
+        updates.push(`revision_requested_at = NULL`);
+        updates.push(`rejection_reason = NULL`);
+      } else if (requestedStatus !== undefined) {
         const allowedStatuses = ['draft', 'pending_review', 'published', 'archived', 'needs_revisions'];
         if (allowedStatuses.includes(requestedStatus)) {
           // Non-admins can only set draft or pending_review
@@ -1804,6 +1841,26 @@ export function createMyContentRouter(): Router {
       }
 
       logger.info({ contentId: id, userId: user.id }, 'Content updated');
+
+      if (requiresRenewedReview && result.rows[0].working_group_id) {
+        const updated = result.rows[0];
+        notifyPendingReview(
+          updated.working_group_id,
+          {
+            id: updated.id,
+            title: updated.title,
+            slug: updated.slug,
+            excerpt: updated.excerpt ?? null,
+            content_type: updated.content_type,
+            content: updated.content ?? null,
+            proposed_at: updated.proposed_at,
+          },
+          updated.author_name || 'Unknown',
+          updated.proposer_user_id || user.id
+        ).catch(err => {
+          logger.error({ err, perspectiveId: id }, 'Failed to send renewed content review notification');
+        });
+      }
 
       res.json(result.rows[0]);
     } catch (error) {

--- a/server/src/services/membership-tiers.ts
+++ b/server/src/services/membership-tiers.ts
@@ -13,6 +13,12 @@
 
 import { resolvePrimaryOrganization } from '../db/users-db.js';
 import { resolveEffectiveMembership } from '../db/org-filters.js';
+import { getPool } from '../db/client.js';
+import {
+  MEMBERSHIP_TIER_COLUMNS,
+  resolveMembershipTier,
+  type MembershipTierRow,
+} from '../db/organization-db.js';
 
 export const API_ACCESS_TIERS = [
   'individual_professional',
@@ -44,6 +50,21 @@ const ACTIVE_SUBSCRIPTION_STATUS_SET: ReadonlySet<string> = new Set(ACTIVE_SUBSC
 
 export function isActiveSubscriptionStatus(status: string | null | undefined): boolean {
   return status != null && ACTIVE_SUBSCRIPTION_STATUS_SET.has(status);
+}
+
+interface ContentSubmissionMembership {
+  membership_tier: string | null;
+  subscription_status: string | null;
+  subscription_canceled_at: Date | null;
+}
+
+export function isContentSubmissionMembershipEligible(
+  membership: ContentSubmissionMembership | null,
+): boolean {
+  return membership != null
+    && membership.subscription_canceled_at === null
+    && isActiveSubscriptionStatus(membership.subscription_status)
+    && isApiAccessTier(membership.membership_tier);
 }
 
 /**
@@ -143,25 +164,58 @@ export async function resolveOwnerMembership(
  * pipelines that legitimately submit content on a cadence and bypass the
  * human-facing membership gate the same way they bypass the rate limiter.
  *
- * For all other users, resolves their primary organization and checks that:
- *   1. The organization's effective membership tier is in API_ACCESS_TIERS.
- *   2. The subscription status is in ACTIVE_SUBSCRIPTION_STATUSES.
+ * For all other users, resolves their primary organization and allows either:
+ *   1. A direct API-access subscription in ACTIVE_SUBSCRIPTION_STATUSES that
+ *      has not been canceled. This Perspectives-specific grace window does not
+ *      widen the global AgenticAdvertising.org membership invariant.
+ *   2. Strict effective membership inherited from a consenting paying parent.
  *
  * Returns false when the user has no primary organization or when either
  * condition is not met.
  */
-export async function checkContentSubmissionTier(userId: string): Promise<boolean> {
+export interface CheckContentSubmissionTierDeps {
+  resolvePrimaryOrganization: (userId: string) => Promise<string | null>;
+  resolveEffectiveMembership: typeof resolveEffectiveMembership;
+  fetchDirectMembership: (orgId: string) => Promise<ContentSubmissionMembership | null>;
+}
+
+async function fetchDirectMembership(orgId: string): Promise<ContentSubmissionMembership | null> {
+  const result = await getPool().query<MembershipTierRow & { subscription_canceled_at: Date | null }>(
+    `SELECT ${MEMBERSHIP_TIER_COLUMNS.join(', ')}, subscription_canceled_at
+     FROM organizations
+     WHERE workos_organization_id = $1`,
+    [orgId],
+  );
+  const row = result.rows[0];
+  if (!row) return null;
+  return {
+    membership_tier: resolveMembershipTier(row),
+    subscription_status: row.subscription_status,
+    subscription_canceled_at: row.subscription_canceled_at,
+  };
+}
+
+const DEFAULT_CONTENT_SUBMISSION_DEPS: CheckContentSubmissionTierDeps = {
+  resolvePrimaryOrganization,
+  resolveEffectiveMembership,
+  fetchDirectMembership,
+};
+
+export async function checkContentSubmissionTier(
+  userId: string,
+  deps: CheckContentSubmissionTierDeps = DEFAULT_CONTENT_SUBMISSION_DEPS,
+): Promise<boolean> {
   if (userId.startsWith('system:')) return true;
 
-  const orgId = await resolvePrimaryOrganization(userId);
+  const orgId = await deps.resolvePrimaryOrganization(userId);
   if (!orgId) return false;
 
-  const membership = await resolveEffectiveMembership(orgId);
+  const directMembership = await deps.fetchDirectMembership(orgId);
+  if (isContentSubmissionMembershipEligible(directMembership)) return true;
 
-  // resolveEffectiveMembership walks the brand hierarchy and sets is_member
-  // only when the org (or a consenting ancestor) has an entitlement-preserving,
-  // non-canceled subscription — so is_member already encodes subscription-status
-  // validity. We additionally require the tier to be in API_ACCESS_TIERS
-  // (Professional+).
+  const membership = await deps.resolveEffectiveMembership(orgId);
+
+  // Preserve the existing hierarchy behavior, but only through the strict
+  // active/non-canceled global membership resolver.
   return membership.is_member && isApiAccessTier(membership.membership_tier);
 }

--- a/server/tests/integration/content-my-content.test.ts
+++ b/server/tests/integration/content-my-content.test.ts
@@ -522,6 +522,108 @@ describe('My Content — body, admin scope, status, delete', () => {
   // ---------------------------------------------------------------------------
 
   describe('PUT /api/me/content/:id status transitions', () => {
+    it('returns a proposer substantive edit of published content to review when status is omitted', async () => {
+      authState.userId = OTHER_USER_ID;
+      authState.email = 'mc-other@example.com';
+      const id = await insertPerspective({
+        slug: 'mc-test-published-proposer-edit',
+        title: 'Published proposer article',
+        proposerUserId: OTHER_USER_ID,
+      });
+      await pool.query(
+        `UPDATE perspectives
+         SET reviewed_by_user_id = 'prior-reviewer', reviewed_at = NOW(),
+             revision_notes = 'stale notes', revision_requested_at = NOW(),
+             rejection_reason = 'stale rejection reason'
+         WHERE id = $1`,
+        [id]
+      );
+
+      const response = await request(app)
+        .put(`/api/me/content/${id}`)
+        .send({ title: 'Revised proposer article' })
+        .expect(200);
+
+      expect(response.body.status).toBe('pending_review');
+      expect(response.body.published_at).toBeNull();
+      expect(response.body.proposed_at).not.toBeNull();
+      expect(response.body.reviewed_by_user_id).toBeNull();
+      expect(response.body.reviewed_at).toBeNull();
+      expect(response.body.revision_notes).toBeNull();
+      expect(response.body.revision_requested_at).toBeNull();
+      expect(response.body.rejection_reason).toBeNull();
+    });
+
+    it('returns a committee lead substantive edit to review even when published is requested', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-published-lead-edit',
+        title: 'Published committee article',
+        proposerUserId: OTHER_USER_ID,
+        workingGroupId: wgId,
+      });
+
+      const response = await request(app)
+        .put(`/api/me/content/${id}`)
+        .send({ title: 'Revised by committee lead', status: 'published' })
+        .expect(200);
+
+      expect(response.body.status).toBe('pending_review');
+    });
+
+    it('returns a co-author substantive edit to review even when published is requested', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-published-coauthor-edit',
+        title: 'Published co-authored article',
+        proposerUserId: USER_ID,
+      });
+      await pool.query(
+        `INSERT INTO content_authors (perspective_id, user_id, display_name)
+         VALUES ($1, $2, 'Co-author')`,
+        [id, OTHER_USER_ID]
+      );
+      authState.userId = OTHER_USER_ID;
+      authState.email = 'mc-other@example.com';
+
+      const response = await request(app)
+        .put(`/api/me/content/${id}`)
+        .send({ excerpt: 'A co-author revision', status: 'published' })
+        .expect(200);
+
+      expect(response.body.status).toBe('pending_review');
+    });
+
+    it('still forbids a stranger from editing published content', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-published-stranger-edit',
+        title: 'Someone else\'s published article',
+        proposerUserId: USER_ID,
+      });
+      authState.userId = OTHER_USER_ID;
+      authState.email = 'mc-other@example.com';
+
+      await request(app)
+        .put(`/api/me/content/${id}`)
+        .send({ title: 'Unauthorized revision' })
+        .expect(403);
+    });
+
+    it('preserves an admin override when editing published content', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-published-admin-edit',
+        title: 'Published admin article',
+        proposerUserId: OTHER_USER_ID,
+      });
+      adminState.isAdmin = true;
+
+      const response = await request(app)
+        .put(`/api/me/content/${id}`)
+        .send({ title: 'Admin revision stays live', status: 'published' })
+        .expect(200);
+
+      expect(response.body.status).toBe('published');
+      expect(response.body.published_at).not.toBeNull();
+    });
+
     it('prevents non-admin co-author from resurrecting a rejected item', async () => {
       const id = await insertPerspective({
         slug: 'mc-test-resurrect',

--- a/server/tests/integration/find-paying-org-for-domain.test.ts
+++ b/server/tests/integration/find-paying-org-for-domain.test.ts
@@ -379,7 +379,7 @@ describe('resolveEffectiveMembership coherence with findPayingOrgForDomain', () 
     expect(result.membership_tier).toBe('individual_professional');
   });
 
-  it('resolves past_due direct membership during the Stripe dunning window', async () => {
+  it('does not treat past_due as global organization membership', async () => {
     await seedPayingOrg(pool, TEST_DIRECT_ORG, CHILD_DOMAIN, {
       subscription_status: 'past_due',
       membership_tier: 'company_icl',
@@ -390,9 +390,9 @@ describe('resolveEffectiveMembership coherence with findPayingOrgForDomain', () 
 
     const result = await resolveEffectiveMembership(TEST_DIRECT_ORG);
 
-    expect(result.is_member).toBe(true);
+    expect(result.is_member).toBe(false);
     expect(result.is_inherited).toBe(false);
-    expect(result.membership_tier).toBe('company_icl');
+    expect(result.membership_tier).toBeNull();
   });
 
   it('resolves direct membership tier through amount fallback when lookup key is absent', async () => {

--- a/server/tests/unit/membership-tiers.test.ts
+++ b/server/tests/unit/membership-tiers.test.ts
@@ -6,6 +6,9 @@ import {
   isActiveSubscriptionStatus,
   tierLabel,
   resolveOwnerMembership,
+  isContentSubmissionMembershipEligible,
+  checkContentSubmissionTier,
+  type CheckContentSubmissionTierDeps,
 } from '../../src/services/membership-tiers.js';
 
 describe('membership-tiers', () => {
@@ -88,6 +91,67 @@ describe('membership-tiers', () => {
 
   it('subscription statuses match the heartbeat query', () => {
     expect(ACTIVE_SUBSCRIPTION_STATUSES).toEqual(['active', 'past_due', 'trialing']);
+  });
+
+  describe('Perspectives content submission eligibility', () => {
+    const directMembership = (
+      subscription_status: string | null,
+      subscription_canceled_at: Date | null = null,
+      membership_tier = 'company_standard',
+    ) => ({ membership_tier, subscription_status, subscription_canceled_at });
+
+    it.each(['active', 'past_due', 'trialing'])(
+      'allows an uncanceled API-access tier with %s status',
+      (status) => {
+        expect(isContentSubmissionMembershipEligible(directMembership(status))).toBe(true);
+      },
+    );
+
+    it('rejects canceled, inactive, and non-API direct memberships', () => {
+      expect(isContentSubmissionMembershipEligible(
+        directMembership('active', new Date('2026-01-01')),
+      )).toBe(false);
+      expect(isContentSubmissionMembershipEligible(directMembership('unpaid'))).toBe(false);
+      expect(isContentSubmissionMembershipEligible(
+        directMembership('active', null, 'explorer'),
+      )).toBe(false);
+      expect(isContentSubmissionMembershipEligible(null)).toBe(false);
+    });
+
+    it('keeps past_due eligibility local to content submission', async () => {
+      const deps: CheckContentSubmissionTierDeps = {
+        resolvePrimaryOrganization: vi.fn().mockResolvedValue('org_123'),
+        fetchDirectMembership: vi.fn().mockResolvedValue(directMembership('past_due')),
+        resolveEffectiveMembership: vi.fn().mockResolvedValue({
+          is_member: false,
+          is_inherited: false,
+          paying_org_id: null,
+          paying_org_name: null,
+          hierarchy_chain: [],
+          membership_tier: null,
+        }),
+      };
+
+      await expect(checkContentSubmissionTier('user_123', deps)).resolves.toBe(true);
+      expect(deps.resolveEffectiveMembership).not.toHaveBeenCalled();
+    });
+
+    it('preserves strict inherited paid membership as a fallback', async () => {
+      const deps: CheckContentSubmissionTierDeps = {
+        resolvePrimaryOrganization: vi.fn().mockResolvedValue('org_child'),
+        fetchDirectMembership: vi.fn().mockResolvedValue(null),
+        resolveEffectiveMembership: vi.fn().mockResolvedValue({
+          is_member: true,
+          is_inherited: true,
+          paying_org_id: 'org_parent',
+          paying_org_name: 'Parent company',
+          hierarchy_chain: ['child.example', 'parent.example'],
+          membership_tier: 'company_standard',
+        }),
+      };
+
+      await expect(checkContentSubmissionTier('user_123', deps)).resolves.toBe(true);
+    });
   });
 
   describe('resolveOwnerMembership — security boundary', () => {


### PR DESCRIPTION
## Summary

- restore strict global membership semantics while allowing uncanceled active, past_due, and trialing API-tier organizations to submit Perspectives
- force substantive non-admin edits of published Perspectives back through pending review
- reset stale review metadata, notify reviewers, and make the UI explain and enforce the transition
- preserve administrator override behavior

Closes #5640.
Closes #5801.
Closes #5636.

## Validation

- focused membership tests: 57 passed
- content integration suite: 36 passed
- combined focused unit suite: 64 passed
- repository precommit: 999 tests passed, typecheck and source lints passed
- git diff --check