### PR TITLE
fix(membership): complete rosters and individual invite flows

### DIFF
--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -172,6 +172,11 @@ import {
 } from "../../services/brand-identity.js";
 import { canonicalizeBrandDomain } from "../../services/identifier-normalization.js";
 import { upsertEmailContact } from "../../db/contacts-db.js";
+import { validateEmail } from "../../middleware/validation.js";
+import {
+  getGoogleEmailAliases,
+  normalizeEmail,
+} from "../../utils/email-domain.js";
 
 const logger = createLogger("addie-admin-tools");
 const orgDb = new OrganizationDatabase();
@@ -681,6 +686,12 @@ Actions:
             "Email of the human who will sign in to complete billing in their own session. Used only to deliver the invite — never used as a Stripe customer email or invoice recipient directly. Required for send_invite.",
         },
         contact_title: { type: "string", description: "Contact job title" },
+        customer_type: {
+          type: "string",
+          enum: ["company", "individual"],
+          description:
+            'Membership customer type. Defaults to "company". Individual requests require contact_email so the personal workspace can be safely reused.',
+        },
         action: {
           type: "string",
           enum: ["lookup_only", "draft_invoice", "send_invite"],
@@ -802,6 +813,12 @@ Actions:
         org_id: {
           type: "string",
           description: "WorkOS organization ID (org_…) the invite belongs to",
+        },
+        customer_type: {
+          type: "string",
+          enum: ["company", "individual"],
+          description:
+            "Optional consistency check. When omitted, the persisted organization type is used so existing individual invites remain resendable.",
         },
       },
       required: ["token", "org_id"],
@@ -4750,6 +4767,10 @@ export function createAdminToolHandlers(
     const contactName = input.contact_name as string | undefined;
     const contactEmail = input.contact_email as string | undefined;
     const contactTitle = input.contact_title as string | undefined;
+    const customerType =
+      (input.customer_type as "company" | "individual" | undefined) ||
+      "company";
+    const isPersonal = customerType === "individual";
     const action = (input.action as string) || "lookup_only";
     const lookupKey = input.lookup_key as string | undefined;
     // Discount parameters (preview-only — applied during draft_invoice)
@@ -4759,6 +4780,17 @@ export function createAdminToolHandlers(
       | undefined;
     const discountReason = input.discount_reason as string | undefined;
     const useExistingDiscount = input.use_existing_discount !== false; // default true
+
+    if (input.customer_type && !["company", "individual"].includes(customerType)) {
+      return '❌ customer_type must be either "company" or "individual".';
+    }
+
+    const normalizedContactEmail = contactEmail
+      ? normalizeEmail(contactEmail)
+      : null;
+    if (isPersonal && !validateEmail(normalizedContactEmail).valid) {
+      return "❌ contact_email is required for an individual membership and must be a valid email address.";
+    }
 
     // The admin invoking this tool. Their identity is used as
     // `invited_by_user_id` on the membership invite. We never propagate it as
@@ -4789,44 +4821,80 @@ export function createAdminToolHandlers(
     let created = false;
 
     // Step 1: Find the organization
-    const searchPattern = `%${companyName}%`;
-    const searchParams: string[] = [searchPattern];
-    let paramIdx = 2;
-    const domainClause = domain
-      ? `OR LOWER(email_domain) LIKE LOWER($${paramIdx++})`
-      : "";
-    if (domain) searchParams.push(`%${domain}%`);
-    const exactIdx = paramIdx++;
-    const prefixIdx = paramIdx++;
-    searchParams.push(companyName, `${companyName}%`);
-    const searchResult = await pool.query(
-      `SELECT workos_organization_id, name, is_personal, company_type, revenue_tier,
-              prospect_contact_email, prospect_contact_name,
-              enrichment_employee_count, enrichment_revenue, stripe_customer_id,
-              discount_percent, discount_amount_cents, stripe_coupon_id, stripe_promotion_code
-       FROM organizations
-       WHERE is_personal = false
-         AND (LOWER(name) LIKE LOWER($1) ${domainClause})
-       ORDER BY
-         CASE WHEN LOWER(name) = LOWER($${exactIdx}) THEN 0
-              WHEN LOWER(name) LIKE LOWER($${prefixIdx}) THEN 1
-              ELSE 2 END
-       LIMIT 5`,
-      searchParams,
-    );
+    let searchResult;
+    if (isPersonal) {
+      const emailAliases = [
+        normalizedContactEmail!,
+        ...getGoogleEmailAliases(normalizedContactEmail!),
+      ];
+      searchResult = await pool.query(
+        `SELECT DISTINCT o.workos_organization_id, o.name, o.is_personal,
+                o.company_type, o.revenue_tier, o.prospect_contact_email,
+                o.prospect_contact_name, o.enrichment_employee_count,
+                o.enrichment_revenue, o.stripe_customer_id, o.discount_percent,
+                o.discount_amount_cents, o.stripe_coupon_id, o.stripe_promotion_code
+         FROM organizations o
+         LEFT JOIN organization_memberships om
+           ON om.workos_organization_id = o.workos_organization_id
+         LEFT JOIN users u ON u.workos_user_id = om.workos_user_id
+         LEFT JOIN membership_invites mi
+           ON mi.workos_organization_id = o.workos_organization_id
+         WHERE o.is_personal = true
+           AND (
+             LOWER(TRIM(o.prospect_contact_email)) = ANY($1::text[])
+             OR LOWER(TRIM(om.email)) = ANY($1::text[])
+             OR LOWER(TRIM(u.email)) = ANY($1::text[])
+             OR LOWER(TRIM(mi.contact_email)) = ANY($1::text[])
+           )
+         ORDER BY o.workos_organization_id
+         LIMIT 2`,
+        [emailAliases],
+      );
+    } else {
+      const searchPattern = `%${companyName}%`;
+      const searchParams: string[] = [searchPattern];
+      let paramIdx = 2;
+      const domainClause = domain
+        ? `OR LOWER(email_domain) LIKE LOWER($${paramIdx++})`
+        : "";
+      if (domain) searchParams.push(`%${domain}%`);
+      const exactIdx = paramIdx++;
+      const prefixIdx = paramIdx++;
+      searchParams.push(companyName, `${companyName}%`);
+      searchResult = await pool.query(
+        `SELECT workos_organization_id, name, is_personal, company_type, revenue_tier,
+                prospect_contact_email, prospect_contact_name,
+                enrichment_employee_count, enrichment_revenue, stripe_customer_id,
+                discount_percent, discount_amount_cents, stripe_coupon_id, stripe_promotion_code
+         FROM organizations
+         WHERE is_personal = false
+           AND (LOWER(name) LIKE LOWER($1) ${domainClause})
+         ORDER BY
+           CASE WHEN LOWER(name) = LOWER($${exactIdx}) THEN 0
+                WHEN LOWER(name) LIKE LOWER($${prefixIdx}) THEN 1
+                ELSE 2 END
+         LIMIT 5`,
+        searchParams,
+      );
+    }
+
+    if (isPersonal && searchResult.rows.length > 1) {
+      return `❌ Multiple individual workspaces are associated with ${normalizedContactEmail}. Resolve the duplicate before sending an invite.`;
+    }
 
     if (searchResult.rows.length === 0) {
       // Create the prospect
       const createResult = await createProspect({
         name: companyName,
         domain,
+        is_personal: isPersonal,
         prospect_source: "addie_payment_request",
         prospect_contact_name: contactName,
-        prospect_contact_email: contactEmail,
+        prospect_contact_email: normalizedContactEmail || undefined,
         prospect_contact_title: contactTitle,
       });
 
-      if (!createResult.success || !createResult.organization) {
+      if (!createResult.organization) {
         return `❌ Failed to create prospect: ${createResult.error}`;
       }
 
@@ -4840,7 +4908,7 @@ export function createAdminToolHandlers(
         [createResult.organization.workos_organization_id],
       );
       org = newOrgResult.rows[0];
-      created = true;
+      created = createResult.success;
     } else if (searchResult.rows.length === 1) {
       org = searchResult.rows[0];
     } else {
@@ -4863,6 +4931,11 @@ export function createAdminToolHandlers(
 
     if (!org) {
       return `❌ Could not find or create organization "${companyName}"`;
+    }
+
+    const persistedCustomerType = org.is_personal ? "individual" : "company";
+    if (persistedCustomerType !== customerType) {
+      return `❌ ${org.name} is a ${persistedCustomerType} workspace, not a ${customerType} workspace.`;
     }
 
     // Update contact name/title on the org for visibility. We deliberately do
@@ -4909,7 +4982,6 @@ export function createAdminToolHandlers(
     const members = membersResult.rows;
 
     // Get available products
-    const customerType = org.is_personal ? "individual" : "company";
     let products: BillingProduct[] = [];
     try {
       products = await getProductsForCustomer({
@@ -5039,9 +5111,8 @@ export function createAdminToolHandlers(
         );
       }
 
-      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
-      const normalizedEmail = contactEmail.trim().toLowerCase();
-      if (!emailRegex.test(normalizedEmail)) {
+      const normalizedEmail = normalizedContactEmail!;
+      if (!validateEmail(normalizedEmail).valid) {
         return response + `\n❌ Invalid contact_email: ${contactEmail}`;
       }
 
@@ -11332,10 +11403,20 @@ Use add_committee_leader to assign a leader.`;
   handlers.set("resend_invite", async (input) => {
     const token = input.token as string;
     const orgId = input.org_id as string;
+    const requestedCustomerType = input.customer_type as
+      | "company"
+      | "individual"
+      | undefined;
 
     if (!token) return "❌ token is required.";
     if (!orgId || !orgId.startsWith("org_")) {
       return "❌ org_id is required (org_…).";
+    }
+    if (
+      requestedCustomerType &&
+      !["company", "individual"].includes(requestedCustomerType)
+    ) {
+      return '❌ customer_type must be either "company" or "individual".';
     }
 
     const adminUser = memberContext?.workos_user;
@@ -11363,6 +11444,9 @@ Use add_committee_leader to assign a leader.`;
       }
 
       const customerType = org.is_personal ? "individual" : "company";
+      if (requestedCustomerType && requestedCustomerType !== customerType) {
+        return `❌ Organization ${orgId} is a ${customerType} workspace, not a ${requestedCustomerType} workspace.`;
+      }
       const eligibleProducts = await getProductsForCustomer({
         customerType,
         category: "membership",

--- a/server/src/routes/admin/organizations.ts
+++ b/server/src/routes/admin/organizations.ts
@@ -15,6 +15,7 @@ import {
   setMembershipRole,
   upsertOrganizationMembership,
 } from "../../db/membership-db.js";
+import { collectWorkOSPages } from "../../services/workos-pagination.js";
 
 const orgDb = new OrganizationDatabase();
 const logger = createLogger("admin-organizations");
@@ -70,14 +71,17 @@ export function setupOrganizationRoutes(
         let members: any[] = [];
         try {
           if (workos) {
-            const memberships =
-              await workos.userManagement.listOrganizationMemberships({
+            const memberships = await collectWorkOSPages((after) =>
+              workos.userManagement.listOrganizationMemberships({
                 organizationId: orgId,
-              });
-            memberCount = memberships.data?.length || 0;
+                limit: 100,
+                after,
+              })
+            );
+            memberCount = memberships.length;
 
             // Get user details for each membership
-            for (const membership of memberships.data || []) {
+            for (const membership of memberships) {
               try {
                 const user = await workos.userManagement.getUser(
                   membership.userId

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -45,6 +45,7 @@ import {
 import { getOrgAdminEmails } from "../utils/org-admins.js";
 import { emailPrefsDb } from "../db/email-preferences-db.js";
 import { performCreateOrganization } from "../services/organization-bootstrap.js";
+import { collectWorkOSPages } from "../services/workos-pagination.js";
 
 const logger = createLogger("organization-routes");
 
@@ -2326,9 +2327,13 @@ export function createOrganizationsRouter(): Router {
       );
 
       // Get pending invitations for this organization
-      const invitations = await workos!.userManagement.listInvitations({
-        organizationId: orgId,
-      });
+      const invitations = await collectWorkOSPages((after) =>
+        workos!.userManagement.listInvitations({
+          organizationId: orgId,
+          limit: 100,
+          after,
+        })
+      );
 
       // Fetch seat types for pending invitations
       const invSeatResult = await query<{ email: string; seat_type: string }>(
@@ -2337,7 +2342,7 @@ export function createOrganizationsRouter(): Router {
       );
       const invSeatMap = new Map(invSeatResult.rows.map(r => [r.email.toLowerCase(), r.seat_type]));
 
-      const pendingInvitations = invitations.data
+      const pendingInvitations = invitations
         .filter(inv => inv.state === 'pending')
         .map(inv => ({
           id: inv.id,

--- a/server/src/services/prospect.ts
+++ b/server/src/services/prospect.ts
@@ -15,7 +15,13 @@ import { enrichOrganization } from './enrichment.js';
 import { isLushaConfigured } from './lusha.js';
 import { COMPANY_TYPE_VALUES } from '../config/company-types.js';
 import { VALID_REVENUE_TIERS } from '../db/organization-db.js';
-import { getCompanyDomain, isFreeEmailDomain } from '../utils/email-domain.js';
+import {
+  getCompanyDomain,
+  getGoogleEmailAliases,
+  isFreeEmailDomain,
+  normalizeEmail,
+} from '../utils/email-domain.js';
+import { validateEmail } from '../middleware/validation.js';
 import {
   assertClaimableBrandDomain,
   canonicalizeBrandDomain,
@@ -60,6 +66,7 @@ function inferBusinessDomainFromContactEmail(email: string | undefined): string 
 }
 
 function normalizeProspectDomain(input: CreateProspectInput): string | null {
+  if (input.is_personal) return null;
   const explicit = input.domain?.trim();
   if (explicit) return normalizeExplicitDomain(explicit);
   return inferBusinessDomainFromContactEmail(input.prospect_contact_email);
@@ -83,6 +90,7 @@ function prospectDomainTrust(input: CreateProspectInput): {
 export interface CreateProspectInput {
   name: string;
   domain?: string;
+  is_personal?: boolean;
   company_type?: string;
   prospect_status?: string;
   prospect_source?: string;
@@ -102,6 +110,7 @@ export interface CreateProspectResult {
     name: string;
     company_type?: string;
     email_domain?: string;
+    is_personal?: boolean;
     prospect_status: string;
   };
   error?: string;
@@ -127,6 +136,17 @@ export async function createProspect(
   }
 
   const name = input.name.trim();
+  const isPersonal = input.is_personal === true;
+  const contactEmail = input.prospect_contact_email
+    ? normalizeEmail(input.prospect_contact_email)
+    : null;
+
+  if (isPersonal && !validateEmail(contactEmail).valid) {
+    return {
+      success: false,
+      error: 'A valid contact email is required to create an individual prospect',
+    };
+  }
 
   // Validate prospect_status if provided
   if (input.prospect_status && !VALID_PROSPECT_STATUSES.includes(input.prospect_status as typeof VALID_PROSPECT_STATUSES[number])) {
@@ -146,11 +166,63 @@ export async function createProspect(
     };
   }
 
-  if (!normalizedDomain) {
+  if (!isPersonal && !normalizedDomain) {
     return {
       success: false,
       error: 'A valid business domain or business contact email is required to create a prospect',
     };
+  }
+
+  if (isPersonal && contactEmail) {
+    const emailAliases = [contactEmail, ...getGoogleEmailAliases(contactEmail)];
+    const existingPersonal = await pool.query<{
+      workos_organization_id: string;
+      name: string;
+      company_type: string | null;
+      prospect_status: string | null;
+      is_personal: boolean;
+    }>(
+      `SELECT DISTINCT o.workos_organization_id, o.name, o.company_type,
+              o.prospect_status, o.is_personal
+       FROM organizations o
+       LEFT JOIN organization_memberships om
+         ON om.workos_organization_id = o.workos_organization_id
+       LEFT JOIN users u ON u.workos_user_id = om.workos_user_id
+       LEFT JOIN membership_invites mi
+         ON mi.workos_organization_id = o.workos_organization_id
+       WHERE o.is_personal = true
+         AND (
+           LOWER(TRIM(o.prospect_contact_email)) = ANY($1::text[])
+           OR LOWER(TRIM(om.email)) = ANY($1::text[])
+           OR LOWER(TRIM(u.email)) = ANY($1::text[])
+           OR LOWER(TRIM(mi.contact_email)) = ANY($1::text[])
+         )
+       ORDER BY o.workos_organization_id
+       LIMIT 2`,
+      [emailAliases],
+    );
+
+    if (existingPersonal.rows.length > 1) {
+      return {
+        success: false,
+        alreadyExists: true,
+        error: `Multiple individual workspaces are associated with ${contactEmail}; resolve the duplicate before sending an invite`,
+      };
+    }
+
+    if (existingPersonal.rows.length === 1) {
+      const existing = existingPersonal.rows[0];
+      return {
+        success: false,
+        alreadyExists: true,
+        organization: {
+          ...existing,
+          company_type: existing.company_type ?? undefined,
+          prospect_status: existing.prospect_status ?? '',
+        },
+        error: `An individual workspace for ${contactEmail} already exists`,
+      };
+    }
   }
 
   // Check if domain resolves to an existing organization (exact, alias, sub-brand, or redirect)
@@ -181,11 +253,13 @@ export async function createProspect(
   }
 
   // Check for existing organization with same name
-  const existing = await pool.query(
-    `SELECT workos_organization_id, name FROM organizations
-     WHERE LOWER(name) = LOWER($1) AND is_personal = false`,
-    [name]
-  );
+  const existing = isPersonal
+    ? { rows: [] }
+    : await pool.query(
+        `SELECT workos_organization_id, name FROM organizations
+         WHERE LOWER(name) = LOWER($1) AND is_personal = false`,
+        [name]
+      );
 
   if (existing.rows.length > 0) {
     return {
@@ -197,12 +271,13 @@ export async function createProspect(
   }
 
   try {
-    const domainTrust = prospectDomainTrust(input);
+    const domainTrust = normalizedDomain ? prospectDomainTrust(input) : null;
     // Create organization in WorkOS
-    const workosOrg = await workos.organizations.createOrganization({
-      name,
-      domainData: [{ domain: normalizedDomain, state: domainTrust.workosState }],
-    });
+    const workosOrg = await workos.organizations.createOrganization(
+      normalizedDomain && domainTrust
+        ? { name, domainData: [{ domain: normalizedDomain, state: domainTrust.workosState }] }
+        : { name },
+    );
 
     logger.info(
       { orgId: workosOrg.id, name, domain: normalizedDomain },
@@ -228,8 +303,8 @@ export async function createProspect(
         is_personal,
         created_at,
         updated_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, false, NOW(), NOW())
-      RETURNING workos_organization_id, name, company_type, email_domain, prospect_status`,
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NOW(), NOW())
+      RETURNING workos_organization_id, name, company_type, email_domain, prospect_status, is_personal`,
       [
         workosOrg.id,
         name,
@@ -239,43 +314,46 @@ export async function createProspect(
         input.prospect_source || 'manual',
         input.prospect_notes || null,
         input.prospect_contact_name || null,
-        input.prospect_contact_email || null,
+        contactEmail,
         input.prospect_contact_title || null,
         input.prospect_next_action || null,
         input.prospect_next_action_date || null,
         input.prospect_owner || null,
+        isPersonal,
       ]
     );
 
     const org = result.rows[0];
 
-    const linkResult = await linkDomain({
-      orgId: workosOrg.id,
-      domain: normalizedDomain,
-      source: domainTrust.source,
-      verified: domainTrust.verified,
-      isPrimary: true,
-    });
-    if (linkResult.conflictOrgId) {
-      await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [workosOrg.id]);
-      return {
-        success: false,
-        alreadyExists: true,
-        error: `Domain ${normalizedDomain} is already linked to another organization (${linkResult.conflictOrgId})`,
-      };
-    }
+    if (normalizedDomain && domainTrust) {
+      const linkResult = await linkDomain({
+        orgId: workosOrg.id,
+        domain: normalizedDomain,
+        source: domainTrust.source,
+        verified: domainTrust.verified,
+        isPrimary: true,
+      });
+      if (linkResult.conflictOrgId) {
+        await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [workosOrg.id]);
+        return {
+          success: false,
+          alreadyExists: true,
+          error: `Domain ${normalizedDomain} is already linked to another organization (${linkResult.conflictOrgId})`,
+        };
+      }
 
-    const bgPromise = researchDomain(normalizedDomain, { org_id: workosOrg.id }).catch((err) => {
-      logger.warn(
-        { err, domain: normalizedDomain, orgId: workosOrg.id },
-        'Background research failed for new prospect'
-      );
-    });
-    trackBackground(bgPromise);
+      const bgPromise = researchDomain(normalizedDomain, { org_id: workosOrg.id }).catch((err) => {
+        logger.warn(
+          { err, domain: normalizedDomain, orgId: workosOrg.id },
+          'Background research failed for new prospect'
+        );
+      });
+      trackBackground(bgPromise);
+    }
 
     return {
       success: true,
-      organization: { ...org, email_domain: normalizedDomain },
+      organization: { ...org, email_domain: normalizedDomain || undefined },
     };
   } catch (error) {
     logger.error({ err: error, name }, 'Error creating prospect');

--- a/server/src/services/workos-pagination.ts
+++ b/server/src/services/workos-pagination.ts
@@ -1,0 +1,22 @@
+interface WorkOSPage<T> {
+  data: T[];
+  listMetadata?: {
+    after?: string | null;
+  };
+}
+
+/** Collect every page from a cursor-paginated WorkOS list endpoint. */
+export async function collectWorkOSPages<T>(
+  fetchPage: (after: string | undefined) => Promise<WorkOSPage<T>>
+): Promise<T[]> {
+  const results: T[] = [];
+  let after: string | undefined;
+
+  do {
+    const page = await fetchPage(after);
+    results.push(...page.data);
+    after = page.listMetadata?.after ?? undefined;
+  } while (after);
+
+  return results;
+}

--- a/server/tests/integration/admin-invite-tools.test.ts
+++ b/server/tests/integration/admin-invite-tools.test.ts
@@ -14,6 +14,7 @@ import { createMembershipInvite } from '../../src/db/membership-invites-db.js';
 
 const ORG_PUBX = 'org_admin_invite_tools_pubx';
 const ORG_NONMEMBER = 'org_admin_invite_tools_nonmember';
+const ORG_INDIVIDUAL = 'org_admin_invite_tools_individual';
 const TEST_DOMAIN = 'admin-invite-tools.test';
 const ADMIN_ID = 'user_admin_invite_tools_admin';
 const ADMIN_EMAIL = `admin@${TEST_DOMAIN}`;
@@ -25,18 +26,21 @@ async function cleanup() {
     [`%@${TEST_DOMAIN}`]
   );
   await query('DELETE FROM person_relationships WHERE email LIKE $1', [`%@${TEST_DOMAIN}`]);
-  await query('DELETE FROM membership_invites WHERE workos_organization_id IN ($1, $2)', [
+  await query('DELETE FROM membership_invites WHERE workos_organization_id IN ($1, $2, $3)', [
     ORG_PUBX,
     ORG_NONMEMBER,
+    ORG_INDIVIDUAL,
   ]);
-  await query('DELETE FROM organizations WHERE workos_organization_id IN ($1, $2)', [
+  await query('DELETE FROM organizations WHERE workos_organization_id IN ($1, $2, $3)', [
     ORG_PUBX,
     ORG_NONMEMBER,
+    ORG_INDIVIDUAL,
   ]);
 }
 
 describe('admin invite tools', () => {
   let listInvites: (input: Record<string, unknown>) => Promise<string>;
+  let sendPaymentRequest: (input: Record<string, unknown>) => Promise<string>;
   let resendInvite: (input: Record<string, unknown>) => Promise<string>;
   let revokeInvite: (input: Record<string, unknown>) => Promise<string>;
   let diagnoseSigninBlock: (input: Record<string, unknown>) => Promise<string>;
@@ -61,10 +65,11 @@ describe('admin invite tools', () => {
     });
 
     listInvites = handlers.get('list_invites_for_org')!;
+    sendPaymentRequest = handlers.get('send_payment_request')!;
     resendInvite = handlers.get('resend_invite')!;
     revokeInvite = handlers.get('revoke_invite')!;
     diagnoseSigninBlock = handlers.get('diagnose_signin_block')!;
-    if (!listInvites || !resendInvite || !revokeInvite || !diagnoseSigninBlock) {
+    if (!listInvites || !sendPaymentRequest || !resendInvite || !revokeInvite || !diagnoseSigninBlock) {
       throw new Error('One or more invite tool handlers not registered');
     }
   }, 60000);
@@ -161,6 +166,44 @@ describe('admin invite tools', () => {
       const out = await listInvites({ org_id: ORG_PUBX, include_accepted: true });
       expect(out).toContain(accepted.token.slice(0, 8));
       expect(out).toContain('[accepted]');
+    });
+  });
+
+  describe('send_payment_request', () => {
+    it('finds an existing individual workspace by normalized contact email', async () => {
+      await query(
+        `INSERT INTO organizations (
+           workos_organization_id, name, is_personal, prospect_contact_email,
+           created_at, updated_at
+         ) VALUES ($1, $2, true, $3, NOW(), NOW())`,
+        [ORG_INDIVIDUAL, 'Existing Individual', 'individual@gmail.com']
+      );
+
+      const out = await sendPaymentRequest({
+        company_name: 'A Different Display Name',
+        contact_email: 'INDIVIDUAL@googlemail.com',
+        customer_type: 'individual',
+        action: 'lookup_only',
+      });
+
+      expect(out).toContain('Existing Individual');
+      expect(out).not.toContain('Created');
+      const personalOrgs = await query(
+        `SELECT COUNT(*)::int AS count FROM organizations
+         WHERE is_personal = true
+           AND workos_organization_id LIKE 'org_admin_invite_tools_%'`,
+      );
+      expect(personalOrgs.rows[0].count).toBe(1);
+    });
+
+    it('requires a valid contact email before creating an individual workspace', async () => {
+      const out = await sendPaymentRequest({
+        company_name: 'No Email Individual',
+        customer_type: 'individual',
+        action: 'lookup_only',
+      });
+
+      expect(out).toMatch(/contact_email is required for an individual membership/);
     });
   });
 
@@ -393,6 +436,34 @@ describe('admin invite tools', () => {
       );
       const out = await resendInvite({ token: 'tok_unknown', org_id: ORG_PUBX });
       expect(out).toMatch(/Invite not found/);
+    });
+
+    it('rejects an explicit customer type that disagrees with the persisted workspace', async () => {
+      await query(
+        `INSERT INTO organizations (
+           workos_organization_id, name, is_personal, created_at, updated_at
+         ) VALUES ($1, $2, true, NOW(), NOW())`,
+        [ORG_INDIVIDUAL, 'Individual Invite Test']
+      );
+      const inv = await createMembershipInvite({
+        workos_organization_id: ORG_INDIVIDUAL,
+        lookup_key: 'aao_membership_individual',
+        contact_email: `individual@${TEST_DOMAIN}`,
+        invited_by_user_id: ADMIN_ID,
+      });
+
+      const out = await resendInvite({
+        token: inv.token,
+        org_id: ORG_INDIVIDUAL,
+        customer_type: 'company',
+      });
+
+      expect(out).toMatch(/individual workspace, not a company workspace/);
+      const stored = await query(
+        `SELECT revoked_at FROM membership_invites WHERE token = $1`,
+        [inv.token]
+      );
+      expect(stored.rows[0].revoked_at).toBeNull();
     });
 
     it('refuses to resend an already-accepted invite', async () => {

--- a/server/tests/integration/prospect-domain-conflict.test.ts
+++ b/server/tests/integration/prospect-domain-conflict.test.ts
@@ -18,11 +18,13 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vites
 const {
   EXISTING_ORG_ID,
   PROSPECT_ORG_ID,
+  PERSONAL_ORG_ID,
   TAKEN_DOMAIN,
   FRESH_DOMAIN,
   RACE_DOMAIN,
   CONTACT_DOMAIN,
   UPDATE_DOMAIN,
+  PERSONAL_EMAIL,
   mockCreateOrganization,
   mockResolveOrgByDomain,
 } = vi.hoisted(() => {
@@ -31,11 +33,13 @@ const {
   return {
     EXISTING_ORG_ID: 'org_prospect_conflict_existing',
     PROSPECT_ORG_ID: 'org_prospect_conflict_new',
+    PERSONAL_ORG_ID: 'org_prospect_conflict_personal',
     TAKEN_DOMAIN: 'taken-by-original.test',
     FRESH_DOMAIN: 'fresh-domain-for-prospect.test',
     RACE_DOMAIN: 'race-conflict.test',
     CONTACT_DOMAIN: 'contact-only-prospect.test',
     UPDATE_DOMAIN: 'updated-prospect-domain.test',
+    PERSONAL_EMAIL: 'individual.prospect@gmail.com',
     mockCreateOrganization: vi.fn(),
     mockResolveOrgByDomain: vi.fn(),
   };
@@ -75,7 +79,7 @@ import { runMigrations } from '../../src/db/migrate.js';
 import { createProspect, updateProspect } from '../../src/services/prospect.js';
 import type { Pool } from 'pg';
 
-const TEST_ORGS = [EXISTING_ORG_ID, PROSPECT_ORG_ID];
+const TEST_ORGS = [EXISTING_ORG_ID, PROSPECT_ORG_ID, PERSONAL_ORG_ID];
 const TEST_DOMAINS = [TAKEN_DOMAIN, FRESH_DOMAIN, RACE_DOMAIN, CONTACT_DOMAIN, UPDATE_DOMAIN];
 
 async function clearFixtures(pool: Pool) {
@@ -212,6 +216,59 @@ describe('createProspect domain conflict handling (#4321)', () => {
     expect(row.rows[0].is_primary).toBe(true);
     expect(row.rows[0].verified).toBe(true);
     expect(row.rows[0].source).toBe('import');
+  });
+
+  it('creates an individual prospect as a domainless personal workspace', async () => {
+    const result = await createProspect({
+      name: 'Individual Prospect',
+      is_personal: true,
+      prospect_contact_email: `  ${PERSONAL_EMAIL.toUpperCase()}  `,
+      prospect_source: 'addie_payment_request',
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockCreateOrganization).toHaveBeenCalledWith({
+      name: 'Individual Prospect',
+    });
+
+    const org = await pool.query(
+      `SELECT is_personal, email_domain, prospect_contact_email
+       FROM organizations WHERE workos_organization_id = $1`,
+      [PROSPECT_ORG_ID],
+    );
+    expect(org.rows[0]).toMatchObject({
+      is_personal: true,
+      email_domain: null,
+      prospect_contact_email: PERSONAL_EMAIL,
+    });
+
+    const domains = await pool.query(
+      `SELECT domain FROM organization_domains WHERE workos_organization_id = $1`,
+      [PROSPECT_ORG_ID],
+    );
+    expect(domains.rowCount).toBe(0);
+  });
+
+  it('reuses an existing individual workspace by normalized contact email', async () => {
+    await pool.query(
+      `INSERT INTO organizations (
+         workos_organization_id, name, is_personal, prospect_contact_email,
+         created_at, updated_at
+       ) VALUES ($1, $2, true, $3, NOW(), NOW())`,
+      [PERSONAL_ORG_ID, 'Existing Individual', PERSONAL_EMAIL],
+    );
+
+    const result = await createProspect({
+      name: 'A Different Display Name',
+      is_personal: true,
+      prospect_contact_email: 'individual.prospect@googlemail.com',
+      prospect_source: 'addie_payment_request',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.alreadyExists).toBe(true);
+    expect(result.organization?.workos_organization_id).toBe(PERSONAL_ORG_ID);
+    expect(mockCreateOrganization).not.toHaveBeenCalled();
   });
 
   it('infers and verifies the domain from a business contact email when domain is omitted', async () => {

--- a/server/tests/unit/billing-tool-lockdown.test.ts
+++ b/server/tests/unit/billing-tool-lockdown.test.ts
@@ -81,6 +81,14 @@ describe('send_invoice / confirm_send_invoice tools', () => {
 });
 
 describe('send_payment_request admin tool', () => {
+  it('accepts company or individual customer types without making the field required', () => {
+    const schema = getToolSchema('send_payment_request', ADMIN_TOOLS);
+    const customerType = schema.properties.customer_type as { enum?: string[] };
+
+    expect(customerType.enum).toEqual(['company', 'individual']);
+    expect(schema.required).not.toContain('customer_type');
+  });
+
   it('exposes only the safe action enum (no direct-issue actions)', () => {
     const schema = getToolSchema('send_payment_request', ADMIN_TOOLS);
     const action = schema.properties.action as { enum?: string[] };
@@ -96,5 +104,15 @@ describe('send_payment_request admin tool', () => {
   it('does not accept the legacy billing_address parameter', () => {
     const schema = getToolSchema('send_payment_request', ADMIN_TOOLS);
     expect(schema.properties).not.toHaveProperty('billing_address');
+  });
+});
+
+describe('resend_invite admin tool', () => {
+  it('accepts an optional customer type consistency check', () => {
+    const schema = getToolSchema('resend_invite', ADMIN_TOOLS);
+    const customerType = schema.properties.customer_type as { enum?: string[] };
+
+    expect(customerType.enum).toEqual(['company', 'individual']);
+    expect(schema.required).not.toContain('customer_type');
   });
 });

--- a/server/tests/unit/workos-pagination.test.ts
+++ b/server/tests/unit/workos-pagination.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { collectWorkOSPages } from "../../src/services/workos-pagination.js";
+
+describe("collectWorkOSPages", () => {
+  it("collects every page and follows each after cursor", async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: ["member-1", "member-2"],
+        listMetadata: { after: "cursor-2" },
+      })
+      .mockResolvedValueOnce({
+        data: ["member-3"],
+        listMetadata: { after: "cursor-3" },
+      })
+      .mockResolvedValueOnce({
+        data: ["member-4"],
+        listMetadata: { after: null },
+      });
+
+    await expect(collectWorkOSPages(fetchPage)).resolves.toEqual([
+      "member-1",
+      "member-2",
+      "member-3",
+      "member-4",
+    ]);
+    expect(fetchPage.mock.calls).toEqual([
+      [undefined],
+      ["cursor-2"],
+      ["cursor-3"],
+    ]);
+  });
+
+  it("returns an empty list for an empty first page", async () => {
+    const fetchPage = vi.fn().mockResolvedValue({
+      data: [],
+      listMetadata: {},
+    });
+
+    await expect(collectWorkOSPages(fetchPage)).resolves.toEqual([]);
+    expect(fetchPage).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- paginate WorkOS organization memberships and invitations so team rosters and admin counts are complete beyond the default page
- add individual customer_type support to Addie payment requests and safe persisted-type checks to invite resends
- create domainless personal prospects and deduplicate them across normalized email aliases, memberships, users, and prior invitations
- fail closed on ambiguous duplicate personal workspaces

Closes #5632.
Closes #5626.

## Production safety

No sync or write endpoint was run. The affected production records were audited read-only; global WorkOS repair still requires a post-deploy integrity check before any explicit sync.

## Validation

- invite/prospect focused suite: 43 passed
- pagination tests: 2 passed
- combined focused unit suite: 64 passed
- repository precommit: 999 tests passed, typecheck and source lints passed
- git diff --check