### PR TITLE
fix(addie): ground schema answers and repair identity discovery

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.06.1';
+export const CODE_VERSION = '2026.07.1';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/docs-indexer.ts
+++ b/server/src/addie/mcp/docs-indexer.ts
@@ -1,7 +1,7 @@
 /**
  * Docs Indexer for Addie
  *
- * Indexes Mintlify docs and website HTML at startup so Addie can search and reference them.
+ * Indexes Mintlify docs, JSON schemas, and website HTML at startup so Addie can search and reference them.
  * Content is read from the filesystem and stored in memory for fast access.
  */
 
@@ -22,6 +22,14 @@ const WEBSITE_PAGES_TO_EXCLUDE = [
   /^member-profile/,  // Member profile (dynamic)
   /^org-index/,       // Organization index (dynamic)
 ];
+
+// Aggregate schemas duplicate large portions of the component schemas and
+// overwhelm keyword ranking. Their referenced component schemas are indexed.
+const SCHEMA_FILES_TO_EXCLUDE = new Set([
+  'index.json',
+  'protocol/get-adcp-capabilities-response.json',
+  'brand.json',
+]);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -221,16 +229,15 @@ function extractCategory(filePath: string, docsRoot: string): string {
 /**
  * Clean markdown content - remove frontmatter, imports, JSX components
  */
-function cleanContent(content: string): string {
+export function cleanContent(content: string): string {
   // Remove frontmatter
   content = content.replace(/^---\s*\n[\s\S]*?\n---\s*\n/, '');
 
   // Remove import statements
   content = content.replace(/^import\s+.*$/gm, '');
 
-  // Remove JSX components (simple cases)
-  content = content.replace(/<[A-Z][a-zA-Z]*[^>]*>[\s\S]*?<\/[A-Z][a-zA-Z]*>/g, '');
-  content = content.replace(/<[A-Z][a-zA-Z]*[^>]*\/>/g, '');
+  // Remove JSX component tags while preserving their searchable children.
+  content = content.replace(/<\/?[A-Z][a-zA-Z]*[^>]*>/g, '');
 
   // Clean up extra whitespace
   content = content.replace(/\n{3,}/g, '\n\n').trim();
@@ -345,6 +352,146 @@ function findMarkdownFiles(dir: string): string[] {
   }
 
   return files;
+}
+
+/** Recursively find JSON schema files. */
+function findJsonFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  if (!fs.existsSync(dir)) {
+    return files;
+  }
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...findJsonFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.json')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+type JsonObject = Record<string, unknown>;
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringValues(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item) => ['string', 'number', 'boolean'].includes(typeof item) || item === null)
+    .map((item) => JSON.stringify(item));
+}
+
+/**
+ * Extract the human-meaningful/searchable portion of a JSON schema.
+ * Structural validation keywords are deliberately omitted unless they name
+ * fields, references, required fields, or allowed values.
+ */
+export function extractSchemaContent(schema: unknown): string {
+  if (!isJsonObject(schema)) return '';
+
+  const lines = new Set<string>();
+  const rootId = typeof schema.$id === 'string' ? schema.$id : null;
+  if (rootId) lines.add(`Schema ID: ${rootId}`);
+  if (typeof schema.description === 'string') lines.add(schema.description.trim());
+
+  const visit = (node: unknown, fieldPath: string): void => {
+    if (!isJsonObject(node)) return;
+
+    const label = fieldPath || 'Schema';
+    if (typeof node.description === 'string') {
+      lines.add(`${label}: ${node.description.trim()}`);
+    }
+    if (typeof node.$ref === 'string') {
+      lines.add(`${label} references ${node.$ref}`);
+    }
+
+    const enumValues = stringValues(node.enum);
+    if (enumValues.length > 0) {
+      lines.add(`${label} allowed values: ${enumValues.join(', ')}`);
+    }
+    if (['string', 'number', 'boolean'].includes(typeof node.const) || node.const === null) {
+      lines.add(`${label} fixed value: ${JSON.stringify(node.const)}`);
+    }
+
+    const required = stringValues(node.required);
+    if (required.length > 0) {
+      lines.add(`${label} required fields: ${required.join(', ')}`);
+    }
+
+    if (isJsonObject(node.properties)) {
+      for (const [propertyName, propertySchema] of Object.entries(node.properties)) {
+        const propertyPath = fieldPath ? `${fieldPath}.${propertyName}` : propertyName;
+        lines.add(`Field: ${propertyPath}`);
+        visit(propertySchema, propertyPath);
+      }
+    }
+
+    if (node.items) visit(node.items, fieldPath ? `${fieldPath}[]` : 'items[]');
+
+    for (const keyword of ['allOf', 'anyOf', 'oneOf'] as const) {
+      const alternatives = node[keyword];
+      if (Array.isArray(alternatives)) {
+        for (const alternative of alternatives) visit(alternative, fieldPath);
+      }
+    }
+
+    for (const keyword of ['$defs', 'definitions'] as const) {
+      const definitions = node[keyword];
+      if (!isJsonObject(definitions)) continue;
+      for (const [definitionName, definitionSchema] of Object.entries(definitions)) {
+        visit(definitionSchema, fieldPath || definitionName);
+      }
+    }
+  };
+
+  visit(schema, '');
+  return [...lines].filter(Boolean).join('\n');
+}
+
+function schemaTitle(schema: JsonObject, relativePath: string): string {
+  if (typeof schema.title === 'string' && schema.title.trim()) return schema.title.trim();
+
+  const id = typeof schema.$id === 'string' ? schema.$id : relativePath;
+  return path.basename(id)
+    .replace(/\.json$/, '')
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function indexSchemaFiles(schemaRoot: string): IndexedDoc[] {
+  const indexed: IndexedDoc[] = [];
+
+  for (const filePath of findJsonFiles(schemaRoot)) {
+    const relativePath = path.relative(schemaRoot, filePath).replace(/\\/g, '/');
+    if (SCHEMA_FILES_TO_EXCLUDE.has(relativePath)) continue;
+
+    try {
+      const schema = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as unknown;
+      if (!isJsonObject(schema)) continue;
+
+      const content = extractSchemaContent(schema);
+      if (!content) continue;
+
+      indexed.push({
+        id: `schema:${relativePath.replace(/\.json$/, '')}`,
+        title: schemaTitle(schema, relativePath),
+        category: 'schema',
+        path: relativePath,
+        content,
+        sourceUrl: `https://adcontextprotocol.org/schemas/latest/${relativePath}`,
+      });
+    } catch (error) {
+      logger.warn({ error, filePath }, 'Addie Docs: Failed to index schema');
+    }
+  }
+
+  return indexed;
 }
 
 /**
@@ -474,6 +621,14 @@ export async function initializeDocsIndex(): Promise<void> {
     '/app/server/public',
   ];
 
+  const possibleSchemaPaths = [
+    // From server/src/addie/mcp/ to static schemas
+    path.resolve(__dirname, '../../../../static/schemas/source'),
+    // From dist/addie/mcp/ to static schemas
+    path.resolve(__dirname, '../../../static/schemas/source'),
+    '/app/static/schemas/source',
+  ];
+
   let docsRoot: string | null = null;
   for (const p of possibleDocsPaths) {
     if (fs.existsSync(p)) {
@@ -486,6 +641,14 @@ export async function initializeDocsIndex(): Promise<void> {
   for (const p of possiblePublicPaths) {
     if (fs.existsSync(p)) {
       publicRoot = p;
+      break;
+    }
+  }
+
+  let schemaRoot: string | null = null;
+  for (const p of possibleSchemaPaths) {
+    if (fs.existsSync(p)) {
+      schemaRoot = p;
       break;
     }
   }
@@ -537,6 +700,15 @@ export async function initializeDocsIndex(): Promise<void> {
     logger.warn({ paths: possibleDocsPaths }, 'Addie Docs: Could not find docs directory');
   }
 
+  // Index schema facts separately from prose so callers can retrieve the
+  // complete extracted schema document by its stable schema: ID.
+  if (schemaRoot) {
+    logger.info({ schemaRoot }, 'Addie Docs: Indexing JSON schemas');
+    nextDocsIndex.push(...indexSchemaFiles(schemaRoot));
+  } else {
+    logger.warn({ paths: possibleSchemaPaths }, 'Addie Docs: Could not find schema directory');
+  }
+
   // Index website HTML pages
   if (publicRoot) {
     logger.info({ publicRoot }, 'Addie Docs: Indexing website pages');
@@ -576,7 +748,8 @@ export async function initializeDocsIndex(): Promise<void> {
   const websiteCount = docsIndex.filter((d) => d.category === 'website').length;
   const workingGroupCount = docsIndex.filter((d) => d.category.startsWith('working group')).length;
   const perspectiveCount = docsIndex.filter((d) => d.category === 'perspective').length;
-  const protocolDocCount = docsIndex.length - websiteCount - workingGroupCount - perspectiveCount;
+  const schemaCount = docsIndex.filter((d) => d.category === 'schema').length;
+  const protocolDocCount = docsIndex.length - websiteCount - workingGroupCount - perspectiveCount - schemaCount;
 
   // Warn if protocol docs index seems suspiciously empty (expect 50+ docs)
   if (docsRoot && protocolDocCount < 10) {
@@ -591,6 +764,7 @@ export async function initializeDocsIndex(): Promise<void> {
       totalDocs: docsIndex.length,
       totalHeadings: headingsIndex.length,
       protocolDocs: protocolDocCount,
+      schemas: schemaCount,
       websitePages: websiteCount,
       workingGroupDocs: workingGroupCount,
       perspectives: perspectiveCount,
@@ -620,7 +794,24 @@ export function searchDocs(
 
   const limit = options.limit ?? 5;
   const queryLower = query.toLowerCase();
-  const queryWords = queryLower.split(/\s+/).filter((w) => w.length > 2);
+  const queryWords = [...new Set(
+    queryLower
+      .split(/[^a-z0-9_-]+/)
+      .flatMap((word) => [word, word.replace(/_/g, '-'), word.replace(/-/g, '_')])
+      .filter((word) => word.length > 2)
+  )];
+
+  const countOccurrences = (content: string, word: string, max: number): number => {
+    let count = 0;
+    let offset = 0;
+    while (count < max) {
+      const match = content.indexOf(word, offset);
+      if (match === -1) break;
+      count++;
+      offset = match + word.length;
+    }
+    return count;
+  };
 
   // Score each document
   const scored = docsIndex
@@ -634,6 +825,7 @@ export function searchDocs(
     .map((doc) => {
       const titleLower = doc.title.toLowerCase();
       const contentLower = doc.content.toLowerCase();
+      const identityLower = `${doc.id} ${doc.path}`.toLowerCase();
 
       let score = 0;
 
@@ -647,13 +839,22 @@ export function searchDocs(
         score += 50;
       }
 
+      // Schema/task names often arrive as snake_case while filenames use
+      // kebab-case. Stable IDs and paths provide the bridge between them.
+      if (identityLower.includes(queryLower.replace(/_/g, '-'))) {
+        score += 75;
+      }
+
       // Individual word matches
       for (const word of queryWords) {
         if (titleLower.includes(word)) {
           score += 20;
         }
+        if (identityLower.includes(word)) {
+          score += 15;
+        }
         // Count occurrences in content (limited to avoid huge scores)
-        const occurrences = Math.min((contentLower.match(new RegExp(word, 'g')) || []).length, 10);
+        const occurrences = countOccurrences(contentLower, word, 10);
         score += occurrences * 2;
       }
 
@@ -676,6 +877,7 @@ export function getDocById(id: string): IndexedDoc | null {
   return docsIndex.find((doc) => doc.id === id)
     || docsIndex.find((doc) => doc.id === `doc:${id}`)
     || docsIndex.find((doc) => doc.id === `website:${id}`)
+    || docsIndex.find((doc) => doc.id === `schema:${id.replace(/\.json$/, '')}`)
     || docsIndex.find((doc) => doc.id === `wg-doc:${id}`)
     || null;
 }

--- a/server/src/addie/mcp/knowledge-search.ts
+++ b/server/src/addie/mcp/knowledge-search.ts
@@ -161,7 +161,7 @@ export const KNOWLEDGE_TOOLS: AddieTool[] = [
   {
     name: 'search_docs',
     description:
-      'Search the official AdCP documentation and working group documents. Includes protocol docs, website content, and documents published by working groups (brand guidelines, positioning, governance docs, etc.). Returns excerpts with source URLs. IMPORTANT: Use ONE well-crafted search with specific keywords rather than multiple searches. For detailed content, use get_doc with the doc ID from results.',
+      'Search the official AdCP documentation, extracted JSON schema facts, and working group documents. Includes protocol docs, website content, and documents published by working groups (brand guidelines, positioning, governance docs, etc.). Returns excerpts with source URLs. IMPORTANT: Use ONE well-crafted search with specific keywords rather than multiple searches. For complete request/response fields or enum values, verify with get_schema. To determine whether a schema or protocol feature exists, use list_schemas. For detailed prose or an extracted schema result, use get_doc with the doc ID from results.',
     usage_hints: 'use for learning, understanding concepts, "how does X work?", "what is X?", "explain X", brand guidelines, working group documents',
     input_schema: {
       type: 'object',

--- a/server/src/addie/rules/behaviors.md
+++ b/server/src/addie/rules/behaviors.md
@@ -176,7 +176,8 @@ Before drafting a GitHub issue about a missing tool, look up the canonical catal
 
 ## Verify Claims With Tools
 When discussing protocol details, schema structures, or implementation specifics:
-- ALWAYS use search_docs or get_schema to verify before stating facts about AdCP
+- Any answer containing a field name, enum value, or feature-presence claim must be supported by a successful tool call in this turn. Use `get_schema` for fields and enum values, and `list_schemas` to verify whether a schema or feature exists. Use `search_docs` and `get_doc` for prose guidance and channel-specific behavior.
+- Never state a wire-level claim and then close by offering to verify it; verify it before answering.
 - Use search_repos to check actual code before describing how something works
 - When helping test agents, use validate_adagents, get_agent_status, or evaluate_agent_quality — do not just describe what the user should do. `get_agent_status` reads the registry's cached health + comply verdict (the same data the dashboard renders); `evaluate_agent_quality` runs the comply storyboard suite live.
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -949,7 +949,11 @@ export class HTTPServer {
     // AAO domain redirects to the DB-managed hosted brand.
     this.app.get('/.well-known/brand.json', (req, res) => {
       res.setHeader('Cache-Control', 'public, max-age=3600');
-      if (this.isAdcpDomain(req)) {
+      // The training-agent hostname publishes the same operator record as the
+      // AdCP site. Its capabilities point at this exact origin, so returning
+      // the AAO authoritative-location stub here would break the required
+      // capabilities -> brand.json -> agents[] -> JWKS discovery chain.
+      if (this.isAdcpDomain(req) || TRAINING_AGENT_HOSTNAMES.has(req.hostname)) {
         return res.json({
           "$schema": "https://adcontextprotocol.org/schemas/latest/brand.json",
           "agents": [

--- a/server/tests/unit/docs-indexer.test.ts
+++ b/server/tests/unit/docs-indexer.test.ts
@@ -1,9 +1,21 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class {
+    async getIndexedDocumentsWithContent() { return []; }
+  },
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn().mockResolvedValue({ rows: [] }),
+}));
+
 // Import the actual indexer functions
 import {
+  cleanContent,
+  extractSchemaContent,
   initializeDocsIndex,
   searchDocs,
   searchHeadings,
@@ -112,6 +124,81 @@ describe('docs-indexer', () => {
     it('returns empty for nonsense queries', () => {
       const results = searchDocs('xyzzy_nonexistent_term_12345');
       expect(results.length).toBe(0);
+    });
+  });
+
+  describe('schema and MDX retrieval (#5861)', () => {
+    it('preserves Mintlify component children while removing JSX tags', () => {
+      const cleaned = cleanContent(`---
+title: Targeting
+---
+<Accordion title="Structured filters">
+The request includes a structured \`filters\` object.
+<ParamField path="filters.channels">Includes ctv.</ParamField>
+</Accordion>`);
+
+      expect(cleaned).toContain('The request includes a structured `filters` object.');
+      expect(cleaned).toContain('Includes ctv.');
+      expect(cleaned).not.toContain('<Accordion');
+      expect(cleaned).not.toContain('<ParamField');
+    });
+
+    it('extracts searchable schema facts without structural validation noise', () => {
+      const content = extractSchemaContent({
+        $id: '/schemas/example.json',
+        description: 'Example request.',
+        type: 'object',
+        properties: {
+          channel: {
+            description: 'Requested channel.',
+            enum: ['display', 'ctv'],
+          },
+          filters: { $ref: '/schemas/core/product-filters.json' },
+        },
+        required: ['channel'],
+        additionalProperties: false,
+      });
+
+      expect(content).toContain('Field: channel');
+      expect(content).toContain('channel allowed values: "display", "ctv"');
+      expect(content).toContain('filters references /schemas/core/product-filters.json');
+      expect(content).toContain('Schema required fields: "channel"');
+      expect(content).not.toContain('additionalProperties');
+    });
+
+    it('indexes get_products and product filter schema facts', () => {
+      const results = searchDocs('get_products filters geo', { limit: 5 });
+      expect(results.some((doc) => [
+        'schema:media-buy/get-products-request',
+        'schema:core/product-filters',
+      ].includes(doc.id))).toBe(true);
+
+      const filters = getDocById('core/product-filters.json');
+      expect(filters?.id).toBe('schema:core/product-filters');
+      expect(filters?.content).toContain('Field: countries');
+      expect(filters?.content).toContain('Field: channels');
+    });
+
+    it('excludes duplicate aggregate schemas', () => {
+      expect(getDocById('schema:index')).toBeNull();
+      expect(getDocById('schema:brand')).toBeNull();
+      expect(getDocById('schema:protocol/get-adcp-capabilities-response')).toBeNull();
+    });
+
+    it('ranks the Trusted Match CTV surface guide for a channel query', () => {
+      const results = searchDocs('trusted match ctv', { limit: 3 });
+      expect(results.map((doc) => doc.id)).toContain('doc:trusted-match/surfaces/ctv');
+    });
+
+    it('retrieves CTV enum and standard format registry sources', () => {
+      const enumResults = searchDocs('ctv_app property type', { limit: 5 });
+      expect(enumResults.map((doc) => doc.id)).toContain('schema:enums/property-type');
+
+      const formatResults = searchDocs(
+        'standard format registry creative.adcontextprotocol.org',
+        { limit: 5 },
+      );
+      expect(formatResults.map((doc) => doc.id)).toContain('doc:creative/formats');
     });
   });
 });

--- a/server/tests/unit/public-brand-json-route.test.ts
+++ b/server/tests/unit/public-brand-json-route.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
 import { HTTPServer } from '../../src/http.js';
+import { TRAINING_AGENT_URL } from '../../src/training-agent/config.js';
 
 const ORIGINAL_WORKOS_ENV = vi.hoisted(() => ({
   apiKey: process.env.WORKOS_API_KEY,
@@ -83,6 +84,23 @@ describe('GET /brands/:domain/brand.json real route', () => {
       colors: { primary: '#123456' },
     });
     expect(res.body.brand_context).toBeUndefined();
+  });
+
+  it('publishes the training agent operator record on its canonical hostname', async () => {
+    server = new HTTPServer();
+    const app = (server as unknown as { app: unknown }).app;
+
+    const res = await request(app)
+      .get('/.well-known/brand.json')
+      .set('Host', new URL(TRAINING_AGENT_URL).host);
+
+    expect(res.status).toBe(200);
+    expect(res.body.authoritative_location).toBeUndefined();
+    expect(res.body.agents).toContainEqual(expect.objectContaining({
+      id: 'training_agent',
+      url: `${TRAINING_AGENT_URL}/api/training-agent/mcp`,
+      jwks_uri: 'https://adcontextprotocol.org/.well-known/jwks.json',
+    }));
   });
 
   it('strips legacy Brand Context API data from discovered brand edit-status responses', async () => {


### PR DESCRIPTION
## Summary

- index extracted facts from 645 source JSON schemas alongside prose and website content
- preserve the searchable children of Mintlify JSX components
- route field, enum, and feature-existence claims through schema tools before Addie answers
- improve snake_case/kebab-case schema retrieval and remove dynamic-regex scoring
- publish the training-agent operator record on its canonical hostname so capabilities → brand.json → JWKS discovery works after deployment

Closes #5861.
Closes #3842.

## Validation

- docs-indexer regressions: 18 passed
- Addie tool-reference check passed
- public brand.json route tests passed
- combined focused unit suite: 64 passed
- repository precommit: 999 tests passed, typecheck and source lints passed
- Mintlify broken-link validation passed
- git diff --check

## Deployment verification

The current production chain was exercised read-only and fails at the hostname-specific brand.json record, which this patch fixes. Re-run scripts/e2e-resolve-training-agent.ts against production after deploy before closing the operational loop.