### PR TITLE
fix(compliance): restore available actions patch changeset

### DIFF
--- a/.changeset/available-actions-non-guaranteed.md
+++ b/.changeset/available-actions-non-guaranteed.md
@@ -1,4 +1,5 @@
 ---
+"adcontextprotocol": patch
 ---
 
 compliance(media-buy): the `available_actions` scenario uses a non-guaranteed product fixture so `sales-non-guaranteed`-only sellers can run it.

--- a/static/compliance/source/protocols/media-buy/scenarios/available_actions.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/available_actions.yaml
@@ -66,7 +66,8 @@ fixtures:
       # sellers (a guaranteed-only fixture made create_buy_from_product fail with
       # DELIVERY_MODE_NOT_SUPPORTED, cascading the whole available-actions flow).
       # The allowed_actions below — what this scenario actually grades — are
-      # delivery-type-agnostic. Mirrors the base media-buy flow fix.
+      # delivery-type-agnostic. Keep this fixture non-guaranteed when extending
+      # the scenario; it mirrors the base media-buy flow compatibility fix.
       delivery_type: "non_guaranteed"
       channels: ["display"]
       format_ids:


### PR DESCRIPTION
## Summary

- replace the empty changeset merged in #5731 with the required adcontextprotocol patch declaration
- strengthen the source comment preserving the non-guaranteed fixture invariant

#5731 correctly fixed the false compliance failure, but its changeset frontmatter remained empty. Empty padding changesets are disallowed by the repository playbook and would omit the fix from the next protocol patch release; this follow-up repairs that release metadata immediately.

## Validation

- git diff --check
- changeset scope now includes the compliance source asset
- #5731 functional change had a fully green CI matrix before merge