### PR TITLE
fix(ci): let Argus review routine changesets

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -184,7 +184,10 @@ jobs:
       #   .agents/**              — agent prompts & context (prompt-injection
       #     would target these to expand the agent's capabilities).
       #   static/schemas/source/** — protocol source of truth for the spec.
-      #   .changeset/**           — release tooling.
+      #   .changeset/config.json, .changeset/pre.json — release configuration and
+      #     prerelease state. Routine .changeset/*.md release notes remain reviewable
+      #     so the required changeset policy does not prevent Argus from approving
+      #     otherwise eligible PRs.
       #
       # Even though pull_request_target keeps this run on the base-branch
       # prompt and workflow, a human should own these changes. Bail with a
@@ -209,7 +212,7 @@ jobs:
           MODIFIED=""
           while IFS= read -r f; do
             case "$f" in
-              .github/ai-review/*|.github/workflows/ai-review.yml|.agents/*|.github/workflows/*|static/schemas/source/*|.changeset/*)
+              .github/ai-review/*|.github/workflows/ai-review.yml|.agents/*|.github/workflows/*|static/schemas/source/*|.changeset/config.json|.changeset/pre.json)
                 MODIFIED="${MODIFIED}${f}"$'\n'
                 ;;
             esac


### PR DESCRIPTION
## Summary

- allow Argus to review PRs containing routine `.changeset/*.md` release notes
- keep `.changeset/config.json` and `.changeset/pre.json` behind the human-review gate
- preserve the existing human routing for generated release PRs and review infrastructure

## Root cause

The sensitive-path classifier matched all of `.changeset/*`. Because releaseable protocol fixes are required to include a changeset, Secretariat abstained from reviewing otherwise eligible PRs such as #5847 and #5904.

## Impact

Argus can now review and approve ordinary releaseable changes. Changes to Changesets configuration, prerelease state, CI, agent prompts, and protocol schema sources still require human review.

## Validation

- `git diff --check`
- `actionlint -ignore SC2129 .github/workflows/ai-review.yml`
- path-classifier smoke test covering routine markdown, `config.json`, and `pre.json`
- pre-push version, changeset-policy, and scope checks
