### PR TITLE
fix(release): preserve schema release status

### DIFF
--- a/.changeset/preserve-schema-release-status.md
+++ b/.changeset/preserve-schema-release-status.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Preserve withdrawn and unpublished release status when generating file-based schema discovery so exact artifacts remain available without becoming stable alias targets.

--- a/scripts/build-schemas.cjs
+++ b/scripts/build-schemas.cjs
@@ -37,6 +37,18 @@ const DIST_DIR = path.join(__dirname, '../dist/schemas');
 const PACKAGE_JSON = path.join(__dirname, '../package.json');
 const SKILLS_DIR = path.join(__dirname, '../skills');
 
+// Keep generated file-based discovery aligned with the CDN and server
+// middleware. Exact artifacts remain available, but non-selectable releases
+// must never win latest/major/minor aliases.
+const RELEASE_STATUS_OVERRIDES = new Map([
+  ['3.1.3', 'withdrawn'],
+  ['3.2.0', 'unpublished'],
+]);
+
+function isSelectableRelease(version) {
+  return !RELEASE_STATUS_OVERRIDES.has(version);
+}
+
 // Parse command line arguments
 const args = process.argv.slice(2);
 const isRelease = args.includes('--release');
@@ -57,7 +69,10 @@ function getAllReleasedVersions() {
 
   const entries = fs.readdirSync(DIST_DIR, { withFileTypes: true });
   return entries
-    .filter(e => e.isDirectory() && semver.valid(e.name) !== null && semver.prerelease(e.name) === null)
+    .filter(e => e.isDirectory()
+      && semver.valid(e.name) !== null
+      && semver.prerelease(e.name) === null
+      && isSelectableRelease(e.name))
     .map(e => e.name)
     .sort(semver.rcompare);
 }
@@ -120,6 +135,24 @@ function getReleaseMetadata(version, knownVersions = []) {
       stability: 'development',
       prerelease: false,
       deprecated: false,
+    };
+  }
+
+  const statusOverride = RELEASE_STATUS_OVERRIDES.get(version);
+  if (statusOverride === 'withdrawn') {
+    return {
+      stability: 'withdrawn',
+      prerelease: false,
+      deprecated: true,
+      withdrawn: true,
+    };
+  }
+  if (statusOverride === 'unpublished') {
+    return {
+      stability: 'unpublished',
+      prerelease: false,
+      deprecated: false,
+      published: false,
     };
   }
 
@@ -2184,7 +2217,18 @@ async function main() {
   console.log('📖 See docs/reference/versioning.mdx for guidance on which to use.');
 }
 
-module.exports = { hoistDuplicateInlineEnums, hoistMarkedSchemas, resolveRefs, versionInlineSchemaIds, dedupBundledSchemaIds, stripIdsFromSubtreesWithLocalRefs, copyAsyncResponseRefsToCore };
+module.exports = {
+  hoistDuplicateInlineEnums,
+  hoistMarkedSchemas,
+  resolveRefs,
+  versionInlineSchemaIds,
+  dedupBundledSchemaIds,
+  stripIdsFromSubtreesWithLocalRefs,
+  copyAsyncResponseRefsToCore,
+  getReleaseMetadata,
+  buildRootSchemaDiscovery,
+  isSelectableRelease,
+};
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/schema-release-status.test.ts
+++ b/tests/schema-release-status.test.ts
@@ -1,0 +1,44 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+  buildRootSchemaDiscovery,
+  getReleaseMetadata,
+  isSelectableRelease,
+} = require('../scripts/build-schemas.cjs');
+
+describe('schema release discovery status', () => {
+  it('keeps withdrawn and unpublished releases exact-addressable but non-selectable', () => {
+    expect(isSelectableRelease('3.1.3')).toBe(false);
+    expect(getReleaseMetadata('3.1.3')).toEqual({
+      stability: 'withdrawn',
+      prerelease: false,
+      deprecated: true,
+      withdrawn: true,
+    });
+
+    expect(isSelectableRelease('3.2.0')).toBe(false);
+    expect(getReleaseMetadata('3.2.0')).toEqual({
+      stability: 'unpublished',
+      prerelease: false,
+      deprecated: false,
+      published: false,
+    });
+  });
+
+  it('excludes non-selectable versions from stable aliases and latest', () => {
+    const discovery = buildRootSchemaDiscovery();
+    const withdrawn = discovery.versions.find(({ version }: { version: string }) => version === '3.1.3');
+    const aliasTargets = Object.values(discovery.aliases);
+
+    expect(['3.1.3', '3.2.0']).not.toContain(discovery.latest_stable);
+    expect(aliasTargets).not.toContain('3.1.3');
+    expect(aliasTargets).not.toContain('3.2.0');
+    expect(withdrawn).toMatchObject({
+      stability: 'withdrawn',
+      deprecated: true,
+      withdrawn: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- teach the schema discovery generator the same withdrawn/unpublished overrides used by CDN and server middleware
- exclude 3.1.3 and 3.2.0 from stable latest/major/minor alias selection
- retain exact-version discovery entries with explicit withdrawn or unpublished metadata
- add regression coverage for generated aliases and metadata

## Verification

- `npm run typecheck`
- `npx vitest run tests/schema-release-status.test.ts --pool=threads`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- `git diff --check`

This prevents future main deploys from regenerating `/schemas/index.json` with 3.1.3 mislabeled as stable.