### PR TITLE
fix: exclude archived working groups from live access

### DIFF
--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -467,7 +467,7 @@ export function buildSubscriptionUpdate(
  * A member is a contributor if any of:
  *   - admin assigned seat_type = 'contributor'
  *   - they have a mapped Slack account
- *   - they are an active member of a working group
+ *   - they are an active member of an active working group
  */
 export async function getSeatUsage(orgId: string): Promise<{ contributor: number; community_only: number }> {
   const pool = getPool();
@@ -477,7 +477,14 @@ export async function getSeatUsage(orgId: string): Promise<{ contributor: number
        COUNT(*) FILTER (WHERE
          om.seat_type = 'contributor'
          OR EXISTS (SELECT 1 FROM slack_user_mappings sm WHERE sm.workos_user_id = om.workos_user_id AND sm.mapping_status = 'mapped')
-         OR EXISTS (SELECT 1 FROM working_group_memberships wgm WHERE wgm.workos_user_id = om.workos_user_id AND wgm.status = 'active')
+         OR EXISTS (
+           SELECT 1
+           FROM working_group_memberships wgm
+           JOIN working_groups wg ON wg.id = wgm.working_group_id
+           WHERE wgm.workos_user_id = om.workos_user_id
+             AND wgm.status = 'active'
+             AND wg.status = 'active'
+         )
        ) as contributor
      FROM organization_memberships om
      WHERE om.workos_organization_id = $1`,
@@ -507,14 +514,21 @@ export async function canAddSeat(
     const tier = await readMembershipTierFromClient(client, orgId, { forUpdate: true });
     const limits = getSeatLimits(tier);
 
-    // Count active members (contributor = admin-assigned OR Slack-mapped OR in working group)
+    // Count active members (contributor = admin-assigned OR Slack-mapped OR in an active working group)
     const memberResult = await client.query<{ total: string; contributor: string }>(
       `SELECT
          COUNT(*) as total,
          COUNT(*) FILTER (WHERE
            om.seat_type = 'contributor'
            OR EXISTS (SELECT 1 FROM slack_user_mappings sm WHERE sm.workos_user_id = om.workos_user_id AND sm.mapping_status = 'mapped')
-           OR EXISTS (SELECT 1 FROM working_group_memberships wgm WHERE wgm.workos_user_id = om.workos_user_id AND wgm.status = 'active')
+           OR EXISTS (
+             SELECT 1
+             FROM working_group_memberships wgm
+             JOIN working_groups wg ON wg.id = wgm.working_group_id
+             WHERE wgm.workos_user_id = om.workos_user_id
+               AND wgm.status = 'active'
+               AND wg.status = 'active'
+           )
          ) as contributor
        FROM organization_memberships om
        WHERE om.workos_organization_id = $1`,
@@ -561,7 +575,7 @@ export async function canAddSeat(
  * Get a user's effective seat type. A user is a contributor if any of:
  *   - admin assigned seat_type = 'contributor'
  *   - they have a mapped Slack account
- *   - they are an active member of a working group
+ *   - they are an active member of an active working group
  */
 export async function getUserSeatType(userId: string): Promise<SeatType | null> {
   const pool = getPool();
@@ -569,7 +583,14 @@ export async function getUserSeatType(userId: string): Promise<SeatType | null> 
     `SELECT (
        EXISTS (SELECT 1 FROM organization_memberships WHERE workos_user_id = $1 AND seat_type = 'contributor')
        OR EXISTS (SELECT 1 FROM slack_user_mappings WHERE workos_user_id = $1 AND mapping_status = 'mapped')
-       OR EXISTS (SELECT 1 FROM working_group_memberships WHERE workos_user_id = $1 AND status = 'active')
+       OR EXISTS (
+         SELECT 1
+         FROM working_group_memberships wgm
+         JOIN working_groups wg ON wg.id = wgm.working_group_id
+         WHERE wgm.workos_user_id = $1
+           AND wgm.status = 'active'
+           AND wg.status = 'active'
+       )
      ) as is_contributor
      FROM organization_memberships WHERE workos_user_id = $1 LIMIT 1`,
     [userId]

--- a/server/src/db/working-group-db.ts
+++ b/server/src/db/working-group-db.ts
@@ -453,7 +453,8 @@ export class WorkingGroupDatabase {
    */
   async getWorkingGroupBySlackChannelId(slackChannelId: string): Promise<WorkingGroup | null> {
     const result = await query<WorkingGroup>(
-      'SELECT * FROM working_groups WHERE slack_channel_id = $1',
+      `SELECT * FROM working_groups
+       WHERE slack_channel_id = $1 AND status = 'active'`,
       [slackChannelId]
     );
     return result.rows[0] || null;
@@ -967,8 +968,12 @@ export class WorkingGroupDatabase {
   async getWorkingGroupIdsByUser(userId: string): Promise<string[]> {
     const canonicalUserId = await this.resolveToCanonicalUserId(userId);
     const result = await query<{ working_group_id: string }>(
-      `SELECT working_group_id FROM working_group_memberships
-       WHERE workos_user_id = $1 AND status = 'active'`,
+      `SELECT wgm.working_group_id
+       FROM working_group_memberships wgm
+       JOIN working_groups wg ON wg.id = wgm.working_group_id
+       WHERE wgm.workos_user_id = $1
+         AND wgm.status = 'active'
+         AND wg.status = 'active'`,
       [canonicalUserId]
     );
     return result.rows.map(r => r.working_group_id);

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -458,7 +458,9 @@ export async function proposeContentForUser(
 
   // Resolve the collection (working group)
   const committeeResult = await pool.query(
-    `SELECT id, name, accepts_public_submissions, slack_channel_id FROM working_groups WHERE slug = $1`,
+    `SELECT id, name, accepts_public_submissions, slack_channel_id
+     FROM working_groups
+     WHERE slug = $1 AND status = 'active'`,
     [committeeSlug]
   );
 
@@ -480,7 +482,8 @@ export async function proposeContentForUser(
   // For non-public collections, user must be a member
   if (!acceptsPublicSubmissions && !userIsLead && !userIsAdmin) {
     const membershipResult = await pool.query(
-      `SELECT 1 FROM working_group_memberships WHERE working_group_id = $1 AND workos_user_id = $2`,
+      `SELECT 1 FROM working_group_memberships
+       WHERE working_group_id = $1 AND workos_user_id = $2 AND status = 'active'`,
       [committeeId, user.id]
     );
     if (membershipResult.rows.length === 0) {
@@ -1145,6 +1148,7 @@ export function createContentRouter(): Router {
         `SELECT id, slug, name, description
          FROM working_groups
          WHERE accepts_public_submissions = TRUE
+           AND status = 'active'
          ORDER BY name`
       );
 
@@ -1160,7 +1164,9 @@ export function createContentRouter(): Router {
          FROM working_group_memberships wgm
          JOIN working_groups wg ON wg.id = wgm.working_group_id
          WHERE wgm.workos_user_id = $1
+           AND wgm.status = 'active'
            AND wg.accepts_public_submissions = FALSE
+           AND wg.status = 'active'
          ORDER BY wg.name`,
         [user.id]
       );

--- a/server/tests/integration/content-my-content.test.ts
+++ b/server/tests/integration/content-my-content.test.ts
@@ -116,6 +116,7 @@ describe('My Content — body, admin scope, status, delete', () => {
   let pool: Pool;
   let wgId: string;
   const WG_SLUG = 'mc-test-wg';
+  const ARCHIVED_WG_SLUG = 'mc-test-archived-wg';
   const USER_ID = 'user_my_content';
   const OTHER_USER_ID = 'user_my_content_other';
   const ELIGIBLE_ORG_ID = 'org_my_content_professional';
@@ -191,6 +192,12 @@ describe('My Content — body, admin scope, status, delete', () => {
   afterAll(async () => {
     await pool.query(`DELETE FROM content_authors WHERE perspective_id IN (SELECT id FROM perspectives WHERE slug LIKE 'mc-test-%')`);
     await pool.query(`DELETE FROM perspectives WHERE slug LIKE 'mc-test-%'`);
+    await pool.query(
+      `DELETE FROM working_group_memberships
+       WHERE working_group_id IN (SELECT id FROM working_groups WHERE slug = $1)`,
+      [ARCHIVED_WG_SLUG]
+    );
+    await pool.query(`DELETE FROM working_groups WHERE slug = $1`, [ARCHIVED_WG_SLUG]);
     await pool.query(`DELETE FROM working_group_leaders WHERE working_group_id = $1`, [wgId]);
     await pool.query(`DELETE FROM working_groups WHERE slug = $1`, [WG_SLUG]);
     // Side tables the propose flow writes into. Clear everything referencing
@@ -295,6 +302,59 @@ describe('My Content — body, admin scope, status, delete', () => {
   // ---------------------------------------------------------------------------
 
   describe('POST /api/content/propose', () => {
+    it('excludes archived working groups from collections and content proposals', async () => {
+      const archivedWg = await pool.query<{ id: string }>(
+        `INSERT INTO working_groups
+           (name, slug, description, accepts_public_submissions, status)
+         VALUES ('Archived Content Test WG', $1, 'lifecycle test', false, 'active')
+         ON CONFLICT (slug) DO UPDATE SET
+           accepts_public_submissions = false,
+           status = 'active'
+         RETURNING id`,
+        [ARCHIVED_WG_SLUG]
+      );
+      const archivedWgId = archivedWg.rows[0].id;
+      await pool.query(
+        `INSERT INTO working_group_memberships
+           (working_group_id, workos_user_id, status)
+         VALUES ($1, $2, 'active')
+         ON CONFLICT (working_group_id, workos_user_id)
+         DO UPDATE SET status = 'active'`,
+        [archivedWgId, USER_ID]
+      );
+
+      const activeCollections = await request(app).get('/api/content/collections').expect(200);
+      expect(activeCollections.body.collections.map((collection: { slug: string }) => collection.slug))
+        .toContain(ARCHIVED_WG_SLUG);
+
+      await request(app)
+        .post('/api/content/propose')
+        .send({
+          title: 'mc-test-active-wg-proposal',
+          content: 'body',
+          content_type: 'article',
+          collection: { slug: ARCHIVED_WG_SLUG },
+        })
+        .expect(201);
+
+      await pool.query(`UPDATE working_groups SET status = 'archived' WHERE id = $1`, [archivedWgId]);
+
+      const archivedCollections = await request(app).get('/api/content/collections').expect(200);
+      expect(archivedCollections.body.collections.map((collection: { slug: string }) => collection.slug))
+        .not.toContain(ARCHIVED_WG_SLUG);
+
+      const archivedProposal = await request(app)
+        .post('/api/content/propose')
+        .send({
+          title: 'mc-test-archived-wg-proposal',
+          content: 'body',
+          content_type: 'article',
+          collection: { slug: ARCHIVED_WG_SLUG },
+        })
+        .expect(400);
+      expect(archivedProposal.body.message).toContain('No collection found');
+    });
+
     it('respects pending_review requested by a committee lead', async () => {
       const response = await request(app)
         .post('/api/content/propose')

--- a/server/tests/integration/seat-lifecycle.test.ts
+++ b/server/tests/integration/seat-lifecycle.test.ts
@@ -21,13 +21,18 @@ import {
   markAdminReminderSent,
   markMemberTimeoutNotified,
   getSeatUsage,
+  getUserSeatType,
+  canAddSeat,
   getSeatLimits,
 } from '../../src/db/organization-db.js';
+import { WorkingGroupDatabase } from '../../src/db/working-group-db.js';
 import type { Pool } from 'pg';
 
 const TEST_ORG_ID = 'org_seat_lifecycle_test';
 const TEST_MEMBER_USER_ID = 'user_seat_member_1';
 const TEST_ADMIN_USER_ID = 'user_seat_admin_1';
+const TEST_LIFECYCLE_WG_SLUG = 'seat-lifecycle-archived-wg';
+const TEST_LIFECYCLE_CHANNEL_ID = 'C0ARCHIVEDWG';
 
 describe('Seat Lifecycle', () => {
   let pool: Pool;
@@ -41,6 +46,8 @@ describe('Seat Lifecycle', () => {
 
   afterAll(async () => {
     await pool.query('DELETE FROM seat_upgrade_requests WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    await pool.query('DELETE FROM working_group_memberships WHERE workos_user_id = $1', [TEST_MEMBER_USER_ID]);
+    await pool.query('DELETE FROM working_groups WHERE slug = $1', [TEST_LIFECYCLE_WG_SLUG]);
     await pool.query('DELETE FROM organization_memberships WHERE workos_organization_id = $1', [TEST_ORG_ID]);
     await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG_ID]);
     await closeDatabase();
@@ -408,6 +415,54 @@ describe('Seat Lifecycle', () => {
       const usage = await getSeatUsage(TEST_ORG_ID);
       expect(usage.contributor).toBeGreaterThanOrEqual(1);
       expect(usage.community_only).toBeGreaterThanOrEqual(0);
+    });
+
+    it('does not grant contributor or working-group capabilities from an archived group', async () => {
+      await pool.query('DELETE FROM working_group_memberships WHERE workos_user_id = $1', [TEST_MEMBER_USER_ID]);
+      await pool.query('DELETE FROM slack_user_mappings WHERE workos_user_id = $1 OR slack_user_id = $1', [TEST_MEMBER_USER_ID]);
+      await pool.query(
+        `UPDATE organizations
+         SET membership_tier = 'individual_professional', subscription_status = 'active'
+         WHERE workos_organization_id = $1`,
+        [TEST_ORG_ID]
+      );
+      await pool.query(
+        `INSERT INTO organization_memberships
+           (workos_user_id, workos_organization_id, email, seat_type, created_at, updated_at, synced_at)
+         VALUES ($1, $2, 'member@test.com', 'community_only', NOW(), NOW(), NOW())
+         ON CONFLICT (workos_user_id, workos_organization_id)
+         DO UPDATE SET seat_type = 'community_only'`,
+        [TEST_MEMBER_USER_ID, TEST_ORG_ID]
+      );
+      const workingGroup = await pool.query<{ id: string }>(
+        `INSERT INTO working_groups (name, slug, status, slack_channel_id)
+         VALUES ('Seat Lifecycle WG', $1, 'active', $2)
+         ON CONFLICT (slug) DO UPDATE SET status = 'active', slack_channel_id = EXCLUDED.slack_channel_id
+         RETURNING id`,
+        [TEST_LIFECYCLE_WG_SLUG, TEST_LIFECYCLE_CHANNEL_ID]
+      );
+      const workingGroupId = workingGroup.rows[0].id;
+      await pool.query(
+        `INSERT INTO working_group_memberships (working_group_id, workos_user_id, status)
+         VALUES ($1, $2, 'active')
+         ON CONFLICT (working_group_id, workos_user_id) DO UPDATE SET status = 'active'`,
+        [workingGroupId, TEST_MEMBER_USER_ID]
+      );
+
+      const wgDb = new WorkingGroupDatabase();
+      expect(await getSeatUsage(TEST_ORG_ID)).toEqual({ contributor: 1, community_only: 0 });
+      expect(await getUserSeatType(TEST_MEMBER_USER_ID)).toBe('contributor');
+      expect((await canAddSeat(TEST_ORG_ID, 'contributor')).allowed).toBe(false);
+      expect((await wgDb.getWorkingGroupBySlackChannelId(TEST_LIFECYCLE_CHANNEL_ID))?.id).toBe(workingGroupId);
+      expect(await wgDb.getWorkingGroupIdsByUser(TEST_MEMBER_USER_ID)).toContain(workingGroupId);
+
+      await pool.query(`UPDATE working_groups SET status = 'archived' WHERE id = $1`, [workingGroupId]);
+
+      expect(await getSeatUsage(TEST_ORG_ID)).toEqual({ contributor: 0, community_only: 1 });
+      expect(await getUserSeatType(TEST_MEMBER_USER_ID)).toBe('community_only');
+      expect((await canAddSeat(TEST_ORG_ID, 'contributor')).allowed).toBe(true);
+      expect(await wgDb.getWorkingGroupBySlackChannelId(TEST_LIFECYCLE_CHANNEL_ID)).toBeNull();
+      expect(await wgDb.getWorkingGroupIdsByUser(TEST_MEMBER_USER_ID)).not.toContain(workingGroupId);
     });
   });
 });


### PR DESCRIPTION
## Summary

- require an active working group as well as an active membership for content collections and proposals
- exclude archived/inactive groups from contributor-seat derivation
- fail closed when resolving Slack channels or user-accessible working-group IDs
- preserve membership and leadership rows for historical reporting

## Root cause

Several current-state queries treated `working_group_memberships.status = 'active'` as sufficient even when the parent working group had been archived. After the Technical Standards WG was archived, those historical membership rows could still grant content and contributor-seat capabilities or appear in Slack access resolution.

## Impact

Archiving a working group now removes its live access and entitlement effects without deleting historical membership data. Active groups and active memberships retain their existing behavior.

## Validation

- TypeScript typecheck
- content integration: 37/37
- seat lifecycle integration: 31/31
- organization DB unit: 57/57
- `git diff --check`

Follow-up work will filter archived memberships from lower-risk profile, Addie-context, and analytics summaries.
