### PR TITLE
fix: validate training list webhook targets

### DIFF
--- a/server/src/training-agent/inventory-governance-handlers.ts
+++ b/server/src/training-agent/inventory-governance-handlers.ts
@@ -11,6 +11,7 @@ import type { TrainingContext, ToolArgs, CollectionListState } from './types.js'
 import { getSession, sessionKeyFromArgs } from './state.js';
 import { ACCOUNT_REF_SCHEMA } from './account-handlers.js';
 import { encodeOffsetCursor, decodeOffsetCursor } from './pagination.js';
+import { assertPublicTarget } from './webhook-fetch.js';
 
 const MAX_ARRAY_INPUT = 100;
 
@@ -149,6 +150,27 @@ function validateListId(value: unknown): { code: string; message: string; field:
   return undefined;
 }
 
+async function validateWebhookUrl(value: string): Promise<{ code: string; message: string; field: string } | undefined> {
+  let target: URL;
+  try {
+    target = new URL(value);
+  } catch {
+    return { code: 'VALIDATION_ERROR', message: 'webhook_url must be a valid URL', field: 'webhook_url' };
+  }
+  if (target.protocol !== 'https:' && (process.env.NODE_ENV === 'production' || target.protocol !== 'http:')) {
+    return { code: 'VALIDATION_ERROR', message: 'webhook_url must use HTTPS', field: 'webhook_url' };
+  }
+  if (target.username || target.password) {
+    return { code: 'VALIDATION_ERROR', message: 'webhook_url must not include userinfo credentials', field: 'webhook_url' };
+  }
+  try {
+    await assertPublicTarget(target);
+  } catch {
+    return { code: 'VALIDATION_ERROR', message: 'webhook_url must target a public network address', field: 'webhook_url' };
+  }
+  return undefined;
+}
+
 // ── Handlers ─────────────────────────────────────────────────────
 
 export async function handleCreateCollectionList(args: ToolArgs, ctx: TrainingContext) {
@@ -212,6 +234,11 @@ export async function handleUpdateCollectionList(args: ToolArgs, ctx: TrainingCo
 
   const list = session.collectionLists.get(input.list_id);
   if (!list) return { errors: [{ code: 'NOT_FOUND', message: `Collection list ${input.list_id} not found` }] };
+
+  if (input.webhook_url !== undefined && input.webhook_url !== '') {
+    const webhookError = await validateWebhookUrl(input.webhook_url);
+    if (webhookError) return { errors: [webhookError] };
+  }
 
   if (input.name !== undefined) list.name = input.name;
   if (input.description !== undefined) list.description = input.description;

--- a/server/src/training-agent/property-handlers.ts
+++ b/server/src/training-agent/property-handlers.ts
@@ -11,6 +11,7 @@ import type { TrainingContext, ToolArgs, AccountRef, PropertyListState } from '.
 import { getSession, sessionKeyFromArgs, MAX_PROPERTY_LISTS_PER_SESSION } from './state.js';
 import { ACCOUNT_REF_SCHEMA } from './account-handlers.js';
 import { encodeOffsetCursor, decodeOffsetCursor } from './pagination.js';
+import { assertPublicTarget } from './webhook-fetch.js';
 
 const MAX_PROPERTIES_PER_LIST = 10_000;
 
@@ -87,6 +88,7 @@ export const PROPERTY_TOOLS = [
         base_properties: { type: 'array', description: 'Complete replacement for the base properties list' },
         filters: { type: 'object', description: 'Complete replacement for the filters' },
         brand: { type: 'object', properties: { domain: { type: 'string' } }, description: 'Update brand reference (campaign metadata)' },
+        webhook_url: { type: 'string', description: 'Update the webhook URL for list change notifications (set to empty string to remove)' },
       },
       required: ['list_id'],
     },
@@ -180,6 +182,27 @@ function extractDomains(properties: unknown[]): string[] {
     }
   }
   return domains;
+}
+
+async function validateWebhookUrl(value: string): Promise<{ code: string; message: string; field: string } | undefined> {
+  let target: URL;
+  try {
+    target = new URL(value);
+  } catch {
+    return { code: 'VALIDATION_ERROR', message: 'webhook_url must be a valid URL', field: 'webhook_url' };
+  }
+  if (target.protocol !== 'https:' && (process.env.NODE_ENV === 'production' || target.protocol !== 'http:')) {
+    return { code: 'VALIDATION_ERROR', message: 'webhook_url must use HTTPS', field: 'webhook_url' };
+  }
+  if (target.username || target.password) {
+    return { code: 'VALIDATION_ERROR', message: 'webhook_url must not include userinfo credentials', field: 'webhook_url' };
+  }
+  try {
+    await assertPublicTarget(target);
+  } catch {
+    return { code: 'VALIDATION_ERROR', message: 'webhook_url must target a public network address', field: 'webhook_url' };
+  }
+  return undefined;
 }
 
 // ── Handlers ─────────────────────────────────────────────────────
@@ -302,12 +325,17 @@ export async function handleUpdatePropertyList(
   args: ToolArgs,
   ctx: TrainingContext,
 ) {
-  const req = args as { list_id: string; name?: string; description?: string; base_properties?: unknown[]; filters?: unknown; brand?: unknown };
+  const req = args as { list_id: string; name?: string; description?: string; base_properties?: unknown[]; filters?: unknown; brand?: unknown; webhook_url?: string };
   const session = await getSession(sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId));
 
   const state = session.propertyLists.get(req.list_id);
   if (!state) {
     return { errors: [{ code: 'REFERENCE_NOT_FOUND', message: 'Property list not found', field: 'list_id' }] };
+  }
+
+  if (req.webhook_url !== undefined && req.webhook_url !== '') {
+    const webhookError = await validateWebhookUrl(req.webhook_url);
+    if (webhookError) return { errors: [webhookError] };
   }
 
   if (req.name) {
@@ -332,6 +360,10 @@ export async function handleUpdatePropertyList(
 
   if (req.brand !== undefined) {
     state.brand = req.brand;
+  }
+
+  if (req.webhook_url !== undefined) {
+    state.webhookUrl = req.webhook_url === '' ? undefined : req.webhook_url;
   }
 
   state.propertyCount = state.baseProperties.length;

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../../src/training-agent/task-handlers.js';
 import {
   MUTATING_TOOLS,
+  clearIdempotencyCache,
 } from '../../src/training-agent/idempotency.js';
 import { randomUUID } from 'node:crypto';
 import { getAgentUrl } from '../../src/training-agent/config.js';
@@ -11431,6 +11432,79 @@ describe('property-list uniform not-found response (issue #2739)', () => {
     expect(probeA.result.code).toBe('REFERENCE_NOT_FOUND');
     expect(probeA.result.message).toBe('Property list not found');
     expect(probeA.result.field).toBe('list_id');
+  });
+});
+
+describe('collection and property list webhook URL handling', () => {
+  beforeEach(async () => {
+    await clearSessions();
+    clearIdempotencyCache();
+  });
+
+  afterEach(async () => {
+    await clearSessions();
+    stopSessionCleanup();
+  });
+
+  it('advertises the schema-defined webhook_url field on both update tools', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { tools } = await simulateListTools(server);
+
+    for (const toolName of ['update_collection_list', 'update_property_list']) {
+      const tool = tools.find(candidate => candidate.name === toolName);
+      expect(tool?.inputSchema?.properties).toHaveProperty('webhook_url');
+    }
+  });
+
+  it.each([
+    { kind: 'collection', createTool: 'create_collection_list', updateTool: 'update_collection_list', getTool: 'get_collection_list' },
+    { kind: 'property', createTool: 'create_property_list', updateTool: 'update_property_list', getTool: 'get_property_list' },
+  ])('rejects a private $kind list webhook without partially applying the update', async ({ createTool, updateTool, getTool }) => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const created = await simulateCallTool(server, createTool, { name: 'Original name' });
+    const listId = (created.result.list as { list_id: string }).list_id;
+
+    const rejected = await simulateCallTool(server, updateTool, {
+      list_id: listId,
+      name: 'Must not persist',
+      webhook_url: 'https://169.254.169.254/latest/meta-data',
+    });
+    expect(rejected.result).toMatchObject({ code: 'VALIDATION_ERROR', field: 'webhook_url' });
+
+    const fetched = await simulateCallTool(server, getTool, { list_id: listId });
+    expect(fetched.result.list).toMatchObject({ name: 'Original name' });
+    expect((fetched.result.list as Record<string, unknown>).webhook_url).toBeUndefined();
+  });
+
+  it.each([
+    { createTool: 'create_collection_list', updateTool: 'update_collection_list' },
+    { createTool: 'create_property_list', updateTool: 'update_property_list' },
+  ])('rejects webhook URLs containing userinfo credentials', async ({ createTool, updateTool }) => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const created = await simulateCallTool(server, createTool, { name: 'Credential test' });
+    const listId = (created.result.list as { list_id: string }).list_id;
+
+    const rejected = await simulateCallTool(server, updateTool, {
+      list_id: listId,
+      webhook_url: 'https://username:password@8.8.8.8/list-changes',
+    });
+    expect(rejected.result).toMatchObject({ code: 'VALIDATION_ERROR', field: 'webhook_url' });
+  });
+
+  it.each([
+    { kind: 'collection', createTool: 'create_collection_list', updateTool: 'update_collection_list' },
+    { kind: 'property', createTool: 'create_property_list', updateTool: 'update_property_list' },
+  ])('stores and removes a public $kind list webhook', async ({ createTool, updateTool }) => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const created = await simulateCallTool(server, createTool, { name: 'Webhook list' });
+    const listId = (created.result.list as { list_id: string }).list_id;
+    const webhookUrl = 'https://8.8.8.8/list-changes';
+
+    const updated = await simulateCallTool(server, updateTool, { list_id: listId, webhook_url: webhookUrl });
+    expect(updated.result.list).toMatchObject({ webhook_url: webhookUrl });
+
+    const cleared = await simulateCallTool(server, updateTool, { list_id: listId, webhook_url: '' });
+    expect((cleared.result.list as Record<string, unknown>).webhook_url).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- validate collection and property-list webhook targets before applying any update
- reject malformed, unsafe-scheme, private-network, and credential-bearing URLs
- implement the schema-defined `update_property_list.webhook_url` field, including empty-string removal
- add schema-parity, atomic rejection, persistence, and clearing regressions

## Root cause

`update_collection_list` persisted a webhook URL without the training agent's SSRF guard. `update_property_list` published the field in the protocol schema but omitted it from the training tool and handler. That created both an unsafe stored target and a sandbox/schema mismatch.

## Impact

Both list types now apply the same public-target policy before mutating session state. Property lists behave consistently with their published schema.

## Validation

- focused webhook tests: 7 passed
- server typecheck
- `git diff --check`

Addresses the concrete webhook mismatch discovered in #5929; the broader sandbox audit remains open.
