### PR TITLE
fix: recover certification attempts across sessions

### DIFF
--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -2112,7 +2112,7 @@ export function createCertificationToolHandlers(
     if (!userId) return 'You need to be logged in to see your certification progress.';
 
     try {
-      const [progress, trackProgress, credentials, userCredentials, tracks, deltaStatuses] = await Promise.all([
+      const [progress, trackProgress, credentials, userCredentials, tracks, deltaStatuses, attempts] = await Promise.all([
         certDb.getProgress(userId),
         certDb.getTrackProgress(userId),
         certDb.getCredentials(),
@@ -2121,6 +2121,7 @@ export function createCertificationToolHandlers(
         Promise.all(
           DELTA_DEFINITIONS.map(async def => ({ def, status: await certDb.getDeltaStatus(def, userId) })),
         ),
+        certDb.getUserAttempts(userId),
       ]);
 
       const lines: string[] = ['# Your certification progress\n'];
@@ -2186,10 +2187,27 @@ export function createCertificationToolHandlers(
 
       const moduleProgress = progress.filter(p => p.status !== 'not_started');
       if (moduleProgress.length > 0) {
+        const activeSpecialistAttempts = new Map<string, certDb.CertificationAttempt>();
+        for (const attempt of attempts) {
+          if (
+            attempt.status === 'in_progress'
+            && attempt.module_id?.startsWith('S')
+            && !activeSpecialistAttempts.has(attempt.module_id)
+          ) {
+            activeSpecialistAttempts.set(attempt.module_id, attempt);
+          }
+        }
+
         lines.push('## Module details');
         for (const p of moduleProgress) {
           const status = p.status === 'completed' ? 'completed' : p.status === 'tested_out' ? 'tested out' : 'in progress';
           lines.push(`- ${p.module_id}: ${status}`);
+          const activeAttempt = p.status === 'in_progress'
+            ? activeSpecialistAttempts.get(p.module_id)
+            : undefined;
+          if (activeAttempt) {
+            lines.push(`  Active attempt: ${activeAttempt.id} (started ${formatUtcDate(activeAttempt.started_at)})`);
+          }
         }
       }
 
@@ -2545,6 +2563,7 @@ export function createCertificationToolHandlers(
 
       // Look up the active attempt: accept the UUID directly, or resolve from module ID
       let attempt: certDb.CertificationAttempt | null;
+      let resolvedFromModuleId = false;
       if (isUuid(attemptId)) {
         attempt = await certDb.getAttempt(attemptId);
       } else {
@@ -2554,6 +2573,7 @@ export function createCertificationToolHandlers(
         if (!/^[A-Z]{1,2}[0-9]+$/.test(normalized)) {
           return `Invalid attempt_id "${attemptId}". Provide the UUID returned by start_certification_exam.`;
         }
+        resolvedFromModuleId = true;
         attempt = await certDb.getActiveAttemptForModule(userId, normalized);
       }
       if (!attempt) return 'Exam attempt not found.';
@@ -2683,18 +2703,21 @@ export function createCertificationToolHandlers(
       const overallScore = Math.round(scoreResult.weightedAvg);
       const allAboveThreshold = Object.values(scores).every(s => s >= 70);
       const passing = allAboveThreshold && overallScore >= 70;
+      const recordedScores: Record<string, number | boolean> = resolvedFromModuleId
+        ? { ...scores, _resolved_from_module_id: true }
+        : scores;
 
       if (isProtocolDelta && deltaDef && passing) {
         await certDb.completeDeltaAttempt(
           deltaDef,
           attempt.id,
           userId,
-          scores,
+          recordedScores,
           overallScore,
           deltaEvidence!.evidenceByCriterionId,
         );
       } else {
-        await certDb.completeAttempt(attempt.id, scores, overallScore, passing);
+        await certDb.completeAttempt(attempt.id, recordedScores, overallScore, passing);
       }
 
       // --- From this point the attempt is recorded. Failures below must not ---

--- a/server/src/db/certification-db.ts
+++ b/server/src/db/certification-db.ts
@@ -113,7 +113,7 @@ export interface CertificationAttempt {
   status: 'in_progress' | 'passed' | 'failed';
   started_at: string;
   completed_at: string | null;
-  scores: Record<string, number> | null;
+  scores: Record<string, number | boolean> | null;
   overall_score: number | null;
   passing: boolean | null;
   addie_thread_id: string | null;
@@ -469,7 +469,7 @@ export async function createAttempt(
 
 export async function completeAttempt(
   attemptId: string,
-  scores: Record<string, number>,
+  scores: Record<string, number | boolean>,
   overallScore: number,
   passing: boolean,
   certifierCredentialId?: string,
@@ -480,13 +480,13 @@ export async function completeAttempt(
     `UPDATE certification_attempts
      SET status = $2, completed_at = NOW(), scores = $3, overall_score = $4,
          passing = $5, certifier_credential_id = $6, certifier_public_id = $7
-     WHERE id = $1
+     WHERE id = $1 AND status = 'in_progress'
      RETURNING *`,
     [attemptId, status, JSON.stringify(scores), overallScore, passing,
      certifierCredentialId || null, certifierPublicId || null]
   );
   if (!result.rows[0]) {
-    throw new Error(`Certification attempt ${attemptId} not found`);
+    throw new Error(`Certification attempt ${attemptId} not found or not in_progress`);
   }
   return result.rows[0];
 }
@@ -855,7 +855,7 @@ export async function completeDeltaAttempt(
   def: DeltaDefinition,
   attemptId: string,
   userId: string,
-  scores: Record<string, number>,
+  scores: Record<string, number | boolean>,
   overallScore: number,
   evidenceByCriterionId: Record<string, string>,
 ): Promise<CertificationAttempt> {

--- a/server/tests/integration/admin-resolve-attempt.test.ts
+++ b/server/tests/integration/admin-resolve-attempt.test.ts
@@ -158,4 +158,25 @@ describe('Admin attempt resolution', () => {
       ).rejects.toThrow('not found or not in_progress');
     });
   });
+
+  describe('completeAttempt', () => {
+    it('allows only one concurrent completion of an in-progress attempt', async () => {
+      const attempt = await certDb.createAttempt(TEST_USER, 'S', undefined, 'S1');
+      const scores = { protocol_mastery: 80 };
+
+      const results = await Promise.allSettled([
+        certDb.completeAttempt(attempt.id, scores, 80, true),
+        certDb.completeAttempt(attempt.id, scores, 80, true),
+      ]);
+
+      expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+      const rejected = results.find(result => result.status === 'rejected');
+      expect(rejected).toMatchObject({
+        status: 'rejected',
+        reason: expect.objectContaining({
+          message: `Certification attempt ${attempt.id} not found or not in_progress`,
+        }),
+      });
+    });
+  });
 });

--- a/server/tests/unit/certification-attempt-recovery.test.ts
+++ b/server/tests/unit/certification-attempt-recovery.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getProgress: vi.fn(),
+  getTrackProgress: vi.fn(),
+  getCredentials: vi.fn(),
+  getUserCredentials: vi.fn(),
+  getTracks: vi.fn(),
+  getDeltaStatus: vi.fn(),
+  getUserAttempts: vi.fn(),
+  getActiveAttemptForModule: vi.fn(),
+  getAttempt: vi.fn(),
+  getModule: vi.fn(),
+  getLatestCheckpoint: vi.fn(),
+  completeAttempt: vi.fn(),
+  completeModule: vi.fn(),
+  checkAndAwardCredentials: vi.fn(),
+  query: vi.fn(),
+}));
+
+vi.mock('../../src/db/certification-db.js', () => ({
+  getProgress: mocks.getProgress,
+  getTrackProgress: mocks.getTrackProgress,
+  getCredentials: mocks.getCredentials,
+  getUserCredentials: mocks.getUserCredentials,
+  getTracks: mocks.getTracks,
+  getDeltaStatus: mocks.getDeltaStatus,
+  getUserAttempts: mocks.getUserAttempts,
+  getActiveAttemptForModule: mocks.getActiveAttemptForModule,
+  getAttempt: mocks.getAttempt,
+  getModule: mocks.getModule,
+  getLatestCheckpoint: mocks.getLatestCheckpoint,
+  completeAttempt: mocks.completeAttempt,
+  completeModule: mocks.completeModule,
+  checkAndAwardCredentials: mocks.checkAndAwardCredentials,
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  query: mocks.query,
+  getPool: vi.fn(),
+}));
+
+import { createCertificationToolHandlers } from '../../src/addie/mcp/certification-tools.js';
+
+const USER_ID = 'user_attempt_recovery';
+const ATTEMPT_ID = '123e4567-e89b-42d3-a456-426614174000';
+
+function memberContext() {
+  return {
+    workos_user: { workos_user_id: USER_ID },
+    is_member: true,
+  } as any;
+}
+
+describe('certification attempt recovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getTrackProgress.mockResolvedValue([]);
+    mocks.getCredentials.mockResolvedValue([]);
+    mocks.getUserCredentials.mockResolvedValue([]);
+    mocks.getTracks.mockResolvedValue([]);
+    mocks.getDeltaStatus.mockResolvedValue({ active: false, status: 'not_required' });
+    mocks.checkAndAwardCredentials.mockResolvedValue([]);
+  });
+
+  it('surfaces an in-progress specialist attempt across handler sessions', async () => {
+    mocks.getProgress.mockResolvedValue([
+      { module_id: 'S3', status: 'in_progress' },
+    ]);
+    mocks.getUserAttempts.mockResolvedValue([
+      {
+        id: ATTEMPT_ID,
+        workos_user_id: USER_ID,
+        track_id: 'S',
+        module_id: 'S3',
+        status: 'in_progress',
+        started_at: '2026-07-19T14:30:00.000Z',
+      },
+    ]);
+
+    const firstSession = createCertificationToolHandlers(memberContext());
+    const secondSession = createCertificationToolHandlers(memberContext());
+    expect(firstSession).not.toBe(secondSession);
+
+    const result = await secondSession.get('get_learner_progress')?.({});
+
+    expect(result).toContain('- S3: in progress');
+    expect(result).toContain(`Active attempt: ${ATTEMPT_ID} (started July 19, 2026)`);
+    expect(mocks.getUserAttempts).toHaveBeenCalledWith(USER_ID);
+  });
+
+  it('marks scores when completion resolves an attempt from a module ID', async () => {
+    const startedAt = new Date(Date.now() - 11 * 60 * 1000).toISOString();
+    const attempt = {
+      id: ATTEMPT_ID,
+      workos_user_id: USER_ID,
+      track_id: 'S',
+      module_id: 'S3',
+      status: 'in_progress',
+      started_at: startedAt,
+      passing: null,
+    };
+    const scores = { protocol_mastery: 85 };
+
+    mocks.getActiveAttemptForModule.mockResolvedValue(attempt);
+    mocks.getModule.mockResolvedValue({
+      id: 'S3',
+      assessment_criteria: {
+        dimensions: [{ name: 'protocol_mastery', weight: 100, description: 'Mastery' }],
+        passing_threshold: 70,
+      },
+      exercise_definitions: [],
+    });
+    mocks.getLatestCheckpoint.mockResolvedValue({
+      preliminary_scores: { protocol_mastery: 85 },
+      demonstrations_verified: [],
+    });
+    mocks.query.mockResolvedValue({ rows: [{ count: '6' }] });
+    mocks.completeAttempt.mockResolvedValue({ ...attempt, status: 'passed', passing: true });
+    mocks.completeModule.mockResolvedValue({ module_id: 'S3', status: 'completed' });
+
+    const handler = createCertificationToolHandlers(memberContext(), { threadId: 'thread_123' })
+      .get('complete_certification_exam');
+    const result = await handler?.({ attempt_id: 's3', scores });
+
+    expect(result).toContain('# Congratulations! The learner passed the capstone!');
+    expect(mocks.getActiveAttemptForModule).toHaveBeenCalledWith(USER_ID, 'S3');
+    expect(mocks.completeAttempt).toHaveBeenCalledWith(
+      ATTEMPT_ID,
+      { protocol_mastery: 85, _resolved_from_module_id: true },
+      85,
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- surface active specialist attempt UUIDs and start dates in learner progress
- audit-mark completions that resolve an attempt from a module ID
- atomically allow only one completion of an in-progress attempt
- add cross-session, fallback-audit, and concurrent-completion regressions

## Root cause

An in-progress specialist attempt ID was only available in the conversation that created it. Later sessions could not reliably discover the canonical UUID, and concurrent sessions could both update the same attempt because completion did not guard its prior status.

## Impact

Addie can resume and finish a specialist assessment across conversations without manual UUID recovery. Module-ID fallback remains compatible but is visible in the stored audit record, and duplicate completion fails closed.

## Validation

- focused certification recovery unit tests: 2 passed
- certification unit suite: 15/15
- PostgreSQL attempt-resolution integration: 9/9
- server typecheck
- `git diff --check`

Closes #5019.
