### PR TITLE
fix: bind governance intent tokens by request shape

### DIFF
--- a/docs/building/by-layer/L1/security.mdx
+++ b/docs/building/by-layer/L1/security.mdx
@@ -1681,7 +1681,7 @@ export async function verifyAdcpRequestSignature(req: Request, ctx: {
   const { jwk } = await ctx.resolveJwk(parsed.keyid!); // throws _key_unknown
   // 8: key purpose
   const j = jwk as any;
-  if (j.use !== "sig" || !Array.isArray(j.key_ops) || !j.key_ops.includes("verify") || j.example_use !== "request-signing") {
+  if (j.use !== "sig" || !Array.isArray(j.key_ops) || !j.key_ops.includes("verify") || j.adcp_use !== "request-signing") {
     throw new RequestSignatureError("request_signature_key_purpose_invalid");
   }
   // 9: revocation (BEFORE crypto verify)

--- a/docs/governance/campaign/specification.mdx
+++ b/docs/governance/campaign/specification.mdx
@@ -528,19 +528,22 @@ Without confidence, every finding is presented as equally certain, which either 
 
 ### Phase inference
 
-The governance agent infers the validation phase from the `tool` parameter in `check_governance`:
+The governance agent determines the token phase from the request shape, not from
+the tool name or a caller-supplied lifecycle phase:
 
-| tool | Phase |
-|------|-------|
-| `get_products` | Discovery -- validates search intent, seller eligibility, product suitability |
-| `create_media_buy` | Purchase -- validates budget authority, targeting compliance, flight dates |
-| `update_media_buy` | Purchase -- validates change magnitude, reallocation thresholds |
-| `acquire_rights` | Purchase -- validates budget authority, geo compliance, flight dates |
-| `update_rights` | Purchase -- validates change magnitude, reallocation thresholds |
-| `activate_signal` | Purchase -- validates budget authority, geo compliance, flight dates |
-| `build_creative` | Purchase -- validates budget authority, geo compliance |
+- `tool` + `payload` is an orchestrator-side intent check. Its signed
+  `governance_context` carries `phase: "intent"` and omits `media_buy_id`, even
+  when the proposed payload contains a media buy ID or the caller supplies a
+  lifecycle `phase`.
+- `planned_delivery` is a seller-side execution check (normally carrying the
+  buyer's prior `governance_context` for lifecycle continuity).
+  Its signed token carries the requested `purchase`, `modification`, or
+  `delivery` phase (defaulting to `purchase`) and binds to the seller-assigned
+  `media_buy_id` when one is supplied.
 
-Phase context is cumulative. During **purchase**, the governance agent considers what was discovered during **discovery**.
+This separation prevents a proposed action from being mistaken for a seller's
+authorization to execute it. The `phase` request field applies only to execution
+checks; it does not override an intent-shaped request.
 
 The `check_id` returned by `check_governance` is used by `report_plan_outcome` to link the seller's response back to the validated action.
 

--- a/server/src/training-agent/governance-handlers.ts
+++ b/server/src/training-agent/governance-handlers.ts
@@ -704,6 +704,15 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
       : 'purchase';
   const phase: GovernancePhase = binding === 'proposed' ? 'intent' : requestedExecutionPhase;
 
+  if (binding === 'committed' && !plannedDelivery?.media_buy_id) {
+    return {
+      errors: [{
+        code: 'VALIDATION_ERROR',
+        message: 'planned_delivery.media_buy_id is required for execution governance checks',
+      }],
+    };
+  }
+
   const plan = session.governancePlans.get(planId);
   if (!plan) {
     const checkId = `chk_${randomUUID().slice(0, 8)}`;

--- a/server/src/training-agent/governance-handlers.ts
+++ b/server/src/training-agent/governance-handlers.ts
@@ -21,7 +21,7 @@ import { getSession, sessionKeyFromArgs, findGovernancePlanAcrossSessions } from
 import { signGovernanceContext, type GovernancePhase, type PolicyDecision } from './governance-context.js';
 import { getCanonicalBase } from './tenants/registry.js';
 
-const GOVERNANCE_PHASES = new Set<GovernancePhase>(['intent', 'purchase', 'modification', 'delivery']);
+const EXECUTION_GOVERNANCE_PHASES = new Set<GovernancePhase>(['purchase', 'modification', 'delivery']);
 
 /**
  * Map plan-level policy_ids + current check status to per-policy outcomes
@@ -188,7 +188,6 @@ interface SyncPlanInput {
 
 interface CheckGovernanceInput extends ToolArgs {
   plan_id: string;
-  binding?: 'proposed' | 'committed';
   caller: string;
   purchase_type?: string;
   tool?: string;
@@ -216,8 +215,8 @@ interface CheckPayload {
   flight?: { start?: string; end?: string; start_time?: string; end_time?: string };
   // Brand rights payload fields
   campaign?: { countries?: string[]; start_date?: string; end_date?: string };
-  // Echoed on modification / delivery phase checks so the JWS audience binding
-  // matches the seller-side media buy.
+  // An update proposal may name an existing buy. Intent tokens still omit it;
+  // execution checks bind their ID from the seller's planned_delivery instead.
   media_buy_id?: string;
   // Target seller URL for `aud` binding. Buyers MUST supply this so the GA
   // can bind the JWS to a specific seller — without it, intent-phase tokens
@@ -227,6 +226,8 @@ interface CheckPayload {
 }
 
 interface PlannedDeliveryInput {
+  // Seller-assigned ID bound into purchase/modification/delivery JWS claims.
+  media_buy_id?: string;
   geo?: { countries?: string[] };
   channels?: string[];
   total_budget?: number;
@@ -680,7 +681,6 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
     : undefined;
   const humanApproval = req.human_approval ?? extHumanApproval;
   const hasHumanApproval = typeof humanApproval === 'object' && humanApproval !== null;
-  const phase = req.phase || req.governance_phase || 'purchase';
   const plannedDelivery = req.planned_delivery;
   const deliveryMetrics = req.delivery_metrics;
 
@@ -688,10 +688,21 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
     return { errors: [{ code: 'VALIDATION_ERROR', message: `Invalid purchase_type: ${req.purchase_type}. Must be one of: ${[...VALID_PURCHASE_TYPES].join(', ')}` }] };
   }
 
-  // Infer binding from field presence per the schema spec:
-  // tool+payload = intent check (proposed), governance_context+planned_delivery = execution check (committed)
-  const binding: 'proposed' | 'committed' = req.binding
-    || (req.governance_context && req.planned_delivery ? 'committed' : 'proposed');
+  // Request shape is authoritative. A caller-supplied phase cannot turn an
+  // orchestrator proposal into a seller execution check.
+  const hasIntentShape = tool !== undefined && payload !== undefined;
+  const hasExecutionShape = plannedDelivery !== undefined;
+  const binding: 'proposed' | 'committed' = hasIntentShape
+    ? 'proposed'
+    : hasExecutionShape
+      ? 'committed'
+      : 'proposed';
+  const requestedExecutionPhase: GovernancePhase = EXECUTION_GOVERNANCE_PHASES.has(req.phase as GovernancePhase)
+    ? (req.phase as GovernancePhase)
+    : EXECUTION_GOVERNANCE_PHASES.has(req.governance_phase as GovernancePhase)
+      ? (req.governance_phase as GovernancePhase)
+      : 'purchase';
+  const phase: GovernancePhase = binding === 'proposed' ? 'intent' : requestedExecutionPhase;
 
   const plan = session.governancePlans.get(planId);
   if (!plan) {
@@ -1157,12 +1168,6 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
   // string across plan revisions. Denied checks carry no token; downstream
   // sellers reject a request that has no signed authorization.
   //
-  // Emit a compact JWS `governance_context` per the AdCP JWS profile on
-  // approved/conditions outcomes; the spec requires a fresh signature on
-  // every check (new jti, iat, exp, plan_hash) — never re-emit a cached
-  // string across plan revisions. Denied checks carry no token; downstream
-  // sellers reject a request that has no signed authorization.
-  //
   // `aud` resolution: spec requires the seller URL from `adagents.json`,
   // byte-exact. We accept `payload.target_seller` for buyers that name
   // their seller explicitly. The sandbox default is the training agent's
@@ -1172,31 +1177,27 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
   // and refuse to issue without one; copying this fallback is the bug the
   // training reference exists to surface.
   //
-  // `phase` downgrade: non-intent phases require `media_buy_id` per spec
-  // §"AdCP JWS profile". When the buyer omits it, downgrade phase to
-  // `intent` rather than emit a structurally-valid-but-step-12-rejected
-  // token.
+  // Token phase follows the already-inferred request binding. Intent checks
+  // never carry a media_buy_id, even if the proposed payload happens to name
+  // an existing buy. Execution checks preserve the seller's lifecycle phase
+  // and bind the seller-assigned media_buy_id when supplied.
   let effectiveContext: string | undefined;
   // Human-review denials also need a context so the buyer can bind the
   // off-protocol approval to the re-check that carries human_approval.
   if (status === 'approved' || status === 'conditions' || humanReviewRequired) {
-    const requestedPhase: GovernancePhase = GOVERNANCE_PHASES.has(phase as GovernancePhase)
-      ? (phase as GovernancePhase)
-      : 'purchase';
-    const requestMediaBuyId = req.payload?.media_buy_id ? String(req.payload.media_buy_id) : undefined;
-    const jwsPhase: GovernancePhase = requestedPhase !== 'intent' && !requestMediaBuyId
-      ? 'intent'
-      : requestedPhase;
+    const requestMediaBuyId = binding === 'committed'
+      ? plannedDelivery?.media_buy_id
+      : undefined;
 
     const targetSeller = req.payload?.target_seller ?? `${getCanonicalBase()}/sales`;
     effectiveContext = await signGovernanceContext({
       issuer: `${getCanonicalBase()}/governance`,
       audience: targetSeller,
       planId,
-      phase: jwsPhase,
+      phase,
       caller,
       checkId,
-      ...(jwsPhase !== 'intent' && requestMediaBuyId ? { mediaBuyId: requestMediaBuyId } : {}),
+      ...(phase !== 'intent' && requestMediaBuyId ? { mediaBuyId: requestMediaBuyId } : {}),
       plan: plan.planAsSupplied,
       ...(plan.policyIds?.length
         ? { policyDecisions: buildPolicyDecisions(plan.policyIds, status, conditions) }

--- a/server/tests/unit/training-agent-governance-intent-binding.test.ts
+++ b/server/tests/unit/training-agent-governance-intent-binding.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { decodeJwt } from 'jose';
+// Initialize the aggregate tool catalog before importing a leaf handler. The
+// training-agent modules intentionally have a catalog/tenant dependency cycle;
+// production enters through task-handlers in the same order.
+import '../../src/training-agent/task-handlers.js';
+import {
+  handleCheckGovernance,
+  handleSyncPlans,
+} from '../../src/training-agent/governance-handlers.js';
+import { clearSessions, runWithSessionContext } from '../../src/training-agent/state.js';
+import { resetGovernanceSigning } from '../../src/training-agent/governance-signing.js';
+import type { TrainingContext } from '../../src/training-agent/types.js';
+
+const CTX: TrainingContext = { mode: 'open' };
+const PLAN = {
+  plan_id: 'plan-intent-binding',
+  brand: { domain: 'intent-binding.example' },
+  objectives: 'Verify governance request-shape binding.',
+  budget: { total: 100_000, currency: 'USD', reallocation_threshold: 100_000 },
+  flight: { start: '2027-01-01T00:00:00Z', end: '2027-12-31T23:59:59Z' },
+};
+
+async function syncPlan() {
+  const result = await handleSyncPlans({ plans: [PLAN] }, CTX) as Record<string, any>;
+  expect(result.errors, JSON.stringify(result)).toBeUndefined();
+}
+
+async function withPlan<T>(fn: () => Promise<T>): Promise<T> {
+  return runWithSessionContext(async () => {
+    await syncPlan();
+    return fn();
+  });
+}
+
+async function check(args: Record<string, unknown>) {
+  return handleCheckGovernance({
+    plan_id: PLAN.plan_id,
+    brand: PLAN.brand,
+    caller: 'https://buyer.example',
+    ...args,
+  }, CTX) as Promise<Record<string, any>>;
+}
+
+function claims(result: Record<string, any>) {
+  expect(result.status, JSON.stringify(result)).toBe('approved');
+  expect(result.governance_context).toEqual(expect.any(String));
+  return decodeJwt(result.governance_context as string);
+}
+
+describe('check_governance request-shape binding', () => {
+  beforeEach(() => {
+    clearSessions();
+    resetGovernanceSigning();
+  });
+
+  afterEach(() => clearSessions());
+
+  it('emits an intent token for create_media_buy proposals', async () => {
+    const payload = await withPlan(async () => claims(await check({
+      tool: 'create_media_buy',
+      phase: 'purchase',
+      payload: {
+        media_buy_id: 'mb_must_not_bind',
+        target_seller: 'https://seller.example',
+        total_budget: { amount: 1_000, currency: 'USD' },
+      },
+    })));
+
+    expect(payload.phase).toBe('intent');
+    expect(payload).not.toHaveProperty('media_buy_id');
+  });
+
+  it('emits an intent token for update_media_buy proposals with an existing buy ID', async () => {
+    const payload = await withPlan(async () => claims(await check({
+      tool: 'update_media_buy',
+      phase: 'modification',
+      payload: {
+        media_buy_id: 'mb_existing',
+        target_seller: 'https://seller.example',
+        total_budget: { amount: 1_500, currency: 'USD' },
+      },
+    })));
+
+    expect(payload.phase).toBe('intent');
+    expect(payload).not.toHaveProperty('media_buy_id');
+  });
+
+  it('does not let a caller-supplied lifecycle phase override an intent-shaped request', async () => {
+    const payload = await withPlan(async () => claims(await check({
+      tool: 'create_media_buy',
+      phase: 'delivery',
+      payload: {
+        media_buy_id: 'mb_caller_phase',
+        target_seller: 'https://seller.example',
+        total_budget: { amount: 1_000, currency: 'USD' },
+      },
+    })));
+
+    expect(payload.phase).toBe('intent');
+    expect(payload).not.toHaveProperty('media_buy_id');
+  });
+
+  it.each(['purchase', 'modification', 'delivery'] as const)(
+    'emits an execution token for governance_context + planned_delivery (%s)',
+    async (phase) => {
+      const payload = await withPlan(async () => {
+        const intent = await check({
+          tool: 'create_media_buy',
+          payload: {
+            target_seller: 'https://seller.example',
+            total_budget: { amount: 1_000, currency: 'USD' },
+          },
+        });
+        return claims(await check({
+          caller: 'https://seller.example',
+          governance_context: intent.governance_context,
+          phase,
+          planned_delivery: {
+            media_buy_id: 'mb_execution',
+            total_budget: 1_000,
+          },
+        }));
+      });
+
+      expect(payload.phase).toBe(phase);
+      expect(payload.media_buy_id).toBe('mb_execution');
+    },
+  );
+
+  it('treats planned_delivery alone as an execution check with the default purchase phase', async () => {
+    const payload = await withPlan(async () => claims(await check({
+      planned_delivery: {
+        media_buy_id: 'mb_without_prior_context',
+        total_budget: 1_000,
+      },
+    })));
+
+    expect(payload.phase).toBe('purchase');
+    expect(payload.media_buy_id).toBe('mb_without_prior_context');
+  });
+});

--- a/server/tests/unit/training-agent-governance-intent-binding.test.ts
+++ b/server/tests/unit/training-agent-governance-intent-binding.test.ts
@@ -139,4 +139,19 @@ describe('check_governance request-shape binding', () => {
     expect(payload.phase).toBe('purchase');
     expect(payload.media_buy_id).toBe('mb_without_prior_context');
   });
+
+  it('rejects an execution check that cannot bind a seller-assigned media buy ID', async () => {
+    const result = await withPlan(async () => check({
+      phase: 'purchase',
+      planned_delivery: { total_budget: 1_000 },
+    }));
+
+    expect(result).toEqual({
+      errors: [{
+        code: 'VALIDATION_ERROR',
+        message: 'planned_delivery.media_buy_id is required for execution governance checks',
+      }],
+    });
+    expect(result).not.toHaveProperty('governance_context');
+  });
 });

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -8935,12 +8935,11 @@ describe('check_governance delegation enforcement', () => {
     // Second check — pass governance_context back for lifecycle continuity
     const { result: check2 } = await simulateCallTool(server, 'check_governance', {
       plan_id: 'plan-deleg',
-      binding: 'committed',
       caller: 'https://delegated.example',
-      media_buy_id: 'mb_test_123',
       governance_context: check1.governance_context,
       phase: 'purchase',
       planned_delivery: {
+        media_buy_id: 'mb_test_123',
         geo: { countries: ['US'] },
         total_budget: 10000,
         currency: 'USD',

--- a/tests/governance-intent-binding.test.ts
+++ b/tests/governance-intent-binding.test.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+
+describe('governance intent binding regressions', () => {
+  it('keeps the request-signature reference verifier on the real adcp_use field', () => {
+    const security = fs.readFileSync(
+      path.join(repoRoot, 'docs/building/by-layer/L1/security.mdx'),
+      'utf8',
+    );
+
+    expect(security).toMatch(/j\.adcp_use\s*!==\s*["']request-signing["']/);
+    expect(security).not.toMatch(/j\.example_use/);
+  });
+
+  it('keeps governance request phases execution-only', () => {
+    const schema = JSON.parse(fs.readFileSync(
+      path.join(repoRoot, 'static/schemas/source/enums/governance-phase.json'),
+      'utf8',
+    ));
+
+    expect(schema.enum).toEqual(['purchase', 'modification', 'delivery']);
+  });
+});


### PR DESCRIPTION
## Summary

- bind governance token phase to the `check_governance` request shape
- always emit intent tokens without `media_buy_id` for `tool + payload` proposals
- preserve execution lifecycle phase and seller-assigned buy ID for `planned_delivery` checks
- reject execution checks that cannot bind a seller-assigned media buy ID
- correct the request-signature reference verifier to read the real `adcp_use` JWK field
- add handler and source-regression tests without introducing the fail-open scaffold from #5833

## Root cause

The training agent inferred token phase partly from payload contents. An `update_media_buy` proposal carrying its existing `media_buy_id` could therefore emit a purchase token instead of an intent token. Separately, the reference verifier checked the nonexistent `example_use` property and rejected every otherwise-valid request-signing key.

## Impact

Buyer proposals cannot be mistaken for seller execution authorization, including when a caller supplies a lifecycle phase or a proposed update names an existing buy. Execution checks fail closed when they cannot bind `media_buy_id`. The request phase enum remains execution-only (`purchase`, `modification`, `delivery`); `intent` is an emitted JWS claim selected by request shape.

## Validation

- focused intent-binding regressions: 10 passed
- existing governance tests: 42 passed
- schema validation: 19 passed
- server typecheck
- `git diff --check`

This supersedes #5833's two valid mechanical fixes. The proposed normative-registry/doctest workflow is intentionally excluded until it fails closed and is a required check.
