### PR TITLE
fix: filter archived groups from member context

### DIFF
--- a/server/src/addie/member-context.ts
+++ b/server/src/addie/member-context.ts
@@ -347,9 +347,11 @@ async function computeTeamWgCoverage(orgMemberUserIds: string[]): Promise<number
   if (orgMemberUserIds.length === 0) return 0;
   const result = await query<{ count: string }>(
     `SELECT COUNT(DISTINCT workos_user_id)::text as count
-       FROM working_group_memberships
-       WHERE workos_user_id = ANY($1::text[])
-         AND status = 'active'`,
+       FROM working_group_memberships wgm
+       JOIN working_groups wg ON wg.id = wgm.working_group_id
+       WHERE wgm.workos_user_id = ANY($1::text[])
+         AND wgm.status = 'active'
+         AND wg.status = 'active'`,
     [orgMemberUserIds]
   );
   const inWgs = parseInt(result.rows[0]?.count || '0', 10);

--- a/server/src/addie/services/relationship-context.ts
+++ b/server/src/addie/services/relationship-context.ts
@@ -541,7 +541,9 @@ async function loadJourneyContext(workosUserId: string): Promise<JourneyContext 
       query<{ name: string }>(
         `SELECT wg.name FROM working_groups wg
          JOIN working_group_memberships wgm ON wgm.working_group_id = wg.id
-         WHERE wgm.workos_user_id = $1 AND wgm.status = 'active'`,
+         WHERE wgm.workos_user_id = $1
+           AND wgm.status = 'active'
+           AND wg.status = 'active'`,
         [workosUserId]
       ),
       query<{ name: string }>(
@@ -566,7 +568,9 @@ async function loadJourneyContext(workosUserId: string): Promise<JourneyContext 
            (SELECT string_agg(DISTINCT wg.name, ', ')
             FROM working_group_memberships wgm
             JOIN working_groups wg ON wg.id = wgm.working_group_id
-            WHERE wgm.workos_user_id = om2.workos_user_id AND wgm.status = 'active') as groups,
+            WHERE wgm.workos_user_id = om2.workos_user_id
+              AND wgm.status = 'active'
+              AND wg.status = 'active') as groups,
            (SELECT COUNT(*) FROM perspectives p
             WHERE (p.author_user_id = om2.workos_user_id OR p.proposer_user_id = om2.workos_user_id)
               AND p.status = 'published') as contribution_count

--- a/server/src/db/community-db.ts
+++ b/server/src/db/community-db.ts
@@ -384,7 +384,9 @@ export class CommunityDatabase {
       `SELECT wg.id, wg.name, wg.slug
        FROM working_groups wg
        JOIN working_group_memberships wgm ON wgm.working_group_id = wg.id
-       WHERE wgm.workos_user_id = $1 AND wgm.status = 'active'
+       WHERE wgm.workos_user_id = $1
+         AND wgm.status = 'active'
+         AND wg.status = 'active'
        ORDER BY wg.name`,
       [userId]
     );
@@ -838,8 +840,12 @@ export class CommunityDatabase {
         FROM users WHERE workos_user_id = $1
       ),
       user_wgs AS (
-        SELECT working_group_id FROM working_group_memberships
-        WHERE workos_user_id = $1 AND status = 'active'
+        SELECT wgm.working_group_id
+        FROM working_group_memberships wgm
+        JOIN working_groups wg ON wg.id = wgm.working_group_id
+        WHERE wgm.workos_user_id = $1
+          AND wgm.status = 'active'
+          AND wg.status = 'active'
       ),
       user_events AS (
         SELECT event_id FROM event_registrations WHERE workos_user_id = $1
@@ -984,7 +990,9 @@ export class CommunityDatabase {
                WHERE wgm2.working_group_id = wg.id AND wgm2.status = 'active') as member_count
        FROM working_groups wg
        JOIN working_group_memberships wgm ON wgm.working_group_id = wg.id
-       WHERE wgm.workos_user_id = $1 AND wgm.status = 'active'
+       WHERE wgm.workos_user_id = $1
+         AND wgm.status = 'active'
+         AND wg.status = 'active'
        ORDER BY wg.name`,
       [userId]
     );

--- a/server/src/services/user-journey.ts
+++ b/server/src/services/user-journey.ts
@@ -349,7 +349,9 @@ export async function assembleUserJourney(userId: string): Promise<UserJourney> 
               ) as is_leader
        FROM working_groups wg
        JOIN working_group_memberships wgm ON wgm.working_group_id = wg.id
-       WHERE wgm.workos_user_id = $1 AND wgm.status = 'active'
+       WHERE wgm.workos_user_id = $1
+         AND wgm.status = 'active'
+         AND wg.status = 'active'
        ORDER BY wg.name`,
       [userId]
     ).then(r => r.rows).catch(err => {

--- a/server/tests/integration/archived-working-group-member-context.test.ts
+++ b/server/tests/integration/archived-working-group-member-context.test.ts
@@ -1,0 +1,152 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { loadRelationshipContext } from '../../src/addie/services/relationship-context.js';
+import { closeDatabase, initializeDatabase, query } from '../../src/db/client.js';
+import { CommunityDatabase } from '../../src/db/community-db.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { resolvePersonId } from '../../src/db/relationship-db.js';
+import { assembleUserJourney } from '../../src/services/user-journey.js';
+
+const ORG_ID = 'org_archived_wg_member_context';
+const USER_ID = 'user_archived_wg_member_context';
+const ACTIVE_COLLEAGUE_ID = 'user_active_wg_colleague';
+const ARCHIVED_COLLEAGUE_ID = 'user_archived_wg_colleague';
+const ACTIVE_GROUP_ID = '59300000-0000-4000-8000-000000000001';
+const ARCHIVED_GROUP_ID = '59300000-0000-4000-8000-000000000002';
+const ACTIVE_GROUP_NAME = 'Current Context Working Group';
+const ARCHIVED_GROUP_NAME = 'Archived Context Working Group';
+
+async function cleanup(): Promise<void> {
+  await query('DELETE FROM person_relationships WHERE workos_user_id = $1', [USER_ID]);
+  await query(
+    'DELETE FROM organization_memberships WHERE workos_user_id = ANY($1::text[])',
+    [[USER_ID, ACTIVE_COLLEAGUE_ID, ARCHIVED_COLLEAGUE_ID]],
+  );
+  await query(
+    'DELETE FROM users WHERE workos_user_id = ANY($1::text[])',
+    [[USER_ID, ACTIVE_COLLEAGUE_ID, ARCHIVED_COLLEAGUE_ID]],
+  );
+  await query('DELETE FROM working_groups WHERE id = ANY($1::uuid[])', [
+    [ACTIVE_GROUP_ID, ARCHIVED_GROUP_ID],
+  ]);
+  await query('DELETE FROM organizations WHERE workos_organization_id = $1', [ORG_ID]);
+}
+
+describe('archived working groups on member and Addie current-state context', () => {
+  let personId: string;
+
+  beforeAll(async () => {
+    initializeDatabase({
+      connectionString:
+        process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:53198/adcp_test',
+    });
+    await runMigrations();
+    await cleanup();
+
+    await query(
+      `INSERT INTO organizations (
+         workos_organization_id, name, subscription_status, created_at, updated_at
+       ) VALUES ($1, 'Context Test Organization', 'active', NOW(), NOW())`,
+      [ORG_ID],
+    );
+    await query(
+      `INSERT INTO users (
+         workos_user_id, email, first_name, last_name, primary_organization_id,
+         slug, is_public, created_at, updated_at
+       ) VALUES
+         ($1, 'member@archived-wg-context.test', 'Main', 'Member', $4, 'archived-wg-main', true, NOW(), NOW()),
+         ($2, 'active@archived-wg-context.test', 'Active', 'Colleague', $4, 'archived-wg-active', true, NOW(), NOW()),
+         ($3, 'archived@archived-wg-context.test', 'Archived', 'Colleague', $4, 'archived-wg-archived', true, NOW(), NOW())`,
+      [USER_ID, ACTIVE_COLLEAGUE_ID, ARCHIVED_COLLEAGUE_ID, ORG_ID],
+    );
+    await query(
+      `INSERT INTO organization_memberships (
+         workos_user_id, workos_organization_id, email, role, seat_type, created_at
+       ) VALUES
+         ($1, $4, 'member@archived-wg-context.test', 'member', 'community_only', NOW()),
+         ($2, $4, 'active@archived-wg-context.test', 'member', 'community_only', NOW()),
+         ($3, $4, 'archived@archived-wg-context.test', 'member', 'community_only', NOW())`,
+      [USER_ID, ACTIVE_COLLEAGUE_ID, ARCHIVED_COLLEAGUE_ID, ORG_ID],
+    );
+    await query(
+      `INSERT INTO working_groups (id, name, slug, status)
+       VALUES
+         ($1, $3, 'current-context-working-group', 'active'),
+         ($2, $4, 'archived-context-working-group', 'archived')`,
+      [ACTIVE_GROUP_ID, ARCHIVED_GROUP_ID, ACTIVE_GROUP_NAME, ARCHIVED_GROUP_NAME],
+    );
+    await query(
+      `INSERT INTO working_group_memberships (
+         working_group_id, workos_user_id, workos_organization_id, status
+       ) VALUES
+         ($1, $3, $5, 'active'),
+         ($2, $3, $5, 'active'),
+         ($1, $4, $5, 'active'),
+         ($2, $6, $5, 'active')`,
+      [
+        ACTIVE_GROUP_ID,
+        ARCHIVED_GROUP_ID,
+        USER_ID,
+        ACTIVE_COLLEAGUE_ID,
+        ORG_ID,
+        ARCHIVED_COLLEAGUE_ID,
+      ],
+    );
+
+    personId = await resolvePersonId({ email: 'member@archived-wg-context.test' });
+    await query('UPDATE person_relationships SET workos_user_id = $1 WHERE id = $2', [
+      USER_ID,
+      personId,
+    ]);
+  }, 60_000);
+
+  afterAll(async () => {
+    await cleanup();
+    await closeDatabase();
+  });
+
+  it('omits archived memberships from community profile and hub working groups', async () => {
+    const communityDb = new CommunityDatabase();
+
+    const profile = await communityDb.getPersonBySlug('archived-wg-main');
+    expect(profile?.working_groups.map((group) => group.name)).toEqual([ACTIVE_GROUP_NAME]);
+
+    const hub = await communityDb.getHubData(USER_ID);
+    expect(hub.working_groups.map((group) => group.name)).toEqual([ACTIVE_GROUP_NAME]);
+    expect(Number(hub.working_groups[0].member_count)).toBe(2);
+  });
+
+  it('only uses active parent groups for shared-working-group suggestions', async () => {
+    const suggestions = await new CommunityDatabase().getSuggestedConnections(USER_ID, 10);
+    const activeColleague = suggestions.find(
+      (suggestion) => suggestion.workos_user_id === ACTIVE_COLLEAGUE_ID,
+    );
+    const archivedColleague = suggestions.find(
+      (suggestion) => suggestion.workos_user_id === ARCHIVED_COLLEAGUE_ID,
+    );
+
+    expect(activeColleague?.suggestion_context).toBe('Shared working group');
+    expect(archivedColleague?.suggestion_context).not.toBe('Shared working group');
+  });
+
+  it('omits archived memberships from the user journey and Addie relationship context', async () => {
+    const journey = await assembleUserJourney(USER_ID);
+    expect(journey.working_groups.map((group) => group.name)).toEqual([ACTIVE_GROUP_NAME]);
+
+    const relationship = await loadRelationshipContext(personId);
+    expect(relationship.journey?.working_groups).toEqual([ACTIVE_GROUP_NAME]);
+    expect(relationship.journey?.notable_colleagues).toEqual([
+      {
+        name: 'Active Colleague',
+        highlights: [`In ${ACTIVE_GROUP_NAME}`],
+      },
+    ]);
+
+    const archivedMembership = await query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count
+       FROM working_group_memberships
+       WHERE working_group_id = $1 AND workos_user_id = $2`,
+      [ARCHIVED_GROUP_ID, USER_ID],
+    );
+    expect(archivedMembership.rows[0]?.count).toBe('1');
+  });
+});

--- a/server/tests/integration/user-context.test.ts
+++ b/server/tests/integration/user-context.test.ts
@@ -155,6 +155,8 @@ describe('User Context API Tests', () => {
   const TEST_SINGLE_ORG_WORKOS_USER_ID = 'user_test_single_context';
   const TEST_STALE_WORKOS_USER_ID = 'user_test_stale_context';
   const TEST_SLACK_USER_ID = 'U_test_context';
+  const TEST_ACTIVE_WG_ID = '59300000-0000-4000-8000-000000000003';
+  const TEST_ARCHIVED_WG_ID = '59300000-0000-4000-8000-000000000004';
 
   beforeAll(async () => {
     // Initialize test database
@@ -251,6 +253,31 @@ describe('User Context API Tests', () => {
     );
 
     await pool.query(
+      `INSERT INTO working_groups (id, name, slug, status)
+       VALUES
+         ($1, 'Active Coverage Group', 'active-coverage-group', 'active'),
+         ($2, 'Archived Coverage Group', 'archived-coverage-group', 'archived')
+       ON CONFLICT (id) DO UPDATE SET status = EXCLUDED.status`,
+      [TEST_ACTIVE_WG_ID, TEST_ARCHIVED_WG_ID]
+    );
+    await pool.query(
+      `INSERT INTO working_group_memberships (
+         working_group_id, workos_user_id, workos_organization_id, status
+       ) VALUES
+         ($1, $3, $5, 'active'),
+         ($2, $4, $5, 'active')
+       ON CONFLICT (working_group_id, workos_user_id)
+       DO UPDATE SET status = EXCLUDED.status`,
+      [
+        TEST_ACTIVE_WG_ID,
+        TEST_ARCHIVED_WG_ID,
+        TEST_WORKOS_USER_ID,
+        'user_test_2',
+        TEST_ORG_ID,
+      ]
+    );
+
+    await pool.query(
       `INSERT INTO person_relationships (
         slack_user_id, workos_user_id, email, display_name, stage,
         interaction_count, sentiment_trend, unreplied_outreach_count
@@ -277,6 +304,7 @@ describe('User Context API Tests', () => {
     await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = ANY($1)', [[TEST_ORG_ID, TEST_OTHER_ORG_ID]]);
     await pool.query('DELETE FROM person_relationships WHERE slack_user_id = $1 OR workos_user_id = $2', [TEST_SLACK_USER_ID, TEST_WORKOS_USER_ID]);
     await pool.query('DELETE FROM slack_user_mappings WHERE slack_user_id = $1', [TEST_SLACK_USER_ID]);
+    await pool.query('DELETE FROM working_groups WHERE id = ANY($1::uuid[])', [[TEST_ACTIVE_WG_ID, TEST_ARCHIVED_WG_ID]]);
     await pool.query('DELETE FROM organization_memberships WHERE workos_user_id = ANY($1)', [[TEST_WORKOS_USER_ID, TEST_SINGLE_ORG_WORKOS_USER_ID, TEST_STALE_WORKOS_USER_ID]]);
     await pool.query('DELETE FROM users WHERE workos_user_id = ANY($1)', [[TEST_WORKOS_USER_ID, TEST_SINGLE_ORG_WORKOS_USER_ID, TEST_STALE_WORKOS_USER_ID]]);
     await pool.query('DELETE FROM organizations WHERE workos_organization_id = ANY($1)', [[TEST_ORG_ID, TEST_OTHER_ORG_ID]]);
@@ -420,6 +448,16 @@ describe('User Context API Tests', () => {
       expect(response.body.org_membership).toBeDefined();
       expect(response.body.org_membership.role).toBe('admin');
       expect(response.body.org_membership.member_count).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should count team working-group coverage only for active parent groups', async () => {
+      const response = await request(app)
+        .get(`/api/admin/users/${TEST_WORKOS_USER_ID}/context?type=workos&org=${TEST_ORG_ID}`)
+        .expect(200);
+
+      // The WorkOS fixture has three org members. One belongs to an active
+      // group and another has a retained membership in an archived group.
+      expect(response.body.adoption.team_wg_coverage).toBeCloseTo(1 / 3);
     });
 
     it('should indicate slack_linked status correctly', async () => {


### PR DESCRIPTION
## Summary

- hide archived working-group memberships from community profiles and hubs
- exclude archived groups from shared-connection scoring and user journeys
- remove archived group names from Addie relationship/notable-colleague context
- ignore archived groups in team working-group coverage
- preserve the underlying membership rows as history

## Root cause

Current-state member and Addie queries filtered the membership row but not the parent working-group lifecycle. Retained memberships in an archived group therefore appeared as current participation.

## Validation

- active-vs-archived integration fixture: 3 passed
- focused team coverage route: passed
- related community/user-journey units: 18 passed
- server typecheck
- `git diff --check`

Part of #5930. The direct access/entitlement subset landed separately in #5926.
