### PR TITLE
fix: filter archived groups from derived metrics

### DIFF
--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -3766,7 +3766,9 @@ export function createAdminToolHandlers(
           `SELECT DISTINCT wg.name, wg.slug, wgm.status, wgm.joined_at
            FROM working_group_memberships wgm
            JOIN working_groups wg ON wgm.working_group_id = wg.id
-           WHERE wgm.workos_organization_id = $1 AND wgm.status = 'active'`,
+           WHERE wgm.workos_organization_id = $1
+             AND wgm.status = 'active'
+             AND wg.status = 'active'`,
           [orgId],
         ),
         // Recent activities

--- a/server/src/addie/services/journey-computation.ts
+++ b/server/src/addie/services/journey-computation.ts
@@ -44,8 +44,9 @@ export async function checkMilestones(orgId: string): Promise<MilestoneCheck | n
        o.created_at,
        EXISTS (
          SELECT 1 FROM working_group_leaders wgl
+         JOIN working_groups wg ON wg.id = wgl.working_group_id
          JOIN organization_memberships om ON om.workos_user_id = wgl.user_id
-         WHERE om.workos_organization_id = $1
+         WHERE om.workos_organization_id = $1 AND wg.status = 'active'
        ) as has_leadership,
        EXISTS (
          SELECT 1 FROM perspectives p
@@ -54,8 +55,11 @@ export async function checkMilestones(orgId: string): Promise<MilestoneCheck | n
        ) as has_content_proposals,
        EXISTS (
          SELECT 1 FROM working_group_memberships wgm
+         JOIN working_groups wg ON wg.id = wgm.working_group_id
          JOIN organization_memberships om ON om.workos_user_id = wgm.workos_user_id
-         WHERE om.workos_organization_id = $1 AND wgm.status = 'active'
+         WHERE om.workos_organization_id = $1
+           AND wgm.status = 'active'
+           AND wg.status = 'active'
        ) as has_working_groups,
        EXISTS (
          SELECT 1 FROM member_search_analytics msa

--- a/server/src/addie/services/persona-inference.ts
+++ b/server/src/addie/services/persona-inference.ts
@@ -42,7 +42,9 @@ async function gatherSignals(orgId: string): Promise<InferenceSignals> {
        FROM working_group_memberships wgm
        JOIN working_groups wg ON wg.id = wgm.working_group_id
        JOIN organization_memberships om ON om.workos_user_id = wgm.workos_user_id
-       WHERE om.workos_organization_id = $1 AND wgm.status = 'active'`,
+       WHERE om.workos_organization_id = $1
+         AND wgm.status = 'active'
+         AND wg.status = 'active'`,
       [orgId]
     ),
     pool.query(

--- a/server/src/db/digest-db.ts
+++ b/server/src/db/digest-db.ts
@@ -554,7 +554,12 @@ export async function getDigestEmailRecipients(): Promise<DigestEmailRecipient[]
        o.persona,
        o.journey_stage,
        om.seat_type,
-       COALESCE((SELECT COUNT(*) FROM working_group_memberships wgm WHERE wgm.workos_user_id = u.workos_user_id AND wgm.status = 'active'), 0)::int AS wg_count,
+       COALESCE((SELECT COUNT(*)
+                 FROM working_group_memberships wgm
+                 JOIN working_groups wg ON wg.id = wgm.working_group_id
+                 WHERE wgm.workos_user_id = u.workos_user_id
+                   AND wgm.status = 'active'
+                   AND wg.status = 'active'), 0)::int AS wg_count,
        COALESCE((SELECT COUNT(*) FROM learner_progress lp
                  JOIN certification_modules cm ON cm.id = lp.module_id
                  WHERE lp.workos_user_id = u.workos_user_id

--- a/server/src/db/organization-db.ts
+++ b/server/src/db/organization-db.ts
@@ -2114,8 +2114,10 @@ export class OrganizationDatabase {
       pool.query(
         `SELECT COUNT(DISTINCT wgm.working_group_id) as count
          FROM working_group_memberships wgm
+         JOIN working_groups wg ON wg.id = wgm.working_group_id
          WHERE wgm.workos_organization_id = $1
-         AND wgm.status = 'active'`,
+         AND wgm.status = 'active'
+         AND wg.status = 'active'`,
         [workos_organization_id]
       ),
       // Email click count (last 30 days)

--- a/server/src/db/outbound-db.ts
+++ b/server/src/db/outbound-db.ts
@@ -84,16 +84,24 @@ export async function getMemberCapabilities(
       `SELECT
         (SELECT COUNT(DISTINCT wg.id) FROM working_groups wg
          WHERE wg.committee_type = 'working_group'
+         AND wg.status = 'active'
          AND (
-           EXISTS(SELECT 1 FROM working_group_memberships wgm WHERE wgm.working_group_id = wg.id AND wgm.workos_user_id = $1)
+           EXISTS(SELECT 1 FROM working_group_memberships wgm
+                  WHERE wgm.working_group_id = wg.id
+                    AND wgm.workos_user_id = $1
+                    AND wgm.status = 'active')
            OR EXISTS(SELECT 1 FROM working_group_leaders wgl
                      LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id AND sm.workos_user_id IS NOT NULL
                      WHERE wgl.working_group_id = wg.id AND (wgl.user_id = $1 OR sm.workos_user_id = $1))
          )) as wg_count,
         (SELECT COUNT(DISTINCT wg.id) FROM working_groups wg
          WHERE wg.committee_type = 'council'
+         AND wg.status = 'active'
          AND (
-           EXISTS(SELECT 1 FROM working_group_memberships wgm WHERE wgm.working_group_id = wg.id AND wgm.workos_user_id = $1)
+           EXISTS(SELECT 1 FROM working_group_memberships wgm
+                  WHERE wgm.working_group_id = wg.id
+                    AND wgm.workos_user_id = $1
+                    AND wgm.status = 'active')
            OR EXISTS(SELECT 1 FROM working_group_leaders wgl
                      LEFT JOIN slack_user_mappings sm ON wgl.user_id = sm.slack_user_id AND sm.workos_user_id IS NOT NULL
                      WHERE wgl.working_group_id = wg.id AND (wgl.user_id = $1 OR sm.workos_user_id = $1))
@@ -136,7 +144,11 @@ export async function getMemberCapabilities(
 
     // Leadership
     query<{ is_leader: boolean }>(
-      `SELECT EXISTS(SELECT 1 FROM working_group_leaders WHERE user_id = $1) as is_leader`,
+      `SELECT EXISTS(
+         SELECT 1 FROM working_group_leaders wgl
+         JOIN working_groups wg ON wg.id = wgl.working_group_id
+         WHERE wgl.user_id = $1 AND wg.status = 'active'
+       ) as is_leader`,
       [workosUserId]
     ),
 

--- a/server/src/db/relationship-db.ts
+++ b/server/src/db/relationship-db.ts
@@ -532,9 +532,12 @@ export async function evaluateStageTransitions(personId: string): Promise<void> 
     const wgResult = await query<{ wg_count: number }>(
       `SELECT COUNT(DISTINCT wg.id) as wg_count
        FROM working_groups wg
-       WHERE EXISTS(
+       WHERE wg.status = 'active'
+       AND EXISTS(
          SELECT 1 FROM working_group_memberships wgm
-         WHERE wgm.working_group_id = wg.id AND wgm.workos_user_id = $1
+         WHERE wgm.working_group_id = wg.id
+           AND wgm.workos_user_id = $1
+           AND wgm.status = 'active'
        )`,
       [person.workos_user_id]
     );
@@ -546,12 +549,19 @@ export async function evaluateStageTransitions(personId: string): Promise<void> 
 
     const leaderResult = await query<{ is_leader: boolean; council_count: number }>(
       `SELECT
-        EXISTS(SELECT 1 FROM working_group_leaders WHERE user_id = $1) as is_leader,
+        EXISTS(
+          SELECT 1 FROM working_group_leaders wgl
+          JOIN working_groups leader_wg ON leader_wg.id = wgl.working_group_id
+          WHERE wgl.user_id = $1 AND leader_wg.status = 'active'
+        ) as is_leader,
         (SELECT COUNT(DISTINCT wg.id) FROM working_groups wg
          WHERE wg.committee_type = 'council'
+         AND wg.status = 'active'
          AND EXISTS(
            SELECT 1 FROM working_group_memberships wgm
-           WHERE wgm.working_group_id = wg.id AND wgm.workos_user_id = $1
+           WHERE wgm.working_group_id = wg.id
+             AND wgm.workos_user_id = $1
+             AND wgm.status = 'active'
          )) as council_count`,
       [person.workos_user_id]
     );

--- a/server/src/services/org-health.ts
+++ b/server/src/services/org-health.ts
@@ -285,7 +285,9 @@ export async function assembleOrgHealth(orgId: string): Promise<OrgHealth> {
          (SELECT string_agg(DISTINCT wg.name, ', ')
           FROM working_group_memberships wgm
           JOIN working_groups wg ON wg.id = wgm.working_group_id
-          WHERE wgm.workos_user_id = om.workos_user_id AND wgm.status = 'active') as working_groups,
+          WHERE wgm.workos_user_id = om.workos_user_id
+            AND wgm.status = 'active'
+            AND wg.status = 'active') as working_groups,
          (SELECT MAX(cp.created_at)
           FROM community_points cp
           WHERE cp.workos_user_id = om.workos_user_id) as last_active,
@@ -325,9 +327,10 @@ export async function assembleOrgHealth(orgId: string): Promise<OrgHealth> {
     query<{ count: string }>(
       `SELECT COUNT(DISTINCT wgl.working_group_id) as count
        FROM working_group_leaders wgl
+       JOIN working_groups wg ON wg.id = wgl.working_group_id
        LEFT JOIN slack_user_mappings sm ON sm.slack_user_id = wgl.user_id
        JOIN organization_memberships om ON om.workos_user_id = COALESCE(sm.workos_user_id, wgl.user_id)
-       WHERE om.workos_organization_id = $1`,
+       WHERE om.workos_organization_id = $1 AND wg.status = 'active'`,
       [orgId]
     ).then(r => r).catch(err => {
       logger.error({ err, orgId }, 'Failed to fetch leadership count');

--- a/server/tests/integration/archived-working-group-derived-metrics.test.ts
+++ b/server/tests/integration/archived-working-group-derived-metrics.test.ts
@@ -1,0 +1,217 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createAdminToolHandlers } from '../../src/addie/mcp/admin-tools.js';
+import { checkMilestones } from '../../src/addie/services/journey-computation.js';
+import { inferPersonaForOrg } from '../../src/addie/services/persona-inference.js';
+import { closeDatabase, initializeDatabase, query } from '../../src/db/client.js';
+import { getDigestEmailRecipients } from '../../src/db/digest-db.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { OrganizationDatabase } from '../../src/db/organization-db.js';
+import { getMemberCapabilities } from '../../src/db/outbound-db.js';
+import { evaluateStageTransitions, getRelationship } from '../../src/db/relationship-db.js';
+import { assembleOrgHealth } from '../../src/services/org-health.js';
+
+const ORG_ID = 'org-archived-wg-derived-metrics';
+const USER_ID = 'user-archived-wg-derived-metrics';
+const USER_EMAIL = 'archived-wg-derived-metrics@test.example.com';
+const ORG_NAME = 'Archived WG Derived Metrics Test Org';
+const ACTIVE_WG_SLUG = 'creative-active-derived-test';
+const ARCHIVED_WG_SLUG = 'technical-standards-archived-derived-test';
+const INACTIVE_MEMBERSHIP_WG_SLUG = 'inactive-membership-derived-test';
+const ACTIVE_COUNCIL_SLUG = 'active-council-derived-test';
+const ARCHIVED_COUNCIL_SLUG = 'archived-council-derived-test';
+const TEST_GROUP_SLUGS = [
+  ACTIVE_WG_SLUG,
+  ARCHIVED_WG_SLUG,
+  INACTIVE_MEMBERSHIP_WG_SLUG,
+  ACTIVE_COUNCIL_SLUG,
+  ARCHIVED_COUNCIL_SLUG,
+];
+
+async function groupId(slug: string): Promise<string> {
+  const result = await query<{ id: string }>('SELECT id FROM working_groups WHERE slug = $1', [slug]);
+  if (!result.rows[0]) throw new Error(`Missing test working group: ${slug}`);
+  return result.rows[0].id;
+}
+
+async function cleanup(): Promise<void> {
+  await query('DELETE FROM org_knowledge WHERE workos_organization_id = $1', [ORG_ID]);
+  await query('DELETE FROM person_relationships WHERE workos_user_id = $1', [USER_ID]);
+  await query('DELETE FROM community_points WHERE workos_user_id = $1', [USER_ID]);
+  await query(
+    'DELETE FROM user_email_category_preferences WHERE user_preference_id IN (SELECT id FROM user_email_preferences WHERE workos_user_id = $1)',
+    [USER_ID],
+  );
+  await query('DELETE FROM user_email_preferences WHERE workos_user_id = $1', [USER_ID]);
+  await query(
+    `DELETE FROM working_group_leaders
+     WHERE working_group_id IN (SELECT id FROM working_groups WHERE slug = ANY($1::text[]))`,
+    [TEST_GROUP_SLUGS],
+  );
+  await query(
+    `DELETE FROM working_group_memberships
+     WHERE working_group_id IN (SELECT id FROM working_groups WHERE slug = ANY($1::text[]))`,
+    [TEST_GROUP_SLUGS],
+  );
+  await query('DELETE FROM organization_memberships WHERE workos_user_id = $1', [USER_ID]);
+  await query('DELETE FROM users WHERE workos_user_id = $1', [USER_ID]);
+  await query('DELETE FROM working_groups WHERE slug = ANY($1::text[])', [TEST_GROUP_SLUGS]);
+  await query('DELETE FROM organizations WHERE workos_organization_id = $1', [ORG_ID]);
+}
+
+async function seed(): Promise<void> {
+  await query(
+    `INSERT INTO organizations (workos_organization_id, name, is_personal, created_at)
+     VALUES ($1, $2, FALSE, NOW() - INTERVAL '120 days')`,
+    [ORG_ID, ORG_NAME],
+  );
+  await query(
+    `INSERT INTO users (workos_user_id, email, first_name, last_name, primary_organization_id)
+     VALUES ($1, $2, 'Active', 'Control', $3)`,
+    [USER_ID, USER_EMAIL, ORG_ID],
+  );
+  await query(
+    `INSERT INTO organization_memberships
+       (workos_organization_id, workos_user_id, email, first_name, last_name, role, seat_type)
+     VALUES ($1, $2, $3, 'Active', 'Control', 'member', 'contributor')`,
+    [ORG_ID, USER_ID, USER_EMAIL],
+  );
+  await query(
+    `INSERT INTO user_email_preferences
+       (workos_user_id, email, unsubscribe_token, marketing_opt_in, marketing_opt_in_at)
+     VALUES ($1, $2, $3, TRUE, NOW())`,
+    [USER_ID, USER_EMAIL, `token-${USER_ID}`],
+  );
+  await query(
+    `INSERT INTO community_points (workos_user_id, action, points)
+     VALUES ($1, 'test_fixture', 100)`,
+    [USER_ID],
+  );
+  await query(
+    `INSERT INTO working_groups (name, slug, status, committee_type)
+     VALUES
+       ('Active creative group', $1, 'active', 'working_group'),
+       ('Archived technical standards group', $2, 'archived', 'working_group'),
+       ('Inactive membership group', $3, 'active', 'working_group'),
+       ('Active council', $4, 'active', 'council'),
+       ('Archived council', $5, 'archived', 'council')`,
+    TEST_GROUP_SLUGS,
+  );
+
+  const activeWgId = await groupId(ACTIVE_WG_SLUG);
+  const archivedWgId = await groupId(ARCHIVED_WG_SLUG);
+  const inactiveMembershipWgId = await groupId(INACTIVE_MEMBERSHIP_WG_SLUG);
+  const activeCouncilId = await groupId(ACTIVE_COUNCIL_SLUG);
+  const archivedCouncilId = await groupId(ARCHIVED_COUNCIL_SLUG);
+
+  await query(
+    `INSERT INTO working_group_memberships
+       (working_group_id, workos_user_id, user_email, workos_organization_id, status)
+     VALUES
+       ($1, $6, $7, $8, 'active'),
+       ($2, $6, $7, $8, 'active'),
+       ($3, $6, $7, $8, 'inactive'),
+       ($4, $6, $7, $8, 'active'),
+       ($5, $6, $7, $8, 'active')`,
+    [activeWgId, archivedWgId, inactiveMembershipWgId, activeCouncilId, archivedCouncilId, USER_ID, USER_EMAIL, ORG_ID],
+  );
+  await query(
+    `INSERT INTO working_group_leaders (working_group_id, user_id)
+     VALUES ($1, $3), ($2, $3)`,
+    [activeWgId, archivedWgId, USER_ID],
+  );
+  await query(
+    `INSERT INTO person_relationships (workos_user_id, email, display_name, stage)
+     VALUES ($1, $2, 'Active Control', 'exploring')`,
+    [USER_ID, USER_EMAIL],
+  );
+}
+
+describe('archived working groups in derived current-state metrics', () => {
+  beforeAll(async () => {
+    initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:51734/adcp_registry',
+    });
+    await runMigrations();
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+    await seed();
+  });
+
+  it('counts only active parent groups and active memberships in Addie-facing metrics', async () => {
+    const milestones = await checkMilestones(ORG_ID);
+    expect(milestones).toMatchObject({ has_working_groups: true, has_leadership: true });
+
+    const recipient = (await getDigestEmailRecipients()).find(row => row.workos_user_id === USER_ID);
+    expect(recipient?.wg_count).toBe(2);
+
+    const capabilities = await getMemberCapabilities('unused-slack-id', USER_ID);
+    expect(capabilities).toMatchObject({
+      working_group_count: 1,
+      council_count: 1,
+      is_committee_leader: true,
+    });
+
+    const inferred = await inferPersonaForOrg(ORG_ID);
+    expect(inferred?.persona).toBe('molecule_builder');
+    expect(inferred?.reasons).toContain(`working group: ${ACTIVE_WG_SLUG}`);
+    expect(inferred?.reasons).not.toContain(`working group: ${ARCHIVED_WG_SLUG}`);
+  });
+
+  it('omits archived names from health and admin summaries while keeping the active control', async () => {
+    const health = await assembleOrgHealth(ORG_ID);
+    expect(health.people).toHaveLength(1);
+    expect(health.people[0].working_groups).toHaveLength(2);
+    expect(health.people[0].working_groups).toEqual(
+      expect.arrayContaining(['Active creative group', 'Active council']),
+    );
+    expect(health.health_breakdown.leadership_roles).toBe(1);
+
+    const signals = await new OrganizationDatabase().getEngagementSignals(ORG_ID);
+    expect(signals.working_group_count).toBe(2);
+
+    const getAccount = createAdminToolHandlers().get('get_account');
+    if (!getAccount) throw new Error('get_account handler not registered');
+    const summary = await getAccount({ query: ORG_NAME });
+    expect(summary).toContain('Active creative group');
+    expect(summary).toContain('Active council');
+    expect(summary).not.toContain('Archived technical standards group');
+    expect(summary).not.toContain('Archived council');
+  });
+
+  it('does not progress a relationship from archived or inactive rows', async () => {
+    await query(
+      `UPDATE working_group_memberships
+       SET status = 'inactive'
+       WHERE workos_user_id = $1 AND working_group_id IN (
+         SELECT id FROM working_groups WHERE status = 'active'
+       )`,
+      [USER_ID],
+    );
+    await query(
+      `DELETE FROM working_group_leaders
+       WHERE user_id = $1 AND working_group_id IN (
+         SELECT id FROM working_groups WHERE status = 'active'
+       )`,
+      [USER_ID],
+    );
+
+    const milestones = await checkMilestones(ORG_ID);
+    expect(milestones).toMatchObject({ has_working_groups: false, has_leadership: false });
+
+    const relationshipId = (await query<{ id: string }>(
+      'SELECT id FROM person_relationships WHERE workos_user_id = $1',
+      [USER_ID],
+    )).rows[0].id;
+    await evaluateStageTransitions(relationshipId);
+    const relationship = await getRelationship(relationshipId);
+    expect(relationship?.stage).toBe('exploring');
+  });
+});


### PR DESCRIPTION
## Summary

- ignore archived groups in Addie journey, persona, digest, and outbound capability metrics
- filter archived memberships and leadership from relationship progression
- remove archived group names/counts from org health, engagement, and admin account summaries
- keep historical membership and leadership rows intact

## Root cause

Derived current-state queries treated retained membership and leadership rows as live without checking the parent working-group lifecycle. Archived participation could therefore change prompts, personas, journey stages, email eligibility, org health, and admin summaries.

## Validation

- active/archived/inactive derived-metrics integration fixture: 3 passed
- server typecheck
- `git diff --check`

Part of #5930. This complements the access/entitlement fix in #5926 and member-context fix in #5935.
