### PR TITLE
fix(addie): align training module and certification catalog

### DIFF
--- a/docs/learning/overview.mdx
+++ b/docs/learning/overview.mdx
@@ -123,7 +123,7 @@ Each specialist module combines a hands-on lab with an adaptive exam in a specif
 | [S7: Brand identity](/docs/learning/specialist/brand) | brand.json identity, distributed publishing, verify_brand_claim verification, trademark disambiguation | 60 min |
 
 <Note>
-S6 (Security) is in development and not yet available via Addie — its curriculum and lab exercises are being finalized. The other specialist modules — S1–S5 and S7 (Brand) — are live.
+S5 (Sponsored Intelligence) is temporarily unavailable via Addie while its `si_*` sandbox labs are completed. S1–S4, S6 (Security), and S7 (Brand identity) are live.
 </Note>
 
 ## Get started

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -994,6 +994,11 @@ async function createUserScopedTools(
   threadContext?: ThreadContext | null
 ): Promise<UserScopedToolsResult> {
   const memberHandlers = createMemberToolHandlers(memberContext, slackUserId);
+  const trainingModuleContext: { moduleId?: string } = {
+    moduleId: memberContext?.certification?.status === 'in_progress'
+      ? memberContext.certification.module_id ?? undefined
+      : undefined,
+  };
   let allTools = [...MEMBER_TOOLS];
   const allHandlers = new Map(memberHandlers);
 
@@ -1051,7 +1056,7 @@ async function createUserScopedTools(
   logger.debug('Addie Bolt: Newsletter suggestion tools enabled');
 
   // Add AdCP protocol tools (standard MCP tools for interacting with agents)
-  const adcpHandlers = createAdcpToolHandlers(memberContext);
+  const adcpHandlers = createAdcpToolHandlers(memberContext, trainingModuleContext);
   allTools.push(...ADCP_TOOLS);
   for (const [name, handler] of adcpHandlers) {
     allHandlers.set(name, handler);
@@ -1197,7 +1202,10 @@ async function createUserScopedTools(
   }
 
   // Add certification tools (learning modules, exams, progress tracking)
-  const certificationHandlers = createCertificationToolHandlers(memberContext, { threadId });
+  const certificationHandlers = createCertificationToolHandlers(memberContext, {
+    threadId,
+    trainingModuleContext,
+  });
   allTools.push(...CERTIFICATION_TOOLS);
   for (const [name, handler] of certificationHandlers) {
     allHandlers.set(name, handler);

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.07.1';
+export const CODE_VERSION = '2026.07.2';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -679,7 +679,8 @@ export const ADCP_TOOLS: AddieTool[] = [
  * These wrap the AdCPClient to execute tasks with proper parameter mapping.
  */
 export function createAdcpToolHandlers(
-  memberContext: MemberContext | null
+  memberContext: MemberContext | null,
+  trainingModuleContext?: { moduleId?: string },
 ): Map<string, ToolHandler> {
   const handlers = new Map<string, ToolHandler>();
   const agentContextDb = new AgentContextDatabase();
@@ -782,7 +783,14 @@ export function createAdcpToolHandlers(
       if (isTrainingAgentUrl(parsedUrl)) {
         const { executeTrainingAgentTool } = await import('../../training-agent/task-handlers.js');
         const userId = memberContext?.workos_user?.workos_user_id;
-        const ctx = { mode: 'training' as const, userId };
+        const memberModuleId = memberContext?.certification?.status === 'in_progress'
+          ? memberContext.certification.module_id ?? undefined
+          : undefined;
+        const ctx = {
+          mode: 'training' as const,
+          userId,
+          moduleId: trainingModuleContext?.moduleId ?? memberModuleId,
+        };
         const result = await executeTrainingAgentTool(task, params, ctx);
         if (!result.success) {
           return [

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -104,6 +104,13 @@ const MIN_PLACEMENT_TURNS = 3;
 const MIN_MODULE_TIME_MS = 5 * 60 * 1000; // 5 minutes
 const MIN_CAPSTONE_TIME_MS = 10 * 60 * 1000; // 10 minutes
 
+const UNAVAILABLE_SPECIALIST_MODULES = new Set(['S5']);
+
+function unavailableSpecialistMessage(moduleId: string): string | null {
+  if (!UNAVAILABLE_SPECIALIST_MODULES.has(moduleId)) return null;
+  return `Module ${moduleId} (Sponsored Intelligence) is not currently available for assessment because the sandbox does not yet expose the required si_* lab tools. No module progress or capstone attempt was changed.`;
+}
+
 export const PRIOR_TURN_RESTATEMENT_NO_RAW_JSON_RULE = 'for prior-turn re-statements, no raw JSON';
 export const LIVE_DEMO_RESULT_FORMATTING_RULE = 'When pasting the tool result, preserve the exact formatting returned by the tool -- including any code fence wrappers. Do NOT flatten to prose or strip the fence.';
 export const LIVE_DEMO_CODE_FENCE_ARTIFACT_RULE = 'The code fence is the artifact learners are here to see.';
@@ -1003,15 +1010,15 @@ export const CERTIFICATION_TOOLS: AddieTool[] = [
   },
   {
     name: 'start_certification_exam',
-    description: 'Begin a specialist deep dive module (S1: Media Buy, S2: Creative, S3: Signals, S4: Governance, S5: Sponsored Intelligence). The learner must hold the Practitioner credential. Returns the capstone format, lab exercises, and assessment criteria. You (Sage) will conduct the combined hands-on lab and adaptive exam — technically assess the learner against the spec.',
-    usage_hints: 'use for "take the exam", "start capstone", "specialist exam", "ready for certification", "start S1", "media buy specialist", "sponsored intelligence"',
+    description: 'Begin an available specialist deep dive module (S1: Media Buy, S2: Creative, S3: Signals, S4: Governance, S6: Security). S5 Sponsored Intelligence is listed in the curriculum but is not assessable until its sandbox labs exist. The learner must hold the Practitioner credential. Returns the capstone format, lab exercises, and assessment criteria. You (Sage) will conduct the combined hands-on lab and adaptive exam — technically assess the learner against the spec.',
+    usage_hints: 'use for "take the exam", "start capstone", "specialist exam", "ready for certification", "start S1", "media buy specialist", "security specialist"',
     input_schema: {
       type: 'object',
       properties: {
         module_id: {
           type: 'string',
-          enum: ['S1', 'S2', 'S3', 'S4', 'S5'],
-          description: 'Specialist module ID: S1 (Media Buy), S2 (Creative), S3 (Signals), S4 (Governance), S5 (Sponsored Intelligence)',
+          enum: ['S1', 'S2', 'S3', 'S4', 'S5', 'S6'],
+          description: 'Specialist module ID: S1 (Media Buy), S2 (Creative), S3 (Signals), S4 (Governance), S5 (Sponsored Intelligence — currently unavailable), S6 (Security)',
         },
       },
       required: ['module_id'],
@@ -1564,7 +1571,7 @@ function isCredentialIssued(
  */
 export function createCertificationToolHandlers(
   initialMemberContext: MemberContext | null,
-  options?: { threadId?: string },
+  options?: { threadId?: string; trainingModuleContext?: { moduleId?: string } },
 ): Map<string, ToolHandler> {
   const handlers = new Map<string, ToolHandler>();
 
@@ -1694,7 +1701,10 @@ export function createCertificationToolHandlers(
 
         for (const mod of trackModules) {
           const freeLabel = mod.is_free ? ' (free)' : '';
-          lines.push(`- ${mod.id}: ${mod.title} — ${mod.duration_minutes} min, ${mod.format}${freeLabel}`);
+          const availabilityLabel = UNAVAILABLE_SPECIALIST_MODULES.has(mod.id)
+            ? ' — unavailable (sandbox labs pending)'
+            : '';
+          lines.push(`- ${mod.id}: ${mod.title} — ${mod.duration_minutes} min, ${mod.format}${freeLabel}${availabilityLabel}`);
         }
         lines.push('');
       }
@@ -1702,7 +1712,7 @@ export function createCertificationToolHandlers(
       lines.push('---');
       lines.push('Modules A1, A2, A2B, and A3 are free for everyone. Other modules require AgenticAdvertising.org membership.');
       lines.push('To start a module, say "start module [ID]" (e.g., "start module A1").');
-      lines.push('To start a specialist deep dive, say "start capstone S1" (or S2–S5, or S7 Brand).');
+      lines.push('To start a specialist deep dive, say "start capstone S1" (S1–S4, S6 Security, or S7 Brand are available; S5 is pending sandbox labs).');
       lines.push('Already familiar with AdCP? Say "assess my level" to take a placement assessment and skip modules you already know.');
 
       return lines.join('\n');
@@ -1818,6 +1828,8 @@ export function createCertificationToolHandlers(
 
     try {
       const moduleId = (input.module_id as string).toUpperCase();
+      const unavailable = unavailableSpecialistMessage(moduleId);
+      if (unavailable) return unavailable;
       const mod = await certDb.getModule(moduleId);
       if (!mod) return `Module "${moduleId}" not found.`;
 
@@ -1866,6 +1878,9 @@ export function createCertificationToolHandlers(
       }
 
       await certDb.startModule(userId, moduleId);
+      if (options?.trainingModuleContext) {
+        options.trainingModuleContext.moduleId = moduleId;
+      }
 
       // Return the lesson plan so Sage can teach it
       const lines: string[] = [
@@ -1980,6 +1995,8 @@ export function createCertificationToolHandlers(
 
     try {
       const moduleId = (input.module_id as string).toUpperCase();
+      const unavailable = unavailableSpecialistMessage(moduleId);
+      if (unavailable) return notCompleted(moduleId, 'state', unavailable);
 
       // Verify module is in-progress before allowing completion
       const progress = await certDb.getProgress(userId);
@@ -2308,6 +2325,8 @@ export function createCertificationToolHandlers(
 
     try {
       const moduleId = (input.module_id as string).toUpperCase();
+      const unavailable = unavailableSpecialistMessage(moduleId);
+      if (unavailable) return unavailable;
 
       // Validate it's a capstone module
       const mod = await certDb.getModule(moduleId);
@@ -2439,12 +2458,18 @@ export function createCertificationToolHandlers(
       // Check for existing active attempt (module-scoped so S1 doesn't block S4)
       const active = await certDb.getActiveAttemptForModule(userId, moduleId);
       if (active) {
+        if (options?.trainingModuleContext) {
+          options.trainingModuleContext.moduleId = moduleId;
+        }
         return `You already have an active capstone attempt (started ${new Date(active.started_at).toLocaleDateString()}). Continue the capstone.\n\nAttempt ID: ${active.id}`;
       }
 
       // Start the module and create an attempt
       await certDb.startModule(userId, moduleId);
       const attempt = await certDb.createAttempt(userId, mod.track_id, options?.threadId, moduleId);
+      if (options?.trainingModuleContext) {
+        options.trainingModuleContext.moduleId = moduleId;
+      }
 
       const criteria = mod.assessment_criteria as certDb.AssessmentCriteria | null;
       const lessonPlan = mod.lesson_plan as certDb.LessonPlan | null;
@@ -2457,6 +2482,7 @@ export function createCertificationToolHandlers(
         'S3': 'AdCP Specialist — Signals',
         'S4': 'AdCP Specialist — Governance',
         'S5': 'AdCP Specialist — Sponsored Intelligence',
+        'S6': 'AdCP Specialist — Security',
       };
 
       const lines = [
@@ -2630,6 +2656,8 @@ export function createCertificationToolHandlers(
       const examAc = capstoneMod.assessment_criteria as certDb.AssessmentCriteria | undefined;
 
       const capstoneId = capstoneMod.id;
+      const unavailable = unavailableSpecialistMessage(capstoneId);
+      if (unavailable) return notCompleted(capstoneId, 'state', unavailable);
       const deltaDef = getDeltaForModule(capstoneId) ?? null;
       const deltaStatus = deltaDef
         ? await certDb.getDeltaStatus(deltaDef, userId)

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -571,11 +571,16 @@ export async function prepareRequestWithMemberTools(
 
   // Create per-request tools (same tools as Slack, minus Slack-specific ones)
   // Re-register billing with memberContext so org-scoped operations work (overrides baseline)
+  const trainingModuleContext: { moduleId?: string } = {
+    moduleId: memberContext?.certification?.status === 'in_progress'
+      ? memberContext.certification.module_id ?? undefined
+      : undefined,
+  };
   const allTools = [...MEMBER_TOOLS, ...SI_HOST_TOOLS, ...ADCP_TOOLS, ...ESCALATION_TOOLS, ...BILLING_TOOLS, ...IMAGE_TOOLS];
   const combinedHandlers = new Map([
     ...createMemberToolHandlers(memberContext),
     ...createSiHostToolHandlers(() => memberContext, () => threadExternalId),
-    ...createAdcpToolHandlers(memberContext),
+    ...createAdcpToolHandlers(memberContext, trainingModuleContext),
     ...createEscalationToolHandlers(memberContext, linkedSlackUserId, threadId),
     ...createBillingToolHandlers(memberContext),
     ...createImageToolHandlers(linkedSlackUserId, threadExternalId),
@@ -584,7 +589,10 @@ export async function prepareRequestWithMemberTools(
   // Certification tools (for authenticated users)
   if (userId) {
     allTools.push(...CERTIFICATION_TOOLS);
-    for (const [name, handler] of createCertificationToolHandlers(memberContext, { threadId: threadExternalId })) {
+    for (const [name, handler] of createCertificationToolHandlers(memberContext, {
+      threadId: threadExternalId,
+      trainingModuleContext,
+    })) {
       combinedHandlers.set(name, handler);
     }
   }

--- a/server/tests/unit/addie/adcp-tools.test.ts
+++ b/server/tests/unit/addie/adcp-tools.test.ts
@@ -1,4 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+const executeTrainingAgentTool = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/training-agent/task-handlers.js', () => ({
+  executeTrainingAgentTool,
+}));
 import {
   ADCP_TASK_REGISTRY,
   ADCP_TOOLS,
@@ -286,5 +292,41 @@ describe('call_adcp_task handler validation boundary', () => {
         media_buy_id: 'mb_123',
       },
     })).resolves.toContain('account.operator must be a string domain, not an array');
+  });
+});
+
+describe('call_adcp_task training module isolation', () => {
+  it('passes the shared current module to the embedded training agent', async () => {
+    executeTrainingAgentTool.mockResolvedValue({ success: true, data: { formats: [] } });
+    const trainingModuleContext = { moduleId: 'S1' };
+    const handlers = createAdcpToolHandlers({
+      workos_user: { workos_user_id: 'user_training' },
+    } as any, trainingModuleContext);
+    const callAdcpTask = handlers.get('call_adcp_task');
+
+    await callAdcpTask?.({
+      agent_url: 'https://test-agent.adcontextprotocol.org/sales/mcp',
+      task: 'list_creative_formats',
+      params: {},
+    });
+    trainingModuleContext.moduleId = 'S4';
+    await callAdcpTask?.({
+      agent_url: 'https://test-agent.adcontextprotocol.org/governance/mcp',
+      task: 'list_creative_formats',
+      params: {},
+    });
+
+    expect(executeTrainingAgentTool).toHaveBeenNthCalledWith(
+      1,
+      'list_creative_formats',
+      {},
+      expect.objectContaining({ mode: 'training', userId: 'user_training', moduleId: 'S1' }),
+    );
+    expect(executeTrainingAgentTool).toHaveBeenNthCalledWith(
+      2,
+      'list_creative_formats',
+      {},
+      expect.objectContaining({ mode: 'training', userId: 'user_training', moduleId: 'S4' }),
+    );
   });
 });

--- a/server/tests/unit/certification-specialist-catalog.test.ts
+++ b/server/tests/unit/certification-specialist-catalog.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getModule: vi.fn(),
+  getUserCredentials: vi.fn(),
+  checkPrerequisites: vi.fn(),
+  getModuleProgress: vi.fn(),
+  expireStaleAttempts: vi.fn(),
+  getActiveAttemptForModule: vi.fn(),
+  startModule: vi.fn(),
+  createAttempt: vi.fn(),
+  getAttempt: vi.fn(),
+  getModulesForTrack: vi.fn(),
+}));
+
+vi.mock('../../src/db/certification-db.js', () => ({
+  ...mocks,
+}));
+
+import {
+  CERTIFICATION_TOOLS,
+  createCertificationToolHandlers,
+} from '../../src/addie/mcp/certification-tools.js';
+
+const USER_ID = 'user_specialist_catalog';
+const ATTEMPT_ID = '123e4567-e89b-42d3-a456-426614174000';
+
+function memberContext() {
+  return {
+    workos_user: { workos_user_id: USER_ID },
+    is_member: true,
+  } as any;
+}
+
+describe('specialist certification catalog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getUserCredentials.mockResolvedValue([{ credential_id: 'practitioner' }]);
+    mocks.checkPrerequisites.mockResolvedValue({ met: true, missing: [] });
+    mocks.getModuleProgress.mockResolvedValue(null);
+    mocks.expireStaleAttempts.mockResolvedValue(0);
+    mocks.getActiveAttemptForModule.mockResolvedValue(null);
+    mocks.startModule.mockResolvedValue(undefined);
+    mocks.createAttempt.mockResolvedValue({
+      id: ATTEMPT_ID,
+      workos_user_id: USER_ID,
+      track_id: 'S',
+      module_id: 'S6',
+      status: 'in_progress',
+      started_at: new Date().toISOString(),
+    });
+  });
+
+  it('advertises S6 as a specialist module and labels S5 unavailable', () => {
+    const tool = CERTIFICATION_TOOLS.find(candidate => candidate.name === 'start_certification_exam');
+    const moduleSchema = tool?.input_schema.properties?.module_id as {
+      enum?: string[];
+      description?: string;
+    } | undefined;
+
+    expect(moduleSchema?.enum).toContain('S6');
+    expect(moduleSchema?.description).toContain('S5 (Sponsored Intelligence — currently unavailable)');
+    expect(moduleSchema?.description).toContain('S6 (Security)');
+  });
+
+  it('blocks S5 starts before changing progress or attempts', async () => {
+    const handlers = createCertificationToolHandlers(memberContext());
+
+    await expect(handlers.get('start_certification_module')?.({ module_id: 'S5' }))
+      .resolves.toContain('not currently available for assessment');
+    await expect(handlers.get('start_certification_exam')?.({ module_id: 'S5' }))
+      .resolves.toContain('not currently available for assessment');
+
+    expect(mocks.startModule).not.toHaveBeenCalled();
+    expect(mocks.createAttempt).not.toHaveBeenCalled();
+  });
+
+  it('blocks completion of an existing S5 attempt', async () => {
+    mocks.getAttempt.mockResolvedValue({
+      id: ATTEMPT_ID,
+      workos_user_id: USER_ID,
+      track_id: 'S',
+      module_id: 'S5',
+      status: 'in_progress',
+      started_at: new Date(Date.now() - 20 * 60 * 1000).toISOString(),
+    });
+    mocks.getModule.mockResolvedValue({ id: 'S5', track_id: 'S', format: 'capstone' });
+
+    const result = await createCertificationToolHandlers(memberContext())
+      .get('complete_certification_exam')?.({
+        attempt_id: ATTEMPT_ID,
+        scores: { protocol_mastery: 90 },
+      });
+
+    expect(result).toContain('NOT COMPLETED — module S5 is not recorded as complete.');
+    expect(result).toContain('not currently available for assessment');
+  });
+
+  it('starts S6 with the security credential and updates sandbox module context', async () => {
+    mocks.getModule.mockResolvedValue({
+      id: 'S6',
+      track_id: 'S',
+      title: 'Security',
+      description: 'Security capstone',
+      format: 'capstone',
+      lesson_plan: null,
+      exercise_definitions: [],
+      assessment_criteria: { dimensions: [], passing_threshold: 70 },
+    });
+    const trainingModuleContext: { moduleId?: string } = {};
+    const handler = createCertificationToolHandlers(memberContext(), { trainingModuleContext })
+      .get('start_certification_exam');
+
+    const result = await handler?.({ module_id: 'S6' });
+
+    expect(result).toContain('Credential: **AdCP Specialist — Security**');
+    expect(result).toContain(`Attempt ID: ${ATTEMPT_ID}`);
+    expect(trainingModuleContext.moduleId).toBe('S6');
+    expect(mocks.startModule).toHaveBeenCalledWith(USER_ID, 'S6');
+    expect(mocks.createAttempt).toHaveBeenCalledWith(USER_ID, 'S', undefined, 'S6');
+  });
+});


### PR DESCRIPTION
## Summary

- isolate embedded training-agent state by the learner's active certification module
- expose S6 Security as a supported specialist exam and credential
- mark S5 Sponsored Intelligence unavailable and block starts/completions until its `si_*` sandbox exists
- keep Slack and web Addie tool wiring on the same mutable module context

## Why

The live certification catalog and sandbox had drifted: S1 and S4 could share the default training session, S5 advertised labs that do not exist, and S6 had live curriculum but could not be started or credentialed.

## Validation

- 45 focused certification/Addie tests passed
- `npm run typecheck`
- `git diff --check`

Part of #5929.
