### PR TITLE
fix(addie): scope certification attempts to the learner

### DIFF
--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -2591,7 +2591,7 @@ export function createCertificationToolHandlers(
       let attempt: certDb.CertificationAttempt | null;
       let resolvedFromModuleId = false;
       if (isUuid(attemptId)) {
-        attempt = await certDb.getAttempt(attemptId);
+        attempt = await certDb.getAttemptForUser(attemptId, userId);
       } else {
         // Claude sometimes sends the module ID instead of the attempt UUID
         logger.warn({ attemptId, userId }, 'complete_certification_exam received module ID instead of UUID, resolving');
@@ -2602,8 +2602,7 @@ export function createCertificationToolHandlers(
         resolvedFromModuleId = true;
         attempt = await certDb.getActiveAttemptForModule(userId, normalized);
       }
-      if (!attempt) return 'Exam attempt not found.';
-      if (attempt.workos_user_id !== userId) return 'This exam attempt belongs to a different user.';
+      if (!attempt || attempt.workos_user_id !== userId) return 'Exam attempt not found.';
 
       if (attempt.status !== 'in_progress') {
         if (attempt.status === 'passed' && attempt.passing === true) {

--- a/server/src/db/certification-db.ts
+++ b/server/src/db/certification-db.ts
@@ -499,6 +499,17 @@ export async function getAttempt(attemptId: string): Promise<CertificationAttemp
   return result.rows[0] || null;
 }
 
+export async function getAttemptForUser(
+  attemptId: string,
+  userId: string,
+): Promise<CertificationAttempt | null> {
+  const result = await query<CertificationAttempt>(
+    'SELECT * FROM certification_attempts WHERE id = $1 AND workos_user_id = $2',
+    [attemptId, userId]
+  );
+  return result.rows[0] || null;
+}
+
 export async function getUserAttempts(userId: string): Promise<CertificationAttempt[]> {
   const result = await query<CertificationAttempt>(
     'SELECT * FROM certification_attempts WHERE workos_user_id = $1 ORDER BY created_at DESC',

--- a/server/tests/unit/certification-attempt-lookup.test.ts
+++ b/server/tests/unit/certification-attempt-lookup.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+  getClient: vi.fn(),
+}));
+
+import { getAttemptForUser } from '../../src/db/certification-db.js';
+import { query } from '../../src/db/client.js';
+
+const mockedQuery = vi.mocked(query);
+const ATTEMPT_ID = '123e4567-e89b-42d3-a456-426614174000';
+const USER_ID = 'user_attempt_owner';
+
+describe('getAttemptForUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('scopes the attempt lookup to both its ID and learner', async () => {
+    const attempt = {
+      id: ATTEMPT_ID,
+      workos_user_id: USER_ID,
+      track_id: 'S',
+      module_id: 'S3',
+      status: 'in_progress' as const,
+      started_at: new Date().toISOString(),
+      completed_at: null,
+      scores: null,
+      overall_score: null,
+      passing: null,
+      addie_thread_id: null,
+      certifier_credential_id: null,
+      certifier_public_id: null,
+      created_at: new Date().toISOString(),
+    };
+    mockedQuery.mockResolvedValueOnce({ rows: [attempt] } as never);
+
+    await expect(getAttemptForUser(ATTEMPT_ID, USER_ID)).resolves.toEqual(attempt);
+    expect(mockedQuery).toHaveBeenCalledWith(
+      expect.stringContaining('WHERE id = $1 AND workos_user_id = $2'),
+      [ATTEMPT_ID, USER_ID],
+    );
+  });
+
+  it('returns null when no attempt belongs to the learner', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    await expect(getAttemptForUser(ATTEMPT_ID, USER_ID)).resolves.toBeNull();
+  });
+});

--- a/server/tests/unit/certification-attempt-recovery.test.ts
+++ b/server/tests/unit/certification-attempt-recovery.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
   getDeltaStatus: vi.fn(),
   getUserAttempts: vi.fn(),
   getActiveAttemptForModule: vi.fn(),
-  getAttempt: vi.fn(),
+  getAttemptForUser: vi.fn(),
   getModule: vi.fn(),
   getLatestCheckpoint: vi.fn(),
   completeAttempt: vi.fn(),
@@ -27,7 +27,7 @@ vi.mock('../../src/db/certification-db.js', () => ({
   getDeltaStatus: mocks.getDeltaStatus,
   getUserAttempts: mocks.getUserAttempts,
   getActiveAttemptForModule: mocks.getActiveAttemptForModule,
-  getAttempt: mocks.getAttempt,
+  getAttemptForUser: mocks.getAttemptForUser,
   getModule: mocks.getModule,
   getLatestCheckpoint: mocks.getLatestCheckpoint,
   completeAttempt: mocks.completeAttempt,
@@ -131,5 +131,74 @@ describe('certification attempt recovery', () => {
       85,
       true,
     );
+  });
+
+  it('does not distinguish another learner\'s attempt UUID from a missing UUID', async () => {
+    const otherUserAttemptId = '123e4567-e89b-42d3-a456-426614174001';
+    const missingAttemptId = '123e4567-e89b-42d3-a456-426614174002';
+    mocks.getAttemptForUser
+      .mockResolvedValueOnce({
+        id: otherUserAttemptId,
+        workos_user_id: 'another_learner',
+        track_id: 'S',
+        module_id: 'S3',
+        status: 'in_progress',
+        started_at: new Date().toISOString(),
+      })
+      .mockResolvedValueOnce(null);
+
+    const handler = createCertificationToolHandlers(memberContext())
+      .get('complete_certification_exam');
+    const otherUserResult = await handler?.({
+      attempt_id: otherUserAttemptId,
+      scores: { protocol_mastery: 85 },
+    });
+    const missingResult = await handler?.({
+      attempt_id: missingAttemptId,
+      scores: { protocol_mastery: 85 },
+    });
+
+    expect(otherUserResult).toBe('Exam attempt not found.');
+    expect(missingResult).toBe(otherUserResult);
+    expect(mocks.getAttemptForUser).toHaveBeenNthCalledWith(1, otherUserAttemptId, USER_ID);
+    expect(mocks.getAttemptForUser).toHaveBeenNthCalledWith(2, missingAttemptId, USER_ID);
+  });
+
+  it('completes an owned attempt resolved from its UUID', async () => {
+    const startedAt = new Date(Date.now() - 11 * 60 * 1000).toISOString();
+    const attempt = {
+      id: ATTEMPT_ID,
+      workos_user_id: USER_ID,
+      track_id: 'S',
+      module_id: 'S3',
+      status: 'in_progress',
+      started_at: startedAt,
+      passing: null,
+    };
+    const scores = { protocol_mastery: 85 };
+
+    mocks.getAttemptForUser.mockResolvedValue(attempt);
+    mocks.getModule.mockResolvedValue({
+      id: 'S3',
+      assessment_criteria: {
+        dimensions: [{ name: 'protocol_mastery', weight: 100, description: 'Mastery' }],
+        passing_threshold: 70,
+      },
+      exercise_definitions: [],
+    });
+    mocks.getLatestCheckpoint.mockResolvedValue({
+      preliminary_scores: { protocol_mastery: 85 },
+      demonstrations_verified: [],
+    });
+    mocks.query.mockResolvedValue({ rows: [{ count: '6' }] });
+    mocks.completeAttempt.mockResolvedValue({ ...attempt, status: 'passed', passing: true });
+    mocks.completeModule.mockResolvedValue({ module_id: 'S3', status: 'completed' });
+
+    const result = await createCertificationToolHandlers(memberContext(), { threadId: 'thread_123' })
+      .get('complete_certification_exam')?.({ attempt_id: ATTEMPT_ID, scores });
+
+    expect(result).toContain('# Congratulations! The learner passed the capstone!');
+    expect(mocks.getAttemptForUser).toHaveBeenCalledWith(ATTEMPT_ID, USER_ID);
+    expect(mocks.completeAttempt).toHaveBeenCalledWith(ATTEMPT_ID, scores, 85, true);
   });
 });

--- a/server/tests/unit/certification-specialist-catalog.test.ts
+++ b/server/tests/unit/certification-specialist-catalog.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
   getActiveAttemptForModule: vi.fn(),
   startModule: vi.fn(),
   createAttempt: vi.fn(),
-  getAttempt: vi.fn(),
+  getAttemptForUser: vi.fn(),
   getModulesForTrack: vi.fn(),
 }));
 
@@ -76,7 +76,7 @@ describe('specialist certification catalog', () => {
   });
 
   it('blocks completion of an existing S5 attempt', async () => {
-    mocks.getAttempt.mockResolvedValue({
+    mocks.getAttemptForUser.mockResolvedValue({
       id: ATTEMPT_ID,
       workos_user_id: USER_ID,
       track_id: 'S',


### PR DESCRIPTION
## Summary

- scope learner-facing certification attempt lookup by both attempt UUID and current user in SQL
- return the same response for missing and cross-user attempt IDs
- preserve the explicit global lookup used by admin repair and background recovery
- add database, oracle-regression, and successful-completion coverage

## Why

`complete_certification_exam` previously loaded an attempt globally and checked ownership afterward, exposing distinguishable missing-versus-unowned responses. UUID entropy kept the practical risk low, but the learner path should not contain an ownership oracle.

## Validation

- 10 focused certification tests passed
- `npm run typecheck`
- `git diff --check`

Closes #5938.
