### PR TITLE
fix(training): harden webhook target validation

### DIFF
--- a/server/src/training-agent/inventory-governance-handlers.ts
+++ b/server/src/training-agent/inventory-governance-handlers.ts
@@ -11,7 +11,7 @@ import type { TrainingContext, ToolArgs, CollectionListState } from './types.js'
 import { getSession, sessionKeyFromArgs } from './state.js';
 import { ACCOUNT_REF_SCHEMA } from './account-handlers.js';
 import { encodeOffsetCursor, decodeOffsetCursor } from './pagination.js';
-import { assertPublicTarget } from './webhook-fetch.js';
+import { validateWebhookUrl } from './webhook-fetch.js';
 
 const MAX_ARRAY_INPUT = 100;
 
@@ -146,27 +146,6 @@ const MAX_LIST_ID_LEN = 128;
 function validateListId(value: unknown): { code: string; message: string; field: string } | undefined {
   if (typeof value !== 'string' || value.length === 0 || value.length > MAX_LIST_ID_LEN) {
     return { code: 'VALIDATION_ERROR', message: `list_id must be a non-empty string up to ${MAX_LIST_ID_LEN} chars`, field: 'list_id' };
-  }
-  return undefined;
-}
-
-async function validateWebhookUrl(value: string): Promise<{ code: string; message: string; field: string } | undefined> {
-  let target: URL;
-  try {
-    target = new URL(value);
-  } catch {
-    return { code: 'VALIDATION_ERROR', message: 'webhook_url must be a valid URL', field: 'webhook_url' };
-  }
-  if (target.protocol !== 'https:' && (process.env.NODE_ENV === 'production' || target.protocol !== 'http:')) {
-    return { code: 'VALIDATION_ERROR', message: 'webhook_url must use HTTPS', field: 'webhook_url' };
-  }
-  if (target.username || target.password) {
-    return { code: 'VALIDATION_ERROR', message: 'webhook_url must not include userinfo credentials', field: 'webhook_url' };
-  }
-  try {
-    await assertPublicTarget(target);
-  } catch {
-    return { code: 'VALIDATION_ERROR', message: 'webhook_url must target a public network address', field: 'webhook_url' };
   }
   return undefined;
 }

--- a/server/src/training-agent/property-handlers.ts
+++ b/server/src/training-agent/property-handlers.ts
@@ -11,7 +11,7 @@ import type { TrainingContext, ToolArgs, AccountRef, PropertyListState } from '.
 import { getSession, sessionKeyFromArgs, MAX_PROPERTY_LISTS_PER_SESSION } from './state.js';
 import { ACCOUNT_REF_SCHEMA } from './account-handlers.js';
 import { encodeOffsetCursor, decodeOffsetCursor } from './pagination.js';
-import { assertPublicTarget } from './webhook-fetch.js';
+import { validateWebhookUrl } from './webhook-fetch.js';
 
 const MAX_PROPERTIES_PER_LIST = 10_000;
 
@@ -182,27 +182,6 @@ function extractDomains(properties: unknown[]): string[] {
     }
   }
   return domains;
-}
-
-async function validateWebhookUrl(value: string): Promise<{ code: string; message: string; field: string } | undefined> {
-  let target: URL;
-  try {
-    target = new URL(value);
-  } catch {
-    return { code: 'VALIDATION_ERROR', message: 'webhook_url must be a valid URL', field: 'webhook_url' };
-  }
-  if (target.protocol !== 'https:' && (process.env.NODE_ENV === 'production' || target.protocol !== 'http:')) {
-    return { code: 'VALIDATION_ERROR', message: 'webhook_url must use HTTPS', field: 'webhook_url' };
-  }
-  if (target.username || target.password) {
-    return { code: 'VALIDATION_ERROR', message: 'webhook_url must not include userinfo credentials', field: 'webhook_url' };
-  }
-  try {
-    await assertPublicTarget(target);
-  } catch {
-    return { code: 'VALIDATION_ERROR', message: 'webhook_url must target a public network address', field: 'webhook_url' };
-  }
-  return undefined;
 }
 
 // ── Handlers ─────────────────────────────────────────────────────

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -315,6 +315,8 @@ export interface CollectionListState {
   filters?: Record<string, unknown>;
   brand?: { domain: string };
   account?: AccountRef;
+  /** Stored target only. Delivery must use createTrainingWebhookFetch so the
+   * address is revalidated and pinned at connection time. */
   webhook_url?: string;
   collection_count: number;
   created_at: string;
@@ -666,6 +668,8 @@ export interface PropertyListState {
   baseProperties: unknown[];
   filters?: unknown;
   brand?: unknown;
+  /** Stored target only. Delivery must use createTrainingWebhookFetch so the
+   * address is revalidated and pinned at connection time. */
   webhookUrl?: string;
   cacheDurationHours: number;
   propertyCount: number;

--- a/server/src/training-agent/webhook-fetch.ts
+++ b/server/src/training-agent/webhook-fetch.ts
@@ -37,6 +37,24 @@ import { buildSsrfSafeDispatcher, isPrivateHostname } from '../utils/url-securit
 
 type FetchInitWithDispatcher = Omit<RequestInit, 'dispatcher'> & { dispatcher?: Dispatcher };
 
+type DnsLookup = (
+  hostname: string,
+  options: { all: true; verbatim: true },
+) => Promise<Array<{ address: string; family: number }>>;
+
+interface PublicTargetOptions {
+  dnsLookup?: DnsLookup;
+  dnsTimeoutMs?: number;
+}
+
+export interface WebhookValidationError {
+  code: 'VALIDATION_ERROR';
+  message: string;
+  field: 'webhook_url';
+}
+
+export const WEBHOOK_DNS_TIMEOUT_MS = 5_000;
+
 const fetchWithDispatcher = undiciFetch as unknown as (
   input: Parameters<typeof fetch>[0],
   init?: FetchInitWithDispatcher,
@@ -85,7 +103,10 @@ function isNumericHostname(hostname: string): boolean {
   return false;
 }
 
-export async function assertPublicTarget(url: URL): Promise<void> {
+export async function assertPublicTarget(
+  url: URL,
+  options: PublicTargetOptions = {},
+): Promise<void> {
   // Scheme refusal is handled by the wrapper before this is called (so it
   // applies unconditionally, including under `allowPrivateIp: true`). By the
   // time we get here the URL is already known to be http(s).
@@ -110,8 +131,20 @@ export async function assertPublicTarget(url: URL): Promise<void> {
   if (isNumericHostname(hostname)) {
     throw new SsrfRefusedError(url.toString(), 'numeric-encoded hostname not allowed');
   }
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
-    const records = await lookup(hostname, { all: true, verbatim: true });
+    const dnsLookup = options.dnsLookup ?? lookup as DnsLookup;
+    const dnsTimeoutMs = options.dnsTimeoutMs ?? WEBHOOK_DNS_TIMEOUT_MS;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        reject(new SsrfRefusedError(url.toString(), 'DNS lookup timed out'));
+      }, dnsTimeoutMs);
+      timeout.unref?.();
+    });
+    const records = await Promise.race([
+      dnsLookup(hostname, { all: true, verbatim: true }),
+      timeoutPromise,
+    ]);
     if (records.length === 0) {
       throw new SsrfRefusedError(url.toString(), 'hostname did not resolve');
     }
@@ -121,7 +154,38 @@ export async function assertPublicTarget(url: URL): Promise<void> {
   } catch (err) {
     if (err instanceof SsrfRefusedError) throw err;
     throw new SsrfRefusedError(url.toString(), `DNS lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    if (timeout) clearTimeout(timeout);
   }
+}
+
+/** Validate a webhook URL before storing it on collection/property state.
+ *
+ * This is only a pre-flight policy check. Any future list-change delivery
+ * must still use `createTrainingWebhookFetch`, which repeats the DNS check,
+ * pins the validated address at connect time, and refuses redirects. */
+export async function validateWebhookUrl(
+  value: string,
+  options: PublicTargetOptions = {},
+): Promise<WebhookValidationError | undefined> {
+  let target: URL;
+  try {
+    target = new URL(value);
+  } catch {
+    return { code: 'VALIDATION_ERROR', message: 'webhook_url must be a valid URL', field: 'webhook_url' };
+  }
+  if (target.protocol !== 'https:' && (process.env.NODE_ENV === 'production' || target.protocol !== 'http:')) {
+    return { code: 'VALIDATION_ERROR', message: 'webhook_url must use HTTPS', field: 'webhook_url' };
+  }
+  if (target.username || target.password) {
+    return { code: 'VALIDATION_ERROR', message: 'webhook_url must not include userinfo credentials', field: 'webhook_url' };
+  }
+  try {
+    await assertPublicTarget(target, options);
+  } catch {
+    return { code: 'VALIDATION_ERROR', message: 'webhook_url must target a public network address', field: 'webhook_url' };
+  }
+  return undefined;
 }
 
 /** Build a `fetch`-shaped function gated by the SSRF guard.
@@ -136,6 +200,9 @@ export async function assertPublicTarget(url: URL): Promise<void> {
  * The returned function uses userland `undici.fetch` so its dispatcher and
  * request-handler contract stay aligned with the imported undici version. */
 export function createWebhookFetch(options: { allowPrivateIp: boolean }): typeof fetch {
+  if (process.env.NODE_ENV === 'production' && options.allowPrivateIp) {
+    throw new Error('Private webhook targets cannot be enabled in production');
+  }
   return async (input, init) => {
     const href = typeof input === 'string' || input instanceof URL
       ? input.toString()
@@ -164,4 +231,16 @@ export function createWebhookFetch(options: { allowPrivateIp: boolean }): typeof
       dispatcher,
     });
   };
+}
+
+/** The required fetch policy for every training-agent webhook delivery,
+ * including future collection/property list-change notifications.
+ *
+ * Production behavior is intentionally derived here rather than at call
+ * sites: callers cannot accidentally enable private targets in production.
+ * Tests and local conformance receivers retain loopback access. */
+export function createTrainingWebhookFetch(
+  environment: string | undefined = process.env.NODE_ENV,
+): typeof fetch {
+  return createWebhookFetch({ allowPrivateIp: environment !== 'production' });
 }

--- a/server/src/training-agent/webhooks.ts
+++ b/server/src/training-agent/webhooks.ts
@@ -23,7 +23,7 @@ import {
 import type { SignerKey, SigningProvider } from '@adcp/sdk/signing';
 import type { AdcpJsonWebKey } from '@adcp/sdk/signing';
 import { createLogger } from '../logger.js';
-import { createWebhookFetch } from './webhook-fetch.js';
+import { createTrainingWebhookFetch } from './webhook-fetch.js';
 import { getWebhookSigningProvider } from '../security/gcp-kms-signer.js';
 import {
   WEBHOOK_SIGNING_KID,
@@ -380,18 +380,20 @@ export function getWebhookSigningMaterial():
     : { signerKey: m.signerKey };
 }
 
+/** Return the only training-agent webhook emitter.
+ *
+ * Future collection/property list-change notifications must route through
+ * this emitter (or use `createTrainingWebhookFetch` directly). Storage-time
+ * URL validation is not sufficient: this fetch policy repeats validation at
+ * delivery time and pins the public address at connect time. */
 export function getWebhookEmitter(): WebhookEmitter {
   if (emitter) return emitter;
   const m = ensureMaterial();
-  // Production (`NODE_ENV=production`, i.e. fly.io) refuses webhook delivery
-  // to private/loopback/metadata addresses. Dev and CI need loopback for
-  // conformance storyboards using `http://127.0.0.1:<port>` receivers.
-  const allowPrivateIp = process.env.NODE_ENV !== 'production';
   emitter = createWebhookEmitter({
     ...(m.kind === 'kms' ? { signerProvider: m.signerProvider } : { signerKey: m.signerKey }),
     idempotencyKeyStore: memoryWebhookKeyStore(),
     userAgent: 'adcp-training-agent/1.0',
-    fetch: createWebhookFetch({ allowPrivateIp }),
+    fetch: createTrainingWebhookFetch(),
   });
   return emitter;
 }

--- a/server/tests/unit/training-agent-webhook-fetch.test.ts
+++ b/server/tests/unit/training-agent-webhook-fetch.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createWebhookFetch, SsrfRefusedError } from '../../src/training-agent/webhook-fetch.js';
+import {
+  assertPublicTarget,
+  createTrainingWebhookFetch,
+  createWebhookFetch,
+  SsrfRefusedError,
+  validateWebhookUrl,
+  WEBHOOK_DNS_TIMEOUT_MS,
+} from '../../src/training-agent/webhook-fetch.js';
 
 const undiciFetchMock = vi.hoisted(() => vi.fn());
 
@@ -24,6 +31,8 @@ describe('createWebhookFetch — SSRF guard', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
     undiciFetchMock.mockReset();
   });
 
@@ -178,6 +187,75 @@ describe('createWebhookFetch — SSRF guard', () => {
       const fetch = createWebhookFetch({ allowPrivateIp: true });
       await fetch('http://127.0.0.1:9999/hook');
       expect((calls[0].init as RequestInit & { dispatcher?: unknown }).dispatcher).toBeUndefined();
+    });
+  });
+
+  describe('stored webhook URL validation', () => {
+    it.each([
+      ['private target', 'https://169.254.169.254/latest/meta-data'],
+      ['decimal-encoded target', 'https://2852039166/latest/meta-data'],
+      ['hex-encoded target', 'https://0x7f000001/private'],
+    ])('returns the stable validation error for a %s', async (_kind, target) => {
+      await expect(validateWebhookUrl(target)).resolves.toEqual({
+        code: 'VALIDATION_ERROR',
+        message: 'webhook_url must target a public network address',
+        field: 'webhook_url',
+      });
+    });
+
+    it('bounds a stalled DNS lookup without a real-time wait', async () => {
+      vi.useFakeTimers();
+      const stalledLookup = vi.fn(() => new Promise<Array<{ address: string; family: number }>>(() => {}));
+      const validation = validateWebhookUrl('https://stalled-dns.example/hook', {
+        dnsLookup: stalledLookup,
+      });
+      const expectation = expect(validation).resolves.toEqual({
+        code: 'VALIDATION_ERROR',
+        message: 'webhook_url must target a public network address',
+        field: 'webhook_url',
+      });
+
+      await vi.advanceTimersByTimeAsync(WEBHOOK_DNS_TIMEOUT_MS);
+      await expectation;
+      expect(stalledLookup).toHaveBeenCalledOnce();
+    });
+
+    it('uses a stable refusal reason when DNS lookup times out', async () => {
+      vi.useFakeTimers();
+      const refusal = assertPublicTarget(new URL('https://stalled-dns.example/hook'), {
+        dnsLookup: () => new Promise<Array<{ address: string; family: number }>>(() => {}),
+      });
+      const expectation = expect(refusal).rejects.toMatchObject({
+        name: 'SsrfRefusedError',
+        reason: 'DNS lookup timed out',
+      });
+
+      await vi.advanceTimersByTimeAsync(WEBHOOK_DNS_TIMEOUT_MS);
+      await expectation;
+    });
+  });
+
+  describe('training-agent delivery policy', () => {
+    it('cannot enable private delivery explicitly in production', () => {
+      vi.stubEnv('NODE_ENV', 'production');
+
+      expect(() => createWebhookFetch({ allowPrivateIp: true }))
+        .toThrow('Private webhook targets cannot be enabled in production');
+    });
+
+    it('forces the production delivery path through the public-target guard', async () => {
+      const fetch = createTrainingWebhookFetch('production');
+
+      await expect(fetch('https://169.254.169.254/latest/meta-data'))
+        .rejects.toBeInstanceOf(SsrfRefusedError);
+      expect(urls()).toEqual([]);
+    });
+
+    it('retains loopback receivers outside production', async () => {
+      const fetch = createTrainingWebhookFetch('test');
+
+      await expect(fetch('http://127.0.0.1:9999/hook')).resolves.toBeInstanceOf(Response);
+      expect(urls()).toEqual(['http://127.0.0.1:9999/hook']);
     });
   });
 });

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -11454,9 +11454,39 @@ describe('collection and property list webhook URL handling', () => {
   });
 
   it.each([
-    { kind: 'collection', createTool: 'create_collection_list', updateTool: 'update_collection_list', getTool: 'get_collection_list' },
-    { kind: 'property', createTool: 'create_property_list', updateTool: 'update_property_list', getTool: 'get_property_list' },
-  ])('rejects a private $kind list webhook without partially applying the update', async ({ createTool, updateTool, getTool }) => {
+    {
+      kind: 'collection',
+      targetKind: 'private',
+      webhookUrl: 'https://169.254.169.254/latest/meta-data',
+      createTool: 'create_collection_list',
+      updateTool: 'update_collection_list',
+      getTool: 'get_collection_list',
+    },
+    {
+      kind: 'property',
+      targetKind: 'private',
+      webhookUrl: 'https://169.254.169.254/latest/meta-data',
+      createTool: 'create_property_list',
+      updateTool: 'update_property_list',
+      getTool: 'get_property_list',
+    },
+    {
+      kind: 'collection',
+      targetKind: 'numeric-encoded',
+      webhookUrl: 'https://2852039166/latest/meta-data',
+      createTool: 'create_collection_list',
+      updateTool: 'update_collection_list',
+      getTool: 'get_collection_list',
+    },
+    {
+      kind: 'property',
+      targetKind: 'numeric-encoded',
+      webhookUrl: 'https://2852039166/latest/meta-data',
+      createTool: 'create_property_list',
+      updateTool: 'update_property_list',
+      getTool: 'get_property_list',
+    },
+  ])('rejects a $targetKind $kind list webhook without partially applying the update', async ({ webhookUrl, createTool, updateTool, getTool }) => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const created = await simulateCallTool(server, createTool, { name: 'Original name' });
     const listId = (created.result.list as { list_id: string }).list_id;
@@ -11464,7 +11494,7 @@ describe('collection and property list webhook URL handling', () => {
     const rejected = await simulateCallTool(server, updateTool, {
       list_id: listId,
       name: 'Must not persist',
-      webhook_url: 'https://169.254.169.254/latest/meta-data',
+      webhook_url: webhookUrl,
     });
     expect(rejected.result).toMatchObject({ code: 'VALIDATION_ERROR', field: 'webhook_url' });
 


### PR DESCRIPTION
## Summary

- centralize collection/property webhook URL validation in the SSRF-safe fetch module
- bound stored-target DNS resolution to five seconds
- force production training-agent deliveries through public-target validation and address pinning
- document the storage-versus-delivery TOCTOU boundary for future list-change emitters
- cover private/numeric targets, stalled DNS, both handler families, and production delivery policy

## Why

The immediate stored-target SSRF gap was fixed in #5931, but duplicated validation could drift and unbounded DNS could exhaust the Node thread pool. Storage-time validation alone also cannot prevent DNS rebinding when a callback is eventually delivered.

## Validation

- webhook tests: 34 passed
- full training-agent suite: 501 passed
- `npm run typecheck`
- `git diff --check`

Closes #5937.
