### PR TITLE
fix(admin): persist OAuth grants across agent URL variants

### DIFF
--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -2,6 +2,7 @@ import { query } from './client.js';
 import { encrypt as encryptToken, decrypt as decryptToken } from './encryption.js';
 import { createLogger } from '../logger.js';
 import crypto from 'crypto';
+import { canonicalizeAgentUrl } from './publisher-db.js';
 
 const logger = createLogger('agent-context-db');
 
@@ -110,6 +111,7 @@ export interface CreateAgentContextInput {
 }
 
 export interface UpdateAgentContextInput {
+  agent_url?: string;
   agent_name?: string;
   agent_type?: AgentType;
   protocol?: Protocol;
@@ -117,6 +119,14 @@ export interface UpdateAgentContextInput {
   last_test_scenario?: string;
   last_test_passed?: boolean;
   last_test_summary?: string;
+}
+
+function requireCanonicalAgentUrl(agentUrl: string): string {
+  const canonical = canonicalizeAgentUrl(agentUrl);
+  if (!canonical) {
+    throw new Error('Invalid agent URL');
+  }
+  return canonical;
 }
 
 export interface RecordTestInput {
@@ -270,6 +280,7 @@ export class AgentContextDatabase {
    * Get agent context by organization and URL
    */
   async getByOrgAndUrl(organizationId: string, agentUrl: string): Promise<AgentContext | null> {
+    const canonicalUrl = requireCanonicalAgentUrl(agentUrl);
     const result = await query(
       `SELECT
         id,
@@ -305,7 +316,7 @@ export class AgentContextDatabase {
         created_by
       FROM agent_context_with_latest_test
       WHERE organization_id = $1 AND agent_url = $2`,
-      [organizationId, agentUrl]
+      [organizationId, canonicalUrl]
     );
     return result.rows[0] || null;
   }
@@ -322,6 +333,7 @@ export class AgentContextDatabase {
    * the periodic snapshot is a single shared row anyway.
    */
   async findOrgWithSavedAuth(agentUrl: string): Promise<string | null> {
+    const canonicalUrl = requireCanonicalAgentUrl(agentUrl);
     const result = await query<{ organization_id: string }>(
       `SELECT organization_id
        FROM agent_contexts
@@ -335,7 +347,7 @@ export class AgentContextDatabase {
          )
        ORDER BY updated_at DESC
        LIMIT 1`,
-      [agentUrl],
+      [canonicalUrl],
     );
     return result.rows[0]?.organization_id ?? null;
   }
@@ -344,6 +356,7 @@ export class AgentContextDatabase {
    * Create a new agent context
    */
   async create(input: CreateAgentContextInput): Promise<AgentContext> {
+    const canonicalUrl = requireCanonicalAgentUrl(input.agent_url);
     const result = await query(
       `INSERT INTO agent_contexts (
         organization_id,
@@ -379,7 +392,7 @@ export class AgentContextDatabase {
         created_by`,
       [
         input.organization_id,
-        input.agent_url,
+        canonicalUrl,
         input.agent_name || null,
         input.agent_type || 'unknown',
         input.protocol || 'mcp',
@@ -397,6 +410,10 @@ export class AgentContextDatabase {
     const values: any[] = [];
     let paramIndex = 1;
 
+    if (input.agent_url !== undefined) {
+      updates.push(`agent_url = $${paramIndex++}`);
+      values.push(requireCanonicalAgentUrl(input.agent_url));
+    }
     if (input.agent_name !== undefined) {
       updates.push(`agent_name = $${paramIndex++}`);
       values.push(input.agent_name);
@@ -522,11 +539,12 @@ export class AgentContextDatabase {
    * Used by the AdCP tool passthrough to determine Bearer vs Basic auth.
    */
   async getAuthInfoByOrgAndUrl(organizationId: string, agentUrl: string): Promise<{ token: string; authType: AuthType } | null> {
+    const canonicalUrl = requireCanonicalAgentUrl(agentUrl);
     const result = await query(
       `SELECT id, auth_token_encrypted, auth_token_iv, auth_type
        FROM agent_contexts
        WHERE organization_id = $1 AND agent_url = $2`,
-      [organizationId, agentUrl]
+      [organizationId, canonicalUrl]
     );
 
     const row = result.rows[0];
@@ -648,6 +666,7 @@ export class AgentContextDatabase {
    * Get OAuth tokens by org and URL
    */
   async getOAuthTokensByOrgAndUrl(organizationId: string, agentUrl: string): Promise<OAuthTokens | null> {
+    const canonicalUrl = requireCanonicalAgentUrl(agentUrl);
     const result = await query(
       `SELECT
         id,
@@ -658,7 +677,7 @@ export class AgentContextDatabase {
         oauth_token_expires_at
        FROM agent_contexts
        WHERE organization_id = $1 AND agent_url = $2`,
-      [organizationId, agentUrl]
+      [organizationId, canonicalUrl]
     );
 
     const row = result.rows[0];
@@ -870,6 +889,7 @@ export class AgentContextDatabase {
     organizationId: string,
     agentUrl: string,
   ): Promise<OAuthClientCredentials | null> {
+    const canonicalUrl = requireCanonicalAgentUrl(agentUrl);
     const result = await query(
       `SELECT
         oauth_cc_token_endpoint,
@@ -882,7 +902,7 @@ export class AgentContextDatabase {
         oauth_cc_auth_method
        FROM agent_contexts
        WHERE organization_id = $1 AND agent_url = $2`,
-      [organizationId, agentUrl]
+      [organizationId, canonicalUrl]
     );
 
     const row = result.rows[0];

--- a/server/src/db/migrations/525_canonicalize_agent_context_urls.sql
+++ b/server/src/db/migrations/525_canonicalize_agent_context_urls.sql
@@ -1,0 +1,216 @@
+-- Canonicalize agent_context URLs and merge historical URL variants.
+--
+-- Application canonicalization lowercases the endpoint and removes trailing
+-- slashes. Before that invariant was enforced at the DB boundary, a single
+-- org could hold both canonical and cosmetic variants because the original
+-- unique constraint compares agent_url byte-for-byte. Preserve credentials
+-- and test history while collapsing those rows.
+
+CREATE TEMP TABLE agent_context_url_merge ON COMMIT DROP AS
+WITH canonicalized AS (
+  SELECT
+    id AS source_id,
+    organization_id,
+    lower(rtrim(btrim(agent_url), '/')) AS canonical_url,
+    oauth_access_token_encrypted IS NOT NULL
+      AND oauth_access_token_iv IS NOT NULL AS has_oauth_access,
+    oauth_refresh_token_encrypted IS NOT NULL
+      AND oauth_refresh_token_iv IS NOT NULL AS has_oauth_refresh,
+    oauth_client_id IS NOT NULL AS has_oauth_client,
+    auth_token_encrypted IS NOT NULL
+      AND auth_token_iv IS NOT NULL AS has_static_auth,
+    oauth_cc_token_endpoint IS NOT NULL
+      AND oauth_cc_client_id IS NOT NULL
+      AND oauth_cc_client_secret_encrypted IS NOT NULL
+      AND oauth_cc_client_secret_iv IS NOT NULL AS has_client_credentials,
+    updated_at,
+    created_at
+  FROM agent_contexts
+  WHERE lower(rtrim(btrim(agent_url), '/')) <> ''
+), ranked AS (
+  SELECT
+    *,
+    first_value(source_id) OVER (
+      PARTITION BY organization_id, canonical_url
+      ORDER BY
+        has_oauth_refresh DESC,
+        has_oauth_access DESC,
+        has_oauth_client DESC,
+        has_static_auth DESC,
+        has_client_credentials DESC,
+        updated_at DESC,
+        created_at DESC,
+        source_id
+    ) AS survivor_id
+  FROM canonicalized
+)
+SELECT source_id, survivor_id, organization_id, canonical_url
+FROM ranked;
+
+-- Keep each encrypted value and its IV from the same row. Prefer a refreshable
+-- OAuth grant over a newer access-only grant because it remains renewable.
+WITH oauth_source AS (
+  SELECT DISTINCT ON (m.survivor_id)
+    m.survivor_id,
+    source.oauth_access_token_encrypted,
+    source.oauth_access_token_iv,
+    source.oauth_refresh_token_encrypted,
+    source.oauth_refresh_token_iv,
+    source.oauth_token_expires_at
+  FROM agent_context_url_merge m
+  JOIN agent_contexts source ON source.id = m.source_id
+  WHERE source.oauth_access_token_encrypted IS NOT NULL
+    AND source.oauth_access_token_iv IS NOT NULL
+  ORDER BY
+    m.survivor_id,
+    (source.oauth_refresh_token_encrypted IS NOT NULL
+      AND source.oauth_refresh_token_iv IS NOT NULL) DESC,
+    source.updated_at DESC,
+    source.id
+)
+UPDATE agent_contexts target
+SET oauth_access_token_encrypted = source.oauth_access_token_encrypted,
+    oauth_access_token_iv = source.oauth_access_token_iv,
+    oauth_refresh_token_encrypted = source.oauth_refresh_token_encrypted,
+    oauth_refresh_token_iv = source.oauth_refresh_token_iv,
+    oauth_token_expires_at = source.oauth_token_expires_at
+FROM oauth_source source
+WHERE target.id = source.survivor_id;
+
+WITH oauth_client_source AS (
+  SELECT DISTINCT ON (m.survivor_id)
+    m.survivor_id,
+    source.oauth_client_id,
+    source.oauth_client_secret_encrypted,
+    source.oauth_client_secret_iv,
+    source.oauth_registered_redirect_uri
+  FROM agent_context_url_merge m
+  JOIN agent_contexts source ON source.id = m.source_id
+  WHERE source.oauth_client_id IS NOT NULL
+  ORDER BY m.survivor_id, source.updated_at DESC, source.id
+)
+UPDATE agent_contexts target
+SET oauth_client_id = source.oauth_client_id,
+    oauth_client_secret_encrypted = source.oauth_client_secret_encrypted,
+    oauth_client_secret_iv = source.oauth_client_secret_iv,
+    oauth_registered_redirect_uri = source.oauth_registered_redirect_uri
+FROM oauth_client_source source
+WHERE target.id = source.survivor_id;
+
+WITH static_auth_source AS (
+  SELECT DISTINCT ON (m.survivor_id)
+    m.survivor_id,
+    source.auth_token_encrypted,
+    source.auth_token_iv,
+    source.auth_token_hint,
+    source.auth_type
+  FROM agent_context_url_merge m
+  JOIN agent_contexts source ON source.id = m.source_id
+  WHERE source.auth_token_encrypted IS NOT NULL
+    AND source.auth_token_iv IS NOT NULL
+  ORDER BY m.survivor_id, source.updated_at DESC, source.id
+)
+UPDATE agent_contexts target
+SET auth_token_encrypted = source.auth_token_encrypted,
+    auth_token_iv = source.auth_token_iv,
+    auth_token_hint = source.auth_token_hint,
+    auth_type = source.auth_type
+FROM static_auth_source source
+WHERE target.id = source.survivor_id;
+
+WITH client_credentials_source AS (
+  SELECT DISTINCT ON (m.survivor_id)
+    m.survivor_id,
+    source.oauth_cc_token_endpoint,
+    source.oauth_cc_client_id,
+    source.oauth_cc_client_secret_encrypted,
+    source.oauth_cc_client_secret_iv,
+    source.oauth_cc_scope,
+    source.oauth_cc_resource,
+    source.oauth_cc_audience,
+    source.oauth_cc_auth_method
+  FROM agent_context_url_merge m
+  JOIN agent_contexts source ON source.id = m.source_id
+  WHERE source.oauth_cc_token_endpoint IS NOT NULL
+    AND source.oauth_cc_client_id IS NOT NULL
+    AND source.oauth_cc_client_secret_encrypted IS NOT NULL
+    AND source.oauth_cc_client_secret_iv IS NOT NULL
+  ORDER BY m.survivor_id, source.updated_at DESC, source.id
+)
+UPDATE agent_contexts target
+SET oauth_cc_token_endpoint = source.oauth_cc_token_endpoint,
+    oauth_cc_client_id = source.oauth_cc_client_id,
+    oauth_cc_client_secret_encrypted = source.oauth_cc_client_secret_encrypted,
+    oauth_cc_client_secret_iv = source.oauth_cc_client_secret_iv,
+    oauth_cc_scope = source.oauth_cc_scope,
+    oauth_cc_resource = source.oauth_cc_resource,
+    oauth_cc_audience = source.oauth_cc_audience,
+    oauth_cc_auth_method = source.oauth_cc_auth_method
+FROM client_credentials_source source
+WHERE target.id = source.survivor_id;
+
+-- Preserve all detailed run history before removing duplicate parents.
+UPDATE agent_test_history history
+SET agent_context_id = m.survivor_id
+FROM agent_context_url_merge m
+WHERE history.agent_context_id = m.source_id
+  AND m.source_id <> m.survivor_id;
+
+-- Carry forward useful non-secret state from any cosmetic duplicate.
+WITH merged_state AS (
+  SELECT
+    m.survivor_id,
+    max(source.last_discovered_at) AS last_discovered_at,
+    min(source.created_at) AS created_at,
+    max(source.updated_at) AS updated_at,
+    coalesce(sum(source.total_tests_run), 0)::integer AS total_tests_run
+  FROM agent_context_url_merge m
+  JOIN agent_contexts source ON source.id = m.source_id
+  GROUP BY m.survivor_id
+)
+UPDATE agent_contexts target
+SET last_discovered_at = coalesce(state.last_discovered_at, target.last_discovered_at),
+    created_at = state.created_at,
+    updated_at = state.updated_at,
+    total_tests_run = state.total_tests_run
+FROM merged_state state
+WHERE target.id = state.survivor_id;
+
+WITH name_source AS (
+  SELECT DISTINCT ON (m.survivor_id)
+    m.survivor_id, source.agent_name
+  FROM agent_context_url_merge m
+  JOIN agent_contexts source ON source.id = m.source_id
+  WHERE source.agent_name IS NOT NULL
+  ORDER BY m.survivor_id, source.updated_at DESC, source.id
+)
+UPDATE agent_contexts target
+SET agent_name = coalesce(target.agent_name, source.agent_name)
+FROM name_source source
+WHERE target.id = source.survivor_id;
+
+WITH tools_source AS (
+  SELECT DISTINCT ON (m.survivor_id)
+    m.survivor_id, source.tools_discovered
+  FROM agent_context_url_merge m
+  JOIN agent_contexts source ON source.id = m.source_id
+  WHERE source.tools_discovered IS NOT NULL
+  ORDER BY m.survivor_id, source.last_discovered_at DESC NULLS LAST, source.id
+)
+UPDATE agent_contexts target
+SET tools_discovered = coalesce(target.tools_discovered, source.tools_discovered)
+FROM tools_source source
+WHERE target.id = source.survivor_id;
+
+DELETE FROM agent_contexts duplicate
+USING agent_context_url_merge m
+WHERE duplicate.id = m.source_id
+  AND m.source_id <> m.survivor_id;
+
+-- The exact unique constraint is now sufficient because all write paths and
+-- existing rows share the same canonical representation.
+UPDATE agent_contexts context
+SET agent_url = m.canonical_url
+FROM agent_context_url_merge m
+WHERE context.id = m.survivor_id
+  AND context.agent_url IS DISTINCT FROM m.canonical_url;

--- a/server/src/routes/helpers/resolve-user-agent-auth.ts
+++ b/server/src/routes/helpers/resolve-user-agent-auth.ts
@@ -12,6 +12,7 @@
  */
 
 import type { AgentContextDatabase } from '../../db/agent-context-db.js';
+import { canonicalizeAgentUrl } from '../../db/publisher-db.js';
 import {
   decodeBasicCredentials,
   type ResolvedOwnerAuth,
@@ -27,10 +28,16 @@ export async function resolveUserAgentAuth(
   agentUrl: string,
   logger: WarnLogger,
 ): Promise<ResolvedOwnerAuth | undefined> {
+  const canonicalUrl = canonicalizeAgentUrl(agentUrl);
+  if (!canonicalUrl) {
+    logger.warn({ agentUrl, orgId }, 'resolveUserAgentAuth: invalid agent URL');
+    return undefined;
+  }
+
   // Static token lookup throwing falls through to the OAuth branch below —
   // the connect-form token and the OAuth token are independent paths.
   try {
-    const staticAuth = await agentContextDb.getAuthInfoByOrgAndUrl(orgId, agentUrl);
+    const staticAuth = await agentContextDb.getAuthInfoByOrgAndUrl(orgId, canonicalUrl);
     if (staticAuth) {
       if (staticAuth.authType === 'basic') {
         const basic = decodeBasicCredentials(staticAuth.token);
@@ -48,11 +55,11 @@ export async function resolveUserAgentAuth(
   }
 
   try {
-    const context = await agentContextDb.getByOrgAndUrl(orgId, agentUrl);
+    const context = await agentContextDb.getByOrgAndUrl(orgId, canonicalUrl);
     if (!context) return undefined;
 
     if (context.has_oauth_token) {
-      const tokens = await agentContextDb.getOAuthTokensByOrgAndUrl(orgId, agentUrl);
+      const tokens = await agentContextDb.getOAuthTokensByOrgAndUrl(orgId, canonicalUrl);
       if (tokens?.access_token) {
         if (!tokens.refresh_token) {
           return { type: 'bearer', token: tokens.access_token };
@@ -79,7 +86,7 @@ export async function resolveUserAgentAuth(
     }
 
     if (context.has_oauth_client_credentials) {
-      const creds = await agentContextDb.getOAuthClientCredentialsByOrgAndUrl(orgId, agentUrl);
+      const creds = await agentContextDb.getOAuthClientCredentialsByOrgAndUrl(orgId, canonicalUrl);
       if (creds) return { type: 'oauth_client_credentials', credentials: creds };
     }
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -6183,11 +6183,13 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
    */
   async function ensureAgentContextId(orgId: string, agentUrl: string, userId: string): Promise<string | null> {
     try {
-      let context = await agentContextDb.getByOrgAndUrl(orgId, agentUrl);
+      const canonicalUrl = canonicalizeAgentUrl(agentUrl);
+      if (!canonicalUrl) return null;
+      let context = await agentContextDb.getByOrgAndUrl(orgId, canonicalUrl);
       if (!context) {
         context = await agentContextDb.create({
           organization_id: orgId,
-          agent_url: agentUrl,
+          agent_url: canonicalUrl,
           created_by: userId,
         });
       }

--- a/server/tests/integration/agent-context-url-canonicalization.test.ts
+++ b/server/tests/integration/agent-context-url-canonicalization.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { Pool } from 'pg';
+import { closeDatabase, initializeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { decrypt, encrypt } from '../../src/db/encryption.js';
+
+const ORG = 'org_agent_context_canonicalization_test';
+const CANONICAL = 'https://platform.loopme.ai/mcp/seller';
+const MIGRATION_SQL = readFileSync(
+  resolve(__dirname, '../../src/db/migrations/525_canonicalize_agent_context_urls.sql'),
+  'utf8',
+);
+
+describe('migration 525: canonicalize agent context URLs', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, 'Agent context canonicalization test', NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [ORG],
+    );
+  }, 60_000);
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [ORG]);
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+  });
+
+  async function cleanup() {
+    if (!pool) return;
+    await pool.query('DELETE FROM agent_contexts WHERE organization_id = $1', [ORG]);
+  }
+
+  it('collapses path/trailing-slash variants without losing the refreshable OAuth grant or history', async () => {
+    const accessOnly = encrypt('access-only', ORG);
+    const refreshableAccess = encrypt('refreshable-access', ORG);
+    const refreshToken = encrypt('refresh-token', ORG);
+    const clientSecret = encrypt('client-secret', ORG);
+
+    const canonicalRow = await pool.query<{ id: string }>(
+      `INSERT INTO agent_contexts (organization_id, agent_url, agent_name, updated_at)
+       VALUES ($1, $2, 'Canonical without tokens', NOW()) RETURNING id`,
+      [ORG, CANONICAL],
+    );
+    const accessOnlyRow = await pool.query<{ id: string }>(
+      `INSERT INTO agent_contexts (
+         organization_id, agent_url,
+         oauth_access_token_encrypted, oauth_access_token_iv, updated_at
+       ) VALUES ($1, 'HTTPS://PLATFORM.LOOPME.AI/MCP/SELLER/', $2, $3, NOW() + INTERVAL '1 hour')
+       RETURNING id`,
+      [ORG, accessOnly.encrypted, accessOnly.iv],
+    );
+    const refreshableRow = await pool.query<{ id: string }>(
+      `INSERT INTO agent_contexts (
+         organization_id, agent_url,
+         oauth_access_token_encrypted, oauth_access_token_iv,
+         oauth_refresh_token_encrypted, oauth_refresh_token_iv,
+         oauth_client_id, oauth_client_secret_encrypted, oauth_client_secret_iv,
+         updated_at
+       ) VALUES (
+         $1, 'https://platform.loopme.ai/mcp/seller//',
+         $2, $3, $4, $5, 'loopme-client', $6, $7, NOW() - INTERVAL '1 hour'
+       ) RETURNING id`,
+      [
+        ORG,
+        refreshableAccess.encrypted,
+        refreshableAccess.iv,
+        refreshToken.encrypted,
+        refreshToken.iv,
+        clientSecret.encrypted,
+        clientSecret.iv,
+      ],
+    );
+
+    for (const contextId of [canonicalRow.rows[0].id, accessOnlyRow.rows[0].id]) {
+      await pool.query(
+        `INSERT INTO agent_test_history (
+           agent_context_id, scenario, overall_passed, steps_passed, steps_failed
+         ) VALUES ($1, 'oauth-regression', TRUE, 1, 0)`,
+        [contextId],
+      );
+    }
+
+    await pool.query(MIGRATION_SQL);
+
+    const contexts = await pool.query(
+      `SELECT * FROM agent_contexts WHERE organization_id = $1`,
+      [ORG],
+    );
+    expect(contexts.rows).toHaveLength(1);
+    const context = contexts.rows[0];
+    expect(context.id).toBe(refreshableRow.rows[0].id);
+    expect(context.agent_url).toBe(CANONICAL);
+    expect(decrypt(context.oauth_access_token_encrypted, context.oauth_access_token_iv, ORG))
+      .toBe('refreshable-access');
+    expect(decrypt(context.oauth_refresh_token_encrypted, context.oauth_refresh_token_iv, ORG))
+      .toBe('refresh-token');
+    expect(context.oauth_client_id).toBe('loopme-client');
+    expect(decrypt(context.oauth_client_secret_encrypted, context.oauth_client_secret_iv, ORG))
+      .toBe('client-secret');
+
+    const history = await pool.query(
+      `SELECT agent_context_id FROM agent_test_history WHERE scenario = 'oauth-regression'`,
+    );
+    expect(history.rows).toHaveLength(2);
+    expect(history.rows.every((row) => row.agent_context_id === context.id)).toBe(true);
+
+    await pool.query(MIGRATION_SQL);
+    const rerun = await pool.query(
+      `SELECT id, agent_url FROM agent_contexts WHERE organization_id = $1`,
+      [ORG],
+    );
+    expect(rerun.rows).toEqual([{ id: context.id, agent_url: CANONICAL }]);
+  });
+});

--- a/server/tests/unit/agent-context-url-canonicalization.test.ts
+++ b/server/tests/unit/agent-context-url-canonicalization.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '../../src/db/client.js';
+import { AgentContextDatabase } from '../../src/db/agent-context-db.js';
+
+const queryMock = vi.mocked(query);
+const ORG = 'org_loopme';
+const VARIANT = ' HTTPS://PLATFORM.LOOPME.AI/MCP/SELLER/// ';
+const CANONICAL = 'https://platform.loopme.ai/mcp/seller';
+
+describe('AgentContextDatabase URL canonicalization', () => {
+  const db = new AgentContextDatabase();
+
+  beforeEach(() => {
+    queryMock.mockReset();
+    queryMock.mockResolvedValue({ rows: [], rowCount: 0 } as never);
+  });
+
+  it('canonicalizes every organization-and-URL read at the database boundary', async () => {
+    await db.getByOrgAndUrl(ORG, VARIANT);
+    await db.getAuthInfoByOrgAndUrl(ORG, VARIANT);
+    await db.getOAuthTokensByOrgAndUrl(ORG, VARIANT);
+    await db.getOAuthClientCredentialsByOrgAndUrl(ORG, VARIANT);
+    await db.findOrgWithSavedAuth(VARIANT);
+
+    expect(queryMock).toHaveBeenCalledTimes(5);
+    for (const call of queryMock.mock.calls.slice(0, 4)) {
+      expect(call[1]).toEqual([ORG, CANONICAL]);
+    }
+    expect(queryMock.mock.calls[4][1]).toEqual([CANONICAL]);
+  });
+
+  it('canonicalizes create and URL updates', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ id: 'ctx_created', agent_url: CANONICAL }] } as never);
+    await db.create({ organization_id: ORG, agent_url: VARIANT });
+    expect(queryMock.mock.calls[0][1]?.[1]).toBe(CANONICAL);
+
+    queryMock.mockResolvedValueOnce({ rows: [{ id: 'ctx_created', agent_url: CANONICAL }] } as never);
+    await db.update('ctx_created', { agent_url: VARIANT });
+    expect(queryMock.mock.calls[1][1]).toEqual([CANONICAL, 'ctx_created']);
+  });
+
+  it('rejects an invalid URL key instead of writing an unmatchable context', async () => {
+    await expect(db.create({ organization_id: ORG, agent_url: '   ' })).rejects.toThrow('Invalid agent URL');
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/resolve-user-agent-auth.test.ts
+++ b/server/tests/unit/resolve-user-agent-auth.test.ts
@@ -43,6 +43,26 @@ describe('resolveUserAgentAuth', () => {
   const call = () =>
     resolveUserAgentAuth(db as unknown as AgentContextDatabase, ORG, URL, logger);
 
+  it('canonicalizes LoopMe-style path and trailing-slash variants before every lookup', async () => {
+    const variant = 'HTTPS://PLATFORM.LOOPME.AI/MCP/SELLER/';
+    const canonical = 'https://platform.loopme.ai/mcp/seller';
+    db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce(null);
+    db.getByOrgAndUrl.mockResolvedValueOnce({ id: 'ctx_loopme', has_oauth_token: true });
+    db.getOAuthTokensByOrgAndUrl.mockResolvedValueOnce({ access_token: 'loopme-access' });
+
+    const auth = await resolveUserAgentAuth(
+      db as unknown as AgentContextDatabase,
+      ORG,
+      variant,
+      logger,
+    );
+
+    expect(auth).toEqual({ type: 'bearer', token: 'loopme-access' });
+    expect(db.getAuthInfoByOrgAndUrl).toHaveBeenCalledWith(ORG, canonical);
+    expect(db.getByOrgAndUrl).toHaveBeenCalledWith(ORG, canonical);
+    expect(db.getOAuthTokensByOrgAndUrl).toHaveBeenCalledWith(ORG, canonical);
+  });
+
   it('returns static bearer when the connect form saved one', async () => {
     db.getAuthInfoByOrgAndUrl.mockResolvedValueOnce({ token: 'static_bearer', authType: 'bearer' });
 


### PR DESCRIPTION
## Summary

- canonicalize agent URLs at every agent-context organization/URL read and write boundary
- canonicalize the registry's agent-context creation path
- backfill historical URL variants and safely merge duplicate contexts while preserving OAuth/static/client-credential material and test history
- cover path/case/trailing-slash variants, credential survivor selection, route behavior, and migration idempotency

## Root cause

OAuth callback storage writes tokens by agent-context UUID, but dashboard/storyboard authorization reads used exact `organization_id + agent_url` equality. Cosmetic URL variants could therefore miss a successfully persisted token. Production confirms the reported LoopMe context has a valid stored token and no duplicate row, so deployment of the canonicalized read path resolves the live incident without manual data repair.

## Validation

- 59 focused unit/route/integration tests passed
- fresh-Postgres migration test passed
- migration validation passed
- `npm run typecheck`
- `git diff --check`

Closes #5946.
