### PR TITLE
fix(training): fail closed on unknown webhook runtimes

### DIFF
--- a/server/src/training-agent/account-handlers.ts
+++ b/server/src/training-agent/account-handlers.ts
@@ -12,7 +12,11 @@ import { getAgentUrl } from './config.js';
 import { encodeOffsetCursor, decodeOffsetCursor } from './pagination.js';
 import { getCommercialRelationship } from './commercial-relationships.js';
 import { isPerAccountBillingRestricted } from './account-billing-relationships.js';
-import { assertPublicTarget, SsrfRefusedError } from './webhook-fetch.js';
+import {
+  assertPublicTarget,
+  isWebhookTestOrDevelopment,
+  SsrfRefusedError,
+} from './webhook-fetch.js';
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -342,7 +346,7 @@ async function normalizeNotificationConfigs(input: SyncAccountInput): Promise<No
       return { error: validationFailure(input, `${field}.url`, 'url must be a valid URL') };
     }
     const isLocalWebhook = ['localhost', '127.0.0.1', '::1'].includes(parsed.hostname);
-    if (parsed.protocol !== 'https:' && !(process.env.NODE_ENV !== 'production' && isLocalWebhook)) {
+    if (parsed.protocol !== 'https:' && !(isWebhookTestOrDevelopment(process.env.NODE_ENV) && isLocalWebhook)) {
       return { error: validationFailure(input, `${field}.url`, 'url must use HTTPS') };
     }
     if (parsed.username || parsed.password) {

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -38,6 +38,7 @@ import {
 import { getPool } from '../../db/client.js';
 import { getIdempotencyStore, scopedPrincipal } from '../idempotency.js';
 import { emitFrameworkTaskWebhook, getWebhookSigningMaterial } from '../webhooks.js';
+import { isWebhookTestOrDevelopment } from '../webhook-fetch.js';
 import { buildSignalsTenantConfig } from './signals.js';
 import { buildSalesTenantConfig } from './sales.js';
 import { buildGovernanceTenantConfig } from './governance.js';
@@ -205,13 +206,14 @@ function buildDefaultServerOptions(storyboardCompat?: TrainingContext['storyboar
     stateStore: pickStateStore(),
     mergeSeam: 'log-once',
     validation: { requests: 'off', responses: 'off' },
-    // F11 — accept loopback push_notification_config.url in non-production.
+    // F11 — accept loopback push_notification_config.url only in explicit
+    // test/development environments.
     // Conformance storyboards bind a loopback HTTP receiver and supply
-    // `http://127.0.0.1:<port>/webhook`; production deployments
-    // (NODE_ENV=production) keep the SSRF-safe rejection. The framework
-    // emits a footgun warning if this is set in production without an
-    // ack env, which we tolerate (the warning surfaces operator misconfig).
-    allowPrivateWebhookUrls: process.env.NODE_ENV !== 'production',
+    // `http://127.0.0.1:<port>/webhook`; production and unknown runtimes keep
+    // the SSRF-safe rejection. The framework emits a footgun warning if this
+    // is set in production without an ack env, which we tolerate (the warning
+    // surfaces operator misconfig).
+    allowPrivateWebhookUrls: isWebhookTestOrDevelopment(process.env.NODE_ENV),
     resolveIdempotencyPrincipal: (
       ctx: { authInfo?: { clientId?: string } },
       params: Record<string, unknown>,

--- a/server/src/training-agent/webhook-fetch.ts
+++ b/server/src/training-agent/webhook-fetch.ts
@@ -33,7 +33,11 @@
 import { lookup } from 'node:dns/promises';
 import { isIP } from 'node:net';
 import { fetch as undiciFetch, type Dispatcher } from 'undici';
-import { buildSsrfSafeDispatcher, isPrivateHostname } from '../utils/url-security.js';
+import {
+  buildSsrfSafeDispatcher,
+  isPrivateHostname,
+  SSRF_CONNECT_TIMEOUT_MS,
+} from '../utils/url-security.js';
 
 type FetchInitWithDispatcher = Omit<RequestInit, 'dispatcher'> & { dispatcher?: Dispatcher };
 
@@ -53,7 +57,15 @@ export interface WebhookValidationError {
   field: 'webhook_url';
 }
 
-export const WEBHOOK_DNS_TIMEOUT_MS = 5_000;
+export const WEBHOOK_DNS_TIMEOUT_MS = SSRF_CONNECT_TIMEOUT_MS;
+
+/** Private/loopback webhook targets are a test and local-development affordance.
+ * Unknown, unset, staging, and misspelled runtime names fail closed. */
+export function isWebhookTestOrDevelopment(
+  environment: string | undefined,
+): boolean {
+  return environment === 'test' || environment === 'development';
+}
 
 const fetchWithDispatcher = undiciFetch as unknown as (
   input: Parameters<typeof fetch>[0],
@@ -174,7 +186,10 @@ export async function validateWebhookUrl(
   } catch {
     return { code: 'VALIDATION_ERROR', message: 'webhook_url must be a valid URL', field: 'webhook_url' };
   }
-  if (target.protocol !== 'https:' && (process.env.NODE_ENV === 'production' || target.protocol !== 'http:')) {
+  if (
+    target.protocol !== 'https:' &&
+    (!isWebhookTestOrDevelopment(process.env.NODE_ENV) || target.protocol !== 'http:')
+  ) {
     return { code: 'VALIDATION_ERROR', message: 'webhook_url must use HTTPS', field: 'webhook_url' };
   }
   if (target.username || target.password) {
@@ -200,8 +215,8 @@ export async function validateWebhookUrl(
  * The returned function uses userland `undici.fetch` so its dispatcher and
  * request-handler contract stay aligned with the imported undici version. */
 export function createWebhookFetch(options: { allowPrivateIp: boolean }): typeof fetch {
-  if (process.env.NODE_ENV === 'production' && options.allowPrivateIp) {
-    throw new Error('Private webhook targets cannot be enabled in production');
+  if (options.allowPrivateIp && !isWebhookTestOrDevelopment(process.env.NODE_ENV)) {
+    throw new Error('Private webhook targets can only be enabled in test or development');
   }
   return async (input, init) => {
     const href = typeof input === 'string' || input instanceof URL
@@ -236,11 +251,11 @@ export function createWebhookFetch(options: { allowPrivateIp: boolean }): typeof
 /** The required fetch policy for every training-agent webhook delivery,
  * including future collection/property list-change notifications.
  *
- * Production behavior is intentionally derived here rather than at call
- * sites: callers cannot accidentally enable private targets in production.
- * Tests and local conformance receivers retain loopback access. */
+ * Runtime behavior is intentionally derived here rather than at call sites:
+ * callers cannot accidentally enable private targets unless the environment
+ * is explicitly `test` or `development`. */
 export function createTrainingWebhookFetch(
   environment: string | undefined = process.env.NODE_ENV,
 ): typeof fetch {
-  return createWebhookFetch({ allowPrivateIp: environment !== 'production' });
+  return createWebhookFetch({ allowPrivateIp: isWebhookTestOrDevelopment(environment) });
 }

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -7,6 +7,8 @@ import { createLogger } from '../logger.js';
 
 const logger = createLogger('url-security');
 
+export const SSRF_CONNECT_TIMEOUT_MS = 5_000;
+
 const TRANSIENT_DNS_CODES = new Set(['EAI_AGAIN', 'ESERVFAIL', 'ETIMEOUT', 'ECONNREFUSED']);
 const PERMANENT_DNS_CODES = new Set(['ENOTFOUND', 'EAI_NONAME', 'ENODATA', 'ENONAME', 'EAI_NODATA']);
 const DNS_CODE_RE = /\b(EAI_AGAIN|ESERVFAIL|ETIMEOUT|ECONNREFUSED|ENOTFOUND|EAI_NONAME|ENODATA|ENONAME|EAI_NODATA)\b/i;
@@ -401,6 +403,7 @@ export function buildSsrfSafeDispatcher(): Dispatcher {
   return new Agent({
     connect: {
       lookup: ssrfSafeLookup,
+      timeout: SSRF_CONNECT_TIMEOUT_MS,
     },
   });
 }

--- a/server/tests/unit/account-handlers.test.ts
+++ b/server/tests/unit/account-handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -95,6 +95,10 @@ describe('sync_accounts', () => {
     clearIdempotencyCache();
     invalidateCache();
     server = createTrainingAgentServer(DEFAULT_CTX);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('sandbox account is active immediately', async () => {
@@ -793,6 +797,58 @@ describe('sync_accounts', () => {
     expect(acct.errors).toEqual([expect.objectContaining({
       code: 'VALIDATION_ERROR',
       field: 'notification_configs[0].active',
+    })]);
+  });
+
+  it('rejects loopback notification configs in an unknown runtime', async () => {
+    vi.stubEnv('NODE_ENV', 'staging');
+
+    const { result } = await simulateCallTool(server, 'sync_accounts', {
+      accounts: [{
+        brand: { domain: 'acme.com' },
+        operator: 'agency-one',
+        billing: 'operator',
+        sandbox: true,
+        notification_configs: [{
+          subscriber_id: 'buyer-primary',
+          url: 'http://127.0.0.1:9999/webhook',
+          event_types: ['creative.status_changed'],
+          active: false,
+        }],
+      }],
+    });
+
+    const acct = (result.accounts as Record<string, unknown>[])[0];
+    expect(acct.action).toBe('failed');
+    expect(acct.errors).toEqual([expect.objectContaining({
+      code: 'VALIDATION_ERROR',
+      field: 'notification_configs[0].url',
+      message: 'url must use HTTPS',
+    })]);
+  });
+
+  it('allows loopback notification configs in explicit development mode', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    const { result } = await simulateCallTool(server, 'sync_accounts', {
+      accounts: [{
+        brand: { domain: 'acme.com' },
+        operator: 'agency-one',
+        billing: 'operator',
+        sandbox: true,
+        notification_configs: [{
+          subscriber_id: 'buyer-primary',
+          url: 'http://127.0.0.1:9999/webhook',
+          event_types: ['creative.status_changed'],
+          active: false,
+        }],
+      }],
+    });
+
+    const acct = (result.accounts as Record<string, unknown>[])[0];
+    expect(acct.action).toBe('created');
+    expect(acct.notification_configs).toEqual([expect.objectContaining({
+      url: 'http://127.0.0.1:9999/webhook',
     })]);
   });
 });

--- a/server/tests/unit/training-agent-webhook-fetch.test.ts
+++ b/server/tests/unit/training-agent-webhook-fetch.test.ts
@@ -3,6 +3,7 @@ import {
   assertPublicTarget,
   createTrainingWebhookFetch,
   createWebhookFetch,
+  isWebhookTestOrDevelopment,
   SsrfRefusedError,
   validateWebhookUrl,
   WEBHOOK_DNS_TIMEOUT_MS,
@@ -191,6 +192,26 @@ describe('createWebhookFetch — SSRF guard', () => {
   });
 
   describe('stored webhook URL validation', () => {
+    it('rejects HTTP before DNS resolution in an unknown runtime', async () => {
+      vi.stubEnv('NODE_ENV', 'staging');
+      const dnsLookup = vi.fn(async () => [{ address: '93.184.216.34', family: 4 }]);
+
+      await expect(validateWebhookUrl('http://example.com/hook', { dnsLookup })).resolves.toEqual({
+        code: 'VALIDATION_ERROR',
+        message: 'webhook_url must use HTTPS',
+        field: 'webhook_url',
+      });
+      expect(dnsLookup).not.toHaveBeenCalled();
+    });
+
+    it.each(['test', 'development'])('allows HTTP in explicit %s mode', async (environment) => {
+      vi.stubEnv('NODE_ENV', environment);
+      const dnsLookup = vi.fn(async () => [{ address: '93.184.216.34', family: 4 }]);
+
+      await expect(validateWebhookUrl('http://example.com/hook', { dnsLookup })).resolves.toBeUndefined();
+      expect(dnsLookup).toHaveBeenCalledOnce();
+    });
+
     it.each([
       ['private target', 'https://169.254.169.254/latest/meta-data'],
       ['decimal-encoded target', 'https://2852039166/latest/meta-data'],
@@ -236,11 +257,43 @@ describe('createWebhookFetch — SSRF guard', () => {
   });
 
   describe('training-agent delivery policy', () => {
+    it.each([
+      ['test', true],
+      ['development', true],
+      ['production', false],
+      ['staging', false],
+      ['developmnt', false],
+      [undefined, false],
+    ])('classifies the %s runtime explicitly', (environment, expected) => {
+      expect(isWebhookTestOrDevelopment(environment)).toBe(expected);
+    });
+
     it('cannot enable private delivery explicitly in production', () => {
       vi.stubEnv('NODE_ENV', 'production');
 
       expect(() => createWebhookFetch({ allowPrivateIp: true }))
-        .toThrow('Private webhook targets cannot be enabled in production');
+        .toThrow('Private webhook targets can only be enabled in test or development');
+    });
+
+    it('cannot enable private delivery in an unknown runtime', () => {
+      vi.stubEnv('NODE_ENV', 'staging');
+
+      expect(() => createWebhookFetch({ allowPrivateIp: true }))
+        .toThrow('Private webhook targets can only be enabled in test or development');
+    });
+
+    it('fails closed when NODE_ENV is unset', async () => {
+      const originalEnvironment = process.env.NODE_ENV;
+      delete process.env.NODE_ENV;
+      try {
+        const fetch = createTrainingWebhookFetch();
+
+        await expect(fetch('https://169.254.169.254/latest/meta-data'))
+          .rejects.toBeInstanceOf(SsrfRefusedError);
+      } finally {
+        if (originalEnvironment === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = originalEnvironment;
+      }
     });
 
     it('forces the production delivery path through the public-target guard', async () => {
@@ -253,6 +306,13 @@ describe('createWebhookFetch — SSRF guard', () => {
 
     it('retains loopback receivers outside production', async () => {
       const fetch = createTrainingWebhookFetch('test');
+
+      await expect(fetch('http://127.0.0.1:9999/hook')).resolves.toBeInstanceOf(Response);
+      expect(urls()).toEqual(['http://127.0.0.1:9999/hook']);
+    });
+
+    it('retains loopback receivers in explicit development mode', async () => {
+      const fetch = createTrainingWebhookFetch('development');
 
       await expect(fetch('http://127.0.0.1:9999/hook')).resolves.toBeInstanceOf(Response);
       expect(urls()).toEqual(['http://127.0.0.1:9999/hook']);

--- a/server/tests/unit/url-security-dispatcher-wiring.test.ts
+++ b/server/tests/unit/url-security-dispatcher-wiring.test.ts
@@ -27,21 +27,26 @@ vi.mock('undici', async (importOriginal) => {
   return { ...actual, Agent: agentSpy };
 });
 
-import { buildSsrfSafeDispatcher, ssrfSafeLookup } from '../../src/utils/url-security.js';
+import {
+  buildSsrfSafeDispatcher,
+  SSRF_CONNECT_TIMEOUT_MS,
+  ssrfSafeLookup,
+} from '../../src/utils/url-security.js';
 
 describe('buildSsrfSafeDispatcher', () => {
-  it('constructs an undici Agent with ssrfSafeLookup as the connect.lookup', () => {
+  it('constructs an undici Agent with bounded ssrfSafeLookup connect wiring', () => {
     agentSpy.mockClear();
     buildSsrfSafeDispatcher();
     expect(agentSpy).toHaveBeenCalledOnce();
 
     const opts = agentSpy.mock.calls[0][0] as {
-      connect?: { lookup?: typeof ssrfSafeLookup };
+      connect?: { lookup?: typeof ssrfSafeLookup; timeout?: number };
     };
     expect(opts.connect).toBeDefined();
     // Identity check — the dispatcher must wire OUR lookup, not Node's default.
     // If someone refactors the option name (e.g. `connect.dns.lookup`), this
     // assertion fails before the SSRF gap can ship.
     expect(opts.connect!.lookup).toBe(ssrfSafeLookup);
+    expect(opts.connect!.timeout).toBe(SSRF_CONNECT_TIMEOUT_MS);
   });
 });


### PR DESCRIPTION
## Summary

- allow private/loopback webhook targets only in explicit `test` or `development` runtimes
- fail closed for unset, staging, and misspelled runtime names across storage and delivery paths
- bound connect-time DNS/TCP resolution to the same five-second SSRF policy window
- add regression coverage for runtime classification, account validation, and dispatcher wiring

## Validation

- focused webhook/account/dispatcher unit tests: 78 passed
- full training-agent unit suite: 501 passed
- TypeScript typecheck
- `git diff --check`

No changeset or Addie version bump: this is server-side security hardening.

Fixes #5952.