### PR TITLE
fix(security): fail closed for private external URLs

### DIFF
--- a/server/src/training-agent/webhook-fetch.ts
+++ b/server/src/training-agent/webhook-fetch.ts
@@ -36,8 +36,11 @@ import { fetch as undiciFetch, type Dispatcher } from 'undici';
 import {
   buildSsrfSafeDispatcher,
   isPrivateHostname,
+  isTestOrDevelopmentRuntime as isWebhookTestOrDevelopment,
   SSRF_CONNECT_TIMEOUT_MS,
 } from '../utils/url-security.js';
+
+export { isWebhookTestOrDevelopment };
 
 type FetchInitWithDispatcher = Omit<RequestInit, 'dispatcher'> & { dispatcher?: Dispatcher };
 
@@ -58,14 +61,6 @@ export interface WebhookValidationError {
 }
 
 export const WEBHOOK_DNS_TIMEOUT_MS = SSRF_CONNECT_TIMEOUT_MS;
-
-/** Private/loopback webhook targets are a test and local-development affordance.
- * Unknown, unset, staging, and misspelled runtime names fail closed. */
-export function isWebhookTestOrDevelopment(
-  environment: string | undefined,
-): boolean {
-  return environment === 'test' || environment === 'development';
-}
 
 const fetchWithDispatcher = undiciFetch as unknown as (
   input: Parameters<typeof fetch>[0],

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -9,6 +9,16 @@ const logger = createLogger('url-security');
 
 export const SSRF_CONNECT_TIMEOUT_MS = 5_000;
 
+/**
+ * Private network access is a local test/development affordance only.
+ * Unknown, unset, staging, and misspelled runtime names must fail closed.
+ */
+export function isTestOrDevelopmentRuntime(
+  environment: string | undefined,
+): boolean {
+  return environment === 'test' || environment === 'development';
+}
+
 const TRANSIENT_DNS_CODES = new Set(['EAI_AGAIN', 'ESERVFAIL', 'ETIMEOUT', 'ECONNREFUSED']);
 const PERMANENT_DNS_CODES = new Set(['ENOTFOUND', 'EAI_NONAME', 'ENODATA', 'ENONAME', 'EAI_NODATA']);
 const DNS_CODE_RE = /\b(EAI_AGAIN|ESERVFAIL|ETIMEOUT|ECONNREFUSED|ENOTFOUND|EAI_NONAME|ENODATA|ENONAME|EAI_NODATA)\b/i;
@@ -309,12 +319,12 @@ export async function validateCrawlDomain(domain: string): Promise<string> {
  * - Must parse as a URL.
  * - Protocol must be http or https.
  * - Cloud metadata hosts are always blocked, every environment (AWS/GCP).
- * - In production only: localhost/loopback and RFC1918 private IPv4 ranges
- *   are blocked. Development keeps them allowed so local agents and local
- *   auth servers are reachable.
+ * - Private/internal hosts are allowed only in explicit test or development
+ *   runtimes so local agents and auth servers remain reachable. Unknown,
+ *   unset, staging, and misspelled runtime names fail closed.
  *
- * For stronger SSRF guarantees (DNS rebind defence, redirect-hop validation,
- * IPv6, CGNAT, link-local), prefer `safeFetch` at fetch time.
+ * For stronger SSRF guarantees (DNS resolution/rebind defence, redirect-hop
+ * validation, and connect-time enforcement), prefer `safeFetch` at fetch time.
  */
 export function validateExternalUrl(raw: string): string | null {
   try {
@@ -322,18 +332,17 @@ export function validateExternalUrl(raw: string): string | null {
     if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
 
     const hostname = url.hostname.toLowerCase();
+    const normalizedHostname = hostname.startsWith('[') && hostname.endsWith(']')
+      ? hostname.slice(1, -1)
+      : hostname;
 
-    if (hostname === '169.254.169.254' || hostname === 'metadata.google.internal') return null;
+    if (normalizedHostname === '169.254.169.254' || normalizedHostname === 'metadata.google.internal') return null;
 
-    if (process.env.NODE_ENV === 'production') {
-      if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '0.0.0.0') {
-        return null;
-      }
-      const ipMatch = hostname.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
-      if (ipMatch) {
-        const [, a, b] = ipMatch.map(Number);
-        if (a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168)) return null;
-      }
+    if (
+      !isTestOrDevelopmentRuntime(process.env.NODE_ENV) &&
+      isPrivateHostname(normalizedHostname)
+    ) {
+      return null;
     }
 
     return raw;

--- a/server/tests/unit/url-security-external-url.test.ts
+++ b/server/tests/unit/url-security-external-url.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  isTestOrDevelopmentRuntime,
+  validateExternalUrl,
+} from '../../src/utils/url-security.js';
+
+describe('validateExternalUrl runtime policy', () => {
+  let originalEnvironment: string | undefined;
+
+  beforeEach(() => {
+    originalEnvironment = process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    if (originalEnvironment === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalEnvironment;
+  });
+
+  function setEnvironment(environment: string | undefined): void {
+    if (environment === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = environment;
+  }
+
+  it.each([
+    ['test', true],
+    ['development', true],
+    ['production', false],
+    ['staging', false],
+    ['developmnt', false],
+    [undefined, false],
+  ])('classifies the %s runtime explicitly', (environment, expected) => {
+    expect(isTestOrDevelopmentRuntime(environment)).toBe(expected);
+  });
+
+  it.each(['production', 'staging', 'developmnt', undefined])(
+    'rejects private and loopback targets when NODE_ENV is %s',
+    (environment) => {
+      setEnvironment(environment);
+
+      for (const target of [
+        'http://localhost:3000',
+        'http://0.0.0.0',
+        'http://127.0.0.1',
+        'http://10.0.0.1',
+        'http://172.20.0.1',
+        'http://192.168.1.1',
+        'http://169.254.1.1',
+        'http://100.64.0.1',
+        'http://[::1]',
+        'http://[fc00::1]',
+        'http://[fe80::1]',
+      ]) {
+        expect(validateExternalUrl(target), target).toBeNull();
+      }
+    },
+  );
+
+  it.each(['test', 'development'])(
+    'allows private and loopback targets in explicit %s mode',
+    (environment) => {
+      setEnvironment(environment);
+
+      for (const target of [
+        'http://localhost:3000',
+        'http://0.0.0.0',
+        'http://127.0.0.1',
+        'http://10.0.0.1',
+        'http://192.168.1.1',
+        'http://169.254.1.1',
+        'http://100.64.0.1',
+        'http://[::1]',
+        'http://[fc00::1]',
+      ]) {
+        expect(validateExternalUrl(target), target).toBe(target);
+      }
+    },
+  );
+
+  it.each(['test', 'development', 'production', 'staging', undefined])(
+    'always rejects cloud metadata targets when NODE_ENV is %s',
+    (environment) => {
+      setEnvironment(environment);
+
+      expect(validateExternalUrl('http://169.254.169.254/latest/meta-data')).toBeNull();
+      expect(validateExternalUrl('http://metadata.google.internal/computeMetadata/v1')).toBeNull();
+    },
+  );
+
+  it.each(['test', 'development', 'production', 'staging', undefined])(
+    'allows public URLs when NODE_ENV is %s',
+    (environment) => {
+      setEnvironment(environment);
+      const target = 'https://agent.example.com/mcp';
+
+      expect(validateExternalUrl(target)).toBe(target);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- centralize the explicit `test`/`development` runtime allowlist used by SSRF guards
- make `validateExternalUrl` reject private and loopback targets when runtime is unset, staging, or misspelled
- preserve local test/development access while continuing to block cloud metadata targets everywhere
- cover IPv4, IPv6, CGNAT, link-local, runtime, and public-URL cases

## Validation

- focused URL-security and webhook-fetch suites: 66 passed
- related training webhook suites: 23 passed, 2 skipped
- TypeScript typecheck
- `git diff --check`

No changeset or Addie version bump: this is server-side security hardening.

Fixes #5957.