### PR TITLE
fix(security): normalize trailing-dot URL hosts

### DIFF
--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -332,9 +332,16 @@ export function validateExternalUrl(raw: string): string | null {
     if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
 
     const hostname = url.hostname.toLowerCase();
-    const normalizedHostname = hostname.startsWith('[') && hostname.endsWith(']')
+    const hostnameWithoutIpv6Brackets = hostname.startsWith('[') && hostname.endsWith(']')
       ? hostname.slice(1, -1)
       : hostname;
+    // A single terminal dot is the DNS root label, so `example.com.` and
+    // `example.com` identify the same host. Remove only that canonical root
+    // label; additional terminal dots are meaningful (and generally invalid)
+    // hostname input and should not be silently normalized away.
+    const normalizedHostname = hostnameWithoutIpv6Brackets.endsWith('.')
+      ? hostnameWithoutIpv6Brackets.slice(0, -1)
+      : hostnameWithoutIpv6Brackets;
 
     if (normalizedHostname === '169.254.169.254' || normalizedHostname === 'metadata.google.internal') return null;
 

--- a/server/tests/unit/url-security-external-url.test.ts
+++ b/server/tests/unit/url-security-external-url.test.ts
@@ -39,6 +39,8 @@ describe('validateExternalUrl runtime policy', () => {
 
       for (const target of [
         'http://localhost:3000',
+        'http://localhost.:3000',
+        'http://service.internal./health',
         'http://0.0.0.0',
         'http://127.0.0.1',
         'http://10.0.0.1',
@@ -62,6 +64,8 @@ describe('validateExternalUrl runtime policy', () => {
 
       for (const target of [
         'http://localhost:3000',
+        'http://localhost.:3000',
+        'http://service.internal./health',
         'http://0.0.0.0',
         'http://127.0.0.1',
         'http://10.0.0.1',
@@ -83,16 +87,28 @@ describe('validateExternalUrl runtime policy', () => {
 
       expect(validateExternalUrl('http://169.254.169.254/latest/meta-data')).toBeNull();
       expect(validateExternalUrl('http://metadata.google.internal/computeMetadata/v1')).toBeNull();
+      expect(validateExternalUrl('http://metadata.google.internal./computeMetadata/v1')).toBeNull();
     },
   );
+
+  it('removes only one trailing DNS root dot for classification', () => {
+    setEnvironment('production');
+    const target = 'http://metadata.google.internal../computeMetadata/v1';
+
+    expect(validateExternalUrl(target)).toBe(target);
+  });
 
   it.each(['test', 'development', 'production', 'staging', undefined])(
     'allows public URLs when NODE_ENV is %s',
     (environment) => {
       setEnvironment(environment);
-      const target = 'https://agent.example.com/mcp';
-
-      expect(validateExternalUrl(target)).toBe(target);
+      for (const target of [
+        'https://agent.example.com/mcp',
+        'https://agent.example.com./mcp',
+        'https://[2001:4860:4860::8888]/mcp',
+      ]) {
+        expect(validateExternalUrl(target), target).toBe(target);
+      }
     },
   );
 });


### PR DESCRIPTION
## Summary

- remove one canonical DNS root trailing dot before external-host security classification
- block trailing-dot metadata and internal hosts consistently across runtime modes
- preserve the caller's original URL on successful validation
- cover metadata, localhost/internal, public, IPv6, and non-canonical double-dot cases

## Validation

- focused external URL tests: 23 passed
- TypeScript typecheck
- `git diff --check`

No changeset or Addie version bump: this is server-side URL security hardening.

Fixes #5959.