### PR TITLE
fix(security): reject malformed external URL hostnames

### DIFF
--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -20,7 +20,7 @@ import { PostgresTaskStore } from '@adcp/sdk';
 import { mergeSeedProduct } from '@adcp/sdk/testing';
 import { isDatabaseInitialized, getPool } from '../db/client.js';
 import { createLogger } from '../logger.js';
-import { isPrivateHostname, safeFetchAxiosLike } from '../utils/url-security.js';
+import { isPrivateHostname, normalizeExternalHostname, safeFetchAxiosLike } from '../utils/url-security.js';
 import type { TrainingContext, CatalogProduct, MediaBuyState, MediaBuyAvailableActionState, MediaBuyProductAllowedActionState, PackageState, SignalActivationState, CreativeState, CreativeManifest, ToolArgs, ListReference, PackageTargeting, AccountRef, SessionState } from './types.js';
 import { encodeOffsetCursor, decodeOffsetCursor } from './pagination.js';
 import type {
@@ -3603,7 +3603,8 @@ function validateExternalUrlValue(field: string, raw: unknown): ValidateInputVio
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     return { rule: 'url_scheme', field, expected: 'http or https', predicted: parsed.protocol };
   }
-  if (isPrivateHostname(parsed.hostname)) {
+  const hostname = normalizeExternalHostname(parsed.hostname);
+  if (!hostname || isPrivateHostname(hostname)) {
     return { rule: 'url_host_public', field, expected: 'public hostname', predicted: parsed.hostname };
   }
   return null;
@@ -3815,7 +3816,8 @@ function parseThirdPartyFormatTarget(target: ValidateInputTarget): { url: string
     if (parsed.protocol !== 'https:') {
       return thirdPartyResolutionViolation(target, 'https URI', parsed.protocol);
     }
-    if (isPrivateHostname(parsed.hostname)) {
+    const hostname = normalizeExternalHostname(parsed.hostname);
+    if (!hostname || isPrivateHostname(hostname)) {
       return thirdPartyResolutionViolation(target, 'public hostname', parsed.hostname);
     }
   } catch {

--- a/server/src/utils/url-security.ts
+++ b/server/src/utils/url-security.ts
@@ -180,6 +180,29 @@ export function isPrivateHostname(hostname: string): boolean {
   return false;
 }
 
+/**
+ * Normalize a URL parser hostname for security classification.
+ *
+ * A single terminal dot is the canonical DNS root label. Empty labels in any
+ * other position are malformed and must fail closed rather than reaching a
+ * resolver or proxy that may interpret them differently. WHATWG URL parsing
+ * maps the IDNA dot variants to ASCII dots before this helper is called.
+ */
+export function normalizeExternalHostname(hostname: string): string | null {
+  const lowerHostname = hostname.toLowerCase();
+  const hostnameWithoutIpv6Brackets = lowerHostname.startsWith('[') && lowerHostname.endsWith(']')
+    ? lowerHostname.slice(1, -1)
+    : lowerHostname;
+  const normalizedHostname = hostnameWithoutIpv6Brackets.endsWith('.')
+    ? hostnameWithoutIpv6Brackets.slice(0, -1)
+    : hostnameWithoutIpv6Brackets;
+
+  if (!normalizedHostname || normalizedHostname.split('.').some(label => label.length === 0)) {
+    return null;
+  }
+  return normalizedHostname;
+}
+
 function extractDnsErrorCode(reason: unknown): string | undefined {
   if (!reason || typeof reason !== 'object') return undefined;
   const err = reason as { code?: unknown; message?: unknown };
@@ -331,17 +354,8 @@ export function validateExternalUrl(raw: string): string | null {
     const url = new URL(raw);
     if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
 
-    const hostname = url.hostname.toLowerCase();
-    const hostnameWithoutIpv6Brackets = hostname.startsWith('[') && hostname.endsWith(']')
-      ? hostname.slice(1, -1)
-      : hostname;
-    // A single terminal dot is the DNS root label, so `example.com.` and
-    // `example.com` identify the same host. Remove only that canonical root
-    // label; additional terminal dots are meaningful (and generally invalid)
-    // hostname input and should not be silently normalized away.
-    const normalizedHostname = hostnameWithoutIpv6Brackets.endsWith('.')
-      ? hostnameWithoutIpv6Brackets.slice(0, -1)
-      : hostnameWithoutIpv6Brackets;
+    const normalizedHostname = normalizeExternalHostname(url.hostname);
+    if (!normalizedHostname) return null;
 
     if (normalizedHostname === '169.254.169.254' || normalizedHostname === 'metadata.google.internal') return null;
 

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1866,6 +1866,64 @@ describe('validate_input handler', () => {
     ]));
   });
 
+  it.each([
+    'https://cdn..example/mrec.png',
+    'https://。cdn.example/mrec.png',
+    'https://cdn。。example/mrec.png',
+    'https://cdn.example。。/mrec.png',
+  ])('returns validated_fail for malformed asset hostname %s', async (url) => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result } = await simulateCallTool(server, 'validate_input', {
+      manifest: {
+        format_kind: 'image',
+        assets: {
+          image_main: {
+            asset_type: 'image',
+            url,
+            width: 300,
+            height: 250,
+          },
+        },
+      },
+      targets: [{ kind: 'canonical', id: 'image' }],
+    });
+
+    const results = result.results as Array<Record<string, unknown>>;
+    expect(results[0].result_kind).toBe('validated_fail');
+    expect(results[0].violations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        rule: 'url_host_public',
+        field: 'assets.image_main.url',
+      }),
+    ]));
+  });
+
+  it.each([
+    'https://cdn.example.com./mrec.png',
+    'https://cdn.example.com。/mrec.png',
+    'https://cdn．example｡com/mrec.png',
+  ])('accepts a valid FQDN asset hostname %s', async (url) => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result } = await simulateCallTool(server, 'validate_input', {
+      manifest: {
+        format_kind: 'image',
+        assets: {
+          image_main: {
+            asset_type: 'image',
+            url,
+            width: 300,
+            height: 250,
+          },
+        },
+      },
+      targets: [{ kind: 'canonical', id: 'image' }],
+    });
+
+    expect(result.results).toEqual([
+      { target: { kind: 'canonical', id: 'image' }, result_kind: 'validated_pass' },
+    ]);
+  });
+
   it('returns validated_fail for unsafe nested URL-bearing assets', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { result } = await simulateCallTool(server, 'validate_input', {

--- a/server/tests/unit/url-security-external-url.test.ts
+++ b/server/tests/unit/url-security-external-url.test.ts
@@ -91,12 +91,25 @@ describe('validateExternalUrl runtime policy', () => {
     },
   );
 
-  it('removes only one trailing DNS root dot for classification', () => {
-    setEnvironment('production');
-    const target = 'http://metadata.google.internal../computeMetadata/v1';
+  it.each(['test', 'development', 'production', 'staging', undefined])(
+    'rejects malformed empty DNS labels when NODE_ENV is %s',
+    (environment) => {
+      setEnvironment(environment);
 
-    expect(validateExternalUrl(target)).toBe(target);
-  });
+      for (const target of [
+        'https://.example.com/path',
+        'https://..example.com/path',
+        'https://example..com/path',
+        'http://metadata.google.internal../computeMetadata/v1',
+        'https://。example.com/path',
+        'https://example。。com/path',
+        'https://example.com。。/path',
+        'https://example．｡com/path',
+      ]) {
+        expect(validateExternalUrl(target), target).toBeNull();
+      }
+    },
+  );
 
   it.each(['test', 'development', 'production', 'staging', undefined])(
     'allows public URLs when NODE_ENV is %s',
@@ -105,6 +118,8 @@ describe('validateExternalUrl runtime policy', () => {
       for (const target of [
         'https://agent.example.com/mcp',
         'https://agent.example.com./mcp',
+        'https://agent.example.com。/mcp',
+        'https://agent．example｡com/mcp',
         'https://[2001:4860:4860::8888]/mcp',
       ]) {
         expect(validateExternalUrl(target), target).toBe(target);


### PR DESCRIPTION
## Summary

- reject leading, interior, and residual trailing empty DNS labels during external URL preflight
- preserve valid single-root-dot FQDNs, including IDNA dot variants normalized by URL parsing
- apply the same hostname normalization to training-agent asset and third-party format URL validation

## Why

A hostname such as metadata.google.internal.. could pass synchronous preflight because only one terminal root dot was removed. Connect-time safeguards usually reject it, but malformed hostnames should fail closed before reaching alternate transports or resolvers.

## Validation

- focused URL-security and training-agent suites: 535 passed
- npm run typecheck
- Prettier check
- git diff --check

No changeset: this is server-side security hardening.

Closes #5965.