### PR TITLE
fix(content): allow deleting linked perspectives

### DIFF
--- a/server/public/admin-content.html
+++ b/server/public/admin-content.html
@@ -1474,9 +1474,13 @@
           if (currentTab === 'all') await loadAdminContent();
         } else {
           const d = await res.json().catch(() => ({}));
-          alert(d.message || d.error || 'Failed to delete');
+          if (res.status === 403) {
+            alert(d.message || 'You do not have permission to delete this content.');
+          } else {
+            alert(d.message || d.error || 'Failed to delete content. Please try again.');
+          }
         }
-      } catch (e) { alert('Failed to delete'); }
+      } catch (e) { alert(e.message || 'Failed to delete content. Please try again.'); }
     }
 
     function closeModal() { document.getElementById('contentModal').style.display = 'none'; editingContent = null; }

--- a/server/src/db/migrations/526_perspective_publication_links_set_null.sql
+++ b/server/src/db/migrations/526_perspective_publication_links_set_null.sql
@@ -1,0 +1,21 @@
+-- Preserve publication history when its source perspective is deleted.
+--
+-- Newsletter editions, Build editions, and Moltbook posts remain useful audit
+-- records after an article is removed. Their perspective links are optional,
+-- so clearing the link is safer than either blocking the delete or cascading
+-- into those records.
+
+ALTER TABLE weekly_digests
+  DROP CONSTRAINT IF EXISTS weekly_digests_perspective_id_fkey,
+  ADD CONSTRAINT weekly_digests_perspective_id_fkey
+    FOREIGN KEY (perspective_id) REFERENCES perspectives(id) ON DELETE SET NULL;
+
+ALTER TABLE build_editions
+  DROP CONSTRAINT IF EXISTS build_editions_perspective_id_fkey,
+  ADD CONSTRAINT build_editions_perspective_id_fkey
+    FOREIGN KEY (perspective_id) REFERENCES perspectives(id) ON DELETE SET NULL;
+
+ALTER TABLE moltbook_posts
+  DROP CONSTRAINT IF EXISTS moltbook_posts_perspective_id_fkey,
+  ADD CONSTRAINT moltbook_posts_perspective_id_fkey
+    FOREIGN KEY (perspective_id) REFERENCES perspectives(id) ON DELETE SET NULL;

--- a/server/tests/integration/content-my-content.test.ts
+++ b/server/tests/integration/content-my-content.test.ts
@@ -797,6 +797,58 @@ describe('My Content — body, admin scope, status, delete', () => {
     });
   });
 
+  describe('DELETE /api/admin/content/:id', () => {
+    it('deletes linked content while preserving publication history', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-admin-delete-linked',
+        title: 'linked publication',
+        status: 'published',
+        proposerUserId: OTHER_USER_ID,
+      });
+
+      const weeklyDigest = await pool.query(
+        `INSERT INTO weekly_digests (edition_date, status, content, perspective_id)
+         VALUES ('2999-01-01', 'sent', '{}'::jsonb, $1)
+         RETURNING id`,
+        [id]
+      );
+      const buildEdition = await pool.query(
+        `INSERT INTO build_editions (edition_date, status, content, perspective_id)
+         VALUES ('2999-01-02', 'sent', '{}'::jsonb, $1)
+         RETURNING id`,
+        [id]
+      );
+      const moltbookPost = await pool.query(
+        `INSERT INTO moltbook_posts (moltbook_post_id, perspective_id, title)
+         VALUES ('mc-test-admin-delete-linked', $1, 'Linked publication')
+         RETURNING id`,
+        [id]
+      );
+
+      try {
+        await request(app).delete(`/api/admin/content/${id}`).expect(200);
+
+        const perspective = await pool.query(`SELECT id FROM perspectives WHERE id = $1`, [id]);
+        expect(perspective.rows).toHaveLength(0);
+
+        const links = await pool.query(
+          `SELECT perspective_id FROM weekly_digests WHERE id = $1
+           UNION ALL
+           SELECT perspective_id FROM build_editions WHERE id = $2
+           UNION ALL
+           SELECT perspective_id FROM moltbook_posts WHERE id = $3`,
+          [weeklyDigest.rows[0].id, buildEdition.rows[0].id, moltbookPost.rows[0].id]
+        );
+        expect(links.rows).toHaveLength(3);
+        expect(links.rows.every(row => row.perspective_id === null)).toBe(true);
+      } finally {
+        await pool.query(`DELETE FROM weekly_digests WHERE id = $1`, [weeklyDigest.rows[0].id]);
+        await pool.query(`DELETE FROM build_editions WHERE id = $1`, [buildEdition.rows[0].id]);
+        await pool.query(`DELETE FROM moltbook_posts WHERE id = $1`, [moltbookPost.rows[0].id]);
+      }
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // #2569 — proposer relationship in GET /api/me/content (edit-button fix)
   //

--- a/server/tests/unit/admin-content-delete-ux.test.ts
+++ b/server/tests/unit/admin-content-delete-ux.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("member content deletion UX", () => {
+  it("surfaces the server-provided 403 message", () => {
+    const html = readFileSync(
+      join(process.cwd(), "server/public/admin-content.html"),
+      "utf8"
+    );
+    const deleteHandler = html.match(
+      /async function deleteMyContent\(id\) \{[\s\S]*?\n    \}/
+    )?.[0];
+
+    expect(deleteHandler).toBeDefined();
+    expect(deleteHandler).toContain("res.status === 403");
+    expect(deleteHandler).toContain(
+      "alert(d.message || 'You do not have permission to delete this content.')"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- preserve newsletter, Build, and Moltbook publication history when a linked perspective is deleted
- clear those optional source links through `ON DELETE SET NULL` foreign keys
- surface the server-provided permission message when a member receives a 403 while deleting content
- cover the real admin deletion route and member-facing error behavior

## Root cause

`weekly_digests`, `build_editions`, and `moltbook_posts` referenced `perspectives` without an `ON DELETE` action. PostgreSQL therefore rejected an otherwise authorized admin deletion whenever any of those records linked to the perspective, and the route returned 500.

These records are publication and audit history, so deleting them by cascade would lose useful history. The migration preserves each record and atomically clears its optional `perspective_id` when the perspective is removed.

## Validation

- focused admin DELETE integration test against all three foreign keys
- member delete UX unit test
- migration filename/duplicate-number validation
- TypeScript typecheck
- `git diff --check`

No changeset: this is application/database behavior, not a published protocol-package change.

Fixes #5973.
