### PR TITLE
fix(registry): keep community property writes identity-only

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.07.2';
+export const CODE_VERSION = '2026.07.3';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/property-tools.ts
+++ b/server/src/addie/mcp/property-tools.ts
@@ -18,6 +18,7 @@ import { syncHostedPropertyToFederatedIndex } from '../../services/hosted-proper
 import { fileDispute } from '../../services/catalog-governance.js';
 import type { DisputeType } from '../../db/catalog-disputes-db.js';
 import { AAO_HOST } from '../../config/aao.js';
+import { scrubCommunityAuthorizedAgents } from '../../utils/community-adagents.js';
 
 const adagentsManager = new AdAgentsManager();
 const propertyDb = new PropertyDatabase();
@@ -69,17 +70,6 @@ export const PROPERTY_TOOLS: AddieTool[] = [
         publisher_domain: {
           type: 'string',
           description: 'Publisher domain',
-        },
-        authorized_agents: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              url: { type: 'string' },
-              authorized_for: { type: 'string' },
-            },
-          },
-          description: 'Array of authorized agents with their URLs and scopes',
         },
         properties: {
           type: 'array',
@@ -398,7 +388,6 @@ export function createPropertyToolHandlers(): Map<string, (args: Record<string, 
       return JSON.stringify({ error: 'publisher_domain is required' });
     }
 
-    const authorizedAgents = args.authorized_agents as Array<{ url: string; authorized_for?: string }> || [];
     const properties = args.properties as Array<{ type: string; name: string }> || [];
     const catalogEtag = args.catalog_etag as string | undefined;
     const formats = args.formats as Array<Record<string, unknown>> | undefined;
@@ -406,11 +395,10 @@ export function createPropertyToolHandlers(): Map<string, (args: Record<string, 
     const contact = args.contact as { name?: string; email?: string } | undefined;
     const sourceType = (args.source_type as string) || 'community';
 
-    const adagentsJson: Record<string, unknown> = {
+    const adagentsJson = scrubCommunityAuthorizedAgents({
       $schema: 'https://adcontextprotocol.org/schemas/latest/adagents.json',
-      authorized_agents: authorizedAgents,
       properties: properties,
-    };
+    });
 
     if (catalogEtag) {
       adagentsJson.catalog_etag = catalogEtag;
@@ -445,10 +433,9 @@ export function createPropertyToolHandlers(): Map<string, (args: Record<string, 
           ...existingAdagents,
           ...adagentsJson,
         };
-        // Preserve existing data when caller didn't provide replacements
-        if (!args.authorized_agents && existingAdagents.authorized_agents) {
-          mergedAdagents.authorized_agents = existingAdagents.authorized_agents;
-        }
+        // Community rows never preserve or accept sales authorization. Only
+        // the publisher's origin adagents.json can assert authorized agents.
+        mergedAdagents.authorized_agents = [];
         if (!args.properties && existingAdagents.properties) {
           mergedAdagents.properties = existingAdagents.properties;
         }

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -54,6 +54,7 @@ import { handleSlashCommand } from "./slack/commands.js";
 import { getCompanyDomain, getGoogleEmailAliases } from "./utils/email-domain.js";
 import { isUuid } from "./utils/uuid.js";
 import { resolveUserNameWithFallbacks, sanitizeName } from "./utils/resolve-user-name.js";
+import { scrubCommunityAuthorizedAgents } from "./utils/community-adagents.js";
 import { requireAuth, requireAdmin, requireGlobalAdmin, optionalAuth, invalidateSessionCache, isDevModeEnabled, getDevUser, getAvailableDevUsers, getDevSessionCookieName, encodeDevSessionCookie, DEV_USERS, type DevUserConfig } from "./middleware/auth.js";
 import { invitationRateLimiter, brandCreationRateLimiter, notificationRateLimiter, emailPrefsRateLimiter, adminContentWriteRateLimiter, newsletterSubscribeRateLimiter, newsletterConfirmRateLimiter } from "./middleware/rate-limit.js";
 import { findOrCreateUserByEmail } from "./auth/workos-client.js";
@@ -3632,7 +3633,7 @@ export class HTTPServer {
 
         const property = await this.propertyDb.createHostedProperty({
           publisher_domain: publisher_domain.toLowerCase(),
-          adagents_json,
+          adagents_json: scrubCommunityAuthorizedAgents(adagents_json),
           source_type: source_type || 'community',
           created_by_user_id: req.user?.id,
           created_by_email: req.user?.email,
@@ -3666,7 +3667,7 @@ export class HTTPServer {
 
         const property = await this.propertyDb.createCommunityProperty({
           publisher_domain: publisher_domain.toLowerCase(),
-          adagents_json,
+          adagents_json: scrubCommunityAuthorizedAgents(adagents_json),
           source_type: 'community',
           created_by_user_id: req.user!.id,
           created_by_email: req.user!.email,
@@ -3751,7 +3752,9 @@ export class HTTPServer {
         }
 
         const { property, revision_number } = await this.propertyDb.editCommunityProperty(domain, {
-          adagents_json,
+          adagents_json: adagents_json === undefined
+            ? undefined
+            : scrubCommunityAuthorizedAgents(adagents_json),
           edit_summary,
           editor_user_id: req.user!.id,
           editor_email: req.user!.email,

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -3626,14 +3626,19 @@ export class HTTPServer {
     // POST /api/properties/hosted - Create a hosted property (authenticated)
     this.app.post('/api/properties/hosted', requireAuth, async (req, res) => {
       try {
-        const { publisher_domain, adagents_json, source_type } = req.body;
-        if (!publisher_domain || !adagents_json) {
+        // Establish the identity-only write invariant before any validation
+        // branch derived from caller input. Only this scrubbed value may reach
+        // the database boundary below.
+        const requestedAdagentsJson = req.body?.adagents_json;
+        const adagentsJsonForStorage = scrubCommunityAuthorizedAgents(requestedAdagentsJson);
+        const { publisher_domain, source_type } = req.body;
+        if (!publisher_domain || !requestedAdagentsJson) {
           return res.status(400).json({ error: 'publisher_domain and adagents_json required' });
         }
 
         const property = await this.propertyDb.createHostedProperty({
           publisher_domain: publisher_domain.toLowerCase(),
-          adagents_json: scrubCommunityAuthorizedAgents(adagents_json),
+          adagents_json: adagentsJsonForStorage,
           source_type: source_type || 'community',
           created_by_user_id: req.user?.id,
           created_by_email: req.user?.email,
@@ -3649,13 +3654,18 @@ export class HTTPServer {
     // POST /api/properties/hosted/community - Create a new community property (member-authenticated, pending review)
     this.app.post('/api/properties/hosted/community', requireAuth, async (req, res) => {
       try {
+        // Scrub unconditionally, before membership and payload validation can
+        // branch on request-derived values.
+        const requestedAdagentsJson = req.body?.adagents_json;
+        const adagentsJsonForStorage = scrubCommunityAuthorizedAgents(requestedAdagentsJson);
+
         await enrichUserWithMembership(req.user as any);
         if (!(req.user as any)?.isMember) {
           return res.status(403).json({ error: 'Membership required to create properties' });
         }
 
-        const { publisher_domain, adagents_json } = req.body;
-        if (!publisher_domain || !adagents_json) {
+        const { publisher_domain } = req.body;
+        if (!publisher_domain || !requestedAdagentsJson) {
           return res.status(400).json({ error: 'publisher_domain and adagents_json required' });
         }
 
@@ -3667,7 +3677,7 @@ export class HTTPServer {
 
         const property = await this.propertyDb.createCommunityProperty({
           publisher_domain: publisher_domain.toLowerCase(),
-          adagents_json: scrubCommunityAuthorizedAgents(adagents_json),
+          adagents_json: adagentsJsonForStorage,
           source_type: 'community',
           created_by_user_id: req.user!.id,
           created_by_email: req.user!.email,
@@ -3733,6 +3743,15 @@ export class HTTPServer {
     // PUT /api/properties/hosted/:domain - Edit a community property with revision tracking
     this.app.put('/api/properties/hosted/:domain', requireAuth, async (req, res) => {
       try {
+        // Always scrub before request-dependent branching. Preserve the
+        // existing optional-update behavior by selecting undefined only after
+        // the scrub has established the safe storage value.
+        const requestedAdagentsJson = req.body?.adagents_json;
+        const adagentsJsonForStorage = scrubCommunityAuthorizedAgents(requestedAdagentsJson);
+        const adagentsJsonUpdate = requestedAdagentsJson === undefined
+          ? undefined
+          : adagentsJsonForStorage;
+
         await enrichUserWithMembership(req.user as any);
         if (!(req.user as any)?.isMember) {
           return res.status(403).json({ error: 'Membership required to edit properties' });
@@ -3740,7 +3759,7 @@ export class HTTPServer {
 
         const domain = decodeURIComponent(req.params.domain).toLowerCase();
 
-        const { edit_summary, adagents_json } = req.body;
+        const { edit_summary } = req.body;
         if (!edit_summary || typeof edit_summary !== 'string') {
           return res.status(400).json({ error: 'edit_summary required' });
         }
@@ -3752,9 +3771,7 @@ export class HTTPServer {
         }
 
         const { property, revision_number } = await this.propertyDb.editCommunityProperty(domain, {
-          adagents_json: adagents_json === undefined
-            ? undefined
-            : scrubCommunityAuthorizedAgents(adagents_json),
+          adagents_json: adagentsJsonUpdate,
           edit_summary,
           editor_user_id: req.user!.id,
           editor_email: req.user!.email,

--- a/server/src/mcp-tools.ts
+++ b/server/src/mcp-tools.ts
@@ -26,6 +26,7 @@ import { notifyRegistryCreate, notifyRegistryEdit } from "./notifications/regist
 import { reviewNewRecord, reviewRegistryEdit } from "./addie/mcp/registry-review.js";
 import type { MCPAuthContext } from "./mcp/auth.js";
 import { createLogger } from "./logger.js";
+import { scrubCommunityAuthorizedAgents } from "./utils/community-adagents.js";
 
 const logger = createLogger('mcp-tools');
 
@@ -474,17 +475,6 @@ export const TOOL_DEFINITIONS = [
         publisher_domain: {
           type: "string",
           description: "Publisher domain (e.g., 'example-news.com')",
-        },
-        authorized_agents: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              url: { type: "string" },
-              authorized_for: { type: "string" },
-            },
-          },
-          description: "Authorized agents for this property",
         },
         properties: {
           type: "array",
@@ -1794,35 +1784,15 @@ export class MCPToolHandler {
           };
         }
 
-        const authorizedAgents = args?.authorized_agents as Array<{ url: string; authorized_for?: string }> || [];
         const propertyItems = args?.properties as Array<{ type: string; name: string }> || [];
         const formats = args?.formats as Array<Record<string, unknown>> | undefined;
         const placements = args?.placements as Array<Record<string, unknown>> | undefined;
         const contact = args?.contact as { name?: string; email?: string } | undefined;
 
-        // Validate agent URLs
-        for (const agent of authorizedAgents) {
-          try {
-            const parsed = new URL(agent.url);
-            if (parsed.protocol !== 'https:') {
-              return {
-                content: [{ type: "text", text: JSON.stringify({ error: `Agent URL must use HTTPS: ${agent.url}` }) }],
-                isError: true,
-              };
-            }
-          } catch {
-            return {
-              content: [{ type: "text", text: JSON.stringify({ error: `Invalid agent URL: ${agent.url}` }) }],
-              isError: true,
-            };
-          }
-        }
-
-        const adagentsJson: Record<string, unknown> = {
+        const adagentsJson = scrubCommunityAuthorizedAgents({
           $schema: 'https://adcontextprotocol.org/schemas/latest/adagents.json',
-          authorized_agents: authorizedAgents,
           properties: propertyItems,
-        };
+        });
         if (contact) {
           adagentsJson.contact = contact;
         }

--- a/server/src/services/property-enhancement.ts
+++ b/server/src/services/property-enhancement.ts
@@ -197,7 +197,10 @@ export async function enhanceProperty(
     risk = 'normal';
   }
 
-  // Build a minimal adagents_json for the pending entry.
+  // Build a minimal, identity-only adagents_json for the pending entry.
+  // Validation above records only whether an origin document exists; it does
+  // not copy the origin body. Authorization remains origin-derived at read
+  // time and is never projected into this community row.
   // Metadata goes in the ext field for reference.
   const adagentsJson: Record<string, unknown> = {
     $schema: 'https://adcontextprotocol.org/schemas/latest/adagents.json',

--- a/server/src/utils/community-adagents.ts
+++ b/server/src/utils/community-adagents.ts
@@ -1,0 +1,20 @@
+/**
+ * Build the identity-only adagents.json document stored by community-registry
+ * write surfaces.
+ *
+ * Community contributors, administrators, and Addie can curate catalog and
+ * identity data, but they cannot authorize a sales agent on a publisher's
+ * behalf. Authorization is sourced only from the publisher's origin-hosted
+ * adagents.json, so caller-provided values must always be replaced with an
+ * explicit empty array.
+ *
+ * Do not use this helper on origin-crawled documents.
+ */
+export function scrubCommunityAuthorizedAgents(
+  adagentsJson: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...adagentsJson,
+    authorized_agents: [],
+  };
+}

--- a/server/tests/integration/property-enhancement-function.test.ts
+++ b/server/tests/integration/property-enhancement-function.test.ts
@@ -128,6 +128,7 @@ describe('enhanceProperty — analyzeProperty tool_use output → hosted_propert
     expect(aiAnalysis?.is_publisher).toBe(true);
     expect(aiAnalysis?.likely_inventory_types).toEqual(['display', 'video']);
     expect(aiAnalysis?.confidence).toBe('high');
+    expect(row.rows[0].adagents_json.authorized_agents).toEqual([]);
   });
 
   it('writes is_publisher=false correctly when the model classifies a non-publisher domain', async () => {

--- a/server/tests/integration/registry-property-save-identity.test.ts
+++ b/server/tests/integration/registry-property-save-identity.test.ts
@@ -86,6 +86,10 @@ describe('POST /api/properties/save — identity, not authorization', () => {
   let propertyDb: PropertyDatabase;
 
   async function clearFixtures() {
+    // Community creates write revision #1. Revisions are intentionally not
+    // cascade-deleted with hosted properties, so clear them explicitly to
+    // keep this suite repeatable against a persistent local test database.
+    await pool.query('DELETE FROM property_revisions WHERE publisher_domain LIKE $1', [DOMAIN_LIKE]);
     await pool.query('DELETE FROM hosted_properties WHERE publisher_domain LIKE $1', [DOMAIN_LIKE]);
     // The edit-path success case calls syncHostedPropertyToFederatedIndex, which
     // derives a discovered_properties row; clear it too so re-runs against a

--- a/server/tests/integration/registry-property-save-identity.test.ts
+++ b/server/tests/integration/registry-property-save-identity.test.ts
@@ -17,12 +17,13 @@ import type { Pool } from 'pg';
 vi.hoisted(() => {
   process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
   process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgresql://adcp:localdev@localhost:5432/adcp_test';
 });
 
 vi.mock('../../src/middleware/auth.js', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('../../src/middleware/auth.js');
   const pass = (req: { user: unknown }, _res: unknown, next: () => void) => {
-    req.user = { id: 'user_save_test', email: 'save@test.com', isAdmin: false };
+    req.user = { id: 'user_save_test', email: 'save@test.com', isAdmin: false, isMember: true };
     next();
   };
   return { ...actual, requireAuth: pass, requireAdmin: (_r: unknown, _s: unknown, n: () => void) => n() };
@@ -41,16 +42,42 @@ vi.mock('../../src/billing/stripe-client.js', () => ({
   createBillingPortalSession: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock('../../src/notifications/registry.js', () => ({
+  notifyRegistryCreate: vi.fn().mockResolvedValue(null),
+  notifyRegistryEdit: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/addie/mcp/registry-review.js', () => ({
+  reviewNewRecord: vi.fn().mockResolvedValue(undefined),
+  reviewRegistryEdit: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import { PropertyDatabase } from '../../src/db/property-db.js';
 import { HTTPServer } from '../../src/http.js';
+import { createPropertyToolHandlers, PROPERTY_TOOLS } from '../../src/addie/mcp/property-tools.js';
+import { MCPToolHandler, TOOL_DEFINITIONS } from '../../src/mcp-tools.js';
+import type { MCPAuthContext } from '../../src/mcp/auth.js';
 
 const DOMAIN_PREFIX = 'save-identity';
 const DOMAIN_LIKE = `${DOMAIN_PREFIX}-%`;
 const WITH_AGENTS = `${DOMAIN_PREFIX}-with-agents.registry-baseline.example`;
 const NO_AGENTS = `${DOMAIN_PREFIX}-no-agents.registry-baseline.example`;
 const EDIT_DOMAIN = `${DOMAIN_PREFIX}-edit.registry-baseline.example`;
+const HTTP_HOSTED_DOMAIN = `${DOMAIN_PREFIX}-http-hosted.registry-baseline.example`;
+const HTTP_COMMUNITY_DOMAIN = `${DOMAIN_PREFIX}-http-community.registry-baseline.example`;
+const HTTP_EDIT_DOMAIN = `${DOMAIN_PREFIX}-http-edit.registry-baseline.example`;
+const ADDIE_DOMAIN = `${DOMAIN_PREFIX}-addie.registry-baseline.example`;
+const MCP_DOMAIN = `${DOMAIN_PREFIX}-mcp.registry-baseline.example`;
+const ATTACKER_AGENT = 'https://agent.attacker.example';
+
+const mcpAuth: MCPAuthContext = {
+  sub: 'user_save_test',
+  isM2M: false,
+  email: 'save@test.com',
+  payload: {},
+};
 
 describe('POST /api/properties/save — identity, not authorization', () => {
   let server: HTTPServer;
@@ -158,5 +185,102 @@ describe('POST /api/properties/save — identity, not authorization', () => {
     expect(stored).not.toBeNull();
     const adagents = stored!.adagents_json as { authorized_agents: unknown[] };
     expect(adagents.authorized_agents).toEqual([]);
+  });
+
+  it('scrubs caller authorization on the authenticated hosted-property create route', async () => {
+    const res = await request(app)
+      .post('/api/properties/hosted')
+      .send({
+        publisher_domain: HTTP_HOSTED_DOMAIN,
+        adagents_json: {
+          authorized_agents: [{ url: ATTACKER_AGENT }],
+          properties: [{ type: 'website', name: 'Hosted route' }],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const stored = await propertyDb.getHostedPropertyByDomain(HTTP_HOSTED_DOMAIN);
+    expect((stored!.adagents_json as { authorized_agents: unknown[] }).authorized_agents).toEqual([]);
+  });
+
+  it('scrubs caller authorization on the member community-property create route', async () => {
+    const res = await request(app)
+      .post('/api/properties/hosted/community')
+      .send({
+        publisher_domain: HTTP_COMMUNITY_DOMAIN,
+        adagents_json: {
+          authorized_agents: [{ url: ATTACKER_AGENT }],
+          properties: [{ type: 'website', name: 'Community route' }],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const stored = await propertyDb.getHostedPropertyByDomain(HTTP_COMMUNITY_DOMAIN);
+    expect((stored!.adagents_json as { authorized_agents: unknown[] }).authorized_agents).toEqual([]);
+  });
+
+  it('scrubs caller authorization on the member community-property edit route', async () => {
+    await propertyDb.createHostedProperty({
+      publisher_domain: HTTP_EDIT_DOMAIN,
+      adagents_json: { authorized_agents: [{ url: ATTACKER_AGENT }], properties: [] },
+      source_type: 'community',
+      review_status: 'approved',
+      is_public: true,
+    });
+
+    const res = await request(app)
+      .put(`/api/properties/hosted/${encodeURIComponent(HTTP_EDIT_DOMAIN)}`)
+      .send({
+        edit_summary: 'Identity-only edit',
+        adagents_json: {
+          authorized_agents: [{ url: 'https://replacement.attacker.example' }],
+          properties: [{ type: 'website', name: 'Edited route' }],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const stored = await propertyDb.getHostedPropertyByDomain(HTTP_EDIT_DOMAIN);
+    expect((stored!.adagents_json as { authorized_agents: unknown[] }).authorized_agents).toEqual([]);
+  });
+
+  it('scrubs supplied and previously-preserved authorization on Addie approval', async () => {
+    await propertyDb.createHostedProperty({
+      publisher_domain: ADDIE_DOMAIN,
+      adagents_json: { authorized_agents: [{ url: ATTACKER_AGENT }], properties: [] },
+      source_type: 'community',
+      review_status: 'pending',
+      is_public: false,
+    });
+
+    const saveProperty = createPropertyToolHandlers().get('save_property');
+    const result = JSON.parse(await saveProperty!({
+      publisher_domain: ADDIE_DOMAIN,
+      authorized_agents: [{ url: 'https://replacement.attacker.example' }],
+      properties: [],
+    }));
+
+    expect(result.success).toBe(true);
+    const stored = await propertyDb.getHostedPropertyByDomain(ADDIE_DOMAIN);
+    expect((stored!.adagents_json as { authorized_agents: unknown[] }).authorized_agents).toEqual([]);
+  });
+
+  it('scrubs caller authorization on the authenticated directory MCP tool', async () => {
+    const result = await new MCPToolHandler().handleToolCall('save_property', {
+      publisher_domain: MCP_DOMAIN,
+      authorized_agents: [{ url: ATTACKER_AGENT }],
+      properties: [{ type: 'website', name: 'MCP route' }],
+    }, mcpAuth);
+
+    expect(result.isError).not.toBe(true);
+    const stored = await propertyDb.getHostedPropertyByDomain(MCP_DOMAIN);
+    expect((stored!.adagents_json as { authorized_agents: unknown[] }).authorized_agents).toEqual([]);
+  });
+
+  it('does not advertise authorized_agents on Addie or directory MCP save tools', () => {
+    const addieTool = PROPERTY_TOOLS.find(tool => tool.name === 'save_property');
+    const directoryTool = TOOL_DEFINITIONS.find(tool => tool.name === 'save_property');
+
+    expect(addieTool?.input_schema.properties).not.toHaveProperty('authorized_agents');
+    expect(directoryTool?.inputSchema.properties).not.toHaveProperty('authorized_agents');
   });
 });


### PR DESCRIPTION
## Summary

- force authorized_agents to an empty array across Addie, directory MCP, and authenticated hosted/community property write routes
- remove authorized_agents from both save_property tool schemas and stop Addie from preserving historical non-empty values during approval
- centralize the identity-only transformation while leaving origin-crawled documents untouched
- bump Addie CODE_VERSION for the tool behavior change

## Root cause

PR #5750 protected the public registry save route, but parallel hosted-property writers still accepted caller or model supplied authorized_agents. Addie could approve and immediately federate those claims, and its pending-row merge could preserve a historical spoof when the caller omitted the field.

Community registry data can describe publisher identity and catalog content, but only the publisher origin adagents.json can authorize a sales agent.

## Provenance audit

property-enhancement creates its own minimal pending document with authorized_agents empty. It records only whether origin validation succeeded and never copies the fetched origin body, so that path remains identity-only without altering origin-derived crawler storage.

## Validation

- registry property writer integration suite: 9 passed
- property enhancement integration suite: 2 passed
- npm run typecheck
- git diff --check

No changeset: this is server-side registry and Addie security hardening.

Closes #5751.