### PR TITLE
fix(oauth): block redirects for credential posts

### DIFF
--- a/server/src/utils/oauth-safe-fetch.ts
+++ b/server/src/utils/oauth-safe-fetch.ts
@@ -4,7 +4,9 @@ import { safeFetch } from './url-security.js';
  * Fetch adapter for server-side OAuth requests. OAuth discovery, dynamic
  * registration, and token exchange only use GET and POST requests, so keep
  * this surface deliberately narrow while routing every request and redirect
- * hop through the SSRF-safe fetcher.
+ * hop through the SSRF-safe fetcher. Credential-bearing POST requests never
+ * follow redirects; OAuth token and dynamic-registration endpoints are not
+ * expected to redirect, and forwarding their headers or bodies is unsafe.
  */
 export const oauthSafeFetch: typeof fetch = async (input, init) => {
   if (typeof input !== 'string' && !(input instanceof URL)) {
@@ -43,6 +45,7 @@ export const oauthSafeFetch: typeof fetch = async (input, init) => {
     method,
     headers,
     ...(body !== undefined && { body }),
+    ...(method === 'POST' && { maxRedirects: 0 }),
     ...(init?.signal && { signal: init.signal }),
   });
 };

--- a/server/tests/unit/oauth-safe-fetch.test.ts
+++ b/server/tests/unit/oauth-safe-fetch.test.ts
@@ -62,6 +62,7 @@ describe('oauthSafeFetch', () => {
         method: 'POST',
         headers: { 'content-type': 'application/x-www-form-urlencoded' },
         body: expectedBody,
+        maxRedirects: 0,
       },
     );
   });

--- a/server/tests/unit/url-security-redirects.test.ts
+++ b/server/tests/unit/url-security-redirects.test.ts
@@ -26,6 +26,74 @@ vi.mock('dns/promises', () => ({
 }));
 
 import { safeFetch } from '../../src/utils/url-security.js';
+import { oauthSafeFetch } from '../../src/utils/oauth-safe-fetch.js';
+
+describe('oauthSafeFetch redirect policy', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    agentMock.mockClear();
+    resolve4Mock.mockClear();
+    resolve6Mock.mockClear();
+    resolve4Mock.mockResolvedValue(['93.184.216.34']);
+    resolve6Mock.mockResolvedValue([]);
+  });
+
+  it.each([302, 307, 308])(
+    'does not forward credential-bearing POST data across a %i redirect',
+    async (status) => {
+      fetchMock.mockResolvedValueOnce(new Response('', {
+        status,
+        headers: { Location: 'https://attacker.example/collect' },
+      }));
+
+      const response = await oauthSafeFetch('https://auth.example/token', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Basic client-secret',
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: 'authorization-code',
+          code_verifier: 'pkce-verifier',
+        }),
+      });
+
+      expect(response.status).toBe(status);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe('https://auth.example/token');
+      expect(fetchMock.mock.calls[0][1]).toMatchObject({
+        method: 'POST',
+        headers: {
+          authorization: 'Basic client-secret',
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        body: 'grant_type=authorization_code&code=authorization-code&code_verifier=pkce-verifier',
+      });
+    },
+  );
+
+  it('continues to follow same-origin discovery GET redirects', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response('', {
+        status: 302,
+        headers: { Location: '/oauth-configuration' },
+      }))
+      .mockResolvedValueOnce(new Response('{"token_endpoint":"https://auth.example/token"}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+
+    const response = await oauthSafeFetch(
+      'https://auth.example/.well-known/oauth-authorization-server',
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe('https://auth.example/oauth-configuration');
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: 'GET' });
+  });
+});
 
 describe('safeFetch redirects', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- prevent OAuth token and dynamic-registration POST requests from following redirects
- preserve SSRF-safe redirect handling for discovery GET requests
- cover 302, 307, and 308 responses and verify credentials are never sent to the redirect target

## Dependency
This is intentionally stacked on #5961 because the scoped OAuth fetch adapter is not on main yet. Do not merge this PR before #5961. After #5961 merges, retarget this PR to main; auto-merge is intentionally disabled.

## Testing
- npx vitest run server/tests/unit/oauth-safe-fetch.test.ts server/tests/unit/url-security-redirects.test.ts --pool=threads (20 passed)
- npm run typecheck
- git diff --check

Closes #5963.