### PR TITLE
docs(media-buy): add Budget & Pacing Controls reference to create_media_buy

### DIFF
--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -1098,6 +1098,51 @@ Each package specifies its `pricing_option_id`, which determines:
 
 Packages can use different currencies when sellers support it. See [Pricing Models](/docs/media-buy/advanced-topics/pricing-models).
 
+### Budget & Pacing Controls
+
+Budget constraints are set **per package**, not at the media-buy level. The one exception is `total_budget`, which applies only when [executing a proposal](#executing-a-proposal) — the seller then derives per-package budgets from the proposal's allocation percentages.
+
+| Field | Level | Type | Controls |
+|-------|-------|------|----------|
+| `total_budget.amount` + `total_budget.currency` | Media buy | TotalBudget | Total spend when executing a proposal. Not used when supplying explicit `packages`. |
+| `budget` | Package | number | Total spend cap for the package, in the currency the package's `pricing_option_id` specifies. Delivery stops when the package budget is exhausted. |
+| `impressions` | Package | number | Impression goal for the package. An alternative volume target to `budget`; a seller may pace to whichever binds first. |
+| `pacing` | Package | enum | How the seller spreads the package budget across the flight: `even` (default), `asap`, or `front_loaded`. |
+| `bid_price` | Package | number | For auction pricing options — the exact bid, or the ceiling when the pricing option has `max_bid: true`. |
+| `start_time` / `end_time` | Package | string | The flight window the budget is spread across. When omitted, the package inherits the media buy's flight dates. |
+
+**Pacing modes** (from [`/schemas/v3/enums/pacing.json`](https://adcontextprotocol.org/schemas/v3/enums/pacing.json)):
+
+| Mode | Behavior |
+|------|----------|
+| `even` | Allocate remaining budget evenly over the remaining flight (default). |
+| `asap` | Spend remaining budget as quickly as possible. |
+| `front_loaded` | Allocate more of the remaining budget earlier in the remaining flight. |
+
+Example package with an even-paced budget over a fixed flight:
+
+```json
+{
+  "product_id": "prod_ctv_sports",
+  "pricing_option_id": "po_cpm_fixed",
+  "budget": 50000,
+  "pacing": "even",
+  "start_time": "2026-08-01T00:00:00Z",
+  "end_time": "2026-08-31T23:59:59Z"
+}
+```
+
+With `even` pacing over the 31-day flight above, the seller spreads the $50,000 budget across the month — roughly $1,613/day — subject to the seller's own pacing engine and available inventory.
+
+#### Known gap: no explicit daily cap
+
+AdCP 3.1 has **no per-day (or per-hour) budget cap field.** Delivery rate is governed by the combination of `budget`, `pacing`, and the flight window (`start_time` / `end_time`) — not a hard daily ceiling the buyer can pin. To constrain daily spend today:
+
+- **Approximate a daily rate** by setting `pacing: "even"` and choosing `budget` and flight length so `budget ÷ flight_days` lands near the target daily spend. Enforcement is seller-side and best-effort, not a guaranteed hard cap.
+- **Tighten the window** by splitting a long flight into shorter packages (e.g. weekly packages), each with its own `budget`, when finer control is needed.
+
+A first-class daily-cap field is not yet specified. Tracking: [#5983](https://github.com/adcontextprotocol/adcp/issues/5983).
+
 ### Targeting Overlays
 
 **Use sparingly** - most targeting should be in your brief and handled through product selection.

--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -250,6 +250,8 @@ Configure automated delivery reporting for this media buy:
 
 `package_id` is required to identify the package to update.
 
+For how `budget`, `pacing`, `impressions`, and flight dates interact — and the current lack of an explicit daily-cap field — see [Budget & Pacing Controls](/docs/media-buy/task-reference/create_media_buy#budget--pacing-controls) on the `create_media_buy` reference.
+
 ## Response
 
 ### Success Response


### PR DESCRIPTION
## Summary

Adds a **Budget & Pacing Controls** section to the `create_media_buy` reference, closing the documentation gap in #4429 (buyers asking Addie how to set budget/daily caps couldn't find a definitive reference).

- Enumerates every budget-constraint field in one table: `total_budget` (proposal path), package `budget`, `impressions`, `pacing`, `bid_price`, and the flight window (`start_time`/`end_time`) — with the level each lives at.
- Documents the three pacing modes (`even`, `asap`, `front_loaded`) from `pacing.json`.
- Worked example: an even-paced package budget over a fixed flight.
- **Marks the daily-cap gap explicitly:** AdCP 3.1 has no per-day cap field. Documents the pacing-based workaround and links the follow-up RFC (#5983) filed to track a first-class field.
- Cross-links the section from `update_media_buy`.

Verified against schema (`create-media-buy-request.json`, `package-request.json`, `pacing.json`) — no daily-cap field exists, confirming the gap. Example uses fictional IDs per the repo's no-real-brands rule.

Closes #4429

## Test plan

- [x] All documented fields verified against the source schemas
- [x] Schema link uses the canonical absolute form (passes `lint:schema-links`)
- [x] Cross-link anchor (`#budget--pacing-controls`) follows the repo's `&` → `--` slug convention
- [ ] Mintlify broken-links CI passes