### PR TITLE
fix(schema): require check_id on budget-committing report_plan_outcome outcomes (3.2 hardening)

### DIFF
--- a/.changeset/report-plan-outcome-check-id-required.md
+++ b/.changeset/report-plan-outcome-check-id-required.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": minor
+---
+
+Partial validation hardening (targets 3.2): enforce `check_id` on budget-committing `report_plan_outcome` outcomes. The schema description and task reference both state `check_id` is "Required for `completed` and `failed` outcomes," but `report-plan-outcome-request.json` never listed it in any `required[]`, so a conformant validator accepted a budget-committing self-report with no reference to the authorizing `check_governance` decision.
+
+Adds an `if/then` conditional: when `outcome` is `completed` or `failed`, `check_id` is required; `delivery` outcomes (not budget-committing) are unaffected. This aligns the schema with the already-documented contract — no prose change.
+
+**Scope note:** this is not the fix for #5827. `check_id` is a correlator, not a cryptographic binding between the verified authorization and the committed budget; the bound-token work that actually closes the P0 is deferred to the 3.2 governance design. This change only closes the enforcement drift where the schema failed to require a field its own prose marks required. Regression coverage added to `tests/composed-schema-validation.test.cjs`.

--- a/static/schemas/source/governance/report-plan-outcome-request.json
+++ b/static/schemas/source/governance/report-plan-outcome-request.json
@@ -7,6 +7,27 @@
   "allOf": [
     {
       "$ref": "/schemas/core/version-envelope.json"
+    },
+    {
+      "$comment": "check_id links the outcome to the check_governance decision that authorized it. Required for 'completed' and 'failed' outcomes so budget-committing self-reports cannot be submitted without a reference to the authorizing check (NS-GOV-002).",
+      "if": {
+        "properties": {
+          "outcome": {
+            "enum": [
+              "completed",
+              "failed"
+            ]
+          }
+        },
+        "required": [
+          "outcome"
+        ]
+      },
+      "then": {
+        "required": [
+          "check_id"
+        ]
+      }
     }
   ],
   "x-status": "experimental",

--- a/tests/composed-schema-validation.test.cjs
+++ b/tests/composed-schema-validation.test.cjs
@@ -2076,6 +2076,63 @@ async function runTests() {
   );
   log('');
 
+  // report_plan_outcome: check_id is required for budget-committing outcomes (partial hardening for 3.2; refs #5827)
+  log('Report Plan Outcome Schema (check_id binding):', 'info');
+  await testSchemaValidation(
+    '/schemas/governance/report-plan-outcome-request.json',
+    {
+      adcp_version: '3.1',
+      plan_id: 'plan_123',
+      outcome: 'completed',
+      check_id: 'chk_xyz789',
+      idempotency_key: 'idem_0123456789abcdef',
+      governance_context: 'ctx_abc',
+      seller_response: { committed_budget: 50000 }
+    },
+    'Accepts completed outcome carrying check_id'
+  );
+  await testSchemaRejection(
+    '/schemas/governance/report-plan-outcome-request.json',
+    {
+      adcp_version: '3.1',
+      plan_id: 'plan_123',
+      outcome: 'completed',
+      idempotency_key: 'idem_0123456789abcdef',
+      governance_context: 'ctx_abc',
+      seller_response: { committed_budget: 50000 }
+    },
+    'Rejects completed outcome missing check_id'
+  );
+  await testSchemaRejection(
+    '/schemas/governance/report-plan-outcome-request.json',
+    {
+      adcp_version: '3.1',
+      plan_id: 'plan_123',
+      outcome: 'failed',
+      idempotency_key: 'idem_0123456789abcdef',
+      governance_context: 'ctx_abc',
+      error: { code: 'BUDGET_EXCEEDED', message: 'over cap' }
+    },
+    'Rejects failed outcome missing check_id'
+  );
+  await testSchemaValidation(
+    '/schemas/governance/report-plan-outcome-request.json',
+    {
+      adcp_version: '3.1',
+      plan_id: 'plan_123',
+      outcome: 'delivery',
+      idempotency_key: 'idem_0123456789abcdef',
+      governance_context: 'ctx_abc',
+      delivery: {
+        reporting_period: { start: '2026-08-01T00:00:00Z', end: '2026-08-07T23:59:59Z' },
+        impressions: 100000,
+        spend: 5000
+      }
+    },
+    'Accepts delivery outcome without check_id (not budget-committing)'
+  );
+  log('');
+
   // Test 7: Bundled schemas (no $ref resolution needed)
   // Only test against latest/ — versioned dirs in dist/ may be from a prior release
   // and are not updated on every source change.


### PR DESCRIPTION
## Summary

**Reframed per @bokelley's review.** This is a narrow **validation-drift fix targeted at 3.2** — it does **not** close #5827, and does not claim to.

`report-plan-outcome-request.json` documents `check_id` as *"Required for `completed` and `failed` outcomes"* (both in the field description and the task reference), but never listed it in any `required[]`. A conformant validator therefore accepted a budget-committing self-report (`outcome: "completed"` / `"failed"`) carrying no reference to the authorizing `check_governance` decision.

Adds an `if/then` conditional: when `outcome` is `completed` or `failed`, `check_id` is required. `delivery` outcomes (not budget-committing) are unaffected. No prose change — the schema is brought in line with its own documented contract.

## Scope / release line
- **Targets 3.2** (changeset is now `minor`, was `patch`).
- **Not the #5827 fix.** `check_id` is a correlator, not a cryptographic binding between the verified authorization and the committed budget. The bound-token work that actually closes the P0 is deferred to the 3.2 governance design. This PR only closes the enforcement drift where the schema failed to require a field its own prose marks required. `Refs #5827`.
- Rebased onto `main` — the stray #5984 doc commit is gone; the branch now carries only the `report_plan_outcome` change.

## Test plan
- [x] `if/then` validates: accepts completed/failed with `check_id`, rejects without, accepts `delivery` without — in `composed-schema-validation`
- [x] Full composed suite green after rebase (resolved against the merged #5987 cancellation cases)
- [x] Changeset `minor`

If the WG would rather fold this into the 3.2 bound-token work wholesale, happy to close this in favor of that.