### PR TITLE
fix(schema): require cancellation_fee rate/amount by fee type

### DIFF
--- a/.changeset/cancellation-fee-required-conditionals.md
+++ b/.changeset/cancellation-fee-required-conditionals.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+Enforce `cancellation_fee.rate` / `.amount` by fee `type` in `cancellation-policy.json`. Both fields are documented as conditionally required — `rate` "Required when type is 'percent_remaining'", `amount` "Required when type is 'fixed_fee'" — and the requirement is restated in the pricing-models reference, but `cancellation_fee` listed only `["type"]` in `required[]`. A validator therefore accepted `{ "type": "percent_remaining" }` (or `{ "type": "fixed_fee" }`) with no fee value at all, leaving a money-path term that declares nothing computable for a buyer accepting the product's cancellation terms.
+
+Adds `if/then` conditionals: `percent_remaining` requires `rate`, `fixed_fee` requires `amount`; `full_commitment` and `none` are unaffected. No prose change — this aligns the schema with the already-documented contract, and no existing example regresses (both doc examples already carry `rate`). Regression coverage added to `tests/composed-schema-validation.test.cjs`.

--- a/static/schemas/source/core/cancellation-policy.json
+++ b/static/schemas/source/core/cancellation-policy.json
@@ -31,6 +31,24 @@
         }
       },
       "required": ["type"],
+      "allOf": [
+        {
+          "$comment": "rate quantifies a percent_remaining fee; without it the cancellation cost is undefined.",
+          "if": {
+            "properties": { "type": { "const": "percent_remaining" } },
+            "required": ["type"]
+          },
+          "then": { "required": ["rate"] }
+        },
+        {
+          "$comment": "amount quantifies a fixed_fee; without it the cancellation cost is undefined.",
+          "if": {
+            "properties": { "type": { "const": "fixed_fee" } },
+            "required": ["type"]
+          },
+          "then": { "required": ["amount"] }
+        }
+      ],
       "additionalProperties": true
     }
   },

--- a/tests/composed-schema-validation.test.cjs
+++ b/tests/composed-schema-validation.test.cjs
@@ -2032,6 +2032,50 @@ async function runTests() {
   );
   log('');
 
+  // cancellation_fee: rate/amount required by fee type (money-path integrity)
+  log('Cancellation Policy Schema (fee-type conditionals):', 'info');
+  await testSchemaValidation(
+    '/schemas/core/cancellation-policy.json',
+    {
+      notice_period: { interval: 30, unit: 'days' },
+      cancellation_fee: { type: 'percent_remaining', rate: 0.5 }
+    },
+    'Accepts percent_remaining fee carrying rate'
+  );
+  await testSchemaRejection(
+    '/schemas/core/cancellation-policy.json',
+    {
+      notice_period: { interval: 30, unit: 'days' },
+      cancellation_fee: { type: 'percent_remaining' }
+    },
+    'Rejects percent_remaining fee missing rate'
+  );
+  await testSchemaValidation(
+    '/schemas/core/cancellation-policy.json',
+    {
+      notice_period: { interval: 30, unit: 'days' },
+      cancellation_fee: { type: 'fixed_fee', amount: 2500 }
+    },
+    'Accepts fixed_fee carrying amount'
+  );
+  await testSchemaRejection(
+    '/schemas/core/cancellation-policy.json',
+    {
+      notice_period: { interval: 30, unit: 'days' },
+      cancellation_fee: { type: 'fixed_fee' }
+    },
+    'Rejects fixed_fee missing amount'
+  );
+  await testSchemaValidation(
+    '/schemas/core/cancellation-policy.json',
+    {
+      notice_period: { interval: 30, unit: 'days' },
+      cancellation_fee: { type: 'none' }
+    },
+    'Accepts none fee with neither rate nor amount'
+  );
+  log('');
+
   // Test 7: Bundled schemas (no $ref resolution needed)
   // Only test against latest/ — versioned dirs in dist/ may be from a prior release
   // and are not updated on every source change.


### PR DESCRIPTION
## Summary

Closes **#5986**. Money-path schema/prose drift in `core/cancellation-policy.json`.

`cancellation_fee.type` ∈ {`percent_remaining`, `full_commitment`, `fixed_fee`, `none`} is the only required property, but two siblings are documented as conditionally required and never enforced:

- `rate` — "Required when type is 'percent_remaining'"
- `amount` — "Required when type is 'fixed_fee'"

The requirement is also stated in the reference docs (`pricing-models.mdx`: "`percent_remaining` … (requires `rate`)"). A conformant validator nonetheless accepted `{ "type": "percent_remaining" }` — or `{ "type": "fixed_fee" }` — with no fee value, leaving the cancellation cost undefined for a buyer accepting the product's terms.

## Change

Adds two `if/then` conditionals on `cancellation_fee`:

- `type: "percent_remaining"` → require `rate`
- `type: "fixed_fee"` → require `amount`

`full_commitment` and `none` are unaffected. **No prose change** — this aligns the schema with its own already-documented contract. Same drift class as #5892 and #5827; scoped to one schema per the narrow-PR disposition on #5833.

## Test plan

Regression coverage added to `tests/composed-schema-validation.test.cjs`:

- [x] Accepts `percent_remaining` with `rate`; rejects without
- [x] Accepts `fixed_fee` with `amount`; rejects without
- [x] Accepts `none` with neither
- [x] `test:examples` (55) and `test:json-schema` (284 doc blocks) pass — no existing example regressed (both doc examples already carry `rate`)
- [x] Changeset included (patch)