### PR TITLE
docs(release): update 3.1 maintenance guidance

### DIFF
--- a/.agents/playbook.md
+++ b/.agents/playbook.md
@@ -250,7 +250,8 @@ When linking to schemas in docs, use the correct version alias:
 - `/schemas/v1/` → points to `latest` (for backward compatibility)
 - `/schemas/latest/` → development version (`static/schemas/source/`)
 
-This avoids drift with the release-line section below, where `3.0.x` continues to advance after release candidates.
+This avoids drift with the release-line section below, where maintenance
+patches continue to advance independently of the next-minor line.
 
 **CI validation:** The `check-schema-links.yml` workflow validates schema URLs in PRs and will warn about unreleased schemas or suggest the correct version.
 
@@ -376,47 +377,60 @@ Only use `patch`/`minor`/`major` when the change affects the published AdCP prot
 
 ### Release lines
 
-AdCP runs two release lines simultaneously:
+AdCP runs two active release lines:
 
-- **`main`** → next minor (currently `3.1.0-beta.N` while in pre mode; see `.changeset/pre.json`)
-- **`3.0.x`** → patches to the current minor (`3.0.2`, `3.0.3`, …)
+- **`3.1.x`** → stable maintenance patches (`3.1.4`, `3.1.5`, …)
+- **`main`** → the next minor, which must use Changesets beta pre mode
+  (`.changeset/pre.json`) to produce `3.2.0-beta.N`
 
 Branch naming follows `<major>.<minor>.x` to match the existing `2.6.x` precedent. No `release/` prefix.
+
+The root `adcontextprotocol` package is private. Changesets versions it so the
+release workflow can tag and build immutable protocol artifacts, but the
+package is never published to npm. Distribution is the signed protocol
+tarball on the GitHub Release and artifact CDN. `@adcp/sdk` is published from
+the separate `adcp-client` repository.
 
 #### Cherry-pick convention
 
 Default flow when a fix is needed in both lines:
 
 1. Author lands on `main` first (normal PR flow)
-2. After merge, cherry-pick to `3.0.x`:
+2. After merge, cherry-pick to a clean branch based on `3.1.x` and open a PR:
    ```bash
-   git checkout 3.0.x && git pull
+   git fetch origin
+   git checkout -b backport/3.1.x-<descriptor> origin/3.1.x
    git cherry-pick <main-sha>
-   git push origin 3.0.x
+   git push -u origin backport/3.1.x-<descriptor>
+   gh pr create --base 3.1.x --head backport/3.1.x-<descriptor>
    ```
-3. The forward-merge workflow (`.github/workflows/forward-merge-3.0.yml`) opens a PR back to `main` whenever `3.0.x` updates. Merging it keeps the lines provably in sync. Auto-resolution is **metadata-only** — anything else fails the workflow loud and requires human review.
+3. After the backport and Version Packages PRs merge, the forward-merge
+   workflow (`.github/workflows/forward-merge-3.1.yml`) opens a PR back to
+   `main`. Direction is **only `3.1.x → main`**; never merge `main` into
+   `3.1.x`. Auto-resolution is metadata-only — anything else fails loud and
+   requires human review.
 
    **Auto-resolved (metadata that legitimately diverges by-design):**
-   - `package.json` / `package-lock.json` → preserve main's (main may carry structural changes — package renames, new deps — that 3.0.x doesn't)
+   - `package.json` / `package-lock.json` → preserve main's (main may carry structural changes and 3.2 prerelease metadata)
    - `.changeset/*.md` / `.changeset/pre.json` → preserve main's (independent pre-mode pool)
    - `static/schemas/source/index.json` / `static/schemas/source/registry/index.yaml` → preserve main's (branch-local package/version metadata must stay aligned with main)
-   - `CHANGELOG.md` → take 3.0.x's (main's next Version Packages cut prepends its own entries above)
-   - `dist/{schemas,compliance,protocol,docs}/*` → take 3.0.x's (immutable per release; main only ever ADDS)
+   - `CHANGELOG.md` → take 3.1.x's (main's next Version Packages cut prepends its own entries)
+   - `dist/{schemas,compliance,protocol,docs}/*` → take 3.1.x's (immutable release artifacts; main only adds versions)
 
-   **Fails loud (everything else):** every other conflict is a real backport decision and surfaces for human review. This includes the known cross-line divergences in `static/compliance/source/universal/{storyboard-schema,runner-output-contract}.yaml`, `static/schemas/source/{core/error.json,enums/error-code.json,protocol/get-adcp-capabilities-response.json}`, `.github/workflows/training-agent-storyboards.yml`, and `docs/building/implementation/error-handling.mdx` — main carries 3.1-track additions (new enum codes, schema discriminators, the CANONICAL CHECK ENUM block) that can't ship to 3.0.x without breaking the patch contract. Each push to 3.0.x that touches one of these regions will require a manual forward-merge PR until 3.1.0 cuts and replaces both lines.
-
-   **Why metadata-only:** an earlier version of the workflow auto-resolved the cross-line content files via whole-file `git checkout --ours`, which silently dropped 3.0.x's non-conflicting changes alongside the divergent regions. Five days of patches (v3.0.5 → v3.0.9, ~30 commits) silently failed to forward-merge before the bug was found. Loud failure on every content conflict is the right primitive: it's annoying for the divergent files but it surfaces real decisions instead of dropping work. See #4306 / #4308 / #4310 for context.
+   **Fails loud (everything else):** every other conflict is a real decision
+   about whether the stable patch belongs on the 3.2 line. Never resolve a
+   whole content file with `git checkout --ours`; that can silently discard
+   non-conflicting maintenance changes.
 
    **Manual resolution recipe** (when the workflow fails):
    ```bash
    git fetch origin
-   git checkout -b forward-merge/3.0.x-<descriptor> origin/main
-   git merge origin/3.0.x  # resolve conflicts in editor — for the 7 known-divergent files,
-                            # take main's side (it carries 3.1-track shape)
-   git push origin forward-merge/3.0.x-<descriptor>
-   gh pr create --base main --head forward-merge/3.0.x-<descriptor>
+   git checkout -b forward-merge/3.1.x-<descriptor> origin/main
+   git merge origin/3.1.x  # resolve every content conflict deliberately
+   git push origin forward-merge/3.1.x-<descriptor>
+   gh pr create --base main --head forward-merge/3.1.x-<descriptor>
    ```
-   Branch name **must** start with `forward-merge/` — the changeset-check workflow skips on this prefix (the merge brings package-changing commits whose changesets were already consumed by 3.0.x's Version Packages cut).
+   Branch name **must** start with `forward-merge/` — the changeset-check workflow skips on this prefix (the merge brings package-changing commits whose changesets were already consumed by 3.1.x's Version Packages cut).
 
 4. **Skip rules for release-machinery PRs.** The changeset-check workflow (`.github/workflows/changeset-check.yml`) skips PRs whose `head_ref` starts with:
    - `changeset-release/` — Version Packages PRs (changesets already consumed)
@@ -430,9 +444,11 @@ For each surface a PR touches, the corresponding rule must hold. A PR touching m
 
 **Stable schemas** — no new fields, no renamed fields, no new enum values, no new error codes, no new normative requirements. Clarifications are patch-eligible only when both:
 1. The prior spec was demonstrably silent or ambiguous on the input (not just unstated), AND
-2. Any conformant 3.0.0 implementation of the surrounding behavior would already satisfy the new MUST.
+2. Any conformant 3.1.0 implementation of the surrounding behavior would already satisfy the new MUST.
 
-If a previously-conformant implementation could fail the clause, it's a new requirement and ships in `3.1.x` only. (This is the IETF errata vs. bis test.)
+If a previously-conformant implementation could fail the clause, it is a new
+requirement and ships in 3.2, not a 3.1.x patch. (This is the IETF errata vs.
+bis test.)
 
 **Experimental surfaces** (governance, TMP, anything `x-status: experimental`) — additive changes are always patch-eligible without notice. Breaking changes follow the 6-week notice rule in `docs/reference/experimental-status.mdx` and therefore ship in the next minor, not a patch.
 
@@ -450,76 +466,48 @@ If a previously-conformant implementation could fail the clause, it's a new requ
 These are version-level concerns. Security fixes ship as out-of-band advisories or in the next minor.
 
 If unsure, default to no changeset and discuss whether the change belongs on
-`3.0.x` at all. Many fixes are stable-only and ship in `3.1.x` only.
+`3.1.x` at all. New protocol surface stays on `main` for 3.2.
 
 #### Pre mode (beta releases)
 
-`.changeset/pre.json` puts main in **pre mode** — every Version Packages cut produces `3.1.0-beta.N` instead of `3.1.0`. This is a deliberate safety net: if a `minor` changeset slips into `main` accidentally, it ships as a beta drop, not as 3.1.0 stable.
+When present, `.changeset/pre.json` puts `main` in **beta pre mode**. During
+3.2 development, every Version Packages cut must produce `3.2.0-beta.N`,
+never stable `3.2.0`. Enter pre mode before accepting 3.2 release changes, in
+a reviewed PR:
 
-To exit pre mode and cut 3.1.0 stable:
+```bash
+npx changeset pre enter beta
+git add .changeset/pre.json
+git commit -m "chore(release): enter pre mode for 3.2 beta"
+```
+
+The pre-mode file and pending 3.2 changesets belong only on `main`; the
+forward-merge workflow preserves main's copies. Do not cherry-pick them to
+`3.1.x`.
+
+To exit pre mode for the eventual 3.2 stable cut:
 
 ```bash
 npx changeset pre exit   # deletes .changeset/pre.json
-git add -A && git commit -m "chore(release): exit pre mode for 3.1.0 stable cut"
+git add -A && git commit -m "chore(release): exit pre mode for 3.2 stable cut"
 # open PR, land it
 ```
 
-Next Version Packages cut after the exit PR merges produces `3.1.0` stable.
-
-The stable cut is not complete until public docs and package tags stop presenting
-the line as a prerelease:
-
-- Mintlify navigation uses the stable label (`3.1`), not `3.1-rc` or
-  `3.1-beta`, and points at the final `dist/docs/3.1.0/` snapshot after the docs
-  snapshot PR lands.
-- The docs banner says 3.1 is released or is removed. No primary docs page
-  should say 3.1 is still in RC validation.
-- Release notes, versions, what's-new, and migration pages describe the final
-  GA release. Keep RC/beta guidance only in prerelease migration/archive pages.
-- SDK examples on GA-facing pages use the stable wire pin (`"3.1"`). Exact RC
-  pins belong only in prerelease guidance.
-- npm dist-tags for the stable line point at the intended GA package. Old
-  beta/RC package versions remain available.
-
-#### When 3.1.0 cuts — release-line transition
-
-Cutting 3.1.0 ends the 3.0.x ↔ main divergence and starts a new 3.0.x → 3.1.x lifecycle. Steps to take **at the same time as the 3.1.0 stable release**:
-
-1. **Cut the `3.1.x` branch.** Branch off `main` immediately after the 3.1.0 tag is published:
-   ```bash
-   git checkout main && git pull
-   git checkout -b 3.1.x origin/main
-   git push -u origin 3.1.x
-   ```
-   `main` then advances toward `3.2.0-beta.N` (re-enter pre mode with `npx changeset pre enter beta` and a new `.changeset/pre.json`).
-
-2. **Update `forward-merge-3.0.yml` → `forward-merge-3.1.yml`.** The workflow targets `3.1.x` now; rename the file and update `branches:` and the merge target. Keep `3.0.x` only if 3.0.x stays in maintenance for security fixes (see step 4).
-
-3. **Reset the auto-resolve allowlist if needed.** When 3.1.0 absorbs the 3.1-track additions on main, the cross-line divergences in `error-code.json`, `error.json`, `runner-output-contract.yaml`, `storyboard-schema.yaml`, `get-adcp-capabilities-response.json`, `training-agent-storyboards.yml`, and `error-handling.mdx` collapse — `3.1.x` and `main` start identical. The allowlist stays metadata-only (the same list as for 3.0.x is correct for 3.1.x), but the **known-divergent file list documented in the cherry-pick section above no longer applies**. Update that list in this playbook to reflect any new 3.2-track-only divergences that emerge.
-
-4. **Decide 3.0.x's fate.** Options:
-   - **Sunset immediately**: archive the `3.0.x` branch, stop publishing patches. Document the EOL in `docs/reference/version-support.mdx` and announce in the release notes.
-   - **Maintenance window**: keep `3.0.x` for security-only fixes for N months. If you do this, **also keep `forward-merge-3.0.yml`** so security patches still flow forward — but expect every push to fail loud (3.1.x has structurally diverged from 3.0.x at this point) and require manual resolution. Maintenance windows are heavy ops; only do this if there's an active security commitment.
-
-5. **Update `RELEASING.md` and this playbook** with the new release-line topology. The stale 3.0.x examples in this section will need to be rewritten in terms of 3.1.x.
-
-**Lessons captured from the 3.0.x line** (apply to every future maintenance line):
-- **Never auto-resolve content files with `git checkout --ours` on whole files.** Whole-file resolution silently drops non-conflict changes. Allowlist metadata only; let content fail loud.
-- **The forward-merge workflow's exit code must reflect actual merge state.** A "success" run that produced no PR for a non-empty divergence is a silent failure mode. Always log the merge tree-state explicitly (the workflow now does: `git diff --quiet origin/main HEAD` gates the PR-creation step).
-- **Permanent cross-line divergences accumulate.** Once a file has any divergent region, every subsequent 3.0.x patch that lands near that region produces a real conflict. Manual forward-merges are the steady state, not the exception. Plan ops capacity accordingly.
-- **Forward-merge PRs can't carry their own changesets** — the source branch's changesets are already consumed. The changeset-check workflow needs an explicit skip rule keyed on `head_ref` prefix (`forward-merge/*`). Carry this skip rule forward when you create the 3.1.x → main pipeline.
-- **Reference implementations should land on `main` first**, then cherry-pick to maintenance lines only when truly needed (security, severe bugs). Don't dual-track features — that's how you grow the divergent-file list.
+Do not exit pre mode until the 3.2 freeze and GA checklist are explicitly
+approved. The next Version Packages cut after the exit PR produces stable
+`3.2.0`.
 
 #### App-token convention
 
-`release.yml`, `release-docs.yml`, and `forward-merge-3.0.yml` mint a GitHub App installation token via `actions/create-github-app-token@v3` (secrets `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) instead of using the default `GITHUB_TOKEN`. App-token-triggered events (push, PR open, release publish) DO fire downstream workflows; `GITHUB_TOKEN`-triggered events don't (GitHub's recursion-blocking rule). Without this swap, the Version Packages PR's required CI never fires, the release-docs snapshot is never created on `release: published`, and the auto-snapshot PR's required CI never fires either.
+`release.yml`, `release-docs.yml`, and `forward-merge-3.1.yml` mint a GitHub App installation token via `actions/create-github-app-token@v3` (secrets `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) instead of using the default `GITHUB_TOKEN`. App-token-triggered events (push, PR open, release publish) DO fire downstream workflows; `GITHUB_TOKEN`-triggered events don't (GitHub's recursion-blocking rule). Without this swap, the Version Packages PR's required CI never fires, the release-docs snapshot is never created on `release: published`, and the auto-snapshot PR's required CI never fires either.
 
 Two Apps, two trust surfaces: release machinery uses the release App above; the Secretariat (Argus reviews in `ai-review.yml`, server-side GitHub writes from Addie jobs) uses the **AAO Secretariat** App (`aao-secretariat[bot]`, secrets `SECRETARIAT_APP_ID` / `SECRETARIAT_APP_PRIVATE_KEY` — Actions secrets for the workflow, Fly secrets for the server). Server code mints installation tokens through `server/src/addie/jobs/github-app-token.ts`; `resolveGitHubToken()` is the single seam, and a configured-but-failing App fails closed rather than falling back to a PAT.
 
 #### Runbooks
 
-- `.agents/shortcuts/cut-patch.md` — cutting a `3.0.X` patch
-- `.agents/shortcuts/cut-beta.md` — cutting a `3.1.0-beta.N` and exiting pre mode for 3.1.0 stable
+- `.agents/shortcuts/cut-patch.md` — cutting a `3.1.X` patch
+- `RELEASING.md` — current `3.2.0-beta.N` pre-mode operation and release verification
+- `.agents/shortcuts/cut-beta.md` — historical 3.1 beta/GA transition notes
 - `.agents/shortcuts/cut-major.md` — cutting a major (4.0 when its time comes)
 
 ### Addie Code Version

--- a/.agents/shortcuts/cut-patch.md
+++ b/.agents/shortcuts/cut-patch.md
@@ -1,88 +1,105 @@
-# Cut a 3.0.X Patch Release
+# Cut a 3.1.X Patch Release
 
-Runbook for cutting a patch release on the `3.0.x` line. Patches ship docs corrections, normative clarifications on stable surfaces, additive changes on experimental surfaces, or fixes to release tooling.
+Runbook for the stable `3.1.x` maintenance line. See `.agents/playbook.md`
+§ Release lines for the patch contract.
 
-See `.agents/playbook.md` § Release lines for what counts as patch-eligible.
+The root protocol package is private. This process creates a tag, GitHub
+Release, signed protocol bundle, CDN artifacts, and docs snapshot; it does not
+publish `adcontextprotocol` to npm.
 
-## Preconditions
+## 1. Audit and backport
 
-- A patch-eligible fix has merged to `main` (the cherry-pick convention — see playbook).
-- `3.0.x` branch exists and tracks the prior patch tag (`v3.0.1`, `v3.0.2`, …).
-
-## 1. Audit patch eligibility BEFORE cherry-picking
-
-Before cherry-picking, inspect the changeset(s) added by the source commit on `main`:
-
-```bash
-MAIN_SHA=<main-merge-commit-sha>
-git show "$MAIN_SHA" -- .changeset/ | head -30
-```
-
-Any frontmatter line `"adcontextprotocol": (minor|major)` is a stop. **Do not cherry-pick changes whose changeset bumps the protocol package above patch.** A minor on `3.0.x` would cut `3.1.0` from the patch line — exactly the failure mode this audit prevents.
-
-If the source commit's only protocol changesets are `"adcontextprotocol": patch`, proceed. If the commit has no changeset, it probably is not a protocol patch release candidate; do not add an empty changeset just to cut a package version.
-
-If the change is genuinely patch-eligible (per `.agents/playbook.md` § Patch eligibility) but the original commit shipped a higher bump, you'll need to author a fresh patch-level protocol changeset for the cherry-pick. Land that on `main` first, then cherry-pick.
-
-## 2. Cherry-pick the fix to 3.0.x
+Patch candidates land on `main` first. Inspect the merged commit before
+backporting:
 
 ```bash
-git checkout 3.0.x
-git pull origin 3.0.x
-git cherry-pick <main-sha>
+MAIN_SHA=<main-merge-sha>
+git show "$MAIN_SHA" -- .changeset/
+git cherry origin/3.1.x "$MAIN_SHA" "$MAIN_SHA^"
 ```
 
-If the cherry-pick conflicts, you have two options:
+- A protocol changeset must say `"adcontextprotocol": patch`.
+- `minor` or `major` is a stop; do not downgrade it on the maintenance branch.
+- No changeset is correct for non-protocol docs/tooling, but those changes do
+  not create a release by themselves.
+- Confirm the change is absent from `3.1.x` and does not depend on 3.2-only
+  fields, enums, tasks, or behavior.
 
-- **Resolve and continue** — only if the conflict is mechanical (line-noise rebase artifacts). Run `git cherry-pick --continue` after staging.
-- **Abort** — `git cherry-pick --abort` and stop. Conflicting cherry-picks usually mean the fix depends on minor-line changes that aren't on `3.0.x`, which means the fix isn't patch-eligible as-is. Either author a 3.0.x-specific version of the fix on a fresh branch, or accept that the fix only ships in 3.1.x.
-
-**Do not push a half-resolved cherry-pick.** When you've successfully completed the cherry-pick:
+Prepare a reviewed backport PR rather than pushing directly:
 
 ```bash
-git push origin 3.0.x
+git fetch origin
+git switch -c backport/3.1.x-<descriptor> origin/3.1.x
+git cherry-pick "$MAIN_SHA"
+git diff --check origin/3.1.x...HEAD
+git push -u origin backport/3.1.x-<descriptor>
+gh pr create --base 3.1.x --head backport/3.1.x-<descriptor>
 ```
 
-## 3. Wait for the Version Packages PR
+Abort a conflict that reveals a 3.2 dependency. Resolve only changes whose
+3.1 behavior remains patch-compatible, then run the focused tests plus schema,
+compliance, typecheck, and Changesets status checks appropriate to the diff.
 
-`release.yml` fires on push to `3.0.x`, runs `changesets/action`, and opens (or refreshes) the Version Packages PR on `changeset-release/3.0.x`. The PR title is `Version Packages` and its body lists `adcontextprotocol@3.0.X`.
+## 2. Review the Version Packages PR
 
-**Verify the bump level and scope on the PR body.** The body shows `## adcontextprotocol@3.0.X` and a `### Patch Changes` section. If you see `### Minor Changes` or `### Major Changes`, stop — a non-patch changeset slipped through. If you see app, site, billing, admin, Addie, newsletter, digest, infra, migration-only, or operational work under the package release, stop — a non-protocol changeset slipped through. Find the offending changeset on `3.0.x` (`git diff v3.0.{X-1}..3.0.x -- .changeset/`), drop it, fix on `main`, re-cherry-pick.
+After the backport merges, `release.yml` refreshes
+`changeset-release/3.1.x`.
 
-## 4. Review and merge
+Before merging, verify:
 
-Required CI runs automatically (the Release workflow uses an App token, so its push events fire downstream workflows). Approve and merge through normal review.
+- the body lists only `adcontextprotocol@3.1.X` under `Patch Changes`;
+- no app, website, Addie, infrastructure, or operational entry leaked into
+  the protocol changelog;
+- `package.json`, `CHANGELOG.md`, versioned schemas/compliance, and
+  `dist/protocol/3.1.X.tgz{,.sha256,.sig,.crt}` agree on the version; and
+- required CI and human review are green.
 
-## 5. Tag + release
+If the body shows `Minor Changes` or `Major Changes`, stop and remove or
+correct the offending changeset on `main` before rebuilding the backport.
 
-The Release workflow runs `npm run version` (writes `package.json: "version": "3.0.X"`, builds + signs the protocol tarball), creates the GitHub Release, and tags `v3.0.X`.
+## 3. Merge and verify (3.1.5 example)
 
-**If the Release workflow fails after merge** (e.g., `changeset tag` silent no-op, cosign signing failure, tag creation rejected), recover manually following the same fallback pattern as `cut-major.md` § 4:
+Merge the Version Packages PR. The workflow tags the merge, creates the
+GitHub Release, uploads four assets, publishes them to R2, and verifies the
+CDN copy.
 
 ```bash
-VERSION=3.0.X
-MERGE_SHA=$(git rev-parse origin/main)
-git tag -a "v$VERSION" "$MERGE_SHA" -m "AdCP $VERSION"
-git push origin "v$VERSION"
-gh release create "v$VERSION" --title "AdCP v$VERSION" --latest \
-  --notes-file /tmp/release-notes.md \
-  dist/protocol/$VERSION.tgz{,.crt,.sha256,.sig}
+VERSION=3.1.5
+
+git fetch origin --tags
+test "$(git rev-parse "v$VERSION^{}")" = "$(git rev-parse origin/3.1.x)"
+gh release view "v$VERSION" --json tagName,targetCommitish,assets,url
+
+tmpdir="$(mktemp -d)"
+gh release download "v$VERSION" --dir "$tmpdir"
+cd "$tmpdir"
+shasum -a 256 -c "$VERSION.tgz.sha256"
+cosign verify-blob \
+  --signature "$VERSION.tgz.sig" \
+  --certificate "$VERSION.tgz.crt" \
+  --certificate-identity-regexp '^https://github\.com/adcontextprotocol/adcp/\.github/workflows/release\.yml@refs/heads/.*$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  "$VERSION.tgz"
+
+curl -fsSI "https://adcontextprotocol.org/protocol/$VERSION.tgz"
+curl -fsS "https://adcontextprotocol.org/schemas/$VERSION/index.json" >/dev/null
+curl -fsS "https://adcontextprotocol.org/compliance/$VERSION/index.json" >/dev/null
 ```
 
-## 6. Docs snapshot
+The GitHub Release must contain exactly the tarball, `.sha256`, `.sig`, and
+`.crt` assets. Existing assets are immutable; never overwrite a digest
+mismatch.
 
-`release-docs.yml` fires automatically on `release: published`, snapshots `dist/docs/$VERSION/`, opens an auto-merging PR titled `chore: snapshot docs for v$VERSION`. Required CI runs; auto-merge fires when green.
+## 4. Complete downstream work
 
-## 7. Forward-merge to main
+- Merge the automatic docs snapshot PR and confirm `dist/docs/3.1.5/` plus the
+  stable `3.1` docs selector.
+- Review and merge the automatic `3.1.x → main` forward-merge PR. Never merge
+  `main` into `3.1.x`; main must retain its 3.2 pre-mode metadata and
+  changesets.
+- Confirm the tag targets the Version Packages merge and no release commits
+  are stranded: `git log v3.1.5..origin/3.1.x` should be empty.
 
-The `forward-merge-3.0.yml` workflow opens a PR back to `main` automatically. Review (typically a near-no-op since the patch came from `main` originally) and merge.
-
-## 8. Verification checklist
-
-- [ ] Tag `v3.0.X` exists; GitHub Release renders
-- [ ] `https://adcontextprotocol.org/protocol/3.0.X.tgz` returns 200
-- [ ] `https://adcontextprotocol.org/schemas/3.0.X/` directory listing works
-- [ ] Docs site at the `3.0` selector reflects the new patch content (Mintlify redeploy after snapshot PR merges)
-- [ ] Forward-merge PR opened and merged so `main` includes the patch
-- [ ] No stranded patches: `git log v3.0.X..origin/3.0.x` is empty after forward-merge
-- [ ] CHANGELOG.md on `main` has the new `## 3.0.X` block
+If automation fails after the Version Packages merge, prefer fixing and
+rerunning the workflow. Use `.agents/shortcuts/cut-major.md` § 4 for manual
+tag/release recovery only when rerun is unsafe or impossible.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,232 +1,123 @@
 # Release Process
 
-This document describes how to manage releases of the AdCP specification using Changesets. **For deeper operational guidance** — release lines, cherry-pick conventions, the forward-merge workflow, manual resolution recipes, and the 3.1.0 transition plan — see `.agents/playbook.md` (§ Release lines). The playbook is canonical; this file is the introductory walkthrough.
+This is the operational overview for AdCP releases. For patch eligibility and
+conflict policy, see `.agents/playbook.md` (§ Release lines). For the complete
+maintenance-line checklist, see `.agents/shortcuts/cut-patch.md`.
 
-## Overview
+## Current topology
 
-We use [Changesets](https://github.com/changesets/changesets) to manage versions and releases. Changesets automatically:
+- `3.1.x` is the stable maintenance line. Patch fixes are reviewed on `main`
+  first, then cherry-picked to a PR targeting `3.1.x`.
+- `main` is the next-minor line. It must be in Changesets beta pre mode
+  (`.changeset/pre.json` with `"tag": "beta"`) while developing 3.2, so its
+  Version Packages PRs produce `3.2.0-beta.N` rather than stable `3.2.0`.
+- Forward merges are one-way: `3.1.x → main`. Never merge `main` into the
+  maintenance branch.
 
-- Updates `package.json` version
-- Updates all schema `adcp_version` defaults
-- Updates documentation examples
-- Generates CHANGELOG entries
-- Creates git tags
+The root `adcontextprotocol` package is private. Its version is release
+metadata for Changesets and the protocol artifacts; it is **not published to
+npm**. Protocol releases are distributed as signed tarballs through GitHub
+Releases and `https://adcontextprotocol.org/protocol/`. SDK npm releases happen
+in the separate `adcp-client` repository.
 
-AdCP runs **two release lines simultaneously**: `main` (next minor, currently `3.1.0-beta.N`) and `3.0.x` (patches to the current stable). Most contributors only touch `main` — the cherry-pick + forward-merge dance is documented in the playbook for cases where a fix needs to ship in both lines.
+## Changes and changesets
 
-## Workflow
-
-### 1. Making Changes
-
-When you make changes to the protocol (adding features, fixing bugs, etc.):
+Protocol changes need a changeset:
 
 ```bash
 npm run changeset
 ```
 
-This will prompt you to:
-1. Select the type of change (patch/minor/major)
-2. Write a description of the change
+Use `patch` for compatible fixes and clarifications, `minor` for additive
+stable protocol surface, and `major` for breaking stable changes. Addie,
+website, infrastructure, internal tooling, and non-normative docs do not get a
+protocol changeset.
 
-A changeset file will be created in `.changeset/` directory. Commit this with your changes.
+For a fix that must ship in 3.1.x:
 
-### 2. Creating a Release
+1. Land the normal PR on `main`.
+2. Confirm every protocol changeset in the merged commit is `patch`.
+3. Create a clean branch from `origin/3.1.x`, cherry-pick the merged commit,
+   resolve only maintenance-compatible conflicts, and open a PR to `3.1.x`.
+4. Merge only after CI and human review. The push to `3.1.x` refreshes the
+   `changeset-release/3.1.x` Version Packages PR.
 
-When ready to release:
+Do not downgrade a `minor` or `major` changeset during a backport. Reclassify
+the change on `main` first or leave it for 3.2.
 
-```bash
-npm run version
-```
+## Cutting a 3.1.x patch
 
-This will:
-- Apply all pending changesets
-- Update `package.json` version
-- Run `scripts/update-schema-versions.js` to sync all schemas and docs
-- Update CHANGELOG.md
+1. Audit `changeset-release/3.1.x`. The PR must show only
+   `adcontextprotocol@3.1.X` under `Patch Changes`; unexpected non-protocol or
+   higher-level entries are a stop.
+2. Review the generated version, changelog, versioned schemas/compliance, and
+   `dist/protocol/3.1.X.tgz{,.sha256,.sig,.crt}`.
+3. Merge the Version Packages PR. `release.yml` tags `v3.1.X`, creates the
+   GitHub Release, uploads the four assets, publishes the immutable artifacts
+   to R2, and verifies the CDN copy. It does not run `npm publish`.
+4. Let `release-docs.yml` open and merge the versioned docs snapshot PR.
+5. Review and merge the automated forward-merge PR from `3.1.x` to `main`.
+   Metadata may resolve by policy; content conflicts require human review.
 
-Review the changes, then commit:
+## Patch verification (3.1.5 example)
 
-```bash
-git add -A
-git commit -m "Version packages"
-git push
-```
-
-Or use the convenience script:
-
-```bash
-npm run release
-```
-
-### 3. Tagging the Release
-
-After the version commit is merged to main:
+Use the exact release version; do not verify through a moving alias:
 
 ```bash
-git tag -a v0.5.0 -m "Release v0.5.0"
-git push origin v0.5.0
+VERSION=3.1.5
+
+git fetch origin --tags
+git rev-parse "v$VERSION^{}"
+git rev-parse origin/3.1.x
+gh release view "v$VERSION" --json tagName,targetCommitish,assets,url
+
+tmpdir="$(mktemp -d)"
+gh release download "v$VERSION" --dir "$tmpdir"
+cd "$tmpdir"
+shasum -a 256 -c "$VERSION.tgz.sha256"
+cosign verify-blob \
+  --signature "$VERSION.tgz.sig" \
+  --certificate "$VERSION.tgz.crt" \
+  --certificate-identity-regexp '^https://github\.com/adcontextprotocol/adcp/\.github/workflows/release\.yml@refs/heads/.*$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  "$VERSION.tgz"
+
+curl -fsSI "https://adcontextprotocol.org/protocol/$VERSION.tgz"
+curl -fsS "https://adcontextprotocol.org/schemas/$VERSION/index.json" >/dev/null
+curl -fsS "https://adcontextprotocol.org/compliance/$VERSION/index.json" >/dev/null
 ```
 
-Then create a GitHub release from the tag.
+Then confirm:
 
-## Version Management
+- the tag and `origin/3.1.x` identify the Version Packages merge;
+- the GitHub Release has exactly the tarball, checksum, signature, and
+  certificate assets;
+- `dist/docs/3.1.5/` lands on `main` and the `3.1` docs selector reflects it;
+- the `3.1.x → main` forward-merge PR lands; and
+- `git log v3.1.5..origin/3.1.x` contains no stranded release work.
 
-### Semantic Versioning
+## 3.2 beta pre mode
 
-We follow [Semantic Versioning](https://semver.org/):
-
-- **Patch** (0.5.x): Bug fixes, documentation clarifications, schema fixes
-  - Fix typos in schemas or docs
-  - Correct validation patterns
-  - Fix broken references
-
-- **Minor** (0.x.0): New features, backward-compatible changes
-  - Add new optional fields
-  - Add new tasks
-  - Add new enum values
-  - Add new standard formats
-
-- **Major** (x.0.0): Breaking changes
-  - Remove or rename fields
-  - Change field types
-  - Make optional fields required
-  - Remove enum values
-
-### What Gets Versioned
-
-When you run `npm run version`, these files are automatically updated:
-
-1. **package.json**: The main version number
-2. **Schema Registry** (`static/schemas/source/index.json`): `adcp_version` field and `lastUpdated` date
-
-**That's it!** Version is maintained in only two places:
-- The npm package version
-- The schema registry (single source of truth for protocol version)
-
-Individual request/response schemas and documentation do not contain version fields. Version is indicated by the schema path (`/schemas/latest/`) and the schema registry.
-
-### Manual Version Updates (Not Recommended)
-
-If you need to manually update versions (avoid this - use Changesets instead):
+Enter beta pre mode on `main` before accepting 3.2 release changes:
 
 ```bash
-# Update package.json version
-npm version 0.6.0 --no-git-tag-version
-
-# Run the sync script
-npm run update-schema-versions
-
-# Commit changes
-git add -A
-git commit -m "Bump version to 0.6.0"
+git switch main
+git pull --ff-only origin main
+npx changeset pre enter beta
+git add .changeset/pre.json
+git commit -m "chore(release): enter pre mode for 3.2 beta"
 ```
 
-## Best Practices
+Land that through a normal PR. While `.changeset/pre.json` exists, merge only
+Version Packages PRs that resolve to `3.2.0-beta.N`. Keep pre mode and its
+changeset pool on `main`; neither belongs on `3.1.x`. Exiting pre mode for 3.2
+GA is a separate, explicitly reviewed release operation.
 
-### Before Making Changes
+## Recovery
 
-1. **Check current version**: Look at `package.json`
-2. **Review pending changesets**: Check `.changeset/` directory
-3. **Consider impact**: Will this be patch, minor, or major?
-
-### When Adding Features
-
-1. Make your changes to code/docs/schemas
-2. Run `npm run changeset` to create changeset
-3. Select "minor" for new features
-4. Write clear description of what was added
-5. Commit both your changes and the changeset file
-
-### When Fixing Bugs
-
-1. Fix the bug
-2. Run `npm run changeset`
-3. Select "patch" for bug fixes
-4. Describe what was fixed
-5. Commit both the fix and the changeset
-
-### When Making Breaking Changes
-
-1. **Carefully consider** if the breaking change is necessary
-2. Make your changes
-3. Run `npm run changeset`
-4. Select "major" for breaking changes
-5. Write detailed description including migration path
-6. Update migration documentation
-7. Commit changes and changeset
-
-## Release Checklist
-
-Before releasing:
-
-- [ ] All tests pass (`npm test`)
-- [ ] Documentation is up to date
-- [ ] CHANGELOG.md entries are accurate
-- [ ] All changesets describe changes clearly
-- [ ] Breaking changes have migration guides
-- [ ] Schema validation works with new changes
-
-After releasing:
-
-- [ ] Version commit is pushed to main
-- [ ] Git tag is created and pushed
-- [ ] GitHub release is created with notes
-- [ ] Documentation site is updated
-- [ ] Community is notified (if major/minor)
-
-## Automation
-
-Our version management is automated through npm scripts:
-
-```json
-{
-  "changeset": "changeset",
-  "version": "changeset version && npm run update-schema-versions",
-  "update-schema-versions": "node scripts/update-schema-versions.js",
-  "release": "npm run version && npm test && git add -A && git commit -m 'Version packages' && git push"
-}
-```
-
-The `scripts/update-schema-versions.js` script updates the schema registry version to match package.json.
-
-## Troubleshooting
-
-### Forward-merge PR fails on `Check for changeset`
-
-PRs whose head branch starts with `forward-merge/` skip the changeset check (the merge brings package-changing commits whose changesets were already consumed by 3.0.x's Version Packages cut). If the check is firing on a forward-merge PR, the head branch isn't using the `forward-merge/` prefix — rename it:
-
-```bash
-git push origin HEAD:refs/heads/forward-merge/3.0.x-<descriptor>
-```
-
-See `.agents/playbook.md` for the full manual forward-merge runbook.
-
-### Forward-merge workflow fails loud on content conflicts
-
-Expected behavior when 3.0.x has changes in the cross-line-divergent files (`error-code.json`, `storyboard-schema.yaml`, `runner-output-contract.yaml`, `error.json`, `get-adcp-capabilities-response.json`, `training-agent-storyboards.yml`, `error-handling.mdx`). The workflow's error message includes the manual resolution recipe. See `.agents/playbook.md` (§ Cherry-pick convention) for the full procedure and rationale.
-
-### Changesets not found
-
-Install dependencies:
-```bash
-npm install
-```
-
-### Schema versions out of sync
-
-Run the sync script:
-```bash
-npm run update-schema-versions
-```
-
-### Tests failing after version bump
-
-The version script runs tests automatically. If they fail:
-1. Check what broke
-2. Fix the issue
-3. Commit the fix
-4. Re-run `npm run version`
-
-## Questions?
-
-For questions about the release process, open an issue on GitHub or reach out to the maintainers.
+If the automated release fails after the Version Packages merge, fix and
+rerun the workflow when safe. Manual tag/release recovery is the last resort:
+the tag must target the Version Packages merge, and the same four signed
+assets must be uploaded without overwriting an existing artifact with a
+different digest. See `.agents/shortcuts/cut-major.md` for the fallback
+commands.


### PR DESCRIPTION
## Summary

- update the canonical release topology for the stable 3.1.x maintenance line and the 3.2 next-minor line
- replace the 3.0.x patch runbook with the reviewed backport, release verification, docs snapshot, and forward-merge flow for 3.1.x
- clarify that the private protocol package ships signed release artifacts rather than publishing to npm

## Validation

- `npm run test:release-workflow`
- `npm run test:release-docs-nav`
- `git diff --check`
- `node scripts/check-pr-title.cjs "docs(release): update 3.1 maintenance guidance"`

No changeset: this updates non-normative release documentation only.