### PR TITLE
fix(admin): authenticate applicable storyboard discovery

### DIFF
--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -339,11 +339,14 @@ export class AgentContextDatabase {
        FROM agent_contexts
        WHERE agent_url = $1
          AND (
-           auth_token_encrypted IS NOT NULL
-           OR oauth_access_token_encrypted IS NOT NULL
+           (auth_token_encrypted IS NOT NULL
+            AND auth_token_iv IS NOT NULL)
+           OR (oauth_access_token_encrypted IS NOT NULL
+               AND oauth_access_token_iv IS NOT NULL)
            OR (oauth_cc_token_endpoint IS NOT NULL
                AND oauth_cc_client_id IS NOT NULL
-               AND oauth_cc_client_secret_encrypted IS NOT NULL)
+               AND oauth_cc_client_secret_encrypted IS NOT NULL
+               AND oauth_cc_client_secret_iv IS NOT NULL)
          )
        ORDER BY updated_at DESC
        LIMIT 1`,

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -202,8 +202,8 @@ export class AgentContextDatabase {
         auth_token_encrypted IS NOT NULL as has_auth_token,
         auth_token_hint,
         auth_type,
-        oauth_access_token_encrypted IS NOT NULL as has_oauth_token,
-        oauth_refresh_token_encrypted IS NOT NULL as has_oauth_refresh_token,
+        (oauth_access_token_encrypted IS NOT NULL AND oauth_access_token_iv IS NOT NULL) as has_oauth_token,
+        (oauth_refresh_token_encrypted IS NOT NULL AND oauth_refresh_token_iv IS NOT NULL) as has_oauth_refresh_token,
         oauth_token_expires_at,
         oauth_client_id IS NOT NULL as has_oauth_client,
         (oauth_cc_token_endpoint IS NOT NULL
@@ -247,8 +247,8 @@ export class AgentContextDatabase {
         auth_token_encrypted IS NOT NULL as has_auth_token,
         auth_token_hint,
         auth_type,
-        oauth_access_token_encrypted IS NOT NULL as has_oauth_token,
-        oauth_refresh_token_encrypted IS NOT NULL as has_oauth_refresh_token,
+        (oauth_access_token_encrypted IS NOT NULL AND oauth_access_token_iv IS NOT NULL) as has_oauth_token,
+        (oauth_refresh_token_encrypted IS NOT NULL AND oauth_refresh_token_iv IS NOT NULL) as has_oauth_refresh_token,
         oauth_token_expires_at,
         oauth_client_id IS NOT NULL as has_oauth_client,
         (oauth_cc_token_endpoint IS NOT NULL
@@ -292,8 +292,8 @@ export class AgentContextDatabase {
         auth_token_encrypted IS NOT NULL as has_auth_token,
         auth_token_hint,
         auth_type,
-        oauth_access_token_encrypted IS NOT NULL as has_oauth_token,
-        oauth_refresh_token_encrypted IS NOT NULL as has_oauth_refresh_token,
+        (oauth_access_token_encrypted IS NOT NULL AND oauth_access_token_iv IS NOT NULL) as has_oauth_token,
+        (oauth_refresh_token_encrypted IS NOT NULL AND oauth_refresh_token_iv IS NOT NULL) as has_oauth_refresh_token,
         oauth_token_expires_at,
         oauth_client_id IS NOT NULL as has_oauth_client,
         (oauth_cc_token_endpoint IS NOT NULL
@@ -465,8 +465,8 @@ export class AgentContextDatabase {
          auth_token_encrypted IS NOT NULL as has_auth_token,
          auth_token_hint,
          auth_type,
-         oauth_access_token_encrypted IS NOT NULL as has_oauth_token,
-         oauth_refresh_token_encrypted IS NOT NULL as has_oauth_refresh_token,
+         (oauth_access_token_encrypted IS NOT NULL AND oauth_access_token_iv IS NOT NULL) as has_oauth_token,
+         (oauth_refresh_token_encrypted IS NOT NULL AND oauth_refresh_token_iv IS NOT NULL) as has_oauth_refresh_token,
          oauth_token_expires_at,
          oauth_client_id IS NOT NULL as has_oauth_client,
          (oauth_cc_token_endpoint IS NOT NULL

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -117,7 +117,11 @@ import { ComplianceDatabase, type LifecycleStage } from "../db/compliance-db.js"
 import { VERIFICATION_MODES, isVerificationMode } from "../services/adcp-taxonomy.js";
 import { AgentSnapshotDatabase } from "../db/agent-snapshot-db.js";
 import { resolveUserAgentAuth } from "./helpers/resolve-user-agent-auth.js";
-import { adaptAuthForSdk, type SdkAuth } from "../services/sdk-auth-adapter.js";
+import {
+  adaptAuthForSdk,
+  authForSdkDiscoveryProbe,
+  type SdkAuth,
+} from "../services/sdk-auth-adapter.js";
 import { parseOAuthClientCredentialsInput } from "./helpers/oauth-client-credentials-input.js";
 import { isOAuthRequiredErrorMessage } from "./helpers/oauth-error-detection.js";
 import { AgentContextDatabase, validateAuthTokenChars } from "../db/agent-context-db.js";
@@ -7108,12 +7112,13 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     try {
       const auth = await resolveUserAgentAuth(agentContextDb, orgId, agentUrl, logger);
       const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `test-agent:${agentUrl}` });
+      const probeAuth = authForSdkDiscoveryProbe(sdkAuth);
 
       let profile;
       try {
         const caps = await testCapabilityDiscovery(
           agentUrl,
-          { ...(sdkAuth && { auth: sdkAuth }) },
+          { ...(probeAuth && { auth: probeAuth }) },
         );
         profile = caps.profile;
 

--- a/server/src/services/sdk-auth-adapter.ts
+++ b/server/src/services/sdk-auth-adapter.ts
@@ -69,6 +69,19 @@ export async function adaptAuthForSdk(
 }
 
 /**
+ * Authentication shape for the SDK's capability-discovery preflight.
+ *
+ * @adcp/sdk 9.x attaches the OAuth provider after endpoint discovery, while
+ * discovery itself only reads the bearer token. Preserve bearer/basic auth as
+ * supplied, but expose the current OAuth access token as bearer credentials so
+ * an already-authorized agent is not probed anonymously.
+ */
+export function authForSdkDiscoveryProbe(auth: SdkAuth | undefined): SdkAuth | undefined {
+  if (auth?.type !== 'oauth') return auth;
+  return { type: 'bearer', token: auth.tokens.access_token };
+}
+
+/**
  * Subset of `AgentConfig` (from `@adcp/sdk`) populated from saved auth.
  * Spread into the config literal passed to `new AdCPClient(...)` to make
  * authenticated probe / discovery / health calls. Bearer maps to

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -42,6 +42,7 @@ const ALL_OWNED_URLS = [
   ownedAgentUrl('canonical-saved-bearer'),
   ownedAgentUrl('badge-fanout'),
   ownedAgentUrl('static-admin'),
+  ownedAgentUrl('applicable-oauth'),
 ];
 
 // Toggle which user the auth middleware stamps onto the request. Tests
@@ -119,6 +120,18 @@ vi.mock('../../src/addie/services/compliance-testing.js', async () => {
   return {
     ...actual,
     comply: (agentUrl: string, options?: unknown) => complyMock(agentUrl, options),
+  };
+});
+
+const { testCapabilityDiscoveryMock } = vi.hoisted(() => ({
+  testCapabilityDiscoveryMock: vi.fn(),
+}));
+vi.mock('@adcp/sdk/testing', async () => {
+  const actual = await vi.importActual<typeof import('@adcp/sdk/testing')>('@adcp/sdk/testing');
+  return {
+    ...actual,
+    testCapabilityDiscovery: (agentUrl: string, options?: unknown) =>
+      testCapabilityDiscoveryMock(agentUrl, options),
   };
 });
 
@@ -238,6 +251,16 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
     });
     complyMock.mockReset();
     complyMock.mockResolvedValue(makeComplianceResult());
+    testCapabilityDiscoveryMock.mockReset();
+    testCapabilityDiscoveryMock.mockResolvedValue({
+      profile: {
+        name: 'OAuth test agent',
+        tools: [],
+        supported_protocols: ['media_buy'],
+        specialisms: [],
+      },
+      steps: [{ step: 'Discover agent profile', passed: true, duration_ms: 1 }],
+    });
   });
 
   const url = (agentUrl: string) => `/api/registry/agents/${encodeURIComponent(agentUrl)}/refresh`;
@@ -436,6 +459,36 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
           auth: { type: 'bearer', token: FAKE_BEARER },
           ownerOrgId: TEST_ORG_ID,
         }),
+      );
+    } finally {
+      await pool.query('DELETE FROM agent_contexts WHERE id = $1', [context.id]);
+    }
+  });
+
+  it('sends the saved OAuth access token as bearer auth for applicable-storyboards discovery', async () => {
+    const agentUrl = ownedAgentUrl('applicable-oauth');
+    const { AgentContextDatabase } = await import('../../src/db/agent-context-db.js');
+    const db = new AgentContextDatabase();
+    const context = await db.create({
+      organization_id: TEST_ORG_ID,
+      agent_url: agentUrl,
+      created_by: OWNER_USER_ID,
+    });
+    const accessToken = 'fresh-oauth-access-token-do-not-use-in-prod';
+    await db.saveOAuthTokens(context.id, {
+      access_token: accessToken,
+      refresh_token: 'refresh-token-do-not-use-in-prod',
+    });
+
+    try {
+      const res = await request(app)
+        .get(`/api/registry/agents/${encodeURIComponent(agentUrl)}/applicable-storyboards`)
+        .send();
+
+      expect(res.status).toBe(200);
+      expect(testCapabilityDiscoveryMock).toHaveBeenCalledWith(
+        agentUrl,
+        { auth: { type: 'bearer', token: accessToken } },
       );
     } finally {
       await pool.query('DELETE FROM agent_contexts WHERE id = $1', [context.id]);

--- a/server/tests/unit/agent-context-url-canonicalization.test.ts
+++ b/server/tests/unit/agent-context-url-canonicalization.test.ts
@@ -36,14 +36,20 @@ describe('AgentContextDatabase URL canonicalization', () => {
 
   it('reports OAuth grants only when their ciphertext and IV are both present', async () => {
     await db.getByOrgAndUrl(ORG, VARIANT);
+    await db.findOrgWithSavedAuth(VARIANT);
 
-    const sql = String(queryMock.mock.calls[0][0]);
-    expect(sql).toContain(
+    const projectionSql = String(queryMock.mock.calls[0][0]);
+    expect(projectionSql).toContain(
       '(oauth_access_token_encrypted IS NOT NULL AND oauth_access_token_iv IS NOT NULL) as has_oauth_token',
     );
-    expect(sql).toContain(
+    expect(projectionSql).toContain(
       '(oauth_refresh_token_encrypted IS NOT NULL AND oauth_refresh_token_iv IS NOT NULL) as has_oauth_refresh_token',
     );
+
+    const savedAuthSql = String(queryMock.mock.calls[1][0]);
+    expect(savedAuthSql).toContain('auth_token_iv IS NOT NULL');
+    expect(savedAuthSql).toContain('oauth_access_token_iv IS NOT NULL');
+    expect(savedAuthSql).toContain('oauth_cc_client_secret_iv IS NOT NULL');
   });
 
   it('canonicalizes create and URL updates', async () => {

--- a/server/tests/unit/agent-context-url-canonicalization.test.ts
+++ b/server/tests/unit/agent-context-url-canonicalization.test.ts
@@ -34,6 +34,18 @@ describe('AgentContextDatabase URL canonicalization', () => {
     expect(queryMock.mock.calls[4][1]).toEqual([CANONICAL]);
   });
 
+  it('reports OAuth grants only when their ciphertext and IV are both present', async () => {
+    await db.getByOrgAndUrl(ORG, VARIANT);
+
+    const sql = String(queryMock.mock.calls[0][0]);
+    expect(sql).toContain(
+      '(oauth_access_token_encrypted IS NOT NULL AND oauth_access_token_iv IS NOT NULL) as has_oauth_token',
+    );
+    expect(sql).toContain(
+      '(oauth_refresh_token_encrypted IS NOT NULL AND oauth_refresh_token_iv IS NOT NULL) as has_oauth_refresh_token',
+    );
+  });
+
   it('canonicalizes create and URL updates', async () => {
     queryMock.mockResolvedValueOnce({ rows: [{ id: 'ctx_created', agent_url: CANONICAL }] } as never);
     await db.create({ organization_id: ORG, agent_url: VARIANT });

--- a/server/tests/unit/sdk-auth-adapter.test.ts
+++ b/server/tests/unit/sdk-auth-adapter.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from 'vitest';
-import { agentConfigAuthFields } from '../../src/services/sdk-auth-adapter.js';
+import { agentConfigAuthFields, authForSdkDiscoveryProbe } from '../../src/services/sdk-auth-adapter.js';
+
+describe('authForSdkDiscoveryProbe', () => {
+  it('exposes an OAuth access token as bearer auth during endpoint discovery', () => {
+    expect(authForSdkDiscoveryProbe({
+      type: 'oauth',
+      tokens: {
+        access_token: 'fresh-access-token',
+        refresh_token: 'refresh-token',
+      },
+      client: { client_id: 'client-id' },
+    })).toEqual({ type: 'bearer', token: 'fresh-access-token' });
+  });
+
+  it('preserves non-OAuth auth and missing auth', () => {
+    const bearer = { type: 'bearer' as const, token: 'static-token' };
+    const basic = { type: 'basic' as const, username: 'user', password: 'pass' };
+
+    expect(authForSdkDiscoveryProbe(bearer)).toBe(bearer);
+    expect(authForSdkDiscoveryProbe(basic)).toBe(basic);
+    expect(authForSdkDiscoveryProbe(undefined)).toBeUndefined();
+  });
+});
 
 describe('agentConfigAuthFields', () => {
   it('maps bearer auth to the SDK auth_token field', () => {


### PR DESCRIPTION
## Summary
- send the stored OAuth access token as bearer auth during applicable-storyboards capability discovery
- keep bearer/basic behavior unchanged while avoiding the SDK 9.x anonymous OAuth preflight
- report saved OAuth grants only when both ciphertext and IV are present
- add an HTTP regression covering the exact dashboard route and OAuth grant shape

## Root cause
The applicable-storyboards route passed the full OAuth object to SDK 9.x. Endpoint discovery happens before the SDK attaches its OAuth provider and only reads bearer auth, so the probe was anonymous, received 401, and falsely returned needs_oauth even though the stored grant was valid.

## Validation
- typecheck
- 10 focused unit tests
- HTTP regression statically reviewed; local execution reached setup but local Postgres on port 53198 is unavailable, so CI will run the DB-backed suite
- git diff --check

No changeset: this is server/admin behavior only.

Fixes #5946