### PR TITLE
fix(release): fail closed when release tarball is missing

### DIFF
--- a/.changeset/fail-closed-missing-release-tarball.md
+++ b/.changeset/fail-closed-missing-release-tarball.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fail closed during release signing when the current protocol tarball is missing.

--- a/scripts/sign-protocol-tarball.sh
+++ b/scripts/sign-protocol-tarball.sh
@@ -18,28 +18,33 @@
 
 set -euo pipefail
 
-DIR="dist/protocol"
-CURRENT_VERSION="$(node -p "require('./package.json').version" 2>/dev/null || true)"
-
-if [ ! -d "$DIR" ]; then
-  echo "sign-protocol-tarball: $DIR not found, nothing to sign"
-  exit 0
-fi
-
-shopt -s nullglob
-tarballs=("$DIR"/*.tgz)
-if [ ${#tarballs[@]} -eq 0 ]; then
-  echo "sign-protocol-tarball: no .tgz files in $DIR"
-  exit 0
-fi
-
 if [ "${GITHUB_ACTIONS:-}" != "true" ] && [ "${SIGN_PROTOCOL_TARBALL:-}" != "true" ]; then
   echo "ℹ sign-protocol-tarball: skipping (set SIGN_PROTOCOL_TARBALL=true to sign locally)"
   exit 0
 fi
 
+DIR="dist/protocol"
+CURRENT_VERSION="$(node -p "require('./package.json').version || ''" 2>/dev/null || true)"
+
 if [ -z "$CURRENT_VERSION" ] && [ "${SIGN_ALL_PROTOCOL_TARBALLS:-}" != "true" ]; then
   echo "❌ Could not resolve package.json version for protocol tarball signing" >&2
+  exit 1
+fi
+
+if [ ! -d "$DIR" ]; then
+  echo "❌ sign-protocol-tarball: $DIR not found while signing was requested" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+tarballs=("$DIR"/*.tgz)
+if [ ${#tarballs[@]} -eq 0 ]; then
+  echo "❌ sign-protocol-tarball: no .tgz files in $DIR while signing was requested" >&2
+  exit 1
+fi
+
+if [ "${SIGN_ALL_PROTOCOL_TARBALLS:-}" != "true" ] && [ ! -f "$DIR/${CURRENT_VERSION}.tgz" ]; then
+  echo "❌ Expected current protocol tarball $DIR/${CURRENT_VERSION}.tgz was not found" >&2
   exit 1
 fi
 

--- a/tests/sign-protocol-tarball.test.cjs
+++ b/tests/sign-protocol-tarball.test.cjs
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { execFileSync } = require('node:child_process');
+const { execFileSync, spawnSync } = require('node:child_process');
 const { describe, it } = require('node:test');
 
 const ROOT = path.resolve(__dirname, '..');
@@ -54,6 +54,19 @@ function runSign(workspace, extraEnv = {}) {
   });
 }
 
+function runSignResult(workspace, extraEnv = {}) {
+  return spawnSync('bash', ['scripts/sign-protocol-tarball.sh'], {
+    cwd: workspace.dir,
+    env: {
+      ...process.env,
+      ...extraEnv,
+      GITHUB_ACTIONS: 'true',
+      PATH: `${workspace.binDir}${path.delimiter}${process.env.PATH}`,
+    },
+    encoding: 'utf8',
+  });
+}
+
 describe('sign-protocol-tarball.sh', () => {
   it('replaces sidecars for the current package version on rerun', () => {
     const workspace = makeWorkspace('1.2.3');
@@ -71,6 +84,7 @@ describe('sign-protocol-tarball.sh', () => {
 
   it('does not rewrite already signed older tarballs by default', () => {
     const workspace = makeWorkspace('1.2.3');
+    fs.writeFileSync(path.join(workspace.dir, 'dist/protocol/1.2.3.tgz'), 'current-tarball');
     const oldTarball = path.join(workspace.dir, 'dist/protocol/1.2.2.tgz');
     fs.writeFileSync(oldTarball, 'old-tarball');
     fs.writeFileSync(`${oldTarball}.sig`, 'old-signature');
@@ -79,6 +93,60 @@ describe('sign-protocol-tarball.sh', () => {
     const output = runSign(workspace);
 
     assert.match(output, /Skipping 1\.2\.2\.tgz \(not current package version 1\.2\.3\)/);
+    assert.equal(fs.readFileSync(`${oldTarball}.sig`, 'utf8'), 'old-signature');
+    assert.equal(fs.readFileSync(`${oldTarball}.crt`, 'utf8'), 'old-certificate');
+  });
+
+  it('fails closed when the expected current tarball is missing', () => {
+    const workspace = makeWorkspace('1.2.3');
+    const oldTarball = path.join(workspace.dir, 'dist/protocol/1.2.2.tgz');
+    fs.writeFileSync(oldTarball, 'old-tarball');
+    fs.writeFileSync(`${oldTarball}.sig`, 'old-signature');
+    fs.writeFileSync(`${oldTarball}.crt`, 'old-certificate');
+
+    const result = runSignResult(workspace);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Expected current protocol tarball .*1\.2\.3\.tgz was not found/);
+    assert.equal(fs.readFileSync(`${oldTarball}.sig`, 'utf8'), 'old-signature');
+    assert.equal(fs.readFileSync(`${oldTarball}.crt`, 'utf8'), 'old-certificate');
+  });
+
+  it('fails closed when package.json has no version', () => {
+    const workspace = makeWorkspace('1.2.3');
+    fs.writeFileSync(path.join(workspace.dir, 'package.json'), '{}');
+    fs.writeFileSync(path.join(workspace.dir, 'dist/protocol/1.2.3.tgz'), 'tarball');
+
+    const result = runSignResult(workspace);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Could not resolve package\.json version/);
+  });
+
+  it('refuses a partial historical sidecar set in explicit sign-all mode', () => {
+    const workspace = makeWorkspace('1.2.3');
+    const oldTarball = path.join(workspace.dir, 'dist/protocol/1.2.2.tgz');
+    fs.writeFileSync(oldTarball, 'old-tarball');
+    fs.writeFileSync(`${oldTarball}.sig`, 'old-signature');
+
+    const result = runSignResult(workspace, { SIGN_ALL_PROTOCOL_TARBALLS: 'true' });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Refusing to overwrite partial signature sidecars/);
+    assert.equal(fs.readFileSync(`${oldTarball}.sig`, 'utf8'), 'old-signature');
+    assert.equal(fs.existsSync(`${oldTarball}.crt`), false);
+  });
+
+  it('preserves complete historical sidecars in explicit sign-all mode', () => {
+    const workspace = makeWorkspace('1.2.3');
+    const oldTarball = path.join(workspace.dir, 'dist/protocol/1.2.2.tgz');
+    fs.writeFileSync(oldTarball, 'old-tarball');
+    fs.writeFileSync(`${oldTarball}.sig`, 'old-signature');
+    fs.writeFileSync(`${oldTarball}.crt`, 'old-certificate');
+
+    const output = runSign(workspace, { SIGN_ALL_PROTOCOL_TARBALLS: 'true' });
+
+    assert.match(output, /Skipping 1\.2\.2\.tgz \(signature sidecars already exist\)/);
     assert.equal(fs.readFileSync(`${oldTarball}.sig`, 'utf8'), 'old-signature');
     assert.equal(fs.readFileSync(`${oldTarball}.crt`, 'utf8'), 'old-certificate');
   });


### PR DESCRIPTION
## Summary

Fails closed when protocol-tarball signing is requested but the expected current release tarball is missing.

Previously, a missing or mismatched package version could leave the signing loop with zero outputs while still printing a success message. This change:

- treats missing artifact directories/tarballs as errors when signing is requested
- normalizes a missing package.json version to an empty value
- requires dist/protocol/{currentVersion}.tgz in default release mode
- preserves explicit sign-all maintenance behavior
- expands regression coverage for missing artifacts, missing versions, partial historical sidecars, and complete historical sidecars

This is release tooling only and does not alter protocol artifacts or versioning.

## Validation

- npm run test:sign-protocol-tarball (6/6)
- npm run test:immutable-release-artifacts
- git diff --check