### PR TITLE
fix(release): add immutable protocol CDN recovery

### DIFF
--- a/.github/workflows/recover-protocol-cdn.yml
+++ b/.github/workflows/recover-protocol-cdn.yml
@@ -1,0 +1,158 @@
+name: Recover protocol release on CDN
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact stable semver to recover (for example, 3.0.22)
+        required: true
+        type: string
+
+concurrency:
+  group: recover-protocol-cdn-${{ inputs.version }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  recover:
+    name: Recover immutable protocol tuple
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository history
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Validate release input and checkout tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must be an exact stable semver (for example, 3.0.22)"
+            exit 1
+          fi
+
+          git checkout --detach "v${VERSION}"
+          ACTUAL_VERSION="$(node -p "require('./package.json').version || ''")"
+          if [[ "${ACTUAL_VERSION}" != "${VERSION}" ]]; then
+            echo "::error::tag v${VERSION} contains package version ${ACTUAL_VERSION}"
+            exit 1
+          fi
+
+          for suffix in tgz tgz.sha256 tgz.sig tgz.crt; do
+            test -f "dist/protocol/${VERSION}.${suffix}" || {
+              echo "::error::missing dist/protocol/${VERSION}.${suffix} in tag v${VERSION}"
+              exit 1
+            }
+          done
+
+      - name: Verify signed local release tuple
+        env:
+          VERSION: ${{ inputs.version }}
+        working-directory: dist/protocol
+        run: |
+          set -euo pipefail
+          shasum -a 256 -c "${VERSION}.tgz.sha256"
+          cosign verify-blob \
+            --signature "${VERSION}.tgz.sig" \
+            --certificate "${VERSION}.tgz.crt" \
+            --certificate-identity-regexp '^https://github\.com/adcontextprotocol/adcp/\.github/workflows/release\.yml@refs/heads/.*$' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+            "${VERSION}.tgz"
+
+      - name: Upload only missing immutable R2 objects
+        env:
+          VERSION: ${{ inputs.version }}
+          BUCKET: ${{ vars.ADCP_ARTIFACT_R2_BUCKET || 'adcp-artifacts' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID || secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY || secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          set -euo pipefail
+          if [[ -z "${R2_ACCOUNT_ID:-}" || -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+            echo "::error::Missing R2 publication credentials"
+            exit 1
+          fi
+
+          endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          upload_immutable() {
+            local source="$1"
+            local key="$2"
+            local content_type="$3"
+            local existing head_error
+            existing="$(mktemp)"
+            head_error="$(mktemp)"
+
+            if aws s3api head-object \
+              --bucket "${BUCKET}" \
+              --key "${key}" \
+              --endpoint-url "${endpoint}" \
+              --region auto \
+              --no-cli-pager >/dev/null 2>"${head_error}"; then
+              aws s3 cp "s3://${BUCKET}/${key}" "${existing}" \
+                --endpoint-url "${endpoint}" \
+                --region auto \
+                --no-progress \
+                --only-show-errors
+              if ! cmp -s "${source}" "${existing}"; then
+                echo "::error::R2 object ${key} exists with different bytes; refusing overwrite"
+                exit 1
+              fi
+              echo "Verified existing immutable object ${key}"
+              return 0
+            fi
+
+            if ! grep -Eq '(404|Not Found)' "${head_error}"; then
+              cat "${head_error}" >&2
+              echo "::error::Could not safely determine whether R2 object ${key} exists"
+              exit 1
+            fi
+
+            aws s3 cp "${source}" "s3://${BUCKET}/${key}" \
+              --endpoint-url "${endpoint}" \
+              --region auto \
+              --no-progress \
+              --only-show-errors \
+              --no-guess-mime-type \
+              --cache-control 'public, max-age=31536000, immutable' \
+              --content-type "${content_type}"
+            echo "Uploaded missing immutable object ${key}"
+          }
+
+          upload_immutable "dist/protocol/${VERSION}.tgz" "protocol/${VERSION}.tgz" 'application/gzip'
+          upload_immutable "dist/protocol/${VERSION}.tgz.sha256" "protocol/${VERSION}.tgz.sha256" 'text/plain; charset=utf-8'
+          upload_immutable "dist/protocol/${VERSION}.tgz.sig" "protocol/${VERSION}.tgz.sig" 'application/octet-stream'
+          upload_immutable "dist/protocol/${VERSION}.tgz.crt" "protocol/${VERSION}.tgz.crt" 'application/x-pem-file'
+
+      - name: Verify recovered public CDN tuple
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "${workdir}"' EXIT
+          cd "${workdir}"
+
+          bust="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(date +%s)"
+          base_url="https://adcontextprotocol.org/protocol"
+          curl -fsSLo "${VERSION}.tgz" "${base_url}/${VERSION}.tgz?cache_bust=${bust}"
+          curl -fsSLo "${VERSION}.tgz.sha256" "${base_url}/${VERSION}.tgz.sha256?cache_bust=${bust}"
+          curl -fsSLo "${VERSION}.tgz.sig" "${base_url}/${VERSION}.tgz.sig?cache_bust=${bust}"
+          curl -fsSLo "${VERSION}.tgz.crt" "${base_url}/${VERSION}.tgz.crt?cache_bust=${bust}"
+          shasum -a 256 -c "${VERSION}.tgz.sha256"
+          cosign verify-blob \
+            --signature "${VERSION}.tgz.sig" \
+            --certificate "${VERSION}.tgz.crt" \
+            --certificate-identity-regexp '^https://github\.com/adcontextprotocol/adcp/\.github/workflows/release\.yml@refs/heads/.*$' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+            "${VERSION}.tgz"


### PR DESCRIPTION
## Summary

Adds an operator-only recovery workflow for a signed protocol release tuple that exists on a GitHub tag/release but is missing from the public R2-backed CDN.

The workflow:

- accepts only an exact stable semver and checks out the matching immutable tag
- verifies package version, all four local artifacts, SHA-256, and Sigstore identity before upload
- checks every exact R2 key first
- byte-compares existing objects and refuses overwrite on mismatch
- uploads only absent versioned objects with immutable cache metadata
- never updates latest aliases
- downloads and verifies the complete public CDN tuple after recovery

Immediate use: recover v3.0.22, whose legacy 3.0.x release workflow published GitHub assets but predates R2 publication.

## Validation

- actionlint
- YAML parse
- git diff --check