### PR TITLE
fix(server): enforce safe transport for hosted SDK traffic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.1.1",
       "dependencies": {
-        "@adcp/sdk": "9.6.2",
+        "@adcp/sdk": "12.1.1",
         "@anthropic-ai/sdk": "^0.112.3",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.6.3",
@@ -124,15 +124,18 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-9.6.2.tgz",
-      "integrity": "sha512-dz62Ff343kMLJWFJ+oux6aeXEoWjA6QW0MF5W0oYtIWaBVjNk56j16F7US1nUs8cwCjusLD8PKJUs+A2d+ehWw==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-12.1.1.tgz",
+      "integrity": "sha512-KlhfTF6maNGcdy5A7uDfU+YAPbkvraI5/UrqXVWuLsZL5mqBqWTRHxT98yxR9fjQTI0AYkd1NiQTtOGk+XxNYA==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
         "packages/*"
       ],
       "dependencies": {
+        "@modelcontextprotocol/client": "2.0.0-beta.4",
+        "@modelcontextprotocol/node": "2.0.0-beta.4",
+        "@modelcontextprotocol/server": "2.0.0-beta.4",
         "@types/ws": "^8.18.1",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
@@ -149,11 +152,11 @@
         "adcp": "bin/adcp.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@a2a-js/sdk": "^0.3.4",
-        "@modelcontextprotocol/sdk": "^1.17.5",
+        "@a2a-js/sdk": "^0.3.13",
+        "@modelcontextprotocol/sdk": "^1.24.0",
         "@opentelemetry/api": "^1.0.0",
         "pg": "^8.0.0",
         "redis": "^4.6.0 || ^5.0.0",
@@ -4473,6 +4476,57 @@
         "zod": "^3.20.0"
       }
     },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0-beta.4.tgz",
+      "integrity": "sha512-VNHA/UXDk7mCpVl+jOg5B4WMRRD2OEl+it360Lhi6HiCbrIB2f6pZ0cqSDKXQVUtZvqnhdQHzZAM9h8EKWhq/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0-beta.4",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0-beta.4.tgz",
+      "integrity": "sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0-beta.4.tgz",
+      "integrity": "sha512-OqbrRVNYNfLxBB2BRkP5oIHKHa0IPHluMbaLgw7YCRKcj5be9ExzyWFJY3KVMb+1F2AVn+0SRoH0XKcNzh3HYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0-beta.4",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -4511,6 +4565,19 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.4.tgz",
+      "integrity": "sha512-pjMZcNEt1dOq0aJCcY3b7w1Ayh+qmQN2xlfTELcGV9yiAjEGIczBPBLWWW0k0zzo5T8kiv15jtKPsWeHGxLvLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0-beta.4",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@mozilla/readability": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.1.1",
   "private": true,
   "type": "module",
+  "packageManager": "npm@10.9.4",
   "scripts": {
     "start": "bash -c 'source <(grep CONDUCTOR_PORT .env.local | sed \"s/^/export /\") && DOTENV_CONFIG_PATH=.env.local PORT=${CONDUCTOR_PORT:-3000} tsx watch server/src/index.ts'",
     "start:mintlify": "bash scripts/start-mintlify.sh",
@@ -133,7 +134,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "9.6.2",
+    "@adcp/sdk": "12.1.1",
     "@anthropic-ai/sdk": "^0.112.3",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.6.3",
@@ -217,6 +218,13 @@
   },
   "engines": {
     "node": ">=22.22.0"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "^10.9.4",
+      "onFail": "error"
+    }
   },
   "overrides": {
     "webpack-dev-server": "^5.2.2",

--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -1,6 +1,7 @@
 import { PropertyDefinition, PlacementDefinition } from './types.js';
 import { AAO_UA_VALIDATOR } from './config/user-agents.js';
 import { safeFetchAxiosLike, classifySafeFetchError } from './utils/url-security.js';
+import { withSdkSafeTransport } from './utils/sdk-safe-fetch.js';
 import { canonicalizePublisherDomain } from './services/publisher-domain.js';
 
 const MCP_ACCEPT_HEADER = 'application/json, text/event-stream';
@@ -1741,7 +1742,7 @@ export class AdAgentsManager {
         name: 'Health Checker',
         agent_uri: agentUrl,
         protocol: 'mcp',
-      }]);
+      }], withSdkSafeTransport({ userAgent: AAO_UA_VALIDATOR }));
       const client = multiClient.agent('health-check');
 
       // Add timeout to prevent hanging on slow/unresponsive agents

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.07.3';
+export const CODE_VERSION = '2026.07.4';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -22,6 +22,8 @@ import { AgentContextDatabase } from '../../db/agent-context-db.js';
 import { AuthenticationRequiredError } from '@adcp/sdk';
 import { buildAgentOAuthAuthorizeUrl } from '../../routes/helpers/agent-oauth-prompt.js';
 import { TRAINING_AGENT_HOSTNAMES } from '../../training-agent/config.js';
+import { agentConfigAuthFields, type SdkAuth } from '../../services/sdk-auth-adapter.js';
+import { withSdkSafeTransport } from '../../utils/sdk-safe-fetch.js';
 
 // Tool handler type (matches claude-client.ts internal type)
 type ToolHandler = (input: Record<string, unknown>) => Promise<string>;
@@ -686,40 +688,63 @@ export function createAdcpToolHandlers(
   const agentContextDb = new AgentContextDatabase();
 
   // Helper to get auth credentials for an agent (checks OAuth first, then static token)
-  async function getAuthInfo(agentUrl: string): Promise<{ token: string; authType: 'bearer' | 'basic' } | undefined> {
+  async function getAuthInfo(agentUrl: string): Promise<SdkAuth | undefined> {
     const organizationId = memberContext?.organization?.workos_organization_id;
     if (!organizationId) return undefined;
 
     try {
-      // First check for OAuth tokens (always bearer)
-      const oauthTokens = await agentContextDb.getOAuthTokensByOrgAndUrl(organizationId, agentUrl);
-      if (oauthTokens) {
-        // Check if token is expired
-        if (oauthTokens.expires_at) {
-          const expiresAt = new Date(oauthTokens.expires_at);
-          if (expiresAt.getTime() - Date.now() > 5 * 60 * 1000) {
-            logger.debug({ agentUrl }, 'Using OAuth access token for agent');
-            return { token: oauthTokens.access_token, authType: 'bearer' };
+      // Preserve this tool's established OAuth-first precedence while passing
+      // the full refresh shape to the SDK. A saved static token remains the
+      // fallback when no usable OAuth grant exists.
+      const context = await agentContextDb.getByOrgAndUrl(organizationId, agentUrl);
+      if (context?.has_oauth_token) {
+        const tokens = await agentContextDb.getOAuthTokensByOrgAndUrl(organizationId, agentUrl);
+        if (tokens?.access_token) {
+          const refreshToken = tokens.refresh_token;
+          const unexpired = !tokens.expires_at || tokens.expires_at.getTime() - Date.now() > 5 * 60 * 1000;
+          if (refreshToken) {
+            const client = await agentContextDb.getOAuthClient(context.id);
+            return {
+              type: 'oauth',
+              tokens: {
+                access_token: tokens.access_token,
+                refresh_token: refreshToken,
+                ...(tokens.expires_at && { expires_at: tokens.expires_at.toISOString() }),
+              },
+              ...(client && {
+                client: {
+                  client_id: client.client_id,
+                  ...(client.client_secret && { client_secret: client.client_secret }),
+                },
+              }),
+            };
           }
-          // Token expired or expiring soon - could refresh here in future
-          logger.debug({ agentUrl, expiresAt }, 'OAuth token expired or expiring soon');
-        } else {
-          // No expiration, use the token
-          logger.debug({ agentUrl }, 'Using OAuth access token for agent (no expiration)');
-          return { token: oauthTokens.access_token, authType: 'bearer' };
+          if (unexpired) return { type: 'bearer', token: tokens.access_token };
         }
       }
 
-      // Fall back to static auth token (may be bearer or basic)
-      const authInfo = await agentContextDb.getAuthInfoByOrgAndUrl(organizationId, agentUrl);
-      if (authInfo) {
-        logger.debug({ agentUrl, authType: authInfo.authType }, 'Using static auth token for agent');
-        return authInfo;
+      if (context?.has_oauth_client_credentials) {
+        const credentials = await agentContextDb.getOAuthClientCredentialsByOrgAndUrl(organizationId, agentUrl);
+        if (credentials) return { type: 'oauth_client_credentials', credentials };
       }
+
+      const staticAuth = await agentContextDb.getAuthInfoByOrgAndUrl(organizationId, agentUrl);
+      if (!staticAuth) return undefined;
+      if (staticAuth.authType === 'basic') {
+        const decoded = Buffer.from(staticAuth.token, 'base64').toString();
+        const separator = decoded.indexOf(':');
+        if (separator <= 0) return undefined;
+        return {
+          type: 'basic',
+          username: decoded.slice(0, separator),
+          password: decoded.slice(separator + 1),
+        };
+      }
+      return { type: 'bearer', token: staticAuth.token };
     } catch (error) {
       logger.debug({ error, agentUrl }, 'Failed to get auth info for agent');
+      return undefined;
     }
-    return undefined;
   }
 
   // The training agent is served at multiple hostnames and as an internal path
@@ -811,7 +836,7 @@ export function createAdcpToolHandlers(
 
     const authInfo = await getAuthInfo(agentUrl);
 
-    logger.info({ agentUrl, task, hasAuth: !!authInfo, authType: authInfo?.authType, debug }, `AdCP: executing ${task}`);
+    logger.info({ agentUrl, task, hasAuth: !!authInfo, authType: authInfo?.type, debug }, `AdCP: executing ${task}`);
 
     try {
       const { AdCPClient } = await import('@adcp/sdk');
@@ -840,9 +865,7 @@ export function createAdcpToolHandlers(
         name: 'target',
         agent_uri: agentUrl,
         protocol: 'mcp' as const,
-        ...(authInfo?.authType === 'basic'
-          ? { headers: { 'Authorization': `Basic ${authInfo.token}` } }
-          : authInfo ? { auth_token: authInfo.token } : {}),
+        ...agentConfigAuthFields(authInfo),
         ...(signingProvider
           ? {
               request_signing: {
@@ -856,7 +879,7 @@ export function createAdcpToolHandlers(
 
       const multiClient = new AdCPClient(
         [agentConfig],
-        { debug }
+        withSdkSafeTransport({ debug }),
       );
       const client = multiClient.agent('target');
 

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -81,7 +81,10 @@ import {
 } from '../../services/hosted-compliance-version.js';
 import { AgentContextDatabase, validateAuthTokenChars, type OAuthClientCredentials } from '../../db/agent-context-db.js';
 import { buildAgentOAuthAuthorizeUrl, isOAuthRequiredError } from '../../routes/helpers/agent-oauth-prompt.js';
+import { resolveUserAgentAuth } from '../../routes/helpers/resolve-user-agent-auth.js';
 import { isOAuthRequiredErrorMessage } from '../../routes/helpers/oauth-error-detection.js';
+import { agentConfigAuthFields, type SdkAuth } from '../../services/sdk-auth-adapter.js';
+import { withSdkSafeTransport } from '../../utils/sdk-safe-fetch.js';
 import {
   findExistingProposalOrFeed,
   createFeedProposal,
@@ -253,9 +256,9 @@ async function explicitTargetSupportErrorFromAgent(
   if (!hasExplicitComplianceTarget(input) || !requiresAdvertisedHostedComplianceSupport(target)) return undefined;
 
   try {
-    const caps = await testCapabilityDiscovery(agentUrl, {
+    const caps = await testCapabilityDiscovery(agentUrl, withSdkSafeTransport({
       ...(auth && { auth }),
-    });
+    }));
     const oauthError = capabilityDiscoveryOAuthError(caps);
     if (oauthError) return explicitTargetOAuthRequiredMessage(agentUrl, organizationId);
 
@@ -396,6 +399,7 @@ interface ResolvedAgentAuth {
   authType: 'bearer' | 'basic';
   source: 'explicit' | 'saved' | 'oauth' | 'public' | 'none';
   resolvedUrl: string;
+  sdkAuth?: SdkAuth;
 }
 
 /**
@@ -471,15 +475,25 @@ export async function resolveAgentAuth(
       logger.debug({ error, agentUrl: resolvedUrl }, 'Could not lookup saved auth token');
     }
 
-    // Check OAuth tokens
+    // Preserve refresh-capable OAuth and client-credentials shapes for the
+    // SDK. Static auth was already handled above, so this branch represents
+    // OAuth-backed credentials (or no credentials).
     try {
-      const oauthTokens = await agentContextDb.getOAuthTokensByOrgAndUrl(organizationId, resolvedUrl);
-      if (oauthTokens?.access_token) {
-        const isExpired = oauthTokens.expires_at &&
-          new Date(oauthTokens.expires_at).getTime() - Date.now() < 5 * 60 * 1000;
-        if (!isExpired) {
-          return { authToken: oauthTokens.access_token, authType: 'bearer', source: 'oauth', resolvedUrl };
-        }
+      const sdkAuth = await resolveUserAgentAuth(agentContextDb, organizationId, resolvedUrl, logger);
+      if (sdkAuth?.type === 'oauth') {
+        return {
+          authToken: sdkAuth.tokens.access_token,
+          authType: 'bearer',
+          source: 'oauth',
+          resolvedUrl,
+          sdkAuth,
+        };
+      }
+      if (sdkAuth?.type === 'oauth_client_credentials') {
+        return { authType: 'bearer', source: 'oauth', resolvedUrl, sdkAuth };
+      }
+      if (sdkAuth?.type === 'bearer') {
+        return { authToken: sdkAuth.token, authType: 'bearer', source: 'oauth', resolvedUrl, sdkAuth };
       }
     } catch (error) {
       logger.debug({ error, agentUrl: resolvedUrl }, 'Could not lookup OAuth token');
@@ -537,7 +551,8 @@ function validateAgentUrl(agentUrl: string): string | null {
 /**
  * Build auth options for the SDK from resolved auth. Exported for unit testing.
  */
-export function buildAuthOption(resolved: ResolvedAgentAuth): { type: 'bearer'; token: string } | { type: 'basic'; username: string; password: string } | undefined {
+export function buildAuthOption(resolved: ResolvedAgentAuth): SdkAuth | undefined {
+  if (resolved.sdkAuth) return resolved.sdkAuth;
   if (!resolved.authToken) return undefined;
 
   if (resolved.authType === 'basic') {
@@ -569,7 +584,10 @@ async function inferHostedAuthProbeTask(
   if (!auth) return undefined;
 
   try {
-    const caps = await testCapabilityDiscovery(agentUrl, withHostedTestOptions({ auth }, runTarget));
+    const caps = await testCapabilityDiscovery(
+      agentUrl,
+      withSdkSafeTransport(withHostedTestOptions({ auth }, runTarget)),
+    );
     return hostedAuthProbeTaskForProfile(caps.profile);
   } catch (error) {
     logger.warn({ error, agentUrl }, 'Addie: could not infer hosted auth probe task; using default');
@@ -586,9 +604,9 @@ async function classifyCapabilityResolutionErrorWithDeclaredProtocols(
   if (initial?.kind !== 'specialism_parent_protocol_missing') return initial;
 
   try {
-    const caps = await testCapabilityDiscovery(agentUrl, {
+    const caps = await testCapabilityDiscovery(agentUrl, withSdkSafeTransport({
       ...(auth && { auth }),
-    });
+    }));
     return classifyCapabilityResolutionError(error, caps.profile?.supported_protocols ?? []) ?? initial;
   } catch (probeError) {
     logger.warn({ probeError, agentUrl }, 'evaluate_agent_quality: could not reprobe capabilities after resolver error');
@@ -4867,9 +4885,9 @@ export function createMemberToolHandlers(
     let profile: AgentProfile | undefined;
     let discoveryProbeError: string | undefined;
     try {
-      const caps = await testCapabilityDiscovery(resolved.resolvedUrl, {
+      const caps = await testCapabilityDiscovery(resolved.resolvedUrl, withSdkSafeTransport({
         ...(authOption && { auth: authOption }),
-      });
+      }));
       profile = caps.profile;
       discoveryProbeError = capabilityDiscoveryProbeError(caps);
       if (!hasExplicitComplianceTarget(input)) {
@@ -5240,9 +5258,13 @@ export function createMemberToolHandlers(
 
     try {
       const authProbeTask = await inferHostedAuthProbeTask(resolved.resolvedUrl, authOption, runTarget);
-      const result = await runStoryboard(resolved.resolvedUrl, sb, withHostedStoryboardRunOptions({
-        ...(authOption && { auth: authOption }),
-      }, runTarget, authProbeTask));
+      const result = await runStoryboard(
+        resolved.resolvedUrl,
+        sb,
+        withSdkSafeTransport(withHostedStoryboardRunOptions({
+          ...(authOption && { auth: authOption }),
+        }, runTarget, authProbeTask)),
+      );
 
       // runStoryboard catches its own throws and surfaces them as step
       // errors. Detect OAuth on the first failing step before rendering a
@@ -5447,10 +5469,15 @@ export function createMemberToolHandlers(
 
     try {
       const authProbeTask = await inferHostedAuthProbeTask(resolved.resolvedUrl, authOption, runTarget);
-      const result: StoryboardStepResult = await runStoryboardStep(resolved.resolvedUrl, sb, resolvedStepId, withHostedStoryboardRunOptions({
-        context,
-        ...(authOption && { auth: authOption }),
-      }, runTarget, authProbeTask));
+      const result: StoryboardStepResult = await runStoryboardStep(
+        resolved.resolvedUrl,
+        sb,
+        resolvedStepId,
+        withSdkSafeTransport(withHostedStoryboardRunOptions({
+          context,
+          ...(authOption && { auth: authOption }),
+        }, runTarget, authProbeTask)),
+      );
 
       // runStoryboardStep catches its own throws and surfaces them as
       // result.error strings. Detect OAuth before rendering.
@@ -5610,12 +5637,10 @@ export function createMemberToolHandlers(
         name: 'target',
         agent_uri: resolved.resolvedUrl,
         protocol: 'mcp' as const,
-        ...(resolved.authToken && resolved.authType === 'basic'
-          ? { headers: { 'Authorization': `Basic ${resolved.authToken}` } }
-          : resolved.authToken ? { auth_token: resolved.authToken } : {}),
+        ...agentConfigAuthFields(buildAuthOption(resolved)),
       };
 
-      const multiClient = new AdCPClient([agentConfig], { debug: false });
+      const multiClient = new AdCPClient([agentConfig], withSdkSafeTransport({ debug: false }));
       const client = multiClient.agent('target');
 
       // Run each brief and collect results
@@ -5850,11 +5875,9 @@ export function createMemberToolHandlers(
         id: 'target', name: 'target',
         agent_uri: resolved.resolvedUrl,
         protocol: 'mcp' as const,
-        ...(resolved.authToken && resolved.authType === 'basic'
-          ? { headers: { 'Authorization': `Basic ${resolved.authToken}` } }
-          : resolved.authToken ? { auth_token: resolved.authToken } : {}),
+        ...agentConfigAuthFields(buildAuthOption(resolved)),
       };
-      const multiClient = new AdCPClient([agentConfig], { debug: false });
+      const multiClient = new AdCPClient([agentConfig], withSdkSafeTransport({ debug: false }));
       const client = multiClient.agent('target');
 
       const result = await Promise.race([
@@ -6088,11 +6111,9 @@ export function createMemberToolHandlers(
         id: 'target', name: 'target',
         agent_uri: resolved.resolvedUrl,
         protocol: 'mcp' as const,
-        ...(resolved.authToken && resolved.authType === 'basic'
-          ? { headers: { 'Authorization': `Basic ${resolved.authToken}` } }
-          : resolved.authToken ? { auth_token: resolved.authToken } : {}),
+        ...agentConfigAuthFields(buildAuthOption(resolved)),
       };
-      const multiClient = new AdCPClient([agentConfig], { debug: false });
+      const multiClient = new AdCPClient([agentConfig], withSdkSafeTransport({ debug: false }));
       const client = multiClient.agent('target');
 
       // Get full catalog via wholesale mode

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -33,6 +33,7 @@ import {
 } from '../../services/hosted-compliance-version.js';
 import { getStoryboard } from '../../services/storyboards.js';
 import { createLogger } from '../../logger.js';
+import { withSdkSafeTransport } from '../../utils/sdk-safe-fetch.js';
 
 import type {
   TrackSummaryEntry,
@@ -121,10 +122,13 @@ export async function comply(
   options: ComplyOptions,
   target: HostedComplianceTarget,
 ): Promise<ComplianceResult> {
-  const authDefaults = await hostedAuthDefaultsForRun(agentUrl, options);
+  const safeOptions = withSdkSafeTransport(options);
+  const authDefaults = await hostedAuthDefaultsForRun(agentUrl, safeOptions);
   const result = await sdkComply(
     agentUrl,
-    withHostedComplianceRunOptions(options, target, authDefaults.probeTask, authDefaults.apiKey),
+    withSdkSafeTransport(
+      withHostedComplianceRunOptions(safeOptions, target, authDefaults.probeTask, authDefaults.apiKey),
+    ),
   );
   result.adcp_version ??= target.version;
   (result as ComplianceResult & { requested_compliance_target?: string }).requested_compliance_target = target.requested;
@@ -132,7 +136,9 @@ export async function comply(
 }
 
 export function loadComplianceIndex(target: HostedComplianceTarget, options: ComplyOptions = {}) {
-  return sdkLoadComplianceIndex(withHostedComplianceRunOptions(options, target));
+  return sdkLoadComplianceIndex(
+    withSdkSafeTransport(withHostedComplianceRunOptions(options, target)),
+  );
 }
 
 export function defaultComplianceTarget(): HostedComplianceTarget {
@@ -146,9 +152,10 @@ export async function selectComplianceTargetForAgentSelection(
   mode: 'preferred' | 'canonical' = 'preferred',
 ): Promise<ComplianceTargetSelection> {
   try {
+    const safeOptions = withSdkSafeTransport(options);
     const discovery = await withTimeout(
-      testCapabilityDiscovery(agentUrl, options),
-      complianceTargetDiscoveryTimeoutMs(options),
+      testCapabilityDiscovery(agentUrl, safeOptions),
+      complianceTargetDiscoveryTimeoutMs(safeOptions),
       'Hosted compliance target pre-discovery',
     );
     const target = mode === 'canonical'

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -10,6 +10,7 @@ import type {
   KellerType,
 } from './types';
 import { AAO_UA_VALIDATOR } from './config/user-agents.js';
+import { withSdkSafeTransport } from './utils/sdk-safe-fetch.js';
 
 export interface BrandValidationError {
   field: string;
@@ -862,7 +863,7 @@ export class BrandManager {
           agent_uri: agentUrl,
           protocol: 'mcp',
         },
-      ]);
+      ], withSdkSafeTransport({ userAgent: AAO_UA_VALIDATOR }));
       const client = multiClient.agent('brand-agent-check');
 
       const agentInfo = await Promise.race([

--- a/server/src/capabilities.ts
+++ b/server/src/capabilities.ts
@@ -5,6 +5,7 @@ import { is401Error, AuthenticationRequiredError } from "@adcp/sdk";
 import { AAO_UA_DISCOVERY } from "./config/user-agents.js";
 import { logOutboundRequest } from "./db/outbound-log-db.js";
 import { agentConfigAuthFields, type SdkAuth } from "./services/sdk-auth-adapter.js";
+import { withSdkSafeTransport } from "./utils/sdk-safe-fetch.js";
 
 const logger = createLogger('capabilities');
 
@@ -376,7 +377,10 @@ export class CapabilityDiscovery {
       // TODO(adcp-client#1799): maxResponseBytes is currently dormant on
       // getAgentInfo/listTools — the SDK doesn't yet wrap that path in
       // withResponseSizeLimit. Re-verify when upstream lands.
-      }], { userAgent: AAO_UA_DISCOVERY, transport: { maxResponseBytes: 4 * 1024 * 1024 } });
+      }], withSdkSafeTransport({
+        userAgent: AAO_UA_DISCOVERY,
+        transport: { maxResponseBytes: 4 * 1024 * 1024 },
+      }));
       const client = multiClient.agent("discovery");
 
       const agentInfo = await client.getAgentInfo();
@@ -417,7 +421,10 @@ export class CapabilityDiscovery {
         protocol: "a2a",
         ...agentConfigAuthFields(auth),
       // TODO(adcp-client#1799): cap dormant on A2AClient.fromCardUrl until upstream wraps it.
-      }], { userAgent: AAO_UA_DISCOVERY, transport: { maxResponseBytes: 4 * 1024 * 1024 } });
+      }], withSdkSafeTransport({
+        userAgent: AAO_UA_DISCOVERY,
+        transport: { maxResponseBytes: 4 * 1024 * 1024 },
+      }));
       const client = multiClient.agent("discovery");
 
       const agentInfo = await client.getAgentInfo();
@@ -544,7 +551,10 @@ export class CapabilityDiscovery {
         agent_uri: agent.url,
         protocol: agent.protocol || "mcp",
         ...agentConfigAuthFields(auth),
-      }], { userAgent: AAO_UA_DISCOVERY, transport: { maxResponseBytes: 1024 * 1024 } });
+      }], withSdkSafeTransport({
+        userAgent: AAO_UA_DISCOVERY,
+        transport: { maxResponseBytes: 1024 * 1024 },
+      }));
       const client = multiClient.agent("discovery");
 
       // 10s timeout matches the existing tools/list discovery budget.

--- a/server/src/formats.ts
+++ b/server/src/formats.ts
@@ -2,6 +2,7 @@ import { AdCPClient } from "@adcp/sdk";
 import type { Agent, FormatInfo } from "./types.js";
 import { AAO_UA_DISCOVERY } from "./config/user-agents.js";
 import { agentConfigAuthFields, type SdkAuth } from "./services/sdk-auth-adapter.js";
+import { withSdkSafeTransport } from "./utils/sdk-safe-fetch.js";
 
 type AdCPClientInstance = InstanceType<typeof AdCPClient>;
 
@@ -86,7 +87,10 @@ export class FormatsService {
       protocol: (agent.protocol || "mcp") as "mcp" | "a2a",
       ...agentConfigAuthFields(auth),
     };
-    const client = new AdCPClient([agentConfig], { userAgent: AAO_UA_DISCOVERY });
+    const client = new AdCPClient(
+      [agentConfig],
+      withSdkSafeTransport({ userAgent: AAO_UA_DISCOVERY }),
+    );
     clientPool.set(key, client);
     return client;
   }

--- a/server/src/health.ts
+++ b/server/src/health.ts
@@ -8,6 +8,7 @@ import { safeFetch } from "./utils/url-security.js";
 import { logger } from "./logger.js";
 import { promises as dnsPromises } from "node:dns";
 import { agentConfigAuthFields, type SdkAuth } from "./services/sdk-auth-adapter.js";
+import { withSdkSafeTransport } from "./utils/sdk-safe-fetch.js";
 
 export interface ClassifiedProbeError {
   kind: ProbeErrorKind;
@@ -231,7 +232,7 @@ export class HealthChecker {
         agent_uri: agent.url,
         protocol: "mcp",
         ...agentConfigAuthFields(auth),
-      }], { userAgent: AAO_UA_HEALTH_CHECK });
+      }], withSdkSafeTransport({ userAgent: AAO_UA_HEALTH_CHECK }));
       const client = multiClient.agent("health-check");
 
       const agentInfo = await client.getAgentInfo();

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -25,6 +25,7 @@ import { AdAgentsManager } from "./adagents-manager.js";
 import { mountSchemasRoutes, mountComplianceRoutes, mountProtocolRoutes } from "./schemas-middleware.js";
 import { closeDatabase, getPool, healthCheck } from "./db/client.js";
 import { AuthenticationRequiredError, CreativeAgentClient, SingleAgentClient } from "@adcp/sdk";
+import { sdkSafeFetch, withSdkSafeTransport } from "./utils/sdk-safe-fetch.js";
 import type { Agent, AgentType, AgentWithStats, Company } from "./types.js";
 import { isValidAgentType, VALID_MEMBER_OFFERINGS, VALID_LEGAL_DOCUMENT_TYPES } from "./types.js";
 import type { Server } from "http";
@@ -9275,7 +9276,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
           name: 'discovery-client',
           agent_uri: url,
           protocol: 'mcp', // Library handles protocol detection internally
-        });
+        }, withSdkSafeTransport({}));
 
         // getAgentInfo() handles all the protocol detection and tool discovery
         const agentInfo = await client.getAgentInfo();
@@ -9301,7 +9302,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
           // Check for A2A agent card if we detected MCP
           if (agentInfo.protocol === 'mcp') {
             const a2aUrl = new URL('/.well-known/agent.json', url).toString();
-            const a2aResponse = await fetch(a2aUrl, {
+            const a2aResponse = await sdkSafeFetch(a2aUrl, {
               headers: { 'Accept': 'application/json' },
               signal: AbortSignal.timeout(3000),
             });
@@ -9322,7 +9323,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
 
         if (agentType === 'creative') {
           try {
-            const creativeClient = new CreativeAgentClient({ agentUrl: url });
+            const creativeClient = new CreativeAgentClient(withSdkSafeTransport({ agentUrl: url }));
             const formats = await creativeClient.listFormats();
             stats.format_count = formats.length;
           } catch (statsError) {

--- a/server/src/mcp-tools.ts
+++ b/server/src/mcp-tools.ts
@@ -27,6 +27,7 @@ import { reviewNewRecord, reviewRegistryEdit } from "./addie/mcp/registry-review
 import type { MCPAuthContext } from "./mcp/auth.js";
 import { createLogger } from "./logger.js";
 import { scrubCommunityAuthorizedAgents } from "./utils/community-adagents.js";
+import { withSdkSafeTransport } from "./utils/sdk-safe-fetch.js";
 
 const logger = createLogger('mcp-tools');
 
@@ -897,7 +898,7 @@ export class MCPToolHandler {
             name: "Query",
             agent_uri: agentUrl,
             protocol: "mcp",
-          }]);
+          }], withSdkSafeTransport({}));
           const client = multiClient.agent("query");
 
           const result = await client.executeTask("get_products", params);
@@ -957,7 +958,7 @@ export class MCPToolHandler {
             name: "Query",
             agent_uri: agentUrl,
             protocol: "mcp",
-          }]);
+          }], withSdkSafeTransport({}));
           const client = multiClient.agent("query");
 
           const result = await client.executeTask("list_creative_formats", params);
@@ -1016,7 +1017,7 @@ export class MCPToolHandler {
             name: "Query",
             agent_uri: agentUrl,
             protocol: "mcp",
-          }]);
+          }], withSdkSafeTransport({}));
           const client = multiClient.agent("query");
 
           const result = await client.executeTask("list_authorized_properties", {});

--- a/server/src/properties.ts
+++ b/server/src/properties.ts
@@ -1,6 +1,7 @@
 import { AdCPClient } from "@adcp/sdk";
 import type { Agent } from "./types.js";
 import { AAO_UA_DISCOVERY } from "./config/user-agents.js";
+import { withSdkSafeTransport } from "./utils/sdk-safe-fetch.js";
 import { AgentValidator } from "./validator.js";
 
 export interface PropertyInfo {
@@ -49,7 +50,10 @@ export class PropertiesService {
         agent_uri: agent.url,
         protocol: (agent.protocol || "mcp") as "mcp" | "a2a",
       };
-      const multiClient = new AdCPClient([agentConfig], { userAgent: AAO_UA_DISCOVERY });
+      const multiClient = new AdCPClient(
+        [agentConfig],
+        withSdkSafeTransport({ userAgent: AAO_UA_DISCOVERY }),
+      );
       const client = multiClient.agent(agent.name);
       const result = await client.executeTask("list_authorized_properties", {});
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -126,7 +126,7 @@ import { parseOAuthClientCredentialsInput } from "./helpers/oauth-client-credent
 import { isOAuthRequiredErrorMessage } from "./helpers/oauth-error-detection.js";
 import { AgentContextDatabase, validateAuthTokenChars } from "../db/agent-context-db.js";
 import { normalizeBasicAuthForStorage } from "../utils/basic-auth-credentials.js";
-import { withSdkSafeTransport } from "../utils/sdk-safe-fetch.js";
+import { sdkSafeFetch, withSdkSafeTransport } from "../utils/sdk-safe-fetch.js";
 import { getRequestLog, getRequestCount, logOutboundRequest } from "../db/outbound-log-db.js";
 import { enrichUserWithMembership } from "../utils/html-config.js";
 import { classifyProbeError } from "../utils/probe-error.js";
@@ -7017,7 +7017,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
         const start = Date.now();
         try {
-          await exchangeClientCredentials(creds);
+          await exchangeClientCredentials(creds, { fetch: sdkSafeFetch });
           return res.json({ ok: true, latency_ms: Date.now() - start });
         } catch (err) {
           if (err instanceof ClientCredentialsExchangeError) {
@@ -8906,7 +8906,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         name: "discovery-client",
         agent_uri: url,
         protocol: "mcp",
-      });
+      }, withSdkSafeTransport({}));
 
       const agentInfo = await client.getAgentInfo();
       const tools = agentInfo.tools || [];
@@ -8926,7 +8926,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       try {
         if (agentInfo.protocol === "mcp") {
           const a2aUrl = new URL("/.well-known/agent.json", url).toString();
-          const a2aResponse = await fetch(a2aUrl, {
+          const a2aResponse = await sdkSafeFetch(a2aUrl, {
             headers: { Accept: "application/json" },
             signal: AbortSignal.timeout(3000),
           });
@@ -8942,7 +8942,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
       if (agentType === "creative") {
         try {
-          const creativeClient = new CreativeAgentClient({ agentUrl: url });
+          const creativeClient = new CreativeAgentClient(withSdkSafeTransport({ agentUrl: url }));
           const formats = await creativeClient.listFormats();
           stats.format_count = formats.length;
         } catch (statsError) {
@@ -8983,7 +8983,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     }
 
     try {
-      const creativeClient = new CreativeAgentClient({ agentUrl: url });
+      const creativeClient = new CreativeAgentClient(withSdkSafeTransport({ agentUrl: url }));
       const formats = await creativeClient.listFormats();
 
       return res.json({
@@ -9025,7 +9025,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         name: "products-discovery-client",
         agent_uri: url,
         protocol: "mcp",
-      });
+      }, withSdkSafeTransport({}));
 
       const result = await client.getProducts({ buying_mode: 'wholesale' });
       const products = result.data?.products || [];

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -126,6 +126,7 @@ import { parseOAuthClientCredentialsInput } from "./helpers/oauth-client-credent
 import { isOAuthRequiredErrorMessage } from "./helpers/oauth-error-detection.js";
 import { AgentContextDatabase, validateAuthTokenChars } from "../db/agent-context-db.js";
 import { normalizeBasicAuthForStorage } from "../utils/basic-auth-credentials.js";
+import { withSdkSafeTransport } from "../utils/sdk-safe-fetch.js";
 import { getRequestLog, getRequestCount, logOutboundRequest } from "../db/outbound-log-db.js";
 import { enrichUserWithMembership } from "../utils/html-config.js";
 import { classifyProbeError } from "../utils/probe-error.js";
@@ -7118,7 +7119,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       try {
         const caps = await testCapabilityDiscovery(
           agentUrl,
-          { ...(probeAuth && { auth: probeAuth }) },
+          withSdkSafeTransport({ ...(probeAuth && { auth: probeAuth }) }),
         );
         profile = caps.profile;
 
@@ -7289,9 +7290,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         }
 
         let authProbeTask: string | undefined;
-        if (sdkAuth?.type === 'bearer' || sdkAuth?.type === 'basic') {
+        if (sdkAuth) {
           try {
-            const caps = await testCapabilityDiscovery(agentUrl, withHostedTestOptions({ auth: sdkAuth }, runTarget));
+            const caps = await testCapabilityDiscovery(
+              agentUrl,
+              withSdkSafeTransport(withHostedTestOptions({ auth: sdkAuth }, runTarget)),
+            );
             authProbeTask = hostedAuthProbeTaskForProfile(caps.profile);
           } catch (err) {
             logger.warn({ err, agentUrl }, "Could not infer hosted auth probe task for storyboard step; using default");
@@ -7306,10 +7310,15 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.status(400).json({ error: "context too large" });
         }
 
-        const result = await runStoryboardStep(agentUrl, storyboard, req.params.stepId, withHostedStoryboardRunOptions({
-          ...(sdkAuth && { auth: sdkAuth }),
-          ...(context && { context }),
-        }, runTarget, authProbeTask));
+        const result = await runStoryboardStep(
+          agentUrl,
+          storyboard,
+          req.params.stepId,
+          withSdkSafeTransport(withHostedStoryboardRunOptions({
+            ...(sdkAuth && { auth: sdkAuth }),
+            ...(context && { context }),
+          }, runTarget, authProbeTask)),
+        );
 
         if (!result.passed && isOAuthRequiredErrorMessage(result.error)) {
           const agentContextId = await ensureAgentContextId(orgId, agentUrl, req.user.id);

--- a/server/src/services/sdk-auth-adapter.ts
+++ b/server/src/services/sdk-auth-adapter.ts
@@ -3,22 +3,12 @@
  * shape `@adcp/sdk`'s `ComplyOptions.auth` / `TestOptions.auth`
  * accepts (bearer | basic | oauth).
  *
- * The server supports an `oauth_client_credentials` variant (#2800)
- * that the SDK doesn't. For that variant we perform the RFC 6749 §4.4
- * exchange here and hand the SDK the resulting bearer token. All
- * other variants pass through unchanged. Failed exchanges yield
- * `undefined` so the compliance / test path proceeds unauthenticated
- * with a warning log — the alternative is dropping the entire check.
- *
- * Remove this bridge when @adcp/sdk learns native
- * client_credentials with 401-triggered refresh.
+ * @adcp/sdk accepts the same auth union. Keep this seam so server call sites
+ * do not import SDK-internal auth types and so future storage variants still
+ * have one conversion point.
  */
 
 import type { ResolvedOwnerAuth } from '../db/compliance-db.js';
-import { exchangeClientCredentials } from './oauth-client-credentials-exchange.js';
-import { createLogger } from '../logger.js';
-
-const logger = createLogger('sdk-auth-adapter');
 
 /**
  * The subset of `ResolvedOwnerAuth` the SDK accepts. Kept as a
@@ -32,40 +22,18 @@ export type SdkAuth =
       type: 'oauth';
       tokens: { access_token: string; refresh_token: string; expires_at?: string };
       client?: { client_id: string; client_secret?: string };
-    };
+    }
+  | Extract<ResolvedOwnerAuth, { type: 'oauth_client_credentials' }>;
 
 /**
- * Narrow server-resolved auth into the SDK's accepted shape. Exchanges
- * client-credentials configs on the spot. Returns `undefined` for
- * missing auth OR for exchange failures (caller proceeds unauthed).
+ * Narrow server-resolved auth into the SDK's accepted shape. Returns
+ * `undefined` for missing auth.
  */
 export async function adaptAuthForSdk(
   auth: ResolvedOwnerAuth | undefined,
-  context: { tokenEndpointLabel?: string } = {},
+  _context: { tokenEndpointLabel?: string } = {},
 ): Promise<SdkAuth | undefined> {
-  if (!auth) return undefined;
-
-  switch (auth.type) {
-    case 'bearer':
-    case 'basic':
-    case 'oauth':
-      return auth;
-    case 'oauth_client_credentials': {
-      const result = await exchangeClientCredentials(auth.credentials);
-      if (!result.ok) {
-        logger.warn(
-          {
-            tokenEndpoint: auth.credentials.token_endpoint,
-            context: context.tokenEndpointLabel,
-            reason: result.error,
-          },
-          'OAuth client-credentials exchange failed — falling back to unauthenticated request',
-        );
-        return undefined;
-      }
-      return { type: 'bearer', token: result.access_token };
-    }
-  }
+  return auth;
 }
 
 /**
@@ -101,6 +69,7 @@ export type AgentConfigAuthFields = {
     expires_at?: string;
   };
   oauth_client?: { client_id: string; client_secret?: string };
+  oauth_client_credentials?: Extract<SdkAuth, { type: 'oauth_client_credentials' }>['credentials'];
 };
 
 export function agentConfigAuthFields(auth: SdkAuth | undefined): AgentConfigAuthFields {
@@ -120,5 +89,7 @@ export function agentConfigAuthFields(auth: SdkAuth | undefined): AgentConfigAut
       if (auth.client) fields.oauth_client = auth.client;
       return fields;
     }
+    case 'oauth_client_credentials':
+      return { oauth_client_credentials: auth.credentials };
   }
 }

--- a/server/src/utils/sdk-safe-fetch.ts
+++ b/server/src/utils/sdk-safe-fetch.ts
@@ -1,6 +1,12 @@
 import { safeFetch } from './url-security.js';
 
 const SDK_MAX_REQUEST_BYTES = 10 * 1024 * 1024;
+const SENSITIVE_REDIRECT_HEADERS = [
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'x-adcp-auth',
+] as const;
 
 type SafeFetchImpl = typeof safeFetch;
 
@@ -19,10 +25,10 @@ export interface SdkTransportOptions {
  * safeFetch then validates every redirect hop and repeats the private-address
  * check in undici's connect-time DNS lookup hook.
  *
- * POST redirects are intentionally disabled. AdCP POST bodies and their
- * Authorization headers can carry credentials or commercially sensitive task
- * input, and neither should be replayed to a redirect target. Endpoint
- * discovery is responsible for selecting the final MCP/A2A URL.
+ * POST redirects and every credential-bearing redirect are intentionally
+ * disabled. AdCP bodies, cookies, and auth headers can carry credentials or
+ * commercially sensitive input, and none should be replayed to another URL.
+ * Endpoint discovery is responsible for selecting the final MCP/A2A URL.
  */
 export function createSdkSafeFetch(safeFetchImpl: SafeFetchImpl = safeFetch): typeof fetch {
   return async (input, init) => {
@@ -38,17 +44,36 @@ export function createSdkSafeFetch(safeFetchImpl: SafeFetchImpl = safeFetch): ty
       if (!request.body) {
         throw new Error('SDK safe fetch POST requests require a body');
       }
+      const contentLength = request.headers.get('content-length');
+      if (contentLength !== null) {
+        const declaredBytes = Number(contentLength);
+        if (!Number.isSafeInteger(declaredBytes) || declaredBytes < 0) {
+          throw new Error('SDK safe fetch received an invalid Content-Length header');
+        }
+        if (declaredBytes > SDK_MAX_REQUEST_BYTES) {
+          throw new Error(
+            `SDK safe fetch body exceeds ${SDK_MAX_REQUEST_BYTES} byte cap (declared ${declaredBytes})`,
+          );
+        }
+      }
       body = new Uint8Array(await request.arrayBuffer());
+      if (body.byteLength > SDK_MAX_REQUEST_BYTES) {
+        throw new Error(
+          `SDK safe fetch body exceeds ${SDK_MAX_REQUEST_BYTES} byte cap (got ${body.byteLength})`,
+        );
+      }
     } else if (request.body) {
       throw new Error(`SDK safe fetch ${method} requests cannot carry a body`);
     }
+
+    const carriesSensitiveHeaders = SENSITIVE_REDIRECT_HEADERS.some(header => request.headers.has(header));
 
     return safeFetchImpl(request.url, {
       method,
       headers: Object.fromEntries(request.headers.entries()),
       ...(body && { body }),
       maxRequestBytes: SDK_MAX_REQUEST_BYTES,
-      ...(method === 'POST' && { maxRedirects: 0 }),
+      ...((method === 'POST' || carriesSensitiveHeaders) && { maxRedirects: 0 }),
       signal: request.signal,
     });
   };

--- a/server/src/utils/sdk-safe-fetch.ts
+++ b/server/src/utils/sdk-safe-fetch.ts
@@ -1,0 +1,75 @@
+import { safeFetch } from './url-security.js';
+
+const SDK_MAX_REQUEST_BYTES = 10 * 1024 * 1024;
+
+type SafeFetchImpl = typeof safeFetch;
+
+export interface SdkTransportOptions {
+  maxResponseBytes?: number;
+  requestTimeoutMs?: number;
+  fetchFn?: typeof fetch;
+}
+
+/**
+ * Build the fetch boundary used by hosted @adcp/sdk calls.
+ *
+ * The SDK can pass either a URL-like input or a fully-formed Request. Turning
+ * both into a Request first gives us standard fetch merge semantics for
+ * headers, method, signal, and body before handing the request to safeFetch.
+ * safeFetch then validates every redirect hop and repeats the private-address
+ * check in undici's connect-time DNS lookup hook.
+ *
+ * POST redirects are intentionally disabled. AdCP POST bodies and their
+ * Authorization headers can carry credentials or commercially sensitive task
+ * input, and neither should be replayed to a redirect target. Endpoint
+ * discovery is responsible for selecting the final MCP/A2A URL.
+ */
+export function createSdkSafeFetch(safeFetchImpl: SafeFetchImpl = safeFetch): typeof fetch {
+  return async (input, init) => {
+    const request = new Request(input, init);
+    const method = request.method.toUpperCase();
+
+    if (method !== 'GET' && method !== 'HEAD' && method !== 'POST') {
+      throw new Error(`SDK safe fetch does not support ${method} requests`);
+    }
+
+    let body: Uint8Array | undefined;
+    if (method === 'POST') {
+      if (!request.body) {
+        throw new Error('SDK safe fetch POST requests require a body');
+      }
+      body = new Uint8Array(await request.arrayBuffer());
+    } else if (request.body) {
+      throw new Error(`SDK safe fetch ${method} requests cannot carry a body`);
+    }
+
+    return safeFetchImpl(request.url, {
+      method,
+      headers: Object.fromEntries(request.headers.entries()),
+      ...(body && { body }),
+      maxRequestBytes: SDK_MAX_REQUEST_BYTES,
+      ...(method === 'POST' && { maxRedirects: 0 }),
+      signal: request.signal,
+    });
+  };
+}
+
+export const sdkSafeFetch: typeof fetch = createSdkSafeFetch();
+
+/**
+ * Merge the mandatory hosted-network boundary without discarding SDK knobs
+ * such as response limits or request timeouts. The server-owned fetch policy
+ * deliberately wins over a caller-provided fetch implementation.
+ */
+export function withSdkSafeTransport<T extends object>(
+  options: T,
+): T & { transport: SdkTransportOptions & { fetchFn: typeof fetch } } {
+  const existingTransport = (options as { transport?: SdkTransportOptions }).transport;
+  return {
+    ...options,
+    transport: {
+      ...existingTransport,
+      fetchFn: sdkSafeFetch,
+    },
+  };
+}

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -488,7 +488,12 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
       expect(res.status).toBe(200);
       expect(testCapabilityDiscoveryMock).toHaveBeenCalledWith(
         agentUrl,
-        { auth: { type: 'bearer', token: accessToken } },
+        expect.objectContaining({
+          auth: { type: 'bearer', token: accessToken },
+          transport: expect.objectContaining({
+            fetchFn: expect.any(Function),
+          }),
+        }),
       );
     } finally {
       await pool.query('DELETE FROM agent_contexts WHERE id = $1', [context.id]);

--- a/server/tests/unit/oauth-client-credentials-exchange.test.ts
+++ b/server/tests/unit/oauth-client-credentials-exchange.test.ts
@@ -16,9 +16,9 @@ import { adaptAuthForSdk } from '../../src/services/sdk-auth-adapter.js';
 
 /**
  * Tests for the server-side OAuth 2.0 client-credentials exchange
- * (#2800 follow-up). `@adcp/sdk`'s ComplyOptions/TestOptions don't
- * accept the `oauth_client_credentials` auth variant, so we exchange
- * for a bearer token server-side before handing it to the SDK.
+ * (#2800 follow-up). The low-level helper remains covered for direct
+ * callers, while the SDK adapter now passes client credentials through
+ * so `@adcp/sdk` owns token acquisition and refresh.
  */
 
 function mockFetch(response: { status: number; body: string | object }) {
@@ -238,40 +238,39 @@ describe('adaptAuthForSdk', () => {
     expect(await adaptAuthForSdk(oauth)).toBe(oauth);
   });
 
-  it('exchanges oauth_client_credentials and narrows to bearer', async () => {
-    process.env.ADCP_OAUTH_BRIDGE_TEST = 'sec';
-    oauthFetchMocks.oauthSafeFetch.mockImplementation(mockFetch({
-      status: 200,
-      body: { access_token: 'exchanged-tok', expires_in: 600 },
-    }));
-    try {
-      const result = await adaptAuthForSdk({
-        type: 'oauth_client_credentials',
-        credentials: {
-          token_endpoint: 'https://idp.example/token',
-          client_id: 'client-x',
-          client_secret: '$ENV:ADCP_OAUTH_BRIDGE_TEST',
-        },
-      });
-      expect(result).toEqual({ type: 'bearer', token: 'exchanged-tok' });
-    } finally {
-      delete process.env.ADCP_OAUTH_BRIDGE_TEST;
-    }
+  it('passes oauth_client_credentials through for SDK-managed token refresh', async () => {
+    const auth = {
+      type: 'oauth_client_credentials',
+      credentials: {
+        token_endpoint: 'https://idp.example/token',
+        client_id: 'client-x',
+        client_secret: '$ENV:ADCP_OAUTH_BRIDGE_TEST',
+      },
+    } as const;
+
+    const result = await adaptAuthForSdk(auth);
+
+    expect(result).toBe(auth);
+    expect(oauthFetchMocks.oauthSafeFetch).not.toHaveBeenCalled();
   });
 
-  it('returns undefined (falls back to unauthenticated) when the exchange fails', async () => {
+  it('does not preflight the token endpoint before handing auth to the SDK', async () => {
     oauthFetchMocks.oauthSafeFetch.mockImplementation(
       mockFetch({ status: 500, body: 'internal' }),
     );
 
-    const result = await adaptAuthForSdk({
+    const auth = {
       type: 'oauth_client_credentials',
       credentials: {
         token_endpoint: 'https://idp.example/token',
         client_id: 'c',
         client_secret: 's',
       },
-    });
-    expect(result).toBeUndefined();
+    } as const;
+
+    const result = await adaptAuthForSdk(auth);
+
+    expect(result).toBe(auth);
+    expect(oauthFetchMocks.oauthSafeFetch).not.toHaveBeenCalled();
   });
 });

--- a/tests/sdk-auth-adapter.test.ts
+++ b/tests/sdk-auth-adapter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { adaptAuthForSdk, agentConfigAuthFields } from '../server/src/services/sdk-auth-adapter.js';
+
+describe('SDK auth adapter', () => {
+  it('preserves refresh-capable OAuth tokens and client registration', async () => {
+    const auth = {
+      type: 'oauth' as const,
+      tokens: {
+        access_token: 'expired-token',
+        refresh_token: 'refresh-token',
+        expires_at: '2026-07-23T00:00:00.000Z',
+      },
+      client: { client_id: 'client-id', client_secret: 'client-secret' },
+    };
+
+    const sdkAuth = await adaptAuthForSdk(auth);
+    expect(sdkAuth).toEqual(auth);
+    expect(agentConfigAuthFields(sdkAuth)).toEqual({
+      auth_token: 'expired-token',
+      oauth_tokens: auth.tokens,
+      oauth_client: auth.client,
+    });
+  });
+
+  it('preserves client credentials for SDK-managed exchange and retry', async () => {
+    const auth = {
+      type: 'oauth_client_credentials' as const,
+      credentials: {
+        token_endpoint: 'https://issuer.example/token',
+        client_id: 'client-id',
+        client_secret: 'client-secret',
+        scope: 'adcp',
+      },
+    };
+
+    const sdkAuth = await adaptAuthForSdk(auth);
+    expect(sdkAuth).toEqual(auth);
+    expect(agentConfigAuthFields(sdkAuth)).toEqual({
+      oauth_client_credentials: auth.credentials,
+    });
+  });
+});

--- a/tests/sdk-safe-fetch-callsites.test.ts
+++ b/tests/sdk-safe-fetch-callsites.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const registryApiSource = readFileSync(
+  new URL('../server/src/routes/registry-api.ts', import.meta.url),
+  'utf8',
+);
+const httpSource = readFileSync(
+  new URL('../server/src/http.ts', import.meta.url),
+  'utf8',
+);
+
+describe('hosted SDK safe-fetch call sites', () => {
+  it('scopes the registry client-credentials diagnostic exchange', () => {
+    expect(registryApiSource).toContain(
+      'exchangeClientCredentials(creds, { fetch: sdkSafeFetch })',
+    );
+  });
+
+  it('does not use ambient fetch for hosted A2A probes', () => {
+    expect(registryApiSource).not.toContain('await fetch(a2aUrl');
+    expect(httpSource).not.toContain('await fetch(a2aUrl');
+    expect(registryApiSource).toContain('await sdkSafeFetch(a2aUrl');
+    expect(httpSource).toContain('await sdkSafeFetch(a2aUrl');
+  });
+
+  it('does not construct unscoped public discovery clients', () => {
+    const unsafeCreativeConstructor = 'new CreativeAgentClient({ agentUrl: url })';
+    expect(registryApiSource).not.toContain(unsafeCreativeConstructor);
+    expect(httpSource).not.toContain(unsafeCreativeConstructor);
+    expect(registryApiSource).toContain(
+      'new CreativeAgentClient(withSdkSafeTransport({ agentUrl: url }))',
+    );
+    expect(httpSource).toContain(
+      'new CreativeAgentClient(withSdkSafeTransport({ agentUrl: url }))',
+    );
+    expect(registryApiSource.split('}, withSdkSafeTransport({}));')).toHaveLength(3);
+    expect(httpSource.split('}, withSdkSafeTransport({}));')).toHaveLength(2);
+  });
+});

--- a/tests/sdk-safe-fetch.test.ts
+++ b/tests/sdk-safe-fetch.test.ts
@@ -38,6 +38,58 @@ describe('SDK safe fetch adapter', () => {
     expect(new TextDecoder().decode(options?.body as Uint8Array)).toContain('tools/list');
   });
 
+  it.each([
+    'Authorization',
+    'Proxy-Authorization',
+    'Cookie',
+    'x-adcp-auth',
+  ])('refuses GET redirects carrying the sensitive %s header', async header => {
+    const safeFetchImpl = vi.fn(async () => new Response('{}', { status: 200 }));
+    const fetchFn = createSdkSafeFetch(safeFetchImpl);
+
+    await fetchFn('https://agent.example/metadata', {
+      headers: { [header]: 'secret' },
+    });
+
+    expect(safeFetchImpl.mock.calls[0][1]).toMatchObject({
+      method: 'GET',
+      maxRedirects: 0,
+    });
+  });
+
+  it('refuses HEAD redirects carrying credentials', async () => {
+    const safeFetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const fetchFn = createSdkSafeFetch(safeFetchImpl);
+
+    await fetchFn('https://agent.example/health', {
+      method: 'HEAD',
+      headers: { Authorization: 'Bearer secret' },
+    });
+
+    expect(safeFetchImpl.mock.calls[0][1]).toMatchObject({
+      method: 'HEAD',
+      maxRedirects: 0,
+    });
+  });
+
+  it('rejects an oversized declared body before allocating it', async () => {
+    const safeFetchImpl = vi.fn(async () => new Response('{}', { status: 200 }));
+    const fetchFn = createSdkSafeFetch(safeFetchImpl);
+    const arrayBuffer = vi.fn(async () => new ArrayBuffer(0));
+    vi.stubGlobal('Request', class {
+      url = 'https://agent.example/mcp';
+      method = 'POST';
+      headers = new Headers({ 'content-length': String(10 * 1024 * 1024 + 1) });
+      body = {};
+      signal = new AbortController().signal;
+      arrayBuffer = arrayBuffer;
+    });
+
+    await expect(fetchFn('https://agent.example/mcp')).rejects.toThrow('exceeds 10485760 byte cap');
+    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(safeFetchImpl).not.toHaveBeenCalled();
+  });
+
   it('preserves transport limits while enforcing the server fetch boundary', () => {
     const callerFetch = vi.fn();
     const merged = withSdkSafeTransport({

--- a/tests/sdk-safe-fetch.test.ts
+++ b/tests/sdk-safe-fetch.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AdCPClient, closeMCPConnections } from '@adcp/sdk';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  createSdkSafeFetch,
+  sdkSafeFetch,
+  withSdkSafeTransport,
+} from '../server/src/utils/sdk-safe-fetch.js';
+
+describe('SDK safe fetch adapter', () => {
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await closeMCPConnections();
+  });
+
+  it('normalizes Request POST bodies and refuses to follow their redirects', async () => {
+    const safeFetchImpl = vi.fn(async () => new Response('{}', { status: 200 }));
+    const fetchFn = createSdkSafeFetch(safeFetchImpl);
+    const request = new Request('https://agent.example/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer secret',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list' }),
+    });
+
+    await fetchFn(request);
+
+    expect(safeFetchImpl).toHaveBeenCalledOnce();
+    const [url, options] = safeFetchImpl.mock.calls[0];
+    expect(url).toBe('https://agent.example/mcp');
+    expect(options).toMatchObject({ method: 'POST', maxRedirects: 0 });
+    expect(options?.headers?.authorization).toBe('Bearer secret');
+    expect(new TextDecoder().decode(options?.body as Uint8Array)).toContain('tools/list');
+  });
+
+  it('preserves transport limits while enforcing the server fetch boundary', () => {
+    const callerFetch = vi.fn();
+    const merged = withSdkSafeTransport({
+      debug: true,
+      transport: {
+        fetchFn: callerFetch as typeof fetch,
+        maxResponseBytes: 1234,
+        requestTimeoutMs: 5678,
+      },
+    });
+
+    expect(merged.debug).toBe(true);
+    expect(merged.transport).toEqual({
+      fetchFn: sdkSafeFetch,
+      maxResponseBytes: 1234,
+      requestTimeoutMs: 5678,
+    });
+  });
+
+  it('runs a real SDK OAuth refresh and MCP discovery without ambient fetch', async () => {
+    const state = { refreshCalls: 0, mcpCalls: 0 };
+    let origin = '';
+
+    const server = createServer(async (req, res) => {
+      const path = new URL(req.url ?? '/', origin).pathname;
+      if (path.startsWith('/.well-known/oauth-protected-resource')) {
+        return json(res, 200, {
+          resource: `${origin}/mcp`,
+          authorization_servers: [origin],
+        });
+      }
+      if (path.startsWith('/.well-known/oauth-authorization-server')) {
+        return json(res, 200, {
+          issuer: origin,
+          authorization_endpoint: `${origin}/authorize`,
+          token_endpoint: `${origin}/token`,
+          grant_types_supported: ['authorization_code', 'refresh_token'],
+          response_types_supported: ['code'],
+          token_endpoint_auth_methods_supported: ['none'],
+        });
+      }
+      if (path === '/token' && req.method === 'POST') {
+        const body = new URLSearchParams(await readBody(req));
+        expect(body.get('grant_type')).toBe('refresh_token');
+        expect(body.get('refresh_token')).toBe('refresh-token');
+        state.refreshCalls++;
+        return json(res, 200, {
+          access_token: 'fresh-token',
+          refresh_token: 'refresh-token',
+          token_type: 'Bearer',
+          expires_in: 3600,
+        });
+      }
+      if (path !== '/mcp' && path !== '/mcp/') {
+        res.writeHead(404).end();
+        return;
+      }
+      if (req.headers.authorization !== 'Bearer fresh-token') {
+        res.writeHead(401, {
+          'www-authenticate': `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`,
+        }).end('unauthorized');
+        return;
+      }
+
+      state.mcpCalls++;
+      const body = req.method === 'POST' ? JSON.parse(await readBody(req)) : undefined;
+      const mcp = new McpServer({ name: 'server-safe-fetch-test', version: '1.0.0' });
+      mcp.registerTool('ping', { inputSchema: {} }, async () => ({
+        content: [{ type: 'text', text: 'pong' }],
+      }));
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      try {
+        await mcp.connect(transport);
+        await transport.handleRequest(req, res, body);
+      } finally {
+        await mcp.close();
+      }
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+
+    const originalFetch = globalThis.fetch;
+    const bridgedSafeFetch = createSdkSafeFetch(async (url, options) =>
+      originalFetch(url, {
+        method: options?.method,
+        headers: options?.headers,
+        body: options?.body,
+        redirect: 'manual',
+        signal: options?.signal,
+      }),
+    );
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('ambient fetch must not be used');
+    }));
+
+    try {
+      const client = new AdCPClient([
+        {
+          id: 'refresh-test',
+          name: 'Refresh Test',
+          agent_uri: `${origin}/mcp`,
+          protocol: 'mcp',
+          oauth_tokens: {
+            access_token: 'expired-token',
+            refresh_token: 'refresh-token',
+            token_type: 'Bearer',
+            issuer: origin,
+          },
+          oauth_client: { client_id: 'refresh-client' },
+        },
+      ], { transport: { fetchFn: bridgedSafeFetch } });
+
+      const info = await client.agent('refresh-test').getAgentInfo();
+      expect(info.tools.some(tool => tool.name === 'ping')).toBe(true);
+      expect(state.refreshCalls).toBe(1);
+      expect(state.mcpCalls).toBeGreaterThan(0);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    } finally {
+      if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  }, 30_000);
+});
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  let body = '';
+  for await (const chunk of req) body += chunk;
+  return body;
+}


### PR DESCRIPTION
## Summary

- upgrade `@adcp/sdk` to 12.1.1, which threads request-scoped fetch through high-level clients and OAuth refresh
- route hosted SDK traffic through the server's SSRF-safe fetch boundary
- fail closed on unsupported methods, oversized request bodies, POST redirects, and credential-bearing redirects
- replace the server-side client-credentials pre-exchange shim with the SDK's refresh-aware credential path
- cover every hosted SDK call site and the real expired-token OAuth refresh flow

## Root cause

The server validated agent URLs before invoking the SDK, but high-level SDK calls and later OAuth refreshes could still use ambient `fetch`. That reopened DNS-rebinding and redirect paths after the initial validation boundary. SDK 12.1.1 exposes a request-scoped fetch hook across discovery, refresh, MCP/A2A calls, and compliance runners; this change injects the server-owned safe transport everywhere hosted agent traffic enters the SDK.

## Impact

Hosted agent discovery, capability reads, creative operations, compliance/storyboard runs, and OAuth refreshes now share the same redirect-aware, connect-time DNS-checked transport. Client-credentials auth remains refreshable inside the SDK instead of degrading to a one-time bearer token.

Closes #5962.

## Validation

- `npx vitest run tests/sdk-safe-fetch.test.ts tests/sdk-safe-fetch-callsites.test.ts tests/sdk-auth-adapter.test.ts` — 14 passed
- `npm run typecheck`
- `npm run test:unit`
- `npm run test:server-unit`
- `git diff --check origin/main...HEAD`
- `node scripts/check-pr-title.cjs "fix(server): enforce safe transport for hosted SDK traffic"`

