### PR TITLE
fix(creative): publish deployed legacy format aliases

### DIFF
--- a/.changeset/publish-legacy-format-aliases.md
+++ b/.changeset/publish-legacy-format-aliases.md
@@ -1,0 +1,5 @@
+---
+'adcontextprotocol': minor
+---
+
+Publish reviewed canonical mappings for deployed AgenticAdvertising.org legacy creative format IDs.

--- a/.changeset/publish-legacy-format-aliases.md
+++ b/.changeset/publish-legacy-format-aliases.md
@@ -1,5 +1,0 @@
----
-'adcontextprotocol': minor
----
-
-Publish reviewed canonical mappings for deployed AgenticAdvertising.org legacy creative format IDs.

--- a/server/src/creative-agent/reference-formats.json
+++ b/server/src/creative-agent/reference-formats.json
@@ -5241,5 +5241,497 @@
     "canonical": {
       "kind": "agent_placement"
     }
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_320x50_html"
+    },
+    "name": "Mobile Leaderboard - HTML5",
+    "description": "320x50 HTML5 creative",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 50,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 320
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "html_creative",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 320,
+          "height": 50,
+          "max_file_size_mb": 0.5,
+          "description": "HTML5 creative code"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "requirements": {
+          "description": "3rd party impression tracking pixel URL"
+        },
+        "event": "impression",
+        "method": "img"
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "viewability_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "event": "viewable_mrc_50",
+        "method": "img",
+        "requirements": {
+          "description": "MRC 50% viewable tracker pixel (1-second viewability for display, 2-seconds with audio for video). Optional — measurement vendor URLs the seller's renderer fires when the viewable threshold is met."
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "event": "click",
+        "method": "img",
+        "requirements": {
+          "description": "Click measurement tracker pixel (distinct from landing_page_url, the destination). Optional — measurement vendor URL fired when the user clicks the creative, in addition to navigating to landing_page_url."
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "html_creative",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 320,
+          "height": 50,
+          "max_file_size_mb": 0.5,
+          "description": "HTML5 creative code"
+        }
+      }
+    ],
+    "canonical": {
+      "kind": "html5"
+    }
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_300x50_html"
+    },
+    "name": "Mobile Banner - HTML5",
+    "description": "300x50 HTML5 creative",
+    "type": "display",
+    "renders": [
+      {
+        "dimensions": {
+          "height": 50,
+          "responsive": {
+            "height": false,
+            "width": false
+          },
+          "width": 300
+        },
+        "role": "primary"
+      }
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "html_creative",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 300,
+          "height": 50,
+          "max_file_size_mb": 0.5,
+          "description": "HTML5 creative code"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "requirements": {
+          "description": "3rd party impression tracking pixel URL"
+        },
+        "event": "impression",
+        "method": "img"
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "viewability_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "event": "viewable_mrc_50",
+        "method": "img",
+        "requirements": {
+          "description": "MRC 50% viewable tracker pixel (1-second viewability for display, 2-seconds with audio for video). Optional — measurement vendor URLs the seller's renderer fires when the viewable threshold is met."
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "event": "click",
+        "method": "img",
+        "requirements": {
+          "description": "Click measurement tracker pixel (distinct from landing_page_url, the destination). Optional — measurement vendor URL fired when the user clicks the creative, in addition to navigating to landing_page_url."
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "html_creative",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "html",
+        "requirements": {
+          "sandbox": "none",
+          "width": 300,
+          "height": 50,
+          "max_file_size_mb": 0.5,
+          "description": "HTML5 creative code"
+        }
+      }
+    ],
+    "canonical": {
+      "kind": "html5"
+    }
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "display_static"
+    },
+    "name": "Static Display",
+    "description": "Legacy static image display format (supports any dimensions)",
+    "type": "display",
+    "accepts_parameters": [
+      "dimensions"
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "banner_image",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_url",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "requirements": {
+          "description": "3rd party impression tracking pixel URL"
+        },
+        "event": "impression",
+        "method": "img"
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "viewability_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "event": "viewable_mrc_50",
+        "method": "img",
+        "requirements": {
+          "description": "MRC 50% viewable tracker pixel (1-second viewability for display, 2-seconds with audio for video). Optional — measurement vendor URLs the seller's renderer fires when the viewable threshold is met."
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "event": "click",
+        "method": "img",
+        "requirements": {
+          "description": "Click measurement tracker pixel (distinct from landing_page_url, the destination). Optional — measurement vendor URL fired when the user clicks the creative, in addition to navigating to landing_page_url."
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "banner_image",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "image",
+        "requirements": {
+          "containers": [
+            "jpg",
+            "png",
+            "gif",
+            "webp"
+          ]
+        }
+      },
+      {
+        "asset_id": "click_url",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "url",
+        "requirements": {
+          "url_type": "clickthrough",
+          "description": "Clickthrough destination URL"
+        }
+      }
+    ],
+    "canonical": {
+      "kind": "image"
+    }
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "video_hosted"
+    },
+    "name": "Hosted Video",
+    "description": "Legacy hosted video format (supports any duration)",
+    "type": "video",
+    "accepts_parameters": [
+      "duration"
+    ],
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "video_file",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "requirements": {
+          "description": "3rd party impression tracking pixel URL"
+        },
+        "event": "impression",
+        "method": "img"
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "viewability_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "event": "viewable_mrc_50",
+        "method": "img",
+        "requirements": {
+          "description": "MRC 50% viewable tracker pixel (1-second viewability for display, 2-seconds with audio for video). Optional — measurement vendor URLs the seller's renderer fires when the viewable threshold is met."
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "event": "click",
+        "method": "img",
+        "requirements": {
+          "description": "Click measurement tracker pixel (distinct from landing_page_url, the destination). Optional — measurement vendor URL fired when the user clicks the creative, in addition to navigating to landing_page_url."
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "VIDEO_ID",
+      "POD_POSITION",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "video_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "video",
+        "requirements": {
+          "containers": [
+            "mp4",
+            "mov",
+            "webm"
+          ]
+        }
+      }
+    ],
+    "canonical": {
+      "kind": "video_hosted"
+    }
+  },
+  {
+    "format_id": {
+      "agent_url": "https://creative.adcontextprotocol.org/",
+      "id": "audio_30s"
+    },
+    "name": "Hosted Audio - 30 seconds",
+    "description": "Legacy 30-second hosted audio format",
+    "type": "audio",
+    "assets": [
+      {
+        "item_type": "individual",
+        "asset_id": "audio_file",
+        "required": true,
+        "asset_type": "audio",
+        "requirements": {
+          "min_duration_ms": 30000,
+          "max_duration_ms": 30000,
+          "containers": [
+            "mp3",
+            "aac",
+            "m4a"
+          ]
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "impression_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "requirements": {
+          "description": "3rd party impression tracking pixel URL"
+        },
+        "event": "impression",
+        "method": "img"
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "viewability_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "event": "viewable_mrc_50",
+        "method": "img",
+        "requirements": {
+          "description": "MRC 50% viewable tracker pixel (1-second viewability for display, 2-seconds with audio for video). Optional — measurement vendor URLs the seller's renderer fires when the viewable threshold is met."
+        }
+      },
+      {
+        "item_type": "individual",
+        "asset_id": "click_tracker",
+        "required": false,
+        "asset_type": "pixel_tracker",
+        "event": "click",
+        "method": "img",
+        "requirements": {
+          "description": "Click measurement tracker pixel (distinct from landing_page_url, the destination). Optional — measurement vendor URL fired when the user clicks the creative, in addition to navigating to landing_page_url."
+        }
+      }
+    ],
+    "supported_macros": [
+      "MEDIA_BUY_ID",
+      "CREATIVE_ID",
+      "CACHEBUSTER",
+      "CLICK_URL",
+      "DEVICE_TYPE",
+      "GDPR",
+      "GDPR_CONSENT",
+      "US_PRIVACY",
+      "GPP_STRING",
+      "CONTENT_GENRE"
+    ],
+    "assets_required": [
+      {
+        "asset_id": "audio_file",
+        "item_type": "individual",
+        "required": true,
+        "asset_type": "audio",
+        "requirements": {
+          "min_duration_ms": 30000,
+          "max_duration_ms": 30000,
+          "containers": [
+            "mp3",
+            "aac",
+            "m4a"
+          ]
+        }
+      }
+    ],
+    "canonical": {
+      "kind": "audio_hosted"
+    }
   }
 ]

--- a/server/src/creative-agent/task-handlers.ts
+++ b/server/src/creative-agent/task-handlers.ts
@@ -37,7 +37,7 @@ const MAX_BATCH_SIZE = 20;
 /**
  * Build formats with agent_url rewritten to the local endpoint.
  * Source data is the exact format catalog from the live creative.adcontextprotocol.org agent.
- * Unions reference-formats (50 ad formats with canonical: {kind,...} annotations) with
+ * Unions reference-formats (55 ad formats with canonical: {kind,...} annotations) with
  * ui-element-formats (7 card scaffolding formats used by training-agent + preview-renderer).
  * Cards are emitted in list_creative_formats so consumers (training-agent product-factory,
  * preview-renderer) can resolve them by format_id; they are NOT ad formats and never project

--- a/server/tests/unit/creative-agent.test.ts
+++ b/server/tests/unit/creative-agent.test.ts
@@ -23,6 +23,55 @@ describe('training agent formats', () => {
     }
   });
 
+  it('publishes reviewed canonical mappings for deployed legacy IDs', () => {
+    const formats = buildReferenceFormats(TEST_AGENT_URL);
+    const byId = new Map(
+      formats.map(format => [(format.format_id as { id: string }).id, format as Record<string, unknown>])
+    );
+
+    for (const [id, width] of [
+      ['display_320x50_html', 320],
+      ['display_300x50_html', 300],
+    ] as const) {
+      const format = byId.get(id)!;
+      expect(format.canonical).toEqual({ kind: 'html5' });
+      expect(format.renders).toEqual([
+        {
+          dimensions: {
+            height: 50,
+            responsive: { height: false, width: false },
+            width,
+          },
+          role: 'primary',
+        },
+      ]);
+      const htmlAsset = (format.assets as Array<Record<string, unknown>>).find(
+        asset => asset.asset_id === 'html_creative'
+      )!;
+      expect(htmlAsset.requirements).toMatchObject({ width, height: 50 });
+    }
+
+    expect(byId.get('display_static')).toMatchObject({
+      accepts_parameters: ['dimensions'],
+      canonical: { kind: 'image' },
+    });
+    expect(byId.get('video_hosted')).toMatchObject({
+      accepts_parameters: ['duration'],
+      canonical: { kind: 'video_hosted' },
+    });
+    expect(byId.get('audio_30s')).toMatchObject({
+      canonical: { kind: 'audio_hosted' },
+    });
+    const audioAsset = (byId.get('audio_30s')!.assets as Array<Record<string, unknown>>).find(
+      asset => asset.asset_id === 'audio_file'
+    )!;
+    expect(audioAsset.requirements).toMatchObject({
+      min_duration_ms: 30_000,
+      max_duration_ms: 30_000,
+    });
+  });
+
+
   it('all format IDs are unique', () => {
     const formats = buildFormats(TEST_TRAINING_URL);
     const ids = formats.map(f => (f.format_id as { id: string }).id);
@@ -40,13 +89,12 @@ describe('training agent formats', () => {
     }
   });
 });
-
 // ── Reference formats (creative agent) ──────────────────────────────
 
 describe('reference formats', () => {
   it('loads reference formats and rewrites agent_url', () => {
     const formats = buildReferenceFormats(TEST_AGENT_URL);
-    expect(formats.length).toBe(57);
+    expect(formats.length).toBe(62);
     for (const f of formats) {
       const fid = f.format_id as { agent_url: string; id: string };
       expect(fid.agent_url).toBe(TEST_AGENT_URL);
@@ -112,7 +160,7 @@ describe('handleListCreativeFormats', () => {
   it('returns all formats when no filters provided', () => {
     const result = handleListCreativeFormats({}, formats);
     const returned = result.formats as unknown[];
-    expect(returned.length).toBe(57);
+    expect(returned.length).toBe(62);
   });
 
   it('response structure matches schema: { formats: [...] }', () => {
@@ -523,7 +571,7 @@ describe('MCP tool responses include structuredContent', () => {
     const structured = result.structuredContent as { formats: unknown[] };
     expect(structured.formats).toBeDefined();
     expect(Array.isArray(structured.formats)).toBe(true);
-    expect(structured.formats.length).toBe(3);
+    expect(structured.formats.length).toBe(4);
   });
 
   it('list_creative_formats structuredContent matches content text', async () => {
@@ -584,7 +632,7 @@ describe('MCP tool responses include structuredContent', () => {
     });
 
     const structured = result.structuredContent as { formats: unknown[] };
-    expect(structured.formats.length).toBe(57);
+    expect(structured.formats.length).toBe(62);
   });
 
   it('preview_creative batch mode returns structuredContent', async () => {


### PR DESCRIPTION
## Why

The trailing 30-day production replay identified five AgenticAdvertising.org-owned legacy format IDs that could not reach canonical creatives because their authoritative public catalog entries were missing. Most observed refs also omit inline dimensions or duration, so the catalog must carry the fixed requirements rather than relying on SDK name heuristics.

Closes #6025.

## What changed

- Publish `display_320x50_html` and `display_300x50_html` as fixed-size `html5` formats.
- Publish `display_static` as the historical parameterized static-image format (`image`).
- Publish `video_hosted` as the historical parameterized hosted-video format.
- Publish `audio_30s` as fixed 30-second hosted audio.
- Add focused catalog assertions for canonical kinds, dimensions, duration, and parameterized aliases.
- Leave ambiguous bare display IDs fail-closed; this PR adds no ID-only heuristic.

`display_static` uses the image disposition documented by the historical `server/src/shared/formats.ts` definition and creative format documentation (`banner_image`, `asset_type: image`, parameterized dimensions).

## Validation

- Creative-agent unit test: 59/59 passed
- Server TypeScript check passed
- Canonical-format convention lint passed (55 catalog entries)
- TypeScript SDK v13 vendored-fixture and end-to-end projection tests passed
- Protocol, security, and adopter-DX expert reviews: SHIP
