### PR TITLE
fix(training-agent): apply proposal pricing refinements

### DIFF
--- a/server/src/training-agent/product-factory.ts
+++ b/server/src/training-agent/product-factory.ts
@@ -991,6 +991,11 @@ export function buildCatalog(): CatalogProduct[] {
       pricingAliases: ['cpm_guaranteed_fixed'],
     },
     {
+      id: 'sports_preroll_q2',
+      name: 'Sports Preroll Q2 (legacy refinement storyboard fixture)',
+      source: catalog.find(cp => cp.publisherId === guaranteedCtvPublisher.id && (cp.product.channels ?? []).includes('ctv')),
+    },
+    {
       id: 'outdoor_ctv_q2_guaranteed',
       name: 'Outdoor CTV Q2 Guaranteed (storyboard fixture)',
       source: catalog.find(cp => cp.publisherId === guaranteedCtvPublisher.id && (cp.product.channels ?? []).includes('ctv')),

--- a/server/src/training-agent/state.ts
+++ b/server/src/training-agent/state.ts
@@ -180,6 +180,7 @@ function createSession(): SessionState {
     collectionLists: new Map(),
     contentStandards: new Map(),
     rightsGrants: new Map(),
+    negotiatedPricingOptions: new Map(),
     creatives: new Map(),
     signalActivations: new Map(),
     usageRecords: [],
@@ -395,6 +396,7 @@ function deserializeSession(data: Record<string, unknown>): SessionState {
     collectionLists: asMap(hydrated.collectionLists, fresh.collectionLists),
     contentStandards: asMap(hydrated.contentStandards, fresh.contentStandards),
     rightsGrants: asMap(hydrated.rightsGrants, fresh.rightsGrants),
+    negotiatedPricingOptions: asMap(hydrated.negotiatedPricingOptions, fresh.negotiatedPricingOptions),
     usageRecords: Array.isArray(hydrated.usageRecords) ? hydrated.usageRecords : [],
     complyExtensions: {
       accountStatuses: asMap(hydratedComply.accountStatuses, fresh.complyExtensions.accountStatuses),

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -3197,9 +3197,20 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
   const refinementApplied: RefinementAppliedEntry[] = [];
   const proposalOmitIds = new Set<string>();
   const refinedProposalOverrides = new Map<string, Proposal>();
+  const explicitlySelectedProposals = new Map<string, Proposal>();
   if (buyingMode === 'refine' && req.refine) {
     const refineOps = req.refine as unknown as RefineEntry[];
     const previousProposals = session.lastGetProductsContext?.proposals || getProposals();
+    const registryProposals = getProposals();
+    const resolveProposal = (proposalId: string): Proposal | undefined => {
+      const proposal = previousProposals.find(candidate => candidate.proposal_id === proposalId)
+        ?? registryProposals.find(candidate => candidate.proposal_id === proposalId);
+      if (proposal) return proposal;
+      if (isThreeZeroStoryboardCompat(ctx) && proposalId === THREE_ZERO_LEGACY_PROPOSAL_ID) {
+        return resolveThreeZeroProposalAlias([...previousProposals, ...registryProposals]);
+      }
+      return undefined;
+    };
     const omitIds = new Set<string>();
     const includeIds = new Set<string>();
     const knownProductIds = new Set(
@@ -3229,10 +3240,7 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
         continue;
       }
       if (op.scope !== 'proposal') continue;
-      let proposal = previousProposals.find(p => p.proposal_id === op.proposal_id);
-      if (!proposal && isThreeZeroStoryboardCompat(ctx) && op.proposal_id === THREE_ZERO_LEGACY_PROPOSAL_ID) {
-        proposal = resolveThreeZeroProposalAlias([...previousProposals, ...getProposals()]);
-      }
+      const proposal = resolveProposal(op.proposal_id);
       if (!proposal) {
         return {
           errors: [{
@@ -3276,15 +3284,13 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
       } else if (op.scope === 'proposal') {
         const action = op.action ?? 'include';
         let proposal = refinedProposalOverrides.get(op.proposal_id)
-          ?? previousProposals.find(p => p.proposal_id === op.proposal_id);
-        if (!proposal && isThreeZeroStoryboardCompat(ctx) && op.proposal_id === THREE_ZERO_LEGACY_PROPOSAL_ID) {
-          proposal = resolveThreeZeroProposalAlias([...previousProposals, ...getProposals()]);
-        }
+          ?? resolveProposal(op.proposal_id);
         if (!proposal) continue;
         if (action === 'omit') {
-          proposalOmitIds.add(op.proposal_id);
+          proposalOmitIds.add(proposal.proposal_id);
           refinementApplied.push({ scope: 'proposal', proposal_id: op.proposal_id, status: 'applied' });
         } else if (action === 'include') {
+          explicitlySelectedProposals.set(proposal.proposal_id, proposal);
           for (const allocation of proposal.allocations) includeIds.add(allocation.product_id);
           const concreteCpmAsk = parseConcreteCpmAsk(op.ask);
           if (concreteCpmAsk) {
@@ -3311,7 +3317,8 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
                 })),
               } as Proposal;
               if (budget) refinedProposal = withProposalBudgetGuidance(refinedProposal, budget);
-              refinedProposalOverrides.set(op.proposal_id, refinedProposal);
+              refinedProposalOverrides.set(proposal.proposal_id, refinedProposal);
+              explicitlySelectedProposals.set(proposal.proposal_id, refinedProposal);
               for (const [productId, pricing] of stagedProducts) {
                 session.negotiatedPricingOptions.set(`${productId}:${pricing!.pricingOptionId}`, {
                   productId,
@@ -3425,9 +3432,15 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
   }
 
   // In refine mode, use session proposals (which may include finalized versions)
-  const sourceProposals = (buyingMode === 'refine' && session.lastGetProductsContext?.proposals)
+  const contextualProposals = (buyingMode === 'refine' && session.lastGetProductsContext?.proposals)
     ? session.lastGetProductsContext.proposals
     : getProposals();
+  const sourceProposals = [
+    ...contextualProposals,
+    ...Array.from(explicitlySelectedProposals.values()).filter(selected =>
+      !contextualProposals.some(contextual => contextual.proposal_id === selected.proposal_id),
+    ),
+  ];
 
   const productsById = new Map(products.map(p => [p.product_id, p]));
   const proposals = sourceProposals

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -7,6 +7,7 @@
  */
 
 import { createHash, randomUUID } from 'node:crypto';
+import { isDeepStrictEqual } from 'node:util';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   CallToolRequestSchema,
@@ -608,6 +609,171 @@ interface ProposalLifecycle {
 }
 function proposalLifecycle(proposal: Proposal): ProposalLifecycle {
   return proposal as unknown as ProposalLifecycle;
+}
+
+type ConcreteCpmAsk = {
+  currency?: string;
+  budget?: { amount: number; currency: string };
+};
+
+const ISO_CURRENCY_CODES = new Set(Intl.supportedValuesOf('currency'));
+
+/**
+ * Recognize the training agent's deterministic proposal-pricing refinement.
+ * Other natural-language asks intentionally remain partial so buyers can test
+ * both successful and honest incomplete refinement outcomes.
+ */
+function parseConcreteCpmAsk(ask?: string): ConcreteCpmAsk | undefined {
+  if (!ask) return undefined;
+  const normalized = ask.toLowerCase();
+  if (!/\bcpm\b/.test(normalized)) return undefined;
+  if (!/\b(?:concrete|firm|fixed|price|pricing|rate|per[ -]unit)\b/.test(normalized)) return undefined;
+
+  const contextualCurrency = ask.match(/\b(?:in|currency(?:\s+of)?)\s+([a-z]{3})\b/i)?.[1]?.toUpperCase();
+  const explicitCurrency = contextualCurrency && ISO_CURRENCY_CODES.has(contextualCurrency)
+    ? contextualCurrency
+    : ask.includes('$') ? 'USD' : undefined;
+  const budgetClause = ask.match(/\b(?:budget|total)\b[^.!?]{0,120}/i)?.[0];
+  const containsExplicitCpmAmount = /(?:\$\s*\d[\d,.]*|\b\d[\d,.]*\s*[a-z]{3})\s*(?:per[- ]unit\s+)?cpm\b/i.test(ask);
+  if (containsExplicitCpmAmount) return undefined;
+  if (!budgetClause) {
+    return { ...(explicitCurrency && { currency: explicitCurrency }) };
+  }
+
+  const amountPattern = '([0-9][0-9,]*(?:\\.[0-9]{1,2})?)\\s*([km])?';
+  const currencyBefore = budgetClause.match(new RegExp(`\\b([A-Z]{3})\\s*\\$?\\s*${amountPattern}\\b`, 'i'));
+  const currencyAfter = budgetClause.match(new RegExp(`\\b${amountPattern}\\s*([A-Z]{3})\\b`, 'i'));
+  const dollarAmount = budgetClause.match(new RegExp(`\\$\\s*${amountPattern}\\b`, 'i'));
+
+  let amountText: string | undefined;
+  let scale: string | undefined;
+  let currency: string | undefined;
+  if (currencyAfter) {
+    [, amountText, scale, currency] = currencyAfter;
+  } else if (currencyBefore) {
+    [, currency, amountText, scale] = currencyBefore;
+  } else if (dollarAmount) {
+    [, amountText, scale] = dollarAmount;
+    currency = 'USD';
+  }
+
+  if (!amountText || !currency) {
+    return { ...(explicitCurrency && { currency: explicitCurrency }) };
+  }
+  const multiplier = scale?.toLowerCase() === 'm' ? 1_000_000 : scale?.toLowerCase() === 'k' ? 1_000 : 1;
+  const amount = Number(amountText.replaceAll(',', '')) * multiplier;
+  if (!Number.isFinite(amount) || amount <= 0) return undefined;
+  const normalizedCurrency = currency.toUpperCase();
+  if (!ISO_CURRENCY_CODES.has(normalizedCurrency)) return undefined;
+  return {
+    currency: normalizedCurrency,
+    budget: { amount, currency: normalizedCurrency },
+  };
+}
+
+function concreteCpmPricing(
+  product: Product,
+  requestedCurrency?: string,
+): {
+  product: Product;
+  pricingOption: PricingOption;
+  pricingOptionId: string;
+  fixedPrice: number;
+  currency: string;
+} | undefined {
+  const optionIndex = product.pricing_options.findIndex(option =>
+    option.pricing_model === 'cpm'
+    && (!requestedCurrency || option.currency === requestedCurrency),
+  );
+  if (optionIndex < 0) return undefined;
+
+  const option = product.pricing_options[optionIndex] as Extract<PricingOption, { pricing_model: 'cpm' }>;
+  const fixedPrice = option.fixed_price
+    ?? option.price_guidance?.p50
+    ?? option.floor_price;
+  if (fixedPrice === undefined) return undefined;
+
+  const {
+    floor_price: _floorPrice,
+    price_guidance: _priceGuidance,
+    max_bid: _maxBid,
+    min_spend_per_package: _minSpendPerPackage,
+    ...concreteOptionBase
+  } = option;
+  const fingerprint = createHash('sha256')
+    .update(`${product.product_id}|${option.pricing_option_id}|${option.currency}|${fixedPrice}`)
+    .digest('hex')
+    .slice(0, 32);
+  const pricingOptionId = `${option.pricing_option_id}_concrete_${fingerprint}`;
+  const pricingOptions = [...product.pricing_options];
+  const negotiatedOption = { ...concreteOptionBase, pricing_option_id: pricingOptionId, fixed_price: fixedPrice } as PricingOption;
+  const negotiatedIndex = pricingOptions.findIndex(candidate => candidate.pricing_option_id === pricingOptionId);
+  let effectiveOption = negotiatedOption;
+  if (negotiatedIndex >= 0) {
+    const existing = pricingOptions[negotiatedIndex] as PricingOption;
+    if (!isDeepStrictEqual(existing, negotiatedOption)) return undefined;
+    effectiveOption = existing;
+  } else {
+    pricingOptions.push(negotiatedOption);
+  }
+
+  return {
+    product: { ...product, pricing_options: pricingOptions },
+    pricingOption: effectiveOption,
+    pricingOptionId,
+    fixedPrice,
+    currency: option.currency,
+  };
+}
+
+function withProposalBudgetGuidance(
+  proposal: Proposal,
+  budget: { amount: number; currency: string },
+): Proposal {
+  const guidance = {
+    ...proposal.total_budget_guidance,
+    min: Math.min(proposal.total_budget_guidance?.min ?? budget.amount, budget.amount),
+    recommended: budget.amount,
+    currency: budget.currency,
+  };
+  const ext = proposal.ext as unknown as Record<string, unknown> | undefined;
+  const updateCard = (card: unknown): unknown => {
+    if (!card || typeof card !== 'object' || Array.isArray(card)) return card;
+    const typedCard = card as Record<string, unknown>;
+    const manifest = typedCard.manifest;
+    if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) return card;
+    const typedManifest = manifest as Record<string, unknown>;
+    const assets = typedManifest.assets;
+    if (!assets || typeof assets !== 'object' || Array.isArray(assets)) return card;
+    const {
+      estimated_delivery: _staleEstimatedDelivery,
+      ...currentAssets
+    } = assets as Record<string, unknown>;
+    return {
+      ...typedCard,
+      manifest: {
+        ...typedManifest,
+        assets: {
+          ...currentAssets,
+          budget_min: { content: String(guidance.min) },
+          budget_recommended: { content: String(guidance.recommended) },
+          budget_currency: { content: guidance.currency },
+        },
+      },
+    };
+  };
+
+  return {
+    ...proposal,
+    total_budget_guidance: guidance,
+    ...(ext && {
+      ext: {
+        ...ext,
+        proposal_card: updateCard(ext.proposal_card),
+        proposal_card_detailed: updateCard(ext.proposal_card_detailed),
+      },
+    }),
+  } as Proposal;
 }
 
 const THREE_ZERO_LEGACY_PROPOSAL_ID = 'balanced_reach_q2';
@@ -2020,6 +2186,27 @@ function overlaySeededProducts(
   }
 }
 
+/** Overlay proposal-specific pricing created by successful refine asks. */
+function overlayNegotiatedPricingOptions(
+  session: import('./types.js').SessionState,
+  productMap: Map<string, Product>,
+): void {
+  for (const { productId, option } of session.negotiatedPricingOptions.values()) {
+    const product = productMap.get(productId);
+    if (!product) continue;
+    const pricingOptions = [...product.pricing_options];
+    const existingIndex = pricingOptions.findIndex(
+      candidate => candidate.pricing_option_id === option.pricing_option_id,
+    );
+    if (existingIndex >= 0) {
+      pricingOptions[existingIndex] = option;
+    } else {
+      pricingOptions.push(option);
+    }
+    productMap.set(productId, { ...product, pricing_options: pricingOptions });
+  }
+}
+
 function seededProductIds(session: import('./types.js').SessionState): Set<string> {
   const ids = new Set<string>(session.complyExtensions.seededProducts.keys());
   for (const key of session.complyExtensions.seededPricingOptions.keys()) {
@@ -2899,7 +3086,9 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
   // to repeat boilerplate. Catalog products are not touched.
   const productMap = new Map(products.map(p => [p.product_id, p]));
   overlaySeededProducts(session, productMap);
+  if (buyingMode !== 'wholesale') overlayNegotiatedPricingOptions(session, productMap);
   products = Array.from(productMap.values());
+  const registryProducts = products;
 
   // Apply filters
   if (req.filters) {
@@ -3007,20 +3196,38 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
 
   const refinementApplied: RefinementAppliedEntry[] = [];
   const proposalOmitIds = new Set<string>();
+  const refinedProposalOverrides = new Map<string, Proposal>();
   if (buyingMode === 'refine' && req.refine) {
     const refineOps = req.refine as unknown as RefineEntry[];
-    const previousProducts = session.lastGetProductsContext?.products || products;
     const previousProposals = session.lastGetProductsContext?.proposals || getProposals();
     const omitIds = new Set<string>();
     const includeIds = new Set<string>();
+    const knownProductIds = new Set(
+      registryProducts
+        .filter(product => !product.expires_at || new Date(product.expires_at) >= new Date())
+        .map(product => product.product_id),
+    );
 
     const askAckNotes = (ask?: string) =>
       ask ? { notes: `Ask acknowledged but not applied by training agent: ${ask}` } : {};
 
-    // Validate proposal references before applying any refinements. This keeps
+    // Validate entity references before applying any refinements. This keeps
     // failed multi-entry refine calls from partially finalizing earlier entries.
     for (let opIndex = 0; opIndex < refineOps.length; opIndex++) {
       const op = refineOps[opIndex];
+      if (op.scope === 'product') {
+        if (!knownProductIds.has(op.product_id)) {
+          return {
+            errors: [{
+              code: 'PRODUCT_NOT_FOUND',
+              message: `Product not found: ${op.product_id}`,
+              field: `refine[${opIndex}].product_id`,
+              recovery: 'correctable',
+            }] as TaskError[],
+          };
+        }
+        continue;
+      }
       if (op.scope !== 'proposal') continue;
       let proposal = previousProposals.find(p => p.proposal_id === op.proposal_id);
       if (!proposal && isThreeZeroStoryboardCompat(ctx) && op.proposal_id === THREE_ZERO_LEGACY_PROPOSAL_ID) {
@@ -3042,15 +3249,18 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
       const op = refineOps[opIndex];
       if (op.scope === 'product') {
         const action = op.action ?? 'include';
+        const passesFilters = filteredProducts.some(product => product.product_id === op.product_id);
         if (action === 'omit') {
           omitIds.add(op.product_id);
           refinementApplied.push({ scope: 'product', product_id: op.product_id, status: 'applied' });
         } else if (action === 'include') {
           includeIds.add(op.product_id);
-          refinementApplied.push({ scope: 'product', product_id: op.product_id, status: op.ask ? 'partial' : 'applied', ...askAckNotes(op.ask) });
+          refinementApplied.push(passesFilters
+            ? { scope: 'product', product_id: op.product_id, status: op.ask ? 'partial' : 'applied', ...askAckNotes(op.ask) }
+            : { scope: 'product', product_id: op.product_id, status: 'partial', notes: 'Product is excluded by the request filters' });
         } else if (action === 'more_like_this') {
           includeIds.add(op.product_id);
-          const source = previousProducts.find(p => p.product_id === op.product_id);
+          const source = registryProducts.find(p => p.product_id === op.product_id);
           if (source) {
             const sourceChannels = source.channels;
             for (const p of filteredProducts) {
@@ -3059,11 +3269,14 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
               }
             }
           }
-          refinementApplied.push({ scope: 'product', product_id: op.product_id, status: 'applied' });
+          refinementApplied.push(passesFilters
+            ? { scope: 'product', product_id: op.product_id, status: 'applied' }
+            : { scope: 'product', product_id: op.product_id, status: 'partial', notes: 'Source product is excluded by the request filters' });
         }
       } else if (op.scope === 'proposal') {
         const action = op.action ?? 'include';
-        let proposal = previousProposals.find(p => p.proposal_id === op.proposal_id);
+        let proposal = refinedProposalOverrides.get(op.proposal_id)
+          ?? previousProposals.find(p => p.proposal_id === op.proposal_id);
         if (!proposal && isThreeZeroStoryboardCompat(ctx) && op.proposal_id === THREE_ZERO_LEGACY_PROPOSAL_ID) {
           proposal = resolveThreeZeroProposalAlias([...previousProposals, ...getProposals()]);
         }
@@ -3072,7 +3285,56 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
           proposalOmitIds.add(op.proposal_id);
           refinementApplied.push({ scope: 'proposal', proposal_id: op.proposal_id, status: 'applied' });
         } else if (action === 'include') {
-          refinementApplied.push({ scope: 'proposal', proposal_id: op.proposal_id, status: op.ask ? 'partial' : 'applied', ...askAckNotes(op.ask) });
+          for (const allocation of proposal.allocations) includeIds.add(allocation.product_id);
+          const concreteCpmAsk = parseConcreteCpmAsk(op.ask);
+          if (concreteCpmAsk) {
+            const stagedProducts = new Map<string, ReturnType<typeof concreteCpmPricing>>();
+            let allAllocationsPriced = true;
+            for (const allocation of proposal.allocations) {
+              const product = products.find(p => p.product_id === allocation.product_id);
+              const concretePricing = product && concreteCpmPricing(product, concreteCpmAsk.currency);
+              if (!concretePricing) {
+                allAllocationsPriced = false;
+                break;
+              }
+              stagedProducts.set(allocation.product_id, concretePricing);
+            }
+
+            if (allAllocationsPriced) {
+              products = products.map(product => stagedProducts.get(product.product_id)?.product ?? product);
+              const budget = concreteCpmAsk.budget;
+              let refinedProposal = {
+                ...proposal,
+                allocations: proposal.allocations.map(allocation => ({
+                  ...allocation,
+                  pricing_option_id: stagedProducts.get(allocation.product_id)!.pricingOptionId,
+                })),
+              } as Proposal;
+              if (budget) refinedProposal = withProposalBudgetGuidance(refinedProposal, budget);
+              refinedProposalOverrides.set(op.proposal_id, refinedProposal);
+              for (const [productId, pricing] of stagedProducts) {
+                session.negotiatedPricingOptions.set(`${productId}:${pricing!.pricingOptionId}`, {
+                  productId,
+                  option: pricing!.pricingOption,
+                });
+              }
+              const rates = proposal.allocations.map(allocation => {
+                const pricing = stagedProducts.get(allocation.product_id)!;
+                return `${allocation.product_id}: ${pricing.currency} ${pricing.fixedPrice} CPM`;
+              }).join('; ');
+              const budgetNote = budget ? ` Recommended total set to ${budget.currency} ${budget.amount}.` : '';
+              refinementApplied.push({
+                scope: 'proposal',
+                proposal_id: op.proposal_id,
+                status: 'applied',
+                notes: `Concrete fixed CPM pricing applied (${rates}).${budgetNote}`,
+              });
+            } else {
+              refinementApplied.push({ scope: 'proposal', proposal_id: op.proposal_id, status: 'partial', ...askAckNotes(op.ask) });
+            }
+          } else {
+            refinementApplied.push({ scope: 'proposal', proposal_id: op.proposal_id, status: op.ask ? 'partial' : 'applied', ...askAckNotes(op.ask) });
+          }
         } else if (action === 'finalize') {
           const status = proposalLifecycle(proposal).proposal_status;
           if (status === 'committed') {
@@ -3132,9 +3394,10 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
 
     // Apply includes first (expand), then omits (filter) for products
     if (includeIds.size > 0) {
+      const currentProductsById = new Map(products.map(product => [product.product_id, product]));
       products = filteredProducts
         .filter(p => includeIds.has(p.product_id))
-        .map(p => ({ ...p }));
+        .map(p => currentProductsById.get(p.product_id) ?? { ...p });
     }
     if (omitIds.size > 0) {
       products = products.filter(p => !omitIds.has(p.product_id));
@@ -3168,6 +3431,7 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
 
   const productsById = new Map(products.map(p => [p.product_id, p]));
   const proposals = sourceProposals
+    .map(proposal => refinedProposalOverrides.get(proposal.proposal_id) ?? proposal)
     .filter(proposal =>
       proposal.allocations.every(a => productIds.has(a.product_id)) &&
       !proposalOmitIds.has(proposal.proposal_id),
@@ -3175,7 +3439,10 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
     .map(proposal => ({
       ...proposal,
       allocations: proposal.allocations.map(alloc => {
-        const selectedPricing = productsById.get(alloc.product_id)?.pricing_options[0];
+        const pricingOptions = productsById.get(alloc.product_id)?.pricing_options;
+        const selectedPricing = pricingOptions?.find(
+          option => option.pricing_option_id === alloc.pricing_option_id,
+        ) ?? pricingOptions?.[0];
         return selectedPricing
           ? { ...alloc, pricing_option_id: selectedPricing.pricing_option_id }
           : alloc;
@@ -4265,6 +4532,7 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   const catalog = getCatalog();
   const productMap = new Map(catalog.map(cp => [cp.product.product_id, cp.product]));
   overlaySeededProducts(session, productMap);
+  overlayNegotiatedPricingOptions(session, productMap);
 
   // Validate metric-kind optimization_goals against the package's product
   // metric_optimization declarations. reach goals must declare a reach_unit

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -292,6 +292,13 @@ export interface SessionState {
   collectionLists: Map<string, CollectionListState>;
   contentStandards: Map<string, ContentStandardsState>;
   rightsGrants: Map<string, RightsGrantState>;
+  /** Proposal-specific pricing options created by successful refine asks.
+   * Keyed by product_id + pricing_option_id and overlaid onto the deterministic
+   * catalog on later get_products/create_media_buy requests. */
+  negotiatedPricingOptions: Map<string, {
+    productId: string;
+    option: Product['pricing_options'][number];
+  }>;
   usageRecords: UsageRecord[];
   /** Data set by comply_test_controller. Persisted so scenarios survive the
    * serialize/deserialize round trip that every request does, even in the

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { buildCatalog } from '../../src/training-agent/product-factory.js';
+import { buildCatalog, buildProposals } from '../../src/training-agent/product-factory.js';
 import { buildFormats, FORMAT_CHANNEL_MAP } from '../../src/training-agent/formats.js';
 import { PUBLISHERS } from '../../src/training-agent/publishers.js';
 import { SIGNAL_PROVIDERS, getAllSignals } from '../../src/training-agent/signal-providers.js';
@@ -6422,6 +6422,23 @@ describe('get_products refine mode', () => {
     expect(result.recovery).toBe('correctable');
   });
 
+  it('recognizes the legacy sports preroll refinement fixture as a catalog product', async () => {
+    const server = createTrainingAgentServer({ ...DEFAULT_CTX, storyboardCompat: { version: '3.0' } });
+    const { result, isError } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'refine',
+      account: { brand: { domain: 'legacy-refine.example' }, operator: 'legacy-refine.example' },
+      refine: [
+        { scope: 'request', ask: 'Only guaranteed packages.' },
+        { scope: 'product', product_id: 'sports_preroll_q2', ask: 'Increase budget allocation to $30K' },
+      ],
+    });
+
+    expect(isError).toBeFalsy();
+    expect((result.products as Array<Record<string, unknown>>).some(
+      product => product.product_id === 'sports_preroll_q2',
+    )).toBe(true);
+  });
+
   it('rejects mixed refinements before applying an earlier proposal pricing change', async () => {
     const account = { brand: { domain: 'atomic-product-refine.example' }, operator: 'atomic-product-refine.example' };
     const server1 = createTrainingAgentServer(DEFAULT_CTX);
@@ -6750,6 +6767,61 @@ describe('get_products refine mode', () => {
       expect(pricingOption!.max_bid).toBeUndefined();
       expect(pricingOption!.min_spend_per_package).toBeUndefined();
     }
+  });
+
+  it('returns a legacy 3.0 proposal alias even when the preceding brief selected other proposals', async () => {
+    const compatCtx = { ...DEFAULT_CTX, storyboardCompat: { version: '3.0' as const } };
+    const account = { brand: { domain: 'legacy-proposal.example' }, operator: 'legacy-proposal.example' };
+    const server1 = createTrainingAgentServer(compatCtx);
+    await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'Premium video and display across outdoor lifestyle and sports.',
+      account,
+    });
+
+    const server2 = createTrainingAgentServer(compatCtx);
+    const { result, isError } = await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [
+        { scope: 'proposal', proposal_id: 'balanced_reach_q2', ask: 'Shift budget to CTV.' },
+        { scope: 'request', ask: 'All products must support frequency capping.' },
+      ],
+    });
+
+    expect(isError).toBeFalsy();
+    expect(result.proposals).toEqual(expect.arrayContaining([
+      expect.objectContaining({ proposal_id: 'sparq_social_amplification' }),
+    ]));
+  });
+
+  it('resolves a canonical proposal from the seller registry when it was absent from the preceding brief', async () => {
+    const account = { brand: { domain: 'registry-proposal.example' }, operator: 'registry-proposal.example' };
+    const server1 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: initial } = await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'Premium video and display across outdoor lifestyle and sports.',
+      account,
+    });
+    const returnedProposalIds = new Set(
+      ((initial.proposals ?? []) as Array<Record<string, unknown>>).map(proposal => proposal.proposal_id),
+    );
+    const registryProposal = buildProposals(buildCatalog()).find(
+      proposal => !returnedProposalIds.has(proposal.proposal_id),
+    );
+    expect(registryProposal).toBeDefined();
+
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result, isError } = await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{ scope: 'proposal', proposal_id: registryProposal!.proposal_id }],
+    });
+
+    expect(isError).toBeFalsy();
+    expect(result.proposals).toEqual(expect.arrayContaining([
+      expect.objectContaining({ proposal_id: registryProposal!.proposal_id }),
+    ]));
   });
 
   it('persists concrete proposal pricing across subsequent get_products requests', async () => {

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -6406,6 +6406,69 @@ describe('get_products refine mode', () => {
     expect(refinedIds).not.toContain(firstProductId);
   });
 
+  it('rejects an unknown product reference with PRODUCT_NOT_FOUND', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'unknown-refine.example' }, operator: 'unknown-refine.example' };
+
+    const { result, isError } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{ scope: 'product', action: 'include', product_id: 'unknown_product' }],
+    });
+
+    expect(isError).toBe(true);
+    expect(result.code).toBe('PRODUCT_NOT_FOUND');
+    expect(result.field).toBe('refine[0].product_id');
+    expect(result.recovery).toBe('correctable');
+  });
+
+  it('rejects mixed refinements before applying an earlier proposal pricing change', async () => {
+    const account = { brand: { domain: 'atomic-product-refine.example' }, operator: 'atomic-product-refine.example' };
+    const server1 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: initial } = await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'cross-channel news video and display',
+      account,
+    });
+    const initialProposal = (initial.proposals as Array<Record<string, unknown>>).find(
+      proposal => proposal.proposal_id === 'pinnacle_cross_channel',
+    )!;
+
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: rejected, isError } = await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [
+        {
+          scope: 'proposal',
+          proposal_id: 'pinnacle_cross_channel',
+          ask: 'Provide concrete per-unit CPM pricing and set the recommended total to 5000 USD',
+        },
+        { scope: 'product', action: 'include', product_id: 'unknown_product' },
+      ],
+    });
+
+    expect(isError).toBe(true);
+    expect(rejected.code).toBe('PRODUCT_NOT_FOUND');
+    expect(rejected.field).toBe('refine[1].product_id');
+
+    const server3 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: afterRejected } = await simulateCallTool(server3, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{
+        scope: 'proposal',
+        proposal_id: 'pinnacle_cross_channel',
+        ask: 'Confirm the current recommendation without changing it',
+      }],
+    });
+    const proposalAfterRejected = (afterRejected.proposals as Array<Record<string, unknown>>).find(
+      proposal => proposal.proposal_id === 'pinnacle_cross_channel',
+    )!;
+    expect(proposalAfterRejected.total_budget_guidance).toEqual(initialProposal.total_budget_guidance);
+    expect(proposalAfterRejected.allocations).toEqual(initialProposal.allocations);
+  });
+
   it('finds similar products with more_like_this', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const account = { brand: { domain: 'morelike.example' }, operator: 'morelike.example' };
@@ -6443,6 +6506,45 @@ describe('get_products refine mode', () => {
 
     // Should have more than just the source product
     expect(refinedProducts.length).toBeGreaterThan(1);
+  });
+
+  it('resolves more_like_this from the seller registry without prior response state', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'self-contained-refine.example' }, operator: 'self-contained-refine.example' };
+    const source = buildCatalog()[0].product;
+
+    const { result: refined } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{ scope: 'product', action: 'more_like_this', product_id: source.product_id }],
+    });
+
+    expect((refined.refinement_applied as Array<Record<string, unknown>>)[0].status).toBe('applied');
+    const products = refined.products as Array<Record<string, unknown>>;
+    expect(products.some(product => product.product_id === source.product_id)).toBe(true);
+    expect(products.length).toBeGreaterThan(1);
+  });
+
+  it('reports partial when absolute filters exclude a referenced product', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'filtered-refine.example' }, operator: 'filtered-refine.example' };
+    const source = buildCatalog().find(entry => !entry.product.channels?.includes('gaming'))!.product;
+
+    const { result: refined } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      filters: { channels: ['gaming'] },
+      refine: [{ scope: 'product', action: 'include', product_id: source.product_id }],
+    });
+
+    const applied = refined.refinement_applied as Array<Record<string, unknown>>;
+    expect(applied[0]).toMatchObject({
+      scope: 'product',
+      product_id: source.product_id,
+      status: 'partial',
+    });
+    expect((refined.products as Array<Record<string, unknown>>)
+      .some(product => product.product_id === source.product_id)).toBe(false);
   });
 
   it('defaults missing action to include on product scope', async () => {
@@ -6581,6 +6683,354 @@ describe('get_products refine mode', () => {
     expect(refinementApplied[0].status).toBe('applied');
     expect(refinementApplied[0].scope).toBe('proposal');
     expect(refinementApplied[0].proposal_id).toBe(targetProposalId);
+  });
+
+  it('applies a concrete proposal CPM and recommended-budget refinement', async () => {
+    const account = { brand: { domain: 'firm-cpm.example' }, operator: 'firm-cpm.example' };
+
+    const server1 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: initial } = await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'cross-channel news video and display',
+      account,
+    });
+    const initialProposal = (initial.proposals as Array<Record<string, unknown>>).find(
+      proposal => proposal.proposal_id === 'pinnacle_cross_channel',
+    );
+    expect(initialProposal).toBeDefined();
+
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: refined } = await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{
+        scope: 'proposal',
+        proposal_id: 'pinnacle_cross_channel',
+        action: 'include',
+        ask: 'Provide a concrete per-unit CPM for each allocation and a firm recommended total for a 5000 USD September flight',
+      }],
+    });
+
+    const applied = refined.refinement_applied as Array<Record<string, unknown>>;
+    expect(applied).toHaveLength(1);
+    expect(applied[0].status).toBe('applied');
+    expect(applied[0].notes).toContain('Concrete fixed CPM pricing applied');
+
+    const refinedProposal = (refined.proposals as Array<Record<string, unknown>>).find(
+      proposal => proposal.proposal_id === 'pinnacle_cross_channel',
+    );
+    expect(refinedProposal).toBeDefined();
+    expect(refinedProposal).not.toEqual(initialProposal);
+    expect(refinedProposal!.total_budget_guidance).toMatchObject({
+      min: 5000,
+      recommended: 5000,
+      currency: 'USD',
+    });
+    const ext = refinedProposal!.ext as Record<string, {
+      manifest: { assets: Record<string, { content?: string } | undefined> };
+    }>;
+    for (const cardKey of ['proposal_card', 'proposal_card_detailed']) {
+      expect(ext[cardKey].manifest.assets.budget_min.content).toBe('5000');
+      expect(ext[cardKey].manifest.assets.budget_recommended.content).toBe('5000');
+      expect(ext[cardKey].manifest.assets.budget_currency.content).toBe('USD');
+      expect(ext[cardKey].manifest.assets.estimated_delivery).toBeUndefined();
+    }
+
+    const products = refined.products as Array<Record<string, unknown>>;
+    for (const allocation of refinedProposal!.allocations as Array<Record<string, unknown>>) {
+      expect(allocation.pricing_option_id).toMatch(/_concrete_[a-f0-9]{32}$/);
+      const product = products.find(candidate => candidate.product_id === allocation.product_id)!;
+      const pricingOption = (product.pricing_options as Array<Record<string, unknown>>).find(
+        option => option.pricing_option_id === allocation.pricing_option_id,
+      );
+      expect(pricingOption).toMatchObject({ pricing_model: 'cpm', currency: 'USD' });
+      expect(pricingOption!.fixed_price).toBeGreaterThan(0);
+      expect(pricingOption!.floor_price).toBeUndefined();
+      expect(pricingOption!.price_guidance).toBeUndefined();
+      expect(pricingOption!.max_bid).toBeUndefined();
+      expect(pricingOption!.min_spend_per_package).toBeUndefined();
+    }
+  });
+
+  it('persists concrete proposal pricing across subsequent get_products requests', async () => {
+    const account = { brand: { domain: 'persisted-cpm.example' }, operator: 'persisted-cpm.example' };
+    const server1 = createTrainingAgentServer(DEFAULT_CTX);
+    await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'cross-channel news video and display',
+      account,
+    });
+
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{
+        scope: 'proposal',
+        proposal_id: 'pinnacle_cross_channel',
+        ask: 'Provide concrete per-unit CPM pricing and set the recommended total to 5000 USD',
+      }],
+    });
+
+    const server3 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: reread } = await simulateCallTool(server3, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{ scope: 'proposal', proposal_id: 'pinnacle_cross_channel' }],
+    });
+    const proposal = (reread.proposals as Array<Record<string, unknown>>).find(
+      candidate => candidate.proposal_id === 'pinnacle_cross_channel',
+    )!;
+    expect(proposal.total_budget_guidance).toMatchObject({ recommended: 5000, currency: 'USD' });
+    const products = reread.products as Array<Record<string, unknown>>;
+    for (const allocation of proposal.allocations as Array<Record<string, unknown>>) {
+      expect(allocation.pricing_option_id).toMatch(/_concrete_[a-f0-9]{32}$/);
+      const product = products.find(candidate => candidate.product_id === allocation.product_id)!;
+      const option = (product.pricing_options as Array<Record<string, unknown>>).find(
+        candidate => candidate.pricing_option_id === allocation.pricing_option_id,
+      );
+      expect(option).toMatchObject({ pricing_model: 'cpm', currency: 'USD' });
+      expect(option!.fixed_price).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps account-scoped negotiated options out of the public wholesale feed', async () => {
+    const account = { brand: { domain: 'wholesale-scope.example' }, operator: 'wholesale-scope.example' };
+    const server1 = createTrainingAgentServer(DEFAULT_CTX);
+    await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'cross-channel news video and display',
+      account,
+    });
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{
+        scope: 'proposal',
+        proposal_id: 'pinnacle_cross_channel',
+        ask: 'Provide concrete fixed CPM pricing in USD',
+      }],
+    });
+
+    const server3 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: wholesale } = await simulateCallTool(server3, 'get_products', {
+      buying_mode: 'wholesale',
+      account,
+    });
+    expect(wholesale.cache_scope).toBe('public');
+    for (const product of wholesale.products as Array<Record<string, unknown>>) {
+      expect((product.pricing_options as Array<Record<string, unknown>>).some(
+        option => String(option.pricing_option_id).includes('_concrete_'),
+      )).toBe(false);
+    }
+  });
+
+  it('honors supported currencies and keeps unsupported currencies partial', async () => {
+    const account = { brand: { domain: 'cpm-currency.example' }, operator: 'cpm-currency.example' };
+    const server1 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: initial } = await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'premium live sports video',
+      account,
+    });
+    const initialProposal = (initial.proposals as Array<Record<string, unknown>>).find(
+      proposal => proposal.proposal_id === 'viewpoint_multi_screen',
+    )!;
+
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: refined } = await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{
+        scope: 'proposal',
+        proposal_id: 'viewpoint_multi_screen',
+        ask: 'Provide concrete fixed CPM pricing in EUR for a 30 day flight',
+      }],
+    });
+    expect((refined.refinement_applied as Array<Record<string, unknown>>)[0].status).toBe('applied');
+    const proposal = (refined.proposals as Array<Record<string, unknown>>).find(
+      candidate => candidate.proposal_id === 'viewpoint_multi_screen',
+    )!;
+    expect(proposal.total_budget_guidance).toEqual(initialProposal.total_budget_guidance);
+    const products = refined.products as Array<Record<string, unknown>>;
+    for (const allocation of proposal.allocations as Array<Record<string, unknown>>) {
+      const product = products.find(candidate => candidate.product_id === allocation.product_id)!;
+      const option = (product.pricing_options as Array<Record<string, unknown>>).find(
+        candidate => candidate.pricing_option_id === allocation.pricing_option_id,
+      )!;
+      expect(option.currency).toBe('EUR');
+      expect(option.fixed_price).toBeGreaterThan(0);
+    }
+
+    const server3 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: unsupported } = await simulateCallTool(server3, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{
+        scope: 'proposal',
+        proposal_id: 'viewpoint_multi_screen',
+        ask: 'Provide concrete fixed CPM pricing in JPY',
+      }],
+    });
+    expect((unsupported.refinement_applied as Array<Record<string, unknown>>)[0].status).toBe('partial');
+    const unchangedProposal = (unsupported.proposals as Array<Record<string, unknown>>).find(
+      candidate => candidate.proposal_id === 'viewpoint_multi_screen',
+    )!;
+    expect(unchangedProposal.allocations).toEqual(proposal.allocations);
+  });
+
+  it('does not reinterpret an explicit CPM amount or flight duration as total budget', async () => {
+    const account = { brand: { domain: 'cpm-parser.example' }, operator: 'cpm-parser.example' };
+    const server1 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: initial } = await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'cross-channel news video and display',
+      account,
+    });
+    const initialProposal = (initial.proposals as Array<Record<string, unknown>>).find(
+      proposal => proposal.proposal_id === 'pinnacle_cross_channel',
+    )!;
+
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: refined } = await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{
+        scope: 'proposal',
+        proposal_id: 'pinnacle_cross_channel',
+        ask: 'Set the total budget to 5000 USD with no more than $12 CPM for a 30 day flight',
+      }],
+    });
+    expect((refined.refinement_applied as Array<Record<string, unknown>>)[0].status).toBe('partial');
+    const proposal = (refined.proposals as Array<Record<string, unknown>>).find(
+      candidate => candidate.proposal_id === 'pinnacle_cross_channel',
+    )!;
+    expect(proposal.total_budget_guidance).toEqual(initialProposal.total_budget_guidance);
+    expect(proposal.allocations).toEqual(initialProposal.allocations);
+  });
+
+  it('preserves concrete pricing when the same call includes a product selection', async () => {
+    const account = { brand: { domain: 'mixed-cpm.example' }, operator: 'mixed-cpm.example' };
+    const server1 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: initial } = await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'cross-channel news video and display',
+      account,
+    });
+    const initialProposal = (initial.proposals as Array<Record<string, unknown>>).find(
+      proposal => proposal.proposal_id === 'pinnacle_cross_channel',
+    )!;
+    const productId = (initialProposal.allocations as Array<Record<string, unknown>>)[0].product_id as string;
+
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: refined } = await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [
+        {
+          scope: 'proposal',
+          proposal_id: 'pinnacle_cross_channel',
+          ask: 'Provide concrete fixed CPM pricing in USD',
+        },
+        { scope: 'product', product_id: productId },
+      ],
+    });
+    expect((refined.refinement_applied as Array<Record<string, unknown>>).map(entry => entry.status))
+      .toEqual(['applied', 'applied']);
+    const proposal = (refined.proposals as Array<Record<string, unknown>>).find(
+      candidate => candidate.proposal_id === 'pinnacle_cross_channel',
+    )!;
+    const products = refined.products as Array<Record<string, unknown>>;
+    for (const allocation of proposal.allocations as Array<Record<string, unknown>>) {
+      const product = products.find(candidate => candidate.product_id === allocation.product_id)!;
+      expect((product.pricing_options as Array<Record<string, unknown>>).some(
+        option => option.pricing_option_id === allocation.pricing_option_id,
+      )).toBe(true);
+    }
+  });
+
+  it('uses persisted concrete pricing when a refined proposal is finalized and purchased', async () => {
+    const account = { brand: { domain: 'buy-refined.example' }, operator: 'buy-refined.example' };
+    const server1 = createTrainingAgentServer(DEFAULT_CTX);
+    await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'cross-channel news video and display',
+      account,
+    });
+
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{
+        scope: 'proposal',
+        proposal_id: 'pinnacle_cross_channel',
+        ask: 'Provide concrete per-unit CPM pricing and set the recommended total to 5000 USD',
+      }],
+    });
+
+    const server3 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: finalized } = await simulateCallTool(server3, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{ scope: 'proposal', action: 'finalize', proposal_id: 'pinnacle_cross_channel' }],
+    });
+    const committed = (finalized.proposals as Array<Record<string, unknown>>).find(
+      proposal => proposal.proposal_id === 'pinnacle_cross_channel',
+    )!;
+    expect(committed.proposal_status).toBe('committed');
+    const insertionOrder = committed.insertion_order as Record<string, unknown>;
+
+    const server4 = createTrainingAgentServer(DEFAULT_CTX);
+    const startTime = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    const endTime = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString();
+    const { result: created, isError } = await simulateCallTool(server4, 'create_media_buy', {
+      account,
+      brand: { domain: 'buy-refined.example' },
+      proposal_id: 'pinnacle_cross_channel',
+      total_budget: { amount: 5000, currency: 'USD' },
+      start_time: startTime,
+      end_time: endTime,
+      io_acceptance: {
+        io_id: insertionOrder.io_id,
+        accepted_at: new Date().toISOString(),
+        signatory: 'training-buyer',
+      },
+    });
+    expect(isError).toBeFalsy();
+    expect(created.media_buy_id).toBeDefined();
+    for (const pkg of created.packages as Array<Record<string, unknown>>) {
+      expect(pkg.pricing_option_id).toMatch(/_concrete_[a-f0-9]{32}$/);
+      expect(pkg.bid_price).toBeUndefined();
+    }
+  });
+
+  it('keeps unsupported proposal asks partial', async () => {
+    const account = { brand: { domain: 'partial-refine.example' }, operator: 'partial-refine.example' };
+
+    const server1 = createTrainingAgentServer(DEFAULT_CTX);
+    await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'cross-channel news video and display',
+      account,
+    });
+
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: refined } = await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{
+        scope: 'proposal',
+        proposal_id: 'pinnacle_cross_channel',
+        ask: 'Guarantee exclusive inventory on Mars',
+      }],
+    });
+
+    const applied = refined.refinement_applied as Array<Record<string, unknown>>;
+    expect(applied).toHaveLength(1);
+    expect(applied[0].status).toBe('partial');
+    expect(applied[0].notes).toContain('Ask acknowledged but not applied');
   });
 });
 


### PR DESCRIPTION
## Summary

- add a deterministic proposal refinement path that returns concrete fixed CPM options and applies an explicitly requested total budget
- persist negotiated pricing per training session so subsequent refine, finalize, and `create_media_buy` calls use the same option IDs
- reject unknown or expired product references atomically with `PRODUCT_NOT_FOUND`
- keep unsupported currencies, rate constraints, filtered products, and unrelated asks honest with `partial` outcomes

## Root cause

The training agent treated every natural-language proposal ask as an acknowledgement-only `partial` response. It had no session-scoped representation for negotiated pricing, and product references were not prevalidated, so it could not provide a truthful successful refine path or reliably reject phantom product IDs.

## Impact

Buyer implementations can now exercise the successful proposal-refinement leg against the hosted reference agent. The negotiated result remains usable through proposal finalization and media-buy creation, while unsupported asks retain deterministic non-success coverage.

## Testing

- `vitest run --config server/vitest.config.ts server/tests/unit/training-agent.test.ts` — 520 passed
- `tsc --project server/tsconfig.json --noEmit`
- changeset protocol-scope check passed; no changeset required for training-agent-only behavior
- expert review: AdCP protocol, code correctness, Node testing, and security; no merge blockers or High/Medium security findings remain
- precommit general suite: 1,018 passed; dynamic-import and callApi state-change lints passed
- local full server-unit hook exceeded its 240-second wrapper under multi-workspace contention; remote CI is the authoritative full-suite gate
- local storyboard matrix: `/signals` passed (91 clean, 114 steps) before the redundant serial run was stopped; remote CI is the authoritative matrix gate

## Follow-up

- #6027 tracks deterministic product/request ask success and an `unable` outcome

Closes #6024
