### PR TITLE
fix(training-agent): complete refine outcome matrix

### DIFF
--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -619,7 +619,7 @@ type ConcreteCpmAsk = {
 const ISO_CURRENCY_CODES = new Set(Intl.supportedValuesOf('currency'));
 
 /**
- * Recognize the training agent's deterministic proposal-pricing refinement.
+ * Recognize the training agent's deterministic CPM-pricing refinement.
  * Other natural-language asks intentionally remain partial so buyers can test
  * both successful and honest incomplete refinement outcomes.
  */
@@ -669,6 +669,19 @@ function parseConcreteCpmAsk(ask?: string): ConcreteCpmAsk | undefined {
     currency: normalizedCurrency,
     budget: { amount, currency: normalizedCurrency },
   };
+}
+
+/**
+ * Recognize the request-level selection refinement that the training agent
+ * can apply deterministically. Keeping this grammar deliberately narrow
+ * leaves compound or arbitrary natural-language constraints on the honest
+ * partial path.
+ */
+function requestsGuaranteedOnlyProducts(ask?: string): boolean {
+  if (!ask) return false;
+  const normalized = ask.trim().toLowerCase().replace(/[.!?]+$/, '').trim();
+  return /^(?:(?:show|return|include|select|keep)\s+)?only\s+guaranteed\s+(?:products|packages)$/.test(normalized)
+    || /^limit\s+(?:the\s+)?(?:results|selection)\s+to\s+guaranteed\s+(?:products|packages)$/.test(normalized);
 }
 
 function concreteCpmPricing(
@@ -3198,6 +3211,7 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
   const proposalOmitIds = new Set<string>();
   const refinedProposalOverrides = new Map<string, Proposal>();
   const explicitlySelectedProposals = new Map<string, Proposal>();
+  let guaranteedOnlyRequested = false;
   if (buyingMode === 'refine' && req.refine) {
     const refineOps = req.refine as unknown as RefineEntry[];
     const previousProposals = session.lastGetProductsContext?.proposals || getProposals();
@@ -3263,9 +3277,51 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
           refinementApplied.push({ scope: 'product', product_id: op.product_id, status: 'applied' });
         } else if (action === 'include') {
           includeIds.add(op.product_id);
-          refinementApplied.push(passesFilters
-            ? { scope: 'product', product_id: op.product_id, status: op.ask ? 'partial' : 'applied', ...askAckNotes(op.ask) }
-            : { scope: 'product', product_id: op.product_id, status: 'partial', notes: 'Product is excluded by the request filters' });
+          if (!passesFilters) {
+            refinementApplied.push({
+              scope: 'product',
+              product_id: op.product_id,
+              status: 'partial',
+              notes: 'Product is excluded by the request filters',
+            });
+          } else {
+            const concreteCpmAsk = parseConcreteCpmAsk(op.ask);
+            if (concreteCpmAsk) {
+              const product = products.find(candidate => candidate.product_id === op.product_id);
+              const concretePricing = product && concreteCpmPricing(product, concreteCpmAsk.currency);
+              if (concretePricing) {
+                products = products.map(candidate =>
+                  candidate.product_id === op.product_id ? concretePricing.product : candidate,
+                );
+                session.negotiatedPricingOptions.set(`${op.product_id}:${concretePricing.pricingOptionId}`, {
+                  productId: op.product_id,
+                  option: concretePricing.pricingOption,
+                });
+                refinementApplied.push({
+                  scope: 'product',
+                  product_id: op.product_id,
+                  status: 'applied',
+                  notes: `Concrete fixed CPM pricing applied (${concretePricing.currency} ${concretePricing.fixedPrice} CPM).`,
+                });
+              } else {
+                refinementApplied.push({
+                  scope: 'product',
+                  product_id: op.product_id,
+                  status: 'unable',
+                  notes: concreteCpmAsk.currency
+                    ? `No CPM pricing option is available in ${concreteCpmAsk.currency}.`
+                    : 'No CPM pricing option can be converted to concrete fixed pricing.',
+                });
+              }
+            } else {
+              refinementApplied.push({
+                scope: 'product',
+                product_id: op.product_id,
+                status: op.ask ? 'partial' : 'applied',
+                ...askAckNotes(op.ask),
+              });
+            }
+          }
         } else if (action === 'more_like_this') {
           includeIds.add(op.product_id);
           const source = registryProducts.find(p => p.product_id === op.product_id);
@@ -3395,7 +3451,25 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
           }
         }
       } else if (op.scope === 'request') {
-        refinementApplied.push({ scope: 'request', status: 'partial', notes: 'Request-level refinement acknowledged but not applied by training agent' });
+        if (requestsGuaranteedOnlyProducts(op.ask)) {
+          const guaranteedProducts = products.filter(product => product.delivery_type === 'guaranteed');
+          if (guaranteedProducts.length === 0) {
+            refinementApplied.push({
+              scope: 'request',
+              status: 'unable',
+              notes: 'No guaranteed products are available in the current selection.',
+            });
+          } else {
+            guaranteedOnlyRequested = true;
+            refinementApplied.push({
+              scope: 'request',
+              status: 'applied',
+              notes: 'Selection limited to guaranteed products.',
+            });
+          }
+        } else {
+          refinementApplied.push({ scope: 'request', status: 'partial', notes: 'Request-level refinement acknowledged but not applied by training agent' });
+        }
       }
     }
 
@@ -3408,6 +3482,9 @@ export async function handleGetProducts(args: ToolArgs, ctx: TrainingContext): P
     }
     if (omitIds.size > 0) {
       products = products.filter(p => !omitIds.has(p.product_id));
+    }
+    if (guaranteedOnlyRequested) {
+      products = products.filter(product => product.delivery_type === 'guaranteed');
     }
   }
 

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -6439,6 +6439,119 @@ describe('get_products refine mode', () => {
     )).toBe(true);
   });
 
+  it('applies and persists concrete CPM pricing for a product-scoped ask', async () => {
+    const account = { brand: { domain: 'product-cpm.example' }, operator: 'product-cpm.example' };
+    const product = buildCatalog().map(entry => entry.product).find(candidate =>
+      candidate.pricing_options.some(option => option.pricing_model === 'cpm' && option.currency === 'USD'),
+    )!;
+
+    const server1 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: refined } = await simulateCallTool(server1, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{
+        scope: 'product',
+        product_id: product.product_id,
+        ask: 'Provide concrete fixed CPM pricing in USD.',
+      }],
+    });
+
+    expect(refined.refinement_applied).toEqual([
+      expect.objectContaining({ scope: 'product', product_id: product.product_id, status: 'applied' }),
+    ]);
+    const returnedProduct = (refined.products as Array<Record<string, unknown>>).find(
+      candidate => candidate.product_id === product.product_id,
+    )!;
+    const negotiatedOption = (returnedProduct.pricing_options as Array<Record<string, unknown>>).find(
+      option => String(option.pricing_option_id).includes('_concrete_'),
+    );
+    expect(negotiatedOption).toMatchObject({ pricing_model: 'cpm', currency: 'USD' });
+    expect(negotiatedOption!.fixed_price).toBeGreaterThan(0);
+    expect(returnedProduct.pricing_options).not.toEqual(product.pricing_options);
+
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: reread } = await simulateCallTool(server2, 'get_products', {
+      buying_mode: 'refine',
+      account,
+      refine: [{ scope: 'product', product_id: product.product_id }],
+    });
+    const persistedProduct = (reread.products as Array<Record<string, unknown>>).find(
+      candidate => candidate.product_id === product.product_id,
+    )!;
+    expect(persistedProduct.pricing_options).toContainEqual(negotiatedOption);
+  });
+
+  it('applies a guaranteed-only request ask by changing the returned selection', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'refine',
+      account: { brand: { domain: 'guaranteed-only.example' }, operator: 'guaranteed-only.example' },
+      refine: [{ scope: 'request', ask: 'Only guaranteed products.' }],
+    });
+
+    expect(result.refinement_applied).toEqual([
+      expect.objectContaining({ scope: 'request', status: 'applied' }),
+    ]);
+    const products = result.products as Array<Record<string, unknown>>;
+    expect(products.length).toBeGreaterThan(0);
+    expect(products.length).toBeLessThan(buildCatalog().length);
+    expect(products.every(product => product.delivery_type === 'guaranteed')).toBe(true);
+  });
+
+  it('returns unable without changing product pricing when concrete CPM cannot be fulfilled', async () => {
+    const product = buildCatalog().map(entry => entry.product).find(candidate =>
+      candidate.pricing_options.some(option => option.pricing_model === 'cpm')
+      && candidate.pricing_options.every(option => option.currency !== 'JPY'),
+    )!;
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'refine',
+      account: { brand: { domain: 'unable-cpm.example' }, operator: 'unable-cpm.example' },
+      refine: [{
+        scope: 'product',
+        product_id: product.product_id,
+        ask: 'Provide concrete fixed CPM pricing in JPY.',
+      }],
+    });
+
+    expect(result.refinement_applied).toEqual([
+      expect.objectContaining({ scope: 'product', product_id: product.product_id, status: 'unable' }),
+    ]);
+    const unchangedProduct = (result.products as Array<Record<string, unknown>>).find(
+      candidate => candidate.product_id === product.product_id,
+    )!;
+    expect(unchangedProduct.pricing_options).toEqual(product.pricing_options);
+  });
+
+  it('keeps mixed ask outcomes position-aligned and leaves unsupported asks partial', async () => {
+    const products = buildCatalog().map(entry => entry.product).filter(candidate =>
+      candidate.pricing_options.some(option => option.pricing_model === 'cpm' && option.currency === 'USD')
+      && candidate.pricing_options.every(option => option.currency !== 'JPY'),
+    );
+    expect(products.length).toBeGreaterThanOrEqual(3);
+    const [appliedProduct, partialProduct, unableProduct] = products;
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'refine',
+      account: { brand: { domain: 'aligned-refine.example' }, operator: 'aligned-refine.example' },
+      refine: [
+        { scope: 'request', ask: 'Prioritize premium inventory with strong completion rates.' },
+        { scope: 'product', product_id: appliedProduct.product_id, ask: 'Provide concrete fixed CPM pricing in USD.' },
+        { scope: 'product', product_id: partialProduct.product_id, ask: 'Increase budget allocation to $30K.' },
+        { scope: 'product', product_id: unableProduct.product_id, ask: 'Provide concrete fixed CPM pricing in JPY.' },
+        { scope: 'request', ask: 'Only guaranteed products.' },
+      ],
+    });
+
+    expect(result.refinement_applied).toEqual([
+      expect.objectContaining({ scope: 'request', status: 'partial' }),
+      expect.objectContaining({ scope: 'product', product_id: appliedProduct.product_id, status: 'applied' }),
+      expect.objectContaining({ scope: 'product', product_id: partialProduct.product_id, status: 'partial' }),
+      expect.objectContaining({ scope: 'product', product_id: unableProduct.product_id, status: 'unable' }),
+      expect.objectContaining({ scope: 'request', status: 'applied' }),
+    ]);
+  });
+
   it('rejects mixed refinements before applying an earlier proposal pricing change', async () => {
     const account = { brand: { domain: 'atomic-product-refine.example' }, operator: 'atomic-product-refine.example' };
     const server1 = createTrainingAgentServer(DEFAULT_CTX);


### PR DESCRIPTION
Closes #6027.

## What changed

- apply deterministic product-scoped concrete CPM asks and persist the negotiated pricing option
- apply exact request-scoped guaranteed-only asks by filtering the returned product selection
- return `unable` when a recognized concrete CPM ask cannot be fulfilled in the requested currency, without changing product pricing
- preserve `partial` for unsupported natural-language asks
- keep mixed `refinement_applied` results position-aligned with the request

## Why

The training agent exposed only proposal-scoped ask success. Product and request asks could not demonstrate observable `applied` behavior, and no refine path exercised the protocol's `unable` outcome.

The recognized grammar remains deliberately narrow so this stays a deterministic reference fixture rather than pretending to provide general natural-language planning.

## Verification

- `527/527` training-agent unit tests pass
- `25/25` focused refine tests pass
- server TypeScript compilation passes
- changeset protocol-scope check passes
- `git diff --check` passes

The local pre-push storyboard wrapper could not launch under the host's npm 11 because this repository pins npm 10; the remote npm-10 storyboard matrix is the authoritative run.

## Out of scope

#2630 remains a separate generative conformance-runner project built around reusable semantic invariants.
