### PR TITLE
fix(certification): harden targeted credential recovery

### DIFF
--- a/server/public/admin-certification.html
+++ b/server/public/admin-certification.html
@@ -763,15 +763,21 @@
         }).join('');
 
         const credentialRows = data.credentials.map(c => {
-          const badgeStatus = c.certifier_credential_id
+          const badgeStatus = c.certifier_credential_id && c.certifier_badge_url
             ? '<span class="badge badge-active">issued</span>'
-            : '<span class="badge badge-stuck">pending</span>';
+            : c.certifier_credential_id
+              ? '<span class="badge badge-stuck">badge pending</span>'
+              : '<span class="badge badge-stuck">not issued</span>';
+          const repairAction = c.certifier_configured && (!c.certifier_credential_id || !c.certifier_badge_url)
+            ? `<button type="button" data-user-id="${escapeHtml(userId)}" data-credential-id="${escapeHtml(c.credential_id)}" onclick="reissueCredential(event)">Re-issue</button>`
+            : '-';
           return `
             <tr>
               <td>${escapeHtml(c.name)}</td>
               <td>${tierBadge(c.tier)}</td>
               <td>${formatDate(c.awarded_at)}</td>
               <td>${badgeStatus}</td>
+              <td>${repairAction}</td>
             </tr>
           `;
         }).join('');
@@ -804,7 +810,7 @@
             <div class="detail-section">
               <h4>Credentials</h4>
               <table>
-                <thead><tr><th>Credential</th><th>Tier</th><th>Awarded</th><th>Badge</th></tr></thead>
+                <thead><tr><th>Credential</th><th>Tier</th><th>Awarded</th><th>Badge</th><th>Action</th></tr></thead>
                 <tbody>${credentialRows}</tbody>
               </table>
             </div>
@@ -859,6 +865,32 @@
 
     function closeDetail() {
       document.getElementById('learner-modal').style.display = 'none';
+    }
+
+    async function reissueCredential(event) {
+      const btn = event.currentTarget;
+      const userId = btn.dataset.userId;
+      const credentialId = btn.dataset.credentialId;
+      btn.disabled = true;
+      btn.textContent = 'Issuing...';
+
+      try {
+        const response = await AdminSidebar.fetch(
+          `/api/admin/certification/learners/${encodeURIComponent(userId)}/credentials/${encodeURIComponent(credentialId)}/reissue`,
+          { method: 'POST' },
+        );
+        const data = await response.json();
+        if (!response.ok) {
+          alert(data.error || 'Failed to re-issue credential');
+          return;
+        }
+        await Promise.all([showDetail(userId), loadLearners(currentPage), loadOverview()]);
+      } catch (err) {
+        alert('Network error re-issuing credential');
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Re-issue';
+      }
     }
 
     async function adminCompleteModule(event) {

--- a/server/public/admin-certification.html
+++ b/server/public/admin-certification.html
@@ -763,13 +763,34 @@
         }).join('');
 
         const credentialRows = data.credentials.map(c => {
-          const badgeStatus = c.certifier_credential_id && c.certifier_badge_url
-            ? '<span class="badge badge-active">issued</span>'
-            : c.certifier_credential_id
-              ? '<span class="badge badge-stuck">badge pending</span>'
-              : '<span class="badge badge-stuck">not issued</span>';
-          const repairAction = c.certifier_configured && (!c.certifier_credential_id || !c.certifier_badge_url)
-            ? `<button type="button" data-user-id="${escapeHtml(userId)}" data-credential-id="${escapeHtml(c.credential_id)}" onclick="reissueCredential(event)">Re-issue</button>`
+          const badgeStatus = !c.certifier_configured
+            ? '<span class="badge">Certifier not configured</span>'
+            : !c.certifier_credential_id && c.certifier_issuance_state !== 'not_started'
+              ? '<span class="badge badge-stuck">manual reconciliation required</span>'
+            : !c.certifier_credential_id
+              ? '<span class="badge badge-stuck">not issued</span>'
+              : !c.certifier_public_id
+                ? '<span class="badge badge-stuck">issued · sharing ID missing</span>'
+                : !c.certifier_badge_url
+                  ? '<span class="badge badge-stuck">issued · badge pending</span>'
+                  : '<span class="badge badge-active">issued</span>';
+          let actionType = '';
+          let actionLabel = '';
+          if (c.certifier_configured && !c.certifier_credential_id && c.certifier_issuance_state === 'not_started') {
+            actionType = 'issue';
+            actionLabel = 'Issue credential';
+          } else if (c.certifier_configured && c.certifier_credential_id && !c.certifier_public_id && !c.certifier_badge_url) {
+            actionType = 'metadata';
+            actionLabel = 'Repair credential metadata';
+          } else if (c.certifier_configured && c.certifier_credential_id && !c.certifier_public_id) {
+            actionType = 'metadata';
+            actionLabel = 'Repair sharing ID';
+          } else if (c.certifier_configured && c.certifier_credential_id && !c.certifier_badge_url) {
+            actionType = 'badge';
+            actionLabel = 'Retry badge lookup';
+          }
+          const repairAction = actionType
+            ? `<button type="button" data-user-id="${escapeHtml(userId)}" data-credential-id="${escapeHtml(c.credential_id)}" data-action="${actionType}" data-learner-name="${escapeHtml(data.user.name)}" data-learner-email="${escapeHtml(data.user.email)}" data-credential-name="${escapeHtml(c.name)}" onclick="reissueCredential(event)">${actionLabel}</button>`
             : '-';
           return `
             <tr>
@@ -809,6 +830,7 @@
           ${data.credentials.length > 0 ? `
             <div class="detail-section">
               <h4>Credentials</h4>
+              <div id="credential-action-result" class="repair-result" role="status" aria-live="polite"></div>
               <table>
                 <thead><tr><th>Credential</th><th>Tier</th><th>Awarded</th><th>Badge</th><th>Action</th></tr></thead>
                 <tbody>${credentialRows}</tbody>
@@ -867,29 +889,88 @@
       document.getElementById('learner-modal').style.display = 'none';
     }
 
+    function showCredentialActionResult(message, isError = false) {
+      const result = document.getElementById('credential-action-result');
+      if (!result) return;
+      result.style.display = 'block';
+      result.style.background = isError ? 'var(--color-error-50)' : 'var(--color-success-50, #f0fdf4)';
+      result.style.color = isError ? 'var(--color-error-800)' : 'var(--color-success-800, #166534)';
+      result.textContent = message;
+    }
+
     async function reissueCredential(event) {
       const btn = event.currentTarget;
       const userId = btn.dataset.userId;
       const credentialId = btn.dataset.credentialId;
+      const action = btn.dataset.action;
+      const learnerName = btn.dataset.learnerName;
+      const learnerEmail = btn.dataset.learnerEmail;
+      const credentialName = btn.dataset.credentialName;
+      const promptMessage = action === 'issue'
+        ? `Issue ${credentialName} to ${learnerName} (${learnerEmail})?\n\nThis creates and emails an external credential. Enter the incident or escalation reason to confirm:`
+        : `Recover ${credentialName} for ${learnerName} (${learnerEmail})?\n\nEnter the incident or escalation reason to confirm:`;
+      const reasonInput = window.prompt(promptMessage);
+      if (reasonInput === null) return;
+      const reason = reasonInput.trim();
+      if (reason.length < 10) {
+        showCredentialActionResult('Enter a reason of at least 10 characters.', true);
+        return;
+      }
+
       btn.disabled = true;
-      btn.textContent = 'Issuing...';
+      btn.textContent = action === 'issue' ? 'Issuing...' : 'Checking...';
+      showCredentialActionResult(action === 'issue'
+        ? `Issuing credential to ${learnerEmail}…`
+        : `Checking credential metadata for ${learnerEmail}…`);
 
       try {
         const response = await AdminSidebar.fetch(
           `/api/admin/certification/learners/${encodeURIComponent(userId)}/credentials/${encodeURIComponent(credentialId)}/reissue`,
-          { method: 'POST' },
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ reason }),
+          },
         );
         const data = await response.json();
         if (!response.ok) {
-          alert(data.error || 'Failed to re-issue credential');
+          const operationNote = data.operation_id ? ` Operation ID: ${data.operation_id}.` : '';
+          showCredentialActionResult((data.error || 'Failed to recover credential.') + operationNote, true);
           return;
         }
-        await Promise.all([showDetail(userId), loadLearners(currentPage), loadOverview()]);
+        let message;
+        if (data.outcome === 'issued' && data.badge_available) {
+          message = `Credential issued and badge retrieved. External ID: ${data.credential.certifier_credential_id}.`;
+        } else if (data.outcome === 'issued') {
+          message = `Credential issued, but the badge is still processing. Retry badge lookup later. External ID: ${data.credential.certifier_credential_id}.`;
+        } else if (data.outcome === 'badge_refreshed') {
+          message = 'Badge retrieved successfully.';
+        } else if (data.outcome === 'metadata_refreshed') {
+          message = data.badge_available
+            ? 'Credential sharing ID and badge metadata repaired successfully.'
+            : 'Credential sharing ID repaired; its badge is not available yet.';
+        } else if (data.outcome === 'already_complete') {
+          message = 'Credential was already complete; no external changes were made.';
+        } else {
+          message = 'Credential exists, but its badge is not available yet. Retry later.';
+        }
+        if (data.email_delivery === 'unknown') {
+          message += ' Email delivery could not be confirmed; check Certifier before sending again.';
+        } else if (data.email_delivery === 'not_attempted' && data.outcome !== 'already_complete') {
+          message += ' Email was not sent by this recovery; verify existing delivery in Certifier before sending manually.';
+        }
+        if (data.warnings?.length) message += ` Warning: ${data.warnings.join(' ')}`;
+        if (data.operation_id) message += ` Operation ID: ${data.operation_id}.`;
+        await showDetail(userId);
+        showCredentialActionResult(message);
       } catch (err) {
-        alert('Network error re-issuing credential');
+        showCredentialActionResult(
+          'Network error while recovering the credential. Check the audit log and Certifier before retrying.',
+          true,
+        );
       } finally {
         btn.disabled = false;
-        btn.textContent = 'Re-issue';
+        btn.textContent = action === 'issue' ? 'Issue credential' : action === 'badge' ? 'Retry badge lookup' : 'Repair credential metadata';
       }
     }
 

--- a/server/public/admin-certification.html
+++ b/server/public/admin-certification.html
@@ -893,8 +893,8 @@
       const result = document.getElementById('credential-action-result');
       if (!result) return;
       result.style.display = 'block';
-      result.style.background = isError ? 'var(--color-error-50)' : 'var(--color-success-50, #f0fdf4)';
-      result.style.color = isError ? 'var(--color-error-800)' : 'var(--color-success-800, #166534)';
+      result.style.background = isError ? 'var(--color-error-50)' : 'var(--color-success-50)';
+      result.style.color = isError ? 'var(--color-error-800)' : 'var(--color-success-800)';
       result.textContent = message;
     }
 

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.07.4';
+export const CODE_VERSION = '2026.07.5';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -32,6 +32,14 @@ import { stripe } from '../../billing/stripe-client.js';
 import { attemptStripeReconciliation } from '../../billing/lazy-reconcile.js';
 import { coerceStringArray } from './input-coercion.js';
 import { wrapUntrustedInput } from './untrusted-input.js';
+import {
+  CertifierNotConfiguredError,
+  CredentialNameRequiredError,
+  NAME_REQUIRED_MARKER,
+  ensureCertifierCredential,
+} from '../../services/certification-credential-issuance.js';
+
+export { NAME_REQUIRED_MARKER };
 
 const logger = createLogger('certification-tools');
 
@@ -513,7 +521,6 @@ function validateDemonstrationIds(
  * Certifier-side issuance is deferred. `checkAndFormatCredentials` retries
  * deferred issuances on its next call.
  */
-export const NAME_REQUIRED_MARKER = 'NAME_REQUIRED';
 type IssueResult = string | null | 'NAME_REQUIRED';
 
 /**
@@ -530,59 +537,22 @@ async function issueCertifierBadge(
   credId: string,
   cred: { name: string; tier: number; certifier_group_id: string | null },
   memberContext: MemberContext | null,
-  extraAttributes?: Record<string, string>,
 ): Promise<IssueResult> {
   if (!cred.certifier_group_id || !memberContext?.workos_user) return null;
 
-  // Resolve the name from the freshest source available: the helper falls
-  // back to the DB when memberContext is stale (the closure-bound context
-  // doesn't see the row `set_my_name` just wrote), and to the Slack mapping
-  // when neither has a value.
-  const { resolveUserNameWithFallbacks } = await import('../../utils/resolve-user-name.js');
-  const wu = memberContext.workos_user;
-  const resolved = await resolveUserNameWithFallbacks(
-    getPool(), userId, wu.first_name, wu.last_name,
-  );
-  if (!(resolved.firstName ?? '').trim()) {
-    logger.info({ userId, credId, email: wu.email }, 'Credential issuance gated: no first_name on file');
-    return NAME_REQUIRED_MARKER;
-  }
-
   try {
-    const { issueCredential, isCertifierConfigured, getCredentialBadgeUrl, buildRecipientName } = await import('../../services/certifier-client.js');
-    if (!isCertifierConfigured()) return null;
-
-    const expiryDate = cred.tier === 1 ? undefined : (() => {
-      const d = new Date();
-      d.setFullYear(d.getFullYear() + 2);
-      return d.toISOString().split('T')[0];
-    })();
-
-    const credential = await issueCredential({
-      groupId: cred.certifier_group_id,
-      recipient: {
-        name: buildRecipientName({
-          first_name: resolved.firstName,
-          last_name: resolved.lastName,
-          email: wu.email,
-        }),
-        email: wu.email,
-      },
-      ...(expiryDate ? { expiryDate } : {}),
-      ...(extraAttributes ? { customAttributes: extraAttributes } : {}),
-    });
-
-    let badgeUrl: string | null = null;
-    try {
-      badgeUrl = await getCredentialBadgeUrl(credential.id);
-    } catch (badgeErr) {
-      logger.warn({ error: badgeErr, credentialId: credential.id }, 'Failed to fetch badge URL');
-    }
-
-    await certDb.awardCredential(userId, credId, credential.id, credential.publicId, badgeUrl || undefined);
-    logger.info({ credentialId: credential.id, userId, credId, badgeUrl }, 'Credential issued via Certifier');
-    return credential.publicId || credential.id;
+    const result = await ensureCertifierCredential({ userId, credentialId: credId });
+    logger.info(
+      { credentialId: result.credentialId, userId, credId, badgeUrl: result.badgeUrl, outcome: result.outcome },
+      'Credential ensured via Certifier',
+    );
+    return result.publicId || result.credentialId;
   } catch (certError) {
+    if (certError instanceof CredentialNameRequiredError) {
+      logger.info({ userId, credId, email: memberContext.workos_user.email }, 'Credential issuance gated: no first_name on file');
+      return NAME_REQUIRED_MARKER;
+    }
+    if (certError instanceof CertifierNotConfiguredError) return null;
     logger.error({ error: certError, credId }, 'Failed to issue Certifier credential (continuing)');
     return null;
   }

--- a/server/src/db/certification-db.ts
+++ b/server/src/db/certification-db.ts
@@ -1958,7 +1958,16 @@ export interface AdminLearnerDetail {
     score: Record<string, number> | null;
     attempts: number;
   }>;
-  credentials: Array<{ name: string; tier: number; awarded_at: string; certifier_credential_id: string | null }>;
+  credentials: Array<{
+    credential_id: string;
+    name: string;
+    tier: number;
+    awarded_at: string;
+    certifier_credential_id: string | null;
+    certifier_public_id: string | null;
+    certifier_badge_url: string | null;
+    certifier_configured: boolean;
+  }>;
   checkpoints: Array<{
     id: string;
     module_id: string;
@@ -1994,8 +2003,14 @@ export async function getAdminLearnerDetail(userId: string): Promise<AdminLearne
        ORDER BY m.track_id, m.sort_order`,
       [userId]
     ),
-    query<{ name: string; tier: number; awarded_at: string; certifier_credential_id: string | null }>(
-      `SELECT cc.name, cc.tier, uc.awarded_at, uc.certifier_credential_id
+    query<{
+      credential_id: string; name: string; tier: number; awarded_at: string;
+      certifier_credential_id: string | null; certifier_public_id: string | null;
+      certifier_badge_url: string | null; certifier_configured: boolean;
+    }>(
+      `SELECT cc.id AS credential_id, cc.name, cc.tier, uc.awarded_at,
+              uc.certifier_credential_id, uc.certifier_public_id, uc.certifier_badge_url,
+              (cc.certifier_group_id IS NOT NULL) AS certifier_configured
        FROM user_credentials uc
        JOIN certification_credentials cc ON cc.id = uc.credential_id
        WHERE uc.workos_user_id = $1

--- a/server/src/db/certification-db.ts
+++ b/server/src/db/certification-db.ts
@@ -1081,6 +1081,32 @@ export async function awardCredential(
   return result.rows[0];
 }
 
+/** Append one immutable event to an admin credential-recovery audit trail. */
+export async function recordAdminCredentialReissueEvent(input: {
+  operationId: string;
+  userId: string;
+  credentialId: string;
+  adminUserId: string;
+  reason: string;
+  eventType: 'started' | 'succeeded' | 'failed';
+  details: Record<string, unknown>;
+}): Promise<void> {
+  await query(
+    `INSERT INTO admin_credential_reissue_events
+       (operation_id, workos_user_id, credential_id, admin_user_id, reason, event_type, details)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    [
+      input.operationId,
+      input.userId,
+      input.credentialId,
+      input.adminUserId,
+      input.reason,
+      input.eventType,
+      JSON.stringify(input.details),
+    ],
+  );
+}
+
 /**
  * Check and auto-award any credentials the user has become eligible for.
  * Returns a list of newly awarded credential IDs.
@@ -1967,6 +1993,8 @@ export interface AdminLearnerDetail {
     certifier_public_id: string | null;
     certifier_badge_url: string | null;
     certifier_configured: boolean;
+    certifier_issuance_state: string;
+    certifier_delivery_state: string;
   }>;
   checkpoints: Array<{
     id: string;
@@ -2007,9 +2035,11 @@ export async function getAdminLearnerDetail(userId: string): Promise<AdminLearne
       credential_id: string; name: string; tier: number; awarded_at: string;
       certifier_credential_id: string | null; certifier_public_id: string | null;
       certifier_badge_url: string | null; certifier_configured: boolean;
+      certifier_issuance_state: string; certifier_delivery_state: string;
     }>(
       `SELECT cc.id AS credential_id, cc.name, cc.tier, uc.awarded_at,
               uc.certifier_credential_id, uc.certifier_public_id, uc.certifier_badge_url,
+              uc.certifier_issuance_state, uc.certifier_delivery_state,
               (cc.certifier_group_id IS NOT NULL) AS certifier_configured
        FROM user_credentials uc
        JOIN certification_credentials cc ON cc.id = uc.credential_id

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -138,6 +138,50 @@ export async function getClient(): Promise<PoolClient> {
 }
 
 /**
+ * Open a one-off database connection outside the application pool.
+ *
+ * Use this only for session-scoped work that must retain one connection while
+ * waiting on slow external systems (for example, a PostgreSQL advisory lock).
+ * Callers own the returned client and must close it with `client.end()`.
+ */
+export async function getDedicatedClient(): Promise<Client> {
+  if (!poolConfig) {
+    throw new Error("Database not initialized. Call initializeDatabase() first.");
+  }
+  const config = poolConfig;
+
+  const connect = async (): Promise<Client> => {
+    const client = new Client({
+      connectionString: config.connectionString,
+      host: config.host,
+      port: config.port,
+      database: config.database,
+      user: config.user,
+      password: config.password,
+      ssl: config.ssl,
+      connectionTimeoutMillis: config.connectionTimeoutMillis ?? 5000,
+    });
+    try {
+      await client.connect();
+      return client;
+    } catch (error) {
+      await client.end().catch(() => undefined);
+      throw error;
+    }
+  };
+
+  try {
+    return await connect();
+  } catch (err) {
+    if (isTransientConnectionError(err)) {
+      console.warn("Transient DB connection error, retrying dedicated connection:", (err as Error).message);
+      return connect();
+    }
+    throw err;
+  }
+}
+
+/**
  * Perform a health check using a one-off connection, outside the application
  * pool, so saturated worker traffic does not make a reachable database look
  * down to the load balancer.

--- a/server/src/db/migrations/527_admin_credential_reissue_events.sql
+++ b/server/src/db/migrations/527_admin_credential_reissue_events.sql
@@ -1,0 +1,50 @@
+-- Append-only provenance for admin-triggered Certifier credential recovery.
+
+ALTER TABLE user_credentials
+  ADD COLUMN IF NOT EXISTS certifier_issuance_key UUID,
+  ADD COLUMN IF NOT EXISTS certifier_issuance_state TEXT NOT NULL DEFAULT 'not_started',
+  ADD COLUMN IF NOT EXISTS certifier_delivery_state TEXT NOT NULL DEFAULT 'not_started';
+
+ALTER TABLE user_credentials
+  DROP CONSTRAINT IF EXISTS user_credentials_certifier_issuance_state_check,
+  ADD CONSTRAINT user_credentials_certifier_issuance_state_check
+    CHECK (certifier_issuance_state IN (
+      'not_started', 'creating', 'draft_created', 'issuing', 'issued', 'complete', 'reconcile_required'
+    )),
+  DROP CONSTRAINT IF EXISTS user_credentials_certifier_delivery_state_check,
+  ADD CONSTRAINT user_credentials_certifier_delivery_state_check
+    CHECK (certifier_delivery_state IN ('not_started', 'sending', 'sent', 'unknown'));
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_credentials_certifier_issuance_key
+  ON user_credentials(certifier_issuance_key)
+  WHERE certifier_issuance_key IS NOT NULL;
+
+UPDATE user_credentials
+SET certifier_issuance_state = 'issued',
+    certifier_delivery_state = 'unknown'
+WHERE certifier_credential_id IS NOT NULL
+  AND certifier_issuance_state = 'not_started';
+
+CREATE TABLE IF NOT EXISTS admin_credential_reissue_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  operation_id UUID NOT NULL,
+  workos_user_id TEXT NOT NULL REFERENCES users(workos_user_id),
+  credential_id VARCHAR(50) NOT NULL REFERENCES certification_credentials(id),
+  admin_user_id TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  event_type TEXT NOT NULL CHECK (event_type IN ('started', 'succeeded', 'failed')),
+  details JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_credential_reissue_events_operation
+  ON admin_credential_reissue_events(operation_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_admin_credential_reissue_events_target
+  ON admin_credential_reissue_events(workos_user_id, credential_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_admin_credential_reissue_events_admin
+  ON admin_credential_reissue_events(admin_user_id, created_at DESC);
+
+COMMENT ON TABLE admin_credential_reissue_events IS
+  'Append-only audit events for admin-triggered Certifier credential recovery.';

--- a/server/src/routes/certification.ts
+++ b/server/src/routes/certification.ts
@@ -1,15 +1,23 @@
 import { Router } from 'express';
+import { randomUUID } from 'node:crypto';
 import { WorkOS } from '@workos-inc/node';
 import { Resend } from 'resend';
 import rateLimit from 'express-rate-limit';
 import { createLogger } from '../logger.js';
-import { requireAuth, requireAdmin, optionalAuth, isDevModeEnabled } from '../middleware/auth.js';
+import { requireAuth, requireGlobalAdmin, optionalAuth, isDevModeEnabled } from '../middleware/auth.js';
 import { enrichUserWithMembership } from '../utils/html-config.js';
 import * as certDb from '../db/certification-db.js';
 import { query } from '../db/client.js';
 import { notifyUser } from '../notifications/notification-service.js';
 import { isUuid } from '../utils/uuid.js';
 import { CachedPostgresStore } from '../middleware/pg-rate-limit-store.js';
+import {
+  CertifierNotConfiguredError,
+  CredentialNameRequiredError,
+  CredentialNotEarnedError,
+  CredentialRecoveryConflictError,
+  ensureCertifierCredential,
+} from '../services/certification-credential-issuance.js';
 
 const logger = createLogger('certification-routes');
 
@@ -35,6 +43,16 @@ const adminModuleCompletionLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   store: new CachedPostgresStore('cert-admin-module-complete:'),
+  keyGenerator: (req) => req.user?.id || req.ip || 'unknown',
+  validate: { keyGeneratorIpFallback: false },
+});
+
+const adminCredentialRecoveryLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  store: new CachedPostgresStore('cert-admin-credential-recovery:'),
   keyGenerator: (req) => req.user?.id || req.ip || 'unknown',
   validate: { keyGeneratorIpFallback: false },
 });
@@ -987,7 +1005,7 @@ export function createCertificationRouters() {
   // =====================================================
 
   const adminRouter = Router();
-  adminRouter.use(requireAuth, requireAdmin);
+  adminRouter.use(...requireGlobalAdmin);
 
   // POST /api/admin/certification/backfill-badges — retry Certifier for credentials missing data
   let backfillInProgress = false;
@@ -997,8 +1015,7 @@ export function createCertificationRouters() {
     }
     backfillInProgress = true;
     try {
-      const { issueCredential, isCertifierConfigured, getCredentialBadgeUrl, buildRecipientName } =
-        await import('../services/certifier-client.js');
+      const { isCertifierConfigured } = await import('../services/certifier-client.js');
 
       if (!isCertifierConfigured()) {
         return res.status(503).json({ error: 'Certifier not configured' });
@@ -1038,50 +1055,11 @@ export function createCertificationRouters() {
 
       for (const row of needsBadgeUrl.rows) {
         try {
-          if (row.certifier_credential_id) {
-            // Has certifier ID but missing badge URL — just fetch the badge
-            const badgeUrl = await getCredentialBadgeUrl(row.certifier_credential_id);
-            if (badgeUrl) {
-              await certDb.awardCredential(
-                row.workos_user_id, row.credential_id,
-                row.certifier_credential_id, row.certifier_public_id || undefined,
-                badgeUrl,
-              );
-              updated++;
-            }
-          } else {
-            // No certifier ID at all — need to re-issue
-            const cred = await certDb.getCredential(row.credential_id);
-            if (!cred?.certifier_group_id) continue;
-
-            // Get user info for Certifier
-            const userResult = await query<{ first_name: string; last_name: string; email: string }>(
-              'SELECT first_name, last_name, email FROM users WHERE workos_user_id = $1',
-              [row.workos_user_id]
-            );
-            const user = userResult.rows[0];
-            if (!user) continue;
-
-            const credential = await issueCredential({
-              groupId: cred.certifier_group_id,
-              recipient: {
-                name: buildRecipientName(user),
-                email: user.email,
-              },
-            });
-
-            let badgeUrl: string | null = null;
-            try {
-              badgeUrl = await getCredentialBadgeUrl(credential.id);
-            } catch { /* badge URL is optional */ }
-
-            await certDb.awardCredential(
-              row.workos_user_id, row.credential_id,
-              credential.id, credential.publicId,
-              badgeUrl || undefined,
-            );
-            updated++;
-          }
+          const result = await ensureCertifierCredential({
+            userId: row.workos_user_id,
+            credentialId: row.credential_id,
+          });
+          if (result.badgeUrl) updated++;
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           errors.push(`${row.credential_id}/${row.workos_user_id}: ${msg}`);
@@ -1126,11 +1104,34 @@ export function createCertificationRouters() {
 
   // POST /api/admin/certification/learners/:userId/credentials/:credentialId/reissue
   // Targeted recovery for an already-awarded local credential whose Certifier
-  // issuance or badge lookup failed. Idempotent when the external credential is
-  // already complete, so a retry never creates a second Certifier credential.
-  adminRouter.post('/learners/:userId/credentials/:credentialId/reissue', async (req, res) => {
+  // issuance or badge lookup failed. The shared issuance service serializes all
+  // recovery paths and persists a draft external ID before issue/send.
+  adminRouter.post('/learners/:userId/credentials/:credentialId/reissue', adminCredentialRecoveryLimiter, async (req, res) => {
     const { userId, credentialId } = req.params;
+    let operationId: string | null = null;
+    let auditContext: {
+      adminUserId: string;
+      reason: string;
+    } | null = null;
     try {
+      if (!userId || userId.length > 255 || !credentialId || credentialId.length > 50) {
+        return res.status(400).json({ error: 'Invalid learner or credential identifier' });
+      }
+
+      const reason = typeof req.body?.reason === 'string' ? req.body.reason.trim() : '';
+      if (reason.length < 10 || reason.length > 1000) {
+        return res.status(400).json({ error: 'Reason must be between 10 and 1000 characters' });
+      }
+
+      const isStaticAdminApiKey = Boolean(
+        (req as typeof req & { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey,
+      );
+      if (!req.user?.id && !isStaticAdminApiKey) {
+        return res.status(401).json({ error: 'Global admin identity is required' });
+      }
+      const adminUserId = req.user?.id || 'static-admin-api-key';
+      auditContext = { adminUserId, reason };
+
       const credential = await certDb.getCredential(credentialId);
       if (!credential) {
         return res.status(404).json({ error: 'Credential definition not found' });
@@ -1140,17 +1141,12 @@ export function createCertificationRouters() {
       }
 
       const awardedResult = await query<{
-        first_name: string | null;
-        last_name: string | null;
-        email: string;
         certifier_credential_id: string | null;
         certifier_public_id: string | null;
         certifier_badge_url: string | null;
       }>(
-        `SELECT u.first_name, u.last_name, u.email,
-                uc.certifier_credential_id, uc.certifier_public_id, uc.certifier_badge_url
+        `SELECT uc.certifier_credential_id, uc.certifier_public_id, uc.certifier_badge_url
          FROM user_credentials uc
-         JOIN users u ON u.workos_user_id = uc.workos_user_id
          WHERE uc.workos_user_id = $1 AND uc.credential_id = $2`,
         [userId, credentialId],
       );
@@ -1159,62 +1155,98 @@ export function createCertificationRouters() {
         return res.status(404).json({ error: 'Learner has not earned this credential' });
       }
 
-      const { issueCredential, isCertifierConfigured, getCredentialBadgeUrl, buildRecipientName } =
-        await import('../services/certifier-client.js');
-      if (!isCertifierConfigured()) {
-        return res.status(503).json({ error: 'Certifier not configured' });
-      }
-
-      let certifierCredentialId = awarded.certifier_credential_id;
-      let certifierPublicId = awarded.certifier_public_id;
-      let badgeUrl = awarded.certifier_badge_url;
-      let issued = false;
-
-      if (!certifierCredentialId) {
-        const issuedCredential = await issueCredential({
-          groupId: credential.certifier_group_id,
-          recipient: {
-            name: buildRecipientName(awarded),
-            email: awarded.email,
-          },
-        });
-        certifierCredentialId = issuedCredential.id;
-        certifierPublicId = issuedCredential.publicId;
-        issued = true;
-      }
-
-      if (!badgeUrl) {
-        try {
-          badgeUrl = await getCredentialBadgeUrl(certifierCredentialId);
-        } catch (badgeError) {
-          // Persist successful issuance even if Certifier's rendered badge is
-          // not available yet. A later retry will only repeat the badge lookup.
-          logger.warn({ error: badgeError, userId, credentialId }, 'Credential issued but badge lookup failed');
-        }
-      }
-
-      const saved = await certDb.awardCredential(
+      operationId = randomUUID();
+      await certDb.recordAdminCredentialReissueEvent({
+        operationId,
         userId,
         credentialId,
-        certifierCredentialId,
-        certifierPublicId || undefined,
-        badgeUrl || undefined,
-      );
+        adminUserId,
+        reason,
+        eventType: 'started',
+        details: {
+          before: {
+            certifier_credential_id: awarded.certifier_credential_id,
+            certifier_public_id: awarded.certifier_public_id,
+            badge_available: Boolean(awarded.certifier_badge_url),
+          },
+        },
+      });
+
+      const result = await ensureCertifierCredential({ userId, credentialId });
+
+      let auditWarning = false;
+      try {
+        await certDb.recordAdminCredentialReissueEvent({
+          operationId,
+          userId,
+          credentialId,
+          adminUserId,
+          reason,
+          eventType: 'succeeded',
+          details: {
+            outcome: result.outcome,
+            email_delivery: result.emailDelivery,
+            after: {
+              certifier_credential_id: result.credentialId,
+              certifier_public_id: result.publicId,
+              badge_available: Boolean(result.badgeUrl),
+            },
+          },
+        });
+      } catch (auditError) {
+        auditWarning = true;
+        logger.error(
+          { error: auditError, operationId, userId, credentialId },
+          'Credential recovery succeeded but success audit event failed',
+        );
+      }
 
       return res.json({
-        issued,
-        badge_available: Boolean(saved.certifier_badge_url),
+        operation_id: operationId,
+        outcome: result.outcome,
+        issued: result.outcome === 'issued',
+        badge_available: Boolean(result.badgeUrl),
+        email_delivery: result.emailDelivery,
+        ...(auditWarning && { warnings: ['Credential recovered, but the success audit event could not be recorded'] }),
         credential: {
           credential_id: credentialId,
           name: credential.name,
-          certifier_credential_id: saved.certifier_credential_id,
-          certifier_public_id: saved.certifier_public_id,
-          certifier_badge_url: saved.certifier_badge_url,
+          certifier_credential_id: result.credentialId,
+          certifier_public_id: result.publicId,
+          certifier_badge_url: result.badgeUrl,
         },
       });
     } catch (error) {
+      if (operationId && auditContext) {
+        try {
+          await certDb.recordAdminCredentialReissueEvent({
+            operationId,
+            userId,
+            credentialId,
+            adminUserId: auditContext.adminUserId,
+            reason: auditContext.reason,
+            eventType: 'failed',
+            details: { error_type: error instanceof Error ? error.constructor.name : 'UnknownError' },
+          });
+        } catch (auditError) {
+          logger.error({ error: auditError, operationId }, 'Failed to append credential recovery failure audit event');
+        }
+      }
+
+      if (error instanceof CredentialNotEarnedError) {
+        return res.status(404).json({ error: error.message, ...(operationId && { operation_id: operationId }) });
+      }
+      if (error instanceof CredentialNameRequiredError || error instanceof CredentialRecoveryConflictError) {
+        return res.status(409).json({ error: error.message, ...(operationId && { operation_id: operationId }) });
+      }
+      if (error instanceof CertifierNotConfiguredError) {
+        return res.status(503).json({ error: error.message, ...(operationId && { operation_id: operationId }) });
+      }
       logger.error({ error, userId, credentialId }, 'Failed to reissue Certifier credential');
-      return res.status(502).json({ error: 'Certifier credential recovery failed' });
+      return res.status(502).json({
+        error: 'Certifier credential recovery failed',
+        ...(operationId && { operation_id: operationId }),
+      });
     }
   });
 

--- a/server/src/routes/certification.ts
+++ b/server/src/routes/certification.ts
@@ -1124,6 +1124,100 @@ export function createCertificationRouters() {
     }
   });
 
+  // POST /api/admin/certification/learners/:userId/credentials/:credentialId/reissue
+  // Targeted recovery for an already-awarded local credential whose Certifier
+  // issuance or badge lookup failed. Idempotent when the external credential is
+  // already complete, so a retry never creates a second Certifier credential.
+  adminRouter.post('/learners/:userId/credentials/:credentialId/reissue', async (req, res) => {
+    const { userId, credentialId } = req.params;
+    try {
+      const credential = await certDb.getCredential(credentialId);
+      if (!credential) {
+        return res.status(404).json({ error: 'Credential definition not found' });
+      }
+      if (!credential.certifier_group_id) {
+        return res.status(409).json({ error: 'Credential is not configured for Certifier issuance' });
+      }
+
+      const awardedResult = await query<{
+        first_name: string | null;
+        last_name: string | null;
+        email: string;
+        certifier_credential_id: string | null;
+        certifier_public_id: string | null;
+        certifier_badge_url: string | null;
+      }>(
+        `SELECT u.first_name, u.last_name, u.email,
+                uc.certifier_credential_id, uc.certifier_public_id, uc.certifier_badge_url
+         FROM user_credentials uc
+         JOIN users u ON u.workos_user_id = uc.workos_user_id
+         WHERE uc.workos_user_id = $1 AND uc.credential_id = $2`,
+        [userId, credentialId],
+      );
+      const awarded = awardedResult.rows[0];
+      if (!awarded) {
+        return res.status(404).json({ error: 'Learner has not earned this credential' });
+      }
+
+      const { issueCredential, isCertifierConfigured, getCredentialBadgeUrl, buildRecipientName } =
+        await import('../services/certifier-client.js');
+      if (!isCertifierConfigured()) {
+        return res.status(503).json({ error: 'Certifier not configured' });
+      }
+
+      let certifierCredentialId = awarded.certifier_credential_id;
+      let certifierPublicId = awarded.certifier_public_id;
+      let badgeUrl = awarded.certifier_badge_url;
+      let issued = false;
+
+      if (!certifierCredentialId) {
+        const issuedCredential = await issueCredential({
+          groupId: credential.certifier_group_id,
+          recipient: {
+            name: buildRecipientName(awarded),
+            email: awarded.email,
+          },
+        });
+        certifierCredentialId = issuedCredential.id;
+        certifierPublicId = issuedCredential.publicId;
+        issued = true;
+      }
+
+      if (!badgeUrl) {
+        try {
+          badgeUrl = await getCredentialBadgeUrl(certifierCredentialId);
+        } catch (badgeError) {
+          // Persist successful issuance even if Certifier's rendered badge is
+          // not available yet. A later retry will only repeat the badge lookup.
+          logger.warn({ error: badgeError, userId, credentialId }, 'Credential issued but badge lookup failed');
+        }
+      }
+
+      const saved = await certDb.awardCredential(
+        userId,
+        credentialId,
+        certifierCredentialId,
+        certifierPublicId || undefined,
+        badgeUrl || undefined,
+      );
+
+      return res.json({
+        issued,
+        badge_available: Boolean(saved.certifier_badge_url),
+        credential: {
+          credential_id: credentialId,
+          name: credential.name,
+          certifier_credential_id: saved.certifier_credential_id,
+          certifier_public_id: saved.certifier_public_id,
+          certifier_badge_url: saved.certifier_badge_url,
+        },
+      });
+    } catch (error) {
+      logger.error({ error, userId, credentialId }, 'Failed to reissue Certifier credential');
+      return res.status(502).json({ error: 'Certifier credential recovery failed' });
+    }
+  });
+
   // GET /api/admin/certification/stuck-attempts — list stuck attempts
   adminRouter.get('/stuck-attempts', async (req, res) => {
     try {

--- a/server/src/routes/certification.ts
+++ b/server/src/routes/certification.ts
@@ -1234,13 +1234,28 @@ export function createCertificationRouters() {
       }
 
       if (error instanceof CredentialNotEarnedError) {
-        return res.status(404).json({ error: error.message, ...(operationId && { operation_id: operationId }) });
+        return res.status(404).json({
+          error: 'Learner has not earned this credential',
+          ...(operationId && { operation_id: operationId }),
+        });
       }
-      if (error instanceof CredentialNameRequiredError || error instanceof CredentialRecoveryConflictError) {
-        return res.status(409).json({ error: error.message, ...(operationId && { operation_id: operationId }) });
+      if (error instanceof CredentialNameRequiredError) {
+        return res.status(409).json({
+          error: 'Learner name is required before issuance',
+          ...(operationId && { operation_id: operationId }),
+        });
+      }
+      if (error instanceof CredentialRecoveryConflictError) {
+        return res.status(409).json({
+          error: 'Credential recovery requires manual reconciliation',
+          ...(operationId && { operation_id: operationId }),
+        });
       }
       if (error instanceof CertifierNotConfiguredError) {
-        return res.status(503).json({ error: error.message, ...(operationId && { operation_id: operationId }) });
+        return res.status(503).json({
+          error: 'Certifier not configured',
+          ...(operationId && { operation_id: operationId }),
+        });
       }
       logger.error({ error, userId, credentialId }, 'Failed to reissue Certifier credential');
       return res.status(502).json({

--- a/server/src/services/certification-credential-issuance.ts
+++ b/server/src/services/certification-credential-issuance.ts
@@ -1,6 +1,6 @@
-import type { PoolClient } from 'pg';
+import type { Client } from 'pg';
 import { randomUUID } from 'node:crypto';
-import { getClient } from '../db/client.js';
+import { getDedicatedClient } from '../db/client.js';
 import { createLogger } from '../logger.js';
 import { resolveUserNameWithFallbacks } from '../utils/resolve-user-name.js';
 import {
@@ -9,6 +9,7 @@ import {
   getCredential,
   getCredentialBadgeUrl,
   isCertifierConfigured,
+  isDefinitiveCertifierNonDelivery,
   issueCredentialDraft,
   sendCredential,
   type CertifierCredential,
@@ -53,7 +54,7 @@ export function credentialExpiryDate(tier: number, now: Date = new Date()): stri
 }
 
 async function loadAwardedCredential(
-  client: PoolClient,
+  client: Client,
   userId: string,
   credentialId: string,
 ): Promise<AwardedCredentialRow | null> {
@@ -72,7 +73,7 @@ async function loadAwardedCredential(
 }
 
 async function persistDraftId(
-  client: PoolClient,
+  client: Client,
   userId: string,
   credentialId: string,
   issuanceKey: string,
@@ -99,7 +100,7 @@ async function persistDraftId(
 }
 
 async function setIssuanceState(
-  client: PoolClient,
+  client: Client,
   userId: string,
   credentialId: string,
   externalCredentialId: string,
@@ -118,7 +119,7 @@ async function setIssuanceState(
 }
 
 async function setDeliveryState(
-  client: PoolClient,
+  client: Client,
   userId: string,
   credentialId: string,
   externalCredentialId: string,
@@ -137,7 +138,7 @@ async function setDeliveryState(
 }
 
 async function persistProviderState(
-  client: PoolClient,
+  client: Client,
   userId: string,
   credentialId: string,
   externalCredentialId: string,
@@ -179,10 +180,12 @@ export async function ensureCertifierCredential(input: {
     throw new CertifierNotConfiguredError('Certifier not configured');
   }
 
-  const client = await getClient();
+  // A dedicated connection keeps the session-scoped advisory lock from
+  // consuming one of the application's pooled request connections while
+  // Certifier calls are in flight.
+  const client = await getDedicatedClient();
   const lockKey = `certifier:${input.userId}:${input.credentialId}`;
   let lockHeld = false;
-  let releaseError: Error | undefined;
 
   try {
     const lock = await client.query<{ locked: boolean }>(
@@ -209,7 +212,7 @@ export async function ensureCertifierCredential(input: {
     const hadPublicId = Boolean(awarded.certifier_public_id);
     let external: CertifierCredential;
     let issuedInThisCall = false;
-    let deliveryState = awarded.certifier_delivery_state;
+    const deliveryState = awarded.certifier_delivery_state;
     let emailDelivery: EnsureCertifierCredentialResult['emailDelivery'] = deliveryState === 'sent'
       ? 'sent'
       : deliveryState === 'unknown' || deliveryState === 'sending'
@@ -304,20 +307,31 @@ export async function ensureCertifierCredential(input: {
       try {
         external = await sendCredential(external.id);
         await setDeliveryState(client, input.userId, input.credentialId, external.id, 'sent');
-        deliveryState = 'sent';
         emailDelivery = 'sent';
       } catch (error) {
-        await setDeliveryState(client, input.userId, input.credentialId, external.id, 'unknown');
-        deliveryState = 'unknown';
-        emailDelivery = 'unknown';
-        logger.error(
-          { error, userId: input.userId, credentialId: input.credentialId, externalCredentialId: external.id },
-          'Credential issued but email delivery outcome is unknown; automatic resend suppressed',
+        const definitiveNonDelivery = isDefinitiveCertifierNonDelivery(error);
+        await setDeliveryState(
+          client,
+          input.userId,
+          input.credentialId,
+          external.id,
+          definitiveNonDelivery ? 'not_started' : 'unknown',
         );
+        emailDelivery = definitiveNonDelivery ? 'not_attempted' : 'unknown';
+        const context = {
+          error,
+          userId: input.userId,
+          credentialId: input.credentialId,
+          externalCredentialId: external.id,
+        };
+        if (definitiveNonDelivery) {
+          logger.warn(context, 'Credential issued but email was not dispatched; retry remains available');
+        } else {
+          logger.error(context, 'Credential issued but email delivery outcome is unknown; automatic resend suppressed');
+        }
       }
     } else if (deliveryState === 'sending') {
       await setDeliveryState(client, input.userId, input.credentialId, external.id, 'unknown');
-      deliveryState = 'unknown';
       emailDelivery = 'unknown';
     }
 
@@ -375,14 +389,14 @@ export async function ensureCertifierCredential(input: {
           [lockKey],
         );
         if (unlock.rows[0]?.unlocked !== true) {
-          releaseError = new Error('Credential issuance advisory unlock returned false');
-          logger.error({ lockKey }, 'Failed to release credential issuance advisory lock; destroying client');
+          logger.error({ lockKey }, 'Credential issuance advisory unlock returned false; closing dedicated client');
         }
       } catch (error) {
-        releaseError = error instanceof Error ? error : new Error(String(error));
-        logger.error({ error: releaseError, lockKey }, 'Failed to release credential issuance advisory lock');
+        logger.error({ error, lockKey }, 'Failed to release credential issuance advisory lock');
       }
     }
-    client.release(releaseError);
+    await client.end().catch((error) => {
+      logger.error({ error, lockKey }, 'Failed to close credential issuance database connection');
+    });
   }
 }

--- a/server/src/services/certification-credential-issuance.ts
+++ b/server/src/services/certification-credential-issuance.ts
@@ -1,0 +1,388 @@
+import type { PoolClient } from 'pg';
+import { randomUUID } from 'node:crypto';
+import { getClient } from '../db/client.js';
+import { createLogger } from '../logger.js';
+import { resolveUserNameWithFallbacks } from '../utils/resolve-user-name.js';
+import {
+  buildRecipientName,
+  createCredentialDraft,
+  getCredential,
+  getCredentialBadgeUrl,
+  isCertifierConfigured,
+  issueCredentialDraft,
+  sendCredential,
+  type CertifierCredential,
+} from './certifier-client.js';
+
+const logger = createLogger('certification-credential-issuance');
+
+export const NAME_REQUIRED_MARKER = 'NAME_REQUIRED';
+
+export class CredentialNotEarnedError extends Error {}
+export class CredentialNameRequiredError extends Error {}
+export class CertifierNotConfiguredError extends Error {}
+export class CredentialRecoveryConflictError extends Error {}
+
+interface AwardedCredentialRow {
+  first_name: string | null;
+  last_name: string | null;
+  email: string;
+  tier: number;
+  certifier_group_id: string | null;
+  certifier_credential_id: string | null;
+  certifier_public_id: string | null;
+  certifier_badge_url: string | null;
+  certifier_issuance_key: string | null;
+  certifier_issuance_state: 'not_started' | 'creating' | 'draft_created' | 'issuing' | 'issued' | 'complete' | 'reconcile_required';
+  certifier_delivery_state: 'not_started' | 'sending' | 'sent' | 'unknown';
+}
+
+export interface EnsureCertifierCredentialResult {
+  outcome: 'issued' | 'metadata_refreshed' | 'badge_refreshed' | 'already_complete' | 'badge_pending';
+  credentialId: string;
+  publicId: string | null;
+  badgeUrl: string | null;
+  emailDelivery: 'sent' | 'not_attempted' | 'unknown';
+}
+
+export function credentialExpiryDate(tier: number, now: Date = new Date()): string | undefined {
+  if (tier === 1) return undefined;
+  const expiry = new Date(now);
+  expiry.setUTCFullYear(expiry.getUTCFullYear() + 2);
+  return expiry.toISOString().slice(0, 10);
+}
+
+async function loadAwardedCredential(
+  client: PoolClient,
+  userId: string,
+  credentialId: string,
+): Promise<AwardedCredentialRow | null> {
+  const result = await client.query<AwardedCredentialRow>(
+    `SELECT u.first_name, u.last_name, u.email,
+            cc.tier, cc.certifier_group_id,
+            uc.certifier_credential_id, uc.certifier_public_id, uc.certifier_badge_url,
+            uc.certifier_issuance_key, uc.certifier_issuance_state, uc.certifier_delivery_state
+       FROM user_credentials uc
+       JOIN users u ON u.workos_user_id = uc.workos_user_id
+       JOIN certification_credentials cc ON cc.id = uc.credential_id
+      WHERE uc.workos_user_id = $1 AND uc.credential_id = $2`,
+    [userId, credentialId],
+  );
+  return result.rows[0] ?? null;
+}
+
+async function persistDraftId(
+  client: PoolClient,
+  userId: string,
+  credentialId: string,
+  issuanceKey: string,
+  credential: CertifierCredential,
+): Promise<void> {
+  const result = await client.query(
+    `UPDATE user_credentials
+        SET certifier_credential_id = $3,
+            certifier_public_id = COALESCE($4, certifier_public_id),
+            certifier_issuance_state = 'draft_created'
+      WHERE workos_user_id = $1
+        AND credential_id = $2
+        AND certifier_credential_id IS NULL
+        AND certifier_issuance_key = $5
+        AND certifier_issuance_state = 'creating'
+      RETURNING id`,
+    [userId, credentialId, credential.id, credential.publicId || null, issuanceKey],
+  );
+  if (result.rowCount !== 1) {
+    throw new CredentialRecoveryConflictError(
+      'Credential award changed while the external draft was being created; reconcile in Certifier before retrying',
+    );
+  }
+}
+
+async function setIssuanceState(
+  client: PoolClient,
+  userId: string,
+  credentialId: string,
+  externalCredentialId: string,
+  state: AwardedCredentialRow['certifier_issuance_state'],
+): Promise<void> {
+  const result = await client.query(
+    `UPDATE user_credentials
+        SET certifier_issuance_state = $4
+      WHERE workos_user_id = $1 AND credential_id = $2 AND certifier_credential_id = $3
+      RETURNING id`,
+    [userId, credentialId, externalCredentialId, state],
+  );
+  if (result.rowCount !== 1) {
+    throw new CredentialRecoveryConflictError('Credential award changed during issuance');
+  }
+}
+
+async function setDeliveryState(
+  client: PoolClient,
+  userId: string,
+  credentialId: string,
+  externalCredentialId: string,
+  state: AwardedCredentialRow['certifier_delivery_state'],
+): Promise<void> {
+  const result = await client.query(
+    `UPDATE user_credentials
+        SET certifier_delivery_state = $4
+      WHERE workos_user_id = $1 AND credential_id = $2 AND certifier_credential_id = $3
+      RETURNING id`,
+    [userId, credentialId, externalCredentialId, state],
+  );
+  if (result.rowCount !== 1) {
+    throw new CredentialRecoveryConflictError('Credential award changed during delivery');
+  }
+}
+
+async function persistProviderState(
+  client: PoolClient,
+  userId: string,
+  credentialId: string,
+  externalCredentialId: string,
+  publicId: string | null,
+  badgeUrl: string | null,
+): Promise<void> {
+  const result = await client.query(
+    `UPDATE user_credentials
+        SET certifier_public_id = COALESCE($4, certifier_public_id),
+            certifier_badge_url = COALESCE($5, certifier_badge_url)
+      WHERE workos_user_id = $1
+        AND credential_id = $2
+        AND certifier_credential_id = $3
+      RETURNING id`,
+    [userId, credentialId, externalCredentialId, publicId, badgeUrl],
+  );
+  if (result.rowCount !== 1) {
+    throw new CredentialRecoveryConflictError(
+      'Credential award changed during external recovery; the local mapping was not overwritten',
+    );
+  }
+}
+
+/**
+ * Ensure an earned credential has one issued Certifier credential and a badge.
+ *
+ * All issuance entry points use this helper. A session-level advisory lock
+ * serializes the learner/credential pair across app processes. New credentials
+ * are created as drafts and their IDs are conditionally persisted before they
+ * are issued or emailed, eliminating the duplicate-active-credential window in
+ * the former create/issue/send all-in-one flow.
+ */
+export async function ensureCertifierCredential(input: {
+  userId: string;
+  credentialId: string;
+  now?: Date;
+}): Promise<EnsureCertifierCredentialResult> {
+  if (!isCertifierConfigured()) {
+    throw new CertifierNotConfiguredError('Certifier not configured');
+  }
+
+  const client = await getClient();
+  const lockKey = `certifier:${input.userId}:${input.credentialId}`;
+  let lockHeld = false;
+  let releaseError: Error | undefined;
+
+  try {
+    const lock = await client.query<{ locked: boolean }>(
+      'SELECT pg_try_advisory_lock(hashtextextended($1, 0)) AS locked',
+      [lockKey],
+    );
+    if (lock.rows[0]?.locked !== true) {
+      throw new CredentialRecoveryConflictError('Credential recovery is already in progress');
+    }
+    lockHeld = true;
+
+    const awarded = await loadAwardedCredential(client, input.userId, input.credentialId);
+    if (!awarded) {
+      throw new CredentialNotEarnedError('Learner has not earned this credential');
+    }
+    if (!awarded.certifier_group_id) {
+      throw new CredentialRecoveryConflictError('Credential is not configured for Certifier issuance');
+    }
+
+    const wasComplete = Boolean(
+      awarded.certifier_credential_id && awarded.certifier_public_id && awarded.certifier_badge_url,
+    );
+    const hadBadge = Boolean(awarded.certifier_badge_url);
+    const hadPublicId = Boolean(awarded.certifier_public_id);
+    let external: CertifierCredential;
+    let issuedInThisCall = false;
+    let deliveryState = awarded.certifier_delivery_state;
+    let emailDelivery: EnsureCertifierCredentialResult['emailDelivery'] = deliveryState === 'sent'
+      ? 'sent'
+      : deliveryState === 'unknown' || deliveryState === 'sending'
+        ? 'unknown'
+        : 'not_attempted';
+
+    if (!awarded.certifier_credential_id) {
+      const resolved = await resolveUserNameWithFallbacks(
+        client,
+        input.userId,
+        awarded.first_name,
+        awarded.last_name,
+      );
+      if (!(resolved.firstName ?? '').trim()) {
+        throw new CredentialNameRequiredError('Learner name is required before issuance');
+      }
+      if (awarded.certifier_issuance_state !== 'not_started') {
+        throw new CredentialRecoveryConflictError(
+          'A prior Certifier creation attempt requires manual reconciliation before retrying',
+        );
+      }
+      const issuanceKey = awarded.certifier_issuance_key || randomUUID();
+      const claim = await client.query(
+        `UPDATE user_credentials
+            SET certifier_issuance_key = $3,
+                certifier_issuance_state = 'creating'
+          WHERE workos_user_id = $1
+            AND credential_id = $2
+            AND certifier_credential_id IS NULL
+            AND certifier_issuance_state = 'not_started'
+          RETURNING id`,
+        [input.userId, input.credentialId, issuanceKey],
+      );
+      if (claim.rowCount !== 1) {
+        throw new CredentialRecoveryConflictError('Credential issuance was claimed by another recovery');
+      }
+
+      const expiryDate = credentialExpiryDate(awarded.tier, input.now);
+      try {
+        external = await createCredentialDraft({
+          groupId: awarded.certifier_group_id,
+          recipient: {
+            name: buildRecipientName({
+              first_name: resolved.firstName,
+              last_name: resolved.lastName,
+              email: awarded.email,
+            }),
+            email: awarded.email,
+          },
+          ...(expiryDate && { expiryDate }),
+        });
+      } catch (error) {
+        await client.query(
+          `UPDATE user_credentials
+              SET certifier_issuance_state = 'reconcile_required'
+            WHERE workos_user_id = $1 AND credential_id = $2
+              AND certifier_issuance_key = $3 AND certifier_issuance_state = 'creating'`,
+          [input.userId, input.credentialId, issuanceKey],
+        );
+        throw error;
+      }
+      await persistDraftId(client, input.userId, input.credentialId, issuanceKey, external);
+    } else {
+      external = await getCredential(awarded.certifier_credential_id);
+      if (external.groupId !== awarded.certifier_group_id) {
+        throw new CredentialRecoveryConflictError(
+          'Stored Certifier credential belongs to a different credential group',
+        );
+      }
+      if (external.recipient?.email?.trim().toLowerCase() !== awarded.email.trim().toLowerCase()) {
+        throw new CredentialRecoveryConflictError(
+          'Stored Certifier credential belongs to a different recipient',
+        );
+      }
+    }
+
+    if (external.status === 'draft') {
+      await setIssuanceState(client, input.userId, input.credentialId, external.id, 'issuing');
+      external = await issueCredentialDraft(external.id);
+      await setIssuanceState(client, input.userId, input.credentialId, external.id, 'issued');
+      issuedInThisCall = true;
+    } else if (external.status === 'issued') {
+      await setIssuanceState(client, input.userId, input.credentialId, external.id, 'issued');
+    } else {
+      throw new CredentialRecoveryConflictError(
+        `Certifier credential has unsupported recovery status: ${external.status}`,
+      );
+    }
+
+    if (deliveryState === 'not_started') {
+      await setDeliveryState(client, input.userId, input.credentialId, external.id, 'sending');
+      try {
+        external = await sendCredential(external.id);
+        await setDeliveryState(client, input.userId, input.credentialId, external.id, 'sent');
+        deliveryState = 'sent';
+        emailDelivery = 'sent';
+      } catch (error) {
+        await setDeliveryState(client, input.userId, input.credentialId, external.id, 'unknown');
+        deliveryState = 'unknown';
+        emailDelivery = 'unknown';
+        logger.error(
+          { error, userId: input.userId, credentialId: input.credentialId, externalCredentialId: external.id },
+          'Credential issued but email delivery outcome is unknown; automatic resend suppressed',
+        );
+      }
+    } else if (deliveryState === 'sending') {
+      await setDeliveryState(client, input.userId, input.credentialId, external.id, 'unknown');
+      deliveryState = 'unknown';
+      emailDelivery = 'unknown';
+    }
+
+    let badgeUrl = awarded.certifier_badge_url;
+    if (!badgeUrl) {
+      try {
+        badgeUrl = await getCredentialBadgeUrl(external.id);
+      } catch (error) {
+        logger.warn(
+          { error, userId: input.userId, credentialId: input.credentialId, externalCredentialId: external.id },
+          'Credential issued but badge lookup failed',
+        );
+      }
+    }
+
+    const publicId = external.publicId || awarded.certifier_public_id;
+    await persistProviderState(
+      client,
+      input.userId,
+      input.credentialId,
+      external.id,
+      publicId || null,
+      badgeUrl || null,
+    );
+    await setIssuanceState(
+      client,
+      input.userId,
+      input.credentialId,
+      external.id,
+      badgeUrl ? 'complete' : 'issued',
+    );
+
+    const outcome: EnsureCertifierCredentialResult['outcome'] = issuedInThisCall
+      ? 'issued'
+      : wasComplete
+        ? 'already_complete'
+        : !hadPublicId && publicId
+          ? 'metadata_refreshed'
+          : !hadBadge && badgeUrl
+            ? 'badge_refreshed'
+            : 'badge_pending';
+
+    return {
+      outcome,
+      credentialId: external.id,
+      publicId: publicId || null,
+      badgeUrl: badgeUrl || null,
+      emailDelivery,
+    };
+  } finally {
+    if (lockHeld) {
+      try {
+        const unlock = await client.query<{ unlocked: boolean }>(
+          'SELECT pg_advisory_unlock(hashtextextended($1, 0)) AS unlocked',
+          [lockKey],
+        );
+        if (unlock.rows[0]?.unlocked !== true) {
+          releaseError = new Error('Credential issuance advisory unlock returned false');
+          logger.error({ lockKey }, 'Failed to release credential issuance advisory lock; destroying client');
+        }
+      } catch (error) {
+        releaseError = error instanceof Error ? error : new Error(String(error));
+        logger.error({ error: releaseError, lockKey }, 'Failed to release credential issuance advisory lock');
+      }
+    }
+    client.release(releaseError);
+  }
+}

--- a/server/src/services/certifier-client.ts
+++ b/server/src/services/certifier-client.ts
@@ -12,6 +12,7 @@ const logger = createLogger('certifier');
 const CERTIFIER_API_TOKEN = process.env.CERTIFIER_API_TOKEN;
 const CERTIFIER_API_URL = 'https://api.certifier.io/v1';
 const CERTIFIER_VERSION = '2022-10-26';
+const CERTIFIER_TIMEOUT_MS = 15_000;
 
 export interface CertifierRecipient {
   name: string;
@@ -82,6 +83,7 @@ function getClient(): AxiosInstance {
   }
   return axios.create({
     baseURL: CERTIFIER_API_URL,
+    timeout: CERTIFIER_TIMEOUT_MS,
     headers: {
       'Authorization': `Bearer ${CERTIFIER_API_TOKEN}`,
       'Certifier-Version': CERTIFIER_VERSION,
@@ -107,6 +109,45 @@ export async function issueCredential(options: IssueCredentialOptions): Promise<
 
   const response = await client.post<CertifierCredential>('/credentials/create-issue-send', body);
   logger.info({ credentialId: response.data.id, publicId: response.data.publicId }, 'Credential issued');
+  return response.data;
+}
+
+/**
+ * Create a draft credential without issuing or emailing it. Recovery flows use
+ * this two-phase path so the external ID can be persisted locally before any
+ * irreversible learner-facing action occurs.
+ */
+export async function createCredentialDraft(options: IssueCredentialOptions): Promise<CertifierCredential> {
+  const client = getClient();
+  const body: Record<string, unknown> = {
+    groupId: options.groupId,
+    recipient: options.recipient,
+  };
+  if (options.issueDate) body.issueDate = options.issueDate;
+  if (options.expiryDate) body.expiryDate = options.expiryDate;
+  if (options.customAttributes) body.customAttributes = options.customAttributes;
+
+  logger.info({ groupId: options.groupId, recipientEmail: options.recipient.email }, 'Creating draft credential');
+  const response = await client.post<CertifierCredential>('/credentials', body);
+  logger.info({ credentialId: response.data.id, publicId: response.data.publicId }, 'Draft credential created');
+  return response.data;
+}
+
+/** Issue a previously-created draft credential. */
+export async function issueCredentialDraft(credentialId: string): Promise<CertifierCredential> {
+  const client = getClient();
+  const response = await client.post<CertifierCredential>(`/credentials/${credentialId}/issue`);
+  logger.info({ credentialId: response.data.id }, 'Draft credential issued');
+  return response.data;
+}
+
+/** Email a previously-issued credential to its recipient. */
+export async function sendCredential(credentialId: string): Promise<CertifierCredential> {
+  const client = getClient();
+  const response = await client.post<CertifierCredential>(`/credentials/${credentialId}/send`, {
+    deliveryMethod: 'email',
+  });
+  logger.info({ credentialId: response.data.id }, 'Credential email sent');
   return response.data;
 }
 

--- a/server/src/services/certifier-client.ts
+++ b/server/src/services/certifier-client.ts
@@ -13,6 +13,29 @@ const CERTIFIER_API_TOKEN = process.env.CERTIFIER_API_TOKEN;
 const CERTIFIER_API_URL = 'https://api.certifier.io/v1';
 const CERTIFIER_VERSION = '2022-10-26';
 const CERTIFIER_TIMEOUT_MS = 15_000;
+const DEFINITIVE_PRE_DISPATCH_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+]);
+
+/**
+ * Return true only when a failed send is known not to have reached Certifier's
+ * delivery handler. Timeouts and connection resets remain ambiguous because
+ * the provider may have accepted the request before the connection was lost.
+ */
+export function isDefinitiveCertifierNonDelivery(error: unknown): boolean {
+  if (!axios.isAxiosError(error)) return false;
+
+  const status = error.response?.status;
+  if (status !== undefined && status >= 400 && status < 500) return true;
+
+  return (
+    error.response === undefined &&
+    typeof error.code === 'string' &&
+    DEFINITIVE_PRE_DISPATCH_ERROR_CODES.has(error.code)
+  );
+}
 
 export interface CertifierRecipient {
   name: string;

--- a/server/src/utils/resolve-user-name.ts
+++ b/server/src/utils/resolve-user-name.ts
@@ -1,4 +1,4 @@
-import type { PoolClient, Pool } from 'pg';
+import type { Client, PoolClient, Pool } from 'pg';
 
 const MAX_NAME_LEN = 255;
 
@@ -75,7 +75,7 @@ export function splitFullName(fullName: string): { firstName: string; lastName: 
  * callback and the user.updated webhook agree on the resolved name.
  */
 export async function resolveUserNameWithFallbacks(
-  db: Pick<Pool | PoolClient, 'query'>,
+  db: Pick<Pool | PoolClient | Client, 'query'>,
   workosUserId: string,
   workosFirstName: string | null | undefined,
   workosLastName: string | null | undefined,

--- a/server/tests/integration/admin-module-completion.test.ts
+++ b/server/tests/integration/admin-module-completion.test.ts
@@ -25,6 +25,7 @@ vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
     ...(await importOriginal<typeof import('../../src/middleware/auth.js')>()),
     requireAuth: mockedRequireAuth,
     requireAdmin: passThrough,
+    requireGlobalAdmin: [mockedRequireAuth, passThrough, passThrough],
     optionalAuth: passThrough,
   };
 });

--- a/server/tests/unit/admin-certification-credential-reissue-route.test.ts
+++ b/server/tests/unit/admin-certification-credential-reissue-route.test.ts
@@ -4,16 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockCertDb = vi.hoisted(() => ({
   getCredential: vi.fn(),
-  awardCredential: vi.fn(),
+  recordAdminCredentialReissueEvent: vi.fn(),
 }));
 const mockQuery = vi.hoisted(() => vi.fn());
-const mockCertifier = vi.hoisted(() => ({
-  issueCredential: vi.fn(),
-  isCertifierConfigured: vi.fn(),
-  getCredentialBadgeUrl: vi.fn(),
-  buildRecipientName: vi.fn((user: { first_name: string | null; last_name: string | null; email: string }) =>
-    `${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() || user.email),
-}));
+const mockEnsureCredential = vi.hoisted(() => vi.fn());
+const authState = vi.hoisted(() => ({ allowGlobalAdmin: true }));
 
 vi.hoisted(() => {
   process.env.WORKOS_API_KEY ??= 'sk_test_mock_key';
@@ -26,11 +21,18 @@ vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
     req.user = { id: 'user_test_admin', email: 'admin@test.local' };
     next();
   };
+  const globalGate = (_req: any, res: any, next: any) => {
+    if (!authState.allowGlobalAdmin) {
+      return res.status(403).json({ error: 'global_admin_required' });
+    }
+    next();
+  };
   const passThrough = (_req: any, _res: any, next: any) => next();
   return {
     ...(await importOriginal<typeof import('../../src/middleware/auth.js')>()),
     requireAuth: mockedRequireAuth,
     requireAdmin: passThrough,
+    requireGlobalAdmin: [mockedRequireAuth, globalGate, passThrough],
     optionalAuth: passThrough,
   };
 });
@@ -40,12 +42,16 @@ vi.mock('../../src/db/client.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../src/db/client.js')>()),
   query: mockQuery,
 }));
-vi.mock('../../src/services/certifier-client.js', () => mockCertifier);
+vi.mock('../../src/services/certification-credential-issuance.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/services/certification-credential-issuance.js')>()),
+  ensureCertifierCredential: mockEnsureCredential,
+}));
 
 import { createCertificationRouters } from '../../src/routes/certification.js';
 
 const USER_ID = 'user_learner';
 const CREDENTIAL_ID = 'specialist_signals';
+const REASON = 'Escalation #6032 credential recovery';
 
 function buildApp() {
   const app = express();
@@ -57,84 +63,101 @@ function buildApp() {
 describe('admin credential reissue route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    authState.allowGlobalAdmin = true;
     mockCertDb.getCredential.mockResolvedValue({
       id: CREDENTIAL_ID,
       name: 'AdCP Specialist — Signals',
       certifier_group_id: 'group_signals',
     });
-    mockCertifier.isCertifierConfigured.mockReturnValue(true);
-    mockCertifier.issueCredential.mockResolvedValue({ id: 'cert_new', publicId: 'public_new' });
-    mockCertifier.getCredentialBadgeUrl.mockResolvedValue('https://cdn.test/badge.png');
-    mockCertDb.awardCredential.mockResolvedValue({
-      credential_id: CREDENTIAL_ID,
-      certifier_credential_id: 'cert_new',
-      certifier_public_id: 'public_new',
-      certifier_badge_url: 'https://cdn.test/badge.png',
-    });
-  });
-
-  it('issues and stores a missing external credential for an earned credential', async () => {
+    mockCertDb.recordAdminCredentialReissueEvent.mockResolvedValue(undefined);
     mockQuery.mockResolvedValue({ rows: [{
-      first_name: 'Test',
-      last_name: 'Learner',
-      email: 'learner@test.example',
       certifier_credential_id: null,
       certifier_public_id: null,
       certifier_badge_url: null,
     }] });
-
-    const response = await request(buildApp())
-      .post(`/api/admin/certification/learners/${USER_ID}/credentials/${CREDENTIAL_ID}/reissue`);
-
-    expect(response.status).toBe(200);
-    expect(response.body).toMatchObject({ issued: true, badge_available: true });
-    expect(mockCertifier.issueCredential).toHaveBeenCalledWith({
-      groupId: 'group_signals',
-      recipient: { name: 'Test Learner', email: 'learner@test.example' },
+    mockEnsureCredential.mockResolvedValue({
+      outcome: 'issued',
+      credentialId: 'cert_new',
+      publicId: 'public_new',
+      badgeUrl: 'https://cdn.test/badge.png',
+      emailDelivery: 'sent',
     });
-    expect(mockCertDb.awardCredential).toHaveBeenCalledWith(
-      USER_ID,
-      CREDENTIAL_ID,
-      'cert_new',
-      'public_new',
-      'https://cdn.test/badge.png',
-    );
   });
 
-  it('only retries badge lookup when the external credential already exists', async () => {
-    mockQuery.mockResolvedValue({ rows: [{
-      first_name: 'Test',
-      last_name: 'Learner',
-      email: 'learner@test.example',
-      certifier_credential_id: 'cert_existing',
-      certifier_public_id: 'public_existing',
-      certifier_badge_url: null,
-    }] });
-    mockCertDb.awardCredential.mockResolvedValue({
-      credential_id: CREDENTIAL_ID,
-      certifier_credential_id: 'cert_existing',
-      certifier_public_id: 'public_existing',
-      certifier_badge_url: 'https://cdn.test/badge.png',
-    });
-
+  it('recovers an earned credential and appends actor-attributed audit events', async () => {
     const response = await request(buildApp())
-      .post(`/api/admin/certification/learners/${USER_ID}/credentials/${CREDENTIAL_ID}/reissue`);
+      .post(`/api/admin/certification/learners/${USER_ID}/credentials/${CREDENTIAL_ID}/reissue`)
+      .send({ reason: REASON });
 
     expect(response.status).toBe(200);
-    expect(response.body.issued).toBe(false);
-    expect(mockCertifier.issueCredential).not.toHaveBeenCalled();
-    expect(mockCertifier.getCredentialBadgeUrl).toHaveBeenCalledWith('cert_existing');
+    expect(response.body).toMatchObject({
+      outcome: 'issued',
+      issued: true,
+      badge_available: true,
+      email_delivery: 'sent',
+    });
+    expect(response.body.operation_id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(mockEnsureCredential).toHaveBeenCalledWith({ userId: USER_ID, credentialId: CREDENTIAL_ID });
+    expect(mockCertDb.recordAdminCredentialReissueEvent).toHaveBeenCalledTimes(2);
+    expect(mockCertDb.recordAdminCredentialReissueEvent).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      userId: USER_ID,
+      credentialId: CREDENTIAL_ID,
+      adminUserId: 'user_test_admin',
+      reason: REASON,
+      eventType: 'started',
+    }));
+    expect(mockCertDb.recordAdminCredentialReissueEvent).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      eventType: 'succeeded',
+    }));
   });
 
-  it('does not issue a credential the learner has not earned', async () => {
+  it('returns partial-success semantics when the success audit append fails', async () => {
+    mockCertDb.recordAdminCredentialReissueEvent
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('audit unavailable'));
+
+    const response = await request(buildApp())
+      .post(`/api/admin/certification/learners/${USER_ID}/credentials/${CREDENTIAL_ID}/reissue`)
+      .send({ reason: REASON });
+
+    expect(response.status).toBe(200);
+    expect(response.body.credential.certifier_credential_id).toBe('cert_new');
+    expect(response.body.warnings[0]).toContain('audit event');
+    expect(mockCertDb.recordAdminCredentialReissueEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('requires a bounded incident reason before performing an external action', async () => {
+    const response = await request(buildApp())
+      .post(`/api/admin/certification/learners/${USER_ID}/credentials/${CREDENTIAL_ID}/reissue`)
+      .send({ reason: 'short' });
+
+    expect(response.status).toBe(400);
+    expect(mockEnsureCredential).not.toHaveBeenCalled();
+    expect(mockCertDb.recordAdminCredentialReissueEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not recover a credential the learner has not earned', async () => {
     mockQuery.mockResolvedValue({ rows: [] });
 
     const response = await request(buildApp())
-      .post(`/api/admin/certification/learners/${USER_ID}/credentials/${CREDENTIAL_ID}/reissue`);
+      .post(`/api/admin/certification/learners/${USER_ID}/credentials/${CREDENTIAL_ID}/reissue`)
+      .send({ reason: REASON });
 
     expect(response.status).toBe(404);
     expect(response.body.error).toContain('has not earned');
-    expect(mockCertifier.issueCredential).not.toHaveBeenCalled();
-    expect(mockCertDb.awardCredential).not.toHaveBeenCalled();
+    expect(mockEnsureCredential).not.toHaveBeenCalled();
+    expect(mockCertDb.recordAdminCredentialReissueEvent).not.toHaveBeenCalled();
+  });
+
+  it('refuses tenant-scoped admin API keys through the global-admin gate', async () => {
+    authState.allowGlobalAdmin = false;
+
+    const response = await request(buildApp())
+      .post(`/api/admin/certification/learners/${USER_ID}/credentials/${CREDENTIAL_ID}/reissue`)
+      .send({ reason: REASON });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('global_admin_required');
+    expect(mockEnsureCredential).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/unit/admin-certification-credential-reissue-route.test.ts
+++ b/server/tests/unit/admin-certification-credential-reissue-route.test.ts
@@ -1,0 +1,140 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCertDb = vi.hoisted(() => ({
+  getCredential: vi.fn(),
+  awardCredential: vi.fn(),
+}));
+const mockQuery = vi.hoisted(() => vi.fn());
+const mockCertifier = vi.hoisted(() => ({
+  issueCredential: vi.fn(),
+  isCertifierConfigured: vi.fn(),
+  getCredentialBadgeUrl: vi.fn(),
+  buildRecipientName: vi.fn((user: { first_name: string | null; last_name: string | null; email: string }) =>
+    `${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() || user.email),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY ??= 'sk_test_mock_key';
+  process.env.WORKOS_CLIENT_ID ??= 'client_mock_id';
+  process.env.WORKOS_COOKIE_PASSWORD ??= 'test-cookie-password-at-least-32-chars-long';
+});
+
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
+  const mockedRequireAuth = (req: any, _res: any, next: any) => {
+    req.user = { id: 'user_test_admin', email: 'admin@test.local' };
+    next();
+  };
+  const passThrough = (_req: any, _res: any, next: any) => next();
+  return {
+    ...(await importOriginal<typeof import('../../src/middleware/auth.js')>()),
+    requireAuth: mockedRequireAuth,
+    requireAdmin: passThrough,
+    optionalAuth: passThrough,
+  };
+});
+
+vi.mock('../../src/db/certification-db.js', () => mockCertDb);
+vi.mock('../../src/db/client.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/db/client.js')>()),
+  query: mockQuery,
+}));
+vi.mock('../../src/services/certifier-client.js', () => mockCertifier);
+
+import { createCertificationRouters } from '../../src/routes/certification.js';
+
+const USER_ID = 'user_learner';
+const CREDENTIAL_ID = 'specialist_signals';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/certification', createCertificationRouters().adminRouter);
+  return app;
+}
+
+describe('admin credential reissue route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCertDb.getCredential.mockResolvedValue({
+      id: CREDENTIAL_ID,
+      name: 'AdCP Specialist — Signals',
+      certifier_group_id: 'group_signals',
+    });
+    mockCertifier.isCertifierConfigured.mockReturnValue(true);
+    mockCertifier.issueCredential.mockResolvedValue({ id: 'cert_new', publicId: 'public_new' });
+    mockCertifier.getCredentialBadgeUrl.mockResolvedValue('https://cdn.test/badge.png');
+    mockCertDb.awardCredential.mockResolvedValue({
+      credential_id: CREDENTIAL_ID,
+      certifier_credential_id: 'cert_new',
+      certifier_public_id: 'public_new',
+      certifier_badge_url: 'https://cdn.test/badge.png',
+    });
+  });
+
+  it('issues and stores a missing external credential for an earned credential', async () => {
+    mockQuery.mockResolvedValue({ rows: [{
+      first_name: 'Test',
+      last_name: 'Learner',
+      email: 'learner@test.example',
+      certifier_credential_id: null,
+      certifier_public_id: null,
+      certifier_badge_url: null,
+    }] });
+
+    const response = await request(buildApp())
+      .post(`/api/admin/certification/learners/${USER_ID}/credentials/${CREDENTIAL_ID}/reissue`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ issued: true, badge_available: true });
+    expect(mockCertifier.issueCredential).toHaveBeenCalledWith({
+      groupId: 'group_signals',
+      recipient: { name: 'Test Learner', email: 'learner@test.example' },
+    });
+    expect(mockCertDb.awardCredential).toHaveBeenCalledWith(
+      USER_ID,
+      CREDENTIAL_ID,
+      'cert_new',
+      'public_new',
+      'https://cdn.test/badge.png',
+    );
+  });
+
+  it('only retries badge lookup when the external credential already exists', async () => {
+    mockQuery.mockResolvedValue({ rows: [{
+      first_name: 'Test',
+      last_name: 'Learner',
+      email: 'learner@test.example',
+      certifier_credential_id: 'cert_existing',
+      certifier_public_id: 'public_existing',
+      certifier_badge_url: null,
+    }] });
+    mockCertDb.awardCredential.mockResolvedValue({
+      credential_id: CREDENTIAL_ID,
+      certifier_credential_id: 'cert_existing',
+      certifier_public_id: 'public_existing',
+      certifier_badge_url: 'https://cdn.test/badge.png',
+    });
+
+    const response = await request(buildApp())
+      .post(`/api/admin/certification/learners/${USER_ID}/credentials/${CREDENTIAL_ID}/reissue`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.issued).toBe(false);
+    expect(mockCertifier.issueCredential).not.toHaveBeenCalled();
+    expect(mockCertifier.getCredentialBadgeUrl).toHaveBeenCalledWith('cert_existing');
+  });
+
+  it('does not issue a credential the learner has not earned', async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const response = await request(buildApp())
+      .post(`/api/admin/certification/learners/${USER_ID}/credentials/${CREDENTIAL_ID}/reissue`);
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toContain('has not earned');
+    expect(mockCertifier.issueCredential).not.toHaveBeenCalled();
+    expect(mockCertDb.awardCredential).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/admin-certification-module-completion-route.test.ts
+++ b/server/tests/unit/admin-certification-module-completion-route.test.ts
@@ -25,6 +25,7 @@ vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
     ...(await importOriginal<typeof import('../../src/middleware/auth.js')>()),
     requireAuth: mockedRequireAuth,
     requireAdmin: passThrough,
+    requireGlobalAdmin: [mockedRequireAuth, passThrough, passThrough],
     optionalAuth: passThrough,
   };
 });

--- a/server/tests/unit/certification-credential-issuance.test.ts
+++ b/server/tests/unit/certification-credential-issuance.test.ts
@@ -1,0 +1,268 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  release: vi.fn(),
+  resolveName: vi.fn(),
+  isConfigured: vi.fn(),
+  createDraft: vi.fn(),
+  getCredential: vi.fn(),
+  issueDraft: vi.fn(),
+  sendCredential: vi.fn(),
+  getBadge: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  getClient: vi.fn(async () => ({ query: mocks.query, release: mocks.release })),
+}));
+
+vi.mock('../../src/utils/resolve-user-name.js', () => ({
+  resolveUserNameWithFallbacks: mocks.resolveName,
+}));
+
+vi.mock('../../src/services/certifier-client.js', () => ({
+  buildRecipientName: (user: { first_name?: string | null; last_name?: string | null; email: string }) =>
+    `${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() || user.email,
+  createCredentialDraft: mocks.createDraft,
+  getCredential: mocks.getCredential,
+  getCredentialBadgeUrl: mocks.getBadge,
+  isCertifierConfigured: mocks.isConfigured,
+  issueCredentialDraft: mocks.issueDraft,
+  sendCredential: mocks.sendCredential,
+}));
+
+import {
+  CredentialNameRequiredError,
+  CredentialRecoveryConflictError,
+  credentialExpiryDate,
+  ensureCertifierCredential,
+} from '../../src/services/certification-credential-issuance.js';
+
+const awardedRow = {
+  first_name: 'Test',
+  last_name: 'Learner',
+  email: 'learner@test.example',
+  credential_name: 'AdCP Specialist — Signals',
+  tier: 3,
+  certifier_group_id: 'group_signals',
+  certifier_credential_id: null,
+  certifier_public_id: null,
+  certifier_badge_url: null,
+  certifier_issuance_key: null,
+  certifier_issuance_state: 'not_started' as const,
+  certifier_delivery_state: 'not_started' as const,
+};
+
+function setDbRow(row = awardedRow) {
+  mocks.query.mockImplementation(async (sql: string) => {
+    if (sql.includes('FROM user_credentials uc')) return { rows: [row], rowCount: 1 };
+    if (sql.includes('UPDATE user_credentials')) return { rows: [{ id: 'award_1' }], rowCount: 1 };
+    if (sql.includes('pg_try_advisory_lock')) return { rows: [{ locked: true }], rowCount: 1 };
+    if (sql.includes('pg_advisory_unlock')) return { rows: [{ unlocked: true }], rowCount: 1 };
+    return { rows: [], rowCount: 1 };
+  });
+}
+
+describe('certification credential issuance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isConfigured.mockReturnValue(true);
+    mocks.resolveName.mockResolvedValue({ firstName: 'Test', lastName: 'Learner' });
+    mocks.createDraft.mockResolvedValue({
+      id: 'cert_new', publicId: 'public_new', groupId: 'group_signals', status: 'draft',
+      recipient: { name: 'Test Learner', email: 'learner@test.example' },
+    });
+    mocks.issueDraft.mockResolvedValue({
+      id: 'cert_new', publicId: 'public_new', groupId: 'group_signals', status: 'issued',
+      recipient: { name: 'Test Learner', email: 'learner@test.example' },
+    });
+    mocks.sendCredential.mockResolvedValue({
+      id: 'cert_new', publicId: 'public_new', groupId: 'group_signals', status: 'issued',
+      recipient: { name: 'Test Learner', email: 'learner@test.example' },
+    });
+    mocks.getBadge.mockResolvedValue('https://cdn.test/badge.png');
+    setDbRow();
+  });
+
+  it('serializes, persists a draft, then issues and sends with canonical expiry', async () => {
+    const result = await ensureCertifierCredential({
+      userId: 'user_learner',
+      credentialId: 'specialist_signals',
+      now: new Date('2026-07-27T12:00:00.000Z'),
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'issued',
+      credentialId: 'cert_new',
+      publicId: 'public_new',
+      badgeUrl: 'https://cdn.test/badge.png',
+      emailDelivery: 'sent',
+    });
+    expect(mocks.createDraft).toHaveBeenCalledWith(expect.objectContaining({
+      groupId: 'group_signals',
+      recipient: { name: 'Test Learner', email: 'learner@test.example' },
+      expiryDate: '2028-07-27',
+    }));
+    expect(mocks.issueDraft).toHaveBeenCalledWith('cert_new');
+    expect(mocks.sendCredential).toHaveBeenCalledWith('cert_new');
+    expect(mocks.query.mock.calls.some(([sql]) => sql.includes('pg_try_advisory_lock'))).toBe(true);
+    expect(mocks.query.mock.calls.some(([sql]) => sql.includes('certifier_credential_id IS NULL'))).toBe(true);
+  });
+
+  it('gates issuance when no real first name can be resolved', async () => {
+    mocks.resolveName.mockResolvedValue({ firstName: null, lastName: null });
+
+    await expect(ensureCertifierCredential({
+      userId: 'user_learner',
+      credentialId: 'specialist_signals',
+    })).rejects.toBeInstanceOf(CredentialNameRequiredError);
+
+    expect(mocks.createDraft).not.toHaveBeenCalled();
+    expect(mocks.issueDraft).not.toHaveBeenCalled();
+  });
+
+  it('does not resend an already-issued credential while repairing its badge', async () => {
+    setDbRow({
+      ...awardedRow,
+      certifier_credential_id: 'cert_existing',
+      certifier_public_id: 'public_existing',
+      certifier_issuance_state: 'issued',
+      certifier_delivery_state: 'unknown',
+    });
+    mocks.getCredential.mockResolvedValue({
+      id: 'cert_existing', publicId: 'public_existing', groupId: 'group_signals', status: 'issued',
+      recipient: { name: 'Test Learner', email: 'learner@test.example' },
+    });
+
+    const result = await ensureCertifierCredential({
+      userId: 'user_learner',
+      credentialId: 'specialist_signals',
+    });
+
+    expect(result.outcome).toBe('badge_refreshed');
+    expect(mocks.createDraft).not.toHaveBeenCalled();
+    expect(mocks.issueDraft).not.toHaveBeenCalled();
+    expect(mocks.sendCredential).not.toHaveBeenCalled();
+  });
+
+  it('retains the external mapping when badge lookup fails', async () => {
+    mocks.getBadge.mockRejectedValue(new Error('badge rendering pending'));
+
+    const result = await ensureCertifierCredential({
+      userId: 'user_learner',
+      credentialId: 'specialist_signals',
+    });
+
+    expect(result).toMatchObject({ outcome: 'issued', credentialId: 'cert_new', badgeUrl: null });
+    const providerUpdate = mocks.query.mock.calls.find(([sql]) =>
+      sql.includes('certifier_badge_url = COALESCE'));
+    expect(providerUpdate?.[1]).toEqual([
+      'user_learner', 'specialist_signals', 'cert_new', 'public_new', null,
+    ]);
+  });
+
+  it('refuses to attach an existing external credential from another group', async () => {
+    setDbRow({
+      ...awardedRow,
+      certifier_credential_id: 'cert_wrong',
+      certifier_issuance_state: 'issued',
+      certifier_delivery_state: 'unknown',
+    });
+    mocks.getCredential.mockResolvedValue({
+      id: 'cert_wrong', publicId: 'public_wrong', groupId: 'group_other', status: 'issued',
+      recipient: { name: 'Test Learner', email: 'learner@test.example' },
+    });
+
+    await expect(ensureCertifierCredential({
+      userId: 'user_learner',
+      credentialId: 'specialist_signals',
+    })).rejects.toBeInstanceOf(CredentialRecoveryConflictError);
+  });
+
+  it('returns an in-progress conflict instead of waiting for the advisory lock', async () => {
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('pg_try_advisory_lock')) return { rows: [{ locked: false }], rowCount: 1 };
+      return { rows: [], rowCount: 1 };
+    });
+
+    await expect(ensureCertifierCredential({
+      userId: 'user_learner',
+      credentialId: 'specialist_signals',
+    })).rejects.toThrow('already in progress');
+    expect(mocks.createDraft).not.toHaveBeenCalled();
+  });
+
+  it('does not create again when a prior draft creation needs reconciliation', async () => {
+    setDbRow({
+      ...awardedRow,
+      certifier_issuance_key: '00000000-0000-4000-8000-000000000001',
+      certifier_issuance_state: 'reconcile_required',
+    });
+
+    await expect(ensureCertifierCredential({
+      userId: 'user_learner',
+      credentialId: 'specialist_signals',
+    })).rejects.toThrow('manual reconciliation');
+    expect(mocks.createDraft).not.toHaveBeenCalled();
+  });
+
+  it('resumes a persisted draft without creating a second credential', async () => {
+    setDbRow({
+      ...awardedRow,
+      certifier_credential_id: 'cert_draft',
+      certifier_issuance_key: '00000000-0000-4000-8000-000000000002',
+      certifier_issuance_state: 'draft_created',
+    });
+    mocks.getCredential.mockResolvedValue({
+      id: 'cert_draft', publicId: 'public_draft', groupId: 'group_signals', status: 'draft',
+      recipient: { name: 'Test Learner', email: 'learner@test.example' },
+    });
+    mocks.issueDraft.mockResolvedValue({
+      id: 'cert_draft', publicId: 'public_draft', groupId: 'group_signals', status: 'issued',
+      recipient: { name: 'Test Learner', email: 'learner@test.example' },
+    });
+    mocks.sendCredential.mockResolvedValue({
+      id: 'cert_draft', publicId: 'public_draft', groupId: 'group_signals', status: 'issued',
+      recipient: { name: 'Test Learner', email: 'learner@test.example' },
+    });
+
+    await ensureCertifierCredential({ userId: 'user_learner', credentialId: 'specialist_signals' });
+
+    expect(mocks.createDraft).not.toHaveBeenCalled();
+    expect(mocks.issueDraft).toHaveBeenCalledWith('cert_draft');
+    expect(mocks.sendCredential).toHaveBeenCalledWith('cert_draft');
+  });
+
+  it('marks an ambiguous draft-creation failure for reconciliation before retry', async () => {
+    mocks.createDraft.mockRejectedValue(new Error('provider timeout'));
+
+    await expect(ensureCertifierCredential({
+      userId: 'user_learner',
+      credentialId: 'specialist_signals',
+    })).rejects.toThrow('provider timeout');
+
+    expect(mocks.query.mock.calls.some(([sql]) => sql.includes("certifier_issuance_state = 'reconcile_required'"))).toBe(true);
+  });
+
+  it('refuses an existing credential belonging to a different recipient', async () => {
+    setDbRow({
+      ...awardedRow,
+      certifier_credential_id: 'cert_other_recipient',
+      certifier_issuance_state: 'issued',
+      certifier_delivery_state: 'unknown',
+    });
+    mocks.getCredential.mockResolvedValue({
+      id: 'cert_other_recipient', publicId: 'public_other', groupId: 'group_signals', status: 'issued',
+      recipient: { name: 'Other Learner', email: 'other@test.example' },
+    });
+
+    await expect(ensureCertifierCredential({
+      userId: 'user_learner',
+      credentialId: 'specialist_signals',
+    })).rejects.toThrow('different recipient');
+  });
+
+  it('omits expiry for tier-one credentials', () => {
+    expect(credentialExpiryDate(1, new Date('2026-07-27T12:00:00.000Z'))).toBeUndefined();
+  });
+});

--- a/server/tests/unit/certification-credential-issuance.test.ts
+++ b/server/tests/unit/certification-credential-issuance.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   query: vi.fn(),
-  release: vi.fn(),
+  end: vi.fn(),
   resolveName: vi.fn(),
   isConfigured: vi.fn(),
   createDraft: vi.fn(),
@@ -10,10 +10,11 @@ const mocks = vi.hoisted(() => ({
   issueDraft: vi.fn(),
   sendCredential: vi.fn(),
   getBadge: vi.fn(),
+  isDefinitiveNonDelivery: vi.fn(),
 }));
 
 vi.mock('../../src/db/client.js', () => ({
-  getClient: vi.fn(async () => ({ query: mocks.query, release: mocks.release })),
+  getDedicatedClient: vi.fn(async () => ({ query: mocks.query, end: mocks.end })),
 }));
 
 vi.mock('../../src/utils/resolve-user-name.js', () => ({
@@ -27,6 +28,7 @@ vi.mock('../../src/services/certifier-client.js', () => ({
   getCredential: mocks.getCredential,
   getCredentialBadgeUrl: mocks.getBadge,
   isCertifierConfigured: mocks.isConfigured,
+  isDefinitiveCertifierNonDelivery: mocks.isDefinitiveNonDelivery,
   issueCredentialDraft: mocks.issueDraft,
   sendCredential: mocks.sendCredential,
 }));
@@ -66,7 +68,9 @@ function setDbRow(row = awardedRow) {
 describe('certification credential issuance', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.end.mockResolvedValue(undefined);
     mocks.isConfigured.mockReturnValue(true);
+    mocks.isDefinitiveNonDelivery.mockReturnValue(false);
     mocks.resolveName.mockResolvedValue({ firstName: 'Test', lastName: 'Learner' });
     mocks.createDraft.mockResolvedValue({
       id: 'cert_new', publicId: 'public_new', groupId: 'group_signals', status: 'draft',
@@ -107,6 +111,7 @@ describe('certification credential issuance', () => {
     expect(mocks.sendCredential).toHaveBeenCalledWith('cert_new');
     expect(mocks.query.mock.calls.some(([sql]) => sql.includes('pg_try_advisory_lock'))).toBe(true);
     expect(mocks.query.mock.calls.some(([sql]) => sql.includes('certifier_credential_id IS NULL'))).toBe(true);
+    expect(mocks.end).toHaveBeenCalledTimes(1);
   });
 
   it('gates issuance when no real first name can be resolved', async () => {
@@ -242,6 +247,36 @@ describe('certification credential issuance', () => {
     })).rejects.toThrow('provider timeout');
 
     expect(mocks.query.mock.calls.some(([sql]) => sql.includes("certifier_issuance_state = 'reconcile_required'"))).toBe(true);
+  });
+
+  it('keeps a definitive email non-delivery retryable', async () => {
+    const sendError = new Error('connect ECONNREFUSED');
+    mocks.sendCredential.mockRejectedValue(sendError);
+    mocks.isDefinitiveNonDelivery.mockReturnValue(true);
+
+    const result = await ensureCertifierCredential({
+      userId: 'user_learner',
+      credentialId: 'specialist_signals',
+    });
+
+    expect(mocks.isDefinitiveNonDelivery).toHaveBeenCalledWith(sendError);
+    expect(result.emailDelivery).toBe('not_attempted');
+    expect(mocks.query.mock.calls.some(([sql, params]) =>
+      sql.includes('certifier_delivery_state') && params?.[3] === 'not_started')).toBe(true);
+  });
+
+  it('suppresses resend when an email failure is ambiguous', async () => {
+    const sendError = new Error('provider timeout');
+    mocks.sendCredential.mockRejectedValue(sendError);
+
+    const result = await ensureCertifierCredential({
+      userId: 'user_learner',
+      credentialId: 'specialist_signals',
+    });
+
+    expect(result.emailDelivery).toBe('unknown');
+    expect(mocks.query.mock.calls.some(([sql, params]) =>
+      sql.includes('certifier_delivery_state') && params?.[3] === 'unknown')).toBe(true);
   });
 
   it('refuses an existing credential belonging to a different recipient', async () => {

--- a/server/tests/unit/certifier-client-timeout.test.ts
+++ b/server/tests/unit/certifier-client-timeout.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   create: vi.fn(),
   post: vi.fn(),
+  isAxiosError: vi.fn(),
 }));
 
 vi.hoisted(() => {
@@ -10,15 +11,20 @@ vi.hoisted(() => {
 });
 
 vi.mock('axios', () => ({
-  default: { create: mocks.create },
+  default: { create: mocks.create, isAxiosError: mocks.isAxiosError },
 }));
 
-import { createCredentialDraft } from '../../src/services/certifier-client.js';
+import {
+  createCredentialDraft,
+  isDefinitiveCertifierNonDelivery,
+} from '../../src/services/certifier-client.js';
 
 describe('Certifier client timeout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.create.mockReturnValue({ post: mocks.post });
+    mocks.isAxiosError.mockImplementation((error: unknown) =>
+      typeof error === 'object' && error !== null && 'isAxiosError' in error);
     mocks.post.mockResolvedValue({
       data: {
         id: 'cert_draft',
@@ -37,5 +43,28 @@ describe('Certifier client timeout', () => {
     });
 
     expect(mocks.create).toHaveBeenCalledWith(expect.objectContaining({ timeout: 15_000 }));
+  });
+
+  it('only treats 4xx and pre-dispatch connection failures as definitive non-delivery', () => {
+    expect(isDefinitiveCertifierNonDelivery({
+      isAxiosError: true,
+      response: { status: 400 },
+    })).toBe(true);
+    expect(isDefinitiveCertifierNonDelivery({
+      isAxiosError: true,
+      response: { status: 503 },
+    })).toBe(false);
+    expect(isDefinitiveCertifierNonDelivery({
+      isAxiosError: true,
+      code: 'ECONNREFUSED',
+    })).toBe(true);
+    expect(isDefinitiveCertifierNonDelivery({
+      isAxiosError: true,
+      code: 'ECONNABORTED',
+    })).toBe(false);
+    expect(isDefinitiveCertifierNonDelivery({
+      isAxiosError: true,
+      code: 'ECONNRESET',
+    })).toBe(false);
   });
 });

--- a/server/tests/unit/certifier-client-timeout.test.ts
+++ b/server/tests/unit/certifier-client-timeout.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.CERTIFIER_API_TOKEN = 'certifier_test_token';
+});
+
+vi.mock('axios', () => ({
+  default: { create: mocks.create },
+}));
+
+import { createCredentialDraft } from '../../src/services/certifier-client.js';
+
+describe('Certifier client timeout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.create.mockReturnValue({ post: mocks.post });
+    mocks.post.mockResolvedValue({
+      data: {
+        id: 'cert_draft',
+        publicId: 'public_draft',
+        groupId: 'group_test',
+        status: 'draft',
+        recipient: { name: 'Test Learner', email: 'learner@test.example' },
+      },
+    });
+  });
+
+  it('bounds external calls while a credential recovery lock is held', async () => {
+    await createCredentialDraft({
+      groupId: 'group_test',
+      recipient: { name: 'Test Learner', email: 'learner@test.example' },
+    });
+
+    expect(mocks.create).toHaveBeenCalledWith(expect.objectContaining({ timeout: 15_000 }));
+  });
+});

--- a/server/tests/unit/db-client-checkout.test.ts
+++ b/server/tests/unit/db-client-checkout.test.ts
@@ -92,4 +92,21 @@ describe('db client checkout and health checks', () => {
 
     await db.closeDatabase();
   });
+
+  it('opens dedicated session work outside the application pool', async () => {
+    const pg = mockPg();
+
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    const client = await db.getDedicatedClient();
+
+    expect(pg.poolConnect).not.toHaveBeenCalled();
+    expect(pg.clientInstances).toHaveLength(1);
+    expect(pg.clientConnect).toHaveBeenCalledTimes(1);
+
+    await client.end();
+    expect(pg.clientEnd).toHaveBeenCalledTimes(1);
+    await db.closeDatabase();
+  });
 });


### PR DESCRIPTION
## Summary

- add a global-admin-only targeted recovery action for an already-earned certification credential
- route learner issuance, bulk backfill, and admin recovery through one shared serialized Certifier service
- claim durable issuance/delivery state before provider calls, create and persist a draft before issue/send, and suppress ambiguous retries
- enforce canonical learner-name and tier expiry policy while validating external credential group and recipient
- require an operator reason, append actor-attributed audit events, rate-limit recovery, and expose clear state-specific UI actions/results

## Root cause

Credential recovery previously depended on the broad `backfill-badges` route, which processes at most 50 records and offers no learner-specific action. The learner detail also omitted the state needed to distinguish “not issued,” “metadata missing,” and “badge pending.”

The original targeted implementation still had race and crash windows around Certifier's create/issue/send call. This revision durably claims the award before external creation, serializes every issuance path with a nonblocking PostgreSQL advisory lock, persists the draft external ID before issuance, and records ambiguous provider or delivery outcomes instead of blindly retrying.

The affected learner from #6032 has already been repaired in production using the recorded passing S3 checkpoint; this PR makes future recovery targeted, attributable, and safe.

## Review

- deep code review: ship-ready
- deep security review: approved with no remaining Must Fix or Should Fix findings
- internal-tools/operations review: ship-ready

## Validation

- full repository precommit hook with npm 10.9.4
- root unit suite: 1,018 passed
- server unit suite: 4,565 passed, 30 skipped
- focused recovery/auth/crash/timeout tests: 23 passed
- migration validation
- server TypeScript typecheck

No changeset: this is an admin-only application change, not a published protocol surface.

Closes #6032
