### PR TITLE
fix(registry): resolve legacy brand.json as canonical v3

### DIFF
--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -62,7 +62,8 @@ print(brand["brand_name"], brand["canonical_domain"])
 
 | Endpoint | Limit |
 |----------|-------|
-| Bulk resolve (`/api/brands/resolve/bulk`, `/api/properties/resolve/bulk`) | 20 requests/minute per IP |
+| Brand bulk resolve (`/api/brands/resolve/bulk`) | 20 requests and 100 unique domain resolutions/minute per IP; 25 domains/request |
+| Property bulk resolve (`/api/properties/resolve/bulk`) | 20 requests/minute per IP |
 | Save endpoints (`/api/brands/save`, `/api/properties/save`) | 60 requests/hour per user |
 | Crawl request (`/api/registry/crawl-request`) | 5 minutes per domain, 30 requests/hour per user |
 | All other endpoints | No limit |
@@ -111,6 +112,7 @@ These endpoints resolve domains to brand identities. The `source` field in the r
 
 | Source | Meaning |
 |--------|---------|
+| `hosted` | Registered by a domain owner whose control of the domain has been verified |
 | `brand_json` | Resolved from the domain's `/.well-known/brand.json` file |
 | `enriched` | Enriched via Brandfetch API |
 | `community` | Submitted by a community member |
@@ -120,7 +122,7 @@ All sources produce the same resolution response structure. To get full brand id
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/api/brands/resolve` | Resolve a domain to its canonical brand |
-| POST | `/api/brands/resolve/bulk` | Resolve up to 100 domains at once |
+| POST | `/api/brands/resolve/bulk` | Resolve up to 25 domains at once |
 | GET | `/api/brands/brand-json` | Fetch raw brand.json for a domain |
 | GET | `/api/brands/registry` | List all brands (search, pagination) |
 | GET | `/api/brands/enrich` | Enrich brand data via Brandfetch |

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -62,13 +62,14 @@ print(brand["brand_name"], brand["canonical_domain"])
 
 | Endpoint | Limit |
 |----------|-------|
-| Brand bulk resolve (`/api/brands/resolve/bulk`) | 20 requests and 100 unique domain resolutions/minute per IP; 25 domains/request |
+| Brand bulk resolve (`/api/brands/resolve/bulk`) | 20 requests and 100 unique domain resolutions/minute per IP; 25 domains and 16 KB per request |
 | Property bulk resolve (`/api/properties/resolve/bulk`) | 20 requests/minute per IP |
+| Brand reads (`/api/brands/resolve`, `/api/brands/brand-json`) | 60 requests/minute per IP |
 | Save endpoints (`/api/brands/save`, `/api/properties/save`) | 60 requests/hour per user |
 | Crawl request (`/api/registry/crawl-request`) | 5 minutes per domain, 30 requests/hour per user |
 | All other endpoints | No limit |
 
-Rate-limited endpoints return `429 Too Many Requests` when the limit is exceeded.
+Rate-limited endpoints return `429 Too Many Requests` when the limit is exceeded. Brand bulk resolve returns `503` with a `Retry-After` header when too much resolution work is already queued.
 
 ## Endpoint Groups
 
@@ -118,6 +119,27 @@ These endpoints resolve domains to brand identities. The `source` field in the r
 | `community` | Submitted by a community member |
 
 All sources produce the same resolution response structure. To get full brand identity data (logos, colors, tone), use `/api/brands/enrich` or look up the brand in the registry.
+
+#### Reading trust
+
+A domain is authoritative for its own identity — TLS proves the document came from that domain and nothing more. Relationships between a brand and a house need both sides to publish them, so resolution reports how each relationship was established rather than flattening it into a single answer.
+
+| `relationship_trust` | Meaning |
+|---|---|
+| `inline` | The house's own document defines the brand. |
+| `mutual` | Both sides publish the relationship. The trust-extending edge. |
+| `leaf_only` | The brand claims a house that has not named it back. See `claimed_house_domain`. |
+| `house_only` | A house claims the brand, which has not claimed the house. |
+| `standalone` | The brand claims no house. |
+| `unverifiable` | A claimed house exists but could not be checked. |
+
+`house_domain` is only set on a reciprocated relationship; a one-sided claim appears as `claimed_house_domain`. For `mutual`, `relationship_verified_at` records when both sides were last seen agreeing — it does not advance while the house side is unreachable, so you can age edges out on your own schedule.
+
+Following a redirect never lets a domain adopt a house's identity. When a domain's brand.json points at a house that does not name the domain back — in `properties[]` as `relationship: "owned"`, or in `brand_refs[]` — the response carries the claim (`claimed_house_domain` with `relationship_trust: leaf_only`) and no brand identity. A house that lists a domain with `direct`, `delegated`, or `ad_network` is declaring a monetization path, not ownership, so it does not resolve that domain's identity either. If you expected an identity here, the house is missing its half of the relationship.
+
+`fresh=true` bypasses the resolution cache and refetches from the origin. When that fetch fails and a stored record is returned instead, `live_brand_json` carries the failed fetch's diagnostics so you can tell a stale record from a live one.
+
+Pre-v3 documents are promoted to canonical v3 identity for the response, flagged with `promoted_from_schema` and `migration_warnings`. Promotion covers identity only; legacy relationship data is preserved opaquely and never becomes a trust claim.
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -120,6 +120,9 @@ export type BrandJson =
 
 const LEGACY_BRAND_SCHEMA = 'https://schemas.adcontextprotocol.org/brand/v1/brand.json';
 const CURRENT_BRAND_SCHEMA = 'https://adcontextprotocol.org/schemas/v3/brand.json';
+const BRAND_JSON_MAX_RESPONSE_BYTES = 256 * 1024;
+const BRAND_CACHE_MAX_ENTRIES = 200;
+const BRAND_FAILED_CACHE_MAX_ENTRIES = 1000;
 const LAST_VALIDATION_ATTEMPT_TTL_MS = 5 * 60 * 1000;
 const LAST_VALIDATION_ATTEMPT_MAX_ENTRIES = 500;
 
@@ -127,6 +130,11 @@ interface LastValidationAttemptEntry {
   value: BrandValidationResult;
   expiresAt: number;
 }
+
+type CanonicalHouseVerification =
+  | { status: 'mutual'; houseDomain: string; houseName?: string }
+  | { status: 'leaf_only' }
+  | { status: 'unverifiable' };
 
 export interface BrandAgentValidationResult {
   agent_url: string;
@@ -150,9 +158,9 @@ export class BrandManager {
   private lastValidationAttempt = new Map<string, LastValidationAttemptEntry>();
 
   constructor() {
-    this.validationCache = new Cache<BrandValidationResult>(24 * 60); // 24 hours
-    this.resolutionCache = new Cache<ResolvedBrand | null>(24 * 60); // 24 hours
-    this.failedLookupCache = new Cache<BrandValidationResult>(60); // 1 hour
+    this.validationCache = new Cache<BrandValidationResult>(24 * 60, BRAND_CACHE_MAX_ENTRIES); // 24 hours
+    this.resolutionCache = new Cache<ResolvedBrand | null>(24 * 60, BRAND_CACHE_MAX_ENTRIES); // 24 hours
+    this.failedLookupCache = new Cache<BrandValidationResult>(60, BRAND_FAILED_CACHE_MAX_ENTRIES); // 1 hour
   }
 
   /**
@@ -349,13 +357,11 @@ export class BrandManager {
     }
 
     const house = this.isRecord(document.house) ? document.house : undefined;
-    const houseDomain = house && typeof house.domain === 'string' ? house.domain.toLowerCase() : undefined;
     if (house) metadata.legacy_house = house;
 
     const canonical: Record<string, unknown> = {
       ...originBrand,
       $schema: CURRENT_BRAND_SCHEMA,
-      ...(houseDomain && houseDomain !== originDomain ? { house_domain: houseDomain } : {}),
       ...(Object.keys(metadata).length > 0 ? { legacy_metadata: metadata } : {}),
     };
     warnings.push({
@@ -423,6 +429,7 @@ export class BrandManager {
       // /api/registry/publisher auto-crawl path (PR #4128 / issue #4129).
       const response = await safeFetchAxiosLike(url, {
         timeoutMs: 10000,
+        maxResponseBytes: BRAND_JSON_MAX_RESPONSE_BYTES,
         sameSiteRedirectsOnly: true,
         headers: {
           Accept: 'application/json',
@@ -492,8 +499,6 @@ export class BrandManager {
     brandData = normalized.data;
     result.warnings.push(...normalized.warnings);
     result.promoted_from_schema = normalized.promotedFromSchema;
-    result.raw_data = brandData;
-
     const schemaValidation = validateBrandJsonSchema(brandData);
     if (!schemaValidation.valid) {
       for (const issue of schemaValidation.errors.slice(0, 20)) {
@@ -541,6 +546,8 @@ export class BrandManager {
         });
     }
     result.valid = result.errors.length === 0;
+    if (result.valid) result.raw_data = brandData;
+    else delete result.raw_data;
   }
 
   private async validateBrandJsonUrl(
@@ -557,6 +564,7 @@ export class BrandManager {
     try {
       const response = await safeFetchAxiosLike(url, {
         timeoutMs: 10000,
+        maxResponseBytes: BRAND_JSON_MAX_RESPONSE_BYTES,
         sameSiteRedirectsOnly: true,
         headers: { Accept: 'application/json', 'User-Agent': AAO_UA_VALIDATOR },
       });
@@ -1244,7 +1252,7 @@ export class BrandManager {
     const primaryName = this.getPrimaryName(data.names);
     const claimedHouseDomain = data.house_domain?.toLowerCase();
     let relationshipTrust: ResolvedBrand['relationship_trust'] = claimedHouseDomain
-      ? 'leaf_only'
+      ? 'unverifiable'
       : 'standalone';
     let verifiedHouseDomain = options.verifiedHouseDomain;
     let houseName: string | undefined;
@@ -1258,9 +1266,9 @@ export class BrandManager {
         claimedHouseDomain,
         options
       );
-      relationshipTrust = verification.mutual ? 'mutual' : 'leaf_only';
-      verifiedHouseDomain = verification.mutual ? verification.houseDomain : undefined;
-      houseName = verification.mutual ? verification.houseName : undefined;
+      relationshipTrust = verification.status;
+      verifiedHouseDomain = verification.status === 'mutual' ? verification.houseDomain : undefined;
+      houseName = verification.status === 'mutual' ? verification.houseName : undefined;
     }
 
     return {
@@ -1297,19 +1305,19 @@ export class BrandManager {
     brandId: string,
     claimedHouseDomain: string,
     options: { skipCache?: boolean; maxRedirects: number }
-  ): Promise<{ mutual: boolean; houseDomain?: string; houseName?: string }> {
+  ): Promise<CanonicalHouseVerification> {
     let current = claimedHouseDomain;
     let currentUrl: string | undefined;
     const seen = new Set<string>();
 
     for (let redirects = 0; redirects <= options.maxRedirects; redirects++) {
       const visitKey = currentUrl ? `url:${currentUrl}` : `domain:${current}`;
-      if (seen.has(visitKey)) return { mutual: false };
+      if (seen.has(visitKey)) return { status: 'unverifiable' };
       seen.add(visitKey);
       const validation = currentUrl
         ? await this.validateBrandJsonUrl(currentUrl, current)
         : await this.validateDomain(current, { skipCache: options.skipCache });
-      if (!validation.valid || !validation.raw_data) return { mutual: false };
+      if (!validation.valid || !validation.raw_data) return { status: 'unverifiable' };
 
       if (validation.variant === 'house_redirect') {
         current = (validation.raw_data as HouseRedirectVariant).house.toLowerCase();
@@ -1321,7 +1329,7 @@ export class BrandManager {
         currentUrl = location;
         continue;
       }
-      if (validation.variant !== 'house_portfolio') return { mutual: false };
+      if (validation.variant !== 'house_portfolio') return { status: 'unverifiable' };
 
       const portfolio = validation.raw_data as HousePortfolioVariant;
       const reciprocal = portfolio.brand_refs?.some((ref) =>
@@ -1329,13 +1337,13 @@ export class BrandManager {
       );
       return reciprocal
         ? {
-            mutual: true,
+            status: 'mutual',
             houseDomain: portfolio.house.domain,
             houseName: portfolio.house.name,
           }
-        : { mutual: false };
+        : { status: 'leaf_only' };
     }
-    return { mutual: false };
+    return { status: 'unverifiable' };
   }
 
   /**

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -134,7 +134,12 @@ interface LastValidationAttemptEntry {
 type CanonicalHouseVerification =
   | { status: 'mutual'; houseDomain: string; houseName?: string }
   | { status: 'leaf_only' }
-  | { status: 'unverifiable' };
+  | { status: 'unverifiable'; transient: boolean };
+
+interface CanonicalResolution {
+  result: ResolvedBrand;
+  retainCachedMutual: boolean;
+}
 
 export interface BrandAgentValidationResult {
   agent_url: string;
@@ -977,6 +982,9 @@ export class BrandManager {
     const normalizedDomain = this.normalizeLookupDomain(domain);
     if (!normalizedDomain) return null;
     const cacheKey = `resolve:${normalizedDomain}`;
+    const cachedBeforeRefresh = skipCache
+      ? this.resolutionCache.get(cacheKey)
+      : undefined;
 
     // Check resolution cache unless explicitly skipped
     if (!skipCache) {
@@ -1114,7 +1122,7 @@ export class BrandManager {
         }
 
         case 'brand_canonical': {
-          const result = await this.resolveCanonicalDocument(
+          const freshResolution = await this.resolveCanonicalDocument(
             data as BrandCanonicalDocument,
             currentDomain,
             {
@@ -1122,6 +1130,11 @@ export class BrandManager {
               maxRedirects,
               ...this.promotionMetadata(validationResult),
             }
+          );
+          const result = this.retainCachedMutualRelationship(
+            cachedBeforeRefresh,
+            freshResolution.result,
+            freshResolution.retainCachedMutual,
           );
           this.resolutionCache.set(cacheKey, result);
           return result;
@@ -1216,13 +1229,14 @@ export class BrandManager {
     const canonical = validation.raw_data as BrandCanonicalDocument;
     if (canonical.id !== pointer.brand_id) return null;
     const reciprocal = canonical.house_domain?.toLowerCase() === expectedHouseDomain.toLowerCase();
-    return this.resolveCanonicalDocument(canonical, pointer.domain, {
+    const resolution = await this.resolveCanonicalDocument(canonical, pointer.domain, {
       skipCache: options.skipCache,
       maxRedirects: 3,
       knownRelationship: reciprocal ? 'mutual' : 'house_only',
       verifiedHouseDomain: reciprocal ? expectedHouseDomain : undefined,
       ...this.promotionMetadata(validation),
     });
+    return resolution.result;
   }
 
   private async validateCanonicalPointer(
@@ -1248,7 +1262,7 @@ export class BrandManager {
       promoted_from_schema?: string;
       migration_warnings?: BrandValidationWarning[];
     }
-  ): Promise<ResolvedBrand> {
+  ): Promise<CanonicalResolution> {
     const primaryName = this.getPrimaryName(data.names);
     const claimedHouseDomain = data.house_domain?.toLowerCase();
     let relationshipTrust: ResolvedBrand['relationship_trust'] = claimedHouseDomain
@@ -1256,6 +1270,7 @@ export class BrandManager {
       : 'standalone';
     let verifiedHouseDomain = options.verifiedHouseDomain;
     let houseName: string | undefined;
+    let retainCachedMutual = false;
 
     if (options.knownRelationship) {
       relationshipTrust = options.knownRelationship;
@@ -1269,23 +1284,27 @@ export class BrandManager {
       relationshipTrust = verification.status;
       verifiedHouseDomain = verification.status === 'mutual' ? verification.houseDomain : undefined;
       houseName = verification.status === 'mutual' ? verification.houseName : undefined;
+      retainCachedMutual = verification.status === 'unverifiable' && verification.transient;
     }
 
     return {
-      canonical_id: data.id,
-      canonical_domain: domain,
-      brand_name: primaryName || data.id,
-      names: data.names,
-      keller_type: data.keller_type,
-      parent_brand: data.parent_brand,
-      house_domain: verifiedHouseDomain,
-      claimed_house_domain: claimedHouseDomain,
-      house_name: houseName,
-      relationship_trust: relationshipTrust,
-      promoted_from_schema: options.promoted_from_schema,
-      migration_warnings: options.migration_warnings,
-      brand_manifest: this.buildBrandManifest(data),
-      source: 'brand_json',
+      result: {
+        canonical_id: data.id,
+        canonical_domain: domain,
+        brand_name: primaryName || data.id,
+        names: data.names,
+        keller_type: data.keller_type,
+        parent_brand: data.parent_brand,
+        house_domain: verifiedHouseDomain,
+        claimed_house_domain: claimedHouseDomain,
+        house_name: houseName,
+        relationship_trust: relationshipTrust,
+        promoted_from_schema: options.promoted_from_schema,
+        migration_warnings: options.migration_warnings,
+        brand_manifest: this.buildBrandManifest(data),
+        source: 'brand_json',
+      },
+      retainCachedMutual,
     };
   }
 
@@ -1297,6 +1316,37 @@ export class BrandManager {
     return {
       promoted_from_schema: validation.promoted_from_schema,
       migration_warnings: validation.warnings.slice(0, 20),
+    };
+  }
+
+  /**
+   * A fresh leaf document can succeed while its reciprocal house check fails
+   * transiently. Reuse a still-live mutual verification only when the leaf's
+   * identity and claimed house are unchanged; otherwise the fresh relationship
+   * result replaces the cache normally (including a verified leaf_only result).
+   */
+  private retainCachedMutualRelationship(
+    cached: ResolvedBrand | null | undefined,
+    fresh: ResolvedBrand,
+    verificationFailedTransiently: boolean,
+  ): ResolvedBrand {
+    if (
+      !verificationFailedTransiently ||
+      cached?.relationship_trust !== 'mutual' ||
+      fresh.relationship_trust !== 'unverifiable' ||
+      cached.canonical_id !== fresh.canonical_id ||
+      cached.canonical_domain !== fresh.canonical_domain ||
+      !cached.house_domain ||
+      cached.house_domain.toLowerCase() !== fresh.claimed_house_domain?.toLowerCase()
+    ) {
+      return fresh;
+    }
+
+    return {
+      ...fresh,
+      house_domain: cached.house_domain,
+      house_name: cached.house_name,
+      relationship_trust: 'mutual',
     };
   }
 
@@ -1312,12 +1362,17 @@ export class BrandManager {
 
     for (let redirects = 0; redirects <= options.maxRedirects; redirects++) {
       const visitKey = currentUrl ? `url:${currentUrl}` : `domain:${current}`;
-      if (seen.has(visitKey)) return { status: 'unverifiable' };
+      if (seen.has(visitKey)) return { status: 'unverifiable', transient: false };
       seen.add(visitKey);
       const validation = currentUrl
         ? await this.validateBrandJsonUrl(currentUrl, current)
         : await this.validateDomain(current, { skipCache: options.skipCache });
-      if (!validation.valid || !validation.raw_data) return { status: 'unverifiable' };
+      if (!validation.valid || !validation.raw_data) {
+        return {
+          status: 'unverifiable',
+          transient: this.isTransientValidationFailure(validation),
+        };
+      }
 
       if (validation.variant === 'house_redirect') {
         current = (validation.raw_data as HouseRedirectVariant).house.toLowerCase();
@@ -1329,7 +1384,9 @@ export class BrandManager {
         currentUrl = location;
         continue;
       }
-      if (validation.variant !== 'house_portfolio') return { status: 'unverifiable' };
+      if (validation.variant !== 'house_portfolio') {
+        return { status: 'unverifiable', transient: false };
+      }
 
       const portfolio = validation.raw_data as HousePortfolioVariant;
       const reciprocal = portfolio.brand_refs?.some((ref) =>
@@ -1343,7 +1400,17 @@ export class BrandManager {
           }
         : { status: 'leaf_only' };
     }
-    return { status: 'unverifiable' };
+    return { status: 'unverifiable', transient: false };
+  }
+
+  private isTransientValidationFailure(validation: BrandValidationResult): boolean {
+    if (validation.status_code === 429 || (validation.status_code ?? 0) >= 500) {
+      return true;
+    }
+    if (validation.status_code !== undefined) return false;
+    return validation.errors.some((error) =>
+      ['timeout', 'connection', 'network', 'unknown'].includes(error.field)
+    );
   }
 
   /**

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -1,3 +1,4 @@
+import { getDomain } from 'tldts';
 import { Cache } from './cache.js';
 import { safeFetchAxiosLike, classifySafeFetchError } from './utils/url-security.js';
 import { validateBrandJsonSchema } from './services/brand-json-schema-validator.js';
@@ -215,8 +216,18 @@ export class BrandManager {
     };
   }
 
+  /**
+   * Agents call the MCP tools with whatever identifier a human gave them, so a
+   * bare `https://` prefix or trailing slash is stripped before validating.
+   * Everything else — ports, paths, queries — is still rejected outright
+   * rather than guessed at.
+   */
   private normalizeLookupDomain(domain: string): string | null {
-    const normalized = domain.trim().toLowerCase();
+    const normalized = domain
+      .trim()
+      .toLowerCase()
+      .replace(/^https?:\/\//, '')
+      .replace(/\/$/, '');
     try {
       assertValidBrandDomain(normalized);
       return normalized;
@@ -251,8 +262,11 @@ export class BrandManager {
       ? document.brands.filter((brand): brand is Record<string, unknown> => this.isRecord(brand))
       : [];
 
-    // Compatibility promotion is identity-only. Require exactly one explicit
-    // website match to the TLS origin; never infer identity from array position.
+    // Compatibility promotion is identity-only. Require exactly one website
+    // match to the TLS origin; never infer identity from array position.
+    // `relationship` defaults to `owned` and predates these documents, so an
+    // absent value counts — otherwise promotion never fires for the shape it
+    // exists to carry.
     const originMatches: Array<{ brand: Record<string, unknown>; brandIndex: number; propertyIndex: number }> = [];
     for (const [brandIndex, brand] of brands.entries()) {
       if (!Array.isArray(brand.properties)) continue;
@@ -262,19 +276,22 @@ export class BrandManager {
           property.type === 'website' &&
           typeof property.identifier === 'string' &&
           property.identifier.toLowerCase() === originDomain &&
-          property.relationship === 'owned'
+          this.isOwnedProperty(property as BrandProperty)
         ) {
           originMatches.push({ brand, brandIndex, propertyIndex });
         }
       }
     }
 
+    // The early exits below return the document untouched. They keep the
+    // warnings that explain why, but must not report a promotion that did not
+    // happen — `promoted_from_schema` describes the document in the response.
     if (originMatches.length !== 1) {
       warnings.push({
         field: 'brands',
         message: `Legacy promotion requires exactly one owned website property matching ${originDomain}; found ${originMatches.length}`,
       });
-      return { data, warnings, promotedFromSchema: LEGACY_BRAND_SCHEMA };
+      return { data, warnings };
     }
 
     const originMatch = originMatches[0];
@@ -309,7 +326,7 @@ export class BrandManager {
     }
     if (!Array.isArray(originBrand.names) || originBrand.names.length === 0) {
       warnings.push({ field: `brands[${originIndex}].names`, message: 'Legacy origin brand has no promotable name' });
-      return { data, warnings, promotedFromSchema: LEGACY_BRAND_SCHEMA };
+      return { data, warnings };
     }
 
     const topName = typeof document.name === 'string' ? document.name.trim() : '';
@@ -482,10 +499,15 @@ export class BrandManager {
     return result;
   }
 
+  /**
+   * @param fetchedFrom URL the document was actually served from, when that is
+   *   not the attributed domain's own well-known path.
+   */
   private async validateBrandData(
     brandData: unknown,
     attributedDomain: string,
-    result: BrandValidationResult
+    result: BrandValidationResult,
+    fetchedFrom?: string
   ): Promise<void> {
     const normalized = this.normalizeLegacyBrandJson(brandData, attributedDomain);
     brandData = normalized.data;
@@ -529,6 +551,12 @@ export class BrandManager {
         break;
       case 'brand_canonical':
         this.validateCanonicalDocument(brandData as BrandCanonicalDocument, result);
+        this.validateCanonicalDocumentAttribution(
+          brandData as BrandCanonicalDocument,
+          attributedDomain,
+          result,
+          fetchedFrom
+        );
         break;
       default:
         result.errors.push({
@@ -572,7 +600,7 @@ export class BrandManager {
         result.errors.push({ field: 'json', message: 'Invalid JSON at authoritative_location', severity: 'error' });
         return result;
       }
-      await this.validateBrandData(data, attributedDomain, result);
+      await this.validateBrandData(data, attributedDomain, result, url);
     } catch (error) {
       const classified = classifySafeFetchError(error, attributedDomain);
       result.errors.push({ ...classified, severity: 'error' });
@@ -864,6 +892,52 @@ export class BrandManager {
     result: BrandValidationResult
   ): void {
     this.validateBrand(data, 'root', result);
+  }
+
+  /**
+   * An `authoritative_location` may point off-site — central hosting by a
+   * service provider is the documented use for it, and the target is still
+   * "the brand's own document". A document served from another site therefore
+   * has to be consistent with the domain it is answering for: if it declares
+   * owned websites at all, the requested domain must be among them. A document
+   * that names no websites contradicts nothing and still resolves.
+   */
+  private validateCanonicalDocumentAttribution(
+    data: BrandCanonicalDocument,
+    attributedDomain: string,
+    result: BrandValidationResult,
+    fetchedFrom?: string
+  ): void {
+    if (!fetchedFrom || this.isSameSite(fetchedFrom, attributedDomain)) return;
+
+    const ownedWebsites = (data.properties ?? []).filter(
+      (property: BrandProperty) => property.type === 'website' && this.isOwnedProperty(property)
+    );
+    if (ownedWebsites.length === 0) return;
+
+    const namesDomain = ownedWebsites.some(
+      (property: BrandProperty) =>
+        typeof property.identifier === 'string' &&
+        property.identifier.toLowerCase() === attributedDomain.toLowerCase()
+    );
+    if (!namesDomain) {
+      result.errors.push({
+        field: 'properties',
+        message: `Document served from ${fetchedFrom} declares owned websites that do not include ${attributedDomain}, so it is not this domain's brand document`,
+        severity: 'error',
+      });
+    }
+  }
+
+  /** Same registrable domain (eTLD+1), with the PSL private section as the registrant boundary. */
+  private isSameSite(url: string, domain: string): boolean {
+    try {
+      const host = new URL(url).hostname;
+      const site = getDomain(host, { allowPrivateDomains: true });
+      return site !== null && site === getDomain(domain, { allowPrivateDomains: true });
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -123,22 +123,36 @@ const CURRENT_BRAND_SCHEMA = 'https://adcontextprotocol.org/schemas/v3/brand.jso
 const BRAND_JSON_MAX_RESPONSE_BYTES = 256 * 1024;
 const BRAND_CACHE_MAX_ENTRIES = 200;
 const BRAND_FAILED_CACHE_MAX_ENTRIES = 1000;
-const LAST_VALIDATION_ATTEMPT_TTL_MS = 5 * 60 * 1000;
-const LAST_VALIDATION_ATTEMPT_MAX_ENTRIES = 500;
-
-interface LastValidationAttemptEntry {
-  value: BrandValidationResult;
-  expiresAt: number;
-}
+/**
+ * How long a confirmed mutual-assertion edge may be reused while the house
+ * side is transiently unreachable, measured from the last successful
+ * reciprocal check — not from the last resolution. Past this the edge reports
+ * `unverifiable`, per the brand.json edge-aging rule.
+ */
+const MUTUAL_TRUST_RETENTION_MS = 24 * 60 * 60 * 1000;
 
 type CanonicalHouseVerification =
-  | { status: 'mutual'; houseDomain: string; houseName?: string }
+  | { status: 'mutual'; houseDomain: string; houseName?: string; verifiedAt: number }
   | { status: 'leaf_only' }
   | { status: 'unverifiable'; transient: boolean };
 
 interface CanonicalResolution {
   result: ResolvedBrand;
   retainCachedMutual: boolean;
+}
+
+/**
+ * A resolution plus the terminal network attempt that produced it. Diagnostics
+ * are per-call so concurrent resolutions never read each other's state.
+ */
+export interface BrandResolution {
+  brand: ResolvedBrand | null;
+  /** Terminal validation attempt for this call, without the response body. */
+  last_attempt?: BrandValidationResult;
+}
+
+interface ResolutionDiagnostics {
+  last_attempt?: BrandValidationResult;
 }
 
 export interface BrandAgentValidationResult {
@@ -157,10 +171,6 @@ export class BrandManager {
   private resolutionCache: Cache<ResolvedBrand | null>;
   // Cache for failed lookups (1 hour)
   private failedLookupCache: Cache<BrandValidationResult>;
-  // Most recent network attempt per domain, including fresh failures. Used to
-  // report the attempt that actually caused a fallback instead of an older
-  // positive cache entry.
-  private lastValidationAttempt = new Map<string, LastValidationAttemptEntry>();
 
   constructor() {
     this.validationCache = new Cache<BrandValidationResult>(24 * 60, BRAND_CACHE_MAX_ENTRIES); // 24 hours
@@ -175,7 +185,6 @@ export class BrandManager {
     this.validationCache.clear();
     this.resolutionCache.clear();
     this.failedLookupCache.clear();
-    this.lastValidationAttempt.clear();
   }
 
   /**
@@ -189,38 +198,21 @@ export class BrandManager {
     };
   }
 
-  getLastValidationResult(domain: string): BrandValidationResult | undefined {
-    const normalized = domain.trim().toLowerCase();
-    const entry = this.lastValidationAttempt.get(normalized);
-    if (!entry) return undefined;
-    if (entry.expiresAt <= Date.now()) {
-      this.lastValidationAttempt.delete(normalized);
-      return undefined;
-    }
-    return entry.value;
-  }
-
-  private recordLastValidationAttempt(domain: string, result: BrandValidationResult): void {
-    const normalized = domain.trim().toLowerCase();
+  /**
+   * Record the attempt that a caller may report as the reason a resolution
+   * fell back. Bodies are dropped and lists capped so the diagnostic stays
+   * small enough to return over the wire.
+   */
+  private recordAttempt(
+    diagnostics: ResolutionDiagnostics,
+    result: BrandValidationResult
+  ): void {
     const { raw_data: _rawData, ...withoutRawData } = result;
-    const diagnostic: BrandValidationResult = {
+    diagnostics.last_attempt = {
       ...withoutRawData,
       errors: result.errors.slice(0, 20),
       warnings: result.warnings.slice(0, 20),
     };
-
-    // Refresh insertion order so the cap evicts the least-recently recorded
-    // domain. The diagnostic cache intentionally never retains response bodies.
-    this.lastValidationAttempt.delete(normalized);
-    this.lastValidationAttempt.set(normalized, {
-      value: diagnostic,
-      expiresAt: Date.now() + LAST_VALIDATION_ATTEMPT_TTL_MS,
-    });
-    while (this.lastValidationAttempt.size > LAST_VALIDATION_ATTEMPT_MAX_ENTRIES) {
-      const oldestKey = this.lastValidationAttempt.keys().next().value;
-      if (oldestKey === undefined) break;
-      this.lastValidationAttempt.delete(oldestKey);
-    }
   }
 
   private normalizeLookupDomain(domain: string): string | null {
@@ -397,7 +389,6 @@ export class BrandManager {
         domain: domain.trim().toLowerCase(),
         url: '',
       };
-      this.recordLastValidationAttempt(domain, invalidResult);
       return invalidResult;
     }
     const cacheKey = normalizedDomain;
@@ -456,7 +447,6 @@ export class BrandManager {
         });
         // Cache failed lookups for 1 hour
         this.failedLookupCache.set(cacheKey, result);
-        this.recordLastValidationAttempt(cacheKey, result);
         return result;
       }
 
@@ -471,7 +461,6 @@ export class BrandManager {
           severity: 'error',
         });
         this.failedLookupCache.set(cacheKey, result);
-        this.recordLastValidationAttempt(cacheKey, result);
         return result;
       }
 
@@ -489,8 +478,6 @@ export class BrandManager {
       // Cache failed lookups for 1 hour
       this.failedLookupCache.set(cacheKey, result);
     }
-
-    this.recordLastValidationAttempt(cacheKey, result);
 
     return result;
   }
@@ -978,6 +965,27 @@ export class BrandManager {
     domain: string,
     options: { maxRedirects?: number; skipCache?: boolean } = {}
   ): Promise<ResolvedBrand | null> {
+    return (await this.resolveBrandWithDiagnostics(domain, options)).brand;
+  }
+
+  /**
+   * Resolve a domain and report the terminal validation attempt alongside the
+   * result, so a caller can explain a fallback without repeating the fetch.
+   */
+  async resolveBrandWithDiagnostics(
+    domain: string,
+    options: { maxRedirects?: number; skipCache?: boolean } = {}
+  ): Promise<BrandResolution> {
+    const diagnostics: ResolutionDiagnostics = {};
+    const brand = await this.resolveBrandInternal(domain, options, diagnostics);
+    return { brand, last_attempt: diagnostics.last_attempt };
+  }
+
+  private async resolveBrandInternal(
+    domain: string,
+    options: { maxRedirects?: number; skipCache?: boolean },
+    diagnostics: ResolutionDiagnostics
+  ): Promise<ResolvedBrand | null> {
     const { maxRedirects = 3, skipCache = false } = options;
     const normalizedDomain = this.normalizeLookupDomain(domain);
     if (!normalizedDomain) return null;
@@ -997,12 +1005,16 @@ export class BrandManager {
     let currentDomain = normalizedDomain;
     let currentUrl: string | undefined;
     let redirectCount = 0;
+    // Set once a House Redirect moves resolution to another domain. From that
+    // point the document we are reading belongs to the house, not to the
+    // requested domain, so it may only answer for a domain it names.
+    let redirectedHouseDomain: string | undefined;
 
     while (redirectCount <= maxRedirects) {
       const validationResult = currentUrl
         ? await this.validateBrandJsonUrl(currentUrl, currentDomain)
         : await this.validateDomain(currentDomain, { skipCache });
-      this.recordLastValidationAttempt(normalizedDomain, validationResult);
+      this.recordAttempt(diagnostics, validationResult);
 
       if (!validationResult.valid || !validationResult.raw_data) {
         if (!skipCache) this.resolutionCache.set(cacheKey, null);
@@ -1027,7 +1039,10 @@ export class BrandManager {
 
         case 'house_redirect': {
           const redirectData = data as HouseRedirectVariant;
-          currentDomain = redirectData.house;
+          currentDomain = redirectData.house.toLowerCase();
+          redirectedHouseDomain = currentDomain === normalizedDomain
+            ? undefined
+            : currentDomain;
           currentUrl = undefined;
           redirectCount++;
           continue;
@@ -1040,11 +1055,20 @@ export class BrandManager {
             if (!skipCache) this.resolutionCache.set(cacheKey, null);
             return null;
           }
+          // A house's agent is authoritative for the house. Reached through a
+          // redirect it has not yet spoken for the requested domain, so the
+          // identity stays with the requested domain and the house stays a claim.
           const result: ResolvedBrand = {
-            canonical_id: currentDomain,
-            canonical_domain: currentDomain,
-            brand_name: currentDomain, // Agent should provide the name via MCP
+            canonical_id: normalizedDomain,
+            canonical_domain: normalizedDomain,
+            brand_name: normalizedDomain, // Agent should provide the name via MCP
             brand_agent_url: agent.url,
+            ...(redirectedHouseDomain
+              ? {
+                  claimed_house_domain: redirectedHouseDomain,
+                  relationship_trust: 'leaf_only' as const,
+                }
+              : {}),
             ...this.promotionMetadata(validationResult),
             source: 'brand_json',
           };
@@ -1087,14 +1111,18 @@ export class BrandManager {
               pointer,
               { skipCache },
               portfolioData.house.domain,
-              normalizedDomain
+              diagnostics
             );
-            this.resolutionCache.set(cacheKey, pointed);
+            // Same rule as every other branch: a fresh probe that fails must
+            // not overwrite a live entry with a negative one.
+            if (pointed || !skipCache) this.resolutionCache.set(cacheKey, pointed);
             return pointed;
           }
 
-          // Check if the query domain is the house domain itself
-          if (currentDomain === portfolioData.house.domain) {
+          // The house's own master brand answers only for the house domain.
+          // Reached through a redirect from another domain, returning it would
+          // let any domain adopt the house's identity unreciprocated.
+          if (normalizedDomain === portfolioData.house.domain.toLowerCase()) {
             // Return the master brand if there is one
             const masterBrand = brands.find((b) => b.keller_type === 'master');
             if (masterBrand) {
@@ -1117,13 +1145,35 @@ export class BrandManager {
             }
           }
 
+          if (redirectedHouseDomain) {
+            const claim = this.unreciprocatedHouseClaim(
+              normalizedDomain,
+              redirectedHouseDomain,
+              validationResult
+            );
+            this.resolutionCache.set(cacheKey, claim);
+            return claim;
+          }
+
           if (!skipCache) this.resolutionCache.set(cacheKey, null);
           return null;
         }
 
         case 'brand_canonical': {
+          const canonical = data as BrandCanonicalDocument;
+          // The house's own brand document answers for the requested domain
+          // only when it names that domain as an owned property.
+          if (redirectedHouseDomain && !this.documentOwnsWebsite(canonical, normalizedDomain)) {
+            const claim = this.unreciprocatedHouseClaim(
+              normalizedDomain,
+              redirectedHouseDomain,
+              validationResult
+            );
+            this.resolutionCache.set(cacheKey, claim);
+            return claim;
+          }
           const freshResolution = await this.resolveCanonicalDocument(
-            data as BrandCanonicalDocument,
+            canonical,
             currentDomain,
             {
               skipCache,
@@ -1203,21 +1253,66 @@ export class BrandManager {
 
       const pointer = portfolio.brand_refs?.find((entry) => entry.brand_id === ref.brand_id);
       if (pointer) {
-        return this.resolveBrandPointer(pointer, options, portfolio.house.domain, ref.domain);
+        return this.resolveBrandPointer(pointer, options, portfolio.house.domain);
       }
     }
 
     return null;
   }
 
+  /**
+   * A House Redirect the named house has not reciprocated. The requested
+   * domain keeps its own identity and the house stays a claim — the house's
+   * brand is never handed to a domain it does not name.
+   */
+  private unreciprocatedHouseClaim(
+    domain: string,
+    claimedHouseDomain: string,
+    validation: BrandValidationResult
+  ): ResolvedBrand {
+    return {
+      canonical_id: domain,
+      canonical_domain: domain,
+      brand_name: domain,
+      claimed_house_domain: claimedHouseDomain,
+      relationship_trust: 'leaf_only',
+      ...this.promotionMetadata(validation),
+      source: 'brand_json',
+    };
+  }
+
+  /**
+   * Whether a document declares the domain as a website property it owns.
+   * `relationship` defaults to `owned` per the brand.json schema; the other
+   * values (`direct`, `delegated`, `ad_network`) describe monetization paths,
+   * not identity, so they never bind the domain to this brand.
+   */
+  private documentOwnsWebsite(
+    brand: BrandDefinition | BrandCanonicalDocument,
+    domain: string
+  ): boolean {
+    return (brand.properties ?? []).some(
+      (property: BrandProperty) =>
+        property.type === 'website' &&
+        typeof property.identifier === 'string' &&
+        property.identifier.toLowerCase() === domain &&
+        this.isOwnedProperty(property)
+    );
+  }
+
+  private isOwnedProperty(property: BrandProperty): boolean {
+    const relationship = property.relationship as string | undefined;
+    return relationship === undefined || relationship === 'owned';
+  }
+
   private async resolveBrandPointer(
     pointer: NonNullable<HousePortfolioVariant['brand_refs']>[number],
     options: { skipCache?: boolean },
     expectedHouseDomain: string,
-    diagnosticDomain: string
+    diagnostics: ResolutionDiagnostics = {}
   ): Promise<ResolvedBrand | null> {
     const validation = await this.validateCanonicalPointer(pointer.domain, options);
-    this.recordLastValidationAttempt(diagnosticDomain, validation);
+    this.recordAttempt(diagnostics, validation);
     if (
       !validation.valid ||
       validation.variant !== 'brand_canonical' ||
@@ -1271,9 +1366,13 @@ export class BrandManager {
     let verifiedHouseDomain = options.verifiedHouseDomain;
     let houseName: string | undefined;
     let retainCachedMutual = false;
+    let relationshipVerifiedAt: string | undefined;
 
     if (options.knownRelationship) {
       relationshipTrust = options.knownRelationship;
+      if (options.knownRelationship === 'mutual') {
+        relationshipVerifiedAt = new Date().toISOString();
+      }
     } else if (claimedHouseDomain) {
       const verification = await this.verifyCanonicalHouseRelationship(
         domain,
@@ -1284,6 +1383,9 @@ export class BrandManager {
       relationshipTrust = verification.status;
       verifiedHouseDomain = verification.status === 'mutual' ? verification.houseDomain : undefined;
       houseName = verification.status === 'mutual' ? verification.houseName : undefined;
+      relationshipVerifiedAt = verification.status === 'mutual'
+        ? new Date(verification.verifiedAt).toISOString()
+        : undefined;
       retainCachedMutual = verification.status === 'unverifiable' && verification.transient;
     }
 
@@ -1299,6 +1401,7 @@ export class BrandManager {
         claimed_house_domain: claimedHouseDomain,
         house_name: houseName,
         relationship_trust: relationshipTrust,
+        relationship_verified_at: relationshipVerifiedAt,
         promoted_from_schema: options.promoted_from_schema,
         migration_warnings: options.migration_warnings,
         brand_manifest: this.buildBrandManifest(data),
@@ -1324,6 +1427,9 @@ export class BrandManager {
    * transiently. Reuse a still-live mutual verification only when the leaf's
    * identity and claimed house are unchanged; otherwise the fresh relationship
    * result replaces the cache normally (including a verified leaf_only result).
+   *
+   * The retained edge keeps its original verification timestamp, so repeated
+   * transient failures cannot renew it past MUTUAL_TRUST_RETENTION_MS.
    */
   private retainCachedMutualRelationship(
     cached: ResolvedBrand | null | undefined,
@@ -1337,7 +1443,8 @@ export class BrandManager {
       cached.canonical_id !== fresh.canonical_id ||
       cached.canonical_domain !== fresh.canonical_domain ||
       !cached.house_domain ||
-      cached.house_domain.toLowerCase() !== fresh.claimed_house_domain?.toLowerCase()
+      cached.house_domain.toLowerCase() !== fresh.claimed_house_domain?.toLowerCase() ||
+      !this.withinMutualRetentionWindow(cached.relationship_verified_at)
     ) {
       return fresh;
     }
@@ -1347,7 +1454,15 @@ export class BrandManager {
       house_domain: cached.house_domain,
       house_name: cached.house_name,
       relationship_trust: 'mutual',
+      relationship_verified_at: cached.relationship_verified_at,
     };
+  }
+
+  private withinMutualRetentionWindow(verifiedAt: string | undefined): boolean {
+    if (!verifiedAt) return false;
+    const verifiedAtMs = Date.parse(verifiedAt);
+    if (Number.isNaN(verifiedAtMs)) return false;
+    return Date.now() - verifiedAtMs <= MUTUAL_TRUST_RETENTION_MS;
   }
 
   private async verifyCanonicalHouseRelationship(
@@ -1397,6 +1512,7 @@ export class BrandManager {
             status: 'mutual',
             houseDomain: portfolio.house.domain,
             houseName: portfolio.house.name,
+            verifiedAt: Date.now(),
           }
         : { status: 'leaf_only' };
     }
@@ -1452,7 +1568,9 @@ export class BrandManager {
   }
 
   /**
-   * Find a brand in a portfolio by property identifier
+   * Find a brand in a portfolio by property identifier. Only owned properties
+   * bind an identifier to a brand's identity — a house that merely sells or
+   * operates a property does not become that property's brand.
    */
   private findBrandByProperty(
     portfolio: HousePortfolioVariant,
@@ -1467,7 +1585,7 @@ export class BrandManager {
       // Check properties
       if (brand.properties) {
         for (const prop of brand.properties) {
-          if (prop.identifier === identifier) {
+          if (prop.identifier === identifier && this.isOwnedProperty(prop)) {
             return brand;
           }
         }

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -12,6 +12,7 @@ import type {
 } from './types';
 import { AAO_UA_VALIDATOR } from './config/user-agents.js';
 import { withSdkSafeTransport } from './utils/sdk-safe-fetch.js';
+import { assertValidBrandDomain } from './services/identifier-normalization.js';
 
 export interface BrandValidationError {
   field: string;
@@ -119,7 +120,13 @@ export type BrandJson =
 
 const LEGACY_BRAND_SCHEMA = 'https://schemas.adcontextprotocol.org/brand/v1/brand.json';
 const CURRENT_BRAND_SCHEMA = 'https://adcontextprotocol.org/schemas/v3/brand.json';
-const PROPERTY_RELATIONSHIPS = new Set(['owned', 'direct', 'delegated', 'ad_network']);
+const LAST_VALIDATION_ATTEMPT_TTL_MS = 5 * 60 * 1000;
+const LAST_VALIDATION_ATTEMPT_MAX_ENTRIES = 500;
+
+interface LastValidationAttemptEntry {
+  value: BrandValidationResult;
+  expiresAt: number;
+}
 
 export interface BrandAgentValidationResult {
   agent_url: string;
@@ -140,7 +147,7 @@ export class BrandManager {
   // Most recent network attempt per domain, including fresh failures. Used to
   // report the attempt that actually caused a fallback instead of an older
   // positive cache entry.
-  private lastValidationAttempt = new Map<string, BrandValidationResult>();
+  private lastValidationAttempt = new Map<string, LastValidationAttemptEntry>();
 
   constructor() {
     this.validationCache = new Cache<BrandValidationResult>(24 * 60); // 24 hours
@@ -170,17 +177,56 @@ export class BrandManager {
   }
 
   getLastValidationResult(domain: string): BrandValidationResult | undefined {
-    const normalized = domain.replace(/^https?:\/\//, '').replace(/\/$/, '').toLowerCase();
-    return this.lastValidationAttempt.get(normalized);
+    const normalized = domain.trim().toLowerCase();
+    const entry = this.lastValidationAttempt.get(normalized);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= Date.now()) {
+      this.lastValidationAttempt.delete(normalized);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  private recordLastValidationAttempt(domain: string, result: BrandValidationResult): void {
+    const normalized = domain.trim().toLowerCase();
+    const { raw_data: _rawData, ...withoutRawData } = result;
+    const diagnostic: BrandValidationResult = {
+      ...withoutRawData,
+      errors: result.errors.slice(0, 20),
+      warnings: result.warnings.slice(0, 20),
+    };
+
+    // Refresh insertion order so the cap evicts the least-recently recorded
+    // domain. The diagnostic cache intentionally never retains response bodies.
+    this.lastValidationAttempt.delete(normalized);
+    this.lastValidationAttempt.set(normalized, {
+      value: diagnostic,
+      expiresAt: Date.now() + LAST_VALIDATION_ATTEMPT_TTL_MS,
+    });
+    while (this.lastValidationAttempt.size > LAST_VALIDATION_ATTEMPT_MAX_ENTRIES) {
+      const oldestKey = this.lastValidationAttempt.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.lastValidationAttempt.delete(oldestKey);
+    }
+  }
+
+  private normalizeLookupDomain(domain: string): string | null {
+    const normalized = domain.trim().toLowerCase();
+    try {
+      assertValidBrandDomain(normalized);
+      return normalized;
+    } catch {
+      return null;
+    }
   }
 
   /**
    * Promote the narrowly identified pre-v3 shape used by early integrations.
    *
    * The legacy schema URL was never part of the canonical AdCP schema tree, so
-   * this adapter intentionally does not guess at trust semantics. Unsupported
-   * property relationships are preserved as opaque legacy data and excluded
-   * from active v3 properties instead of being rewritten as ownership claims.
+   * this adapter intentionally does not guess at trust semantics. Only the
+   * exact TLS-origin identity property is active; every other legacy property
+   * is preserved opaquely instead of being rewritten as a v3 trust claim.
    */
   private normalizeLegacyBrandJson(
     data: unknown,
@@ -202,39 +248,44 @@ export class BrandManager {
 
     // Compatibility promotion is identity-only. Require exactly one explicit
     // website match to the TLS origin; never infer identity from array position.
-    const originMatches = brands.filter((brand) => {
-      if (!Array.isArray(brand.properties)) return false;
-      return brand.properties.some((property) =>
-        this.isRecord(property) &&
-        property.type === 'website' &&
-        typeof property.identifier === 'string' &&
-        property.identifier.toLowerCase() === originDomain &&
-        property.relationship === 'owned'
-      );
-    });
+    const originMatches: Array<{ brand: Record<string, unknown>; brandIndex: number; propertyIndex: number }> = [];
+    for (const [brandIndex, brand] of brands.entries()) {
+      if (!Array.isArray(brand.properties)) continue;
+      for (const [propertyIndex, property] of brand.properties.entries()) {
+        if (
+          this.isRecord(property) &&
+          property.type === 'website' &&
+          typeof property.identifier === 'string' &&
+          property.identifier.toLowerCase() === originDomain &&
+          property.relationship === 'owned'
+        ) {
+          originMatches.push({ brand, brandIndex, propertyIndex });
+        }
+      }
+    }
 
     if (originMatches.length !== 1) {
       warnings.push({
         field: 'brands',
-        message: `Legacy promotion requires exactly one website property matching ${originDomain}; found ${originMatches.length}`,
+        message: `Legacy promotion requires exactly one owned website property matching ${originDomain}; found ${originMatches.length}`,
       });
       return { data, warnings, promotedFromSchema: LEGACY_BRAND_SCHEMA };
     }
 
-    const originBrand = structuredClone(originMatches[0]);
-    const originIndex = brands.indexOf(originMatches[0]);
+    const originMatch = originMatches[0];
+    const originBrand = structuredClone(originMatch.brand);
+    const originIndex = originMatch.brandIndex;
     const legacyProperties: unknown[] = [];
     const activeProperties: unknown[] = [];
     for (const [propertyIndex, property] of (
       Array.isArray(originBrand.properties) ? originBrand.properties : []
     ).entries()) {
-      const relationship = this.isRecord(property) ? property.relationship : undefined;
-      if (typeof relationship !== 'string' || !PROPERTY_RELATIONSHIPS.has(relationship)) {
+      if (propertyIndex !== originMatch.propertyIndex) {
         legacyProperties.push(property);
         warnings.push({
-          field: `brands[${originIndex}].properties[${propertyIndex}].relationship`,
-          message: 'Preserved a property with missing or unsupported legacy relationship as opaque data; it was not promoted to a v3 trust assertion',
-          suggestion: 'Publish owned, direct, delegated, or ad_network explicitly',
+          field: `brands[${originIndex}].properties[${propertyIndex}]`,
+          message: 'Preserved a non-origin legacy property as opaque data; compatibility promotion does not turn it into a v3 trust assertion',
+          suggestion: `Publish the property explicitly in a ${CURRENT_BRAND_SCHEMA} document`,
         });
       } else {
         activeProperties.push(property);
@@ -288,7 +339,7 @@ export class BrandManager {
         message: `Preserved legacy ${key} as opaque metadata; it is not treated as v3 trust evidence`,
       });
     }
-    const otherBrands = brands.filter((brand) => brand !== originMatches[0]);
+    const otherBrands = brands.filter((brand) => brand !== originMatch.brand);
     if (otherBrands.length > 0) {
       metadata.unpromoted_brands = otherBrands;
       warnings.push({
@@ -322,7 +373,22 @@ export class BrandManager {
    * Validates a domain's brand.json file
    */
   async validateDomain(domain: string, options?: { skipCache?: boolean }): Promise<BrandValidationResult> {
-    const normalizedDomain = domain.replace(/^https?:\/\//, '').replace(/\/$/, '');
+    const normalizedDomain = this.normalizeLookupDomain(domain);
+    if (!normalizedDomain) {
+      const invalidResult: BrandValidationResult = {
+        valid: false,
+        errors: [{
+          field: 'domain',
+          message: 'Domain must be a bare multi-label DNS hostname without a scheme, port, path, query, or fragment',
+          severity: 'error',
+        }],
+        warnings: [],
+        domain: domain.trim().toLowerCase(),
+        url: '',
+      };
+      this.recordLastValidationAttempt(domain, invalidResult);
+      return invalidResult;
+    }
     const cacheKey = normalizedDomain;
 
     // Check caches unless explicitly skipped
@@ -378,7 +444,7 @@ export class BrandManager {
         });
         // Cache failed lookups for 1 hour
         this.failedLookupCache.set(cacheKey, result);
-        this.lastValidationAttempt.set(cacheKey, result);
+        this.recordLastValidationAttempt(cacheKey, result);
         return result;
       }
 
@@ -393,7 +459,7 @@ export class BrandManager {
           severity: 'error',
         });
         this.failedLookupCache.set(cacheKey, result);
-        this.lastValidationAttempt.set(cacheKey, result);
+        this.recordLastValidationAttempt(cacheKey, result);
         return result;
       }
 
@@ -412,7 +478,7 @@ export class BrandManager {
       this.failedLookupCache.set(cacheKey, result);
     }
 
-    this.lastValidationAttempt.set(cacheKey, result);
+    this.recordLastValidationAttempt(cacheKey, result);
 
     return result;
   }
@@ -900,7 +966,8 @@ export class BrandManager {
     options: { maxRedirects?: number; skipCache?: boolean } = {}
   ): Promise<ResolvedBrand | null> {
     const { maxRedirects = 3, skipCache = false } = options;
-    const normalizedDomain = domain.replace(/^https?:\/\//, '').replace(/\/$/, '');
+    const normalizedDomain = this.normalizeLookupDomain(domain);
+    if (!normalizedDomain) return null;
     const cacheKey = `resolve:${normalizedDomain}`;
 
     // Check resolution cache unless explicitly skipped
@@ -919,7 +986,7 @@ export class BrandManager {
       const validationResult = currentUrl
         ? await this.validateBrandJsonUrl(currentUrl, currentDomain)
         : await this.validateDomain(currentDomain, { skipCache });
-      this.lastValidationAttempt.set(normalizedDomain, validationResult);
+      this.recordLastValidationAttempt(normalizedDomain, validationResult);
 
       if (!validationResult.valid || !validationResult.raw_data) {
         if (!skipCache) this.resolutionCache.set(cacheKey, null);
@@ -1129,7 +1196,7 @@ export class BrandManager {
     diagnosticDomain: string
   ): Promise<ResolvedBrand | null> {
     const validation = await this.validateCanonicalPointer(pointer.domain, options);
-    this.lastValidationAttempt.set(diagnosticDomain.toLowerCase(), validation);
+    this.recordLastValidationAttempt(diagnosticDomain, validation);
     if (
       !validation.valid ||
       validation.variant !== 'brand_canonical' ||
@@ -1236,8 +1303,9 @@ export class BrandManager {
     const seen = new Set<string>();
 
     for (let redirects = 0; redirects <= options.maxRedirects; redirects++) {
-      if (seen.has(current)) return { mutual: false };
-      seen.add(current);
+      const visitKey = currentUrl ? `url:${currentUrl}` : `domain:${current}`;
+      if (seen.has(visitKey)) return { mutual: false };
+      seen.add(visitKey);
       const validation = currentUrl
         ? await this.validateBrandJsonUrl(currentUrl, current)
         : await this.validateDomain(current, { skipCache: options.skipCache });

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -1,5 +1,6 @@
 import { Cache } from './cache.js';
 import { safeFetchAxiosLike, classifySafeFetchError } from './utils/url-security.js';
+import { validateBrandJsonSchema } from './services/brand-json-schema-validator.js';
 import type {
   LocalizedName,
   BrandProperty,
@@ -32,8 +33,16 @@ export interface BrandValidationResult {
   url: string;
   status_code?: number;
   raw_data?: unknown;
-  variant?: 'authoritative_location' | 'house_redirect' | 'brand_agent' | 'house_portfolio';
+  variant?: BrandJsonVariant;
+  promoted_from_schema?: string;
 }
+
+type BrandJsonVariant =
+  | 'authoritative_location'
+  | 'house_redirect'
+  | 'brand_agent'
+  | 'house_portfolio'
+  | 'brand_canonical';
 
 // brand.json variant types
 export interface AuthoritativeLocationVariant {
@@ -53,7 +62,8 @@ export interface HouseRedirectVariant {
 export interface BrandAgentVariant {
   $schema?: string;
   version?: string;
-  brand_agent: BrandAgentConfig;
+  brand_agent?: BrandAgentConfig;
+  agents?: Array<BrandAgentConfig & { type: string }>;
   auth?: {
     required?: boolean;
     method?: 'api_key' | 'oauth2' | 'bearer_token';
@@ -73,7 +83,13 @@ export interface HousePortfolioVariant {
   $schema?: string;
   version?: string;
   house: HouseDefinition;  // Object
-  brands: BrandDefinition[];
+  brands?: BrandDefinition[];
+  brand_refs?: Array<{
+    domain: string;
+    brand_id: string;
+    managed_by?: string;
+    effective_at?: string;
+  }>;
   contact?: {
     name: string;
     email?: string;
@@ -87,7 +103,23 @@ export interface HousePortfolioVariant {
   last_updated?: string;
 }
 
-export type BrandJson = AuthoritativeLocationVariant | HouseRedirectVariant | BrandAgentVariant | HousePortfolioVariant;
+export type BrandCanonicalDocument = BrandDefinition & {
+  $schema?: string;
+  version?: string;
+  house_domain?: string;
+  last_updated?: string;
+};
+
+export type BrandJson =
+  | AuthoritativeLocationVariant
+  | HouseRedirectVariant
+  | BrandAgentVariant
+  | HousePortfolioVariant
+  | BrandCanonicalDocument;
+
+const LEGACY_BRAND_SCHEMA = 'https://schemas.adcontextprotocol.org/brand/v1/brand.json';
+const CURRENT_BRAND_SCHEMA = 'https://adcontextprotocol.org/schemas/v3/brand.json';
+const PROPERTY_RELATIONSHIPS = new Set(['owned', 'direct', 'delegated', 'ad_network']);
 
 export interface BrandAgentValidationResult {
   agent_url: string;
@@ -105,6 +137,10 @@ export class BrandManager {
   private resolutionCache: Cache<ResolvedBrand | null>;
   // Cache for failed lookups (1 hour)
   private failedLookupCache: Cache<BrandValidationResult>;
+  // Most recent network attempt per domain, including fresh failures. Used to
+  // report the attempt that actually caused a fallback instead of an older
+  // positive cache entry.
+  private lastValidationAttempt = new Map<string, BrandValidationResult>();
 
   constructor() {
     this.validationCache = new Cache<BrandValidationResult>(24 * 60); // 24 hours
@@ -119,6 +155,7 @@ export class BrandManager {
     this.validationCache.clear();
     this.resolutionCache.clear();
     this.failedLookupCache.clear();
+    this.lastValidationAttempt.clear();
   }
 
   /**
@@ -130,6 +167,155 @@ export class BrandManager {
       resolution: this.resolutionCache.size(),
       failed: this.failedLookupCache.size(),
     };
+  }
+
+  getLastValidationResult(domain: string): BrandValidationResult | undefined {
+    const normalized = domain.replace(/^https?:\/\//, '').replace(/\/$/, '').toLowerCase();
+    return this.lastValidationAttempt.get(normalized);
+  }
+
+  /**
+   * Promote the narrowly identified pre-v3 shape used by early integrations.
+   *
+   * The legacy schema URL was never part of the canonical AdCP schema tree, so
+   * this adapter intentionally does not guess at trust semantics. Unsupported
+   * property relationships are preserved as opaque legacy data and excluded
+   * from active v3 properties instead of being rewritten as ownership claims.
+   */
+  private normalizeLegacyBrandJson(
+    data: unknown,
+    originDomain: string
+  ): { data: unknown; warnings: BrandValidationWarning[]; promotedFromSchema?: string } {
+    if (!this.isRecord(data) || data.$schema !== LEGACY_BRAND_SCHEMA) {
+      return { data, warnings: [] };
+    }
+
+    const document = structuredClone(data) as Record<string, unknown>;
+    const warnings: BrandValidationWarning[] = [{
+      field: '$schema',
+      message: `Promoted legacy brand.json shape to ${CURRENT_BRAND_SCHEMA}`,
+      suggestion: `Publish the document directly against ${CURRENT_BRAND_SCHEMA}`,
+    }];
+    const brands = Array.isArray(document.brands)
+      ? document.brands.filter((brand): brand is Record<string, unknown> => this.isRecord(brand))
+      : [];
+
+    // Compatibility promotion is identity-only. Require exactly one explicit
+    // website match to the TLS origin; never infer identity from array position.
+    const originMatches = brands.filter((brand) => {
+      if (!Array.isArray(brand.properties)) return false;
+      return brand.properties.some((property) =>
+        this.isRecord(property) &&
+        property.type === 'website' &&
+        typeof property.identifier === 'string' &&
+        property.identifier.toLowerCase() === originDomain &&
+        property.relationship === 'owned'
+      );
+    });
+
+    if (originMatches.length !== 1) {
+      warnings.push({
+        field: 'brands',
+        message: `Legacy promotion requires exactly one website property matching ${originDomain}; found ${originMatches.length}`,
+      });
+      return { data, warnings, promotedFromSchema: LEGACY_BRAND_SCHEMA };
+    }
+
+    const originBrand = structuredClone(originMatches[0]);
+    const originIndex = brands.indexOf(originMatches[0]);
+    const legacyProperties: unknown[] = [];
+    const activeProperties: unknown[] = [];
+    for (const [propertyIndex, property] of (
+      Array.isArray(originBrand.properties) ? originBrand.properties : []
+    ).entries()) {
+      const relationship = this.isRecord(property) ? property.relationship : undefined;
+      if (typeof relationship !== 'string' || !PROPERTY_RELATIONSHIPS.has(relationship)) {
+        legacyProperties.push(property);
+        warnings.push({
+          field: `brands[${originIndex}].properties[${propertyIndex}].relationship`,
+          message: 'Preserved a property with missing or unsupported legacy relationship as opaque data; it was not promoted to a v3 trust assertion',
+          suggestion: 'Publish owned, direct, delegated, or ad_network explicitly',
+        });
+      } else {
+        activeProperties.push(property);
+      }
+    }
+    originBrand.properties = activeProperties;
+    if (legacyProperties.length > 0) originBrand.legacy_properties = legacyProperties;
+
+    if (typeof originBrand.name === 'string' && originBrand.name.trim()) {
+      originBrand.names = [{ und: originBrand.name }];
+      delete originBrand.name;
+      warnings.push({
+        field: `brands[${originIndex}].name`,
+        message: 'Promoted legacy name to names[] using the undetermined-language tag "und"',
+      });
+    }
+    if (!Array.isArray(originBrand.names) || originBrand.names.length === 0) {
+      warnings.push({ field: `brands[${originIndex}].names`, message: 'Legacy origin brand has no promotable name' });
+      return { data, warnings, promotedFromSchema: LEGACY_BRAND_SCHEMA };
+    }
+
+    const topName = typeof document.name === 'string' ? document.name.trim() : '';
+    if (
+      topName &&
+      !(originBrand.names as unknown[]).some((entry) =>
+        this.isRecord(entry) && Object.values(entry).includes(topName)
+      )
+    ) {
+      (originBrand.names as unknown[]).push({ und: topName });
+    }
+    if (typeof document.description === 'string' && originBrand.description === undefined) {
+      originBrand.description = document.description;
+    }
+    if (typeof document.logo === 'string') {
+      const logos = Array.isArray(originBrand.logos) ? originBrand.logos : [];
+      if (!logos.some((logo) => this.isRecord(logo) && logo.url === document.logo)) {
+        logos.push({ url: document.logo });
+      }
+      originBrand.logos = logos;
+    }
+    if (this.isRecord(document.colors) && !this.isRecord(originBrand.colors)) {
+      originBrand.colors = document.colors;
+    }
+
+    const metadata: Record<string, unknown> = {};
+    for (const key of ['legal_operator', 'related_domains', 'operator_domain_evidence'] as const) {
+      if (!(key in document)) continue;
+      metadata[key] = document[key];
+      warnings.push({
+        field: key,
+        message: `Preserved legacy ${key} as opaque metadata; it is not treated as v3 trust evidence`,
+      });
+    }
+    const otherBrands = brands.filter((brand) => brand !== originMatches[0]);
+    if (otherBrands.length > 0) {
+      metadata.unpromoted_brands = otherBrands;
+      warnings.push({
+        field: 'brands',
+        message: `Preserved ${otherBrands.length} non-origin legacy brand entries as opaque metadata; no ownership relationship was promoted`,
+      });
+    }
+
+    const house = this.isRecord(document.house) ? document.house : undefined;
+    const houseDomain = house && typeof house.domain === 'string' ? house.domain.toLowerCase() : undefined;
+    if (house) metadata.legacy_house = house;
+
+    const canonical: Record<string, unknown> = {
+      ...originBrand,
+      $schema: CURRENT_BRAND_SCHEMA,
+      ...(houseDomain && houseDomain !== originDomain ? { house_domain: houseDomain } : {}),
+      ...(Object.keys(metadata).length > 0 ? { legacy_metadata: metadata } : {}),
+    };
+    warnings.push({
+      field: 'root',
+      message: 'Promoted only the TLS-origin brand identity to a v3 Brand Canonical Document',
+    });
+    return { data: canonical, warnings, promotedFromSchema: LEGACY_BRAND_SCHEMA };
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
   }
 
   /**
@@ -171,6 +357,7 @@ export class BrandManager {
       // /api/registry/publisher auto-crawl path (PR #4128 / issue #4129).
       const response = await safeFetchAxiosLike(url, {
         timeoutMs: 10000,
+        sameSiteRedirectsOnly: true,
         headers: {
           Accept: 'application/json',
           'User-Agent': AAO_UA_VALIDATOR,
@@ -191,6 +378,7 @@ export class BrandManager {
         });
         // Cache failed lookups for 1 hour
         this.failedLookupCache.set(cacheKey, result);
+        this.lastValidationAttempt.set(cacheKey, result);
         return result;
       }
 
@@ -205,36 +393,11 @@ export class BrandManager {
           severity: 'error',
         });
         this.failedLookupCache.set(cacheKey, result);
+        this.lastValidationAttempt.set(cacheKey, result);
         return result;
       }
-      result.raw_data = brandData;
 
-      // Determine which variant this is and validate
-      const variant = this.detectVariant(brandData);
-      result.variant = variant || undefined;
-
-      switch (variant) {
-        case 'authoritative_location':
-          await this.validateAuthoritativeLocationVariant(brandData as AuthoritativeLocationVariant, result);
-          break;
-        case 'house_redirect':
-          this.validateHouseRedirectVariant(brandData as HouseRedirectVariant, result);
-          break;
-        case 'brand_agent':
-          this.validateBrandAgentVariant(brandData as BrandAgentVariant, result);
-          break;
-        case 'house_portfolio':
-          this.validateHousePortfolioVariant(brandData as HousePortfolioVariant, result);
-          break;
-        default:
-          result.errors.push({
-            field: 'root',
-            message: 'Unable to determine brand.json variant. Must contain one of: authoritative_location, house (string), brand_agent, or house (object) + brands',
-            severity: 'error',
-          });
-      }
-
-      result.valid = result.errors.length === 0;
+      await this.validateBrandData(brandData, normalizedDomain, result);
     } catch (error) {
       const classified = classifySafeFetchError(error, normalizedDomain);
       result.errors.push({ ...classified, severity: 'error' });
@@ -249,6 +412,105 @@ export class BrandManager {
       this.failedLookupCache.set(cacheKey, result);
     }
 
+    this.lastValidationAttempt.set(cacheKey, result);
+
+    return result;
+  }
+
+  private async validateBrandData(
+    brandData: unknown,
+    attributedDomain: string,
+    result: BrandValidationResult
+  ): Promise<void> {
+    const normalized = this.normalizeLegacyBrandJson(brandData, attributedDomain);
+    brandData = normalized.data;
+    result.warnings.push(...normalized.warnings);
+    result.promoted_from_schema = normalized.promotedFromSchema;
+    result.raw_data = brandData;
+
+    const schemaValidation = validateBrandJsonSchema(brandData);
+    if (!schemaValidation.valid) {
+      for (const issue of schemaValidation.errors.slice(0, 20)) {
+        result.errors.push({
+          field: issue.instancePath || 'root',
+          message: issue.message ?? 'Invalid brand.json field',
+          severity: 'error',
+        });
+      }
+    }
+
+    const variant = this.detectVariant(brandData);
+    result.variant = variant || undefined;
+    if (schemaValidation.valid && variant === 'house_portfolio') {
+      const houseDomain = (brandData as HousePortfolioVariant).house.domain.toLowerCase();
+      if (houseDomain !== attributedDomain.toLowerCase()) {
+        result.errors.push({
+          field: 'house.domain',
+          message: 'House Portfolio house.domain must match the TLS-attributed domain',
+          severity: 'error',
+        });
+      }
+    }
+    if (schemaValidation.valid) switch (variant) {
+      case 'authoritative_location':
+        await this.validateAuthoritativeLocationVariant(brandData as AuthoritativeLocationVariant, result);
+        break;
+      case 'house_redirect':
+        this.validateHouseRedirectVariant(brandData as HouseRedirectVariant, result);
+        break;
+      case 'brand_agent':
+        this.validateBrandAgentVariant(brandData as BrandAgentVariant, result);
+        break;
+      case 'house_portfolio':
+        this.validateHousePortfolioVariant(brandData as HousePortfolioVariant, result);
+        break;
+      case 'brand_canonical':
+        this.validateCanonicalDocument(brandData as BrandCanonicalDocument, result);
+        break;
+      default:
+        result.errors.push({
+          field: 'root',
+          message: 'Unable to determine brand.json variant. Expected a redirect, brand agent, house portfolio, or canonical brand document',
+          severity: 'error',
+        });
+    }
+    result.valid = result.errors.length === 0;
+  }
+
+  private async validateBrandJsonUrl(
+    url: string,
+    attributedDomain: string
+  ): Promise<BrandValidationResult> {
+    const result: BrandValidationResult = {
+      valid: false,
+      errors: [],
+      warnings: [],
+      domain: attributedDomain,
+      url,
+    };
+    try {
+      const response = await safeFetchAxiosLike(url, {
+        timeoutMs: 10000,
+        sameSiteRedirectsOnly: true,
+        headers: { Accept: 'application/json', 'User-Agent': AAO_UA_VALIDATOR },
+      });
+      result.status_code = response.status;
+      if (response.status !== 200) {
+        result.errors.push({ field: 'http_status', message: `HTTP ${response.status} fetching authoritative_location`, severity: 'error' });
+        return result;
+      }
+      let data: unknown;
+      try {
+        data = JSON.parse(response.data.toString('utf-8'));
+      } catch {
+        result.errors.push({ field: 'json', message: 'Invalid JSON at authoritative_location', severity: 'error' });
+        return result;
+      }
+      await this.validateBrandData(data, attributedDomain, result);
+    } catch (error) {
+      const classified = classifySafeFetchError(error, attributedDomain);
+      result.errors.push({ ...classified, severity: 'error' });
+    }
     return result;
   }
 
@@ -257,7 +519,7 @@ export class BrandManager {
    */
   private detectVariant(
     data: unknown
-  ): 'authoritative_location' | 'house_redirect' | 'brand_agent' | 'house_portfolio' | null {
+  ): BrandJsonVariant | null {
     if (typeof data !== 'object' || data === null) {
       return null;
     }
@@ -269,19 +531,30 @@ export class BrandManager {
       return 'authoritative_location';
     }
 
-    // Check for brand_agent
-    if ('brand_agent' in obj && typeof obj.brand_agent === 'object') {
-      return 'brand_agent';
-    }
-
     // Check for house - could be string (redirect) or object (portfolio)
     if ('house' in obj) {
       if (typeof obj.house === 'string') {
         return 'house_redirect';
       }
-      if (typeof obj.house === 'object' && 'brands' in obj) {
+      if (
+        typeof obj.house === 'object' && obj.house !== null &&
+        (Array.isArray(obj.brands) || Array.isArray(obj.brand_refs))
+      ) {
         return 'house_portfolio';
       }
+    }
+
+    // Canonical documents may themselves declare agents, so detect their
+    // top-level identity fields before the agent-only variant.
+    if (typeof obj.id === 'string' && Array.isArray(obj.names)) {
+      return 'brand_canonical';
+    }
+
+    if (
+      ('brand_agent' in obj && typeof obj.brand_agent === 'object') ||
+      Array.isArray(obj.agents)
+    ) {
+      return 'brand_agent';
     }
 
     return null;
@@ -367,43 +640,44 @@ export class BrandManager {
     data: BrandAgentVariant,
     result: BrandValidationResult
   ): void {
-    if (!data.brand_agent || typeof data.brand_agent !== 'object') {
+    const agent = data.brand_agent ?? data.agents?.find((entry) => entry.type === 'brand');
+    if (!agent) {
       result.errors.push({
-        field: 'brand_agent',
-        message: 'brand_agent object is required',
+        field: 'agents',
+        message: 'A brand agent entry is required',
         severity: 'error',
       });
       return;
     }
 
-    if (!data.brand_agent.id) {
+    if (!agent.id) {
       result.errors.push({
-        field: 'brand_agent.id',
-        message: 'brand_agent.id is required',
+        field: 'agents.id',
+        message: 'agent id is required',
         severity: 'error',
       });
     }
 
-    if (!data.brand_agent.url) {
+    if (!agent.url) {
       result.errors.push({
-        field: 'brand_agent.url',
-        message: 'brand_agent.url is required',
+        field: 'agents.url',
+        message: 'agent url is required',
         severity: 'error',
       });
     } else {
       try {
-        const url = new URL(data.brand_agent.url);
+        const url = new URL(agent.url);
         if (!url.protocol.startsWith('https:')) {
           result.errors.push({
-            field: 'brand_agent.url',
-            message: 'brand_agent.url must use HTTPS',
+            field: 'agents.url',
+            message: 'agent url must use HTTPS',
             severity: 'error',
           });
         }
       } catch {
         result.errors.push({
-          field: 'brand_agent.url',
-          message: 'brand_agent.url must be a valid URL',
+          field: 'agents.url',
+          message: 'agent url must be a valid URL',
           severity: 'error',
         });
       }
@@ -454,33 +728,26 @@ export class BrandManager {
       });
     }
 
-    // Validate brands array
-    if (!data.brands || !Array.isArray(data.brands)) {
-      result.errors.push({
-        field: 'brands',
-        message: 'brands array is required',
-        severity: 'error',
-      });
-      return;
-    }
+    const brands = Array.isArray(data.brands) ? data.brands : [];
+    const brandRefs = Array.isArray(data.brand_refs) ? data.brand_refs : [];
 
-    if (data.brands.length === 0) {
+    if (brands.length === 0 && brandRefs.length === 0) {
       result.errors.push({
         field: 'brands',
-        message: 'brands array must contain at least one brand',
+        message: 'At least one of brands[] or brand_refs[] is required',
         severity: 'error',
       });
       return;
     }
 
     // Validate each brand
-    data.brands.forEach((brand, index) => {
+    brands.forEach((brand, index) => {
       this.validateBrand(brand, index, result);
     });
 
     // Check for duplicate brand IDs
     const seenIds = new Set<string>();
-    data.brands.forEach((brand, index) => {
+    brands.forEach((brand, index) => {
       if (brand.id) {
         if (seenIds.has(brand.id)) {
           result.errors.push({
@@ -493,8 +760,29 @@ export class BrandManager {
       }
     });
 
+    const seenRefDomains = new Set<string>();
+    brandRefs.forEach((ref, index) => {
+      const domain = ref.domain.toLowerCase();
+      if (seenRefDomains.has(domain)) {
+        result.errors.push({
+          field: `brand_refs[${index}].domain`,
+          message: `Duplicate brand_refs domain: ${ref.domain}`,
+          severity: 'error',
+        });
+      }
+      if (seenIds.has(ref.brand_id)) {
+        result.errors.push({
+          field: `brand_refs[${index}].brand_id`,
+          message: `brand_id "${ref.brand_id}" cannot appear in both brands[] and brand_refs[]`,
+          severity: 'error',
+        });
+      }
+      seenRefDomains.add(domain);
+      seenIds.add(ref.brand_id);
+    });
+
     // Validate parent_brand references
-    data.brands.forEach((brand, index) => {
+    brands.forEach((brand, index) => {
       if (brand.parent_brand && !seenIds.has(brand.parent_brand)) {
         result.warnings.push({
           field: `brands[${index}].parent_brand`,
@@ -505,15 +793,22 @@ export class BrandManager {
     });
   }
 
+  private validateCanonicalDocument(
+    data: BrandCanonicalDocument,
+    result: BrandValidationResult
+  ): void {
+    this.validateBrand(data, 'root', result);
+  }
+
   /**
    * Validate a single brand definition
    */
   private validateBrand(
     brand: BrandDefinition,
-    index: number,
+    index: number | 'root',
     result: BrandValidationResult
   ): void {
-    const prefix = `brands[${index}]`;
+    const prefix = index === 'root' ? 'root' : `brands[${index}]`;
 
     if (!brand.id) {
       result.errors.push({
@@ -617,13 +912,17 @@ export class BrandManager {
     }
 
     let currentDomain = normalizedDomain;
+    let currentUrl: string | undefined;
     let redirectCount = 0;
 
-    while (redirectCount < maxRedirects) {
-      const validationResult = await this.validateDomain(currentDomain, { skipCache });
+    while (redirectCount <= maxRedirects) {
+      const validationResult = currentUrl
+        ? await this.validateBrandJsonUrl(currentUrl, currentDomain)
+        : await this.validateDomain(currentDomain, { skipCache });
+      this.lastValidationAttempt.set(normalizedDomain, validationResult);
 
       if (!validationResult.valid || !validationResult.raw_data) {
-        this.resolutionCache.set(cacheKey, null);
+        if (!skipCache) this.resolutionCache.set(cacheKey, null);
         return null;
       }
 
@@ -634,11 +933,11 @@ export class BrandManager {
           const authData = data as AuthoritativeLocationVariant;
           try {
             const url = new URL(authData.authoritative_location);
-            currentDomain = url.hostname + url.pathname;
+            currentUrl = url.toString();
             redirectCount++;
             continue;
           } catch {
-            this.resolutionCache.set(cacheKey, null);
+            if (!skipCache) this.resolutionCache.set(cacheKey, null);
             return null;
           }
         }
@@ -646,17 +945,24 @@ export class BrandManager {
         case 'house_redirect': {
           const redirectData = data as HouseRedirectVariant;
           currentDomain = redirectData.house;
+          currentUrl = undefined;
           redirectCount++;
           continue;
         }
 
         case 'brand_agent': {
           const agentData = data as BrandAgentVariant;
+          const agent = agentData.brand_agent ?? agentData.agents?.find((entry) => entry.type === 'brand');
+          if (!agent) {
+            if (!skipCache) this.resolutionCache.set(cacheKey, null);
+            return null;
+          }
           const result: ResolvedBrand = {
             canonical_id: currentDomain,
             canonical_domain: currentDomain,
             brand_name: currentDomain, // Agent should provide the name via MCP
-            brand_agent_url: agentData.brand_agent.url,
+            brand_agent_url: agent.url,
+            ...this.promotionMetadata(validationResult),
             source: 'brand_json',
           };
           this.resolutionCache.set(cacheKey, result);
@@ -665,6 +971,7 @@ export class BrandManager {
 
         case 'house_portfolio': {
           const portfolioData = data as HousePortfolioVariant;
+          const brands = portfolioData.brands ?? [];
           // Find the brand that owns this domain
           const brand = this.findBrandByProperty(portfolioData, normalizedDomain);
           if (brand) {
@@ -680,17 +987,33 @@ export class BrandManager {
               parent_brand: brand.parent_brand,
               house_domain: portfolioData.house.domain,
               house_name: portfolioData.house.name,
+              relationship_trust: 'inline',
               brand_manifest: this.buildBrandManifest(brand),
+              ...this.promotionMetadata(validationResult),
               source: 'brand_json',
             };
             this.resolutionCache.set(cacheKey, result);
             return result;
           }
 
+          const pointer = portfolioData.brand_refs?.find(
+            (ref) => ref.domain.toLowerCase() === normalizedDomain
+          );
+          if (pointer) {
+            const pointed = await this.resolveBrandPointer(
+              pointer,
+              { skipCache },
+              portfolioData.house.domain,
+              normalizedDomain
+            );
+            this.resolutionCache.set(cacheKey, pointed);
+            return pointed;
+          }
+
           // Check if the query domain is the house domain itself
           if (currentDomain === portfolioData.house.domain) {
             // Return the master brand if there is one
-            const masterBrand = portfolioData.brands.find((b) => b.keller_type === 'master');
+            const masterBrand = brands.find((b) => b.keller_type === 'master');
             if (masterBrand) {
               const primaryName = this.getPrimaryName(masterBrand.names);
               const result: ResolvedBrand = {
@@ -701,7 +1024,9 @@ export class BrandManager {
                 keller_type: masterBrand.keller_type,
                 house_domain: portfolioData.house.domain,
                 house_name: portfolioData.house.name,
+                relationship_trust: 'inline',
                 brand_manifest: this.buildBrandManifest(masterBrand),
+                ...this.promotionMetadata(validationResult),
                 source: 'brand_json',
               };
               this.resolutionCache.set(cacheKey, result);
@@ -709,17 +1034,31 @@ export class BrandManager {
             }
           }
 
-          this.resolutionCache.set(cacheKey, null);
+          if (!skipCache) this.resolutionCache.set(cacheKey, null);
           return null;
         }
 
+        case 'brand_canonical': {
+          const result = await this.resolveCanonicalDocument(
+            data as BrandCanonicalDocument,
+            currentDomain,
+            {
+              skipCache,
+              maxRedirects,
+              ...this.promotionMetadata(validationResult),
+            }
+          );
+          this.resolutionCache.set(cacheKey, result);
+          return result;
+        }
+
         default:
-          this.resolutionCache.set(cacheKey, null);
+          if (!skipCache) this.resolutionCache.set(cacheKey, null);
           return null;
       }
     }
 
-    this.resolutionCache.set(cacheKey, null);
+    if (!skipCache) this.resolutionCache.set(cacheKey, null);
     return null; // Max redirects exceeded
   }
 
@@ -734,20 +1073,27 @@ export class BrandManager {
     options: { skipCache?: boolean } = {}
   ): Promise<ResolvedBrand | null> {
     const resolved = await this.resolveBrand(ref.domain, options);
-    if (!resolved || !ref.brand_id) {
+    if (!ref.brand_id) {
       return resolved;
     }
 
     // If the resolved brand already matches the requested brand_id, return it
-    if (resolved.canonical_id === ref.brand_id || resolved.canonical_domain === ref.brand_id) {
+    if (
+      resolved &&
+      (resolved.canonical_id === ref.brand_id || resolved.canonical_domain === ref.brand_id)
+    ) {
       return resolved;
     }
 
     // For house portfolios, look up the specific brand by id
     const validationResult = await this.validateDomain(ref.domain, { skipCache: options.skipCache });
-    if (validationResult.variant === 'house_portfolio' && validationResult.raw_data) {
+    if (
+      validationResult.valid &&
+      validationResult.variant === 'house_portfolio' &&
+      validationResult.raw_data
+    ) {
       const portfolio = validationResult.raw_data as HousePortfolioVariant;
-      const brand = portfolio.brands.find((b) => b.id === ref.brand_id);
+      const brand = portfolio.brands?.find((b) => b.id === ref.brand_id);
       if (brand) {
         const primaryName = this.getPrimaryName(brand.names);
         return {
@@ -759,13 +1105,169 @@ export class BrandManager {
           parent_brand: brand.parent_brand,
           house_domain: portfolio.house.domain,
           house_name: portfolio.house.name,
+          relationship_trust: 'inline',
           brand_manifest: this.buildBrandManifest(brand),
+          ...this.promotionMetadata(validationResult),
           source: 'brand_json',
         };
+      }
+
+
+      const pointer = portfolio.brand_refs?.find((entry) => entry.brand_id === ref.brand_id);
+      if (pointer) {
+        return this.resolveBrandPointer(pointer, options, portfolio.house.domain, ref.domain);
       }
     }
 
     return null;
+  }
+
+  private async resolveBrandPointer(
+    pointer: NonNullable<HousePortfolioVariant['brand_refs']>[number],
+    options: { skipCache?: boolean },
+    expectedHouseDomain: string,
+    diagnosticDomain: string
+  ): Promise<ResolvedBrand | null> {
+    const validation = await this.validateCanonicalPointer(pointer.domain, options);
+    this.lastValidationAttempt.set(diagnosticDomain.toLowerCase(), validation);
+    if (
+      !validation.valid ||
+      validation.variant !== 'brand_canonical' ||
+      !validation.raw_data
+    ) {
+      return null;
+    }
+
+    const canonical = validation.raw_data as BrandCanonicalDocument;
+    if (canonical.id !== pointer.brand_id) return null;
+    const reciprocal = canonical.house_domain?.toLowerCase() === expectedHouseDomain.toLowerCase();
+    return this.resolveCanonicalDocument(canonical, pointer.domain, {
+      skipCache: options.skipCache,
+      maxRedirects: 3,
+      knownRelationship: reciprocal ? 'mutual' : 'house_only',
+      verifiedHouseDomain: reciprocal ? expectedHouseDomain : undefined,
+      ...this.promotionMetadata(validation),
+    });
+  }
+
+  private async validateCanonicalPointer(
+    domain: string,
+    options: { skipCache?: boolean }
+  ): Promise<BrandValidationResult> {
+    let validation = await this.validateDomain(domain, { skipCache: options.skipCache });
+    for (let redirects = 0; redirects < 3 && validation.variant === 'authoritative_location'; redirects++) {
+      const location = (validation.raw_data as AuthoritativeLocationVariant).authoritative_location;
+      validation = await this.validateBrandJsonUrl(location, domain);
+    }
+    return validation;
+  }
+
+  private async resolveCanonicalDocument(
+    data: BrandCanonicalDocument,
+    domain: string,
+    options: {
+      skipCache?: boolean;
+      maxRedirects: number;
+      knownRelationship?: 'mutual' | 'house_only';
+      verifiedHouseDomain?: string;
+      promoted_from_schema?: string;
+      migration_warnings?: BrandValidationWarning[];
+    }
+  ): Promise<ResolvedBrand> {
+    const primaryName = this.getPrimaryName(data.names);
+    const claimedHouseDomain = data.house_domain?.toLowerCase();
+    let relationshipTrust: ResolvedBrand['relationship_trust'] = claimedHouseDomain
+      ? 'leaf_only'
+      : 'standalone';
+    let verifiedHouseDomain = options.verifiedHouseDomain;
+    let houseName: string | undefined;
+
+    if (options.knownRelationship) {
+      relationshipTrust = options.knownRelationship;
+    } else if (claimedHouseDomain) {
+      const verification = await this.verifyCanonicalHouseRelationship(
+        domain,
+        data.id,
+        claimedHouseDomain,
+        options
+      );
+      relationshipTrust = verification.mutual ? 'mutual' : 'leaf_only';
+      verifiedHouseDomain = verification.mutual ? verification.houseDomain : undefined;
+      houseName = verification.mutual ? verification.houseName : undefined;
+    }
+
+    return {
+      canonical_id: data.id,
+      canonical_domain: domain,
+      brand_name: primaryName || data.id,
+      names: data.names,
+      keller_type: data.keller_type,
+      parent_brand: data.parent_brand,
+      house_domain: verifiedHouseDomain,
+      claimed_house_domain: claimedHouseDomain,
+      house_name: houseName,
+      relationship_trust: relationshipTrust,
+      promoted_from_schema: options.promoted_from_schema,
+      migration_warnings: options.migration_warnings,
+      brand_manifest: this.buildBrandManifest(data),
+      source: 'brand_json',
+    };
+  }
+
+  private promotionMetadata(validation: BrandValidationResult): Pick<
+    ResolvedBrand,
+    'promoted_from_schema' | 'migration_warnings'
+  > {
+    if (!validation.promoted_from_schema) return {};
+    return {
+      promoted_from_schema: validation.promoted_from_schema,
+      migration_warnings: validation.warnings.slice(0, 20),
+    };
+  }
+
+  private async verifyCanonicalHouseRelationship(
+    leafDomain: string,
+    brandId: string,
+    claimedHouseDomain: string,
+    options: { skipCache?: boolean; maxRedirects: number }
+  ): Promise<{ mutual: boolean; houseDomain?: string; houseName?: string }> {
+    let current = claimedHouseDomain;
+    let currentUrl: string | undefined;
+    const seen = new Set<string>();
+
+    for (let redirects = 0; redirects <= options.maxRedirects; redirects++) {
+      if (seen.has(current)) return { mutual: false };
+      seen.add(current);
+      const validation = currentUrl
+        ? await this.validateBrandJsonUrl(currentUrl, current)
+        : await this.validateDomain(current, { skipCache: options.skipCache });
+      if (!validation.valid || !validation.raw_data) return { mutual: false };
+
+      if (validation.variant === 'house_redirect') {
+        current = (validation.raw_data as HouseRedirectVariant).house.toLowerCase();
+        currentUrl = undefined;
+        continue;
+      }
+      if (validation.variant === 'authoritative_location') {
+        const location = (validation.raw_data as AuthoritativeLocationVariant).authoritative_location;
+        currentUrl = location;
+        continue;
+      }
+      if (validation.variant !== 'house_portfolio') return { mutual: false };
+
+      const portfolio = validation.raw_data as HousePortfolioVariant;
+      const reciprocal = portfolio.brand_refs?.some((ref) =>
+        ref.domain.toLowerCase() === leafDomain.toLowerCase() && ref.brand_id === brandId
+      );
+      return reciprocal
+        ? {
+            mutual: true,
+            houseDomain: portfolio.house.domain,
+            houseName: portfolio.house.name,
+          }
+        : { mutual: false };
+    }
+    return { mutual: false };
   }
 
   /**
@@ -778,16 +1280,24 @@ export class BrandManager {
    * schema. A legacy nested `brand_manifest` sub-key, if present, is merged
    * in for backwards compatibility; flat fields take precedence.
    */
-  private buildBrandManifest(brand: BrandDefinition): Record<string, unknown> | undefined {
+  private buildBrandManifest(
+    brand: BrandDefinition | BrandCanonicalDocument
+  ): Record<string, unknown> | undefined {
     const {
+      $schema: _schema,
+      version: _version,
+      last_updated: _lastUpdated,
+      house_domain: _houseDomain,
       id: _id,
       names: _names,
       keller_type: _kellerType,
       parent_brand: _parentBrand,
       properties: _properties,
+      legacy_properties: _legacyProperties,
+      legacy_metadata: _legacyMetadata,
       brand_manifest: brandManifest,
       ...rest
-    } = brand;
+    } = brand as BrandCanonicalDocument & Record<string, unknown>;
 
     const legacy =
       brandManifest && typeof brandManifest === 'object'
@@ -805,7 +1315,7 @@ export class BrandManager {
     portfolio: HousePortfolioVariant,
     identifier: string
   ): BrandDefinition | null {
-    for (const brand of portfolio.brands) {
+    for (const brand of portfolio.brands ?? []) {
       // Check if identifier matches brand id
       if (brand.id === identifier) {
         return brand;

--- a/server/src/cache.ts
+++ b/server/src/cache.ts
@@ -6,12 +6,24 @@ interface CacheEntry<T> {
 export class Cache<T> {
   private cache: Map<string, CacheEntry<T>> = new Map();
   private ttlMs: number;
+  private maxEntries: number;
 
-  constructor(ttlMinutes: number = 15) {
+  constructor(ttlMinutes: number = 15, maxEntries: number = Number.POSITIVE_INFINITY) {
     this.ttlMs = ttlMinutes * 60 * 1000;
+    if (maxEntries <= 0) throw new Error('maxEntries must be greater than zero');
+    this.maxEntries = maxEntries;
   }
 
   set(key: string, value: T): void {
+    this.pruneExpired();
+    // Refresh insertion order on overwrite so finite caches evict the least
+    // recently written/read entry rather than a hot key.
+    this.cache.delete(key);
+    while (this.cache.size >= this.maxEntries) {
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.cache.delete(oldestKey);
+    }
     this.cache.set(key, {
       value,
       expiresAt: Date.now() + this.ttlMs,
@@ -27,6 +39,10 @@ export class Cache<T> {
       return undefined;
     }
 
+    if (Number.isFinite(this.maxEntries)) {
+      this.cache.delete(key);
+      this.cache.set(key, entry);
+    }
     return entry.value;
   }
 
@@ -39,6 +55,14 @@ export class Cache<T> {
   }
 
   size(): number {
+    this.pruneExpired();
     return this.cache.size;
+  }
+
+  private pruneExpired(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.cache) {
+      if (now > entry.expiresAt) this.cache.delete(key);
+    }
   }
 }

--- a/server/src/cache.ts
+++ b/server/src/cache.ts
@@ -15,7 +15,11 @@ export class Cache<T> {
   }
 
   set(key: string, value: T): void {
-    this.pruneExpired();
+    // Only a bounded cache needs this: it keeps expired entries from consuming
+    // the entry budget and evicting a live one. An unbounded cache never
+    // evicts, so scanning the whole map on every write would be pure cost —
+    // `get` expires entries lazily instead.
+    if (Number.isFinite(this.maxEntries)) this.pruneExpired();
     // Refresh insertion order on overwrite so finite caches evict the least
     // recently written/read entry rather than a hot key.
     this.cache.delete(key);

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -391,21 +391,23 @@ export class CrawlerService {
         // Invalid URL in authoritative_location — skip
       }
     } else if (result.variant === 'house_portfolio' ||
+               result.variant === 'brand_canonical' ||
                result.variant === 'brand_agent' ||
                result.variant === 'house_redirect') {
       const brandName = this.extractBrandName(result.raw_data, domain);
+      const manifest = result.variant === 'house_portfolio' || result.variant === 'brand_canonical'
+        ? this.stripLegacyCompatibilityMetadata(result.raw_data as Record<string, unknown>)
+        : undefined;
       await this.brandDb.upsertDiscoveredBrand({
         domain,
         brand_name: brandName,
-        has_brand_manifest: result.variant === 'house_portfolio',
-        brand_manifest: result.variant === 'house_portfolio'
-          ? result.raw_data as Record<string, unknown>
-          : undefined,
+        has_brand_manifest: Boolean(manifest),
+        brand_manifest: manifest,
         source_type: 'brand_json',
       });
 
       // Extract properties from brand.json and upsert into catalog
-      if (result.variant === 'house_portfolio') {
+      if (result.variant === 'house_portfolio' || result.variant === 'brand_canonical') {
         await this.upsertBrandProperties(domain, result.raw_data as Record<string, unknown>);
       }
     }
@@ -507,11 +509,26 @@ export class CrawlerService {
 
   private extractBrandName(data: unknown, fallback: string): string {
     const obj = data as Record<string, unknown>;
+    if (Array.isArray(obj?.names)) {
+      for (const localized of obj.names) {
+        if (!localized || typeof localized !== 'object' || Array.isArray(localized)) continue;
+        const value = Object.values(localized as Record<string, unknown>)
+          .find((entry): entry is string => typeof entry === 'string');
+        if (value) return value;
+      }
+    }
     if (typeof obj?.house === 'object' && obj.house !== null) {
       const house = obj.house as Record<string, unknown>;
       if (typeof house.name === 'string') return house.name;
     }
     return fallback;
+  }
+
+  private stripLegacyCompatibilityMetadata(
+    data: Record<string, unknown>
+  ): Record<string, unknown> {
+    const { legacy_metadata: _metadata, legacy_properties: _properties, ...publicData } = data;
+    return publicData;
   }
 
   /**

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -274,10 +274,9 @@ export interface ListBrandsOptions {
   source_type?: 'brand_json' | 'community' | 'enriched' | 'stub';
   // Response-label filter for getAllBrandsForRegistry. Maps to the same
   // values the registry response exposes in `source`, so filter and
-  // response round-trip: ?source=hosted returns rows the response labels
-  // hosted (is_public=true), ?source=brand_json returns crawler-discovered
-  // rows with a live /.well-known/brand.json (source_type='brand_json' and
-  // is_public IS NOT TRUE), etc.
+  // response round-trip: ?source=hosted returns rows a verified owner
+  // registered, ?source=brand_json returns crawler-discovered rows with a
+  // live /.well-known/brand.json, etc.
   source?: 'hosted' | 'brand_json' | 'community' | 'enriched';
   has_manifest?: boolean;
   house_domain?: string;
@@ -285,6 +284,23 @@ export interface ListBrandsOptions {
   limit?: number;
   offset?: number;
 }
+
+/**
+ * Provenance predicates for the brand registry. Defined once so the response
+ * label, the `?source=` filter, and the stats buckets cannot drift apart.
+ *
+ * `is_public` is not a provenance signal — it defaults to TRUE, so every
+ * crawler-discovered row carries it. Owner-hosted means a verified
+ * organization registered the row.
+ */
+const OWNER_HOSTED_SQL =
+  `(brands.workos_organization_id IS NOT NULL AND brands.domain_verified = true)`;
+/** Control of the domain was demonstrated, by owner verification or by serving a valid brand.json from it. */
+const DOMAIN_CONTROL_VERIFIED_SQL =
+  `(${OWNER_HOSTED_SQL} OR brands.source_type = 'brand_json')`;
+/** The row carries manifest content, rather than an empty placeholder. */
+const HAS_MANIFEST_SQL =
+  `(brands.brand_manifest IS NOT NULL AND brands.brand_manifest <> '{}'::jsonb)`;
 
 // Column list for queries returning HostedBrand (aliases brands columns to match the interface)
 const HOSTED_BRAND_COLUMNS = `id, workos_organization_id, created_by_user_id, created_by_email,
@@ -899,6 +915,12 @@ export class BrandDatabase {
 
   /**
    * Get all brands (hosted + discovered) for registry view
+   *
+   * Provenance labels use the same definitions as `/api/brands/resolve`:
+   * `hosted` means a verified owner registered the row, `verified` means
+   * control of the domain was demonstrated (owner verification, or a valid
+   * brand.json served from the domain itself), and `has_manifest` means the
+   * row actually carries manifest content.
    */
   async getAllBrandsForRegistry(options: ListBrandsOptions = {}): Promise<Array<{
     domain: string;
@@ -932,14 +954,11 @@ export class BrandDatabase {
     }
 
     if (options.source) {
-      // Match the response-label CASE in the SELECT below: is_public=true
-      // rows are exposed as 'hosted' regardless of source_type, so the
-      // remaining buckets must exclude is_public=true to round-trip.
       if (options.source === 'hosted') {
-        conditions.push(`brands.is_public = true`);
+        conditions.push(OWNER_HOSTED_SQL);
       } else {
         conditions.push(
-          `brands.is_public IS NOT TRUE AND brands.source_type = $${paramIndex++}`
+          `NOT ${OWNER_HOSTED_SQL} AND brands.source_type = $${paramIndex++}`
         );
         params.push(options.source);
       }
@@ -973,9 +992,9 @@ export class BrandDatabase {
       SELECT
         brands.domain,
         COALESCE(brands.brand_name, brands.brand_manifest->>'name', brands.brand_manifest->'house'->>'name', brands.domain) as brand_name,
-        CASE WHEN brands.is_public = true THEN 'hosted' ELSE brands.source_type END as source,
-        CASE WHEN brands.is_public = true THEN true ELSE brands.has_brand_manifest END as has_manifest,
-        CASE WHEN brands.is_public = true THEN brands.domain_verified ELSE true END as verified,
+        CASE WHEN ${OWNER_HOSTED_SQL} THEN 'hosted' ELSE brands.source_type END as source,
+        ${HAS_MANIFEST_SQL} as has_manifest,
+        ${DOMAIN_CONTROL_VERIFIED_SQL} as verified,
         brands.house_domain,
         COALESCE(brands.keller_type, 'master') as keller_type,
         COALESCE(brands.brand_manifest->'logos'->0->>'url', brands.brand_manifest->'brands'->0->'logos'->0->>'url') as logo_url,
@@ -1040,21 +1059,19 @@ export class BrandDatabase {
       sub_brands: string;
       with_manifest: string;
     }>(
-      // Bucket counts mirror the response-label CASE in
-      // getAllBrandsForRegistry: is_public=true rows count once as 'hosted'
-      // and are excluded from the source_type buckets, so stats round-trip
-      // with the four ?source filter values (hosted/brand_json/community/
-      // enriched). hosted+brand_json+community+enriched (excluding 'stub')
-      // reconciles to total.
+      // Bucket counts use the same predicates as the response labels in
+      // getAllBrandsForRegistry, so stats round-trip with the four ?source
+      // filter values. hosted+brand_json+community+enriched (excluding
+      // 'stub') reconciles to total.
       `SELECT
         COUNT(*) AS total,
-        COUNT(*) FILTER (WHERE is_public = true) AS hosted,
-        COUNT(*) FILTER (WHERE source_type = 'brand_json' AND is_public IS NOT TRUE) AS brand_json,
-        COUNT(*) FILTER (WHERE source_type = 'community' AND is_public IS NOT TRUE) AS community,
-        COUNT(*) FILTER (WHERE source_type = 'enriched' AND is_public IS NOT TRUE) AS enriched,
+        COUNT(*) FILTER (WHERE ${OWNER_HOSTED_SQL}) AS hosted,
+        COUNT(*) FILTER (WHERE brands.source_type = 'brand_json' AND NOT ${OWNER_HOSTED_SQL}) AS brand_json,
+        COUNT(*) FILTER (WHERE brands.source_type = 'community' AND NOT ${OWNER_HOSTED_SQL}) AS community,
+        COUNT(*) FILTER (WHERE brands.source_type = 'enriched' AND NOT ${OWNER_HOSTED_SQL}) AS enriched,
         COUNT(*) FILTER (WHERE keller_type IN ('master', 'independent') OR keller_type IS NULL) AS houses,
         COUNT(*) FILTER (WHERE keller_type IN ('sub_brand', 'endorsed')) AS sub_brands,
-        COUNT(*) FILTER (WHERE is_public = true OR has_brand_manifest = true) AS with_manifest
+        COUNT(*) FILTER (WHERE ${HAS_MANIFEST_SQL}) AS with_manifest
       FROM brands
       ${whereClause}`,
       params

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -160,6 +160,15 @@ const logger = createLogger('http-server');
 const PUBLIC_SITE_URL = 'https://agenticadvertising.org';
 const PERSPECTIVES_CRAWLER_LIMIT = 200;
 
+/**
+ * Unauthenticated endpoints whose entire request body is a short list. Parsing
+ * more than that is wasted work no legitimate caller needs.
+ */
+const SMALL_BODY_JSON_ROUTES = new Set([
+  // 25 domains at the 253-byte DNS maximum is under 7 KB.
+  '/api/brands/resolve/bulk',
+]);
+
 interface PublicPerspectiveCrawlerItem {
   slug: string;
   content_type: string;
@@ -930,7 +939,10 @@ export class HTTPServer {
         // `/mcp` endpoint, which rehashes the exact bytes the signer signed.
         // Cheap (one utf-8 decode per request) and unused elsewhere.
         express.json({
-          limit: '10mb',
+          // The 10MB default carries base64-encoded logo uploads in member
+          // profiles. Unauthenticated endpoints that only take a short list get
+          // a tight cap so a caller cannot make the parser the expensive part.
+          limit: SMALL_BODY_JSON_ROUTES.has(req.path) ? '16kb' : '10mb',
           verify: (req, _res, buf) => {
             (req as unknown as { rawBody?: string }).rawBody = buf.toString('utf8');
           },

--- a/server/src/middleware/pg-rate-limit-store.ts
+++ b/server/src/middleware/pg-rate-limit-store.ts
@@ -28,7 +28,15 @@ function startCleanup(): void {
   timer.unref();
 }
 
-export class PostgresStore implements Store {
+/**
+ * A store that can consume several hits as one atomic operation, for endpoints
+ * where a single request costs more than one unit of work.
+ */
+export interface WeightedIncrementStore extends Store {
+  incrementBy(key: string, weight: number): Promise<IncrementResponse>;
+}
+
+export class PostgresStore implements WeightedIncrementStore {
   private windowMs = 60_000;
   prefix: string;
 
@@ -42,6 +50,10 @@ export class PostgresStore implements Store {
   }
 
   async increment(key: string): Promise<IncrementResponse> {
+    return this.incrementBy(key, 1);
+  }
+
+  async incrementBy(key: string, weight: number): Promise<IncrementResponse> {
     if (!isDatabaseInitialized()) {
       // Permit requests if DB not yet ready (startup window)
       return { totalHits: 0, resetTime: undefined };
@@ -52,11 +64,11 @@ export class PostgresStore implements Store {
     try {
       const result = await query<{ hits: number; reset_at: Date }>(
         `INSERT INTO rate_limit_hits (key, hits, reset_at)
-         VALUES ($1, 1, NOW() + interval '1 millisecond' * $2::integer)
+         VALUES ($1, $3::integer, NOW() + interval '1 millisecond' * $2::integer)
          ON CONFLICT (key) DO UPDATE SET
            hits = CASE
-             WHEN rate_limit_hits.reset_at <= NOW() THEN 1
-             ELSE rate_limit_hits.hits + 1
+             WHEN rate_limit_hits.reset_at <= NOW() THEN $3::integer
+             ELSE rate_limit_hits.hits + $3::integer
            END,
            reset_at = CASE
              WHEN rate_limit_hits.reset_at <= NOW()
@@ -64,7 +76,7 @@ export class PostgresStore implements Store {
              ELSE rate_limit_hits.reset_at
            END
          RETURNING hits, reset_at`,
-        [prefixedKey, this.windowMs],
+        [prefixedKey, this.windowMs, weight],
       );
 
       const row = result.rows[0];
@@ -128,7 +140,10 @@ interface CachedEntry {
  * periodically syncs to/from Postgres so counters are shared across pods.
  *
  * This avoids a DB round-trip on every request while still enforcing
- * approximate cross-pod limits.
+ * approximate cross-pod limits. The flush merges with `GREATEST`, so what
+ * crosses pods is each pod's peak rather than the sum: the effective limit
+ * grows with pod count. Use `PostgresStore` where the limit has to hold
+ * exactly across the fleet.
  */
 export class CachedPostgresStore implements Store {
   private windowMs = 60_000;

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -1,5 +1,5 @@
 import rateLimit from 'express-rate-limit';
-import type { Store } from 'express-rate-limit';
+import type { IncrementResponse, Options, Store } from 'express-rate-limit';
 import type { Request, Response } from 'express';
 import { createLogger } from '../logger.js';
 import { CachedPostgresStore, PostgresStore } from './pg-rate-limit-store.js';
@@ -365,7 +365,8 @@ export const agentReadRateLimiter = createAgentReadRateLimiter();
 
 /**
  * Rate limiter for bulk resolve endpoints
- * Limits: 20 requests per minute per IP (each request resolves up to 100 domains)
+ * Limits: 20 requests per minute per user/IP. Individual endpoints may add a
+ * stricter work-weighted limiter when one request can fan out to many targets.
  */
 export const bulkResolveRateLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
@@ -388,6 +389,105 @@ export const bulkResolveRateLimiter = rateLimit({
     });
   },
 });
+
+/**
+ * Adapts an express-rate-limit store so one request can consume multiple hits.
+ * The weight is encoded before the first colon in the generated key; the
+ * underlying store only sees the stable caller key, so all request sizes share
+ * one counter.
+ */
+class WeightedStore implements Store {
+  readonly localKeys?: boolean;
+  readonly prefix?: string;
+
+  constructor(private readonly inner: Store) {
+    this.localKeys = inner.localKeys;
+    this.prefix = inner.prefix;
+  }
+
+  init(options: Options): void | Promise<void> {
+    return this.inner.init?.(options);
+  }
+
+  async increment(weightedKey: string): Promise<IncrementResponse> {
+    const { key, weight } = this.parseKey(weightedKey);
+    let result = await this.inner.increment(key);
+    for (let i = 1; i < weight; i++) {
+      result = await this.inner.increment(key);
+    }
+    return result;
+  }
+
+  async decrement(weightedKey: string): Promise<void> {
+    const { key, weight } = this.parseKey(weightedKey);
+    for (let i = 0; i < weight; i++) {
+      await this.inner.decrement(key);
+    }
+  }
+
+  resetKey(weightedKey: string): void | Promise<void> {
+    return this.inner.resetKey(this.parseKey(weightedKey).key);
+  }
+
+  resetAll(): void | Promise<void> {
+    return this.inner.resetAll?.();
+  }
+
+  shutdown(): void | Promise<void> {
+    return this.inner.shutdown?.();
+  }
+
+  private parseKey(weightedKey: string): { key: string; weight: number } {
+    const separator = weightedKey.indexOf(':');
+    const parsed = Number.parseInt(weightedKey.slice(0, separator), 10);
+    return {
+      key: separator >= 0 ? weightedKey.slice(separator + 1) : weightedKey,
+      weight: Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 1,
+    };
+  }
+}
+
+export function createBrandBulkDomainRateLimiter(options: {
+  windowMs?: number;
+  maxDomains?: number;
+  maxDomainsPerRequest?: number;
+  store?: Store;
+} = {}) {
+  const maxDomainsPerRequest = options.maxDomainsPerRequest ?? 25;
+  return rateLimit({
+    windowMs: options.windowMs ?? 60 * 1000,
+    max: options.maxDomains ?? 100,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: new WeightedStore(options.store ?? new CachedPostgresStore('brand-resolve-domains:')),
+    keyGenerator: (req: Request) => {
+      const domains = Array.isArray(req.body?.domains) ? req.body.domains : [];
+      const uniqueDomains = new Set(
+        domains
+          .filter((domain: unknown): domain is string => typeof domain === 'string')
+          .map((domain: string) => domain.trim().toLowerCase()),
+      );
+      const weight = Math.max(1, Math.min(uniqueDomains.size, maxDomainsPerRequest));
+      return `${weight}:${generateKey(req)}`;
+    },
+    validate: { keyGeneratorIpFallback: false },
+    handler: (req: Request, res: Response) => {
+      logger.warn({
+        userId: (req as any).user?.id,
+        ip: req.ip,
+        path: req.path,
+      }, 'Domain-weighted rate limit exceeded for brand bulk resolve');
+
+      res.status(429).json({
+        error: 'Too many requests',
+        message: 'Bulk brand resolution domain limit exceeded. Please try again later.',
+        retryAfter: 60,
+      });
+    },
+  });
+}
+
+export const brandBulkDomainRateLimiter = createBrandBulkDomainRateLimiter();
 
 export const emailPrefsRateLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
@@ -562,8 +662,8 @@ export const contentFetchUrlRateLimiter = rateLimit({
  * Rate limiter for the unauthenticated /api/registry/publisher endpoint.
  * Tighter than the generic registry read limit because each request fans out
  * to up to 50 DB queries (per-agent rollup cap from PR #4106). At 20 req/min
- * the worst-case load per IP is ~1,000 DB queries/min — comparable to
- * bulkResolveRateLimiter (20 × 100 domains).
+ * the worst-case load per IP is ~1,000 DB queries/min. Brand bulk resolution
+ * has its own domain-weighted limiter because its external-fetch cost differs.
  */
 export const registryPublisherRateLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -2,7 +2,7 @@ import rateLimit from 'express-rate-limit';
 import type { IncrementResponse, Options, Store } from 'express-rate-limit';
 import type { Request, Response } from 'express';
 import { createLogger } from '../logger.js';
-import { CachedPostgresStore, PostgresStore } from './pg-rate-limit-store.js';
+import { CachedPostgresStore, PostgresStore, type WeightedIncrementStore } from './pg-rate-limit-store.js';
 
 const logger = createLogger('rate-limit');
 
@@ -392,15 +392,15 @@ export const bulkResolveRateLimiter = rateLimit({
 
 /**
  * Adapts an express-rate-limit store so one request can consume multiple hits.
- * The weight is encoded before the first colon in the generated key; the
- * underlying store only sees the stable caller key, so all request sizes share
- * one counter.
+ * express-rate-limit hands the store nothing but a key, so the weight rides in
+ * front of the first colon and is stripped here; the underlying store only ever
+ * sees the stable caller key, so all request sizes share one counter.
  */
 class WeightedStore implements Store {
   readonly localKeys?: boolean;
   readonly prefix?: string;
 
-  constructor(private readonly inner: Store) {
+  constructor(private readonly inner: WeightedIncrementStore) {
     this.localKeys = inner.localKeys;
     this.prefix = inner.prefix;
   }
@@ -411,11 +411,10 @@ class WeightedStore implements Store {
 
   async increment(weightedKey: string): Promise<IncrementResponse> {
     const { key, weight } = this.parseKey(weightedKey);
-    let result = await this.inner.increment(key);
-    for (let i = 1; i < weight; i++) {
-      result = await this.inner.increment(key);
-    }
-    return result;
+    // Consume the whole weight in one atomic operation. A loop of single
+    // increments lets concurrent requests interleave, so each reads a total
+    // lower than what they collectively spent and both are admitted.
+    return this.inner.incrementBy(key, weight);
   }
 
   async decrement(weightedKey: string): Promise<void> {
@@ -447,11 +446,17 @@ class WeightedStore implements Store {
   }
 }
 
+/**
+ * Domain-weighted limiter for brand bulk resolution: each unique domain in the
+ * request body costs one hit, because each one can trigger its own chain of
+ * external brand.json fetches. Backed by PostgresStore rather than the cached
+ * store so the ceiling holds across the fleet instead of per pod.
+ */
 export function createBrandBulkDomainRateLimiter(options: {
   windowMs?: number;
   maxDomains?: number;
   maxDomainsPerRequest?: number;
-  store?: Store;
+  store?: WeightedIncrementStore;
 } = {}) {
   const maxDomainsPerRequest = options.maxDomainsPerRequest ?? 25;
   return rateLimit({
@@ -459,7 +464,7 @@ export function createBrandBulkDomainRateLimiter(options: {
     max: options.maxDomains ?? 100,
     standardHeaders: true,
     legacyHeaders: false,
-    store: new WeightedStore(options.store ?? new CachedPostgresStore('brand-resolve-domains:')),
+    store: new WeightedStore(options.store ?? new PostgresStore('brand-resolve-domains:')),
     keyGenerator: (req: Request) => {
       const domains = Array.isArray(req.body?.domains) ? req.body.domains : [];
       const uniqueDomains = new Set(

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -20,7 +20,7 @@ import { query } from "../db/client.js";
 import { resolvePrimaryOrganization } from "../db/users-db.js";
 import * as manifestRefsDb from "../db/manifest-refs-db.js";
 import { isUuid } from "../utils/uuid.js";
-import { bulkResolveRateLimiter, brandCreationRateLimiter, storyboardEvalRateLimiter, storyboardStepRateLimiter, agentReadRateLimiter, registryPublisherRateLimiter, registryReadRateLimiter } from "../middleware/rate-limit.js";
+import { bulkResolveRateLimiter, brandBulkDomainRateLimiter, brandCreationRateLimiter, storyboardEvalRateLimiter, storyboardStepRateLimiter, agentReadRateLimiter, registryPublisherRateLimiter, registryReadRateLimiter } from "../middleware/rate-limit.js";
 import { listStoryboards, getStoryboard, getTestKitForStoryboard } from "../services/storyboards.js";
 import {
   hostedComplianceTarget,
@@ -474,6 +474,45 @@ function extractDomain(raw: string): string {
 
 const VALID_DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
 const BRAND_BULK_RESOLVE_MAX_DOMAINS = 25;
+const BRAND_BULK_PROCESS_CONCURRENCY = 10;
+
+class AsyncSemaphore {
+  private active = 0;
+  private readonly queue: Array<() => void> = [];
+
+  constructor(private readonly limit: number) {}
+
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.active < this.limit) {
+      this.active++;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => this.queue.push(resolve));
+  }
+
+  private release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      // Transfer the released permit directly to the oldest waiter.
+      next();
+      return;
+    }
+    this.active--;
+  }
+}
+
+// Shared by every router instance in this process so simultaneous bulk
+// requests cannot multiply their per-request fan-out into unbounded work.
+const brandBulkResolveSemaphore = new AsyncSemaphore(BRAND_BULK_PROCESS_CONCURRENCY);
 
 function isValidDomain(domain: string): boolean {
   return domain.length <= 253 && VALID_DOMAIN_RE.test(domain);
@@ -589,7 +628,7 @@ registry.registerPath({
   operationId: "resolveBrandsBulk",
   summary: "Bulk resolve brands",
   description:
-    `Resolve up to ${BRAND_BULK_RESOLVE_MAX_DOMAINS} domains to their canonical brand identities in a single request.\n\n**Rate limit:** 20 requests per minute per IP address.`,
+    `Resolve up to ${BRAND_BULK_RESOLVE_MAX_DOMAINS} domains to their canonical brand identities in a single request.\n\n**Rate limits:** 20 requests and 100 unique domain resolutions per minute per IP address.`,
   tags: ["Brand Resolution"],
   request: {
     body: { content: { "application/json": { schema: z.object({ domains: z.array(z.string()).max(BRAND_BULK_RESOLVE_MAX_DOMAINS) }) } } },
@@ -4168,7 +4207,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           .trackRequest("brand", domain)
           .catch((err) => logger.debug({ err }, "Registry request tracking failed"));
 
-        const validation = await brandManager.validateDomain(domain);
+        const validation = liveValidation ?? await brandManager.validateDomain(domain);
         return res.status(404).json({
           error: "Brand not found",
           domain,
@@ -4411,7 +4450,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     }
   });
 
-  router.post("/brands/resolve/bulk", bulkResolveRateLimiter, async (req, res) => {
+  router.post("/brands/resolve/bulk", bulkResolveRateLimiter, brandBulkDomainRateLimiter, async (req, res) => {
     try {
       const { domains } = req.body;
 
@@ -4427,15 +4466,16 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         return res.status(400).json({ error: "All domains must be bare multi-label DNS hostnames" });
       }
 
-      const CONCURRENCY = 10;
       const results: Record<string, unknown> = {};
       const uniqueDomains = [...new Set(domains.map((d: string) => d.trim().toLowerCase()))];
 
-      for (let i = 0; i < uniqueDomains.length; i += CONCURRENCY) {
-        const batch = uniqueDomains.slice(i, i + CONCURRENCY);
+      for (let i = 0; i < uniqueDomains.length; i += BRAND_BULK_PROCESS_CONCURRENCY) {
+        const batch = uniqueDomains.slice(i, i + BRAND_BULK_PROCESS_CONCURRENCY);
         const settled = await Promise.allSettled(
           batch.map(async (domain) => {
-            const resolved = await brandManager.resolveBrand(domain);
+            const resolved = await brandBulkResolveSemaphore.run(
+              () => brandManager.resolveBrand(domain),
+            );
             if (resolved) {
               registryRequestsDb.markResolved("brand", domain, resolved.canonical_domain).catch((err) => logger.debug({ err }, "Registry request tracking failed"));
               return { domain, result: resolved };

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -566,7 +566,7 @@ registry.registerPath({
   operationId: "resolveBrand",
   summary: "Resolve brand",
   description:
-    "Resolve a domain to its canonical brand identity. Follows brand.json redirects and returns the resolved brand with its house, architecture type, and optional manifest.",
+    "Resolve a domain to its canonical brand identity. Follows brand.json redirects and returns the resolved brand with its house, architecture type, and optional manifest. The domain must be a bare DNS hostname.\n\n**Rate limit:** 60 requests per minute per IP address.",
   tags: ["Brand Resolution"],
   request: {
     query: z.object({
@@ -576,7 +576,9 @@ registry.registerPath({
   },
   responses: {
     200: { description: "Brand resolved successfully", content: { "application/json": { schema: ResolvedBrandSchema } } },
+    400: { description: "Invalid or missing domain", content: { "application/json": { schema: ErrorSchema } } },
     404: { description: "Brand not found", content: { "application/json": { schema: z.object({ error: z.string(), domain: z.string(), file_status: z.number().optional().openapi({ description: "HTTP status code from brand.json fetch (e.g. 404 vs 200 with invalid data)" }) }) } } },
+    429: { description: "Rate limit exceeded", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -593,6 +595,7 @@ registry.registerPath({
   },
   responses: {
     200: { description: "Bulk resolution results", content: { "application/json": { schema: z.object({ results: z.record(z.string(), ResolvedBrandSchema.nullable()) }) } } },
+    400: { description: "Invalid domain list", content: { "application/json": { schema: ErrorSchema } } },
     429: { description: "Rate limit exceeded", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
@@ -602,7 +605,7 @@ registry.registerPath({
   path: "/api/brands/brand-json",
   operationId: "getBrandJson",
   summary: "Get brand.json",
-  description: "Fetch the raw brand.json file for a domain.",
+  description: "Fetch the raw brand.json file for a bare DNS hostname.\n\n**Rate limit:** 60 requests per minute per IP address.",
   tags: ["Brand Resolution"],
   request: {
     query: z.object({
@@ -645,7 +648,9 @@ registry.registerPath({
         },
       },
     },
+    400: { description: "Invalid or missing domain", content: { "application/json": { schema: ErrorSchema } } },
     404: { description: "Brand not found", content: { "application/json": { schema: ErrorSchema } } },
+    429: { description: "Rate limit exceeded", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -803,6 +808,34 @@ function stripLegacyBrandContext(manifest: unknown): Record<string, unknown> | u
   if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return undefined;
   const { brand_context: _brandContext, ...publicManifest } = manifest as Record<string, unknown>;
   return publicManifest;
+}
+
+function storedBrandJsonVariant(
+  manifest: Record<string, unknown> | undefined,
+): 'house_portfolio' | 'brand_canonical' | undefined {
+  if (!manifest) return undefined;
+  if (
+    manifest.house &&
+    typeof manifest.house === 'object' &&
+    !Array.isArray(manifest.house) &&
+    (Array.isArray(manifest.brands) || Array.isArray(manifest.brand_refs))
+  ) {
+    return 'house_portfolio';
+  }
+  if (typeof manifest.id === 'string' && Array.isArray(manifest.names)) {
+    return 'brand_canonical';
+  }
+  return undefined;
+}
+
+function resolvedStoredBrandSource(brand: {
+  workos_organization_id?: string;
+  domain_verified?: boolean;
+  source_type: 'brand_json' | 'community' | 'enriched';
+}): 'hosted' | 'brand_json' | 'community' | 'enriched' {
+  return brand.workos_organization_id && brand.domain_verified === true
+    ? 'hosted'
+    : brand.source_type;
 }
 
 registry.registerPath({
@@ -4098,10 +4131,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
   router.get("/brands/resolve", registryReadRateLimiter, async (req, res) => {
     try {
-      const domain = req.query.domain as string;
+      const domain = typeof req.query.domain === 'string'
+        ? req.query.domain.trim().toLowerCase()
+        : '';
       const fresh = req.query.fresh === "true";
-      if (!domain) {
-        return res.status(400).json({ error: "domain parameter required" });
+      if (!isValidDomain(domain)) {
+        return res.status(400).json({ error: "Invalid domain format" });
       }
 
       const resolved = await brandManager.resolveBrand(domain, { skipCache: fresh });
@@ -4121,7 +4156,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             canonical_id: discovered.canonical_domain || discovered.domain,
             canonical_domain: discovered.canonical_domain || discovered.domain,
             brand_name: discovered.brand_name,
-            source: discovered.workos_organization_id ? 'hosted' : discovered.source_type,
+            source: resolvedStoredBrandSource(discovered),
             brand_manifest: stripLegacyBrandContext(discovered.brand_manifest),
             ...(liveValidation ? {
               live_brand_json: serializeBrandValidation(liveValidation),
@@ -4215,8 +4250,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     try {
       const domain = ((req.query.domain as string) || "").toLowerCase();
       const fresh = req.query.fresh === "true";
-      const domainPattern = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
-      if (!domain || !domainPattern.test(domain)) {
+      if (!isValidDomain(domain)) {
         return res.status(400).json({ error: "Invalid domain format" });
       }
 
@@ -4247,7 +4281,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         const data = { name: brand.brand_name || domain, ...manifest };
         const enrichedData = await enrichBrandDataWithVerification(data);
 
-        const variant = brand.source_type === "brand_json" ? "house_portfolio" : undefined;
+        const variant = brand.source_type === "brand_json"
+          ? storedBrandJsonVariant(manifest)
+          : undefined;
         const url = brand.source_type === "brand_json"
           ? `https://${domain}/.well-known/brand.json`
           : `https://agenticadvertising.org/brands/${domain}/brand.json`;
@@ -4384,13 +4420,15 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       if (domains.length > 100) {
         return res.status(400).json({ error: "Maximum 100 domains per request" });
       }
-      if (!domains.every((d: unknown) => typeof d === "string" && d.length > 0)) {
-        return res.status(400).json({ error: "All domains must be non-empty strings" });
+      if (!domains.every((d: unknown) =>
+        typeof d === "string" && isValidDomain(d.trim().toLowerCase())
+      )) {
+        return res.status(400).json({ error: "All domains must be bare multi-label DNS hostnames" });
       }
 
       const CONCURRENCY = 10;
       const results: Record<string, unknown> = {};
-      const uniqueDomains = [...new Set(domains.map((d: string) => d.toLowerCase()))];
+      const uniqueDomains = [...new Set(domains.map((d: string) => d.trim().toLowerCase()))];
 
       for (let i = 0; i < uniqueDomains.length; i += CONCURRENCY) {
         const batch = uniqueDomains.slice(i, i + CONCURRENCY);
@@ -4413,7 +4451,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
                   canonical_id: discovered.canonical_domain || discovered.domain,
                   canonical_domain: discovered.canonical_domain || discovered.domain,
                   brand_name: discovered.brand_name,
-                  source: discovered.workos_organization_id ? 'hosted' : discovered.source_type,
+                  source: resolvedStoredBrandSource(discovered),
                   brand_manifest: stripLegacyBrandContext(discovered.brand_manifest),
                 },
               };

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -20,6 +20,7 @@ import { query } from "../db/client.js";
 import { resolvePrimaryOrganization } from "../db/users-db.js";
 import * as manifestRefsDb from "../db/manifest-refs-db.js";
 import { isUuid } from "../utils/uuid.js";
+import { AsyncSemaphore, SemaphoreOverloadedError } from "../utils/async-semaphore.js";
 import { bulkResolveRateLimiter, brandBulkDomainRateLimiter, brandCreationRateLimiter, storyboardEvalRateLimiter, storyboardStepRateLimiter, agentReadRateLimiter, registryPublisherRateLimiter, registryReadRateLimiter } from "../middleware/rate-limit.js";
 import { listStoryboards, getStoryboard, getTestKitForStoryboard } from "../services/storyboards.js";
 import {
@@ -475,44 +476,16 @@ function extractDomain(raw: string): string {
 const VALID_DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
 const BRAND_BULK_RESOLVE_MAX_DOMAINS = 25;
 const BRAND_BULK_PROCESS_CONCURRENCY = 10;
-
-class AsyncSemaphore {
-  private active = 0;
-  private readonly queue: Array<() => void> = [];
-
-  constructor(private readonly limit: number) {}
-
-  async run<T>(task: () => Promise<T>): Promise<T> {
-    await this.acquire();
-    try {
-      return await task();
-    } finally {
-      this.release();
-    }
-  }
-
-  private acquire(): Promise<void> {
-    if (this.active < this.limit) {
-      this.active++;
-      return Promise.resolve();
-    }
-    return new Promise((resolve) => this.queue.push(resolve));
-  }
-
-  private release(): void {
-    const next = this.queue.shift();
-    if (next) {
-      // Transfer the released permit directly to the oldest waiter.
-      next();
-      return;
-    }
-    this.active--;
-  }
-}
+// Four full requests may wait behind the in-flight batch. Past that the work
+// is queued longer than a caller will wait for it, so shed instead of growing.
+const BRAND_BULK_QUEUE_LIMIT = BRAND_BULK_RESOLVE_MAX_DOMAINS * 4;
 
 // Shared by every router instance in this process so simultaneous bulk
 // requests cannot multiply their per-request fan-out into unbounded work.
-const brandBulkResolveSemaphore = new AsyncSemaphore(BRAND_BULK_PROCESS_CONCURRENCY);
+const brandBulkResolveSemaphore = new AsyncSemaphore(
+  BRAND_BULK_PROCESS_CONCURRENCY,
+  BRAND_BULK_QUEUE_LIMIT,
+);
 
 function isValidDomain(domain: string): boolean {
   return domain.length <= 253 && VALID_DOMAIN_RE.test(domain);
@@ -605,13 +578,20 @@ registry.registerPath({
   path: "/api/brands/resolve",
   operationId: "resolveBrand",
   summary: "Resolve brand",
-  description:
-    "Resolve a domain to its canonical brand identity. Follows brand.json redirects and returns the resolved brand with its house, architecture type, and optional manifest. The domain must be a bare DNS hostname.\n\n**Rate limit:** 60 requests per minute per IP address.",
+  description: [
+    "Resolve a domain to its canonical brand identity. Follows brand.json redirects and returns the resolved brand with its house, architecture type, and optional manifest. The domain must be a bare DNS hostname.",
+    "",
+    "A domain is authoritative for its own identity, so `source` tells you who published the record and `relationship_trust` tells you whether a brand-to-house relationship was confirmed by both sides. Only `mutual` and `inline` are reciprocated; treat everything else as a claim.",
+    "",
+    "**Rate limit:** 60 requests per minute per IP address.",
+  ].join("\n"),
   tags: ["Brand Resolution"],
   request: {
     query: z.object({
       domain: z.string().openapi({ example: "acmecorp.com" }),
-      fresh: z.enum(["true", "false"]).optional(),
+      fresh: z.enum(["true", "false"]).optional().openapi({
+        description: "Bypass the resolution cache and refetch from the origin. When a fresh fetch fails and a stored record is returned instead, `live_brand_json` carries that fetch's diagnostics.",
+      }),
     }),
   },
   responses: {
@@ -627,8 +607,11 @@ registry.registerPath({
   path: "/api/brands/resolve/bulk",
   operationId: "resolveBrandsBulk",
   summary: "Bulk resolve brands",
-  description:
-    `Resolve up to ${BRAND_BULK_RESOLVE_MAX_DOMAINS} domains to their canonical brand identities in a single request.\n\n**Rate limits:** 20 requests and 100 unique domain resolutions per minute per IP address.`,
+  description: [
+    `Resolve up to ${BRAND_BULK_RESOLVE_MAX_DOMAINS} domains to their canonical brand identities in a single request. Unresolvable domains map to \`null\`.`,
+    "",
+    "**Rate limits:** 20 requests and 100 unique domain resolutions per minute per IP address. Request bodies are capped at 16 KB.",
+  ].join("\n"),
   tags: ["Brand Resolution"],
   request: {
     body: { content: { "application/json": { schema: z.object({ domains: z.array(z.string()).max(BRAND_BULK_RESOLVE_MAX_DOMAINS) }) } } },
@@ -636,7 +619,9 @@ registry.registerPath({
   responses: {
     200: { description: "Bulk resolution results", content: { "application/json": { schema: z.object({ results: z.record(z.string(), ResolvedBrandSchema.nullable()) }) } } },
     400: { description: "Invalid domain list", content: { "application/json": { schema: ErrorSchema } } },
+    413: { description: "Request body over 16 KB", content: { "application/json": { schema: ErrorSchema } } },
     429: { description: "Rate limit exceeded", content: { "application/json": { schema: ErrorSchema } } },
+    503: { description: "Too much resolution work is already queued", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -868,6 +853,10 @@ function storedBrandJsonVariant(
   return undefined;
 }
 
+/**
+ * `hosted` means a verified owner registered the row. Same definition as the
+ * registry listing's `OWNER_HOSTED_SQL` — keep the two in step.
+ */
 function resolvedStoredBrandSource(brand: {
   workos_organization_id?: string;
   domain_verified?: boolean;
@@ -4179,10 +4168,10 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         return res.status(400).json({ error: "Invalid domain format" });
       }
 
-      const resolved = await brandManager.resolveBrand(domain, { skipCache: fresh });
-      const liveValidation = fresh && !resolved
-        ? brandManager.getLastValidationResult(domain) ?? await brandManager.validateDomain(domain)
-        : undefined;
+      const resolution = await brandManager.resolveBrandWithDiagnostics(domain, { skipCache: fresh });
+      const resolved = resolution.brand;
+      // Report why this request fell back, from this request's own attempt.
+      const liveValidation = fresh && !resolved ? resolution.last_attempt : undefined;
       if (!resolved) {
         const discovered = await brandDb.getDiscoveredBrandByDomain(domain);
         // Hide orphaned manifests and explicitly non-public rows. The manifest
@@ -4506,12 +4495,24 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         for (const outcome of settled) {
           if (outcome.status === "fulfilled") {
             results[outcome.value.domain] = outcome.value.result;
+          } else if (outcome.reason instanceof SemaphoreOverloadedError) {
+            // Shedding one domain means the process is saturated; say so rather
+            // than returning a partial map that reads as unresolvable domains.
+            throw outcome.reason;
           }
         }
       }
 
       return res.json({ results });
     } catch (error) {
+      if (error instanceof SemaphoreOverloadedError) {
+        logger.warn({ ip: req.ip }, "Brand bulk resolve shed load");
+        res.setHeader("Retry-After", "5");
+        return res.status(503).json({
+          error: "Brand resolution is busy",
+          message: "Too much resolution work is already queued. Retry shortly.",
+        });
+      }
       logger.error({ error }, "Failed to bulk resolve brands");
       return res.status(500).json({ error: "Failed to bulk resolve brands" });
     }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -502,6 +502,27 @@ export interface RegistryApiConfig {
   optionalAuth?: RequestHandler;
 }
 
+function serializeBrandValidation(
+  validation: Awaited<ReturnType<RegistryApiConfig['brandManager']['validateDomain']>>
+) {
+  const truncate = (value: string) => value.length > 500 ? `${value.slice(0, 497)}...` : value;
+  return {
+    valid: validation.valid,
+    url: validation.url,
+    status_code: validation.status_code,
+    errors: validation.errors.slice(0, 20).map((issue) => ({
+      field: truncate(issue.field),
+      message: truncate(issue.message),
+      severity: issue.severity,
+    })),
+    warnings: validation.warnings.slice(0, 20).map((warning) => ({
+      field: truncate(warning.field),
+      message: truncate(warning.message),
+      ...(warning.suggestion ? { suggestion: truncate(warning.suggestion) } : {}),
+    })),
+  };
+}
+
 // ── Helpers ─────────────────────────────────────────────────────
 
 function extractPublisherStats(result: { valid: boolean; raw_data?: any }) {
@@ -590,7 +611,40 @@ registry.registerPath({
     }),
   },
   responses: {
-    200: { description: "Raw brand.json data", content: { "application/json": { schema: z.object({ domain: z.string(), url: z.string(), variant: z.string().optional(), data: z.record(z.string(), z.unknown()), warnings: z.array(z.string()).optional() }) } } },
+    200: {
+      description: "Raw brand.json data",
+      content: {
+        "application/json": {
+          schema: z.object({
+            domain: z.string(),
+            url: z.string(),
+            variant: z.string().optional(),
+            data: z.record(z.string(), z.unknown()),
+            warnings: z.array(z.object({
+              field: z.string(),
+              message: z.string(),
+              suggestion: z.string().optional(),
+            })).optional(),
+            promoted_from_schema: z.string().optional(),
+            live_brand_json: z.object({
+              valid: z.boolean(),
+              url: z.string(),
+              status_code: z.number().int().optional(),
+              errors: z.array(z.object({
+                field: z.string(),
+                message: z.string(),
+                severity: z.literal("error"),
+              })),
+              warnings: z.array(z.object({
+                field: z.string(),
+                message: z.string(),
+                suggestion: z.string().optional(),
+              })),
+            }).optional(),
+          }),
+        },
+      },
+    },
     404: { description: "Brand not found", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
@@ -4042,7 +4096,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     }
   });
 
-  router.get("/brands/resolve", async (req, res) => {
+  router.get("/brands/resolve", registryReadRateLimiter, async (req, res) => {
     try {
       const domain = req.query.domain as string;
       const fresh = req.query.fresh === "true";
@@ -4051,6 +4105,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       }
 
       const resolved = await brandManager.resolveBrand(domain, { skipCache: fresh });
+      const liveValidation = fresh && !resolved
+        ? brandManager.getLastValidationResult(domain) ?? await brandManager.validateDomain(domain)
+        : undefined;
       if (!resolved) {
         const discovered = await brandDb.getDiscoveredBrandByDomain(domain);
         // Hide orphaned manifests and explicitly non-public rows. The manifest
@@ -4064,8 +4121,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             canonical_id: discovered.canonical_domain || discovered.domain,
             canonical_domain: discovered.canonical_domain || discovered.domain,
             brand_name: discovered.brand_name,
-            source: discovered.source_type,
+            source: discovered.workos_organization_id ? 'hosted' : discovered.source_type,
             brand_manifest: stripLegacyBrandContext(discovered.brand_manifest),
+            ...(liveValidation ? {
+              live_brand_json: serializeBrandValidation(liveValidation),
+            } : {}),
           });
         }
         registryRequestsDb
@@ -4151,7 +4211,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     return enriched;
   }
 
-  router.get("/brands/brand-json", async (req, res) => {
+  router.get("/brands/brand-json", registryReadRateLimiter, async (req, res) => {
     try {
       const domain = ((req.query.domain as string) || "").toLowerCase();
       const fresh = req.query.fresh === "true";
@@ -4160,9 +4220,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         return res.status(400).json({ error: "Invalid domain format" });
       }
 
+      let liveValidation: Awaited<ReturnType<typeof brandManager.validateDomain>> | undefined;
+
       // If fresh=true, fetch live from external domain and update DB cache
       if (fresh) {
         const result = await brandManager.validateDomain(domain, { skipCache: true });
+        liveValidation = result;
         if (result.valid && result.raw_data) {
           const enrichedData = await enrichBrandDataWithVerification(result.raw_data);
           return res.json({
@@ -4171,6 +4234,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             variant: result.variant,
             data: enrichedData,
             warnings: result.warnings,
+            promoted_from_schema: result.promoted_from_schema,
           });
         }
         // Live fetch failed — fall through to DB cache
@@ -4188,7 +4252,15 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           ? `https://${domain}/.well-known/brand.json`
           : `https://agenticadvertising.org/brands/${domain}/brand.json`;
 
-        return res.json({ domain, url, variant, data: enrichedData });
+        return res.json({
+          domain,
+          url,
+          variant,
+          data: enrichedData,
+          ...(liveValidation ? {
+            live_brand_json: serializeBrandValidation(liveValidation),
+          } : {}),
+        });
       }
 
       // Nothing in DB — try live fetch as last resort
@@ -4201,6 +4273,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           variant: result.variant,
           data: enrichedData,
           warnings: result.warnings,
+          promoted_from_schema: result.promoted_from_schema,
         });
       }
 
@@ -4340,7 +4413,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
                   canonical_id: discovered.canonical_domain || discovered.domain,
                   canonical_domain: discovered.canonical_domain || discovered.domain,
                   brand_name: discovered.brand_name,
-                  source: discovered.source_type,
+                  source: discovered.workos_organization_id ? 'hosted' : discovered.source_type,
                   brand_manifest: stripLegacyBrandContext(discovered.brand_manifest),
                 },
               };

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -473,6 +473,7 @@ function extractDomain(raw: string): string {
 }
 
 const VALID_DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+const BRAND_BULK_RESOLVE_MAX_DOMAINS = 25;
 
 function isValidDomain(domain: string): boolean {
   return domain.length <= 253 && VALID_DOMAIN_RE.test(domain);
@@ -588,10 +589,10 @@ registry.registerPath({
   operationId: "resolveBrandsBulk",
   summary: "Bulk resolve brands",
   description:
-    "Resolve up to 100 domains to their canonical brand identities in a single request.\n\n**Rate limit:** 20 requests per minute per IP address.",
+    `Resolve up to ${BRAND_BULK_RESOLVE_MAX_DOMAINS} domains to their canonical brand identities in a single request.\n\n**Rate limit:** 20 requests per minute per IP address.`,
   tags: ["Brand Resolution"],
   request: {
-    body: { content: { "application/json": { schema: z.object({ domains: z.array(z.string()).max(100) }) } } },
+    body: { content: { "application/json": { schema: z.object({ domains: z.array(z.string()).max(BRAND_BULK_RESOLVE_MAX_DOMAINS) }) } } },
   },
   responses: {
     200: { description: "Bulk resolution results", content: { "application/json": { schema: z.object({ results: z.record(z.string(), ResolvedBrandSchema.nullable()) }) } } },
@@ -4417,8 +4418,8 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       if (!Array.isArray(domains) || domains.length === 0) {
         return res.status(400).json({ error: "domains array required" });
       }
-      if (domains.length > 100) {
-        return res.status(400).json({ error: "Maximum 100 domains per request" });
+      if (domains.length > BRAND_BULK_RESOLVE_MAX_DOMAINS) {
+        return res.status(400).json({ error: `Maximum ${BRAND_BULK_RESOLVE_MAX_DOMAINS} domains per request` });
       }
       if (!domains.every((d: unknown) =>
         typeof d === "string" && isValidDomain(d.trim().toLowerCase())

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -449,6 +449,26 @@ const MemberRefSchema = z.object({
   }),
 });
 
+const BrandValidationIssueSchema = z.object({
+  field: z.string(),
+  message: z.string(),
+  severity: z.literal("error"),
+});
+
+const BrandValidationWarningSchema = z.object({
+  field: z.string(),
+  message: z.string(),
+  suggestion: z.string().optional(),
+});
+
+const LiveBrandJsonValidationSchema = z.object({
+  valid: z.boolean(),
+  url: z.string(),
+  status_code: z.number().int().optional(),
+  errors: z.array(BrandValidationIssueSchema),
+  warnings: z.array(BrandValidationWarningSchema),
+});
+
 export const ResolvedBrandSchema = z
   .object({
     canonical_id: z.string().openapi({ example: "acmecorp.com" }),
@@ -460,10 +480,26 @@ export const ResolvedBrandSchema = z
       .optional(),
     parent_brand: z.string().optional(),
     house_domain: z.string().optional(),
+    claimed_house_domain: z.string().optional().openapi({
+      description: "Unilateral house claim from a canonical document. Does not extend relationship trust unless relationship_trust is mutual.",
+    }),
     house_name: z.string().optional(),
+    relationship_trust: z.enum([
+      "inline",
+      "mutual",
+      "leaf_only",
+      "house_only",
+      "standalone",
+      "unverifiable",
+    ]).optional(),
+    promoted_from_schema: z.string().optional(),
+    migration_warnings: z.array(BrandValidationWarningSchema).optional(),
     brand_agent_url: z.string().optional(),
     brand_manifest: z.record(z.string(), z.unknown()).optional(),
-    source: z.enum(["brand_json", "community", "enriched"]),
+    source: z.enum(["hosted", "brand_json", "community", "enriched"]),
+    live_brand_json: LiveBrandJsonValidationSchema.optional().openapi({
+      description: "Live origin-validation diagnostics when fresh=true falls back to a stored registry record.",
+    }),
   })
   .openapi("ResolvedBrand");
 

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -481,7 +481,7 @@ export const ResolvedBrandSchema = z
     parent_brand: z.string().optional(),
     house_domain: z.string().optional(),
     claimed_house_domain: z.string().optional().openapi({
-      description: "Unilateral house claim from a canonical document. Does not extend relationship trust unless relationship_trust is mutual.",
+      description: "House the requested domain claims. One-sided until the named house names it back, so it never extends relationship trust on its own.",
     }),
     house_name: z.string().optional(),
     relationship_trust: z.enum([
@@ -491,12 +491,30 @@ export const ResolvedBrandSchema = z
       "house_only",
       "standalone",
       "unverifiable",
-    ]).optional(),
-    promoted_from_schema: z.string().optional(),
+    ]).optional().openapi({
+      description: [
+        "How the brand-to-house relationship was established.",
+        "`inline`: the house's own document defines the brand.",
+        "`mutual`: both sides publish the relationship — the trust-extending edge.",
+        "`leaf_only`: the brand claims a house that has not reciprocated.",
+        "`house_only`: a house claims the brand, which has not reciprocated.",
+        "`standalone`: the brand claims no house.",
+        "`unverifiable`: a claimed house could not be checked.",
+      ].join(" "),
+    }),
+    relationship_verified_at: z.string().optional().openapi({
+      description: "When both sides of a mutual relationship were last seen agreeing. Present only for `mutual`, and it does not advance while the house side is unreachable, so callers can apply their own edge-aging policy.",
+      example: "2026-07-28T12:00:00Z",
+    }),
+    promoted_from_schema: z.string().optional().openapi({
+      description: "Set when a pre-v3 document was promoted to a canonical v3 document for this response. Identity only — legacy relationship data is preserved opaquely, never promoted to a trust claim.",
+    }),
     migration_warnings: z.array(BrandValidationWarningSchema).optional(),
     brand_agent_url: z.string().optional(),
     brand_manifest: z.record(z.string(), z.unknown()).optional(),
-    source: z.enum(["hosted", "brand_json", "community", "enriched"]),
+    source: z.enum(["hosted", "brand_json", "community", "enriched"]).openapi({
+      description: "Where the record came from. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment.",
+    }),
     live_brand_json: LiveBrandJsonValidationSchema.optional().openapi({
       description: "Live origin-validation diagnostics when fresh=true falls back to a stored registry record.",
     }),

--- a/server/src/services/brand-json-schema-validator.ts
+++ b/server/src/services/brand-json-schema-validator.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import Ajv, { type ErrorObject, type ValidateFunction } from 'ajv';
+import addFormats from 'ajv-formats';
+
+let cachedValidator: ValidateFunction | null = null;
+let cachedSchema: Record<string, unknown> | null = null;
+
+function schemaPath(ref: string): string {
+  const relative = ref.startsWith('/schemas/') ? ref.slice('/schemas/'.length) : ref;
+  return join(process.cwd(), 'static/schemas/source', relative);
+}
+
+function brandSchema(): Record<string, unknown> {
+  if (!cachedSchema) {
+    cachedSchema = JSON.parse(
+      readFileSync(join(process.cwd(), 'static/schemas/source/brand.json'), 'utf8')
+    ) as Record<string, unknown>;
+  }
+  return cachedSchema;
+}
+
+function preloadRefs(ajv: Ajv): void {
+  const seen = new Set<string>();
+  const visit = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+
+    const record = node as Record<string, unknown>;
+    const ref = record.$ref;
+    if (typeof ref === 'string' && ref.startsWith('/schemas/') && !seen.has(ref)) {
+      seen.add(ref);
+      const referenced = JSON.parse(readFileSync(schemaPath(ref), 'utf8')) as Record<string, unknown>;
+      if (typeof referenced.$id !== 'string') referenced.$id = ref;
+      ajv.addSchema(referenced, ref);
+      visit(referenced);
+    }
+    Object.values(record).forEach(visit);
+  };
+  visit(brandSchema());
+}
+
+function validator(): ValidateFunction {
+  if (!cachedValidator) {
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    addFormats(ajv);
+    preloadRefs(ajv);
+    cachedValidator = ajv.compile(brandSchema());
+  }
+  return cachedValidator;
+}
+
+export function validateBrandJsonSchema(data: unknown): {
+  valid: boolean;
+  errors: ErrorObject[];
+} {
+  const validate = validator();
+  return {
+    valid: Boolean(validate(data)),
+    errors: [...(validate.errors ?? [])],
+  };
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -601,6 +601,8 @@ export interface ResolvedBrand {
   claimed_house_domain?: string;
   house_name?: string;
   relationship_trust?: 'inline' | 'mutual' | 'leaf_only' | 'house_only' | 'standalone' | 'unverifiable';
+  /** When the mutual-assertion edge was last confirmed by both sides. */
+  relationship_verified_at?: string;
   promoted_from_schema?: string;
   migration_warnings?: Array<{ field: string; message: string; suggestion?: string }>;
   brand_agent_url?: string;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -597,10 +597,15 @@ export interface ResolvedBrand {
   keller_type?: KellerType;
   parent_brand?: string;
   house_domain?: string;
+  /** Unilateral parent claim from a canonical document; not trust-extending. */
+  claimed_house_domain?: string;
   house_name?: string;
+  relationship_trust?: 'inline' | 'mutual' | 'leaf_only' | 'house_only' | 'standalone' | 'unverifiable';
+  promoted_from_schema?: string;
+  migration_warnings?: Array<{ field: string; message: string; suggestion?: string }>;
   brand_agent_url?: string;
   brand_manifest?: Record<string, unknown>;
-  source: 'brand_json' | 'community' | 'enriched';
+  source: 'hosted' | 'brand_json' | 'community' | 'enriched';
 }
 
 /**

--- a/server/src/utils/async-semaphore.ts
+++ b/server/src/utils/async-semaphore.ts
@@ -1,0 +1,55 @@
+/**
+ * Bounds how much concurrent work a process will take on, and how much it will
+ * hold in memory waiting. Once the wait list is full, `run` rejects with
+ * `SemaphoreOverloadedError` so the caller can shed load instead of queueing
+ * work nobody is still waiting for.
+ */
+export class SemaphoreOverloadedError extends Error {
+  constructor(maxQueued: number) {
+    super(`Work queue is full (${maxQueued} waiting)`);
+    this.name = 'SemaphoreOverloadedError';
+  }
+}
+
+export class AsyncSemaphore {
+  private active = 0;
+  private readonly queue: Array<() => void> = [];
+
+  constructor(
+    private readonly limit: number,
+    private readonly maxQueued: number,
+  ) {
+    if (limit < 1) throw new Error('AsyncSemaphore limit must be at least 1');
+    if (maxQueued < 0) throw new Error('AsyncSemaphore maxQueued cannot be negative');
+  }
+
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.active < this.limit) {
+      this.active++;
+      return Promise.resolve();
+    }
+    if (this.queue.length >= this.maxQueued) {
+      return Promise.reject(new SemaphoreOverloadedError(this.maxQueued));
+    }
+    return new Promise((resolve) => this.queue.push(resolve));
+  }
+
+  private release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      // Transfer the released permit directly to the oldest waiter.
+      next();
+      return;
+    }
+    this.active--;
+  }
+}

--- a/server/tests/integration/brand-registry-list.test.ts
+++ b/server/tests/integration/brand-registry-list.test.ts
@@ -16,16 +16,29 @@ describe('BrandDatabase.getAllBrandsForRegistry', () => {
     brandDb = new BrandDatabase();
   });
 
+  const OWNER_ORG_ID = 'org_brand_registry_list_test';
+
   afterAll(async () => {
     await pool.query("DELETE FROM brands WHERE domain LIKE '%.example.com'");
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [OWNER_ORG_ID]);
     await closeDatabase();
   });
 
   beforeEach(async () => {
     await pool.query("DELETE FROM brands WHERE domain LIKE '%.example.com'");
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, 'Brand Registry List Test Org', NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [OWNER_ORG_ID]
+    );
   });
 
-  async function insertBrand(overrides: Record<string, unknown>) {
+  /**
+   * `owner_verified: true` is the shape the registry labels `hosted`: an
+   * organization owns the row and control of the domain was verified.
+   */
+  async function insertBrand(overrides: Record<string, unknown> & { owner_verified?: boolean }) {
     const defaults = {
       domain: 'test.example.com',
       brand_name: 'Test Brand',
@@ -35,10 +48,12 @@ describe('BrandDatabase.getAllBrandsForRegistry', () => {
       domain_verified: false,
       review_status: 'approved',
     };
-    const row = { ...defaults, ...overrides };
+    const { owner_verified, ...rest } = overrides;
+    const row = { ...defaults, ...rest };
+    if (owner_verified) row.domain_verified = true;
     await pool.query(
-      `INSERT INTO brands (domain, brand_name, source_type, is_public, has_brand_manifest, domain_verified, review_status, brand_manifest, house_domain)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      `INSERT INTO brands (domain, brand_name, source_type, is_public, has_brand_manifest, domain_verified, review_status, brand_manifest, house_domain, workos_organization_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
        ON CONFLICT (domain) DO UPDATE SET
          brand_name = EXCLUDED.brand_name,
          source_type = EXCLUDED.source_type,
@@ -47,7 +62,8 @@ describe('BrandDatabase.getAllBrandsForRegistry', () => {
          domain_verified = EXCLUDED.domain_verified,
          review_status = EXCLUDED.review_status,
          brand_manifest = EXCLUDED.brand_manifest,
-         house_domain = EXCLUDED.house_domain`,
+         house_domain = EXCLUDED.house_domain,
+         workos_organization_id = EXCLUDED.workos_organization_id`,
       [
         row.domain,
         row.brand_name,
@@ -58,6 +74,9 @@ describe('BrandDatabase.getAllBrandsForRegistry', () => {
         row.review_status,
         row.brand_manifest ? JSON.stringify(row.brand_manifest) : null,
         row.house_domain || null,
+        owner_verified || (overrides as Record<string, unknown>).workos_organization_id
+          ? (overrides as Record<string, unknown>).workos_organization_id ?? OWNER_ORG_ID
+          : null,
       ]
     );
   }
@@ -68,13 +87,14 @@ describe('BrandDatabase.getAllBrandsForRegistry', () => {
     expect(result).toBeInstanceOf(Array);
   });
 
-  it('returns hosted brands with source=hosted', async () => {
+  it('returns owner-verified brands with source=hosted', async () => {
     await insertBrand({
       domain: 'hosted-brand.example.com',
       brand_name: 'Hosted Brand',
       is_public: true,
       source_type: 'community',
-      domain_verified: true,
+      owner_verified: true,
+      brand_manifest: { name: 'Hosted Brand' },
     });
     const result = await brandDb.getAllBrandsForRegistry({});
     const hosted = result.find((b) => b.domain === 'hosted-brand.example.com');
@@ -82,6 +102,52 @@ describe('BrandDatabase.getAllBrandsForRegistry', () => {
     expect(hosted!.source).toBe('hosted');
     expect(hosted!.has_manifest).toBe(true);
     expect(hosted!.verified).toBe(true);
+  });
+
+  // is_public defaults to TRUE on every crawler-discovered row, so it cannot
+  // stand in for "an owner registered this".
+  it('does not label a public crawler-discovered row as hosted', async () => {
+    await insertBrand({
+      domain: 'crawled-brand.example.com',
+      brand_name: 'Crawled Brand',
+      is_public: true,
+      source_type: 'brand_json',
+    });
+    const result = await brandDb.getAllBrandsForRegistry({});
+    const crawled = result.find((b) => b.domain === 'crawled-brand.example.com');
+    expect(crawled!.source).toBe('brand_json');
+    // A document served from the domain's own origin proves control of it.
+    expect(crawled!.verified).toBe(true);
+  });
+
+  it('does not label an unverified owner claim as hosted', async () => {
+    await insertBrand({
+      domain: 'unverified-owner.example.com',
+      brand_name: 'Unverified Owner',
+      is_public: true,
+      source_type: 'community',
+      workos_organization_id: OWNER_ORG_ID,
+      domain_verified: false,
+    });
+    const result = await brandDb.getAllBrandsForRegistry({});
+    const row = result.find((b) => b.domain === 'unverified-owner.example.com');
+    expect(row!.source).toBe('community');
+    expect(row!.verified).toBe(false);
+  });
+
+  it('reports has_manifest from actual manifest content', async () => {
+    await insertBrand({
+      domain: 'empty-manifest.example.com',
+      brand_name: 'Empty Manifest',
+      is_public: true,
+      source_type: 'community',
+      owner_verified: true,
+      brand_manifest: {},
+    });
+    const result = await brandDb.getAllBrandsForRegistry({});
+    const row = result.find((b) => b.domain === 'empty-manifest.example.com');
+    expect(row!.source).toBe('hosted');
+    expect(row!.has_manifest).toBe(false);
   });
 
   it('returns community brands with their actual source_type', async () => {
@@ -159,12 +225,13 @@ describe('BrandDatabase.getAllBrandsForRegistry', () => {
     // bug (#3521) was that the filter was ignored entirely.
 
     async function seedAllSources(prefix = 'src') {
-      // Owner-registered: source_type='community' AND is_public=true → response label 'hosted'
+      // Owner-registered and domain-verified → response label 'hosted'
       await insertBrand({
         domain: `${prefix}-hosted.example.com`,
         brand_name: 'Hosted Owner',
         is_public: true,
         source_type: 'community',
+        owner_verified: true,
       });
       // Crawler-discovered with live brand.json → response label 'brand_json'
       await insertBrand({
@@ -189,7 +256,7 @@ describe('BrandDatabase.getAllBrandsForRegistry', () => {
       });
     }
 
-    it('?source=hosted returns only is_public=true rows', async () => {
+    it('?source=hosted returns only owner-verified rows', async () => {
       await seedAllSources('hosted');
       const result = await brandDb.getAllBrandsForRegistry({ search: 'hosted-', source: 'hosted' });
       expect(result.length).toBe(1);
@@ -198,13 +265,14 @@ describe('BrandDatabase.getAllBrandsForRegistry', () => {
     });
 
     it('?source=brand_json excludes hosted rows even if source_type would match', async () => {
-      // A pathological row: source_type='brand_json' AND is_public=true.
-      // Response labels it 'hosted', so ?source=brand_json must NOT return it.
+      // A row an owner claimed that also has a live brand.json. The response
+      // labels it 'hosted', so ?source=brand_json must NOT return it.
       await insertBrand({
         domain: 'mixed.example.com',
         brand_name: 'Mixed',
         is_public: true,
         source_type: 'brand_json',
+        owner_verified: true,
       });
       await insertBrand({
         domain: 'pure-bj.example.com',
@@ -260,7 +328,7 @@ describe('BrandDatabase.getAllBrandsForRegistry', () => {
 
   describe('getBrandRegistryStats', () => {
     it('hosted, brand_json, community, enriched are disjoint and reconcile with filter results', async () => {
-      // is_public=true is counted ONLY as hosted; the source_type buckets
+      // An owner-verified row counts ONLY as hosted; the source_type buckets
       // exclude it. Otherwise the dashboard double-counts owner-registered
       // brands and the filter+stats pair becomes inconsistent.
       await insertBrand({
@@ -268,6 +336,7 @@ describe('BrandDatabase.getAllBrandsForRegistry', () => {
         brand_name: 'Stats Hosted',
         is_public: true,
         source_type: 'community',
+        owner_verified: true,
       });
       await insertBrand({
         domain: 'stats-bj.example.com',

--- a/server/tests/unit/async-semaphore.test.ts
+++ b/server/tests/unit/async-semaphore.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { AsyncSemaphore, SemaphoreOverloadedError } from '../../src/utils/async-semaphore.js';
+
+/** A task that only settles when the test says so. */
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+describe('AsyncSemaphore', () => {
+  it('runs up to the limit concurrently and defers the rest', async () => {
+    const semaphore = new AsyncSemaphore(2, 10);
+    const gates = [deferred(), deferred(), deferred()];
+    let started = 0;
+
+    const runs = gates.map((gate) => semaphore.run(async () => {
+      started++;
+      await gate.promise;
+    }));
+
+    await Promise.resolve();
+    expect(started).toBe(2);
+
+    gates[0].resolve();
+    await runs[0];
+    expect(started).toBe(3);
+
+    gates[1].resolve();
+    gates[2].resolve();
+    await Promise.all(runs);
+  });
+
+  it('rejects once the wait list is full instead of queueing without bound', async () => {
+    const semaphore = new AsyncSemaphore(1, 1);
+    const active = deferred();
+    const queued = deferred();
+
+    const running = semaphore.run(async () => { await active.promise; });
+    const waiting = semaphore.run(async () => { await queued.promise; });
+
+    await expect(semaphore.run(async () => undefined)).rejects.toBeInstanceOf(SemaphoreOverloadedError);
+
+    active.resolve();
+    queued.resolve();
+    await Promise.all([running, waiting]);
+  });
+
+  it('frees capacity again after a shed request', async () => {
+    const semaphore = new AsyncSemaphore(1, 0);
+    const active = deferred();
+
+    const running = semaphore.run(async () => { await active.promise; });
+    await expect(semaphore.run(async () => undefined)).rejects.toBeInstanceOf(SemaphoreOverloadedError);
+
+    active.resolve();
+    await running;
+
+    await expect(semaphore.run(async () => 'ok')).resolves.toBe('ok');
+  });
+
+  it('releases the permit when a task throws', async () => {
+    const semaphore = new AsyncSemaphore(1, 0);
+
+    await expect(semaphore.run(async () => { throw new Error('task failed'); })).rejects.toThrow('task failed');
+    await expect(semaphore.run(async () => 'ok')).resolves.toBe('ok');
+  });
+});

--- a/server/tests/unit/brand-manager-cache.test.ts
+++ b/server/tests/unit/brand-manager-cache.test.ts
@@ -122,8 +122,46 @@ describe('BrandManager caching', () => {
       expect((await manager.validateDomain('stable.example')).valid).toBe(true);
       expect((await manager.validateDomain('stable.example', { skipCache: true })).valid).toBe(false);
       expect(manager.getLastValidationResult('stable.example')?.status_code).toBe(503);
+      expect(manager.getLastValidationResult('stable.example')?.raw_data).toBeUndefined();
       expect((await manager.validateDomain('stable.example')).valid).toBe(true);
       expect(mockedSafeFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects non-hostname lookup inputs without issuing a request', async () => {
+      const result = await manager.validateDomain('public.example:8443/admin?probe=true');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toEqual(expect.arrayContaining([
+        expect.objectContaining({ field: 'domain' }),
+      ]));
+      expect(mockedSafeFetch).not.toHaveBeenCalled();
+    });
+
+    it('bounds and expires body-free validation diagnostics', () => {
+      vi.useFakeTimers();
+      const recordAttempt = (manager as unknown as {
+        recordLastValidationAttempt(domain: string, result: Record<string, unknown>): void;
+      }).recordLastValidationAttempt.bind(manager);
+      try {
+        for (let i = 0; i <= 500; i++) {
+          recordAttempt(`brand-${i}.example`, {
+            valid: true,
+            errors: [],
+            warnings: [],
+            domain: `brand-${i}.example`,
+            url: `https://brand-${i}.example/.well-known/brand.json`,
+            raw_data: { oversized: 'not retained' },
+          });
+        }
+
+        expect(manager.getLastValidationResult('brand-0.example')).toBeUndefined();
+        expect(manager.getLastValidationResult('brand-500.example')).not.toHaveProperty('raw_data');
+
+        vi.advanceTimersByTime(5 * 60 * 1000);
+        expect(manager.getLastValidationResult('brand-500.example')).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('promotes the narrow legacy portfolio shape without inventing trust relationships', async () => {
@@ -143,6 +181,7 @@ describe('BrandManager caching', () => {
             properties: [
               { type: 'website', identifier: 'example.com', relationship: 'owned' },
               { type: 'website', identifier: 'alias.example' },
+              { type: 'website', identifier: 'distribution.example', relationship: 'direct' },
             ],
           },
           {
@@ -180,6 +219,7 @@ describe('BrandManager caching', () => {
       ]);
       expect(promoted.legacy_properties).toEqual([
         { type: 'website', identifier: 'alias.example' },
+        { type: 'website', identifier: 'distribution.example', relationship: 'direct' },
       ]);
       expect(promoted.legacy_metadata.unpromoted_brands[0].id).toBe('partner');
       expect(promoted.legacy_metadata.legal_operator).toEqual(legacyBrandJson.legal_operator);
@@ -229,6 +269,34 @@ describe('BrandManager caching', () => {
       });
       expect((result.raw_data as Record<string, any>).legacy_properties[0].relationship)
         .toBe('registered_account_operator');
+    });
+
+    it('rejects ambiguous legacy identity when the origin property is duplicated', async () => {
+      const legacyBrandJson = {
+        $schema: 'https://schemas.adcontextprotocol.org/brand/v1/brand.json',
+        brands: [{
+          id: 'ambiguous',
+          name: 'Ambiguous',
+          properties: [
+            { type: 'website', identifier: 'ambiguous.example', relationship: 'owned' },
+            { type: 'website', identifier: 'ambiguous.example', relationship: 'owned' },
+          ],
+        }],
+      };
+      mockedSafeFetch.mockResolvedValueOnce({
+        status: 200,
+        data: Buffer.from(JSON.stringify(legacyBrandJson)),
+      });
+
+      const result = await manager.validateDomain('ambiguous.example');
+
+      expect(result.valid).toBe(false);
+      expect(result.warnings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          field: 'brands',
+          message: expect.stringContaining('found 2'),
+        }),
+      ]));
     });
 
     it.each([
@@ -541,6 +609,39 @@ describe('BrandManager caching', () => {
         house_name: 'Example House',
         relationship_trust: 'mutual',
       });
+    });
+
+    it('verifies a canonical house claim through an authoritative_location portfolio', async () => {
+      const canonical = {
+        id: 'leaf',
+        names: [{ en: 'Leaf Brand' }],
+        house_domain: 'house.example',
+      };
+      const pointer = {
+        authoritative_location: 'https://cdn.house.example/portfolio/brand.json',
+      };
+      const portfolio = {
+        house: { domain: 'house.example', name: 'Example House' },
+        brand_refs: [{ domain: 'leaf.example', brand_id: 'leaf' }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(pointer)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) });
+
+      const result = await manager.resolveBrand('leaf.example');
+
+      expect(result).toMatchObject({
+        house_domain: 'house.example',
+        claimed_house_domain: 'house.example',
+        house_name: 'Example House',
+        relationship_trust: 'mutual',
+      });
+      expect(mockedSafeFetch).toHaveBeenNthCalledWith(
+        3,
+        pointer.authoritative_location,
+        expect.objectContaining({ sameSiteRedirectsOnly: true }),
+      );
     });
 
     it('fetches authoritative_location at the exact published URL', async () => {

--- a/server/tests/unit/brand-manager-cache.test.ts
+++ b/server/tests/unit/brand-manager-cache.test.ts
@@ -126,8 +126,6 @@ describe('BrandManager caching', () => {
 
       expect((await manager.validateDomain('stable.example')).valid).toBe(true);
       expect((await manager.validateDomain('stable.example', { skipCache: true })).valid).toBe(false);
-      expect(manager.getLastValidationResult('stable.example')?.status_code).toBe(503);
-      expect(manager.getLastValidationResult('stable.example')?.raw_data).toBeUndefined();
       expect((await manager.validateDomain('stable.example')).valid).toBe(true);
       expect(mockedSafeFetch).toHaveBeenCalledTimes(2);
     });
@@ -142,31 +140,26 @@ describe('BrandManager caching', () => {
       expect(mockedSafeFetch).not.toHaveBeenCalled();
     });
 
-    it('bounds and expires body-free validation diagnostics', () => {
-      vi.useFakeTimers();
-      const recordAttempt = (manager as unknown as {
-        recordLastValidationAttempt(domain: string, result: Record<string, unknown>): void;
-      }).recordLastValidationAttempt.bind(manager);
-      try {
-        for (let i = 0; i <= 500; i++) {
-          recordAttempt(`brand-${i}.example`, {
-            valid: true,
-            errors: [],
-            warnings: [],
-            domain: `brand-${i}.example`,
-            url: `https://brand-${i}.example/.well-known/brand.json`,
-            raw_data: { oversized: 'not retained' },
-          });
-        }
+    it('reports body-free diagnostics scoped to each resolution', async () => {
+      const oversized = {
+        id: 'oversized',
+        names: [{ en: 'Oversized' }],
+        description: 'x'.repeat(1024),
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(oversized)) })
+        .mockResolvedValueOnce({ status: 503, data: Buffer.from('unavailable') });
 
-        expect(manager.getLastValidationResult('brand-0.example')).toBeUndefined();
-        expect(manager.getLastValidationResult('brand-500.example')).not.toHaveProperty('raw_data');
+      const resolved = await manager.resolveBrandWithDiagnostics('body.example');
+      expect(resolved.brand?.canonical_id).toBe('oversized');
+      expect(resolved.last_attempt).not.toHaveProperty('raw_data');
 
-        vi.advanceTimersByTime(5 * 60 * 1000);
-        expect(manager.getLastValidationResult('brand-500.example')).toBeUndefined();
-      } finally {
-        vi.useRealTimers();
-      }
+      const failed = await manager.resolveBrandWithDiagnostics('other.example');
+      expect(failed.brand).toBeNull();
+      expect(failed.last_attempt).toMatchObject({
+        domain: 'other.example',
+        status_code: 503,
+      });
     });
 
     it('promotes the narrow legacy portfolio shape without inventing trust relationships', async () => {
@@ -514,14 +507,16 @@ describe('BrandManager caching', () => {
       expect(mockedSafeFetch).toHaveBeenCalledTimes(2);
     });
 
-    it('retains terminal redirect diagnostics under the originally requested domain', async () => {
+    it('reports the terminal redirect attempt that ended the resolution', async () => {
       const redirect = { house: 'house.example' };
       mockedSafeFetch
         .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(redirect)) })
         .mockResolvedValueOnce({ status: 503, data: Buffer.from('unavailable') });
 
-      expect(await manager.resolveBrand('leaf.example', { skipCache: true })).toBeNull();
-      expect(manager.getLastValidationResult('leaf.example')).toMatchObject({
+      const resolution = await manager.resolveBrandWithDiagnostics('leaf.example', { skipCache: true });
+
+      expect(resolution.brand).toBeNull();
+      expect(resolution.last_attempt).toMatchObject({
         valid: false,
         domain: 'house.example',
         status_code: 503,
@@ -848,6 +843,211 @@ describe('BrandManager caching', () => {
 
       expect(result).toBeNull();
       expect(mockedSafeFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // brand.json trust invariant: relationship trust requires reciprocation.
+  // A House Redirect is the leaf's one-sided claim, so the named house's
+  // document must name the leaf before its identity can answer for the leaf.
+  describe('house redirect reciprocation', () => {
+    const redirect = { house: 'house.example' };
+
+    it('does not hand a house master brand to a domain the house never names', async () => {
+      const portfolio = {
+        house: { domain: 'house.example', name: 'Example House' },
+        brands: [{
+          id: 'house_master',
+          names: [{ en: 'Example House' }],
+          keller_type: 'master',
+          properties: [{ type: 'website', identifier: 'house.example', relationship: 'owned' }],
+        }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(redirect)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) });
+
+      const result = await manager.resolveBrand('squatter.example');
+
+      expect(result).toMatchObject({
+        canonical_id: 'squatter.example',
+        canonical_domain: 'squatter.example',
+        claimed_house_domain: 'house.example',
+        relationship_trust: 'leaf_only',
+      });
+      expect(result?.house_domain).toBeUndefined();
+      expect(result?.names).toBeUndefined();
+    });
+
+    it('resolves a redirect the house reciprocates with an owned property', async () => {
+      const portfolio = {
+        house: { domain: 'house.example', name: 'Example House' },
+        brands: [{
+          id: 'regional',
+          names: [{ en: 'Regional Brand' }],
+          properties: [{ type: 'website', identifier: 'regional.example', relationship: 'owned' }],
+        }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(redirect)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) });
+
+      expect(await manager.resolveBrand('regional.example')).toMatchObject({
+        canonical_id: 'regional',
+        brand_name: 'Regional Brand',
+        house_domain: 'house.example',
+        relationship_trust: 'inline',
+      });
+    });
+
+    it('treats a monetization property as a path to inventory, not an identity', async () => {
+      const portfolio = {
+        house: { domain: 'house.example', name: 'Example House' },
+        brands: [{
+          id: 'network',
+          names: [{ en: 'Ad Network' }],
+          properties: [{ type: 'website', identifier: 'publisher.example', relationship: 'delegated' }],
+        }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(redirect)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) });
+
+      const result = await manager.resolveBrand('publisher.example');
+
+      expect(result).toMatchObject({
+        canonical_id: 'publisher.example',
+        relationship_trust: 'leaf_only',
+      });
+      expect(result?.brand_name).not.toBe('Ad Network');
+    });
+
+    it('does not hand a house canonical document to an unnamed domain', async () => {
+      const houseCanonical = {
+        id: 'house_brand',
+        names: [{ en: 'House Brand' }],
+        properties: [{ type: 'website', identifier: 'house.example', relationship: 'owned' }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(redirect)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(houseCanonical)) });
+
+      const result = await manager.resolveBrand('squatter.example');
+
+      expect(result).toMatchObject({
+        canonical_id: 'squatter.example',
+        claimed_house_domain: 'house.example',
+        relationship_trust: 'leaf_only',
+      });
+      expect(result?.brand_name).not.toBe('House Brand');
+    });
+
+    it('resolves a redirect to a house canonical document that names the leaf', async () => {
+      const houseCanonical = {
+        id: 'house_brand',
+        names: [{ en: 'House Brand' }],
+        properties: [
+          { type: 'website', identifier: 'house.example', relationship: 'owned' },
+          { type: 'website', identifier: 'legacy.example', relationship: 'owned' },
+        ],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(redirect)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(houseCanonical)) });
+
+      expect(await manager.resolveBrand('legacy.example')).toMatchObject({
+        canonical_id: 'house_brand',
+        brand_name: 'House Brand',
+      });
+    });
+
+    it('keeps a redirected brand agent pointer without adopting the house identity', async () => {
+      const agentDocument = {
+        brand_agent: { id: 'house_agent', url: 'https://agent.house.example/mcp' },
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(redirect)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(agentDocument)) });
+
+      expect(await manager.resolveBrand('squatter.example')).toMatchObject({
+        canonical_id: 'squatter.example',
+        canonical_domain: 'squatter.example',
+        brand_agent_url: 'https://agent.house.example/mcp',
+        claimed_house_domain: 'house.example',
+        relationship_trust: 'leaf_only',
+      });
+    });
+  });
+
+  describe('mutual trust aging', () => {
+    const canonical = {
+      id: 'leaf',
+      names: [{ en: 'Leaf Brand' }],
+      house_domain: 'house.example',
+    };
+    const portfolio = {
+      house: { domain: 'house.example', name: 'Example House' },
+      brand_refs: [{ domain: 'leaf.example', brand_id: 'leaf' }],
+    };
+
+    it('stamps a mutual edge with the time both sides were seen', async () => {
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) });
+
+      const result = await manager.resolveBrand('leaf.example');
+
+      expect(result?.relationship_trust).toBe('mutual');
+      expect(Date.parse(result?.relationship_verified_at ?? '')).toBeGreaterThan(0);
+    });
+
+    it('does not advance the verification time while reusing a retained edge', async () => {
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 503, data: Buffer.from('unavailable') });
+
+      const verified = await manager.resolveBrand('leaf.example');
+      const retained = await manager.resolveBrand('leaf.example', { skipCache: true });
+
+      expect(retained?.relationship_trust).toBe('mutual');
+      expect(retained?.relationship_verified_at).toBe(verified?.relationship_verified_at);
+    });
+
+    it('ages a retained edge out even while refreshes keep the cache entry alive', async () => {
+      const hour = 60 * 60 * 1000;
+      vi.useFakeTimers();
+      try {
+        mockedSafeFetch
+          .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+          .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) });
+        expect((await manager.resolveBrand('leaf.example'))?.relationship_trust).toBe('mutual');
+
+        // A refresh inside the window rewrites the cache entry with a fresh TTL,
+        // so the entry outlives the verification it was built from.
+        vi.advanceTimersByTime(12 * hour);
+        mockedSafeFetch
+          .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+          .mockResolvedValueOnce({ status: 503, data: Buffer.from('unavailable') });
+        expect(
+          (await manager.resolveBrand('leaf.example', { skipCache: true }))?.relationship_trust,
+        ).toBe('mutual');
+
+        vi.advanceTimersByTime(13 * hour);
+        mockedSafeFetch
+          .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+          .mockResolvedValueOnce({ status: 503, data: Buffer.from('unavailable') });
+        const aged = await manager.resolveBrand('leaf.example', { skipCache: true });
+
+        expect(aged).toMatchObject({
+          relationship_trust: 'unverifiable',
+          claimed_house_domain: 'house.example',
+        });
+        expect(aged?.house_domain).toBeUndefined();
+        expect(aged?.relationship_verified_at).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/server/tests/unit/brand-manager-cache.test.ts
+++ b/server/tests/unit/brand-manager-cache.test.ts
@@ -109,6 +109,176 @@ describe('BrandManager caching', () => {
       await manager.validateDomain('fresh.com', { skipCache: true });
       expect(mockedSafeFetch).toHaveBeenCalledTimes(2);
     });
+
+    it('retains a prior positive cache while exposing the latest fresh failure', async () => {
+      const validDocument = {
+        id: 'stable',
+        names: [{ en: 'Stable' }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(validDocument)) })
+        .mockResolvedValueOnce({ status: 503, data: Buffer.from('unavailable') });
+
+      expect((await manager.validateDomain('stable.example')).valid).toBe(true);
+      expect((await manager.validateDomain('stable.example', { skipCache: true })).valid).toBe(false);
+      expect(manager.getLastValidationResult('stable.example')?.status_code).toBe(503);
+      expect((await manager.validateDomain('stable.example')).valid).toBe(true);
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('promotes the narrow legacy portfolio shape without inventing trust relationships', async () => {
+      const legacyBrandJson = {
+        $schema: 'https://schemas.adcontextprotocol.org/brand/v1/brand.json',
+        name: 'Example House',
+        domain: 'example.com',
+        legal_operator: {
+          name: 'Example LLC',
+          domain: 'example.com',
+          relationship: 'registered_account_operator',
+        },
+        brands: [
+          {
+            id: 'example',
+            name: 'Example',
+            properties: [
+              { type: 'website', identifier: 'example.com', relationship: 'owned' },
+              { type: 'website', identifier: 'alias.example' },
+            ],
+          },
+          {
+            id: 'partner',
+            name: 'Partner',
+            properties: [
+              {
+                type: 'website',
+                identifier: 'partner.com',
+                relationship: 'operated_publisher_brand',
+              },
+            ],
+          },
+        ],
+      };
+      mockedSafeFetch.mockResolvedValueOnce({
+        status: 200,
+        data: Buffer.from(JSON.stringify(legacyBrandJson)),
+      });
+
+      const result = await manager.validateDomain('example.com');
+
+      expect(result.valid).toBe(true);
+      expect(result.variant).toBe('brand_canonical');
+      expect(result.promoted_from_schema).toBe(legacyBrandJson.$schema);
+      expect(result.warnings).toEqual(expect.arrayContaining([
+        expect.objectContaining({ field: 'brands' }),
+        expect.objectContaining({ field: 'legal_operator' }),
+      ]));
+      const promoted = result.raw_data as Record<string, any>;
+      expect(promoted.$schema).toBe('https://adcontextprotocol.org/schemas/v3/brand.json');
+      expect(promoted.names).toEqual([{ und: 'Example' }, { und: 'Example House' }]);
+      expect(promoted.properties).toEqual([
+        { type: 'website', identifier: 'example.com', relationship: 'owned' },
+      ]);
+      expect(promoted.legacy_properties).toEqual([
+        { type: 'website', identifier: 'alias.example' },
+      ]);
+      expect(promoted.legacy_metadata.unpromoted_brands[0].id).toBe('partner');
+      expect(promoted.legacy_metadata.legal_operator).toEqual(legacyBrandJson.legal_operator);
+
+      const resolved = await manager.resolveBrand('example.com');
+      expect(resolved).toMatchObject({
+        source: 'brand_json',
+        relationship_trust: 'standalone',
+        promoted_from_schema: legacyBrandJson.$schema,
+      });
+      expect(resolved?.migration_warnings?.length).toBeGreaterThan(0);
+    });
+
+    it('promotes a leaf-hosted legacy shape to a canonical v3 document', async () => {
+      const legacyBrandJson = {
+        $schema: 'https://schemas.adcontextprotocol.org/brand/v1/brand.json',
+        name: 'Leaf Brand',
+        domain: 'leaf.example',
+        house: { domain: 'house.example', name: 'Example House' },
+        brands: [{
+          id: 'leaf',
+          name: 'Leaf Brand',
+          properties: [
+            { type: 'website', identifier: 'leaf.example', relationship: 'owned' },
+            {
+              type: 'website',
+              identifier: 'house.example',
+              relationship: 'registered_account_operator',
+            },
+          ],
+        }],
+      };
+      mockedSafeFetch.mockResolvedValueOnce({
+        status: 200,
+        data: Buffer.from(JSON.stringify(legacyBrandJson)),
+      });
+
+      const result = await manager.validateDomain('leaf.example');
+
+      expect(result.valid).toBe(true);
+      expect(result.variant).toBe('brand_canonical');
+      expect(result.raw_data).toMatchObject({
+        id: 'leaf',
+        names: [{ und: 'Leaf Brand' }],
+        house_domain: 'house.example',
+        properties: [{ type: 'website', identifier: 'leaf.example', relationship: 'owned' }],
+      });
+      expect((result.raw_data as Record<string, any>).legacy_properties[0].relationship)
+        .toBe('registered_account_operator');
+    });
+
+    it.each([
+      {
+        label: 'a forbidden canonical brand_refs field',
+        document: {
+          id: 'leaf',
+          names: [{ en: 'Leaf' }],
+          brand_refs: [{ domain: 'child.example', brand_id: 'child' }],
+        },
+      },
+      {
+        label: 'an unsupported property relationship',
+        document: {
+          id: 'leaf',
+          names: [{ en: 'Leaf' }],
+          properties: [{ type: 'website', identifier: 'leaf.example', relationship: 'bogus' }],
+        },
+      },
+    ])('rejects v3 documents containing $label', async ({ document }) => {
+      mockedSafeFetch.mockResolvedValueOnce({
+        status: 200,
+        data: Buffer.from(JSON.stringify(document)),
+      });
+
+      const result = await manager.validateDomain('leaf.example');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects a House Portfolio whose house.domain is not bound to the TLS origin', async () => {
+      const forgedPortfolio = {
+        house: { domain: 'trusted.example', name: 'Trusted House' },
+        brands: [{
+          id: 'evil',
+          names: [{ en: 'Evil' }],
+          properties: [{ type: 'website', identifier: 'evil.example', relationship: 'owned' }],
+        }],
+      };
+      mockedSafeFetch.mockResolvedValueOnce({
+        status: 200,
+        data: Buffer.from(JSON.stringify(forgedPortfolio)),
+      });
+
+      const result = await manager.validateDomain('evil.example');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual(expect.objectContaining({ field: 'house.domain' }));
+    });
   });
 
   describe('UTF-8 encoding', () => {
@@ -233,6 +403,190 @@ describe('BrandManager caching', () => {
       await manager.resolveBrand('bypass.com', { skipCache: true });
       expect(mockedSafeFetch).toHaveBeenCalled();
     });
+
+    it('does not replace a positive resolution cache on a transient fresh failure', async () => {
+      const canonical = { id: 'stable', names: [{ en: 'Stable' }] };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 503, data: Buffer.from('unavailable') });
+
+      expect((await manager.resolveBrand('stable.example'))?.brand_name).toBe('Stable');
+      expect(await manager.resolveBrand('stable.example', { skipCache: true })).toBeNull();
+      expect((await manager.resolveBrand('stable.example'))?.brand_name).toBe('Stable');
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('retains terminal redirect diagnostics under the originally requested domain', async () => {
+      const redirect = { house: 'house.example' };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(redirect)) })
+        .mockResolvedValueOnce({ status: 503, data: Buffer.from('unavailable') });
+
+      expect(await manager.resolveBrand('leaf.example', { skipCache: true })).toBeNull();
+      expect(manager.getLastValidationResult('leaf.example')).toMatchObject({
+        valid: false,
+        domain: 'house.example',
+        status_code: 503,
+      });
+    });
+
+    it('resolves a v3 Brand Canonical Document', async () => {
+      const canonical = {
+        $schema: 'https://adcontextprotocol.org/schemas/v3/brand.json',
+        id: 'leaf',
+        names: [{ en: 'Leaf Brand' }],
+        house_domain: 'house.example',
+        description: 'Leaf-owned identity',
+        properties: [{ type: 'website', identifier: 'leaf.example', relationship: 'owned' }],
+      };
+      mockedSafeFetch.mockResolvedValueOnce({
+        status: 200,
+        data: Buffer.from(JSON.stringify(canonical)),
+      });
+
+      const result = await manager.resolveBrand('leaf.example');
+
+      expect(result).toMatchObject({
+        canonical_id: 'leaf',
+        canonical_domain: 'leaf.example',
+        brand_name: 'Leaf Brand',
+        claimed_house_domain: 'house.example',
+        relationship_trust: 'leaf_only',
+        source: 'brand_json',
+        brand_manifest: { description: 'Leaf-owned identity' },
+      });
+      expect(result?.house_domain).toBeUndefined();
+      expect(result?.brand_manifest).not.toHaveProperty('house_domain');
+      expect(result?.brand_manifest).not.toHaveProperty('$schema');
+    });
+
+    it('follows a house brand_refs pointer only to the matching canonical brand', async () => {
+      const portfolio = {
+        $schema: 'https://adcontextprotocol.org/schemas/v3/brand.json',
+        house: { domain: 'house.example', name: 'Example House' },
+        brand_refs: [{ domain: 'leaf.example', brand_id: 'leaf' }],
+      };
+      const canonical = {
+        $schema: 'https://adcontextprotocol.org/schemas/v3/brand.json',
+        id: 'leaf',
+        names: [{ en: 'Leaf Brand' }],
+        house_domain: 'house.example',
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) });
+
+      const result = await manager.resolveBrandRef({
+        domain: 'house.example',
+        brand_id: 'leaf',
+      });
+
+      expect(result).toMatchObject({
+        canonical_id: 'leaf',
+        canonical_domain: 'leaf.example',
+        brand_name: 'Leaf Brand',
+        house_domain: 'house.example',
+        claimed_house_domain: 'house.example',
+        relationship_trust: 'mutual',
+        source: 'brand_json',
+      });
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('marks a one-sided house pointer as house_only without trusting parentage', async () => {
+      const portfolio = {
+        house: { domain: 'house.example', name: 'Example House' },
+        brand_refs: [{ domain: 'leaf.example', brand_id: 'leaf' }],
+      };
+      const standaloneLeaf = {
+        id: 'leaf',
+        names: [{ en: 'Leaf Brand' }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(standaloneLeaf)) });
+
+      const result = await manager.resolveBrandRef({
+        domain: 'house.example',
+        brand_id: 'leaf',
+      });
+
+      expect(result).toMatchObject({
+        relationship_trust: 'house_only',
+        canonical_domain: 'leaf.example',
+      });
+      expect(result?.house_domain).toBeUndefined();
+      expect(result?.claimed_house_domain).toBeUndefined();
+    });
+
+    it('verifies a direct canonical house claim through reciprocal brand_refs', async () => {
+      const canonical = {
+        id: 'leaf',
+        names: [{ en: 'Leaf Brand' }],
+        house_domain: 'house.example',
+      };
+      const portfolio = {
+        house: { domain: 'house.example', name: 'Example House' },
+        brand_refs: [{ domain: 'leaf.example', brand_id: 'leaf' }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) });
+
+      const result = await manager.resolveBrand('leaf.example');
+
+      expect(result).toMatchObject({
+        house_domain: 'house.example',
+        claimed_house_domain: 'house.example',
+        house_name: 'Example House',
+        relationship_trust: 'mutual',
+      });
+    });
+
+    it('fetches authoritative_location at the exact published URL', async () => {
+      const pointer = {
+        authoritative_location: 'https://cdn.example/custom/brand.json',
+      };
+      const canonical = {
+        id: 'cdn_brand',
+        names: [{ en: 'CDN Brand' }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(pointer)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) });
+
+      const result = await manager.resolveBrand('origin.example');
+
+      expect(result).toMatchObject({
+        canonical_id: 'cdn_brand',
+        canonical_domain: 'origin.example',
+        relationship_trust: 'standalone',
+      });
+      expect(mockedSafeFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://cdn.example/custom/brand.json',
+        expect.objectContaining({ sameSiteRedirectsOnly: true })
+      );
+    });
+
+    it('does not follow brand_refs from a portfolio forged for another house origin', async () => {
+      const forgedPortfolio = {
+        house: { domain: 'trusted.example', name: 'Trusted House' },
+        brand_refs: [{ domain: 'leaf.example', brand_id: 'leaf' }],
+      };
+      mockedSafeFetch.mockResolvedValueOnce({
+        status: 200,
+        data: Buffer.from(JSON.stringify(forgedPortfolio)),
+      });
+
+      const result = await manager.resolveBrandRef({
+        domain: 'evil.example',
+        brand_id: 'leaf',
+      });
+
+      expect(result).toBeNull();
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('brand_manifest construction', () => {
@@ -331,10 +685,15 @@ describe('BrandManager caching', () => {
         ],
       };
 
-      mockedSafeFetch.mockResolvedValue({
-        status: 200,
-        data: Buffer.from(JSON.stringify(mockBrandJson)),
-      });
+      mockedSafeFetch
+        .mockResolvedValueOnce({
+          status: 200,
+          data: Buffer.from(JSON.stringify({ house: 'house.com' })),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: Buffer.from(JSON.stringify(mockBrandJson)),
+        });
 
       const result = await manager.resolveBrand('subbrand.com');
       expect(result).not.toBeNull();
@@ -417,13 +776,13 @@ describe('BrandManager caching', () => {
         },
         brands: [
           {
-            id: 'brand-a',
+            id: 'brand_a',
             names: [{ en: 'Brand A' }],
             keller_type: 'master',
             description: 'Brand A description',
           },
           {
-            id: 'brand-b',
+            id: 'brand_b',
             names: [{ en: 'Brand B' }],
             keller_type: 'sub_brand',
             description: 'Brand B description',
@@ -438,7 +797,7 @@ describe('BrandManager caching', () => {
 
       const result = await manager.resolveBrandRef({
         domain: 'multi.com',
-        brand_id: 'brand-b',
+        brand_id: 'brand_b',
       });
       expect(result).not.toBeNull();
       expect(result?.brand_manifest?.description).toBe('Brand B description');

--- a/server/tests/unit/brand-manager-cache.test.ts
+++ b/server/tests/unit/brand-manager-cache.test.ts
@@ -702,6 +702,70 @@ describe('BrandManager caching', () => {
       });
     });
 
+    it('retains cached mutual trust when a fresh reciprocal check is temporarily unavailable', async () => {
+      const canonical = {
+        id: 'leaf',
+        names: [{ en: 'Leaf Brand' }],
+        house_domain: 'house.example',
+      };
+      const portfolio = {
+        house: { domain: 'house.example', name: 'Example House' },
+        brand_refs: [{ domain: 'leaf.example', brand_id: 'leaf' }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 503, data: Buffer.from('temporarily unavailable') });
+
+      expect(await manager.resolveBrand('leaf.example')).toMatchObject({
+        relationship_trust: 'mutual',
+        house_domain: 'house.example',
+      });
+      expect(await manager.resolveBrand('leaf.example', { skipCache: true })).toMatchObject({
+        relationship_trust: 'mutual',
+        house_domain: 'house.example',
+      });
+
+      vi.clearAllMocks();
+      expect(await manager.resolveBrand('leaf.example')).toMatchObject({
+        relationship_trust: 'mutual',
+        house_domain: 'house.example',
+      });
+      expect(mockedSafeFetch).not.toHaveBeenCalled();
+    });
+
+    it('replaces cached mutual trust when the house returns a definitive non-portfolio document', async () => {
+      const canonical = {
+        id: 'leaf',
+        names: [{ en: 'Leaf Brand' }],
+        house_domain: 'house.example',
+      };
+      const portfolio = {
+        house: { domain: 'house.example', name: 'Example House' },
+        brand_refs: [{ domain: 'leaf.example', brand_id: 'leaf' }],
+      };
+      const replacement = { id: 'house', names: [{ en: 'House' }] };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(replacement)) });
+
+      expect(await manager.resolveBrand('leaf.example')).toMatchObject({
+        relationship_trust: 'mutual',
+      });
+      expect(await manager.resolveBrand('leaf.example', { skipCache: true })).toMatchObject({
+        relationship_trust: 'unverifiable',
+      });
+
+      vi.clearAllMocks();
+      expect(await manager.resolveBrand('leaf.example')).toMatchObject({
+        relationship_trust: 'unverifiable',
+      });
+      expect(mockedSafeFetch).not.toHaveBeenCalled();
+    });
+
     it('verifies a canonical house claim through an authoritative_location portfolio', async () => {
       const canonical = {
         id: 'leaf',

--- a/server/tests/unit/brand-manager-cache.test.ts
+++ b/server/tests/unit/brand-manager-cache.test.ts
@@ -140,6 +140,24 @@ describe('BrandManager caching', () => {
       expect(mockedSafeFetch).not.toHaveBeenCalled();
     });
 
+    // Agents pass through whatever identifier a human gave them.
+    it.each(['https://acme.example', 'https://acme.example/', 'ACME.example'])(
+      'accepts %s as the acme.example lookup',
+      async (input) => {
+        const canonical = { id: 'acme', names: [{ en: 'Acme' }] };
+        mockedSafeFetch.mockResolvedValueOnce({
+          status: 200,
+          data: Buffer.from(JSON.stringify(canonical)),
+        });
+
+        expect((await manager.resolveBrand(input))?.canonical_domain).toBe('acme.example');
+        expect(mockedSafeFetch).toHaveBeenCalledWith(
+          'https://acme.example/.well-known/brand.json',
+          expect.anything(),
+        );
+      },
+    );
+
     it('reports body-free diagnostics scoped to each resolution', async () => {
       const oversized = {
         id: 'oversized',
@@ -298,6 +316,35 @@ describe('BrandManager caching', () => {
           message: expect.stringContaining('found 2'),
         }),
       ]));
+      // The document was returned untouched, so nothing was promoted.
+      expect(result.promoted_from_schema).toBeUndefined();
+    });
+
+    // `relationship` defaults to owned in the schema and postdates these
+    // documents, so a v1 property that omits it is an ownership claim.
+    it('promotes a legacy origin property that omits relationship', async () => {
+      const legacyBrandJson = {
+        $schema: 'https://schemas.adcontextprotocol.org/brand/v1/brand.json',
+        brands: [{
+          id: 'implicit',
+          name: 'Implicit Owner',
+          properties: [{ type: 'website', identifier: 'implicit.example' }],
+        }],
+      };
+      mockedSafeFetch.mockResolvedValueOnce({
+        status: 200,
+        data: Buffer.from(JSON.stringify(legacyBrandJson)),
+      });
+
+      const result = await manager.validateDomain('implicit.example');
+
+      expect(result.valid).toBe(true);
+      expect(result.variant).toBe('brand_canonical');
+      expect(result.promoted_from_schema).toBe('https://schemas.adcontextprotocol.org/brand/v1/brand.json');
+      expect(result.raw_data).toMatchObject({
+        id: 'implicit',
+        names: [{ und: 'Implicit Owner' }],
+      });
     });
 
     it.each([
@@ -824,6 +871,72 @@ describe('BrandManager caching', () => {
           sameSiteRedirectsOnly: true,
         })
       );
+    });
+
+    // The schema documents central hosting as the use for authoritative_location
+    // ("hosted at the brand's own /.well-known/brand.json or via
+    // authoritative_location indirection"), so an off-site target resolves —
+    // but it has to be consistent with the domain it answers for.
+    it('does not adopt an off-site document that names other domains as its own', async () => {
+      const pointer = { authoritative_location: 'https://victim.example/.well-known/brand.json' };
+      const victimCanonical = {
+        id: 'victim',
+        names: [{ en: 'Victim Brand' }],
+        properties: [{ type: 'website', identifier: 'victim.example', relationship: 'owned' }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(pointer)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(victimCanonical)) });
+
+      expect(await manager.resolveBrand('evil.example')).toBeNull();
+    });
+
+    it('resolves an off-site document that names the requested domain', async () => {
+      const pointer = { authoritative_location: 'https://cdn.provider.example/brands/acme.json' };
+      const canonical = {
+        id: 'acme',
+        names: [{ en: 'Acme' }],
+        properties: [
+          { type: 'website', identifier: 'acme.example', relationship: 'owned' },
+          { type: 'website', identifier: 'acme.co.uk', relationship: 'owned' },
+        ],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(pointer)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) });
+
+      expect(await manager.resolveBrand('acme.example')).toMatchObject({
+        canonical_id: 'acme',
+        canonical_domain: 'acme.example',
+        brand_name: 'Acme',
+      });
+    });
+
+    it('resolves a centrally hosted document that declares no websites', async () => {
+      const pointer = { authoritative_location: 'https://cdn.provider.example/brands/minimal.json' };
+      const canonical = { id: 'minimal', names: [{ en: 'Minimal' }] };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(pointer)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) });
+
+      expect(await manager.resolveBrand('minimal.example')).toMatchObject({
+        canonical_id: 'minimal',
+        canonical_domain: 'minimal.example',
+      });
+    });
+
+    it('accepts a same-site authoritative_location that names other domains', async () => {
+      const pointer = { authoritative_location: 'https://cdn.acme.example/brand.json' };
+      const canonical = {
+        id: 'acme',
+        names: [{ en: 'Acme' }],
+        properties: [{ type: 'website', identifier: 'acme-shop.example', relationship: 'owned' }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(pointer)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) });
+
+      expect(await manager.resolveBrand('acme.example')).toMatchObject({ canonical_id: 'acme' });
     });
 
     it('does not follow brand_refs from a portfolio forged for another house origin', async () => {

--- a/server/tests/unit/brand-manager-cache.test.ts
+++ b/server/tests/unit/brand-manager-cache.test.ts
@@ -52,6 +52,10 @@ describe('BrandManager caching', () => {
       const result1 = await manager.validateDomain('acme.com');
       expect(result1.valid).toBe(true);
       expect(mockedSafeFetch).toHaveBeenCalledTimes(1);
+      expect(mockedSafeFetch).toHaveBeenCalledWith(
+        'https://acme.com/.well-known/brand.json',
+        expect.objectContaining({ maxResponseBytes: 256 * 1024 }),
+      );
 
       // Second call - should use cache
       const result2 = await manager.validateDomain('acme.com');
@@ -71,6 +75,7 @@ describe('BrandManager caching', () => {
       // First call - should fetch and fail
       const result1 = await manager.validateDomain('missing.com');
       expect(result1.valid).toBe(false);
+      expect(result1.raw_data).toBeUndefined();
       expect(mockedSafeFetch).toHaveBeenCalledTimes(1);
 
       // Second call - should use failed lookup cache
@@ -264,9 +269,12 @@ describe('BrandManager caching', () => {
       expect(result.raw_data).toMatchObject({
         id: 'leaf',
         names: [{ und: 'Leaf Brand' }],
-        house_domain: 'house.example',
         properties: [{ type: 'website', identifier: 'leaf.example', relationship: 'owned' }],
+        legacy_metadata: {
+          legacy_house: { domain: 'house.example', name: 'Example House' },
+        },
       });
+      expect(result.raw_data).not.toHaveProperty('house_domain');
       expect((result.raw_data as Record<string, any>).legacy_properties[0].relationship)
         .toBe('registered_account_operator');
     });
@@ -326,6 +334,28 @@ describe('BrandManager caching', () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.raw_data).toBeUndefined();
+    });
+
+    it('does not retain an invalid parsed document in the failed cache', async () => {
+      const invalidDocument = {
+        id: 'invalid',
+        names: [{ en: 'Invalid' }],
+        properties: [{ type: 'website', identifier: 'invalid.example', relationship: 'bogus' }],
+        attacker_padding: 'x'.repeat(64 * 1024),
+      };
+      mockedSafeFetch.mockResolvedValueOnce({
+        status: 200,
+        data: Buffer.from(JSON.stringify(invalidDocument)),
+      });
+
+      const first = await manager.validateDomain('invalid.example');
+      const cached = await manager.validateDomain('invalid.example');
+
+      expect(first.valid).toBe(false);
+      expect(first.raw_data).toBeUndefined();
+      expect(cached.raw_data).toBeUndefined();
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(1);
     });
 
     it('rejects a House Portfolio whose house.domain is not bound to the TLS origin', async () => {
@@ -519,13 +549,74 @@ describe('BrandManager caching', () => {
         canonical_domain: 'leaf.example',
         brand_name: 'Leaf Brand',
         claimed_house_domain: 'house.example',
-        relationship_trust: 'leaf_only',
+        relationship_trust: 'unverifiable',
         source: 'brand_json',
         brand_manifest: { description: 'Leaf-owned identity' },
       });
       expect(result?.house_domain).toBeUndefined();
       expect(result?.brand_manifest).not.toHaveProperty('house_domain');
       expect(result?.brand_manifest).not.toHaveProperty('$schema');
+    });
+
+    it('marks a valid house portfolio without reciprocity as leaf_only', async () => {
+      const canonical = {
+        id: 'leaf',
+        names: [{ en: 'Leaf Brand' }],
+        house_domain: 'house.example',
+      };
+      const silentPortfolio = {
+        house: { domain: 'house.example', name: 'Example House' },
+        brand_refs: [{ domain: 'different.example', brand_id: 'different' }],
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(silentPortfolio)) });
+
+      const result = await manager.resolveBrand('leaf.example');
+
+      expect(result).toMatchObject({
+        claimed_house_domain: 'house.example',
+        relationship_trust: 'leaf_only',
+      });
+      expect(result?.house_domain).toBeUndefined();
+    });
+
+    it('marks a failed house fetch as unverifiable', async () => {
+      const canonical = {
+        id: 'leaf',
+        names: [{ en: 'Leaf Brand' }],
+        house_domain: 'house.example',
+      };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 503, data: Buffer.from('unavailable') });
+
+      const result = await manager.resolveBrand('leaf.example');
+
+      expect(result).toMatchObject({
+        claimed_house_domain: 'house.example',
+        relationship_trust: 'unverifiable',
+      });
+    });
+
+    it('marks a house redirect loop as unverifiable', async () => {
+      const canonical = {
+        id: 'leaf',
+        names: [{ en: 'Leaf Brand' }],
+        house_domain: 'house.example',
+      };
+      const loop = { house: 'house.example' };
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(loop)) });
+
+      const result = await manager.resolveBrand('leaf.example');
+
+      expect(result).toMatchObject({
+        claimed_house_domain: 'house.example',
+        relationship_trust: 'unverifiable',
+      });
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(2);
     });
 
     it('follows a house brand_refs pointer only to the matching canonical brand', async () => {
@@ -640,7 +731,10 @@ describe('BrandManager caching', () => {
       expect(mockedSafeFetch).toHaveBeenNthCalledWith(
         3,
         pointer.authoritative_location,
-        expect.objectContaining({ sameSiteRedirectsOnly: true }),
+        expect.objectContaining({
+          maxResponseBytes: 256 * 1024,
+          sameSiteRedirectsOnly: true,
+        }),
       );
     });
 
@@ -666,7 +760,10 @@ describe('BrandManager caching', () => {
       expect(mockedSafeFetch).toHaveBeenNthCalledWith(
         2,
         'https://cdn.example/custom/brand.json',
-        expect.objectContaining({ sameSiteRedirectsOnly: true })
+        expect.objectContaining({
+          maxResponseBytes: 256 * 1024,
+          sameSiteRedirectsOnly: true,
+        })
       );
     });
 

--- a/server/tests/unit/cache.test.ts
+++ b/server/tests/unit/cache.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Cache } from '../../src/cache.js';
+
+describe('Cache capacity', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('evicts the least recently used entry at the configured cap', () => {
+    const cache = new Cache<number>(60, 2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+
+    expect(cache.get('a')).toBe(1);
+    cache.set('c', 3);
+
+    expect(cache.get('a')).toBe(1);
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBe(3);
+    expect(cache.size()).toBe(2);
+  });
+
+  it('prunes expired entries before applying the cap', () => {
+    vi.useFakeTimers();
+    const cache = new Cache<number>(1, 1);
+    cache.set('expired', 1);
+    vi.advanceTimersByTime(60_001);
+
+    cache.set('fresh', 2);
+
+    expect(cache.get('expired')).toBeUndefined();
+    expect(cache.get('fresh')).toBe(2);
+    expect(cache.size()).toBe(1);
+  });
+});

--- a/server/tests/unit/crawler-brand-json.test.ts
+++ b/server/tests/unit/crawler-brand-json.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+describe('CrawlerService brand.json ingestion', () => {
+  it('stores canonical documents without opaque legacy compatibility metadata', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const canonical = {
+      $schema: 'https://adcontextprotocol.org/schemas/v3/brand.json',
+      id: 'leaf',
+      names: [{ en: 'Leaf Brand' }],
+      properties: [{ type: 'website', identifier: 'leaf.example', relationship: 'owned' }],
+      legacy_properties: [{ type: 'website', identifier: 'unverified.example', relationship: 'direct' }],
+      legacy_metadata: { unpromoted_brands: [{ id: 'unverified' }] },
+    };
+    const upsertDiscoveredBrand = vi.fn().mockResolvedValue(undefined);
+    const upsertBrandProperties = vi.fn().mockResolvedValue(undefined);
+
+    Object.assign(ctx, {
+      brandManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: true,
+          errors: [],
+          warnings: [],
+          domain: 'leaf.example',
+          url: 'https://leaf.example/.well-known/brand.json',
+          variant: 'brand_canonical',
+          raw_data: canonical,
+        }),
+      },
+      brandDb: { upsertDiscoveredBrand },
+      upsertBrandProperties,
+    });
+
+    await ctx.scanBrandForDomain('leaf.example');
+
+    expect(upsertDiscoveredBrand).toHaveBeenCalledWith({
+      domain: 'leaf.example',
+      brand_name: 'Leaf Brand',
+      has_brand_manifest: true,
+      brand_manifest: {
+        $schema: canonical.$schema,
+        id: 'leaf',
+        names: canonical.names,
+        properties: canonical.properties,
+      },
+      source_type: 'brand_json',
+    });
+    expect(upsertBrandProperties).toHaveBeenCalledWith('leaf.example', canonical);
+  }, 30_000);
+});

--- a/server/tests/unit/rate-limit-retry-after.test.ts
+++ b/server/tests/unit/rate-limit-retry-after.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { MemoryStore } from 'express-rate-limit';
+import type { IncrementResponse, Options } from 'express-rate-limit';
 import { parseRetryAfterSeconds, createAgentReadRateLimiter, createBrandBulkDomainRateLimiter } from '../../src/middleware/rate-limit.js';
+import type { WeightedIncrementStore } from '../../src/middleware/pg-rate-limit-store.js';
 
 /**
  * Tests for the retryAfter fallback field we surface on the 429 body
@@ -85,13 +86,54 @@ describe('agentReadRateLimiter 429 body', () => {
 });
 
 describe('brand bulk domain rate limiter', () => {
-  it('charges each request by unique domain count', async () => {
+  /**
+   * Records every weighted increment so the test can assert the limiter spends
+   * a request's whole domain count in one atomic operation. A loop of single
+   * increments would let concurrent requests interleave and each read a total
+   * below what they collectively spent.
+   */
+  class RecordingWeightedStore implements WeightedIncrementStore {
+    readonly increments: Array<{ key: string; weight: number }> = [];
+    private windowMs = 60_000;
+    private hits = new Map<string, number>();
+
+    init(options: Options): void {
+      this.windowMs = options.windowMs;
+    }
+
+    async increment(key: string): Promise<IncrementResponse> {
+      return this.incrementBy(key, 1);
+    }
+
+    async incrementBy(key: string, weight: number): Promise<IncrementResponse> {
+      this.increments.push({ key, weight });
+      const totalHits = (this.hits.get(key) ?? 0) + weight;
+      this.hits.set(key, totalHits);
+      return { totalHits, resetTime: new Date(Date.now() + this.windowMs) };
+    }
+
+    async decrement(key: string): Promise<void> {
+      this.hits.set(key, Math.max((this.hits.get(key) ?? 0) - 1, 0));
+    }
+
+    async resetKey(key: string): Promise<void> {
+      this.hits.delete(key);
+    }
+  }
+
+  function buildApp(store: WeightedIncrementStore) {
     const app = express();
     app.use(express.json());
     app.post('/resolve', createBrandBulkDomainRateLimiter({
       maxDomains: 3,
-      store: new MemoryStore(),
+      store,
     }), (_req, res) => res.json({ ok: true }));
+    return app;
+  }
+
+  it('charges each request by unique domain count', async () => {
+    const store = new RecordingWeightedStore();
+    const app = buildApp(store);
 
     const first = await request(app)
       .post('/resolve')
@@ -103,5 +145,26 @@ describe('brand bulk domain rate limiter', () => {
     expect(first.status).toBe(200);
     expect(second.status).toBe(429);
     expect(second.body.message).toContain('domain limit exceeded');
+  });
+
+  it('spends the whole request weight in one store operation', async () => {
+    const store = new RecordingWeightedStore();
+
+    await request(buildApp(store))
+      .post('/resolve')
+      .send({ domains: ['one.example', 'two.example', 'one.example'] });
+
+    expect(store.increments).toHaveLength(1);
+    expect(store.increments[0].weight).toBe(2);
+  });
+
+  it('keys all request sizes to the same counter', async () => {
+    const store = new RecordingWeightedStore();
+    const app = buildApp(store);
+
+    await request(app).post('/resolve').send({ domains: ['one.example'] });
+    await request(app).post('/resolve').send({ domains: ['two.example', 'three.example'] });
+
+    expect(new Set(store.increments.map((entry) => entry.key)).size).toBe(1);
   });
 });

--- a/server/tests/unit/rate-limit-retry-after.test.ts
+++ b/server/tests/unit/rate-limit-retry-after.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { parseRetryAfterSeconds, createAgentReadRateLimiter } from '../../src/middleware/rate-limit.js';
+import { MemoryStore } from 'express-rate-limit';
+import { parseRetryAfterSeconds, createAgentReadRateLimiter, createBrandBulkDomainRateLimiter } from '../../src/middleware/rate-limit.js';
 
 /**
  * Tests for the retryAfter fallback field we surface on the 429 body
@@ -81,4 +82,26 @@ describe('agentReadRateLimiter 429 body', () => {
     expect(headerSeconds).toBeGreaterThan(0);
     expect(last!.body.retryAfter).toBe(headerSeconds);
   }, 30_000);
+});
+
+describe('brand bulk domain rate limiter', () => {
+  it('charges each request by unique domain count', async () => {
+    const app = express();
+    app.use(express.json());
+    app.post('/resolve', createBrandBulkDomainRateLimiter({
+      maxDomains: 3,
+      store: new MemoryStore(),
+    }), (_req, res) => res.json({ ok: true }));
+
+    const first = await request(app)
+      .post('/resolve')
+      .send({ domains: ['one.example', 'one.example', 'two.example'] });
+    const second = await request(app)
+      .post('/resolve')
+      .send({ domains: ['three.example', 'four.example'] });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(429);
+    expect(second.body.message).toContain('domain limit exceeded');
+  });
 });

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -323,12 +323,13 @@ describe('public registry brand read paths', () => {
     expect(res.body.brand_manifest).toEqual({ name: 'Acme', url: 'https://acme.com' });
   });
 
-  it('distinguishes owner-registered fallback records from community records', async () => {
+  it('reports verified owner-registered fallback records as hosted', async () => {
     const brandDb = {
       getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
         ...discoveredBrandWithContext(),
         source_type: 'community',
         workos_organization_id: 'org_owner',
+        domain_verified: true,
       }),
       upsertDiscoveredBrand: vi.fn(),
     };
@@ -337,6 +338,38 @@ describe('public registry brand read paths', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.source).toBe('hosted');
+  });
+
+  it('does not report an unverified organization-attributed record as hosted', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        ...discoveredBrandWithContext(),
+        source_type: 'community',
+        workos_organization_id: 'org_unverified',
+        domain_verified: false,
+      }),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb)).get('/api/brands/resolve?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body.source).toBe('community');
+  });
+
+  it('rejects path and port lookup inputs before brand resolution', async () => {
+    const resolveBrand = vi.fn().mockResolvedValue(null);
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb, false, { resolveBrand }))
+      .get('/api/brands/resolve?domain=public.example%3A8443%2Fadmin');
+
+    expect(res.status).toBe(400);
+    expect(resolveBrand).not.toHaveBeenCalled();
+    expect(brandDb.getDiscoveredBrandByDomain).not.toHaveBeenCalled();
   });
 
   it('surfaces live brand.json diagnostics when fresh resolution falls back', async () => {
@@ -383,6 +416,21 @@ describe('public registry brand read paths', () => {
     expect(res.body.results['acme.com'].brand_manifest).toEqual({ name: 'Acme', url: 'https://acme.com' });
   });
 
+  it('rejects non-hostname inputs from bulk resolution', async () => {
+    const resolveBrand = vi.fn().mockResolvedValue(null);
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb, false, { resolveBrand }))
+      .post('/api/brands/resolve/bulk')
+      .send({ domains: ['acme.com', 'public.example:8443/admin'] });
+
+    expect(res.status).toBe(400);
+    expect(resolveBrand).not.toHaveBeenCalled();
+  });
+
   it('strips legacy brand_context from /api/brands/brand-json cached data', async () => {
     const brandDb = {
       getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(discoveredBrandWithContext()),
@@ -393,6 +441,27 @@ describe('public registry brand read paths', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual({ name: 'Acme', url: 'https://acme.com' });
+  });
+
+  it('reports a cached canonical document with the canonical variant', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        ...discoveredBrandWithContext(),
+        source_type: 'brand_json',
+        brand_manifest: {
+          $schema: 'https://adcontextprotocol.org/schemas/v3/brand.json',
+          id: 'acme',
+          names: [{ en: 'Acme' }],
+          properties: [{ type: 'website', identifier: 'acme.com', relationship: 'owned' }],
+        },
+      }),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb)).get('/api/brands/brand-json?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body.variant).toBe('brand_canonical');
   });
 
   it('surfaces live validation diagnostics when fresh brand-json falls back to cached data', async () => {

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -43,8 +43,8 @@ function buildApp(
   app.use('/api', createRegistryApiRouter({
     brandManager: {
       resolveBrand: vi.fn().mockResolvedValue(null),
+      resolveBrandWithDiagnostics: vi.fn().mockResolvedValue({ brand: null }),
       validateDomain: vi.fn().mockResolvedValue({ valid: false, errors: [] }),
-      getLastValidationResult: vi.fn().mockReturnValue(undefined),
       ...brandManager,
     } as RegistryApiConfig['brandManager'],
     brandDb: brandDb as RegistryApiConfig['brandDb'],
@@ -387,8 +387,10 @@ describe('public registry brand read paths', () => {
     };
 
     const res = await request(buildApp(brandDb, false, {
-      resolveBrand: vi.fn().mockResolvedValue(null),
-      validateDomain: vi.fn().mockResolvedValue(validation),
+      resolveBrandWithDiagnostics: vi.fn().mockResolvedValue({
+        brand: null,
+        last_attempt: validation,
+      }),
     })).get('/api/brands/resolve?domain=acme.com&fresh=true');
 
     expect(res.status).toBe(200);
@@ -402,7 +404,7 @@ describe('public registry brand read paths', () => {
     });
   });
 
-  it('uses the latest fresh failure status in a not-found response', async () => {
+  it("uses this request's own fresh failure status in a not-found response", async () => {
     const brandDb = {
       getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
       upsertDiscoveredBrand: vi.fn(),
@@ -423,8 +425,10 @@ describe('public registry brand read paths', () => {
     });
 
     const res = await request(buildApp(brandDb, false, {
-      resolveBrand: vi.fn().mockResolvedValue(null),
-      getLastValidationResult: vi.fn().mockReturnValue(freshFailure),
+      resolveBrandWithDiagnostics: vi.fn().mockResolvedValue({
+        brand: null,
+        last_attempt: freshFailure,
+      }),
       validateDomain,
     })).get('/api/brands/resolve?domain=acme.com&fresh=true');
 

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -431,6 +431,22 @@ describe('public registry brand read paths', () => {
     expect(resolveBrand).not.toHaveBeenCalled();
   });
 
+  it('caps anonymous bulk resolution at 25 domains', async () => {
+    const resolveBrand = vi.fn().mockResolvedValue(null);
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb, false, { resolveBrand }))
+      .post('/api/brands/resolve/bulk')
+      .send({ domains: Array.from({ length: 26 }, (_, i) => `brand-${i}.example`) });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Maximum 25 domains per request');
+    expect(resolveBrand).not.toHaveBeenCalled();
+  });
+
   it('strips legacy brand_context from /api/brands/brand-json cached data', async () => {
     const brandDb = {
       getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(discoveredBrandWithContext()),

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -402,6 +402,37 @@ describe('public registry brand read paths', () => {
     });
   });
 
+  it('uses the latest fresh failure status in a not-found response', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+    const freshFailure = {
+      valid: false,
+      domain: 'acme.com',
+      url: 'https://acme.com/.well-known/brand.json',
+      status_code: 503,
+      errors: [{ field: 'http_status', message: 'HTTP 503', severity: 'error' }],
+      warnings: [],
+    };
+    const validateDomain = vi.fn().mockResolvedValue({
+      valid: true,
+      status_code: 200,
+      errors: [],
+      warnings: [],
+    });
+
+    const res = await request(buildApp(brandDb, false, {
+      resolveBrand: vi.fn().mockResolvedValue(null),
+      getLastValidationResult: vi.fn().mockReturnValue(freshFailure),
+      validateDomain,
+    })).get('/api/brands/resolve?domain=acme.com&fresh=true');
+
+    expect(res.status).toBe(404);
+    expect(res.body.file_status).toBe(503);
+    expect(validateDomain).not.toHaveBeenCalled();
+  });
+
   it('strips legacy brand_context from /api/brands/resolve/bulk fallback manifests', async () => {
     const brandDb = {
       getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(discoveredBrandWithContext()),
@@ -445,6 +476,41 @@ describe('public registry brand read paths', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('Maximum 25 domains per request');
     expect(resolveBrand).not.toHaveBeenCalled();
+  });
+
+  it('shares one concurrency ceiling across simultaneous bulk requests', async () => {
+    let active = 0;
+    let maxActive = 0;
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const resolveBrand = vi.fn().mockImplementation(async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await gate;
+      active--;
+      return null;
+    });
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+    const app = buildApp(brandDb, false, { resolveBrand });
+    const firstDomains = Array.from({ length: 10 }, (_, i) => `first-${i}.example`);
+    const secondDomains = Array.from({ length: 10 }, (_, i) => `second-${i}.example`);
+
+    const pending = Promise.all([
+      request(app).post('/api/brands/resolve/bulk').send({ domains: firstDomains }),
+      request(app).post('/api/brands/resolve/bulk').send({ domains: secondDomains }),
+    ]);
+
+    await vi.waitFor(() => expect(resolveBrand).toHaveBeenCalledTimes(10));
+    expect(maxActive).toBe(10);
+    release?.();
+
+    const responses = await pending;
+    expect(responses.map((response) => response.status)).toEqual([200, 200]);
+    expect(maxActive).toBe(10);
+    expect(resolveBrand).toHaveBeenCalledTimes(20);
   });
 
   it('strips legacy brand_context from /api/brands/brand-json cached data', async () => {

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -44,6 +44,7 @@ function buildApp(
     brandManager: {
       resolveBrand: vi.fn().mockResolvedValue(null),
       validateDomain: vi.fn().mockResolvedValue({ valid: false, errors: [] }),
+      getLastValidationResult: vi.fn().mockReturnValue(undefined),
       ...brandManager,
     } as RegistryApiConfig['brandManager'],
     brandDb: brandDb as RegistryApiConfig['brandDb'],
@@ -322,6 +323,52 @@ describe('public registry brand read paths', () => {
     expect(res.body.brand_manifest).toEqual({ name: 'Acme', url: 'https://acme.com' });
   });
 
+  it('distinguishes owner-registered fallback records from community records', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        ...discoveredBrandWithContext(),
+        source_type: 'community',
+        workos_organization_id: 'org_owner',
+      }),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb)).get('/api/brands/resolve?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body.source).toBe('hosted');
+  });
+
+  it('surfaces live brand.json diagnostics when fresh resolution falls back', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(discoveredBrandWithContext()),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+    const validation = {
+      valid: false,
+      domain: 'acme.com',
+      url: 'https://acme.com/.well-known/brand.json',
+      status_code: 200,
+      errors: [{ field: 'brands[0].names', message: 'Required', severity: 'error' }],
+      warnings: [{ field: '$schema', message: 'Legacy schema detected' }],
+    };
+
+    const res = await request(buildApp(brandDb, false, {
+      resolveBrand: vi.fn().mockResolvedValue(null),
+      validateDomain: vi.fn().mockResolvedValue(validation),
+    })).get('/api/brands/resolve?domain=acme.com&fresh=true');
+
+    expect(res.status).toBe(200);
+    expect(res.body.source).toBe('enriched');
+    expect(res.body.live_brand_json).toEqual({
+      valid: false,
+      url: validation.url,
+      status_code: 200,
+      errors: validation.errors,
+      warnings: validation.warnings,
+    });
+  });
+
   it('strips legacy brand_context from /api/brands/resolve/bulk fallback manifests', async () => {
     const brandDb = {
       getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(discoveredBrandWithContext()),
@@ -346,5 +393,34 @@ describe('public registry brand read paths', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual({ name: 'Acme', url: 'https://acme.com' });
+  });
+
+  it('surfaces live validation diagnostics when fresh brand-json falls back to cached data', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(discoveredBrandWithContext()),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+    const validation = {
+      valid: false,
+      domain: 'acme.com',
+      url: 'https://acme.com/.well-known/brand.json',
+      status_code: 200,
+      errors: [{ field: 'root', message: 'Invalid brand.json', severity: 'error' }],
+      warnings: [{ field: '$schema', message: 'Legacy schema detected' }],
+    };
+
+    const res = await request(buildApp(brandDb, false, {
+      validateDomain: vi.fn().mockResolvedValue(validation),
+    })).get('/api/brands/brand-json?domain=acme.com&fresh=true');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ name: 'Acme', url: 'https://acme.com' });
+    expect(res.body.live_brand_json).toEqual({
+      valid: false,
+      url: validation.url,
+      status_code: 200,
+      errors: validation.errors,
+      warnings: validation.warnings,
+    });
   });
 });

--- a/server/tests/unit/registry-feed-stream-route.test.ts
+++ b/server/tests/unit/registry-feed-stream-route.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../src/middleware/rate-limit.js', () => {
   const pass: import('express').RequestHandler = (_req, _res, next) => next();
   return {
     bulkResolveRateLimiter: pass,
+    brandBulkDomainRateLimiter: pass,
     brandCreationRateLimiter: pass,
     storyboardEvalRateLimiter: pass,
     storyboardStepRateLimiter: pass,

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -4666,7 +4666,10 @@ paths:
     get:
       operationId: resolveBrand
       summary: Resolve brand
-      description: Resolve a domain to its canonical brand identity. Follows brand.json redirects and returns the resolved brand with its house, architecture type, and optional manifest.
+      description: |-
+        Resolve a domain to its canonical brand identity. Follows brand.json redirects and returns the resolved brand with its house, architecture type, and optional manifest. The domain must be a bare DNS hostname.
+
+        **Rate limit:** 60 requests per minute per IP address.
       tags:
         - Brand Resolution
       parameters:
@@ -4691,6 +4694,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResolvedBrand"
+        "400":
+          description: Invalid or missing domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "404":
           description: Brand not found
           content:
@@ -4708,6 +4717,12 @@ paths:
                 required:
                   - error
                   - domain
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/brands/resolve/bulk:
     post:
       operationId: resolveBrandsBulk
@@ -4749,6 +4764,12 @@ paths:
                             - "null"
                 required:
                   - results
+        "400":
+          description: Invalid domain list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "429":
           description: Rate limit exceeded
           content:
@@ -4759,7 +4780,10 @@ paths:
     get:
       operationId: getBrandJson
       summary: Get brand.json
-      description: Fetch the raw brand.json file for a domain.
+      description: |-
+        Fetch the raw brand.json file for a bare DNS hostname.
+
+        **Rate limit:** 60 requests per minute per IP address.
       tags:
         - Brand Resolution
       parameters:
@@ -4859,8 +4883,20 @@ paths:
                   - domain
                   - url
                   - data
+        "400":
+          description: Invalid or missing domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "404":
           description: Brand not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
           content:
             application/json:
               schema:

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -4730,7 +4730,7 @@ paths:
       description: |-
         Resolve up to 25 domains to their canonical brand identities in a single request.
 
-        **Rate limit:** 20 requests per minute per IP address.
+        **Rate limits:** 20 requests and 100 unique domain resolutions per minute per IP address.
       tags:
         - Brand Resolution
       requestBody:

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -4728,7 +4728,7 @@ paths:
       operationId: resolveBrandsBulk
       summary: Bulk resolve brands
       description: |-
-        Resolve up to 100 domains to their canonical brand identities in a single request.
+        Resolve up to 25 domains to their canonical brand identities in a single request.
 
         **Rate limit:** 20 requests per minute per IP address.
       tags:
@@ -4743,7 +4743,7 @@ paths:
                   type: array
                   items:
                     type: string
-                  maxItems: 100
+                  maxItems: 25
               required:
                 - domains
       responses:

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -89,8 +89,36 @@ components:
           type: string
         house_domain:
           type: string
+        claimed_house_domain:
+          type: string
+          description: Unilateral house claim from a canonical document. Does not extend relationship trust unless relationship_trust is mutual.
         house_name:
           type: string
+        relationship_trust:
+          type: string
+          enum:
+            - inline
+            - mutual
+            - leaf_only
+            - house_only
+            - standalone
+            - unverifiable
+        promoted_from_schema:
+          type: string
+        migration_warnings:
+          type: array
+          items:
+            type: object
+            properties:
+              field:
+                type: string
+              message:
+                type: string
+              suggestion:
+                type: string
+            required:
+              - field
+              - message
         brand_agent_url:
           type: string
         brand_manifest:
@@ -99,9 +127,56 @@ components:
         source:
           type: string
           enum:
+            - hosted
             - brand_json
             - community
             - enriched
+        live_brand_json:
+          type: object
+          properties:
+            valid:
+              type: boolean
+            url:
+              type: string
+            status_code:
+              type: integer
+            errors:
+              type: array
+              items:
+                type: object
+                properties:
+                  field:
+                    type: string
+                  message:
+                    type: string
+                  severity:
+                    type: string
+                    enum:
+                      - error
+                required:
+                  - field
+                  - message
+                  - severity
+            warnings:
+              type: array
+              items:
+                type: object
+                properties:
+                  field:
+                    type: string
+                  message:
+                    type: string
+                  suggestion:
+                    type: string
+                required:
+                  - field
+                  - message
+          required:
+            - valid
+            - url
+            - errors
+            - warnings
+          description: Live origin-validation diagnostics when fresh=true falls back to a stored registry record.
       required:
         - canonical_id
         - canonical_domain
@@ -4722,7 +4797,64 @@ paths:
                   warnings:
                     type: array
                     items:
-                      type: string
+                      type: object
+                      properties:
+                        field:
+                          type: string
+                        message:
+                          type: string
+                        suggestion:
+                          type: string
+                      required:
+                        - field
+                        - message
+                  promoted_from_schema:
+                    type: string
+                  live_brand_json:
+                    type: object
+                    properties:
+                      valid:
+                        type: boolean
+                      url:
+                        type: string
+                      status_code:
+                        type: integer
+                      errors:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            field:
+                              type: string
+                            message:
+                              type: string
+                            severity:
+                              type: string
+                              enum:
+                                - error
+                          required:
+                            - field
+                            - message
+                            - severity
+                      warnings:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            field:
+                              type: string
+                            message:
+                              type: string
+                            suggestion:
+                              type: string
+                          required:
+                            - field
+                            - message
+                    required:
+                      - valid
+                      - url
+                      - errors
+                      - warnings
                 required:
                   - domain
                   - url

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -91,7 +91,7 @@ components:
           type: string
         claimed_house_domain:
           type: string
-          description: Unilateral house claim from a canonical document. Does not extend relationship trust unless relationship_trust is mutual.
+          description: House the requested domain claims. One-sided until the named house names it back, so it never extends relationship trust on its own.
         house_name:
           type: string
         relationship_trust:
@@ -103,8 +103,14 @@ components:
             - house_only
             - standalone
             - unverifiable
+          description: "How the brand-to-house relationship was established. `inline`: the house's own document defines the brand. `mutual`: both sides publish the relationship — the trust-extending edge. `leaf_only`: the brand claims a house that has not reciprocated. `house_only`: a house claims the brand, which has not reciprocated. `standalone`: the brand claims no house. `unverifiable`: a claimed house could not be checked."
+        relationship_verified_at:
+          type: string
+          description: When both sides of a mutual relationship were last seen agreeing. Present only for `mutual`, and it does not advance while the house side is unreachable, so callers can apply their own edge-aging policy.
+          example: 2026-07-28T12:00:00Z
         promoted_from_schema:
           type: string
+          description: Set when a pre-v3 document was promoted to a canonical v3 document for this response. Identity only — legacy relationship data is preserved opaquely, never promoted to a trust claim.
         migration_warnings:
           type: array
           items:
@@ -131,6 +137,7 @@ components:
             - brand_json
             - community
             - enriched
+          description: "Where the record came from. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment."
         live_brand_json:
           type: object
           properties:
@@ -4669,6 +4676,8 @@ paths:
       description: |-
         Resolve a domain to its canonical brand identity. Follows brand.json redirects and returns the resolved brand with its house, architecture type, and optional manifest. The domain must be a bare DNS hostname.
 
+        A domain is authoritative for its own identity, so `source` tells you who published the record and `relationship_trust` tells you whether a brand-to-house relationship was confirmed by both sides. Only `mutual` and `inline` are reciprocated; treat everything else as a claim.
+
         **Rate limit:** 60 requests per minute per IP address.
       tags:
         - Brand Resolution
@@ -4684,7 +4693,9 @@ paths:
             enum:
               - "true"
               - "false"
+            description: Bypass the resolution cache and refetch from the origin. When a fresh fetch fails and a stored record is returned instead, `live_brand_json` carries that fetch's diagnostics.
           required: false
+          description: Bypass the resolution cache and refetch from the origin. When a fresh fetch fails and a stored record is returned instead, `live_brand_json` carries that fetch's diagnostics.
           name: fresh
           in: query
       responses:
@@ -4728,9 +4739,9 @@ paths:
       operationId: resolveBrandsBulk
       summary: Bulk resolve brands
       description: |-
-        Resolve up to 25 domains to their canonical brand identities in a single request.
+        Resolve up to 25 domains to their canonical brand identities in a single request. Unresolvable domains map to `null`.
 
-        **Rate limits:** 20 requests and 100 unique domain resolutions per minute per IP address.
+        **Rate limits:** 20 requests and 100 unique domain resolutions per minute per IP address. Request bodies are capped at 16 KB.
       tags:
         - Brand Resolution
       requestBody:
@@ -4770,8 +4781,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "413":
+          description: Request body over 16 KB
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "429":
           description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Too much resolution work is already queued
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary

Resolve a domain's brand identity from its live `/.well-known/brand.json`, promote pre-v3 documents to canonical v3 identity, and report exactly how much of the answer was proven.

One rule holds the feature together:

> A document served from an origin is authoritative for that origin's own identity. It can only speak for a *different* domain when both sides publish the relationship.

Identity is self-asserted and TLS-scoped — a domain saying "I am Acme" proves only that the domain said it. Relationships are what confer inherited trust, so those need reciprocation.

## Trust model

- **Legacy promotion is origin-identity-only.** A pre-v3 document must contain exactly one website property matching the requested origin with `relationship: owned`. Canonical documents are schema-validated. Legacy relationship data is preserved opaquely, never promoted to a v3 trust claim.
- **A House Redirect is the leaf's one-sided claim.** The house's master brand answers only for the house domain itself. Reached from another domain, the response carries the claim (`claimed_house_domain` + `relationship_trust: leaf_only`) and no brand identity. Same rule for a house canonical document and a house brand agent.
- **Only owned properties bind a domain to a brand.** `direct`, `delegated`, and `ad_network` declare monetization paths, so an operator listing a publisher's domain does not become that domain's brand.
- **Trust labels expire.** A `mutual` edge carries `relationship_verified_at`, the time both sides were last seen agreeing. Retention through a transient house outage keeps that original timestamp and stops 24h after it, so repeated failures cannot renew trust indefinitely. Callers get the timestamp and can apply their own edge-aging policy.
- **Cross-domain `brand_refs` pointers** still require the leaf to name the house back, and a portfolio must be served from its own `house.domain`.

## Provenance

`source` has one definition on every surface: `hosted` means a verified owner registered the row (`workos_organization_id` + `domain_verified`). The registry listing and stats previously labelled every `is_public` row `hosted` — which every crawler-discovered row is, by column default. `verified` and `has_manifest` are now computed from evidence too (a document served from the domain's own origin, and actual manifest content).

`fresh=true` diagnostics are request-scoped: `resolveBrandWithDiagnostics` returns the terminal attempt for that call, replacing a per-domain map that concurrent requests shared.

## Bounds

- Domain-weighted bulk resolution consumes a request's whole weight in one atomic statement against Postgres, so the 100-domain/minute ceiling holds across the fleet rather than per pod.
- The process-wide fan-out semaphore bounds its wait list and sheds with `503` + `Retry-After` instead of queueing work nobody is waiting for.
- Bulk resolve is capped at 25 domains and 16 KB per request.

## Validation

- `npm run test:unit` — 66 files / 1,022 tests passed
- `npm run precommit:server-unit` — 306 files / 4,622 tests passed, 30 skipped
- `tests/integration/brand-registry-list.test.ts` against a real Postgres — 18 tests passed
- `npm run typecheck` clean; OpenAPI regenerated
- New regression tests: house-redirect reciprocation (6), mutual-trust aging (3), semaphore load shedding (4), weighted rate limiting (3), registry provenance labels (3)

## Notes

The repository pre-push policy reports no protocol release-surface change, so no changeset is required.
