### PR TITLE
fix(compliance): remove tab character from runner-output-contract.yaml

### DIFF
--- a/.changeset/fix-runner-output-contract-tab.md
+++ b/.changeset/fix-runner-output-contract-tab.md
@@ -1,0 +1,10 @@
+---
+"adcontextprotocol": patch
+---
+
+Remove a literal tab character from a comment line in
+`static/compliance/source/universal/runner-output-contract.yaml` (line 303).
+Tabs cannot start a token in YAML, so strict parsers fail to load the file
+entirely — platform engines consuming the packaged 3.1.4/3.1.5 compliance
+caches could not parse the runner output contract. Comment text unchanged;
+no semantic content changes.

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -300,7 +300,7 @@ validation_result:
                               #                          value (scoped to envelope)
                               #   envelope_field_absent → observed value at path (any JSON
                               #                          type); emitted only on failure
-	                              #                          and scoped to envelope
+                                #                          and scoped to envelope
                               #   envelope_field_pattern → observed envelope value at path
                               #                          (any JSON type); null when the field
                               #                          was missing


### PR DESCRIPTION
Implements the ready-to-implement triage on #6038.

## What

One-character fix: line 303 of `static/compliance/source/universal/runner-output-contract.yaml` began with a literal tab (a pure comment line — `#                          and scoped to envelope`). Tabs cannot start a token in YAML, so strict parsers fail to load the entire file; platform engines consuming the packaged 3.1.4/3.1.5 compliance caches could not parse the runner output contract (observed as capability-discovery errors and grading degradation, detailed in #6038). The tab is replaced with spaces; comment text and semantic content are unchanged.

## Verification

- `yaml.safe_load` parses the file clean after the change (it raised `ScannerError: found character '\t' that cannot start any token` before).
- `grep -rP '^\t' static/compliance/source/` → zero remaining tab-leading lines; this was the only occurrence in the source tree.
- `patch` changeset added under the `adcontextprotocol` scope.

## Follow-ups (per the triage, not in this PR)

- Backport to `3.1.x` after merge (→ ships as 3.1.6), then an `@adcp/sdk` release bundling the fixed cache.
- CI lint gate (`grep -rP "^\t" static/compliance/source/` or yamllint) to prevent reintroduction.

Refs #6038

🤖 Generated with [Claude Code](https://claude.com/claude-code)