### PR TITLE
fix(release): backport schema discovery status test correction

### DIFF
--- a/tests/dist-schema-version-ids.test.cjs
+++ b/tests/dist-schema-version-ids.test.cjs
@@ -80,9 +80,19 @@ test('dist schema root discovery marks prereleases but points canonical aliases 
   assert.equal(latest.latest_stable, discovery.latest_stable);
   assert.equal(latest.channel, 'stable');
 
+  const entriesByVersion = new Map(discovery.versions.map((entry) => [entry.version, entry]));
+  const assertSelectableStableTarget = (version, label) => {
+    const entry = entriesByVersion.get(version);
+    assert.ok(entry, `${label} must point at a discovered release`);
+    assert.equal(entry.stability, 'stable', `${label} must not point at a withdrawn or unpublished release`);
+    assert.equal(entry.prerelease, false, `${label} must not point at a prerelease`);
+  };
+
+  assertSelectableStableTarget(discovery.latest_stable, 'latest_stable');
   for (const [alias, version] of Object.entries(discovery.aliases)) {
     assert.match(alias, /^v\d+(?:\.\d+)?$/);
     assert.match(version, stableVersion, `${alias} must not point at a prerelease`);
+    assertSelectableStableTarget(version, alias);
   }
 
   assert.ok(discovery.versions.some((entry) => entry.prerelease === true), 'historical prerelease dirs should remain discoverable');
@@ -91,7 +101,10 @@ test('dist schema root discovery marks prereleases but points canonical aliases 
     .map((entry) => entry.version));
   for (const entry of discovery.versions) {
     if (stableVersion.test(entry.version)) {
-      assert.equal(entry.stability, 'stable');
+      assert.ok(
+        ['stable', 'withdrawn', 'unpublished'].includes(entry.stability),
+        `${entry.version} has unexpected release stability ${entry.stability}`,
+      );
       assert.equal(entry.prerelease, false);
     } else {
       assert.match(entry.version, /^\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/);


### PR DESCRIPTION
## Summary

- backport #6043 to the 3.1.x maintenance line
- allow exact stable-semver artifacts to retain `withdrawn` or `unpublished` discovery status
- require `latest_stable` and aliases to resolve only to discovered entries with `stability: stable`

## Why

The 3.1.6 artifact audit exposed the stale assertion after the release branch correctly regenerated 3.1.3 as `withdrawn`. This correction is required before merging the 3.1.6 Version Packages PR.

## Validation

- `npm run test:dist-schema-version-ids` — 2/2 passed
- `git diff --check origin/3.1.x...HEAD` — passed

No changeset: test-only release tooling correction; no protocol surface change.

Backport of #6043.