### PR TITLE
fix(schema): backport canonical list_creatives identities

### DIFF
--- a/.changeset/fix-list-creatives-canonical-identity.md
+++ b/.changeset/fix-list-creatives-canonical-identity.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Allow `list_creatives` response rows to use either the legacy `format_id` identity or the AdCP 3.1 canonical `format_kind` and optional `format_option_ref` identity.

--- a/scripts/oneof-discriminators.baseline.json
+++ b/scripts/oneof-discriminators.baseline.json
@@ -221,6 +221,11 @@
       "variants": 2,
       "note": "0:[results] | 1:[errors]"
     },
+    "creative/list-creatives-response.json##/properties/creatives/items/oneOf": {
+      "kind": "narrowable",
+      "variants": 2,
+      "note": "0:[format_id] | 1:[format_kind]"
+    },
     "creative/list-creatives-response.json##/properties/creatives/items/properties/assets/patternProperties/^[a-z0-9_]+$/oneOf": {
       "kind": "dangerous",
       "variants": 2,
@@ -265,11 +270,6 @@
       "kind": "narrowable",
       "variants": 3,
       "note": "0:[media_buy_id,confirmed_at,revision,packages] | 1:[errors] | 2:[status,task_id]"
-    },
-    "media-buy/get-media-buy-delivery-request.json##/properties/reporting_dimensions/properties/geo/properties/system/oneOf": {
-      "kind": "dangerous",
-      "variants": 2,
-      "note": "shared-required=[∅]; 0:ref-only(/schemas/enums/metro-system.json) | 1:ref-only(/schemas/enums/postal-system.json)"
     },
     "media-buy/get-media-buy-delivery-request.json##/properties/status_filter/oneOf": {
       "kind": "dangerous",

--- a/static/schemas/source/creative/list-creatives-response.json
+++ b/static/schemas/source/creative/list-creatives-response.json
@@ -77,7 +77,15 @@
           },
           "format_id": {
             "$ref": "/schemas/core/format-id.json",
-            "description": "Format identifier specifying which format this creative conforms to"
+            "description": "Legacy named-format path. Structured format identifier specifying which legacy format this creative conforms to. Mutually exclusive with `format_kind`."
+          },
+          "format_kind": {
+            "$ref": "/schemas/core/canonical-format-kind.json",
+            "description": "3.1+ canonical-format path. The canonical format kind this creative targets. Mutually exclusive with `format_id`."
+          },
+          "format_option_ref": {
+            "$ref": "/schemas/core/format-option-ref.json",
+            "description": "Optional 3.1+ reference to the concrete canonical format option this creative targets. Required when `format_kind` alone is ambiguous in the enclosing product context."
           },
           "status": {
             "$ref": "/schemas/enums/creative-status.json",
@@ -266,10 +274,33 @@
         "required": [
           "creative_id",
           "name",
-          "format_id",
           "status",
           "created_date",
           "updated_date"
+        ],
+        "oneOf": [
+          {
+            "title": "Legacy listed creative (named-format reference)",
+            "required": [
+              "format_id"
+            ],
+            "not": {
+              "required": [
+                "format_kind"
+              ]
+            }
+          },
+          {
+            "title": "3.1+ listed creative (canonical format kind)",
+            "required": [
+              "format_kind"
+            ],
+            "not": {
+              "required": [
+                "format_id"
+              ]
+            }
+          }
         ],
         "additionalProperties": true
       }

--- a/tests/schema-validation.test.cjs
+++ b/tests/schema-validation.test.cjs
@@ -467,6 +467,55 @@ async function runTests() {
     return true;
   });
 
+  await test('list_creatives accepts exactly one legacy or canonical creative identity', async () => {
+    const responseSchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'creative/list-creatives-response.json'));
+    const testAjv = new Ajv({
+      allErrors: true,
+      verbose: true,
+      strict: false,
+      discriminator: true,
+      loadSchema: loadExternalSchema
+    });
+    addFormats(testAjv);
+    const validate = await testAjv.compileAsync(responseSchema);
+    const baseResponse = {
+      status: 'completed',
+      query_summary: { total_matching: 1, returned: 1 },
+      pagination: { has_more: false },
+      creatives: [
+        {
+          creative_id: 'creative_1',
+          name: 'Canonical image',
+          status: 'approved',
+          created_date: '2026-07-27T00:00:00Z',
+          updated_date: '2026-07-27T00:00:00Z'
+        }
+      ]
+    };
+    const creative = baseResponse.creatives[0];
+    const legacyIdentity = {
+      format_id: {
+        agent_url: 'https://creative.example',
+        id: 'display_image'
+      }
+    };
+    const canonicalIdentity = { format_kind: 'image' };
+
+    for (const identity of [legacyIdentity, canonicalIdentity]) {
+      if (!validate({ ...baseResponse, creatives: [{ ...creative, ...identity }] })) {
+        return `valid creative identity was rejected: ${testAjv.errorsText(validate.errors)}`;
+      }
+    }
+
+    for (const identity of [{}, { ...legacyIdentity, ...canonicalIdentity }]) {
+      if (validate({ ...baseResponse, creatives: [{ ...creative, ...identity }] })) {
+        return 'creative identity must contain exactly one of format_id or format_kind';
+      }
+    }
+
+    return true;
+  });
+
   // Test 7: Validate preview_creative supports non-expiring preview URLs
   await test('preview_creative responses may omit expires_at for non-expiring preview URLs', async () => {
     const previewResponseSchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'creative/preview-creative-response.json'));


### PR DESCRIPTION
## Summary

- backport #6047 to the supported AdCP 3.1.x maintenance line
- allow `list_creatives` rows to use either legacy `format_id` or canonical `format_kind` with optional `format_option_ref`
- preserve strict rejection when neither identity or both identities are supplied

## Why this is a patch

AdCP 3.1 introduced canonical creative identities, but the `list_creatives` response schema still required the deprecated legacy identity. This restores the intended 3.1 response shape without removing legacy compatibility.

## Verification

- `node tests/schema-validation.test.cjs` (20/20)
- `node scripts/audit-oneof.mjs --check`
- `npm run build:schemas`
- `git diff --check origin/3.1.x...HEAD`

Mainline PR: #6047
