### PR TITLE
feat(addie): secretariat console — human-approved action queue, executor, and admin page

### DIFF
--- a/server/public/admin-sidebar.js
+++ b/server/public/admin-sidebar.js
@@ -75,6 +75,7 @@
         items: [
           { href: '/admin/agreements', label: 'Agreements', icon: '📋' },
           { href: '/admin/addie', label: 'Addie', icon: '🤖' },
+          { href: '/admin/secretariat', label: 'Secretariat', icon: '✅' },
           { href: '/admin/prompt-metrics', label: 'Prompt Metrics', icon: '📈' },
           { href: '/admin/manifest-refs', label: 'Manifest Registry', icon: '📋' },
           { href: '/admin/moltbook', label: 'Moltbook', icon: '📱' },

--- a/server/public/secretariat.html
+++ b/server/public/secretariat.html
@@ -1,0 +1,670 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <title>Admin - Secretariat console - AdCP Registry</title>
+  <link rel="stylesheet" href="/design-system.css">
+  <script src="/nav.js"></script>
+  <script src="/admin-sidebar.js"></script>
+  <style>
+    /* =============================================================================
+       Secretariat console styles
+       Uses design system variables - see /design-system.css for tokens
+       ============================================================================= */
+
+    body {
+      background: var(--color-bg-page);
+      min-height: 100vh;
+    }
+    .container {
+      max-width: var(--container-lg);
+      margin: var(--space-8) auto;
+      padding: 0 var(--space-5);
+    }
+    .card {
+      background: var(--color-bg-card);
+      border-radius: var(--radius-md);
+      padding: var(--space-6);
+      margin-bottom: var(--space-5);
+      box-shadow: var(--shadow-xs);
+    }
+    h1 { margin-bottom: var(--space-2); color: var(--color-text-heading); }
+    h2 { margin-bottom: var(--space-4); color: var(--color-text-heading); font-size: var(--text-xl); }
+    h3 { margin-bottom: var(--space-2); color: var(--color-text-heading); font-size: var(--text-base); }
+    .subtitle { color: var(--color-text-secondary); margin-bottom: var(--space-6); }
+
+    /* Stat chips */
+    .stats-row {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: var(--space-4);
+      margin-bottom: var(--space-6);
+    }
+    .stat-card {
+      background: var(--color-bg-card);
+      border-radius: var(--radius-md);
+      padding: var(--space-5);
+      box-shadow: var(--shadow-xs);
+      text-align: center;
+    }
+    .stat-value { font-size: var(--text-3xl); font-weight: var(--font-bold); color: var(--color-brand); }
+    .stat-label { font-size: var(--text-sm); color: var(--color-text-secondary); margin-top: var(--space-1); }
+
+    /* Tabs */
+    .tabs {
+      display: flex;
+      gap: var(--space-1);
+      border-bottom: var(--border-1) solid var(--color-gray-200);
+      margin-bottom: var(--space-5);
+    }
+    .tab {
+      padding: var(--space-3) var(--space-5);
+      background: transparent;
+      border: none;
+      border-bottom: var(--border-2) solid transparent;
+      cursor: pointer;
+      font-size: var(--text-sm);
+      font-weight: var(--font-medium);
+      color: var(--color-text-secondary);
+      transition: var(--transition-all);
+    }
+    .tab:hover { color: var(--color-text-heading); }
+    .tab.active { color: var(--color-brand); border-bottom-color: var(--color-brand); }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+
+    /* Action cards */
+    .action-list { display: grid; gap: var(--space-3); }
+    .action-card {
+      border: var(--border-1) solid var(--color-gray-200);
+      border-radius: var(--radius-md);
+      padding: var(--space-4);
+    }
+    .action-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: var(--space-3);
+      margin-bottom: var(--space-2);
+    }
+    .action-title-row { display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap; }
+    .action-title { font-weight: var(--font-medium); color: var(--color-text-heading); }
+    .action-meta { font-size: var(--text-xs); color: var(--color-text-muted); margin-top: var(--space-1); }
+    .action-rationale {
+      font-size: var(--text-sm);
+      color: var(--color-text-secondary);
+      margin-top: var(--space-2);
+      padding: var(--space-3);
+      background: var(--color-bg-subtle);
+      border-radius: var(--radius-sm);
+      white-space: pre-wrap;
+    }
+    .action-result {
+      font-size: var(--text-sm);
+      margin-top: var(--space-2);
+      padding: var(--space-3);
+      background: var(--color-success-50);
+      border-radius: var(--radius-sm);
+    }
+    .action-error {
+      font-size: var(--text-sm);
+      margin-top: var(--space-2);
+      padding: var(--space-3);
+      background: var(--color-error-50);
+      border: 1px solid var(--color-error-200);
+      border-radius: var(--radius-sm);
+      white-space: pre-wrap;
+      color: var(--color-error-700);
+    }
+    .payload-details { margin-top: var(--space-2); font-size: var(--text-sm); }
+    .payload-details summary { cursor: pointer; color: var(--color-text-secondary); }
+    .payload-pre {
+      background: var(--color-bg-subtle);
+      border-radius: var(--radius-sm);
+      padding: var(--space-3);
+      margin-top: var(--space-2);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .file-block { margin-top: var(--space-2); }
+    .file-path { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-text-secondary); }
+
+    /* Badges */
+    .badge {
+      display: inline-block;
+      padding: 2px var(--space-2);
+      border-radius: var(--radius-sm);
+      font-size: var(--text-xs);
+      font-weight: var(--font-medium);
+    }
+    .badge-kind { background: var(--color-primary-100); color: var(--color-primary-700); }
+    .badge-status-proposed { background: var(--color-info-100); color: var(--color-info-700); }
+    .badge-status-approved { background: var(--color-primary-100); color: var(--color-primary-700); }
+    .badge-status-executing { background: var(--color-warning-100); color: var(--color-warning-700); }
+    .badge-status-done { background: var(--color-success-100); color: var(--color-success-700); }
+    .badge-status-failed { background: var(--color-error-100); color: var(--color-error-700); }
+    .badge-status-rejected { background: var(--color-gray-200); color: var(--color-text-secondary); }
+
+    /* Buttons */
+    .btn {
+      padding: var(--space-2) var(--space-4);
+      border: none;
+      border-radius: var(--radius-md);
+      font-size: var(--text-sm);
+      cursor: pointer;
+      transition: var(--transition-all);
+    }
+    .btn-approve { background: var(--color-success-500); color: white; }
+    .btn-approve:hover { background: var(--color-success-600); }
+    .btn-reject { background: var(--color-bg-button-secondary); color: var(--color-text-heading); }
+    .btn-reject:hover { background: var(--color-bg-button-secondary-hover); }
+    .btn-edit { background: var(--color-bg-button-secondary); color: var(--color-text-heading); }
+    .btn-retry { background: var(--color-warning-500); color: white; }
+    .btn-save { background: var(--color-brand); color: white; }
+    .btn-cancel { background: var(--color-bg-button-secondary); color: var(--color-text-heading); }
+    .btn:disabled { background: var(--color-gray-400); cursor: not-allowed; }
+    .button-row { display: flex; gap: var(--space-2); margin-top: var(--space-3); flex-wrap: wrap; }
+    .edit-box { margin-top: var(--space-3); }
+    .edit-box textarea {
+      width: 100%;
+      min-height: 160px;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      padding: var(--space-2);
+      border: var(--border-1) solid var(--color-gray-300);
+      border-radius: var(--radius-sm);
+    }
+    .edit-box input[type="text"] {
+      width: 100%;
+      margin-bottom: var(--space-2);
+      padding: var(--space-2);
+      border: var(--border-1) solid var(--color-gray-300);
+      border-radius: var(--radius-sm);
+      font-size: var(--text-sm);
+    }
+
+    /* Watching section */
+    .pr-list { display: grid; gap: var(--space-2); }
+    .pr-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: var(--space-3);
+      border: var(--border-1) solid var(--color-gray-200);
+      border-radius: var(--radius-sm);
+      font-size: var(--text-sm);
+    }
+    .pr-title { color: var(--color-text-heading); }
+    .pr-meta { color: var(--color-text-muted); font-size: var(--text-xs); }
+    .wg-review-summary {
+      display: flex;
+      gap: var(--space-4);
+      flex-wrap: wrap;
+    }
+    .wg-bucket {
+      background: var(--color-bg-subtle);
+      padding: var(--space-3) var(--space-4);
+      border-radius: var(--radius-md);
+      text-align: center;
+    }
+    .wg-bucket-value { font-size: var(--text-lg); font-weight: var(--font-semibold); color: var(--color-text-heading); }
+    .wg-bucket-label { font-size: var(--text-xs); color: var(--color-text-secondary); }
+
+    .loading { text-align: center; padding: var(--space-8); color: var(--color-text-secondary); }
+    .empty-state { text-align: center; padding: var(--space-6); color: var(--color-text-muted); }
+  </style>
+</head>
+<body>
+  <div id="adcp-nav"></div>
+
+  <div id="loading" class="loading">Loading...</div>
+
+  <div id="content" style="display: none;">
+    <div class="container">
+      <h1>Secretariat console</h1>
+      <p class="subtitle">Human-approved action queue for the AAO Secretariat. Nothing runs until you approve it here.</p>
+
+      <div class="stats-row" id="statsRow"></div>
+
+      <!-- Watching -->
+      <div class="card">
+        <h2>Watching</h2>
+        <h3>Open pull requests</h3>
+        <div class="pr-list" id="prList"><div class="loading">Loading…</div></div>
+        <h3 style="margin-top: var(--space-5);">Needs WG review</h3>
+        <div class="wg-review-summary" id="wgReviewSummary"></div>
+      </div>
+
+      <!-- Tabs -->
+      <div class="tabs">
+        <button class="tab active" data-tab="proposed">Proposed</button>
+        <button class="tab" data-tab="inflight">In flight</button>
+        <button class="tab" data-tab="done">Done</button>
+        <button class="tab" data-tab="failed">Failed</button>
+      </div>
+
+      <div class="tab-content active" id="proposed-tab">
+        <div class="action-list" id="proposedList"><div class="loading">Loading…</div></div>
+      </div>
+      <div class="tab-content" id="inflight-tab">
+        <div class="action-list" id="inflightList"><div class="loading">Loading…</div></div>
+      </div>
+      <div class="tab-content" id="done-tab">
+        <div class="action-list" id="doneList"><div class="loading">Loading…</div></div>
+      </div>
+      <div class="tab-content" id="failed-tab">
+        <div class="action-list" id="failedList"><div class="loading">Loading…</div></div>
+      </div>
+    </div>
+  </div>
+
+  <div id="adcp-footer"></div>
+
+  <script>
+    const STATUS_LABELS = {
+      proposed: 'Proposed',
+      approved: 'Approved',
+      rejected: 'Rejected',
+      executing: 'Executing',
+      done: 'Done',
+      failed: 'Failed',
+    };
+
+    // ---- Small DOM-construction helpers. We build nodes with textContent
+    // rather than innerHTML template interpolation so payload-controlled
+    // strings (titles, rationale, file contents, error text) can never be
+    // parsed as markup.
+    function el(tag, opts = {}) {
+      const node = document.createElement(tag);
+      if (opts.className) node.className = opts.className;
+      if (opts.text !== undefined) node.textContent = opts.text;
+      if (opts.attrs) {
+        for (const [k, v] of Object.entries(opts.attrs)) node.setAttribute(k, v);
+      }
+      if (opts.onClick) node.addEventListener('click', opts.onClick);
+      if (opts.children) opts.children.forEach((c) => c && node.appendChild(c));
+      return node;
+    }
+
+    function formatRelativeTime(dateStr) {
+      if (!dateStr) return '';
+      const diff = Date.now() - new Date(dateStr).getTime();
+      const minutes = Math.floor(diff / 60000);
+      const hours = Math.floor(diff / 3600000);
+      const days = Math.floor(diff / 86400000);
+      if (minutes < 1) return 'just now';
+      if (minutes < 60) return `${minutes}m ago`;
+      if (hours < 24) return `${hours}h ago`;
+      return `${days}d ago`;
+    }
+
+    // ---- Tabs ----
+    document.querySelectorAll('.tab').forEach((tab) => {
+      tab.addEventListener('click', () => {
+        document.querySelectorAll('.tab').forEach((t) => t.classList.remove('active'));
+        tab.classList.add('active');
+        document.querySelectorAll('.tab-content').forEach((c) => c.classList.remove('active'));
+        document.getElementById(tab.dataset.tab + '-tab').classList.add('active');
+      });
+    });
+
+    // ---- Stats ----
+    async function loadStats() {
+      try {
+        const res = await AdminSidebar.fetch('/api/admin/secretariat/stats');
+        const data = await res.json();
+        const totals = { proposed: 0, approved: 0, executing: 0, done: 0, failed: 0, rejected: 0 };
+        for (const row of data.by_kind_status || []) {
+          totals[row.status] = (totals[row.status] || 0) + row.count;
+        }
+        const box = document.getElementById('statsRow');
+        box.innerHTML = '';
+        for (const status of ['proposed', 'approved', 'executing', 'done', 'failed']) {
+          box.appendChild(el('div', {
+            className: 'stat-card',
+            children: [
+              el('div', { className: 'stat-value', text: String(totals[status] || 0) }),
+              el('div', { className: 'stat-label', text: STATUS_LABELS[status] }),
+            ],
+          }));
+        }
+      } catch (err) {
+        console.error('Error loading stats:', err);
+      }
+    }
+
+    // ---- Watching ----
+    async function loadWatching() {
+      const prList = document.getElementById('prList');
+      const wgBox = document.getElementById('wgReviewSummary');
+      try {
+        const res = await AdminSidebar.fetch('/api/admin/secretariat/watching');
+        if (!res.ok) throw new Error('watching fetch failed: ' + res.status);
+        const data = await res.json();
+
+        prList.innerHTML = '';
+        if (!data.openPrs || data.openPrs.length === 0) {
+          prList.appendChild(el('div', { className: 'empty-state', text: 'No open pull requests.' }));
+        } else {
+          for (const pr of data.openPrs) {
+            const link = el('a', { text: `#${pr.number} ${pr.title}`, attrs: { href: pr.url, target: '_blank', rel: 'noopener' } });
+            link.className = 'pr-title';
+            prList.appendChild(el('div', {
+              className: 'pr-row',
+              children: [
+                link,
+                el('span', { className: 'pr-meta', text: `${pr.author} · ${pr.ageDays}d old · ${pr.reviewState.replace(/_/g, ' ')}` }),
+              ],
+            }));
+          }
+        }
+
+        wgBox.innerHTML = '';
+        const buckets = data.needsWgReview?.ageBuckets || { under7d: 0, d7to14: 0, over14d: 0 };
+        wgBox.appendChild(el('div', {
+          className: 'wg-bucket',
+          children: [
+            el('div', { className: 'wg-bucket-value', text: String(data.needsWgReview?.count ?? 0) }),
+            el('div', { className: 'wg-bucket-label', text: 'Total open' }),
+          ],
+        }));
+        wgBox.appendChild(el('div', {
+          className: 'wg-bucket',
+          children: [
+            el('div', { className: 'wg-bucket-value', text: String(buckets.under7d) }),
+            el('div', { className: 'wg-bucket-label', text: '< 7 days' }),
+          ],
+        }));
+        wgBox.appendChild(el('div', {
+          className: 'wg-bucket',
+          children: [
+            el('div', { className: 'wg-bucket-value', text: String(buckets.d7to14) }),
+            el('div', { className: 'wg-bucket-label', text: '7-14 days' }),
+          ],
+        }));
+        wgBox.appendChild(el('div', {
+          className: 'wg-bucket',
+          children: [
+            el('div', { className: 'wg-bucket-value', text: String(buckets.over14d) }),
+            el('div', { className: 'wg-bucket-label', text: '> 14 days' }),
+          ],
+        }));
+      } catch (err) {
+        console.error('Error loading watching snapshot:', err);
+        prList.innerHTML = '';
+        prList.appendChild(el('div', { className: 'empty-state', text: 'Unable to load watching snapshot.' }));
+      }
+    }
+
+    // ---- Payload preview ----
+    function buildPayloadPreview(action) {
+      const details = el('details', { className: 'payload-details' });
+      details.appendChild(el('summary', { text: 'Payload' }));
+
+      if (action.kind === 'open_pr' && Array.isArray(action.payload?.files)) {
+        for (const file of action.payload.files) {
+          const block = el('div', { className: 'file-block' });
+          block.appendChild(el('div', { className: 'file-path', text: file.path }));
+          const pre = el('pre', { className: 'payload-pre' });
+          pre.textContent = file.content;
+          block.appendChild(pre);
+          details.appendChild(block);
+        }
+        const rest = { ...action.payload, files: undefined };
+        const pre = el('pre', { className: 'payload-pre' });
+        pre.textContent = JSON.stringify(rest, null, 2);
+        details.appendChild(pre);
+      } else {
+        const pre = el('pre', { className: 'payload-pre' });
+        pre.textContent = JSON.stringify(action.payload, null, 2);
+        details.appendChild(pre);
+      }
+      return details;
+    }
+
+    // ---- Action mutations ----
+    async function postAction(id, path, body) {
+      const res = await AdminSidebar.fetch(`/api/admin/secretariat/actions/${id}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert('Action failed: ' + (err.error || res.status));
+        return false;
+      }
+      return true;
+    }
+
+    async function approveAction(id) {
+      if (await postAction(id, '/approve')) await loadAll();
+    }
+
+    async function rejectAction(id) {
+      const reason = prompt('Reason for rejecting this action:');
+      if (!reason) return;
+      if (await postAction(id, '/reject', { reason })) await loadAll();
+    }
+
+    async function retryAction(id) {
+      if (await postAction(id, '/retry')) await loadAll();
+    }
+
+    async function saveEdit(id, textarea, titleInput) {
+      let payload;
+      try {
+        payload = JSON.parse(textarea.value);
+      } catch (err) {
+        alert('Payload is not valid JSON: ' + err.message);
+        return;
+      }
+      const res = await AdminSidebar.fetch(`/api/admin/secretariat/actions/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ payload, title: titleInput.value || undefined }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert('Edit failed: ' + (err.error || res.status));
+        return;
+      }
+      await loadAll();
+    }
+
+    // ---- Card builders ----
+    function buildBaseCard(action) {
+      const card = el('div', { className: 'action-card' });
+      const header = el('div', { className: 'action-header' });
+
+      const titleRow = el('div', { className: 'action-title-row' });
+      titleRow.appendChild(el('span', { className: 'action-title', text: action.title }));
+      titleRow.appendChild(el('span', { className: 'badge badge-kind', text: action.kind }));
+      titleRow.appendChild(el('span', { className: `badge badge-status-${action.status}`, text: STATUS_LABELS[action.status] || action.status }));
+      if (action.edited) titleRow.appendChild(el('span', { className: 'badge', text: 'edited' }));
+
+      const meta = el('div', {
+        className: 'action-meta',
+        text: `origin: ${action.origin} · created ${formatRelativeTime(action.created_at)}` +
+          (action.decided_by ? ` · decided by ${action.decided_by}` : ''),
+      });
+
+      const left = el('div', {});
+      left.appendChild(titleRow);
+      left.appendChild(meta);
+      header.appendChild(left);
+      card.appendChild(header);
+
+      const rationale = el('div', { className: 'action-rationale', text: action.rationale });
+      card.appendChild(rationale);
+      card.appendChild(buildPayloadPreview(action));
+
+      return card;
+    }
+
+    function buildProposedCard(action) {
+      const card = buildBaseCard(action);
+      const buttons = el('div', { className: 'button-row' });
+
+      buttons.appendChild(el('button', { className: 'btn btn-approve', text: 'Approve', onClick: () => approveAction(action.id) }));
+      buttons.appendChild(el('button', { className: 'btn btn-reject', text: 'Reject', onClick: () => rejectAction(action.id) }));
+
+      const editBox = el('div', { className: 'edit-box' });
+      editBox.style.display = 'none';
+      const titleInput = el('input', { attrs: { type: 'text' } });
+      titleInput.value = action.title;
+      const textarea = el('textarea');
+      textarea.value = JSON.stringify(action.payload, null, 2);
+      editBox.appendChild(titleInput);
+      editBox.appendChild(textarea);
+      const editButtons = el('div', { className: 'button-row' });
+      editButtons.appendChild(el('button', { className: 'btn btn-save', text: 'Save', onClick: () => saveEdit(action.id, textarea, titleInput) }));
+      editButtons.appendChild(el('button', { className: 'btn btn-cancel', text: 'Cancel', onClick: () => { editBox.style.display = 'none'; } }));
+      editBox.appendChild(editButtons);
+
+      buttons.appendChild(el('button', {
+        className: 'btn btn-edit',
+        text: 'Edit',
+        onClick: () => { editBox.style.display = editBox.style.display === 'none' ? 'block' : 'none'; },
+      }));
+
+      card.appendChild(buttons);
+      card.appendChild(editBox);
+      return card;
+    }
+
+    function buildResultOrErrorBlock(action) {
+      const frag = document.createDocumentFragment();
+      if (action.result) {
+        const url = action.result.prUrl || action.result.commentUrl || action.result.issueUrl || null;
+        const box = el('div', { className: 'action-result' });
+        if (url) {
+          const link = el('a', { text: url, attrs: { href: url, target: '_blank', rel: 'noopener' } });
+          box.appendChild(link);
+        } else {
+          box.appendChild(el('span', { text: JSON.stringify(action.result) }));
+        }
+        frag.appendChild(box);
+      }
+      if (action.error) {
+        frag.appendChild(el('div', { className: 'action-error', text: action.error }));
+      }
+      return frag;
+    }
+
+    function buildInFlightCard(action) {
+      const card = buildBaseCard(action);
+      card.appendChild(buildResultOrErrorBlock(action));
+      return card;
+    }
+
+    function buildDoneCard(action) {
+      const card = buildBaseCard(action);
+      card.appendChild(buildResultOrErrorBlock(action));
+      return card;
+    }
+
+    function buildFailedCard(action) {
+      const card = buildBaseCard(action);
+      card.appendChild(buildResultOrErrorBlock(action));
+      const buttons = el('div', { className: 'button-row' });
+      buttons.appendChild(el('button', { className: 'btn btn-retry', text: 'Retry', onClick: () => retryAction(action.id) }));
+      card.appendChild(buttons);
+      return card;
+    }
+
+    async function fetchActions(status) {
+      const res = await AdminSidebar.fetch(`/api/admin/secretariat/actions?status=${encodeURIComponent(status)}`);
+      if (!res.ok) throw new Error('actions fetch failed: ' + res.status);
+      const data = await res.json();
+      return data.actions || [];
+    }
+
+    async function loadProposed() {
+      const list = document.getElementById('proposedList');
+      try {
+        const actions = await fetchActions('proposed');
+        list.innerHTML = '';
+        if (actions.length === 0) {
+          list.appendChild(el('div', { className: 'empty-state', text: 'No proposed actions.' }));
+          return;
+        }
+        for (const action of actions) list.appendChild(buildProposedCard(action));
+      } catch (err) {
+        console.error('Error loading proposed actions:', err);
+        list.innerHTML = '';
+        list.appendChild(el('div', { className: 'empty-state', text: 'Unable to load proposed actions.' }));
+      }
+    }
+
+    async function loadInFlight() {
+      const list = document.getElementById('inflightList');
+      try {
+        const [approved, executing] = await Promise.all([fetchActions('approved'), fetchActions('executing')]);
+        const actions = [...approved, ...executing].sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+        list.innerHTML = '';
+        if (actions.length === 0) {
+          list.appendChild(el('div', { className: 'empty-state', text: 'Nothing in flight.' }));
+          return;
+        }
+        for (const action of actions) list.appendChild(buildInFlightCard(action));
+      } catch (err) {
+        console.error('Error loading in-flight actions:', err);
+        list.innerHTML = '';
+        list.appendChild(el('div', { className: 'empty-state', text: 'Unable to load in-flight actions.' }));
+      }
+    }
+
+    async function loadDone() {
+      const list = document.getElementById('doneList');
+      try {
+        const actions = await fetchActions('done');
+        list.innerHTML = '';
+        if (actions.length === 0) {
+          list.appendChild(el('div', { className: 'empty-state', text: 'No completed actions yet.' }));
+          return;
+        }
+        for (const action of actions) list.appendChild(buildDoneCard(action));
+      } catch (err) {
+        console.error('Error loading done actions:', err);
+        list.innerHTML = '';
+        list.appendChild(el('div', { className: 'empty-state', text: 'Unable to load done actions.' }));
+      }
+    }
+
+    async function loadFailed() {
+      const list = document.getElementById('failedList');
+      try {
+        const actions = await fetchActions('failed');
+        list.innerHTML = '';
+        if (actions.length === 0) {
+          list.appendChild(el('div', { className: 'empty-state', text: 'No failed actions.' }));
+          return;
+        }
+        for (const action of actions) list.appendChild(buildFailedCard(action));
+      } catch (err) {
+        console.error('Error loading failed actions:', err);
+        list.innerHTML = '';
+        list.appendChild(el('div', { className: 'empty-state', text: 'Unable to load failed actions.' }));
+      }
+    }
+
+    async function loadAll() {
+      await Promise.all([loadStats(), loadWatching(), loadProposed(), loadInFlight(), loadDone(), loadFailed()]);
+    }
+
+    async function init() {
+      await loadAll();
+      document.getElementById('loading').style.display = 'none';
+      document.getElementById('content').style.display = 'block';
+    }
+
+    init();
+  </script>
+</body>
+</html>

--- a/server/src/addie/jobs/github-filer.ts
+++ b/server/src/addie/jobs/github-filer.ts
@@ -25,6 +25,19 @@ export interface FiledIssue {
   repo: string;
 }
 
+export interface PostIssueCommentInput {
+  /** Issue or PR number to comment on. */
+  issueNumber: number;
+  body: string;
+  /** Repo slug `owner/name`. Defaults to `GITHUB_REPO` env or `adcontextprotocol/adcp`. */
+  repo?: string;
+}
+
+export interface PostedComment {
+  url: string;
+  id: number;
+}
+
 /**
  * Create a GitHub issue via resolveGitHubToken() (Secretariat App token
  * when configured, legacy PAT otherwise). Returns null on any failure
@@ -70,6 +83,56 @@ export async function fileGitHubIssue(input: FileIssueInput): Promise<FiledIssue
     return { url: issue.html_url, number: issue.number, repo };
   } catch (err) {
     logger.error({ err, repo }, 'GitHub issue create threw');
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Post a comment on an issue or PR via resolveGitHubToken() (Secretariat
+ * App token when configured, legacy PAT otherwise). Works on both issues
+ * and PRs — GitHub's REST API treats PR conversations as issue comments.
+ * Returns null on any failure so callers can keep the proposal open
+ * without swallowing the exception.
+ */
+export async function postIssueComment(input: PostIssueCommentInput): Promise<PostedComment | null> {
+  const token = await resolveGitHubToken();
+  if (!token) {
+    logger.warn('No GitHub credential available; cannot post comment');
+    return null;
+  }
+
+  const repo = input.repo ?? process.env.GITHUB_REPO ?? 'adcontextprotocol/adcp';
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const resp = await fetch(
+      `https://api.github.com/repos/${repo}/issues/${input.issueNumber}/comments`,
+      {
+        method: 'POST',
+        signal: controller.signal,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/vnd.github.v3+json',
+          'User-Agent': 'aao-secretariat/1.0',
+        },
+        body: JSON.stringify({ body: redactSupportSecrets(input.body) ?? '' }),
+      }
+    );
+
+    if (!resp.ok) {
+      const err = await resp.text().catch(() => '');
+      logger.error({ status: resp.status, err, repo, issueNumber: input.issueNumber }, 'GitHub comment create failed');
+      return null;
+    }
+
+    const comment = (await resp.json()) as { html_url: string; id: number };
+    return { url: comment.html_url, id: comment.id };
+  } catch (err) {
+    logger.error({ err, repo, issueNumber: input.issueNumber }, 'GitHub comment create threw');
     return null;
   } finally {
     clearTimeout(timer);

--- a/server/src/addie/jobs/github-pr.ts
+++ b/server/src/addie/jobs/github-pr.ts
@@ -30,6 +30,25 @@ export interface UpsertFilePrInput {
   prBody: string;
 }
 
+export interface FileChange {
+  /** Repo-relative file path to create or update. */
+  path: string;
+  content: string;
+}
+
+export interface UpsertFilesPrInput {
+  /** Repo slug `owner/name`. Defaults to `GITHUB_REPO` env or `adcontextprotocol/adcp`. */
+  repo?: string;
+  /** Head branch the PR ships from, e.g. `addie/secretariat-1234`. */
+  branch: string;
+  /** Base branch. Defaults to `main`. */
+  baseBranch?: string;
+  files: FileChange[];
+  commitMessage: string;
+  prTitle: string;
+  prBody: string;
+}
+
 export interface UpsertFilePrResult {
   prUrl: string;
   prNumber: number;
@@ -84,10 +103,147 @@ export async function getFileContent(
 }
 
 /**
+ * Ensure `branch` exists at `base`'s current head, force-resetting it if
+ * it already exists so stale content never leaks into the diff. Returns
+ * the base sha on success, null on any failure.
+ */
+async function resetBranchToBase(
+  token: string,
+  api: string,
+  branch: string,
+  base: string,
+  repo: string
+): Promise<string | null> {
+  const refResp = await ghFetch(token, `${api}/git/ref/heads/${base}`);
+  if (!refResp.ok) {
+    logger.error({ status: refResp.status, repo, base }, 'Base ref lookup failed');
+    return null;
+  }
+  const baseSha = ((await refResp.json()) as { object: { sha: string } }).object.sha;
+
+  const createResp = await ghFetch(token, `${api}/git/refs`, {
+    method: 'POST',
+    body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: baseSha }),
+  });
+  if (!createResp.ok) {
+    if (createResp.status !== 422) {
+      logger.error({ status: createResp.status, repo }, 'Branch create failed');
+      return null;
+    }
+    const resetResp = await ghFetch(token, `${api}/git/refs/heads/${branch}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ sha: baseSha, force: true }),
+    });
+    if (!resetResp.ok) {
+      logger.error({ status: resetResp.status, repo }, 'Branch reset failed');
+      return null;
+    }
+  }
+  return baseSha;
+}
+
+/**
+ * PUT a single file's content onto `branch` via the Contents API,
+ * looking up the existing blob sha first (absent on a first-ever write).
+ * Returns true on success.
+ */
+async function putFileContent(
+  token: string,
+  api: string,
+  branch: string,
+  file: FileChange,
+  commitMessage: string,
+  repo: string
+): Promise<boolean> {
+  const fileResp = await ghFetch(
+    token,
+    `${api}/contents/${file.path}?ref=${encodeURIComponent(branch)}`
+  );
+  let existingSha: string | undefined;
+  if (fileResp.ok) {
+    existingSha = ((await fileResp.json()) as { sha?: string }).sha;
+  } else if (fileResp.status !== 404) {
+    logger.error({ status: fileResp.status, repo, path: file.path }, 'File lookup failed');
+    return false;
+  }
+
+  const putResp = await ghFetch(token, `${api}/contents/${file.path}`, {
+    method: 'PUT',
+    body: JSON.stringify({
+      message: commitMessage,
+      content: Buffer.from(file.content, 'utf8').toString('base64'),
+      branch,
+      ...(existingSha ? { sha: existingSha } : {}),
+    }),
+  });
+  if (!putResp.ok) {
+    const err = await putResp.text().catch(() => '');
+    logger.error({ status: putResp.status, err, repo, path: file.path }, 'File commit failed');
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Reuse the open PR for `branch` if one exists, or open a new one.
+ */
+async function reuseOrOpenPr(
+  token: string,
+  api: string,
+  repo: string,
+  branch: string,
+  base: string,
+  prTitle: string,
+  prBody: string
+): Promise<UpsertFilePrResult | null> {
+  const owner = repo.split('/')[0];
+  const listResp = await ghFetch(
+    token,
+    `${api}/pulls?head=${owner}:${encodeURIComponent(branch)}&base=${base}&state=open`
+  );
+  if (listResp.ok) {
+    const open = (await listResp.json()) as Array<{ html_url: string; number: number }>;
+    if (open.length > 0) {
+      return { prUrl: open[0].html_url, prNumber: open[0].number, created: false };
+    }
+  }
+
+  const prResp = await ghFetch(token, `${api}/pulls`, {
+    method: 'POST',
+    body: JSON.stringify({ title: prTitle, head: branch, base, body: prBody }),
+  });
+  if (!prResp.ok) {
+    const err = await prResp.text().catch(() => '');
+    logger.error({ status: prResp.status, err, repo }, 'PR create failed');
+    return null;
+  }
+  const pr = (await prResp.json()) as { html_url: string; number: number };
+  return { prUrl: pr.html_url, prNumber: pr.number, created: true };
+}
+
+/**
  * Create or refresh a single-file PR. Returns null on any failure so
  * job callers can record the miss without throwing.
  */
 export async function upsertFilePr(input: UpsertFilePrInput): Promise<UpsertFilePrResult | null> {
+  return upsertFilesPr({
+    repo: input.repo,
+    branch: input.branch,
+    baseBranch: input.baseBranch,
+    files: [{ path: input.path, content: input.content }],
+    commitMessage: input.commitMessage,
+    prTitle: input.prTitle,
+    prBody: input.prBody,
+  });
+}
+
+/**
+ * Create or refresh a multi-file PR: force-resets the working branch to
+ * base head, PUTs each file's content, then reuses or opens the PR.
+ * Returns null on any failure so job callers can record the miss without
+ * throwing.
+ */
+export async function upsertFilesPr(input: UpsertFilesPrInput): Promise<UpsertFilePrResult | null> {
   const token = await resolveGitHubToken();
   if (!token) {
     logger.warn('No GitHub credential available; cannot open PR');
@@ -98,94 +254,17 @@ export async function upsertFilePr(input: UpsertFilePrInput): Promise<UpsertFile
   const api = `https://api.github.com/repos/${repo}`;
 
   try {
-    const refResp = await ghFetch(token, `${api}/git/ref/heads/${base}`);
-    if (!refResp.ok) {
-      logger.error({ status: refResp.status, repo, base }, 'Base ref lookup failed');
-      return null;
-    }
-    const baseSha = ((await refResp.json()) as { object: { sha: string } }).object.sha;
+    const baseSha = await resetBranchToBase(token, api, input.branch, base, repo);
+    if (!baseSha) return null;
 
-    // Ensure the working branch exists at base head. Force-reset an
-    // existing branch so stale content never leaks into the diff.
-    const createResp = await ghFetch(token, `${api}/git/refs`, {
-      method: 'POST',
-      body: JSON.stringify({ ref: `refs/heads/${input.branch}`, sha: baseSha }),
-    });
-    if (!createResp.ok) {
-      if (createResp.status !== 422) {
-        logger.error({ status: createResp.status, repo }, 'Branch create failed');
-        return null;
-      }
-      const resetResp = await ghFetch(token, `${api}/git/refs/heads/${input.branch}`, {
-        method: 'PATCH',
-        body: JSON.stringify({ sha: baseSha, force: true }),
-      });
-      if (!resetResp.ok) {
-        logger.error({ status: resetResp.status, repo }, 'Branch reset failed');
-        return null;
-      }
+    for (const file of input.files) {
+      const ok = await putFileContent(token, api, input.branch, file, input.commitMessage, repo);
+      if (!ok) return null;
     }
 
-    // Blob sha of the file on the branch (equals base's copy after the
-    // reset); absent for a first-ever refresh.
-    const fileResp = await ghFetch(
-      token,
-      `${api}/contents/${input.path}?ref=${encodeURIComponent(input.branch)}`
-    );
-    let existingSha: string | undefined;
-    if (fileResp.ok) {
-      existingSha = ((await fileResp.json()) as { sha?: string }).sha;
-    } else if (fileResp.status !== 404) {
-      logger.error({ status: fileResp.status, repo }, 'File lookup failed');
-      return null;
-    }
-
-    const putResp = await ghFetch(token, `${api}/contents/${input.path}`, {
-      method: 'PUT',
-      body: JSON.stringify({
-        message: input.commitMessage,
-        content: Buffer.from(input.content, 'utf8').toString('base64'),
-        branch: input.branch,
-        ...(existingSha ? { sha: existingSha } : {}),
-      }),
-    });
-    if (!putResp.ok) {
-      const err = await putResp.text().catch(() => '');
-      logger.error({ status: putResp.status, err, repo }, 'File commit failed');
-      return null;
-    }
-
-    // Reuse the open PR for this branch, or open one.
-    const owner = repo.split('/')[0];
-    const listResp = await ghFetch(
-      token,
-      `${api}/pulls?head=${owner}:${encodeURIComponent(input.branch)}&base=${base}&state=open`
-    );
-    if (listResp.ok) {
-      const open = (await listResp.json()) as Array<{ html_url: string; number: number }>;
-      if (open.length > 0) {
-        return { prUrl: open[0].html_url, prNumber: open[0].number, created: false };
-      }
-    }
-
-    const prResp = await ghFetch(token, `${api}/pulls`, {
-      method: 'POST',
-      body: JSON.stringify({
-        title: input.prTitle,
-        head: input.branch,
-        base,
-        body: input.prBody,
-      }),
-    });
-    if (!prResp.ok) {
-      const err = await prResp.text().catch(() => '');
-      logger.error({ status: prResp.status, err, repo }, 'PR create failed');
-      return null;
-    }
-    const pr = (await prResp.json()) as { html_url: string; number: number };
-    return { prUrl: pr.html_url, prNumber: pr.number, created: true };
+    return await reuseOrOpenPr(token, api, repo, input.branch, base, input.prTitle, input.prBody);
   } catch (err) {
-    logger.error({ err, repo }, 'upsertFilePr threw');
+    logger.error({ err, repo }, 'upsertFilesPr threw');
     return null;
   }
 }

--- a/server/src/addie/jobs/job-definitions.ts
+++ b/server/src/addie/jobs/job-definitions.ts
@@ -41,6 +41,8 @@ import { runCertificationRecoveryJob } from './certification-recovery.js';
 import { runBrandLogoDigestJob } from './brand-logo-digest.js';
 import { runWgDigestJob, runWgDigestPrepJob } from './wg-digest.js';
 import { runWgSlackContextJob } from './wg-slack-context.js';
+import { runSecretariatExecutorJob } from './secretariat-executor.js';
+import { runSecretariatPrShepherdJob } from './secretariat-pr-shepherd.js';
 import { runComplianceHeartbeatJob } from './compliance-heartbeat.js';
 import { runShadowEvaluatorJob } from './shadow-evaluator.js';
 import { runAddieCorrectedCaptureJob } from './shadow-corrected-capture.js';
@@ -399,6 +401,33 @@ export function registerAllJobs(): void {
     runner: runWgSlackContextJob,
     failureThreshold: 1,
     shouldLogResult: (r) => !!r.prUrl || r.skipped === 'pr-failed',
+  });
+
+  // Secretariat executor - carries out human-approved actions from the
+  // Secretariat console. No businessHours gate: approvals should execute
+  // promptly regardless of when the admin clicked Approve. Never approves
+  // or auto-generates actions itself — see secretariat-executor.ts's hard
+  // safety rules.
+  jobScheduler.register({
+    name: 'secretariat-executor',
+    description: 'Execute human-approved Secretariat actions',
+    interval: { value: 2, unit: 'minutes' },
+    initialDelay: { value: 1, unit: 'minutes' },
+    runner: runSecretariatExecutorJob,
+    options: { limit: 10 },
+    shouldLogResult: (r) => r.executed > 0 || r.failed > 0,
+  });
+
+  // Secretariat PR shepherd - proposes IPR-signature nudges for stale
+  // open PRs. Only proposes; a human approves in the Secretariat console
+  // before anything posts.
+  jobScheduler.register({
+    name: 'secretariat-pr-shepherd',
+    description: 'Propose IPR-signature nudges for stale open PRs',
+    interval: { value: 1, unit: 'hours' },
+    initialDelay: { value: 16, unit: 'minutes' },
+    runner: runSecretariatPrShepherdJob,
+    shouldLogResult: (r) => r.proposed > 0,
   });
 
   // Credential digest - weekly summary of certification awards to Slack
@@ -968,4 +997,6 @@ export const JOB_NAMES = {
   NETWORK_CONSISTENCY_REPORTER: 'network-consistency-reporter',
   ESCALATION_TRIAGE: 'escalation-triage',
   ESCALATION_SLA: 'escalation-sla',
+  SECRETARIAT_EXECUTOR: 'secretariat-executor',
+  SECRETARIAT_PR_SHEPHERD: 'secretariat-pr-shepherd',
 } as const;

--- a/server/src/addie/jobs/secretariat-executor.ts
+++ b/server/src/addie/jobs/secretariat-executor.ts
@@ -1,0 +1,246 @@
+/**
+ * Secretariat action executor.
+ *
+ * Claims `approved` rows from `secretariat_actions` one at a time and
+ * executes them. Nothing in this file ever approves an action — approval
+ * happens only via a human clicking Approve in the Secretariat console
+ * (`server/src/routes/secretariat-admin.ts`). This file's only job is to
+ * carry out a decision a human already made.
+ *
+ * HARD SAFETY RULES:
+ * 1. `ALLOWED_KINDS` is the single allowlist of action kinds this executor
+ *    will ever run. An unrecognized kind fails closed (markFailed), never
+ *    silently executes.
+ * 2. This executor must NEVER call a PR-merge, PR-review, or PR-approve
+ *    endpoint. Adding such a capability here would let an automated loop
+ *    close the human-approval loop it exists to enforce.
+ * 3. Every kind's payload is validated before use; a malformed payload
+ *    fails the action (markFailed) rather than throwing past the caller.
+ */
+
+import { createLogger } from '../../logger.js';
+import * as secretariatDb from '../../db/secretariat-actions-db.js';
+import type { SecretariatAction } from '../../db/secretariat-actions-db.js';
+import { upsertFilesPr, type FileChange } from './github-pr.js';
+import { fileGitHubIssue, postIssueComment } from './github-filer.js';
+import { sendChannelMessage } from '../../slack/client.js';
+
+const logger = createLogger('secretariat-executor');
+
+/**
+ * The only action kinds the executor will run. Also the source of truth
+ * for the manual-enqueue admin route's kind validation.
+ */
+export const ALLOWED_KINDS = ['open_pr', 'post_issue_comment', 'file_issue', 'post_slack_message'] as const;
+export type AllowedKind = (typeof ALLOWED_KINDS)[number];
+
+export interface OpenPrPayload {
+  repo?: string;
+  branch: string;
+  baseBranch?: string;
+  files: FileChange[];
+  commitMessage: string;
+  prTitle: string;
+  prBody: string;
+}
+
+export interface PostIssueCommentPayload {
+  repo?: string;
+  issueNumber: number;
+  body: string;
+}
+
+export interface FileIssuePayload {
+  repo?: string;
+  title: string;
+  body: string;
+  labels?: string[];
+}
+
+export interface PostSlackMessagePayload {
+  channelId: string;
+  text: string;
+}
+
+export interface SecretariatExecutorOptions {
+  /** Max approved actions to claim and process per tick. Default 10. */
+  limit?: number;
+}
+
+export interface SecretariatExecutorResult {
+  /** Approved actions successfully claimed this tick. */
+  claimed: number;
+  executed: number;
+  failed: number;
+}
+
+function requireString(payload: Record<string, unknown>, key: string): string {
+  const value = payload[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(payload: Record<string, unknown>, key: string): string | undefined {
+  const value = payload[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string') throw new Error(`${key} must be a string when present`);
+  return value;
+}
+
+function validateOpenPr(payload: Record<string, unknown>): OpenPrPayload {
+  const branch = requireString(payload, 'branch');
+  const commitMessage = requireString(payload, 'commitMessage');
+  const prTitle = requireString(payload, 'prTitle');
+  const prBody = requireString(payload, 'prBody');
+  const repo = optionalString(payload, 'repo');
+  const baseBranch = optionalString(payload, 'baseBranch');
+
+  const rawFiles = payload.files;
+  if (!Array.isArray(rawFiles) || rawFiles.length === 0) {
+    throw new Error('files must be a non-empty array');
+  }
+  const files: FileChange[] = rawFiles.map((f, i) => {
+    if (!f || typeof f !== 'object') throw new Error(`files[${i}] must be an object`);
+    const path = (f as Record<string, unknown>).path;
+    const content = (f as Record<string, unknown>).content;
+    if (typeof path !== 'string' || path.length === 0) throw new Error(`files[${i}].path must be a non-empty string`);
+    if (typeof content !== 'string') throw new Error(`files[${i}].content must be a string`);
+    return { path, content };
+  });
+
+  return { repo, branch, baseBranch, files, commitMessage, prTitle, prBody };
+}
+
+function validatePostIssueComment(payload: Record<string, unknown>): PostIssueCommentPayload {
+  const issueNumber = payload.issueNumber;
+  if (typeof issueNumber !== 'number' || !Number.isInteger(issueNumber) || issueNumber <= 0) {
+    throw new Error('issueNumber must be a positive integer');
+  }
+  const body = requireString(payload, 'body');
+  const repo = optionalString(payload, 'repo');
+  return { repo, issueNumber, body };
+}
+
+function validateFileIssue(payload: Record<string, unknown>): FileIssuePayload {
+  const title = requireString(payload, 'title');
+  const body = requireString(payload, 'body');
+  const repo = optionalString(payload, 'repo');
+  const rawLabels = payload.labels;
+  let labels: string[] | undefined;
+  if (rawLabels !== undefined) {
+    if (!Array.isArray(rawLabels) || !rawLabels.every((l) => typeof l === 'string')) {
+      throw new Error('labels must be an array of strings when present');
+    }
+    labels = rawLabels;
+  }
+  return { repo, title, body, labels };
+}
+
+function validatePostSlackMessage(payload: Record<string, unknown>): PostSlackMessagePayload {
+  const channelId = requireString(payload, 'channelId');
+  const text = requireString(payload, 'text');
+  return { channelId, text };
+}
+
+async function executeOpenPr(payload: OpenPrPayload): Promise<Record<string, unknown>> {
+  const pr = await upsertFilesPr({
+    repo: payload.repo,
+    branch: payload.branch,
+    baseBranch: payload.baseBranch,
+    files: payload.files,
+    commitMessage: payload.commitMessage,
+    prTitle: payload.prTitle,
+    prBody: payload.prBody,
+  });
+  if (!pr) throw new Error('upsertFilesPr failed (see logs for the failing GitHub call)');
+  return { prUrl: pr.prUrl, prNumber: pr.prNumber, created: pr.created };
+}
+
+async function executePostIssueComment(payload: PostIssueCommentPayload): Promise<Record<string, unknown>> {
+  const comment = await postIssueComment({
+    repo: payload.repo,
+    issueNumber: payload.issueNumber,
+    body: payload.body,
+  });
+  if (!comment) throw new Error('postIssueComment failed (see logs for the failing GitHub call)');
+  return { commentUrl: comment.url, commentId: comment.id };
+}
+
+async function executeFileIssue(payload: FileIssuePayload): Promise<Record<string, unknown>> {
+  const issue = await fileGitHubIssue({
+    repo: payload.repo,
+    title: payload.title,
+    body: payload.body,
+    labels: payload.labels,
+  });
+  if (!issue) throw new Error('fileGitHubIssue failed (see logs for the failing GitHub call)');
+  return { issueUrl: issue.url, issueNumber: issue.number };
+}
+
+async function executePostSlackMessage(payload: PostSlackMessagePayload): Promise<Record<string, unknown>> {
+  const sent = await sendChannelMessage(payload.channelId, { text: payload.text });
+  if (!sent.ok) throw new Error(`sendChannelMessage failed: ${sent.error ?? 'unknown error'}`);
+  return { slackTs: sent.ts ?? null };
+}
+
+/**
+ * Dispatch a claimed action to its executor seam. The `default` branch
+ * is the fail-closed path for kinds outside `ALLOWED_KINDS` — including
+ * any kind that might reach here from a data path that skipped the
+ * admin route's allowlist check.
+ */
+async function dispatch(kind: string, payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+  switch (kind) {
+    case 'open_pr':
+      return executeOpenPr(validateOpenPr(payload));
+    case 'post_issue_comment':
+      return executePostIssueComment(validatePostIssueComment(payload));
+    case 'file_issue':
+      return executeFileIssue(validateFileIssue(payload));
+    case 'post_slack_message':
+      return executePostSlackMessage(validatePostSlackMessage(payload));
+    default:
+      throw new Error(`Unknown or disallowed action kind: ${kind}`);
+  }
+}
+
+/**
+ * Process up to `options.limit` approved actions: claim, execute,
+ * mark done or failed. Runs on a short interval (see job-definitions.ts)
+ * so an approval in the console is picked up within a couple of minutes.
+ */
+export async function runSecretariatExecutorJob(
+  options: SecretariatExecutorOptions = {}
+): Promise<SecretariatExecutorResult> {
+  const limit = options.limit ?? 10;
+  const result: SecretariatExecutorResult = { claimed: 0, executed: 0, failed: 0 };
+
+  const approved = await secretariatDb.listByStatus({ status: 'approved', limit });
+
+  for (const action of approved) {
+    const claimed: SecretariatAction | null = await secretariatDb.claimForExecution(action.id);
+    if (!claimed) {
+      // Another executor tick (or a concurrent instance) already claimed
+      // this row. Skip — no double execution.
+      logger.debug({ id: action.id }, 'Secretariat action already claimed; skipping');
+      continue;
+    }
+    result.claimed++;
+
+    try {
+      const output = await dispatch(claimed.kind, claimed.payload);
+      await secretariatDb.markDone(claimed.id, output);
+      result.executed++;
+      logger.info({ id: claimed.id, kind: claimed.kind, output }, 'Secretariat action executed');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await secretariatDb.markFailed(claimed.id, message);
+      result.failed++;
+      logger.error({ err, id: claimed.id, kind: claimed.kind }, 'Secretariat action failed');
+    }
+  }
+
+  return result;
+}

--- a/server/src/addie/jobs/secretariat-pr-shepherd.ts
+++ b/server/src/addie/jobs/secretariat-pr-shepherd.ts
@@ -1,0 +1,179 @@
+/**
+ * Secretariat PR shepherd — proposer job v1.
+ *
+ * Sweeps open PRs on `adcontextprotocol/adcp` for ones whose
+ * `IPR Policy / Signature` commit status (set by
+ * `scripts/ipr/check-and-record.mjs`) is still `pending` after the PR has
+ * been open a while. The IPR bot only comments once, at PR-open time; this
+ * job is the backstop for authors who missed that comment or forgot to
+ * follow up.
+ *
+ * This job only PROPOSES a `post_issue_comment` action — a human approves
+ * it in the Secretariat console before anything posts to GitHub. Detection
+ * is resilient by design: any failure to read a PR's status is treated as
+ * "skip this PR," never as a job failure.
+ */
+
+import { createLogger } from '../../logger.js';
+import { resolveGitHubToken } from './github-app-token.js';
+import * as secretariatDb from '../../db/secretariat-actions-db.js';
+
+const logger = createLogger('secretariat-pr-shepherd');
+
+const STATUS_CONTEXT = 'IPR Policy / Signature';
+const DEFAULT_REPO = 'adcontextprotocol/adcp';
+const API_TIMEOUT_MS = 10_000;
+
+export interface PrShepherdOptions {
+  repo?: string;
+  /** PR age (days) after which a pending IPR check earns a nudge. Default 7. */
+  minAgeDays?: number;
+}
+
+export interface PrShepherdResult {
+  prsScanned: number;
+  proposed: number;
+  skippedNotPending: number;
+  skippedTooNew: number;
+  skippedLookupFailed: number;
+}
+
+interface GhPullRequest {
+  number: number;
+  created_at: string;
+  user: { login: string } | null;
+  head: { sha: string };
+}
+
+interface GhCombinedStatus {
+  statuses?: Array<{ context: string; state: string }>;
+}
+
+async function ghFetch(token: string, url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'aao-secretariat/1.0',
+      },
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function ageInDays(createdAt: string): number {
+  return (Date.now() - new Date(createdAt).getTime()) / (24 * 60 * 60 * 1000);
+}
+
+/**
+ * True when the PR's combined commit status carries a pending
+ * `IPR Policy / Signature` entry. Returns null (not false) when the
+ * lookup itself fails, so the caller can tell "checked, not pending"
+ * apart from "couldn't check."
+ */
+async function isIprSignaturePending(
+  token: string,
+  repo: string,
+  sha: string,
+  prNumber: number
+): Promise<boolean | null> {
+  try {
+    const resp = await ghFetch(token, `https://api.github.com/repos/${repo}/commits/${sha}/status`);
+    if (!resp.ok) {
+      logger.debug({ status: resp.status, repo, pr: prNumber }, 'PR shepherd: status lookup failed; skipping PR');
+      return null;
+    }
+    const combined = (await resp.json()) as GhCombinedStatus;
+    const iprStatus = combined.statuses?.find((s) => s.context === STATUS_CONTEXT);
+    return iprStatus?.state === 'pending';
+  } catch (err) {
+    logger.debug({ err, repo, pr: prNumber }, 'PR shepherd: status lookup threw; skipping PR');
+    return null;
+  }
+}
+
+export async function runSecretariatPrShepherdJob(
+  options: PrShepherdOptions = {}
+): Promise<PrShepherdResult> {
+  const repo = options.repo ?? DEFAULT_REPO;
+  const minAgeDays = options.minAgeDays ?? 7;
+
+  const result: PrShepherdResult = {
+    prsScanned: 0,
+    proposed: 0,
+    skippedNotPending: 0,
+    skippedTooNew: 0,
+    skippedLookupFailed: 0,
+  };
+
+  const token = await resolveGitHubToken();
+  if (!token) {
+    logger.warn('No GitHub credential available; skipping PR shepherd sweep');
+    return result;
+  }
+
+  let pulls: GhPullRequest[];
+  try {
+    // MVP: single page (100 open PRs). Revisit with pagination if adcp
+    // ever carries more open PRs than that at once.
+    const resp = await ghFetch(token, `https://api.github.com/repos/${repo}/pulls?state=open&per_page=100`);
+    if (!resp.ok) {
+      logger.warn({ status: resp.status, repo }, 'PR shepherd: PR list lookup failed');
+      return result;
+    }
+    pulls = (await resp.json()) as GhPullRequest[];
+  } catch (err) {
+    logger.warn({ err, repo }, 'PR shepherd: PR list lookup threw');
+    return result;
+  }
+  result.prsScanned = pulls.length;
+
+  for (const pr of pulls) {
+    if (ageInDays(pr.created_at) < minAgeDays) {
+      result.skippedTooNew++;
+      continue;
+    }
+
+    const pending = await isIprSignaturePending(token, repo, pr.head.sha, pr.number);
+    if (pending === null) {
+      result.skippedLookupFailed++;
+      continue;
+    }
+    if (!pending) {
+      result.skippedNotPending++;
+      continue;
+    }
+
+    const author = pr.user?.login ?? 'there';
+    const ageDays = Math.floor(ageInDays(pr.created_at));
+    const prUrl = `https://github.com/${repo}/pull/${pr.number}`;
+
+    await secretariatDb.propose({
+      kind: 'post_issue_comment',
+      title: `Nudge PR #${pr.number} for IPR signature (${ageDays}d open)`,
+      rationale:
+        `[PR #${pr.number}](${prUrl}) on \`${repo}\` has been open ${ageDays} days and its ` +
+        `\`${STATUS_CONTEXT}\` commit status is still pending. The IPR bot only comments once, ` +
+        `at PR-open time — this is a one-time follow-up nudge.`,
+      payload: {
+        repo,
+        issueNumber: pr.number,
+        body:
+          `Hi @${author} — friendly nudge: this PR is still waiting on the IPR Policy signature. ` +
+          `Whenever you have a moment, comment with the phrase "I have read the IPR Policy" ` +
+          `(see [IPR_POLICY.md](https://github.com/${repo}/blob/main/IPR_POLICY.md)) so this can ` +
+          `move forward once everything else is ready.`,
+      },
+      origin: 'secretariat-pr-shepherd',
+      dedupe_key: `ipr-nudge:${pr.number}`,
+    });
+    result.proposed++;
+  }
+
+  return result;
+}

--- a/server/src/db/migrations/528_secretariat_actions.sql
+++ b/server/src/db/migrations/528_secretariat_actions.sql
@@ -1,0 +1,37 @@
+-- Secretariat console (Stage A): a human-approved action queue for the AAO
+-- Secretariat. Proposer jobs write rows here; nothing executes until an
+-- admin approves it in the console. See specs/spec-guardian.md.
+--
+-- State machine: proposed -> approved -> executing -> done
+--                proposed -> rejected
+--                approved -> failed -> proposed (via retry)
+-- Enforced in application code (server/src/db/secretariat-actions-db.ts),
+-- not a DB CHECK constraint, so the allowed-kind allowlist can evolve
+-- without a migration.
+
+CREATE TABLE IF NOT EXISTS secretariat_actions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  kind VARCHAR(50) NOT NULL,
+  title TEXT NOT NULL,
+  rationale TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'proposed',
+  origin VARCHAR(100) NOT NULL,
+  dedupe_key TEXT UNIQUE NULL,
+  edited BOOLEAN NOT NULL DEFAULT false,
+  result JSONB NULL,
+  error TEXT NULL,
+  decided_by TEXT NULL,
+  decided_at TIMESTAMPTZ NULL,
+  executed_at TIMESTAMPTZ NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_secretariat_actions_status_created
+  ON secretariat_actions(status, created_at);
+
+CREATE TRIGGER update_secretariat_actions_updated_at
+  BEFORE UPDATE ON secretariat_actions
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();

--- a/server/src/db/secretariat-actions-db.ts
+++ b/server/src/db/secretariat-actions-db.ts
@@ -1,0 +1,293 @@
+/**
+ * Database layer for the Secretariat console's action queue.
+ *
+ * Proposer jobs write rows via `propose()`; nothing executes until a human
+ * approves in the admin console. State machine:
+ *
+ *   proposed -> approved -> executing -> done
+ *   proposed -> rejected
+ *   executing -> failed -> (retry) -> proposed
+ *
+ * Every transition is a single atomic `UPDATE ... WHERE status = '<from>'`
+ * so concurrent callers (two admins clicking approve, or the executor and
+ * a manual retry racing) can't double-apply a transition — the second
+ * caller's WHERE clause matches zero rows and gets null back.
+ */
+
+import { query } from './client.js';
+
+export type SecretariatActionStatus =
+  | 'proposed'
+  | 'approved'
+  | 'rejected'
+  | 'executing'
+  | 'done'
+  | 'failed';
+
+/** Allowlisted action kinds. Keep in sync with secretariat-executor.ts. */
+export type SecretariatActionKind =
+  | 'open_pr'
+  | 'post_issue_comment'
+  | 'file_issue'
+  | 'post_slack_message';
+
+export interface SecretariatAction {
+  id: string;
+  kind: string;
+  title: string;
+  rationale: string;
+  payload: Record<string, unknown>;
+  status: SecretariatActionStatus;
+  origin: string;
+  dedupe_key: string | null;
+  edited: boolean;
+  result: Record<string, unknown> | null;
+  error: string | null;
+  decided_by: string | null;
+  decided_at: Date | null;
+  executed_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface ProposeActionInput {
+  kind: string;
+  title: string;
+  rationale: string;
+  payload: Record<string, unknown>;
+  origin: string;
+  dedupe_key?: string | null;
+}
+
+const COLUMNS = `id, kind, title, rationale, payload, status, origin, dedupe_key,
+  edited, result, error, decided_by, decided_at, executed_at, created_at, updated_at`;
+
+/**
+ * Insert a proposed action. When `dedupe_key` collides with an existing
+ * row, the insert is a no-op and the existing row is returned — proposer
+ * jobs can be re-invoked freely without duplicating proposals.
+ */
+export async function propose(input: ProposeActionInput): Promise<SecretariatAction> {
+  const inserted = await query<SecretariatAction>(
+    `INSERT INTO secretariat_actions (kind, title, rationale, payload, origin, dedupe_key)
+     VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+     ON CONFLICT (dedupe_key) DO NOTHING
+     RETURNING ${COLUMNS}`,
+    [
+      input.kind,
+      input.title,
+      input.rationale,
+      JSON.stringify(input.payload),
+      input.origin,
+      input.dedupe_key ?? null,
+    ],
+  );
+  if (inserted.rows[0]) return inserted.rows[0];
+
+  // Conflict: dedupe_key already exists. Fetch and return the existing row.
+  const existing = await query<SecretariatAction>(
+    `SELECT ${COLUMNS} FROM secretariat_actions WHERE dedupe_key = $1`,
+    [input.dedupe_key],
+  );
+  if (!existing.rows[0]) {
+    throw new Error(`propose: dedupe_key conflict but no existing row found for ${input.dedupe_key}`);
+  }
+  return existing.rows[0];
+}
+
+export interface ListActionsFilters {
+  status?: SecretariatActionStatus;
+  limit?: number;
+}
+
+export async function listByStatus(filters: ListActionsFilters = {}): Promise<SecretariatAction[]> {
+  const limit = Math.min(Math.max(filters.limit ?? 200, 1), 200);
+  if (filters.status) {
+    const result = await query<SecretariatAction>(
+      `SELECT ${COLUMNS} FROM secretariat_actions
+       WHERE status = $1
+       ORDER BY created_at DESC
+       LIMIT $2`,
+      [filters.status, limit],
+    );
+    return result.rows;
+  }
+  const result = await query<SecretariatAction>(
+    `SELECT ${COLUMNS} FROM secretariat_actions
+     ORDER BY created_at DESC
+     LIMIT $1`,
+    [limit],
+  );
+  return result.rows;
+}
+
+export async function get(id: string): Promise<SecretariatAction | null> {
+  const result = await query<SecretariatAction>(
+    `SELECT ${COLUMNS} FROM secretariat_actions WHERE id = $1`,
+    [id],
+  );
+  return result.rows[0] ?? null;
+}
+
+/** Approve a proposed action. Returns null if it was not in `proposed`. */
+export async function approve(id: string, decidedBy: string): Promise<SecretariatAction | null> {
+  const result = await query<SecretariatAction>(
+    `UPDATE secretariat_actions
+     SET status = 'approved', decided_by = $2, decided_at = NOW()
+     WHERE id = $1 AND status = 'proposed'
+     RETURNING ${COLUMNS}`,
+    [id, decidedBy],
+  );
+  return result.rows[0] ?? null;
+}
+
+/** Reject a proposed action. Returns null if it was not in `proposed`. */
+export async function reject(
+  id: string,
+  decidedBy: string,
+  reason: string,
+): Promise<SecretariatAction | null> {
+  const result = await query<SecretariatAction>(
+    `UPDATE secretariat_actions
+     SET status = 'rejected', decided_by = $2, decided_at = NOW(), error = $3
+     WHERE id = $1 AND status = 'proposed'
+     RETURNING ${COLUMNS}`,
+    [id, decidedBy, reason],
+  );
+  return result.rows[0] ?? null;
+}
+
+/**
+ * Edit the payload (and optionally title) of a still-proposed action.
+ * Marks `edited = true` so the approved-without-edit autonomy metric
+ * stays accurate. Returns null if the action is not in `proposed`.
+ */
+export async function editPayload(
+  id: string,
+  payload: Record<string, unknown>,
+  title?: string,
+): Promise<SecretariatAction | null> {
+  const result = await query<SecretariatAction>(
+    `UPDATE secretariat_actions
+     SET payload = $2::jsonb, title = COALESCE($3, title), edited = true
+     WHERE id = $1 AND status = 'proposed'
+     RETURNING ${COLUMNS}`,
+    [id, JSON.stringify(payload), title ?? null],
+  );
+  return result.rows[0] ?? null;
+}
+
+/**
+ * Atomically claim an approved action for execution. Returns null if the
+ * action is not (or no longer) `approved` — e.g. a concurrent executor
+ * tick already claimed it. This is the sole guard against double
+ * execution; callers must not execute a payload without a successful
+ * claim.
+ */
+export async function claimForExecution(id: string): Promise<SecretariatAction | null> {
+  const result = await query<SecretariatAction>(
+    `UPDATE secretariat_actions
+     SET status = 'executing'
+     WHERE id = $1 AND status = 'approved'
+     RETURNING ${COLUMNS}`,
+    [id],
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function markDone(
+  id: string,
+  result_: Record<string, unknown>,
+): Promise<SecretariatAction | null> {
+  const result = await query<SecretariatAction>(
+    `UPDATE secretariat_actions
+     SET status = 'done', result = $2::jsonb, executed_at = NOW()
+     WHERE id = $1 AND status = 'executing'
+     RETURNING ${COLUMNS}`,
+    [id, JSON.stringify(result_)],
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function markFailed(id: string, error: string): Promise<SecretariatAction | null> {
+  const result = await query<SecretariatAction>(
+    `UPDATE secretariat_actions
+     SET status = 'failed', error = $2
+     WHERE id = $1 AND status = 'executing'
+     RETURNING ${COLUMNS}`,
+    [id, error],
+  );
+  return result.rows[0] ?? null;
+}
+
+/**
+ * Send a failed action back to `proposed` so it can be reviewed, edited
+ * if needed, and re-approved. Clears the prior decision and error so the
+ * inbox card looks like a fresh proposal.
+ */
+export async function retry(id: string): Promise<SecretariatAction | null> {
+  const result = await query<SecretariatAction>(
+    `UPDATE secretariat_actions
+     SET status = 'proposed', error = NULL, decided_by = NULL, decided_at = NULL
+     WHERE id = $1 AND status = 'failed'
+     RETURNING ${COLUMNS}`,
+    [id],
+  );
+  return result.rows[0] ?? null;
+}
+
+export interface SecretariatActionStats {
+  by_kind_status: Array<{ kind: string; status: SecretariatActionStatus; count: number }>;
+  approval_rate_by_kind: Array<{
+    kind: string;
+    decided: number;
+    approved_without_edit: number;
+    rate: number | null;
+  }>;
+}
+
+/**
+ * Counts by kind x status, plus per-kind approved-without-edit rate
+ * (approved where edited=false / all decided). Feeds the future
+ * autonomy toggles: a kind with a consistently high rate is a candidate
+ * to promote from "propose" to "auto-execute".
+ */
+export async function getStats(): Promise<SecretariatActionStats> {
+  const [byKindStatus, byKind] = await Promise.all([
+    query<{ kind: string; status: SecretariatActionStatus; count: string }>(
+      `SELECT kind, status, COUNT(*)::text AS count
+       FROM secretariat_actions
+       GROUP BY kind, status
+       ORDER BY kind, status`,
+    ),
+    query<{ kind: string; decided: string; approved_without_edit: string }>(
+      `SELECT
+         kind,
+         COUNT(*) FILTER (WHERE decided_by IS NOT NULL)::text AS decided,
+         COUNT(*) FILTER (
+           WHERE decided_by IS NOT NULL AND status <> 'rejected' AND edited = false
+         )::text AS approved_without_edit
+       FROM secretariat_actions
+       GROUP BY kind
+       ORDER BY kind`,
+    ),
+  ]);
+
+  return {
+    by_kind_status: byKindStatus.rows.map((r) => ({
+      kind: r.kind,
+      status: r.status,
+      count: parseInt(r.count, 10),
+    })),
+    approval_rate_by_kind: byKind.rows.map((r) => {
+      const decided = parseInt(r.decided, 10);
+      const approvedWithoutEdit = parseInt(r.approved_without_edit, 10);
+      return {
+        kind: r.kind,
+        decided,
+        approved_without_edit: approvedWithoutEdit,
+        rate: decided > 0 ? approvedWithoutEdit / decided : null,
+      };
+    }),
+  };
+}

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -75,6 +75,7 @@ import {
 import { createAdminRouter } from "./routes/admin.js";
 import { createAdminInsightsRouter } from "./routes/admin-insights.js";
 import { createAddieAdminRouter } from "./routes/addie-admin.js";
+import { createSecretariatAdminRouter } from "./routes/secretariat-admin.js";
 import { createAddieChatRouter } from "./routes/addie-chat.js";
 import { createTavusRouter } from "./routes/tavus.js";
 import { createSiChatRoutes } from "./routes/si-chat.js";
@@ -1311,6 +1312,11 @@ export class HTTPServer {
     const { pageRouter: addiePageRouter, apiRouter: addieApiRouter } = createAddieAdminRouter();
     this.app.use('/admin/addie', addiePageRouter);      // Page routes: /admin/addie
     this.app.use('/api/admin/addie', addieApiRouter);   // API routes: /api/admin/addie/*
+
+    // Mount Secretariat console routes (human-approved action queue)
+    const { pageRouter: secretariatPageRouter, apiRouter: secretariatApiRouter } = createSecretariatAdminRouter();
+    this.app.use('/admin/secretariat', secretariatPageRouter);      // Page routes: /admin/secretariat
+    this.app.use('/api/admin/secretariat', secretariatApiRouter);   // API routes: /api/admin/secretariat/*
 
 
     // Mount Addie chat routes (public chat interface)

--- a/server/src/routes/secretariat-admin.ts
+++ b/server/src/routes/secretariat-admin.ts
@@ -1,0 +1,370 @@
+/**
+ * Secretariat console admin routes.
+ *
+ * Human-approved action queue for the AAO Secretariat: proposer jobs write
+ * `secretariat_actions` rows, admins review/edit/approve/reject them here,
+ * and the executor job (server/src/addie/jobs/secretariat-executor.ts)
+ * carries out approved actions. Nothing executes without a human clicking
+ * Approve — see the executor's hard safety rules.
+ */
+
+import { Router } from "express";
+import { validate as uuidValidate } from "uuid";
+import { createLogger } from "../logger.js";
+import { requireAuth, requireAdmin } from "../middleware/auth.js";
+import { serveHtmlWithConfig } from "../utils/html-config.js";
+import * as secretariatDb from "../db/secretariat-actions-db.js";
+import type { SecretariatActionStatus } from "../db/secretariat-actions-db.js";
+import { ALLOWED_KINDS } from "../addie/jobs/secretariat-executor.js";
+import { resolveGitHubToken } from "../addie/jobs/github-app-token.js";
+
+const logger = createLogger("secretariat-admin-routes");
+
+const VALID_STATUSES: SecretariatActionStatus[] = [
+  'proposed', 'approved', 'rejected', 'executing', 'done', 'failed',
+];
+
+const DEFAULT_REPO = 'adcontextprotocol/adcp';
+const NEEDS_WG_REVIEW_LABEL = 'needs-wg-review';
+const WATCHING_CACHE_TTL_MS = 5 * 60_000;
+const API_TIMEOUT_MS = 10_000;
+
+function isValidUuid(id: string): boolean {
+  return uuidValidate(id);
+}
+
+/** Who made this decision, for the audit trail. */
+function resolveDecider(req: { user?: { email?: string } }): string {
+  return req.user?.email ?? 'unknown-admin';
+}
+
+async function ghFetch(token: string, url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'aao-secretariat/1.0',
+      },
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface GhPullRequest {
+  number: number;
+  title: string;
+  user: { login: string } | null;
+  created_at: string;
+  draft?: boolean;
+  requested_reviewers?: unknown[];
+  requested_teams?: unknown[];
+  html_url: string;
+}
+
+interface GhIssue {
+  number: number;
+  created_at: string;
+  pull_request?: unknown;
+}
+
+export interface WatchingPr {
+  number: number;
+  title: string;
+  author: string;
+  ageDays: number;
+  reviewState: 'draft' | 'awaiting_reviewers' | 'no_reviewers_requested';
+  url: string;
+}
+
+export interface WatchingSnapshot {
+  openPrs: WatchingPr[];
+  needsWgReview: {
+    count: number;
+    ageBuckets: { under7d: number; d7to14: number; over14d: number };
+  };
+  fetchedAt: string;
+}
+
+function ageInDays(createdAt: string): number {
+  return Math.floor((Date.now() - new Date(createdAt).getTime()) / (24 * 60 * 60 * 1000));
+}
+
+async function buildWatchingSnapshot(repo: string): Promise<WatchingSnapshot | null> {
+  const token = await resolveGitHubToken();
+  if (!token) {
+    logger.warn('No GitHub credential available; cannot build watching snapshot');
+    return null;
+  }
+
+  const [prsResp, issuesResp] = await Promise.all([
+    ghFetch(token, `https://api.github.com/repos/${repo}/pulls?state=open&per_page=100`),
+    ghFetch(
+      token,
+      `https://api.github.com/repos/${repo}/issues?state=open&labels=${encodeURIComponent(NEEDS_WG_REVIEW_LABEL)}&per_page=100`
+    ),
+  ]);
+
+  if (!prsResp.ok || !issuesResp.ok) {
+    logger.warn({ prsStatus: prsResp.status, issuesStatus: issuesResp.status, repo }, 'Watching snapshot: GitHub lookup failed');
+    return null;
+  }
+
+  const pulls = (await prsResp.json()) as GhPullRequest[];
+  const issues = (await issuesResp.json()) as GhIssue[];
+
+  const openPrs: WatchingPr[] = pulls.map((pr) => {
+    let reviewState: WatchingPr['reviewState'] = 'no_reviewers_requested';
+    if (pr.draft) reviewState = 'draft';
+    else if ((pr.requested_reviewers?.length ?? 0) > 0 || (pr.requested_teams?.length ?? 0) > 0) {
+      reviewState = 'awaiting_reviewers';
+    }
+    return {
+      number: pr.number,
+      title: pr.title,
+      author: pr.user?.login ?? 'unknown',
+      ageDays: ageInDays(pr.created_at),
+      reviewState,
+      url: pr.html_url,
+    };
+  });
+
+  // The issues endpoint returns PRs too; exclude them from the WG-review queue.
+  const wgReviewIssues = issues.filter((i) => !i.pull_request);
+  const ageBuckets = { under7d: 0, d7to14: 0, over14d: 0 };
+  for (const issue of wgReviewIssues) {
+    const age = ageInDays(issue.created_at);
+    if (age < 7) ageBuckets.under7d++;
+    else if (age <= 14) ageBuckets.d7to14++;
+    else ageBuckets.over14d++;
+  }
+
+  return {
+    openPrs,
+    needsWgReview: { count: wgReviewIssues.length, ageBuckets },
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+let watchingCache: { snapshot: WatchingSnapshot; expiresAtMs: number } | null = null;
+
+async function getWatchingSnapshot(repo: string): Promise<WatchingSnapshot | null> {
+  if (watchingCache && watchingCache.expiresAtMs > Date.now()) {
+    return watchingCache.snapshot;
+  }
+  const snapshot = await buildWatchingSnapshot(repo);
+  if (snapshot) {
+    watchingCache = { snapshot, expiresAtMs: Date.now() + WATCHING_CACHE_TTL_MS };
+  }
+  return snapshot;
+}
+
+export function createSecretariatAdminRouter(): { pageRouter: Router; apiRouter: Router } {
+  const pageRouter = Router();
+  const apiRouter = Router();
+
+  // =========================================================================
+  // PAGE ROUTES (mounted at /admin/secretariat)
+  // =========================================================================
+
+  pageRouter.get("/", requireAuth, requireAdmin, (req, res) => {
+    serveHtmlWithConfig(req, res, "secretariat.html").catch((err) => {
+      logger.error({ err }, "Error serving Secretariat admin page");
+      res.status(500).send("Internal server error");
+    });
+  });
+
+  // =========================================================================
+  // ACTIONS API (mounted at /api/admin/secretariat)
+  // =========================================================================
+
+  // GET /api/admin/secretariat/actions?status=proposed
+  apiRouter.get("/actions", requireAuth, requireAdmin, async (req, res) => {
+    try {
+      const { status } = req.query;
+      let validatedStatus: SecretariatActionStatus | undefined;
+      if (typeof status === 'string' && status.length > 0) {
+        if (!VALID_STATUSES.includes(status as SecretariatActionStatus)) {
+          return res.status(400).json({ error: `status must be one of: ${VALID_STATUSES.join(', ')}` });
+        }
+        validatedStatus = status as SecretariatActionStatus;
+      }
+
+      const actions = await secretariatDb.listByStatus({ status: validatedStatus, limit: 200 });
+      res.json({ actions, total: actions.length });
+    } catch (error) {
+      logger.error({ err: error }, "Error listing Secretariat actions");
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // GET /api/admin/secretariat/watching
+  // NOTE: defined before /actions/:id-shaped routes don't collide since path differs.
+  apiRouter.get("/watching", requireAuth, requireAdmin, async (_req, res) => {
+    try {
+      const snapshot = await getWatchingSnapshot(DEFAULT_REPO);
+      if (!snapshot) {
+        return res.status(502).json({ error: "GitHub lookup unavailable" });
+      }
+      res.json(snapshot);
+    } catch (error) {
+      logger.error({ err: error }, "Error building watching snapshot");
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // GET /api/admin/secretariat/stats
+  apiRouter.get("/stats", requireAuth, requireAdmin, async (_req, res) => {
+    try {
+      const stats = await secretariatDb.getStats();
+      res.json(stats);
+    } catch (error) {
+      logger.error({ err: error }, "Error fetching Secretariat stats");
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // POST /api/admin/secretariat/actions - manual enqueue/seed
+  apiRouter.post("/actions", requireAuth, requireAdmin, async (req, res) => {
+    try {
+      const { kind, title, rationale, payload, dedupe_key } = req.body;
+
+      if (typeof kind !== 'string' || !ALLOWED_KINDS.includes(kind as (typeof ALLOWED_KINDS)[number])) {
+        return res.status(400).json({ error: `kind must be one of: ${ALLOWED_KINDS.join(', ')}` });
+      }
+      if (typeof title !== 'string' || title.length === 0) {
+        return res.status(400).json({ error: "title is required" });
+      }
+      if (typeof rationale !== 'string' || rationale.length === 0) {
+        return res.status(400).json({ error: "rationale is required" });
+      }
+      if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        return res.status(400).json({ error: "payload must be an object" });
+      }
+      if (dedupe_key !== undefined && typeof dedupe_key !== 'string') {
+        return res.status(400).json({ error: "dedupe_key must be a string when present" });
+      }
+
+      const action = await secretariatDb.propose({
+        kind,
+        title,
+        rationale,
+        payload,
+        origin: `manual:${resolveDecider(req)}`,
+        dedupe_key: dedupe_key ?? null,
+      });
+
+      logger.info({ id: action.id, kind }, "Manually enqueued Secretariat action");
+      res.status(201).json(action);
+    } catch (error) {
+      logger.error({ err: error }, "Error enqueuing Secretariat action");
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // GET /api/admin/secretariat/actions/:id
+  apiRouter.get("/actions/:id", requireAuth, requireAdmin, async (req, res) => {
+    try {
+      const { id } = req.params;
+      if (!isValidUuid(id)) return res.status(400).json({ error: "Invalid action id" });
+
+      const action = await secretariatDb.get(id);
+      if (!action) return res.status(404).json({ error: "Action not found" });
+      res.json(action);
+    } catch (error) {
+      logger.error({ err: error }, "Error fetching Secretariat action");
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // PATCH /api/admin/secretariat/actions/:id - edit payload/title (proposed only)
+  apiRouter.patch("/actions/:id", requireAuth, requireAdmin, async (req, res) => {
+    try {
+      const { id } = req.params;
+      if (!isValidUuid(id)) return res.status(400).json({ error: "Invalid action id" });
+
+      const { payload, title } = req.body;
+      if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        return res.status(400).json({ error: "payload must be an object" });
+      }
+      if (title !== undefined && typeof title !== 'string') {
+        return res.status(400).json({ error: "title must be a string when present" });
+      }
+
+      const updated = await secretariatDb.editPayload(id, payload, title);
+      if (!updated) {
+        return res.status(409).json({ error: "Action is not in proposed state" });
+      }
+      logger.info({ id }, "Edited Secretariat action payload");
+      res.json(updated);
+    } catch (error) {
+      logger.error({ err: error }, "Error editing Secretariat action");
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // POST /api/admin/secretariat/actions/:id/approve
+  apiRouter.post("/actions/:id/approve", requireAuth, requireAdmin, async (req, res) => {
+    try {
+      const { id } = req.params;
+      if (!isValidUuid(id)) return res.status(400).json({ error: "Invalid action id" });
+
+      const approved = await secretariatDb.approve(id, resolveDecider(req));
+      if (!approved) {
+        return res.status(409).json({ error: "Action is not in proposed state" });
+      }
+      logger.info({ id, decidedBy: approved.decided_by }, "Approved Secretariat action");
+      res.json(approved);
+    } catch (error) {
+      logger.error({ err: error }, "Error approving Secretariat action");
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // POST /api/admin/secretariat/actions/:id/reject {reason}
+  apiRouter.post("/actions/:id/reject", requireAuth, requireAdmin, async (req, res) => {
+    try {
+      const { id } = req.params;
+      if (!isValidUuid(id)) return res.status(400).json({ error: "Invalid action id" });
+
+      const { reason } = req.body;
+      if (typeof reason !== 'string' || reason.length === 0) {
+        return res.status(400).json({ error: "reason is required" });
+      }
+
+      const rejected = await secretariatDb.reject(id, resolveDecider(req), reason);
+      if (!rejected) {
+        return res.status(409).json({ error: "Action is not in proposed state" });
+      }
+      logger.info({ id, decidedBy: rejected.decided_by }, "Rejected Secretariat action");
+      res.json(rejected);
+    } catch (error) {
+      logger.error({ err: error }, "Error rejecting Secretariat action");
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // POST /api/admin/secretariat/actions/:id/retry - failed -> proposed
+  apiRouter.post("/actions/:id/retry", requireAuth, requireAdmin, async (req, res) => {
+    try {
+      const { id } = req.params;
+      if (!isValidUuid(id)) return res.status(400).json({ error: "Invalid action id" });
+
+      const retried = await secretariatDb.retry(id);
+      if (!retried) {
+        return res.status(409).json({ error: "Action is not in failed state" });
+      }
+      logger.info({ id }, "Reset failed Secretariat action to proposed");
+      res.json(retried);
+    } catch (error) {
+      logger.error({ err: error }, "Error retrying Secretariat action");
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  return { pageRouter, apiRouter };
+}

--- a/server/tests/unit/github-pr.test.ts
+++ b/server/tests/unit/github-pr.test.ts
@@ -87,6 +87,89 @@ describe('upsertFilePr', () => {
   });
 });
 
+describe('upsertFilesPr', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('GITHUB_TOKEN', 'test-token');
+    vi.stubEnv('GITHUB_REPO', 'acme/spec');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  const multiFileInput = {
+    branch: 'addie/secretariat-1',
+    files: [
+      { path: 'a.md', content: 'file a\n' },
+      { path: 'nested/b.md', content: 'file b\n' },
+    ],
+    commitMessage: 'chore: two files',
+    prTitle: 'chore: two files',
+    prBody: 'body',
+  };
+
+  it('PUTs each file onto the same branch and opens one PR', async () => {
+    fetchMock
+      .mockResolvedValueOnce(json({ object: { sha: 'base-sha' } })) // GET base ref
+      .mockResolvedValueOnce(json({}, 201)) // POST create branch
+      .mockResolvedValueOnce(json({}, 404)) // GET a.md on branch (absent)
+      .mockResolvedValueOnce(json({ commit: { sha: 'c1' } })) // PUT a.md
+      .mockResolvedValueOnce(json({}, 404)) // GET nested/b.md on branch (absent)
+      .mockResolvedValueOnce(json({ commit: { sha: 'c2' } })) // PUT nested/b.md
+      .mockResolvedValueOnce(json([])) // GET open PRs (none)
+      .mockResolvedValueOnce(json({ html_url: 'https://github.com/acme/spec/pull/11', number: 11 }, 201)); // POST create PR
+
+    const { upsertFilesPr } = await import('../../src/addie/jobs/github-pr.js');
+    const result = await upsertFilesPr(multiFileInput);
+
+    expect(result).toEqual({ prUrl: 'https://github.com/acme/spec/pull/11', prNumber: 11, created: true });
+
+    const putCalls = fetchMock.mock.calls.filter(([url]) => typeof url === 'string' && url.includes('/contents/') && !url.includes('?ref='));
+    expect(putCalls).toHaveLength(2);
+
+    const putABody = JSON.parse(putCalls[0][1].body as string);
+    expect(putCalls[0][0]).toContain('/contents/a.md');
+    expect(putABody.branch).toBe('addie/secretariat-1');
+    expect(Buffer.from(putABody.content, 'base64').toString('utf8')).toBe('file a\n');
+
+    const putBBody = JSON.parse(putCalls[1][1].body as string);
+    expect(putCalls[1][0]).toContain('/contents/nested/b.md');
+    expect(putBBody.branch).toBe('addie/secretariat-1');
+    expect(Buffer.from(putBBody.content, 'base64').toString('utf8')).toBe('file b\n');
+
+    // Exactly one PR create call, not one per file.
+    const prCreateCalls = fetchMock.mock.calls.filter(
+      ([url, init]) => typeof url === 'string' && url.endsWith('/pulls') && init?.method === 'POST'
+    );
+    expect(prCreateCalls).toHaveLength(1);
+  });
+
+  it('stops after the first failing file PUT and does not attempt the PR', async () => {
+    fetchMock
+      .mockResolvedValueOnce(json({ object: { sha: 'base-sha' } })) // GET base ref
+      .mockResolvedValueOnce(json({}, 201)) // POST create branch
+      .mockResolvedValueOnce(json({}, 404)) // GET a.md (absent)
+      .mockResolvedValueOnce(json({ message: 'boom' }, 500)); // PUT a.md fails
+
+    const { upsertFilesPr } = await import('../../src/addie/jobs/github-pr.js');
+    const result = await upsertFilesPr(multiFileInput);
+
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('returns null without calling GitHub when the token is missing', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '');
+    const { upsertFilesPr } = await import('../../src/addie/jobs/github-pr.js');
+    const result = await upsertFilesPr(multiFileInput);
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
 describe('getFileContent', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/server/tests/unit/secretariat-actions-db.test.ts
+++ b/server/tests/unit/secretariat-actions-db.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+}));
+
+import * as secretariatDb from '../../src/db/secretariat-actions-db.js';
+import { query } from '../../src/db/client.js';
+
+const mockedQuery = vi.mocked(query);
+
+function row(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'action-1',
+    kind: 'file_issue',
+    title: 'Test action',
+    rationale: 'Because reasons',
+    payload: { title: 'x', body: 'y' },
+    status: 'proposed',
+    origin: 'test',
+    dedupe_key: null,
+    edited: false,
+    result: null,
+    error: null,
+    decided_by: null,
+    decided_at: null,
+    executed_at: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function qResult(rows: unknown[]) {
+  return { rows, rowCount: rows.length, command: '', oid: 0, fields: [] } as any;
+}
+
+describe('secretariat-actions-db', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('propose', () => {
+    it('inserts and returns the new row when there is no dedupe conflict', async () => {
+      const inserted = row({ dedupe_key: 'k1' });
+      mockedQuery.mockResolvedValueOnce(qResult([inserted]));
+
+      const result = await secretariatDb.propose({
+        kind: 'file_issue',
+        title: 'Test action',
+        rationale: 'Because reasons',
+        payload: { title: 'x', body: 'y' },
+        origin: 'test',
+        dedupe_key: 'k1',
+      });
+
+      expect(result).toEqual(inserted);
+      expect(mockedQuery).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockedQuery.mock.calls[0];
+      expect(sql).toMatch(/INSERT INTO secretariat_actions/);
+      expect(sql).toMatch(/ON CONFLICT \(dedupe_key\) DO NOTHING/);
+      expect(params).toEqual(['file_issue', 'Test action', 'Because reasons', JSON.stringify({ title: 'x', body: 'y' }), 'test', 'k1']);
+    });
+
+    it('returns the existing row on dedupe_key conflict instead of inserting a duplicate', async () => {
+      const existing = row({ dedupe_key: 'k1', id: 'existing-1' });
+      mockedQuery
+        .mockResolvedValueOnce(qResult([])) // INSERT ... ON CONFLICT DO NOTHING -> no row
+        .mockResolvedValueOnce(qResult([existing])); // SELECT existing
+
+      const result = await secretariatDb.propose({
+        kind: 'file_issue',
+        title: 'Test action',
+        rationale: 'Because reasons',
+        payload: {},
+        origin: 'test',
+        dedupe_key: 'k1',
+      });
+
+      expect(result).toEqual(existing);
+      expect(mockedQuery).toHaveBeenCalledTimes(2);
+      const [selectSql, selectParams] = mockedQuery.mock.calls[1];
+      expect(selectSql).toMatch(/SELECT .* FROM secretariat_actions WHERE dedupe_key = \$1/s);
+      expect(selectParams).toEqual(['k1']);
+    });
+
+    it('null-pads dedupe_key when omitted', async () => {
+      mockedQuery.mockResolvedValueOnce(qResult([row()]));
+      await secretariatDb.propose({
+        kind: 'file_issue',
+        title: 't',
+        rationale: 'r',
+        payload: {},
+        origin: 'test',
+      });
+      const [, params] = mockedQuery.mock.calls[0];
+      expect(params?.[5]).toBeNull();
+    });
+  });
+
+  describe('approve', () => {
+    it('transitions proposed -> approved and records the decider', async () => {
+      const approved = row({ status: 'approved', decided_by: 'admin@example.com' });
+      mockedQuery.mockResolvedValueOnce(qResult([approved]));
+
+      const result = await secretariatDb.approve('action-1', 'admin@example.com');
+
+      expect(result).toEqual(approved);
+      const [sql, params] = mockedQuery.mock.calls[0];
+      expect(sql).toMatch(/UPDATE secretariat_actions/);
+      expect(sql).toMatch(/SET status = 'approved'/);
+      expect(sql).toMatch(/WHERE id = \$1 AND status = 'proposed'/);
+      expect(params).toEqual(['action-1', 'admin@example.com']);
+    });
+
+    it('returns null when the action is not in proposed (already decided)', async () => {
+      mockedQuery.mockResolvedValueOnce(qResult([]));
+      const result = await secretariatDb.approve('action-1', 'admin@example.com');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('reject', () => {
+    it('transitions proposed -> rejected and stores the reason', async () => {
+      const rejected = row({ status: 'rejected', decided_by: 'admin@example.com', error: 'not needed' });
+      mockedQuery.mockResolvedValueOnce(qResult([rejected]));
+
+      const result = await secretariatDb.reject('action-1', 'admin@example.com', 'not needed');
+
+      expect(result).toEqual(rejected);
+      const [sql, params] = mockedQuery.mock.calls[0];
+      expect(sql).toMatch(/SET status = 'rejected'/);
+      expect(sql).toMatch(/WHERE id = \$1 AND status = 'proposed'/);
+      expect(params).toEqual(['action-1', 'admin@example.com', 'not needed']);
+    });
+
+    it('returns null when the action is not in proposed', async () => {
+      mockedQuery.mockResolvedValueOnce(qResult([]));
+      const result = await secretariatDb.reject('action-1', 'admin@example.com', 'reason');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('editPayload', () => {
+    it('updates payload, optionally title, and sets edited = true, only while proposed', async () => {
+      const edited = row({ payload: { a: 1 }, title: 'New title', edited: true });
+      mockedQuery.mockResolvedValueOnce(qResult([edited]));
+
+      const result = await secretariatDb.editPayload('action-1', { a: 1 }, 'New title');
+
+      expect(result).toEqual(edited);
+      const [sql, params] = mockedQuery.mock.calls[0];
+      expect(sql).toMatch(/SET payload = \$2::jsonb, title = COALESCE\(\$3, title\), edited = true/);
+      expect(sql).toMatch(/WHERE id = \$1 AND status = 'proposed'/);
+      expect(params).toEqual(['action-1', JSON.stringify({ a: 1 }), 'New title']);
+    });
+
+    it('returns null when the action is not in proposed', async () => {
+      mockedQuery.mockResolvedValueOnce(qResult([]));
+      const result = await secretariatDb.editPayload('action-1', { a: 1 });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('claimForExecution', () => {
+    it('atomically transitions approved -> executing', async () => {
+      const executing = row({ status: 'executing' });
+      mockedQuery.mockResolvedValueOnce(qResult([executing]));
+
+      const result = await secretariatDb.claimForExecution('action-1');
+
+      expect(result).toEqual(executing);
+      const [sql, params] = mockedQuery.mock.calls[0];
+      expect(sql).toMatch(/SET status = 'executing'/);
+      expect(sql).toMatch(/WHERE id = \$1 AND status = 'approved'/);
+      expect(params).toEqual(['action-1']);
+    });
+
+    it('returns null when the action is not (or no longer) approved — the double-execution guard', async () => {
+      mockedQuery.mockResolvedValueOnce(qResult([]));
+      const result = await secretariatDb.claimForExecution('action-1');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('markDone / markFailed', () => {
+    it('markDone transitions executing -> done and stores the result', async () => {
+      const done = row({ status: 'done', result: { prUrl: 'https://x/pr/1' } });
+      mockedQuery.mockResolvedValueOnce(qResult([done]));
+
+      const result = await secretariatDb.markDone('action-1', { prUrl: 'https://x/pr/1' });
+
+      expect(result).toEqual(done);
+      const [sql, params] = mockedQuery.mock.calls[0];
+      expect(sql).toMatch(/SET status = 'done'/);
+      expect(sql).toMatch(/WHERE id = \$1 AND status = 'executing'/);
+      expect(params).toEqual(['action-1', JSON.stringify({ prUrl: 'https://x/pr/1' })]);
+    });
+
+    it('markFailed transitions executing -> failed and stores the error', async () => {
+      const failed = row({ status: 'failed', error: 'boom' });
+      mockedQuery.mockResolvedValueOnce(qResult([failed]));
+
+      const result = await secretariatDb.markFailed('action-1', 'boom');
+
+      expect(result).toEqual(failed);
+      const [sql, params] = mockedQuery.mock.calls[0];
+      expect(sql).toMatch(/SET status = 'failed'/);
+      expect(sql).toMatch(/WHERE id = \$1 AND status = 'executing'/);
+      expect(params).toEqual(['action-1', 'boom']);
+    });
+  });
+
+  describe('retry', () => {
+    it('transitions failed -> proposed and clears the prior decision', async () => {
+      const retried = row({ status: 'proposed', error: null, decided_by: null, decided_at: null });
+      mockedQuery.mockResolvedValueOnce(qResult([retried]));
+
+      const result = await secretariatDb.retry('action-1');
+
+      expect(result).toEqual(retried);
+      const [sql, params] = mockedQuery.mock.calls[0];
+      expect(sql).toMatch(/SET status = 'proposed', error = NULL, decided_by = NULL, decided_at = NULL/);
+      expect(sql).toMatch(/WHERE id = \$1 AND status = 'failed'/);
+      expect(params).toEqual(['action-1']);
+    });
+
+    it('returns null when the action is not in failed', async () => {
+      mockedQuery.mockResolvedValueOnce(qResult([]));
+      const result = await secretariatDb.retry('action-1');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listByStatus', () => {
+    it('filters by status when provided', async () => {
+      mockedQuery.mockResolvedValueOnce(qResult([row()]));
+      await secretariatDb.listByStatus({ status: 'proposed', limit: 50 });
+      const [sql, params] = mockedQuery.mock.calls[0];
+      expect(sql).toMatch(/WHERE status = \$1/);
+      expect(params).toEqual(['proposed', 50]);
+    });
+
+    it('clamps limit to 200 max', async () => {
+      mockedQuery.mockResolvedValueOnce(qResult([]));
+      await secretariatDb.listByStatus({ limit: 5000 });
+      const [, params] = mockedQuery.mock.calls[0];
+      expect(params).toEqual([200]);
+    });
+  });
+
+  describe('getStats', () => {
+    it('returns by_kind_status counts and per-kind approval rate', async () => {
+      mockedQuery
+        .mockResolvedValueOnce(qResult([
+          { kind: 'file_issue', status: 'done', count: '3' },
+          { kind: 'file_issue', status: 'failed', count: '1' },
+        ]))
+        .mockResolvedValueOnce(qResult([
+          { kind: 'file_issue', decided: '4', approved_without_edit: '2' },
+        ]));
+
+      const stats = await secretariatDb.getStats();
+
+      expect(stats.by_kind_status).toEqual([
+        { kind: 'file_issue', status: 'done', count: 3 },
+        { kind: 'file_issue', status: 'failed', count: 1 },
+      ]);
+      expect(stats.approval_rate_by_kind).toEqual([
+        { kind: 'file_issue', decided: 4, approved_without_edit: 2, rate: 0.5 },
+      ]);
+    });
+
+    it('reports rate: null when a kind has never been decided', async () => {
+      mockedQuery
+        .mockResolvedValueOnce(qResult([]))
+        .mockResolvedValueOnce(qResult([{ kind: 'open_pr', decided: '0', approved_without_edit: '0' }]));
+
+      const stats = await secretariatDb.getStats();
+      expect(stats.approval_rate_by_kind).toEqual([
+        { kind: 'open_pr', decided: 0, approved_without_edit: 0, rate: null },
+      ]);
+    });
+  });
+});

--- a/server/tests/unit/secretariat-executor.test.ts
+++ b/server/tests/unit/secretariat-executor.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const listByStatus = vi.fn();
+const claimForExecution = vi.fn();
+const markDone = vi.fn();
+const markFailed = vi.fn();
+const upsertFilesPr = vi.fn();
+const fileGitHubIssue = vi.fn();
+const postIssueComment = vi.fn();
+const sendChannelMessage = vi.fn();
+
+vi.mock('../../src/db/secretariat-actions-db.js', () => ({
+  listByStatus,
+  claimForExecution,
+  markDone,
+  markFailed,
+}));
+
+vi.mock('../../src/addie/jobs/github-pr.js', () => ({
+  upsertFilesPr,
+}));
+
+vi.mock('../../src/addie/jobs/github-filer.js', () => ({
+  fileGitHubIssue,
+  postIssueComment,
+}));
+
+vi.mock('../../src/slack/client.js', () => ({
+  sendChannelMessage,
+}));
+
+function action(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'a1',
+    kind: 'file_issue',
+    title: 't',
+    rationale: 'r',
+    payload: {},
+    status: 'approved',
+    origin: 'test',
+    dedupe_key: null,
+    edited: false,
+    result: null,
+    error: null,
+    decided_by: 'admin@example.com',
+    decided_at: new Date(),
+    executed_at: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+describe('runSecretariatExecutorJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('dispatches open_pr to upsertFilesPr and marks done with the PR result', async () => {
+    const openPrAction = action({
+      id: 'a-open-pr',
+      kind: 'open_pr',
+      payload: {
+        branch: 'addie/x',
+        files: [{ path: 'a.md', content: 'hi' }],
+        commitMessage: 'chore: x',
+        prTitle: 'chore: x',
+        prBody: 'body',
+      },
+    });
+    listByStatus.mockResolvedValue([openPrAction]);
+    claimForExecution.mockResolvedValue({ ...openPrAction, status: 'executing' });
+    upsertFilesPr.mockResolvedValue({ prUrl: 'https://github.com/x/pr/1', prNumber: 1, created: true });
+
+    const { runSecretariatExecutorJob } = await import('../../src/addie/jobs/secretariat-executor.js');
+    const result = await runSecretariatExecutorJob();
+
+    expect(upsertFilesPr).toHaveBeenCalledWith(expect.objectContaining({
+      branch: 'addie/x',
+      files: [{ path: 'a.md', content: 'hi' }],
+      commitMessage: 'chore: x',
+      prTitle: 'chore: x',
+      prBody: 'body',
+    }));
+    expect(markDone).toHaveBeenCalledWith('a-open-pr', { prUrl: 'https://github.com/x/pr/1', prNumber: 1, created: true });
+    expect(result).toEqual({ claimed: 1, executed: 1, failed: 0 });
+  });
+
+  it('dispatches post_issue_comment to postIssueComment and marks done with the comment result', async () => {
+    const commentAction = action({
+      id: 'a-comment',
+      kind: 'post_issue_comment',
+      payload: { repo: 'acme/spec', issueNumber: 42, body: 'hello' },
+    });
+    listByStatus.mockResolvedValue([commentAction]);
+    claimForExecution.mockResolvedValue({ ...commentAction, status: 'executing' });
+    postIssueComment.mockResolvedValue({ url: 'https://github.com/acme/spec/pull/42#comment-1', id: 1 });
+
+    const { runSecretariatExecutorJob } = await import('../../src/addie/jobs/secretariat-executor.js');
+    await runSecretariatExecutorJob();
+
+    expect(postIssueComment).toHaveBeenCalledWith({ repo: 'acme/spec', issueNumber: 42, body: 'hello' });
+    expect(markDone).toHaveBeenCalledWith('a-comment', { commentUrl: 'https://github.com/acme/spec/pull/42#comment-1', commentId: 1 });
+  });
+
+  it('dispatches file_issue to fileGitHubIssue and marks done with the issue result', async () => {
+    const fileIssueAction = action({
+      id: 'a-file-issue',
+      kind: 'file_issue',
+      payload: { title: 'Bug', body: 'desc', labels: ['bug'] },
+    });
+    listByStatus.mockResolvedValue([fileIssueAction]);
+    claimForExecution.mockResolvedValue({ ...fileIssueAction, status: 'executing' });
+    fileGitHubIssue.mockResolvedValue({ url: 'https://github.com/acme/spec/issues/9', number: 9, repo: 'acme/spec' });
+
+    const { runSecretariatExecutorJob } = await import('../../src/addie/jobs/secretariat-executor.js');
+    await runSecretariatExecutorJob();
+
+    expect(fileGitHubIssue).toHaveBeenCalledWith({ repo: undefined, title: 'Bug', body: 'desc', labels: ['bug'] });
+    expect(markDone).toHaveBeenCalledWith('a-file-issue', { issueUrl: 'https://github.com/acme/spec/issues/9', issueNumber: 9 });
+  });
+
+  it('dispatches post_slack_message to sendChannelMessage and marks done with the ts', async () => {
+    const slackAction = action({
+      id: 'a-slack',
+      kind: 'post_slack_message',
+      payload: { channelId: 'C123', text: 'hi there' },
+    });
+    listByStatus.mockResolvedValue([slackAction]);
+    claimForExecution.mockResolvedValue({ ...slackAction, status: 'executing' });
+    sendChannelMessage.mockResolvedValue({ ok: true, ts: '123.456' });
+
+    const { runSecretariatExecutorJob } = await import('../../src/addie/jobs/secretariat-executor.js');
+    await runSecretariatExecutorJob();
+
+    expect(sendChannelMessage).toHaveBeenCalledWith('C123', { text: 'hi there' });
+    expect(markDone).toHaveBeenCalledWith('a-slack', { slackTs: '123.456' });
+  });
+
+  it('fails closed on an unknown or disallowed kind', async () => {
+    const weirdAction = action({ id: 'a-weird', kind: 'merge_pr' as unknown as string, payload: {} });
+    listByStatus.mockResolvedValue([weirdAction]);
+    claimForExecution.mockResolvedValue({ ...weirdAction, status: 'executing' });
+
+    const { runSecretariatExecutorJob } = await import('../../src/addie/jobs/secretariat-executor.js');
+    const result = await runSecretariatExecutorJob();
+
+    expect(upsertFilesPr).not.toHaveBeenCalled();
+    expect(fileGitHubIssue).not.toHaveBeenCalled();
+    expect(postIssueComment).not.toHaveBeenCalled();
+    expect(sendChannelMessage).not.toHaveBeenCalled();
+    expect(markFailed).toHaveBeenCalledWith('a-weird', expect.stringContaining('Unknown or disallowed action kind'));
+    expect(result).toEqual({ claimed: 1, executed: 0, failed: 1 });
+  });
+
+  it('marks failed when the underlying seam returns null (e.g. no GitHub credential)', async () => {
+    const openPrAction = action({
+      id: 'a-open-pr-fail',
+      kind: 'open_pr',
+      payload: { branch: 'addie/x', files: [{ path: 'a.md', content: 'hi' }], commitMessage: 'm', prTitle: 't', prBody: 'b' },
+    });
+    listByStatus.mockResolvedValue([openPrAction]);
+    claimForExecution.mockResolvedValue({ ...openPrAction, status: 'executing' });
+    upsertFilesPr.mockResolvedValue(null);
+
+    const { runSecretariatExecutorJob } = await import('../../src/addie/jobs/secretariat-executor.js');
+    const result = await runSecretariatExecutorJob();
+
+    expect(markFailed).toHaveBeenCalledWith('a-open-pr-fail', expect.stringContaining('upsertFilesPr failed'));
+    expect(result).toEqual({ claimed: 1, executed: 0, failed: 1 });
+  });
+
+  it('marks failed when the payload is malformed for the kind', async () => {
+    const badAction = action({ id: 'a-bad-payload', kind: 'file_issue', payload: { title: 'ok' } }); // missing body
+    listByStatus.mockResolvedValue([badAction]);
+    claimForExecution.mockResolvedValue({ ...badAction, status: 'executing' });
+
+    const { runSecretariatExecutorJob } = await import('../../src/addie/jobs/secretariat-executor.js');
+    const result = await runSecretariatExecutorJob();
+
+    expect(fileGitHubIssue).not.toHaveBeenCalled();
+    expect(markFailed).toHaveBeenCalledWith('a-bad-payload', expect.stringContaining('body'));
+    expect(result).toEqual({ claimed: 1, executed: 0, failed: 1 });
+  });
+
+  it('skips (does not execute) an action it fails to claim — the double-execution guard', async () => {
+    const raceAction = action({ id: 'a-race', kind: 'file_issue', payload: { title: 't', body: 'b' } });
+    listByStatus.mockResolvedValue([raceAction]);
+    claimForExecution.mockResolvedValue(null); // another tick/instance already claimed it
+
+    const { runSecretariatExecutorJob } = await import('../../src/addie/jobs/secretariat-executor.js');
+    const result = await runSecretariatExecutorJob();
+
+    expect(fileGitHubIssue).not.toHaveBeenCalled();
+    expect(markDone).not.toHaveBeenCalled();
+    expect(markFailed).not.toHaveBeenCalled();
+    expect(result).toEqual({ claimed: 0, executed: 0, failed: 0 });
+  });
+
+  it('passes the limit option through to listByStatus', async () => {
+    listByStatus.mockResolvedValue([]);
+    const { runSecretariatExecutorJob } = await import('../../src/addie/jobs/secretariat-executor.js');
+    await runSecretariatExecutorJob({ limit: 3 });
+    expect(listByStatus).toHaveBeenCalledWith({ status: 'approved', limit: 3 });
+  });
+});

--- a/server/tests/unit/secretariat-pr-shepherd.test.ts
+++ b/server/tests/unit/secretariat-pr-shepherd.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const resolveGitHubToken = vi.fn();
+const propose = vi.fn();
+const fetchMock = vi.fn();
+
+vi.mock('../../src/addie/jobs/github-app-token.js', () => ({
+  resolveGitHubToken,
+}));
+
+vi.mock('../../src/db/secretariat-actions-db.js', () => ({
+  propose,
+}));
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function pr(number: number, ageDays: number, sha = `sha-${number}`) {
+  return { number, created_at: daysAgoIso(ageDays), user: { login: `author${number}` }, head: { sha } };
+}
+
+function statusResponse(state: string | null) {
+  return { statuses: state ? [{ context: 'IPR Policy / Signature', state }] : [] };
+}
+
+describe('runSecretariatPrShepherdJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    resolveGitHubToken.mockResolvedValue('test-token');
+    propose.mockResolvedValue({ id: 'proposed-1' });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('proposes an IPR nudge for a PR older than 7 days with a pending status', async () => {
+    fetchMock
+      .mockResolvedValueOnce(json([pr(101, 10)])) // PR list
+      .mockResolvedValueOnce(json(statusResponse('pending'))); // combined status
+
+    const { runSecretariatPrShepherdJob } = await import('../../src/addie/jobs/secretariat-pr-shepherd.js');
+    const result = await runSecretariatPrShepherdJob();
+
+    expect(result.prsScanned).toBe(1);
+    expect(result.proposed).toBe(1);
+    expect(propose).toHaveBeenCalledTimes(1);
+    const call = propose.mock.calls[0][0];
+    expect(call.kind).toBe('post_issue_comment');
+    expect(call.origin).toBe('secretariat-pr-shepherd');
+    expect(call.dedupe_key).toBe('ipr-nudge:101');
+    expect(call.payload.issueNumber).toBe(101);
+    expect(call.payload.body).toContain('I have read the IPR Policy');
+  });
+
+  it('does not propose a duplicate nudge for the same PR — dedupe_key is stable per PR number', async () => {
+    fetchMock
+      .mockResolvedValueOnce(json([pr(101, 10)]))
+      .mockResolvedValueOnce(json(statusResponse('pending')))
+      .mockResolvedValueOnce(json([pr(101, 11)])) // second sweep, PR aged one more day
+      .mockResolvedValueOnce(json(statusResponse('pending')));
+
+    const { runSecretariatPrShepherdJob } = await import('../../src/addie/jobs/secretariat-pr-shepherd.js');
+    await runSecretariatPrShepherdJob();
+    await runSecretariatPrShepherdJob();
+
+    expect(propose).toHaveBeenCalledTimes(2);
+    expect(propose.mock.calls[0][0].dedupe_key).toBe('ipr-nudge:101');
+    expect(propose.mock.calls[1][0].dedupe_key).toBe('ipr-nudge:101');
+    // The actual de-duplication is enforced at the DB layer (unique dedupe_key,
+    // see secretariat-actions-db.test.ts) — the job's contract is to always
+    // propose with the same stable key so the DB can no-op the second call.
+  });
+
+  it('skips a PR younger than the minimum age without checking its status', async () => {
+    fetchMock.mockResolvedValueOnce(json([pr(202, 2)]));
+
+    const { runSecretariatPrShepherdJob } = await import('../../src/addie/jobs/secretariat-pr-shepherd.js');
+    const result = await runSecretariatPrShepherdJob();
+
+    expect(result.skippedTooNew).toBe(1);
+    expect(result.proposed).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // only the PR list call
+    expect(propose).not.toHaveBeenCalled();
+  });
+
+  it('skips a PR whose IPR status is not pending', async () => {
+    fetchMock
+      .mockResolvedValueOnce(json([pr(303, 10)]))
+      .mockResolvedValueOnce(json(statusResponse('success')));
+
+    const { runSecretariatPrShepherdJob } = await import('../../src/addie/jobs/secretariat-pr-shepherd.js');
+    const result = await runSecretariatPrShepherdJob();
+
+    expect(result.skippedNotPending).toBe(1);
+    expect(propose).not.toHaveBeenCalled();
+  });
+
+  it('is resilient to a status lookup failure: skips that PR, keeps processing others, never throws', async () => {
+    fetchMock
+      .mockResolvedValueOnce(json([pr(404, 10), pr(405, 10)])) // PR list
+      .mockResolvedValueOnce(json({ message: 'boom' }, 500)) // status lookup for 404 fails
+      .mockResolvedValueOnce(json(statusResponse('pending'))); // status lookup for 405 succeeds
+
+    const { runSecretariatPrShepherdJob } = await import('../../src/addie/jobs/secretariat-pr-shepherd.js');
+    const result = await runSecretariatPrShepherdJob();
+
+    expect(result.skippedLookupFailed).toBe(1);
+    expect(result.proposed).toBe(1);
+    expect(propose).toHaveBeenCalledTimes(1);
+    expect(propose.mock.calls[0][0].dedupe_key).toBe('ipr-nudge:405');
+  });
+
+  it('is resilient when the status lookup throws (network error)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(json([pr(500, 10)]))
+      .mockRejectedValueOnce(new Error('network down'));
+
+    const { runSecretariatPrShepherdJob } = await import('../../src/addie/jobs/secretariat-pr-shepherd.js');
+    const result = await runSecretariatPrShepherdJob();
+
+    expect(result.skippedLookupFailed).toBe(1);
+    expect(propose).not.toHaveBeenCalled();
+  });
+
+  it('returns early without calling GitHub when no credential is available', async () => {
+    resolveGitHubToken.mockResolvedValue(null);
+
+    const { runSecretariatPrShepherdJob } = await import('../../src/addie/jobs/secretariat-pr-shepherd.js');
+    const result = await runSecretariatPrShepherdJob();
+
+    expect(result).toEqual({ prsScanned: 0, proposed: 0, skippedNotPending: 0, skippedTooNew: 0, skippedLookupFailed: 0 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns early when the PR list lookup fails', async () => {
+    fetchMock.mockResolvedValueOnce(json({ message: 'nope' }, 500));
+
+    const { runSecretariatPrShepherdJob } = await import('../../src/addie/jobs/secretariat-pr-shepherd.js');
+    const result = await runSecretariatPrShepherdJob();
+
+    expect(result.prsScanned).toBe(0);
+    expect(propose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Stage A of the Secretariat console (`specs/spec-guardian.md`): the operating surface where humans watch and approve everything the AAO Secretariat wants to do. Every intended action becomes a **proposed row** — nothing executes until an admin approves it at `/admin/secretariat`; approved actions are executed by a worker job as `aao-secretariat[bot]`.

## What's in it

- **Migration 528** — `secretariat_actions`: kind, title, rationale (with evidence links), JSONB payload, dedupe key, edited flag, result/error, decided_by/at. State machine `proposed → approved → executing → done` (plus `rejected`, and `failed → proposed` via retry), every transition an atomic `UPDATE … WHERE status = '<from>'` so nothing double-executes. *(Builder originally picked 524; renumbered after verifying main had advanced to 527.)*
- **Executor job** (2-minute tick) — single kind-allowlist (`open_pr`, `post_issue_comment`, `file_issue`, `post_slack_message`); unknown kinds fail closed; hard rule enforced in code and comments: **never calls PR-merge or PR-review endpoints**. Executes through the existing Secretariat seams (`resolveGitHubToken()` → App token).
- **PR shepherd job** (hourly) — the first proposer: finds open PRs stuck >7 days on a pending IPR signature and *proposes* a friendly nudge comment, dedupe-keyed to one per PR. Proposes only; a human approves before anything posts.
- **`github-pr.ts`** refactored into shared internals with a multi-file `upsertFilesPr` (single-file API preserved — the digest job keeps working; multi-file PUT stops at first failure with no orphan PR). **`postIssueComment`** added on the filer's auth/timeout/secret-redaction pattern.
- **Admin API** — all routes `requireAuth + requireAdmin`: list/get, approve, reject (reason required), edit-payload (proposed only, sets `edited` for the autonomy stats), retry, manual enqueue (kind-validated), `/watching` (open PRs + `needs-wg-review` queue snapshot, 5-min cache), `/stats` (per-kind approved-without-edit rate — the evidence feed for future autonomy toggles).
- **Admin page** — `/admin/secretariat`: Watching / Proposed inbox (full draft previews) / In-flight / Done+Failed. All dynamic DOM built via `textContent` helpers; the 13 `innerHTML` uses are container-clears only. Design-system variables, sentence case. Sidebar link added.

## Safety posture

Nothing self-executes: rows are born `proposed` and only a human admin can move them to `approved`. The executor's allowlist is the single source (`ALLOWED_KINDS`), reused by the enqueue route's validation. Merge/review/approve of PRs is structurally outside the action vocabulary. Failed actions surface with errors and require explicit human retry.

## Test plan

- [x] 55 tests across 5 suites: state-machine gates (approve only from proposed, atomic claim, dedupe conflict returns existing, edit sets flag), executor dispatch per kind + fail-closed unknown kind, shepherd propose/dedupe/resilience, multi-file PR helper (one branch, one PR, stop-on-first-failure), plus the pre-existing digest-job suite unaffected.
- [x] `tsc --noEmit` clean; full precommit suite passed on commit; branch rebased onto current main.
- [ ] Post-deploy: `/admin/secretariat` loads; seed the two Docket #1 docs-PR actions via the enqueue endpoint; approve; verify both PRs open as `aao-secretariat[bot]`.

Implementation by a Sonnet subagent; reviewed by the session orchestrator (migration numbering, state-machine atomicity, executor allowlist, route auth, XSS posture). No changeset — Addie server work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)