### PR TITLE
fix(compliance): remove tab character from runner-output-contract.yaml (backport 3.1.x)

### DIFF
--- a/.changeset/fix-runner-output-contract-tab.md
+++ b/.changeset/fix-runner-output-contract-tab.md
@@ -1,0 +1,10 @@
+---
+"adcontextprotocol": patch
+---
+
+Remove a literal tab character from a comment line in
+`static/compliance/source/universal/runner-output-contract.yaml` (line 303).
+Tabs cannot start a token in YAML, so strict parsers fail to load the file
+entirely — platform engines consuming the packaged 3.1.4/3.1.5 compliance
+caches could not parse the runner output contract. Comment text unchanged;
+no semantic content changes.

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -300,7 +300,7 @@ validation_result:
                               #                          value (scoped to envelope)
                               #   envelope_field_absent → observed value at path (any JSON
                               #                          type); emitted only on failure
-	                              #                          and scoped to envelope
+                                #                          and scoped to envelope
                               #   envelope_field_pattern → observed envelope value at path
                               #                          (any JSON type); null when the field
                               #                          was missing


### PR DESCRIPTION
Backport of #6042 to the `3.1.x` line, per the triage recipe on #6038 — cherry-pick of the merged main commit, no conflicts.

Note: v3.1.6 was cut before #6042 merged on main, so the shipped 3.1.6 cache still carries the malformed `runner-output-contract.yaml`; this backport is what gets the fix into the next 3.1.x cache release for platform-engine consumers.

Refs #6038

🤖 Generated with [Claude Code](https://claude.com/claude-code)