### PR TITLE
fix: recover Argus reviews and age brand relationships

### DIFF
--- a/.changeset/age-brand-relationship-declarations.md
+++ b/.changeset/age-brand-relationship-declarations.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Clarify that future brand relationship declarations do not extend trust before their effective time and that omitted declaration timestamps age from a durable first observation.

--- a/.github/ai-review/expert-adcp-reviewer.md
+++ b/.github/ai-review/expert-adcp-reviewer.md
@@ -208,8 +208,7 @@ Every other PR runs `code-reviewer`. No exceptions for "small" PRs, "obvious" PR
 7. Synthesize by **severity**, not volume. A long list of `code-reviewer` nits is not a block. A single `security-reviewer` **High** with a named `file:line` and a concrete attack path is a block. Map only Major/Critical findings to `--request-changes`: `security-reviewer` **High**, `ad-tech-protocol-expert` **unsound** (with cited spec divergence), `code-reviewer` **Blocker**, or a breaking wire change without a `major` changeset. Medium/Low/sound-with-caveats verdicts become Follow-ups, not blocks.
 8. **Apply the mandatory coverage checks** (largest-file rule, schema-vs-docs audit, test-plan honesty). Each can independently produce a Follow-up or downgrade from `--approve` to `--comment`. Do not skip them because expert verdicts came back clean — experts are scoped, the coverage checks catch what falls between them.
 9. Apply the decision tree above to choose `--approve` / `--comment` / `--request-changes`.
-10. Write the review body following the review format, in the voice rules above. Cite subagent verdicts inline where they drove the decision ("`ad-tech-protocol-expert`: unsound — enum value `xyz` not in the WG-published 3.0 spec").
-11. Post the review with `gh pr review $PR_NUMBER --<action> --body "<body>"` — heredoc for multi-line bodies:
+10. Post the review. Compose the body inline as the heredoc argument to `gh pr review`, following the review format and voice rules above. Cite subagent verdicts inline where they drove the decision ("`ad-tech-protocol-expert`: unsound — enum value `xyz` not in the WG-published 3.0 spec"). Do not write the review as standalone text output — the heredoc is the writing step. If you find yourself writing the review body as output first, stop: that output is discarded; compose directly into the heredoc.
 
     ```bash
     gh pr review $PR_NUMBER --approve --body "$(cat <<'EOF'
@@ -221,7 +220,7 @@ Every other PR runs `code-reviewer`. No exceptions for "small" PRs, "obvious" PR
     )"
     ```
 
-12. That's the deliverable. Don't summarize what you did afterward.
+11. That's the deliverable. Don't summarize what you did afterward.
 
 **Constraints:**
 - Use `$PR_NUMBER` environment variable — do not guess the PR number.

--- a/.github/ai-review/inspect-execution.mjs
+++ b/.github/ai-review/inspect-execution.mjs
@@ -1,0 +1,93 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+const REVIEW_SENTINEL = '## Things I checked';
+const MAX_DENIAL_LOG_LENGTH = 2_000;
+
+function escapeWorkflowCommand(value) {
+  return value
+    .replaceAll('%', '%25')
+    .replaceAll('\r', '%0D')
+    .replaceAll('\n', '%0A');
+}
+
+function truncate(value, maxLength = MAX_DENIAL_LOG_LENGTH) {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
+}
+
+function denialSummary(denial) {
+  const toolName = typeof denial?.tool_name === 'string' ? denial.tool_name : 'unknown tool';
+  const toolInput = denial?.tool_input && typeof denial.tool_input === 'object'
+    ? denial.tool_input
+    : {};
+  return truncate(`${toolName}: ${JSON.stringify(toolInput)}`);
+}
+
+function assistantText(message) {
+  if (message?.type !== 'assistant' || !Array.isArray(message.message?.content)) return '';
+  return message.message.content
+    .filter((block) => block?.type === 'text' && typeof block.text === 'string')
+    .map((block) => block.text)
+    .join('\n')
+    .trim();
+}
+
+export function inspectExecution(messages) {
+  if (!Array.isArray(messages)) {
+    throw new Error('Argus execution trace must be a JSON array');
+  }
+
+  const result = [...messages].reverse().find((message) => message?.type === 'result');
+  const completed = result?.subtype === 'success' && result.is_error === false;
+  const denials = Array.isArray(result?.permission_denials) ? result.permission_denials : [];
+
+  const candidates = [];
+  if (typeof result?.result === 'string') candidates.push(result.result.trim());
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const text = assistantText(messages[index]);
+    if (text) candidates.push(text);
+  }
+  const recoveryBody = completed
+    ? candidates.find((candidate) => candidate.includes(REVIEW_SENTINEL))
+    : undefined;
+
+  return {
+    completed,
+    denials,
+    recoveryBody: recoveryBody || undefined,
+  };
+}
+
+async function appendOutput(outputFile, name, value) {
+  await writeFile(outputFile, `${name}=${value}\n`, { flag: 'a' });
+}
+
+async function main() {
+  const [executionFile, recoveryFile, outputFile] = process.argv.slice(2);
+  if (!executionFile || !recoveryFile || !outputFile) {
+    throw new Error('Usage: inspect-execution.mjs <execution-file> <recovery-file> <github-output>');
+  }
+
+  const messages = JSON.parse(await readFile(executionFile, 'utf8'));
+  const inspection = inspectExecution(messages);
+
+  for (const denial of inspection.denials) {
+    const summary = escapeWorkflowCommand(denialSummary(denial));
+    console.log(`::warning title=Argus tool call denied::${summary}`);
+  }
+
+  await appendOutput(outputFile, 'completed', String(inspection.completed));
+  await appendOutput(outputFile, 'denial_count', String(inspection.denials.length));
+  await appendOutput(outputFile, 'recovery_available', String(Boolean(inspection.recoveryBody)));
+  if (inspection.recoveryBody) {
+    await writeFile(recoveryFile, inspection.recoveryBody, 'utf8');
+    await appendOutput(outputFile, 'recovery_file', recoveryFile);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`::warning title=Argus trace inspection failed::${escapeWorkflowCommand(String(error))}`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -384,6 +384,25 @@ jobs:
             --model claude-opus-4-8
             --effort high
 
+      - name: Inspect Argus execution trace
+        id: trace
+        if: always() && steps.ai-review.outcome != 'skipped'
+        continue-on-error: true
+        shell: bash
+        env:
+          EXECUTION_FILE: ${{ steps.ai-review.outputs.execution_file }}
+          RECOVERY_FILE: ${{ runner.temp }}/argus-recovered-review.md
+        run: |
+          set -euo pipefail
+          if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
+            echo "::warning::Argus execution trace is unavailable"
+            exit 0
+          fi
+          node .github/ai-review/inspect-execution.mjs \
+            "$EXECUTION_FILE" \
+            "$RECOVERY_FILE" \
+            "$GITHUB_OUTPUT"
+
       - name: Verify Argus posted a review
         id: verify
         if: always() && steps.app-token.outcome == 'success' && steps.review-route.outputs.skip != 'true' && steps.workflow-mod.outputs.modified != 'true' && steps.skip-check.outputs.skip != 'true'
@@ -402,6 +421,7 @@ jobs:
             --jq "[.[] | select(
               .user.login == \"${ARGUS_BOT_LOGIN}\"
               and (((.body // \"\") | contains(\"<!-- argus-skip:\")) | not)
+              and (((.body // \"\") | contains(\"<!-- argus-recovered-output -->\")) | not)
               and (((.body // \"\") | contains(\"Argus is **not auto-reviewing**\")) | not)
               and (((.body // \"\") | contains(\"Argus review could not complete\")) | not)
             )] | sort_by(.submitted_at) | last // {}")"
@@ -424,19 +444,41 @@ jobs:
           echo "review_posted=true" >> "$GITHUB_OUTPUT"
           echo "review_state=$STATE" >> "$GITHUB_OUTPUT"
 
-      - name: Comment on PR if Argus review failed
-        if: steps.review-route.outputs.skip != 'true' && steps.workflow-mod.outputs.modified != 'true' && steps.skip-check.outputs.skip != 'true' && (steps.ai-review.outcome == 'failure' || steps.verify.outputs.review_posted != 'true')
+      - name: Recover completed output or hand off failed review
+        if: steps.review-route.outputs.skip != 'true' && steps.workflow-mod.outputs.modified != 'true' && steps.skip-check.outputs.skip != 'true' && steps.verify.outputs.review_posted != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ARGUS_COMPLETED: ${{ steps.trace.outputs.completed }}
+          RECOVERY_AVAILABLE: ${{ steps.trace.outputs.recovery_available }}
+          RECOVERY_FILE: ${{ steps.trace.outputs.recovery_file }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
+            const fs = require('fs');
             const runUrl = process.env.RUN_URL;
+            const canRecover = process.env.ARGUS_COMPLETED === 'true'
+              && process.env.RECOVERY_AVAILABLE === 'true'
+              && process.env.RECOVERY_FILE
+              && fs.existsSync(process.env.RECOVERY_FILE);
+            const body = canRecover
+              ? [
+                  '⚠️ **Argus — recovered output; no formal verdict recorded.**',
+                  '',
+                  'The model completed its analysis but did not post the required GitHub review. Re-run Argus or have a human issue the verdict before merging.',
+                  '<!-- argus-recovered-output -->',
+                  '',
+                  fs.readFileSync(process.env.RECOVERY_FILE, 'utf8').trim(),
+                  '',
+                  `[View workflow run](${runUrl})`,
+                  '',
+                  '<sub>This is recovered output from the Argus AI review workflow.</sub>'
+                ].join('\n')
+              : `⚠️ **Argus review could not complete**\n\nThe automated review failed before producing a recoverable review body. A human reviewer should take this PR.\n\n[View workflow run](${runUrl})\n\n<sub>This is an automated message from the Argus AI review workflow.</sub>`;
             await github.rest.pulls.createReview({
               pull_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               event: 'COMMENT',
-              body: `⚠️ **Argus review could not complete**\n\nThe automated review encountered an issue (possibly reached max turns, timed out, or failed to post the final \`gh pr review\`). A human reviewer should take this PR.\n\n[View workflow run](${runUrl})\n\n<sub>This is an automated message from the Argus AI review workflow.</sub>`
+              body
             })

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -1383,7 +1383,7 @@ These invariants MUST be enforced by validators and crawlers; JSON Schema cannot
 **Resolution invariants**
 
 - **Compliance fields strictest-of.** For governance fields — including `data_subject_contestation`, `compliance_policies`, `policy_categories`, audience exclusions, regulated-category flags, and brand-level `disclaimers[]` that the house also publishes — the resolved value is the union/strictest of house-level and brand-level. Brand-level publishers MUST NOT rely on weakening house-level assertions. This is distinct from relationship trust — strictest-of is a resolution rule, not a trust gate.
-- **Edge aging.** Mutual-assertion edges SHOULD be aged: consumers SHOULD treat an edge as one-sided when the gap between the publisher-declared `brand_refs[].effective_at` (or, if absent, the consumer's first observation) and the last successful re-validation exceeds the consumer's chosen TTL. AAO's reference crawler ages at 180 days; consumers MAY choose differently.
+- **Edge aging.** Mutual-assertion edges SHOULD be aged on two independent clocks. Consumers SHOULD treat an edge as one-sided when the publisher-declared `brand_refs[].effective_at` (or, if absent, the consumer's durable first observation) exceeds the consumer's declaration-age ceiling, even if re-validation continues to succeed. A future `effective_at` is not active yet and MUST NOT extend trust before that time. Consumers SHOULD separately bound how long a previously confirmed edge may remain trusted while re-validation is unavailable. AgenticAdvertising.org's reference resolver uses a 180-day declaration-age ceiling and a 24-hour confirmation-retention window; consumers MAY choose stricter values.
 
 **Self-healing**
 

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -128,12 +128,12 @@ A domain is authoritative for its own identity — TLS proves the document came 
 |---|---|
 | `inline` | The house's own document defines the brand. |
 | `mutual` | Both sides publish the relationship. The trust-extending edge. |
-| `leaf_only` | The brand claims a house that has not named it back. See `claimed_house_domain`. |
+| `leaf_only` | The brand claims a house whose reciprocal declaration is missing, not yet active, or older than the resolver's trust ceiling. See `claimed_house_domain`. |
 | `house_only` | A house claims the brand, which has not claimed the house. |
 | `standalone` | The brand claims no house. |
 | `unverifiable` | A claimed house exists but could not be checked. |
 
-`house_domain` is only set on a reciprocated relationship; a one-sided claim appears as `claimed_house_domain`. For `mutual`, `relationship_verified_at` records when both sides were last seen agreeing — it does not advance while the house side is unreachable, so you can age edges out on your own schedule.
+`house_domain` is only set on a trust-extending relationship; a one-sided claim appears as `claimed_house_domain`. For `mutual`, `relationship_verified_at` records when both sides were last seen agreeing — it does not advance while the house side is unreachable. `relationship_declared_at` records the house's `brand_refs[].effective_at`, falling back to the resolver's durable first observation when the publisher omits it. AgenticAdvertising.org's reference resolver requires both clocks to remain live: confirmation may be retained for at most 24 hours while the house is unreachable, and declarations age out after 180 days even when re-confirmation keeps succeeding. Future declarations remain `leaf_only` until their effective time. Callers can apply stricter policies to either timestamp.
 
 Following a redirect never lets a domain adopt a house's identity. When a domain's brand.json points at a house that does not name the domain back — in `properties[]` as `relationship: "owned"`, or in `brand_refs[]` — the response carries the claim (`claimed_house_domain` with `relationship_trust: leaf_only`) and no brand identity. A house that lists a domain with `direct`, `delegated`, or `ad_network` is declaring a monetization path, not ownership, so it does not resolve that domain's identity either. If you expected an identity here, the house is missing its half of the relationship.
 

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -14,6 +14,10 @@ import type {
 import { AAO_UA_VALIDATOR } from './config/user-agents.js';
 import { withSdkSafeTransport } from './utils/sdk-safe-fetch.js';
 import { assertValidBrandDomain } from './services/identifier-normalization.js';
+import {
+  observeBrandRelationshipDeclaration,
+  type BrandRelationshipDeclaration,
+} from './db/brand-relationship-db.js';
 
 export interface BrandValidationError {
   field: string;
@@ -131,10 +135,26 @@ const BRAND_FAILED_CACHE_MAX_ENTRIES = 1000;
  * `unverifiable`, per the brand.json edge-aging rule.
  */
 const MUTUAL_TRUST_RETENTION_MS = 24 * 60 * 60 * 1000;
+/**
+ * Maximum age of the house's ownership declaration, independent of how
+ * recently both sides were re-validated. This implements the 180-day ceiling
+ * documented for the AgenticAdvertising.org reference resolver.
+ */
+const MUTUAL_DECLARATION_MAX_AGE_MS = 180 * 24 * 60 * 60 * 1000;
+
+type RelationshipDeclarationObserver = (
+  declaration: BrandRelationshipDeclaration,
+) => Promise<number>;
 
 type CanonicalHouseVerification =
-  | { status: 'mutual'; houseDomain: string; houseName?: string; verifiedAt: number }
-  | { status: 'leaf_only' }
+  | {
+      status: 'mutual';
+      houseDomain: string;
+      houseName?: string;
+      verifiedAt: number;
+      declaredAt: number;
+    }
+  | { status: 'leaf_only'; declaredAt?: number }
   | { status: 'unverifiable'; transient: boolean };
 
 interface CanonicalResolution {
@@ -172,11 +192,16 @@ export class BrandManager {
   private resolutionCache: Cache<ResolvedBrand | null>;
   // Cache for failed lookups (1 hour)
   private failedLookupCache: Cache<BrandValidationResult>;
+  private observeRelationshipDeclaration: RelationshipDeclarationObserver;
 
-  constructor() {
+  constructor(options: {
+    observeRelationshipDeclaration?: RelationshipDeclarationObserver;
+  } = {}) {
     this.validationCache = new Cache<BrandValidationResult>(24 * 60, BRAND_CACHE_MAX_ENTRIES); // 24 hours
     this.resolutionCache = new Cache<ResolvedBrand | null>(24 * 60, BRAND_CACHE_MAX_ENTRIES); // 24 hours
     this.failedLookupCache = new Cache<BrandValidationResult>(60, BRAND_FAILED_CACHE_MAX_ENTRIES); // 1 hour
+    this.observeRelationshipDeclaration = options.observeRelationshipDeclaration
+      ?? observeBrandRelationshipDeclaration;
   }
 
   /**
@@ -1072,7 +1097,9 @@ export class BrandManager {
     if (!skipCache) {
       const cached = this.resolutionCache.get(cacheKey);
       if (cached !== undefined) {
-        return cached;
+        const aged = this.applyDeclarationAgeCeiling(cached);
+        if (aged !== cached) this.resolutionCache.set(cacheKey, aged);
+        return aged;
       }
     }
 
@@ -1398,11 +1425,28 @@ export class BrandManager {
     const canonical = validation.raw_data as BrandCanonicalDocument;
     if (canonical.id !== pointer.brand_id) return null;
     const reciprocal = canonical.house_domain?.toLowerCase() === expectedHouseDomain.toLowerCase();
+    let knownRelationship: 'mutual' | 'house_only' | 'unverifiable' = reciprocal
+      ? 'mutual'
+      : 'house_only';
+    let relationshipDeclaredAt: number | undefined;
+    if (reciprocal) {
+      try {
+        relationshipDeclaredAt = await this.relationshipDeclaredAt(
+          pointer,
+          pointer.domain,
+          pointer.brand_id,
+          expectedHouseDomain,
+        );
+      } catch {
+        knownRelationship = 'unverifiable';
+      }
+    }
     const resolution = await this.resolveCanonicalDocument(canonical, pointer.domain, {
       skipCache: options.skipCache,
       maxRedirects: 3,
-      knownRelationship: reciprocal ? 'mutual' : 'house_only',
-      verifiedHouseDomain: reciprocal ? expectedHouseDomain : undefined,
+      knownRelationship,
+      verifiedHouseDomain: knownRelationship === 'mutual' ? expectedHouseDomain : undefined,
+      relationshipDeclaredAt,
       ...this.promotionMetadata(validation),
     });
     return resolution.result;
@@ -1426,8 +1470,9 @@ export class BrandManager {
     options: {
       skipCache?: boolean;
       maxRedirects: number;
-      knownRelationship?: 'mutual' | 'house_only';
+      knownRelationship?: 'mutual' | 'house_only' | 'unverifiable';
       verifiedHouseDomain?: string;
+      relationshipDeclaredAt?: number;
       promoted_from_schema?: string;
       migration_warnings?: BrandValidationWarning[];
     }
@@ -1441,11 +1486,20 @@ export class BrandManager {
     let houseName: string | undefined;
     let retainCachedMutual = false;
     let relationshipVerifiedAt: string | undefined;
+    let relationshipDeclaredAt = options.relationshipDeclaredAt;
 
     if (options.knownRelationship) {
       relationshipTrust = options.knownRelationship;
       if (options.knownRelationship === 'mutual') {
-        relationshipVerifiedAt = new Date().toISOString();
+        if (
+          relationshipDeclaredAt !== undefined &&
+          this.withinDeclarationAgeCeiling(relationshipDeclaredAt)
+        ) {
+          relationshipVerifiedAt = new Date().toISOString();
+        } else {
+          relationshipTrust = 'leaf_only';
+          verifiedHouseDomain = undefined;
+        }
       }
     } else if (claimedHouseDomain) {
       const verification = await this.verifyCanonicalHouseRelationship(
@@ -1457,6 +1511,9 @@ export class BrandManager {
       relationshipTrust = verification.status;
       verifiedHouseDomain = verification.status === 'mutual' ? verification.houseDomain : undefined;
       houseName = verification.status === 'mutual' ? verification.houseName : undefined;
+      relationshipDeclaredAt = verification.status === 'mutual' || verification.status === 'leaf_only'
+        ? verification.declaredAt
+        : undefined;
       relationshipVerifiedAt = verification.status === 'mutual'
         ? new Date(verification.verifiedAt).toISOString()
         : undefined;
@@ -1476,6 +1533,9 @@ export class BrandManager {
         house_name: houseName,
         relationship_trust: relationshipTrust,
         relationship_verified_at: relationshipVerifiedAt,
+        relationship_declared_at: relationshipDeclaredAt === undefined
+          ? undefined
+          : new Date(relationshipDeclaredAt).toISOString(),
         promoted_from_schema: options.promoted_from_schema,
         migration_warnings: options.migration_warnings,
         brand_manifest: this.buildBrandManifest(data),
@@ -1523,12 +1583,21 @@ export class BrandManager {
       return fresh;
     }
 
+    if (!this.withinDeclarationAgeCeiling(cached.relationship_declared_at)) {
+      return {
+        ...fresh,
+        relationship_trust: 'leaf_only',
+        relationship_declared_at: cached.relationship_declared_at,
+      };
+    }
+
     return {
       ...fresh,
       house_domain: cached.house_domain,
       house_name: cached.house_name,
       relationship_trust: 'mutual',
       relationship_verified_at: cached.relationship_verified_at,
+      relationship_declared_at: cached.relationship_declared_at,
     };
   }
 
@@ -1537,6 +1606,56 @@ export class BrandManager {
     const verifiedAtMs = Date.parse(verifiedAt);
     if (Number.isNaN(verifiedAtMs)) return false;
     return Date.now() - verifiedAtMs <= MUTUAL_TRUST_RETENTION_MS;
+  }
+
+  private withinDeclarationAgeCeiling(declaredAt: number | string | undefined): boolean {
+    if (declaredAt === undefined) return false;
+    const declaredAtMs = typeof declaredAt === 'number' ? declaredAt : Date.parse(declaredAt);
+    if (Number.isNaN(declaredAtMs)) return false;
+    const now = Date.now();
+    return declaredAtMs <= now
+      && now - declaredAtMs <= MUTUAL_DECLARATION_MAX_AGE_MS;
+  }
+
+  private applyDeclarationAgeCeiling(cached: ResolvedBrand | null): ResolvedBrand | null {
+    if (
+      cached?.relationship_trust !== 'mutual' ||
+      this.withinDeclarationAgeCeiling(cached.relationship_declared_at)
+    ) {
+      return cached;
+    }
+    return {
+      ...cached,
+      house_domain: undefined,
+      house_name: undefined,
+      relationship_trust: 'leaf_only',
+      relationship_verified_at: undefined,
+    };
+  }
+
+  private async relationshipDeclaredAt(
+    ref: NonNullable<HousePortfolioVariant['brand_refs']>[number],
+    leafDomain: string,
+    brandId: string,
+    houseDomain: string,
+  ): Promise<number> {
+    try {
+      return await this.observeRelationshipDeclaration({
+        houseDomain,
+        leafDomain,
+        brandId,
+        effectiveAt: ref.effective_at,
+      });
+    } catch (error) {
+      // An explicit publisher timestamp is still usable if persistence is
+      // temporarily unavailable. Missing effective_at must fail closed: using
+      // Date.now() would silently renew an edge after every storage outage.
+      if (ref.effective_at) {
+        const declaredAt = Date.parse(ref.effective_at);
+        if (!Number.isNaN(declaredAt)) return declaredAt;
+      }
+      throw error;
+    }
   }
 
   private async verifyCanonicalHouseRelationship(
@@ -1578,17 +1697,31 @@ export class BrandManager {
       }
 
       const portfolio = validation.raw_data as HousePortfolioVariant;
-      const reciprocal = portfolio.brand_refs?.some((ref) =>
+      const reciprocal = portfolio.brand_refs?.find((ref) =>
         ref.domain.toLowerCase() === leafDomain.toLowerCase() && ref.brand_id === brandId
       );
-      return reciprocal
-        ? {
-            status: 'mutual',
-            houseDomain: portfolio.house.domain,
-            houseName: portfolio.house.name,
-            verifiedAt: Date.now(),
-          }
-        : { status: 'leaf_only' };
+      if (!reciprocal) return { status: 'leaf_only' };
+      let declaredAt: number;
+      try {
+        declaredAt = await this.relationshipDeclaredAt(
+          reciprocal,
+          leafDomain,
+          brandId,
+          portfolio.house.domain,
+        );
+      } catch {
+        return { status: 'unverifiable', transient: true };
+      }
+      if (!this.withinDeclarationAgeCeiling(declaredAt)) {
+        return { status: 'leaf_only', declaredAt };
+      }
+      return {
+        status: 'mutual',
+        houseDomain: portfolio.house.domain,
+        houseName: portfolio.house.name,
+        verifiedAt: Date.now(),
+        declaredAt,
+      };
     }
     return { status: 'unverifiable', transient: false };
   }

--- a/server/src/db/brand-relationship-db.ts
+++ b/server/src/db/brand-relationship-db.ts
@@ -1,0 +1,42 @@
+import { query } from './client.js';
+
+export interface BrandRelationshipDeclaration {
+  houseDomain: string;
+  leafDomain: string;
+  brandId: string;
+  effectiveAt?: string;
+}
+
+/**
+ * Atomically records a publisher declaration or returns the shared first
+ * observation when effective_at is absent. An explicit timestamp replaces a
+ * prior value; later omission cannot erase or renew the stored clock.
+ */
+export async function observeBrandRelationshipDeclaration(
+  declaration: BrandRelationshipDeclaration,
+): Promise<number> {
+  const result = await query<{ declared_at: Date | string }>(
+    `INSERT INTO brand_relationship_declarations (
+       house_domain, leaf_domain, brand_id, declared_at
+     ) VALUES ($1, $2, $3, COALESCE($4::timestamptz, NOW()))
+     ON CONFLICT (house_domain, leaf_domain, brand_id) DO UPDATE SET
+       declared_at = CASE
+         WHEN $4::timestamptz IS NULL
+           THEN brand_relationship_declarations.declared_at
+         ELSE EXCLUDED.declared_at
+       END,
+       last_observed_at = NOW()
+     RETURNING declared_at`,
+    [
+      declaration.houseDomain.toLowerCase(),
+      declaration.leafDomain.toLowerCase(),
+      declaration.brandId,
+      declaration.effectiveAt ?? null,
+    ],
+  );
+  const declaredAt = new Date(result.rows[0].declared_at).getTime();
+  if (Number.isNaN(declaredAt)) {
+    throw new Error('Stored brand relationship declaration has an invalid timestamp');
+  }
+  return declaredAt;
+}

--- a/server/src/db/migrations/528_brand_relationship_declarations.sql
+++ b/server/src/db/migrations/528_brand_relationship_declarations.sql
@@ -1,0 +1,14 @@
+-- Durable declaration clocks for mutual brand/house relationship aging.
+
+CREATE TABLE IF NOT EXISTS brand_relationship_declarations (
+  house_domain TEXT NOT NULL,
+  leaf_domain TEXT NOT NULL,
+  brand_id TEXT NOT NULL,
+  declared_at TIMESTAMPTZ NOT NULL,
+  first_observed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_observed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (house_domain, leaf_domain, brand_id)
+);
+
+COMMENT ON TABLE brand_relationship_declarations IS
+  'Shared declaration-age anchors for canonical brand/house relationships. declared_at is publisher effective_at when present, otherwise the first observation retained across processes and deploys.';

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -481,7 +481,7 @@ export const ResolvedBrandSchema = z
     parent_brand: z.string().optional(),
     house_domain: z.string().optional(),
     claimed_house_domain: z.string().optional().openapi({
-      description: "House the requested domain claims. One-sided until the named house names it back, so it never extends relationship trust on its own.",
+      description: "House the requested domain claims. This field never extends trust on its own; `relationship_trust` reports whether the reciprocal declaration is current enough to do so.",
     }),
     house_name: z.string().optional(),
     relationship_trust: z.enum([
@@ -496,15 +496,19 @@ export const ResolvedBrandSchema = z
         "How the brand-to-house relationship was established.",
         "`inline`: the house's own document defines the brand.",
         "`mutual`: both sides publish the relationship — the trust-extending edge.",
-        "`leaf_only`: the brand claims a house that has not reciprocated.",
+        "`leaf_only`: the brand claims a house whose reciprocal declaration is missing, not yet active, or too old to extend trust.",
         "`house_only`: a house claims the brand, which has not reciprocated.",
         "`standalone`: the brand claims no house.",
         "`unverifiable`: a claimed house could not be checked.",
       ].join(" "),
     }),
-    relationship_verified_at: z.string().optional().openapi({
+    relationship_verified_at: z.string().datetime().optional().openapi({
       description: "When both sides of a mutual relationship were last seen agreeing. Present only for `mutual`, and it does not advance while the house side is unreachable, so callers can apply their own edge-aging policy.",
       example: "2026-07-28T12:00:00Z",
+    }),
+    relationship_declared_at: z.string().datetime().optional().openapi({
+      description: "When the house declared the relationship in `brand_refs[].effective_at`, or the resolver's durable first observation if the publisher omitted that field. Callers can apply a declaration-age ceiling independently of `relationship_verified_at`.",
+      example: "2026-01-29T12:00:00Z",
     }),
     promoted_from_schema: z.string().optional().openapi({
       description: "Set when a pre-v3 document was promoted to a canonical v3 document for this response. Identity only — legacy relationship data is preserved opaquely, never promoted to a trust claim.",

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -603,6 +603,8 @@ export interface ResolvedBrand {
   relationship_trust?: 'inline' | 'mutual' | 'leaf_only' | 'house_only' | 'standalone' | 'unverifiable';
   /** When the mutual-assertion edge was last confirmed by both sides. */
   relationship_verified_at?: string;
+  /** House declaration time, or this consumer's first observation when omitted. */
+  relationship_declared_at?: string;
   promoted_from_schema?: string;
   migration_warnings?: Array<{ field: string; message: string; suggestion?: string }>;
   brand_agent_url?: string;

--- a/server/tests/unit/brand-manager-cache.test.ts
+++ b/server/tests/unit/brand-manager-cache.test.ts
@@ -15,9 +15,31 @@ const mockedSafeFetch = vi.mocked(safeFetchAxiosLike);
 
 describe('BrandManager caching', () => {
   let manager: BrandManager;
+  let relationshipDeclarations: Map<string, number>;
+
+  const createManager = () => new BrandManager({
+    observeRelationshipDeclaration: async (declaration) => {
+      const key = [
+        declaration.houseDomain.toLowerCase(),
+        declaration.leafDomain.toLowerCase(),
+        declaration.brandId,
+      ].join('|');
+      if (declaration.effectiveAt) {
+        const declaredAt = Date.parse(declaration.effectiveAt);
+        relationshipDeclarations.set(key, declaredAt);
+        return declaredAt;
+      }
+      const firstObserved = relationshipDeclarations.get(key);
+      if (firstObserved !== undefined) return firstObserved;
+      const observedAt = Date.now();
+      relationshipDeclarations.set(key, observedAt);
+      return observedAt;
+    },
+  });
 
   beforeEach(() => {
-    manager = new BrandManager();
+    relationshipDeclarations = new Map();
+    manager = createManager();
     vi.clearAllMocks();
   });
 
@@ -1111,6 +1133,190 @@ describe('BrandManager caching', () => {
 
       expect(result?.relationship_trust).toBe('mutual');
       expect(Date.parse(result?.relationship_verified_at ?? '')).toBeGreaterThan(0);
+      expect(Date.parse(result?.relationship_declared_at ?? '')).toBeGreaterThan(0);
+    });
+
+    it('exposes effective_at as the declaration clock', async () => {
+      const effectiveAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: Buffer.from(JSON.stringify({
+            ...portfolio,
+            brand_refs: [{ ...portfolio.brand_refs[0], effective_at: effectiveAt }],
+          })),
+        });
+
+      const result = await manager.resolveBrand('leaf.example');
+
+      expect(result?.relationship_trust).toBe('mutual');
+      expect(result?.relationship_declared_at).toBe(effectiveAt);
+    });
+
+    it('degrades a reciprocal declaration older than 180 days to leaf_only', async () => {
+      const effectiveAt = new Date(Date.now() - 181 * 24 * 60 * 60 * 1000).toISOString();
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: Buffer.from(JSON.stringify({
+            ...portfolio,
+            brand_refs: [{ ...portfolio.brand_refs[0], effective_at: effectiveAt }],
+          })),
+        });
+
+      const result = await manager.resolveBrand('leaf.example');
+
+      expect(result).toMatchObject({
+        relationship_trust: 'leaf_only',
+        claimed_house_domain: 'house.example',
+        relationship_declared_at: effectiveAt,
+      });
+      expect(result?.house_domain).toBeUndefined();
+      expect(result?.relationship_verified_at).toBeUndefined();
+    });
+
+    it('keeps first observation stable across manager instances when effective_at is absent', async () => {
+      const hour = 60 * 60 * 1000;
+      vi.useFakeTimers();
+      try {
+        mockedSafeFetch
+          .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+          .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) });
+        const first = await manager.resolveBrand('leaf.example');
+
+        vi.advanceTimersByTime(30 * 24 * hour);
+        manager = createManager();
+        mockedSafeFetch
+          .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+          .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) });
+        const refreshed = await manager.resolveBrand('leaf.example', { skipCache: true });
+
+        expect(refreshed?.relationship_trust).toBe('mutual');
+        expect(refreshed?.relationship_declared_at).toBe(first?.relationship_declared_at);
+        expect(refreshed?.relationship_verified_at).not.toBe(first?.relationship_verified_at);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not activate a future declaration before its effective time', async () => {
+      const effectiveAt = new Date(Date.now() + 4 * 60 * 1000).toISOString();
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: Buffer.from(JSON.stringify({
+            ...portfolio,
+            brand_refs: [{ ...portfolio.brand_refs[0], effective_at: effectiveAt }],
+          })),
+        });
+
+      const result = await manager.resolveBrand('leaf.example');
+
+      expect(result).toMatchObject({
+        relationship_trust: 'leaf_only',
+        relationship_declared_at: effectiveAt,
+      });
+      expect(result?.house_domain).toBeUndefined();
+      expect(result?.relationship_verified_at).toBeUndefined();
+    });
+
+    it('fails closed when a missing effective_at cannot be durably observed', async () => {
+      manager = new BrandManager({
+        observeRelationshipDeclaration: async () => {
+          throw new Error('database unavailable');
+        },
+      });
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) });
+
+      const result = await manager.resolveBrand('leaf.example');
+
+      expect(result?.relationship_trust).toBe('unverifiable');
+      expect(result?.house_domain).toBeUndefined();
+      expect(result?.relationship_declared_at).toBeUndefined();
+    });
+
+    it('can evaluate explicit effective_at while durable storage is unavailable', async () => {
+      const effectiveAt = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      manager = new BrandManager({
+        observeRelationshipDeclaration: async () => {
+          throw new Error('database unavailable');
+        },
+      });
+      mockedSafeFetch
+        .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: Buffer.from(JSON.stringify({
+            ...portfolio,
+            brand_refs: [{ ...portfolio.brand_refs[0], effective_at: effectiveAt }],
+          })),
+        });
+
+      const result = await manager.resolveBrand('leaf.example');
+
+      expect(result?.relationship_trust).toBe('mutual');
+      expect(result?.relationship_declared_at).toBe(effectiveAt);
+    });
+
+    it('does not reset the declaration clock when effective_at is later omitted', async () => {
+      const hour = 60 * 60 * 1000;
+      vi.useFakeTimers();
+      try {
+        const effectiveAt = new Date(Date.now() - 30 * 24 * hour).toISOString();
+        mockedSafeFetch
+          .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+          .mockResolvedValueOnce({
+            status: 200,
+            data: Buffer.from(JSON.stringify({
+              ...portfolio,
+              brand_refs: [{ ...portfolio.brand_refs[0], effective_at: effectiveAt }],
+            })),
+          });
+        await manager.resolveBrand('leaf.example');
+
+        vi.advanceTimersByTime(30 * 24 * hour);
+        manager = createManager();
+        mockedSafeFetch
+          .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+          .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(portfolio)) });
+        const refreshed = await manager.resolveBrand('leaf.example', { skipCache: true });
+
+        expect(refreshed?.relationship_declared_at).toBe(effectiveAt);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('applies the declaration ceiling to a cached mutual edge', async () => {
+      const hour = 60 * 60 * 1000;
+      vi.useFakeTimers();
+      try {
+        const effectiveAt = new Date(Date.now() - (179 * 24 + 18) * hour).toISOString();
+        mockedSafeFetch
+          .mockResolvedValueOnce({ status: 200, data: Buffer.from(JSON.stringify(canonical)) })
+          .mockResolvedValueOnce({
+            status: 200,
+            data: Buffer.from(JSON.stringify({
+              ...portfolio,
+              brand_refs: [{ ...portfolio.brand_refs[0], effective_at: effectiveAt }],
+            })),
+          });
+        expect((await manager.resolveBrand('leaf.example'))?.relationship_trust).toBe('mutual');
+
+        vi.advanceTimersByTime(7 * hour);
+        const aged = await manager.resolveBrand('leaf.example');
+
+        expect(aged?.relationship_trust).toBe('leaf_only');
+        expect(aged?.relationship_declared_at).toBe(effectiveAt);
+        expect(aged?.house_domain).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('does not advance the verification time while reusing a retained edge', async () => {

--- a/server/tests/unit/brand-relationship-db.test.ts
+++ b/server/tests/unit/brand-relationship-db.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockedQuery } = vi.hoisted(() => ({
+  mockedQuery: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  query: mockedQuery,
+}));
+
+import { observeBrandRelationshipDeclaration } from '../../src/db/brand-relationship-db.js';
+
+describe('brand relationship declaration persistence', () => {
+  beforeEach(() => {
+    mockedQuery.mockReset();
+  });
+
+  it('atomically retains first observation when effective_at is absent', async () => {
+    const firstObserved = new Date('2026-01-01T00:00:00Z');
+    mockedQuery.mockResolvedValue({ rows: [{ declared_at: firstObserved }] });
+
+    await expect(observeBrandRelationshipDeclaration({
+      houseDomain: 'House.Example',
+      leafDomain: 'Leaf.Example',
+      brandId: 'leaf',
+    })).resolves.toBe(firstObserved.getTime());
+
+    expect(mockedQuery).toHaveBeenCalledWith(
+      expect.stringContaining('ON CONFLICT (house_domain, leaf_domain, brand_id) DO UPDATE'),
+      ['house.example', 'leaf.example', 'leaf', null],
+    );
+    expect(mockedQuery.mock.calls[0][0]).toContain(
+      'THEN brand_relationship_declarations.declared_at',
+    );
+  });
+
+  it('passes an explicit publisher declaration to shared storage', async () => {
+    const effectiveAt = '2026-02-01T00:00:00Z';
+    mockedQuery.mockResolvedValue({ rows: [{ declared_at: effectiveAt }] });
+
+    await observeBrandRelationshipDeclaration({
+      houseDomain: 'house.example',
+      leafDomain: 'leaf.example',
+      brandId: 'leaf',
+      effectiveAt,
+    });
+
+    expect(mockedQuery.mock.calls[0][1]).toEqual([
+      'house.example',
+      'leaf.example',
+      'leaf',
+      effectiveAt,
+    ]);
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -91,7 +91,7 @@ components:
           type: string
         claimed_house_domain:
           type: string
-          description: House the requested domain claims. One-sided until the named house names it back, so it never extends relationship trust on its own.
+          description: House the requested domain claims. This field never extends trust on its own; `relationship_trust` reports whether the reciprocal declaration is current enough to do so.
         house_name:
           type: string
         relationship_trust:
@@ -103,11 +103,17 @@ components:
             - house_only
             - standalone
             - unverifiable
-          description: "How the brand-to-house relationship was established. `inline`: the house's own document defines the brand. `mutual`: both sides publish the relationship — the trust-extending edge. `leaf_only`: the brand claims a house that has not reciprocated. `house_only`: a house claims the brand, which has not reciprocated. `standalone`: the brand claims no house. `unverifiable`: a claimed house could not be checked."
+          description: "How the brand-to-house relationship was established. `inline`: the house's own document defines the brand. `mutual`: both sides publish the relationship — the trust-extending edge. `leaf_only`: the brand claims a house whose reciprocal declaration is missing, not yet active, or too old to extend trust. `house_only`: a house claims the brand, which has not reciprocated. `standalone`: the brand claims no house. `unverifiable`: a claimed house could not be checked."
         relationship_verified_at:
           type: string
+          format: date-time
           description: When both sides of a mutual relationship were last seen agreeing. Present only for `mutual`, and it does not advance while the house side is unreachable, so callers can apply their own edge-aging policy.
           example: 2026-07-28T12:00:00Z
+        relationship_declared_at:
+          type: string
+          format: date-time
+          description: When the house declared the relationship in `brand_refs[].effective_at`, or the resolver's durable first observation if the publisher omitted that field. Callers can apply a declaration-age ceiling independently of `relationship_verified_at`.
+          example: 2026-01-29T12:00:00Z
         promoted_from_schema:
           type: string
           description: Set when a pre-v3 document was promoted to a canonical v3 document for this response. Identity only — legacy relationship data is preserved opaquely, never promoted to a trust claim.

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -85,7 +85,7 @@
         "effective_at": {
           "type": "string",
           "format": "date-time",
-          "description": "ISO 8601 timestamp when the house established this ownership claim. Consumers age mutual-assertion edges from this date for TTL purposes. Optional; absent means the consumer ages from its own first observation."
+          "description": "ISO 8601 timestamp when the house established this ownership claim. Consumers age mutual-assertion edges from this date for TTL purposes and MUST NOT extend relationship trust before a future effective_at is reached. Optional; absent means the consumer ages from its own durable first observation."
         }
       },
       "required": ["domain", "brand_id"],

--- a/tests/inspect-argus-execution.test.ts
+++ b/tests/inspect-argus-execution.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { inspectExecution } from '../.github/ai-review/inspect-execution.mjs';
+
+describe('Argus execution inspection', () => {
+  it('recovers a completed review and exposes denied tool calls', () => {
+    const messages = [
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        result: 'Request changes.\n\n## Things I checked\n- Trust boundary',
+        permission_denials: [
+          { tool_name: 'Bash', tool_use_id: 'tool-1', tool_input: { command: 'git status' } },
+        ],
+      },
+    ];
+
+    expect(inspectExecution(messages)).toEqual({
+      completed: true,
+      denials: messages[0].permission_denials,
+      recoveryBody: messages[0].result,
+    });
+  });
+
+  it('falls back to the final assistant message when the result omits the review', () => {
+    const review = 'LGTM.\n\n## Things I checked\n- Schema and docs';
+    const messages = [
+      { type: 'assistant', message: { content: [{ type: 'text', text: review }] } },
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        result: 'Done',
+        permission_denials: [],
+      },
+    ];
+
+    expect(inspectExecution(messages).recoveryBody).toBe(review);
+  });
+
+  it('does not recover errors or non-review final messages', () => {
+    expect(inspectExecution([{
+      type: 'result',
+      subtype: 'success',
+      is_error: true,
+      result: '## Things I checked\n- incomplete',
+      permission_denials: [],
+    }]).recoveryBody).toBeUndefined();
+
+    expect(inspectExecution([{
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: 'Analysis completed, but no review body was produced.',
+      permission_denials: [],
+    }]).recoveryBody).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Recover a completed Argus review from the model execution when the verifier finds no posted review, and emit each denied tool call to the workflow log.
- Give brand relationship declarations their own durable 180-day age ceiling, independent of the existing confirmation-age window.

## Root causes

- Argus could finish successfully with the review in its final model message but never invoke `gh pr review`; the verifier then discarded that paid-for result.
- Brand relationship evaluation did not persist a shared declaration clock when `effective_at` was omitted, and future declaration dates could be treated as active.

## What changed

- Parse the Argus SDK execution artifact, log denied tool names and inputs, and recover a completed review body as a GitHub comment when no real review exists. Recovered comments are marked and excluded from later verifier checks.
- Persist first declaration observations atomically in PostgreSQL, return `relationship_declared_at`, enforce the 180-day declaration ceiling and strict future-date gate, and fail closed when an omitted declaration date cannot be persisted.
- Add migration 528, schema/OpenAPI/docs updates, focused tests, and a patch changeset.

## Validation

- Full pre-commit hook: 307 test files passed; 4,640 tests passed and 30 skipped; TypeScript typecheck passed.
- Full pre-push hook: version/changeset policy, schema-link lint, and Mintlify broken-link validation passed.
- Focused tests: 69 passed; schema validation: 20/20; migration validation and PostgreSQL 16 migration smoke passed.
- Expert review: code review ready to push; protocol review found the behavior sound; security review found no high- or medium-severity issues.

## Follow-up

- Consider per-domain cardinality limits or crawler mediation as defense in depth against declaration-table growth from many wildcard subdomains.

Closes #6062
Closes #6063
