### PR TITLE
fix(compliance): remove stale vector count from signed-requests-runner header

### DIFF
--- a/.changeset/fix-signed-requests-runner-vector-count-comment.md
+++ b/.changeset/fix-signed-requests-runner-vector-count-comment.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix inaccurate vector count in signed-requests-runner.yaml header comment. The comment stated "28 conformance vectors" but the actual set is 40 (12 positive + 28 negative). Updated to reference positive/ and negative/ directories directly — consistent with the storyboard's own pass_criteria wording — so the comment cannot drift as vectors are added.

--- a/static/compliance/source/test-kits/signed-requests-runner.yaml
+++ b/static/compliance/source/test-kits/signed-requests-runner.yaml
@@ -3,8 +3,9 @@
 # Applies to: universal/signed-requests.yaml (gated on
 # `request_signing.supported: true` in get_adcp_capabilities).
 #
-# The signed-requests storyboard grades an agent's RFC 9421 verifier against 28
-# conformance vectors at /compliance/{version}/test-vectors/request-signing/.
+# The signed-requests storyboard grades an agent's RFC 9421 verifier against
+# vectors in positive/ and negative/ at
+# /compliance/{version}/test-vectors/request-signing/.
 # Most vectors are pure black-box: the runner constructs a signed HTTP request,
 # sends it, and checks the response. Three negative vectors assert behavior that
 # depends on verifier state the runner cannot set from the outside:


### PR DESCRIPTION
Closes #6071

The header comment in `static/compliance/source/test-kits/signed-requests-runner.yaml` said "28 conformance vectors" but the actual set has been 40 (12 positive + 28 negative) since 3.1.0. The count was never accurate for any released version — at 3.0.x the set was 39 (12 + 27), and "28" only happened to equal `len(negative/)` after vector `028-unsigned-protocol-method-required` was added in 3.1.0. This PR removes the hard-coded count and replaces it with a directory reference (`positive/ and negative/`), matching the style used by the storyboard's own `pass_criteria` block, which deliberately avoids stating a total for the same reason.

**Non-breaking justification:** Comment-only change in a YAML source file. No runner logic, schema field, or generated output is affected. Released dist artifacts (`dist/compliance/3.1.4/`) remain immutable and carry the old wording by design; the fix ships into the next patch via source.

**Pre-PR review:**
- code-reviewer: approved — no blockers; one wording nit addressed (article "the" before bare dir name → "vectors in positive/ and negative/ at …")
- ad-tech-protocol-expert: approved — wording correct, `patch` bump level correct per patch-eligibility table (non-normative compliance harness comment); dist immutability rule confirmed unaffected

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or request a new first draft PR:** comment `/triage execute`
>   on the source issue only when no triage-managed PR is already
>   open. Triage does not update existing PRs.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01EYYPbYTWZUnMa1KXb8tJZT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYYPbYTWZUnMa1KXb8tJZT)_