### PR TITLE
fix(compliance): drop stale request-signing vector counts

### DIFF
--- a/.changeset/fix-request-signing-vector-counts.md
+++ b/.changeset/fix-request-signing-vector-counts.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Remove hard-coded request-signing conformance vector counts from the compliance runner header and request-signing documentation. The guidance now describes the applicable profile and vector directories without totals, so future fixture additions cannot make the prose stale. Comment and documentation text only — no schema, runner logic, or generated artifact is affected.

--- a/docs/building/by-layer/L1/request-signing.mdx
+++ b/docs/building/by-layer/L1/request-signing.mdx
@@ -710,11 +710,11 @@ For emergency rotation (key compromise), add the old `kid` to `revoked_kids` in 
 
 ### Conformance vectors
 
-The spec ships **40 legacy-profile wire vectors**, two dedicated 3.2 wire vectors, and the 3.2 post-parse body-integrity reference-evaluator matrix at `/compliance/latest/test-vectors/request-signing/` (source at `static/compliance/source/test-vectors/request-signing/`). Select fixtures by `signing_profile_version`; the root positive and negative directories are 3.1 compatibility fixtures, not 3.2 conformance cases.
+The spec ships legacy-profile wire vectors, dedicated 3.2 wire vectors, and the 3.2 post-parse body-integrity reference-evaluator matrix at `/compliance/latest/test-vectors/request-signing/` (source at `static/compliance/source/test-vectors/request-signing/`). Select fixtures by `signing_profile_version`; the root positive and negative directories are 3.1 compatibility fixtures, not 3.2 conformance cases.
 
-- **12 legacy 3.1 positive vectors**: valid signed requests using the legacy binary encoding
-- **28 legacy 3.1 negative vectors**: invalid requests a 3.1 verifier must reject with the stated error code
-- **2 profile-3.2 wire vectors**: one body-bound positive and one rejection of legacy Base64URL as malformed RFC 8941 `sf-binary`
+- **Legacy 3.1 positive vectors**: valid signed requests using the legacy binary encoding
+- **Legacy 3.1 negative vectors**: invalid requests a 3.1 verifier must reject with the stated error code
+- **Profile-3.2 wire vectors**: body-bound positives and rejections of malformed RFC 8941 `sf-binary`
 
 ```bash
 # Debug a single vector

--- a/static/compliance/source/test-kits/signed-requests-runner.yaml
+++ b/static/compliance/source/test-kits/signed-requests-runner.yaml
@@ -4,7 +4,7 @@
 # `request_signing.supported: true` in get_adcp_capabilities).
 #
 # The signed-requests storyboard's current black-box contract grades the legacy
-# 3.1 RFC 9421 profile against 28 conformance vectors at
+# 3.1 RFC 9421 profile against conformance vectors at
 # /compliance/{version}/test-vectors/request-signing/negative/.
 # Most vectors are pure black-box: the runner constructs a signed HTTP request,
 # sends it, and checks the response. Three negative vectors assert behavior that


### PR DESCRIPTION
Fixes the vector-count defect reported in #6071, in both places it appears.

## The defect

The request-signing conformance vector set is **40 — 12 positive + 28 negative**. I verified by listing the source directories at `static/compliance/source/test-vectors/request-signing/`:

| directory | count |
|---|---|
| `positive/` | 12 |
| `negative/` | 28 |

Two files stated a count, and both were wrong — with **different** wrong numbers, which is the argument for stating no count at all:

**1. `static/compliance/source/test-kits/signed-requests-runner.yaml:6` — the file #6071 reports.** Said `28`, which is the size of `negative/` alone, so the count omitted the positive set entirely. This is the generator input that propagates to every published version. It was never accurate: at 3.0.x the set was 39 (12 + 27), matching neither the total nor the negative count; `028-unsigned-protocol-method-required` landed in 3.1.0, which is what made `28` coincide with `len(negative/)`.

**2. `docs/building/by-layer/L1/request-signing.mdx:711` — found while confirming the fix was complete.** Said `39 test vectors` / `12 positive` / `27 negative` — the stale 3.0.x numbers, in the implementer-facing prose that is the first thing someone reads when planning a conformance run.

Taking either at face value under-grades the positive set — the canonicalization edges (default-port stripping, dot-segment paths, percent-encoding, query-byte preservation, IPv6 authority, multiple signature labels, ES256). A verifier can pass all 28 negatives and still fail those, and the symptom is rejecting validly-signed requests from conformant counterparties.

## The fix

Both now name the directories instead of stating a total, matching `universal/signed-requests.yaml:208`, whose `pass_criteria` grades *"all vectors in `positive/` … and all vectors in `negative/`"* and therefore cannot drift as vectors are added.

The runner header uses the **exact wording** of #6073, which fixes the same line — so if both land, git resolves the identical edit rather than conflicting.

## Completeness sweep

Swept `static/` for every count phrasing, not just the one already matched — `against [0-9]+ conformance`, `[0-9]+ (conformance|test) vectors?`, `[0-9]+ vectors`, `[0-9]+ positive`, `[0-9]+ negative`, spelled-out numerals, and `all/both/only NN vectors`. Everything still standing is accurate and deliberately left alone:

| Location | Claim | Why unchanged |
|---|---|---|
| `signed-requests-runner.yaml:10` | "Three negative vectors" | Correct — enumerates 016, 017, 020 inline; all three present in `negative/`. Self-verifying. |
| `universal/signed-requests.yaml:63` | "Three negative vectors" | Correct — same three, enumerated inline. |
| `webhook-signing/README.md:160` | "Three negative vectors" | Correct — enumerates 016, 017, 018; all present in webhook `negative/`. Different profile. |
| `substitution-observer-runner.yaml:437` | "Minimum 3 vectors" | Correct, and a normative floor rather than a set size, followed by exactly 3 enumerated items. |
| `request-signing/README.md:166` | "…Ed25519 positive vectors" | Regex artifact (`25519 positive`), not a count. |

`docs/` is now clean of numeric vector counts. Worth noting the webhook-signing README states no total anywhere — it was written the drift-proof way from the start.

## Scope

- Comment and prose only. No schema, runner logic, storyboard, or generated artifact is affected; the graded contract in `universal/signed-requests.yaml` already stated no total.
- **Changeset included** (`patch`). Touching `static/compliance/source/` puts this on the protocol release surface — confirmed by running the gate itself: `node scripts/check-changeset-protocol-scope.cjs origin/main --has-protocol-scoped-changes` → *"Protocol-scoped changes detected"*. (The `.mdx` change alone would not have required one; `docs/building/` is not in `PROTOCOL_SCOPED_PATHS`.)
- **No `dist/` changes.** `git diff --name-only origin/main...HEAD | grep '^dist/'` is empty. The published `dist/compliance/<version>/` and `dist/docs/<version>/` snapshots are frozen per release by `release-docs.yml` and keep the old wording by design; the fix ships into the next patch via source.
- Targets `main` per CONTRIBUTING.md. Forward-merge is one-way 3.1.x → main, so a version branch would not reach main.

## One thing deliberately not changed

The `.mdx` section also references `compliance/cache/3.0.0/test-vectors/request-signing/`, which is stale — per `scripts/overlay-compliance-cache.sh` that directory is the SDK's bundled cache and its subdirectory tracks the SDK's pinned `ADCP_VERSION`, no longer `3.0.0`. It appears twice, including as the `--vector` argument in a copy-pasteable command. Left alone because the correct form depends on `adcp-client` resolution behaviour not verifiable from this repo — happy to fix here if a maintainer confirms the right form, or to file it separately.

Refs #6071. Overlaps #6073 on the runner header (identical edit).
