### PR TITLE
fix(security): harden global admin and private content

### DIFF
--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -2889,6 +2889,68 @@
 
   <script src="/nav.js"></script>
   <script>
+    window.siBranding = (() => {
+      'use strict';
+
+      const BRAND_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+      const BRAND_LOGO_URL_MAX_LENGTH = 2048;
+
+      function nonEmptyText(value) {
+        return typeof value === 'string' && value.trim() ? value : '';
+      }
+
+      function safeLogoUrl(value) {
+        if (typeof value !== 'string' || value.length === 0 || value.length > BRAND_LOGO_URL_MAX_LENGTH) {
+          return null;
+        }
+        if (['"', "'", '<', '>', '`', '\\'].some(char => value.includes(char))) {
+          return null;
+        }
+
+        try {
+          const parsed = new URL(value);
+          if (parsed.protocol !== 'https:' || parsed.username || parsed.password || !parsed.hostname) {
+            return null;
+          }
+          return parsed.toString();
+        } catch {
+          return null;
+        }
+      }
+
+      function safeBrandColor(value) {
+        return typeof value === 'string' && BRAND_COLOR_PATTERN.test(value) ? value : null;
+      }
+
+      function renderHeader(elements, brand, fallbackName) {
+        const name = nonEmptyText(brand?.name) || nonEmptyText(fallbackName) || 'Brand agent';
+        const tagline = nonEmptyText(brand?.tagline);
+        const color = safeBrandColor(brand?.brand_color);
+        const logoUrl = safeLogoUrl(brand?.logo_url);
+
+        elements.title.textContent = name;
+        elements.tagline.textContent = tagline;
+        if (color) {
+          elements.header.style.setProperty('--si-brand-color', color);
+        } else {
+          elements.header.style.removeProperty('--si-brand-color');
+        }
+
+        elements.icon.replaceChildren();
+        if (logoUrl) {
+          const image = document.createElement('img');
+          image.src = logoUrl;
+          image.alt = name;
+          elements.icon.appendChild(image);
+        } else {
+          elements.icon.textContent = name.trim().charAt(0).toUpperCase() || 'B';
+        }
+      }
+
+      return Object.freeze({ renderHeader, safeLogoUrl, safeBrandColor });
+    })();
+  </script>
+  <script>
     (function() {
       'use strict';
 
@@ -2932,6 +2994,12 @@
       const siModalMessages = document.getElementById('siModalMessages');
       const siModalInput = document.getElementById('siModalInput');
       const siModalSend = document.getElementById('siModalSend');
+      const siBrandHeaderElements = {
+        header: siModalHeader,
+        icon: siModalIconEmoji,
+        title: siModalTitle,
+        tagline: siModalTagline,
+      };
 
       // Dark mode toggle
       const darkModeToggle = document.getElementById('darkModeToggle');
@@ -3392,8 +3460,8 @@
         historyList.innerHTML = allItems.map(item => {
           if (item.type === 'si_session') {
             // Branded SI session item
-            const brandColor = item.brand_color || '#667eea';
-            const logoUrl = item.brand_logo_url;
+            const brandColor = window.siBranding.safeBrandColor(item.brand_color) || 'var(--color-brand)';
+            const logoUrl = window.siBranding.safeLogoUrl(item.brand_logo_url);
             const initial = (item.brand_name || 'B').charAt(0).toUpperCase();
             return `
               <div class="history-item si-branded"
@@ -3401,7 +3469,7 @@
                    data-brand-name="${escapeHtml(item.brand_name)}"
                    style="--si-item-color: ${brandColor}">
                 <div class="si-brand-avatar">
-                  ${logoUrl ? `<img src="${escapeHtml(logoUrl)}" alt="${escapeHtml(item.brand_name)}">` : initial}
+                  ${logoUrl ? `<img src="${escapeHtml(logoUrl)}" alt="${escapeHtml(item.brand_name)}">` : escapeHtml(initial)}
                 </div>
                 <div class="history-item-content">
                   <div class="history-item-title">
@@ -5155,21 +5223,7 @@
           siBrandName = brandName;
           siBrandInfo = data.brand || null;
 
-          // Update modal header
-          siModalTitle.textContent = data.brand?.name || brandName;
-          siModalTagline.textContent = data.brand?.tagline || '';
-
-          // Apply brand color if available
-          if (data.brand?.brand_color) {
-            siModalHeader.style.setProperty('--si-brand-color', data.brand.brand_color);
-          }
-
-          // Update icon
-          if (data.brand?.logo_url) {
-            siModalIconEmoji.innerHTML = `<img src="${data.brand.logo_url}" alt="${data.brand.name}" style="width:100%;height:100%;object-fit:contain;border-radius:inherit;">`;
-          } else {
-            siModalIconEmoji.textContent = (brandName || 'B').charAt(0).toUpperCase();
-          }
+          window.siBranding.renderHeader(siBrandHeaderElements, data.brand, brandName);
 
           // Clear and populate messages
           siModalMessages.innerHTML = '';
@@ -5237,9 +5291,8 @@
         siSessionId = sessionData.session_id;
         siBrandName = sessionData.brand_name;
 
-        // Update modal header
-        siModalTitle.textContent = siBrandName || 'Brand Agent';
-        siModalTagline.textContent = '';
+        // Update modal header and clear any styling left by the previous brand.
+        window.siBranding.renderHeader(siBrandHeaderElements, null, siBrandName);
 
         // Clear previous messages
         siModalMessages.innerHTML = '';
@@ -5254,20 +5307,7 @@
             // Apply brand styling
             if (data.brand) {
               siBrandInfo = data.brand;
-              siModalTitle.textContent = data.brand.name || siBrandName;
-              if (data.brand.tagline) {
-                siModalTagline.textContent = data.brand.tagline;
-              }
-              // Apply brand color if available
-              if (data.brand.brand_color) {
-                siModalHeader.style.setProperty('--si-brand-color', data.brand.brand_color);
-              }
-              // Update icon with logo or first letter
-              if (data.brand.logo_url) {
-                siModalIconEmoji.innerHTML = `<img src="${data.brand.logo_url}" alt="${data.brand.name}" style="width:100%;height:100%;object-fit:contain;border-radius:inherit;">`;
-              } else {
-                siModalIconEmoji.textContent = (data.brand.name || siBrandName || 'B').charAt(0).toUpperCase();
-              }
+              window.siBranding.renderHeader(siBrandHeaderElements, data.brand, siBrandName);
             }
 
             // Load messages from API (includes UI elements and surfaces)
@@ -6280,6 +6320,10 @@
 
       videoCallBtn.addEventListener('click', startVideoCall);
       videoEndBtn.addEventListener('click', endVideoCall);
+
+      if (window.__ENABLE_SI_CHAT_TEST_HOOKS__) {
+        window.__siChatTestHooks = Object.freeze({ openSession: siOpenModal });
+      }
 
       // Initialize
       extractNativeToken(); // Check for native app auth token in URL hash

--- a/server/public/dashboard-api-keys.html
+++ b/server/public/dashboard-api-keys.html
@@ -351,6 +351,13 @@
   <div class="page-content">
     <div id="loading" class="loading">Loading API keys...</div>
 
+    <div id="accessDenied" class="settings-section" style="display: none;">
+      <div class="settings-section-body">
+        <h2>API key access</h2>
+        <p>Only active organization owners and admins can create, view, or revoke API keys.</p>
+      </div>
+    </div>
+
     <div id="content" style="display: none;">
       <div class="settings-section">
         <div class="settings-section-header">
@@ -577,6 +584,9 @@
 
         currentOrg = org;
 
+        const canManageApiKeys = currentOrg.status === 'active'
+          && (currentOrg.role === 'owner' || currentOrg.role === 'admin');
+
         // Initialize sidebar
         const hasPersonalWorkspace = data.organizations?.some(o => o.is_personal);
         const showSwitcher = (data.organizations?.length > 1) || !hasPersonalWorkspace;
@@ -595,6 +605,12 @@
         }
 
         document.getElementById('loading').style.display = 'none';
+
+        if (!canManageApiKeys) {
+          document.getElementById('accessDenied').style.display = 'block';
+          return;
+        }
+
         document.getElementById('content').style.display = 'block';
 
         await loadKeys();

--- a/server/src/addie/mcp/docs-indexer.ts
+++ b/server/src/addie/mcp/docs-indexer.ts
@@ -1001,7 +1001,7 @@ async function loadWorkingGroupDocuments(): Promise<IndexedDoc[]> {
 
     // Append asset descriptions so visual content is searchable
     try {
-      const assets = await workingGroupDb.getDocumentAssets(doc.id);
+      const assets = await workingGroupDb.getDocumentAssets(doc.id, doc.working_group_id);
       const described = assets.filter(a => a.description);
       if (described.length > 0) {
         const assetSection = described

--- a/server/src/db/working-group-db.ts
+++ b/server/src/db/working-group-db.ts
@@ -2388,15 +2388,33 @@ export class WorkingGroupDatabase {
     return result.rows[0];
   }
 
-  async getDocumentAssetData(id: string): Promise<{ asset_data: Buffer; mime_type: string } | null> {
-    const result = await query<{ asset_data: Buffer; mime_type: string }>(
-      `SELECT asset_data, mime_type FROM committee_document_assets WHERE id = $1`,
+  async getDocumentAssetMetadata(id: string): Promise<{ mime_type: string; working_group_id: string } | null> {
+    const result = await query<{ mime_type: string; working_group_id: string }>(
+      `SELECT cda.mime_type, cda.working_group_id
+       FROM committee_document_assets cda
+       JOIN committee_documents cd
+         ON cd.id = cda.document_id
+        AND cd.working_group_id = cda.working_group_id
+       WHERE cda.id = $1`,
       [id]
     );
     return result.rows[0] || null;
   }
 
-  async getDocumentAssets(documentId: string): Promise<Array<{
+  async getDocumentAssetData(id: string, workingGroupId: string): Promise<{ asset_data: Buffer; mime_type: string } | null> {
+    const result = await query<{ asset_data: Buffer; mime_type: string }>(
+      `SELECT cda.asset_data, cda.mime_type
+       FROM committee_document_assets cda
+       JOIN committee_documents cd
+         ON cd.id = cda.document_id
+        AND cd.working_group_id = cda.working_group_id
+       WHERE cda.id = $1 AND cda.working_group_id = $2`,
+      [id, workingGroupId]
+    );
+    return result.rows[0] || null;
+  }
+
+  async getDocumentAssets(documentId: string, workingGroupId: string): Promise<Array<{
     id: string;
     filename: string;
     mime_type: string;
@@ -2417,10 +2435,16 @@ export class WorkingGroupDatabase {
       extraction_order: number;
     }>(
       `SELECT id, filename, mime_type, width, height, description, page_number, extraction_order
-       FROM committee_document_assets
-       WHERE document_id = $1
-       ORDER BY extraction_order`,
-      [documentId]
+       FROM committee_document_assets cda
+       WHERE cda.document_id = $1
+         AND cda.working_group_id = $2
+         AND EXISTS (
+           SELECT 1 FROM committee_documents cd
+           WHERE cd.id = cda.document_id
+             AND cd.working_group_id = cda.working_group_id
+         )
+       ORDER BY cda.extraction_order`,
+      [documentId, workingGroupId]
     );
     return result.rows;
   }

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -7,7 +7,7 @@
 import { Router } from "express";
 import { validate as uuidValidate } from "uuid";
 import { createLogger } from "../logger.js";
-import { requireAuth, requireAdmin } from "../middleware/auth.js";
+import { requireGlobalAdmin } from "../middleware/auth.js";
 import { serveHtmlWithConfig } from "../utils/html-config.js";
 import { AddieDatabase } from "../db/addie-db.js";
 import { query } from "../db/client.js";
@@ -121,12 +121,18 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   const pageRouter = Router();
   const apiRouter = Router();
 
+  // Every route in this module reads or mutates cross-organization Addie
+  // state. Apply the global-admin chain at the router boundary so
+  // tenant-scoped WorkOS API keys are refused for current and future routes.
+  pageRouter.use(...requireGlobalAdmin);
+  apiRouter.use(...requireGlobalAdmin);
+
   // =========================================================================
   // ADMIN PAGE ROUTES (mounted at /admin/addie)
   // =========================================================================
 
   // Main Addie dashboard
-  pageRouter.get("/", requireAuth, requireAdmin, (req, res) => {
+  pageRouter.get("/", (req, res) => {
     serveHtmlWithConfig(req, res, "admin-addie.html").catch((err) => {
       logger.error({ err }, "Error serving Addie admin page");
       res.status(500).send("Internal server error");
@@ -138,7 +144,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   // =========================================================================
 
   // GET /api/admin/addie/knowledge - List all knowledge documents
-  apiRouter.get("/knowledge", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/knowledge", async (req, res) => {
     try {
       const { category, active_only, source_type, status, limit, offset } = req.query;
 
@@ -165,7 +171,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // GET /api/admin/addie/knowledge/categories - Get category list with counts
-  apiRouter.get("/knowledge/categories", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/knowledge/categories", async (req, res) => {
     try {
       const categories = await addieDb.getKnowledgeCategories();
       res.json({ categories });
@@ -179,7 +185,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // GET /api/admin/addie/knowledge/search - Search knowledge documents
-  apiRouter.get("/knowledge/search", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/knowledge/search", async (req, res) => {
     try {
       const { q, category, limit } = req.query;
 
@@ -207,7 +213,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // GET /api/admin/addie/knowledge/:id - Get a specific knowledge document
-  apiRouter.get("/knowledge/:id", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/knowledge/:id", async (req, res) => {
     try {
       const numericId = parseNumericId(req.params.id);
       if (!numericId) {
@@ -231,7 +237,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // POST /api/admin/addie/knowledge - Create a new knowledge document
-  apiRouter.post("/knowledge", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.post("/knowledge", async (req, res) => {
     try {
       const { title, category, content, source_url } = req.body;
 
@@ -265,7 +271,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // PUT /api/admin/addie/knowledge/:id - Update a knowledge document
-  apiRouter.put("/knowledge/:id", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.put("/knowledge/:id", async (req, res) => {
     try {
       const numericId = parseNumericId(req.params.id);
       if (!numericId) {
@@ -296,7 +302,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // PUT /api/admin/addie/knowledge/:id/active - Toggle active status
-  apiRouter.put("/knowledge/:id/active", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.put("/knowledge/:id/active", async (req, res) => {
     try {
       const numericId = parseNumericId(req.params.id);
       if (!numericId) {
@@ -326,7 +332,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // DELETE /api/admin/addie/knowledge/:id - Delete a knowledge document
-  apiRouter.delete("/knowledge/:id", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.delete("/knowledge/:id", async (req, res) => {
     try {
       const numericId = parseNumericId(req.params.id);
       if (!numericId) {
@@ -354,7 +360,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   // =========================================================================
 
   // GET /api/admin/addie/interactions - List interactions (audit log)
-  apiRouter.get("/interactions", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/interactions", async (req, res) => {
     try {
       const { flagged_only, unreviewed_only, user_id, limit, offset } = req.query;
 
@@ -380,7 +386,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // GET /api/admin/addie/interactions/stats - Get interaction statistics
-  apiRouter.get("/interactions/stats", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/interactions/stats", async (req, res) => {
     try {
       const { days } = req.query;
 
@@ -399,7 +405,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // PUT /api/admin/addie/interactions/:id/review - Mark an interaction as reviewed
-  apiRouter.put("/interactions/:id/review", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.put("/interactions/:id/review", async (req, res) => {
     try {
       const { id } = req.params;
 
@@ -422,7 +428,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   // =========================================================================
 
   // GET /api/admin/addie/threads - List all threads (unified view across channels)
-  apiRouter.get("/threads", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/threads", async (req, res) => {
     try {
       const threadService = getThreadService();
       const {
@@ -475,7 +481,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // GET /api/admin/addie/threads/stats - Get unified thread statistics
-  apiRouter.get("/threads/stats", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/threads/stats", async (req, res) => {
     try {
       const threadService = getThreadService();
       const { timeframe } = req.query;
@@ -506,7 +512,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   // GET /api/admin/addie/threads/performance - Get tool performance metrics
   // NOTE: Must be defined BEFORE /threads/:id to avoid matching "performance" as an ID
   // Accepts days param (can be fractional, e.g., 0.125 for 3 hours)
-  apiRouter.get("/threads/performance", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/threads/performance", async (req, res) => {
     try {
       const threadService = getThreadService();
       const { days } = req.query;
@@ -536,7 +542,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
 
   // GET /api/admin/addie/threads/tools - Get list of available tool names for filtering
   // NOTE: Must be defined BEFORE /threads/:id to avoid matching "tools" as an ID
-  apiRouter.get("/threads/tools", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/threads/tools", async (req, res) => {
     try {
       const threadService = getThreadService();
       const tools = await threadService.getAvailableTools();
@@ -551,7 +557,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // GET /api/admin/addie/threads/:id - Get a single thread with messages
-  apiRouter.get("/threads/:id", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/threads/:id", async (req, res) => {
     try {
       const threadService = getThreadService();
       const { id } = req.params;
@@ -609,7 +615,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // PUT /api/admin/addie/threads/:id/review - Mark a thread as reviewed
-  apiRouter.put("/threads/:id/review", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.put("/threads/:id/review", async (req, res) => {
     try {
       const threadService = getThreadService();
       const { id } = req.params;
@@ -633,7 +639,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // PUT /api/admin/addie/threads/:id/flag - Flag a thread
-  apiRouter.put("/threads/:id/flag", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.put("/threads/:id/flag", async (req, res) => {
     try {
       const threadService = getThreadService();
       const { id } = req.params;
@@ -661,7 +667,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // PUT /api/admin/addie/threads/:id/unflag - Unflag a thread
-  apiRouter.put("/threads/:id/unflag", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.put("/threads/:id/unflag", async (req, res) => {
     try {
       const threadService = getThreadService();
       const { id } = req.params;
@@ -684,7 +690,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // PUT /api/admin/addie/threads/messages/:messageId/feedback - Add feedback to a message
-  apiRouter.put("/threads/messages/:messageId/feedback", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.put("/threads/messages/:messageId/feedback", async (req, res) => {
     try {
       const threadService = getThreadService();
       const { messageId } = req.params;
@@ -743,7 +749,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // PUT /api/admin/addie/threads/messages/:messageId/outcome - Set outcome on a message
-  apiRouter.put("/threads/messages/:messageId/outcome", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.put("/threads/messages/:messageId/outcome", async (req, res) => {
     try {
       const threadService = getThreadService();
       const { messageId } = req.params;
@@ -772,7 +778,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // PUT /api/admin/addie/threads/messages/:messageId/flag - Flag a message
-  apiRouter.put("/threads/messages/:messageId/flag", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.put("/threads/messages/:messageId/flag", async (req, res) => {
     try {
       const threadService = getThreadService();
       const { messageId } = req.params;
@@ -800,7 +806,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // POST /api/admin/addie/threads/:id/diagnose - Get Claude's analysis of a thread
-  apiRouter.post("/threads/:id/diagnose", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.post("/threads/:id/diagnose", async (req, res) => {
     try {
       // Verify API key is configured
       const apiKey = process.env.ANTHROPIC_API_KEY;
@@ -918,7 +924,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // GET /api/admin/addie/feedback/summary - Get aggregated feedback stats for dashboard
-  apiRouter.get("/feedback/summary", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/feedback/summary", async (req, res) => {
     try {
       const { days = '30' } = req.query;
       // Validate and clamp days to reasonable range (1-365)
@@ -1025,7 +1031,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // =========================================================================
 
   // GET /api/admin/addie/conversations - List all web conversations
-  apiRouter.get("/conversations", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/conversations", async (req, res) => {
     try {
       const { limit, offset } = req.query;
 
@@ -1049,7 +1055,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
 
   // GET /api/admin/addie/conversations/stats - Get conversation statistics
   // NOTE: Must be defined BEFORE /conversations/:id to avoid matching "stats" as an ID
-  apiRouter.get("/conversations/stats", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/conversations/stats", async (req, res) => {
     try {
       const stats = await addieDb.getWebConversationStats();
       res.json(stats);
@@ -1063,7 +1069,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // GET /api/admin/addie/conversations/:id - Get a single conversation with messages
-  apiRouter.get("/conversations/:id", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/conversations/:id", async (req, res) => {
     try {
       const { id } = req.params;
 
@@ -1090,7 +1096,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // GET /api/admin/addie/listings/unpublished-backlog
   // Orgs with an active membership whose directory listing is missing or not
   // public. Use for cleanup of the pre-autopublish backlog.
-  apiRouter.get("/listings/unpublished-backlog", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/listings/unpublished-backlog", async (req, res) => {
     try {
       const { limit, offset } = req.query;
       const lim = clampLimit(limit, 25);
@@ -1157,7 +1163,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // =========================================================================
 
   // GET /api/admin/addie/config/current - Get current config version info
-  apiRouter.get("/config/current", requireAuth, requireAdmin, async (_req, res) => {
+  apiRouter.get("/config/current", async (_req, res) => {
     try {
       const configVersion = await addieDb.getCurrentConfigVersion();
       res.json({ config_version: configVersion });
@@ -1171,7 +1177,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // GET /api/admin/addie/config/history - Get config version history
-  apiRouter.get("/config/history", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/config/history", async (req, res) => {
     try {
       const history = await addieDb.getConfigVersionHistory(clampLimit(req.query.limit, 20, 100));
       res.json({ versions: history });
@@ -1189,7 +1195,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // =========================================================================
 
   // GET /api/admin/addie/system-prompt - Get the compiled system prompt (from MD files)
-  apiRouter.get("/system-prompt", requireAuth, requireAdmin, (_req, res) => {
+  apiRouter.get("/system-prompt", (_req, res) => {
     try {
       // Same shape as claude-client.ts assembly minus the tool reference,
       // which is autogenerated and lives in code rather than rule files.
@@ -1209,7 +1215,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // =========================================================================
 
   // PUT /api/admin/addie/interactions/:id/rate - Rate an interaction
-  apiRouter.put("/interactions/:id/rate", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.put("/interactions/:id/rate", async (req, res) => {
     try {
       const { id } = req.params;
       const { rating, notes, outcome, user_sentiment, intent_category } = req.body;
@@ -1241,7 +1247,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // =========================================================================
 
   // GET /api/admin/addie/resources - List curated resources
-  apiRouter.get("/resources", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/resources", async (req, res) => {
     try {
       const { status, limit, offset } = req.query;
 
@@ -1265,7 +1271,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // GET /api/admin/addie/resources/stats - Get curated resource statistics
-  apiRouter.get("/resources/stats", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/resources/stats", async (req, res) => {
     try {
       const stats = await addieDb.getCuratedResourceStats();
       res.json(stats);
@@ -1279,7 +1285,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // GET /api/admin/addie/resources/:id - Get a specific resource
-  apiRouter.get("/resources/:id", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/resources/:id", async (req, res) => {
     try {
       const numericId = parseNumericId(req.params.id);
       if (!numericId) {
@@ -1303,7 +1309,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // PUT /api/admin/addie/resources/:id - Update resource (mainly for editing addie_notes)
-  apiRouter.put("/resources/:id", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.put("/resources/:id", async (req, res) => {
     try {
       const numericId = parseNumericId(req.params.id);
       if (!numericId) {
@@ -1334,7 +1340,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // POST /api/admin/addie/resources/:id/refetch - Re-fetch and regenerate analysis
-  apiRouter.post("/resources/:id/refetch", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.post("/resources/:id/refetch", async (req, res) => {
     try {
       const numericId = parseNumericId(req.params.id);
       if (!numericId) {
@@ -1356,7 +1362,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // DELETE /api/admin/addie/resources/:id - Delete a resource
-  apiRouter.delete("/resources/:id", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.delete("/resources/:id", async (req, res) => {
     try {
       const numericId = parseNumericId(req.params.id);
       if (!numericId) {
@@ -1386,7 +1392,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // =========================================================================
 
   // GET /api/admin/addie/home/preview - Preview Addie Home for any user
-  apiRouter.get("/home/preview", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/home/preview", async (req, res) => {
     try {
       const { user_id, email, slack_user_id, format } = req.query;
 
@@ -1483,7 +1489,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
    *
    * Body: { message: string, source?: 'channel' | 'dm' | 'mention', isThread?: boolean }
    */
-  apiRouter.post("/test-router", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.post("/test-router", async (req, res) => {
     try {
       const { message, source = 'channel', isThread = false } = req.body;
 
@@ -1576,7 +1582,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // =========================================================================
 
   // POST /api/admin/addie/backfill/slack - Trigger Slack history backfill
-  apiRouter.post("/backfill/slack", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.post("/backfill/slack", async (req, res) => {
     try {
       const {
         days_back,
@@ -1661,7 +1667,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // GET /api/admin/addie/backfill/slack/status - Get current Slack index status
-  apiRouter.get("/backfill/slack/status", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/backfill/slack/status", async (req, res) => {
     try {
       // Get count of indexed messages
       const totalCount = await addieDb.getSlackMessageCount();
@@ -1715,7 +1721,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // =========================================================================
 
   // GET /api/admin/addie/escalations - List escalations with optional filters
-  apiRouter.get("/escalations", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/escalations", async (req, res) => {
     try {
       const { status, category, limit, offset } = req.query;
 
@@ -1768,7 +1774,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
 
   // GET /api/admin/addie/escalations/suggestions - List triage suggestions.
   // `pending_only` defaults to true; pass ?pending_only=false to include reviewed rows.
-  apiRouter.get("/escalations/suggestions", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/escalations/suggestions", async (req, res) => {
     try {
       const { confidence, bucket, pending_only, limit, offset } = req.query;
       const [suggestions, stats] = await Promise.all([
@@ -1799,7 +1805,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // POST /api/admin/addie/escalations/suggestions/run - Trigger an on-demand triage run.
-  apiRouter.post("/escalations/suggestions/run", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.post("/escalations/suggestions/run", async (req, res) => {
     try {
       const { minAgeDays, limit, staleOpsDays } = req.body ?? {};
       // Clamp caller-supplied knobs to protect the outbound probe budget.
@@ -1829,8 +1835,6 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // Applies the suggested status to the escalation and marks the suggestion accepted.
   apiRouter.post(
     "/escalations/suggestions/:id/accept",
-    requireAuth,
-    requireAdmin,
     async (req, res) => {
       try {
         const id = parseNumericId(req.params.id);
@@ -1953,8 +1957,6 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // POST /api/admin/addie/escalations/suggestions/:id/reject
   apiRouter.post(
     "/escalations/suggestions/:id/reject",
-    requireAuth,
-    requireAdmin,
     async (req, res) => {
       try {
         const id = parseNumericId(req.params.id);
@@ -1977,7 +1979,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   );
 
   // GET /api/admin/addie/escalations/:id - Get single escalation with thread context
-  apiRouter.get("/escalations/:id", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/escalations/:id", async (req, res) => {
     try {
       const id = parseNumericId(req.params.id);
       if (!id) {
@@ -2018,7 +2020,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // PATCH /api/admin/addie/escalations/:id - Update escalation status
-  apiRouter.patch("/escalations/:id", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.patch("/escalations/:id", async (req, res) => {
     try {
       const id = parseNumericId(req.params.id);
       if (!id) {
@@ -2113,7 +2115,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // =========================================================================
 
   // GET /api/admin/addie/images/stats - Dashboard stats
-  apiRouter.get("/images/stats", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/images/stats", async (req, res) => {
     try {
       const stats = await imageDb.getSearchStats();
       res.json(stats);
@@ -2124,7 +2126,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // GET /api/admin/addie/images - List all images
-  apiRouter.get("/images", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/images", async (req, res) => {
     try {
       const { category, approved, limit, offset } = req.query;
       const images = await imageDb.listImages({
@@ -2141,7 +2143,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // POST /api/admin/addie/images - Create a new image
-  apiRouter.post("/images", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.post("/images", async (req, res) => {
     try {
       const { filename, alt_text, topics, category, characters, description, image_url, approved } = req.body;
       if (!filename || !alt_text || !image_url) {
@@ -2165,7 +2167,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // PUT /api/admin/addie/images/:id - Update an image
-  apiRouter.put("/images/:id", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.put("/images/:id", async (req, res) => {
     try {
       const numericId = parseNumericId(req.params.id);
       if (!numericId) {
@@ -2183,7 +2185,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // DELETE /api/admin/addie/images/:id - Delete an image
-  apiRouter.delete("/images/:id", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.delete("/images/:id", async (req, res) => {
     try {
       const numericId = parseNumericId(req.params.id);
       if (!numericId) {
@@ -2201,7 +2203,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // GET /api/admin/addie/images/searches - List search events
-  apiRouter.get("/images/searches", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/images/searches", async (req, res) => {
     try {
       const { limit, offset, zero_results_only } = req.query;
       const searches = await imageDb.listSearches({
@@ -2217,7 +2219,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // GET /api/admin/addie/images/misses - Top zero-result queries
-  apiRouter.get("/images/misses", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/images/misses", async (req, res) => {
     try {
       const misses = await imageDb.getTopMisses(clampLimit(req.query.limit, 20, 100));
       res.json({ misses });
@@ -2232,7 +2234,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // =========================================================================
 
   // GET /api/admin/addie/conversation-insights - List past insights
-  apiRouter.get("/conversation-insights", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/conversation-insights", async (req, res) => {
     try {
       const insights = await listInsights(clampLimit(req.query.limit, 12, 52));
       res.json({ insights });
@@ -2243,7 +2245,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // GET /api/admin/addie/conversation-insights/:weekStart - Get specific week
-  apiRouter.get("/conversation-insights/:weekStart", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.get("/conversation-insights/:weekStart", async (req, res) => {
     try {
       const weekStart = req.params.weekStart;
       if (!/^\d{4}-\d{2}-\d{2}$/.test(weekStart)) {
@@ -2261,7 +2263,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   });
 
   // POST /api/admin/addie/conversation-insights/run - Manually trigger
-  apiRouter.post("/conversation-insights/run", requireAuth, requireAdmin, async (req, res) => {
+  apiRouter.post("/conversation-insights/run", async (req, res) => {
     try {
       const result = await runConversationInsightsJob({ force: true });
       res.json(result);

--- a/server/src/routes/api-keys.ts
+++ b/server/src/routes/api-keys.ts
@@ -11,8 +11,17 @@ import { Router } from "express";
 import { WorkOS } from "@workos-inc/node";
 import { createLogger } from "../logger.js";
 import { requireAuth } from "../middleware/auth.js";
+import {
+  resolveUserOrgMembership,
+  type UserOrgMembership,
+} from "../utils/resolve-user-org-membership.js";
 
 const logger = createLogger("api-keys-routes");
+
+// These are the only elevated permissions the server recognizes for
+// tenant-scoped WorkOS API keys. Keep this allow-list next to issuance so a
+// caller cannot mint new authority merely by inventing a permission string.
+const ALLOWED_PRIVILEGED_PERMISSIONS = new Set(["admin:read", "admin:*"]);
 
 const WORKOS_API_KEY = process.env.WORKOS_API_KEY;
 const WORKOS_BASE_URL = "https://api.workos.com";
@@ -79,31 +88,52 @@ async function workosRequest(
 }
 
 /**
- * Verify the authenticated user is a member of the specified organization.
- * Returns true if verified, false if not (and sends the appropriate error response).
+ * Resolve the authenticated user's active membership in the specified organization.
+ * Returns null and sends the appropriate error response when access is denied.
  */
 async function verifyOrgMembership(
   req: Request,
   res: Response,
   organizationId: string,
-): Promise<boolean> {
-  const memberships =
-    await workos!.userManagement.listOrganizationMemberships({
-      userId: req.user!.id,
-    });
-
-  const isMember = memberships.data.some(
-    (m) => m.organizationId === organizationId,
+): Promise<UserOrgMembership | null> {
+  const membership = await resolveUserOrgMembership(
+    workos,
+    req.user!.id,
+    organizationId,
   );
 
-  if (!isMember) {
+  // resolveUserOrgMembership currently derives roles from active rows only,
+  // but keep the status check at this key-management boundary so a future
+  // resolver change (or inconsistent upstream response) cannot create, expose,
+  // or revoke keys for a pending or inactive membership.
+  if (!membership || membership.status !== "active") {
     res.status(403).json({
       error: "Access denied",
       message: "You are not a member of this organization",
     });
-    return false;
+    return null;
   }
-  return true;
+  return membership;
+}
+
+/**
+ * API key creation, inventory, and revocation are organization-wide
+ * operations: keys act for the organization, listing exposes privileged
+ * automation keys, and revocation can disable them. Keep the full lifecycle
+ * restricted to active organization owners and admins.
+ */
+function requireOrgAdmin(
+  membership: UserOrgMembership,
+  res: Response,
+  action: "create" | "list" | "revoke",
+): boolean {
+  if (membership.role === "owner" || membership.role === "admin") return true;
+
+  res.status(403).json({
+    error: "Access denied",
+    message: `Only organization owners and admins can ${action} API keys`,
+  });
+  return false;
 }
 
 /**
@@ -140,7 +170,8 @@ export function createApiKeysRouter(): Router {
           .json({ error: "org query parameter is required" });
       }
 
-      if (!(await verifyOrgMembership(req, res, organizationId))) return;
+      const membership = await verifyOrgMembership(req, res, organizationId);
+      if (!membership || !requireOrgAdmin(membership, res, "list")) return;
 
       const params: Record<string, string> = {};
       if (req.query.after) params.after = req.query.after as string;
@@ -176,16 +207,41 @@ export function createApiKeysRouter(): Router {
         });
       }
 
-      if (!(await verifyOrgMembership(req, res, organizationId))) return;
+      const membership = await verifyOrgMembership(req, res, organizationId);
+      if (!membership || !requireOrgAdmin(membership, res, "create")) return;
 
       const { name, permissions } = req.body;
       if (!name) {
         return res.status(400).json({ error: "name is required" });
       }
 
+      if (
+        permissions !== undefined &&
+        (!Array.isArray(permissions) ||
+          permissions.some((permission) => typeof permission !== "string"))
+      ) {
+        return res.status(400).json({
+          error: "Invalid permissions",
+          message: "permissions must be an array of supported permission strings",
+        });
+      }
+
+      const requestedPermissions = [
+        ...new Set((permissions as string[] | undefined) ?? []),
+      ];
+      const unsupportedPermissions = requestedPermissions.filter(
+        (permission) => !ALLOWED_PRIVILEGED_PERMISSIONS.has(permission),
+      );
+      if (unsupportedPermissions.length > 0) {
+        return res.status(400).json({
+          error: "Invalid permissions",
+          message: "One or more requested permissions are not supported",
+        });
+      }
+
       const body: { name: string; permissions?: string[] } = { name };
-      if (permissions && permissions.length > 0) {
-        body.permissions = permissions;
+      if (requestedPermissions.length > 0) {
+        body.permissions = requestedPermissions;
       }
 
       const result = await workosRequest(
@@ -221,7 +277,8 @@ export function createApiKeysRouter(): Router {
           .json({ error: "org query parameter is required" });
       }
 
-      if (!(await verifyOrgMembership(req, res, organizationId))) return;
+      const membership = await verifyOrgMembership(req, res, organizationId);
+      if (!membership || !requireOrgAdmin(membership, res, "revoke")) return;
 
       const apiKeyId = req.params.id;
       try {

--- a/server/src/routes/api-keys.ts
+++ b/server/src/routes/api-keys.ts
@@ -162,16 +162,18 @@ export function createApiKeysRouter(): Router {
         return res.status(500).json({ error: "Authentication not configured" });
       }
 
-      // codeql[js/user-controlled-bypass] - org ID is validated by verifyOrgMembership before use
-      const organizationId = req.query.org as string;
-      if (!organizationId) {
+      const requestedOrganizationId = req.query.org as string;
+      // Missing IDs terminate here; authorization below returns a canonical
+      // organization ID from an exact-match WorkOS membership.
+      if (!requestedOrganizationId) {
         return res
           .status(400)
           .json({ error: "org query parameter is required" });
       }
 
-      const membership = await verifyOrgMembership(req, res, organizationId);
+      const membership = await verifyOrgMembership(req, res, requestedOrganizationId);
       if (!membership || !requireOrgAdmin(membership, res, "list")) return;
+      const authorizedOrganizationId = membership.organizationId;
 
       const params: Record<string, string> = {};
       if (req.query.after) params.after = req.query.after as string;
@@ -180,7 +182,7 @@ export function createApiKeysRouter(): Router {
 
       const result = await workosRequest(
         "GET",
-        `/organizations/${organizationId}/api_keys`,
+        `/organizations/${authorizedOrganizationId}/api_keys`,
         { query: params },
       );
 
@@ -198,17 +200,19 @@ export function createApiKeysRouter(): Router {
         return res.status(500).json({ error: "Authentication not configured" });
       }
 
-      // codeql[js/user-controlled-bypass] - org ID is validated by verifyOrgMembership before use
-      const organizationId =
+      const requestedOrganizationId =
         (req.query.org as string) || req.body.organizationId;
-      if (!organizationId) {
+      // Missing IDs terminate here; authorization below returns a canonical
+      // organization ID from an exact-match WorkOS membership.
+      if (!requestedOrganizationId) {
         return res.status(400).json({
           error: "org query parameter or organizationId in body is required",
         });
       }
 
-      const membership = await verifyOrgMembership(req, res, organizationId);
+      const membership = await verifyOrgMembership(req, res, requestedOrganizationId);
       if (!membership || !requireOrgAdmin(membership, res, "create")) return;
+      const authorizedOrganizationId = membership.organizationId;
 
       const { name, permissions } = req.body;
       if (!name) {
@@ -246,12 +250,16 @@ export function createApiKeysRouter(): Router {
 
       const result = await workosRequest(
         "POST",
-        `/organizations/${organizationId}/api_keys`,
+        `/organizations/${authorizedOrganizationId}/api_keys`,
         { body },
       );
 
       logger.info(
-        { userId: req.user!.id, organizationId, keyName: name },
+        {
+          userId: req.user!.id,
+          organizationId: authorizedOrganizationId,
+          keyName: name,
+        },
         "API key created",
       );
 
@@ -269,22 +277,28 @@ export function createApiKeysRouter(): Router {
         return res.status(500).json({ error: "Authentication not configured" });
       }
 
-      // codeql[js/user-controlled-bypass] - org ID is validated by verifyOrgMembership before use
-      const organizationId = req.query.org as string;
-      if (!organizationId) {
+      const requestedOrganizationId = req.query.org as string;
+      // Missing IDs terminate here; authorization below returns a canonical
+      // organization ID from an exact-match WorkOS membership.
+      if (!requestedOrganizationId) {
         return res
           .status(400)
           .json({ error: "org query parameter is required" });
       }
 
-      const membership = await verifyOrgMembership(req, res, organizationId);
+      const membership = await verifyOrgMembership(req, res, requestedOrganizationId);
       if (!membership || !requireOrgAdmin(membership, res, "revoke")) return;
+      const authorizedOrganizationId = membership.organizationId;
 
       const apiKeyId = req.params.id;
       try {
-        await workosRequest("DELETE", `/organizations/${organizationId}/api_keys/${apiKeyId}`);
+        await workosRequest("DELETE", `/organizations/${authorizedOrganizationId}/api_keys/${apiKeyId}`);
         logger.info(
-          { userId: req.user!.id, organizationId, apiKeyId },
+          {
+            userId: req.user!.id,
+            organizationId: authorizedOrganizationId,
+            apiKeyId,
+          },
           "API key revoked",
         );
       } catch (error) {
@@ -294,7 +308,11 @@ export function createApiKeysRouter(): Router {
             : null;
         if (status !== 404) throw error;
         logger.info(
-          { userId: req.user!.id, organizationId, apiKeyId },
+          {
+            userId: req.user!.id,
+            organizationId: authorizedOrganizationId,
+            apiKeyId,
+          },
           "API key revoke: already absent in WorkOS",
         );
       }

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -10,7 +10,13 @@ import { WorkOS } from "@workos-inc/node";
 import { getPool, query } from "../db/client.js";
 import { createLogger } from "../logger.js";
 import { isUuid } from "../utils/uuid.js";
-import { requireAuth, requireAdmin, optionalAuth, createRequireWorkingGroupLeader, createRequireWorkingGroupMember } from "../middleware/auth.js";
+import {
+  requireAuth,
+  requireGlobalAdmin,
+  optionalAuth,
+  createRequireWorkingGroupLeader,
+  createRequireWorkingGroupMember,
+} from "../middleware/auth.js";
 import { WorkingGroupDatabase } from "../db/working-group-db.js";
 import { eventsDb } from "../db/events-db.js";
 import { invalidateMemberContextCache } from "../addie/index.js";
@@ -42,6 +48,7 @@ import {
   deleteCommitteeDocument as deleteCommitteeDocumentService,
   WorkingGroupContentError,
 } from "../services/working-group-content-service.js";
+import type { WorkingGroup } from "../types.js";
 
 const logger = createLogger("committee-routes");
 
@@ -218,16 +225,55 @@ export function createCommitteeRouters(): {
   const publicApiRouter = Router();
   const userApiRouter = Router();
 
+  // Working-group administration is global state, including the aao-admin
+  // group that grants SSO platform-admin authority. Refuse tenant-scoped
+  // WorkOS keys once at the router boundary and keep future admin routes under
+  // the same global-admin policy automatically.
+  adminApiRouter.use(...requireGlobalAdmin);
+
   const workingGroupDb = new WorkingGroupDatabase();
   const requireWorkingGroupLeader = createRequireWorkingGroupLeader(workingGroupDb);
   const requireWorkingGroupMember = createRequireWorkingGroupMember(workingGroupDb);
+
+  /**
+   * Document-derived content follows the same visibility boundary as the
+   * working group itself. As with the private group detail and posts routes,
+   * private content is visible only to direct members; leadership, parent-
+   * group membership, and site-admin status do not bypass that boundary.
+   * Callers outside it receive the same 404 as they would for a missing group
+   * so private group existence is not disclosed.
+   */
+  const canViewWorkingGroupContent = async (req: Request, group: WorkingGroup): Promise<boolean> => {
+    if (!group.is_private) return true;
+
+    const user = req.user;
+    if (!user?.id) return false;
+
+    return workingGroupDb.isMember(group.id, user.id);
+  };
+
+  const findVisibleActiveWorkingGroup = async (
+    req: Request,
+    res: Response,
+    slug: string,
+  ): Promise<WorkingGroup | null> => {
+    const group = await workingGroupDb.getWorkingGroupBySlug(slug);
+    if (!group || group.status !== 'active' || !(await canViewWorkingGroupContent(req, group))) {
+      res.status(404).json({
+        error: 'Working group not found',
+        message: `No working group found with slug: ${slug}`,
+      });
+      return null;
+    }
+    return group;
+  };
 
   // =========================================================================
   // ADMIN API ROUTES (/api/admin/working-groups)
   // =========================================================================
 
   // GET /api/admin/working-groups - List all working groups
-  adminApiRouter.get('/', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.get('/', async (req: Request, res: Response) => {
     try {
       const typeParam = req.query.type as string | undefined;
       let committeeType: CommitteeType | undefined;
@@ -249,7 +295,7 @@ export function createCommitteeRouters(): {
   });
 
   // GET /api/admin/working-groups/search-users - Search users for leadership selection
-  adminApiRouter.get('/search-users', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.get('/search-users', async (req: Request, res: Response) => {
     try {
       const { q } = req.query;
       if (!q || typeof q !== 'string' || q.length < 2) {
@@ -277,7 +323,7 @@ export function createCommitteeRouters(): {
   });
 
   // POST /api/admin/working-groups/sync-all-from-slack - Sync all working groups with Slack channels
-  adminApiRouter.post('/sync-all-from-slack', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.post('/sync-all-from-slack', async (req: Request, res: Response) => {
     try {
       const results = await syncAllWorkingGroupMembersFromSlack();
 
@@ -302,7 +348,7 @@ export function createCommitteeRouters(): {
   });
 
   // GET /api/admin/working-groups/:id - Get single working group with details
-  adminApiRouter.get('/:id', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.get('/:id', async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
       const group = await workingGroupDb.getWorkingGroupWithDetails(id);
@@ -324,7 +370,7 @@ export function createCommitteeRouters(): {
   });
 
   // POST /api/admin/working-groups - Create working group
-  adminApiRouter.post('/', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.post('/', async (req: Request, res: Response) => {
     try {
       const { name, slug, description, slack_channel_url, is_private, status, display_order,
               leader_user_ids, committee_type, region, parent_id } = req.body;
@@ -442,7 +488,7 @@ export function createCommitteeRouters(): {
   });
 
   // PUT /api/admin/working-groups/:id - Update working group
-  adminApiRouter.put('/:id', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.put('/:id', async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
       const updates = req.body;
@@ -552,7 +598,7 @@ export function createCommitteeRouters(): {
   });
 
   // POST /api/admin/working-groups/:id/deactivate - Deactivate working group
-  adminApiRouter.post('/:id/deactivate', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.post('/:id/deactivate', async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
       if (!isUuid(id)) {
@@ -578,7 +624,7 @@ export function createCommitteeRouters(): {
   });
 
   // POST /api/admin/working-groups/:id/reactivate - Reactivate working group
-  adminApiRouter.post('/:id/reactivate', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.post('/:id/reactivate', async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
       if (!isUuid(id)) {
@@ -604,7 +650,7 @@ export function createCommitteeRouters(): {
   });
 
   // GET /api/admin/working-groups/:id/members - List working group members
-  adminApiRouter.get('/:id/members', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.get('/:id/members', async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
       const members = await workingGroupDb.getMembershipsByWorkingGroup(id);
@@ -618,7 +664,7 @@ export function createCommitteeRouters(): {
   });
 
   // POST /api/admin/working-groups/:id/members - Add member to working group
-  adminApiRouter.post('/:id/members', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.post('/:id/members', async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
       const { workos_user_id, user_email, user_name, user_org_name, workos_organization_id } = req.body;
@@ -667,7 +713,7 @@ export function createCommitteeRouters(): {
   });
 
   // DELETE /api/admin/working-groups/:id/members/:userId - Remove member from working group
-  adminApiRouter.delete('/:id/members/:userId', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.delete('/:id/members/:userId', async (req: Request, res: Response) => {
     try {
       const { id, userId } = req.params;
       const deleted = await workingGroupDb.deleteMembership(id, userId);
@@ -694,7 +740,7 @@ export function createCommitteeRouters(): {
   // POST /api/admin/working-groups/:slug/topics/:topicSlug/graduate
   // Promote a topic on the given working group into a full subgroup.
   const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,99}$/;
-  adminApiRouter.post('/:slug/topics/:topicSlug/graduate', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.post('/:slug/topics/:topicSlug/graduate', async (req: Request, res: Response) => {
     try {
       const { slug, topicSlug } = req.params;
       if (!SLUG_PATTERN.test(slug) || !SLUG_PATTERN.test(topicSlug)) {
@@ -719,7 +765,7 @@ export function createCommitteeRouters(): {
 
   // GET /api/admin/working-groups/:id/interest - Get users who expressed interest in a committee
 
-  adminApiRouter.get('/:id/interest', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.get('/:id/interest', async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
 
@@ -751,7 +797,7 @@ export function createCommitteeRouters(): {
   });
 
   // POST /api/admin/working-groups/:id/sync-from-slack - Sync members from Slack channel
-  adminApiRouter.post('/:id/sync-from-slack', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.post('/:id/sync-from-slack', async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
 
@@ -790,7 +836,7 @@ export function createCommitteeRouters(): {
   });
 
   // GET /api/admin/working-groups/:id/posts - List all posts for a working group
-  adminApiRouter.get('/:id/posts', requireAuth, requireAdmin, async (req: Request, res: Response) => {
+  adminApiRouter.get('/:id/posts', async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
       const pool = getPool();
@@ -1607,18 +1653,13 @@ export function createCommitteeRouters(): {
   // COMMITTEE DOCUMENT ROUTES (/api/working-groups/:slug/documents)
   // =========================================================================
 
-  // GET /api/working-groups/:slug/documents - Get documents for a committee (public)
+  // GET /api/working-groups/:slug/documents - Get visible documents for a committee
   publicApiRouter.get('/:slug/documents', optionalAuth, async (req: Request, res: Response) => {
     try {
       const { slug } = req.params;
 
-      const group = await workingGroupDb.getWorkingGroupBySlug(slug);
-      if (!group || group.status !== 'active') {
-        return res.status(404).json({
-          error: 'Committee not found',
-          message: `No committee found with slug: ${slug}`,
-        });
-      }
+      const group = await findVisibleActiveWorkingGroup(req, res, slug);
+      if (!group) return;
 
       const documents = await workingGroupDb.getDocumentsByWorkingGroup(group.id);
 
@@ -1660,13 +1701,8 @@ export function createCommitteeRouters(): {
     try {
       const { slug } = req.params;
 
-      const group = await workingGroupDb.getWorkingGroupBySlug(slug);
-      if (!group || group.status !== 'active') {
-        return res.status(404).json({
-          error: 'Committee not found',
-          message: `No committee found with slug: ${slug}`,
-        });
-      }
+      const group = await findVisibleActiveWorkingGroup(req, res, slug);
+      if (!group) return;
 
       const activity = await workingGroupDb.getRecentActivity(group.id);
       res.json({ activity });
@@ -1684,13 +1720,8 @@ export function createCommitteeRouters(): {
       const { slug } = req.params;
       const summaryType = (req.query.type as string) || 'activity';
 
-      const group = await workingGroupDb.getWorkingGroupBySlug(slug);
-      if (!group || group.status !== 'active') {
-        return res.status(404).json({
-          error: 'Committee not found',
-          message: `No committee found with slug: ${slug}`,
-        });
-      }
+      const group = await findVisibleActiveWorkingGroup(req, res, slug);
+      if (!group) return;
 
       if (!['activity', 'overview', 'changes'].includes(summaryType)) {
         return res.status(400).json({
@@ -1874,7 +1905,7 @@ export function createCommitteeRouters(): {
   });
 
   // GET /api/working-groups/:slug/documents/:documentId/file - Download uploaded file
-  publicApiRouter.get('/:slug/documents/:documentId/file', async (req: Request, res: Response) => {
+  publicApiRouter.get('/:slug/documents/:documentId/file', optionalAuth, async (req: Request, res: Response) => {
     try {
       const { slug, documentId } = req.params;
 
@@ -1882,10 +1913,8 @@ export function createCommitteeRouters(): {
         return res.status(400).json({ error: 'Invalid document ID' });
       }
 
-      const group = await workingGroupDb.getWorkingGroupBySlug(slug);
-      if (!group) {
-        return res.status(404).json({ error: 'Committee not found' });
-      }
+      const group = await findVisibleActiveWorkingGroup(req, res, slug);
+      if (!group) return;
 
       const fileData = await workingGroupDb.getDocumentFileData(documentId, group.id);
       if (!fileData) {
@@ -2062,7 +2091,7 @@ export function createCommitteeRouters(): {
   });
 
   // GET /api/working-groups/assets/:assetId — Serve an extracted document asset (image)
-  publicApiRouter.get('/assets/:assetId', async (req: Request, res: Response) => {
+  publicApiRouter.get('/assets/:assetId', optionalAuth, async (req: Request, res: Response) => {
     try {
       const { assetId } = req.params;
 
@@ -2070,12 +2099,26 @@ export function createCommitteeRouters(): {
         return res.status(400).send('Invalid asset ID');
       }
 
-      const asset = await workingGroupDb.getDocumentAssetData(assetId);
-      if (!asset) {
+      const assetMetadata = await workingGroupDb.getDocumentAssetMetadata(assetId);
+      if (!assetMetadata) {
+        return res.status(404).send('Asset not found');
+      }
+
+      const group = await workingGroupDb.getWorkingGroupById(assetMetadata.working_group_id);
+      if (!group || group.status !== 'active' || !(await canViewWorkingGroupContent(req, group))) {
         return res.status(404).send('Asset not found');
       }
 
       const SAFE_SERVE_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
+      if (!SAFE_SERVE_TYPES.has(assetMetadata.mime_type)) {
+        return res.status(415).send('Unsupported media type');
+      }
+
+      const asset = await workingGroupDb.getDocumentAssetData(assetId, group.id);
+      if (!asset) {
+        return res.status(404).send('Asset not found');
+      }
+
       if (!SAFE_SERVE_TYPES.has(asset.mime_type)) {
         return res.status(415).send('Unsupported media type');
       }
@@ -2085,7 +2128,7 @@ export function createCommitteeRouters(): {
         'X-Content-Type-Options': 'nosniff',
         'Content-Security-Policy': "default-src 'none'",
         'Content-Disposition': 'inline',
-        'Cache-Control': 'public, max-age=86400',
+        'Cache-Control': group.is_private ? 'private, no-cache' : 'public, max-age=86400',
       });
       return res.send(asset.asset_data);
     } catch (error) {
@@ -2097,13 +2140,21 @@ export function createCommitteeRouters(): {
   // GET /api/working-groups/:slug/documents/:documentId/assets — List assets for a document
   publicApiRouter.get('/:slug/documents/:documentId/assets', optionalAuth, async (req: Request, res: Response) => {
     try {
-      const { documentId } = req.params;
+      const { slug, documentId } = req.params;
 
       if (!isUuid(documentId)) {
         return res.status(400).json({ error: 'Invalid document ID' });
       }
 
-      const assets = await workingGroupDb.getDocumentAssets(documentId);
+      const group = await findVisibleActiveWorkingGroup(req, res, slug);
+      if (!group) return;
+
+      const document = await workingGroupDb.getDocumentById(documentId);
+      if (!document || document.working_group_id !== group.id) {
+        return res.status(404).json({ error: 'Document not found' });
+      }
+
+      const assets = await workingGroupDb.getDocumentAssets(documentId, group.id);
 
       res.json(assets.map(a => ({
         ...a,

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -98,7 +98,7 @@ import {
 } from "../schemas/registry.js";
 
 import type { BrandManager } from "../brand-manager.js";
-import type { BrandDatabase } from "../db/brand-db.js";
+import { resolveBrandFromJson, type BrandDatabase } from "../db/brand-db.js";
 import type { PropertyDatabase } from "../db/property-db.js";
 import { CatalogDatabase } from "../db/catalog-db.js";
 import type { AdAgentsManager } from "../adagents-manager.js";
@@ -153,6 +153,56 @@ type PublisherBrandSummary = {
   colors?: string[];
   industries?: string[];
 };
+
+const BRAND_LOGO_URL_MAX_LENGTH = 2048;
+const BRAND_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+function normalizeBrandLogoUrl(value: unknown): string | null {
+  if (typeof value !== "string" || value.length === 0 || value.length > BRAND_LOGO_URL_MAX_LENGTH) {
+    return null;
+  }
+
+  // Reject markup-significant characters instead of relying on URL parsing to
+  // percent-encode them. Branding is rendered on multiple public surfaces, so
+  // keeping the stored value attribute-safe is useful defense in depth.
+  if (["\"", "'", "<", ">", "`", "\\"].some(char => value.includes(char))) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "https:" || parsed.username || parsed.password || !parsed.hostname) {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+function isValidBrandColor(value: unknown): value is string {
+  return typeof value === "string" && BRAND_COLOR_PATTERN.test(value);
+}
+
+type BrandManifestBrandingError = "invalid_brand_data" | "unsafe_logo" | "unsafe_color";
+
+function validateBrandManifestBranding(
+  domain: string,
+  brandJson: Record<string, unknown>,
+): BrandManifestBrandingError | null {
+  try {
+    const resolvedBrand = resolveBrandFromJson(domain, brandJson, false);
+    if (resolvedBrand.logos?.some(logo => normalizeBrandLogoUrl(logo.url) === null)) {
+      return "unsafe_logo";
+    }
+    if (resolvedBrand.brand_color !== undefined && !isValidBrandColor(resolvedBrand.brand_color)) {
+      return "unsafe_color";
+    }
+    return null;
+  } catch {
+    return "invalid_brand_data";
+  }
+}
 
 type PublisherFormatSummary = {
   format_option_id?: string;
@@ -3686,9 +3736,21 @@ registry.registerPath({
           schema: z.object({
             domain: z.string().openapi({ example: "acmecorp.com" }),
             brand_name: z.string(),
-            brand_json: z.record(z.string(), z.any()).optional().openapi({ description: "Optional full brand.json draft to host in the registry" }),
-            logo_url: z.string().optional(),
-            brand_color: z.string().optional(),
+            brand_json: z.record(z.string(), z.any()).optional().openapi({
+              description: "Optional full brand.json draft to host in the registry. Every recognized logo URL must be an absolute HTTPS URL of at most 2048 characters without userinfo credentials, backslashes, or markup-significant characters. The primary brand color must use #RRGGBB format.",
+            }),
+            logo_url: z.string()
+              .url()
+              .max(BRAND_LOGO_URL_MAX_LENGTH)
+              .refine(value => normalizeBrandLogoUrl(value) !== null, "Logo URL must be an absolute HTTPS URL without credentials")
+              .optional()
+              .openapi({
+                description: "Absolute HTTPS URL for the brand logo. Userinfo credentials, backslashes, and markup-significant characters are not allowed.",
+                example: "https://cdn.example.com/brand/logo.svg",
+              }),
+            brand_color: z.string()
+              .regex(BRAND_COLOR_PATTERN, "Brand color must use #RRGGBB format")
+              .optional(),
           }),
         },
       },
@@ -9273,11 +9335,32 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       return res.status(400).json({ error: "brand_json exceeds maximum size (100KB)" });
     }
 
+    const normalizedLogoUrl = logo_url === undefined ? undefined : normalizeBrandLogoUrl(logo_url);
+    if (logo_url !== undefined && normalizedLogoUrl === null) {
+      return res.status(400).json({ error: "logo_url must be an absolute HTTPS URL without credentials" });
+    }
+    if (brand_color !== undefined && !isValidBrandColor(brand_color)) {
+      return res.status(400).json({ error: "brand_color must use #RRGGBB format" });
+    }
+
     const domain = extractDomain(rawDomain).replace(/^www\./, "");
 
     const domainPattern = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
     if (!domainPattern.test(domain)) {
       return res.status(400).json({ error: "Invalid domain format" });
+    }
+
+    if (brand_json !== undefined) {
+      const brandingError = validateBrandManifestBranding(domain, brand_json as Record<string, unknown>);
+      if (brandingError === "unsafe_logo") {
+        return res.status(400).json({ error: "brand_json logo URLs must be absolute HTTPS URLs without credentials" });
+      }
+      if (brandingError === "unsafe_color") {
+        return res.status(400).json({ error: "brand_json primary brand color must use #RRGGBB format" });
+      }
+      if (brandingError === "invalid_brand_data") {
+        return res.status(400).json({ error: "brand_json contains invalid brand data" });
+      }
     }
 
     try {
@@ -9325,9 +9408,16 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         // Otherwise build a minimal entry from the request params.
         let brandJson: Record<string, unknown>;
         const manifest = discovered?.brand_manifest as Record<string, unknown> | undefined;
+        const canAdoptDiscoveredManifest = !!(
+          manifest
+          && discovered!.review_status !== 'pending'
+          && typeof manifest.house === 'object'
+          && manifest.house !== null
+          && validateBrandManifestBranding(domain, manifest) === null
+        );
         if (brand_json) {
           brandJson = brand_json as Record<string, unknown>;
-        } else if (manifest && discovered!.review_status !== 'pending' && typeof manifest.house === 'object' && manifest.house !== null) {
+        } else if (canAdoptDiscoveredManifest) {
           brandJson = manifest;
         } else {
           const brandId = brand_name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
@@ -9336,7 +9426,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             keller_type: 'master',
             names: [{ en: brand_name }],
           };
-          if (logo_url) brandEntry.logos = [{ url: logo_url }];
+          if (normalizedLogoUrl) brandEntry.logos = [{ url: normalizedLogoUrl }];
           if (brand_color) brandEntry.colors = { primary: brand_color };
           brandJson = {
             house: { domain, name: brand_name },

--- a/server/src/utils/resolve-user-org-membership.ts
+++ b/server/src/utils/resolve-user-org-membership.ts
@@ -30,6 +30,8 @@ const logger = createLogger('resolve-user-org-membership');
 export type MembershipRole = 'owner' | 'admin' | 'member';
 
 export interface UserOrgMembership {
+  /** Canonical organization ID returned by the authoritative membership row. */
+  organizationId: string;
   /** Highest-privilege active role slug (member < admin < owner). */
   role: MembershipRole;
   /** Membership status from WorkOS or 'active' for dev memberships. */
@@ -63,15 +65,21 @@ export async function resolveUserOrgMembership(
   if (isDevModeEnabled()) {
     const devUser = Object.values(DEV_USERS).find((du) => du.id === userId);
     if (devUser) {
-      const result = await query<{ role: string }>(
-        `SELECT role FROM organization_memberships
+      const result = await query<{ workos_organization_id: string; role: string }>(
+        `SELECT workos_organization_id, role FROM organization_memberships
          WHERE workos_user_id = $1 AND workos_organization_id = $2`,
         [userId, organizationId],
       );
       if (result.rows.length === 0) return null;
-      const rawRole = result.rows[0].role || 'member';
+      const membershipRow = result.rows[0];
+      const rawRole = membershipRow.role || 'member';
       const role = (VALID_ROLES.has(rawRole) ? rawRole : 'member') as MembershipRole;
-      return { role, status: 'active', via_dev_bypass: true };
+      return {
+        organizationId: membershipRow.workos_organization_id,
+        role,
+        status: 'active',
+        via_dev_bypass: true,
+      };
     }
     // Real users in dev mode (e.g. someone running tsx with their actual
     // WorkOS account) fall through to the WorkOS path below.
@@ -88,14 +96,23 @@ export async function resolveUserOrgMembership(
     organizationId,
   });
 
-  if (memberships.data.length === 0) return null;
+  // Bind authorization to the organization ID returned by the authoritative
+  // membership row instead of relying solely on the request filter.
+  const matchingMemberships = memberships.data.filter(
+    (membership) => membership.organizationId === organizationId,
+  );
+  if (matchingMemberships.length === 0) return null;
 
-  const roleSlug = resolveUserRole(memberships.data);
+  const roleSlug = resolveUserRole(matchingMemberships);
   if (!roleSlug || !VALID_ROLES.has(roleSlug)) return null;
 
-  // Pick the active row's status if any; otherwise the first.
-  const activeRow = memberships.data.find((m) => m.status === 'active');
-  const status = (activeRow?.status ?? memberships.data[0].status) as 'active' | 'pending' | 'inactive';
+  const activeRow = matchingMemberships.find((m) => m.status === 'active');
+  if (!activeRow) return null;
 
-  return { role: roleSlug as MembershipRole, status, via_dev_bypass: false };
+  return {
+    organizationId: activeRow.organizationId,
+    role: roleSlug as MembershipRole,
+    status: 'active',
+    via_dev_bypass: false,
+  };
 }

--- a/server/tests/integration/billing-portal-gate.test.ts
+++ b/server/tests/integration/billing-portal-gate.test.ts
@@ -23,7 +23,7 @@ const {
     TEST_USER_ID: 'user_portal_test',
     TEST_ORG: 'org_portal_gate_test',
     mockListMemberships: vi.fn().mockResolvedValue({
-      data: [{ id: 'om_test', role: { slug: 'owner' }, status: 'active' }],
+      data: [{ id: 'om_test', organizationId: 'org_portal_gate_test', role: { slug: 'owner' }, status: 'active' }],
     }),
     mockCreatePortalSession: vi.fn().mockResolvedValue('https://billing.stripe.com/p/session/x'),
   };

--- a/server/tests/integration/escalation-triage-endpoints.test.ts
+++ b/server/tests/integration/escalation-triage-endpoints.test.ts
@@ -22,18 +22,23 @@ vi.mock('../../src/addie/jobs/github-filer.js', () => ({
   fileGitHubIssue: mocks.fileGitHubIssue,
 }));
 
-vi.mock('../../src/middleware/auth.js', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../src/middleware/auth.js')>()),
-  requireAuth: (req: { user?: unknown }, _res: unknown, next: () => void) => {
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
+  const mockedRequireAuth = (req: { user?: unknown }, _res: unknown, next: () => void) => {
     (req as { user: unknown }).user = {
       id: 'user_test_admin',
       email: 'triage-tester@test.com',
       is_admin: true,
     };
     next();
-  },
-  requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
-}));
+  };
+  const passThrough = (_req: unknown, _res: unknown, next: () => void) => next();
+  return {
+    ...(await importOriginal<typeof import('../../src/middleware/auth.js')>()),
+    requireAuth: mockedRequireAuth,
+    requireAdmin: passThrough,
+    requireGlobalAdmin: [mockedRequireAuth, passThrough, passThrough],
+  };
+});
 
 vi.mock('../../src/middleware/csrf.js', () => ({
   csrfProtection: (_req: unknown, _res: unknown, next: () => void) => next(),

--- a/server/tests/integration/org-auto-provision-toggles.test.ts
+++ b/server/tests/integration/org-auto-provision-toggles.test.ts
@@ -90,7 +90,7 @@ describe('org auto-provisioning toggles', () => {
     await seedSubsidiary(pool, SUB_DOMAIN_A, TEST_DOMAIN, 'Subsidiary A');
     await seedSubsidiary(pool, SUB_DOMAIN_B, TEST_DOMAIN, 'Subsidiary B');
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'owner' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'owner' }, status: 'active' }],
     });
 
     const res = await request(app).get(`/api/organizations/${TEST_ORG}/domains`);
@@ -121,7 +121,7 @@ describe('org auto-provisioning toggles', () => {
       ['parent-of-apt.test', JSON.stringify({ classification: { confidence: 'high' } })]
     );
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'owner' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'owner' }, status: 'active' }],
     });
 
     const res = await request(app).get(`/api/organizations/${TEST_ORG}/domains`);
@@ -151,7 +151,7 @@ describe('org auto-provisioning toggles', () => {
       [TEST_DOMAIN, JSON.stringify({ classification: { confidence: 'high' } })]
     );
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'owner' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'owner' }, status: 'active' }],
     });
 
     const res = await request(app).get(`/api/organizations/${TEST_ORG}/domains`);
@@ -174,7 +174,7 @@ describe('org auto-provisioning toggles', () => {
       [TEST_DOMAIN, JSON.stringify({ classification: { confidence: 'high' } })]
     );
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'owner' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'owner' }, status: 'active' }],
     });
 
     const res = await request(app).get(`/api/organizations/${TEST_ORG}/domains`);
@@ -197,7 +197,7 @@ describe('org auto-provisioning toggles', () => {
       [TEST_DOMAIN, JSON.stringify({ classification: { confidence: 'high' } })]
     );
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'owner' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'owner' }, status: 'active' }],
     });
 
     const res = await request(app).get(`/api/organizations/${TEST_ORG}/domains`);
@@ -225,7 +225,7 @@ describe('org auto-provisioning toggles', () => {
       [JSON.stringify({ classification: { confidence: 'high' } })]
     );
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'owner' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'owner' }, status: 'active' }],
     });
 
     const res = await request(app).get(`/api/organizations/${TEST_ORG}/domains`);
@@ -240,7 +240,7 @@ describe('org auto-provisioning toggles', () => {
     await seedTestOrg(pool);
     // No brands row for TEST_DOMAIN.
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'owner' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'owner' }, status: 'active' }],
     });
 
     const res = await request(app).get(`/api/organizations/${TEST_ORG}/domains`);
@@ -256,7 +256,7 @@ describe('org auto-provisioning toggles', () => {
     const stale = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000);
     await seedSubsidiary(pool, SUB_DOMAIN_B, TEST_DOMAIN, 'Stale Sub', { last_validated: stale });
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'owner' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'owner' }, status: 'active' }],
     });
 
     const res = await request(app).get(`/api/organizations/${TEST_ORG}/domains`);
@@ -266,7 +266,7 @@ describe('org auto-provisioning toggles', () => {
   it('owner PATCH /settings flips auto_provision_brand_hierarchy_children, trigger sets enabled_at', async () => {
     await seedTestOrg(pool, { hierarchyOptIn: false });
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'owner' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'owner' }, status: 'active' }],
     });
 
     const res = await request(app)
@@ -295,7 +295,7 @@ describe('org auto-provisioning toggles', () => {
     currentMockUser = ADMIN_USER;
     currentMockEmail = 'admin@apt-co.test';
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'admin' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'admin' }, status: 'active' }],
     });
 
     const res = await request(app)
@@ -320,7 +320,7 @@ describe('org auto-provisioning toggles', () => {
   it('flipping the flag back to false sets disabled_at and preserves enabled_at', async () => {
     await seedTestOrg(pool, { hierarchyOptIn: true });
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'owner' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'owner' }, status: 'active' }],
     });
 
     // Confirm enabled_at is set on the seeded row.
@@ -357,7 +357,7 @@ describe('org auto-provisioning toggles', () => {
   it('enable → disable → re-enable cycle preserves full timestamp history', async () => {
     await seedTestOrg(pool, { hierarchyOptIn: false });
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'owner' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'owner' }, status: 'active' }],
     });
 
     // Enable.
@@ -420,7 +420,7 @@ describe('org auto-provisioning toggles', () => {
   it('member POST /brand-classification-report records audit row, validates kind', async () => {
     await seedTestOrg(pool);
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'member' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'member' }, status: 'active' }],
     });
 
     // Happy path: parent kind, valid domain
@@ -465,7 +465,7 @@ describe('org auto-provisioning toggles', () => {
   it('rejects non-boolean auto_provision_brand_hierarchy_children', async () => {
     await seedTestOrg(pool);
     workosMocks.listOrganizationMemberships.mockResolvedValue({
-      data: [{ role: { slug: 'owner' }, status: 'active' }],
+      data: [{ organizationId: TEST_ORG, role: { slug: 'owner' }, status: 'active' }],
     });
 
     const res = await request(app)

--- a/server/tests/integration/resolve-user-org-membership.test.ts
+++ b/server/tests/integration/resolve-user-org-membership.test.ts
@@ -62,7 +62,12 @@ describe('resolveUserOrgMembership', () => {
       // workos arg is a no-op in dev path — pass null to prove it.
       const result = await resolveUserOrgMembership(null, DEV_ADMIN_USER, DEV_ORG);
 
-      expect(result).toEqual({ role: 'owner', status: 'active', via_dev_bypass: true });
+      expect(result).toEqual({
+        organizationId: DEV_ORG,
+        role: 'owner',
+        status: 'active',
+        via_dev_bypass: true,
+      });
     });
 
     it('returns null for a dev user who has no membership in the requested org', async () => {
@@ -80,14 +85,19 @@ describe('resolveUserOrgMembership', () => {
 
       const result = await resolveUserOrgMembership(null, DEV_MEMBER_USER, DEV_ORG);
 
-      expect(result).toEqual({ role: 'member', status: 'active', via_dev_bypass: true });
+      expect(result).toEqual({
+        organizationId: DEV_ORG,
+        role: 'member',
+        status: 'active',
+        via_dev_bypass: true,
+      });
     });
 
     it('falls through to WorkOS for users not in DEV_USERS even when dev mode is enabled', async () => {
       const mockWorkos = {
         userManagement: {
           listOrganizationMemberships: vi.fn().mockResolvedValue({
-            data: [{ status: 'active', role: { slug: 'admin' } }],
+            data: [{ organizationId: NON_DEV_ORG, status: 'active', role: { slug: 'admin' } }],
           }),
         },
       } as unknown as WorkOS;
@@ -95,7 +105,12 @@ describe('resolveUserOrgMembership', () => {
       // NON_DEV_USER isn't in DEV_USERS, so we hit WorkOS even in dev mode.
       const result = await resolveUserOrgMembership(mockWorkos, NON_DEV_USER, NON_DEV_ORG);
 
-      expect(result).toEqual({ role: 'admin', status: 'active', via_dev_bypass: false });
+      expect(result).toEqual({
+        organizationId: NON_DEV_ORG,
+        role: 'admin',
+        status: 'active',
+        via_dev_bypass: false,
+      });
       expect(mockWorkos.userManagement.listOrganizationMemberships).toHaveBeenCalledWith({
         userId: NON_DEV_USER,
         organizationId: NON_DEV_ORG,
@@ -109,9 +124,9 @@ describe('resolveUserOrgMembership', () => {
         userManagement: {
           listOrganizationMemberships: vi.fn().mockResolvedValue({
             data: [
-              { status: 'pending', role: { slug: 'owner' } },
-              { status: 'active', role: { slug: 'admin' } },
-              { status: 'active', role: { slug: 'member' } },
+              { organizationId: NON_DEV_ORG, status: 'pending', role: { slug: 'owner' } },
+              { organizationId: NON_DEV_ORG, status: 'active', role: { slug: 'admin' } },
+              { organizationId: NON_DEV_ORG, status: 'active', role: { slug: 'member' } },
             ],
           }),
         },
@@ -136,13 +151,30 @@ describe('resolveUserOrgMembership', () => {
       expect(result).toBeNull();
     });
 
+    it.each([
+      ['another organization', { organizationId: 'org_other' }],
+      ['no organization ID', {}],
+    ])('returns null for an active owner membership bound to %s', async (_label, identity) => {
+      const mockWorkos = {
+        userManagement: {
+          listOrganizationMemberships: vi.fn().mockResolvedValue({
+            data: [{ ...identity, status: 'active', role: { slug: 'owner' } }],
+          }),
+        },
+      } as unknown as WorkOS;
+
+      const result = await resolveUserOrgMembership(mockWorkos, NON_DEV_USER, NON_DEV_ORG);
+
+      expect(result).toBeNull();
+    });
+
     it('returns null when only inactive memberships exist (no active role)', async () => {
       const mockWorkos = {
         userManagement: {
           listOrganizationMemberships: vi.fn().mockResolvedValue({
             data: [
-              { status: 'pending', role: { slug: 'admin' } },
-              { status: 'inactive', role: { slug: 'owner' } },
+              { organizationId: NON_DEV_ORG, status: 'pending', role: { slug: 'admin' } },
+              { organizationId: NON_DEV_ORG, status: 'inactive', role: { slug: 'owner' } },
             ],
           }),
         },

--- a/server/tests/integration/threads-api.test.ts
+++ b/server/tests/integration/threads-api.test.ts
@@ -6,9 +6,8 @@ import { runMigrations } from '../../src/db/migrate.js';
 import type { Pool } from 'pg';
 
 // Mock auth middleware to bypass authentication in tests
-vi.mock('../../src/middleware/auth.js', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../src/middleware/auth.js')>()),
-  requireAuth: (req: any, _res: any, next: any) => {
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
+  const mockedRequireAuth = (req: any, _res: any, next: any) => {
     req.user = {
       id: 'user_test_threads',
       email: 'test@example.com',
@@ -16,17 +15,24 @@ vi.mock('../../src/middleware/auth.js', async (importOriginal) => ({
       firstName: 'Test',
     };
     next();
-  },
-  requireAdmin: (_req: any, _res: any, next: any) => next(),
-  optionalAuth: (req: any, _res: any, next: any) => {
+  };
+  const passThrough = (_req: any, _res: any, next: any) => next();
+  const optionalAuth = (req: any, _res: any, next: any) => {
     req.user = {
       id: 'user_test_threads',
       email: 'test@example.com',
       firstName: 'Test',
     };
     next();
-  },
-}));
+  };
+  return {
+    ...(await importOriginal<typeof import('../../src/middleware/auth.js')>()),
+    requireAuth: mockedRequireAuth,
+    requireAdmin: passThrough,
+    optionalAuth,
+    requireGlobalAdmin: [mockedRequireAuth, passThrough, passThrough],
+  };
+});
 
 vi.mock('../../src/middleware/csrf.js', () => ({
   csrfProtection: (_req: any, _res: any, next: any) => next(),

--- a/server/tests/integration/working-group-document-privacy.test.ts
+++ b/server/tests/integration/working-group-document-privacy.test.ts
@@ -1,0 +1,330 @@
+import express from 'express';
+import request from 'supertest';
+import type { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/middleware/auth.js', () => {
+  const optionalAuth = (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    const identity = req.header('x-test-user');
+    if (identity) {
+      req.user = { id: identity, email: `${identity}@example.com` } as Express.Request['user'];
+    }
+    next();
+  };
+  const passthrough = (_req: express.Request, _res: express.Response, next: express.NextFunction) => next();
+  return {
+    optionalAuth,
+    requireAuth: optionalAuth,
+    requireAdmin: passthrough,
+    requireGlobalAdmin: [optionalAuth, passthrough, passthrough],
+    createRequireWorkingGroupLeader: () => passthrough,
+    createRequireWorkingGroupMember: () => passthrough,
+  };
+});
+
+vi.mock('../../src/addie/mcp/admin-tools.js', () => ({
+  invalidateWebAdminStatusCache: vi.fn(),
+  isWebUserAAOAdmin: vi.fn(async (userId: string) => userId === 'privacy-admin'),
+}));
+vi.mock('../../src/addie/index.js', () => ({ invalidateMemberContextCache: vi.fn() }));
+vi.mock('../../src/addie/jobs/committee-document-indexer.js', () => ({ reindexDocument: vi.fn() }));
+vi.mock('../../src/addie/mcp/docs-indexer.js', () => ({ refreshWorkingGroupDocs: vi.fn() }));
+vi.mock('../../src/slack/sync.js', () => ({
+  syncWorkingGroupMembersFromSlack: vi.fn(),
+  syncAllWorkingGroupMembersFromSlack: vi.fn(),
+}));
+vi.mock('../../src/notifications/slack.js', () => ({ notifyPublishedPost: vi.fn() }));
+vi.mock('../../src/notifications/notification-service.js', () => ({ notifyUser: vi.fn() }));
+vi.mock('../../src/slack/client.js', () => ({
+  createChannel: vi.fn(),
+  setChannelPurpose: vi.fn(),
+  sendChannelMessage: vi.fn(),
+  inviteToChannel: vi.fn(),
+  isSlackConfigured: vi.fn(() => false),
+}));
+vi.mock('../../src/addie/services/wg-welcome.js', () => ({ sendWgWelcomeMessage: vi.fn() }));
+
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { createCommitteeRouters } from '../../src/routes/committees.js';
+
+const databaseUrl = process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test';
+const suffix = `privacy-${process.pid}-${Date.now()}`;
+const slugs = {
+  public: `${suffix}-public`,
+  private: `${suffix}-private`,
+  archived: `${suffix}-archived`,
+};
+
+const users = {
+  active: `${suffix}-active`,
+  inactive: `${suffix}-inactive`,
+  pending: `${suffix}-pending`,
+  outsider: `${suffix}-outsider`,
+  leader: `${suffix}-leader`,
+  admin: 'privacy-admin',
+};
+
+const fileBytes = Buffer.from('private file bytes\n');
+const assetBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+describe('working-group document privacy with migrated database', () => {
+  let pool: Pool;
+  let app: express.Express;
+  let publicGroupId: string;
+  let privateGroupId: string;
+  let archivedGroupId: string;
+  let publicDocumentId: string;
+  let privateDocumentId: string;
+  let archivedDocumentId: string;
+  let publicAssetId: string;
+  let privateAssetId: string;
+  let archivedAssetId: string;
+  let inconsistentAssetId: string;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({ connectionString: databaseUrl });
+    await runMigrations();
+
+    const groups = await pool.query<{ id: string; slug: string }>(
+      `INSERT INTO working_groups (name, slug, is_private, status)
+       VALUES
+         ('Privacy public', $1, false, 'active'),
+         ('Privacy private', $2, true, 'active'),
+         ('Privacy archived', $3, true, 'archived')
+       RETURNING id, slug`,
+      [slugs.public, slugs.private, slugs.archived],
+    );
+    publicGroupId = groups.rows.find(row => row.slug === slugs.public)!.id;
+    privateGroupId = groups.rows.find(row => row.slug === slugs.private)!.id;
+    archivedGroupId = groups.rows.find(row => row.slug === slugs.archived)!.id;
+
+    const documents = await pool.query<{ id: string; working_group_id: string }>(
+      `INSERT INTO committee_documents
+         (working_group_id, title, document_url, document_type, document_summary,
+          index_status, file_data, file_name, file_mime_type)
+       VALUES
+         ($1, 'Public document', 'https://example.com/public', 'pdf', 'Public document summary',
+          'success', $4, 'public.pdf', 'application/pdf'),
+         ($2, 'Private document', 'https://example.com/private', 'pdf', 'Private document summary',
+          'success', $5, 'private.pdf', 'application/pdf'),
+         ($3, 'Archived document', 'https://example.com/archived', 'pdf', 'Archived document summary',
+          'success', $6, 'archived.pdf', 'application/pdf')
+       RETURNING id, working_group_id`,
+      [publicGroupId, privateGroupId, archivedGroupId, Buffer.from('public file'), fileBytes, Buffer.from('archived file')],
+    );
+    publicDocumentId = documents.rows.find(row => row.working_group_id === publicGroupId)!.id;
+    privateDocumentId = documents.rows.find(row => row.working_group_id === privateGroupId)!.id;
+    archivedDocumentId = documents.rows.find(row => row.working_group_id === archivedGroupId)!.id;
+
+    await pool.query(
+      `INSERT INTO committee_summaries (working_group_id, summary_type, summary_text)
+       VALUES ($1, 'activity', 'Public group summary'),
+              ($2, 'activity', 'Private group summary'),
+              ($3, 'activity', 'Archived group summary')`,
+      [publicGroupId, privateGroupId, archivedGroupId],
+    );
+    await pool.query(
+      `INSERT INTO committee_document_activity
+         (document_id, working_group_id, activity_type, change_summary)
+       VALUES ($1, $2, 'content_changed', 'Public activity'),
+              ($3, $4, 'content_changed', 'Private activity'),
+              ($5, $6, 'content_changed', 'Archived activity')`,
+      [publicDocumentId, publicGroupId, privateDocumentId, privateGroupId, archivedDocumentId, archivedGroupId],
+    );
+
+    const assets = await pool.query<{ id: string; working_group_id: string; filename: string }>(
+      `INSERT INTO committee_document_assets
+         (document_id, working_group_id, filename, mime_type, file_size, asset_data, extraction_order)
+       VALUES
+         ($1, $2, 'public.png', 'image/png', 4, $7, 0),
+         ($3, $4, 'private.png', 'image/png', $8, $9, 0),
+         ($5, $6, 'archived.png', 'image/png', 4, $10, 0),
+         ($3, $2, 'inconsistent.png', 'image/png', 4, $11, 1)
+       RETURNING id, working_group_id, filename`,
+      [
+        publicDocumentId, publicGroupId,
+        privateDocumentId, privateGroupId,
+        archivedDocumentId, archivedGroupId,
+        Buffer.from('pub'), assetBytes.length, assetBytes,
+        Buffer.from('arch'), Buffer.from('bad!'),
+      ],
+    );
+    publicAssetId = assets.rows.find(row => row.filename === 'public.png')!.id;
+    privateAssetId = assets.rows.find(row => row.filename === 'private.png')!.id;
+    archivedAssetId = assets.rows.find(row => row.filename === 'archived.png')!.id;
+    inconsistentAssetId = assets.rows.find(row => row.filename === 'inconsistent.png')!.id;
+
+    await pool.query(
+      `INSERT INTO working_group_memberships (working_group_id, workos_user_id, status)
+       VALUES ($1, $2, 'active'), ($1, $3, 'inactive'), ($4, $2, 'active')`,
+      [privateGroupId, users.active, users.inactive, archivedGroupId],
+    );
+    await pool.query(
+      `INSERT INTO working_group_leaders (working_group_id, user_id) VALUES ($1, $2)`,
+      [privateGroupId, users.leader],
+    );
+
+    app = express();
+    app.use('/api/working-groups', createCommitteeRouters().publicApiRouter);
+  }, 30_000);
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query('DELETE FROM working_groups WHERE slug = ANY($1::text[])', [Object.values(slugs)]);
+    }
+    await closeDatabase();
+  });
+
+  function privateReadPaths() {
+    return [
+      `/api/working-groups/${slugs.private}/documents`,
+      `/api/working-groups/${slugs.private}/activity`,
+      `/api/working-groups/${slugs.private}/summary`,
+      `/api/working-groups/${slugs.private}/documents/${privateDocumentId}/file`,
+      `/api/working-groups/${slugs.private}/documents/${privateDocumentId}/assets`,
+      `/api/working-groups/assets/${privateAssetId}`,
+    ];
+  }
+
+  it.each([
+    ['anonymous', undefined],
+    ['outsider', users.outsider],
+    ['pending applicant', users.pending],
+    ['inactive member', users.inactive],
+    ['non-member leader', users.leader],
+    ['AAO admin', users.admin],
+  ])('hides every private document read from an %s', async (_label, userId) => {
+    for (const path of privateReadPaths()) {
+      const call = request(app).get(path);
+      if (userId) call.set('x-test-user', userId);
+      await call.expect(404);
+    }
+  });
+
+  it('does not admit a pending membership state as direct membership', async () => {
+    await expect(pool.query(
+      `INSERT INTO working_group_memberships (working_group_id, workos_user_id, status)
+       VALUES ($1, $2, 'pending')`,
+      [privateGroupId, users.pending],
+    )).rejects.toMatchObject({ code: '23514' });
+
+    await request(app)
+      .get(`/api/working-groups/${slugs.private}/documents`)
+      .set('x-test-user', users.pending)
+      .expect(404);
+  });
+
+  it('returns exact private metadata, summaries, file bytes, and assets to an active direct member', async () => {
+    const documents = await request(app)
+      .get(`/api/working-groups/${slugs.private}/documents`)
+      .set('x-test-user', users.active)
+      .expect(200);
+    expect(documents.body.documents).toEqual([
+      expect.objectContaining({
+        id: privateDocumentId,
+        title: 'Private document',
+        document_summary: 'Private document summary',
+      }),
+    ]);
+
+    const activity = await request(app)
+      .get(`/api/working-groups/${slugs.private}/activity`)
+      .set('x-test-user', users.active)
+      .expect(200);
+    expect(activity.body.activity).toEqual([
+      expect.objectContaining({ document_id: privateDocumentId, change_summary: 'Private activity' }),
+    ]);
+
+    const summary = await request(app)
+      .get(`/api/working-groups/${slugs.private}/summary`)
+      .set('x-test-user', users.active)
+      .expect(200);
+    expect(summary.body.summary).toEqual(expect.objectContaining({ summary_text: 'Private group summary' }));
+
+    const file = await request(app)
+      .get(`/api/working-groups/${slugs.private}/documents/${privateDocumentId}/file`)
+      .set('x-test-user', users.active)
+      .expect(200)
+      .expect('content-type', 'application/pdf')
+      .expect('cache-control', 'private, no-cache')
+      .expect('x-content-type-options', 'nosniff')
+      .expect('content-security-policy', "default-src 'none'");
+    expect(file.body).toEqual(fileBytes);
+
+    const assets = await request(app)
+      .get(`/api/working-groups/${slugs.private}/documents/${privateDocumentId}/assets`)
+      .set('x-test-user', users.active)
+      .expect(200);
+    expect(assets.body).toEqual([
+      expect.objectContaining({
+        id: privateAssetId,
+        filename: 'private.png',
+        url: `/api/working-groups/assets/${privateAssetId}`,
+      }),
+    ]);
+
+    const asset = await request(app)
+      .get(`/api/working-groups/assets/${privateAssetId}`)
+      .set('x-test-user', users.active)
+      .expect(200)
+      .expect('content-type', 'image/png')
+      .expect('cache-control', 'private, no-cache')
+      .expect('x-content-type-options', 'nosniff')
+      .expect('content-security-policy', "default-src 'none'");
+    expect(asset.body).toEqual(assetBytes);
+  });
+
+  it('preserves anonymous reads and public caching for every public document surface', async () => {
+    await request(app).get(`/api/working-groups/${slugs.public}/documents`).expect(200);
+    await request(app).get(`/api/working-groups/${slugs.public}/activity`).expect(200);
+    await request(app).get(`/api/working-groups/${slugs.public}/summary`).expect(200);
+    await request(app)
+      .get(`/api/working-groups/${slugs.public}/documents/${publicDocumentId}/file`)
+      .expect(200)
+      .expect('cache-control', 'private, no-cache');
+    const assets = await request(app)
+      .get(`/api/working-groups/${slugs.public}/documents/${publicDocumentId}/assets`)
+      .expect(200);
+    expect(assets.body).toHaveLength(1);
+    await request(app)
+      .get(`/api/working-groups/assets/${publicAssetId}`)
+      .expect(200)
+      .expect('cache-control', 'public, max-age=86400');
+  });
+
+  it('hides all archived-group document surfaces even from an active direct member', async () => {
+    const paths = [
+      `/api/working-groups/${slugs.archived}/documents`,
+      `/api/working-groups/${slugs.archived}/activity`,
+      `/api/working-groups/${slugs.archived}/summary`,
+      `/api/working-groups/${slugs.archived}/documents/${archivedDocumentId}/file`,
+      `/api/working-groups/${slugs.archived}/documents/${archivedDocumentId}/assets`,
+      `/api/working-groups/assets/${archivedAssetId}`,
+    ];
+    for (const path of paths) {
+      await request(app).get(path).set('x-test-user', users.active).expect(404);
+    }
+  });
+
+  it('binds file and asset-list reads to both document ID and requested group', async () => {
+    await request(app)
+      .get(`/api/working-groups/${slugs.public}/documents/${privateDocumentId}/file`)
+      .expect(404);
+    await request(app)
+      .get(`/api/working-groups/${slugs.public}/documents/${privateDocumentId}/assets`)
+      .expect(404);
+  });
+
+  it('rejects denormalized assets whose document and group ownership disagree', async () => {
+    const assets = await request(app)
+      .get(`/api/working-groups/${slugs.private}/documents/${privateDocumentId}/assets`)
+      .set('x-test-user', users.active)
+      .expect(200);
+    expect(assets.body.map((asset: { id: string }) => asset.id)).not.toContain(inconsistentAssetId);
+
+    await request(app)
+      .get(`/api/working-groups/assets/${inconsistentAssetId}`)
+      .expect(404);
+  });
+});

--- a/server/tests/unit/addie-admin-global-auth.test.ts
+++ b/server/tests/unit/addie-admin-global-auth.test.ts
@@ -75,10 +75,12 @@ vi.mock('../../src/utils/html-config.js', () => ({
 
 const { createAddieAdminRouter } = await import('../../src/routes/addie-admin.js');
 const { stopAuthTimers } = await import('../../src/middleware/auth.js');
+const { csrfProtection } = await import('../../src/middleware/csrf.js');
 
 function createApp() {
   const app = express();
   app.use(cookieParser());
+  app.use(csrfProtection);
   const { pageRouter, apiRouter } = createAddieAdminRouter();
   app.use('/admin/addie', pageRouter);
   app.use('/api/admin/addie', apiRouter);

--- a/server/tests/unit/addie-admin-global-auth.test.ts
+++ b/server/tests/unit/addie-admin-global-auth.test.ts
@@ -79,8 +79,6 @@ const { csrfProtection } = await import('../../src/middleware/csrf.js');
 
 function createApp() {
   const app = express();
-  // Test fixture installs the real custom CSRF middleware immediately below.
-  // codeql[js/missing-token-validation]
   app.use(cookieParser());
   app.use(csrfProtection);
   const { pageRouter, apiRouter } = createAddieAdminRouter();

--- a/server/tests/unit/addie-admin-global-auth.test.ts
+++ b/server/tests/unit/addie-admin-global-auth.test.ts
@@ -1,0 +1,205 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  createValidation: vi.fn(),
+  loadSealedSession: vi.fn(),
+  checkPlatformBanForApiKey: vi.fn(),
+  checkPlatformBan: vi.fn(),
+  resolveEffectiveMembership: vi.fn(),
+  getAdminWorkingGroupBySlug: vi.fn(),
+  isAdminGroupMember: vi.fn(),
+  poolQuery: vi.fn(),
+  getWebConversations: vi.fn(),
+  serveHtmlWithConfig: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = 'sk_test_global_boundary';
+  process.env.WORKOS_CLIENT_ID = 'client_test_global_boundary';
+  process.env.WORKOS_COOKIE_PASSWORD =
+    'test-cookie-password-at-least-32-characters';
+  process.env.ADMIN_API_KEY = 'static-global-admin-key';
+  delete process.env.DEV_USER_EMAIL;
+  delete process.env.DEV_USER_ID;
+});
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: class WorkOS {
+    apiKeys = { createValidation: mocks.createValidation };
+    userManagement = { loadSealedSession: mocks.loadSealedSession };
+  },
+}));
+
+vi.mock('../../src/db/bans-db.js', () => ({
+  bansDb: {
+    checkPlatformBanForApiKey: mocks.checkPlatformBanForApiKey,
+    checkPlatformBan: mocks.checkPlatformBan,
+  },
+}));
+
+vi.mock('../../src/db/org-filters.js', () => ({
+  resolveEffectiveMembership: mocks.resolveEffectiveMembership,
+}));
+
+vi.mock('../../src/db/client.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/db/client.js')>()),
+  getPool: () => ({ query: mocks.poolQuery }),
+}));
+
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class WorkingGroupDatabase {
+    getWorkingGroupBySlug = mocks.getAdminWorkingGroupBySlug;
+    isMember = mocks.isAdminGroupMember;
+  },
+}));
+
+vi.mock('../../src/addie/mcp/admin-tools.js', async () => {
+  const { isWebUserAAOAdmin } = await import(
+    '../../src/addie/admin-status-lookup.js'
+  );
+  return { isWebUserAAOAdmin };
+});
+
+vi.mock('../../src/db/addie-db.js', () => ({
+  AddieDatabase: class AddieDatabase {
+    getWebConversations = mocks.getWebConversations;
+  },
+}));
+
+vi.mock('../../src/utils/html-config.js', () => ({
+  serveHtmlWithConfig: mocks.serveHtmlWithConfig,
+}));
+
+const { createAddieAdminRouter } = await import('../../src/routes/addie-admin.js');
+const { stopAuthTimers } = await import('../../src/middleware/auth.js');
+
+function createApp() {
+  const app = express();
+  app.use(cookieParser());
+  const { pageRouter, apiRouter } = createAddieAdminRouter();
+  app.use('/admin/addie', pageRouter);
+  app.use('/api/admin/addie', apiRouter);
+  return app;
+}
+
+function validatedTenantKey(permission: 'admin:*' | 'admin:read') {
+  return {
+    apiKey: {
+      id: `key_${permission}`,
+      owner: { id: 'org_tenant' },
+      name: 'Tenant admin key',
+      permissions: [permission],
+    },
+  };
+}
+
+describe('Addie real global-admin boundary', () => {
+  const app = createApp();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createValidation.mockImplementation(
+      ({ value }: { value: string }) => Promise.resolve(
+        validatedTenantKey(value.includes('read') ? 'admin:read' : 'admin:*'),
+      ),
+    );
+    mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: true });
+    mocks.checkPlatformBanForApiKey.mockResolvedValue({ banned: false });
+    mocks.checkPlatformBan.mockResolvedValue({ banned: false });
+    mocks.getAdminWorkingGroupBySlug.mockResolvedValue({
+      id: 'wg_aao_admin',
+      slug: 'aao-admin',
+    });
+    mocks.isAdminGroupMember.mockResolvedValue(true);
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes('FROM users')) {
+        return Promise.resolve({
+          rows: [{ first_name: 'SSO', last_name: 'Admin' }],
+          rowCount: 1,
+        });
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+    mocks.loadSealedSession.mockReturnValue({
+      authenticate: vi.fn().mockResolvedValue({
+        authenticated: true,
+        accessToken: 'sso-access-token',
+        user: {
+          id: 'user_sso_admin',
+          email: 'sso-admin@example.test',
+          firstName: 'SSO',
+          lastName: 'Admin',
+          emailVerified: true,
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        },
+      }),
+    });
+    mocks.getWebConversations.mockResolvedValue([]);
+    mocks.serveHtmlWithConfig.mockImplementation(
+      (_req: express.Request, res: express.Response) => {
+        res.status(200).send('Addie admin');
+        return Promise.resolve();
+      },
+    );
+  });
+
+  it.each(['admin:*', 'admin:read'] as const)(
+    'refuses a tenant key with %s before the Addie conversation query',
+    async (permission) => {
+      const response = await request(app)
+        .get('/api/admin/addie/conversations')
+        .set('Authorization', `Bearer sk_tenant_${permission === 'admin:read' ? 'read' : 'full'}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('global_admin_required');
+      expect(mocks.getWebConversations).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['admin:*', 'admin:read'] as const)(
+    'refuses a tenant key with %s before serving the Addie admin page',
+    async (permission) => {
+      const response = await request(app)
+        .get('/admin/addie/')
+        .set('Accept', 'text/html')
+        .set('Authorization', `Bearer sk_tenant_${permission === 'admin:read' ? 'read' : 'full'}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('global_admin_required');
+      expect(mocks.serveHtmlWithConfig).not.toHaveBeenCalled();
+    },
+  );
+
+  it('allows a static global admin key to reach the Addie page', async () => {
+    const response = await request(app)
+      .get('/admin/addie/')
+      .set('Accept', 'text/html')
+      .set('Authorization', 'Bearer static-global-admin-key');
+
+    expect(response.status).toBe(200);
+    expect(mocks.serveHtmlWithConfig).toHaveBeenCalledOnce();
+  });
+
+  it('allows an SSO aao-admin to reach the Addie conversation API', async () => {
+    const response = await request(app)
+      .get('/api/admin/addie/conversations')
+      .set('Cookie', 'wos-session=valid-sso-admin-session');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ conversations: [], total: 0 });
+    expect(mocks.getAdminWorkingGroupBySlug).toHaveBeenCalledWith('aao-admin');
+    expect(mocks.isAdminGroupMember).toHaveBeenCalledWith(
+      'wg_aao_admin',
+      'user_sso_admin',
+    );
+    expect(mocks.getWebConversations).toHaveBeenCalledOnce();
+  });
+});
+
+afterAll(() => {
+  stopAuthTimers();
+});

--- a/server/tests/unit/addie-admin-global-auth.test.ts
+++ b/server/tests/unit/addie-admin-global-auth.test.ts
@@ -79,6 +79,8 @@ const { csrfProtection } = await import('../../src/middleware/csrf.js');
 
 function createApp() {
   const app = express();
+  // Test fixture installs the real custom CSRF middleware immediately below.
+  // codeql[js/missing-token-validation]
   app.use(cookieParser());
   app.use(csrfProtection);
   const { pageRouter, apiRouter } = createAddieAdminRouter();

--- a/server/tests/unit/api-key-dashboard-role-gate.test.ts
+++ b/server/tests/unit/api-key-dashboard-role-gate.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const dashboardHtml = readFileSync(
+  join(process.cwd(), 'server/public/dashboard-api-keys.html'),
+  'utf8',
+);
+
+describe('API key dashboard organization-role gate', () => {
+  it('offers key management only to active organization owners and admins', () => {
+    expect(dashboardHtml).toContain("currentOrg.status === 'active'");
+    expect(dashboardHtml).toContain("currentOrg.role === 'owner'");
+    expect(dashboardHtml).toContain("currentOrg.role === 'admin'");
+
+    const roleGate = dashboardHtml.indexOf('if (!canManageApiKeys)');
+    const contentReveal = dashboardHtml.indexOf(
+      "document.getElementById('content').style.display = 'block'",
+    );
+    const keyLoad = dashboardHtml.indexOf('await loadKeys()');
+
+    expect(roleGate).toBeGreaterThan(-1);
+    expect(contentReveal).toBeGreaterThan(roleGate);
+    expect(keyLoad).toBeGreaterThan(contentReveal);
+  });
+
+  it('shows a clear non-admin explanation instead of the management workflow', () => {
+    expect(dashboardHtml).toContain('id="accessDenied"');
+    expect(dashboardHtml).toContain(
+      'Only active organization owners and admins can create, view, or revoke API keys.',
+    );
+  });
+});

--- a/server/tests/unit/api-key-issuance-permissions.test.ts
+++ b/server/tests/unit/api-key-issuance-permissions.test.ts
@@ -1,0 +1,303 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  listOrganizationMemberships: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = 'sk_test_api_key_issuance';
+  process.env.WORKOS_CLIENT_ID = 'client_test_api_key_issuance';
+  process.env.WORKOS_COOKIE_PASSWORD =
+    'test-cookie-password-at-least-32-characters';
+});
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: class WorkOS {
+    userManagement = {
+      listOrganizationMemberships: mocks.listOrganizationMemberships,
+    };
+  },
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  DEV_USERS: {},
+  isDevModeEnabled: () => false,
+  requireAuth: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = {
+      id: 'user_caller',
+      email: 'caller@example.test',
+      emailVerified: true,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    };
+    next();
+  },
+}));
+
+const { createApiKeysRouter } = await import('../../src/routes/api-keys.js');
+
+// Own the process-global transport for the lifetime of this file. Installing
+// and restoring it independently in sibling suites lets one suite's teardown
+// expose native fetch while another suite is still issuing a request under a
+// loaded full-suite worker, leaking the request to WorkOS. Individual tests
+// only reset/configure the mock implementation below.
+beforeAll(() => {
+  vi.stubGlobal('fetch', mocks.fetch);
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+function setMembership(
+  role: 'owner' | 'admin' | 'member',
+  status: 'active' | 'pending' | 'inactive' = 'active',
+) {
+  mocks.listOrganizationMemberships.mockResolvedValue({
+    data: [
+      {
+        organizationId: 'org_target',
+        role: { slug: role },
+        status,
+      },
+    ],
+  });
+}
+
+function setNoMembership() {
+  mocks.listOrganizationMemberships.mockResolvedValue({ data: [] });
+}
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/me/api-keys', createApiKeysRouter());
+  return app;
+}
+
+describe('tenant API key issuance permissions', () => {
+  const app = createApp();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: vi.fn().mockResolvedValue({ id: 'key_created', value: 'secret' }),
+    });
+  });
+
+  it.each([[], ['admin:*']] as const)(
+    'refuses an active ordinary member creating a key with permissions %j',
+    async (permissions) => {
+      setMembership('member');
+
+      const response = await request(app)
+        .post('/api/me/api-keys?org=org_target')
+        .send({ name: 'Member key', permissions });
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toContain('owners and admins');
+      expect(mocks.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ['owner', 'admin:*'],
+    ['admin', 'admin:read'],
+  ] as const)(
+    'allows an organization %s to create a key with server-approved permission %s',
+    async (role, permission) => {
+      setMembership(role);
+
+      const response = await request(app)
+        .post('/api/me/api-keys?org=org_target')
+        .send({ name: 'Automation key', permissions: [permission] });
+
+      expect(response.status).toBe(201);
+      const [, options] = mocks.fetch.mock.calls[0] as [string, RequestInit];
+      expect(JSON.parse(options.body as string)).toEqual({
+        name: 'Automation key',
+        permissions: [permission],
+      });
+    },
+  );
+
+  it('allows an active owner to create an unprivileged key', async () => {
+    setMembership('owner');
+
+    const response = await request(app)
+      .post('/api/me/api-keys?org=org_target')
+      .send({ name: 'Registry key', permissions: [] });
+
+    expect(response.status).toBe(201);
+    expect(mocks.listOrganizationMemberships).toHaveBeenCalledWith({
+      userId: 'user_caller',
+      organizationId: 'org_target',
+    });
+    const [, options] = mocks.fetch.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(options.body as string)).toEqual({ name: 'Registry key' });
+  });
+
+  it('deduplicates server-approved permissions before sending them to WorkOS', async () => {
+    setMembership('owner');
+
+    const response = await request(app)
+      .post('/api/me/api-keys?org=org_target')
+      .send({
+        name: 'Deduplicated key',
+        permissions: ['admin:read', 'admin:read'],
+      });
+
+    expect(response.status).toBe(201);
+    const [, options] = mocks.fetch.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(options.body as string)).toEqual({
+      name: 'Deduplicated key',
+      permissions: ['admin:read'],
+    });
+  });
+
+  it.each([
+    { label: 'a scalar', permissions: 'admin:*' },
+    { label: 'a non-string array item', permissions: ['admin:*', 7] },
+  ])('rejects malformed permissions supplied as $label', async ({ permissions }) => {
+    setMembership('owner');
+
+    const response = await request(app)
+      .post('/api/me/api-keys?org=org_target')
+      .send({ name: 'Malformed key', permissions });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Invalid permissions');
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects caller-invented permissions even for an organization owner', async () => {
+    setMembership('owner');
+
+    const response = await request(app)
+      .post('/api/me/api-keys?org=org_target')
+      .send({ name: 'Unknown scope', permissions: ['admin:billing'] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Invalid permissions');
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('organization-wide API key management permissions', () => {
+  const app = createApp();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ data: [] }),
+    });
+  });
+
+  it('refuses an ordinary member listing organization API keys before WorkOS is called', async () => {
+    setMembership('member');
+
+    const response = await request(app).get('/api/me/api-keys?org=org_target');
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toContain('owners and admins');
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses an ordinary member revoking an organization API key before WorkOS is called', async () => {
+    setMembership('member');
+
+    const response = await request(app).delete(
+      '/api/me/api-keys/key_owner_automation?org=org_target',
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toContain('owners and admins');
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('allows an active owner to list organization API keys', async () => {
+    setMembership('owner');
+
+    const response = await request(app).get('/api/me/api-keys?org=org_target');
+
+    expect(response.status).toBe(200);
+    expect(mocks.fetch).toHaveBeenCalledOnce();
+    const [url, options] = mocks.fetch.mock.calls[0] as [string, RequestInit];
+    expect(new URL(url).pathname).toBe('/organizations/org_target/api_keys');
+    expect(options.method).toBe('GET');
+  });
+
+  it('allows an active admin to revoke an organization API key', async () => {
+    setMembership('admin');
+    mocks.fetch.mockResolvedValue({ ok: true, status: 204 });
+
+    const response = await request(app).delete(
+      '/api/me/api-keys/key_owner_automation?org=org_target',
+    );
+
+    expect(response.status).toBe(204);
+    expect(mocks.fetch).toHaveBeenCalledOnce();
+    const [url, options] = mocks.fetch.mock.calls[0] as [string, RequestInit];
+    expect(new URL(url).pathname).toBe(
+      '/organizations/org_target/api_keys/key_owner_automation',
+    );
+    expect(options.method).toBe('DELETE');
+  });
+});
+
+describe('inactive API key lifecycle principals', () => {
+  const app = createApp();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ data: [] }),
+    });
+  });
+
+  const cases = [
+    ['pending', 'create'],
+    ['pending', 'list'],
+    ['pending', 'revoke'],
+    ['inactive', 'create'],
+    ['inactive', 'list'],
+    ['inactive', 'revoke'],
+    ['none', 'create'],
+    ['none', 'list'],
+    ['none', 'revoke'],
+  ] as const;
+
+  it.each(cases)(
+    'refuses a %s owner attempting to %s organization API keys',
+    async (membershipState, operation) => {
+      if (membershipState === 'none') {
+        setNoMembership();
+      } else {
+        setMembership('owner', membershipState);
+      }
+
+      const response = operation === 'create'
+        ? await request(app)
+          .post('/api/me/api-keys?org=org_target')
+          .send({ name: 'Lifecycle key', permissions: [] })
+        : operation === 'list'
+          ? await request(app).get('/api/me/api-keys?org=org_target')
+          : await request(app).delete(
+            '/api/me/api-keys/key_lifecycle?org=org_target',
+          );
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('Access denied');
+      expect(mocks.fetch).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/server/tests/unit/api-key-issuance-permissions.test.ts
+++ b/server/tests/unit/api-key-issuance-permissions.test.ts
@@ -67,6 +67,18 @@ function setMembership(
   });
 }
 
+function setUnboundMembership(organizationId?: string) {
+  mocks.listOrganizationMemberships.mockResolvedValue({
+    data: [
+      {
+        ...(organizationId ? { organizationId } : {}),
+        role: { slug: 'owner' },
+        status: 'active',
+      },
+    ],
+  });
+}
+
 function setNoMembership() {
   mocks.listOrganizationMemberships.mockResolvedValue({ data: [] });
 }
@@ -250,6 +262,33 @@ describe('organization-wide API key management permissions', () => {
     );
     expect(options.method).toBe('DELETE');
   });
+
+  it.each([
+    ['another organization', 'org_attacker'],
+    ['no organization ID', undefined],
+  ] as const)(
+    'refuses all key operations when WorkOS returns an owner membership for %s',
+    async (_label, returnedOrganizationId) => {
+      for (const operation of ['create', 'list', 'revoke'] as const) {
+        vi.clearAllMocks();
+        setUnboundMembership(returnedOrganizationId);
+
+        const response = operation === 'create'
+          ? await request(app)
+            .post('/api/me/api-keys?org=org_target')
+            .send({ name: 'Cross-org key', permissions: [] })
+          : operation === 'list'
+          ? await request(app).get('/api/me/api-keys?org=org_target')
+          : await request(app).delete(
+            '/api/me/api-keys/key_cross_org?org=org_target',
+          );
+
+        expect(response.status).toBe(403);
+        expect(response.body.error).toBe('Access denied');
+        expect(mocks.fetch).not.toHaveBeenCalled();
+      }
+    },
+  );
 });
 
 describe('inactive API key lifecycle principals', () => {

--- a/server/tests/unit/chat-si-branding-xss.test.ts
+++ b/server/tests/unit/chat-si-branding-xss.test.ts
@@ -1,0 +1,246 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const chatHtml = readFileSync(join(process.cwd(), 'server/public/chat.html'), 'utf8');
+
+interface BrandHeaderElements {
+  header: HTMLElement;
+  icon: HTMLElement;
+  title: HTMLElement;
+  tagline: HTMLElement;
+}
+
+interface SiBranding {
+  renderHeader: (
+    elements: BrandHeaderElements,
+    brand: { name?: unknown; tagline?: unknown; logo_url?: unknown; brand_color?: unknown } | null,
+    fallbackName?: unknown,
+  ) => void;
+  safeLogoUrl: (value: unknown) => string | null;
+  safeBrandColor: (value: unknown) => string | null;
+}
+
+interface SessionSummary {
+  session_id: string;
+  brand_name: string;
+  status: string;
+  message_count: number;
+  last_activity_at: string;
+  brand_color: unknown;
+  brand_logo_url: unknown;
+}
+
+interface SessionDetail {
+  brand: Record<string, unknown> | null;
+  messages: Array<Record<string, unknown>>;
+}
+
+type ChatWindow = Window & typeof globalThis & {
+  siBranding: SiBranding;
+  fetch: typeof fetch;
+  matchMedia: (query: string) => MediaQueryList;
+  __ENABLE_SI_CHAT_TEST_HOOKS__: boolean;
+  __siChatTestHooks: {
+    openSession: (session: { session_id: string; brand_name: string }) => Promise<void>;
+  };
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function requestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.pathname + input.search;
+  return new URL(input.url).pathname + new URL(input.url).search;
+}
+
+function createDom(options: {
+  sessions?: SessionSummary[];
+  details?: Record<string, SessionDetail>;
+} = {}): JSDOM {
+  const sessions = options.sessions ?? [];
+  const details = options.details ?? {};
+
+  return new JSDOM(chatHtml, {
+    url: 'https://example.test/chat.html',
+    runScripts: 'dangerously',
+    pretendToBeVisual: true,
+    beforeParse(window) {
+      const chatWindow = window as unknown as ChatWindow;
+      chatWindow.__ENABLE_SI_CHAT_TEST_HOOKS__ = true;
+      chatWindow.fetch = (async (input: RequestInfo | URL) => {
+        const path = requestPath(input);
+        if (path === '/api/addie/chat/status') return jsonResponse({ ready: true });
+        if (path === '/api/me') return jsonResponse({ user: { id: 'user_test', email: 'user@example.test' } });
+        if (path.startsWith('/api/me/addie-home')) return jsonResponse({ css: '', html: '' });
+        if (path === '/api/addie/chat/threads') return jsonResponse({ conversations: [] });
+        if (path === '/api/si/sessions/user') return jsonResponse({ sessions });
+        if (path.startsWith('/api/si/sessions/')) {
+          const sessionId = path.split('/').pop()!;
+          const detail = details[sessionId];
+          return detail ? jsonResponse(detail) : jsonResponse({ error: 'Not found' }, 404);
+        }
+        return jsonResponse({ error: 'Not found' }, 404);
+      }) as typeof fetch;
+      chatWindow.matchMedia = (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      });
+    },
+  });
+}
+
+async function waitForElement(document: Document, selector: string): Promise<Element> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const element = document.querySelector(selector);
+    if (element) return element;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${selector}`);
+}
+
+describe('Sponsored chat brand header XSS hardening', () => {
+  let dom: JSDOM | null = null;
+
+  afterEach(() => {
+    dom?.window.close();
+    dom = null;
+  });
+
+  it('renders quote-breaking and event-handler payloads as inert DOM properties', () => {
+    dom = createDom();
+    const window = dom.window as unknown as ChatWindow;
+    const elements = {
+      header: window.document.getElementById('siModalHeader')!,
+      icon: window.document.getElementById('siModalIconEmoji')!,
+      title: window.document.getElementById('siModalTitle')!,
+      tagline: window.document.getElementById('siModalTagline')!,
+    };
+    const hostileName = 'Nova\"><img src=x onerror="window.__brandPwned=true">';
+
+    window.siBranding.renderHeader(elements, {
+      name: hostileName,
+      tagline: '<svg onload="window.__taglinePwned=true">',
+      logo_url: 'https://cdn.example.test/logo.png',
+      brand_color: '#123456',
+    });
+
+    const image = elements.icon.querySelector('img');
+    expect(elements.title.textContent).toBe(hostileName);
+    expect(elements.tagline.textContent).toBe('<svg onload="window.__taglinePwned=true">');
+    expect(image?.alt).toBe(hostileName);
+    expect(image?.hasAttribute('onerror')).toBe(false);
+    expect(elements.icon.querySelectorAll('svg, script')).toHaveLength(0);
+    expect((window as unknown as { __brandPwned?: boolean }).__brandPwned).toBeUndefined();
+  });
+
+  it('executes legacy history rendering and resume without creating attacker-controlled DOM', async () => {
+    const hostileName = '\"><img src=x onerror="window.__historyPwned=true">';
+    const hostileTagline = '<svg onload="window.__taglinePwned=true">';
+    dom = createDom({
+      sessions: [{
+        session_id: 'legacy-session',
+        brand_name: hostileName,
+        status: 'active',
+        message_count: 1,
+        last_activity_at: '2026-07-29T12:00:00.000Z',
+        brand_color: '#123456\" onmouseover=\"window.__stylePwned=true',
+        brand_logo_url: 'https://cdn.example.test/history.png" onerror="window.__logoPwned=true',
+      }],
+      details: {
+        'legacy-session': {
+          brand: {
+            name: hostileName,
+            tagline: hostileTagline,
+            logo_url: 'https://cdn.example.test/resume.png" onerror="window.__resumePwned=true',
+            brand_color: '#123456; background: url(javascript:alert(1))',
+          },
+          messages: [],
+        },
+      },
+    });
+    const window = dom.window as unknown as ChatWindow;
+    const historyItem = await waitForElement(window.document, '.history-item.si-branded') as HTMLElement;
+
+    expect(historyItem.querySelector('img, script, svg, [onerror], [onmouseover]')).toBeNull();
+    expect(historyItem.querySelector('.si-brand-name')?.textContent).toBe(hostileName);
+    expect(historyItem.style.length).toBe(1);
+    expect(historyItem.style.getPropertyValue('--si-item-color')).toBe('var(--color-brand)');
+    expect(historyItem.style.background).toBe('');
+
+    historyItem.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    const title = window.document.getElementById('siModalTitle')!;
+    for (let attempt = 0; attempt < 100 && title.textContent !== hostileName; attempt++) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+
+    const icon = window.document.getElementById('siModalIconEmoji')!;
+    const tagline = window.document.getElementById('siModalTagline')!;
+    const header = window.document.getElementById('siModalHeader')!;
+    expect(title.textContent).toBe(hostileName);
+    expect(tagline.textContent).toBe(hostileTagline);
+    expect(icon.querySelector('img, script, svg, [onerror]')).toBeNull();
+    expect(tagline.querySelector('svg, script, [onload]')).toBeNull();
+    expect(header.style.getPropertyValue('--si-brand-color')).toBe('');
+    expect((window as unknown as Record<string, unknown>).__historyPwned).toBeUndefined();
+    expect((window as unknown as Record<string, unknown>).__stylePwned).toBeUndefined();
+    expect((window as unknown as Record<string, unknown>).__resumePwned).toBeUndefined();
+  });
+
+  it('executes the new-session modal path and clears stale branding before the next brand', async () => {
+    const hostileName = 'Hostile\"><img src=x onerror="window.__newSessionPwned=true">';
+    dom = createDom({
+      details: {
+        'valid-session': {
+          brand: {
+            name: 'Nova',
+            tagline: 'Helpful recommendations',
+            logo_url: 'https://cdn.example.test/brand/logo.svg?theme=dark',
+            brand_color: '#12Ab9F',
+          },
+          messages: [],
+        },
+        'hostile-session': {
+          brand: {
+            name: hostileName,
+            tagline: '<svg onload="window.__newTaglinePwned=true">',
+            logo_url: 'javascript:window.__newLogoPwned=true',
+            brand_color: '#123456; background: red',
+          },
+          messages: [],
+        },
+      },
+    });
+    const window = dom.window as unknown as ChatWindow;
+    const header = window.document.getElementById('siModalHeader')!;
+    const icon = window.document.getElementById('siModalIconEmoji')!;
+    const title = window.document.getElementById('siModalTitle')!;
+    const tagline = window.document.getElementById('siModalTagline')!;
+
+    await window.__siChatTestHooks.openSession({ session_id: 'valid-session', brand_name: 'Nova' });
+    expect(header.style.getPropertyValue('--si-brand-color')).toBe('#12Ab9F');
+    expect(icon.querySelector('img')?.getAttribute('src')).toBe('https://cdn.example.test/brand/logo.svg?theme=dark');
+
+    await window.__siChatTestHooks.openSession({ session_id: 'hostile-session', brand_name: hostileName });
+    expect(title.textContent).toBe(hostileName);
+    expect(tagline.textContent).toBe('<svg onload="window.__newTaglinePwned=true">');
+    expect(header.style.getPropertyValue('--si-brand-color')).toBe('');
+    expect(icon.querySelector('img, script, svg, [onerror]')).toBeNull();
+    expect(icon.textContent).toBe('H');
+    expect(tagline.querySelector('svg, script, [onload]')).toBeNull();
+    expect((window as unknown as Record<string, unknown>).__newSessionPwned).toBeUndefined();
+    expect((window as unknown as Record<string, unknown>).__newLogoPwned).toBeUndefined();
+  });
+});

--- a/server/tests/unit/openapi-brand-setup-security.test.ts
+++ b/server/tests/unit/openapi-brand-setup-security.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import YAML from 'yaml';
+
+const specPath = new URL('../../../static/openapi/registry.yaml', import.meta.url);
+
+describe('Brand setup OpenAPI security contract', () => {
+  it('documents the enforced logo URL and brand color constraints', () => {
+    const spec = YAML.parse(readFileSync(specPath, 'utf8'));
+    const requestProperties = spec.paths['/api/brands/setup-my-brand'].post.requestBody
+      .content['application/json'].schema.properties;
+
+    expect(requestProperties.logo_url).toMatchObject({
+      type: 'string',
+      format: 'uri',
+      maxLength: 2048,
+      description: expect.stringContaining('Absolute HTTPS URL'),
+    });
+    expect(requestProperties.logo_url.description).toContain('credentials');
+    expect(requestProperties.logo_url.description).toContain('backslashes');
+    expect(requestProperties.brand_color).toMatchObject({
+      type: 'string',
+      pattern: '^#[0-9a-fA-F]{6}$',
+    });
+    expect(requestProperties.brand_json.description).toContain('Every recognized logo URL');
+    expect(requestProperties.brand_json.description).toContain('absolute HTTPS URL');
+    expect(requestProperties.brand_json.description).toContain('at most 2048 characters');
+    expect(requestProperties.brand_json.description).toContain('backslashes');
+    expect(requestProperties.brand_json.description).toContain('#RRGGBB');
+  });
+});

--- a/server/tests/unit/registry-brand-setup-route.test.ts
+++ b/server/tests/unit/registry-brand-setup-route.test.ts
@@ -124,6 +124,216 @@ describe('POST /api/brands/setup-my-brand', () => {
     expect(res.body.error).toBe('brand_json must be a JSON object');
   });
 
+  it.each([
+    'javascript:alert(1)',
+    'data:image/svg+xml,<svg onload=alert(1)>',
+    'http://cdn.example.test/logo.png',
+    'https://cdn.example.test/logo.png\" onerror=\"alert(1)',
+    'https://cdn.example.test/logo\\evil.png',
+    'https://user:password@cdn.example.test/logo.png',
+  ])('rejects unsafe logo URL %s', async (logoUrl) => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn(),
+      getHostedBrandByDomain: vi.fn(),
+      createHostedBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/setup-my-brand')
+      .send({
+        domain: 'nova.example',
+        brand_name: 'Nova',
+        logo_url: logoUrl,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('logo_url must be an absolute HTTPS URL without credentials');
+    expect(brandDb.createHostedBrand).not.toHaveBeenCalled();
+  });
+
+  it('rejects logo URLs longer than 2048 characters', async () => {
+    const brandDb = { createHostedBrand: vi.fn() };
+    const logoUrl = `https://cdn.example.test/${'a'.repeat(2025)}`;
+    expect(logoUrl.length).toBeGreaterThan(2048);
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/setup-my-brand')
+      .send({ domain: 'nova.example', brand_name: 'Nova', logo_url: logoUrl });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('logo_url must be an absolute HTTPS URL without credentials');
+    expect(brandDb.createHostedBrand).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['logo_url', 42, 'logo_url must be an absolute HTTPS URL without credentials'],
+    ['brand_color', ['#123456'], 'brand_color must use #RRGGBB format'],
+  ])('rejects non-string %s values', async (field, value, expectedError) => {
+    const brandDb = { createHostedBrand: vi.fn() };
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/setup-my-brand')
+      .send({ domain: 'nova.example', brand_name: 'Nova', [field]: value });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe(expectedError);
+    expect(brandDb.createHostedBrand).not.toHaveBeenCalled();
+  });
+
+  it.each(['red', '#123', '#12345g', '#123456; background: red'])('rejects unsafe brand color %s', async (brandColor) => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn(),
+      getHostedBrandByDomain: vi.fn(),
+      createHostedBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/setup-my-brand')
+      .send({
+        domain: 'nova.example',
+        brand_name: 'Nova',
+        brand_color: brandColor,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('brand_color must use #RRGGBB format');
+    expect(brandDb.createHostedBrand).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsafe branding nested in a full brand.json draft', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn(),
+      getHostedBrandByDomain: vi.fn(),
+      createHostedBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/setup-my-brand')
+      .send({
+        domain: 'nova.example',
+        brand_name: 'Nova',
+        brand_json: {
+          brands: [{
+            names: [{ en: 'Nova' }],
+            logos: [{ url: 'data:image/svg+xml,<svg onload=alert(1)>' }],
+            colors: { primary: '#123456; color: red' },
+          }],
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('brand_json logo URLs must be absolute HTTPS URLs without credentials');
+    expect(brandDb.createHostedBrand).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsafe primary color nested in a full brand.json draft', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn(),
+      getHostedBrandByDomain: vi.fn(),
+      createHostedBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/setup-my-brand')
+      .send({
+        domain: 'nova.example',
+        brand_name: 'Nova',
+        brand_json: {
+          brands: [{
+            names: [{ en: 'Nova' }],
+            colors: { primary: '#123456; color: red' },
+          }],
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('brand_json primary brand color must use #RRGGBB format');
+    expect(brandDb.createHostedBrand).not.toHaveBeenCalled();
+  });
+
+  it('rejects a full draft containing both valid and unsafe nested logos', async () => {
+    const brandDb = { createHostedBrand: vi.fn() };
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/setup-my-brand')
+      .send({
+        domain: 'nova.example',
+        brand_name: 'Nova',
+        brand_json: {
+          house: { domain: 'nova.example', name: 'Nova' },
+          brands: [{
+            names: [{ en: 'Nova' }],
+            logos: [
+              { url: 'https://cdn.example.test/logo.png' },
+              { url: 'javascript:alert(1)' },
+            ],
+          }],
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('brand_json logo URLs must be absolute HTTPS URLs without credentials');
+    expect(brandDb.createHostedBrand).not.toHaveBeenCalled();
+  });
+
+  it('does not adopt unsafe branding from an approved legacy manifest', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        review_status: 'approved',
+        brand_manifest: {
+          house: { domain: 'nova.example', name: 'Legacy Nova' },
+          brands: [{
+            names: [{ en: 'Legacy Nova' }],
+            logos: [{ url: 'data:image/svg+xml,<svg onload=alert(1)>' }],
+            colors: { primary: '#123456; background: red' },
+          }],
+        },
+      }),
+      getHostedBrandByDomain: vi.fn().mockResolvedValue(null),
+      createHostedBrand: vi.fn().mockResolvedValue({ id: 'brand_1' }),
+    };
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/setup-my-brand')
+      .send({ domain: 'nova.example', brand_name: 'Nova' });
+
+    expect(res.status).toBe(200);
+    const savedBrandJson = brandDb.createHostedBrand.mock.calls[0][0].brand_json;
+    expect(savedBrandJson.house).toEqual({ domain: 'nova.example', name: 'Nova' });
+    expect(savedBrandJson.brands[0]).not.toHaveProperty('logos');
+    expect(savedBrandJson.brands[0]).not.toHaveProperty('colors');
+  });
+
+  it('preserves valid HTTPS branding and treats hostile names as text data', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
+      getHostedBrandByDomain: vi.fn().mockResolvedValue(null),
+      createHostedBrand: vi.fn().mockResolvedValue({ id: 'brand_1' }),
+    };
+    const hostileName = 'Nova\"><img src=x onerror="alert(1)">';
+
+    const res = await request(buildApp(brandDb))
+      .post('/api/brands/setup-my-brand')
+      .send({
+        domain: 'nova.example',
+        brand_name: hostileName,
+        logo_url: 'https://cdn.example.test/brand/logo.svg?theme=dark',
+        brand_color: '#12Ab9F',
+      });
+
+    expect(res.status).toBe(200);
+    expect(brandDb.createHostedBrand).toHaveBeenCalledWith(expect.objectContaining({
+      brand_json: expect.objectContaining({
+        house: { domain: 'nova.example', name: hostileName },
+        brands: [expect.objectContaining({
+          names: [{ en: hostileName }],
+          logos: [{ url: 'https://cdn.example.test/brand/logo.svg?theme=dark' }],
+          colors: { primary: '#12Ab9F' },
+        })],
+      }),
+    }));
+  });
+
   it('denies non-dev callers without a resolvable organization', async () => {
     delete process.env.DEV_USER_EMAIL;
     delete process.env.DEV_USER_ID;

--- a/server/tests/unit/working-group-admin-global-auth.test.ts
+++ b/server/tests/unit/working-group-admin-global-auth.test.ts
@@ -82,6 +82,8 @@ const { csrfProtection } = await import('../../src/middleware/csrf.js');
 
 function createApp() {
   const app = express();
+  // Test fixture installs the real custom CSRF middleware immediately below.
+  // codeql[js/missing-token-validation]
   app.use(cookieParser());
   app.use(csrfProtection);
   app.use(express.json());

--- a/server/tests/unit/working-group-admin-global-auth.test.ts
+++ b/server/tests/unit/working-group-admin-global-auth.test.ts
@@ -1,0 +1,214 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  createValidation: vi.fn(),
+  loadSealedSession: vi.fn(),
+  checkPlatformBanForApiKey: vi.fn(),
+  checkPlatformBan: vi.fn(),
+  resolveEffectiveMembership: vi.fn(),
+  poolQuery: vi.fn(),
+  listWorkingGroups: vi.fn(),
+  addMembership: vi.fn(),
+  getWorkingGroupById: vi.fn(),
+  getWorkingGroupBySlug: vi.fn(),
+  isMember: vi.fn(),
+  invalidateMemberContextCache: vi.fn(),
+  invalidateWebAdminStatusCache: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = 'sk_test_working_group_boundary';
+  process.env.WORKOS_CLIENT_ID = 'client_test_working_group_boundary';
+  process.env.WORKOS_COOKIE_PASSWORD =
+    'test-cookie-password-at-least-32-characters';
+  process.env.ADMIN_API_KEY = 'static-global-admin-key';
+  delete process.env.DEV_USER_EMAIL;
+  delete process.env.DEV_USER_ID;
+});
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: class WorkOS {
+    apiKeys = { createValidation: mocks.createValidation };
+    userManagement = { loadSealedSession: mocks.loadSealedSession };
+  },
+}));
+
+vi.mock('../../src/db/bans-db.js', () => ({
+  bansDb: {
+    checkPlatformBanForApiKey: mocks.checkPlatformBanForApiKey,
+    checkPlatformBan: mocks.checkPlatformBan,
+  },
+}));
+
+vi.mock('../../src/db/org-filters.js', () => ({
+  resolveEffectiveMembership: mocks.resolveEffectiveMembership,
+}));
+
+vi.mock('../../src/db/client.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/db/client.js')>()),
+  getPool: () => ({ query: mocks.poolQuery }),
+}));
+
+vi.mock('../../src/addie/mcp/admin-tools.js', async () => {
+  const { isWebUserAAOAdmin } = await import(
+    '../../src/addie/admin-status-lookup.js'
+  );
+  return {
+    isWebUserAAOAdmin,
+    invalidateWebAdminStatusCache: mocks.invalidateWebAdminStatusCache,
+  };
+});
+
+vi.mock('../../src/addie/index.js', () => ({
+  invalidateMemberContextCache: mocks.invalidateMemberContextCache,
+}));
+
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class WorkingGroupDatabase {
+    listWorkingGroups = mocks.listWorkingGroups;
+    addMembership = mocks.addMembership;
+    getWorkingGroupById = mocks.getWorkingGroupById;
+    getWorkingGroupBySlug = mocks.getWorkingGroupBySlug;
+    isMember = mocks.isMember;
+  },
+}));
+
+const { createCommitteeRouters } = await import('../../src/routes/committees.js');
+const { stopAuthTimers } = await import('../../src/middleware/auth.js');
+
+function createApp() {
+  const app = express();
+  app.use(cookieParser());
+  app.use(express.json());
+  const { adminApiRouter } = createCommitteeRouters();
+  app.use('/api/admin/working-groups', adminApiRouter);
+  return app;
+}
+
+function validatedTenantKey(permission: 'admin:*' | 'admin:read') {
+  return {
+    apiKey: {
+      id: `key_${permission}`,
+      owner: { id: 'org_tenant' },
+      name: 'Tenant admin key',
+      permissions: [permission],
+    },
+  };
+}
+
+describe('working-group real global-admin boundary', () => {
+  const app = createApp();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createValidation.mockImplementation(
+      ({ value }: { value: string }) => Promise.resolve(
+        validatedTenantKey(value.includes('read') ? 'admin:read' : 'admin:*'),
+      ),
+    );
+    mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: true });
+    mocks.checkPlatformBanForApiKey.mockResolvedValue({ banned: false });
+    mocks.checkPlatformBan.mockResolvedValue({ banned: false });
+    mocks.getWorkingGroupBySlug.mockImplementation((slug: string) =>
+      Promise.resolve(slug === 'aao-admin'
+        ? { id: 'wg_aao_admin', slug: 'aao-admin' }
+        : null),
+    );
+    mocks.isMember.mockResolvedValue(true);
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes('FROM users')) {
+        return Promise.resolve({
+          rows: [{ first_name: 'SSO', last_name: 'Admin' }],
+          rowCount: 1,
+        });
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+    mocks.loadSealedSession.mockReturnValue({
+      authenticate: vi.fn().mockResolvedValue({
+        authenticated: true,
+        accessToken: 'sso-access-token',
+        user: {
+          id: 'user_sso_admin',
+          email: 'sso-admin@example.test',
+          firstName: 'SSO',
+          lastName: 'Admin',
+          emailVerified: true,
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        },
+      }),
+    });
+    mocks.listWorkingGroups.mockResolvedValue([]);
+    mocks.addMembership.mockResolvedValue({
+      working_group_id: 'wg_aao_admin',
+      workos_user_id: 'user_new_member',
+    });
+    mocks.getWorkingGroupById.mockResolvedValue(null);
+  });
+
+  it.each(['admin:*', 'admin:read'] as const)(
+    'refuses a tenant key with %s before listing working groups',
+    async (permission) => {
+      const response = await request(app)
+        .get('/api/admin/working-groups')
+        .set('Authorization', `Bearer sk_tenant_${permission === 'admin:read' ? 'read' : 'full'}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('global_admin_required');
+      expect(mocks.listWorkingGroups).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['admin:*', 'admin:read'] as const)(
+    'refuses a tenant key with %s before adding a member to aao-admin',
+    async (permission) => {
+      const response = await request(app)
+        .post('/api/admin/working-groups/wg_aao_admin/members')
+        .set('Authorization', `Bearer sk_tenant_${permission === 'admin:read' ? 'read' : 'full'}`)
+        .send({ workos_user_id: 'user_new_member' });
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('global_admin_required');
+      expect(mocks.addMembership).not.toHaveBeenCalled();
+    },
+  );
+
+  it('allows an SSO aao-admin to list working groups', async () => {
+    const response = await request(app)
+      .get('/api/admin/working-groups')
+      .set('Cookie', 'wos-session=valid-sso-admin-session');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([]);
+    expect(mocks.getWorkingGroupBySlug).toHaveBeenCalledWith('aao-admin');
+    expect(mocks.isMember).toHaveBeenCalledWith(
+      'wg_aao_admin',
+      'user_sso_admin',
+    );
+    expect(mocks.listWorkingGroups).toHaveBeenCalledOnce();
+  });
+
+  it('allows a static global admin key to add a member to aao-admin', async () => {
+    const response = await request(app)
+      .post('/api/admin/working-groups/wg_aao_admin/members')
+      .set('Authorization', 'Bearer static-global-admin-key')
+      .send({ workos_user_id: 'user_new_member' });
+
+    expect(response.status).toBe(201);
+    expect(mocks.addMembership).toHaveBeenCalledWith(
+      expect.objectContaining({
+        working_group_id: 'wg_aao_admin',
+        workos_user_id: 'user_new_member',
+        added_by_user_id: 'admin_api_key',
+      }),
+    );
+  });
+});
+
+afterAll(() => {
+  stopAuthTimers();
+});

--- a/server/tests/unit/working-group-admin-global-auth.test.ts
+++ b/server/tests/unit/working-group-admin-global-auth.test.ts
@@ -78,10 +78,12 @@ vi.mock('../../src/db/working-group-db.js', () => ({
 
 const { createCommitteeRouters } = await import('../../src/routes/committees.js');
 const { stopAuthTimers } = await import('../../src/middleware/auth.js');
+const { csrfProtection } = await import('../../src/middleware/csrf.js');
 
 function createApp() {
   const app = express();
   app.use(cookieParser());
+  app.use(csrfProtection);
   app.use(express.json());
   const { adminApiRouter } = createCommitteeRouters();
   app.use('/api/admin/working-groups', adminApiRouter);
@@ -206,6 +208,20 @@ describe('working-group real global-admin boundary', () => {
         added_by_user_id: 'admin_api_key',
       }),
     );
+  });
+
+  it('rejects an SSO cookie write without a matching CSRF token', async () => {
+    const response = await request(app)
+      .post('/api/admin/working-groups/wg_aao_admin/members')
+      .set('Cookie', 'wos-session=valid-sso-admin-session')
+      .send({ workos_user_id: 'user_new_member' });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual(expect.objectContaining({
+      error: 'CSRF validation failed',
+      reason: 'cookie_expired',
+    }));
+    expect(mocks.addMembership).not.toHaveBeenCalled();
   });
 });
 

--- a/server/tests/unit/working-group-admin-global-auth.test.ts
+++ b/server/tests/unit/working-group-admin-global-auth.test.ts
@@ -82,8 +82,6 @@ const { csrfProtection } = await import('../../src/middleware/csrf.js');
 
 function createApp() {
   const app = express();
-  // Test fixture installs the real custom CSRF middleware immediately below.
-  // codeql[js/missing-token-validation]
   app.use(cookieParser());
   app.use(csrfProtection);
   app.use(express.json());

--- a/server/tests/unit/working-group-document-privacy.test.ts
+++ b/server/tests/unit/working-group-document-privacy.test.ts
@@ -1,0 +1,278 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ids = {
+  document: '11111111-1111-4111-8111-111111111111',
+  asset: '22222222-2222-4222-8222-222222222222',
+  privateGroup: '33333333-3333-4333-8333-333333333333',
+  publicGroup: '44444444-4444-4444-8444-444444444444',
+};
+
+const privateGroup = {
+  id: ids.privateGroup,
+  slug: 'private-group',
+  name: 'Private group',
+  is_private: true,
+  status: 'active',
+};
+
+const publicGroup = {
+  id: ids.publicGroup,
+  slug: 'public-group',
+  name: 'Public group',
+  is_private: false,
+  status: 'active',
+};
+
+const db = vi.hoisted(() => ({
+  getWorkingGroupBySlug: vi.fn(),
+  getWorkingGroupById: vi.fn(),
+  isMember: vi.fn(),
+  isLeader: vi.fn(),
+  getDocumentsByWorkingGroup: vi.fn(),
+  getRecentActivity: vi.fn(),
+  getCurrentSummary: vi.fn(),
+  getDocumentFileData: vi.fn(),
+  getDocumentAssetMetadata: vi.fn(),
+  getDocumentAssetData: vi.fn(),
+  getDocumentById: vi.fn(),
+  getDocumentAssets: vi.fn(),
+}));
+
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class {
+    constructor() {
+      return db;
+    }
+  },
+}));
+
+vi.mock('../../src/middleware/auth.js', () => {
+  const optionalAuth = (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    const identity = req.header('x-test-user');
+    if (identity) {
+      req.user = {
+        id: identity,
+        email: `${identity}@example.com`,
+      } as Express.Request['user'];
+    }
+    next();
+  };
+  const passthrough = (_req: express.Request, _res: express.Response, next: express.NextFunction) => next();
+  return {
+    optionalAuth,
+    requireAuth: optionalAuth,
+    requireAdmin: passthrough,
+    requireGlobalAdmin: [optionalAuth, passthrough, passthrough],
+    createRequireWorkingGroupLeader: () => passthrough,
+    createRequireWorkingGroupMember: () => passthrough,
+  };
+});
+
+vi.mock('../../src/addie/mcp/admin-tools.js', () => ({
+  invalidateWebAdminStatusCache: vi.fn(),
+  isWebUserAAOAdmin: vi.fn(async (userId: string) => userId === 'admin'),
+}));
+
+vi.mock('../../src/addie/index.js', () => ({ invalidateMemberContextCache: vi.fn() }));
+vi.mock('../../src/addie/jobs/committee-document-indexer.js', () => ({ reindexDocument: vi.fn() }));
+vi.mock('../../src/addie/mcp/docs-indexer.js', () => ({ refreshWorkingGroupDocs: vi.fn() }));
+vi.mock('../../src/slack/sync.js', () => ({
+  syncWorkingGroupMembersFromSlack: vi.fn(),
+  syncAllWorkingGroupMembersFromSlack: vi.fn(),
+}));
+vi.mock('../../src/notifications/slack.js', () => ({ notifyPublishedPost: vi.fn() }));
+vi.mock('../../src/notifications/notification-service.js', () => ({ notifyUser: vi.fn() }));
+vi.mock('../../src/slack/client.js', () => ({
+  createChannel: vi.fn(),
+  setChannelPurpose: vi.fn(),
+  sendChannelMessage: vi.fn(),
+  inviteToChannel: vi.fn(),
+  isSlackConfigured: vi.fn(() => false),
+}));
+vi.mock('../../src/addie/services/wg-welcome.js', () => ({ sendWgWelcomeMessage: vi.fn() }));
+
+import { createCommitteeRouters } from '../../src/routes/committees.js';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/working-groups', createCommitteeRouters().publicApiRouter);
+  return app;
+}
+
+describe('private working-group document reads', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ADMIN_EMAILS;
+
+    db.getWorkingGroupBySlug.mockImplementation(async (slug: string) => (
+      slug === privateGroup.slug ? privateGroup : slug === publicGroup.slug ? publicGroup : null
+    ));
+    db.getWorkingGroupById.mockImplementation(async (id: string) => (
+      id === privateGroup.id ? privateGroup : id === publicGroup.id ? publicGroup : null
+    ));
+    db.isMember.mockImplementation(async (_groupId: string, userId: string) => userId === 'member');
+    db.isLeader.mockImplementation(async (_groupId: string, userId: string) => userId === 'leader');
+    db.getDocumentsByWorkingGroup.mockResolvedValue([{ id: ids.document, title: 'Secret plan' }]);
+    db.getRecentActivity.mockResolvedValue([{ document_title: 'Secret plan' }]);
+    db.getCurrentSummary.mockResolvedValue({ summary_text: 'Secret summary' });
+    db.getDocumentFileData.mockImplementation(async (documentId: string, groupId: string) => (
+      documentId === ids.document && groupId === privateGroup.id
+        ? {
+            file_data: Buffer.from('secret bytes'),
+            file_mime_type: 'application/pdf',
+            file_name: 'secret.pdf',
+          }
+        : null
+    ));
+    db.getDocumentAssetMetadata.mockResolvedValue({
+      mime_type: 'image/png',
+      working_group_id: privateGroup.id,
+    });
+    db.getDocumentAssetData.mockResolvedValue({
+      asset_data: Buffer.from('image bytes'),
+      mime_type: 'image/png',
+    });
+    db.getDocumentById.mockResolvedValue({ id: ids.document, working_group_id: privateGroup.id });
+    db.getDocumentAssets.mockResolvedValue([{ id: ids.asset, filename: 'figure.png' }]);
+  });
+
+  it.each([
+    ['anonymous caller', undefined],
+    ['authenticated non-member', 'outsider'],
+  ])('hides private document metadata from an %s', async (_label, userId) => {
+    const app = createApp();
+    const call = request(app).get('/api/working-groups/private-group/documents');
+    if (userId) call.set('x-test-user', userId);
+
+    const response = await call.expect(404);
+
+    expect(response.body).toEqual({
+      error: 'Working group not found',
+      message: 'No working group found with slug: private-group',
+    });
+    expect(db.getDocumentsByWorkingGroup).not.toHaveBeenCalled();
+  });
+
+  it('allows a direct member to list private documents', async () => {
+    const response = await request(createApp())
+      .get('/api/working-groups/private-group/documents')
+      .set('x-test-user', 'member')
+      .expect(200);
+
+    expect(response.body.documents).toEqual([expect.objectContaining({ id: ids.document, title: 'Secret plan' })]);
+  });
+
+  it.each(['leader', 'admin'])('does not let a non-member %s bypass private-group visibility', async (userId) => {
+    await request(createApp())
+      .get('/api/working-groups/private-group/documents')
+      .set('x-test-user', userId)
+      .expect(404);
+
+    expect(db.getDocumentsByWorkingGroup).not.toHaveBeenCalled();
+  });
+
+  it('keeps public document reads anonymous', async () => {
+    const response = await request(createApp())
+      .get('/api/working-groups/public-group/documents')
+      .expect(200);
+
+    expect(response.body.documents).toHaveLength(1);
+    expect(db.isMember).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['/api/working-groups/private-group/activity', 'getRecentActivity'],
+    ['/api/working-groups/private-group/summary', 'getCurrentSummary'],
+    [`/api/working-groups/private-group/documents/${ids.document}/file`, 'getDocumentFileData'],
+    [`/api/working-groups/private-group/documents/${ids.document}/assets`, 'getDocumentAssets'],
+  ])('blocks a non-member before reading private data at %s', async (path, sink) => {
+    await request(createApp())
+      .get(path)
+      .set('x-test-user', 'outsider')
+      .expect(404);
+
+    expect(db[sink as keyof typeof db]).not.toHaveBeenCalled();
+  });
+
+  it('serves private summaries, files, and asset metadata to a direct member', async () => {
+    const app = createApp();
+
+    await request(app)
+      .get('/api/working-groups/private-group/summary')
+      .set('x-test-user', 'member')
+      .expect(200, { summary: { summary_text: 'Secret summary' } });
+    const file = await request(app)
+      .get(`/api/working-groups/private-group/documents/${ids.document}/file`)
+      .set('x-test-user', 'member')
+      .expect(200)
+      .expect('content-type', 'application/pdf')
+      .expect('cache-control', 'private, no-cache')
+      .expect('x-content-type-options', 'nosniff')
+      .expect('content-security-policy', "default-src 'none'");
+    expect(file.body).toEqual(Buffer.from('secret bytes'));
+    expect(db.getDocumentFileData).toHaveBeenCalledWith(ids.document, privateGroup.id);
+    await request(app)
+      .get(`/api/working-groups/private-group/documents/${ids.document}/assets`)
+      .set('x-test-user', 'member')
+      .expect(200)
+      .expect([{ id: ids.asset, filename: 'figure.png', url: `/api/working-groups/assets/${ids.asset}` }]);
+    expect(db.getDocumentAssets).toHaveBeenCalledWith(ids.document, privateGroup.id);
+  });
+
+  it('binds file bytes to both the document ID and requested group', async () => {
+    await request(createApp())
+      .get(`/api/working-groups/public-group/documents/${ids.document}/file`)
+      .expect(404, { error: 'No file data available' });
+
+    expect(db.getDocumentFileData).toHaveBeenCalledWith(ids.document, publicGroup.id);
+  });
+
+  it('does not allow a public group slug to expose another group document assets', async () => {
+    await request(createApp())
+      .get(`/api/working-groups/public-group/documents/${ids.document}/assets`)
+      .expect(404, { error: 'Document not found' });
+
+    expect(db.getDocumentAssets).not.toHaveBeenCalled();
+  });
+
+  it('hides private extracted asset bytes from non-members', async () => {
+    const response = await request(createApp())
+      .get(`/api/working-groups/assets/${ids.asset}`)
+      .set('x-test-user', 'outsider')
+      .expect(404);
+
+    expect(response.text).toBe('Asset not found');
+    expect(db.getDocumentAssetMetadata).toHaveBeenCalledWith(ids.asset);
+    expect(db.getDocumentAssetData).not.toHaveBeenCalled();
+  });
+
+  it('serves private extracted assets only with private caching for a member', async () => {
+    const response = await request(createApp())
+      .get(`/api/working-groups/assets/${ids.asset}`)
+      .set('x-test-user', 'member')
+      .expect(200)
+      .expect('cache-control', 'private, no-cache')
+      .expect('content-type', 'image/png')
+      .expect('x-content-type-options', 'nosniff')
+      .expect('content-security-policy', "default-src 'none'");
+
+    expect(response.body).toEqual(Buffer.from('image bytes'));
+    expect(db.getDocumentAssetData).toHaveBeenCalledWith(ids.asset, privateGroup.id);
+  });
+
+  it('preserves anonymous serving and public caching for public extracted assets', async () => {
+    db.getDocumentAssetMetadata.mockResolvedValue({
+      mime_type: 'image/png',
+      working_group_id: publicGroup.id,
+    });
+    db.getDocumentAssetData.mockResolvedValue({ asset_data: Buffer.from('public image'), mime_type: 'image/png' });
+
+    await request(createApp())
+      .get(`/api/working-groups/assets/${ids.asset}`)
+      .expect(200)
+      .expect('cache-control', 'public, max-age=86400');
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -10751,11 +10751,16 @@ paths:
                 brand_json:
                   type: object
                   additionalProperties: {}
-                  description: Optional full brand.json draft to host in the registry
+                  description: "Optional full brand.json draft to host in the registry. Every recognized logo URL must be an absolute HTTPS URL of at most 2048 characters without userinfo credentials, backslashes, or markup-significant characters. The primary brand color must use #RRGGBB format."
                 logo_url:
                   type: string
+                  maxLength: 2048
+                  format: uri
+                  description: Absolute HTTPS URL for the brand logo. Userinfo credentials, backslashes, and markup-significant characters are not allowed.
+                  example: https://cdn.example.com/brand/logo.svg
                 brand_color:
                   type: string
+                  pattern: ^#[0-9a-fA-F]{6}$
               required:
                 - domain
                 - brand_name


### PR DESCRIPTION
## Summary

- Enforce active organization owner/admin authorization for API-key creation, listing, and revocation, with matching dashboard behavior.
- Reject tenant-scoped WorkOS keys from global Addie and working-group administration, closing the path to persistent global-admin escalation.
- Enforce direct membership and group-bound reads for private working-group documents, files, and assets; authorize metadata before serving bytes.
- Validate and render sponsored-chat branding safely across new, resumed, legacy, and discovered-manifest paths, with matching OpenAPI constraints.

## Root cause

Tenant-scoped admin permissions were treated as global on routers without organization parameters. Private document-derived routes did not consistently apply private-group visibility. Sponsored branding values were interpolated into HTML and CSS without one shared, sink-safe validation boundary.

## Validation

- Independent expert gates: `Security gate clean`; `Testing gate clean`; `Ready to push.`
- Repository pre-commit suite: 314 server test files; 4,714 passed; 30 skipped.
- Focused security unit suite: 115 passed.
- Migrated-Postgres privacy integration suite: 12 passed.
- TypeScript, OpenAPI parity/contract, and diff checks passed.

## Operational follow-up

- Audit, revoke, or rotate existing privileged WorkOS API keys issued under the prior policy.
- Purge cached `/api/working-groups/assets/*` responses that may retain the prior public cache headers.

## Scope

The local Codex Security scanner dependency-install changes are intentionally excluded from this PR.
