### PR TITLE
fix: make registry brand resolution evidence explicit

### DIFF
--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -109,7 +109,7 @@ Three endpoints answer different questions about who is in the registry. They sp
 
 ### Brand Resolution
 
-These endpoints resolve domains to brand identities. The `source` field in the response indicates where the data came from:
+These endpoints resolve domains to brand identities. The `source` field identifies the provenance of the selected registry record. When more than one candidate fact exists for a domain, selection is deterministic: `hosted` wins over `brand_json`, then `community`, then `enriched`. Ties among stored rows use the most recently validated record and a stable ID tie-breaker. A normal read prefers that durable stored winner on a source tie; `fresh=true` lets a successful live origin read win a tie, but never override a higher-provenance stored record. Identical normal requests therefore do not randomly change records or labels.
 
 | Source | Meaning |
 |--------|---------|
@@ -118,11 +118,20 @@ These endpoints resolve domains to brand identities. The `source` field in the r
 | `enriched` | Enriched via Brandfetch API |
 | `community` | Submitted by a community member |
 
-All sources produce the same resolution response structure. To get full brand identity data (logos, colors, tone), use `/api/brands/enrich` or look up the brand in the registry.
+All sources produce the same resolution response structure, but they are not equivalent evidence. `hosted` and `brand_json` are backed by domain control; `community` and `enriched` describe what the registry has learned without proving that the domain operator asserted it. `source` is identity provenance, not proof of a house relationship—use `relationship_trust` for that. To get full brand identity data (logos, colors, tone), use `/api/brands/enrich` or look up the brand in the registry.
 
 #### Reading trust
 
 A domain is authoritative for its own identity — TLS proves the document came from that domain and nothing more. Relationships between a brand and a house need both sides to publish them, so resolution reports how each relationship was established rather than flattening it into a single answer.
+
+For third-party verification, call `GET /api/brands/resolve?domain=<leaf-domain>` and inspect `relationship_trust`. Only `mutual` and `inline` are reciprocated relationships suitable for extending trust to `house_domain`:
+
+- `mutual` means the leaf publishes `house_domain` and the house names the leaf in `brand_refs[]`; `relationship_verified_at` reports when the resolver last observed both sides agreeing.
+- `inline` means the house's own canonical document defines the leaf, so the ownership statement and identity come from the house authority itself.
+
+Every other value is non-reciprocated. In particular, `claimed_house_domain` with `leaf_only` is one side's self-assertion and must not authorize the leaf as part of that house. There is no separate ordered-chain endpoint in v3: the hierarchy is one level deep, and the reciprocated `house_domain` edge in this response is the supported ownership-verification result.
+
+An absent `relationship_trust` is not the same as `standalone`: it means the selected record carries no relationship verdict. Consumers must treat missing evidence as unknown, not as evidence that no relationship exists.
 
 | `relationship_trust` | Meaning |
 |---|---|
@@ -137,9 +146,9 @@ A domain is authoritative for its own identity — TLS proves the document came 
 
 Following a redirect never lets a domain adopt a house's identity. When a domain's brand.json points at a house that does not name the domain back — in `properties[]` as `relationship: "owned"`, or in `brand_refs[]` — the response carries the claim (`claimed_house_domain` with `relationship_trust: leaf_only`) and no brand identity. A house that lists a domain with `direct`, `delegated`, or `ad_network` is declaring a monetization path, not ownership, so it does not resolve that domain's identity either. If you expected an identity here, the house is missing its half of the relationship.
 
-`fresh=true` bypasses the resolution cache and refetches from the origin. When that fetch fails and a stored record is returned instead, `live_brand_json` carries the failed fetch's diagnostics so you can tell a stale record from a live one.
+`fresh=true` bypasses the resolution cache and refetches from the origin. When that fetch fails and a stored record is returned instead, `live_brand_json` carries that request's failed-fetch diagnostics so you can distinguish “stored evidence returned” from “origin checked successfully.” Apply your own freshness policy to that fallback rather than silently treating it as live.
 
-Pre-v3 documents are promoted to canonical v3 identity for the response, flagged with `promoted_from_schema` and `migration_warnings`. Promotion covers identity only; legacy relationship data is preserved opaquely and never becomes a trust claim.
+Pre-v3 documents are promoted to canonical v3 identity for the response, flagged with `promoted_from_schema` and `migration_warnings`. Promotion covers identity only; legacy relationship data is preserved opaquely and never becomes a trust claim. In particular, a warning with `field: "house"` means the legacy house object was moved to `legacy_metadata.legacy_house` and did **not** establish `house_domain`. The publisher must add `house_domain` to the leaf document and a reciprocal `brand_refs[]` entry to the house document.
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -396,7 +396,14 @@ export class BrandManager {
     }
 
     const house = this.isRecord(document.house) ? document.house : undefined;
-    if (house) metadata.legacy_house = house;
+    if (house) {
+      metadata.legacy_house = house;
+      warnings.push({
+        field: 'house',
+        message: 'Preserved legacy house object as opaque metadata; it is not treated as a v3 portfolio claim.',
+        suggestion: 'Set house_domain on this Brand Canonical Document pointing at the parent domain. The parent must declare this domain in brand_refs[] for mutual-assertion trust.',
+      });
+    }
 
     const canonical: Record<string, unknown> = {
       ...originBrand,

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -36,6 +36,19 @@ import type {
 const DISALLOWED_MANIFEST_KEYS: ReadonlySet<string> = new Set(['classification', 'brand_context']);
 
 /**
+ * Stable precedence for selecting a registry fact when legacy or partially
+ * migrated databases contain more than one row for a domain. `hosted` is
+ * derived from verified ownership columns rather than stored in source_type.
+ */
+const BRAND_RESOLUTION_SOURCE_PRIORITY_SQL = `CASE
+  WHEN workos_organization_id IS NOT NULL AND domain_verified IS TRUE THEN 1
+  WHEN source_type = 'brand_json' THEN 2
+  WHEN source_type = 'community' THEN 3
+  WHEN source_type = 'enriched' THEN 4
+  ELSE 5
+END`;
+
+/**
  * Strip auth-relevant keys from a caller-supplied brand_manifest. Returns
  * undefined when the input is undefined so caller checks for "provided"
  * still work. Mutates a shallow copy — does not touch the caller's object.
@@ -738,7 +751,14 @@ export class BrandDatabase {
    */
   async getDiscoveredBrandByDomain(domain: string): Promise<DiscoveredBrand | null> {
     const result = await query<DiscoveredBrand>(
-      'SELECT * FROM brands WHERE domain = $1',
+      `SELECT *
+       FROM brands
+       WHERE domain = $1
+       ORDER BY ${BRAND_RESOLUTION_SOURCE_PRIORITY_SQL},
+                last_validated DESC NULLS LAST,
+                discovered_at DESC NULLS LAST,
+                id ASC
+       LIMIT 1`,
       [domain.toLowerCase()]
     );
     return result.rows[0] ? this.deserializeDiscoveredBrand(result.rows[0]) : null;
@@ -753,12 +773,19 @@ export class BrandDatabase {
     const lower = domains.map(d => d.toLowerCase());
     const placeholders = lower.map((_, i) => `$${i + 1}`).join(', ');
     const result = await query<DiscoveredBrand>(
-      `SELECT * FROM brands WHERE domain IN (${placeholders})`,
+      `SELECT DISTINCT ON (domain) *
+       FROM brands
+       WHERE domain IN (${placeholders})
+       ORDER BY domain,
+                ${BRAND_RESOLUTION_SOURCE_PRIORITY_SQL},
+                last_validated DESC NULLS LAST,
+                discovered_at DESC NULLS LAST,
+                id ASC`,
       lower
     );
     const map = new Map<string, DiscoveredBrand>();
     for (const row of result.rows) {
-      map.set(row.domain, this.deserializeDiscoveredBrand(row));
+      map.set(row.domain.toLowerCase(), this.deserializeDiscoveredBrand(row));
     }
     return map;
   }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -582,6 +582,8 @@ registry.registerPath({
     "Resolve a domain to its canonical brand identity. Follows brand.json redirects and returns the resolved brand with its house, architecture type, and optional manifest. The domain must be a bare DNS hostname.",
     "",
     "A domain is authoritative for its own identity, so `source` tells you who published the record and `relationship_trust` tells you whether a brand-to-house relationship was confirmed by both sides. Only `mutual` and `inline` are reciprocated; treat everything else as a claim.",
+    "Record selection is deterministic: `hosted` > `brand_json` > `community` > `enriched`. `source` reports provenance only and must not be used as a substitute for `relationship_trust`.",
+    "The v3 hierarchy is one level deep. There is no ordered-chain endpoint: third-party verifiers use the reciprocated `house_domain` edge returned here. `claimed_house_domain` is unilateral and never extends trust.",
     "",
     "**Rate limit:** 60 requests per minute per IP address.",
   ].join("\n"),
@@ -865,6 +867,55 @@ function resolvedStoredBrandSource(brand: {
   return brand.workos_organization_id && brand.domain_verified === true
     ? 'hosted'
     : brand.source_type;
+}
+
+type ResolvedBrandResponse = z.infer<typeof ResolvedBrandSchema>;
+type StoredBrandResolutionRecord = NonNullable<
+  Awaited<ReturnType<BrandDatabase["getDiscoveredBrandByDomain"]>>
+>;
+
+const RESOLVED_BRAND_SOURCE_PRIORITY: Record<ResolvedBrandResponse["source"], number> = {
+  hosted: 1,
+  brand_json: 2,
+  community: 3,
+  enriched: 4,
+};
+
+function storedBrandResolutionResponse(
+  brand: StoredBrandResolutionRecord,
+  liveValidation?: ReturnType<typeof serializeBrandValidation>,
+): ResolvedBrandResponse {
+  return {
+    canonical_id: brand.canonical_domain || brand.domain,
+    canonical_domain: brand.canonical_domain || brand.domain,
+    brand_name: brand.brand_name || brand.domain,
+    source: resolvedStoredBrandSource(brand),
+    brand_manifest: stripLegacyBrandContext(brand.brand_manifest),
+    ...(liveValidation ? { live_brand_json: liveValidation } : {}),
+  };
+}
+
+/**
+ * Select the actual response candidate, not just its label. Default reads use
+ * the durable stored candidate on a source-priority tie so every pod returns
+ * the same document. `fresh=true` lets a successful live read win a tie, while
+ * a strictly higher-provenance stored record (for example `hosted`) still wins.
+ */
+function selectResolvedBrandResponse(
+  live: ResolvedBrandResponse,
+  stored: StoredBrandResolutionRecord | null,
+  fresh: boolean,
+): ResolvedBrandResponse {
+  // A private or orphaned row is not a public resolution candidate. In
+  // particular, it must never replace a valid live-origin response merely
+  // because its provenance would otherwise rank higher.
+  if (!stored || stored.manifest_orphaned || stored.is_public === false) return live;
+  const storedCandidate = storedBrandResolutionResponse(stored);
+  const storedPriority = RESOLVED_BRAND_SOURCE_PRIORITY[storedCandidate.source];
+  const livePriority = RESOLVED_BRAND_SOURCE_PRIORITY[live.source];
+  return storedPriority < livePriority || (storedPriority === livePriority && !fresh)
+    ? storedCandidate
+    : live;
 }
 
 registry.registerPath({
@@ -4170,10 +4221,10 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
       const resolution = await brandManager.resolveBrandWithDiagnostics(domain, { skipCache: fresh });
       const resolved = resolution.brand;
+      const discovered = await brandDb.getDiscoveredBrandByDomain(domain);
       // Report why this request fell back, from this request's own attempt.
       const liveValidation = fresh && !resolved ? resolution.last_attempt : undefined;
       if (!resolved) {
-        const discovered = await brandDb.getDiscoveredBrandByDomain(domain);
         // Hide orphaned manifests and explicitly non-public rows. The manifest
         // is preserved server-side for adoption-at-claim-time but must not
         // surface on public read paths until the next claim is applied.
@@ -4181,16 +4232,10 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           registryRequestsDb
             .markResolved("brand", domain, discovered.canonical_domain || discovered.domain)
             .catch((err) => logger.debug({ err }, "Registry request tracking failed"));
-          return res.json({
-            canonical_id: discovered.canonical_domain || discovered.domain,
-            canonical_domain: discovered.canonical_domain || discovered.domain,
-            brand_name: discovered.brand_name,
-            source: resolvedStoredBrandSource(discovered),
-            brand_manifest: stripLegacyBrandContext(discovered.brand_manifest),
-            ...(liveValidation ? {
-              live_brand_json: serializeBrandValidation(liveValidation),
-            } : {}),
-          });
+          return res.json(storedBrandResolutionResponse(
+            discovered,
+            liveValidation ? serializeBrandValidation(liveValidation) : undefined,
+          ));
         }
         registryRequestsDb
           .trackRequest("brand", domain)
@@ -4204,10 +4249,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         });
       }
 
+      const selected = selectResolvedBrandResponse(resolved, discovered, fresh);
       registryRequestsDb
-        .markResolved("brand", domain, resolved.canonical_domain)
+        .markResolved("brand", domain, selected.canonical_domain)
         .catch((err) => logger.debug({ err }, "Registry request tracking failed"));
-      return res.json(resolved);
+      return res.json(selected);
     } catch (error) {
       logger.error({ error }, "Failed to resolve brand");
       return res.status(500).json({ error: "Failed to resolve brand" });
@@ -4465,25 +4511,23 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             const resolved = await brandBulkResolveSemaphore.run(
               () => brandManager.resolveBrand(domain),
             );
+            const discovered = await brandDb.getDiscoveredBrandByDomain(domain);
             if (resolved) {
-              registryRequestsDb.markResolved("brand", domain, resolved.canonical_domain).catch((err) => logger.debug({ err }, "Registry request tracking failed"));
-              return { domain, result: resolved };
+              const selected = selectResolvedBrandResponse(resolved, discovered, false);
+              registryRequestsDb.markResolved("brand", domain, selected.canonical_domain).catch((err) => logger.debug({ err }, "Registry request tracking failed"));
+              return {
+                domain,
+                result: selected,
+              };
             }
 
-            const discovered = await brandDb.getDiscoveredBrandByDomain(domain);
             // Hide orphaned manifests and explicitly non-public rows; same
             // rationale as the single-resolve route above.
             if (discovered && !discovered.manifest_orphaned && discovered.is_public !== false) {
               registryRequestsDb.markResolved("brand", domain, discovered.canonical_domain || discovered.domain).catch((err) => logger.debug({ err }, "Registry request tracking failed"));
               return {
                 domain,
-                result: {
-                  canonical_id: discovered.canonical_domain || discovered.domain,
-                  canonical_domain: discovered.canonical_domain || discovered.domain,
-                  brand_name: discovered.brand_name,
-                  source: resolvedStoredBrandSource(discovered),
-                  brand_manifest: stripLegacyBrandContext(discovered.brand_manifest),
-                },
+                result: storedBrandResolutionResponse(discovered),
               };
             }
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -889,6 +889,10 @@ function storedBrandResolutionResponse(
     canonical_id: brand.canonical_domain || brand.domain,
     canonical_domain: brand.canonical_domain || brand.domain,
     brand_name: brand.brand_name || brand.domain,
+    ...(brand.brand_names?.length ? { names: brand.brand_names } : {}),
+    ...(brand.keller_type ? { keller_type: brand.keller_type } : {}),
+    ...(brand.parent_brand ? { parent_brand: brand.parent_brand } : {}),
+    ...(brand.brand_agent_url ? { brand_agent_url: brand.brand_agent_url } : {}),
     source: resolvedStoredBrandSource(brand),
     brand_manifest: stripLegacyBrandContext(brand.brand_manifest),
     ...(liveValidation ? { live_brand_json: liveValidation } : {}),
@@ -913,9 +917,16 @@ function selectResolvedBrandResponse(
   const storedCandidate = storedBrandResolutionResponse(stored);
   const storedPriority = RESOLVED_BRAND_SOURCE_PRIORITY[storedCandidate.source];
   const livePriority = RESOLVED_BRAND_SOURCE_PRIORITY[live.source];
-  return storedPriority < livePriority || (storedPriority === livePriority && !fresh)
-    ? storedCandidate
-    : live;
+  if (storedPriority > livePriority || (storedPriority === livePriority && fresh)) {
+    return live;
+  }
+
+  // Identity provenance and persisted identity fields come from the selected
+  // stored winner. Relationship trust, verification timestamps, and promotion
+  // diagnostics are computed by the live resolver for the requested domain;
+  // retain them instead of collapsing a verified edge to "unknown" merely
+  // because a higher-provenance stored identity exists.
+  return { ...live, ...storedCandidate };
 }
 
 registry.registerPath({

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -513,14 +513,16 @@ export const ResolvedBrandSchema = z
     promoted_from_schema: z.string().optional().openapi({
       description: "Set when a pre-v3 document was promoted to a canonical v3 document for this response. Identity only — legacy relationship data is preserved opaquely, never promoted to a trust claim.",
     }),
-    migration_warnings: z.array(BrandValidationWarningSchema).optional(),
+    migration_warnings: z.array(BrandValidationWarningSchema).optional().openapi({
+      description: "Loss or ambiguity encountered while promoting a pre-v3 document. A `house` warning means the legacy house object was preserved only as opaque metadata and did not establish a trusted relationship.",
+    }),
     brand_agent_url: z.string().optional(),
     brand_manifest: z.record(z.string(), z.unknown()).optional(),
     source: z.enum(["hosted", "brand_json", "community", "enriched"]).openapi({
-      description: "Where the record came from. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment.",
+      description: "Provenance of the selected record, not relationship authorization. Deterministic precedence is `hosted` > `brand_json` > `community` > `enriched`; normal reads prefer the durable stored winner on a source tie, while `fresh=true` lets a successful live origin read win a tie. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment.",
     }),
     live_brand_json: LiveBrandJsonValidationSchema.optional().openapi({
-      description: "Live origin-validation diagnostics when fresh=true falls back to a stored registry record.",
+      description: "This request's origin-validation diagnostics when `fresh=true` falls back to a stored registry record. Presence means the response is stored evidence, not a successful live-origin read.",
     }),
   })
   .openapi("ResolvedBrand");

--- a/server/tests/unit/brand-db-resolution-precedence.test.ts
+++ b/server/tests/unit/brand-db-resolution-precedence.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  getClient: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  query: mocks.query,
+  getClient: mocks.getClient,
+}));
+
+import { BrandDatabase } from '../../src/db/brand-db.js';
+
+function row(domain: string) {
+  return {
+    id: `id-${domain}`,
+    domain,
+    brand_name: domain,
+    brand_names: '[]',
+    brand_manifest: JSON.stringify({ name: domain }),
+    has_brand_manifest: true,
+    source_type: 'community',
+    discovered_at: new Date('2026-01-01T00:00:00Z'),
+  };
+}
+
+describe('BrandDatabase resolution precedence', () => {
+  const db = new BrandDatabase();
+
+  beforeEach(() => {
+    mocks.query.mockReset();
+    mocks.getClient.mockReset();
+  });
+
+  it('selects one domain row by hosted, brand_json, community, enriched precedence', async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [row('leaf.example')] });
+
+    await db.getDiscoveredBrandByDomain('LEAF.EXAMPLE');
+
+    const [sql, params] = mocks.query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('workos_organization_id IS NOT NULL AND domain_verified IS TRUE THEN 1');
+    expect(sql).toContain("source_type = 'brand_json' THEN 2");
+    expect(sql).toContain("source_type = 'community' THEN 3");
+    expect(sql).toContain("source_type = 'enriched' THEN 4");
+    expect(sql).toContain('last_validated DESC NULLS LAST');
+    expect(sql).toContain('id ASC');
+    expect(sql).toContain('LIMIT 1');
+    expect(params).toEqual(['leaf.example']);
+  });
+
+  it('returns only the highest-priority row per domain in batch lookups', async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [row('leaf.example'), row('house.example')] });
+
+    const result = await db.getDiscoveredBrandsByDomains(['LEAF.EXAMPLE', 'house.example']);
+
+    const [sql, params] = mocks.query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('SELECT DISTINCT ON (domain)');
+    expect(sql).toContain('ORDER BY domain');
+    expect(sql).toContain('domain_verified IS TRUE THEN 1');
+    expect(params).toEqual(['leaf.example', 'house.example']);
+    expect([...result.keys()]).toEqual(['leaf.example', 'house.example']);
+  });
+});

--- a/server/tests/unit/brand-manager-cache.test.ts
+++ b/server/tests/unit/brand-manager-cache.test.ts
@@ -310,6 +310,16 @@ describe('BrandManager caching', () => {
       expect(result.raw_data).not.toHaveProperty('house_domain');
       expect((result.raw_data as Record<string, any>).legacy_properties[0].relationship)
         .toBe('registered_account_operator');
+      expect(result.warnings).toContainEqual(expect.objectContaining({
+        field: 'house',
+        suggestion: expect.stringContaining('brand_refs[]'),
+      }));
+
+      const resolved = await manager.resolveBrand('leaf.example');
+      expect(resolved?.migration_warnings).toContainEqual(expect.objectContaining({
+        field: 'house',
+        suggestion: expect.stringContaining('house_domain'),
+      }));
     });
 
     it('rejects ambiguous legacy identity when the origin property is duplicated', async () => {

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -389,6 +389,60 @@ describe('public registry brand read paths', () => {
     expect(liveResponse.body.source).toBe('hosted');
   });
 
+  it('retains live relationship evidence when a hosted stored identity wins', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        ...discoveredBrandWithContext(),
+        canonical_domain: 'stored-acme',
+        brand_name: 'Stored Acme',
+        source_type: 'community',
+        workos_organization_id: 'org_owner',
+        domain_verified: true,
+      }),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+    const live = {
+      canonical_id: 'live-acme',
+      canonical_domain: 'acme.com',
+      brand_name: 'Live Acme',
+      names: [{ en: 'Live Acme' }],
+      keller_type: 'sub_brand' as const,
+      parent_brand: 'parent-acme',
+      house_domain: 'house.example',
+      claimed_house_domain: 'house.example',
+      house_name: 'Example House',
+      relationship_trust: 'mutual' as const,
+      relationship_verified_at: '2026-07-29T12:00:00.000Z',
+      relationship_declared_at: '2026-07-28T12:00:00.000Z',
+      promoted_from_schema: 'https://schemas.adcontextprotocol.org/brand/v1/brand.json',
+      migration_warnings: [{ field: 'house', message: 'Preserved as opaque metadata' }],
+      source: 'brand_json' as const,
+    };
+
+    const res = await request(buildApp(brandDb, false, {
+      resolveBrandWithDiagnostics: vi.fn().mockResolvedValue({ brand: live }),
+    })).get('/api/brands/resolve?domain=acme.com&fresh=true');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      canonical_id: 'stored-acme',
+      canonical_domain: 'stored-acme',
+      brand_name: 'Stored Acme',
+      source: 'hosted',
+      names: live.names,
+      keller_type: live.keller_type,
+      parent_brand: live.parent_brand,
+      house_domain: live.house_domain,
+      claimed_house_domain: live.claimed_house_domain,
+      house_name: live.house_name,
+      relationship_trust: live.relationship_trust,
+      relationship_verified_at: live.relationship_verified_at,
+      relationship_declared_at: live.relationship_declared_at,
+      promoted_from_schema: live.promoted_from_schema,
+      migration_warnings: live.migration_warnings,
+    });
+  });
+
   it('lets a live brand_json record outrank stored enrichment', async () => {
     const brandDb = {
       getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(discoveredBrandWithContext()),

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -357,6 +357,94 @@ describe('public registry brand read paths', () => {
     expect(res.body.source).toBe('community');
   });
 
+  it('keeps identical live and stored records on the same provenance label', async () => {
+    const stored = {
+      ...discoveredBrandWithContext(),
+      source_type: 'community' as const,
+      workos_organization_id: 'org_owner',
+      domain_verified: true,
+    };
+    const live = {
+      canonical_id: 'acme.com',
+      canonical_domain: 'acme.com',
+      brand_name: 'Acme',
+      source: 'brand_json' as const,
+      brand_manifest: { name: 'Acme', url: 'https://acme.com' },
+    };
+    const resolveBrandWithDiagnostics = vi.fn()
+      .mockResolvedValueOnce({ brand: live })
+      .mockResolvedValueOnce({ brand: null });
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(stored),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+    const app = buildApp(brandDb, false, { resolveBrandWithDiagnostics });
+
+    const liveResponse = await request(app).get('/api/brands/resolve?domain=acme.com');
+    const storedResponse = await request(app).get('/api/brands/resolve?domain=acme.com');
+
+    expect(liveResponse.status).toBe(200);
+    expect(storedResponse.status).toBe(200);
+    expect(liveResponse.body).toEqual(storedResponse.body);
+    expect(liveResponse.body.source).toBe('hosted');
+  });
+
+  it('lets a live brand_json record outrank stored enrichment', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(discoveredBrandWithContext()),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+    const live = {
+      canonical_id: 'acme-live',
+      canonical_domain: 'acme.com',
+      brand_name: 'Acme Live',
+      source: 'brand_json' as const,
+      promoted_from_schema: 'https://schemas.adcontextprotocol.org/brand/v1/brand.json',
+      migration_warnings: [{ field: 'house', message: 'Not promoted' }],
+    };
+
+    const res = await request(buildApp(brandDb, false, {
+      resolveBrandWithDiagnostics: vi.fn().mockResolvedValue({ brand: live }),
+    })).get('/api/brands/resolve?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      canonical_id: 'acme-live',
+      source: 'brand_json',
+      promoted_from_schema: live.promoted_from_schema,
+      migration_warnings: live.migration_warnings,
+    });
+  });
+
+  it.each([
+    { is_public: false, manifest_orphaned: false },
+    { is_public: true, manifest_orphaned: true },
+  ])('never lets a non-public stored record override a live record (%o)', async (visibility) => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        ...discoveredBrandWithContext(),
+        ...visibility,
+        source_type: 'community',
+        workos_organization_id: 'org_owner',
+        domain_verified: true,
+      }),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+    const live = {
+      canonical_id: 'acme-live',
+      canonical_domain: 'acme.com',
+      brand_name: 'Acme Live',
+      source: 'brand_json' as const,
+    };
+
+    const res = await request(buildApp(brandDb, false, {
+      resolveBrandWithDiagnostics: vi.fn().mockResolvedValue({ brand: live }),
+    })).get('/api/brands/resolve?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(live);
+  });
+
   it('rejects path and port lookup inputs before brand resolution', async () => {
     const resolveBrand = vi.fn().mockResolvedValue(null);
     const brandDb = {

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -131,6 +131,7 @@ components:
             required:
               - field
               - message
+          description: Loss or ambiguity encountered while promoting a pre-v3 document. A `house` warning means the legacy house object was preserved only as opaque metadata and did not establish a trusted relationship.
         brand_agent_url:
           type: string
         brand_manifest:
@@ -143,7 +144,7 @@ components:
             - brand_json
             - community
             - enriched
-          description: "Where the record came from. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment."
+          description: "Provenance of the selected record, not relationship authorization. Deterministic precedence is `hosted` > `brand_json` > `community` > `enriched`; normal reads prefer the durable stored winner on a source tie, while `fresh=true` lets a successful live origin read win a tie. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment."
         live_brand_json:
           type: object
           properties:
@@ -189,7 +190,7 @@ components:
             - url
             - errors
             - warnings
-          description: Live origin-validation diagnostics when fresh=true falls back to a stored registry record.
+          description: This request's origin-validation diagnostics when `fresh=true` falls back to a stored registry record. Presence means the response is stored evidence, not a successful live-origin read.
       required:
         - canonical_id
         - canonical_domain
@@ -4683,6 +4684,8 @@ paths:
         Resolve a domain to its canonical brand identity. Follows brand.json redirects and returns the resolved brand with its house, architecture type, and optional manifest. The domain must be a bare DNS hostname.
 
         A domain is authoritative for its own identity, so `source` tells you who published the record and `relationship_trust` tells you whether a brand-to-house relationship was confirmed by both sides. Only `mutual` and `inline` are reciprocated; treat everything else as a claim.
+        Record selection is deterministic: `hosted` > `brand_json` > `community` > `enriched`. `source` reports provenance only and must not be used as a substitute for `relationship_trust`.
+        The v3 hierarchy is one level deep. There is no ordered-chain endpoint: third-party verifiers use the reciprocated `house_domain` edge returned here. `claimed_house_domain` is unilateral and never extends trust.
 
         **Rate limit:** 60 requests per minute per IP address.
       tags:


### PR DESCRIPTION
## Summary

- make brand resolution select the actual response candidate deterministically using `hosted > brand_json > community > enriched`
- keep private and orphaned stored records out of public resolution, and make single and bulk resolution use the same selection seam
- preserve failed live-origin diagnostics separately from stored fallback evidence
- emit an explicit migration warning when a legacy `house` object is preserved opaquely rather than promoted to a v3 relationship
- document the supported third-party verification contract: only `relationship_trust: mutual | inline` extends trust to `house_domain`
- clarify that v3 deliberately has no ordered hierarchy-chain endpoint and that missing relationship evidence means unknown, not standalone

## Root cause

The registry had multiple resolution paths that could answer the same domain from live `brand.json` data or a stored registry row without a shared precedence rule. That made both the selected document and its `source` label depend on which path succeeded. Separately, legacy promotion preserved `house` data but did not report that it had declined to create a relationship edge.

Git history confirms the public hierarchy endpoints were deliberately retired during the v3 transition rather than accidentally omitted. The supported public contract is the one-level relationship returned by `/api/brands/resolve`; the SDK correction is tracked in adcontextprotocol/adcp-client#2415.

## Consumer impact

Consumers can now tell what the registry actually knows:

- `source` is deterministic identity provenance, not relationship authorization
- `relationship_trust: mutual | inline` is reciprocated evidence
- `claimed_house_domain` and `leaf_only` remain unilateral claims
- absent `relationship_trust` means no verdict is present
- `live_brand_json` means a requested fresh origin check failed and stored evidence was returned
- a `migration_warnings` entry for `house` means no portfolio edge was established during legacy promotion

Closes #6082.
Closes #6083.
Closes #6084.

## Validation

- generated `static/openapi/registry.yaml`
- focused registry contract suite: 89 passing
- repository unit phase from the commit hook: 1,025 passing
- TypeScript typecheck passed
- docs navigation: 21 passing
- diff and generated-file checks passed

The broader server-unit hook could not complete in this checkout because the installed `@contentauth/c2pa-node` native binary is not a valid macOS binary; unrelated C2PA tests failed and the hook timed out. The pre-push Mintlify step also loses the pinned npm 10 executable when it temporarily moves `.context` and then rejects global npm 11. CI remains authoritative for those checks.
