### PR TITLE
feat(media-buy): add identifier-based place targeting

### DIFF
--- a/.changeset/geo-place-targeting.md
+++ b/.changeset/geo-place-targeting.md
@@ -1,0 +1,16 @@
+---
+"adcontextprotocol": minor
+---
+
+Add identifier-based named-place geographic targeting:
+
+- `targeting_overlay.geo_places` and `geo_places_exclude` carry stable identifiers with country, system, place type, optional catalog version, and diagnostic labels.
+- `get_adcp_capabilities` declares exact country/type pairs, accepted catalog versions, and a standard resolver for every collision-safe identifier system.
+- `get_products.targeting_overlay` carries known place IDs so configured products, pricing, and forecasts reflect them; `required_overlay_support` and Product `overlay_support` declare collision-safe permission for place values selected later.
+- Package status MUST echo persisted place overlays with the applied catalog version through the existing `targeting_overlay` contract.
+- Resolver responses echo their normalized query, carry machine-verifiable disambiguation and lifecycle metadata, and support existing-ID refresh after catalog rollover.
+- `PLACE_TARGET_UNAVAILABLE` provides a nonfatal, correctable read-path signal when a pinned target can no longer execute without silently changing geography.
+- Create-time place overlays use deterministic `UNSUPPORTED_FEATURE`, `INVALID_REQUEST`, and `PRODUCT_UNAVAILABLE` dispositions while preserving the configured product's binding pricing contract.
+- Place forecast and delivery breakdowns remain deferred; package echo is the interim configuration-audit path.
+
+Refs #5588.

--- a/docs/media-buy/advanced-topics/targeting.mdx
+++ b/docs/media-buy/advanced-topics/targeting.mdx
@@ -436,7 +436,11 @@ forecasting; otherwise confirmation remains a best practice.
 `required_overlay_support` asks whether a product lets the buyer choose a
 dimension later. For example, requesting `geo_metros` support asks for products
 that can be narrowed by metro on packages; it does not ask the seller to return
-one product per metro. The product answers with `overlay_support`.
+one product per metro. Named places follow the same rule: known IDs belong in
+`targeting_overlay.geo_places`, while a buyer that will choose them later asks
+for `required_overlay_support.geo_places`. The product answers with binding
+selectable permission in `overlay_support`; that permission is not a
+value-specific availability guarantee.
 
 Support guarantees selectability subject to disclosed limits, not inventory or
 a forecast for every possible value. A forecast returned without concrete metro
@@ -490,12 +494,14 @@ Use geo fields **only** for:
 - `geo_regions`: ISO 3166-2 subdivision codes (e.g., `["US-CA", "GB-SCT"]`)
 - `geo_metros`: Structured metro areas with explicit system (e.g., `nielsen_dma`, `uk_itl2`) — not all publishers support metro-level targeting
 - `geo_postal_areas`: Structured postal areas with explicit country and system (e.g., `US` / `zip`, `GB` / `outward`, `ZA` / `postal_code`) — not all publishers support postal-level targeting
+- `geo_places`: Catalog-backed named places with explicit country, identifier system, place type, and stable IDs — use this for platform place entities such as cities or municipalities, not raw place names
 
 **Exclusion fields** (exclude these locations from delivery):
 - `geo_countries_exclude`: Same format as `geo_countries`
 - `geo_regions_exclude`: Same format as `geo_regions`
 - `geo_metros_exclude`: Same format as `geo_metros`
 - `geo_postal_areas_exclude`: Same format as `geo_postal_areas`
+- `geo_places_exclude`: Same format as `geo_places`
 
 **Note**: Inclusion and exclusion can be combined. Metro and postal targeting require specifying the classification system, enabling international support. Not all geographic granularities are supported by all publishers. Country and region are most widely supported.
 
@@ -775,6 +781,53 @@ Geographic targeting supports both inclusion (restrict to) and exclusion (exclud
 - **Example**: `[{ "country": "US", "system": "zip", "values": ["90210"] }]`
 - **Use cases**: RCT holdout zip codes, restricted delivery areas
 - **Note**: Seller must declare supported systems in `get_adcp_capabilities`; the deprecated legacy form remains accepted during the 3.x migration.
+
+### geo_places
+
+- **Description**: Restrict delivery to named administrative or local places represented by stable catalog identifiers
+- **Format**: Array of objects with required `country`, `system`, `place_type`, and `values`; optional `system_version`, `value_labels`, and `ext`
+- **Systems**: Registered namespaces are `geonames`, `google_ads`, and `microsoft_ads`. Other catalogs use an owner-controlled absolute HTTPS URI, such as `https://seller.example/geo/catalogs/places`. MaxMind `geoname_id` values use the `geonames` namespace; MaxMind is a catalog source/version, not a separate identifier namespace.
+- **Example**: `[{ "country": "NL", "system": "geonames", "system_version": "2026-05", "place_type": "city", "values": ["2759794"], "value_labels": { "2759794": "Amsterdam, North Holland, Netherlands" } }]`
+- **Use cases**: Target a platform's named city, municipality, borough, neighborhood, post town, city region, or county entity without relying on ambiguous names
+- **Note**: `values` are the authoritative targeting keys. Every `value_labels` key MUST appear in `values`; labels exist only for diagnostics and audit readability, and sellers MUST NOT resolve or apply targeting from them. Raw names such as `Amsterdam` are unresolved intent, not valid values.
+
+Within `geo_places`, values and entries have union semantics: delivery may occur in any included place. `geo_places_exclude` subtracts matching places from the current candidate geography, including when no `geo_places` inclusion is present. Inclusion across different geographic dimensions is intersected. Sellers MUST reject the same `(country, system, place_type, value)` in both include and exclude lists, even when the include and exclude entries specify different catalog versions: version is not part of stable place identity. Sellers MAY reject cross-level combinations they cannot resolve safely rather than silently approximating them.
+
+Before sending a place target, buyers inspect `get_adcp_capabilities.media_buy.execution.targeting.geo_places`. Support is declared as exact country/type pairs, not independent lists. Each system also declares `catalog.current_version`, exact `supported_versions`, and an `adcp_geo_place_resolver_v1` endpoint. Buyers resolve raw names—or refresh an existing ID—using an HTTPS GET with exactly one of `q` or `value` from `get-geo-place-resolution-request.json`. The response echoes the normalized request and follows `get-geo-place-resolution-response.json`, carrying machine-readable country/subdivision/type context plus active, removal-planned, or deprecated identifiers and replacements. Ambiguous results require user or agent disambiguation before trafficking.
+
+If `system_version` is omitted from a new target, the seller applies its declared `current_version`. Sellers MUST reject unsupported systems, country/type pairs, versions, deprecated identifiers, and unknown identifiers rather than silently dropping or reinterpreting them. If an identifier is stale, the seller returns a validation error and may surface resolver-provided replacements; it MUST NOT silently substitute a replacement. Sellers MUST echo persisted `geo_places` and `geo_places_exclude` in package `targeting_overlay` state with the exact applied `system_version` and values.
+
+Accepted place targeting is pinned to the echoed `system_version` for the life of the package. Removing that version from `supported_versions` stops new targeting and target-changing updates from using it, but MUST NOT silently mutate, drop, or invalidate an existing package. An unrelated package update preserves the pinned place overlay. If a seller can no longer execute a pinned target, `get_media_buys` MUST still echo it and return a nonfatal `errors[]` entry with `code: "PLACE_TARGET_UNAVAILABLE"`, `recovery: "correctable"`, `field` pointing to the exact `media_buys[N].packages[M].targeting_overlay.geo_places[_exclude][A].values[V]` response path, and `details` containing `media_buy_id`, `package_id`, `system`, `system_version`, `country`, `place_type`, and `value`. The buyer can use resolver `value` lookup against the current catalog to find lifecycle status and proposed replacements, then submit an intentional target update.
+
+Place forecast and delivery breakdown rows are intentionally not part of this release: `geo_level: "place"` remains invalid on reporting surfaces. Package-state echo provides configuration auditability, but not delivery-by-place verification. Place-level forecast, delivery, pacing, and reconciliation require a follow-up reporting RFC.
+
+Known place IDs belong in `get_products.targeting_overlay.geo_places`, so every
+returned product, price, and aggregate forecast reflects that effective
+targeting even though a place-level breakdown is unavailable. If IDs will be
+chosen on packages later, the buyer requests `required_overlay_support.geo_places`
+(and independently `geo_places_exclude`) with the required system,
+country/type pairs, and optional catalog versions. Returned Product
+`overlay_support` is binding selectable permission, not a value-specific
+inventory, price, or forecast guarantee. At create, the seller applies this
+deterministic disposition matrix to the actual place overlay:
+
+| Condition | Result |
+|---|---|
+| The dimension, identifier system, country, place type, or combination is outside the selected Product `overlay_support` | `UNSUPPORTED_FEATURE` |
+| The tuple is supported, but an ID is invalid, unknown, or deprecated, or an explicit `system_version` is not supported | `INVALID_REQUEST`, with `error.field` identifying the offending field |
+| The identifiers are valid and supported, but their effective intersection has no current inventory | `PRODUCT_UNAVAILABLE`; rediscover with the concrete values or choose another product, without silent substitution or repricing |
+
+An accepted create confirms that the returned terms apply to the complete
+effective targeting. `PLACE_TARGET_UNAVAILABLE` is reserved for later
+degradation of a previously accepted, persisted place target; it is not a
+create-time substitute for any result above.
+
+### geo_places_exclude
+
+- **Description**: Exclude catalog-backed named places
+- **Format**: Same as `geo_places`
+- **Example**: `[{ "country": "US", "system": "geonames", "place_type": "city", "values": ["5392171"], "value_labels": { "5392171": "San Jose, California, United States" } }]`
+- **Note**: Seller must declare the system, exact country/type pair, and applied catalog version in `get_adcp_capabilities` and echo the persisted exclusion on package state.
 
 ### axe_include_segment
 - **Description**: Segment ID for inclusion targeting (legacy AXE field)
@@ -1197,7 +1250,7 @@ To remove all keyword targeting while preserving other overlay fields, send the 
 
 ### Publishers MUST:
 
-1. **Support Geographic Targeting**: Handle geographic inclusion and exclusion parameters (`geo_countries`, `geo_countries_exclude`, `geo_regions`, `geo_regions_exclude`, `geo_metros`, `geo_metros_exclude`, `geo_postal_areas`, `geo_postal_areas_exclude`) to the extent your platform supports them. Declare supported metro and postal systems in `get_adcp_capabilities`
+1. **Support Geographic Targeting**: Handle geographic inclusion and exclusion parameters (`geo_countries`, `geo_countries_exclude`, `geo_regions`, `geo_regions_exclude`, `geo_metros`, `geo_metros_exclude`, `geo_postal_areas`, `geo_postal_areas_exclude`, `geo_places`, `geo_places_exclude`) to the extent your platform supports them. Declare supported metro, postal, and place systems in `get_adcp_capabilities`
 2. **Interpret Briefs**: Use briefs to determine appropriate audience and content targeting
 3. **Validate Targeting**: Reject media buys with targeting that cannot be supported
 4. **Document Limitations**: Clearly communicate any geographic targeting limitations in product descriptions

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -199,6 +199,16 @@ An unexpired `committed` proposal carries an inventory hold and cannot be reject
 | `start_time` | string | No | ISO 8601 date-time for this package's flight start. When omitted, inherits the media buy's `start_time`. Must fall within the media buy's date range. Does not support `"asap"`. |
 | `end_time` | string | No | ISO 8601 date-time for this package's flight end. When omitted, inherits the media buy's `end_time`. Must fall within the media buy's date range. |
 | `creative_assignments` | CreativeAssignment[] | No | Assign existing library creatives with optional weights and placement targeting |
+
+For `targeting_overlay.geo_places` and `geo_places_exclude`, create-time values
+must be within the selected Product's corresponding `overlay_support` tuple.
+Unsupported dimensions, systems, countries, place types, or combinations return
+`UNSUPPORTED_FEATURE`. A supported tuple with an invalid, unknown, or deprecated
+ID—or an unsupported explicit catalog version—returns [`INVALID_REQUEST`](/docs/building/verification/compliance-catalog#error-code-invalid-request) with
+`error.field` on the offending field. A supported selection with no current
+inventory returns `PRODUCT_UNAVAILABLE`, without silent substitution or
+repricing. An accepted create confirms the selected terms for the complete
+effective targeting.
 | `creatives` | CreativeAsset[] | No | Upload new creative assets inline and assign. Requires `media_buy.features.inline_creative_management: true`; when the seller also advertises `creative.has_creative_library: true`, `creative_id` must not already exist in the library. |
 | `context` | object | No | Opaque correlation data echoed unchanged in the package response, webhooks, and read surfaces. Use to map seller-assigned `package_id` back to your internal line items, campaign structure, or tracking state. Buyers targeting mixed seller populations SHOULD include a per-package correlation value here, commonly `context.buyer_ref`, for legacy sellers that do not echo `product_id`. |
 | `measurement_terms` | [MeasurementTerms](/docs/media-buy/advanced-topics/pricing-models#measurement-terms-and-performance-standards) | No | Buyer's proposed billing measurement and makegood terms. Overrides product defaults. Seller accepts (echoed on confirmed package), rejects with [`TERMS_REJECTED`](/docs/building/verification/compliance-catalog#error-code-terms-rejected), or adjusts. When omitted, product's `measurement_terms` apply. |

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -254,8 +254,11 @@ The buyer request contains dimensions and required systems, never seller maxima.
 A requirement value of `true` matches product support `true` or any valid
 support object. An object requirement matches support `true` or a support object
 where every requested boolean is true and every requested array is a subset of
-the corresponding product array. Unrequested object fields and numeric seller
-limits do not participate. Missing or unknown requirements do not match.
+the corresponding product array. For `geo_places` and `geo_places_exclude`,
+every requested identifier system and country key must exist, and requested
+place-type and catalog-version arrays must be subsets of the corresponding
+product support arrays. Unrequested object fields and numeric seller limits do
+not participate. Missing or unknown requirements do not match.
 
 Support guarantees the ability to select a value subject to disclosed limits;
 it does not guarantee inventory or forecast every possible value. Forecasts
@@ -378,6 +381,50 @@ Seller behavior is normative:
 - Buyers inspect `media_buy.audience_evidence` capabilities first. Sellers MUST NOT silently ignore unsupported hard requirement or presence modes; they return a structured unsupported/invalid-request error. A preferred mode the seller does not support may be omitted by the buyer or explicitly rejected by the seller, but is never misrepresented as applied.
 
 Audience evidence does not populate `targeting_overlay`, `demographic_targeting`, or an age-verification field. If the buyer also needs exact execution, it requests that independently through the corresponding product and package targeting surfaces.
+
+Known place IDs belong in `targeting_overlay`, so the returned product's
+availability, pricing, and forecast are scoped to the effective place
+constraint. If the buyer will choose IDs later, `required_overlay_support`
+asks for the country, identifier system, place type, and optional catalog
+version that the product must let the buyer select:
+
+```json
+{
+  "$schema": "/schemas/media-buy/get-products-request.json",
+  "buying_mode": "brief",
+  "brief": "Local video inventory for a municipal services campaign",
+  "targeting_overlay": {
+    "geo_places": [{
+      "country": "NL",
+      "system": "geonames",
+      "system_version": "2026-05",
+      "place_type": "city",
+      "values": ["2759794"]
+    }]
+  },
+  "required_overlay_support": {
+    "geo_places": {
+      "systems": {
+        "geonames": {
+          "countries": { "NL": ["city"] },
+          "system_versions": ["2026-05"]
+        }
+      }
+    }
+  }
+}
+```
+
+The returned Product `overlay_support.geo_places` is binding permission to
+supply matching place IDs on packages later, subject to disclosed limits. It
+does not guarantee value-specific inventory or preserve an earlier forecast
+before the IDs are provided. Fixed prices and floors retain their binding
+semantics for every value within declared support; price guidance remains
+non-binding. If the eventual values have no current inventory, create returns
+[`PRODUCT_UNAVAILABLE`](/docs/building/verification/compliance-catalog#error-code-product-unavailable)
+without silent substitution or repricing. Inclusion and exclusion permission
+are independent; request `geo_places_exclude` separately when exclusions will
+be chosen later.
 
 ### Placement fields
 

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -592,6 +592,7 @@ Buyers discover AXE support via `get_adcp_capabilities` and filter products to A
 | `geo_regions` | boolean | Region/state-level targeting using ISO 3166-2 codes (e.g., `US-NY`, `GB-SCT`) |
 | `geo_metros` | object | Metro area targeting with system-specific support |
 | `geo_postal_areas` | object | Postal area targeting with country and precision support |
+| `geo_places` | object | Named-place targeting keyed by collision-safe identifier system, with exact country/type support, catalog versions, and resolver metadata |
 | `age_restriction` | object | Age restriction capabilities with `supported` flag and `verification_methods` |
 | `demographics` | object | Seller-wide discovery rollup for canonical demographic targeting. `supported: true` means at least one product supports the surface; inspect each product's `demographic_targeting` declaration for exact execution. |
 | `language` | boolean | Language targeting (ISO 639-1 codes) |
@@ -641,6 +642,94 @@ Sellers that support a geographic targeting level SHOULD support both inclusion 
 
 Use `postal_code` for the normal postal code string in countries without a more specific registered local system. During the 3.x migration, sellers SHOULD emit equivalent deprecated aliases such as `us_zip` alongside native country keys where an alias exists. Buyers and SDKs SHOULD normalize both shapes before making capability decisions.
 
+**geo_places** is keyed by place identifier system. Registered keys are `geonames`, `google_ads`, and `microsoft_ads`; private or additional catalogs use an owner-controlled absolute HTTPS URI. Each system declares exact country-to-place-type support, exact accepted versions, and a machine-readable resolver:
+
+```json
+{
+  "geonames": {
+    "countries": {
+      "US": ["city", "county"],
+      "NL": ["city", "municipality"],
+      "GB": ["city", "post_town"]
+    },
+    "catalog": {
+      "source": "https://seller.example/data-sources/geonames-mirror",
+      "current_version": "2026-05",
+      "supported_versions": ["2026-05", "2026-04"],
+      "resolver": {
+        "url": "https://seller.example/adcp/geo/resolve/geonames",
+        "auth": "seller_credentials",
+        "protocol": "adcp_geo_place_resolver_v1"
+      }
+    }
+  },
+  "https://seller.example/geo/catalogs/places": {
+    "countries": {
+      "NL": ["city"]
+    },
+    "catalog": {
+      "current_version": "2026-q2",
+      "supported_versions": ["2026-q2"],
+      "resolver": {
+        "url": "https://seller.example/adcp/geo/resolve/private",
+        "auth": "seller_credentials",
+        "protocol": "adcp_geo_place_resolver_v1"
+      }
+    }
+  }
+}
+```
+
+If `geo_places` is absent, buyers MUST NOT assume place targeting is available. If present, the seller MUST honor only the explicitly declared country/type pairs and exact `supported_versions`, or return a validation error. `current_version` MUST appear in `supported_versions` and is applied when the buyer omits `system_version` on new targeting. `supported_versions` describes versions accepted for new targets and target-changing updates; removing a version MUST NOT silently mutate, drop, or invalidate existing packages already pinned to that version. Optional `source` identifies a dataset or derivative without creating a new ID namespace—for example, a MaxMind-derived catalog still uses `system: "geonames"`. The resolver accepts an HTTPS GET with `get-geo-place-resolution-request.json` query fields and returns `get-geo-place-resolution-response.json`, including lifecycle status and replacement IDs. Unsupported or deprecated identifiers must be rejected rather than silently ignored or replaced. Display labels are never authoritative targeting keys.
+
+Registered system semantics are exact:
+
+| System | Authoritative `values` namespace | Type mapping |
+|---|---|---|
+| `geonames` | GeoNames `geonameId` integers encoded as strings. MaxMind `geoname_id` uses this same namespace. | The resolver maps GeoNames feature class/code into the registered AdCP type. Populated-place targets such as `PPL`, `PPLA`, `PPLC`, and `PPLG` map to `city`; administrative features map according to their official country-specific meaning. |
+| `google_ads` | Google Ads geo target Criterion IDs encoded as strings | Lowercase snake-case mapping of Google target types to the registered AdCP type when one exists; otherwise use an owner-controlled HTTPS type URI. |
+| `microsoft_ads` | Microsoft Advertising Location IDs encoded as strings | Lowercase snake-case mapping of Microsoft location types to the registered AdCP type when one exists; otherwise use an owner-controlled HTTPS type URI. |
+
+Registered place types are semantic classes, not a universal hierarchy. `city`, `municipality`, and `post_town` are distinct; likewise `borough`, `neighborhood`, `quarter`, and `ward` are not interchangeable. The resolver's country-specific mapping is authoritative for the system/version it serves. Sellers MUST NOT claim a country/type pair unless their resolver returns that type and their execution platform can honor it.
+
+Resolver calls use HTTPS GET. Supply exactly one of `q` for name search or `value` to refresh an existing identifier against a catalog version. For example:
+
+```text
+GET https://seller.example/adcp/geo/resolve/geonames?q=Springfield&country=US&subdivision=US-IL&place_type=city&system_version=2026-05&limit=20
+```
+
+`auth: "seller_credentials"` means the buyer uses the same authorization credentials as the seller's AdCP endpoint and is valid only when the resolver has the same origin as that endpoint. Buyers MUST NOT forward seller credentials cross-origin and MUST apply normal SSRF protections to resolver requests. `auth: "none"` declares a public resolver. A URI-valued `system` is an opaque namespace identifier and is not automatically fetched. Results identify the exact system version and lifecycle state:
+
+```json
+{
+  "request": {
+    "q": "Springfield",
+    "country": "US",
+    "subdivision": "US-IL",
+    "place_type": "city",
+    "system_version": "2026-05",
+    "limit": 20
+  },
+  "system": "geonames",
+  "system_version": "2026-05",
+  "matches": [{
+    "value": "4250542",
+    "country": "US",
+    "subdivision": "US-IL",
+    "place_type": "city",
+    "label": "Springfield",
+    "canonical_name": "Springfield, Illinois, United States",
+    "parent_labels": ["Illinois", "United States"],
+    "status": "active"
+  }]
+}
+```
+
+The response `system` MUST equal the capability-map key that advertised the resolver. Its version MUST equal the requested `system_version`, or the advertised `current_version` when omitted. The response echoes the normalized request, and every match MUST equal its `country` and any requested `subdivision` and `place_type`. `canonical_name` and `parent_labels` are required so same-named results remain distinguishable; `subdivision` is also required on a match when the request constrained it. Registered numeric systems reject non-numeric values and replacement IDs.
+
+Successful searches, including zero matches, return `200` with `Content-Type: application/json` and the response schema above. Invalid queries return `400`; missing or invalid credentials return `401` or `403`; throttling returns `429`; and resolver failures return an appropriate `5xx`. Non-`200` responses MUST NOT be interpreted as an empty result set. Pagination repeats the normalized original request and uses `cursor`/`next_cursor`.
+
+Buyers MUST traffic only an unambiguous `active` result. `removal_planned` results may still describe an existing target but should not be used for a new buy. `deprecated` results are invalid for new targeting; `replaced_by_values` may guide a new resolution, but sellers MUST require the buyer to submit the replacement rather than silently changing intent. To refresh a persisted ID after catalog rollover, query `value=<existing ID>` against the current version. Existing packages remain pinned to their echoed applied version until the buyer intentionally changes targeting; unrelated updates preserve that overlay. If the seller can no longer execute it, `get_media_buys` MUST preserve the echoed target and return nonfatal [`PLACE_TARGET_UNAVAILABLE`](/docs/building/verification/compliance-catalog#error-code-place-target-unavailable) in response-level `errors[]`, with `recovery: "correctable"`, an exact package-target `field` path, and target identity in `details`, rather than silently changing geography.
 #### rights_attestations
 
 Declares how this seller evaluates portable rights-grant credentials carried in creative `rights[]`. Presence requires `adcp.attestations`, and its `accepted_claim_types` MUST include `https://adcontextprotocol.org/claims/rights/grant`.
@@ -1446,6 +1535,39 @@ const buy = await client.createMediaBuy({
           "GB": ["outward", "full"],
           "CA": ["fsa", "full"],
           "ZA": ["postal_code"]
+        },
+        "geo_places": {
+          "geonames": {
+            "countries": {
+              "US": ["city", "county"],
+              "NL": ["city", "municipality"],
+              "GB": ["city", "post_town"]
+            },
+            "catalog": {
+              "source": "https://seller.example/data-sources/geonames-mirror",
+              "current_version": "2026-05",
+              "supported_versions": ["2026-05", "2026-04"],
+              "resolver": {
+                "url": "https://seller.example/adcp/geo/resolve/geonames",
+                "auth": "seller_credentials",
+                "protocol": "adcp_geo_place_resolver_v1"
+              }
+            }
+          },
+          "https://seller.example/geo/catalogs/places": {
+            "countries": {
+              "NL": ["city"]
+            },
+            "catalog": {
+              "current_version": "2026-q2",
+              "supported_versions": ["2026-q2"],
+              "resolver": {
+                "url": "https://seller.example/adcp/geo/resolve/private",
+                "auth": "seller_credentials",
+                "protocol": "adcp_geo_place_resolver_v1"
+              }
+            }
+          }
         },
         "language": true,
         "keyword_targets": {

--- a/docs/snippets/compliance-error-codes.mdx
+++ b/docs/snippets/compliance-error-codes.mdx
@@ -77,6 +77,7 @@ description: "Canonical AdCP error codes with recovery classifications, remediat
 | `PERMISSION_DENIED` | correctable | call check_governance to mint a valid token, or contact the seller to resolve the underlying permission; when error.details.scope is 'agent' with reason 'sandbox_only' the rejection is terminal-pending-onboarding — surface to a human rather than auto-retrying. For suspended/blocked agent relationships, sellers emit AGENT_SUSPENDED / AGENT_BLOCKED instead (those codes carry recovery: terminal directly). |
 | `PIXEL_TRACKER_LOSSY_DOWNGRADE` | correctable | advisory — emitted alongside the v1 downgrade emission: SDK collapsed a pixel_tracker asset to v1 <code>{"{asset_type: url, url_type: tracker_pixel}"}</code> for a seller that doesn't support pixel_tracker natively. The URL still fires; what's lost is in <code>{"error.details.lost_fields"}</code> (event variant, method:js execution context, or custom event timing). Buyer decision: accept the loss (most counter pixels survive), or fail the buy and route to a 3.1-capable seller. Non-fatal — do not auto-retry |
 | `PIXEL_TRACKER_UPGRADE_INFERRED` | correctable | advisory — emitted when a 3.1 SDK upgrades a v1 url+tracker_pixel asset to pixel_tracker by inferring event and method from asset_id conventions. The inference may not match the buyer's original intent; check <code>{"error.details.inferred_event"}</code> / <code>{"inferred_method"}</code> and re-prompt the seller for explicit values if precise measurement matters. Non-fatal — do not auto-retry |
+| `PLACE_TARGET_UNAVAILABLE` | correctable | resolve the pinned value against the current catalog, review any replacement, and submit an intentional package targeting update |
 | `PLAN_NOT_FOUND` | correctable | verify plan_id via sync_plans, or register the plan first |
 | `POLICY_VIOLATION` | correctable | review policy requirements in the error details |
 | `PRIVATE_FIELD_IN_PUBLIC_PLACEMENT` | correctable | seller-side fix needed: remove private operational fields (<code>{"visibility"}</code>, <code>{"source"}</code>, <code>{"origin"}</code>, <code>{"delivery_mappings"}</code>, or similar) from public placement objects. Consumers MUST fail closed for the affected placement and alert operators; do not echo private field values in logs or error details |
@@ -760,6 +761,15 @@ Inference rules (normative):
 Surface: SDK MUST augment the response's <code>{"errors[]"}</code> with <code>{"code: \"PIXEL_TRACKER_UPGRADE_INFERRED\""}</code>, <code>{"field"}</code> pointing at the upgraded asset path, and <code>{"error.details"}</code> SHOULD carry <code>{"{ asset_id, inferred_event, inferred_method, inference_basis: \"asset_id_convention\" \u007c \"default\" }"}</code>. Buyer agents reading the response can re-prompt the seller for explicit values if precise measurement matters.
 
 Recovery: warning — non-fatal, no retry. Seller-side: upgrade emit path to ship pixel_tracker shape directly when 3.1-capable; until then, conventional asset_id values give the SDK enough signal to upgrade without losing critical semantics.
+
+</Accordion>
+<a id="error-code-place-target-unavailable"></a>
+
+<Accordion title="PLACE_TARGET_UNAVAILABLE — correctable">
+
+**Suggested action:** resolve the pinned value against the current catalog, review any replacement, and submit an intentional package targeting update
+
+A place identifier previously accepted and pinned on a package can no longer be executed. This is a nonfatal resource-state error returned in get_media_buys.errors[] alongside the affected buy. error.field MUST point to the exact media_buys[N].packages[M].targeting_overlay.geo_places[_exclude][A].values[V] response path. error.details MUST include media_buy_id, package_id, system, system_version, country, place_type, and value. The seller MUST preserve and echo the pinned target rather than silently changing geography. Recovery: correctable (look up the value through the declared resolver at the current catalog version and submit an intentional targeting update).
 
 </Accordion>
 <a id="error-code-plan-not-found"></a>

--- a/scripts/error-code-drift-dispositions.json
+++ b/scripts/error-code-drift-dispositions.json
@@ -226,6 +226,11 @@
       "target_version": "3.1",
       "note": "Placement catalog public/private boundary error (#4993). Surfaces when get_products or adagents.json public placements leak seller-private fields such as visibility/source/origin/delivery_mappings so monitoring can alarm distinctly from generic schema failures."
     },
+    "PLACE_TARGET_UNAVAILABLE": {
+      "disposition": "held-for-next-minor",
+      "target_version": "3.1",
+      "note": "Identifier-based place targeting (#5588). Non-fatal get_media_buys resource-state error when a catalog-pinned target can no longer execute; preserves the echoed target and provides a correctable resolver/update path. Wire change — held for 3.1."
+    },
     "FORMAT_DECLARATION_V1_LOSSY_MULTI_SIZE": {
       "disposition": "held-for-next-minor",
       "target_version": "3.1",

--- a/scripts/lint-storyboard-context-output-paths.cjs
+++ b/scripts/lint-storyboard-context-output-paths.cjs
@@ -128,33 +128,63 @@ function isPureExtensionPoint(node) {
 /**
  * Walk a JSON Schema node to determine whether a dotted path resolves to
  * any defined element. Follows `$ref`, descends through `properties.<name>`
- * for object steps and `items` for numeric-index steps, and accepts any
- * variant of `oneOf` / `anyOf` / `allOf` that resolves. Returns true when
+ * for object steps, schema-valued `additionalProperties` for dynamic map
+ * keys, and `items` for numeric-index steps, and accepts any variant of
+ * `oneOf` / `anyOf` / `allOf` that resolves. Returns true when
  * EVERY segment was either resolved by a defined property/items, accepted
  * by at least one composite variant, or descended into a pure extension
  * point (e.g., `core/context.json`, `error.details`).
  *
  * Empty path resolves trivially (the root itself exists).
  */
-function pathResolves(node, segments, seen = new Set()) {
+function resolveLocalRef(root, ref) {
+  if (!root || typeof root !== 'object' || typeof ref !== 'string' || !ref.startsWith('#/')) {
+    return null;
+  }
+  return ref
+    .slice(2)
+    .split('/')
+    .map((token) => token.replace(/~1/g, '/').replace(/~0/g, '~'))
+    .reduce(
+      (current, token) =>
+        current && typeof current === 'object' ? current[token] : undefined,
+      root,
+    );
+}
+
+function pathResolves(node, segments, seen = new Set(), root = node) {
   if (!node || typeof node !== 'object') return false;
   if (segments.length === 0) return true;
 
   if (node.$ref) {
-    if (seen.has(node.$ref)) return false;
+    const refKey = `${root?.$id || '<inline>'}:${node.$ref}`;
+    if (seen.has(refKey)) return false;
     const next = new Set(seen);
-    next.add(node.$ref);
+    next.add(refKey);
+    if (node.$ref.startsWith('#/')) {
+      return pathResolves(resolveLocalRef(root, node.$ref), segments, next, root);
+    }
     const resolved = loadSchema(node.$ref);
-    return pathResolves(resolved, segments, next);
+    return pathResolves(resolved, segments, next, resolved);
   }
 
   const [seg, ...rest] = segments;
 
   // Numeric — array index. Only valid when this node has `items`.
   if (/^\d+$/.test(seg)) {
-    if (node.items && pathResolves(node.items, rest, seen)) return true;
-  } else if (node.properties && Object.prototype.hasOwnProperty.call(node.properties, seg)) {
-    if (pathResolves(node.properties[seg], rest, seen)) return true;
+    if (node.items && pathResolves(node.items, rest, seen, root)) return true;
+  } else {
+    const isDeclaredProperty =
+      node.properties && Object.prototype.hasOwnProperty.call(node.properties, seg);
+    if (isDeclaredProperty) {
+      if (pathResolves(node.properties[seg], rest, seen, root)) return true;
+    } else if (
+      node.additionalProperties &&
+      typeof node.additionalProperties === 'object' &&
+      pathResolves(node.additionalProperties, rest, seen, root)
+    ) {
+      return true;
+    }
   }
 
   // Composite variants — any variant that resolves the FULL remaining path
@@ -167,7 +197,7 @@ function pathResolves(node, segments, seen = new Set()) {
   const variants = node.oneOf || node.anyOf || node.allOf;
   if (Array.isArray(variants)) {
     for (const variant of variants) {
-      if (pathResolves(variant, segments, seen)) return true;
+      if (pathResolves(variant, segments, seen, root)) return true;
     }
   }
 

--- a/scripts/lint-storyboard-validations-paths.cjs
+++ b/scripts/lint-storyboard-validations-paths.cjs
@@ -182,24 +182,53 @@ function isPureExtensionPoint(node) {
   return true;
 }
 
-function pathResolves(node, segments, seen = new Set()) {
+function resolveLocalRef(root, ref) {
+  if (!root || typeof root !== 'object' || typeof ref !== 'string' || !ref.startsWith('#/')) {
+    return null;
+  }
+  return ref
+    .slice(2)
+    .split('/')
+    .map((token) => token.replace(/~1/g, '/').replace(/~0/g, '~'))
+    .reduce(
+      (current, token) =>
+        current && typeof current === 'object' ? current[token] : undefined,
+      root,
+    );
+}
+
+function pathResolves(node, segments, seen = new Set(), root = node) {
   if (!node || typeof node !== 'object') return false;
   if (segments.length === 0) return true;
 
   if (node.$ref) {
-    if (seen.has(node.$ref)) return false;
+    const refKey = `${root?.$id || '<inline>'}:${node.$ref}`;
+    if (seen.has(refKey)) return false;
     const next = new Set(seen);
-    next.add(node.$ref);
+    next.add(refKey);
+    if (node.$ref.startsWith('#/')) {
+      return pathResolves(resolveLocalRef(root, node.$ref), segments, next, root);
+    }
     const resolved = loadSchema(node.$ref);
-    return pathResolves(resolved, segments, next);
+    return pathResolves(resolved, segments, next, resolved);
   }
 
   const [seg, ...rest] = segments;
 
-  if (/^\d+$/.test(seg) || seg === '*') {
-    if (node.items && pathResolves(node.items, rest, seen)) return true;
-  } else if (node.properties && Object.prototype.hasOwnProperty.call(node.properties, seg)) {
-    if (pathResolves(node.properties[seg], rest, seen)) return true;
+  if ((/^\d+$/.test(seg) || seg === '*') && node.items) {
+    if (pathResolves(node.items, rest, seen, root)) return true;
+  } else {
+    const isDeclaredProperty =
+      node.properties && Object.prototype.hasOwnProperty.call(node.properties, seg);
+    if (isDeclaredProperty) {
+      if (pathResolves(node.properties[seg], rest, seen, root)) return true;
+    } else if (
+      node.additionalProperties &&
+      typeof node.additionalProperties === 'object' &&
+      pathResolves(node.additionalProperties, rest, seen, root)
+    ) {
+      return true;
+    }
   }
 
   // Union semantics across `oneOf` / `anyOf` / `allOf` — see
@@ -207,7 +236,7 @@ function pathResolves(node, segments, seen = new Set()) {
   const variants = node.oneOf || node.anyOf || node.allOf;
   if (Array.isArray(variants)) {
     for (const variant of variants) {
-      if (pathResolves(variant, segments, seen)) return true;
+      if (pathResolves(variant, segments, seen, root)) return true;
     }
   }
 

--- a/server/tests/unit/product-discovery-schema-parity.test.ts
+++ b/server/tests/unit/product-discovery-schema-parity.test.ts
@@ -121,6 +121,18 @@ describe('product discovery MCP schema parity', () => {
     expect(criteria.properties.offer_filters).toBeDefined();
     expect(criteria.properties.targeting_overlay).toBeDefined();
     expect(criteria.properties.required_overlay_support).toBeDefined();
+    const targeting = resolveLocalRef(list, criteria.properties.targeting_overlay);
+    expect(targeting.properties.geo_places.items).toMatchObject({
+      type: 'object',
+      'x-adcp-schema-uri': '/schemas/core/geo-place-area.json',
+      additionalProperties: true,
+    });
+    const overlayRequirements = resolveLocalRef(list, criteria.properties.required_overlay_support);
+    expect(overlayRequirements.properties.geo_places).toMatchObject({
+      type: 'object',
+      'x-adcp-schema-uri': '/schemas/core/geo-place-requirement.json',
+      additionalProperties: true,
+    });
 
     const request = tools.find(tool => tool.name === 'request_proposals')!.inputSchema as JsonSchema;
     const requestCriteria = resolveLocalRef(request, request.properties.criteria);

--- a/specs/targeting-aware-product-discovery.md
+++ b/specs/targeting-aware-product-discovery.md
@@ -386,8 +386,10 @@ superset operation:
 - an object requirement matches product support `true` or a support object in
   which every requested boolean is true;
 - every requested array is a subset of the corresponding product array;
-- object fields the request did not name, including `systems`, do not
-  participate; and
+- for named places, every required identifier-system and country key exists,
+  and requested type/version arrays are subsets of the corresponding Product
+  support arrays;
+- object fields the request did not name do not participate; and
 - a missing or unknown required field does not match.
 
 Every valid structured support object represents at least one positive
@@ -465,6 +467,37 @@ exclusion values belong in `targeting_overlay` and affect discovery forecasts
 like every other concrete constraint. If inclusion and exclusion overlap,
 exclusion wins; a seller that cannot enforce the result rejects the request
 rather than silently broadening it.
+
+Named-place overlays are stricter: the seller rejects the same
+`(country, system, place_type, value)` in `geo_places` and
+`geo_places_exclude`, even across catalog versions, rather than applying
+exclusion precedence.
+
+Named-place requirements bind the identifier namespace before values are
+known. They key first by `system`, then by country, so two catalogs or two
+same-named places cannot collide and country/type support is never interpreted
+as a Cartesian product:
+
+```json
+{
+  "required_overlay_support": {
+    "geo_places": {
+      "systems": {
+        "geonames": {
+          "countries": { "NL": ["city"] },
+          "system_versions": ["2026-05"]
+        }
+      }
+    }
+  }
+}
+```
+
+A matching Product returns the same keyed structure under
+`overlay_support.geo_places`, adds `current_version` and its complete selectable
+`system_versions`, and may disclose package/value limits. This is binding
+permission to provide values later, not a value-specific availability promise.
+`geo_places_exclude` is requested and declared independently.
 
 ## Sparse targeting resolution
 

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -19,6 +19,7 @@ requires_scenarios:
   - media_buy_seller/demographic_targeting
   - media_buy_seller/product_filter_behavior
   - media_buy_seller/targeting_aware_discovery
+  - media_buy_seller/geo_place_targeting
   - media_buy_seller/available_actions
   - media_buy_seller/invalid_transitions
   - media_buy_seller/creative_fate_after_cancellation

--- a/static/compliance/source/protocols/media-buy/scenarios/geo_place_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/geo_place_targeting.yaml
@@ -1,0 +1,1003 @@
+id: media_buy_seller/geo_place_targeting
+version: "1.0.0"
+title: "Seller resolves, validates, and echoes identifier-based place targeting"
+category: media_buy_seller
+summary: "Verifies known-now place discovery, declared-later place permission, create/update persistence, package-state echo, and deterministic semantic rejection cases."
+track: media_buy
+
+requires_capability:
+  path: media_buy.execution.targeting.geo_places.geonames.countries.NL
+  contains: city
+
+required_tools:
+  - get_adcp_capabilities
+  - get_products
+  - create_media_buy
+  - update_media_buy
+  - get_media_buys
+  - comply_test_controller
+
+invariants:
+  - status.monotonic
+
+narrative: |
+  Identifier-based place targeting crosses capability discovery, product
+  discovery, create/update execution, catalog lifecycle, and package audit.
+  Shape-only validation is insufficient: a seller can accept a valid object and
+  still silently drop the place, use another catalog release, or reinterpret a
+  stale identifier.
+
+  This scenario applies only to sellers declaring GeoNames city support in the
+  Netherlands. It captures the seller's current catalog version, supplies the
+  active Amsterdam ID during product discovery so the configured product and
+  forecast are scoped to it, and explicitly requests permission to select
+  GeoNames exclusions later. It creates that configured product without
+  repeating Amsterdam, reads the buy back to verify the complete applied tuple,
+  adds The Hague as an exclusion through update_media_buy, and verifies both
+  persisted lists. A final negative probe sends a well-formed but unknown
+  GeoNames ID and requires rejection rather than silent dropping. Create-time
+  probes cover every disposition in the place-overlay matrix: unsupported
+  capability, invalid version or identifier, and unavailable inventory.
+
+  The current compliance harness verifies the resolver declaration and schema
+  contract but does not make an arbitrary HTTP call to the advertised URL.
+  Place reporting is deliberately not asserted. Package-state echo is the
+  configuration-audit contract until a follow-up reporting RFC adds
+  geo_level=place forecast and delivery rows.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - supports_non_guaranteed
+    - identifier_based_place_targeting
+  examples:
+    - "Sales agents mapping portable place identifiers into platform-native geographic targets"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The seller declares geonames/NL/city support and exposes its current version
+    through get_adcp_capabilities. The product and auction pricing fixtures are
+    seeded through comply_test_controller. GeoNames IDs 2759794 (Amsterdam) and
+    2747373 (The Hague) are external catalog identifiers, not seller-local
+    fixture IDs. The product fixture's namespaced compliance extension makes
+    the target-specific forecast, price, and create dispositions deterministic;
+    it is sandbox controller behavior, not a production Product contract.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "geo_place_display_nl"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+      overlay_support:
+        geo_places:
+          systems:
+            geonames:
+              countries:
+                NL: ["city"]
+              current_version: "2026-05"
+              system_versions: ["2026-05", "2025-11"]
+          max_values_per_package: 25
+        geo_places_exclude:
+          systems:
+            geonames:
+              countries:
+                NL: ["city"]
+              current_version: "2026-05"
+              system_versions: ["2026-05", "2025-11"]
+          max_values_per_package: 25
+      forecast:
+        forecast_range_unit: "availability"
+        method: "modeled"
+        currency: "EUR"
+        points:
+          - metrics:
+              impressions: { mid: 1000000 }
+      ext:
+        adcp_compliance:
+          geo_place_cases:
+            - country: "NL"
+              system: "geonames"
+              system_version: "2026-05"
+              place_type: "city"
+              value: "2759794"
+              outcome: "accepted"
+              forecast_impressions_mid: 240000
+              floor_price: 3.75
+            - country: "NL"
+              system: "geonames"
+              system_version: "2026-05"
+              place_type: "city"
+              value: "2747891"
+              outcome: "PRODUCT_UNAVAILABLE"
+  pricing_options:
+    - product_id: "geo_place_display_nl"
+      pricing_option_id: "geo_place_auction_cpm"
+      pricing_model: "cpm"
+      currency: "EUR"
+      floor_price: 3.00
+
+phases:
+  - id: discover_capability_and_product
+    title: "Discover exact place support before create"
+    steps:
+      - id: get_place_capabilities
+        title: "Read place system and catalog version"
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        stateful: false
+        expected: |
+          Return geonames support with NL containing city, a current version that
+          is also in supported_versions, and an adcp_geo_place_resolver_v1
+          endpoint.
+        sample_request:
+          context:
+            correlation_id: "geo_place_targeting--get_place_capabilities"
+        context_outputs:
+          - key: "place_system_version"
+            path: "media_buy.execution.targeting.geo_places.geonames.catalog.current_version"
+          - key: "place_supported_version_0"
+            path: "media_buy.execution.targeting.geo_places.geonames.catalog.supported_versions[0]"
+          - key: "place_supported_version_1"
+            path: "media_buy.execution.targeting.geo_places.geonames.catalog.supported_versions[1]"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json"
+          - check: field_contains
+            path: "media_buy.execution.targeting.geo_places.geonames.countries.NL[*]"
+            value: "city"
+            description: "Seller explicitly supports the NL/city pair"
+          - check: field_present
+            path: "media_buy.execution.targeting.geo_places.geonames.catalog.resolver.url"
+            description: "Seller exposes a machine-readable resolver"
+          - check: field_contains
+            path: "media_buy.execution.targeting.geo_places.geonames.catalog.supported_versions[*]"
+            value: "$context.place_system_version"
+            description: "current_version is included in supported_versions"
+
+      - id: get_place_targetable_product
+        title: "Discover known Amsterdam targeting and later exclusion permission"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        stateful: true
+        expected: |
+          Return a configured product whose price and aggregate forecast are
+          scoped to Amsterdam. Its overlay_support grants later GeoNames
+          NL/city exclusions at the captured catalog version.
+        sample_request:
+          buying_mode: "wholesale"
+          filters:
+            channels: ["display"]
+            is_fixed_price: false
+          targeting_overlay:
+            geo_places:
+              - country: "NL"
+                system: "geonames"
+                system_version: "$context.place_system_version"
+                place_type: "city"
+                values: ["2759794"]
+          required_overlay_support:
+            geo_places_exclude:
+              systems:
+                geonames:
+                  countries:
+                    NL: ["city"]
+                  system_versions: ["$context.place_system_version"]
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          context:
+            correlation_id: "geo_place_targeting--get_place_targetable_product"
+        context_outputs:
+          - key: "product_id"
+            path: "products[0].product_id"
+          - key: "pricing_option_id"
+            path: "products[0].pricing_options[0].pricing_option_id"
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json"
+          - check: field_present
+            path: "products[0].product_id"
+            description: "At least one matching product is returned"
+          - check: field_value
+            path: "products[0].is_custom"
+            value: true
+            description: "Exact Amsterdam targeting produces a request-scoped configured product"
+          - check: field_present
+            path: "products[0].expires_at"
+            description: "The target-specific forecast and price are time-bound"
+          - check: field_present
+            path: "products[0].forecast"
+            description: "Aggregate forecast is scoped to the known Amsterdam target"
+          - check: field_value
+            path: "products[0].forecast.points[0].metrics.impressions.mid"
+            value: 240000
+            description: "Amsterdam discovery returns the deterministic target-scoped forecast, not the one-million-impression base forecast"
+          - check: field_value
+            path: "products[0].pricing_options[0].floor_price"
+            value: 3.75
+            description: "Amsterdam discovery returns the deterministic target-scoped price, not the EUR 3.00 base floor"
+          - check: field_contains
+            path: "products[0].overlay_support.geo_places_exclude.systems.geonames.countries.NL[*]"
+            value: "city"
+            description: "Product grants the requested collision-safe NL/city exclusion tuple"
+          - check: field_contains
+            path: "products[0].overlay_support.geo_places_exclude.systems.geonames.system_versions[*]"
+            value: "$context.place_system_version"
+            description: "Product grants the exact requested exclusion catalog version"
+
+      - id: get_place_deferred_product
+        title: "Declare that place values will be supplied later"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        stateful: true
+        expected: |
+          Return a product that binds selectable GeoNames NL/city inclusion and
+          exclusion support without claiming availability, price, or forecast
+          for any place value that the buyer has not supplied yet.
+        sample_request:
+          buying_mode: "wholesale"
+          filters:
+            channels: ["display"]
+            is_fixed_price: false
+          required_overlay_support:
+            geo_places:
+              systems:
+                geonames:
+                  countries:
+                    NL: ["city"]
+                  system_versions: ["$context.place_system_version"]
+            geo_places_exclude:
+              systems:
+                geonames:
+                  countries:
+                    NL: ["city"]
+                  system_versions: ["$context.place_system_version"]
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          context:
+            correlation_id: "geo_place_targeting--get_place_deferred_product"
+        context_outputs:
+          - key: "deferred_product_id"
+            path: "products[0].product_id"
+          - key: "deferred_pricing_option_id"
+            path: "products[0].pricing_options[0].pricing_option_id"
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json"
+          - check: field_contains
+            path: "products[0].overlay_support.geo_places.systems.geonames.countries.NL[*]"
+            value: "city"
+            description: "Product grants the requested later NL/city inclusion tuple"
+          - check: field_contains
+            path: "products[0].overlay_support.geo_places.systems.geonames.system_versions[*]"
+            value: "$context.place_system_version"
+            description: "Product grants the exact requested inclusion catalog version"
+          - check: field_contains
+            path: "products[0].overlay_support.geo_places_exclude.systems.geonames.countries.NL[*]"
+            value: "city"
+            description: "Product independently grants the requested later exclusion tuple"
+          - check: field_contains
+            path: "products[0].overlay_support.geo_places_exclude.systems.geonames.system_versions[*]"
+            value: "$context.place_system_version"
+            description: "Product independently grants the exact exclusion catalog version"
+
+  - id: create_and_echo_place
+    title: "Create and read back applied place targeting"
+    steps:
+      - id: create_place_targeted_buy
+        title: "Create buy targeting Amsterdam"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Selecting the configured product accepts and persists the Amsterdam
+          targeting already supplied during discovery; the buyer does not need
+          to repeat it on the package.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "asap"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.product_id"
+              pricing_option_id: "$context.pricing_option_id"
+              bid_price: 4.25
+              budget: 12000
+          idempotency_key: "$generate:uuid_v4#geo_place_targeting_create"
+          context:
+            correlation_id: "geo_place_targeting--create_place_targeted_buy"
+        context_outputs:
+          - key: "media_buy_id"
+            path: "media_buy_id"
+          - key: "package_id"
+            path: "packages[0].package_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Seller assigns a media_buy_id"
+
+      - id: get_after_create
+        title: "Verify complete applied tuple after create"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: true
+        expected: |
+          Echo geo_places with the exact applied version and identifier, proving
+          the seller persisted rather than merely parsed the target.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          media_buy_ids: ["$context.media_buy_id"]
+          context:
+            correlation_id: "geo_place_targeting--get_after_create"
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json"
+          - check: field_value
+            path: "media_buys[0].packages[0].targeting_overlay.geo_places[0].country"
+            value: "NL"
+            description: "Applied country is echoed"
+          - check: field_value
+            path: "media_buys[0].packages[0].targeting_overlay.geo_places[0].system"
+            value: "geonames"
+            description: "Applied system is echoed"
+          - check: field_value
+            path: "media_buys[0].packages[0].targeting_overlay.geo_places[0].system_version"
+            value: "$context.place_system_version"
+            description: "Applied catalog version is echoed"
+          - check: field_value
+            path: "media_buys[0].packages[0].targeting_overlay.geo_places[0].place_type"
+            value: "city"
+            description: "Applied place type is echoed"
+          - check: field_contains
+            path: "media_buys[0].packages[0].targeting_overlay.geo_places[0].values[*]"
+            value: "2759794"
+            description: "Amsterdam GeoNames ID is echoed"
+
+  - id: update_and_echo_exclusion
+    title: "Add a place exclusion and verify replacement semantics"
+    steps:
+      - id: update_place_exclusion
+        title: "Exclude The Hague"
+        task: update_media_buy
+        schema_ref: "media-buy/update-media-buy-request.json"
+        response_schema_ref: "media-buy/update-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/update_media_buy"
+        stateful: true
+        expected: |
+          Replace the package overlay with the Amsterdam inclusion plus The Hague
+          exclusion, preserving exact catalog identity on both entries.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          media_buy_id: "$context.media_buy_id"
+          packages:
+            - package_id: "$context.package_id"
+              targeting_overlay:
+                geo_places:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "$context.place_system_version"
+                    place_type: "city"
+                    values: ["2759794"]
+                geo_places_exclude:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "$context.place_system_version"
+                    place_type: "city"
+                    values: ["2747373"]
+          idempotency_key: "$generate:uuid_v4#geo_place_targeting_update"
+          context:
+            correlation_id: "geo_place_targeting--update_place_exclusion"
+        validations:
+          - check: response_schema
+            description: "Response matches update-media-buy-response.json"
+          - check: field_present
+            path: "affected_packages"
+            description: "Update reports affected package state"
+          - check: field_contains
+            path: "affected_packages[*]"
+            value:
+              package_id: "$context.package_id"
+              targeting_overlay:
+                geo_places:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "$context.place_system_version"
+                    place_type: "city"
+                    values: ["2759794"]
+                geo_places_exclude:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "$context.place_system_version"
+                    place_type: "city"
+                    values: ["2747373"]
+            description: "Affected package carries complete post-update place targeting"
+
+      - id: get_after_update
+        title: "Verify inclusion and exclusion persisted"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: true
+        expected: |
+          Echo both applied place lists with the exact version and values.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          media_buy_ids: ["$context.media_buy_id"]
+          context:
+            correlation_id: "geo_place_targeting--get_after_update"
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json"
+          - check: field_contains
+            path: "media_buys[0].packages[0].targeting_overlay.geo_places[0].values[*]"
+            value: "2759794"
+            description: "Amsterdam inclusion persisted"
+          - check: field_contains
+            path: "media_buys[0].packages[0].targeting_overlay.geo_places_exclude[0].values[*]"
+            value: "2747373"
+            description: "The Hague exclusion persisted"
+          - check: field_value
+            path: "media_buys[0].packages[0].targeting_overlay.geo_places_exclude[0].system_version"
+            value: "$context.place_system_version"
+            description: "Exclusion applied version is echoed"
+
+  - id: deferred_place_inclusion
+    title: "Supply a permitted place inclusion at create time"
+    depends_on: [discover_capability_and_product]
+    steps:
+      - id: create_deferred_inclusion_buy
+        title: "Create a buy with the later-selected Amsterdam target"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Accept a valid Amsterdam inclusion within the Product's declared
+          GeoNames/NL/city/version support. Success confirms that the selected
+          product terms cover the complete effective targeting.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "asap"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.deferred_product_id"
+              pricing_option_id: "$context.deferred_pricing_option_id"
+              bid_price: 4.25
+              budget: 5000
+              targeting_overlay:
+                geo_places:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "$context.place_system_version"
+                    place_type: "city"
+                    values: ["2759794"]
+          idempotency_key: "$generate:uuid_v4#geo_place_targeting_deferred_inclusion"
+          context:
+            correlation_id: "geo_place_targeting--create_deferred_inclusion_buy"
+        context_outputs:
+          - key: "deferred_inclusion_media_buy_id"
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Seller accepts the permitted later-selected place inclusion"
+
+      - id: get_deferred_inclusion_buy
+        title: "Verify the later-selected inclusion persisted"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: true
+        expected: |
+          Echo Amsterdam with the exact applied catalog version, proving the
+          accepted create compiled and persisted the deferred value.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          media_buy_ids: ["$context.deferred_inclusion_media_buy_id"]
+          context:
+            correlation_id: "geo_place_targeting--get_deferred_inclusion_buy"
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json"
+          - check: field_contains
+            path: "media_buys[0].packages[0].targeting_overlay.geo_places[0].values[*]"
+            value: "2759794"
+            description: "Deferred Amsterdam inclusion persisted"
+          - check: field_value
+            path: "media_buys[0].packages[0].targeting_overlay.geo_places[0].system_version"
+            value: "$context.place_system_version"
+            description: "Seller echoes the exact selected catalog version"
+
+  - id: exclusion_only_place_targeting
+    title: "Apply a place exclusion without a place inclusion"
+    depends_on: [discover_capability_and_product]
+    steps:
+      - id: create_exclusion_only_buy
+        title: "Create a buy excluding The Hague"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Accept geo_places_exclude without geo_places. The exclusion subtracts
+          from the package's otherwise eligible geography; it does not require
+          a place inclusion set.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "asap"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.deferred_product_id"
+              pricing_option_id: "$context.deferred_pricing_option_id"
+              bid_price: 4.25
+              budget: 5000
+              targeting_overlay:
+                geo_places_exclude:
+                  - country: "NL"
+                    system: "geonames"
+                    place_type: "city"
+                    values: ["2747373"]
+          idempotency_key: "$generate:uuid_v4#geo_place_targeting_exclusion_only"
+          context:
+            correlation_id: "geo_place_targeting--create_exclusion_only_buy"
+        context_outputs:
+          - key: "exclusion_only_media_buy_id"
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Seller creates the exclusion-only buy"
+
+      - id: get_exclusion_only_buy
+        title: "Verify exclusion-only targeting persisted"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: true
+        expected: |
+          Echo the exclusion with the applied current catalog version and no
+          synthetic geo_places inclusion.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          media_buy_ids: ["$context.exclusion_only_media_buy_id"]
+          context:
+            correlation_id: "geo_place_targeting--get_exclusion_only_buy"
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json"
+          - check: field_contains
+            path: "media_buys[0].packages[0].targeting_overlay.geo_places_exclude[0].values[*]"
+            value: "2747373"
+            description: "The Hague exclusion persisted without an inclusion"
+          - check: field_value
+            path: "media_buys[0].packages[0].targeting_overlay.geo_places_exclude[0].system_version"
+            value: "$context.place_system_version"
+            description: "Seller echoes the defaulted current catalog version"
+
+  - id: reject_invalid_place_targeting
+    title: "Reject invalid place targeting semantics"
+    depends_on: [discover_capability_and_product]
+    steps:
+      - id: create_with_unknown_geonames_id
+        title: "Submit an unknown GeoNames identifier"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with INVALID_REQUEST and identify the offending geo_places value.
+          The seller must not silently drop, approximate, or reinterpret it.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "asap"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.deferred_product_id"
+              pricing_option_id: "$context.deferred_pricing_option_id"
+              bid_price: 4.25
+              budget: 5000
+              targeting_overlay:
+                geo_places:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "$context.place_system_version"
+                    place_type: "city"
+                    values: ["0"]
+          idempotency_key: "$generate:uuid_v4#geo_place_targeting_unknown_id"
+          context:
+            correlation_id: "geo_place_targeting--create_with_unknown_geonames_id"
+        validations:
+          - check: response_schema
+            description: "Error response matches create-media-buy-response.json"
+          - check: error_code
+            value: "INVALID_REQUEST"
+            description: "Unknown place identifier is a correctable request error"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].targeting_overlay.geo_places[0].values[0]"
+            description: "Error points to the exact unknown identifier"
+
+      - id: create_with_unsupported_place_tuple
+        title: "Submit a country outside Product overlay support"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with UNSUPPORTED_FEATURE because the Product declares
+          geonames/NL/city, not geonames/DE/city. This is capability failure,
+          not an invalid identifier within a supported tuple.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "asap"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.deferred_product_id"
+              pricing_option_id: "$context.deferred_pricing_option_id"
+              bid_price: 4.25
+              budget: 5000
+              targeting_overlay:
+                geo_places:
+                  - country: "DE"
+                    system: "geonames"
+                    place_type: "city"
+                    values: ["2950159"]
+          idempotency_key: "$generate:uuid_v4#geo_place_targeting_unsupported_tuple"
+          context:
+            correlation_id: "geo_place_targeting--create_with_unsupported_place_tuple"
+        validations:
+          - check: response_schema
+            description: "Error response matches create-media-buy-response.json"
+          - check: error_code
+            value: "UNSUPPORTED_FEATURE"
+            description: "A place tuple outside Product overlay support is unsupported"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].targeting_overlay.geo_places[0].country"
+            description: "Error identifies the unsupported tuple field"
+
+      - id: create_with_unsupported_place_version
+        title: "Submit an unsupported version within a supported place tuple"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with INVALID_REQUEST because the NL/city tuple is supported but
+          the explicitly requested catalog version is not in system_versions.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "asap"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.deferred_product_id"
+              pricing_option_id: "$context.deferred_pricing_option_id"
+              bid_price: 4.25
+              budget: 5000
+              targeting_overlay:
+                geo_places:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "1900-01"
+                    place_type: "city"
+                    values: ["2759794"]
+          idempotency_key: "$generate:uuid_v4#geo_place_targeting_unsupported_version"
+          context:
+            correlation_id: "geo_place_targeting--create_with_unsupported_place_version"
+        validations:
+          - check: response_schema
+            description: "Error response matches create-media-buy-response.json"
+          - check: error_code
+            value: "INVALID_REQUEST"
+            description: "An unsupported explicit version on a supported tuple is invalid"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].targeting_overlay.geo_places[0].system_version"
+            description: "Error identifies the unsupported version field"
+
+      - id: create_with_zero_inventory_place
+        title: "Submit a valid place with zero executable inventory"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject valid Rotterdam identifier 2747891 with
+          PRODUCT_UNAVAILABLE because the deterministic fixture has no current
+          inventory for its effective intersection. Do not silently substitute
+          another place or change the configured price.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "asap"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.deferred_product_id"
+              pricing_option_id: "$context.deferred_pricing_option_id"
+              bid_price: 4.25
+              budget: 5000
+              targeting_overlay:
+                geo_places:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "$context.place_system_version"
+                    place_type: "city"
+                    values: ["2747891"]
+          idempotency_key: "$generate:uuid_v4#geo_place_targeting_zero_inventory"
+          context:
+            correlation_id: "geo_place_targeting--create_with_zero_inventory_place"
+        validations:
+          - check: response_schema
+            description: "Error response matches create-media-buy-response.json"
+          - check: error_code
+            value: "PRODUCT_UNAVAILABLE"
+            description: "A supported target with no current inventory is unavailable"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].targeting_overlay.geo_places"
+            description: "Error identifies the place overlay that eliminated inventory"
+
+      - id: create_with_mismatched_value_label
+        title: "Submit a diagnostic label for a value not being targeted"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with INVALID_REQUEST. value_labels keys must be a subset of
+          values even though draft-07 cannot encode that sibling-key constraint.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "asap"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.deferred_product_id"
+              pricing_option_id: "$context.deferred_pricing_option_id"
+              bid_price: 4.25
+              budget: 5000
+              targeting_overlay:
+                geo_places:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "$context.place_system_version"
+                    place_type: "city"
+                    values: ["2759794"]
+                    value_labels:
+                      "2747373": "The Hague, South Holland, Netherlands"
+          idempotency_key: "$generate:uuid_v4#geo_place_targeting_bad_label"
+          context:
+            correlation_id: "geo_place_targeting--create_with_mismatched_value_label"
+        validations:
+          - check: response_schema
+            description: "Error response matches create-media-buy-response.json"
+          - check: error_code
+            value: "INVALID_REQUEST"
+            description: "Mismatched diagnostic label is rejected"
+
+      - id: create_with_include_exclude_overlap
+        title: "Submit the same place in include and exclude"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with INVALID_REQUEST rather than choosing an undocumented
+          precedence for the same applied place identity.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "asap"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.deferred_product_id"
+              pricing_option_id: "$context.deferred_pricing_option_id"
+              bid_price: 4.25
+              budget: 5000
+              targeting_overlay:
+                geo_places:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "$context.place_system_version"
+                    place_type: "city"
+                    values: ["2759794"]
+                geo_places_exclude:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "$context.place_system_version"
+                    place_type: "city"
+                    values: ["2759794"]
+          idempotency_key: "$generate:uuid_v4#geo_place_targeting_overlap"
+          context:
+            correlation_id: "geo_place_targeting--create_with_include_exclude_overlap"
+        validations:
+          - check: response_schema
+            description: "Error response matches create-media-buy-response.json"
+          - check: error_code
+            value: "INVALID_REQUEST"
+            description: "Same-value include/exclude overlap is rejected"
+
+  - id: reject_cross_version_place_overlap
+    title: "Reject cross-version include/exclude overlap"
+    optional: true
+    depends_on: [discover_capability_and_product]
+    requires_capability:
+      path: "media_buy.execution.targeting.geo_places.geonames.catalog.supported_versions[1]"
+      present: true
+    narrative: |
+      When the seller accepts at least two GeoNames catalog versions, the same
+      stable place identifier cannot be included under one version and excluded
+      under another. Catalog version is not part of place identity.
+    steps:
+      - id: create_with_cross_version_include_exclude_overlap
+        title: "Submit the same place across two supported versions"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        expected: |
+          Reject with INVALID_REQUEST because version does not distinguish an
+          included place from the same excluded stable place identity.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "asap"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.deferred_product_id"
+              pricing_option_id: "$context.deferred_pricing_option_id"
+              bid_price: 4.25
+              budget: 5000
+              targeting_overlay:
+                geo_places:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "$context.place_supported_version_0"
+                    place_type: "city"
+                    values: ["2759794"]
+                geo_places_exclude:
+                  - country: "NL"
+                    system: "geonames"
+                    system_version: "$context.place_supported_version_1"
+                    place_type: "city"
+                    values: ["2759794"]
+          idempotency_key: "$generate:uuid_v4#geo_place_targeting_cross_version_overlap"
+          context:
+            correlation_id: "geo_place_targeting--create_with_cross_version_include_exclude_overlap"
+        validations:
+          - check: response_schema
+            description: "Error response matches create-media-buy-response.json"
+          - check: error_code
+            value: "INVALID_REQUEST"
+            description: "Cross-version same-value include/exclude overlap is rejected"

--- a/static/schemas/source/core/geo-place-area.json
+++ b/static/schemas/source/core/geo-place-area.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/geo-place-area.json",
+  "title": "Geographic Place Area",
+  "description": "A catalog-backed named place target. Values are stable identifiers in the declared system. Entries within geo_places form a union; different geographic inclusion dimensions intersect. value_labels are diagnostic only and MUST NOT be used to resolve targeting.",
+  "x-adcp-validation": {
+    "map_keys_subset_of_array": { "map_field": "value_labels", "array_field": "values" },
+    "description": "Every value_labels key MUST also appear in values. JSON Schema draft-07 cannot express this sibling-field key membership constraint, so conformance tooling must enforce it."
+  },
+  "type": "object",
+  "properties": {
+    "country": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}$",
+      "description": "ISO 3166-1 alpha-2 country code containing the place."
+    },
+    "system": {
+      "$ref": "/schemas/core/geo-place-system.json"
+    },
+    "system_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional exact catalog version from the seller's declared supported_versions. When omitted, the seller applies catalog.current_version and MUST echo that version on persisted package state."
+    },
+    "place_type": {
+      "$ref": "/schemas/core/geo-place-type.json"
+    },
+    "values": {
+      "type": "array",
+      "description": "Stable place identifiers in the declared system. Display names are not valid targeting values.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "value_labels": {
+      "type": "object",
+      "description": "Optional human-readable diagnostic labels keyed by identifiers present in values. Extra keys are a conformance error. Labels are non-authoritative and MUST NOT be used to resolve or apply targeting.",
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["country", "system", "place_type", "values"],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "system": { "enum": ["geonames", "google_ads", "microsoft_ads"] }
+        },
+        "required": ["system"]
+      },
+      "then": {
+        "properties": {
+          "values": {
+            "items": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/static/schemas/source/core/geo-place-catalog-capability.json
+++ b/static/schemas/source/core/geo-place-catalog-capability.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/geo-place-catalog-capability.json",
+  "title": "Geographic Place Catalog Capability",
+  "description": "Catalog version and resolution contract for one supported place identifier system. Versions are exact opaque strings, not ordered ranges.",
+  "type": "object",
+  "properties": {
+    "source": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://",
+      "description": "Optional catalog dataset or derivative-source identifier. This records provenance/coverage and does not change the identifier namespace in system."
+    },
+    "current_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Version applied when a buyer omits system_version. Sellers MUST echo this version on persisted package state."
+    },
+    "supported_versions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true,
+      "description": "Exact catalog versions accepted for new targeting or target-changing updates. Must include current_version. Removing a version does not mutate or silently invalidate targets already pinned to it."
+    },
+    "resolver": {
+      "$ref": "/schemas/core/geo-place-resolver.json"
+    }
+  },
+  "required": ["current_version", "supported_versions", "resolver"],
+  "additionalProperties": false,
+  "x-adcp-validation": {
+    "member_of": { "field": "current_version", "array_field": "supported_versions" },
+    "description": "JSON Schema draft-07 cannot express scalar membership in a sibling array; conformance tooling MUST verify current_version is present in supported_versions."
+  }
+}

--- a/static/schemas/source/core/geo-place-catalog-entry.json
+++ b/static/schemas/source/core/geo-place-catalog-entry.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/geo-place-catalog-entry.json",
+  "title": "Geographic Place Catalog Entry",
+  "description": "One resolver result for a stable place identifier, including lifecycle state. Labels and parent_labels are diagnostic only; value is the authoritative targeting key.",
+  "type": "object",
+  "properties": {
+    "value": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier in the response system and system_version."
+    },
+    "country": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}$"
+    },
+    "subdivision": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}-[A-Z0-9]{1,3}$",
+      "description": "ISO 3166-2 subdivision containing the place when the catalog has a subdivision mapping. Required by resolver semantics when the request constrained subdivision."
+    },
+    "place_type": {
+      "$ref": "/schemas/core/geo-place-type.json"
+    },
+    "label": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable display label; never an authoritative targeting key."
+    },
+    "canonical_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Required fully qualified display name suitable for distinguishing same-named results."
+    },
+    "parent_labels": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "description": "Ordered human-readable parent hierarchy for disambiguation only. Must include at least the containing country."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["active", "removal_planned", "deprecated"]
+    },
+    "replaced_by_values": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true,
+      "description": "Replacement identifiers in the same system and response system_version."
+    },
+    "valid_until": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Known time after which the identifier must no longer be accepted for new targeting."
+    },
+    "ext": {
+      "$ref": "/schemas/core/ext.json"
+    }
+  },
+  "required": ["value", "country", "place_type", "label", "canonical_name", "parent_labels", "status"],
+  "additionalProperties": false
+}

--- a/static/schemas/source/core/geo-place-requirement.json
+++ b/static/schemas/source/core/geo-place-requirement.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/geo-place-requirement.json",
+  "title": "Geographic Place Requirement",
+  "description": "Identifier systems and collision-safe country/type pairs the buyer must be allowed to select later.",
+  "type": "object",
+  "definitions": {
+    "catalogRequirement": {
+      "type": "object",
+      "description": "Required country/type pairs and optional exact catalog versions for one identifier system. Country keys prevent a false Cartesian product between countries and place types.",
+      "properties": {
+        "countries": {
+          "type": "object",
+          "propertyNames": { "pattern": "^[A-Z]{2}$" },
+          "additionalProperties": {
+            "type": "array",
+            "items": { "$ref": "/schemas/core/geo-place-type.json" },
+            "minItems": 1,
+            "uniqueItems": true
+          },
+          "minProperties": 1
+        },
+        "system_versions": {
+          "type": "array",
+          "description": "Optional exact catalog versions that must remain selectable. Versions are opaque strings, not ordered ranges.",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      },
+      "required": ["countries"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "systems": {
+      "type": "object",
+      "propertyNames": { "$ref": "/schemas/core/geo-place-system.json" },
+      "additionalProperties": { "$ref": "#/definitions/catalogRequirement" },
+      "minProperties": 1
+    }
+  },
+  "required": ["systems"],
+  "additionalProperties": false
+}

--- a/static/schemas/source/core/geo-place-resolver.json
+++ b/static/schemas/source/core/geo-place-resolver.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/geo-place-resolver.json",
+  "title": "Geographic Place Resolver",
+  "description": "Machine-readable HTTP resolver for converting unresolved place names into seller-accepted stable identifiers or refreshing an existing identifier. Clients send an HTTPS GET to url using the query parameters in get-geo-place-resolution-request.json and validate a 200 application/json response against get-geo-place-resolution-response.json. Non-200 responses are errors, not empty results. Clients MUST apply SSRF protections. seller_credentials may be used only when url has the same origin as the seller's AdCP endpoint.",
+  "type": "object",
+  "properties": {
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://",
+      "description": "HTTPS endpoint accepting the standard geo-place resolution query parameters."
+    },
+    "auth": {
+      "type": "string",
+      "enum": ["none", "seller_credentials"],
+      "description": "Authentication mode. seller_credentials means use the same authorization credentials as the seller's AdCP endpoint and is valid only for a same-origin resolver URL; credentials MUST NOT be forwarded cross-origin."
+    },
+    "protocol": {
+      "type": "string",
+      "const": "adcp_geo_place_resolver_v1",
+      "description": "Resolver request/response contract version."
+    }
+  },
+  "required": ["url", "auth", "protocol"],
+  "additionalProperties": false
+}

--- a/static/schemas/source/core/geo-place-support.json
+++ b/static/schemas/source/core/geo-place-support.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/geo-place-support.json",
+  "title": "Geographic Place System Support",
+  "description": "Declares exact country-to-place-type support plus catalog resolution and version metadata for one place identifier system. The country map avoids falsely implying a Cartesian product of countries and types.",
+  "type": "object",
+  "properties": {
+    "countries": {
+      "type": "object",
+      "description": "Supported place types keyed by ISO 3166-1 alpha-2 country. Only explicitly listed country/type pairs are supported.",
+      "propertyNames": {
+        "pattern": "^[A-Z]{2}$"
+      },
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "/schemas/core/geo-place-type.json"
+        },
+        "minItems": 1,
+        "uniqueItems": true
+      },
+      "minProperties": 1
+    },
+    "catalog": {
+      "$ref": "/schemas/core/geo-place-catalog-capability.json"
+    }
+  },
+  "required": ["countries", "catalog"],
+  "additionalProperties": false
+}

--- a/static/schemas/source/core/geo-place-system.json
+++ b/static/schemas/source/core/geo-place-system.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/geo-place-system.json",
+  "title": "Geographic Place Identifier System",
+  "description": "Collision-safe identifier namespace for geographic places. Registered tokens have protocol-defined semantics. Unregistered systems MUST use an absolute HTTPS URI controlled by the catalog owner; consumers compare URI systems as exact opaque strings.",
+  "anyOf": [
+    {
+      "type": "string",
+      "enum": ["geonames", "google_ads", "microsoft_ads"]
+    },
+    {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://"
+    }
+  ],
+  "examples": ["geonames", "google_ads", "microsoft_ads", "https://seller.example/geo/catalogs/places"]
+}

--- a/static/schemas/source/core/geo-place-type.json
+++ b/static/schemas/source/core/geo-place-type.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/geo-place-type.json",
+  "title": "Geographic Place Type",
+  "description": "Canonical place classification. Registered tokens have protocol-defined meanings. Catalog-specific classifications without a registered mapping MUST use an absolute HTTPS URI controlled by the vocabulary owner; consumers compare URI types as exact opaque strings.",
+  "anyOf": [
+    {
+      "type": "string",
+      "enum": [
+        "airport",
+        "borough",
+        "city",
+        "city_region",
+        "commune",
+        "county",
+        "district",
+        "municipality",
+        "neighborhood",
+        "post_town",
+        "prefecture",
+        "province",
+        "quarter",
+        "state",
+        "territory",
+        "ward"
+      ]
+    },
+    {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://"
+    }
+  ],
+  "examples": ["city", "municipality", "borough", "neighborhood", "post_town", "city_region", "county", "https://seller.example/geo/place-types/trade-area"]
+}

--- a/static/schemas/source/core/get-geo-place-resolution-request.json
+++ b/static/schemas/source/core/get-geo-place-resolution-request.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/get-geo-place-resolution-request.json",
+  "title": "Get Geographic Place Resolution Request",
+  "description": "Read-only query parameters for a geo-place resolver. Supply exactly one of q (unresolved human intent) or value (an existing identifier to refresh). Country is mandatory. Optional subdivision, place_type, system_version, and locale further constrain matching.",
+  "type": "object",
+  "properties": {
+    "q": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unresolved place name or alias supplied by the user."
+    },
+    "value": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Existing identifier to look up in the requested/current catalog version for lifecycle refresh or replacement discovery. Mutually exclusive with q."
+    },
+    "country": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}$",
+      "description": "ISO 3166-1 alpha-2 country code used to disambiguate the query."
+    },
+    "subdivision": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}-[A-Z0-9]{1,3}$",
+      "description": "Optional ISO 3166-2 subdivision constraint."
+    },
+    "place_type": {
+      "$ref": "/schemas/core/geo-place-type.json"
+    },
+    "system_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional exact supported catalog version to search."
+    },
+    "locale": {
+      "type": "string",
+      "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$",
+      "description": "Optional BCP 47 language tag for returned labels."
+    },
+    "cursor": {
+      "type": "string",
+      "minLength": 1
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "default": 20
+    }
+  },
+  "required": ["country"],
+  "anyOf": [
+    { "required": ["q"] },
+    { "required": ["value"] }
+  ],
+  "not": { "required": ["q", "value"] },
+  "additionalProperties": false
+}

--- a/static/schemas/source/core/get-geo-place-resolution-request.json
+++ b/static/schemas/source/core/get-geo-place-resolution-request.json
@@ -34,8 +34,7 @@
       "description": "Optional exact supported catalog version to search."
     },
     "locale": {
-      "type": "string",
-      "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$",
+      "$ref": "/schemas/core/locale-tag.json",
       "description": "Optional BCP 47 language tag for returned labels."
     },
     "cursor": {

--- a/static/schemas/source/core/get-geo-place-resolution-response.json
+++ b/static/schemas/source/core/get-geo-place-resolution-response.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/get-geo-place-resolution-response.json",
+  "title": "Get Geographic Place Resolution Response",
+  "description": "Paginated read-only resolver response containing seller-accepted place identifiers from one exact system version and echoing the request used to produce them.",
+  "x-adcp-validation": {
+    "resolver_response_binding": {
+      "system": "capability_key",
+      "system_version": "request.system_version_or_catalog.current_version",
+      "match_fields": ["country", "subdivision", "place_type"]
+    },
+    "description": "The response system MUST equal the geo_places capability key for the resolver. system_version MUST equal the requested version, or catalog.current_version when omitted. Every match MUST equal request country and any requested subdivision/place_type. For a value lookup, the result MUST describe that value or its lifecycle replacement; for q search, the seller may apply documented text matching."
+  },
+  "type": "object",
+  "properties": {
+    "request": {
+      "$ref": "/schemas/core/get-geo-place-resolution-request.json",
+      "description": "Exact normalized request represented by this page. Pagination responses repeat the original query fields and may carry the page cursor."
+    },
+    "system": {
+      "$ref": "/schemas/core/geo-place-system.json"
+    },
+    "system_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "matches": {
+      "type": "array",
+      "items": {
+        "$ref": "/schemas/core/geo-place-catalog-entry.json"
+      }
+    },
+    "next_cursor": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "required": ["request", "system", "system_version", "matches"],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "system": { "enum": ["geonames", "google_ads", "microsoft_ads"] }
+        },
+        "required": ["system"]
+      },
+      "then": {
+        "properties": {
+          "matches": {
+            "items": {
+              "properties": {
+                "value": { "pattern": "^[0-9]+$" },
+                "replaced_by_values": {
+                  "items": { "pattern": "^[0-9]+$" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/static/schemas/source/core/targeting-overlay-requirements.json
+++ b/static/schemas/source/core/targeting-overlay-requirements.json
@@ -24,46 +24,6 @@
         }
       ]
     },
-    "placeCatalogRequirement": {
-      "type": "object",
-      "description": "Required country/type pairs and optional exact catalog versions for one identifier system. Country keys prevent a false Cartesian product between countries and place types.",
-      "properties": {
-        "countries": {
-          "type": "object",
-          "propertyNames": { "pattern": "^[A-Z]{2}$" },
-          "additionalProperties": {
-            "type": "array",
-            "items": { "$ref": "/schemas/core/geo-place-type.json" },
-            "minItems": 1,
-            "uniqueItems": true
-          },
-          "minProperties": 1
-        },
-        "system_versions": {
-          "type": "array",
-          "description": "Optional exact catalog versions that must remain selectable. Versions are opaque strings, not ordered ranges.",
-          "items": { "type": "string", "minLength": 1 },
-          "minItems": 1,
-          "uniqueItems": true
-        }
-      },
-      "required": ["countries"],
-      "additionalProperties": false
-    },
-    "placeRequirement": {
-      "type": "object",
-      "description": "Identifier systems and collision-safe country/type pairs the buyer must be allowed to select later.",
-      "properties": {
-        "systems": {
-          "type": "object",
-          "propertyNames": { "$ref": "/schemas/core/geo-place-system.json" },
-          "additionalProperties": { "$ref": "#/definitions/placeCatalogRequirement" },
-          "minProperties": 1
-        }
-      },
-      "required": ["systems"],
-      "additionalProperties": false
-    },
     "keywordRequirement": {
       "anyOf": [
         { "$ref": "#/definitions/required" },
@@ -109,8 +69,14 @@
     "geo_regions_exclude": { "$ref": "#/definitions/required" },
     "geo_metros": { "$ref": "#/definitions/metroRequirement" },
     "geo_metros_exclude": { "$ref": "#/definitions/metroRequirement" },
-    "geo_places": { "$ref": "#/definitions/placeRequirement" },
-    "geo_places_exclude": { "$ref": "#/definitions/placeRequirement" },
+    "geo_places": {
+      "$ref": "/schemas/core/geo-place-requirement.json",
+      "x-adcp-schema-uri": "/schemas/core/geo-place-requirement.json"
+    },
+    "geo_places_exclude": {
+      "$ref": "/schemas/core/geo-place-requirement.json",
+      "x-adcp-schema-uri": "/schemas/core/geo-place-requirement.json"
+    },
     "geo_postal_areas": {
       "anyOf": [
         { "$ref": "#/definitions/required" },

--- a/static/schemas/source/core/targeting-overlay-requirements.json
+++ b/static/schemas/source/core/targeting-overlay-requirements.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/targeting-overlay-requirements.json",
   "title": "Targeting Overlay Requirements",
-  "description": "Buyer minimum requirements for targeting dimensions that will be selected on packages later. This request shape deliberately excludes seller limits such as max_values_per_package and max_packages. Matching is capability containment: a requirement value of true matches either product support true or any valid support object for that dimension; an object requirement matches product support true or a support object in which every requested boolean is true and every requested array is a subset of the corresponding product array. Every valid structured requirement or support object represents a positive capability; empty, extension-only, and false-only objects are invalid. Object fields the buyer did not request, including systems, do not participate. Missing or unknown required fields do not match. Numeric seller limits are disclosed only in Product.overlay_support and never participate in matching.",
+  "description": "Buyer minimum requirements for targeting dimensions that will be selected on packages later. This request shape deliberately excludes seller limits such as max_values_per_package and max_packages. Matching is capability containment: a requirement value of true matches either product support true or any valid support object for that dimension; an object requirement matches product support true or a support object in which every requested boolean is true and every requested array is a subset of the corresponding product array. geo_places and geo_places_exclude always use the collision-safe object form: every requested system and country key must exist and each requested place-type and system-version array must be a subset of the corresponding product array. Every valid structured requirement or support object represents a positive capability; empty, extension-only, and false-only objects are invalid. Object fields the buyer did not request do not participate. Missing or unknown required fields do not match. Numeric seller limits are disclosed only in Product.overlay_support and never participate in matching.",
   "type": "object",
   "definitions": {
     "required": { "type": "boolean", "const": true },
@@ -23,6 +23,46 @@
           "additionalProperties": false
         }
       ]
+    },
+    "placeCatalogRequirement": {
+      "type": "object",
+      "description": "Required country/type pairs and optional exact catalog versions for one identifier system. Country keys prevent a false Cartesian product between countries and place types.",
+      "properties": {
+        "countries": {
+          "type": "object",
+          "propertyNames": { "pattern": "^[A-Z]{2}$" },
+          "additionalProperties": {
+            "type": "array",
+            "items": { "$ref": "/schemas/core/geo-place-type.json" },
+            "minItems": 1,
+            "uniqueItems": true
+          },
+          "minProperties": 1
+        },
+        "system_versions": {
+          "type": "array",
+          "description": "Optional exact catalog versions that must remain selectable. Versions are opaque strings, not ordered ranges.",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      },
+      "required": ["countries"],
+      "additionalProperties": false
+    },
+    "placeRequirement": {
+      "type": "object",
+      "description": "Identifier systems and collision-safe country/type pairs the buyer must be allowed to select later.",
+      "properties": {
+        "systems": {
+          "type": "object",
+          "propertyNames": { "$ref": "/schemas/core/geo-place-system.json" },
+          "additionalProperties": { "$ref": "#/definitions/placeCatalogRequirement" },
+          "minProperties": 1
+        }
+      },
+      "required": ["systems"],
+      "additionalProperties": false
     },
     "keywordRequirement": {
       "anyOf": [
@@ -69,6 +109,8 @@
     "geo_regions_exclude": { "$ref": "#/definitions/required" },
     "geo_metros": { "$ref": "#/definitions/metroRequirement" },
     "geo_metros_exclude": { "$ref": "#/definitions/metroRequirement" },
+    "geo_places": { "$ref": "#/definitions/placeRequirement" },
+    "geo_places_exclude": { "$ref": "#/definitions/placeRequirement" },
     "geo_postal_areas": {
       "anyOf": [
         { "$ref": "#/definitions/required" },

--- a/static/schemas/source/core/targeting-overlay-support.json
+++ b/static/schemas/source/core/targeting-overlay-support.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/targeting-overlay-support.json",
   "title": "Targeting Overlay Support",
-  "description": "Product-scoped package targeting dimensions that may be supplied or changed after discovery. This is the seller response shape and may disclose seller limits such as max_values_per_package and max_packages. Product.overlay_support is the binding selectable-targeting contract: the seller can apply protocol-valid values subject to the disclosed limits, but does not guarantee inventory or a forecast for every possible value. Inherent product coverage alone does not satisfy a future-support requirement. Buyer minimums use targeting-overlay-requirements.json. A requirement value of true matches true or any valid support object; an object requirement matches true or a containing support object. Every valid structured support object represents a positive capability; empty, extension-only, and false-only objects are invalid. Unrequested object fields and numeric seller limits do not participate in matching.",
+  "description": "Product-scoped package targeting dimensions that may be supplied or changed after discovery. This is the seller response shape and may disclose seller limits such as max_values_per_package and max_packages. Product.overlay_support is the binding selectable-targeting contract: the seller can apply protocol-valid values subject to the disclosed limits, including values within declared named-place systems, countries, types, and versions, but does not guarantee inventory or a forecast for every possible value. Inherent product coverage alone does not satisfy a future-support requirement. Buyer minimums use targeting-overlay-requirements.json. A requirement value of true matches true or any valid support object; an object requirement matches true or a containing support object. Every valid structured support object represents a positive capability; empty, extension-only, and false-only objects are invalid. Unrequested object fields and numeric seller limits do not participate in matching.",
   "type": "object",
   "definitions": {
     "supported": {
@@ -42,6 +42,63 @@
           "additionalProperties": false
         }
       ]
+    },
+    "placeCatalogSupport": {
+      "type": "object",
+      "description": "Selectable country/type pairs and catalog versions for one identifier system.",
+      "properties": {
+        "countries": {
+          "type": "object",
+          "propertyNames": { "pattern": "^[A-Z]{2}$" },
+          "additionalProperties": {
+            "type": "array",
+            "items": { "$ref": "/schemas/core/geo-place-type.json" },
+            "minItems": 1,
+            "uniqueItems": true
+          },
+          "minProperties": 1
+        },
+        "current_version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Version applied when a later package overlay omits system_version. Must be present in system_versions."
+        },
+        "system_versions": {
+          "type": "array",
+          "description": "Exact catalog versions selectable on later package overlays.",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "ext": { "$ref": "/schemas/core/ext.json" }
+      },
+      "required": ["countries", "current_version", "system_versions"],
+      "additionalProperties": false,
+      "x-adcp-validation": {
+        "member_of": { "field": "current_version", "array_field": "system_versions" },
+        "description": "JSON Schema draft-07 cannot express scalar membership in a sibling array; conformance tooling MUST verify current_version is present in system_versions."
+      }
+    },
+    "placeSupport": {
+      "type": "object",
+      "description": "Binding permission to select named-place values later, keyed first by identifier system and then by country to avoid namespace and place-type collisions.",
+      "properties": {
+        "systems": {
+          "type": "object",
+          "propertyNames": { "$ref": "/schemas/core/geo-place-system.json" },
+          "additionalProperties": { "$ref": "#/definitions/placeCatalogSupport" },
+          "minProperties": 1
+        },
+        "max_values_per_package": { "type": "integer", "minimum": 1 },
+        "max_packages": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Optional maximum number of independently place-targeted packages the seller will create from this configured product."
+        },
+        "ext": { "$ref": "/schemas/core/ext.json" }
+      },
+      "required": ["systems"],
+      "additionalProperties": false
     },
     "keywordSupport": {
       "anyOf": [
@@ -96,6 +153,8 @@
     "geo_regions_exclude": { "$ref": "#/definitions/supported" },
     "geo_metros": { "$ref": "#/definitions/metroSupport" },
     "geo_metros_exclude": { "$ref": "#/definitions/metroSupport" },
+    "geo_places": { "$ref": "#/definitions/placeSupport" },
+    "geo_places_exclude": { "$ref": "#/definitions/placeSupport" },
     "geo_postal_areas": {
       "anyOf": [
         { "$ref": "#/definitions/supported" },

--- a/static/schemas/source/core/targeting.json
+++ b/static/schemas/source/core/targeting.json
@@ -117,7 +117,8 @@
       "type": "array",
       "description": "Restrict delivery to catalog-backed named places. Values MUST be stable identifiers in the declared system, not display names. Sellers must declare supported systems, countries, and place types in get_adcp_capabilities and reject unsupported entries rather than silently dropping them.",
       "items": {
-        "$ref": "/schemas/core/geo-place-area.json"
+        "$ref": "/schemas/core/geo-place-area.json",
+        "x-adcp-schema-uri": "/schemas/core/geo-place-area.json"
       },
       "minItems": 1
     },
@@ -125,7 +126,8 @@
       "type": "array",
       "description": "Exclude catalog-backed named places. Uses the same identifier-based shape as geo_places. Sellers MUST reject overlap with geo_places for the same country, system, place_type, and value.",
       "items": {
-        "$ref": "/schemas/core/geo-place-area.json"
+        "$ref": "/schemas/core/geo-place-area.json",
+        "x-adcp-schema-uri": "/schemas/core/geo-place-area.json"
       },
       "minItems": 1
     },

--- a/static/schemas/source/core/targeting.json
+++ b/static/schemas/source/core/targeting.json
@@ -3,6 +3,14 @@
   "$id": "/schemas/core/targeting.json",
   "title": "Targeting Overlay",
   "description": "Concrete delivery constraints used during product discovery and media-buy execution. Targeting includes both audience eligibility and purchased-inventory selection: geography, demographics, placements, properties, collections, device compatibility, language, keywords, and other explicit controls. Sellers resolve requested outcomes against inherent product scope or selectable execution. A fresh create/update request MUST be applied exactly or rejected; get_products may instead return a request-scoped configured product with sparse, buyer-reviewable targeting_resolution modifications.",
+  "x-adcp-validation": {
+    "disjoint_place_fields": {
+      "include": "geo_places",
+      "exclude": "geo_places_exclude",
+      "identity": ["country", "system", "place_type", "value"]
+    },
+    "description": "JSON Schema draft-07 cannot compare values across sibling arrays. Conformance tooling MUST reject any place identity present in both geo_places and geo_places_exclude. Catalog version is deliberately not part of identity: a stable ID cannot be both included and excluded by assigning different versions."
+  },
   "type": "object",
   "properties": {
     "geo_countries": {
@@ -102,6 +110,22 @@
       "description": "Exclude specific postal areas from delivery. Prefer the native country + postal system form. The deprecated legacy country-fused postal-system tokens remain accepted for compatibility. Seller must declare supported systems in get_adcp_capabilities.",
       "items": {
         "$ref": "/schemas/core/postal-area.json"
+      },
+      "minItems": 1
+    },
+    "geo_places": {
+      "type": "array",
+      "description": "Restrict delivery to catalog-backed named places. Values MUST be stable identifiers in the declared system, not display names. Sellers must declare supported systems, countries, and place types in get_adcp_capabilities and reject unsupported entries rather than silently dropping them.",
+      "items": {
+        "$ref": "/schemas/core/geo-place-area.json"
+      },
+      "minItems": 1
+    },
+    "geo_places_exclude": {
+      "type": "array",
+      "description": "Exclude catalog-backed named places. Uses the same identifier-based shape as geo_places. Sellers MUST reject overlap with geo_places for the same country, system, place_type, and value.",
+      "items": {
+        "$ref": "/schemas/core/geo-place-area.json"
       },
       "minItems": 1
     },

--- a/static/schemas/source/enums/error-code.json
+++ b/static/schemas/source/enums/error-code.json
@@ -47,6 +47,7 @@
     "MEDIA_BUY_NOT_FOUND",
     "NOT_CANCELLABLE",
     "PACKAGE_NOT_FOUND",
+    "PLACE_TARGET_UNAVAILABLE",
     "CREATIVE_NOT_FOUND",
     "SIGNAL_NOT_FOUND",
     "SIGNAL_TARGETING_INCOMPATIBLE",
@@ -147,6 +148,7 @@
     "MEDIA_BUY_NOT_FOUND": "Referenced media buy does not exist or is not accessible to the requesting agent. Recovery: correctable (verify media_buy_id; when recovering across legacy sellers or missing echoed IDs, reconcile via get_media_buys and the opaque request/response context correlation handle, such as context.internal_campaign_id, rather than deprecated top-level buyer_ref).",
     "NOT_CANCELLABLE": "The media buy or package cannot be canceled in its current state. The seller may have contractual or operational constraints that prevent cancellation. Recovery: correctable (check the seller's cancellation policy or contact the seller).",
     "PACKAGE_NOT_FOUND": "Referenced package does not exist within the specified media buy. Recovery: correctable (verify package_id within the media buy; when recovering across legacy sellers or missing echoed product_id, reconcile via get_media_buys and the package-level context correlation handle, such as context.buyer_ref, rather than deprecated top-level buyer_ref).",
+    "PLACE_TARGET_UNAVAILABLE": "A place identifier previously accepted and pinned on a package can no longer be executed. This is a nonfatal resource-state error returned in get_media_buys.errors[] alongside the affected buy. error.field MUST point to the exact media_buys[N].packages[M].targeting_overlay.geo_places[_exclude][A].values[V] response path. error.details MUST include media_buy_id, package_id, system, system_version, country, place_type, and value. The seller MUST preserve and echo the pinned target rather than silently changing geography. Recovery: correctable (look up the value through the declared resolver at the current catalog version and submit an intentional targeting update).",
     "CREATIVE_NOT_FOUND": "Referenced creative does not exist in the agent's creative library. Recovery: correctable (verify creative_id via list_creatives, or sync_creatives to register it). Sellers MUST return this code uniformly for any creative_id not owned by the calling account — never distinguish 'exists in another tenant' from 'does not exist', which would enable cross-tenant enumeration.",
     "SIGNAL_NOT_FOUND": "Referenced signal does not exist in the agent's catalog. Recovery: correctable (verify signal_ref via get_signals, or confirm the signal is available from this agent). Sellers MUST return this code uniformly for any signal_ref not accessible to the calling account — never distinguish 'exists but unauthorized' from 'does not exist', which would enable cross-tenant enumeration.",
     "SIGNAL_TARGETING_INCOMPATIBLE": "A creative carrying a signal_condition (from build_creative signal_conditions fan-out, #5240) was assigned to a package whose signal targeting is incompatible — e.g. a sun creative routed to a rain-targeted package. The trafficking-compatibility invariant: a creative built FOR one signal condition MUST NOT serve into a package targeting an incompatible condition. Enforced reject-at-trafficking on the sales side (create_media_buy / sync_creatives), NOT at build_creative (per #5280, signal pointers are advisory at the build layer; enforcement lives at the trafficking boundary). Compatibility is matched on shared signal_ref identity: when both sides carry signal_agent_segment_id, compare the opaque handle exactly; when both carry only categorical {signal_id,value}, compare signal_ref + value-set semantics; equal categorical labels from DIFFERENT providers are NOT compatible absent an explicit equivalence mechanism; when one side has a segment handle and the other only a categorical value, the seller MAY accept only if it can resolve both to the same provider-issued segment, else reject/warn. For value_type:numeric the comparison is range-overlap (WG-open: range-overlap vs exact-match — see RFC #5240 open decisions). error.field SHOULD point at the offending assignment path (e.g. packages[N].creative_assignments[M] or creatives[N]); error.details SHOULD carry the creative's signal_condition and the package's incompatible signal targeting so the buyer can re-route. Distinct from SIGNAL_NOT_FOUND (signal unknown/inaccessible) by being a compatibility mismatch between a known creative condition and a known package condition. Recovery: correctable (assign the creative to a package whose signal targeting matches its signal_condition, or rebuild for the package's condition).",
@@ -373,6 +375,10 @@
     "PACKAGE_NOT_FOUND": {
       "recovery": "correctable",
       "suggestion": "verify package_id; for legacy package correlation use get_media_buys plus package context, such as context.buyer_ref"
+    },
+    "PLACE_TARGET_UNAVAILABLE": {
+      "recovery": "correctable",
+      "suggestion": "resolve the pinned value against the current catalog, review any replacement, and submit an intentional package targeting update"
     },
     "CREATIVE_NOT_FOUND": {
       "recovery": "correctable",

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -490,6 +490,42 @@
           "$ref": "/schemas/core/postal-area-support.json",
           "description": "Reusable postal area support map for capabilities and reporting"
         },
+        "geo-place-area": {
+          "$ref": "/schemas/core/geo-place-area.json",
+          "description": "Catalog-backed named place target using stable identifiers in a declared system"
+        },
+        "geo-place-support": {
+          "$ref": "/schemas/core/geo-place-support.json",
+          "description": "Countries and place types supported for one place identifier system"
+        },
+        "geo-place-system": {
+          "$ref": "/schemas/core/geo-place-system.json",
+          "description": "Registered geographic place identifier namespaces with HTTPS URI extensions"
+        },
+        "geo-place-type": {
+          "$ref": "/schemas/core/geo-place-type.json",
+          "description": "Registered geographic place classifications with HTTPS URI extensions"
+        },
+        "geo-place-resolver": {
+          "$ref": "/schemas/core/geo-place-resolver.json",
+          "description": "Machine-readable endpoint declaration for resolving place names to seller-accepted IDs"
+        },
+        "get-geo-place-resolution-request": {
+          "$ref": "/schemas/core/get-geo-place-resolution-request.json",
+          "description": "Standard query parameters for geographic place resolution"
+        },
+        "get-geo-place-resolution-response": {
+          "$ref": "/schemas/core/get-geo-place-resolution-response.json",
+          "description": "Paginated geographic place resolver results"
+        },
+        "geo-place-catalog-entry": {
+          "$ref": "/schemas/core/geo-place-catalog-entry.json",
+          "description": "One place identifier with lifecycle and replacement metadata"
+        },
+        "geo-place-catalog-capability": {
+          "$ref": "/schemas/core/geo-place-catalog-capability.json",
+          "description": "Supported versions and resolver for one place identifier system"
+        },
         "asset-group-vocabulary": {
           "$ref": "/schemas/core/asset-group-vocabulary.json",
           "description": "Canonical registry of asset_group_id values with descriptions and v1 alias mapping (e.g., landing_page_url replaces 6 v1 alias names)"

--- a/static/schemas/source/index.json
+++ b/static/schemas/source/index.json
@@ -494,6 +494,10 @@
           "$ref": "/schemas/core/geo-place-area.json",
           "description": "Catalog-backed named place target using stable identifiers in a declared system"
         },
+        "geo-place-requirement": {
+          "$ref": "/schemas/core/geo-place-requirement.json",
+          "description": "Collision-safe identifier systems, countries, place types, and catalog versions required for later package selection"
+        },
         "geo-place-support": {
           "$ref": "/schemas/core/geo-place-support.json",
           "description": "Countries and place types supported for one place identifier system"

--- a/static/schemas/source/media-buy/get-media-buys-response.json
+++ b/static/schemas/source/media-buy/get-media-buys-response.json
@@ -340,7 +340,7 @@
                 },
                 "targeting_overlay": {
                   "$ref": "/schemas/core/targeting.json",
-                  "description": "Complete effective targeting applied to this package, including configured-product targeting and the most recent package-specific overlay. Sellers SHOULD echo persisted targeting so buyers can verify stored state without replaying requests. Sellers using placement, property-list, or collection-list targeting MUST include the committed inventory selection here. placement_selection mode default SHOULD resolve to mode selected with committed refs when enumerable."
+                  "description": "Complete effective targeting applied to this package, including configured-product targeting and the most recent package-specific overlay. Sellers SHOULD echo persisted targeting so buyers can verify stored state without replaying requests. Sellers MUST echo geo_places and geo_places_exclude whenever either was persisted, including the exact applied system_version and normalized values, so buyers can audit catalog-backed targeting. Sellers using placement, property-list, or collection-list targeting MUST include the committed inventory selection here. placement_selection mode default SHOULD resolve to mode selected with committed refs when enumerable."
                 },
                 "targeting_resolution": {
                   "$ref": "/schemas/core/package-targeting-resolution.json",
@@ -828,7 +828,7 @@
     },
     "errors": {
       "type": "array",
-      "description": "Task-specific errors (e.g., media buy not found)",
+      "description": "Task-specific errors. A read may return media_buys plus nonfatal resource-state errors. If a pinned place target becomes unexecutable, sellers MUST include PLACE_TARGET_UNAVAILABLE with recovery=correctable, field pointing to the exact media_buys[N].packages[M].targeting_overlay.geo_places[_exclude][A].values[V] response path, and details containing media_buy_id, package_id, system, system_version, country, place_type, and value. The persisted target remains echoed until an intentional update replaces it.",
       "items": {
         "$ref": "/schemas/core/error.json"
       }

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -1000,6 +1000,17 @@
                   "description": "Postal area targeting. Prefer the native country-keyed map where each ISO 3166-1 alpha-2 country lists supported country-local postal systems. Deprecated legacy country-fused postal-system boolean aliases may be emitted alongside native country keys during migration.",
                   "$ref": "/schemas/core/postal-area-support.json"
                 },
+                "geo_places": {
+                  "type": "object",
+                  "description": "Place targeting support keyed by collision-safe identifier system. Each system declares exact country-to-place-type combinations, accepted catalog versions, and a machine-readable resolver. Sellers MUST reject unsupported systems, country/type pairs, versions, and identifiers rather than silently dropping them.",
+                  "propertyNames": {
+                    "$ref": "/schemas/core/geo-place-system.json"
+                  },
+                  "additionalProperties": {
+                    "$ref": "/schemas/core/geo-place-support.json"
+                  },
+                  "minProperties": 1
+                },
                 "age_restriction": {
                   "type": "object",
                   "description": "Age restriction capabilities for compliance (alcohol, gambling)",

--- a/static/test-vectors/media-buy/package-status-targeting-overlay-echo.json
+++ b/static/test-vectors/media-buy/package-status-targeting-overlay-echo.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "schema": "/schemas/media-buy/get-media-buys-response.json",
-  "description": "Positive wire-level vectors for PackageStatus targeting readback in get_media_buys responses, including audience targeting, purchased inventory selection, and demographic execution under targeting_resolution.demographics. Vectors are dedicated JSON payloads that MUST validate against the bundled schema and whose shape is asserted by SDK code generators. Each vector contains a stable `id` (kebab-case; the stable reference for cross-SDK conformance), a human-readable `description`, the `payload` returned by the seller, and `assertions` — dotted JSON paths that MUST be present with the given value. Downstream tests SHOULD look up vectors by `id`; `description` prose may be revised without notice.",
+  "description": "Positive wire-level vectors for PackageStatus targeting readback in get_media_buys responses, including audience targeting, purchased inventory selection, demographic execution under targeting_resolution.demographics, and the geo-place catalog audit MUST. Vectors are dedicated JSON payloads that MUST validate against the bundled schema and whose shape is asserted by SDK code generators. Each vector contains a stable `id` (kebab-case; the stable reference for cross-SDK conformance), a human-readable `description`, the `payload` returned by the seller, and `assertions` — dotted JSON paths that MUST be present with the given value. Downstream tests SHOULD look up vectors by `id`; `description` prose may be revised without notice.",
   "vectors": [
     {
       "id": "property-and-collection-list-echo",
@@ -128,6 +128,89 @@
         {
           "path": "media_buys[0].packages[0].targeting_overlay.frequency_cap.window.unit",
           "value": "days"
+        }
+      ]
+    },
+    {
+      "id": "geo-place-targeting-echo",
+      "description": "Place-targeting MUST — seller echoes persisted identifier-based geo_places and geo_places_exclude so the buyer can audit the catalog namespace, place type, values, and diagnostic labels that were applied.",
+      "payload": {
+        "status": "completed",
+        "media_buys": [
+          {
+            "media_buy_id": "mb_nova_local_001",
+            "status": "active",
+            "currency": "EUR",
+            "total_budget": 18000,
+            "confirmed_at": "2026-07-01T09:00:00Z",
+            "revision": 1,
+            "start_time": "2026-07-15T00:00:00Z",
+            "end_time": "2026-08-15T23:59:59Z",
+            "created_at": "2026-07-01T09:00:00Z",
+            "updated_at": "2026-07-15T10:30:00Z",
+            "packages": [
+              {
+                "package_id": "pkg_nova_local_video",
+                "product_id": "prod_local_video_nl",
+                "budget": 18000,
+                "currency": "EUR",
+                "start_time": "2026-07-15T00:00:00Z",
+                "end_time": "2026-08-15T23:59:59Z",
+                "targeting_overlay": {
+                  "geo_places": [{
+                    "country": "NL",
+                    "system": "geonames",
+                    "system_version": "2026-05",
+                    "place_type": "city",
+                    "values": ["2759794"],
+                    "value_labels": {
+                      "2759794": "Amsterdam, North Holland, Netherlands"
+                    }
+                  }],
+                  "geo_places_exclude": [{
+                    "country": "NL",
+                    "system": "geonames",
+                    "system_version": "2026-05",
+                    "place_type": "city",
+                    "values": ["2747373"],
+                    "value_labels": {
+                      "2747373": "The Hague, South Holland, Netherlands"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "assertions": [
+        {
+          "path": "media_buys[0].packages[0].targeting_overlay.geo_places[0].values",
+          "value": ["2759794"]
+        },
+        {
+          "path": "media_buys[0].packages[0].targeting_overlay.geo_places[0].country",
+          "value": "NL"
+        },
+        {
+          "path": "media_buys[0].packages[0].targeting_overlay.geo_places[0].system",
+          "value": "geonames"
+        },
+        {
+          "path": "media_buys[0].packages[0].targeting_overlay.geo_places[0].system_version",
+          "value": "2026-05"
+        },
+        {
+          "path": "media_buys[0].packages[0].targeting_overlay.geo_places[0].place_type",
+          "value": "city"
+        },
+        {
+          "path": "media_buys[0].packages[0].targeting_overlay.geo_places[0].value_labels.2759794",
+          "value": "Amsterdam, North Holland, Netherlands"
+        },
+        {
+          "path": "media_buys[0].packages[0].targeting_overlay.geo_places_exclude[0].values",
+          "value": ["2747373"]
         }
       ]
     },

--- a/tests/check-platform-agnostic.cjs
+++ b/tests/check-platform-agnostic.cjs
@@ -140,6 +140,16 @@ const ENUM_VALUE_ALLOWLIST = [
   // enums/metro-system.json — Nielsen DMA is the industry-standard geographic
   // division (same justification as FIELD_ALLOWLIST entry).
   { value: 'nielsen_dma', pathContains: 'enums/metro-system.json' },
+
+  // Geographic place schemas — registered external catalog identifier spaces.
+  // These values select the namespace in which stable place IDs are interpreted;
+  // they do not expose a vendor-specific version of an AdCP resource.
+  { value: 'google_ads',    pathContains: 'core/geo-place-system.json' },
+  { value: 'microsoft_ads', pathContains: 'core/geo-place-system.json' },
+  { value: 'google_ads',    pathContains: 'core/geo-place-area.json' },
+  { value: 'microsoft_ads', pathContains: 'core/geo-place-area.json' },
+  { value: 'google_ads',    pathContains: 'core/get-geo-place-resolution-response.json' },
+  { value: 'microsoft_ads', pathContains: 'core/get-geo-place-resolution-response.json' },
 ];
 
 function findJSONFiles(dir) {

--- a/tests/lint-storyboard-context-output-paths.test.cjs
+++ b/tests/lint-storyboard-context-output-paths.test.cjs
@@ -9,7 +9,7 @@
  *      in the response schema (the offering_id / offering.offering_id typo
  *      that surfaced this lint).
  *   3. The path resolver follows the bracket / dot equivalence and descends
- *      through oneOf / anyOf variants and items.
+ *      through oneOf / anyOf variants, items, and typed dynamic maps.
  *   4. The allowlist mechanism suppresses entries for paths the lint can't
  *      statically verify (error.details polymorphism, additionalProperties
  *      runtime conventions).
@@ -167,6 +167,54 @@ test('mixed schemas (declared properties + additionalProperties: true) stay stri
   assert.equal(pathResolves(schema, parsePath('offering.offering_id')), true);
   assert.equal(pathResolves(schema, parsePath('offering_id')), false);
   assert.equal(pathResolves(schema, parsePath('not_a_real_field')), false);
+});
+
+test('schema-valued additionalProperties resolves typed dynamic map keys', () => {
+  const schema = loadSchema('protocol/get-adcp-capabilities-response.json');
+  assert.equal(
+    pathResolves(
+      schema,
+      parsePath('media_buy.execution.targeting.geo_places.geonames.catalog.current_version'),
+    ),
+    true,
+  );
+  assert.equal(
+    pathResolves(
+      schema,
+      parsePath('media_buy.execution.targeting.geo_places.geonames.not_a_real_field'),
+    ),
+    false,
+  );
+});
+
+test('pathResolves follows local definitions through typed dynamic maps', () => {
+  const schema = {
+    definitions: {
+      systemSupport: {
+        type: 'object',
+        properties: {
+          countries: {
+            type: 'object',
+            additionalProperties: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+    properties: {
+      systems: {
+        type: 'object',
+        additionalProperties: { $ref: '#/definitions/systemSupport' },
+      },
+    },
+  };
+
+  assert.equal(
+    pathResolves(schema, parsePath('systems.geonames.countries.NL.0')),
+    true,
+  );
 });
 
 test('parsePath accepts both bracket and dotted forms', () => {

--- a/tests/lint-storyboard-validations-paths.test.cjs
+++ b/tests/lint-storyboard-validations-paths.test.cjs
@@ -8,7 +8,8 @@
  *      asserts on a path that doesn't resolve in the response schema.
  *   3. Non-path-bearing checks (error_code, response_schema, http_status,
  *      etc.) are silently skipped — they have no path to validate.
- *   4. The path resolver follows $ref / oneOf / anyOf / allOf / items.
+ *   4. The path resolver follows $ref / oneOf / anyOf / allOf / items and
+ *      schema-valued additionalProperties for typed dynamic maps.
  *   5. Pure extension points (additionalProperties: true with no
  *      properties / variants — like core/context.json and error.details)
  *      accept any further segments without flagging.
@@ -127,6 +128,36 @@ test('field_contains accepts wildcard paths that resolve through array items', (
 
   const violations = lintDoc(doc, '/synth/test.yaml');
   assert.deepEqual(violations, []);
+});
+
+test('pathResolves follows local definitions through typed dynamic maps', () => {
+  const schema = {
+    definitions: {
+      systemSupport: {
+        type: 'object',
+        properties: {
+          countries: {
+            type: 'object',
+            additionalProperties: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+    properties: {
+      systems: {
+        type: 'object',
+        additionalProperties: { $ref: '#/definitions/systemSupport' },
+      },
+    },
+  };
+
+  assert.equal(
+    pathResolves(schema, parsePath('systems.geonames.countries.NL[*]')),
+    true,
+  );
 });
 
 test('dependency_impairment verify_impaired matches impairment entries without index coupling', () => {
@@ -264,6 +295,24 @@ test('pure extension points only loosen when there are no defined properties', (
   // `not_a_real_field` does NOT resolve — additionalProperties: true at the
   // root doesn't make typos legal because `properties` is non-empty
   assert.equal(pathResolves(schema, parsePath('not_a_real_field')), false);
+});
+
+test('schema-valued additionalProperties resolves typed dynamic map keys', () => {
+  const schema = loadSchema('protocol/get-adcp-capabilities-response.json');
+  assert.equal(
+    pathResolves(
+      schema,
+      parsePath('media_buy.execution.targeting.geo_places.geonames.catalog.current_version'),
+    ),
+    true,
+  );
+  assert.equal(
+    pathResolves(
+      schema,
+      parsePath('media_buy.execution.targeting.geo_places.geonames.not_a_real_field'),
+    ),
+    false,
+  );
 });
 
 test('pathResolves descends through error.json $ref for errors[0].code', () => {

--- a/tests/media-buy-targeting-overlay-vectors.test.cjs
+++ b/tests/media-buy-targeting-overlay-vectors.test.cjs
@@ -100,6 +100,11 @@ describe('PackageStatus targeting_overlay echo vectors', () => {
       packageStatusSchema.properties.targeting_overlay.$ref,
       '/schemas/core/targeting.json'
     );
+    assert.match(
+      packageStatusSchema.properties.targeting_overlay.description,
+      /MUST echo geo_places and geo_places_exclude/,
+      'PackageStatus targeting_overlay contract must make place echo normative'
+    );
   });
 
   for (const vector of data.vectors) {
@@ -124,9 +129,10 @@ describe('PackageStatus targeting_overlay echo vectors', () => {
     });
   }
 
-  it('covers both the specialism MUST and the general SHOULD paths', () => {
+  it('covers specialism, place-targeting, and general echo paths', () => {
     const ids = new Set(data.vectors.map(v => v.id));
     assert.ok(ids.has('property-and-collection-list-echo'), 'specialism MUST vector required');
+    assert.ok(ids.has('geo-place-targeting-echo'), 'place-targeting MUST vector required');
     assert.ok(ids.has('plain-overlay-fields-echo'), 'general SHOULD vector required');
   });
 });

--- a/tests/schema-validation.test.cjs
+++ b/tests/schema-validation.test.cjs
@@ -1599,6 +1599,312 @@ async function runTests() {
     return true;
   });
 
+  // Test 11D: Validate identifier-based place targeting across execution, discovery, and capabilities
+  await test('Geo place targeting uses stable identifiers and declares discoverable support', async () => {
+    const testAjv = new Ajv({
+      allErrors: true,
+      verbose: true,
+      strict: false,
+      discriminator: true,
+      loadSchema: loadExternalSchema
+    });
+    addFormats(testAjv);
+
+    const validateTargeting = await testAjv.compileAsync(loadSchema(path.join(SCHEMA_BASE_DIR, 'core/targeting.json')));
+    const validateCapabilities = await testAjv.compileAsync(loadSchema(path.join(SCHEMA_BASE_DIR, 'protocol/get-adcp-capabilities-response.json')));
+    const validateForecastGeo = await testAjv.compileAsync(loadSchema(path.join(SCHEMA_BASE_DIR, 'core/forecast-dimension-geo.json')));
+    const validateResolutionRequest = await testAjv.compileAsync(loadSchema(path.join(SCHEMA_BASE_DIR, 'core/get-geo-place-resolution-request.json')));
+    const validateResolutionResponse = await testAjv.compileAsync(loadSchema(path.join(SCHEMA_BASE_DIR, 'core/get-geo-place-resolution-response.json')));
+
+    const assertValid = (validate, value, label) => {
+      if (!validate(value)) {
+        return `${label} unexpectedly failed validation: ${validate.errors.map(err => `${err.instancePath} ${err.message}`).join('; ')}`;
+      }
+      return true;
+    };
+    const assertInvalid = (validate, value, label) => validate(value)
+      ? `${label} unexpectedly passed validation`
+      : true;
+
+    let result = assertValid(
+      validateTargeting,
+      {
+        geo_places: [{
+          country: 'NL',
+          system: 'geonames',
+          system_version: '2026-05',
+          place_type: 'city',
+          values: ['2759794', '2747373'],
+          value_labels: {
+            '2759794': 'Amsterdam, North Holland, Netherlands',
+            '2747373': 'The Hague, South Holland, Netherlands'
+          }
+        }],
+        geo_places_exclude: [{
+          country: 'US',
+          system: 'https://seller.example/geo/catalogs/places',
+          place_type: 'city',
+          values: ['san-jose-ca-001']
+        }]
+      },
+      'targeting overlay with place inclusion and exclusion'
+    );
+    if (result !== true) return result;
+
+    result = assertInvalid(
+      validateTargeting,
+      { geo_places: [{ country: 'NL', system: 'geoname', place_type: 'city', values: ['2759794'] }] },
+      'misspelled registered place system'
+    );
+    if (result !== true) return result;
+
+    result = assertInvalid(
+      validateTargeting,
+      { geo_places: [{ country: 'NL', system: 'geonames', place_type: 'municipalit', values: ['2759794'] }] },
+      'misspelled registered place type'
+    );
+    if (result !== true) return result;
+
+    result = assertInvalid(
+      validateTargeting,
+      { geo_places: [{ country: 'NL', system: 'geonames', place_type: 'city', values: ['Amsterdam'] }] },
+      'GeoNames display name used as a targeting identifier'
+    );
+    if (result !== true) return result;
+
+    result = assertInvalid(
+      validateTargeting,
+      { geo_places: [{ country: 'NL', system: 'geonames', values: ['2759794'] }] },
+      'place target without place_type'
+    );
+    if (result !== true) return result;
+
+    const capabilityBase = {
+      status: 'completed',
+      adcp: { major_versions: [3], idempotency: { supported: false } },
+      supported_protocols: ['media_buy'],
+      media_buy: { execution: { targeting: {} } }
+    };
+    capabilityBase.media_buy.execution.targeting.geo_places = {
+      geonames: {
+        countries: {
+          US: ['city', 'county'],
+          NL: ['city', 'municipality'],
+          GB: ['city', 'post_town']
+        },
+        catalog: {
+          source: 'https://seller.example/data-sources/geonames-mirror',
+          current_version: '2026-05',
+          supported_versions: ['2026-05', '2026-04'],
+          resolver: {
+            url: 'https://seller.example/adcp/geo/resolve/geonames',
+            auth: 'seller_credentials',
+            protocol: 'adcp_geo_place_resolver_v1'
+          }
+        }
+      },
+      'https://seller.example/geo/catalogs/places': {
+        countries: { NL: ['city'] },
+        catalog: {
+          current_version: '2026-q2',
+          supported_versions: ['2026-q2'],
+          resolver: {
+            url: 'https://seller.example/adcp/geo/resolve/private',
+            auth: 'seller_credentials',
+            protocol: 'adcp_geo_place_resolver_v1'
+          }
+        }
+      }
+    };
+    result = assertValid(validateCapabilities, capabilityBase, 'place targeting capability declaration');
+    if (result !== true) return result;
+
+    const legacyCartesianCapabilities = JSON.parse(JSON.stringify(capabilityBase));
+    legacyCartesianCapabilities.media_buy.execution.targeting.geo_places.geonames = {
+      countries: ['US', 'NL'],
+      place_types: ['city', 'municipality'],
+      supports_system_version: true
+    };
+    result = assertInvalid(validateCapabilities, legacyCartesianCapabilities, 'legacy Cartesian place support declaration');
+    if (result !== true) return result;
+
+    const typoCapabilities = JSON.parse(JSON.stringify(capabilityBase));
+    typoCapabilities.media_buy.execution.targeting.geo_places.geoname =
+      typoCapabilities.media_buy.execution.targeting.geo_places.geonames;
+    delete typoCapabilities.media_buy.execution.targeting.geo_places.geonames;
+    result = assertInvalid(validateCapabilities, typoCapabilities, 'misspelled capability system key');
+    if (result !== true) return result;
+
+    const invalidCapabilities = JSON.parse(JSON.stringify(capabilityBase));
+    delete invalidCapabilities.media_buy.execution.targeting.geo_places.geonames.countries.NL;
+    invalidCapabilities.media_buy.execution.targeting.geo_places.geonames.countries.NL = [];
+    result = assertInvalid(validateCapabilities, invalidCapabilities, 'place support with an empty country type list');
+    if (result !== true) return result;
+
+    const catalogCapabilitySchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'core/geo-place-catalog-capability.json'));
+    const membershipRule = catalogCapabilitySchema['x-adcp-validation']?.member_of;
+    if (membershipRule?.field !== 'current_version' || membershipRule?.array_field !== 'supported_versions') {
+      return 'geo-place-catalog-capability must declare current_version membership validation';
+    }
+    const geonamesCatalog = capabilityBase.media_buy.execution.targeting.geo_places.geonames.catalog;
+    if (!geonamesCatalog.supported_versions.includes(geonamesCatalog.current_version)) {
+      return 'valid capability fixture current_version must be in supported_versions';
+    }
+    const invalidCatalogMembership = {
+      current_version: '2026-03',
+      supported_versions: ['2026-05', '2026-04']
+    };
+    if (invalidCatalogMembership.supported_versions.includes(invalidCatalogMembership.current_version)) {
+      return 'semantic catalog membership validation must reject an undeclared current_version';
+    }
+
+    const areaSchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'core/geo-place-area.json'));
+    const labelRule = areaSchema['x-adcp-validation']?.map_keys_subset_of_array;
+    if (labelRule?.map_field !== 'value_labels' || labelRule?.array_field !== 'values') {
+      return 'geo-place-area must declare value_labels key membership validation';
+    }
+    const labelsAreSubset = (area) => Object.keys(area.value_labels || {}).every(value => area.values.includes(value));
+    if (labelsAreSubset({ values: ['2759794'], value_labels: { '999999': 'Wrong place' } })) {
+      return 'semantic value_labels validation must reject labels for absent values';
+    }
+
+    const targetingSchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'core/targeting.json'));
+    const disjointRule = targetingSchema['x-adcp-validation']?.disjoint_place_fields;
+    if (disjointRule?.include !== 'geo_places' || disjointRule?.exclude !== 'geo_places_exclude') {
+      return 'targeting schema must declare geo place include/exclude disjointness validation';
+    }
+    if (JSON.stringify(disjointRule.identity) !== JSON.stringify(['country', 'system', 'place_type', 'value'])) {
+      return 'geo place include/exclude identity must exclude catalog version';
+    }
+    const placeIdentitySet = (areas) => new Set((areas || []).flatMap(area =>
+      area.values.map(value => [area.country, area.system, area.place_type, value].join('\u0000'))));
+    const hasPlaceOverlap = overlay => {
+      const included = placeIdentitySet(overlay.geo_places);
+      return [...placeIdentitySet(overlay.geo_places_exclude)].some(identity => included.has(identity));
+    };
+    if (!hasPlaceOverlap({
+      geo_places: [{ country: 'NL', system: 'geonames', system_version: '2026-05', place_type: 'city', values: ['2759794'] }],
+      geo_places_exclude: [{ country: 'NL', system: 'geonames', system_version: '2026-04', place_type: 'city', values: ['2759794'] }]
+    })) {
+      return 'semantic place overlap validation must reject cross-version overlap';
+    }
+
+    result = assertValid(
+      validateResolutionRequest,
+      { q: 'Amsterdam', country: 'NL', subdivision: 'NL-NH', place_type: 'city', locale: 'nl-NL', limit: 20 },
+      'place resolution request with disambiguation context'
+    );
+    if (result !== true) return result;
+
+    result = assertValid(
+      validateResolutionRequest,
+      { value: '2759794', country: 'NL', place_type: 'city', system_version: '2026-05' },
+      'place identifier lifecycle refresh request'
+    );
+    if (result !== true) return result;
+
+    result = assertInvalid(
+      validateResolutionRequest,
+      { q: 'Amsterdam', value: '2759794', country: 'NL' },
+      'place resolution request containing both name and identifier'
+    );
+    if (result !== true) return result;
+
+    const resolutionResponse = {
+        request: {
+          q: 'Amsterdam',
+          country: 'NL',
+          subdivision: 'NL-NH',
+          place_type: 'city',
+          system_version: '2026-05'
+        },
+        system: 'geonames',
+        system_version: '2026-05',
+        matches: [{
+          value: '2759794',
+          country: 'NL',
+          subdivision: 'NL-NH',
+          place_type: 'city',
+          label: 'Amsterdam',
+          canonical_name: 'Amsterdam, North Holland, Netherlands',
+          parent_labels: ['North Holland', 'Netherlands'],
+          status: 'active'
+        }, {
+          value: '9999999',
+          country: 'NL',
+          subdivision: 'NL-NH',
+          place_type: 'city',
+          label: 'Old Amsterdam target',
+          canonical_name: 'Old Amsterdam target, Netherlands',
+          parent_labels: ['Netherlands'],
+          status: 'deprecated',
+          replaced_by_values: ['2759794']
+        }]
+      };
+    result = assertValid(
+      validateResolutionResponse,
+      resolutionResponse,
+      'place resolution response with lifecycle replacement metadata'
+    );
+    if (result !== true) return result;
+
+    const bindingRule = loadSchema(path.join(SCHEMA_BASE_DIR, 'core/get-geo-place-resolution-response.json'))['x-adcp-validation']?.resolver_response_binding;
+    if (bindingRule?.system !== 'capability_key' || !bindingRule?.match_fields?.includes('subdivision')) {
+      return 'place resolution response must declare capability/request binding semantics';
+    }
+    const responseMatchesResolverContract = (response, capabilitySystem, currentVersion) => {
+      const request = response.request;
+      const expectedVersion = request.system_version || currentVersion;
+      return response.system === capabilitySystem
+        && response.system_version === expectedVersion
+        && response.matches.every(match => match.country === request.country
+          && (!request.subdivision || match.subdivision === request.subdivision)
+          && (!request.place_type || match.place_type === request.place_type));
+    };
+    if (!responseMatchesResolverContract(resolutionResponse, 'geonames', '2026-05')) {
+      return 'valid resolver response fixture must bind to capability and normalized request';
+    }
+    const mismatchedResolverResponse = JSON.parse(JSON.stringify(resolutionResponse));
+    mismatchedResolverResponse.matches[0].subdivision = 'NL-ZH';
+    if (responseMatchesResolverContract(mismatchedResolverResponse, 'geonames', '2026-05')) {
+      return 'resolver response binding must reject a match outside the requested subdivision';
+    }
+
+    const rawNameResponse = JSON.parse(JSON.stringify(resolutionResponse));
+    rawNameResponse.matches[0].value = 'Amsterdam';
+    result = assertInvalid(
+      validateResolutionResponse,
+      rawNameResponse,
+      'registered-system resolver response containing a raw name'
+    );
+    if (result !== true) return result;
+
+    const missingDisambiguationResponse = JSON.parse(JSON.stringify(resolutionResponse));
+    delete missingDisambiguationResponse.matches[0].canonical_name;
+    result = assertInvalid(
+      validateResolutionResponse,
+      missingDisambiguationResponse,
+      'resolver response without required canonical disambiguation name'
+    );
+    if (result !== true) return result;
+
+    result = assertInvalid(
+      validateResolutionRequest,
+      { q: 'Springfield' },
+      'place resolution request without country disambiguation'
+    );
+    if (result !== true) return result;
+
+    result = assertInvalid(
+      validateForecastGeo,
+      { kind: 'geo', geo_level: 'place', country: 'NL', system: 'geonames', geo_code: '2759794' },
+      'place reporting row before reporting support is standardized'
+    );
+    if (result !== true) return result;
+
+    return true;
+  });
+
   // Test 12: Validate ForecastPoint dimension and viewability compatibility gates
   await test('ForecastPoint dimension and viewability compatibility gates behave as intended', async () => {
     const dimensionsSchema = loadSchema(path.join(SCHEMA_BASE_DIR, 'core/forecast-point-dimensions.json'));

--- a/tests/targeting-aware-discovery.test.cjs
+++ b/tests/targeting-aware-discovery.test.cjs
@@ -1259,6 +1259,109 @@ test("product identity and forecast semantics distinguish wholesale from custom 
   assert.match(product.properties.expires_at.description, /PRODUCT_NOT_FOUND/);
 });
 
+test("named-place targeting supports known-now and declared-later discovery", async () => {
+  const [validateRequest, validateRequirements, validateSupport] =
+    await Promise.all([
+      compile("/schemas/media-buy/get-products-request.json"),
+      compile("/schemas/core/targeting-overlay-requirements.json"),
+      compile("/schemas/core/targeting-overlay-support.json"),
+    ]);
+
+  const placeRequirement = {
+    systems: {
+      geonames: {
+        countries: { NL: ["city", "municipality"] },
+        system_versions: ["2026-05"],
+      },
+      "https://places.meridiangeo.example/catalog": {
+        countries: { GB: ["city_region"] },
+      },
+    },
+  };
+
+  assert.equal(
+    validateRequest({
+      buying_mode: "brief",
+      brief: "Local municipal campaign",
+      targeting_overlay: {
+        geo_places: [
+          {
+            country: "NL",
+            system: "geonames",
+            system_version: "2026-05",
+            place_type: "city",
+            values: ["2759794"],
+          },
+        ],
+      },
+      required_overlay_support: {
+        geo_places_exclude: placeRequirement,
+      },
+    }),
+    true,
+    errors(validateRequest)
+  );
+
+  assert.equal(
+    validateRequirements({ geo_places: placeRequirement }),
+    true,
+    errors(validateRequirements)
+  );
+  assert.equal(
+    validateRequirements({ geo_places: true }),
+    false,
+    "future named-place support must bind an identifier system and country/type pairs"
+  );
+  assert.equal(
+    validateRequirements({
+      geo_places: {
+        systems: { geonames: { countries: { Netherlands: ["city"] } } },
+      },
+    }),
+    false,
+    "country keys use collision-safe ISO alpha-2 identifiers"
+  );
+
+  const placeSupport = {
+    systems: {
+      geonames: {
+        countries: { NL: ["city", "municipality"] },
+        current_version: "2026-05",
+        system_versions: ["2026-05", "2025-11"],
+      },
+      "https://places.meridiangeo.example/catalog": {
+        countries: { GB: ["city_region"] },
+        current_version: "2026-Q2",
+        system_versions: ["2026-Q2"],
+      },
+    },
+    max_values_per_package: 50,
+    max_packages: 20,
+  };
+  assert.equal(
+    validateSupport({
+      geo_places: placeSupport,
+      geo_places_exclude: placeSupport,
+    }),
+    true,
+    errors(validateSupport)
+  );
+  assert.equal(
+    validateSupport({
+      geo_places: {
+        systems: {
+          geonames: {
+            countries: { NL: ["city"] },
+            system_versions: ["2026-05"],
+          },
+        },
+      },
+    }),
+    false,
+    "product support discloses the current catalog version used for omitted package versions"
+  );
+});
+
 test("product and package targeting resolutions reject cross-lifecycle fields", async () => {
   const validateProduct = await compile(
     "/schemas/core/product-targeting-resolution.json"


### PR DESCRIPTION
## What changed

- Add `geo_places` and `geo_places_exclude` targeting using stable IDs, explicit countries, identifier systems, catalog versions, and place types.
- Add exact country/type capability discovery, collision-safe registry extensions, version lifecycle metadata, and a standard name/ID resolver contract.
- Add `get_products` place coverage and capability filters so buyers can discover support before creating a buy.
- Require persisted package-state echo with the applied catalog version and define `PLACE_TARGET_UNAVAILABLE` for correctable catalog-rollover failures.
- Add compliance coverage for brief and wholesale discovery, create/update/readback, exclusion-only targeting, unsupported and unavailable values, mismatched labels, and same- and cross-version include/exclude conflicts.
- Document execution semantics and explicitly defer place-level forecasting and delivery breakdowns to a follow-up.

## Alignment with #6203

This branch is now a single clean commit on current `main`, including the merged targeting-aware discovery contract from #6203.

- Buyers that know place values during discovery send them in `targeting_overlay`, so returned configured products and aggregate forecasts reflect those values.
- Buyers that will choose values later must say so explicitly through `required_overlay_support.geo_places` and/or `geo_places_exclude`; matching Products return binding, namespaced `overlay_support` permission.
- Fixed prices and floors retain their binding semantics uniformly for selections inside declared support. Sellers cannot use a create-time `REQUOTE_REQUIRED` to change those terms.
- A supported selection with no current inventory returns `PRODUCT_UNAVAILABLE`, without silent substitution or repricing. `REQUOTE_REQUIRED` remains an update-time response outside the accepted envelope.
- Place-level forecast and delivery breakdown rows remain deferred; package-state echo is the configuration-audit surface in this release.

## Why

Raw city names are ambiguous, localized, and unstable across platforms. Buyers need a portable way to express named-place intent without silently targeting the wrong Bergen, Springfield, municipality, borough, or neighborhood.

The capability shape uses a country-keyed type map to avoid Cartesian false positives. Registered systems have exact semantics, while owner-controlled HTTPS URIs provide collision-safe extensions for private catalogs and types.

## Review

Independent product, protocol-interoperability, and JSON Schema reviews found no remaining correctness blockers. The prior cross-version-overlap review thread is resolved and outdated. Because this changes published schema source, a human approval is still required before merge.

## Validation

- Schema validation: 30/30; schema deprecation metadata: 4/4
- Targeting-aware discovery and overlay/lint tests: 109/109
- MCP schema projection: 16/16
- Compliance build, source-authority, packaged-ref, request/response-schema, and changeset-scope checks
- Current storyboard matrix: 1,458 passing steps across seven tenants; all floors met
- AdCP 3.0 compatibility matrix: 1,050 passing steps across seven tenants; all floors met
- Error-code drift, platform-agnosticism, SDK shim, schema-link, and diff-hygiene checks

Closes #5588.
