### PR TITLE
feat(creative): filter creatives by asset type

### DIFF
--- a/.agents/sdk-shim-ledger.json
+++ b/.agents/sdk-shim-ledger.json
@@ -24,7 +24,7 @@
     "owner": "compliance",
     "upstream": "adcontextprotocol/adcp-client#2105",
     "problem": "The SDK package ships a snapshot of compliance bundles, schema bundles, and generated validators. Current PR storyboard runs need to grade current repo source before a new protocol bundle exists.",
-    "localBehavior": "Build current compliance/schema bundles, copy them into the SDK cache, and patch generated validator enum literals for same-PR comply_test_controller additions.",
+    "localBehavior": "Build current compliance/schema bundles, copy them into the SDK cache, and patch generated validators for same-PR controller enums and request/response schema additions.",
     "removalCondition": "Remove when the storyboard matrix passes current compliance and schema roots through public SDK options instead of overlaying the SDK cache.",
     "paths": [
       "scripts/overlay-compliance-cache.sh",
@@ -34,6 +34,7 @@
       "node_modules/@adcp/sdk/compliance/cache",
       "node_modules/@adcp/sdk/ADCP_VERSION",
       "node_modules/@adcp/sdk/dist/lib/types/schemas.generated.js",
+      "node_modules/@adcp/sdk/dist/lib/types/schemas.generated.mjs",
       "schemas.generated.js"
     ]
   }

--- a/.agents/sdk-shim-ledger.json
+++ b/.agents/sdk-shim-ledger.json
@@ -25,6 +25,7 @@
     "upstream": "adcontextprotocol/adcp-client#2105",
     "problem": "The SDK package ships a snapshot of compliance bundles, schema bundles, and generated validators. Current PR storyboard runs need to grade current repo source before a new protocol bundle exists.",
     "localBehavior": "Build current compliance/schema bundles, copy them into the SDK cache, and patch generated validators for same-PR controller enums and request/response schema additions.",
+    "releaseFollowUp": "This overlay is validation-only and does not publish generated types. After the protocol release, regenerate and publish @adcp/sdk, then explicitly upgrade pinned downstream consumers including agentic-api.",
     "removalCondition": "Remove when the storyboard matrix passes current compliance and schema roots through public SDK options instead of overlaying the SDK cache.",
     "paths": [
       "scripts/overlay-compliance-cache.sh",

--- a/.changeset/filter-creatives-by-asset-type.md
+++ b/.changeset/filter-creatives-by-asset-type.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": minor
 ---
 
-Add `CreativeFilters.asset_types` to `list_creatives`, define exact OR-within-field and AND-across-fields matching semantics for top-level creative assets, and add focused published-post conformance coverage.
+Add `CreativeFilters.asset_types` to `list_creatives`, add `zip` to `AssetContentType`, define exact OR-within-field and AND-across-fields matching semantics for top-level creative assets, and add focused published-post and HTML5-bundle conformance coverage. Generated SDK types expose these additions only after the matching SDK release is published; pinned consumers must upgrade explicitly.

--- a/.changeset/filter-creatives-by-asset-type.md
+++ b/.changeset/filter-creatives-by-asset-type.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `CreativeFilters.asset_types` to `list_creatives`, define exact OR-within-field and AND-across-fields matching semantics for top-level creative assets, and add focused published-post conformance coverage.

--- a/docs/creative/task-reference/list_creatives.mdx
+++ b/docs/creative/task-reference/list_creatives.mdx
@@ -1,11 +1,11 @@
 ---
 title: list_creatives
-description: "list_creatives browses and filters creatives in an AdCP library by format, status, concept, and tags with cursor-based pagination."
+description: "list_creatives browses and filters creatives in an AdCP library by asset type, format, status, concept, and tags with cursor-based pagination."
 "og:title": "AdCP — list_creatives"
 ---
 
 
-Browse and filter creatives in a creative library. Supports filtering by format, status, concept, tags, date range, and dynamic variables, with pagination and optional field enrichment.
+Browse and filter creatives in a creative library. Supports filtering by asset type, format, status, concept, tags, date range, and dynamic variables, with pagination and optional field enrichment.
 
 Implemented by any agent that hosts a creative library — creative agents (ad servers, creative management platforms) and sales agents that manage creatives.
 
@@ -14,7 +14,7 @@ Implemented by any agent that hosts a creative library — creative agents (ad s
 ## Overview
 
 **Key features:**
-- Filter by format, status, tags, dates, assignments, concepts, and variables
+- Filter by asset type, format, status, tags, dates, assignments, concepts, and variables
 - Sort by creation date, update date, name, status, or assignment count
 - Cursor-based pagination for large libraries
 - Optionally include assignments, delivery snapshots, items, and dynamic creative optimization (DCO) variables
@@ -49,7 +49,7 @@ Implemented by any agent that hosts a creative library — creative agents (ad s
 | `include_webhook_activity` | boolean | No | Include recent webhook fires per creative (default: false). See [Webhook activity](#webhook-activity). |
 | `webhook_activity_limit` | integer | No | Maximum `webhook_activity[]` records per creative when `include_webhook_activity: true` (default: 50, range 1–200). |
 | `account` | [AccountRef](/docs/building/by-layer/L2/accounts-and-agents#account-references) | No | Account reference for pricing. When provided with `include_pricing`, the agent returns `pricing_options` from this account's rate card on each creative. |
-| `fields` | array | No | Specific fields to return (omit for all fields). Includes `"pricing_options"` for sparse selection. |
+| `fields` | array | No | Specific fields to return (omit for all fields). Includes `"assets"` for local fallback filtering and `"pricing_options"` for sparse selection. |
 
 ## Filtering options
 
@@ -59,6 +59,7 @@ The `filters` object supports these optional, composable filters:
 |--------|------|-------------|
 | `accounts` | [AccountRef](/docs/building/by-layer/L2/accounts-and-agents#account-references)[] | Filter by owning accounts |
 | `format_ids` | FormatID[] | Filter by structured format IDs |
+| `asset_types` | AssetContentType[] | Filter by asset types directly assigned to top-level creative asset slots; values within the array use OR logic |
 | `statuses` | [CreativeStatus](/docs/creative/specification#creative-status-lifecycle)[] | Filter by approval status |
 | `tags` | string[] | Filter by tags (all must match) |
 | `tags_any` | string[] | Filter by tags (any must match) |
@@ -74,6 +75,30 @@ The `filters` object supports these optional, composable filters:
 | `has_served` | boolean | Filter for creatives that have served at least one impression * |
 
 \* Assignment-related filters are specific to sales agents. Standalone creative agents ignore these.
+
+### Asset-type matching
+
+`asset_types` matches a creative when at least one direct object value in the top-level `creative.assets` map has an exact `asset_type` value in the requested set. Multiple requested values use **OR logic**. Array-valued slots are not inspected, and matching does not recurse into nested asset fields such as `cards[].media`; broader traversal is deferred.
+
+All active filter fields compose with **AND logic**. For example, the following request returns published-post creatives that also match the requested legacy format identity; a creative satisfying only one condition is excluded:
+
+```json
+{
+  "filters": {
+    "asset_types": ["published_post"],
+    "format_ids": [
+      {
+        "agent_url": "https://creative.example.com",
+        "id": "existing_post"
+      }
+    ]
+  }
+}
+```
+
+Use `asset_types: ["published_post"]` to find existing-published-post reference creatives across sellers without enumerating publisher-specific format options. Values such as `url`, `text`, and `image` are common companion assets, so they often produce broad result sets when used alone.
+
+Agents that do not implement `asset_types` MUST ignore that field and apply all other active filters. They must not reject the request solely because the filter is unsupported. Buyers that require an exact filtered result should request `assets` (or omit sparse `fields`), traverse every page until `pagination.has_more` is false, and locally inspect the returned top-level asset objects. When a seller returns `query_summary.filters_applied`, buyers can also verify that it includes `asset_types`.
 
 <Note>
 **Archived creatives are excluded by default.** To include archived creatives in results, explicitly include `"archived"` in the `statuses` array. Suspended creatives are not archived; include `"suspended"` when you specifically want recoverably offline creatives such as published-post references with expired authorization.

--- a/docs/creative/task-reference/list_creatives.mdx
+++ b/docs/creative/task-reference/list_creatives.mdx
@@ -96,9 +96,9 @@ All active filter fields compose with **AND logic**. For example, the following 
 }
 ```
 
-Use `asset_types: ["published_post"]` to find existing-published-post reference creatives across sellers without enumerating publisher-specific format options. Values such as `url`, `text`, and `image` are common companion assets, so they often produce broad result sets when used alone.
+Use `asset_types: ["published_post"]` to find existing-published-post reference creatives across sellers without enumerating publisher-specific format options, or `asset_types: ["zip"]` to find HTML5 bundle archives. Values such as `url`, `text`, and `image` are common companion assets, so they often produce broad result sets when used alone.
 
-Agents that do not implement `asset_types` MUST ignore that field and apply all other active filters. They must not reject the request solely because the filter is unsupported. Buyers that require an exact filtered result should request `assets` (or omit sparse `fields`), traverse every page until `pagination.has_more` is false, and locally inspect the returned top-level asset objects. When a seller returns `query_summary.filters_applied`, buyers can also verify that it includes `asset_types`.
+Agents that do not implement `asset_types` MUST ignore that field and apply all other active filters. They must not reject the request solely because the filter is unsupported. Because unsupported agents deliberately over-return, buyers that require an exact filtered result MUST retain a local fallback: request `assets` (or omit sparse `fields`), traverse every page until `pagination.has_more` is false, and locally inspect the returned top-level asset objects. When a seller returns `query_summary.filters_applied`, buyers can verify that it includes `asset_types`; absence means the local fallback is required.
 
 <Note>
 **Archived creatives are excluded by default.** To include archived creatives in results, explicitly include `"archived"` in the `statuses` array. Suspended creatives are not archived; include `"suspended"` when you specifically want recoverably offline creatives such as published-post references with expired authorization.

--- a/scripts/overlay-compliance-cache.sh
+++ b/scripts/overlay-compliance-cache.sh
@@ -152,6 +152,13 @@ function patchFile(file) {
     `${zod}.literal("format_id"), ${zod}.literal("status")`,
     `${zod}.literal("format_id"), ${zod}.literal("assets"), ${zod}.literal("status")`,
   );
+  // AssetContentType gains zip in current source. Patch the generated SDK
+  // snapshot so current-source request and fixture validation accepts HTML5
+  // bundle assets before the matching SDK release is published.
+  text = text.replaceAll(
+    `${zod}.literal("javascript"), ${zod}.literal("vast")`,
+    `${zod}.literal("javascript"), ${zod}.literal("zip"), ${zod}.literal("vast")`,
+  );
   fs.writeFileSync(file, text);
 }
 

--- a/scripts/overlay-compliance-cache.sh
+++ b/scripts/overlay-compliance-cache.sh
@@ -118,6 +118,7 @@ function patchFile(file) {
     fs.copyFileSync(file, backup);
   }
   let text = fs.readFileSync(file, 'utf8');
+  const zod = file.endsWith('.mjs') ? 'z' : 'import_zod.z';
   const legacyCapabilities =
     'zod_1.z.literal("force_creative_status"), zod_1.z.literal("force_account_status"), zod_1.z.literal("force_media_buy_status"), zod_1.z.literal("force_session_status"), zod_1.z.literal("simulate_delivery"), zod_1.z.literal("simulate_budget_spend")]))';
   const partialCapabilities =
@@ -134,10 +135,28 @@ function patchFile(file) {
     'zod_1.z.literal("seed_creative_format")]))',
     'zod_1.z.literal("seed_creative_format"), zod_1.z.literal("seed_measurement_catalog")]))',
   );
+  // Current source permits list_creatives rows to carry either legacy
+  // format_id or canonical format_kind + format_option_ref. The published SDK
+  // snapshot still requires format_id, so current-PR storyboard runs need the
+  // generated validator relaxed to the current response arms. The overlaid
+  // JSON Schema remains the authoritative mutual-exclusion check.
+  text = text.replace(
+    '    format_id: FormatReferenceStructuredObjectSchema,\n    status: CreativeStatusSchema,',
+    '    format_id: FormatReferenceStructuredObjectSchema.optional(),\n' +
+      '    format_kind: CanonicalFormatKindSchema.optional(),\n' +
+      '    format_option_ref: FormatOptionReferenceSchema.optional(),\n' +
+      '    status: CreativeStatusSchema,',
+  );
+  // Same-PR sparse selection adds assets to list_creatives.fields.
+  text = text.replaceAll(
+    `${zod}.literal("format_id"), ${zod}.literal("status")`,
+    `${zod}.literal("format_id"), ${zod}.literal("assets"), ${zod}.literal("status")`,
+  );
   fs.writeFileSync(file, text);
 }
 
 patchFile('node_modules/@adcp/sdk/dist/lib/types/schemas.generated.js');
+patchFile('node_modules/@adcp/sdk/dist/lib/types/schemas.generated.mjs');
 NODE
 
   echo "Building development compliance bundle for SDK cache overlay"

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -25,13 +25,17 @@ else
 fi
 export ADCP_RELEASE_GIT_REF="${RELEASE_GIT_REF}"
 SDK_GENERATED_SCHEMA_FILE="${REPO_ROOT}/node_modules/@adcp/sdk/dist/lib/types/schemas.generated.js"
+SDK_GENERATED_SCHEMA_MJS_FILE="${REPO_ROOT}/node_modules/@adcp/sdk/dist/lib/types/schemas.generated.mjs"
 
 restore_sdk_generated_schema() {
-  local backup="${SDK_GENERATED_SCHEMA_FILE}.adcp-overlay-backup"
-  if [ -f "${backup}" ]; then
-    cp "${backup}" "${SDK_GENERATED_SCHEMA_FILE}"
-    rm -f "${backup}"
-  fi
+  local file backup
+  for file in "${SDK_GENERATED_SCHEMA_FILE}" "${SDK_GENERATED_SCHEMA_MJS_FILE}"; do
+    backup="${file}.adcp-overlay-backup"
+    if [ -f "${backup}" ]; then
+      cp "${backup}" "${file}"
+      rm -f "${backup}"
+    fi
+  done
 }
 
 usage() {

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -648,10 +648,16 @@ function createStore(session: SessionState, sessionKey: string, principal?: stri
       enforceMapCap(session.creatives, creativeId, 'creatives');
       const existing = session.creatives.get(creativeId);
       const now = new Date().toISOString();
-      const formatId = (fx.format_id as CreativeState['formatId']) ?? existing?.formatId ?? { id: 'display_300x250' };
+      const formatKind = (fx.format_kind as string | undefined) ?? existing?.formatKind;
+      const formatOptionRef = (fx.format_option_ref as Record<string, unknown> | undefined) ?? existing?.formatOptionRef;
+      const formatId = (fx.format_id as CreativeState['formatId'])
+        ?? existing?.formatId
+        ?? (formatKind ? { agent_url: getAgentUrl(), id: formatKind } : { id: 'display_300x250' });
       session.creatives.set(creativeId, {
         creativeId,
         formatId,
+        formatKind,
+        formatOptionRef,
         name: (fx.name as string | undefined) ?? existing?.name,
         status: (fx.status as string | undefined) ?? existing?.status ?? 'approved',
         syncedAt: existing?.syncedAt ?? now,

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -75,6 +75,7 @@ type InlineCreativeInput = {
   name?: string;
   format_id?: FormatID;
   format_kind?: string;
+  format_option_ref?: Record<string, unknown>;
   assets?: Record<string, unknown>;
   manifest?: CreativeManifest;
 };
@@ -345,11 +346,18 @@ function persistInlineCreatives(
       accountId: accountId ?? existing?.accountId,
       accountRef: accountRef ?? existing?.accountRef,
       formatId,
+      formatKind: creative.format_kind,
+      formatOptionRef: creative.format_option_ref,
       name: creative.name ?? existing?.name,
       status: existing?.status ?? 'approved',
       syncedAt,
       manifest: creative.manifest ?? (creative.assets ? {
-        format_id: formatId,
+        ...(creative.format_kind
+          ? {
+            format_kind: creative.format_kind,
+            ...(creative.format_option_ref && { format_option_ref: creative.format_option_ref }),
+          }
+          : { format_id: formatId }),
         assets: creative.assets as CreativeManifest['assets'],
       } : existing?.manifest),
       pricingOptionId: existing?.pricingOptionId,
@@ -2404,6 +2412,22 @@ const ACCOUNT_REF_SCHEMA = {
   ],
 } as const;
 
+const FORMAT_ID_INPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    agent_url: { type: 'string', format: 'uri' },
+    id: { type: 'string', pattern: '^[a-zA-Z0-9_-]+$' },
+    width: { type: 'integer', minimum: 1 },
+    height: { type: 'integer', minimum: 1 },
+    duration_ms: { type: 'number', minimum: 1 },
+  },
+  required: ['agent_url', 'id'],
+  dependencies: {
+    width: ['height'],
+    height: ['width'],
+  },
+} as const;
+
 // Tools whose response schema defines an Error variant at top level
 // (oneOf success | {errors: [...]}). Handler-returned errors are placed
 // in the response body rather than wrapped in an MCP isError envelope,
@@ -2789,7 +2813,7 @@ const TOOLS = [
   },
   {
     name: 'list_creatives',
-    description: 'List creative assets for the current session. Filter by creative_ids or media_buy_id to narrow results. When include_pricing is true and account is provided, returns per-creative pricing from the account rate card. Not for uploading or updating creatives (use sync_creatives).',
+    description: 'List creative assets for the current session. Filter by creative_ids, format_ids, asset_types, status, or media_buy_id to narrow results. When include_pricing is true and account is provided, returns per-creative pricing from the account rate card. Not for uploading or updating creatives (use sync_creatives).',
     annotations: { readOnlyHint: true, idempotentHint: true },
     execution: { taskSupport: 'forbidden' as const },
     inputSchema: {
@@ -2810,7 +2834,33 @@ const TOOLS = [
         include_purged: { type: 'boolean', description: 'Include soft-purged creative tombstones' },
         include_webhook_activity: { type: 'boolean', description: 'Include recent lifecycle webhook activity per creative' },
         webhook_activity_limit: { type: 'integer', minimum: 1, maximum: 200 },
-        filters: { type: 'object', properties: { creative_ids: { type: 'array', items: { type: 'string' } }, statuses: { type: 'array', items: { type: 'string' } } } },
+        fields: {
+          type: 'array',
+          description: 'Optional sparse field selection. Response-required identity and lifecycle fields are always retained.',
+          items: {
+            type: 'string',
+            enum: ['creative_id', 'name', 'format_id', 'assets', 'status', 'created_date', 'updated_date', 'tags', 'assignments', 'snapshot', 'items', 'variables', 'concept', 'pricing_options'],
+          },
+          minItems: 1,
+        },
+        filters: {
+          type: 'object',
+          properties: {
+            creative_ids: { type: 'array', items: { type: 'string' } },
+            statuses: { type: 'array', items: { type: 'string' } },
+            format_ids: { type: 'array', items: FORMAT_ID_INPUT_SCHEMA, minItems: 1 },
+            asset_types: {
+              type: 'array',
+              description: 'Filter creatives by exact asset_type values on direct object values in the top-level assets map (OR within this field; no array or nested traversal).',
+              items: {
+                type: 'string',
+                enum: ['image', 'video', 'audio', 'text', 'markdown', 'html', 'css', 'javascript', 'vast', 'daast', 'url', 'webhook', 'brief', 'catalog', 'published_post'],
+              },
+              minItems: 1,
+              uniqueItems: true,
+            },
+          },
+        },
         // See list_creative_formats above — declared so legacy dispatch keeps
         // `pagination` on the wire.
         pagination: {
@@ -5720,7 +5770,15 @@ export async function handleSyncCreatives(args: ToolArgs, ctx: TrainingContext) 
       };
     }
     const creativeId = creative.creative_id;
-    const formatId = creative.format_id as FormatID;
+    const formatId = creative.format_id as FormatID | undefined;
+    const formatKind = typeof creative.format_kind === 'string' ? creative.format_kind : undefined;
+    const formatOptionRef = (creative as unknown as { format_option_ref?: Record<string, unknown> }).format_option_ref;
+
+    if (!formatId && !formatKind) {
+      return {
+        errors: [{ code: 'INVALID_REQUEST', message: 'Each creative requires either format_id or format_kind.' }] as TaskError[],
+      };
+    }
 
     // Enforce creative_policy.provenance_required / provenance_requirements /
     // accepted_verifiers BEFORE persisting the creative. Per-creative failure
@@ -5770,16 +5828,33 @@ export async function handleSyncCreatives(args: ToolArgs, ctx: TrainingContext) 
     const existingCreative = session.creatives.get(creativeId);
 
     if (!isDryRun) {
+      const internalFormatId = formatId ?? {
+        agent_url: getAgentUrl(),
+        id: formatKind!,
+      };
       session.creatives.set(creativeId, {
         creativeId,
         accountId: accountId ?? existingCreative?.accountId,
         accountRef: req.account ?? existingCreative?.accountRef,
-        formatId,
+        formatId: internalFormatId,
+        formatKind,
+        formatOptionRef,
         name: creative.name,
         status: existingCreative?.status ?? 'approved',
         syncedAt: new Date().toISOString(),
-        // manifest is a training-agent extension, not in SDK CreativeAsset type
-        manifest: (creative as unknown as { manifest?: CreativeManifest }).manifest,
+        // manifest is a training-agent extension, not in SDK CreativeAsset type.
+        // Preserve direct assets too: list_creatives asset-type filtering must
+        // inspect the same library payload accepted by sync_creatives.
+        manifest: (creative as unknown as { manifest?: CreativeManifest }).manifest
+          ?? ((creative as unknown as { assets?: Record<string, unknown> }).assets ? {
+            ...(formatKind
+              ? {
+                format_kind: formatKind,
+                ...(formatOptionRef && { format_option_ref: formatOptionRef }),
+              }
+              : { format_id: internalFormatId }),
+            assets: (creative as unknown as { assets: Record<string, unknown> }).assets as CreativeManifest['assets'],
+          } : existingCreative?.manifest),
         pricingOptionId: existingCreative?.pricingOptionId,
         purge: existingCreative?.purge,
         webhookActivity: existingCreative?.webhookActivity,
@@ -5850,6 +5925,40 @@ function accountRefsOverlap(stored: AccountRef | undefined, requested: AccountRe
   return Boolean(requested.brand?.domain && stored.brand?.domain && requested.brand.domain === stored.brand.domain);
 }
 
+type CreativeListFilters = {
+  creative_ids?: string[];
+  statuses?: string[];
+  format_ids?: FormatID[];
+  asset_types?: string[];
+};
+
+function creativeMatchesAnyFormatId(creative: CreativeState, requested: FormatID[]): boolean {
+  if (creative.formatKind) return false;
+  const actual = creative.formatId;
+  if (!actual?.id) return false;
+  const actualAgentUrl = actual.agent_url ?? getAgentUrl();
+  return requested.some(wanted => {
+    if (!wanted?.id || wanted.id !== actual.id) return false;
+    if (!wanted.agent_url
+      || canonicalizeAgentUrl(wanted.agent_url) !== canonicalizeAgentUrl(actualAgentUrl)) return false;
+    for (const parameter of ['width', 'height', 'duration_ms'] as const) {
+      if (wanted[parameter] !== actual[parameter]) return false;
+    }
+    return true;
+  });
+}
+
+function creativeHasAnyTopLevelAssetType(creative: CreativeState, requested: Set<string>): boolean {
+  const assets = creative.manifest?.assets as Record<string, unknown> | undefined;
+  if (!assets) return false;
+  for (const slotValue of Object.values(assets)) {
+    if (!slotValue || typeof slotValue !== 'object' || Array.isArray(slotValue)) continue;
+    const assetType = (slotValue as { asset_type?: unknown }).asset_type;
+    if (typeof assetType === 'string' && requested.has(assetType)) return true;
+  }
+  return false;
+}
+
 export async function handleListCreatives(args: ToolArgs, ctx: TrainingContext) {
   const req = args as unknown as ListCreativesRequest & ToolArgs & {
     creative_ids?: string[];
@@ -5858,10 +5967,12 @@ export async function handleListCreatives(args: ToolArgs, ctx: TrainingContext) 
     include_purged?: boolean;
     include_webhook_activity?: boolean;
     webhook_activity_limit?: number;
+    fields?: string[];
   };
+  const filters = (req.filters ?? {}) as CreativeListFilters;
   const sessionKey = sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId);
   const session = await getSession(sessionKey);
-  const filterIds = req.creative_ids || req.filters?.creative_ids;
+  const filterIds = req.creative_ids || filters.creative_ids;
   const requestedAccountId = resolveAccountIdForRef(sessionKey, ctx.principal, req.account);
 
   let creatives = Array.from(session.creatives.values());
@@ -5895,9 +6006,16 @@ export async function handleListCreatives(args: ToolArgs, ctx: TrainingContext) 
   if (!req.include_purged) {
     creatives = creatives.filter(c => !c.purge);
   }
-  if (req.filters?.statuses?.length) {
-    const statuses = new Set<string>(req.filters.statuses as string[]);
+  if (filters.statuses?.length) {
+    const statuses = new Set(filters.statuses);
     creatives = creatives.filter(c => statuses.has(c.status));
+  }
+  if (filters.format_ids?.length) {
+    creatives = creatives.filter(c => creativeMatchesAnyFormatId(c, filters.format_ids!));
+  }
+  if (filters.asset_types?.length) {
+    const assetTypes = new Set(filters.asset_types);
+    creatives = creatives.filter(c => creativeHasAnyTopLevelAssetType(c, assetTypes));
   }
 
   const totalMatching = creatives.length;
@@ -5926,6 +6044,7 @@ export async function handleListCreatives(args: ToolArgs, ctx: TrainingContext) 
   // gate in #2847 and tracks the spec-side clarification referenced there.
   const emitPricing = creativeBillsThroughAdcp(ctx) && Boolean(req.account) && req.include_pricing !== false;
   const agentUrl = getAgentUrl();
+  const selectedFields = req.fields?.length ? new Set(req.fields) : undefined;
 
   return {
     query_summary: {
@@ -5949,18 +6068,24 @@ export async function handleListCreatives(args: ToolArgs, ctx: TrainingContext) 
       // in for format_id.agent_url. Keeps list_creatives response-schema
       // valid regardless of what was synced.
       const formatId = {
-        ...(c.formatId ?? { id: 'unknown' }),
-        agent_url: c.formatId?.agent_url ?? agentUrl,
+        ...c.formatId,
+        agent_url: c.formatId.agent_url ?? agentUrl,
       };
       const base: Record<string, unknown> = {
         creative_id: c.creativeId,
-        format_id: formatId,
+        ...(c.formatKind
+          ? {
+            format_kind: c.formatKind,
+            ...(c.formatOptionRef && { format_option_ref: c.formatOptionRef }),
+          }
+          : { format_id: formatId }),
         name: c.name ?? c.creativeId,
         status: c.status,
         created_date: c.syncedAt,
         updated_date: c.syncedAt,
+        ...(c.manifest?.assets && (!selectedFields || selectedFields.has('assets')) && { assets: c.manifest.assets }),
       };
-      if (emitPricing && c.formatId?.id) {
+      if (emitPricing && c.formatId?.id && (!selectedFields || selectedFields.has('pricing_options'))) {
         base.pricing_options = [getCreativePricing(req.account!, c)];
       }
       if (req.include_snapshot) {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2854,7 +2854,7 @@ const TOOLS = [
               description: 'Filter creatives by exact asset_type values on direct object values in the top-level assets map (OR within this field; no array or nested traversal).',
               items: {
                 type: 'string',
-                enum: ['image', 'video', 'audio', 'text', 'markdown', 'html', 'css', 'javascript', 'vast', 'daast', 'url', 'webhook', 'brief', 'catalog', 'published_post'],
+                enum: ['image', 'video', 'audio', 'text', 'markdown', 'html', 'css', 'javascript', 'zip', 'vast', 'daast', 'url', 'webhook', 'brief', 'catalog', 'published_post'],
               },
               minItems: 1,
               uniqueItems: true,

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -480,19 +480,25 @@ export interface ManifestAsset {
   url?: string;
   width?: number;
   height?: number;
+  [key: string]: unknown;
 }
 
 /** Creative manifest with format and named asset slots. */
 export interface CreativeManifest {
-  format_id: FormatID;
-  assets: Record<string, ManifestAsset>;
+  format_id?: FormatID;
+  format_kind?: string;
+  format_option_ref?: Record<string, unknown>;
+  assets: Record<string, ManifestAsset | ManifestAsset[]>;
 }
 
 export interface CreativeState {
   creativeId: string;
   accountId?: string;
   accountRef?: AccountRef;
+  /** Internal legacy-shaped lookup key. Canonical rows emit formatKind instead. */
   formatId: FormatID;
+  formatKind?: string;
+  formatOptionRef?: Record<string, unknown>;
   name?: string;
   status: string;
   syncedAt: string;

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -102,6 +102,7 @@ async function syncCreative(server: ReturnType<typeof createTrainingAgentServer>
     creatives: [{
       creative_id: creativeId,
       name: 'Test Creative',
+      format_kind: 'image',
     }],
   });
   if (isError || (result as any).errors) {
@@ -129,7 +130,7 @@ async function createMediaBuyWithCreatives(server: ReturnType<typeof createTrain
     idempotency_key: crypto.randomUUID(),
     account: ACCOUNT,
     brand: BRAND,
-    creatives: [{ creative_id: creativeId, name: 'Test Creative' }],
+    creatives: [{ creative_id: creativeId, name: 'Test Creative', format_kind: 'image' }],
     assignments: [{ creative_id: creativeId, package_id: packageId, media_buy_id: mediaBuyId }],
   });
 

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -4861,6 +4861,14 @@ describe('list_creatives handler', () => {
           },
         },
         {
+          creative_id: 'cr_zip_bundle',
+          format_id: { agent_url: TEST_AGENT_URL, id: 'html5_bundle' },
+          name: 'HTML5 bundle creative',
+          assets: {
+            bundle: { asset_type: 'zip', url: 'https://cdn.example/html5-bundle.zip', mime_type: 'application/zip' },
+          },
+        },
+        {
           creative_id: 'cr_nested_card_image',
           format_kind: 'image_carousel',
           name: 'Nested card image',
@@ -4875,7 +4883,7 @@ describe('list_creatives handler', () => {
     });
 
     const server2 = createTrainingAgentServer(DEFAULT_CTX);
-    const ids = ['cr_post_mixed', 'cr_post_canonical', 'cr_image', 'cr_nested_card_image'];
+    const ids = ['cr_post_mixed', 'cr_post_canonical', 'cr_image', 'cr_zip_bundle', 'cr_nested_card_image'];
 
     const { result: byAsset } = await simulateCallTool(server2, 'list_creatives', {
       account,
@@ -4934,6 +4942,12 @@ describe('list_creatives handler', () => {
       },
     });
     expect(exactParameterizedFormat.creatives).toEqual([]);
+
+    const { result: zipBundle } = await simulateCallTool(server2, 'list_creatives', {
+      account,
+      filters: { creative_ids: ids, asset_types: ['zip'] },
+    });
+    expect((zipBundle.creatives as Array<{ creative_id: string }>).map(c => c.creative_id)).toEqual(['cr_zip_bundle']);
 
     const { result: nested } = await simulateCallTool(server2, 'list_creatives', {
       account,

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -4822,6 +4822,132 @@ describe('list_creatives handler', () => {
     expect(pg.has_more).toBe(false);
     expect(pg.total_count).toBe(1);
   });
+
+  it('filters by top-level asset type and composes with format_ids', async () => {
+    const account = { brand: { domain: 'assetfilters.example' }, operator: 'assetfilters.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    await simulateCallTool(server, 'sync_creatives', {
+      account,
+      creatives: [
+        {
+          creative_id: 'cr_post_mixed',
+          format_id: { agent_url: TEST_AGENT_URL, id: 'existing_post' },
+          name: 'Mixed published post',
+          assets: {
+            published_post: { asset_type: 'published_post', post_url: 'https://community.example/posts/1' },
+            landing_page_url: { asset_type: 'url', url: 'https://acme.example/landing' },
+          },
+        },
+        {
+          creative_id: 'cr_post_canonical',
+          format_kind: 'video_hosted',
+          format_option_ref: {
+            scope: 'publisher',
+            publisher_domain: 'community.example',
+            format_option_id: 'existing_published_post',
+          },
+          name: 'Canonical published post',
+          assets: {
+            published_post: { asset_type: 'published_post', platform_post_id: 'post-2', platform: 'community' },
+          },
+        },
+        {
+          creative_id: 'cr_image',
+          format_id: { agent_url: TEST_AGENT_URL, id: 'existing_post', width: 300, height: 250 },
+          name: 'Image creative',
+          assets: {
+            image: { asset_type: 'image', url: 'https://cdn.example/image.png', width: 300, height: 250 },
+          },
+        },
+        {
+          creative_id: 'cr_nested_card_image',
+          format_kind: 'image_carousel',
+          name: 'Nested card image',
+          assets: {
+            cards: [{
+              asset_type: 'card',
+              media: { asset_type: 'image', url: 'https://cdn.example/card.png', width: 1200, height: 628 },
+            }],
+          },
+        },
+      ],
+    });
+
+    const server2 = createTrainingAgentServer(DEFAULT_CTX);
+    const ids = ['cr_post_mixed', 'cr_post_canonical', 'cr_image', 'cr_nested_card_image'];
+
+    const { result: byAsset } = await simulateCallTool(server2, 'list_creatives', {
+      account,
+      filters: { creative_ids: ids, asset_types: ['published_post', 'audio'] },
+    });
+    expect((byAsset.creatives as Array<{ creative_id: string }>).map(c => c.creative_id)).toEqual([
+      'cr_post_mixed',
+      'cr_post_canonical',
+    ]);
+    expect((byAsset.creatives as Array<Record<string, any>>)[0].assets).toMatchObject({
+      published_post: { asset_type: 'published_post' },
+      landing_page_url: { asset_type: 'url' },
+    });
+    expect((byAsset.creatives as Array<Record<string, any>>)[1]).toMatchObject({
+      format_kind: 'video_hosted',
+      format_option_ref: { format_option_id: 'existing_published_post' },
+      assets: { published_post: { asset_type: 'published_post' } },
+    });
+    expect((byAsset.creatives as Array<Record<string, any>>)[1].format_id).toBeUndefined();
+
+    const { result: sparseAssets } = await simulateCallTool(server2, 'list_creatives', {
+      account,
+      filters: { creative_ids: ['cr_post_mixed'], asset_types: ['published_post'] },
+      fields: ['assets'],
+    });
+    expect((sparseAssets.creatives as Array<Record<string, any>>)[0]).toMatchObject({
+      creative_id: 'cr_post_mixed',
+      name: 'Mixed published post',
+      format_id: { id: 'existing_post' },
+      status: 'approved',
+      assets: { published_post: { asset_type: 'published_post' } },
+    });
+
+    const { result: sparseWithoutAssets } = await simulateCallTool(server2, 'list_creatives', {
+      account,
+      filters: { creative_ids: ['cr_post_mixed'] },
+      fields: ['creative_id'],
+    });
+    expect((sparseWithoutAssets.creatives as Array<Record<string, any>>)[0].assets).toBeUndefined();
+
+    const { result: composed } = await simulateCallTool(server2, 'list_creatives', {
+      account,
+      filters: {
+        creative_ids: ids,
+        asset_types: ['published_post'],
+        format_ids: [{ agent_url: TEST_AGENT_URL, id: 'existing_post' }],
+      },
+    });
+    expect((composed.creatives as Array<{ creative_id: string }>).map(c => c.creative_id)).toEqual(['cr_post_mixed']);
+
+    const { result: exactParameterizedFormat } = await simulateCallTool(server2, 'list_creatives', {
+      account,
+      filters: {
+        creative_ids: ['cr_image'],
+        format_ids: [{ agent_url: TEST_AGENT_URL, id: 'existing_post' }],
+      },
+    });
+    expect(exactParameterizedFormat.creatives).toEqual([]);
+
+    const { result: nested } = await simulateCallTool(server2, 'list_creatives', {
+      account,
+      filters: { creative_ids: ['cr_nested_card_image'], asset_types: ['image'] },
+    });
+    expect(nested.creatives).toEqual([]);
+
+    const { result: empty } = await simulateCallTool(server2, 'list_creatives', {
+      account,
+      filters: { creative_ids: ids, asset_types: ['audio'] },
+    });
+    expect(empty.creatives).toEqual([]);
+    expect((empty.query_summary as { total_matching: number }).total_matching).toBe(0);
+  });
 });
 
 // ── list_creatives pricing ─────────────────────────────────────────

--- a/static/compliance/source/protocols/creative/scenarios/asset_type_filtering.yaml
+++ b/static/compliance/source/protocols/creative/scenarios/asset_type_filtering.yaml
@@ -3,7 +3,7 @@ version: "1.0.0"
 introduced_in: "3.2"
 title: "Creative library asset-type filtering"
 category: creative
-summary: "Filters list_creatives by published_post asset type, including OR semantics, mixed assets, empty results, and composition with format_ids."
+summary: "Filters list_creatives by published_post and zip asset types, including OR semantics, mixed assets, empty results, and composition with format_ids."
 track: creative
 required_tools:
   - list_creatives
@@ -14,15 +14,15 @@ requires:
 narrative: |
   A cross-platform buyer needs to find existing-published-post references without
   downloading every creative or enumerating each publisher's local format catalog.
-  The runner seeds two published-post creatives, one direct image creative, and one
-  nested carousel-image creative, then verifies
+  The runner seeds two published-post creatives, one direct image creative, one
+  HTML5 zip bundle, and one nested carousel-image creative, then verifies
   exact asset-type matching and AND composition with other filter fields.
 
   Asset matching is limited to values directly assigned to top-level assets slots.
   The fixtures cover a mixed creative (published_post plus url), a canonical-format
-  creative, and a nested carousel image that must not match. Array-valued slots and
-  nested fields inside assets such as cards[].media are outside this storyboard's
-  matching scope.
+  creative, an HTML5 zip bundle, and a nested carousel image that must not match.
+  Array-valued slots and nested fields inside assets such as cards[].media are
+  outside this storyboard's matching scope.
 
 agent:
   interaction_model: stateful_preloaded
@@ -38,7 +38,7 @@ caller:
 
 prerequisites:
   description: |
-    The runner seeds four creative-library rows through comply_test_controller.
+    The runner seeds five creative-library rows through comply_test_controller.
     Agents that do not implement asset_types ignore the field under the protocol's
     forward-compatible fallback and should not claim this focused scenario.
   test_kit: "test-kits/acme-outdoor.yaml"
@@ -99,6 +99,21 @@ fixtures:
             width: 300
             height: 250
             mime_type: "image/png"
+    - creative_id: "asset_filter_zip_bundle"
+      name: "HTML5 bundle creative"
+      status: "approved"
+      format_id:
+        agent_url: "https://creative.example.com"
+        id: "html5_bundle"
+      manifest:
+        format_id:
+          agent_url: "https://creative.example.com"
+          id: "html5_bundle"
+        assets:
+          bundle:
+            asset_type: "zip"
+            url: "https://cdn.pinnacle-agency.example/trail-pro-html5.zip"
+            mime_type: "application/zip"
     - creative_id: "asset_filter_nested_card_image"
       name: "Nested carousel image"
       status: "approved"
@@ -134,7 +149,7 @@ phases:
         expected: |
           Return exactly the two published-post fixtures. The mixed creative matches
           despite also carrying a url asset, the canonical creative retains its
-          format_kind identity, and the image-only and nested-card creatives are excluded.
+          format_kind identity, and the image-only, zip, and nested-card creatives are excluded.
         sample_request:
           account:
             brand:
@@ -146,6 +161,7 @@ phases:
               - "asset_filter_published_mixed"
               - "asset_filter_published_canonical"
               - "asset_filter_image"
+              - "asset_filter_zip_bundle"
               - "asset_filter_nested_card_image"
             asset_types:
               - "published_post"
@@ -215,6 +231,7 @@ phases:
               - "asset_filter_published_mixed"
               - "asset_filter_published_canonical"
               - "asset_filter_image"
+              - "asset_filter_zip_bundle"
               - "asset_filter_nested_card_image"
             asset_types:
               - "published_post"
@@ -239,6 +256,50 @@ phases:
             value: "creative_asset_type_filtering--and_format"
             description: "Context correlation_id returned unchanged"
 
+      - id: zip_bundle
+        title: "Match an HTML5 zip bundle"
+        task: list_creatives
+        schema_ref: "creative/list-creatives-request.json"
+        response_schema_ref: "creative/list-creatives-response.json"
+        doc_ref: "/creative/task-reference/list_creatives#asset-type-matching"
+        comply_scenario: creative_lifecycle
+        stateful: true
+        expected: |
+          Return exactly the HTML5 bundle creative whose direct bundle asset uses
+          the shared AssetContentType value zip.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          filters:
+            creative_ids:
+              - "asset_filter_zip_bundle"
+            asset_types:
+              - "zip"
+          context:
+            correlation_id: "creative_asset_type_filtering--zip"
+        validations:
+          - check: response_schema
+            description: "Response matches list-creatives-response.json schema"
+          - check: field_value
+            path: "query_summary.total_matching"
+            value: 1
+            description: "The direct zip asset satisfies the filter"
+          - check: field_value
+            path: "creatives[0].creative_id"
+            value: "asset_filter_zip_bundle"
+            description: "The HTML5 bundle creative is returned"
+          - check: field_value
+            path: "creatives[0].assets.bundle.asset_type"
+            value: "zip"
+            description: "The returned asset retains the zip discriminator"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_asset_type_filtering--zip"
+            description: "Context correlation_id returned unchanged"
+
       - id: no_audio_assets
         title: "Return an empty result for an absent asset type"
         task: list_creatives
@@ -249,7 +310,7 @@ phases:
         stateful: true
         expected: |
           Return an empty creatives array and zero matching rows because none of the
-          four scoped fixtures has a direct audio asset.
+          five scoped fixtures has a direct audio asset.
         sample_request:
           account:
             brand:
@@ -261,6 +322,7 @@ phases:
               - "asset_filter_published_mixed"
               - "asset_filter_published_canonical"
               - "asset_filter_image"
+              - "asset_filter_zip_bundle"
               - "asset_filter_nested_card_image"
             asset_types:
               - "audio"

--- a/static/compliance/source/protocols/creative/scenarios/asset_type_filtering.yaml
+++ b/static/compliance/source/protocols/creative/scenarios/asset_type_filtering.yaml
@@ -1,0 +1,327 @@
+id: creative/asset_type_filtering
+version: "1.0.0"
+introduced_in: "3.2"
+title: "Creative library asset-type filtering"
+category: creative
+summary: "Filters list_creatives by published_post asset type, including OR semantics, mixed assets, empty results, and composition with format_ids."
+track: creative
+required_tools:
+  - list_creatives
+
+requires:
+  - controller
+
+narrative: |
+  A cross-platform buyer needs to find existing-published-post references without
+  downloading every creative or enumerating each publisher's local format catalog.
+  The runner seeds two published-post creatives, one direct image creative, and one
+  nested carousel-image creative, then verifies
+  exact asset-type matching and AND composition with other filter fields.
+
+  Asset matching is limited to values directly assigned to top-level assets slots.
+  The fixtures cover a mixed creative (published_post plus url), a canonical-format
+  creative, and a nested carousel image that must not match. Array-valued slots and
+  nested fields inside assets such as cards[].media are outside this storyboard's
+  matching scope.
+
+agent:
+  interaction_model: stateful_preloaded
+  capabilities:
+    - has_creative_library
+  examples:
+    - "Creative management platforms"
+    - "Sales agents with account-scoped creative libraries"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The runner seeds four creative-library rows through comply_test_controller.
+    Agents that do not implement asset_types ignore the field under the protocol's
+    forward-compatible fallback and should not claim this focused scenario.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  creatives:
+    - creative_id: "asset_filter_published_mixed"
+      name: "Published post with landing page"
+      status: "approved"
+      format_id:
+        agent_url: "https://creative.example.com"
+        id: "existing_post"
+      manifest:
+        format_id:
+          agent_url: "https://creative.example.com"
+          id: "existing_post"
+        assets:
+          published_post:
+            asset_type: "published_post"
+            post_url: "https://community.example/posts/trail-pro"
+          landing_page_url:
+            asset_type: "url"
+            url: "https://acmeoutdoor.example/trail-pro"
+    - creative_id: "asset_filter_published_canonical"
+      name: "Canonical published post"
+      status: "approved"
+      format_kind: "video_hosted"
+      format_option_ref:
+        scope: "publisher"
+        publisher_domain: "community.example"
+        format_option_id: "existing_published_post"
+      manifest:
+        format_kind: "video_hosted"
+        format_option_ref:
+          scope: "publisher"
+          publisher_domain: "community.example"
+          format_option_id: "existing_published_post"
+        assets:
+          published_post:
+            asset_type: "published_post"
+            platform: "community"
+            platform_post_id: "trail-pro-2"
+    - creative_id: "asset_filter_image"
+      name: "Image-only creative"
+      status: "approved"
+      format_id:
+        agent_url: "https://creative.example.com"
+        id: "existing_post"
+      manifest:
+        format_id:
+          agent_url: "https://creative.example.com"
+          id: "existing_post"
+        assets:
+          image:
+            asset_type: "image"
+            url: "https://cdn.pinnacle-agency.example/trail-pro-300x250.png"
+            width: 300
+            height: 250
+            mime_type: "image/png"
+    - creative_id: "asset_filter_nested_card_image"
+      name: "Nested carousel image"
+      status: "approved"
+      format_kind: "image_carousel"
+      manifest:
+        format_kind: "image_carousel"
+        assets:
+          cards:
+            - asset_type: "card"
+              media:
+                asset_type: "image"
+                url: "https://cdn.pinnacle-agency.example/trail-pro-card.png"
+                width: 1200
+                height: 628
+
+phases:
+  - id: filter_creative_library
+    title: "Filter the seeded creative library"
+    narrative: |
+      The buyer first requests multiple asset types to exercise OR-within-field,
+      then combines asset_types with format_ids to exercise AND-across-fields,
+      and finally requests an absent asset type to verify an empty result.
+
+    steps:
+      - id: published_post_or_audio
+        title: "Match published-post assets with OR semantics"
+        task: list_creatives
+        schema_ref: "creative/list-creatives-request.json"
+        response_schema_ref: "creative/list-creatives-response.json"
+        doc_ref: "/creative/task-reference/list_creatives#asset-type-matching"
+        comply_scenario: creative_lifecycle
+        stateful: true
+        expected: |
+          Return exactly the two published-post fixtures. The mixed creative matches
+          despite also carrying a url asset, the canonical creative retains its
+          format_kind identity, and the image-only and nested-card creatives are excluded.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          filters:
+            creative_ids:
+              - "asset_filter_published_mixed"
+              - "asset_filter_published_canonical"
+              - "asset_filter_image"
+              - "asset_filter_nested_card_image"
+            asset_types:
+              - "published_post"
+              - "audio"
+          context:
+            correlation_id: "creative_asset_type_filtering--or_match"
+        validations:
+          - check: response_schema
+            description: "Response matches list-creatives-response.json schema"
+          - check: field_value
+            path: "query_summary.total_matching"
+            value: 2
+            description: "OR within asset_types matches both published-post fixtures"
+          - check: field_value
+            path: "query_summary.returned"
+            value: 2
+            description: "Both matching fixtures are returned on the unpaginated request"
+          - check: field_contains
+            path: "creatives[*].creative_id"
+            value: "asset_filter_published_mixed"
+            description: "A mixed-asset creative matches when one direct asset is published_post"
+          - check: field_contains
+            path: "creatives[*].creative_id"
+            value: "asset_filter_published_canonical"
+            description: "Canonical-format published-post creative is returned"
+          - check: field_contains
+            path: "creatives[*].format_kind"
+            value: "video_hosted"
+            description: "Canonical identity is preserved without fabricating format_id"
+          - check: field_contains
+            path: "creatives[*].format_option_ref.format_option_id"
+            value: "existing_published_post"
+            description: "Canonical format option reference is preserved"
+          - check: field_contains
+            path: "creatives[*].assets.published_post.asset_type"
+            value: "published_post"
+            description: "Returned assets expose the matched published_post discriminator"
+          - check: field_contains
+            path: "creatives[*].assets.landing_page_url.asset_type"
+            value: "url"
+            description: "Mixed creative retains its non-matching companion URL asset"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_asset_type_filtering--or_match"
+            description: "Context correlation_id returned unchanged"
+
+      - id: published_post_and_format
+        title: "Compose asset_types with format_ids"
+        task: list_creatives
+        schema_ref: "creative/list-creatives-request.json"
+        response_schema_ref: "creative/list-creatives-response.json"
+        doc_ref: "/creative/task-reference/list_creatives#asset-type-matching"
+        comply_scenario: creative_lifecycle
+        stateful: true
+        expected: |
+          Return only asset_filter_published_mixed. The other published-post fixture
+          uses canonical identity rather than format_id, while the image fixture has
+          the requested format_id but not the requested asset type.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          filters:
+            creative_ids:
+              - "asset_filter_published_mixed"
+              - "asset_filter_published_canonical"
+              - "asset_filter_image"
+              - "asset_filter_nested_card_image"
+            asset_types:
+              - "published_post"
+            format_ids:
+              - agent_url: "https://creative.example.com"
+                id: "existing_post"
+          context:
+            correlation_id: "creative_asset_type_filtering--and_format"
+        validations:
+          - check: response_schema
+            description: "Response matches list-creatives-response.json schema"
+          - check: field_value
+            path: "query_summary.total_matching"
+            value: 1
+            description: "asset_types and format_ids compose with AND semantics"
+          - check: field_value
+            path: "creatives[0].creative_id"
+            value: "asset_filter_published_mixed"
+            description: "The sole creative satisfies both active filter fields"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_asset_type_filtering--and_format"
+            description: "Context correlation_id returned unchanged"
+
+      - id: no_audio_assets
+        title: "Return an empty result for an absent asset type"
+        task: list_creatives
+        schema_ref: "creative/list-creatives-request.json"
+        response_schema_ref: "creative/list-creatives-response.json"
+        doc_ref: "/creative/task-reference/list_creatives#asset-type-matching"
+        comply_scenario: creative_lifecycle
+        stateful: true
+        expected: |
+          Return an empty creatives array and zero matching rows because none of the
+          four scoped fixtures has a direct audio asset.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          filters:
+            creative_ids:
+              - "asset_filter_published_mixed"
+              - "asset_filter_published_canonical"
+              - "asset_filter_image"
+              - "asset_filter_nested_card_image"
+            asset_types:
+              - "audio"
+          context:
+            correlation_id: "creative_asset_type_filtering--empty"
+        validations:
+          - check: response_schema
+            description: "Response matches list-creatives-response.json schema"
+          - check: field_value
+            path: "query_summary.total_matching"
+            value: 0
+            description: "No scoped creative carries a direct audio asset"
+          - check: field_value
+            path: "query_summary.returned"
+            value: 0
+            description: "The empty filtered result returns zero rows"
+          - check: field_value
+            path: "creatives"
+            value: []
+            description: "An empty filtered result carries an empty creatives array"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_asset_type_filtering--empty"
+            description: "Context correlation_id returned unchanged"
+
+      - id: nested_card_image_does_not_match
+        title: "Do not recurse into nested card media"
+        task: list_creatives
+        schema_ref: "creative/list-creatives-request.json"
+        response_schema_ref: "creative/list-creatives-response.json"
+        doc_ref: "/creative/task-reference/list_creatives#asset-type-matching"
+        comply_scenario: creative_lifecycle
+        stateful: true
+        expected: |
+          Return no creatives. The scoped carousel carries asset_type card at its
+          top-level slot; its nested cards[].media image is outside v1 traversal.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          filters:
+            creative_ids:
+              - "asset_filter_nested_card_image"
+            asset_types:
+              - "image"
+          context:
+            correlation_id: "creative_asset_type_filtering--nested_excluded"
+        validations:
+          - check: response_schema
+            description: "Response matches list-creatives-response.json schema"
+          - check: field_value
+            path: "query_summary.total_matching"
+            value: 0
+            description: "Nested cards[].media does not satisfy a top-level image filter"
+          - check: field_value
+            path: "creatives"
+            value: []
+            description: "Nested-only image match is excluded"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_asset_type_filtering--nested_excluded"
+            description: "Context correlation_id returned unchanged"

--- a/static/schemas/source/core/creative-filters.json
+++ b/static/schemas/source/core/creative-filters.json
@@ -110,6 +110,15 @@
       },
       "minItems": 1
     },
+    "asset_types": {
+      "type": "array",
+      "description": "Filter by asset types present on direct object values in the creative's top-level `assets` map. A creative matches when any directly assigned object has an `asset_type` in this array (OR within this field); this filter is conjunctive with every other active filter (AND across fields). Do not inspect array-valued slots or recurse into nested asset fields such as `cards[].media`; broader traversal is deferred. Agents that do not implement this filter MUST ignore it and apply the remaining filters rather than reject the request. Exact asset-type values use the shared AssetContentType vocabulary; `published_post` selects existing-published-post reference creatives without relying on publisher-specific format IDs.",
+      "items": {
+        "$ref": "/schemas/enums/asset-content-type.json"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
     "has_variables": {
       "type": "boolean",
       "description": "When true, return only creatives with dynamic variables (DCO). When false, return only static creatives."

--- a/static/schemas/source/creative/list-creatives-request.json
+++ b/static/schemas/source/creative/list-creatives-request.json
@@ -106,6 +106,7 @@
           "creative_id",
           "name",
           "format_id",
+          "assets",
           "status",
           "created_date",
           "updated_date",

--- a/static/schemas/source/enums/asset-content-type.json
+++ b/static/schemas/source/enums/asset-content-type.json
@@ -13,6 +13,7 @@
     "html",
     "css",
     "javascript",
+    "zip",
     "vast",
     "daast",
     "url",


### PR DESCRIPTION
## Summary

Adds `CreativeFilters.asset_types` to `list_creatives` with exact OR-within-field and AND-across-fields semantics for direct top-level asset objects, including published-post discovery, HTML5 `zip` bundles, and fallback behavior for sellers that do not implement the filter.
Preserves canonical `format_kind` / `format_option_ref` creative identities, adds sparse `assets` selection, and updates the training agent plus current-source SDK validator overlay.

## Validation

Conformance coverage includes canonical and legacy published posts, `zip` bundles, mixed assets, empty results, format composition, and nested-card non-recursion; schema/compliance builds, TypeScript, focused unit tests, current and 3.0 storyboard matrices, and docs broken-link validation pass.
Generated SDK types become available only after the matching SDK release is published, and pinned consumers including agentic-api require an explicit dependency upgrade; closes #6089.
