### PR TITLE
fix(security): close runtime XSS and object authorization gaps

### DIFF
--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -1688,12 +1688,12 @@
         if (a.enrichment.employee_count_range || a.enrichment.employee_count) profileHtml += signalRow('Employees', a.enrichment.employee_count_range || a.enrichment.employee_count);
         if (a.enrichment.founded_year) profileHtml += signalRow('Founded', a.enrichment.founded_year);
         if (a.enrichment.city || a.enrichment.country) profileHtml += signalRow('Location', [a.enrichment.city, a.enrichment.country].filter(Boolean).join(', '));
-        if (a.enrichment.linkedin_url) profileHtml += signalRow('LinkedIn', `<a href="${escapeHtml(a.enrichment.linkedin_url)}" target="_blank">View Profile</a>`);
+        if (a.enrichment.linkedin_url) profileHtml += linkedInSignalRow(a.enrichment.linkedin_url);
         if (a.enrichment.description) {
           profileHtml += `<div style="margin-top: var(--space-3); font-size: var(--text-sm); color: var(--color-text-secondary);">${escapeHtml(a.enrichment.description)}</div>`;
         }
         if (a.enrichment.enriched_at) {
-          profileHtml += `<div style="margin-top: var(--space-2); font-size: var(--text-xs); color: var(--color-text-muted);">Updated ${formatDate(a.enrichment.enriched_at)} via ${a.enrichment.source || 'enrichment'}</div>`;
+          profileHtml += enrichmentAttribution(a.enrichment.enriched_at, a.enrichment.source);
         }
         document.getElementById('companyProfileContent').innerHTML = profileHtml;
 
@@ -2824,7 +2824,29 @@
 
     // Helper functions
     function signalRow(label, value) {
-      return `<div class="signal-item"><span class="signal-label">${label}</span><span class="signal-value">${value}</span></div>`;
+      return `<div class="signal-item"><span class="signal-label">${escapeHtml(label)}</span><span class="signal-value">${escapeHtml(value)}</span></div>`;
+    }
+
+    function getSafeLinkedInUrl(value) {
+      if (typeof value !== 'string' || value.length > 2048) return null;
+      try {
+        const parsed = new URL(value);
+        const isLinkedInHost = parsed.hostname === 'linkedin.com' || parsed.hostname.endsWith('.linkedin.com');
+        if (parsed.protocol !== 'https:' || parsed.username || parsed.password || !isLinkedInHost) return null;
+        return parsed.href;
+      } catch {
+        return null;
+      }
+    }
+
+    function linkedInSignalRow(value) {
+      const safeUrl = getSafeLinkedInUrl(value);
+      if (!safeUrl) return signalRow('LinkedIn', value);
+      return `<div class="signal-item"><span class="signal-label">LinkedIn</span><span class="signal-value"><a href="${escapeHtml(safeUrl)}" target="_blank" rel="noopener noreferrer">View profile</a></span></div>`;
+    }
+
+    function enrichmentAttribution(enrichedAt, source) {
+      return `<div style="margin-top: var(--space-2); font-size: var(--text-xs); color: var(--color-text-muted);">Updated ${escapeHtml(formatDate(enrichedAt))} via ${escapeHtml(source || 'enrichment')}</div>`;
     }
 
     function formatCompanyType(type) {

--- a/server/public/admin-addie.html
+++ b/server/public/admin-addie.html
@@ -2210,7 +2210,9 @@
             : '';
 
           // Tags for curated content
-          const tags = doc.relevance_tags?.length ? doc.relevance_tags.join(', ') : '';
+          const tags = Array.isArray(doc.relevance_tags) && doc.relevance_tags.length
+            ? doc.relevance_tags.map(tag => String(tag)).join(', ')
+            : '';
 
           // Fetch status badge for curated content
           const statusBadge = isCurated && doc.fetch_status
@@ -2222,14 +2224,12 @@
 
           // Slack-specific info
           const slackInfo = isSlack && doc.slack_channel_name
-            ? `<span class="badge badge-info">#${doc.slack_channel_name}</span><span style="color: var(--color-text-muted);">@${doc.slack_username || 'unknown'}</span>`
+            ? `<span class="badge badge-info">#${escapeHtml(String(doc.slack_channel_name))}</span><span style="color: var(--color-text-muted);">@${escapeHtml(String(doc.slack_username || 'unknown'))}</span>`
             : '';
 
           // URL link
           const urlLink = doc.source_url || doc.fetch_url || doc.slack_permalink;
-          const urlHtml = urlLink
-            ? `<a href="${escapeHtml(urlLink)}" target="_blank" onclick="event.stopPropagation();" style="color: var(--color-brand);">${isSlack ? 'View in Slack' : 'Source'}</a>`
-            : '';
+          const urlHtml = renderSafeHttpLink(urlLink, isSlack ? 'View in Slack' : 'Source', true);
 
           // Content preview
           const contentPreview = doc.summary
@@ -2282,7 +2282,7 @@
                 </div>
                 ${contentPreview ? `<div class="knowledge-excerpt">${contentPreview}</div>` : ''}
                 ${addieNotes}
-                ${tags ? `<div style="font-size: var(--text-xs); color: var(--color-text-muted); margin-top: var(--space-1);">Tags: ${tags}</div>` : ''}
+                ${tags ? `<div style="font-size: var(--text-xs); color: var(--color-text-muted); margin-top: var(--space-1);">Tags: ${escapeHtml(tags)}</div>` : ''}
               </div>
               ${actions ? `<div class="knowledge-actions" onclick="event.stopPropagation();">${actions}</div>` : ''}
             </div>
@@ -2325,15 +2325,25 @@
 
         document.getElementById('resource-edit-id').value = r.id;
         document.getElementById('resource-title').textContent = r.title;
-        document.getElementById('resource-url').innerHTML = `<a href="${escapeHtml(r.source_url || r.fetch_url)}" target="_blank">${escapeHtml(r.source_url || r.fetch_url)}</a>`;
+        const resourceUrl = r.source_url || r.fetch_url || '';
+        const resourceUrlEl = document.getElementById('resource-url');
+        const safeResourceLink = renderSafeHttpLink(resourceUrl, resourceUrl);
+        if (safeResourceLink) {
+          resourceUrlEl.innerHTML = safeResourceLink;
+        } else {
+          // Preserve legacy values for admins to diagnose without activating them.
+          resourceUrlEl.textContent = resourceUrl || 'No URL';
+        }
         document.getElementById('resource-summary').textContent = r.summary || 'Not yet fetched';
 
         // Display key insights
         const insightsEl = document.getElementById('resource-insights');
         if (r.key_insights && r.key_insights.length > 0) {
-          insightsEl.innerHTML = r.key_insights.map(i =>
-            `<div style="margin-bottom: var(--space-1);"><span class="badge badge-${i.importance === 'high' ? 'error' : i.importance === 'medium' ? 'warning' : 'info'}">${i.importance}</span> ${escapeHtml(i.insight)}</div>`
-          ).join('');
+          insightsEl.innerHTML = r.key_insights.map(i => {
+            const importance = ['high', 'medium', 'low'].includes(i.importance) ? i.importance : 'low';
+            const badge = importance === 'high' ? 'error' : importance === 'medium' ? 'warning' : 'info';
+            return `<div style="margin-bottom: var(--space-1);"><span class="badge badge-${badge}">${importance}</span> ${escapeHtml(i.insight)}</div>`;
+          }).join('');
         } else {
           insightsEl.textContent = 'No insights yet';
         }
@@ -2735,8 +2745,8 @@
         if (data.tags && data.tags.length > 0) {
           tagsContainer.innerHTML = data.tags.map(t => `
             <div class="tag-stat">
-              <span>${t.tag.replace('_', ' ')}</span>
-              <span class="tag-stat-count">${t.count}</span>
+              <span>${escapeHtml(String(t.tag ?? '').replace('_', ' '))}</span>
+              <span class="tag-stat-count">${escapeHtml(String(t.count ?? ''))}</span>
             </div>
           `).join('');
         } else {
@@ -2925,6 +2935,31 @@
       const div = document.createElement('div');
       div.textContent = text;
       return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    function getSafeHttpUrl(value) {
+      if (typeof value !== 'string' || !value.trim()) return null;
+      try {
+        const parsed = new URL(value.trim());
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+        if (parsed.username || parsed.password) return null;
+        return parsed.href;
+      } catch {
+        return null;
+      }
+    }
+
+    function renderSafeHttpLink(value, label, stopPropagation = false) {
+      const safeUrl = getSafeHttpUrl(value);
+      if (!safeUrl) return '';
+      const anchor = document.createElement('a');
+      anchor.href = safeUrl;
+      anchor.target = '_blank';
+      anchor.rel = 'noopener noreferrer';
+      anchor.textContent = String(label || safeUrl);
+      anchor.style.color = 'var(--color-brand)';
+      if (stopPropagation) anchor.setAttribute('onclick', 'event.stopPropagation();');
+      return anchor.outerHTML;
     }
 
     function copyThreadId(el) {
@@ -3126,7 +3161,10 @@
             <h4>External Sources to Reference</h4>
             <div class="suggestion-detail-content">
               <ul style="margin: 0; padding-left: var(--space-4);">
-                ${s.external_sources.map(url => `<li><a href="${escapeHtml(url)}" target="_blank" rel="noopener">${escapeHtml(url)}</a></li>`).join('')}
+                ${s.external_sources.map(url => {
+                  const link = renderSafeHttpLink(url, url);
+                  return `<li>${link || escapeHtml(String(url ?? ''))}</li>`;
+                }).join('')}
               </ul>
             </div>
           </div>
@@ -3438,17 +3476,21 @@
         const linksEl = document.getElementById('extracted-links');
         if (extractedLinks.length > 0) {
           linksEl.style.display = 'block';
-          document.getElementById('links-list').innerHTML = extractedLinks.map(link => `
+          const safeExtractedLinks = extractedLinks.flatMap(link => {
+            const safeUrl = getSafeHttpUrl(link.url);
+            return safeUrl ? [{ ...link, url: safeUrl }] : [];
+          });
+          document.getElementById('links-list').innerHTML = safeExtractedLinks.map(link => `
             <div class="link-item">
-              <span class="link-source">${link.source}</span>
-              <a href="${escapeHtml(link.url)}" target="_blank" rel="noopener">${escapeHtml(link.url)}</a>
+              <span class="link-source">${escapeHtml(String(link.source || ''))}</span>
+              ${renderSafeHttpLink(link.url, link.url)}
             </div>
           `).join('');
 
           // Populate URL dropdown for perspectives form
           const urlSelect = document.getElementById('perspectives-url');
           urlSelect.innerHTML = '<option value="">Select or enter URL...</option>' +
-            extractedLinks.map(link => `<option value="${escapeHtml(link.url)}">${escapeHtml(link.url)}</option>`).join('');
+            safeExtractedLinks.map(link => `<option value="${escapeHtml(link.url)}">${escapeHtml(link.url)}</option>`).join('');
         } else {
           linksEl.style.display = 'none';
         }
@@ -3546,7 +3588,7 @@
           <span class="thumbs">${msg.rating >= 3 ? '👍' : '👎'}</span>
           <span class="rating-source">(${escapeHtml(msg.rating_source || 'unknown')})</span>
           ${msg.rating_notes ? `<span title="${escapeHtml(msg.rating_notes)}">"${escapeHtml(msg.rating_notes.substring(0, 30))}${msg.rating_notes.length > 30 ? '...' : ''}"</span>` : ''}
-          ${msg.feedback_tags && msg.feedback_tags.length > 0 ? `<span>[${msg.feedback_tags.join(', ')}]</span>` : ''}
+          ${msg.feedback_tags && msg.feedback_tags.length > 0 ? `<span>[${escapeHtml(msg.feedback_tags.map(tag => String(tag)).join(', '))}]</span>` : ''}
         </div>
       ` : '';
 
@@ -3570,7 +3612,7 @@
             </div>
             <textarea class="feedback-notes"
                       id="feedback-notes-${msg.message_id}"
-                      placeholder="What's good or bad about this response?">${msg.rating_notes || ''}</textarea>
+                      placeholder="What's good or bad about this response?">${escapeHtml(msg.rating_notes || '')}</textarea>
             <div class="feedback-actions">
               <button class="btn btn-small btn-primary" onclick="saveMessageFeedback('${msg.message_id}')">Save</button>
             </div>
@@ -3704,6 +3746,46 @@
       `;
     }
 
+    function linkifyBareUrls(html) {
+      const template = document.createElement('template');
+      template.innerHTML = html;
+      const walker = document.createTreeWalker(template.content, 4);
+      const textNodes = [];
+      let node;
+
+      while ((node = walker.nextNode())) textNodes.push(node);
+
+      textNodes.forEach(textNode => {
+        if (textNode.parentElement?.closest('a, code, pre')) return;
+
+        const value = textNode.nodeValue || '';
+        const urlPattern = /https?:\/\/[^\s<>"]+/g;
+        let match;
+        let cursor = 0;
+        let fragment = null;
+
+        while ((match = urlPattern.exec(value))) {
+          fragment ||= document.createDocumentFragment();
+          fragment.append(document.createTextNode(value.slice(cursor, match.index)));
+
+          const anchor = document.createElement('a');
+          anchor.href = match[0];
+          anchor.target = '_blank';
+          anchor.rel = 'noopener noreferrer';
+          anchor.textContent = match[0];
+          fragment.append(anchor);
+          cursor = match.index + match[0].length;
+        }
+
+        if (fragment) {
+          fragment.append(document.createTextNode(value.slice(cursor)));
+          textNode.replaceWith(fragment);
+        }
+      });
+
+      return template.innerHTML;
+    }
+
     function renderMarkdown(text) {
       // Replace Slack user mentions with display names before escaping HTML
       // Format: <@U1234567> -> @DisplayName
@@ -3713,7 +3795,11 @@
       });
 
       // Escape HTML first
-      text = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      text = text.replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
 
       // Code blocks
       text = text.replace(/```(\w*)\n?([\s\S]*?)```/g, '<pre><code>$2</code></pre>');
@@ -3728,10 +3814,15 @@
       text = text.replace(/\*([^*]+)\*/g, '<em>$1</em>');
 
       // Links - make them clickable
-      text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
-
-      // Bare URLs (not already in markdown links)
-      text = text.replace(/(?<!href="|>)(https?:\/\/[^\s<>"]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>');
+      text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, label, href) => {
+        try {
+          const parsed = new URL(href.replace(/&amp;/g, '&'));
+          if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return label;
+          return `<a href="${href}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+        } catch {
+          return label;
+        }
+      });
 
       // Line breaks to paragraphs
       const paragraphs = text.split(/\n\n+/);
@@ -3750,7 +3841,8 @@
         return '<p>' + p.replace(/\n/g, '<br>') + '</p>';
       }).join('');
 
-      return text;
+      // Linkify text nodes only, so generated Markdown/code HTML is never reprocessed.
+      return linkifyBareUrls(text);
     }
 
     function renderExecutionPlan(toolExecutions, totalLatency) {

--- a/server/public/admin-brands.html
+++ b/server/public/admin-brands.html
@@ -726,16 +726,23 @@
       }
     }
 
+    function getSafeResearchLogoUrl(value) {
+      if (typeof value !== 'string' || value.length > 2048) return null;
+      try {
+        const parsed = new URL(value);
+        if (parsed.protocol !== 'https:' || parsed.username || parsed.password) return null;
+        return parsed.href;
+      } catch {
+        return null;
+      }
+    }
+
     function displayResearchResults(data) {
       const container = document.getElementById('researchContent');
       const manifest = data.manifest || {};
+      const safeLogoUrl = getSafeResearchLogoUrl(manifest.logos?.[0]?.url);
 
       let html = '<div class="brand-preview">';
-
-      // Logo
-      if (manifest.logos && manifest.logos.length > 0) {
-        html += `<img src="${manifest.logos[0].url}" alt="Logo" onerror="this.style.display='none'">`;
-      }
 
       html += `
         <div>
@@ -768,6 +775,15 @@
       }
 
       container.innerHTML = html;
+      if (safeLogoUrl) {
+        const logo = document.createElement('img');
+        logo.src = safeLogoUrl;
+        logo.alt = 'Logo';
+        logo.addEventListener('error', () => {
+          logo.style.display = 'none';
+        });
+        container.querySelector('.brand-preview')?.prepend(logo);
+      }
       document.getElementById('researchResults').style.display = 'block';
       document.getElementById('researchError').style.display = 'none';
     }
@@ -886,19 +902,25 @@
     async function viewBrand(domain) {
       document.getElementById('viewModal').style.display = 'block';
       document.getElementById('viewModalTitle').textContent = domain;
-      document.getElementById('viewContent').innerHTML = '<div class="loading">Loading...</div>';
+      const viewContent = document.getElementById('viewContent');
+      viewContent.innerHTML = '<div class="loading">Loading...</div>';
 
       try {
         const response = await fetch(`/api/brands/resolve?domain=${encodeURIComponent(domain)}`);
         const data = await response.json();
 
-        let html = '<pre style="background: var(--color-bg-subtle); padding: var(--space-4); border-radius: var(--radius-md); overflow: auto;">';
-        html += JSON.stringify(data, null, 2);
-        html += '</pre>';
-
-        document.getElementById('viewContent').innerHTML = html;
+        const preview = document.createElement('pre');
+        preview.style.background = 'var(--color-bg-subtle)';
+        preview.style.padding = 'var(--space-4)';
+        preview.style.borderRadius = 'var(--radius-md)';
+        preview.style.overflow = 'auto';
+        preview.textContent = JSON.stringify(data, null, 2);
+        viewContent.replaceChildren(preview);
       } catch (error) {
-        document.getElementById('viewContent').innerHTML = `<div class="error-message">${escapeHtml(error.message)}</div>`;
+        const errorMessage = document.createElement('div');
+        errorMessage.className = 'error-message';
+        errorMessage.textContent = error.message;
+        viewContent.replaceChildren(errorMessage);
       }
     }
 

--- a/server/public/admin-feeds.html
+++ b/server/public/admin-feeds.html
@@ -7,6 +7,7 @@
   <title>Admin - Industry Feeds - AdCP Registry</title>
   <script src="/nav.js"></script>
   <script src="/admin-sidebar.js"></script>
+  <script src="/perspective-url.js"></script>
   <link rel="stylesheet" href="/design-system.css">
   <style>
     body {
@@ -937,10 +938,14 @@
           const summary = article.summary
             ? `<div class="article-summary">${escapeHtml(article.summary)}</div>`
             : '';
+          const safeExternalUrl = getSafePerspectiveExternalUrl(article.external_url);
+          const titleHtml = safeExternalUrl
+            ? `<a href="${escapeHtml(safeExternalUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(article.title)}</a>`
+            : escapeHtml(article.title);
           html += `
             <div class="article-item">
               <div class="article-title-row">
-                ${pendingIcon}<a href="${escapeHtml(article.external_url)}" target="_blank">${escapeHtml(article.title)}</a>
+                ${pendingIcon}${titleHtml}
               </div>
               <div class="article-meta">${date} ${quality}</div>
               ${summary}

--- a/server/public/admin-properties.html
+++ b/server/public/admin-properties.html
@@ -542,44 +542,54 @@
 
     function displayValidationResults(data) {
       const container = document.getElementById('validationResults');
-      const isValid = data.valid;
+      const isValid = data.valid === true;
+      const result = document.createElement('div');
+      result.className = `validation-result ${isValid ? 'valid' : 'invalid'}`;
 
-      let html = `<div class="validation-result ${isValid ? 'valid' : 'invalid'}">`;
-      html += `<h4 style="margin-bottom: var(--space-2);">${isValid ? 'Valid adagents.json found' : 'No valid adagents.json'}</h4>`;
-      html += `<p><strong>URL:</strong> ${data.url}</p>`;
-      html += `<p><strong>Status:</strong> ${data.status_code || 'N/A'}</p>`;
+      const heading = document.createElement('h4');
+      heading.style.marginBottom = 'var(--space-2)';
+      heading.textContent = isValid ? 'Valid adagents.json found' : 'No valid adagents.json';
+      result.appendChild(heading);
 
-      if (data.errors && data.errors.length > 0) {
-        html += '<p style="margin-top: var(--space-2);"><strong>Errors:</strong></p><ul>';
-        data.errors.forEach(e => {
-          html += `<li style="color: var(--color-error-600);">${e.message}</li>`;
+      const appendLabeledValue = (label, value, marginTop = null) => {
+        const paragraph = document.createElement('p');
+        if (marginTop) paragraph.style.marginTop = marginTop;
+        const strong = document.createElement('strong');
+        strong.textContent = `${label}:`;
+        paragraph.append(strong, document.createTextNode(` ${String(value ?? '')}`));
+        result.appendChild(paragraph);
+      };
+
+      appendLabeledValue('URL', data.url || 'N/A');
+      appendLabeledValue('Status', data.status_code || 'N/A');
+
+      const appendMessages = (label, messages, color) => {
+        if (!Array.isArray(messages) || messages.length === 0) return;
+        appendLabeledValue(label, '', 'var(--space-2)');
+        const list = document.createElement('ul');
+        messages.forEach(message => {
+          const item = document.createElement('li');
+          item.style.color = color;
+          item.textContent = String(message?.message ?? '');
+          list.appendChild(item);
         });
-        html += '</ul>';
-      }
+        result.appendChild(list);
+      };
 
-      if (data.warnings && data.warnings.length > 0) {
-        html += '<p style="margin-top: var(--space-2);"><strong>Warnings:</strong></p><ul>';
-        data.warnings.forEach(w => {
-          html += `<li style="color: var(--color-warning-600);">${w.message}</li>`;
-        });
-        html += '</ul>';
-      }
+      appendMessages('Errors', data.errors, 'var(--color-error-600)');
+      appendMessages('Warnings', data.warnings, 'var(--color-warning-600)');
 
       if (isValid && data.raw_data) {
-        const agents = data.raw_data.authorized_agents || [];
-        const props = data.raw_data.properties || [];
-        html += `<p style="margin-top: var(--space-2);"><strong>Authorized Agents:</strong> ${agents.length}</p>`;
-        html += `<p><strong>Properties:</strong> ${props.length}</p>`;
+        const agents = Array.isArray(data.raw_data.authorized_agents) ? data.raw_data.authorized_agents : [];
+        const props = Array.isArray(data.raw_data.properties) ? data.raw_data.properties : [];
+        appendLabeledValue('Authorized agents', agents.length, 'var(--space-2)');
+        appendLabeledValue('Properties', props.length);
       }
-
-      html += '</div>';
 
       // Show save button if no valid adagents.json found (for creating synthetic)
-      if (!isValid) {
-        document.getElementById('saveValidatedBtn').style.display = 'inline-block';
-      }
+      document.getElementById('saveValidatedBtn').style.display = isValid ? 'none' : 'inline-block';
 
-      container.innerHTML = html;
+      container.replaceChildren(result);
       container.style.display = 'block';
       document.getElementById('validateError').style.display = 'none';
     }
@@ -666,19 +676,25 @@
     async function viewProperty(domain) {
       document.getElementById('viewModal').style.display = 'block';
       document.getElementById('viewModalTitle').textContent = domain;
-      document.getElementById('viewContent').innerHTML = '<div class="loading">Loading...</div>';
+      const viewContent = document.getElementById('viewContent');
+      viewContent.innerHTML = '<div class="loading">Loading...</div>';
 
       try {
         const response = await fetch(`/api/properties/resolve?domain=${encodeURIComponent(domain)}`);
         const data = await response.json();
 
-        let html = '<pre style="background: var(--color-bg-subtle); padding: var(--space-4); border-radius: var(--radius-md); overflow: auto;">';
-        html += JSON.stringify(data, null, 2);
-        html += '</pre>';
-
-        document.getElementById('viewContent').innerHTML = html;
+        const preview = document.createElement('pre');
+        preview.style.background = 'var(--color-bg-subtle)';
+        preview.style.padding = 'var(--space-4)';
+        preview.style.borderRadius = 'var(--radius-md)';
+        preview.style.overflow = 'auto';
+        preview.textContent = JSON.stringify(data, null, 2);
+        viewContent.replaceChildren(preview);
       } catch (error) {
-        document.getElementById('viewContent').innerHTML = `<div class="error-message">${error.message}</div>`;
+        const errorMessage = document.createElement('div');
+        errorMessage.className = 'error-message';
+        errorMessage.textContent = error.message;
+        viewContent.replaceChildren(errorMessage);
       }
     }
 

--- a/server/public/community/person-profile.html
+++ b/server/public/community/person-profile.html
@@ -779,6 +779,7 @@
   <!-- Navigation -->
   <div id="adcp-nav"></div>
   <script src="/nav.js"></script>
+  <script src="/perspective-url.js"></script>
 
   <div class="profile-container">
     <a href="/community/people" class="back-link" id="back-link">
@@ -902,6 +903,8 @@
         .map(n => n.charAt(0).toUpperCase())
         .join('');
       const hasOpenTo = data.open_to_coffee_chat || data.open_to_intros;
+      const linkedInUrl = getSafeHttpsUrl(data.linkedin_url);
+      const twitterUrl = getSafeHttpsUrl(data.twitter_url);
 
       let html = `<div class="profile-card">`;
 
@@ -938,7 +941,7 @@
                   </span>
                 ` : ''}
               </div>
-              ${data.linkedin_url || data.twitter_url || data.github_username ? `
+              ${linkedInUrl || twitterUrl || data.github_username ? `
                 <div class="profile-social">
                   ${data.github_username ? `
                     <a href="https://github.com/${escapeHtml(data.github_username)}" target="_blank" rel="noopener noreferrer" class="social-link">
@@ -948,16 +951,16 @@
                       GitHub
                     </a>
                   ` : ''}
-                  ${data.linkedin_url ? `
-                    <a href="${escapeHtml(data.linkedin_url)}" target="_blank" rel="noopener noreferrer" class="social-link">
+                  ${linkedInUrl ? `
+                    <a href="${escapeHtml(linkedInUrl)}" target="_blank" rel="noopener noreferrer" class="social-link">
                       <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
                       </svg>
                       LinkedIn
                     </a>
                   ` : ''}
-                  ${data.twitter_url ? `
-                    <a href="${escapeHtml(data.twitter_url)}" target="_blank" rel="noopener noreferrer" class="social-link">
+                  ${twitterUrl ? `
+                    <a href="${escapeHtml(twitterUrl)}" target="_blank" rel="noopener noreferrer" class="social-link">
                       <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
                       </svg>
@@ -1068,10 +1071,11 @@
               <div class="perspective-list">
                 ${data.perspectives.map(p => {
                   const isArticle = p.content_type === 'article';
+                  const safeExternalUrl = getSafePerspectiveExternalUrl(p.external_url);
                   const href = isArticle
                     ? '/perspectives/' + encodeURIComponent(p.slug)
-                    : escapeHtml(p.external_url || '#');
-                  const target = isArticle ? '' : ' target="_blank" rel="noopener noreferrer"';
+                    : escapeHtml(safeExternalUrl || '#');
+                  const target = !isArticle && safeExternalUrl ? ' target="_blank" rel="noopener noreferrer"' : '';
                   const date = new Date(p.published_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
                   const meta = [p.category, !isArticle && p.external_site_name].filter(Boolean).join(' · ');
                   const icon = isArticle
@@ -1431,6 +1435,17 @@
       return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
+    function getSafeHttpsUrl(value) {
+      if (typeof value !== 'string') return null;
+      try {
+        const parsed = new URL(value);
+        if (parsed.protocol !== 'https:' || parsed.username || parsed.password) return null;
+        return parsed.href;
+      } catch {
+        return null;
+      }
+    }
+
     function formatTier(tier) {
       if (!tier) return '';
       // Convert snake_case or lowercase to title case
@@ -1449,4 +1464,3 @@
   </script>
 </body>
 </html>
-

--- a/server/public/latest/index.html
+++ b/server/public/latest/index.html
@@ -25,6 +25,7 @@
 
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
+  <script src="/perspective-url.js"></script>
   <style>
     body { padding-top: 60px; background: var(--color-bg-page); }
 
@@ -289,6 +290,10 @@
         for (const article of data.articles) {
           const tags = (article.relevance_tags || []).slice(0, 3);
           const tagsHtml = tags.map(t => `<span class="article-tag">${escapeHtml(t)}</span>`).join('');
+          const safeSourceUrl = getSafePerspectiveExternalUrl(article.source_url);
+          const titleHtml = safeSourceUrl
+            ? `<a href="${escapeHtml(safeSourceUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(article.title)}</a>`
+            : escapeHtml(article.title);
 
           html += `
             <div class="article-card">
@@ -298,7 +303,7 @@
                   ${article.feed_name ? `<span>${escapeHtml(article.feed_name)}</span>` : ''}
                 </div>
                 <h3 class="article-title">
-                  <a href="${escapeHtml(article.source_url)}" target="_blank" rel="noopener">${escapeHtml(article.title)}</a>
+                  ${titleHtml}
                 </h3>
                 ${article.summary ? `<p class="article-summary">${escapeHtml(article.summary)}</p>` : ''}
                 ${tags.length > 0 ? `<div class="article-tags">${tagsHtml}</div>` : ''}

--- a/server/public/latest/section.html
+++ b/server/public/latest/section.html
@@ -9,6 +9,7 @@
 
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
+  <script src="/perspective-url.js"></script>
   <style>
     body { padding-top: 60px; background: var(--color-bg-page); }
 
@@ -270,6 +271,10 @@
           const tags = (article.relevance_tags || []).slice(0, 5);
           const tagsHtml = tags.map(t => `<span class="article-tag">${escapeHtml(t)}</span>`).join('');
           const qualityHtml = article.quality_score ? `<span class="article-quality">${article.quality_score}/5</span>` : '';
+          const safeSourceUrl = getSafePerspectiveNavigationUrl(article.source_url);
+          const titleHtml = safeSourceUrl
+            ? `<a href="${escapeHtml(safeSourceUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(article.title)}</a>`
+            : escapeHtml(article.title);
 
           html += `
             <div class="article-card">
@@ -278,7 +283,7 @@
                 ${qualityHtml}
               </div>
               <h2 class="article-title">
-                <a href="${escapeHtml(article.source_url)}" target="_blank" rel="noopener">${escapeHtml(article.title)}</a>
+                ${titleHtml}
               </h2>
               ${article.summary ? `<p class="article-summary">${escapeHtml(article.summary)}</p>` : ''}
               ${article.addie_notes ? `<div class="article-notes"><strong>Why it matters:</strong> ${escapeHtml(article.addie_notes)}</div>` : ''}

--- a/server/public/member-card.js
+++ b/server/public/member-card.js
@@ -35,6 +35,9 @@ const offeringLabels = {
 function renderMemberCard(member, options = {}) {
   const { isPreview = false, showVisibilityBadge = false } = options;
   const brand = member.resolved_brand;
+  const linkedInUrl = getSafeHttpsUrl(member.linkedin_url);
+  const contactWebsiteUrl = getSafeHttpsUrl(member.contact_website)
+    || getSafeHttpsUrl(brand?.contact?.domain ? `https://${brand.contact.domain}` : null);
 
   // Name: prefer brand.json, fallback to profile
   const displayName = brand?.name || member.display_name;
@@ -141,11 +144,8 @@ function renderMemberCard(member, options = {}) {
       </div>
       <div class="member-card-footer">
         <div class="member-contact">
-          ${(() => {
-            const website = member.contact_website || (brand?.contact?.domain ? `https://${escapeHtmlSafe(brand.contact.domain)}` : '');
-            return website ? `<a href="${escapeHtmlSafe(website)}" target="_blank" onclick="event.stopPropagation()">Website</a>` : '';
-          })()}
-          ${member.linkedin_url ? `<a href="${member.linkedin_url}" target="_blank" onclick="event.stopPropagation()">LinkedIn</a>` : ''}
+          ${contactWebsiteUrl ? `<a href="${escapeHtmlSafe(contactWebsiteUrl)}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">Website</a>` : ''}
+          ${linkedInUrl ? `<a href="${escapeHtmlSafe(linkedInUrl)}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">LinkedIn</a>` : ''}
         </div>
         ${viewBtn}
       </div>
@@ -855,6 +855,17 @@ function escapeHtmlSafe(str) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;');
+}
+
+function getSafeHttpsUrl(value) {
+  if (typeof value !== 'string') return null;
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'https:' || parsed.username || parsed.password) return null;
+    return parsed.href;
+  } catch {
+    return null;
+  }
 }
 
 // ============================================

--- a/server/public/members.html
+++ b/server/public/members.html
@@ -1121,6 +1121,7 @@
   <script src="/nav.js"></script>
   <script src="/registry-nav.js"></script>
   <script src="/member-card.js"></script>
+  <script src="/perspective-url.js"></script>
 
   <!-- List View -->
   <div id="list-view">
@@ -1467,22 +1468,24 @@
 
       // Build social links array
       const socialLinks = [];
-      if (member.contact_website) {
-        let websiteLabel;
-        try { websiteLabel = new URL(member.contact_website).hostname; } catch { websiteLabel = member.contact_website; }
-        socialLinks.push(`<a href="${escapeHtml(member.contact_website)}" target="_blank" rel="noopener noreferrer" class="detail-social-link">
+      const contactWebsiteUrl = getSafeHttpsUrl(member.contact_website);
+      const linkedInUrl = getSafeHttpsUrl(member.linkedin_url);
+      const twitterUrl = getSafeHttpsUrl(member.twitter_url);
+      if (contactWebsiteUrl) {
+        const websiteLabel = new URL(contactWebsiteUrl).hostname;
+        socialLinks.push(`<a href="${escapeHtml(contactWebsiteUrl)}" target="_blank" rel="noopener noreferrer" class="detail-social-link">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg>
           ${escapeHtml(websiteLabel)}
         </a>`);
       }
-      if (member.linkedin_url) {
-        socialLinks.push(`<a href="${escapeHtml(member.linkedin_url)}" target="_blank" rel="noopener noreferrer" class="detail-social-link">
+      if (linkedInUrl) {
+        socialLinks.push(`<a href="${escapeHtml(linkedInUrl)}" target="_blank" rel="noopener noreferrer" class="detail-social-link">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
           LinkedIn
         </a>`);
       }
-      if (member.twitter_url) {
-        socialLinks.push(`<a href="${escapeHtml(member.twitter_url)}" target="_blank" rel="noopener noreferrer" class="detail-social-link">
+      if (twitterUrl) {
+        socialLinks.push(`<a href="${escapeHtml(twitterUrl)}" target="_blank" rel="noopener noreferrer" class="detail-social-link">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
           X
         </a>`);
@@ -1586,8 +1589,9 @@
               <div style="display: flex; flex-direction: column; gap: 12px;">
                 ${perspectives.map(p => {
                   const isArticle = p.content_type === 'article';
-                  const href = isArticle ? '/perspectives/' + encodeURIComponent(p.slug) : escapeHtml(p.external_url || '#');
-                  const target = isArticle ? '' : ' target="_blank" rel="noopener noreferrer"';
+                  const safeExternalUrl = getSafePerspectiveExternalUrl(p.external_url);
+                  const href = isArticle ? '/perspectives/' + encodeURIComponent(p.slug) : escapeHtml(safeExternalUrl || '#');
+                  const target = !isArticle && safeExternalUrl ? ' target="_blank" rel="noopener noreferrer"' : '';
                   const date = new Date(p.published_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
                   const meta = [p.category, !isArticle && p.external_site_name].filter(Boolean).join(' · ');
                   return `

--- a/server/public/membership/hub.html
+++ b/server/public/membership/hub.html
@@ -2177,8 +2177,9 @@
       const fillClass = pct === 100 ? 'profile-completeness-fill--full' : '';
 
       const initials = ((config?.user?.firstName || '').charAt(0) + (config?.user?.lastName || '').charAt(0)).trim() || 'U';
-      const avatarHtml = profile.avatar_url
-        ? `<img src="${escapeHtml(profile.avatar_url)}" alt="Profile photo">`
+      const avatarUrl = getSafeProfileImageUrl(profile.avatar_url);
+      const avatarHtml = avatarUrl
+        ? `<img src="${escapeHtml(avatarUrl)}" alt="Profile photo">`
         : escapeHtml(initials.toUpperCase());
 
       const desc = profile.bio
@@ -2191,10 +2192,12 @@
           }).join('')}${profile.expertise.length > 4 ? `<span class="profile-offering-tag">+${profile.expertise.length - 4}</span>` : ''}</div>`
         : `<span class="profile-field-value profile-field-value--empty">No expertise tags yet</span>`;
 
+      const linkedInUrl = getSafeHttpsUrl(profile.linkedin_url);
+      const twitterUrl = getSafeHttpsUrl(profile.twitter_url);
       const socials = [];
-      if (profile.linkedin_url) socials.push(`<a class="profile-social-link" href="${escapeHtml(profile.linkedin_url)}" target="_blank" rel="noopener">LinkedIn ↗</a>`);
-      if (profile.twitter_url) socials.push(`<a class="profile-social-link" href="${escapeHtml(profile.twitter_url)}" target="_blank" rel="noopener">X ↗</a>`);
-      if (profile.github_username) socials.push(`<a class="profile-social-link" href="https://github.com/${encodeURIComponent(profile.github_username)}" target="_blank" rel="noopener">GitHub ↗</a>`);
+      if (linkedInUrl) socials.push(`<a class="profile-social-link" href="${escapeHtml(linkedInUrl)}" target="_blank" rel="noopener noreferrer">LinkedIn ↗</a>`);
+      if (twitterUrl) socials.push(`<a class="profile-social-link" href="${escapeHtml(twitterUrl)}" target="_blank" rel="noopener noreferrer">X ↗</a>`);
+      if (profile.github_username) socials.push(`<a class="profile-social-link" href="https://github.com/${encodeURIComponent(profile.github_username)}" target="_blank" rel="noopener noreferrer">GitHub ↗</a>`);
 
       return `
         ${hdr}
@@ -2496,6 +2499,40 @@
       const d = document.createElement('div');
       d.textContent = str;
       return d.innerHTML;
+    }
+
+    function getSafeHttpsUrl(value) {
+      if (typeof value !== 'string' || !value.trim()) return null;
+      try {
+        const parsed = new URL(value.trim());
+        if (parsed.protocol !== 'https:' || parsed.username || parsed.password) return null;
+        return parsed.href;
+      } catch {
+        return null;
+      }
+    }
+
+    function getSafeProfileImageUrl(value) {
+      if (typeof value !== 'string' || !value.trim() || value.length > 2048) return null;
+
+      const candidate = value.trim();
+      if (/[\u0000-\u001F\u007F<>\\]/.test(candidate) || candidate.startsWith('//')) return null;
+
+      try {
+        if (candidate.startsWith('/')) {
+          const base = new URL(document.baseURI);
+          const parsed = new URL(candidate, base);
+          const isAvatarPath = /^\/api\/(?:community\/avatars|portraits)\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.png$/i.test(parsed.pathname);
+          if (parsed.origin !== base.origin || !isAvatarPath) return null;
+          return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+        }
+
+        const parsed = new URL(candidate);
+        if (parsed.protocol !== 'https:' || parsed.username || parsed.password) return null;
+        return parsed.href;
+      } catch {
+        return null;
+      }
     }
 
     function fmtDate(s) {

--- a/server/public/perspective-url.js
+++ b/server/public/perspective-url.js
@@ -1,0 +1,46 @@
+/**
+ * Returns a normalized, credential-free HTTPS URL for public perspective
+ * navigation, or null for unsafe/legacy values.
+ */
+function getSafePerspectiveExternalUrl(value) {
+  if (
+    typeof value !== 'string'
+    || value.length === 0
+    || value.length > 2048
+    || /[\u0000-\u001F\u007F<>\\]/.test(value)
+  ) return null;
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'https:' || parsed.username || parsed.password) return null;
+    return parsed.href.length <= 2048 ? parsed.href : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Allows either a safe external perspective URL or the local perspective
+ * detail fallback returned by the Latest API.
+ */
+function getSafePerspectiveNavigationUrl(value) {
+  const externalUrl = getSafePerspectiveExternalUrl(value);
+  if (externalUrl) return externalUrl;
+  if (
+    typeof value !== 'string'
+    || value.length > 2048
+    || /[\u0000-\u001F\u007F<>\\]/.test(value)
+    || !value.startsWith('/perspectives/')
+  ) {
+    return null;
+  }
+
+  try {
+    const base = new URL('https://agenticadvertising.org');
+    const parsed = new URL(value, base);
+    if (parsed.origin !== base.origin || !parsed.pathname.startsWith('/perspectives/')) return null;
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return null;
+  }
+}

--- a/server/public/perspective-url.js
+++ b/server/public/perspective-url.js
@@ -44,3 +44,9 @@ function getSafePerspectiveNavigationUrl(value) {
     return null;
   }
 }
+
+// Explicitly export the helper consumed by latest/section.html. This file is a
+// classic script, so the browser global is the cross-file API.
+if (typeof window !== 'undefined') {
+  window.getSafePerspectiveNavigationUrl = getSafePerspectiveNavigationUrl;
+}

--- a/server/public/perspectives/article.html
+++ b/server/public/perspectives/article.html
@@ -28,6 +28,7 @@
   <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
   <script src="/perspectives/utils.js"></script>
+  <script src="/perspective-url.js"></script>
   <style>
     /* Page-specific: nav offset */
     body { padding-top: 60px; }
@@ -1007,7 +1008,12 @@
 
         // If it's a link type, redirect to external URL
         if (article.content_type === 'link' && article.external_url) {
-          window.location.href = article.external_url;
+          const externalUrl = getSafePerspectiveExternalUrl(article.external_url);
+          if (!externalUrl) {
+            showError();
+            return;
+          }
+          window.location.href = externalUrl;
           return;
         }
 

--- a/server/public/stories/index.html
+++ b/server/public/stories/index.html
@@ -435,6 +435,7 @@
 
   <div id="adcp-footer"></div>
   <script src="/nav.js"></script>
+  <script src="/perspective-url.js"></script>
   <script>
     (function() {
       function esc(str) {
@@ -669,12 +670,13 @@
         registerTopics(topics);
 
         var card = document.createElement('a');
-        card.href = item.external_url || ('/perspectives/' + item.slug);
+        var safeExternalUrl = getSafePerspectiveExternalUrl(item.external_url);
+        card.href = safeExternalUrl || ('/perspectives/' + encodeURIComponent(item.slug));
         card.className = className;
         card.setAttribute('data-topics', topics);
-        if (item.external_url) {
+        if (safeExternalUrl) {
           card.target = '_blank';
-          card.rel = 'noopener';
+          card.rel = 'noopener noreferrer';
         }
 
         var imageUrl = item.featured_image_url
@@ -801,10 +803,12 @@
             registerTopics(topics);
 
             var link = document.createElement('a');
-            link.href = item.source_url || '#';
+            var safeSourceUrl = getSafePerspectiveExternalUrl(item.source_url);
+            if (!safeSourceUrl) return;
+            link.href = safeSourceUrl;
             link.className = 'news-item';
             link.target = '_blank';
-            link.rel = 'noopener';
+            link.rel = 'noopener noreferrer';
             link.setAttribute('data-topics', topics);
 
             var source = item.feed_name || '';

--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -26,6 +26,7 @@
   <link rel="stylesheet" href="/design-system.css">
   <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+  <script src="/perspective-url.js"></script>
   <style>
     body {
       background: var(--color-bg-page);
@@ -1715,9 +1716,10 @@
 
           // For link posts, link directly to external URL
           // For article posts, use onclick to open the article view
-          if (post.content_type === 'link' && post.external_url) {
+          const safeExternalUrl = getSafePerspectiveExternalUrl(post.external_url);
+          if (post.content_type === 'link' && safeExternalUrl) {
             return `
-              <a href="${escapeHtml(post.external_url)}" target="_blank" rel="noopener" id="post-${escapeHtml(post.slug)}" class="post-card">
+              <a href="${escapeHtml(safeExternalUrl)}" target="_blank" rel="noopener noreferrer" id="post-${escapeHtml(post.slug)}" class="post-card">
                 <div class="post-title">
                   ${escapeHtml(post.title)}
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="opacity: 0.5; margin-left: 4px;">
@@ -2455,9 +2457,10 @@
         const post = postsData.find(p => p.slug === decodedPostSlug);
         if (!post) return;
 
-        if (post.content_type === 'link' && post.external_url) {
+        const safeExternalUrl = getSafePerspectiveExternalUrl(post.external_url);
+        if (post.content_type === 'link' && safeExternalUrl) {
           // For link posts, redirect to external URL
-          window.open(post.external_url, '_blank', 'noopener,noreferrer');
+          window.open(safeExternalUrl, '_blank', 'noopener,noreferrer');
         } else {
           // For article posts, open the article view
           openArticle(decodedPostSlug);

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -2721,7 +2721,7 @@ async function handleFeedbackAction({ ack, body, client }: any): Promise<void> {
       // Update the message with feedback
       // Use numeric rating: 5 for positive, 1 for negative
       try {
-        await threadService.addMessageFeedback(latestAssistant.message_id, {
+        await threadService.addMessageFeedback(thread.thread_id, latestAssistant.message_id, {
           rating: isPositive ? 5 : 1,
           rating_category: isPositive ? 'helpful' : 'not_helpful',
           rated_by: userId,
@@ -5260,7 +5260,7 @@ async function handleReactionAdded({
       userInput = '[User reacted with ' + reaction + ' emoji as positive feedback]';
       // Record as positive feedback
       try {
-        await threadService.addMessageFeedback(lastAssistantMessage.message_id, {
+        await threadService.addMessageFeedback(thread.thread_id, lastAssistantMessage.message_id, {
           rating: 5,
           rating_category: 'emoji_feedback',
           rating_notes: `User reacted with :${reaction}:`,
@@ -5276,7 +5276,7 @@ async function handleReactionAdded({
       userInput = '[User reacted with ' + reaction + ' emoji as negative feedback]';
       // Record as negative feedback
       try {
-        await threadService.addMessageFeedback(lastAssistantMessage.message_id, {
+        await threadService.addMessageFeedback(thread.thread_id, lastAssistantMessage.message_id, {
           rating: 1,
           rating_category: 'emoji_feedback',
           rating_notes: `User reacted with :${reaction}:`,

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.07.5';
+export const CODE_VERSION = '2026.07.6';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -76,6 +76,7 @@ import {
 } from "../../services/lusha.js";
 import { COMPANY_TYPE_VALUES } from "../../config/company-types.js";
 import { createProspect, updateProspect } from "../../services/prospect.js";
+import { validateMemberProfileUrlFields } from "../../utils/member-profile-url.js";
 import {
   getAllFeedsWithStats,
   addFeed,
@@ -10654,6 +10655,11 @@ Use add_committee_leader to assign a leader.`;
           updates[field] = (input[field] as string) || null;
           updatedFields.push(field);
         }
+      }
+
+      const invalidMemberProfileUrlField = validateMemberProfileUrlFields(updates);
+      if (invalidMemberProfileUrlField) {
+        return `❌ ${invalidMemberProfileUrlField} must be an HTTPS URL without credentials.`;
       }
 
       if (input.markets !== undefined) {

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -14,6 +14,7 @@ import { createCipheriv, createDecipheriv, randomBytes, randomUUID, scryptSync }
 import { createLogger } from '../../logger.js';
 import { classifyProbeError, probeReasonLabel } from '../../utils/probe-error.js';
 import { validateExternalUrl } from '../../utils/url-security.js';
+import { validateMemberProfileUrlFields } from '../../utils/member-profile-url.js';
 import { parseOAuthClientCredentialsInput } from '../../routes/helpers/oauth-client-credentials-input.js';
 import {
   verifyAgentHostname,
@@ -2826,19 +2827,9 @@ export function createMemberToolHandlers(
       }
     }
 
-    // Validate URL fields
-    for (const urlField of ['linkedin_url', 'twitter_url'] as const) {
-      const value = updates[urlField];
-      if (value && typeof value === 'string') {
-        try {
-          const parsed = new URL(value);
-          if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-            return `${urlField} must be an HTTP or HTTPS URL.`;
-          }
-        } catch {
-          return `${urlField} must be a valid URL.`;
-        }
-      }
+    const invalidMemberProfileUrlField = validateMemberProfileUrlFields(updates);
+    if (invalidMemberProfileUrlField) {
+      return `${invalidMemberProfileUrlField} must be an HTTPS URL without credentials.`;
     }
 
     if (Object.keys(updates).length === 0) {
@@ -2966,19 +2957,9 @@ export function createMemberToolHandlers(
       return 'Tagline must be 200 characters or fewer.';
     }
 
-    // Validate URL fields
-    for (const urlField of ['linkedin_url', 'twitter_url', 'contact_website'] as const) {
-      const value = updates[urlField];
-      if (value && typeof value === 'string') {
-        try {
-          const parsed = new URL(value);
-          if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-            return `${urlField} must be an HTTP or HTTPS URL.`;
-          }
-        } catch {
-          return `${urlField} must be a valid URL.`;
-        }
-      }
+    const invalidMemberProfileUrlField = validateMemberProfileUrlFields(updates);
+    if (invalidMemberProfileUrlField) {
+      return `${invalidMemberProfileUrlField} must be an HTTPS URL without credentials.`;
     }
 
     // Validate contact email
@@ -3386,6 +3367,9 @@ export function createMemberToolHandlers(
         }
         if (error.is('invalid_post_slug')) {
           return `Generated post slug was invalid (must contain only lowercase letters, numbers, and hyphens). Try again with a different title.`;
+        }
+        if (error.is('invalid_external_url')) {
+          return `Link posts require an HTTPS URL without embedded credentials.`;
         }
         if (error.is('duplicate_post_slug')) {
           return `A post with this slug already exists in "${slug}". Try again with a different title.`;

--- a/server/src/addie/services/content-curator.ts
+++ b/server/src/addie/services/content-curator.ts
@@ -134,6 +134,109 @@ interface ChannelForRouting {
   description: string;
 }
 
+const CURATOR_RELEVANCE_TAGS = new Set([
+  'adcp', 'mcp', 'a2a', 'advertising', 'programmatic', 'creative', 'signals',
+  'media-buying', 'llms', 'ai-models', 'ai-agents', 'machine-learning',
+  'responsible-ai', 'industry-news', 'market-trends', 'case-study',
+  'competitor', 'startup', 'tutorial', 'documentation', 'opinion', 'research',
+  'announcement',
+]);
+
+type CuratorAnalysis = {
+  summary: string;
+  key_insights: KeyInsight[];
+  addie_notes: string;
+  relevance_tags: string[];
+  quality_score: number | null;
+  notification_channels: string[];
+};
+
+function normalizeCuratorText(value: unknown, maxLength: number): string {
+  if (typeof value !== 'string') return '';
+  return value
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, '')
+    .trim()
+    .slice(0, maxLength);
+}
+
+/** Validate model output before it crosses the persistence boundary. */
+export function normalizeCuratorAnalysis(
+  value: unknown,
+  allowedNotificationChannels: readonly string[] = []
+): CuratorAnalysis {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Curator model response must be a JSON object');
+  }
+  const parsed = value as Record<string, unknown>;
+
+  const rawInsights = Array.isArray(parsed.key_insights) ? parsed.key_insights : [];
+  const keyInsights: KeyInsight[] = rawInsights.slice(0, 10).flatMap((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return [];
+    const insight = normalizeCuratorText((entry as Record<string, unknown>).insight, 1_000);
+    const importance = (entry as Record<string, unknown>).importance;
+    if (!insight || !['high', 'medium', 'low'].includes(String(importance))) return [];
+    return [{ insight, importance: importance as KeyInsight['importance'] }];
+  });
+
+  const rawTags = Array.isArray(parsed.relevance_tags) ? parsed.relevance_tags : [];
+  const relevanceTags = [...new Set(rawTags.flatMap((tag) => {
+    if (typeof tag !== 'string') return [];
+    const normalized = tag.trim().toLowerCase();
+    return CURATOR_RELEVANCE_TAGS.has(normalized) ? [normalized] : [];
+  }))].slice(0, 5);
+
+  const allowedChannels = new Set(allowedNotificationChannels);
+  const rawChannels = Array.isArray(parsed.notification_channels)
+    ? parsed.notification_channels
+    : [];
+  const notificationChannels = [...new Set(rawChannels.flatMap((channel) =>
+    typeof channel === 'string' && allowedChannels.has(channel) ? [channel] : []
+  ))];
+
+  const qualityScore = typeof parsed.quality_score === 'number'
+    && Number.isInteger(parsed.quality_score)
+    && parsed.quality_score >= 1
+    && parsed.quality_score <= 5
+    ? parsed.quality_score
+    : null;
+
+  const analysis: CuratorAnalysis = {
+    summary: normalizeCuratorText(parsed.summary, 2_000),
+    key_insights: keyInsights,
+    addie_notes: normalizeCuratorText(parsed.addie_take ?? parsed.addie_notes, 1_000),
+    relevance_tags: relevanceTags,
+    quality_score: qualityScore,
+    notification_channels: notificationChannels,
+  };
+
+  if (
+    !analysis.summary
+    || analysis.key_insights.length === 0
+    || !analysis.addie_notes
+    || analysis.relevance_tags.length === 0
+    || analysis.quality_score === null
+  ) {
+    throw new Error('Curator model response is missing required valid analysis fields');
+  }
+
+  return analysis;
+}
+
+/** Parse and validate the model response so malformed output remains retryable. */
+export function parseCuratorAnalysisResponse(
+  responseText: string,
+  allowedNotificationChannels: readonly string[] = []
+): CuratorAnalysis {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(responseText);
+  } catch {
+    throw new Error('Curator model response was not valid JSON');
+  }
+
+  return normalizeCuratorAnalysis(parsed, allowedNotificationChannels);
+}
+
 /**
  * Generate summary and insights using Claude
  * Optionally includes notification channel routing if channels are provided
@@ -143,14 +246,7 @@ async function generateAnalysis(
   content: string,
   url: string,
   channels?: ChannelForRouting[]
-): Promise<{
-  summary: string;
-  key_insights: KeyInsight[];
-  addie_notes: string;
-  relevance_tags: string[];
-  quality_score: number | null;
-  notification_channels: string[];
-}> {
+): Promise<CuratorAnalysis> {
   if (!isLLMConfigured()) {
     throw new Error('ANTHROPIC_API_KEY not configured');
   }
@@ -227,36 +323,10 @@ Return ONLY the JSON, no markdown formatting.`;
   // Extract JSON from response
   const responseText = response.text;
 
-  try {
-    // Try to parse as JSON directly
-    const parsed = JSON.parse(responseText);
-    return {
-      summary: parsed.summary || '',
-      key_insights: parsed.key_insights || [],
-      // addie_take is the new field name in the prompt, maps to addie_notes in DB
-      addie_notes: parsed.addie_take || parsed.addie_notes || '',
-      relevance_tags: parsed.relevance_tags || [],
-      // Only use AI-provided score if valid, otherwise null (indicates needs human review)
-      quality_score: parsed.quality_score
-        ? Math.min(5, Math.max(1, parsed.quality_score))
-        : null,
-      notification_channels: Array.isArray(parsed.notification_channels)
-        ? parsed.notification_channels
-        : [],
-    };
-  } catch {
-    // If JSON parsing fails, extract what we can
-    // quality_score is null to indicate it needs human review
-    logger.warn({ responseText }, 'Failed to parse curator response as JSON');
-    return {
-      summary: responseText.substring(0, 500),
-      key_insights: [],
-      addie_notes: '',
-      relevance_tags: [],
-      quality_score: null,
-      notification_channels: [],
-    };
-  }
+  return parseCuratorAnalysisResponse(
+    responseText,
+    channels?.map((channel) => channel.slack_channel_id) ?? []
+  );
 }
 
 /**

--- a/server/src/addie/thread-service.ts
+++ b/server/src/addie/thread-service.ts
@@ -602,6 +602,7 @@ export class ThreadService {
    * Add feedback to a message
    */
   async addMessageFeedback(
+    threadId: string,
     messageId: string,
     feedback: MessageFeedback
   ): Promise<boolean> {
@@ -616,7 +617,8 @@ export class ThreadService {
          rated_by = $7,
          rating_source = $8,
          rated_at = NOW()
-       WHERE message_id = $1`,
+       WHERE message_id = $1
+         AND thread_id = $9`,
       [
         messageId,
         feedback.rating,
@@ -626,6 +628,7 @@ export class ThreadService {
         feedback.improvement_suggestion || null,
         feedback.rated_by,
         feedback.rating_source,
+        threadId,
       ]
     );
     return result.rowCount !== null && result.rowCount > 0;

--- a/server/src/db/community-db.ts
+++ b/server/src/db/community-db.ts
@@ -1,5 +1,6 @@
 import { query } from './client.js';
 import { createLogger } from '../logger.js';
+import { validateMemberProfileUrlFields } from '../utils/member-profile-url.js';
 
 const logger = createLogger('community-db');
 
@@ -156,6 +157,13 @@ export class CommunityDatabase {
   // =====================================================
 
   async updateProfile(userId: string, updates: UpdateCommunityProfileInput): Promise<CommunityProfile | null> {
+    const invalidUrlField = validateMemberProfileUrlFields(
+      updates as unknown as Record<string, unknown>,
+    );
+    if (invalidUrlField) {
+      throw new TypeError(`${invalidUrlField} must be an HTTPS URL without credentials`);
+    }
+
     const COLUMN_MAP: Record<keyof UpdateCommunityProfileInput, string> = {
       slug: 'slug',
       headline: 'headline',

--- a/server/src/db/industry-feeds-db.ts
+++ b/server/src/db/industry-feeds-db.ts
@@ -5,6 +5,7 @@
 
 import { query } from './client.js';
 import { logger } from '../logger.js';
+import { normalizePerspectiveExternalUrl } from '../utils/perspective-url.js';
 
 // ============== Types ==============
 
@@ -277,8 +278,14 @@ export async function rssArticleExists(feedId: number, guid: string, externalUrl
  * Returns the perspective ID if created, null if it already exists
  */
 export async function createRssPerspective(article: RssArticleInput): Promise<string | null> {
+  const normalizedExternalUrl = normalizePerspectiveExternalUrl(article.link);
+  if (!normalizedExternalUrl) {
+    logger.warn({ feedId: article.feed_id, guid: article.guid }, 'Skipping RSS article with unsafe external URL');
+    return null;
+  }
+
   // Check if we already have this article (by guid or URL to catch cross-feed duplicates)
-  const existing = await rssArticleExists(article.feed_id, article.guid, article.link);
+  const existing = await rssArticleExists(article.feed_id, article.guid, normalizedExternalUrl);
   if (existing) {
     return null;
   }
@@ -306,7 +313,7 @@ export async function createRssPerspective(article: RssArticleInput): Promise<st
           article.title,
           article.category || 'Industry News',
           article.description?.substring(0, 500),
-          article.link,
+          normalizedExternalUrl,
           article.feed_name,
           article.author,
           article.published_at || new Date(),
@@ -707,8 +714,10 @@ export async function createEmailPerspective(article: EmailArticleInput): Promis
   const slug = generateSlug(article.subject, article.message_id);
 
   // For email newsletters, we create the perspective with the email content as the body
-  // and extract the first link as the external_url if available
-  const primaryLink = article.links[0]?.url;
+  // and extract the first safe HTTPS link as the external_url if available
+  const primaryLink = article.links
+    .map((link) => normalizePerspectiveExternalUrl(link.url))
+    .find((url): url is string => url !== null);
 
   const result = await query<{ id: string }>(
     `INSERT INTO perspectives (

--- a/server/src/db/member-db.ts
+++ b/server/src/db/member-db.ts
@@ -11,6 +11,14 @@ import {
   type BrandConfig,
   type DataProviderConfig,
 } from '../types.js';
+import { validateMemberProfileUrlFields } from '../utils/member-profile-url.js';
+
+function assertValidMemberProfileUrls(input: Record<string, unknown>): void {
+  const invalidField = validateMemberProfileUrlFields(input);
+  if (invalidField) {
+    throw new TypeError(`${invalidField} must be an HTTPS URL without credentials`);
+  }
+}
 
 /**
  * Escape LIKE pattern wildcards to prevent SQL injection
@@ -55,6 +63,7 @@ export class MemberDatabase {
    * Create a new member profile
    */
   async createProfile(input: CreateMemberProfileInput): Promise<MemberProfile> {
+    assertValidMemberProfileUrls(input as unknown as Record<string, unknown>);
     const agents = input.agents || [];
     const publishers = input.publishers || [];
     const data_providers = input.data_providers || [];
@@ -176,6 +185,7 @@ export class MemberDatabase {
     id: string,
     updates: UpdateMemberProfileInput
   ): Promise<MemberProfile | null> {
+    assertValidMemberProfileUrls(updates as unknown as Record<string, unknown>);
     // Build SET clause dynamically using explicit column mapping
     const COLUMN_MAP: Record<keyof UpdateMemberProfileInput, string> = {
       display_name: 'display_name',

--- a/server/src/db/portrait-db.ts
+++ b/server/src/db/portrait-db.ts
@@ -40,10 +40,22 @@ export async function getPortraitById(id: string): Promise<PortraitMetadata | nu
   return result.rows[0] || null;
 }
 
-/** Get portrait binary data for serving (approved portraits, or generated for preview) */
-export async function getPortraitData(id: string): Promise<{ portrait_data: Buffer | null; image_url: string; status: string } | null> {
-  const result = await query<{ portrait_data: Buffer | null; image_url: string; status: string }>(
-    `SELECT portrait_data, image_url, status FROM member_portraits WHERE id = $1 AND status IN ('approved', 'generated')`,
+/** Get portrait binary data and ownership for authorized serving. */
+export async function getPortraitData(id: string): Promise<{
+  portrait_data: Buffer | null;
+  image_url: string;
+  status: 'approved' | 'generated';
+  user_id: string | null;
+} | null> {
+  const result = await query<{
+    portrait_data: Buffer | null;
+    image_url: string;
+    status: 'approved' | 'generated';
+    user_id: string | null;
+  }>(
+    `SELECT portrait_data, image_url, status, user_id
+     FROM member_portraits
+     WHERE id = $1 AND status IN ('approved', 'generated')`,
     [id]
   );
   return result.rows[0] || null;
@@ -114,7 +126,7 @@ export async function approvePortrait(portraitId: string, userId: string): Promi
     await client.query('BEGIN');
     const updateResult = await client.query(
       `UPDATE member_portraits SET status = 'approved', approved_at = NOW(), updated_at = NOW()
-       WHERE id = $1 AND user_id = $2`,
+       WHERE id = $1 AND user_id = $2 AND status = 'generated'`,
       [portraitId, userId]
     );
     if ((updateResult.rowCount ?? 0) === 0) {

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -56,6 +56,7 @@ import { getCompanyDomain, getGoogleEmailAliases } from "./utils/email-domain.js
 import { isUuid } from "./utils/uuid.js";
 import { resolveUserNameWithFallbacks, sanitizeName } from "./utils/resolve-user-name.js";
 import { scrubCommunityAuthorizedAgents } from "./utils/community-adagents.js";
+import { formatPerspectiveUrlAsMarkdownDestination, normalizePerspectiveExternalUrl } from "./utils/perspective-url.js";
 import { requireAuth, requireAdmin, requireGlobalAdmin, optionalAuth, invalidateSessionCache, isDevModeEnabled, getDevUser, getAvailableDevUsers, getDevSessionCookieName, encodeDevSessionCookie, DEV_USERS, type DevUserConfig } from "./middleware/auth.js";
 import { invitationRateLimiter, brandCreationRateLimiter, notificationRateLimiter, emailPrefsRateLimiter, adminContentWriteRateLimiter, newsletterSubscribeRateLimiter, newsletterConfirmRateLimiter } from "./middleware/rate-limit.js";
 import { findOrCreateUserByEmail } from "./auth/workos-client.js";
@@ -252,9 +253,10 @@ function buildPerspectiveUrl(slug: string): string {
 }
 
 function getPerspectiveCrawlerUrl(item: PublicPerspectiveCrawlerItem): string {
-  return item.content_type === 'link' && item.external_url
-    ? item.external_url
-    : buildPerspectiveUrl(item.slug);
+  const externalUrl = item.content_type === 'link'
+    ? normalizePerspectiveExternalUrl(item.external_url)
+    : null;
+  return externalUrl ?? buildPerspectiveUrl(item.slug);
 }
 
 async function getPublicPerspectiveCrawlerItems(limit = PERSPECTIVES_CRAWLER_LIMIT): Promise<PublicPerspectiveCrawlerItem[]> {
@@ -282,6 +284,10 @@ async function getPublicPerspectiveCrawlerItems(limit = PERSPECTIVES_CRAWLER_LIM
 }
 
 function buildLlmsTxt(items: PublicPerspectiveCrawlerItem[]): string {
+  const markdownDestination = (url: string): string => (
+    formatPerspectiveUrlAsMarkdownDestination(url)
+    ?? formatPerspectiveUrlAsMarkdownDestination(PUBLIC_SITE_URL)!
+  );
   const lines = [
     '# AgenticAdvertising.org',
     '',
@@ -289,20 +295,21 @@ function buildLlmsTxt(items: PublicPerspectiveCrawlerItem[]): string {
     '',
     '## Discoverability',
     '',
-    `- [Sitemap](${PUBLIC_SITE_URL}/sitemap.xml)`,
-    `- [Perspectives RSS feed](${PUBLIC_SITE_URL}/perspectives/feed.xml)`,
+    `- [Sitemap](${markdownDestination(`${PUBLIC_SITE_URL}/sitemap.xml`)})`,
+    `- [Perspectives RSS feed](${markdownDestination(`${PUBLIC_SITE_URL}/perspectives/feed.xml`)})`,
     '',
     '## Perspectives',
     '',
   ];
 
   if (items.length === 0) {
-    lines.push(`- [Latest perspectives](${PUBLIC_SITE_URL}/latest/perspectives)`);
+    lines.push(`- [Latest perspectives](${markdownDestination(`${PUBLIC_SITE_URL}/latest/perspectives`)})`);
   } else {
     for (const item of items) {
       const title = escapeMarkdownText(item.title);
       const excerpt = escapeMarkdownText(item.excerpt);
-      lines.push(`- [${title}](${getPerspectiveCrawlerUrl(item)})${excerpt ? `: ${excerpt}` : ''}`);
+      const destination = markdownDestination(getPerspectiveCrawlerUrl(item));
+      lines.push(`- [${title}](${destination})${excerpt ? `: ${excerpt}` : ''}`);
     }
   }
 

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -704,7 +704,17 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
         return res.status(400).json({ error: "Rating must be a number between 1 and 5" });
       }
 
-      const updated = await threadService.addMessageFeedback(messageId, {
+      const threadResult = await query<{ thread_id: string }>(
+        `SELECT thread_id FROM addie_thread_messages WHERE message_id = $1`,
+        [messageId]
+      );
+      const threadId = threadResult.rows[0]?.thread_id;
+      if (!threadId) {
+        logger.warn({ messageId }, "No message found to add feedback to");
+        return res.status(404).json({ error: "Message not found" });
+      }
+
+      const updated = await threadService.addMessageFeedback(threadId, messageId, {
         rating,
         rating_category,
         rating_notes,
@@ -720,21 +730,15 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
       }
 
       // Also mark the thread as reviewed when admin provides feedback
-      const threadResult = await query<{ thread_id: string }>(
-        `SELECT thread_id FROM addie_thread_messages WHERE message_id = $1`,
-        [messageId]
-      );
-      if (threadResult.rows[0]) {
-        try {
-          await threadService.reviewThread(
-            threadResult.rows[0].thread_id,
-            req.user?.id || "admin",
-            rating_notes || undefined
-          );
-        } catch (reviewError) {
-          // Log but don't fail - feedback was saved successfully
-          logger.warn({ err: reviewError, threadId: threadResult.rows[0].thread_id }, "Failed to mark thread as reviewed after feedback");
-        }
+      try {
+        await threadService.reviewThread(
+          threadId,
+          req.user?.id || "admin",
+          rating_notes || undefined
+        );
+      } catch (reviewError) {
+        // Log but don't fail - feedback was saved successfully
+        logger.warn({ err: reviewError, threadId }, "Failed to mark thread as reviewed after feedback");
       }
 
       logger.info({ messageId, rating, ratingSource: 'admin' }, "Added feedback to message");

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -119,6 +119,7 @@ import {
 } from "../addie/member-context.js";
 import {
   getThreadService,
+  type Thread,
   type ThreadContext,
 } from "../addie/thread-service.js";
 import { UsersDatabase } from "../db/users-db.js";
@@ -142,6 +143,53 @@ const logger = createLogger("addie-chat-routes");
 
 let claudeClient: AddieClaudeClient | null = null;
 let initialized = false;
+
+/**
+ * A web conversation is private to the identity that created it. Anonymous
+ * conversation UUIDs remain bearer capabilities, but cannot cross into or out
+ * of authenticated users' threads.
+ */
+function canContinueWebThread(thread: Pick<Thread, 'user_type' | 'user_id'>, userId: string | null): boolean {
+  if (userId) {
+    return thread.user_type === 'workos' && thread.user_id === userId;
+  }
+
+  return thread.user_type === 'anonymous' && thread.user_id === null;
+}
+
+const WEB_FEEDBACK_CATEGORIES = new Set([
+  'accuracy',
+  'completeness',
+  'helpfulness',
+  'clarity',
+  'tone',
+  'session',
+]);
+const WEB_FEEDBACK_TAGS = new Set([
+  'wrong_answer',
+  'missing_info',
+  'too_long',
+  'too_short',
+  'outdated',
+  'off_topic',
+]);
+const MAX_FEEDBACK_TEXT_LENGTH = 2_000;
+
+function parseOptionalFeedbackText(
+  value: unknown,
+  fieldName: string,
+  maxLength = MAX_FEEDBACK_TEXT_LENGTH,
+): { value?: string; error?: string } {
+  if (value === undefined || value === null || value === '') return {};
+  if (typeof value !== 'string') return { error: `${fieldName} must be a string` };
+
+  const trimmed = value.trim();
+  if (!trimmed) return {};
+  if (trimmed.length > maxLength) {
+    return { error: `${fieldName} must be ${maxLength} characters or fewer` };
+  }
+  return { value: trimmed };
+}
 
 /**
  * Anonymous users get directory tools only (fast DB lookups, public data).
@@ -394,6 +442,21 @@ const anonymousDailyLimiter = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
+});
+
+// Feedback does not invoke the model, so it needs a write-specific ceiling
+// rather than sharing chat-message quota.
+const feedbackRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 30,
+  store: new CachedPostgresStore('chat-feedback:'),
+  keyGenerator: (req) => (req as any).user?.id
+    ? `user:${(req as any).user.id}`
+    : `ip:${ipKeyGenerator(req.ip || '')}`,
+  message: { error: 'Too many requests', message: 'Please try again later' },
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { keyGeneratorIpFallback: false },
 });
 
 /**
@@ -839,6 +902,9 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
         if (!thread) {
           return res.status(404).json({ error: "Conversation not found" });
         }
+        if (!canContinueWebThread(thread, userId)) {
+          return res.status(403).json({ error: "Access denied" });
+        }
       }
 
       // Get conversation history for context
@@ -1154,6 +1220,11 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
           res.end();
           return;
         }
+        if (!canContinueWebThread(thread, userId)) {
+          sendEvent("error", { error: "Access denied" });
+          res.end();
+          return;
+        }
       }
 
       // Send conversation_id immediately so client can track it
@@ -1379,7 +1450,7 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
   });
 
   // POST /api/addie/chat/:conversationId/feedback - Submit feedback on a message
-  apiRouter.post("/:conversationId/feedback", optionalAuth, async (req, res) => {
+  apiRouter.post("/:conversationId/feedback", optionalAuth, feedbackRateLimiter, async (req, res) => {
     const threadService = getThreadService();
 
     try {
@@ -1400,38 +1471,64 @@ export function createAddieChatRouter(): { pageRouter: Router; apiRouter: Router
       } = req.body;
 
       // message_id is now a UUID string
-      if (!message_id || typeof message_id !== "string") {
-        return res.status(400).json({ error: "message_id is required" });
+      if (!message_id || typeof message_id !== "string" || !uuidValidate(message_id)) {
+        return res.status(400).json({ error: "message_id must be a valid UUID" });
       }
 
-      if (!rating || rating < 1 || rating > 5) {
-        return res.status(400).json({ error: "rating must be between 1 and 5" });
+      if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+        return res.status(400).json({ error: "rating must be an integer between 1 and 5" });
       }
 
-      // Verify thread exists for this conversation
+      const parsedCategory = parseOptionalFeedbackText(rating_category, 'rating_category', 32);
+      if (parsedCategory.error) return res.status(400).json({ error: parsedCategory.error });
+      if (parsedCategory.value && !WEB_FEEDBACK_CATEGORIES.has(parsedCategory.value)) {
+        return res.status(400).json({ error: "rating_category is not supported" });
+      }
+
+      const parsedFeedbackText = parseOptionalFeedbackText(feedback_text, 'feedback_text');
+      if (parsedFeedbackText.error) return res.status(400).json({ error: parsedFeedbackText.error });
+
+      const parsedSuggestion = parseOptionalFeedbackText(improvement_suggestion, 'improvement_suggestion');
+      if (parsedSuggestion.error) return res.status(400).json({ error: parsedSuggestion.error });
+
+      let validatedTags: string[] | undefined;
+      if (feedback_tags !== undefined && feedback_tags !== null) {
+        if (!Array.isArray(feedback_tags) || feedback_tags.length > WEB_FEEDBACK_TAGS.size) {
+          return res.status(400).json({ error: "feedback_tags must be an array of supported tags" });
+        }
+        if (feedback_tags.some((tag) => typeof tag !== 'string' || !WEB_FEEDBACK_TAGS.has(tag))) {
+          return res.status(400).json({ error: "feedback_tags contains an unsupported tag" });
+        }
+        validatedTags = [...new Set(feedback_tags)];
+      }
+
+      // A missing and an inaccessible conversation deliberately share a response
+      // so the endpoint cannot be used to enumerate conversation capabilities.
+      const userId = req.user?.id || null;
       const thread = await threadService.getThreadByExternalId('web', conversationId);
-      if (!thread) {
-        return res.status(404).json({ error: "Conversation not found" });
+      if (!thread || !canContinueWebThread(thread, userId)) {
+        return res.status(404).json({ error: "Feedback target not found" });
       }
 
-      // Add feedback to message using unified service
-      const updated = await threadService.addMessageFeedback(message_id, {
+      // The service scopes the update to both IDs, preventing a message UUID
+      // from another thread from being substituted after this authorization.
+      const updated = await threadService.addMessageFeedback(thread.thread_id, message_id, {
         rating,
-        rating_category: rating_category || undefined,
-        rating_notes: feedback_text || undefined,
-        feedback_tags: feedback_tags || undefined,
-        improvement_suggestion: improvement_suggestion || undefined,
-        rated_by: req.user?.id || "anonymous",
+        rating_category: parsedCategory.value,
+        rating_notes: parsedFeedbackText.value,
+        feedback_tags: validatedTags,
+        improvement_suggestion: parsedSuggestion.value,
+        rated_by: userId || "anonymous",
         rating_source: 'user',
       });
 
       if (!updated) {
-        logger.warn({ conversationId, message_id }, "Addie Chat: Message not found for feedback");
-        return res.status(404).json({ error: "Message not found" });
+        logger.warn({ conversationId, message_id }, "Addie Chat: Feedback target not found");
+        return res.status(404).json({ error: "Feedback target not found" });
       }
 
       logger.info(
-        { conversationId, message_id, rating, rating_category },
+        { conversationId, message_id, rating, rating_category: parsedCategory.value },
         "Addie Chat: Feedback submitted"
       );
 

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -26,6 +26,7 @@ import { notifyPublishedPost } from "../notifications/slack.js";
 import { notifyUser } from "../notifications/notification-service.js";
 import { decodeHtmlEntities } from "../utils/html-entities.js";
 import { validateFetchUrl, validateRedirectTarget, sanitizeUrl } from "../utils/url-security.js";
+import { normalizePerspectiveExternalUrl } from "../utils/perspective-url.js";
 import { reindexDocument } from "../addie/jobs/committee-document-indexer.js";
 import { refreshWorkingGroupDocs } from "../addie/mcp/docs-indexer.js";
 import { createChannel, setChannelPurpose, sendChannelMessage, inviteToChannel, isSlackConfigured } from "../slack/client.js";
@@ -1431,6 +1432,12 @@ export function createCommitteeRouters(): {
             message: 'Slug must contain only lowercase letters, numbers, and hyphens',
           });
         }
+        if (error.is('invalid_external_url')) {
+          return res.status(400).json({
+            error: 'Invalid external URL',
+            message: 'Link posts require an HTTPS external URL without credentials',
+          });
+        }
         if (error.is('duplicate_post_slug')) {
           return res.status(409).json({
             error: 'Slug already exists',
@@ -1503,6 +1510,27 @@ export function createCommitteeRouters(): {
         }
       }
 
+      const normalizedIncomingExternalUrl = external_url == null
+        ? external_url
+        : normalizePerspectiveExternalUrl(external_url);
+      const effectiveContentType = content_type ?? post.content_type;
+      const effectiveExternalUrl = external_url === undefined
+        ? normalizePerspectiveExternalUrl(post.external_url)
+        : normalizedIncomingExternalUrl;
+      const persistedExternalUrl = external_url == null
+        ? normalizePerspectiveExternalUrl(post.external_url)
+        : normalizedIncomingExternalUrl;
+      if (
+        (external_url != null && !normalizedIncomingExternalUrl) ||
+        (post.external_url != null && !persistedExternalUrl) ||
+        (effectiveContentType === 'link' && !effectiveExternalUrl)
+      ) {
+        return res.status(400).json({
+          error: 'Invalid external URL',
+          message: 'Link posts require an HTTPS external URL without credentials',
+        });
+      }
+
       const result = await pool.query(
         `UPDATE perspectives SET
           slug = COALESCE($1, slug),
@@ -1524,7 +1552,7 @@ export function createCommitteeRouters(): {
           content ?? post.content,
           category ?? post.category,
           excerpt ?? post.excerpt,
-          external_url ?? post.external_url,
+          persistedExternalUrl,
           external_site_name ?? post.external_site_name,
           finalMembersOnly,
           postId,
@@ -2281,6 +2309,16 @@ export function createCommitteeRouters(): {
         });
       }
 
+      const normalizedExternalUrl = external_url == null
+        ? null
+        : normalizePerspectiveExternalUrl(external_url);
+      if (external_url != null && !normalizedExternalUrl) {
+        return res.status(400).json({
+          error: 'Invalid external URL',
+          message: 'Link posts require an HTTPS external URL without credentials',
+        });
+      }
+
       const authorNameFinal = author_name || (user.firstName && user.lastName
         ? `${user.firstName} ${user.lastName}`
         : user.email);
@@ -2301,7 +2339,7 @@ export function createCommitteeRouters(): {
           category || null,
           excerpt || null,
           content || null,
-          external_url || null,
+          normalizedExternalUrl,
           external_site_name || null,
           authorNameFinal,
           author_title || null,
@@ -2328,7 +2366,7 @@ export function createCommitteeRouters(): {
           authorName: authorNameFinal,
           contentType: content_type || 'article',
           excerpt: excerpt || undefined,
-          externalUrl: external_url || undefined,
+          externalUrl: normalizedExternalUrl || undefined,
           category: category || undefined,
           isMembersOnly: is_members_only || false,
         }).catch(err => {
@@ -2392,11 +2430,31 @@ export function createCommitteeRouters(): {
         }
       }
 
-      const wasPublished = existing.rows[0].status === 'published';
+
+      const existingPost = existing.rows[0];
+      const normalizedIncomingExternalUrl = external_url == null
+        ? external_url
+        : normalizePerspectiveExternalUrl(external_url);
+      const effectiveContentType = content_type ?? existingPost.content_type;
+      const effectiveExternalUrl = external_url === undefined
+        ? normalizePerspectiveExternalUrl(existingPost.external_url)
+        : normalizedIncomingExternalUrl;
+      if (
+        (external_url != null && !normalizedIncomingExternalUrl) ||
+        (external_url === undefined && existingPost.external_url != null && !effectiveExternalUrl) ||
+        (effectiveContentType === 'link' && !effectiveExternalUrl)
+      ) {
+        return res.status(400).json({
+          error: 'Invalid external URL',
+          message: 'Link posts require an HTTPS external URL without credentials',
+        });
+      }
+
+      const wasPublished = existingPost.status === 'published';
       const willBePublished = status === 'published';
       const publishedAt = willBePublished && !wasPublished
         ? new Date()
-        : existing.rows[0].published_at;
+        : existingPost.published_at;
 
       const result = await pool.query(
         `UPDATE perspectives SET
@@ -2428,7 +2486,7 @@ export function createCommitteeRouters(): {
           category || null,
           excerpt || null,
           content || null,
-          external_url || null,
+          effectiveExternalUrl,
           external_site_name || null,
           author_name || null,
           author_title || null,

--- a/server/src/routes/community.ts
+++ b/server/src/routes/community.ts
@@ -13,6 +13,7 @@ import { query } from "../db/client.js";
 import { resolvePrimaryOrganization } from "../db/users-db.js";
 import { VALID_MEMBER_OFFERINGS, type MemberOffering } from "../types.js";
 import { notifyUser } from "../notifications/notification-service.js";
+import { validateMemberProfileUrlFields } from "../utils/member-profile-url.js";
 
 const logger = createLogger("community-routes");
 const AVATAR_MAX_FILE_SIZE = 5 * 1024 * 1024;
@@ -366,19 +367,14 @@ export function createCommunityRouters(config: CommunityRoutesConfig) {
         updates.slug = slug;
       }
 
-      // Validate URL fields are HTTP(S) only
-      for (const urlField of ['linkedin_url', 'twitter_url'] as const) {
-        const value = updates[urlField];
-        if (value && typeof value === 'string') {
-          try {
-            const parsed = new URL(value);
-            if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-              return res.status(400).json({ error: `${urlField} must be an HTTP or HTTPS URL` });
-            }
-          } catch {
-            return res.status(400).json({ error: `${urlField} must be a valid URL` });
-          }
-        }
+      const invalidMemberProfileUrlField = validateMemberProfileUrlFields({
+        ...updates,
+        contact_website: req.body.contact_website,
+      });
+      if (invalidMemberProfileUrlField) {
+        return res.status(400).json({
+          error: `${invalidMemberProfileUrlField} must be an HTTPS URL without credentials`,
+        });
       }
 
       // Validate GitHub username format
@@ -405,17 +401,6 @@ export function createCommunityRouters(config: CommunityRoutesConfig) {
           return res.status(400).json({ error: 'Invalid contact phone' });
         }
       }
-      if (req.body.contact_website !== undefined && typeof req.body.contact_website === 'string' && req.body.contact_website) {
-        try {
-          const parsed = new URL(req.body.contact_website);
-          if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-            return res.status(400).json({ error: 'contact_website must be an HTTP or HTTPS URL' });
-          }
-        } catch {
-          return res.status(400).json({ error: 'contact_website must be a valid URL' });
-        }
-      }
-
       const existingProfile = await communityDb.getProfile(user.id);
 
       // Check if github_username is being set for the first time (for one-time points award)
@@ -571,12 +556,27 @@ async function syncIndividualMemberProfile(
   // Build mapped fields for member_profiles
   const memberUpdates: Record<string, unknown> = {
     display_name: displayName,
-    linkedin_url: communityProfile.linkedin_url || null,
-    twitter_url: communityProfile.twitter_url || null,
   };
 
+  // Legacy community rows may contain URL values that predate the current
+  // HTTPS-only policy. An unrelated profile edit must still sync its safe
+  // fields, without copying those legacy values into a new member write.
+  for (const [field, value] of [
+    ['linkedin_url', communityProfile.linkedin_url || null],
+    ['twitter_url', communityProfile.twitter_url || null],
+  ] as const) {
+    if (!validateMemberProfileUrlFields({ [field]: value })) {
+      memberUpdates[field] = value;
+    }
+  }
+
   if (memberFields.contact_email !== undefined) memberUpdates.contact_email = memberFields.contact_email;
-  if (memberFields.contact_website !== undefined) memberUpdates.contact_website = memberFields.contact_website;
+  if (
+    memberFields.contact_website !== undefined
+    && !validateMemberProfileUrlFields({ contact_website: memberFields.contact_website })
+  ) {
+    memberUpdates.contact_website = memberFields.contact_website;
+  }
   if (memberFields.contact_phone !== undefined) memberUpdates.contact_phone = memberFields.contact_phone;
 
   const existingProfile = await memberDb.getProfileByOrgId(orgId);

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -30,6 +30,7 @@ import { createIllustration, approveIllustration } from '../db/illustration-db.j
 import { resolveEscalationsForPerspective } from '../db/escalation-db.js';
 import { listMyContent as listMyContentService, MyContentError } from '../services/my-content-service.js';
 import { checkContentSubmissionTier } from '../services/membership-tiers.js';
+import { normalizePerspectiveExternalUrl } from '../utils/perspective-url.js';
 
 const logger = createLogger('content-routes');
 
@@ -449,6 +450,12 @@ export async function proposeContentForUser(
   if (content_type === 'link' && !external_url) {
     return { success: false, error: 'external_url is required for link type content' };
   }
+  const normalizedExternalUrl = external_url == null
+    ? null
+    : normalizePerspectiveExternalUrl(external_url);
+  if (external_url != null && !normalizedExternalUrl) {
+    return { success: false, error: 'external_url must be an HTTPS URL without credentials' };
+  }
 
   if (content_type === 'article' && !content) {
     return { success: false, error: 'content is required for article type content' };
@@ -547,7 +554,7 @@ export async function proposeContentForUser(
     RETURNING *`,
     [
       slug, content_type, title, subtitle || null, content, excerpt,
-      external_url, external_site_name, category, tags,
+      normalizedExternalUrl, external_site_name, category, tags,
       authorName, requestAuthorTitle || null, user.id,
       featured_image_url || null, effectiveOrigin,
       user.id, proposedAt,
@@ -638,7 +645,7 @@ export async function proposeContentForUser(
       authorName,
       contentType: content_type,
       excerpt: excerpt || undefined,
-      externalUrl: external_url || undefined,
+      externalUrl: normalizedExternalUrl || undefined,
       category: category || undefined,
       isMembersOnly: false,
     }).catch(err => {
@@ -1685,6 +1692,26 @@ export function createMyContentRouter(): Router {
         });
       }
 
+      const normalizedExternalUrl = external_url == null
+        ? external_url
+        : normalizePerspectiveExternalUrl(external_url);
+      if (external_url != null && !normalizedExternalUrl) {
+        return res.status(400).json({
+          error: 'Invalid external URL',
+          message: 'external_url must be an HTTPS URL without credentials',
+        });
+      }
+      const effectiveContentType = content_type ?? contentItem.content_type;
+      const effectiveExternalUrl = external_url === undefined
+        ? normalizePerspectiveExternalUrl(contentItem.external_url)
+        : normalizedExternalUrl;
+      if (effectiveContentType === 'link' && !effectiveExternalUrl) {
+        return res.status(400).json({
+          error: 'Invalid external URL',
+          message: 'Link content requires an HTTPS external_url without credentials',
+        });
+      }
+
       // Published content has already passed editorial review. Any actual
       // content change by a non-admin must go through that review again,
       // regardless of whether the caller omits status or asks to keep it
@@ -1703,7 +1730,7 @@ export function createMyContentRouter(): Router {
         changed(content, contentItem.content),
         changed(content_type, contentItem.content_type),
         changed(excerpt, contentItem.excerpt),
-        changed(external_url, contentItem.external_url),
+        changed(normalizedExternalUrl, contentItem.external_url),
         changed(external_site_name, contentItem.external_site_name),
         changed(category, contentItem.category),
         changed(tags, contentItem.tags),
@@ -1736,7 +1763,7 @@ export function createMyContentRouter(): Router {
       }
       if (external_url !== undefined) {
         updates.push(`external_url = $${paramIndex++}`);
-        values.push(external_url);
+        values.push(normalizedExternalUrl ?? null);
       }
       if (external_site_name !== undefined) {
         updates.push(`external_site_name = $${paramIndex++}`);

--- a/server/src/routes/member-profiles.ts
+++ b/server/src/routes/member-profiles.ts
@@ -11,6 +11,7 @@ import { createLogger } from "../logger.js";
 import {
   requireAuth,
   requireAdmin,
+  requireGlobalAdmin,
   refuseCrossTenantAdminApiKey,
   isDevModeEnabled,
   DEV_USERS,
@@ -64,6 +65,7 @@ import { recordProfilePublishedIfNeeded } from "../services/profile-publish-even
 import { gateAgentVisibilityForCaller, computeAgentVisibilityGate, type VisibilityWarning, type AgentVisibilityGate } from "../services/agent-visibility-gate.js";
 import { getBrandPrimaryDomain, getBrandPrimaryDomainRecord } from "../services/brand-domain-resolver.js";
 import { normalizeFoundingMemberGrant } from "../services/founding-member-grant.js";
+import { validateMemberProfileUrlFields } from "../utils/member-profile-url.js";
 
 const orgKnowledgeDb = new OrgKnowledgeDatabase();
 const snapshotDb = new AgentSnapshotDatabase();
@@ -829,6 +831,14 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
         });
       }
 
+      const invalidProfileUrlField = validateMemberProfileUrlFields(req.body);
+      if (invalidProfileUrlField) {
+        return res.status(400).json({
+          error: 'Invalid profile URL',
+          message: `${invalidProfileUrlField} must be an HTTPS URL without credentials`,
+        });
+      }
+
       // Validate tagline length
       if (tagline && typeof tagline === 'string' && tagline.length > 200) {
         return res.status(400).json({
@@ -1156,6 +1166,14 @@ export function createMemberProfileRouter(config: MemberProfileRoutesConfig): Ro
       const user = req.user!;
       const requestedOrgId = req.query.org as string | undefined;
       const updates = req.body;
+
+      const invalidProfileUrlField = validateMemberProfileUrlFields(updates);
+      if (invalidProfileUrlField) {
+        return res.status(400).json({
+          error: 'Invalid profile URL',
+          message: `${invalidProfileUrlField} must be an HTTPS URL without credentials`,
+        });
+      }
 
       // Dev mode: handle dev organizations without WorkOS
       const isDevUserProfile = isDevModeEnabled() && Object.values(DEV_USERS).some(du => du.id === user.id) && requestedOrgId?.startsWith('org_dev_');
@@ -2610,8 +2628,8 @@ export function createAdminMemberProfileRouter(config: MemberProfileRoutesConfig
   const { memberDb, invalidateMemberContextCache } = config;
   const router = Router();
 
-  // GET /api/admin/member-profiles - List all member profiles (admin)
-  router.get('/', requireAuth, requireAdmin, async (req, res) => {
+  // GET /api/admin/member-profiles - List all member profiles (global admin)
+  router.get('/', ...requireGlobalAdmin, async (req, res) => {
     try {
       const { is_public, search, limit, offset } = req.query;
 
@@ -2631,11 +2649,20 @@ export function createAdminMemberProfileRouter(config: MemberProfileRoutesConfig
     }
   });
 
-  // PUT /api/admin/member-profiles/:id - Update any member profile (admin)
+  // PUT /api/admin/member-profiles/:id - Global admins may update any profile;
+  // tenant admin keys remain limited to a profile owned by their issuing org.
   router.put('/:id', requireAuth, requireAdmin, async (req, res) => {
     try {
       const { id } = req.params;
       const updates = req.body;
+
+      const invalidProfileUrlField = validateMemberProfileUrlFields(updates);
+      if (invalidProfileUrlField) {
+        return res.status(400).json({
+          error: 'Invalid profile URL',
+          message: `${invalidProfileUrlField} must be an HTTPS URL without credentials`,
+        });
+      }
 
       // Cross-tenant gate. `requireAdmin` keys off `:orgId` in the path,
       // but this route uses `:id` (a profile UUID) — resolve the profile's
@@ -2712,7 +2739,7 @@ export function createAdminMemberProfileRouter(config: MemberProfileRoutesConfig
     }
   });
 
-  // DELETE /api/admin/member-profiles/:id - Delete any member profile (admin)
+  // DELETE /api/admin/member-profiles/:id - Same global/same-tenant split as PUT.
   router.delete('/:id', requireAuth, requireAdmin, async (req, res) => {
     try {
       const { id } = req.params;

--- a/server/src/routes/portraits.ts
+++ b/server/src/routes/portraits.ts
@@ -8,12 +8,13 @@
 import { Router, type Request } from 'express';
 import multer from 'multer';
 import { createLogger } from '../logger.js';
-import { requireAuth, requireAdmin, isDevModeEnabled, DEV_USERS } from '../middleware/auth.js';
+import { requireAuth, requireGlobalAdmin, optionalAuth, isDevModeEnabled } from '../middleware/auth.js';
 import { OrganizationDatabase } from '../db/organization-db.js';
 import { MemberDatabase } from '../db/member-db.js';
 import { query as dbQuery } from '../db/client.js';
 import * as portraitDb from '../db/portrait-db.js';
 import { generatePortrait, VIBE_OPTIONS } from '../services/portrait-generator.js';
+import { isUuid } from '../utils/uuid.js';
 
 const logger = createLogger('portrait-routes');
 
@@ -59,7 +60,7 @@ async function isPaidMember(
   if (isDevModeEnabled()) return true;
 
   const user = req.user;
-  const requestedOrgId = req.query.org as string | undefined;
+  const requestedOrgId = typeof req.query.org === 'string' ? req.query.org : undefined;
   const userId = user?.id;
   if (!userId) return false;
 
@@ -75,7 +76,7 @@ async function isPaidMember(
 
   const orgIds = membershipRows.rows.map(row => row.workos_organization_id);
   if (requestedOrgId && !orgIds.includes(requestedOrgId)) {
-    orgIds.unshift(requestedOrgId);
+    return false;
   }
 
   for (const orgId of orgIds) {
@@ -108,10 +109,22 @@ export function createPublicPortraitRouter(): Router {
   const router = Router();
 
   // GET /api/portraits/:id.png — serve portrait image
-  router.get('/:id.png', async (req, res) => {
+  router.get('/:id.png', optionalAuth, async (req, res) => {
     try {
+      if (!isUuid(req.params.id)) {
+        return res.status(404).send('Portrait not found');
+      }
+
       const data = await portraitDb.getPortraitData(req.params.id);
       if (!data) {
+        return res.status(404).send('Portrait not found');
+      }
+
+      const canView = data.status === 'approved'
+        || (data.status === 'generated' && req.user?.id === data.user_id);
+      if (!canView) {
+        // Use the same response as a missing portrait so callers cannot use
+        // generated preview IDs as an existence oracle.
         return res.status(404).send('Portrait not found');
       }
 
@@ -119,10 +132,11 @@ export function createPublicPortraitRouter(): Router {
       if (data.portrait_data) {
         const cacheControl = data.status === 'approved'
           ? 'public, max-age=31536000, immutable'
-          : 'private, no-cache';
+          : 'private, no-store';
         res.set({
           'Content-Type': 'image/png',
           'Cache-Control': cacheControl,
+          'X-Content-Type-Options': 'nosniff',
         });
         return res.send(data.portrait_data);
       }
@@ -131,6 +145,7 @@ export function createPublicPortraitRouter(): Router {
       if (data.status === 'approved') {
         return res.redirect(301, data.image_url);
       }
+      res.set('Cache-Control', 'private, no-store');
       res.redirect(302, data.image_url);
     } catch (err) {
       logger.error({ err, id: req.params.id }, 'Failed to serve portrait');
@@ -321,7 +336,7 @@ export function createAdminPortraitRouter(): Router {
   const router = Router();
 
   // GET / — list all portraits
-  router.get('/', requireAuth, requireAdmin, async (req, res) => {
+  router.get('/', ...requireGlobalAdmin, async (req, res) => {
     try {
       const status = req.query.status as string | undefined;
       const limit = parseInt(req.query.limit as string) || 100;
@@ -336,7 +351,7 @@ export function createAdminPortraitRouter(): Router {
   });
 
   // GET /map — user_id -> portrait_id mapping (lightweight)
-  router.get('/map', requireAuth, requireAdmin, async (_req, res) => {
+  router.get('/map', ...requireGlobalAdmin, async (_req, res) => {
     try {
       const map = await portraitDb.getUserPortraitMap();
       res.json(map);
@@ -347,7 +362,7 @@ export function createAdminPortraitRouter(): Router {
   });
 
   // DELETE /:id — remove inappropriate portrait
-  router.delete('/:id', requireAuth, requireAdmin, async (req, res) => {
+  router.delete('/:id', ...requireGlobalAdmin, async (req, res) => {
     try {
       const portrait = await portraitDb.getPortraitById(req.params.id);
       if (!portrait) {

--- a/server/src/services/working-group-content-service.ts
+++ b/server/src/services/working-group-content-service.ts
@@ -29,6 +29,7 @@ import { refreshWorkingGroupDocs } from '../addie/mcp/docs-indexer.js';
 import { isUuid } from '../utils/uuid.js';
 import { notifySystemError } from '../addie/error-notifier.js';
 import type { WorkingGroupServiceUser } from './working-group-membership-service.js';
+import { normalizePerspectiveExternalUrl } from '../utils/perspective-url.js';
 
 const logger = createLogger('working-group-content-service');
 
@@ -84,6 +85,7 @@ export type WorkingGroupContentErrorCode =
   | 'leader_required_for_public_post'
   | 'missing_required_fields'
   | 'invalid_post_slug'
+  | 'invalid_external_url'
   | 'invalid_document_url'
   | 'invalid_document_id'
   | 'document_not_found'
@@ -96,6 +98,7 @@ export interface WorkingGroupContentErrorMetaByCode {
   leader_required_for_public_post: { slug: string };
   missing_required_fields: { slug: string; fields: string[] };
   invalid_post_slug: { slug: string; postSlug: string };
+  invalid_external_url: { slug: string };
   invalid_document_url: { slug: string };
   invalid_document_id: { slug: string; documentId: string };
   document_not_found: { slug: string; documentId: string };
@@ -205,6 +208,17 @@ export async function createWorkingGroupPost(input: CreateWorkingGroupPostInput)
     ? (contentType as WorkingGroupPostContentType)
     : 'article';
 
+  const normalizedExternalUrl = externalUrl == null
+    ? null
+    : normalizePerspectiveExternalUrl(externalUrl);
+  if ((externalUrl != null && !normalizedExternalUrl) || (normalizedContentType === 'link' && !normalizedExternalUrl)) {
+    throw new WorkingGroupContentError(
+      'invalid_external_url',
+      'Link posts require an HTTPS external URL without credentials',
+      { slug },
+    );
+  }
+
   let inserted;
   try {
     const result = await pool.query(
@@ -222,7 +236,7 @@ export async function createWorkingGroupPost(input: CreateWorkingGroupPostInput)
         content || null,
         category || null,
         excerpt || null,
-        externalUrl || null,
+        normalizedExternalUrl,
         externalSiteName || null,
         authorName,
         user.id,

--- a/server/src/utils/member-profile-url.ts
+++ b/server/src/utils/member-profile-url.ts
@@ -1,0 +1,42 @@
+export const MEMBER_PROFILE_URL_FIELDS = [
+  'linkedin_url',
+  'twitter_url',
+  'contact_website',
+] as const;
+
+export type MemberProfileUrlField = (typeof MEMBER_PROFILE_URL_FIELDS)[number];
+
+// URL parsing silently removes ASCII controls and reinterprets backslashes.
+// Reject those raw forms, plus HTML delimiters, before writers persist them.
+const AMBIGUOUS_MEMBER_PROFILE_URL_CHARACTERS = /[\u0000-\u001F\u007F<>\\]/;
+
+/**
+ * Validate member-controlled URLs before they reach member_profiles.
+ *
+ * Empty values are allowed so callers can omit or clear these optional fields.
+ * Non-empty values must be bounded HTTPS URLs without embedded credentials.
+ */
+export function validateMemberProfileUrlFields(
+  input: Record<string, unknown>,
+): MemberProfileUrlField | null {
+  for (const field of MEMBER_PROFILE_URL_FIELDS) {
+    const value = input[field];
+    if (value === undefined || value === null || value === '') continue;
+    if (
+      typeof value !== 'string'
+      || value.length > 2048
+      || AMBIGUOUS_MEMBER_PROFILE_URL_CHARACTERS.test(value)
+    ) return field;
+
+    try {
+      const parsed = new URL(value);
+      if (parsed.protocol !== 'https:' || parsed.username || parsed.password) {
+        return field;
+      }
+    } catch {
+      return field;
+    }
+  }
+
+  return null;
+}

--- a/server/src/utils/perspective-url.ts
+++ b/server/src/utils/perspective-url.ts
@@ -1,0 +1,54 @@
+const MAX_PERSPECTIVE_EXTERNAL_URL_LENGTH = 2048;
+const AMBIGUOUS_PERSPECTIVE_URL_CHARACTERS = /[\u0000-\u001F\u007F<>\\]/;
+
+/**
+ * External perspective links are rendered on public pages, so only
+ * canonical, credential-free HTTPS URLs may be persisted.
+ *
+ * URL accepts and silently removes ASCII tab/newline characters. It also
+ * reinterprets backslashes as path separators and percent-encodes angle
+ * brackets. Reject those raw boundary characters before parsing so callers
+ * never validate one string and persist or render a meaningfully different
+ * one.
+ */
+export function normalizePerspectiveExternalUrl(value: unknown): string | null {
+  if (
+    typeof value !== 'string'
+    || value.length === 0
+    || value.length > MAX_PERSPECTIVE_EXTERNAL_URL_LENGTH
+    || AMBIGUOUS_PERSPECTIVE_URL_CHARACTERS.test(value)
+  ) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'https:' || parsed.username || parsed.password) {
+      return null;
+    }
+
+    const canonicalUrl = parsed.href;
+    return canonicalUrl.length <= MAX_PERSPECTIVE_EXTERNAL_URL_LENGTH
+      ? canonicalUrl
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compatibility predicate for read-only checks. Writers must use
+ * normalizePerspectiveExternalUrl and persist its return value.
+ */
+export function isSafePerspectiveExternalUrl(value: unknown): value is string {
+  return normalizePerspectiveExternalUrl(value) !== null;
+}
+
+/**
+ * CommonMark's angle-bracket form keeps valid URL punctuation such as
+ * parentheses from being interpreted as link-destination delimiters.
+ */
+export function formatPerspectiveUrlAsMarkdownDestination(value: unknown): string | null {
+  const canonicalUrl = normalizePerspectiveExternalUrl(value);
+  return canonicalUrl ? `<${canonicalUrl}>` : null;
+}

--- a/server/tests/integration/thread-service.test.ts
+++ b/server/tests/integration/thread-service.test.ts
@@ -275,12 +275,13 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
         content: 'Answer',
       });
 
-      await threadService.addMessageFeedback(assistantMsg.message_id, {
+      await threadService.addMessageFeedback(thread.thread_id, assistantMsg.message_id, {
         rating: 5,
         rating_category: 'helpfulness',
         rating_notes: 'Very helpful!',
         feedback_tags: ['clear', 'accurate'],
         rated_by: 'user_test',
+        rating_source: 'user',
       });
 
       // Fetch the message again to verify
@@ -290,6 +291,39 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
       expect(ratedMsg?.rating).toBe(5);
       expect(ratedMsg?.rating_category).toBe('helpfulness');
       expect(ratedMsg?.rated_by).toBe('user_test');
+    });
+
+    it('does not update a message when the supplied thread does not own it', async () => {
+      const ownerThread = await threadService.getOrCreateThread({
+        channel: 'web',
+        external_id: `${TEST_WEB_EXTERNAL_ID}-owner`,
+        user_type: 'workos',
+      });
+      const otherThread = await threadService.getOrCreateThread({
+        channel: 'web',
+        external_id: `${TEST_WEB_EXTERNAL_ID}-other`,
+        user_type: 'workos',
+      });
+      const ownerMessage = await threadService.addMessage({
+        thread_id: ownerThread.thread_id,
+        role: 'assistant',
+        content: 'Private answer',
+      });
+
+      const updated = await threadService.addMessageFeedback(
+        otherThread.thread_id,
+        ownerMessage.message_id,
+        {
+          rating: 1,
+          rating_notes: 'Cross-thread overwrite',
+          rated_by: 'user_other',
+          rating_source: 'user',
+        },
+      );
+
+      expect(updated).toBe(false);
+      const messages = await threadService.getThreadMessages(ownerThread.thread_id);
+      expect(messages.find((message) => message.message_id === ownerMessage.message_id)?.rating).toBeNull();
     });
   });
 

--- a/server/tests/unit/addie-chat-object-authorization.test.ts
+++ b/server/tests/unit/addie-chat-object-authorization.test.ts
@@ -1,0 +1,511 @@
+import express from 'express';
+import request from 'supertest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalApiKey = process.env.ADDIE_ANTHROPIC_API_KEY;
+process.env.ADDIE_ANTHROPIC_API_KEY = 'test-addie-object-authorization-key';
+
+const mocks = vi.hoisted(() => ({
+  authenticated: true,
+  getThreadByExternalId: vi.fn(),
+  getThreadMessages: vi.fn(),
+  addMessage: vi.fn(),
+  addMessageFeedback: vi.fn(),
+  processMessage: vi.fn(),
+  processMessageStream: vi.fn(),
+  initializeKnowledgeSearch: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('express-rate-limit', () => ({
+  default: () => (_req: any, _res: any, next: any) => next(),
+  ipKeyGenerator: (ip: string) => ip,
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  optionalAuth: (req: any, _res: any, next: any) => {
+    if (mocks.authenticated) {
+      req.user = {
+        id: 'user_attacker',
+        email: 'attacker@example.test',
+        firstName: 'Attacker',
+      };
+    }
+    next();
+  },
+}));
+
+vi.mock('../../src/addie/claude-client.js', () => ({
+  AddieClaudeClient: class {
+    registerTool() {}
+    getRegisteredTools() { return []; }
+    processMessage(...args: unknown[]) { return mocks.processMessage(...args); }
+    processMessageStream(...args: unknown[]) { return mocks.processMessageStream(...args); }
+  },
+}));
+
+vi.mock('../../src/addie/thread-service.js', () => ({
+  getThreadService: () => ({
+    getThreadByExternalId: mocks.getThreadByExternalId,
+    getThreadMessages: mocks.getThreadMessages,
+    addMessage: mocks.addMessage,
+    addMessageFeedback: mocks.addMessageFeedback,
+    getOrCreateThread: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/addie/mcp/knowledge-search.js', () => ({
+  isKnowledgeReady: () => true,
+  initializeKnowledgeSearch: mocks.initializeKnowledgeSearch,
+  KNOWLEDGE_TOOLS: [],
+  createKnowledgeToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/mcp/chat-tool.js', () => ({
+  ANONYMOUS_SAFE_KNOWLEDGE_TOOLS: new Set(),
+}));
+
+vi.mock('../../src/addie/mcp/member-tools.js', () => ({
+  MEMBER_TOOLS: [],
+  createMemberToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/directory-tools.js', () => ({
+  DIRECTORY_TOOLS: [],
+  createDirectoryToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/billing-tools.js', () => ({
+  BILLING_TOOLS: [],
+  createBillingToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/schema-tools.js', () => ({
+  SCHEMA_TOOLS: [],
+  createSchemaToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/brand-tools.js', () => ({
+  BRAND_TOOLS: [],
+  createBrandToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/property-tools.js', () => ({
+  PROPERTY_TOOLS: [],
+  createPropertyToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/si-host-tools.js', () => ({
+  SI_HOST_TOOLS: [],
+  createSiHostToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/adcp-tools.js', () => ({
+  ADCP_TOOLS: [],
+  createAdcpToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/escalation-tools.js', () => ({
+  ESCALATION_TOOLS: [],
+  createEscalationToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/admin-tools.js', () => ({
+  ADMIN_TOOLS: [],
+  createAdminToolHandlers: () => new Map(),
+  isWebUserAAOAdmin: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('../../src/addie/mcp/event-tools.js', () => ({
+  EVENT_READONLY_TOOLS: [],
+  EVENT_ADMIN_TOOLS: [],
+  EVENT_CREATOR_COMMITTEE_TYPES: new Set(),
+  createEventToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/meeting-tools.js', () => ({
+  MEETING_TOOLS: [],
+  createMeetingToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/collaboration-tools.js', () => ({
+  COLLABORATION_TOOLS: [],
+  createCollaborationToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/committee-leader-tools.js', () => ({
+  COMMITTEE_LEADER_TOOLS: [],
+  createCommitteeLeaderToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/moltbook-tools.js', () => ({
+  MOLTBOOK_TOOLS: [],
+  createMoltbookToolHandlers: () => ({}),
+}));
+
+vi.mock('../../src/addie/mcp/certification-tools.js', () => ({
+  CERTIFICATION_TOOLS: [],
+  createCertificationToolHandlers: () => new Map(),
+  buildCertificationContext: vi.fn(),
+}));
+
+vi.mock('../../src/addie/mcp/image-tools.js', () => ({
+  IMAGE_TOOLS: [],
+  createImageToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/addie/mcp/auth-grader-tools.js', () => ({
+  AUTH_GRADER_TOOLS: [],
+  createAuthGraderToolHandlers: () => new Map(),
+}));
+
+vi.mock('../../src/utils/anthropic-retry.js', () => ({
+  isRetriesExhaustedError: () => false,
+}));
+
+vi.mock('../../src/addie/member-context.js', () => ({
+  getWebMemberContext: vi.fn().mockResolvedValue({
+    is_mapped: false,
+    is_member: false,
+    slack_linked: false,
+  }),
+  formatMemberContextForPrompt: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/addie/services/si-retriever.js', () => ({
+  siRetriever: {
+    retrieve: vi.fn().mockResolvedValue({ agents: [], retrieval_time_ms: 0 }),
+    formatContext: vi.fn().mockReturnValue(''),
+  },
+}));
+
+vi.mock('../../src/db/certification-db.js', () => ({
+  getProgress: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class {
+    getCommitteesLedByUser = vi.fn().mockResolvedValue([]);
+  },
+}));
+
+vi.mock('../../src/addie/claude-cost-tracker.js', () => ({
+  resolveUserTierFromDb: vi.fn().mockResolvedValue('member_free'),
+}));
+
+vi.mock('../../src/db/relationship-db.js', () => ({
+  resolvePersonId: vi.fn().mockResolvedValue('person_attacker'),
+  recordPersonMessage: vi.fn().mockResolvedValue(undefined),
+  deriveSentiment: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/db/person-events-db.js', () => ({
+  recordEvent: vi.fn().mockResolvedValue(undefined),
+  buildMessageReceivedData: vi.fn().mockReturnValue({}),
+}));
+
+import {
+  createAddieChatRouter,
+  getChatClaudeClient,
+} from '../../src/routes/addie-chat.js';
+
+afterAll(() => {
+  if (originalApiKey === undefined) {
+    delete process.env.ADDIE_ANTHROPIC_API_KEY;
+  } else {
+    process.env.ADDIE_ANTHROPIC_API_KEY = originalApiKey;
+  }
+});
+
+beforeAll(async () => {
+  await getChatClaudeClient();
+});
+
+function successfulModelResponse(text = 'Allowed response') {
+  return {
+    text,
+    tools_used: [],
+    tool_executions: [],
+    flagged: false,
+    usage: { input_tokens: 1, output_tokens: 1 },
+  };
+}
+
+function mountChatRouter() {
+  const timeoutSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation((() => 0) as typeof setTimeout);
+  const { apiRouter } = createAddieChatRouter();
+  timeoutSpy.mockRestore();
+
+  const app = express();
+  app.use(express.json());
+  // Supertest completes the incoming request body before consuming the SSE
+  // response, which emits IncomingMessage's `close` event immediately. A real
+  // browser keeps the stream open. Suppress only the route's disconnect hook
+  // so this harness can observe the emitted SSE events.
+  app.use((req, _res, next) => {
+    const originalOn = req.on.bind(req);
+    req.on = ((event: string, listener: (...args: unknown[]) => void) => {
+      if (event === 'close') return req;
+      return originalOn(event, listener);
+    }) as typeof req.on;
+    next();
+  });
+  app.use(apiRouter);
+  return app;
+}
+
+describe('Addie chat conversation object authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authenticated = true;
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_victim',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_victim',
+    });
+    mocks.getThreadMessages.mockResolvedValue([
+      { role: 'user', content: 'Earlier question', user_display_name: 'Attacker' },
+      { role: 'assistant', content: 'Earlier answer' },
+    ]);
+    mocks.addMessage.mockImplementation(async (message: { role: string }) => ({
+      ...message,
+      message_id: message.role === 'assistant' ? 'message_assistant' : 'message_user',
+    }));
+    mocks.processMessage.mockResolvedValue(successfulModelResponse());
+    mocks.addMessageFeedback.mockResolvedValue(true);
+    mocks.processMessageStream.mockImplementation(async function* () {
+      yield { type: 'text', text: 'Allowed response' };
+      yield { type: 'done', response: successfulModelResponse() };
+    });
+  });
+
+  it('denies a cross-user conversation UUID before reading history, writing, or invoking the model', async () => {
+    const response = await request(mountChatRouter())
+      .post('/')
+      .send({
+        message: 'Summarize the private history',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('Access denied');
+    expect(mocks.getThreadByExternalId).toHaveBeenCalledWith(
+      'web',
+      '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+    );
+    expect(mocks.getThreadMessages).not.toHaveBeenCalled();
+    expect(mocks.addMessage).not.toHaveBeenCalled();
+    expect(mocks.processMessage).not.toHaveBeenCalled();
+  });
+
+  it('allows an anonymous caller to continue an anonymous bearer-capability thread', async () => {
+    mocks.authenticated = false;
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_anonymous',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'anonymous',
+      user_id: null,
+    });
+
+    const response = await request(mountChatRouter())
+      .post('/')
+      .send({
+        message: 'Continue this anonymous conversation',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.response).toBe('Allowed response');
+    expect(mocks.getThreadMessages).toHaveBeenCalledWith('thread_anonymous');
+    expect(mocks.addMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.processMessage).toHaveBeenCalledOnce();
+  });
+
+  it('denies an authenticated caller access to an anonymous thread before effects', async () => {
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_anonymous',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'anonymous',
+      user_id: null,
+    });
+
+    const response = await request(mountChatRouter())
+      .post('/')
+      .send({
+        message: 'Try to absorb an anonymous conversation',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('Access denied');
+    expect(mocks.getThreadMessages).not.toHaveBeenCalled();
+    expect(mocks.addMessage).not.toHaveBeenCalled();
+    expect(mocks.processMessage).not.toHaveBeenCalled();
+  });
+
+  it('allows the owner to continue a conversation through the normal response path', async () => {
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+
+    const response = await request(mountChatRouter())
+      .post('/')
+      .send({
+        message: 'Continue my conversation',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.response).toBe('Allowed response');
+    expect(mocks.getThreadMessages).toHaveBeenCalledWith('thread_attacker');
+    expect(mocks.addMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.processMessage).toHaveBeenCalledOnce();
+  });
+
+  it('denies a cross-user conversation UUID through the streaming path before side effects', async () => {
+    const response = await request(mountChatRouter())
+      .post('/stream')
+      .send({
+        message: 'Stream the private history',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('event: error');
+    expect(response.text).toContain('Access denied');
+    expect(mocks.getThreadByExternalId).toHaveBeenCalledWith(
+      'web',
+      '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+    );
+    expect(mocks.getThreadMessages).not.toHaveBeenCalled();
+    expect(mocks.addMessage).not.toHaveBeenCalled();
+    expect(mocks.processMessage).not.toHaveBeenCalled();
+    expect(mocks.processMessageStream).not.toHaveBeenCalled();
+  });
+
+  it('allows the owner to continue a conversation through the streaming path', async () => {
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+
+    const response = await request(mountChatRouter())
+      .post('/stream')
+      .send({
+        message: 'Stream my conversation',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('event: text');
+    expect(response.text).toContain('Allowed response');
+    expect(response.text).toContain('event: done');
+    expect(mocks.getThreadMessages).toHaveBeenCalledWith('thread_attacker');
+    expect(mocks.addMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.processMessage).not.toHaveBeenCalled();
+    expect(mocks.processMessageStream).toHaveBeenCalledOnce();
+  });
+
+  it('denies cross-user feedback before attempting a message update', async () => {
+    const response = await request(mountChatRouter())
+      .post('/9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489/feedback')
+      .send({
+        message_id: '86b7df04-4c25-4627-bcee-c7c69c671ec3',
+        rating: 1,
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Feedback target not found');
+    expect(mocks.addMessageFeedback).not.toHaveBeenCalled();
+  });
+
+  it('allows the owner to submit validated feedback for a message in the same thread', async () => {
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+
+    const response = await request(mountChatRouter())
+      .post('/9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489/feedback')
+      .send({
+        message_id: '86b7df04-4c25-4627-bcee-c7c69c671ec3',
+        rating: 4,
+        rating_category: ' helpfulness ',
+        feedback_text: ' Clear, but missing one example. ',
+        feedback_tags: ['missing_info', 'too_short', 'missing_info'],
+        improvement_suggestion: ' Add a concrete example. ',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true, message: 'Feedback submitted' });
+    expect(mocks.addMessageFeedback).toHaveBeenCalledOnce();
+    expect(mocks.addMessageFeedback).toHaveBeenCalledWith(
+      'thread_attacker',
+      '86b7df04-4c25-4627-bcee-c7c69c671ec3',
+      {
+        rating: 4,
+        rating_category: 'helpfulness',
+        rating_notes: 'Clear, but missing one example.',
+        feedback_tags: ['missing_info', 'too_short'],
+        improvement_suggestion: 'Add a concrete example.',
+        rated_by: 'user_attacker',
+        rating_source: 'user',
+      },
+    );
+  });
+
+  it('scopes feedback updates to the authorized thread and hides cross-thread misses', async () => {
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+    mocks.addMessageFeedback.mockResolvedValue(false);
+
+    const response = await request(mountChatRouter())
+      .post('/9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489/feedback')
+      .send({
+        message_id: '86b7df04-4c25-4627-bcee-c7c69c671ec3',
+        rating: 1,
+        feedback_text: 'Overwrite another thread',
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Feedback target not found');
+    expect(mocks.addMessageFeedback).toHaveBeenCalledWith(
+      'thread_attacker',
+      '86b7df04-4c25-4627-bcee-c7c69c671ec3',
+      expect.objectContaining({ rating: 1, rating_notes: 'Overwrite another thread' }),
+    );
+  });
+
+  it('rejects oversized or unsupported feedback fields before lookup or write', async () => {
+    const response = await request(mountChatRouter())
+      .post('/9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489/feedback')
+      .send({
+        message_id: '86b7df04-4c25-4627-bcee-c7c69c671ec3',
+        rating: 5,
+        feedback_text: 'x'.repeat(2_001),
+        feedback_tags: ['<img src=x onerror=alert(1)>'],
+      });
+
+    expect(response.status).toBe(400);
+    expect(mocks.getThreadByExternalId).not.toHaveBeenCalled();
+    expect(mocks.addMessageFeedback).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/addie-member-profile-url-validation.test.ts
+++ b/server/tests/unit/addie-member-profile-url-validation.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  getPool: vi.fn(),
+  query: dbMocks.query,
+}));
+
+import { createMemberToolHandlers } from '../../src/addie/mcp/member-tools.js';
+
+const memberContext = {
+  workos_user: {
+    workos_user_id: 'user-profile-url-test',
+  },
+} as any;
+
+describe('Addie update_my_profile URL validation', () => {
+  beforeEach(() => {
+    dbMocks.query.mockReset();
+  });
+
+  it.each([
+    ['linkedin_url', 'javascript:alert(1)'],
+    ['linkedin_url', 'https://user:secret@linkedin.example/in/acme'],
+    ['twitter_url', 'http://social.example/acme'],
+    ['twitter_url', 'https://user:secret@social.example/acme'],
+  ])('rejects unsafe %s before persistence', async (field, value) => {
+    const handler = createMemberToolHandlers(memberContext).get('update_my_profile')!;
+
+    const result = await handler({ [field]: value });
+
+    expect(result).toBe(`${field} must be an HTTPS URL without credentials.`);
+    expect(dbMocks.query).not.toHaveBeenCalled();
+  });
+
+  it('preserves valid HTTPS profile URLs', async () => {
+    dbMocks.query.mockResolvedValue({ rowCount: 1, rows: [{ workos_user_id: 'user-profile-url-test' }] });
+    const handler = createMemberToolHandlers(memberContext).get('update_my_profile')!;
+
+    const result = await handler({
+      linkedin_url: 'https://www.linkedin.com/in/acme?ref=addie',
+      twitter_url: 'https://social.example/acme#profile',
+    });
+
+    expect(result).toContain('Profile updated!');
+    expect(dbMocks.query).toHaveBeenCalledOnce();
+    expect(dbMocks.query.mock.calls[0]?.[1]).toEqual([
+      'https://www.linkedin.com/in/acme?ref=addie',
+      'https://social.example/acme#profile',
+      'user-profile-url-test',
+    ]);
+  });
+
+  it('uses the same Twitter/X policy for company listing updates', async () => {
+    const handler = createMemberToolHandlers(memberContext).get('update_company_listing')!;
+
+    const result = await handler({ twitter_url: 'http://social.example/acme' });
+
+    expect(result).toBe('twitter_url must be an HTTPS URL without credentials.');
+    expect(dbMocks.query).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/admin-addie-curator-xss.test.ts
+++ b/server/tests/unit/admin-addie-curator-xss.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'vitest';
+
+function section(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  if (startIndex < 0 || endIndex < 0) throw new Error(`Missing section: ${start}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function loadUrlHelpers() {
+  const source = readFileSync(join(process.cwd(), 'server/public/admin-addie.html'), 'utf8');
+  const helperSource = section(source, 'function getSafeHttpUrl(value)', 'function copyThreadId(');
+  const dom = new JSDOM('<body></body>');
+  return new Function(
+    'document',
+    `${helperSource}\nreturn { getSafeHttpUrl, renderSafeHttpLink };`,
+  )(dom.window.document) as {
+    getSafeHttpUrl: (value: unknown) => string | null;
+    renderSafeHttpLink: (value: unknown, label: unknown) => string;
+  };
+}
+
+describe('admin Addie curator URL rendering', () => {
+  it.each([
+    'javascript:globalThis.__curatorXss = true',
+    'data:text/html,<script>globalThis.__curatorXss = true</script>',
+    'https://user:secret@example.com/private',
+  ])('does not render a hostile stored URL as a link: %s', (url) => {
+    const { getSafeHttpUrl, renderSafeHttpLink } = loadUrlHelpers();
+    expect(getSafeHttpUrl(url)).toBeNull();
+    expect(renderSafeHttpLink(url, url)).toBe('');
+  });
+
+  it('encodes quote-breaking URL text without creating event attributes', () => {
+    const { renderSafeHttpLink } = loadUrlHelpers();
+    const html = renderSafeHttpLink(
+      'https://safe.example/\" onmouseover=\"globalThis.__curatorXss = true',
+      'Source',
+    );
+    const dom = new JSDOM(`<body>${html}</body>`);
+    const anchor = dom.window.document.querySelector('a');
+
+    expect(anchor).not.toBeNull();
+    expect(anchor?.hasAttribute('onmouseover')).toBe(false);
+    expect(anchor?.href).toContain('%22%20onmouseover');
+  });
+
+  it('programmatically renders valid HTTP(S) URLs with inert labels', () => {
+    const { renderSafeHttpLink } = loadUrlHelpers();
+    const html = renderSafeHttpLink(
+      'https://safe.example/article?a=1&b=2',
+      '<img src=x onerror=globalThis.__curatorXss=true>',
+    );
+    const dom = new JSDOM(`<body>${html}</body>`);
+    const anchor = dom.window.document.querySelector('a');
+
+    expect(anchor?.href).toBe('https://safe.example/article?a=1&b=2');
+    expect(anchor?.rel).toContain('noopener');
+    expect(anchor?.querySelector('img')).toBeNull();
+    expect(anchor?.textContent).toBe('<img src=x onerror=globalThis.__curatorXss=true>');
+  });
+
+  it('escapes relevance tags at the stored-content render sink', () => {
+    const source = readFileSync(join(process.cwd(), 'server/public/admin-addie.html'), 'utf8');
+    expect(source).toContain('Tags: ${escapeHtml(tags)}');
+    expect(source).not.toContain('Tags: ${tags}');
+  });
+});

--- a/server/tests/unit/admin-addie-rendering-xss.test.ts
+++ b/server/tests/unit/admin-addie-rendering-xss.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
+
+const source = readFileSync(join(process.cwd(), 'server/public/admin-addie.html'), 'utf8');
+
+function section(start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  if (startIndex < 0 || endIndex < 0) throw new Error(`Missing section: ${start}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function loadMarkdownRenderer(dom: JSDOM): (text: string) => string {
+  const rendererSource = section(
+    'function linkifyBareUrls(html)',
+    'function renderExecutionPlan(',
+  );
+  return new Function(
+    'document',
+    'currentUserNames',
+    `${rendererSource}\nreturn renderMarkdown;`,
+  )(dom.window.document, {}) as (text: string) => string;
+}
+
+describe('admin Addie rendering XSS regressions', () => {
+  it('does not reprocess generated Markdown anchors during bare URL linkification', () => {
+    const dom = new JSDOM('<body></body>', {
+      runScripts: 'dangerously',
+      url: 'https://agenticadvertising.org/admin/addie',
+    });
+    const renderMarkdown = loadMarkdownRenderer(dom);
+    const payload = '[x](https://safe.example/https://evil.example/onmouseover=globalThis.__xss=1;//)';
+
+    (dom.window as any).__xss = 0;
+    dom.window.document.body.innerHTML = renderMarkdown(payload);
+    dom.window.document.querySelectorAll('*').forEach(element => {
+      element.dispatchEvent(new dom.window.MouseEvent('mouseover', { bubbles: true }));
+    });
+
+    const links = [...dom.window.document.querySelectorAll('a')];
+    expect(links).toHaveLength(1);
+    expect(links[0].textContent).toBe('x');
+    expect(links[0].hasAttribute('onmouseover')).toBe(false);
+    expect((dom.window as any).__xss).toBe(0);
+  });
+
+  it('preserves Markdown links, bare links, and literal code', () => {
+    const dom = new JSDOM('<body></body>');
+    const renderMarkdown = loadMarkdownRenderer(dom);
+    dom.window.document.body.innerHTML = renderMarkdown(
+      '**Guide:** [docs](https://docs.example/guide) https://bare.example/path `https://code.example/literal`',
+    );
+
+    const links = [...dom.window.document.querySelectorAll('a')];
+    expect(links.map(link => link.textContent)).toEqual([
+      'docs',
+      'https://bare.example/path',
+    ]);
+    expect(dom.window.document.querySelector('strong')?.textContent).toBe('Guide:');
+    expect(dom.window.document.querySelector('code')?.textContent).toBe('https://code.example/literal');
+    expect(dom.window.document.querySelector('code a')).toBeNull();
+  });
+
+  it.each([
+    {
+      name: 'hostile legacy values',
+      channel: '<img src=x onerror="globalThis.__slackXss=1">',
+      username: '</span><script>globalThis.__slackXss=1</script>',
+    },
+    { name: 'valid values', channel: 'general', username: 'alice' },
+  ])('renders Slack display fields as text for $name', async ({ channel, username }) => {
+    const dom = new JSDOM(`
+      <select id="source-type-filter"><option value="slack" selected>Slack</option></select>
+      <select id="category-filter"><option value="" selected>All</option></select>
+      <select id="fetch-status-filter"><option value="" selected>All</option></select>
+      <div id="knowledge-stats"></div>
+      <div id="knowledge-list"></div>
+    `);
+    const loadKnowledgeSource = section(
+      'async function loadKnowledge(page)',
+      '// Legacy alias for loadResources',
+    );
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ json: vi.fn().mockResolvedValue({ total: 1 }) })
+      .mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({
+          total: 1,
+          documents: [{
+            id: 1,
+            source_type: 'slack',
+            title: 'Slack message',
+            category: 'community',
+            slack_channel_name: channel,
+            slack_username: username,
+            content: 'Safe preview',
+          }],
+        }),
+      });
+    const loadKnowledge = new Function(
+      'document',
+      'fetch',
+      'escapeHtml',
+      'renderSafeHttpLink',
+      `let knowledgePage = 0; const knowledgePageSize = 100;\n${loadKnowledgeSource}\nreturn loadKnowledge;`,
+    )(
+      dom.window.document,
+      fetchMock,
+      escapeHtml,
+      () => '',
+    ) as (page?: number) => Promise<void>;
+
+    await loadKnowledge();
+
+    const list = dom.window.document.getElementById('knowledge-list')!;
+    expect(list.querySelector('img')).toBeNull();
+    expect(list.querySelector('script')).toBeNull();
+    expect(list.textContent).toContain(`#${channel}`);
+    expect(list.textContent).toContain(`@${username}`);
+  });
+
+  it.each([
+    {
+      name: 'hostile legacy values',
+      tag: '</span><img src=x onerror="globalThis.__feedbackXss=1">',
+      count: '</span><script>globalThis.__feedbackXss=1</script>',
+    },
+    { name: 'valid values', tag: 'wrong_source', count: 12 },
+  ])('renders aggregate feedback fields as text for $name', async ({ tag, count }) => {
+    const dom = new JSDOM(`
+      <select id="eval-days-filter"><option value="30" selected>30</option></select>
+      <div id="eval-total"></div><div id="eval-rated"></div>
+      <div id="eval-avg-rating"></div><div id="eval-positive"></div>
+      <div id="eval-negative"></div><div id="eval-flagged"></div>
+      <div id="eval-tags"></div><div id="eval-low-rated"></div>
+    `);
+    const loadEvaluationSource = section(
+      'async function loadEvaluationData()',
+      '// Knowledge modal functions',
+    );
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        summary: {},
+        tags: [{ tag, count }],
+        low_rated: [],
+      }),
+    });
+    const loadEvaluationData = new Function(
+      'document',
+      'fetch',
+      'escapeHtml',
+      `${loadEvaluationSource}\nreturn loadEvaluationData;`,
+    )(dom.window.document, fetchMock, escapeHtml) as () => Promise<void>;
+
+    await loadEvaluationData();
+
+    const tags = dom.window.document.getElementById('eval-tags')!;
+    expect(tags.querySelector('img')).toBeNull();
+    expect(tags.querySelector('script')).toBeNull();
+    expect(tags.querySelector('.tag-stat > span')?.textContent).toBe(String(tag).replace('_', ' '));
+    expect(tags.querySelector('.tag-stat-count')?.textContent).toBe(String(count));
+  });
+});

--- a/server/tests/unit/content-curator-output-validation.test.ts
+++ b/server/tests/unit/content-curator-output-validation.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  complete: vi.fn(),
+  updateFetchedResource: vi.fn(),
+}));
+
+vi.mock('../../src/utils/llm.js', () => ({
+  isLLMConfigured: () => true,
+  complete: (...args: unknown[]) => mocks.complete(...args),
+}));
+
+vi.mock('../../src/db/addie-db.js', () => ({
+  AddieDatabase: class {
+    updateFetchedResource = (...args: unknown[]) => mocks.updateFetchedResource(...args);
+  },
+}));
+
+import {
+  normalizeCuratorAnalysis,
+  parseCuratorAnalysisResponse,
+  processResource,
+} from '../../src/addie/services/content-curator.js';
+
+describe('content curator output validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('normalizes valid model output before persistence', () => {
+    expect(normalizeCuratorAnalysis({
+      summary: '  A useful summary.  ',
+      key_insights: [{ insight: ' Ship interoperably. ', importance: 'high' }],
+      addie_take: ' 🤖 Open standards win. ',
+      relevance_tags: [' ADCP ', 'research', 'adcp'],
+      quality_score: 5,
+      notification_channels: ['C123', 'C123'],
+    }, ['C123'])).toEqual({
+      summary: 'A useful summary.',
+      key_insights: [{ insight: 'Ship interoperably.', importance: 'high' }],
+      addie_notes: '🤖 Open standards win.',
+      relevance_tags: ['adcp', 'research'],
+      quality_score: 5,
+      notification_channels: ['C123'],
+    });
+  });
+
+  it('drops hostile model-controlled fields while retaining valid analysis', () => {
+    const result = normalizeCuratorAnalysis({
+      summary: 'A useful summary.',
+      key_insights: [
+        { insight: '<img src=x onerror=alert(1)>', importance: 'critical' },
+        '<script>alert(1)</script>',
+        { insight: 'Use interoperable protocols.', importance: 'high' },
+      ],
+      addie_take: '🤖 Open standards win.',
+      relevance_tags: [
+        '</div><script>alert(1)</script>',
+        'javascript:alert(1)',
+        42,
+        'ADCP',
+      ],
+      quality_score: 5,
+      notification_channels: ['C_ATTACKER', '<script>', 'C_ALLOWED'],
+    }, ['C_ALLOWED']);
+
+    expect(result).toEqual({
+      summary: 'A useful summary.',
+      key_insights: [{ insight: 'Use interoperable protocols.', importance: 'high' }],
+      addie_notes: '🤖 Open standards win.',
+      relevance_tags: ['adcp'],
+      quality_score: 5,
+      notification_channels: ['C_ALLOWED'],
+    });
+  });
+
+  it('throws for malformed JSON and parsed output with no valid analysis', () => {
+    expect(() => parseCuratorAnalysisResponse('{"summary":')).toThrow(
+      'Curator model response was not valid JSON'
+    );
+    expect(() => normalizeCuratorAnalysis({
+      summary: 123,
+      key_insights: [],
+      addie_take: null,
+      relevance_tags: ['javascript:alert(1)'],
+      quality_score: '5',
+    })).toThrow('Curator model response is missing required valid analysis fields');
+  });
+
+  it('marks the resource failed when malformed model JSON reaches a caller', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      `<html><body><article><p>${'Substantive article content. '.repeat(10)}</p></article></body></html>`,
+      { status: 200, headers: { 'content-type': 'text/html' } }
+    )));
+    mocks.complete.mockResolvedValue({ text: '{"summary":' });
+    mocks.updateFetchedResource.mockResolvedValue(undefined);
+
+    await expect(processResource({
+      id: 42,
+      fetch_url: 'https://partner.example/article',
+      title: 'Partner field notes',
+    })).resolves.toBe(false);
+
+    expect(mocks.updateFetchedResource).toHaveBeenCalledOnce();
+    expect(mocks.updateFetchedResource).toHaveBeenCalledWith(42, expect.objectContaining({
+      content: '',
+      fetch_status: 'failed',
+      error_message: 'Curator model response was not valid JSON',
+    }));
+  });
+
+  it('persists a valid normalized analysis as successful', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      `<html><body><article><p>${'Substantive article content. '.repeat(10)}</p></article></body></html>`,
+      { status: 200, headers: { 'content-type': 'text/html' } }
+    )));
+    mocks.complete.mockResolvedValue({
+      text: JSON.stringify({
+        summary: ' A useful summary. ',
+        key_insights: [{ insight: ' Ship interoperably. ', importance: 'high' }],
+        addie_take: ' 🤖 Open standards win. ',
+        relevance_tags: ['ADCP'],
+        quality_score: 5,
+      }),
+    });
+    mocks.updateFetchedResource.mockResolvedValue(undefined);
+
+    await expect(processResource({
+      id: 43,
+      fetch_url: 'https://partner.example/valid-article',
+      title: 'Valid partner field notes',
+    })).resolves.toBe(true);
+
+    expect(mocks.updateFetchedResource).toHaveBeenCalledOnce();
+    expect(mocks.updateFetchedResource).toHaveBeenCalledWith(43, expect.objectContaining({
+      summary: 'A useful summary.',
+      key_insights: [{ insight: 'Ship interoperably.', importance: 'high' }],
+      addie_notes: '🤖 Open standards win.',
+      relevance_tags: ['adcp'],
+      quality_score: 5,
+      fetch_status: 'success',
+    }));
+  });
+});

--- a/server/tests/unit/industry-feed-perspective-url-validation.test.ts
+++ b/server/tests/unit/industry-feed-perspective-url-validation.test.ts
@@ -1,0 +1,251 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { JSDOM } from 'jsdom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({ query: mocks.query }));
+vi.mock('../../src/logger.js', () => ({ logger: { warn: mocks.warn } }));
+
+import {
+  createEmailPerspective,
+  createRssPerspective,
+} from '../../src/db/industry-feeds-db.js';
+
+const SAFE_URL = 'https://publisher.example/articles/agentic-media';
+const NON_CANONICAL_URL = 'https://Publisher.Example:443/articles/agentic media?q=(roundup)';
+const CANONICAL_URL = 'https://publisher.example/articles/agentic%20media?q=(roundup)';
+const UNSAFE_URLS = [
+  'javascript:globalThis.__feedXss = true',
+  'data:text/html,<script>globalThis.__feedXss = true</script>',
+  'http://publisher.example/articles/insecure',
+  'https://attacker:secret@publisher.example/articles/credentialed',
+  '\thttps://publisher.example/articles/agentic-media',
+  'https://publisher.example/articles/agentic-media\r\n- [Injected](https://attacker.example)',
+  'https://publisher.example/articles/agentic-media\u007F',
+];
+
+function readPublicFile(relativePath: string): string {
+  return readFileSync(join(process.cwd(), 'server/public', relativePath), 'utf8');
+}
+
+function section(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  if (startIndex < 0 || endIndex < 0) throw new Error(`Missing section: ${start} to ${end}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function loadPublicUrlValidators() {
+  const source = readPublicFile('perspective-url.js');
+  return new Function(
+    `${source}\nreturn { getSafePerspectiveExternalUrl, getSafePerspectiveNavigationUrl };`,
+  )() as {
+    getSafePerspectiveExternalUrl: (value: unknown) => string | null;
+    getSafePerspectiveNavigationUrl: (value: unknown) => string | null;
+  };
+}
+
+describe('industry-feed perspective URL persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(UNSAFE_URLS)('skips RSS articles with an unsafe link before querying: %s', async (link) => {
+    const result = await createRssPerspective({
+      feed_id: 7,
+      feed_name: 'Publisher feed',
+      guid: 'article-1',
+      title: 'Agentic media',
+      link,
+    });
+
+    expect(result).toBeNull();
+    expect(mocks.query).not.toHaveBeenCalled();
+    expect(mocks.warn).toHaveBeenCalledOnce();
+  });
+
+  it('persists valid HTTPS RSS links unchanged', async () => {
+    mocks.query
+      .mockResolvedValueOnce({ rows: [{ exists: false }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'perspective-rss' }] });
+
+    await expect(createRssPerspective({
+      feed_id: 7,
+      feed_name: 'Publisher feed',
+      guid: 'article-1',
+      title: 'Agentic media',
+      link: SAFE_URL,
+    })).resolves.toBe('perspective-rss');
+
+    const insert = mocks.query.mock.calls.find(([sql]) => String(sql).includes('INSERT INTO perspectives'));
+    expect(insert?.[1]).toContain(SAFE_URL);
+  });
+
+  it('deduplicates and persists RSS links by canonical href', async () => {
+    mocks.query
+      .mockResolvedValueOnce({ rows: [{ exists: false }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'perspective-rss' }] });
+
+    await createRssPerspective({
+      feed_id: 7,
+      feed_name: 'Publisher feed',
+      guid: 'article-canonical',
+      title: 'Agentic media',
+      link: NON_CANONICAL_URL,
+    });
+
+    expect(mocks.query.mock.calls[0][1]?.[2]).toBe(CANONICAL_URL);
+    const insert = mocks.query.mock.calls.find(([sql]) => String(sql).includes('INSERT INTO perspectives'));
+    expect(insert?.[1]?.[4]).toBe(CANONICAL_URL);
+  });
+
+  it.each(UNSAFE_URLS)('does not persist unsafe email links as external URLs: %s', async (url) => {
+    mocks.query.mockResolvedValueOnce({ rows: [{ id: 'perspective-email' }] });
+
+    await createEmailPerspective({
+      feed_id: 9,
+      feed_name: 'Publisher newsletter',
+      message_id: 'message-1',
+      subject: 'Newsletter',
+      from_email: 'news@publisher.example',
+      received_at: new Date('2026-07-29T12:00:00Z'),
+      links: [{ url }],
+    });
+
+    const insertValues = mocks.query.mock.calls[0][1] as unknown[];
+    expect(insertValues[1]).toBe('article');
+    expect(insertValues[5]).toBeNull();
+  });
+
+  it('persists a valid HTTPS email link unchanged', async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [{ id: 'perspective-email' }] });
+
+    await createEmailPerspective({
+      feed_id: 9,
+      feed_name: 'Publisher newsletter',
+      message_id: 'message-1',
+      subject: 'Newsletter',
+      from_email: 'news@publisher.example',
+      received_at: new Date('2026-07-29T12:00:00Z'),
+      links: [{ url: SAFE_URL }],
+    });
+
+    const insertValues = mocks.query.mock.calls[0][1] as unknown[];
+    expect(insertValues[1]).toBe('link');
+    expect(insertValues[5]).toBe(SAFE_URL);
+  });
+
+  it('persists the canonical href for email links', async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [{ id: 'perspective-email' }] });
+
+    await createEmailPerspective({
+      feed_id: 9,
+      feed_name: 'Publisher newsletter',
+      message_id: 'message-canonical',
+      subject: 'Newsletter',
+      from_email: 'news@publisher.example',
+      received_at: new Date('2026-07-29T12:00:00Z'),
+      links: [{ url: NON_CANONICAL_URL }],
+    });
+
+    expect(mocks.query.mock.calls[0][1]?.[5]).toBe(CANONICAL_URL);
+  });
+});
+
+describe('Latest perspective navigation', () => {
+  it.each(UNSAFE_URLS)('renders an unsafe section source URL as inert title text: %s', async (sourceUrl) => {
+    const source = readPublicFile('latest/section.html');
+    const loadArticlesSource = section(source, 'async function loadArticles()', 'async function loadMoreArticles()');
+    const dom = new JSDOM(`
+      <div id="articles"></div>
+      <div id="loading"></div>
+      <div id="loadMore"></div>
+    `);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        articles: [{ title: 'Hostile article', source_url: sourceUrl, relevance_tags: [] }],
+        pagination: { has_more: false },
+      }),
+    });
+    const { getSafePerspectiveNavigationUrl } = loadPublicUrlValidators();
+    const loadArticles = new Function(
+      'document',
+      'fetch',
+      'getSafePerspectiveNavigationUrl',
+      'escapeHtml',
+      `const slug = 'perspectives'; let offset = 0; const limit = 20; let hasMore = true;
+       ${loadArticlesSource}
+       return loadArticles;`,
+    )(
+      dom.window.document,
+      fetchMock,
+      getSafePerspectiveNavigationUrl,
+      (value: unknown) => String(value ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;'),
+    ) as () => Promise<void>;
+
+    await loadArticles();
+
+    expect(dom.window.document.querySelector('.article-title')?.textContent?.trim()).toBe('Hostile article');
+    expect(dom.window.document.querySelector('.article-title a')).toBeNull();
+  });
+
+  it.each([
+    [SAFE_URL, SAFE_URL],
+    ['/perspectives/local-article', 'https://agenticadvertising.org/perspectives/local-article'],
+  ])('keeps a safe section navigation target active: %s', async (sourceUrl, expectedUrl) => {
+    const source = readPublicFile('latest/section.html');
+    const loadArticlesSource = section(source, 'async function loadArticles()', 'async function loadMoreArticles()');
+    const dom = new JSDOM(`
+      <div id="articles"></div>
+      <div id="loading"></div>
+      <div id="loadMore"></div>
+    `, { url: 'https://agenticadvertising.org/latest/perspectives' });
+    const { getSafePerspectiveNavigationUrl } = loadPublicUrlValidators();
+    const loadArticles = new Function(
+      'document',
+      'fetch',
+      'getSafePerspectiveNavigationUrl',
+      'escapeHtml',
+      `const slug = 'perspectives'; let offset = 0; const limit = 20; let hasMore = true;
+       ${loadArticlesSource}
+       return loadArticles;`,
+    )(
+      dom.window.document,
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          articles: [{ title: 'Safe article', source_url: sourceUrl, relevance_tags: [] }],
+          pagination: { has_more: false },
+        }),
+      }),
+      getSafePerspectiveNavigationUrl,
+      (value: unknown) => String(value ?? ''),
+    ) as () => Promise<void>;
+
+    await loadArticles();
+
+    expect((dom.window.document.querySelector('.article-title a') as HTMLAnchorElement)?.href).toBe(expectedUrl);
+  });
+
+  it('routes all closely related feed-controlled sinks through the shared validator', () => {
+    const sinks = [
+      readPublicFile('latest/index.html'),
+      readPublicFile('stories/index.html'),
+      readPublicFile('admin-feeds.html'),
+    ];
+
+    for (const sink of sinks) {
+      expect(sink).toContain('<script src="/perspective-url.js"></script>');
+      expect(sink).toContain('getSafePerspectiveExternalUrl');
+    }
+    expect(sinks[0]).not.toContain('href="${escapeHtml(article.source_url)}"');
+    expect(sinks[1]).not.toContain("link.href = item.source_url || '#'");
+    expect(sinks[2]).not.toContain('href="${escapeHtml(article.external_url)}"');
+  });
+});

--- a/server/tests/unit/industry-feed-perspective-url-validation.test.ts
+++ b/server/tests/unit/industry-feed-perspective-url-validation.test.ts
@@ -158,6 +158,16 @@ describe('industry-feed perspective URL persistence', () => {
 });
 
 describe('Latest perspective navigation', () => {
+  it('exports the section navigation validator for classic-script consumers', () => {
+    const browserGlobal: Record<string, unknown> = {};
+    const source = readPublicFile('perspective-url.js');
+
+    new Function('window', source)(browserGlobal);
+
+    const validator = browserGlobal.getSafePerspectiveNavigationUrl as (value: unknown) => string | null;
+    expect(validator('/perspectives/local-article')).toBe('/perspectives/local-article');
+  });
+
   it.each(UNSAFE_URLS)('renders an unsafe section source URL as inert title text: %s', async (sourceUrl) => {
     const source = readPublicFile('latest/section.html');
     const loadArticlesSource = section(source, 'async function loadArticles()', 'async function loadMoreArticles()');

--- a/server/tests/unit/member-profile-admin-global-auth.test.ts
+++ b/server/tests/unit/member-profile-admin-global-auth.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  createValidation: vi.fn(),
+  checkPlatformBanForApiKey: vi.fn(),
+  resolveEffectiveMembership: vi.fn(),
+  listProfiles: vi.fn(),
+  getProfileById: vi.fn(),
+  updateProfile: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = 'sk_test_member_profile_global_boundary';
+  process.env.WORKOS_CLIENT_ID = 'client_test_member_profile_global_boundary';
+  process.env.WORKOS_COOKIE_PASSWORD =
+    'test-cookie-password-at-least-32-characters';
+  process.env.ADMIN_API_KEY = 'static-member-profile-global-admin-key';
+  delete process.env.DEV_USER_EMAIL;
+  delete process.env.DEV_USER_ID;
+});
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: class WorkOS {
+    apiKeys = { createValidation: mocks.createValidation };
+  },
+}));
+
+vi.mock('../../src/db/bans-db.js', () => ({
+  bansDb: {
+    checkPlatformBanForApiKey: mocks.checkPlatformBanForApiKey,
+    checkPlatformBan: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/db/org-filters.js', () => ({
+  resolveEffectiveMembership: mocks.resolveEffectiveMembership,
+}));
+
+vi.mock('../../src/addie/mcp/admin-tools.js', () => ({
+  isWebUserAAOAdmin: vi.fn().mockResolvedValue(false),
+}));
+
+const { createAdminMemberProfileRouter } = await import(
+  '../../src/routes/member-profiles.js'
+);
+const { stopAuthTimers } = await import('../../src/middleware/auth.js');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/member-profiles', createAdminMemberProfileRouter({
+    memberDb: {
+      listProfiles: mocks.listProfiles,
+      getProfileById: mocks.getProfileById,
+      updateProfile: mocks.updateProfile,
+    },
+    brandDb: {},
+    orgDb: {},
+    invalidateMemberContextCache: vi.fn(),
+  } as any));
+  return app;
+}
+
+function validatedTenantKey(permission: 'admin:*' | 'admin:read') {
+  return {
+    apiKey: {
+      id: `key_${permission}`,
+      owner: { id: 'org_tenant' },
+      name: 'Tenant admin key',
+      permissions: [permission],
+    },
+  };
+}
+
+describe('member profile admin route authorization', () => {
+  const app = createApp();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createValidation.mockImplementation(
+      ({ value }: { value: string }) => Promise.resolve(
+        validatedTenantKey(value.includes('read') ? 'admin:read' : 'admin:*'),
+      ),
+    );
+    mocks.checkPlatformBanForApiKey.mockResolvedValue({ banned: false });
+    mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: true });
+    mocks.listProfiles.mockResolvedValue([]);
+    mocks.getProfileById.mockResolvedValue({
+      id: 'profile_tenant',
+      workos_organization_id: 'org_tenant',
+    });
+    mocks.updateProfile.mockResolvedValue({
+      id: 'profile_tenant',
+      workos_organization_id: 'org_tenant',
+      tagline: 'Tenant-owned update',
+    });
+  });
+
+  it.each(['admin:*', 'admin:read'] as const)(
+    'denies a tenant key with %s before the cross-org profile query',
+    async (permission) => {
+      const response = await request(app)
+        .get('/api/admin/member-profiles')
+        .set(
+          'Authorization',
+          `Bearer sk_tenant_${permission === 'admin:read' ? 'read' : 'full'}`,
+        );
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('global_admin_required');
+      expect(mocks.listProfiles).not.toHaveBeenCalled();
+    },
+  );
+
+  it('allows the static global admin key to list profiles', async () => {
+    const response = await request(app)
+      .get('/api/admin/member-profiles')
+      .set('Authorization', 'Bearer static-member-profile-global-admin-key');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ profiles: [] });
+    expect(mocks.listProfiles).toHaveBeenCalledOnce();
+  });
+
+  it('writes safe profile fields for same-tenant admin keys', async () => {
+    const response = await request(app)
+      .put('/api/admin/member-profiles/profile_tenant')
+      .set('Authorization', 'Bearer sk_tenant_full')
+      .send({
+        tagline: 'Tenant-owned update',
+        linkedin_url: 'https://www.linkedin.com/company/acme-media',
+      });
+
+    expect(response.status).toBe(200);
+    expect(mocks.getProfileById).toHaveBeenCalledWith('profile_tenant');
+    expect(mocks.updateProfile).toHaveBeenCalledWith('profile_tenant', {
+      tagline: 'Tenant-owned update',
+      linkedin_url: 'https://www.linkedin.com/company/acme-media',
+    });
+  });
+});
+
+afterAll(() => {
+  stopAuthTimers();
+});

--- a/server/tests/unit/member-profile-url-boundaries.test.ts
+++ b/server/tests/unit/member-profile-url-boundaries.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  resolvePrimaryOrganization: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  query: mocks.query,
+  getPool: vi.fn(),
+}));
+
+vi.mock('../../src/db/users-db.js', () => ({
+  resolvePrimaryOrganization: mocks.resolvePrimaryOrganization,
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: unknown, next: () => void) => {
+    req.user = { id: 'user-profile-url', email: 'profile-url@example.test' };
+    next();
+  },
+  requireAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
+  requireGlobalAdmin: [(_req: unknown, _res: unknown, next: () => void) => next()],
+  refuseCrossTenantAdminApiKey: () => false,
+  isDevModeEnabled: () => false,
+  DEV_USERS: {},
+}));
+
+vi.mock('../../src/middleware/rate-limit.js', () => ({
+  isMemberProfileBootstrapBody: () => false,
+  memberProfileBootstrapRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import {
+  createAdminMemberProfileRouter,
+  createMemberProfileRouter,
+} from '../../src/routes/member-profiles.js';
+import { MemberDatabase } from '../../src/db/member-db.js';
+import { CommunityDatabase } from '../../src/db/community-db.js';
+import { createCommunityRouters } from '../../src/routes/community.js';
+
+function createConfig() {
+  const getProfileByOrgId = vi.fn();
+  const getProfileById = vi.fn();
+  return {
+    config: {
+      memberDb: { getProfileByOrgId, getProfileById },
+      brandDb: {},
+      orgDb: {},
+      invalidateMemberContextCache: vi.fn(),
+    } as any,
+    getProfileByOrgId,
+    getProfileById,
+  };
+}
+
+describe('member profile URL persistence boundaries', () => {
+  it('rejects unsafe URLs at the shared database boundary', async () => {
+    const memberDb = new MemberDatabase();
+
+    await expect(memberDb.createProfile({
+      workos_organization_id: 'org-unsafe',
+      display_name: 'Unsafe Media',
+      slug: 'unsafe-media',
+      linkedin_url: 'javascript:alert(1)',
+    })).rejects.toThrow('linkedin_url must be an HTTPS URL without credentials');
+
+    await expect(memberDb.updateProfile('profile-unsafe', {
+      contact_website: 'https://user:secret@acme.example',
+    })).rejects.toThrow('contact_website must be an HTTPS URL without credentials');
+
+    await expect(memberDb.updateProfile('profile-unsafe', {
+      twitter_url: 'http://social.example/unsafe',
+    })).rejects.toThrow('twitter_url must be an HTTPS URL without credentials');
+
+    await expect(new CommunityDatabase().updateProfile('user-unsafe', {
+      twitter_url: 'javascript:alert(1)',
+    })).rejects.toThrow('twitter_url must be an HTTPS URL without credentials');
+
+    await expect(memberDb.createProfile({
+      workos_organization_id: 'org-control',
+      display_name: 'Control Media',
+      slug: 'control-media',
+      linkedin_url: 'https://social.example/acme\r\nInjected',
+    })).rejects.toThrow('linkedin_url must be an HTTPS URL without credentials');
+
+    await expect(memberDb.updateProfile('profile-control', {
+      contact_website: '\thttps://acme.example',
+    })).rejects.toThrow('contact_website must be an HTTPS URL without credentials');
+
+    await expect(new CommunityDatabase().updateProfile('user-control', {
+      twitter_url: 'https://social.example/acme\u007F',
+    })).rejects.toThrow('twitter_url must be an HTTPS URL without credentials');
+  });
+
+  it.each([
+    ['linkedin_url', 'javascript:alert(1)'],
+    ['twitter_url', 'http://social.example/acme'],
+    ['contact_website', 'https://user:secret@acme.example'],
+  ])('rejects unsafe %s values on create', async (field, value) => {
+    const { config, getProfileByOrgId } = createConfig();
+    const app = express();
+    app.use(express.json());
+    app.use('/api/me/member-profile', createMemberProfileRouter(config));
+
+    const response = await request(app)
+      .post('/api/me/member-profile')
+      .send({ display_name: 'Acme Media', slug: 'acme-media', [field]: value });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(`${field} must be an HTTPS URL without credentials`);
+    expect(getProfileByOrgId).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['linkedin_url', 'data:text/html,<script>alert(1)</script>'],
+    ['twitter_url', 'https://user:secret@social.example/acme'],
+    ['contact_website', 'https://acme.example" onclick="alert(1)'],
+  ])('rejects unsafe %s values on update', async (field, value) => {
+    const { config, getProfileByOrgId } = createConfig();
+    const app = express();
+    app.use(express.json());
+    app.use('/api/me/member-profile', createMemberProfileRouter(config));
+
+    const response = await request(app)
+      .put('/api/me/member-profile')
+      .send({ [field]: value });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(`${field} must be an HTTPS URL without credentials`);
+    expect(getProfileByOrgId).not.toHaveBeenCalled();
+  });
+
+  it('applies the same URL validation to the admin update boundary', async () => {
+    const { config, getProfileById } = createConfig();
+    const app = express();
+    app.use(express.json());
+    app.use('/api/admin/member-profiles', createAdminMemberProfileRouter(config));
+
+    const response = await request(app)
+      .put('/api/admin/member-profiles/profile-1')
+      .send({ twitter_url: 'javascript:alert(1)' });
+
+    expect(response.status).toBe(400);
+    expect(getProfileById).not.toHaveBeenCalled();
+  });
+
+  it('applies the shared URL validation to the community profile writer', async () => {
+    const updateProfile = vi.fn();
+    const app = express();
+    app.use(express.json());
+    const { userRouter } = createCommunityRouters({
+      communityDb: { updateProfile } as any,
+    });
+    app.use('/api/me', userRouter);
+
+    const response = await request(app)
+      .put('/api/me/community-profile')
+      .send({ twitter_url: 'http://social.example/acme' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('twitter_url must be an HTTPS URL without credentials');
+    expect(updateProfile).not.toHaveBeenCalled();
+  });
+
+  it('syncs non-URL fields without rewriting unsafe legacy member URLs', async () => {
+    const communityProfile = {
+      workos_user_id: 'user-profile-url',
+      slug: 'legacy-person',
+      headline: 'Updated headline',
+      bio: 'Existing bio',
+      avatar_url: null,
+      expertise: [],
+      interests: [],
+      linkedin_url: 'javascript:alert(1)',
+      twitter_url: 'http://social.example/legacy',
+      github_username: null,
+      is_public: true,
+      open_to_coffee_chat: false,
+      open_to_intros: false,
+      city: 'New York',
+    };
+    const communityDb = {
+      getProfile: vi.fn().mockResolvedValue(communityProfile),
+      updateProfile: vi.fn().mockResolvedValue(communityProfile),
+      checkAndAwardBadges: vi.fn().mockResolvedValue(undefined),
+    };
+    const updateProfileByOrgId = vi.fn().mockResolvedValue({});
+    const memberDb = {
+      getProfileByOrgId: vi.fn().mockResolvedValue({
+        id: 'member-profile-1',
+        workos_organization_id: 'org-personal',
+        is_public: true,
+        tagline: null,
+        description: 'Independently customized bio',
+        offerings: [],
+        contact_website: 'javascript:alert(2)',
+      }),
+      updateProfileByOrgId,
+    };
+    const orgDb = {
+      getOrganization: vi.fn().mockResolvedValue({ is_personal: true }),
+      hasActiveSubscription: vi.fn(),
+    };
+    const invalidateMemberContextCache = vi.fn();
+    mocks.resolvePrimaryOrganization.mockResolvedValue('org-personal');
+    mocks.query.mockResolvedValue({
+      rows: [{ first_name: 'Legacy', last_name: 'Person' }],
+    });
+
+    const app = express();
+    app.use(express.json());
+    const { userRouter } = createCommunityRouters({
+      communityDb: communityDb as any,
+      memberDb: memberDb as any,
+      orgDb: orgDb as any,
+      invalidateMemberContextCache,
+    });
+    app.use('/api/me', userRouter);
+
+    const response = await request(app)
+      .put('/api/me/community-profile')
+      .send({ headline: 'Updated headline' });
+
+    expect(response.status).toBe(200);
+    expect(updateProfileByOrgId).toHaveBeenCalledWith('org-personal', {
+      display_name: 'Legacy Person',
+      tagline: 'Updated headline',
+    });
+    const memberUpdates = updateProfileByOrgId.mock.calls[0][1];
+    expect(memberUpdates).not.toHaveProperty('linkedin_url');
+    expect(memberUpdates).not.toHaveProperty('twitter_url');
+    expect(memberUpdates).not.toHaveProperty('contact_website');
+    expect(invalidateMemberContextCache).toHaveBeenCalledOnce();
+  });
+});

--- a/server/tests/unit/member-profile-url-validation.test.ts
+++ b/server/tests/unit/member-profile-url-validation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MEMBER_PROFILE_URL_FIELDS,
+  validateMemberProfileUrlFields,
+} from '../../src/utils/member-profile-url.js';
+
+describe('member profile URL validation', () => {
+  it.each([
+    ['linkedin_url', 'javascript:alert(1)'],
+    ['linkedin_url', 'https://user:secret@linkedin.example/company/acme'],
+    ['linkedin_url', 'https://linkedin.example" onmouseover="alert(1)'],
+    ['twitter_url', 'javascript:alert(1)'],
+    ['twitter_url', 'http://social.example/acme'],
+    ['twitter_url', 'https://user:secret@social.example/acme'],
+    ['contact_website', 'data:text/html,<script>alert(1)</script>'],
+    ['contact_website', 'http://acme.example'],
+    ['contact_website', 'https://acme.example" onclick="alert(1)'],
+  ])('rejects an unsafe %s value', (field, value) => {
+    expect(validateMemberProfileUrlFields({ [field]: value })).toBe(field);
+  });
+
+  it.each(MEMBER_PROFILE_URL_FIELDS)('rejects raw control characters in %s before URL parsing', (field) => {
+    for (const control of ['\r', '\n', '\t', '\u007F']) {
+      expect(validateMemberProfileUrlFields({
+        [field]: `https://social.example/acme${control}profile`,
+      })).toBe(field);
+    }
+  });
+
+  it.each(MEMBER_PROFILE_URL_FIELDS)('rejects raw ambiguous URL delimiters in %s', (field) => {
+    for (const delimiter of ['<', '>', '\\']) {
+      expect(validateMemberProfileUrlFields({
+        [field]: `https://social.example/acme${delimiter}profile`,
+      })).toBe(field);
+    }
+  });
+
+  it.each([
+    ['linkedin_url', 'https://social.example/acme%0Dprofile'],
+    ['twitter_url', 'https://social.example/acme%0Aprofile'],
+    ['contact_website', 'https://acme.example/profile%09details'],
+  ])('accepts encoded URL data in %s', (field, value) => {
+    expect(validateMemberProfileUrlFields({ [field]: value })).toBeNull();
+  });
+
+  it('accepts valid HTTPS URLs for every profile URL field', () => {
+    expect(validateMemberProfileUrlFields({
+      linkedin_url: 'https://www.linkedin.com/company/acme-media',
+      twitter_url: 'https://social.example/acme?ref=directory#profile',
+      contact_website: 'https://acme.example/contact?from=directory#team',
+    })).toBeNull();
+  });
+
+  it('allows omitted and cleared optional fields', () => {
+    expect(validateMemberProfileUrlFields({})).toBeNull();
+    expect(validateMemberProfileUrlFields({
+      linkedin_url: null,
+      twitter_url: '',
+      contact_website: '',
+    })).toBeNull();
+  });
+});

--- a/server/tests/unit/perspective-external-url-validation.test.ts
+++ b/server/tests/unit/perspective-external-url-validation.test.ts
@@ -1,0 +1,299 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  isAdmin: vi.fn().mockResolvedValue(false),
+  notifyPublishedPost: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: 'user_editor', email: 'editor@example.test' };
+    next();
+  },
+}));
+
+vi.mock('../../src/middleware/rate-limit.js', () => ({
+  contentProposeRateLimiter: (_req: any, _res: any, next: any) => next(),
+  contentFetchUrlRateLimiter: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  getPool: () => ({ query: mocks.poolQuery }),
+}));
+
+vi.mock('../../src/addie/mcp/admin-tools.js', () => ({
+  isWebUserAAOAdmin: (...args: unknown[]) => mocks.isAdmin(...args),
+}));
+
+vi.mock('../../src/slack/client.js', () => ({
+  sendChannelMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/notifications/slack.js', () => ({
+  notifyPublishedPost: (...args: unknown[]) => mocks.notifyPublishedPost(...args),
+  sendSocialAmplificationDM: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/db/system-settings-db.js', () => ({
+  getEditorialChannel: vi.fn().mockResolvedValue({ channel_id: null }),
+}));
+
+vi.mock('../../src/addie/services/journey-computation.js', () => ({
+  computeJourneyStage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/db/community-db.js', () => ({
+  CommunityDatabase: class {
+    awardPoints = vi.fn().mockResolvedValue(undefined);
+    checkAndAwardBadges = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../../src/db/perspective-asset-db.js', () => ({
+  createAsset: vi.fn(),
+}));
+
+vi.mock('../../src/services/posthog-query.js', () => ({
+  fetchPathPageviewCounts: vi.fn().mockResolvedValue(new Map()),
+}));
+
+vi.mock('../../src/utils/url-security.js', () => ({
+  safeFetch: vi.fn(),
+}));
+
+vi.mock('../../src/services/illustration-generator.js', () => ({
+  generateIllustration: vi.fn(),
+}));
+
+vi.mock('../../src/db/illustration-db.js', () => ({
+  createIllustration: vi.fn(),
+  approveIllustration: vi.fn(),
+}));
+
+vi.mock('../../src/db/escalation-db.js', () => ({
+  resolveEscalationsForPerspective: vi.fn(),
+}));
+
+vi.mock('../../src/services/my-content-service.js', () => ({
+  listMyContent: vi.fn().mockResolvedValue({ items: [] }),
+  MyContentError: class extends Error {
+    is() { return false; }
+    meta = { valid: [] };
+  },
+}));
+
+vi.mock('../../src/services/membership-tiers.js', () => ({
+  checkContentSubmissionTier: vi.fn().mockResolvedValue(true),
+}));
+
+import {
+  createMyContentRouter,
+  proposeContentForUser,
+} from '../../src/routes/content.js';
+
+const SAFE_URL = 'https://partner.example/field-notes';
+const NON_CANONICAL_URL = 'https://Partner.Example:443/field notes?q=(roundup)';
+const CANONICAL_URL = 'https://partner.example/field%20notes?q=(roundup)';
+
+function proposal(externalUrl: string, status: 'draft' | 'published' = 'draft') {
+  return proposeContentForUser(
+    { id: 'system:perspective-url-regression', email: 'system@example.test' },
+    {
+      title: 'External field notes',
+      content_type: 'link',
+      external_url: externalUrl,
+      collection: { slug: 'security-testing' },
+      status,
+    },
+  );
+}
+
+function existingLinkPerspective() {
+  return {
+    id: 'perspective_test',
+    slug: 'external-field-notes',
+    title: 'External field notes',
+    content: null,
+    content_type: 'link',
+    excerpt: null,
+    external_url: 'https://partner.example/original',
+    external_site_name: 'Partner',
+    category: 'Perspective',
+    tags: [],
+    author_name: 'Editor',
+    author_user_id: 'user_editor',
+    content_origin: 'member',
+    proposer_user_id: 'user_editor',
+    working_group_id: null,
+    status: 'draft',
+  };
+}
+
+function mountMyContentRouter() {
+  const app = express();
+  app.use(express.json());
+  app.use('/content', createMyContentRouter());
+  return app;
+}
+
+describe('perspective external URL persistence validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isAdmin.mockResolvedValue(false);
+  });
+
+  it.each([
+    'javascript:globalThis.__perspectiveXss = true',
+    'data:text/html,<script>globalThis.__perspectiveXss = true</script>',
+    'http://partner.example/article',
+    'https://attacker:secret@partner.example/article',
+    '\thttps://partner.example/article',
+    'https://partner.example/article\r\n- [Injected](https://attacker.example)',
+    'https://partner.example/article\u007F',
+  ])('rejects an unsafe URL before proposal persistence: %s', async (externalUrl) => {
+    const result = await proposal(externalUrl);
+
+    expect(result).toEqual({
+      success: false,
+      error: 'external_url must be an HTTPS URL without credentials',
+    });
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+  });
+
+  it('persists a valid HTTPS URL through the proposal service', async () => {
+    mocks.poolQuery.mockImplementation(async (sql: string, values?: unknown[]) => {
+      if (sql.includes('FROM working_groups')) {
+        return {
+          rows: [{
+            id: 'wg_security',
+            name: 'Security testing',
+            accepts_public_submissions: true,
+            slack_channel_id: null,
+          }],
+        };
+      }
+      if (sql.includes('FROM working_group_leaders')) return { rows: [] };
+      if (sql.includes('SELECT first_name, last_name, email FROM users')) {
+        return { rows: [{ first_name: 'System', last_name: 'Editor', email: 'system@example.test' }] };
+      }
+      if (sql.includes('INSERT INTO perspectives')) {
+        return {
+          rows: [{
+            id: 'perspective_created',
+            slug: 'external-field-notes-created',
+            title: 'External field notes',
+            content_type: 'link',
+            content: null,
+            excerpt: null,
+            category: null,
+            external_url: values?.[6],
+            proposed_at: new Date().toISOString(),
+            status: 'draft',
+          }],
+        };
+      }
+      if (sql.includes('FROM organization_memberships')) return { rows: [] };
+      if (sql.includes('INSERT INTO content_authors')) return { rows: [] };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    const result = await proposal(SAFE_URL);
+
+    expect(result.success).toBe(true);
+    const insertCall = mocks.poolQuery.mock.calls.find(([sql]) =>
+      String(sql).includes('INSERT INTO perspectives'));
+    expect(insertCall).toBeDefined();
+    expect(insertCall?.[1]).toContain(SAFE_URL);
+  });
+
+  it('persists the canonical href through the proposal service', async () => {
+    mocks.poolQuery.mockImplementation(async (sql: string, values?: unknown[]) => {
+      if (sql.includes('FROM working_groups')) {
+        return { rows: [{ id: 'wg_security', name: 'Security testing', accepts_public_submissions: true, slack_channel_id: null }] };
+      }
+      if (sql.includes('FROM working_group_leaders')) return { rows: [{}] };
+      if (sql.includes('SELECT first_name, last_name, email FROM users')) return { rows: [] };
+      if (sql.includes('INSERT INTO perspectives')) return { rows: [{ id: 'perspective_created', external_url: values?.[6] }] };
+      if (sql.includes('FROM organization_memberships')) return { rows: [] };
+      if (sql.includes('INSERT INTO content_authors')) return { rows: [] };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    await expect(proposal(NON_CANONICAL_URL, 'published')).resolves.toMatchObject({ success: true });
+    const insert = mocks.poolQuery.mock.calls.find(([sql]) => String(sql).includes('INSERT INTO perspectives'));
+    expect(insert?.[1]?.[6]).toBe(CANONICAL_URL);
+    expect(mocks.notifyPublishedPost).toHaveBeenCalledWith(expect.objectContaining({
+      externalUrl: CANONICAL_URL,
+    }));
+  });
+
+  it.each([
+    'javascript:globalThis.__perspectiveXss = true',
+    'data:text/html,<script>globalThis.__perspectiveXss = true</script>',
+    'http://partner.example/article',
+    'https://attacker:secret@partner.example/article',
+    '\thttps://partner.example/article',
+    'https://partner.example/article\n',
+    'https://partner.example/article\u007F',
+  ])('rejects an unsafe URL before the content update query: %s', async (externalUrl) => {
+    mocks.poolQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT p.*')) return { rows: [existingLinkPerspective()] };
+      if (sql.includes('SELECT 1 FROM content_authors')) return { rows: [] };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    const response = await request(mountMyContentRouter())
+      .put('/content/perspective_test')
+      .send({ external_url: externalUrl });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Invalid external URL');
+    expect(mocks.poolQuery.mock.calls.some(([sql]) =>
+      String(sql).includes('UPDATE perspectives'))).toBe(false);
+  });
+
+  it('persists a valid HTTPS URL through the content update route', async () => {
+    mocks.poolQuery.mockImplementation(async (sql: string, values?: unknown[]) => {
+      if (sql.includes('SELECT p.*')) return { rows: [existingLinkPerspective()] };
+      if (sql.includes('SELECT 1 FROM content_authors')) return { rows: [] };
+      if (sql.includes('UPDATE perspectives SET')) {
+        return { rows: [{ ...existingLinkPerspective(), external_url: values?.[0] }] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    const response = await request(mountMyContentRouter())
+      .put('/content/perspective_test')
+      .send({ external_url: SAFE_URL });
+
+    expect(response.status).toBe(200);
+    expect(response.body.external_url).toBe(SAFE_URL);
+    const updateCall = mocks.poolQuery.mock.calls.find(([sql]) =>
+      String(sql).includes('UPDATE perspectives SET'));
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.[1]).toContain(SAFE_URL);
+  });
+
+  it('persists the canonical href through the content update route', async () => {
+    mocks.poolQuery.mockImplementation(async (sql: string, values?: unknown[]) => {
+      if (sql.includes('SELECT p.*')) return { rows: [existingLinkPerspective()] };
+      if (sql.includes('SELECT 1 FROM content_authors')) return { rows: [] };
+      if (sql.includes('UPDATE perspectives SET')) {
+        return { rows: [{ ...existingLinkPerspective(), external_url: values?.[0] }] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    const response = await request(mountMyContentRouter())
+      .put('/content/perspective_test')
+      .send({ external_url: NON_CANONICAL_URL });
+
+    expect(response.status).toBe(200);
+    expect(response.body.external_url).toBe(CANONICAL_URL);
+    const update = mocks.poolQuery.mock.calls.find(([sql]) => String(sql).includes('UPDATE perspectives SET'));
+    expect(update?.[1]?.[0]).toBe(CANONICAL_URL);
+  });
+});

--- a/server/tests/unit/perspective-url-normalization.test.ts
+++ b/server/tests/unit/perspective-url-normalization.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatPerspectiveUrlAsMarkdownDestination,
+  normalizePerspectiveExternalUrl,
+} from '../../src/utils/perspective-url.js';
+
+describe('perspective external URL normalization', () => {
+  it('returns the canonical href for valid credential-free HTTPS URLs', () => {
+    expect(normalizePerspectiveExternalUrl(
+      'https://Publisher.Example:443/articles/agentic media?q=(roundup)',
+    )).toBe('https://publisher.example/articles/agentic%20media?q=(roundup)');
+  });
+
+  it.each([
+    '\thttps://publisher.example/article',
+    'https://publisher.example/article\n',
+    'https://publisher.example/article\r\n- [Injected](https://attacker.example)',
+    'https://publisher.example/ar\u0000ticle',
+    'https://publisher.example/ar\u001Fticle',
+    'https://publisher.example/ar\u007Fticle',
+  ])('rejects C0 and DEL characters instead of allowing URL to strip them: %j', (value) => {
+    expect(normalizePerspectiveExternalUrl(value)).toBeNull();
+  });
+
+  it.each([
+    'https://publisher.example/a\\b',
+    'https://publisher.example/a<b',
+    'https://publisher.example/a>b',
+  ])('rejects raw URL/Markdown boundary delimiters: %s', (value) => {
+    expect(normalizePerspectiveExternalUrl(value)).toBeNull();
+  });
+
+  it('formats valid parentheses as an unambiguous CommonMark destination', () => {
+    expect(formatPerspectiveUrlAsMarkdownDestination(
+      'https://publisher.example/reports/agentic_(roundup)',
+    )).toBe('<https://publisher.example/reports/agentic_(roundup)>');
+  });
+});

--- a/server/tests/unit/perspectives-crawlability.test.ts
+++ b/server/tests/unit/perspectives-crawlability.test.ts
@@ -95,18 +95,60 @@ describe('Perspectives crawlability routes', () => {
   it('serves dynamic llms.txt with published perspective URLs before static llms.txt', async () => {
     queryMock.mockResolvedValue({ rows: perspectiveRows });
 
-    const res = await request(app()).get('/llms.txt').set('Host', 'agenticadvertising.org');
+    const httpApp = app();
+    const res = await request(httpApp).get('/llms.txt').set('Host', 'agenticadvertising.org');
 
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toContain('text/plain');
     expect(res.headers['cache-control']).toBe('public, max-age=300');
     expect(res.text).toContain('# AgenticAdvertising.org');
     expect(res.text).toContain('## Perspectives');
-    expect(res.text).toContain('[Agentic crawlability & discovery](https://agenticadvertising.org/perspectives/agentic-crawlability)');
-    expect(res.text).toContain('[Partner \\[view\\] \\(field notes\\)](https://partner.example/field-notes): External \\(but curated\\) perspective with \\[brackets\\].');
-    expect(res.text).toContain('[Perspectives RSS feed](https://agenticadvertising.org/perspectives/feed.xml)');
+    expect(res.text).toContain('[Agentic crawlability & discovery](<https://agenticadvertising.org/perspectives/agentic-crawlability>)');
+    expect(res.text).toContain('[Partner \\[view\\] \\(field notes\\)](<https://partner.example/field-notes>): External \\(but curated\\) perspective with \\[brackets\\].');
+    expect(res.text).toContain('[Perspectives RSS feed](<https://agenticadvertising.org/perspectives/feed.xml>)');
     expect(res.text).not.toContain('# AdCP - Ad Context Protocol');
     expect(queryMock).toHaveBeenCalledWith(expect.stringContaining("p.status = 'published'"), [200]);
+  });
+
+  it('normalizes legacy URLs, fails closed on controls, and contains Markdown delimiters', async () => {
+    queryMock.mockResolvedValue({
+      rows: [
+        {
+          ...perspectiveRows[2],
+          slug: 'legacy-control',
+          title: 'Legacy control',
+          external_url: 'https://trusted.example/report\r\n- [Injected](https://attacker.example)',
+        },
+        {
+          ...perspectiveRows[2],
+          slug: 'valid-parentheses',
+          title: 'Valid parentheses',
+          external_url: 'https://Trusted.Example:443/reports/agentic_(roundup)',
+        },
+        {
+          ...perspectiveRows[2],
+          slug: 'legacy-angle',
+          title: 'Legacy angle',
+          external_url: 'https://trusted.example/report>injected',
+        },
+      ],
+    });
+
+    const httpApp = app();
+    const res = await request(httpApp).get('/llms.txt').set('Host', 'agenticadvertising.org');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('[Legacy control](<https://agenticadvertising.org/perspectives/legacy-control>)');
+    expect(res.text).toContain('[Valid parentheses](<https://trusted.example/reports/agentic_(roundup)>)');
+    expect(res.text).toContain('[Legacy angle](<https://agenticadvertising.org/perspectives/legacy-angle>)');
+    expect(res.text).not.toContain('attacker.example');
+    expect(res.text).not.toContain('\n- [Injected]');
+
+    const rss = await request(httpApp).get('/perspectives/feed.xml').set('Host', 'agenticadvertising.org');
+    expect(rss.status).toBe(200);
+    expect(rss.text).toContain('<link>https://agenticadvertising.org/perspectives/legacy-control</link>');
+    expect(rss.text).toContain('<link>https://trusted.example/reports/agentic_(roundup)</link>');
+    expect(rss.text).not.toContain('attacker.example');
   });
 
   it('falls through to the static protocol llms.txt on the AdCP host', async () => {

--- a/server/tests/unit/portrait-admin-global-auth.test.ts
+++ b/server/tests/unit/portrait-admin-global-auth.test.ts
@@ -1,0 +1,148 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  createValidation: vi.fn(),
+  checkPlatformBanForApiKey: vi.fn(),
+  resolveEffectiveMembership: vi.fn(),
+  listPortraits: vi.fn(),
+  getUserPortraitMap: vi.fn(),
+  getPortraitById: vi.fn(),
+  rejectPortrait: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = 'sk_test_portrait_global_boundary';
+  process.env.WORKOS_CLIENT_ID = 'client_test_portrait_global_boundary';
+  process.env.WORKOS_COOKIE_PASSWORD =
+    'test-cookie-password-at-least-32-characters';
+  process.env.ADMIN_API_KEY = 'static-portrait-global-admin-key';
+  delete process.env.DEV_USER_EMAIL;
+  delete process.env.DEV_USER_ID;
+});
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: class WorkOS {
+    apiKeys = { createValidation: mocks.createValidation };
+  },
+}));
+
+vi.mock('../../src/db/bans-db.js', () => ({
+  bansDb: {
+    checkPlatformBanForApiKey: mocks.checkPlatformBanForApiKey,
+    checkPlatformBan: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/db/org-filters.js', () => ({
+  resolveEffectiveMembership: mocks.resolveEffectiveMembership,
+}));
+
+vi.mock('../../src/db/portrait-db.js', () => ({
+  listPortraits: (...args: unknown[]) => mocks.listPortraits(...args),
+  getUserPortraitMap: (...args: unknown[]) => mocks.getUserPortraitMap(...args),
+  getPortraitById: (...args: unknown[]) => mocks.getPortraitById(...args),
+  rejectPortrait: (...args: unknown[]) => mocks.rejectPortrait(...args),
+  getActivePortraitId: vi.fn(),
+  removeFromUser: vi.fn(),
+}));
+
+vi.mock('../../src/services/portrait-generator.js', () => ({
+  VIBE_OPTIONS: { casual: {} },
+  generatePortrait: vi.fn(),
+}));
+
+const { createAdminPortraitRouter } = await import('../../src/routes/portraits.js');
+const { stopAuthTimers } = await import('../../src/middleware/auth.js');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/portraits', createAdminPortraitRouter());
+  return app;
+}
+
+function validatedTenantKey(permission: 'admin:*' | 'admin:read') {
+  return {
+    apiKey: {
+      id: `key_${permission}`,
+      owner: { id: 'org_tenant' },
+      name: 'Tenant admin key',
+      permissions: [permission],
+    },
+  };
+}
+
+describe('portrait admin route authorization', () => {
+  const app = createApp();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createValidation.mockImplementation(
+      ({ value }: { value: string }) => Promise.resolve(
+        validatedTenantKey(value.includes('read') ? 'admin:read' : 'admin:*'),
+      ),
+    );
+    mocks.checkPlatformBanForApiKey.mockResolvedValue({ banned: false });
+    mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: true });
+    mocks.listPortraits.mockResolvedValue([]);
+    mocks.getUserPortraitMap.mockResolvedValue({});
+    mocks.getPortraitById.mockResolvedValue({ id: 'portrait_1', user_id: null });
+    mocks.rejectPortrait.mockResolvedValue(undefined);
+  });
+
+  it.each([
+    ['GET / with admin:*', 'sk_tenant_full', () => request(app).get('/api/admin/portraits')],
+    ['GET / with admin:read', 'sk_tenant_read', () => request(app).get('/api/admin/portraits')],
+    ['GET /map with admin:*', 'sk_tenant_full', () => request(app).get('/api/admin/portraits/map')],
+    ['GET /map with admin:read', 'sk_tenant_read', () => request(app).get('/api/admin/portraits/map')],
+    ['DELETE /:id with admin:*', 'sk_tenant_full', () => request(app).delete('/api/admin/portraits/portrait_1')],
+    ['DELETE /:id with admin:read', 'sk_tenant_read', () => request(app).delete('/api/admin/portraits/portrait_1')],
+  ])('denies a tenant WorkOS admin key on %s before portrait access', async (_name, apiKey, makeRequest) => {
+    const response = await makeRequest()
+      .set('Authorization', `Bearer ${apiKey}`);
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('global_admin_required');
+    expect(mocks.listPortraits).not.toHaveBeenCalled();
+    expect(mocks.getUserPortraitMap).not.toHaveBeenCalled();
+    expect(mocks.getPortraitById).not.toHaveBeenCalled();
+    expect(mocks.rejectPortrait).not.toHaveBeenCalled();
+  });
+
+  it('allows a static global admin key to list portraits', async () => {
+    const response = await request(app)
+      .get('/api/admin/portraits')
+      .set('Authorization', 'Bearer static-portrait-global-admin-key');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ portraits: [] });
+    expect(mocks.listPortraits).toHaveBeenCalledOnce();
+  });
+
+  it('allows a static global admin key to read the portrait map', async () => {
+    const response = await request(app)
+      .get('/api/admin/portraits/map')
+      .set('Authorization', 'Bearer static-portrait-global-admin-key');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({});
+    expect(mocks.getUserPortraitMap).toHaveBeenCalledOnce();
+  });
+
+  it('allows a static global admin key to reject a portrait', async () => {
+    const response = await request(app)
+      .delete('/api/admin/portraits/portrait_1')
+      .set('Authorization', 'Bearer static-portrait-global-admin-key');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true });
+    expect(mocks.getPortraitById).toHaveBeenCalledWith('portrait_1');
+    expect(mocks.rejectPortrait).toHaveBeenCalledWith('portrait_1');
+  });
+});
+
+afterAll(() => {
+  stopAuthTimers();
+});

--- a/server/tests/unit/portrait-data-query.test.ts
+++ b/server/tests/unit/portrait-data-query.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+  getPool: vi.fn(),
+}));
+
+import { getPool, query } from '../../src/db/client.js';
+import { approvePortrait, getPortraitData } from '../../src/db/portrait-db.js';
+
+const mockedQuery = vi.mocked(query);
+const mockedGetPool = vi.mocked(getPool);
+
+describe('getPortraitData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the portrait owner needed to authorize generated previews', async () => {
+    const row = {
+      portrait_data: Buffer.from('portrait'),
+      image_url: '/api/portraits/11111111-1111-4111-8111-111111111111.png',
+      status: 'generated' as const,
+      user_id: 'user_owner',
+    };
+    mockedQuery.mockResolvedValueOnce({ rows: [row] } as never);
+
+    const result = await getPortraitData('11111111-1111-4111-8111-111111111111');
+
+    expect(result).toEqual(row);
+    expect(mockedQuery).toHaveBeenCalledWith(
+      expect.stringMatching(/SELECT portrait_data, image_url, status, user_id[\s\S]+status IN \('approved', 'generated'\)/),
+      ['11111111-1111-4111-8111-111111111111'],
+    );
+  });
+});
+
+describe('approvePortrait', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockTransaction(updateRowCount: number) {
+    const client = {
+      query: vi.fn()
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ rowCount: updateRowCount })
+        .mockResolvedValue({}),
+      release: vi.fn(),
+    };
+    mockedGetPool.mockReturnValue({
+      connect: vi.fn().mockResolvedValue(client),
+    } as never);
+    return client;
+  }
+
+  it('does not let an owner reapprove an admin-rejected portrait or relink it', async () => {
+    const client = mockTransaction(0);
+
+    const result = await approvePortrait(
+      '11111111-1111-4111-8111-111111111111',
+      'user_owner',
+    );
+
+    expect(result).toBeNull();
+    expect(client.query).toHaveBeenNthCalledWith(2,
+      expect.stringMatching(/WHERE id = \$1 AND user_id = \$2 AND status = 'generated'/),
+      ['11111111-1111-4111-8111-111111111111', 'user_owner'],
+    );
+    expect(client.query).toHaveBeenNthCalledWith(3, 'ROLLBACK');
+    expect(client.query).toHaveBeenCalledTimes(3);
+    expect(mockedQuery).not.toHaveBeenCalled();
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('still approves and relinks a generated portrait owned by the caller', async () => {
+    const client = mockTransaction(1);
+    const approved = {
+      id: '11111111-1111-4111-8111-111111111111',
+      user_id: 'user_owner',
+      status: 'approved',
+    };
+    mockedQuery.mockResolvedValueOnce({ rows: [approved] } as never);
+
+    const result = await approvePortrait(approved.id, approved.user_id);
+
+    expect(result).toEqual(approved);
+    expect(client.query).toHaveBeenNthCalledWith(2,
+      expect.stringMatching(/WHERE id = \$1 AND user_id = \$2 AND status = 'generated'/),
+      [approved.id, approved.user_id],
+    );
+    expect(client.query).toHaveBeenNthCalledWith(3,
+      expect.stringContaining('UPDATE users SET portrait_id = $1'),
+      [approved.id, `/api/portraits/${approved.id}.png`, approved.user_id],
+    );
+    expect(client.query).toHaveBeenNthCalledWith(4,
+      expect.stringContaining('UPDATE member_profiles mp'),
+      [approved.id, approved.user_id],
+    );
+    expect(client.query).toHaveBeenNthCalledWith(5, 'COMMIT');
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+});

--- a/server/tests/unit/portrait-object-authorization.test.ts
+++ b/server/tests/unit/portrait-object-authorization.test.ts
@@ -1,0 +1,279 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  countMonthlyGenerations: vi.fn(),
+  createPortrait: vi.fn(),
+  generatePortrait: vi.fn(),
+  getPortraitData: vi.fn(),
+  approvePortrait: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  optionalAuth: (req: any, _res: any, next: any) => {
+    const userId = req.get('x-test-user-id');
+    if (userId) {
+      req.user = { id: userId, email: `${userId}@example.test` };
+    }
+    next();
+  },
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: 'user_attacker', email: 'attacker@example.test' };
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  requireGlobalAdmin: [],
+  isDevModeEnabled: () => false,
+  DEV_USERS: {},
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  query: (...args: unknown[]) => mocks.query(...args),
+}));
+
+vi.mock('../../src/db/portrait-db.js', () => ({
+  countMonthlyGenerations: (...args: unknown[]) => mocks.countMonthlyGenerations(...args),
+  getActivePortrait: vi.fn(),
+  getLatestGenerated: vi.fn(),
+  getPortraitData: (...args: unknown[]) => mocks.getPortraitData(...args),
+  getPublicBuilders: vi.fn(),
+  createPortrait: (...args: unknown[]) => mocks.createPortrait(...args),
+  approvePortrait: (...args: unknown[]) => mocks.approvePortrait(...args),
+  removeFromUser: vi.fn(),
+}));
+
+vi.mock('../../src/services/portrait-generator.js', () => ({
+  VIBE_OPTIONS: { casual: {} },
+  generatePortrait: (...args: unknown[]) => mocks.generatePortrait(...args),
+}));
+
+import { createPortraitRouter, createPublicPortraitRouter } from '../../src/routes/portraits.js';
+
+const GENERATED_PORTRAIT_ID = '11111111-1111-4111-8111-111111111111';
+const APPROVED_PORTRAIT_ID = '22222222-2222-4222-8222-222222222222';
+
+describe('portrait image object authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createApp() {
+    const app = express();
+    app.use('/api/portraits', createPublicPortraitRouter());
+    return app;
+  }
+
+  it('denies an anonymous caller access to a generated preview', async () => {
+    mocks.getPortraitData.mockResolvedValue({
+      portrait_data: Buffer.from('private generated portrait'),
+      image_url: `/api/portraits/${GENERATED_PORTRAIT_ID}.png`,
+      status: 'generated',
+      user_id: 'user_owner',
+    });
+
+    const response = await request(createApp())
+      .get(`/api/portraits/${GENERATED_PORTRAIT_ID}.png`);
+
+    expect(response.status).toBe(404);
+    expect(response.text).toBe('Portrait not found');
+  });
+
+  it('denies another authenticated user access to a generated preview', async () => {
+    mocks.getPortraitData.mockResolvedValue({
+      portrait_data: Buffer.from('private generated portrait'),
+      image_url: `/api/portraits/${GENERATED_PORTRAIT_ID}.png`,
+      status: 'generated',
+      user_id: 'user_owner',
+    });
+
+    const response = await request(createApp())
+      .get(`/api/portraits/${GENERATED_PORTRAIT_ID}.png`)
+      .set('x-test-user-id', 'user_other');
+
+    expect(response.status).toBe(404);
+    expect(response.text).toBe('Portrait not found');
+  });
+
+  it('allows the authenticated owner to view a generated preview', async () => {
+    const image = Buffer.from('private generated portrait');
+    mocks.getPortraitData.mockResolvedValue({
+      portrait_data: image,
+      image_url: `/api/portraits/${GENERATED_PORTRAIT_ID}.png`,
+      status: 'generated',
+      user_id: 'user_owner',
+    });
+
+    const response = await request(createApp())
+      .get(`/api/portraits/${GENERATED_PORTRAIT_ID}.png`)
+      .set('x-test-user-id', 'user_owner');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['cache-control']).toBe('private, no-store');
+    expect(response.body).toEqual(image);
+  });
+
+  it('allows anonymous public access to an approved portrait', async () => {
+    const image = Buffer.from('approved portrait');
+    mocks.getPortraitData.mockResolvedValue({
+      portrait_data: image,
+      image_url: `/api/portraits/${APPROVED_PORTRAIT_ID}.png`,
+      status: 'approved',
+      user_id: 'user_owner',
+    });
+
+    const response = await request(createApp())
+      .get(`/api/portraits/${APPROVED_PORTRAIT_ID}.png`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers['cache-control']).toBe('public, max-age=31536000, immutable');
+    expect(response.body).toEqual(image);
+  });
+});
+
+describe('portrait membership object authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.query.mockResolvedValue({
+      rows: [{ workos_organization_id: 'org_attacker_free' }],
+    });
+    mocks.countMonthlyGenerations.mockResolvedValue(0);
+    mocks.createPortrait.mockResolvedValue({ id: 'portrait_generated' });
+    mocks.generatePortrait.mockResolvedValue({
+      imageBuffer: Buffer.from('generated portrait'),
+      promptUsed: 'test prompt',
+    });
+  });
+
+  it('denies generation when the requested paid organization is not one of the caller memberships', async () => {
+    const hasActiveSubscription = vi.fn(async (orgId: string) => orgId === 'org_victim_paid');
+    const getProfileByOrgId = vi.fn().mockResolvedValue(null);
+    const app = express();
+    app.use(express.json());
+    app.use('/portraits', createPortraitRouter({
+      orgDb: { hasActiveSubscription } as any,
+      memberDb: { getProfileByOrgId } as any,
+      invalidateMemberContextCache: vi.fn(),
+    }));
+
+    const response = await request(app)
+      .post('/portraits/generate?org=org_victim_paid')
+      .send({ vibe: 'casual' });
+
+    expect(response.status).toBe(402);
+    expect(response.body.error).toBe('Active subscription required for portrait generation');
+    expect(hasActiveSubscription).not.toHaveBeenCalledWith('org_victim_paid');
+    expect(getProfileByOrgId).not.toHaveBeenCalledWith('org_victim_paid');
+    expect(mocks.countMonthlyGenerations).not.toHaveBeenCalled();
+    expect(mocks.generatePortrait).not.toHaveBeenCalled();
+  });
+
+  it('preserves portrait eligibility for a paid organization the caller belongs to', async () => {
+    mocks.query.mockResolvedValue({
+      rows: [{ workos_organization_id: 'org_attacker_paid' }],
+    });
+    const hasActiveSubscription = vi.fn(async (orgId: string) => orgId === 'org_attacker_paid');
+    const getProfileByOrgId = vi.fn().mockResolvedValue(null);
+    const app = express();
+    app.use('/portraits', createPortraitRouter({
+      orgDb: { hasActiveSubscription } as any,
+      memberDb: { getProfileByOrgId } as any,
+      invalidateMemberContextCache: vi.fn(),
+    }));
+
+    const response = await request(app)
+      .get('/portraits?org=org_attacker_paid');
+
+    expect(response.status).toBe(200);
+    expect(response.body.canGenerate).toBe(true);
+    expect(hasActiveSubscription).toHaveBeenCalledWith('org_attacker_paid');
+    expect(hasActiveSubscription).not.toHaveBeenCalledWith('org_victim_paid');
+  });
+
+  it('allows generation for a paid organization the caller belongs to', async () => {
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM organization_memberships')) {
+        return { rows: [{ workos_organization_id: 'org_attacker_paid' }] };
+      }
+      if (sql.includes('UPDATE member_portraits')) return { rows: [] };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+    const hasActiveSubscription = vi.fn(async (orgId: string) => orgId === 'org_attacker_paid');
+    const app = express();
+    app.use('/portraits', createPortraitRouter({
+      orgDb: { hasActiveSubscription } as any,
+      memberDb: { getProfileByOrgId: vi.fn() } as any,
+      invalidateMemberContextCache: vi.fn(),
+    }));
+
+    const response = await request(app)
+      .post('/portraits/generate?org=org_attacker_paid')
+      .field('vibe', 'casual');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      id: 'portrait_generated',
+      image_url: '/api/portraits/portrait_generated.png',
+      status: 'generated',
+      vibe: 'casual',
+    });
+    expect(hasActiveSubscription).toHaveBeenCalledWith('org_attacker_paid');
+    expect(mocks.countMonthlyGenerations).toHaveBeenCalledWith('user_attacker');
+    expect(mocks.generatePortrait).toHaveBeenCalledOnce();
+    expect(mocks.createPortrait).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: 'user_attacker',
+      status: 'generated',
+    }));
+  });
+});
+
+describe('portrait approval object authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createApp(invalidateMemberContextCache = vi.fn()) {
+    const app = express();
+    app.use(express.json());
+    app.use('/portraits', createPortraitRouter({
+      orgDb: {} as any,
+      memberDb: {} as any,
+      invalidateMemberContextCache,
+    }));
+    return { app, invalidateMemberContextCache };
+  }
+
+  it('reports a rejected or otherwise ineligible portrait as not found without relinking it', async () => {
+    mocks.approvePortrait.mockResolvedValue(null);
+    const { app, invalidateMemberContextCache } = createApp();
+
+    const response = await request(app)
+      .post('/portraits/approve')
+      .send({ portraitId: GENERATED_PORTRAIT_ID });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'Portrait not found' });
+    expect(mocks.approvePortrait).toHaveBeenCalledWith(GENERATED_PORTRAIT_ID, 'user_attacker');
+    expect(invalidateMemberContextCache).not.toHaveBeenCalled();
+  });
+
+  it('still approves a generated portrait owned by the caller', async () => {
+    const portrait = {
+      id: GENERATED_PORTRAIT_ID,
+      user_id: 'user_attacker',
+      status: 'approved',
+    };
+    mocks.approvePortrait.mockResolvedValue(portrait);
+    const { app, invalidateMemberContextCache } = createApp();
+
+    const response = await request(app)
+      .post('/portraits/approve')
+      .send({ portraitId: GENERATED_PORTRAIT_ID });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ portrait });
+    expect(mocks.approvePortrait).toHaveBeenCalledWith(GENERATED_PORTRAIT_ID, 'user_attacker');
+    expect(invalidateMemberContextCache).toHaveBeenCalledOnce();
+  });
+});

--- a/server/tests/unit/resource-and-member-hub-url-xss.test.ts
+++ b/server/tests/unit/resource-and-member-hub-url-xss.test.ts
@@ -1,0 +1,178 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
+
+function readPublicFile(path: string): string {
+  return readFileSync(join(process.cwd(), 'server/public', path), 'utf8');
+}
+
+function section(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  if (startIndex < 0 || endIndex < 0) throw new Error(`Missing section: ${start}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+describe('stored URL rendering regressions', () => {
+  it('renders hostile resource URLs as inert legacy text and preserves a valid fetch URL', async () => {
+    const source = readPublicFile('admin-addie.html');
+    const helperSource = section(
+      source,
+      'function getSafeHttpUrl(value)',
+      'function copyThreadId(el)',
+    );
+    const editResourceSource = section(
+      source,
+      'async function editResource(id)',
+      'function closeResourceModal()',
+    );
+    const dom = new JSDOM(`
+      <input id="resource-edit-id">
+      <div id="resource-title"></div>
+      <div id="resource-url"></div>
+      <div id="resource-summary"></div>
+      <div id="resource-insights"></div>
+      <textarea id="resource-addie-notes"></textarea>
+      <input id="resource-quality">
+      <input id="resource-tags">
+      <div id="resource-modal"></div>
+    `, { url: 'https://agenticadvertising.org/admin/addie' });
+    const hostileUrl = 'javascript:globalThis.__resourceXss = true';
+    const hostileImportance = '"><img src=x onerror="globalThis.__resourceXss = true">';
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({
+          id: 1,
+          title: 'Legacy resource',
+          source_url: hostileUrl,
+          summary: 'Stored safely',
+          key_insights: [{ importance: hostileImportance, insight: 'Safe insight' }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({
+          id: 2,
+          title: 'Valid resource',
+          fetch_url: 'https://source.example/article?ref=admin#details',
+          key_insights: [],
+        }),
+      });
+    const editResource = new Function(
+      'document',
+      'fetch',
+      'escapeHtml',
+      'alert',
+      `${helperSource}\n${editResourceSource}\nreturn editResource;`,
+    )(
+      dom.window.document,
+      fetchMock,
+      escapeHtml,
+      vi.fn(),
+    ) as (id: number) => Promise<void>;
+
+    await editResource(1);
+
+    const urlContainer = dom.window.document.getElementById('resource-url')!;
+    expect(urlContainer.querySelector('a')).toBeNull();
+    expect(urlContainer.textContent).toBe(hostileUrl);
+    expect(dom.window.document.getElementById('resource-insights')?.querySelector('img')).toBeNull();
+    expect(dom.window.document.querySelector('.badge-info')?.textContent).toBe('low');
+
+    await editResource(2);
+
+    const validLink = urlContainer.querySelector('a');
+    expect(validLink?.href).toBe('https://source.example/article?ref=admin#details');
+    expect(validLink?.target).toBe('_blank');
+    expect(validLink?.rel).toBe('noopener noreferrer');
+  });
+
+  it('hides unsafe member hub URLs and preserves credential-free HTTPS controls', () => {
+    const source = readPublicFile('membership/hub.html');
+    const helperSource = section(
+      source,
+      'function getSafeHttpsUrl(value)',
+      'function fmtDate(s)',
+    );
+    const renderSource = section(
+      source,
+      'function renderProfileCard(profile, profileCompleteness)',
+      'function renderActivity(activity)',
+    );
+    const dom = new JSDOM('<body></body>', {
+      url: 'https://agenticadvertising.org/membership/hub',
+    });
+    const renderProfileCard = new Function(
+      'document',
+      'config',
+      'escapeHtml',
+      `${helperSource}\n${renderSource}\nreturn renderProfileCard;`,
+    )(
+      dom.window.document,
+      { user: { firstName: 'Safe', lastName: 'Member' } },
+      escapeHtml,
+    ) as (profile: Record<string, unknown>, completeness: number) => string;
+
+    dom.window.document.body.innerHTML = renderProfileCard({
+      avatar_url: 'data:image/svg+xml,<svg onload="globalThis.__hubXss = true"></svg>',
+      linkedin_url: 'javascript:globalThis.__hubXss = true',
+      twitter_url: 'https://user:secret@social.example/profile',
+      expertise: [],
+    }, 50);
+
+    expect(dom.window.document.querySelector('.profile-avatar-preview img')).toBeNull();
+    expect(dom.window.document.querySelector('.profile-social-link')).toBeNull();
+    expect(dom.window.document.querySelector('script, [onload], [onerror]')).toBeNull();
+
+    for (const hostileAvatarUrl of [
+      'javascript:globalThis.__hubXss = true',
+      '//attacker.example/avatar.png',
+      'http://cdn.example/avatar.png',
+      'https://user:secret@cdn.example/avatar.png',
+      '/api/portraits/../../admin',
+    ]) {
+      dom.window.document.body.innerHTML = renderProfileCard({
+        avatar_url: hostileAvatarUrl,
+        expertise: [],
+      }, 50);
+      expect(dom.window.document.querySelector('.profile-avatar-preview img')).toBeNull();
+    }
+
+    for (const avatarUrl of [
+      '/api/portraits/11111111-1111-4111-8111-111111111111.png',
+      '/api/community/avatars/22222222-2222-4222-8222-222222222222.png',
+    ]) {
+      dom.window.document.body.innerHTML = renderProfileCard({
+        avatar_url: avatarUrl,
+        expertise: [],
+      }, 75);
+      expect(dom.window.document.querySelector('.profile-avatar-preview img')?.getAttribute('src'))
+        .toBe(avatarUrl);
+    }
+
+    dom.window.document.body.innerHTML = renderProfileCard({
+      avatar_url: 'https://cdn.example/avatar.png?size=small',
+      linkedin_url: 'https://www.linkedin.com/in/safe-member?ref=hub',
+      twitter_url: 'https://social.example/safe-member#profile',
+      expertise: [],
+    }, 100);
+
+    expect(dom.window.document.querySelector('.profile-avatar-preview img')?.getAttribute('src'))
+      .toBe('https://cdn.example/avatar.png?size=small');
+    const socialLinks = [...dom.window.document.querySelectorAll<HTMLAnchorElement>('.profile-social-link')];
+    expect(socialLinks.map(link => link.getAttribute('href'))).toEqual([
+      'https://www.linkedin.com/in/safe-member?ref=hub',
+      'https://social.example/safe-member#profile',
+    ]);
+    expect(socialLinks.every(link => link.rel === 'noopener noreferrer')).toBe(true);
+  });
+});

--- a/server/tests/unit/runtime-xss-regressions.test.ts
+++ b/server/tests/unit/runtime-xss-regressions.test.ts
@@ -1,0 +1,730 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
+
+function readPublicFile(relativePath: string): string {
+  return readFileSync(join(process.cwd(), 'server/public', relativePath), 'utf8');
+}
+
+function section(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  if (startIndex < 0 || endIndex < 0) {
+    throw new Error(`Could not extract section from ${start} to ${end}`);
+  }
+  return source.slice(startIndex, endIndex);
+}
+
+function loadSafePerspectiveExternalUrl(): (value: unknown) => string | null {
+  const source = readPublicFile('perspective-url.js');
+  return new Function(`${source}\nreturn getSafePerspectiveExternalUrl;`)() as (value: unknown) => string | null;
+}
+
+describe('runtime XSS regressions', () => {
+  it('keeps hostile Markdown link destinations out of executable admin transcript markup', () => {
+    const source = readPublicFile('admin-addie.html');
+    const renderMarkdownSource = section(
+      source,
+      'function linkifyBareUrls(html)',
+      'function renderExecutionPlan(',
+    );
+    const rendererDom = new JSDOM('<body></body>');
+    const renderMarkdown = new Function(
+      'document',
+      'currentUserNames',
+      `${renderMarkdownSource}\nreturn renderMarkdown;`,
+    )(rendererDom.window.document, {}) as (text: string) => string;
+
+    const quoteBreaking = renderMarkdown(
+      '[review](https://safe.example/path" onmouseover="globalThis.__xss = true)',
+    );
+    const quoteDom = new JSDOM(`<body>${quoteBreaking}</body>`);
+    const quoteLink = quoteDom.window.document.querySelector('a');
+
+    expect(quoteLink).not.toBeNull();
+    expect(quoteLink?.hasAttribute('onmouseover')).toBe(false);
+    expect(quoteLink?.getAttribute('href')).toMatch(/^https:\/\//);
+
+    const activeScheme = renderMarkdown('[review](javascript:globalThis.__xss = true)');
+    const schemeDom = new JSDOM(`<body>${activeScheme}</body>`);
+
+    expect(schemeDom.window.document.querySelector('a')).toBeNull();
+    expect(schemeDom.window.document.body.textContent).toContain('review');
+  });
+
+  it('renders stored Addie feedback notes and tags as text in the admin transcript', () => {
+    const source = readPublicFile('admin-addie.html');
+    const escapeHtmlSource = section(
+      source,
+      'function escapeHtml(text)',
+      'function copyThreadId(',
+    );
+    const renderThreadMessageSource = section(
+      source,
+      'function renderThreadMessage(msg)',
+      'function toggleRouterDecision(',
+    );
+    const helperDom = new JSDOM('<body></body>');
+    const escapeHtml = new Function(
+      'document',
+      `${escapeHtmlSource}\nreturn escapeHtml;`,
+    )(helperDom.window.document) as (text: string) => string;
+    const renderThreadMessage = new Function(
+      'escapeHtml',
+      'renderMarkdown',
+      'renderToolCalls',
+      `${renderThreadMessageSource}\nreturn renderThreadMessage;`,
+    )(
+      escapeHtml,
+      (text: string) => escapeHtml(text),
+      () => '',
+    ) as (message: Record<string, unknown>) => string;
+    const hostileNotes = '</textarea><img src=x onerror="globalThis.__feedbackXss = true">';
+    const hostileTag = '</span><script>globalThis.__feedbackXss = true</script>';
+
+    const html = renderThreadMessage({
+      message_id: '86b7df04-4c25-4627-bcee-c7c69c671ec3',
+      role: 'assistant',
+      content: 'Answer',
+      rating: 1,
+      rating_source: 'user',
+      rating_notes: hostileNotes,
+      feedback_tags: [hostileTag],
+    });
+    const dom = new JSDOM(`<body>${html}</body>`);
+
+    expect(dom.window.document.querySelector('img')).toBeNull();
+    expect(dom.window.document.querySelector('script')).toBeNull();
+    expect(dom.window.document.querySelector('textarea')?.value).toBe(hostileNotes);
+    expect(dom.window.document.querySelector('.existing-feedback')?.textContent).toContain(hostileTag);
+  });
+
+  it.each([
+    ['admin-brands.html', 'viewBrand'],
+    ['admin-properties.html', 'viewProperty'],
+  ])('renders hostile registry JSON as text in %s', async (fileName, functionName) => {
+    const source = readPublicFile(fileName);
+    const viewFunctionSource = section(
+      source,
+      `async function ${functionName}(domain)`,
+      'function closeViewModal()',
+    );
+    const dom = new JSDOM(`
+      <div id="viewModal"></div>
+      <div id="viewModalTitle"></div>
+      <div id="viewContent"></div>
+    `);
+    const payload = '</pre><img src=x onerror="globalThis.__registryXss = true"><script>globalThis.__registryXss = true</script>';
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({ attackerControlled: payload }),
+    });
+    const viewManifest = new Function(
+      'document',
+      'fetch',
+      `${viewFunctionSource}\nreturn ${functionName};`,
+    )(dom.window.document, fetchMock) as (domain: string) => Promise<void>;
+
+    await viewManifest('attacker.example');
+
+    const viewContent = dom.window.document.getElementById('viewContent')!;
+    expect(viewContent.querySelector('pre')?.textContent).toBe(
+      JSON.stringify({ attackerControlled: payload }, null, 2),
+    );
+    expect(viewContent.querySelector('img')).toBeNull();
+    expect(viewContent.querySelector('script')).toBeNull();
+  });
+
+  it('renders remote property validation details as text', () => {
+    const source = readPublicFile('admin-properties.html');
+    const displayValidationResultsSource = section(
+      source,
+      'function displayValidationResults(data)',
+      'function showValidateError(message)',
+    );
+    const dom = new JSDOM(`
+      <div id="validationResults"></div>
+      <button id="saveValidatedBtn"></button>
+      <div id="validateError"></div>
+    `);
+    const displayValidationResults = new Function(
+      'document',
+      `${displayValidationResultsSource}\nreturn displayValidationResults;`,
+    )(dom.window.document) as (data: Record<string, unknown>) => void;
+    const hostileUrl = '</p><img src=x onerror="globalThis.__propertyXss = true">';
+    const hostileError = '</li><script>globalThis.__propertyXss = true</script><li>';
+    const hostileWarning = '<img src=x onerror="globalThis.__propertyXss = true">';
+
+    displayValidationResults({
+      valid: false,
+      url: hostileUrl,
+      status_code: 400,
+      errors: [{ message: hostileError }],
+      warnings: [{ message: hostileWarning }],
+    });
+
+    const container = dom.window.document.getElementById('validationResults')!;
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.textContent).toContain(hostileUrl);
+    expect(container.textContent).toContain(hostileError);
+    expect(container.textContent).toContain(hostileWarning);
+    expect(dom.window.document.getElementById('saveValidatedBtn')?.style.display).toBe('inline-block');
+
+    displayValidationResults({
+      valid: true,
+      url: 'https://publisher.example/.well-known/adagents.json',
+      status_code: 200,
+      errors: [],
+      warnings: [],
+      raw_data: { authorized_agents: [{ url: 'https://agent.example' }], properties: [{ id: 'site' }] },
+    });
+
+    expect(container.textContent).toContain('Authorized agents: 1');
+    expect(container.textContent).toContain('Properties: 1');
+    expect(dom.window.document.getElementById('saveValidatedBtn')?.style.display).toBe('none');
+  });
+
+  it('assigns only credential-free HTTPS research logos through the DOM', () => {
+    const source = readPublicFile('admin-brands.html');
+    const displayResearchResultsSource = section(
+      source,
+      'function getSafeResearchLogoUrl(value)',
+      'async function saveResearchedBrand()',
+    );
+    const dom = new JSDOM(`
+      <div id="researchContent"></div>
+      <div id="researchResults"></div>
+      <div id="researchError"></div>
+    `, { url: 'https://agenticadvertising.org/admin/brands' });
+    const escapeHtml = (value: unknown) => String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+    const displayResearchResults = new Function(
+      'document',
+      'escapeHtml',
+      `${displayResearchResultsSource}\nreturn displayResearchResults;`,
+    )(dom.window.document, escapeHtml) as (data: Record<string, any>) => void;
+    const content = dom.window.document.getElementById('researchContent')!;
+
+    displayResearchResults({
+      domain: 'hostile.example',
+      manifest: {
+        name: 'Hostile brand',
+        logos: [{ url: 'javascript:globalThis.__brandXss = true' }],
+      },
+    });
+    expect(content.querySelector('img')).toBeNull();
+
+    displayResearchResults({
+      domain: 'quoted.example',
+      manifest: {
+        name: 'Quoted brand',
+        logos: [{ url: 'https://cdn.example/logo.png" onerror="globalThis.__brandXss = true' }],
+      },
+    });
+    const normalizedHostileLogo = content.querySelector('img');
+    expect(normalizedHostileLogo).not.toBeNull();
+    expect(normalizedHostileLogo?.hasAttribute('onerror')).toBe(false);
+    expect(normalizedHostileLogo?.src).toMatch(/^https:\/\/cdn\.example\//);
+
+    displayResearchResults({
+      domain: 'safe.example',
+      manifest: {
+        name: 'Safe brand',
+        logos: [{ url: 'https://cdn.example/logo.png?variant=dark' }],
+      },
+    });
+    expect(content.querySelector('img')?.src).toBe('https://cdn.example/logo.png?variant=dark');
+    expect(content.textContent).toContain('Safe brand');
+  });
+
+  it('does not turn member-controlled profile URLs into active card markup', () => {
+    const source = readPublicFile('member-card.js');
+    const renderMemberCard = new Function(
+      `${source}\nreturn renderMemberCard;`,
+    )() as (member: Record<string, unknown>, options?: Record<string, unknown>) => string;
+    const baseMember = {
+      display_name: 'Acme Builder',
+      slug: 'acme-builder',
+      offerings: [],
+      credentials: [],
+      markets: [],
+      data_providers: [],
+    };
+
+    const quoteBreakingHtml = renderMemberCard({
+      ...baseMember,
+      linkedin_url: 'https://www.linkedin.com/in/acme" onmouseover="globalThis.__memberXss = true',
+    });
+    const quoteDom = new JSDOM(`<body>${quoteBreakingHtml}</body>`);
+    const linkedIn = [...quoteDom.window.document.querySelectorAll('a')]
+      .find((link) => link.textContent === 'LinkedIn');
+
+    expect(linkedIn).toBeDefined();
+    expect(linkedIn?.hasAttribute('onmouseover')).toBe(false);
+    expect(linkedIn?.getAttribute('href')).toMatch(/^https:\/\//);
+
+    const activeSchemeHtml = renderMemberCard({
+      ...baseMember,
+      linkedin_url: 'javascript:globalThis.__memberXss = true',
+    });
+    const schemeDom = new JSDOM(`<body>${activeSchemeHtml}</body>`);
+
+    expect([...schemeDom.window.document.querySelectorAll('a')]
+      .some((link) => link.textContent === 'LinkedIn')).toBe(false);
+
+    const hostileWebsiteHtml = renderMemberCard({
+      ...baseMember,
+      contact_website: 'javascript:globalThis.__memberXss = true',
+    });
+    const websiteDom = new JSDOM(`<body>${hostileWebsiteHtml}</body>`);
+
+    expect([...websiteDom.window.document.querySelectorAll('a')]
+      .some((link) => link.textContent === 'Website')).toBe(false);
+  });
+
+  it('preserves valid member card URLs and the safe brand-domain website fallback', () => {
+    const source = readPublicFile('member-card.js');
+    const renderMemberCard = new Function(
+      `${source}\nreturn renderMemberCard;`,
+    )() as (member: Record<string, unknown>) => string;
+    const baseMember = {
+      display_name: 'Acme Builder',
+      slug: 'acme-builder',
+      offerings: [],
+      credentials: [],
+      markets: [],
+      data_providers: [],
+      linkedin_url: 'https://www.linkedin.com/company/acme-media',
+      resolved_brand: { contact: { domain: 'acme.example' } },
+    };
+    const dom = new JSDOM(`<body>${renderMemberCard(baseMember)}</body>`);
+    const links = [...dom.window.document.querySelectorAll('a')];
+
+    expect(links.find((link) => link.textContent === 'LinkedIn')?.href)
+      .toBe('https://www.linkedin.com/company/acme-media');
+    expect(links.find((link) => link.textContent === 'Website')?.href)
+      .toBe('https://acme.example/');
+  });
+
+  it('filters unsafe legacy profile URLs from the member detail view', () => {
+    const membersSource = readPublicFile('members.html');
+    const memberCardSource = readPublicFile('member-card.js');
+    const safeUrlSource = section(
+      memberCardSource,
+      'function getSafeHttpsUrl(value)',
+      '// ============================================\n// Publisher Card Rendering',
+    );
+    const renderDetailSource = section(
+      membersSource,
+      'function renderMemberDetail(member, perspectives, registryContributions, githubUsername)',
+      'async function loadWorkingGroupsForOrg(orgId)',
+    );
+    const dom = new JSDOM('<body><div id="detail-content"></div></body>');
+    const renderMemberDetail = new Function(
+      'document',
+      'escapeHtml',
+      'updateShareLinks',
+      `${safeUrlSource}\n${renderDetailSource}\nreturn renderMemberDetail;`,
+    )(
+      dom.window.document,
+      (value: unknown) => String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;'),
+      vi.fn(),
+    ) as (member: Record<string, unknown>, perspectives: unknown[], contributions: unknown[], github: null) => void;
+
+    renderMemberDetail({
+      display_name: 'Legacy Acme',
+      contact_website: 'javascript:globalThis.__memberXss = true',
+      linkedin_url: 'https://user:secret@linkedin.example/company/acme',
+      twitter_url: 'data:text/html,<script>globalThis.__memberXss = true</script>',
+      offerings: [],
+      markets: [],
+      agents: [],
+      publishers: [],
+      data_providers: [],
+      tags: [],
+    }, [], [], null);
+
+    expect(dom.window.document.querySelector('.detail-social')).toBeNull();
+  });
+
+  it('filters unsafe legacy profile URLs from the community person view', () => {
+    const source = readPublicFile('community/person-profile.html');
+    const safeUrlSource = section(
+      source,
+      'function getSafeHttpsUrl(value)',
+      'function formatTier(tier)',
+    );
+    const renderMainColumnSource = section(
+      source,
+      'function renderMainColumn(data)',
+      '// =========================================================================\n    // Sidebar rendering',
+    );
+    const dom = new JSDOM('<body><div id="main-column"></div></body>');
+    const renderMainColumn = new Function(
+      'document',
+      'escapeHtml',
+      'getSafePerspectiveExternalUrl',
+      `${safeUrlSource}\n${renderMainColumnSource}\nreturn renderMainColumn;`,
+    )(
+      dom.window.document,
+      (value: unknown) => String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;'),
+      loadSafePerspectiveExternalUrl(),
+    ) as (profile: Record<string, unknown>) => void;
+
+    renderMainColumn({
+      first_name: 'Legacy',
+      last_name: 'Acme',
+      linkedin_url: 'javascript:globalThis.__memberXss = true',
+      twitter_url: 'https://user:secret@social.example/acme',
+      expertise: [],
+      interests: [],
+      working_groups: [],
+      perspectives: [],
+      registry_contributions: [],
+      github_activity: [],
+      certifications: [],
+    });
+
+    expect(dom.window.document.querySelector('.profile-social')).toBeNull();
+  });
+
+  it('preserves valid HTTPS profile URLs in the community person view', () => {
+    const source = readPublicFile('community/person-profile.html');
+    const safeUrlSource = section(
+      source,
+      'function getSafeHttpsUrl(value)',
+      'function formatTier(tier)',
+    );
+    const renderMainColumnSource = section(
+      source,
+      'function renderMainColumn(data)',
+      '// =========================================================================\n    // Sidebar rendering',
+    );
+    const dom = new JSDOM('<body><div id="main-column"></div></body>');
+    const renderMainColumn = new Function(
+      'document',
+      'escapeHtml',
+      'getSafePerspectiveExternalUrl',
+      `${safeUrlSource}\n${renderMainColumnSource}\nreturn renderMainColumn;`,
+    )(
+      dom.window.document,
+      (value: unknown) => String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;'),
+      loadSafePerspectiveExternalUrl(),
+    ) as (profile: Record<string, unknown>) => void;
+
+    renderMainColumn({
+      first_name: 'Safe',
+      last_name: 'Acme',
+      linkedin_url: 'https://www.linkedin.com/in/acme?ref=community',
+      twitter_url: 'https://social.example/acme#profile',
+      expertise: [],
+      interests: [],
+      working_groups: [],
+      perspectives: [],
+      registry_contributions: [],
+      github_activity: [],
+      certifications: [],
+    });
+
+    const socialLinks = [...dom.window.document.querySelectorAll('.profile-social a')];
+    expect(socialLinks.map(link => link.getAttribute('href'))).toEqual([
+      'https://www.linkedin.com/in/acme?ref=community',
+      'https://social.example/acme#profile',
+    ]);
+  });
+
+  it.each([
+    'javascript:globalThis.__perspectiveXss = true',
+    'data:text/html,<script>globalThis.__perspectiveXss = true</script>',
+  ])('does not navigate the public perspective page to an active scheme: %s', async (externalUrl) => {
+    const source = readPublicFile('perspectives/article.html');
+    const loadArticleSource = section(
+      source,
+      'async function loadArticle()',
+      'function showError()',
+    );
+    const fakeWindow = {
+      location: {
+        pathname: '/perspectives/hostile-link',
+        href: 'https://agenticadvertising.org/perspectives/hostile-link',
+      },
+    };
+    const showError = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ content_type: 'link', external_url: externalUrl }),
+    });
+    const loadArticle = new Function(
+      'window',
+      'fetch',
+      'showError',
+      'getSafePerspectiveExternalUrl',
+      `let currentArticle = null;
+       ${loadArticleSource}
+       return loadArticle;`,
+    )(fakeWindow, fetchMock, showError, loadSafePerspectiveExternalUrl()) as () => Promise<void>;
+
+    await loadArticle();
+
+    expect(fakeWindow.location.href).toBe('https://agenticadvertising.org/perspectives/hostile-link');
+    expect(showError).toHaveBeenCalledOnce();
+  });
+
+  it('navigates a public link perspective to a valid HTTPS destination', async () => {
+    const source = readPublicFile('perspectives/article.html');
+    const loadArticleSource = section(
+      source,
+      'async function loadArticle()',
+      'function showError()',
+    );
+    const fakeWindow = {
+      location: {
+        pathname: '/perspectives/safe-link',
+        href: 'https://agenticadvertising.org/perspectives/safe-link',
+      },
+    };
+    const showError = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        content_type: 'link',
+        external_url: 'https://partner.example/field-notes',
+      }),
+    });
+    const loadArticle = new Function(
+      'window',
+      'fetch',
+      'showError',
+      'getSafePerspectiveExternalUrl',
+      `let currentArticle = null;
+       ${loadArticleSource}
+       return loadArticle;`,
+    )(fakeWindow, fetchMock, showError, loadSafePerspectiveExternalUrl()) as () => Promise<void>;
+
+    await loadArticle();
+
+    expect(fakeWindow.location.href).toBe('https://partner.example/field-notes');
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it('renders story cards with runtime-safe external or internal destinations', () => {
+    const source = readPublicFile('stories/index.html');
+    const buildPerspectiveCardSource = section(
+      source,
+      'function buildPerspectiveCard(item, className)',
+      '// Load perspectives and split',
+    );
+    const dom = new JSDOM('<body></body>', {
+      url: 'https://agenticadvertising.org/stories',
+    });
+    const buildPerspectiveCard = new Function(
+      'document',
+      'getSafePerspectiveExternalUrl',
+      'registerTopics',
+      'isNew',
+      `${buildPerspectiveCardSource}\nreturn buildPerspectiveCard;`,
+    )(
+      dom.window.document,
+      loadSafePerspectiveExternalUrl(),
+      vi.fn(),
+      () => false,
+    ) as (item: Record<string, unknown>, className: string) => HTMLAnchorElement;
+
+    const hostileCard = buildPerspectiveCard({
+      slug: 'hostile slug/child',
+      title: 'Hostile story',
+      external_url: 'javascript:globalThis.__perspectiveXss = true',
+      tags: [],
+    }, 'card');
+    expect(hostileCard.getAttribute('href')).toBe('/perspectives/hostile%20slug%2Fchild');
+    expect(hostileCard.hasAttribute('target')).toBe(false);
+    expect(hostileCard.hasAttribute('rel')).toBe(false);
+
+    const safeCard = buildPerspectiveCard({
+      slug: 'safe-story',
+      title: 'Safe story',
+      external_url: 'https://partner.example/field-notes',
+      tags: [],
+    }, 'card');
+    expect(safeCard.href).toBe('https://partner.example/field-notes');
+    expect(safeCard.target).toBe('_blank');
+    expect(safeCard.rel).toBe('noopener noreferrer');
+  });
+
+  it('opens only runtime-safe working-group link destinations externally', () => {
+    const source = readPublicFile('working-groups/detail.html');
+    const handlePostAnchorSource = section(
+      source,
+      'function handlePostAnchor()',
+      'function hasRequestedPostInLocation()',
+    );
+    const openExternal = vi.fn();
+    const openArticle = vi.fn();
+    const runAnchor = (externalUrl: string) => {
+      const handlePostAnchor = new Function(
+        'window',
+        'getSafePerspectiveExternalUrl',
+        'parseWorkingGroupPath',
+        'safeDecodeURIComponent',
+        'openArticle',
+        'post',
+        `const currentSlug = 'measurement'; const postsData = [post];
+         ${handlePostAnchorSource}
+         return handlePostAnchor;`,
+      )(
+        { location: { hash: '#post-field-notes' }, open: openExternal },
+        loadSafePerspectiveExternalUrl(),
+        () => ({ groupSlug: 'measurement', postSlug: null }),
+        decodeURIComponent,
+        openArticle,
+        { slug: 'field-notes', content_type: 'link', external_url: externalUrl },
+      ) as () => void;
+
+      handlePostAnchor();
+    };
+
+    runAnchor('javascript:globalThis.__perspectiveXss = true');
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(openArticle).toHaveBeenCalledWith('field-notes');
+
+    openArticle.mockClear();
+    runAnchor('https://partner.example/field-notes');
+    expect(openExternal).toHaveBeenCalledWith(
+      'https://partner.example/field-notes',
+      '_blank',
+      'noopener,noreferrer',
+    );
+    expect(openArticle).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'javascript:globalThis.__perspectiveXss = true',
+    'data:text/html,<script>globalThis.__perspectiveXss = true</script>',
+    'https://attacker:secret@partner.example/article',
+  ])('rejects unsafe legacy perspective destinations in every public sink: %s', (externalUrl) => {
+    const getSafeUrl = loadSafePerspectiveExternalUrl();
+
+    expect(getSafeUrl(externalUrl)).toBeNull();
+
+    const sinkSections = [
+      section(readPublicFile('working-groups/detail.html'), 'postsList.innerHTML = postsData.map(post => {', '// Check for post anchor'),
+      section(readPublicFile('working-groups/detail.html'), 'function handlePostAnchor()', 'function hasRequestedPostInLocation()'),
+      section(readPublicFile('stories/index.html'), 'function buildPerspectiveCard(item, className)', '// Load perspectives and split'),
+      section(readPublicFile('members.html'), 'const isArticle = p.content_type === \'article\';', 'const date = new Date(p.published_at)'),
+      section(readPublicFile('community/person-profile.html'), 'const isArticle = p.content_type === \'article\';', 'const date = new Date(p.published_at)'),
+    ];
+
+    for (const sinkSource of sinkSections) {
+      expect(sinkSource).toContain('getSafePerspectiveExternalUrl');
+    }
+    expect(sinkSections[0]).not.toContain('href="${escapeHtml(post.external_url)}"');
+    expect(sinkSections[1]).not.toContain('window.open(post.external_url');
+    expect(sinkSections[2]).not.toContain('card.href = item.external_url');
+    expect(sinkSections[3]).not.toContain('escapeHtml(p.external_url');
+    expect(sinkSections[4]).not.toContain('escapeHtml(p.external_url');
+  });
+
+  it('allows valid HTTPS perspective destinations in public sinks', () => {
+    expect(loadSafePerspectiveExternalUrl()('https://partner.example/field-notes?edition=1')).toBe(
+      'https://partner.example/field-notes?edition=1',
+    );
+  });
+
+  it('renders hostile account enrichment values as text and rejects unsafe LinkedIn links', () => {
+    const source = readPublicFile('admin-account-detail.html');
+    const helpersSource = section(
+      source,
+      'function signalRow(label, value)',
+      'function formatCompanyType(type)',
+    );
+    const escapeHtml = (value: unknown) => String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+    const { signalRow, linkedInSignalRow, enrichmentAttribution } = new Function(
+      'escapeHtml',
+      'formatDate',
+      `${helpersSource}\nreturn { signalRow, linkedInSignalRow, enrichmentAttribution };`,
+    )(escapeHtml, () => 'Jul 29, 2026') as {
+      signalRow: (label: unknown, value: unknown) => string;
+      linkedInSignalRow: (value: unknown) => string;
+      enrichmentAttribution: (enrichedAt: unknown, source: unknown) => string;
+    };
+    const hostileValue = '</span><img src=x onerror="globalThis.__enrichmentXss = true">';
+    const hostileLabel = '</span><script>globalThis.__enrichmentXss = true</script>';
+
+    const valueDom = new JSDOM(`<body>${signalRow(hostileLabel, hostileValue)}</body>`);
+    expect(valueDom.window.document.querySelector('img')).toBeNull();
+    expect(valueDom.window.document.querySelector('script')).toBeNull();
+    expect(valueDom.window.document.querySelector('.signal-label')?.textContent).toBe(hostileLabel);
+    expect(valueDom.window.document.querySelector('.signal-value')?.textContent).toBe(hostileValue);
+
+    for (const unsafeUrl of [
+      'javascript:globalThis.__enrichmentXss = true',
+      'https://attacker:secret@www.linkedin.com/company/acme',
+      'https://linkedin.example/company/acme',
+    ]) {
+      const linkDom = new JSDOM(`<body>${linkedInSignalRow(unsafeUrl)}</body>`);
+      expect(linkDom.window.document.querySelector('a')).toBeNull();
+      expect(linkDom.window.document.querySelector('.signal-value')?.textContent).toBe(unsafeUrl);
+    }
+
+    const sourceDom = new JSDOM(`<body>${enrichmentAttribution(
+      '2026-07-29T00:00:00Z',
+      '<img src=x onerror="globalThis.__enrichmentXss = true">',
+    )}</body>`);
+    expect(sourceDom.window.document.querySelector('img')).toBeNull();
+    expect(sourceDom.window.document.body.textContent).toContain(
+      'Updated Jul 29, 2026 via <img src=x onerror="globalThis.__enrichmentXss = true">',
+    );
+  });
+
+  it('renders a valid credential-free HTTPS LinkedIn enrichment URL', () => {
+    const source = readPublicFile('admin-account-detail.html');
+    const helpersSource = section(
+      source,
+      'function signalRow(label, value)',
+      'function formatCompanyType(type)',
+    );
+    const escapeHtml = (value: unknown) => String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+    const linkedInSignalRow = new Function(
+      'escapeHtml',
+      `${helpersSource}\nreturn linkedInSignalRow;`,
+    )(escapeHtml) as (value: unknown) => string;
+    const validUrl = 'https://www.linkedin.com/company/acme?trk=profile';
+    const dom = new JSDOM(`<body>${linkedInSignalRow(validUrl)}</body>`);
+    const link = dom.window.document.querySelector('a');
+
+    expect(link?.getAttribute('href')).toBe(validUrl);
+    expect(link?.textContent).toBe('View profile');
+    expect(link?.getAttribute('target')).toBe('_blank');
+    expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+});

--- a/server/tests/unit/working-group-perspective-url-validation.test.ts
+++ b/server/tests/unit/working-group-perspective-url-validation.test.ts
@@ -1,0 +1,270 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  getGroup: vi.fn(),
+  isMember: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  getPool: () => ({ query: mocks.poolQuery }),
+  query: vi.fn(),
+}));
+
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class {
+    getWorkingGroupBySlug = (...args: unknown[]) => mocks.getGroup(...args);
+    isMember = (...args: unknown[]) => mocks.isMember(...args);
+  },
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: 'user_author', email: 'author@example.test', firstName: 'Test', lastName: 'Author' };
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  requireGlobalAdmin: [(_req: any, _res: any, next: any) => next()],
+  optionalAuth: (_req: any, _res: any, next: any) => next(),
+  createRequireWorkingGroupLeader: () => (_req: any, _res: any, next: any) => next(),
+  createRequireWorkingGroupMember: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../src/notifications/slack.js', () => ({
+  notifyPublishedPost: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/slack/client.js', () => ({
+  createChannel: vi.fn(),
+  setChannelPurpose: vi.fn(),
+  sendChannelMessage: vi.fn(),
+  inviteToChannel: vi.fn(),
+  isSlackConfigured: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../src/addie/error-notifier.js', () => ({ notifySystemError: vi.fn() }));
+vi.mock('../../src/addie/jobs/committee-document-indexer.js', () => ({ reindexDocument: vi.fn() }));
+vi.mock('../../src/addie/mcp/docs-indexer.js', () => ({ refreshWorkingGroupDocs: vi.fn() }));
+vi.mock('../../src/addie/index.js', () => ({ invalidateMemberContextCache: vi.fn() }));
+vi.mock('../../src/addie/mcp/admin-tools.js', () => ({
+  invalidateWebAdminStatusCache: vi.fn(),
+  isWebUserAAOAdmin: vi.fn().mockResolvedValue(false),
+}));
+vi.mock('../../src/slack/sync.js', () => ({
+  syncWorkingGroupMembersFromSlack: vi.fn(),
+  syncAllWorkingGroupMembersFromSlack: vi.fn(),
+}));
+vi.mock('../../src/notifications/notification-service.js', () => ({ notifyUser: vi.fn() }));
+vi.mock('../../src/db/events-db.js', () => ({ eventsDb: {} }));
+vi.mock('../../src/db/community-db.js', () => ({ CommunityDatabase: class {} }));
+vi.mock('../../src/slack/db.js', () => ({ SlackDatabase: class {} }));
+vi.mock('../../src/addie/services/wg-welcome.js', () => ({ sendWgWelcomeMessage: vi.fn() }));
+vi.mock('../../src/services/working-group-membership-service.js', () => ({
+  joinWorkingGroup: vi.fn(),
+  expressCommitteeInterest: vi.fn(),
+  withdrawCommitteeInterest: vi.fn(),
+  listMyWorkingGroups: vi.fn(),
+  listMyCommitteeInterests: vi.fn(),
+  WorkingGroupMembershipError: class extends Error {
+    is() { return false; }
+  },
+}));
+
+import { createCommitteeRouters } from '../../src/routes/committees.js';
+import {
+  createWorkingGroupPost,
+  WorkingGroupContentError,
+} from '../../src/services/working-group-content-service.js';
+
+const SAFE_URL = 'https://partner.example/field-notes';
+const NON_CANONICAL_URL = 'https://Partner.Example:443/field notes?q=(roundup)';
+const CANONICAL_URL = 'https://partner.example/field%20notes?q=(roundup)';
+const UNSAFE_URLS = [
+  'javascript:globalThis.__perspectiveXss = true',
+  'data:text/html,<script>globalThis.__perspectiveXss = true</script>',
+  'http://partner.example/article',
+  'https://attacker:secret@partner.example/article',
+  '\thttps://partner.example/article',
+  'https://partner.example/article\r\n- [Injected](https://attacker.example)',
+  'https://partner.example/article\u007F',
+];
+
+const group = {
+  id: 'wg_security',
+  slug: 'security',
+  name: 'Security',
+  status: 'active',
+  leaders: [{ canonical_user_id: 'user_author' }],
+  slack_channel_id: null,
+};
+
+function mountRouter() {
+  const app = express();
+  app.use(express.json());
+  app.use('/working-groups', createCommitteeRouters().publicApiRouter);
+  return app;
+}
+
+function existingPost() {
+  return {
+    id: 'post_1',
+    slug: 'field-notes',
+    content_type: 'link',
+    title: 'Field notes',
+    content: null,
+    category: null,
+    excerpt: null,
+    external_url: SAFE_URL,
+    external_site_name: 'Partner',
+    author_user_id: 'user_author',
+    is_members_only: true,
+    status: 'draft',
+    published_at: null,
+  };
+}
+
+describe('working-group perspective external URL validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getGroup.mockResolvedValue(group);
+    mocks.isMember.mockResolvedValue(true);
+  });
+
+  it.each(UNSAFE_URLS)('rejects unsafe URLs in the shared create service before persistence: %s', async (externalUrl) => {
+    await expect(createWorkingGroupPost({
+      user: { id: 'user_author', email: 'author@example.test' },
+      slug: 'security',
+      title: 'Field notes',
+      postSlug: 'field-notes',
+      contentType: 'link',
+      externalUrl,
+    })).rejects.toMatchObject<Partial<WorkingGroupContentError>>({ code: 'invalid_external_url' });
+
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+  });
+
+  it('persists a valid HTTPS URL through the shared create service', async () => {
+    mocks.poolQuery.mockResolvedValue({ rows: [{ ...existingPost(), external_url: SAFE_URL }] });
+
+    await createWorkingGroupPost({
+      user: { id: 'user_author', email: 'author@example.test' },
+      slug: 'security',
+      title: 'Field notes',
+      postSlug: 'field-notes',
+      contentType: 'link',
+      externalUrl: SAFE_URL,
+    });
+
+    const insert = mocks.poolQuery.mock.calls.find(([sql]) => String(sql).includes('INSERT INTO perspectives'));
+    expect(insert?.[1]).toContain(SAFE_URL);
+  });
+
+  it.each(UNSAFE_URLS)('rejects unsafe URLs in the member update path before persistence: %s', async (externalUrl) => {
+    mocks.poolQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT * FROM perspectives')) return { rows: [existingPost()] };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    const response = await request(mountRouter())
+      .put('/working-groups/security/posts/post_1')
+      .send({ external_url: externalUrl });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Invalid external URL');
+    expect(mocks.poolQuery.mock.calls.some(([sql]) => String(sql).includes('UPDATE perspectives'))).toBe(false);
+  });
+
+  it.each(UNSAFE_URLS)('rejects unsafe URLs in leader create and update paths: %s', async (externalUrl) => {
+    const createResponse = await request(mountRouter())
+      .post('/working-groups/security/manage/posts')
+      .send({ post_slug: 'field-notes', title: 'Field notes', content_type: 'link', external_url: externalUrl });
+
+    expect(createResponse.status).toBe(400);
+    expect(createResponse.body.error).toBe('Invalid external URL');
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+
+    mocks.poolQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT * FROM perspectives')) return { rows: [existingPost()] };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+    const updateResponse = await request(mountRouter())
+      .put('/working-groups/security/manage/posts/post_1')
+      .send({ external_url: externalUrl });
+
+    expect(updateResponse.status).toBe(400);
+    expect(updateResponse.body.error).toBe('Invalid external URL');
+    expect(mocks.poolQuery.mock.calls.some(([sql]) => String(sql).includes('UPDATE perspectives'))).toBe(false);
+  });
+
+  it('persists valid HTTPS controls through member update and leader create/update', async () => {
+    mocks.poolQuery.mockImplementation(async (sql: string, values?: unknown[]) => {
+      if (sql.includes('SELECT * FROM perspectives')) return { rows: [existingPost()] };
+      if (sql.includes('INSERT INTO perspectives')) {
+        const externalUrlIndex = sql.includes('subtitle') ? 8 : 7;
+        return { rows: [{ ...existingPost(), external_url: values?.[externalUrlIndex] }] };
+      }
+      if (sql.includes('UPDATE perspectives')) return { rows: [{ ...existingPost(), external_url: SAFE_URL }] };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    const memberUpdate = await request(mountRouter())
+      .put('/working-groups/security/posts/post_1')
+      .send({ external_url: SAFE_URL });
+    expect(memberUpdate.status).toBe(200);
+
+    const leaderCreate = await request(mountRouter())
+      .post('/working-groups/security/manage/posts')
+      .send({ post_slug: 'field-notes', title: 'Field notes', content_type: 'link', external_url: SAFE_URL });
+    expect(leaderCreate.status).toBe(201);
+
+    const leaderUpdate = await request(mountRouter())
+      .put('/working-groups/security/manage/posts/post_1')
+      .send({ external_url: SAFE_URL });
+    expect(leaderUpdate.status).toBe(200);
+
+    expect(mocks.poolQuery.mock.calls.filter(([sql]) => String(sql).includes('UPDATE perspectives'))).toHaveLength(2);
+    expect(mocks.poolQuery.mock.calls.filter(([sql]) => String(sql).includes('INSERT INTO perspectives'))).toHaveLength(1);
+  });
+
+  it('persists canonical hrefs through every working-group writer', async () => {
+    mocks.poolQuery.mockImplementation(async (sql: string, values?: unknown[]) => {
+      if (sql.includes('SELECT * FROM perspectives')) return { rows: [existingPost()] };
+      if (sql.includes('INSERT INTO perspectives')) return { rows: [{ ...existingPost(), external_url: values?.[8] }] };
+      if (sql.includes('UPDATE perspectives')) {
+        const externalUrlIndex = sql.includes('external_url = $7') ? 6 : 7;
+        return { rows: [{ ...existingPost(), external_url: values?.[externalUrlIndex] }] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    await createWorkingGroupPost({
+      user: { id: 'user_author', email: 'author@example.test' },
+      slug: 'security',
+      title: 'Field notes',
+      postSlug: 'field-notes',
+      contentType: 'link',
+      externalUrl: NON_CANONICAL_URL,
+    });
+    const memberUpdate = await request(mountRouter())
+      .put('/working-groups/security/posts/post_1')
+      .send({ external_url: NON_CANONICAL_URL });
+    const leaderCreate = await request(mountRouter())
+      .post('/working-groups/security/manage/posts')
+      .send({ post_slug: 'field-notes', title: 'Field notes', content_type: 'link', external_url: NON_CANONICAL_URL });
+    const leaderUpdate = await request(mountRouter())
+      .put('/working-groups/security/manage/posts/post_1')
+      .send({ external_url: NON_CANONICAL_URL });
+
+    expect(memberUpdate.status).toBe(200);
+    expect(leaderCreate.status).toBe(201);
+    expect(leaderUpdate.status).toBe(200);
+    const writes = mocks.poolQuery.mock.calls.filter(([sql]) => /(?:INSERT INTO|UPDATE) perspectives/.test(String(sql)));
+    expect(writes).toHaveLength(4);
+    expect(writes.map(([sql, values]) => {
+      if (String(sql).includes('INSERT INTO perspectives')) return values?.[String(sql).includes('subtitle') ? 8 : 7];
+      return String(sql).includes('external_url = $7') ? values?.[6] : values?.[7];
+    })).toEqual([CANONICAL_URL, CANONICAL_URL, CANONICAL_URL, CANONICAL_URL]);
+  });
+});


### PR DESCRIPTION
## Summary

- close stored and runtime XSS paths across admin, member, registry, perspective, feed, and Addie rendering/writer flows
- enforce ownership and global-admin boundaries for chat continuation, profile administration, portrait eligibility, previews, and approval transitions
- centralize canonical external/member URL validation and add regression coverage for duplicate server and browser dataflows

## Root cause

Untrusted stored strings were reused across multiple HTML and navigation sinks without one canonical validation boundary. Several resource IDs, organization IDs, and lifecycle states were also trusted without consistently binding them to the authenticated owner or required global-admin role.

## Validation

- security review gate: clean
- testing review gate: clean
- code review gate: ready to push
- focused security suite: 193 tests passed across 17 files
- staged pre-commit suite: 1,025 general tests and 4,919 server unit tests passed; 30 skipped
- TypeScript typecheck and diff checks passed

No changeset is required because these are server/UI operational fixes with no protocol-package changes.
