### PR TITLE
fix(schema): unify delivery_status enum across delivery report, webhook, and snapshot

### DIFF
--- a/.changeset/unify-delivery-status-enum.md
+++ b/.changeset/unify-delivery-status-enum.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Extract `enums/delivery-status.json` and `$ref` it from `get-media-buys-response.json`, `get-media-buy-delivery-response.json`, and `media-buy-delivery-webhook-result.json`. These three schemas previously inlined `delivery_status` independently: the `get_media_buys` snapshot path had 6 values (including `not_delivering`), while the delivery report and webhook paths only had 5. A buyer polling `get_media_buy_delivery` or receiving a delivery webhook had no way to observe `not_delivering` even though that is precisely the "zero delivery during flight" signal those paths exist to surface. All three now resolve to the same 6-value enum.
+
+Fixes #6103.

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -663,7 +663,7 @@ The `by_package` array provides per-package delivery details with these key fiel
 **System State**:
 - **`delivery_status`**: System-reported operational state:
   - `delivering` - Package is actively delivering impressions
-  - `not_delivering` - Package is within its scheduled flight but has delivered zero impressions for at least one full staleness cycle
+  - `not_delivering` - Package recorded zero impressions for the entire reporting window while it was in-flight. Sellers should only report this for a final window; a provisional zero may reflect measurement lag.
   - `completed` - Package finished successfully
   - `budget_exhausted` - Package ran out of budget
   - `flight_ended` - Package reached its end date

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -663,6 +663,7 @@ The `by_package` array provides per-package delivery details with these key fiel
 **System State**:
 - **`delivery_status`**: System-reported operational state:
   - `delivering` - Package is actively delivering impressions
+  - `not_delivering` - Package is within its scheduled flight but has delivered zero impressions for at least one full staleness cycle
   - `completed` - Package finished successfully
   - `budget_exhausted` - Package ran out of budget
   - `flight_ended` - Package reached its end date

--- a/static/schemas/source/enums/delivery-status.json
+++ b/static/schemas/source/enums/delivery-status.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/enums/delivery-status.json",
   "title": "Delivery Status",
-  "description": "Operational delivery state of a media buy package",
+  "description": "Operational delivery state of a media buy package. Consumers MUST tolerate unrecognized values.",
   "type": "string",
   "enum": [
     "delivering",
@@ -14,7 +14,7 @@
   ],
   "enumDescriptions": {
     "delivering": "Package is actively delivering impressions within its scheduled flight",
-    "not_delivering": "Package is within its scheduled flight but has delivered zero impressions for at least one full staleness cycle",
+    "not_delivering": "Package is within its scheduled flight but is not delivering impressions for the observation window defined by the response surface",
     "completed": "Package has finished its scheduled flight",
     "budget_exhausted": "Package has spent its full allocated budget",
     "flight_ended": "Package's scheduled flight window has ended",

--- a/static/schemas/source/enums/delivery-status.json
+++ b/static/schemas/source/enums/delivery-status.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/delivery-status.json",
+  "title": "Delivery Status",
+  "description": "Operational delivery state of a media buy package",
+  "type": "string",
+  "enum": [
+    "delivering",
+    "not_delivering",
+    "completed",
+    "budget_exhausted",
+    "flight_ended",
+    "goal_met"
+  ],
+  "enumDescriptions": {
+    "delivering": "Package is actively delivering impressions within its scheduled flight",
+    "not_delivering": "Package is within its scheduled flight but has delivered zero impressions for at least one full staleness cycle",
+    "completed": "Package has finished its scheduled flight",
+    "budget_exhausted": "Package has spent its full allocated budget",
+    "flight_ended": "Package's scheduled flight window has ended",
+    "goal_met": "Package has reached its delivery goal"
+  }
+}

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -313,7 +313,7 @@
                     },
                     "delivery_status": {
                       "$ref": "/schemas/enums/delivery-status.json",
-                      "description": "System-reported operational state of this package. Reflects actual delivery state independent of buyer pause control."
+                      "description": "System-reported operational state of this package. Reflects actual delivery state independent of buyer pause control. 'not_delivering' means zero impressions were recorded for the entire reporting_period while the package was in-flight. Sellers SHOULD only report 'not_delivering' once the package's data is_final for the period — a provisional (is_final: false) zero may still be measurement catching up, not genuine non-delivery."
                     },
                     "paused": {
                       "type": "boolean",

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -312,15 +312,8 @@
                       "pattern": "^[A-Z]{3}$"
                     },
                     "delivery_status": {
-                      "type": "string",
-                      "description": "System-reported operational state of this package. Reflects actual delivery state independent of buyer pause control.",
-                      "enum": [
-                        "delivering",
-                        "completed",
-                        "budget_exhausted",
-                        "flight_ended",
-                        "goal_met"
-                      ]
+                      "$ref": "/schemas/enums/delivery-status.json",
+                      "description": "System-reported operational state of this package. Reflects actual delivery state independent of buyer pause control."
                     },
                     "paused": {
                       "type": "boolean",

--- a/static/schemas/source/media-buy/get-media-buys-response.json
+++ b/static/schemas/source/media-buy/get-media-buys-response.json
@@ -403,16 +403,8 @@
                       "minimum": 0
                     },
                     "delivery_status": {
-                      "type": "string",
-                      "description": "Operational delivery state of this package. 'not_delivering' means the package is within its scheduled flight but has delivered zero impressions for at least one full staleness cycle — the signal for automated price adjustments or buyer alerts. Implementers must not return 'not_delivering' until at least staleness_seconds have elapsed since package activation.",
-                      "enum": [
-                        "delivering",
-                        "not_delivering",
-                        "completed",
-                        "budget_exhausted",
-                        "flight_ended",
-                        "goal_met"
-                      ]
+                      "$ref": "/schemas/enums/delivery-status.json",
+                      "description": "Operational delivery state of this package. 'not_delivering' means the package is within its scheduled flight but has delivered zero impressions for at least one full staleness cycle — the signal for automated price adjustments or buyer alerts. Implementers must not return 'not_delivering' until at least staleness_seconds have elapsed since package activation."
                     },
                     "ext": {
                       "$ref": "/schemas/core/ext.json",

--- a/static/schemas/source/media-buy/media-buy-delivery-webhook-result.json
+++ b/static/schemas/source/media-buy/media-buy-delivery-webhook-result.json
@@ -163,7 +163,8 @@
                       "pattern": "^[A-Z]{3}$"
                     },
                     "delivery_status": {
-                      "$ref": "/schemas/enums/delivery-status.json"
+                      "$ref": "/schemas/enums/delivery-status.json",
+                      "description": "System-reported operational state of this package. Reflects actual delivery state independent of buyer pause control. 'not_delivering' means zero impressions were recorded for the entire reporting_period while the package was in-flight. Sellers SHOULD only report 'not_delivering' once the package's data is_final for the period — a provisional (is_final: false) zero may still be measurement catching up, not genuine non-delivery."
                     },
                     "paused": {
                       "type": "boolean"

--- a/static/schemas/source/media-buy/media-buy-delivery-webhook-result.json
+++ b/static/schemas/source/media-buy/media-buy-delivery-webhook-result.json
@@ -163,14 +163,7 @@
                       "pattern": "^[A-Z]{3}$"
                     },
                     "delivery_status": {
-                      "type": "string",
-                      "enum": [
-                        "delivering",
-                        "completed",
-                        "budget_exhausted",
-                        "flight_ended",
-                        "goal_met"
-                      ]
+                      "$ref": "/schemas/enums/delivery-status.json"
                     },
                     "paused": {
                       "type": "boolean"


### PR DESCRIPTION
## Why

`delivery_status` was inlined independently in three schemas and had drifted: `get-media-buys-response.json` (the `get_media_buys` snapshot path) had 6 values including `not_delivering`, while `get-media-buy-delivery-response.json` and `media-buy-delivery-webhook-result.json` only had 5. A buyer polling `get_media_buy_delivery` or receiving a delivery webhook had no way to observe `not_delivering`, even though "zero delivery during flight" is exactly what those paths exist to surface.

Fixes #6103.

## What Changed

- Extracted `static/schemas/source/enums/delivery-status.json` (6 values, with `enumDescriptions`), following the existing `enums/pricing-model.json` extraction pattern.
- Replaced the three independent inline enums with `$ref` to the shared enum, preserving each schema's existing per-field `description` override where one existed.
- Added a `minor` changeset (new enum value permitted on two existing paths).
- Updated `docs/media-buy/task-reference/get_media_buy_delivery.mdx`, which still listed only the old 5-value set — found during review since it's the doc for the exact endpoint this PR changes.

## Test plan

- [x] `npm run build:schemas` — bundled output resolves the `$ref` to all 6 values on all three schemas
- [x] `npm run test:schemas`, `test:json-schema`, `test:extension-schemas`, `test:build-schemas-hoist-enums` — all pass
- [x] `npm run typecheck`, `npm run lint:schema-links` — clean
- [x] Changeset scope/status gates (`check-changeset-protocol-scope.cjs`, `changesets status --since=origin/main`) — pass
- [x] `npm run test:docs-nav` — pass