### PR TITLE
fix(security): require signed Slack webhooks

### DIFF
--- a/server/src/middleware/slack.ts
+++ b/server/src/middleware/slack.ts
@@ -45,9 +45,9 @@ export function createSlackSignatureVerifier(
   appName: string = 'Slack'
 ): RequestHandler {
   return (req: Request, res: Response, next: NextFunction): void => {
-    if (!signingSecret) {
-      logger.warn(`${appName}: Signing secret not configured, skipping verification`);
-      next();
+    if (!signingSecret?.trim()) {
+      logger.error(`${appName}: Signing secret not configured; rejecting webhook`);
+      res.status(503).json({ error: 'Service unavailable' });
       return;
     }
 
@@ -61,7 +61,7 @@ export function createSlackSignatureVerifier(
     }
 
     const rawBody = (req as any).rawBody;
-    if (!rawBody) {
+    if (typeof rawBody !== 'string') {
       logger.warn(`${appName}: Raw body not captured for signature verification`);
       res.status(500).json({ error: 'Internal error' });
       return;

--- a/server/src/routes/slack.ts
+++ b/server/src/routes/slack.ts
@@ -11,7 +11,6 @@
 
 import { Router } from 'express';
 import { createLogger } from '../logger.js';
-import { isSlackSigningConfigured } from '../slack/verify.js';
 import { handleSlashCommand } from '../slack/commands.js';
 import { handleSlackEvent } from '../slack/events.js';
 import {
@@ -30,6 +29,10 @@ const logger = createLogger('slack-routes');
  */
 export function createSlackRouter(): { aaobotRouter: Router; addieRouter: Router } {
   const aaobotRouter = Router();
+  const verifyAaoSlackSignature = createSlackSignatureVerifier(
+    process.env.SLACK_SIGNING_SECRET,
+    'AAO Bot'
+  );
   // Create wrapper router for Addie that handles URL verification first
   const addieRouter = Router();
 
@@ -41,7 +44,7 @@ export function createSlackRouter(): { aaobotRouter: Router; addieRouter: Router
   aaobotRouter.post(
     '/commands',
     slackUrlencodedParser(),
-    createSlackSignatureVerifier(process.env.SLACK_SIGNING_SECRET, 'AAO Bot'),
+    verifyAaoSlackSignature,
     async (req, res) => {
       try {
         const command = req.body;
@@ -71,26 +74,12 @@ export function createSlackRouter(): { aaobotRouter: Router; addieRouter: Router
   aaobotRouter.post(
     '/events',
     slackJsonParser(),
+    verifyAaoSlackSignature,
     async (req, res) => {
       try {
-        // Handle URL verification challenge (before signature verification)
+        // Signature verification runs before URL verification and event handling.
         if (handleUrlVerification(req, res)) {
           return;
-        }
-
-        // Verify the request is from Slack
-        if (isSlackSigningConfigured()) {
-          const verifier = createSlackSignatureVerifier(
-            process.env.SLACK_SIGNING_SECRET,
-            'AAO Bot'
-          );
-          // Run verification manually since we already parsed the body
-          const result = await new Promise<boolean>((resolve) => {
-            verifier(req, res, () => resolve(true));
-            // If verifier doesn't call next(), it sent a response
-            setTimeout(() => resolve(false), 0);
-          });
-          if (!result) return;
         }
 
         // Handle events asynchronously (don't block response)

--- a/server/src/slack/verify.ts
+++ b/server/src/slack/verify.ts
@@ -6,10 +6,7 @@
  */
 
 import crypto from 'crypto';
-import type { Request, Response, NextFunction } from 'express';
 import { logger } from '../logger.js';
-
-const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
 
 /**
  * Verify a Slack request signature
@@ -52,57 +49,6 @@ export function verifySlackSignature(
   } catch {
     return false;
   }
-}
-
-/**
- * Express middleware to verify Slack request signatures
- *
- * Requires express.raw() or express.text() middleware to be used
- * before this middleware to preserve the raw body.
- */
-export function verifySlackRequest(req: Request, res: Response, next: NextFunction): void {
-  if (!SLACK_SIGNING_SECRET) {
-    logger.warn('SLACK_SIGNING_SECRET not configured, skipping verification');
-    next();
-    return;
-  }
-
-  const signature = req.headers['x-slack-signature'] as string;
-  const timestamp = req.headers['x-slack-request-timestamp'] as string;
-
-  if (!signature || !timestamp) {
-    logger.warn('Missing Slack signature headers');
-    res.status(401).json({ error: 'Missing signature headers' });
-    return;
-  }
-
-  // Get raw body - express.json() parses it, so we need to reconstruct
-  // For URL-encoded forms (slash commands), we need the raw body
-  const rawBody = typeof req.body === 'string'
-    ? req.body
-    : JSON.stringify(req.body);
-
-  const isValid = verifySlackSignature(
-    SLACK_SIGNING_SECRET,
-    signature,
-    timestamp,
-    rawBody
-  );
-
-  if (!isValid) {
-    logger.warn('Invalid Slack signature');
-    res.status(401).json({ error: 'Invalid signature' });
-    return;
-  }
-
-  next();
-}
-
-/**
- * Check if Slack signing secret is configured
- */
-export function isSlackSigningConfigured(): boolean {
-  return Boolean(SLACK_SIGNING_SECRET);
 }
 
 /**

--- a/server/tests/unit/slack-webhook-signature-gate.test.ts
+++ b/server/tests/unit/slack-webhook-signature-gate.test.ts
@@ -1,0 +1,316 @@
+import crypto from 'node:crypto';
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  handleSlashCommand: vi.fn(),
+  handleSlackEvent: vi.fn(),
+}));
+
+vi.mock('../../src/slack/commands.js', () => ({
+  handleSlashCommand: (...args: unknown[]) => mocks.handleSlashCommand(...args),
+}));
+
+vi.mock('../../src/slack/events.js', () => ({
+  handleSlackEvent: (...args: unknown[]) => mocks.handleSlackEvent(...args),
+}));
+
+vi.mock('../../src/addie/index.js', () => ({
+  getAddieBoltRouter: vi.fn(() => null),
+}));
+
+import { createSlackRouter } from '../../src/routes/slack.js';
+import { createSlackSignatureVerifier } from '../../src/middleware/slack.js';
+
+const SIGNING_SECRET = 'test_slack_signing_secret';
+const originalSigningSecret = process.env.SLACK_SIGNING_SECRET;
+
+function timestamp(secondsOffset = 0): string {
+  return String(Math.floor(Date.now() / 1000) + secondsOffset);
+}
+
+function signature(body: string, requestTimestamp: string, secret = SIGNING_SECRET): string {
+  return `v0=${crypto
+    .createHmac('sha256', secret)
+    .update(`v0:${requestTimestamp}:${body}`)
+    .digest('hex')}`;
+}
+
+function mountRouter(signingSecret: string | null = SIGNING_SECRET) {
+  if (signingSecret === null) {
+    delete process.env.SLACK_SIGNING_SECRET;
+  } else {
+    process.env.SLACK_SIGNING_SECRET = signingSecret;
+  }
+
+  const app = express();
+  const { aaobotRouter } = createSlackRouter();
+  app.use('/api/slack/aaobot', aaobotRouter);
+  return app;
+}
+
+function signedHeaders(body: string, requestTimestamp = timestamp()) {
+  return {
+    requestTimestamp,
+    requestSignature: signature(body, requestTimestamp),
+  };
+}
+
+describe('AAO Slack webhook signature gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.handleSlashCommand.mockResolvedValue({ response_type: 'ephemeral', text: 'ok' });
+    mocks.handleSlackEvent.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    if (originalSigningSecret === undefined) {
+      delete process.env.SLACK_SIGNING_SECRET;
+    } else {
+      process.env.SLACK_SIGNING_SECRET = originalSigningSecret;
+    }
+  });
+
+  it.each([
+    ['missing', null],
+    ['empty', ''],
+    ['whitespace-only', '   '],
+  ])('rejects commands and events when the signing secret is %s', async (_name, signingSecret) => {
+    const app = mountRouter(signingSecret);
+
+    const commandResponse = await request(app)
+      .post('/api/slack/aaobot/commands')
+      .type('form')
+      .send('command=%2Faao&text=status');
+    const eventResponse = await request(app)
+      .post('/api/slack/aaobot/events')
+      .send({ type: 'event_callback', event: { type: 'team_join' } });
+
+    expect(commandResponse.status).toBe(503);
+    expect(eventResponse.status).toBe(503);
+    expect(mocks.handleSlashCommand).not.toHaveBeenCalled();
+    expect(mocks.handleSlackEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing signature headers before either handler', async () => {
+    const app = mountRouter();
+
+    const commandResponse = await request(app)
+      .post('/api/slack/aaobot/commands')
+      .type('form')
+      .send('command=%2Faao&text=status');
+    const eventResponse = await request(app)
+      .post('/api/slack/aaobot/events')
+      .send({ type: 'event_callback', event: { type: 'team_join' } });
+
+    expect(commandResponse.status).toBe(401);
+    expect(eventResponse.status).toBe(401);
+    expect(mocks.handleSlashCommand).not.toHaveBeenCalled();
+    expect(mocks.handleSlackEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid signatures before either handler', async () => {
+    const app = mountRouter();
+    const requestTimestamp = timestamp();
+
+    const commandResponse = await request(app)
+      .post('/api/slack/aaobot/commands')
+      .set('X-Slack-Request-Timestamp', requestTimestamp)
+      .set('X-Slack-Signature', 'v0=invalid')
+      .type('form')
+      .send('command=%2Faao&text=status');
+    const eventResponse = await request(app)
+      .post('/api/slack/aaobot/events')
+      .set('X-Slack-Request-Timestamp', requestTimestamp)
+      .set('X-Slack-Signature', 'v0=invalid')
+      .send({ type: 'event_callback', event: { type: 'team_join' } });
+
+    expect(commandResponse.status).toBe(401);
+    expect(eventResponse.status).toBe(401);
+    expect(mocks.handleSlashCommand).not.toHaveBeenCalled();
+    expect(mocks.handleSlackEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects otherwise valid stale signatures before either handler', async () => {
+    const app = mountRouter();
+    const requestTimestamp = timestamp(-360);
+    const commandBody = 'command=%2Faao&text=status';
+    const eventPayload = { type: 'event_callback', event: { type: 'team_join' } };
+    const eventBody = JSON.stringify(eventPayload);
+
+    const commandResponse = await request(app)
+      .post('/api/slack/aaobot/commands')
+      .set('X-Slack-Request-Timestamp', requestTimestamp)
+      .set('X-Slack-Signature', signature(commandBody, requestTimestamp))
+      .type('form')
+      .send(commandBody);
+    const eventResponse = await request(app)
+      .post('/api/slack/aaobot/events')
+      .set('X-Slack-Request-Timestamp', requestTimestamp)
+      .set('X-Slack-Signature', signature(eventBody, requestTimestamp))
+      .send(eventPayload);
+
+    expect(commandResponse.status).toBe(401);
+    expect(eventResponse.status).toBe(401);
+    expect(mocks.handleSlashCommand).not.toHaveBeenCalled();
+    expect(mocks.handleSlackEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects bodies changed after their signatures were created', async () => {
+    const app = mountRouter();
+    const requestTimestamp = timestamp();
+    const signedCommandBody = 'command=%2Faao&text=status';
+    const sentCommandBody = 'command=%2Faao&text=admin';
+    const signedEventBody = JSON.stringify({
+      type: 'event_callback',
+      event: { type: 'team_join', user: { id: 'U_SAFE' } },
+    });
+    const sentEventPayload = {
+      type: 'event_callback',
+      event: { type: 'team_join', user: { id: 'U_ATTACKER' } },
+    };
+
+    const commandResponse = await request(app)
+      .post('/api/slack/aaobot/commands')
+      .set('X-Slack-Request-Timestamp', requestTimestamp)
+      .set('X-Slack-Signature', signature(signedCommandBody, requestTimestamp))
+      .type('form')
+      .send(sentCommandBody);
+    const eventResponse = await request(app)
+      .post('/api/slack/aaobot/events')
+      .set('X-Slack-Request-Timestamp', requestTimestamp)
+      .set('X-Slack-Signature', signature(signedEventBody, requestTimestamp))
+      .send(sentEventPayload);
+
+    expect(commandResponse.status).toBe(401);
+    expect(eventResponse.status).toBe(401);
+    expect(mocks.handleSlashCommand).not.toHaveBeenCalled();
+    expect(mocks.handleSlackEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects semantically equivalent JSON when the transmitted bytes differ', async () => {
+    const app = mountRouter();
+    const requestTimestamp = timestamp();
+    const compactBody = '{"type":"event_callback","event":{"type":"app_mention","text":"hello"}}';
+    const whitespaceChangedBody = '{\n  "type": "event_callback",\n  "event": { "type": "app_mention", "text": "hello" }\n}';
+
+    const response = await request(app)
+      .post('/api/slack/aaobot/events')
+      .set('Content-Type', 'application/json')
+      .set('X-Slack-Request-Timestamp', requestTimestamp)
+      .set('X-Slack-Signature', signature(compactBody, requestTimestamp))
+      .send(whitespaceChangedBody);
+
+    expect(response.status).toBe(401);
+    expect(mocks.handleSlackEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects semantically equivalent URL encoding when the transmitted bytes differ', async () => {
+    const app = mountRouter();
+    const requestTimestamp = timestamp();
+    const percentEncodedBody = 'command=%2Faao&text=a%20b';
+    const plusEncodedBody = 'command=%2Faao&text=a+b';
+
+    const response = await request(app)
+      .post('/api/slack/aaobot/commands')
+      .set('X-Slack-Request-Timestamp', requestTimestamp)
+      .set('X-Slack-Signature', signature(percentEncodedBody, requestTimestamp))
+      .type('form')
+      .send(plusEncodedBody);
+
+    expect(response.status).toBe(401);
+    expect(mocks.handleSlashCommand).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid signed command using the exact URL-encoded body', async () => {
+    const app = mountRouter();
+    const body = 'command=%2Faao&text=a+b%2Bc&note=%E2%9C%93&user_id=U123';
+    const headers = signedHeaders(body);
+
+    const response = await request(app)
+      .post('/api/slack/aaobot/commands')
+      .set('X-Slack-Request-Timestamp', headers.requestTimestamp)
+      .set('X-Slack-Signature', headers.requestSignature)
+      .type('form')
+      .send(body);
+
+    expect(response.status).toBe(200);
+    expect(mocks.handleSlashCommand).toHaveBeenCalledOnce();
+    expect(mocks.handleSlashCommand).toHaveBeenCalledWith(expect.objectContaining({
+      command: '/aao',
+      text: 'a b+c',
+      note: '✓',
+      user_id: 'U123',
+    }));
+    expect(mocks.handleSlackEvent).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid signed event using the exact JSON body', async () => {
+    const app = mountRouter();
+    const body = '{\n  "event": { "text": "Café ☕", "type": "app_mention" },\n  "type": "event_callback"\n}';
+    const headers = signedHeaders(body);
+
+    const response = await request(app)
+      .post('/api/slack/aaobot/events')
+      .set('Content-Type', 'application/json')
+      .set('X-Slack-Request-Timestamp', headers.requestTimestamp)
+      .set('X-Slack-Signature', headers.requestSignature)
+      .send(body);
+
+    expect(response.status).toBe(200);
+    expect(mocks.handleSlackEvent).toHaveBeenCalledOnce();
+    expect(mocks.handleSlackEvent).toHaveBeenCalledWith({
+      event: { text: 'Café ☕', type: 'app_mention' },
+      type: 'event_callback',
+    });
+    expect(mocks.handleSlashCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects a valid signature when exact raw-body capture middleware is missing', async () => {
+    process.env.SLACK_SIGNING_SECRET = SIGNING_SECRET;
+    const app = express();
+    const reachedHandler = vi.fn((_req, res) => res.status(204).send());
+    const requestTimestamp = timestamp();
+    app.post(
+      '/without-parser',
+      createSlackSignatureVerifier(SIGNING_SECRET, 'Test Slack app'),
+      reachedHandler,
+    );
+
+    const response = await request(app)
+      .post('/without-parser')
+      .set('X-Slack-Request-Timestamp', requestTimestamp)
+      .set('X-Slack-Signature', signature('', requestTimestamp));
+
+    expect(response.status).toBe(500);
+    expect(reachedHandler).not.toHaveBeenCalled();
+  });
+
+  it('answers only valid signed URL verification challenges', async () => {
+    const app = mountRouter();
+    const payload = { type: 'url_verification', challenge: 'verified-challenge' };
+    const body = JSON.stringify(payload);
+    const headers = signedHeaders(body);
+
+    const unsignedResponse = await request(app)
+      .post('/api/slack/aaobot/events')
+      .send(payload);
+    const invalidResponse = await request(app)
+      .post('/api/slack/aaobot/events')
+      .set('X-Slack-Request-Timestamp', headers.requestTimestamp)
+      .set('X-Slack-Signature', 'v0=invalid')
+      .send(payload);
+    const validResponse = await request(app)
+      .post('/api/slack/aaobot/events')
+      .set('X-Slack-Request-Timestamp', headers.requestTimestamp)
+      .set('X-Slack-Signature', headers.requestSignature)
+      .send(payload);
+
+    expect(unsignedResponse.status).toBe(401);
+    expect(invalidResponse.status).toBe(401);
+    expect(validResponse.status).toBe(200);
+    expect(validResponse.body).toEqual({ challenge: 'verified-challenge' });
+    expect(mocks.handleSlackEvent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- fail closed when the AAO Slack signing secret is missing, empty, or whitespace-only
- require signature verification for slash commands, events, and URL verification challenges before any handler runs
- verify exact captured request bytes and remove the duplicate fail-open verifier path
- add production-router regressions for unsigned, stale, invalid, tampered, and valid signed requests

## Root cause

The shared Slack verifier called `next()` when `SLACK_SIGNING_SECRET` was absent, while the events route conditionally skipped verification entirely. That allowed public forged commands and events to reach handlers, including identity and prospect-processing side effects.

## Impact

Deployments without a configured AAO Slack signing secret now return `503` from those webhook routes instead of accepting unsigned traffic. Correctly configured Slack requests continue to work, including signed URL verification challenges.

## Validation

- security expert review: clean
- testing expert review: clean
- focused Slack suites: 61/61 passed
- TypeScript no-emit: passed
- Semgrep: 0 findings across 210 rules on the changed runtime files
- diff/package/lock/dist scope checks: passed

No changeset is required because this is an operational server security fix with no protocol or package API change.
