### PR TITLE
fix(security): bound hosted Addie auth probes

### DIFF
--- a/docs/aao/addie-tools.mdx
+++ b/docs/aao/addie-tools.mdx
@@ -352,13 +352,13 @@ Run protocol compliance evaluation on an AdCP agent and return structured result
 
 ### `grade_agent_signing`
 
-Run the RFC 9421 request-signing conformance grader against an agent. Tests whether the agent's verifier accepts valid signed requests and rejects unsigned, expired, replayed, wrong-key, etc. requests with the right error codes. Returns a per-vector pass/fail report with diagnostics. Preconditions: the agent declares `request_signing.supported: true` in get_adcp_capabilities and has its verifier preconfigured per `test-kits/signed-requests-runner.yaml` (accepts the runner's signing keyids `test-ed25519-2026` and `test-es256-2026`, has `test-revoked-2026` in its revocation list). Live-side-effect vectors (real `create_media_buy`, replay-cap flood) are skipped by default — pass `allow_live_side_effects: true` to run them, and only do that against a sandbox endpoint.
+Run the safe-default RFC 9421 request-signing conformance grader against a public HTTPS agent. Tests whether the agent's verifier accepts valid signed requests and rejects unsigned, expired, replayed, wrong-key, etc. requests with the right error codes. Returns a per-vector pass/fail report with diagnostics. Preconditions: the agent declares `request_signing.supported: true` in get_adcp_capabilities and has its verifier preconfigured per `test-kits/signed-requests-runner.yaml` (accepts the runner's signing keyids `test-ed25519-2026` and `test-es256-2026`, has `test-revoked-2026` in its revocation list). Hosted Addie never probes private networks and always skips replay and rate-abuse live-side-effect vectors. Run the SDK CLI locally when testing trusted development endpoints or explicitly enabling live-side-effect vectors.
 
 *Source: `server/src/addie/mcp/auth-grader-tools.ts`*
 
 ### `diagnose_agent_auth`
 
-Diagnose an agent's OAuth handshake by probing RFC 9728 protected-resource metadata and RFC 8414 authorization-server metadata, decoding any access token in scope, and reporting ranked hypotheses about what's wrong (likely / possible / ruled out). Use when an agent returns 401/403 unexpectedly, when OAuth metadata might be misconfigured, or when validating an agent's OAuth setup before integrating. This is anonymous-mode diagnosis — token refresh and authenticated tool-call probes are skipped, so the report describes what the public surface advertises rather than whether a specific token works.
+Diagnose a public HTTPS agent's OAuth handshake by probing RFC 9728 protected-resource metadata and RFC 8414 authorization-server metadata, decoding any access token in scope, and reporting ranked hypotheses about what's wrong (likely / possible / ruled out). Use when an agent returns 401/403 unexpectedly, when OAuth metadata might be misconfigured, or when validating an agent's OAuth setup before integrating. This is anonymous-mode diagnosis — token refresh and authenticated tool-call probes are skipped, so the report describes what the public surface advertises rather than whether a specific token works. Hosted Addie never probes private networks; use the SDK CLI locally for trusted development endpoints.
 
 *Source: `server/src/addie/mcp/auth-grader-tools.ts`*
 
@@ -1357,7 +1357,7 @@ Mark modules as tested out after a placement assessment confirms the learner alr
 
 ### `start_certification_exam`
 
-Begin a specialist deep dive module (S1: Media Buy, S2: Creative, S3: Signals, S4: Governance, S5: Sponsored Intelligence). The learner must hold the Practitioner credential. Returns the capstone format, lab exercises, and assessment criteria. You (Sage) will conduct the combined hands-on lab and adaptive exam — technically assess the learner against the spec.
+Begin an available specialist deep dive module (S1: Media Buy, S2: Creative, S3: Signals, S4: Governance, S6: Security). S5 Sponsored Intelligence is listed in the curriculum but is not assessable until its sandbox labs exist. The learner must hold the Practitioner credential. Returns the capstone format, lab exercises, and assessment criteria. You (Sage) will conduct the combined hands-on lab and adaptive exam — technically assess the learner against the spec.
 
 *Source: `server/src/addie/mcp/certification-tools.ts`*
 

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -989,7 +989,7 @@ async function buildRequestContext(
  */
 async function createUserScopedTools(
   memberContext: MemberContext | null,
-  slackUserId?: string,
+  slackUserId: string,
   threadId?: string,
   threadContext?: ThreadContext | null
 ): Promise<UserScopedToolsResult> {
@@ -1063,10 +1063,10 @@ async function createUserScopedTools(
   }
   logger.debug('Addie Bolt: AdCP protocol tools enabled');
 
-  // Auth graders — RFC 9421 signing + OAuth handshake diagnosis. Available
-  // to every user; the underlying graders only probe the target agent's
-  // public surface and live-side-effect vectors are opt-in.
-  const authGraderHandlers = createAuthGraderToolHandlers();
+  // Auth graders use a stable WorkOS identity when mapped and a namespaced
+  // Slack identity otherwise, so unmapped Slack users cannot bypass limits.
+  const authGraderCallerId = memberContext?.workos_user?.workos_user_id ?? `slack:${slackUserId}`;
+  const authGraderHandlers = createAuthGraderToolHandlers(authGraderCallerId);
   allTools.push(...AUTH_GRADER_TOOLS);
   for (const [name, handler] of authGraderHandlers) {
     allHandlers.set(name, handler);

--- a/server/src/addie/mcp/auth-grader-tools.ts
+++ b/server/src/addie/mcp/auth-grader-tools.ts
@@ -8,9 +8,9 @@
  * surface — follow-up issue tracks promoting it. The same CLI is what users
  * would run locally, so shelling out also exercises the path they hit.
  *
- * Live-side-effect vectors (real `create_media_buy`, replay-cap flood) are
- * skipped by default; the caller must explicitly opt in to run them and
- * should only do so against a sandbox endpoint.
+ * Hosted Addie only probes public HTTPS endpoints and always skips the
+ * rate-abuse/live-side-effect path. Operators who need private dev loops or
+ * explicit live vectors must run the SDK CLI in their own trusted environment.
  */
 
 import { execFile } from 'node:child_process';
@@ -21,7 +21,14 @@ import { runAuthDiagnosis, type AuthDiagnosisReport } from '@adcp/sdk/auth';
 import type { AddieTool } from '../types.js';
 import type { AgentConfig } from '@adcp/sdk/types';
 import { createLogger } from '../../logger.js';
-import { sanitizeUrl, validateFetchUrl } from '../../utils/url-security.js';
+import { AsyncSemaphore, SemaphoreOverloadedError } from '../../utils/async-semaphore.js';
+import {
+  isPrivateHostname,
+  normalizeExternalHostname,
+  safeFetch,
+  validateFetchUrl,
+} from '../../utils/url-security.js';
+import { withToolRateLimit } from './tool-rate-limiter.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -44,6 +51,11 @@ const ADCP_CLIENT_BIN = (() => {
 })();
 
 const logger = createLogger('addie-auth-grader-tools');
+const signingGraderSemaphore = new AsyncSemaphore(2, 0);
+const HOSTED_ALWAYS_SKIPPED_VECTORS = [
+  '016-replayed-nonce',
+  '020-rate-abuse',
+] as const;
 
 type ContentDigestMode = 'either' | 'required' | 'forbidden';
 
@@ -61,15 +73,13 @@ const PROBE_BODY_CAP_BYTES = 64 * 1024;
  * Returns null (skip nothing) on any probe failure: better to over-report
  * than to silently swallow a real verifier bug.
  *
- * SSRF defense: `validateFetchUrl` resolves the hostname and rejects any URL
- * whose A/AAAA records land on private/link-local/loopback addresses before
- * we issue the fetch. Body is capped at PROBE_BODY_CAP_BYTES.
+ * SSRF defense: `safeFetch` validates DNS and pins the validated address at
+ * connect time. Redirects are disabled, the request is bounded to 10 seconds,
+ * and the response is streamed only up to PROBE_BODY_CAP_BYTES.
  */
 async function probeContentDigestMode(agentUrl: string): Promise<ContentDigestMode | null> {
   try {
-    const url = new URL(agentUrl);
-    await validateFetchUrl(url);
-    const res = await fetch(sanitizeUrl(url), {
+    const res = await safeFetch(agentUrl, {
       method: 'POST',
       headers: { 'content-type': 'application/json', accept: 'application/json' },
       body: JSON.stringify({
@@ -79,13 +89,32 @@ async function probeContentDigestMode(agentUrl: string): Promise<ContentDigestMo
         id: 'addie-capability-probe',
       }),
       signal: AbortSignal.timeout(10_000),
-      redirect: 'manual',
+      maxRedirects: 0,
     });
-    if (!res.ok) return null;
+    if (!res.ok) {
+      await res.body?.cancel();
+      return null;
+    }
     const declared = Number(res.headers.get('content-length') ?? 0);
-    if (declared > PROBE_BODY_CAP_BYTES) return null;
-    const text = await res.text();
-    if (text.length > PROBE_BODY_CAP_BYTES) return null;
+    if (declared > PROBE_BODY_CAP_BYTES) {
+      await res.body?.cancel();
+      return null;
+    }
+    const reader = res.body?.getReader();
+    if (!reader) return null;
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > PROBE_BODY_CAP_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+    const text = Buffer.concat(chunks).toString('utf8');
     const body = JSON.parse(text) as {
       result?: { content?: Array<{ text?: string }> };
     };
@@ -127,22 +156,40 @@ export function contentDigestSkipsForMode(mode: ContentDigestMode | null): strin
   return skip;
 }
 
-function validateAgentUrl(url: string): string | null {
+async function validateAgentUrl(url: string): Promise<string | null> {
   let parsed: URL;
   try {
     parsed = new URL(url);
   } catch {
     return 'Invalid agent URL format.';
   }
-  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-    return 'Agent URL must use HTTP or HTTPS.';
+  if (parsed.protocol !== 'https:') {
+    return 'Hosted Addie can only probe public HTTPS agent URLs.';
   }
-  if (process.env.NODE_ENV === 'production' && parsed.protocol !== 'https:') {
-    return 'Agent URL must use HTTPS.';
+  if (parsed.username || parsed.password) {
+    return 'Agent URL must not contain credentials.';
   }
-  const hostname = parsed.hostname.toLowerCase();
-  if (hostname === '169.254.169.254' || hostname === 'metadata.google.internal') {
-    return 'Agent URL points to a blocked address.';
+  const hostname = normalizeExternalHostname(parsed.hostname);
+  if (!hostname || isPrivateHostname(hostname)) {
+    return 'Agent URL must point to a public network address.';
+  }
+  try {
+    await validateFetchUrl(parsed);
+  } catch {
+    return 'Agent URL must resolve only to public network addresses.';
+  }
+  return null;
+}
+
+function rejectLegacyUnsafeOptions(
+  input: Record<string, unknown>,
+  includeLiveSideEffects: boolean,
+): string | null {
+  if (input.allow_http === true) {
+    return '**Error:** Hosted Addie cannot probe HTTP or private-network targets. Run the SDK CLI locally for trusted development loops.';
+  }
+  if (includeLiveSideEffects && input.allow_live_side_effects === true) {
+    return '**Error:** Hosted Addie cannot enable live-side-effect vectors. Run the SDK CLI locally against a trusted sandbox.';
   }
   return null;
 }
@@ -151,7 +198,7 @@ export const AUTH_GRADER_TOOLS: AddieTool[] = [
   {
     name: 'grade_agent_signing',
     description:
-      "Run the RFC 9421 request-signing conformance grader against an agent. Tests whether the agent's verifier accepts valid signed requests and rejects unsigned, expired, replayed, wrong-key, etc. requests with the right error codes. Returns a per-vector pass/fail report with diagnostics. Preconditions: the agent declares `request_signing.supported: true` in get_adcp_capabilities and has its verifier preconfigured per `test-kits/signed-requests-runner.yaml` (accepts the runner's signing keyids `test-ed25519-2026` and `test-es256-2026`, has `test-revoked-2026` in its revocation list). Live-side-effect vectors (real `create_media_buy`, replay-cap flood) are skipped by default — pass `allow_live_side_effects: true` to run them, and only do that against a sandbox endpoint.",
+      "Run the safe-default RFC 9421 request-signing conformance grader against a public HTTPS agent. Tests whether the agent's verifier accepts valid signed requests and rejects unsigned, expired, replayed, wrong-key, etc. requests with the right error codes. Returns a per-vector pass/fail report with diagnostics. Preconditions: the agent declares `request_signing.supported: true` in get_adcp_capabilities and has its verifier preconfigured per `test-kits/signed-requests-runner.yaml` (accepts the runner's signing keyids `test-ed25519-2026` and `test-es256-2026`, has `test-revoked-2026` in its revocation list). Hosted Addie never probes private networks and always skips replay and rate-abuse live-side-effect vectors. Run the SDK CLI locally when testing trusted development endpoints or explicitly enabling live-side-effect vectors.",
     usage_hints:
       'use for "grade my request signing", "is my RFC 9421 setup correct?", "test my signing verifier". Sandbox-safe by default. Pair with diagnose_agent_auth when the user is troubleshooting end-to-end auth.',
     input_schema: {
@@ -159,17 +206,7 @@ export const AUTH_GRADER_TOOLS: AddieTool[] = [
       properties: {
         agent_url: {
           type: 'string',
-          description:
-            'The agent URL to grade. Should point at a sandbox or test-kit-declared endpoint unless `allow_live_side_effects` is set.',
-        },
-        allow_live_side_effects: {
-          type: 'boolean',
-          description:
-            'Run vectors that produce live agent-side effects (a real create_media_buy and a replay-cap flood). Default false. Only set true against a sandbox endpoint or one whose test-kit contract declares `endpoint_scope: sandbox`.',
-        },
-        allow_http: {
-          type: 'boolean',
-          description: 'Allow http:// and private-IP targets (dev loops only). Default false.',
+          description: 'The public HTTPS agent URL to grade.',
         },
         transport: {
           type: 'string',
@@ -188,36 +225,53 @@ export const AUTH_GRADER_TOOLS: AddieTool[] = [
   {
     name: 'diagnose_agent_auth',
     description:
-      "Diagnose an agent's OAuth handshake by probing RFC 9728 protected-resource metadata and RFC 8414 authorization-server metadata, decoding any access token in scope, and reporting ranked hypotheses about what's wrong (likely / possible / ruled out). Use when an agent returns 401/403 unexpectedly, when OAuth metadata might be misconfigured, or when validating an agent's OAuth setup before integrating. This is anonymous-mode diagnosis — token refresh and authenticated tool-call probes are skipped, so the report describes what the public surface advertises rather than whether a specific token works.",
+      "Diagnose a public HTTPS agent's OAuth handshake by probing RFC 9728 protected-resource metadata and RFC 8414 authorization-server metadata, decoding any access token in scope, and reporting ranked hypotheses about what's wrong (likely / possible / ruled out). Use when an agent returns 401/403 unexpectedly, when OAuth metadata might be misconfigured, or when validating an agent's OAuth setup before integrating. This is anonymous-mode diagnosis — token refresh and authenticated tool-call probes are skipped, so the report describes what the public surface advertises rather than whether a specific token works. Hosted Addie never probes private networks; use the SDK CLI locally for trusted development endpoints.",
     usage_hints:
-      'use for "diagnose OAuth on this agent", "why is the agent rejecting my token?", "is this agent\'s OAuth metadata correct?", "validate OAuth setup". For deeper diagnosis with a saved token the user can run `npx @adcp/sdk@latest diagnose-auth <alias>` locally — point them there if a token-aware probe is needed.',
+      'use for "diagnose OAuth on this agent", "why is the agent rejecting my token?", "is this agent\'s OAuth metadata correct?", "validate OAuth setup". For deeper diagnosis with a saved token or a trusted private development endpoint, point the user to the SDK CLI\'s local `adcp diagnose-auth <alias>` command.',
     input_schema: {
       type: 'object',
       properties: {
-        agent_url: { type: 'string', description: 'The agent URL to probe.' },
-        allow_http: {
-          type: 'boolean',
-          description: 'Allow http:// and private-IP targets (dev loops only). Default false.',
-        },
+        agent_url: { type: 'string', description: 'The public HTTPS agent URL to probe.' },
       },
       required: ['agent_url'],
     },
   },
 ];
 
-export function createAuthGraderToolHandlers(): Map<
+export type AuthGraderProcessRunner = (
+  args: readonly string[],
+  options: { timeout: number; maxBuffer: number },
+) => Promise<{ stdout: string }>;
+
+const defaultAuthGraderProcessRunner: AuthGraderProcessRunner = async (args, options) => {
+  const { stdout } = await execFileAsync(process.execPath, [...args], options);
+  return { stdout: String(stdout) };
+};
+
+let authGraderProcessRunner = defaultAuthGraderProcessRunner;
+
+/** Test-only process boundary override. Passing null restores production. */
+export function __setAuthGraderProcessRunnerForTests(
+  runner: AuthGraderProcessRunner | null,
+): void {
+  authGraderProcessRunner = runner ?? defaultAuthGraderProcessRunner;
+}
+
+export function createAuthGraderToolHandlers(callerId: string): Map<
   string,
   (args: Record<string, unknown>) => Promise<string>
 > {
+  if (typeof callerId !== 'string' || !callerId.trim()) {
+    throw new Error('createAuthGraderToolHandlers requires a stable caller ID');
+  }
+
   const handlers = new Map<string, (args: Record<string, unknown>) => Promise<string>>();
 
-  handlers.set('grade_agent_signing', async (input) => {
+  const gradeAgentSigning = async (input: Record<string, unknown>) => {
     const agentUrl = String(input.agent_url ?? '');
-    const allowLive = input.allow_live_side_effects === true;
-    const allowHttp = input.allow_http === true;
     const rawTransport = input.transport === 'raw';
 
-    const urlError = validateAgentUrl(agentUrl);
+    const urlError = await validateAgentUrl(agentUrl);
     if (urlError) return `**Error:** ${urlError}`;
 
     // Run the bundled @adcp/sdk CLI's `grade request-signing --json`.
@@ -246,26 +300,29 @@ export function createAuthGraderToolHandlers(): Map<
     const probedMode =
       explicitMode ?? (rawTransport ? null : await probeContentDigestMode(agentUrl));
     const autoSkip = contentDigestSkipsForMode(probedMode);
+    const skipVectors = [...new Set([...HOSTED_ALWAYS_SKIPPED_VECTORS, ...autoSkip])];
 
     const args = [ADCP_CLIENT_BIN, 'grade', 'request-signing', agentUrl, '--json'];
     args.push('--transport', rawTransport ? 'raw' : 'mcp');
-    if (allowLive) args.push('--allow-live-side-effects');
-    else args.push('--skip-rate-abuse');
-    if (allowHttp) args.push('--allow-http');
-    if (autoSkip.length > 0) args.push('--skip', autoSkip.join(','));
+    args.push('--skip-rate-abuse');
+    args.push('--skip', skipVectors.join(','));
 
     try {
-      // 90s is enough for the safe-default path (rate-abuse skipped, ~25
-      // vectors). When the caller opts into live side effects the cap-flood
-      // vector takes minutes — give it 5min.
-      const timeout = allowLive ? 5 * 60_000 : 90_000;
-      const { stdout } = await execFileAsync(process.execPath, args, {
-        timeout,
-        maxBuffer: 10 * 1024 * 1024,
-      });
+      // Only the child-process lifetime holds a semaphore permit. URL checks
+      // and the bounded capability probe happen before it; JSON formatting
+      // happens after the child exits and releases the permit.
+      const { stdout } = await signingGraderSemaphore.run(() =>
+        authGraderProcessRunner(args, {
+          timeout: 90_000,
+          maxBuffer: 10 * 1024 * 1024,
+        })
+      );
       const report = JSON.parse(stdout) as GradeReport;
       return formatGradeReport(report);
     } catch (err) {
+      if (err instanceof SemaphoreOverloadedError) {
+        return '**RFC 9421 grader capacity is busy.** Try again after an in-progress grade finishes.';
+      }
       // execFile rejects on non-zero exit. The grader exits 1 when at least
       // one vector failed but still emits the report on stdout — parse and
       // format it as a normal FAIL result. Other exit codes (2 = config
@@ -291,13 +348,12 @@ export function createAuthGraderToolHandlers(): Map<
         '- Agent URL unreachable from this server',
       ].join('\n');
     }
-  });
+  };
 
-  handlers.set('diagnose_agent_auth', async (input) => {
+  const diagnoseAgentAuth = async (input: Record<string, unknown>) => {
     const agentUrl = String(input.agent_url ?? '');
-    const allowHttp = input.allow_http === true;
 
-    const urlError = validateAgentUrl(agentUrl);
+    const urlError = await validateAgentUrl(agentUrl);
     if (urlError) return `**Error:** ${urlError}`;
 
     const agentConfig: AgentConfig = {
@@ -309,7 +365,7 @@ export function createAuthGraderToolHandlers(): Map<
 
     try {
       const report = await runAuthDiagnosis(agentConfig, {
-        allowPrivateIp: allowHttp,
+        allowPrivateIp: false,
         skipRefresh: true,
         skipToolCall: true,
       });
@@ -319,6 +375,20 @@ export function createAuthGraderToolHandlers(): Map<
       logger.error({ err: message, agentUrl }, 'diagnose_agent_auth failed');
       return `**Error running OAuth diagnosis:** ${message}`;
     }
+  };
+
+  const rateLimitedGrade = withToolRateLimit('grade_agent_signing', callerId, gradeAgentSigning);
+  handlers.set('grade_agent_signing', async (input) => {
+    const unsafeOptionError = rejectLegacyUnsafeOptions(input, true);
+    if (unsafeOptionError) return unsafeOptionError;
+    return rateLimitedGrade(input);
+  });
+
+  const rateLimitedDiagnosis = withToolRateLimit('diagnose_agent_auth', callerId, diagnoseAgentAuth);
+  handlers.set('diagnose_agent_auth', async (input) => {
+    const unsafeOptionError = rejectLegacyUnsafeOptions(input, false);
+    if (unsafeOptionError) return unsafeOptionError;
+    return rateLimitedDiagnosis(input);
   });
 
   return handlers;
@@ -330,8 +400,8 @@ export function createAuthGraderToolHandlers(): Map<
  * upstream type because the type lives behind the same internal subpath the
  * runtime export does. Keep field names in sync with
  * `@adcp/sdk/dist/lib/testing/storyboard/request-signing/grader.d.ts`.
- * Verified against @adcp/sdk@5.21.x; will move to a public type import
- * once the upstream PR promotes it.
+ * Verified against the package version pinned by this repository; move to a
+ * public type import once the upstream package promotes it.
  */
 interface VectorGradeResult {
   vector_id: string;
@@ -376,7 +446,7 @@ function formatGradeReport(report: GradeReport): string {
   if (report.live_endpoint_warning) {
     lines.push('');
     lines.push(
-      "Warning: this endpoint isn't declared as sandbox in its test-kit contract. If `allow_live_side_effects` was set, real side effects may have been produced."
+      "Warning: this endpoint isn't declared as sandbox in its test-kit contract. Hosted Addie skips rate-abuse and caller-enabled live-side-effect vectors; use the SDK CLI locally for explicit live testing."
     );
   }
 
@@ -451,7 +521,7 @@ function formatAuthDiagnosisReport(report: AuthDiagnosisReport): string {
 
   lines.push(
     '',
-    'This is anonymous-mode diagnosis (no token, no authenticated tool call). For a deeper probe with a saved token, run `npx @adcp/sdk@latest diagnose-auth <alias>` locally.'
+    'This is anonymous-mode diagnosis (no token, no authenticated tool call). For a deeper probe with a saved token, run `adcp diagnose-auth <alias>` locally.'
   );
   return lines.join('\n');
 }

--- a/server/src/addie/mcp/tool-rate-limiter.ts
+++ b/server/src/addie/mcp/tool-rate-limiter.ts
@@ -267,6 +267,16 @@ export async function checkToolRateLimit(
  * thrown error — the LLM needs to surface the message) when exceeded,
  * and otherwise delegates to the original handler.
  */
+function formatRateLimitWindow(windowMs: number): string {
+  if (windowMs < 60 * 60 * 1000) {
+    const minutes = Math.round(windowMs / 60000);
+    return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+  }
+
+  const hours = Math.round(windowMs / 3600000);
+  return `${hours} hour${hours === 1 ? '' : 's'}`;
+}
+
 export function withToolRateLimit<T extends (input: Record<string, unknown>) => Promise<string>>(
   toolName: string,
   userId: string | undefined | null,
@@ -280,7 +290,7 @@ export function withToolRateLimit<T extends (input: Record<string, unknown>) => 
       let limit: string;
       if (check.scope === 'workspace') {
         const ws = WORKSPACE_CAPS[toolName];
-        limit = `workspace-wide ${toolName} limit (${ws.max} per ${Math.round(ws.windowMs / 3600000)} hour${ws.windowMs >= 7200000 ? 's' : ''})`;
+        limit = `workspace-wide ${toolName} limit (${ws.max} per ${formatRateLimitWindow(ws.windowMs)})`;
       } else if (check.scope === 'global') {
         limit = `overall Addie tool call limit (${GLOBAL_CAP.max} per ${GLOBAL_CAP.windowMs / 60000} minutes)`;
       } else {

--- a/server/src/addie/mcp/tool-rate-limiter.ts
+++ b/server/src/addie/mcp/tool-rate-limiter.ts
@@ -55,6 +55,10 @@ const CAPS: Record<string, ToolRateLimitConfig> = {
   read_google_doc: { windowMs: 10 * 60 * 1000, max: 20 },
   attach_content_asset: { windowMs: 10 * 60 * 1000, max: 20 },
   generate_perspective_illustration: { windowMs: 10 * 60 * 1000, max: 10 },
+  // Signing grades spawn a Node child for up to 90 seconds; OAuth diagnosis
+  // performs several outbound probes. Keep both well below the generic cap.
+  grade_agent_signing: { windowMs: 10 * 60 * 1000, max: 3 },
+  diagnose_agent_auth: { windowMs: 10 * 60 * 1000, max: 10 },
 };
 const DEFAULT_CAP: ToolRateLimitConfig = { windowMs: 10 * 60 * 1000, max: 60 };
 const GLOBAL_CAP: ToolRateLimitConfig = { windowMs: 10 * 60 * 1000, max: 200 };
@@ -76,6 +80,9 @@ export const WORKSPACE_CAPS: Record<string, ToolRateLimitConfig> = {
   // (~1500 generations/mo max). The per-user 5/month quota + per-user
   // 10/10min tool limit still apply on top.
   generate_perspective_illustration: { windowMs: 24 * 60 * 60 * 1000, max: 50 },
+  // Service-wide child-process budget. The in-process semaphore also limits
+  // bursts to two concurrent children per server instance.
+  grade_agent_signing: { windowMs: 10 * 60 * 1000, max: 12 },
 };
 
 /**

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -598,12 +598,12 @@ export async function prepareRequestWithMemberTools(
   }
 
   // Auth graders — RFC 9421 signing + OAuth handshake diagnosis. Authenticated
-  // users only on the web path; each call spawns a child Node process and
-  // makes outbound HTTP probes from the server, so we keep it gated behind a
+  // users only on the web path; signing grades spawn a child Node process and
+  // both tools make outbound HTTP probes, so we keep them gated behind a
   // signed-in identity. (The Slack path in bolt-app.ts is always authenticated.)
   if (userId) {
     allTools.push(...AUTH_GRADER_TOOLS);
-    for (const [name, handler] of createAuthGraderToolHandlers()) {
+    for (const [name, handler] of createAuthGraderToolHandlers(userId)) {
       combinedHandlers.set(name, handler);
     }
   }

--- a/server/tests/unit/auth-grader-security-boundaries.test.ts
+++ b/server/tests/unit/auth-grader-security-boundaries.test.ts
@@ -1,0 +1,354 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ReadableStream } from 'node:stream/web';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  validateFetchUrl: vi.fn(),
+  safeFetch: vi.fn(),
+  runAuthDiagnosis: vi.fn(),
+  processRunner: vi.fn(),
+}));
+
+vi.mock('../../src/utils/url-security.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/utils/url-security.js')>();
+  return {
+    ...actual,
+    validateFetchUrl: (...args: unknown[]) => mocks.validateFetchUrl(...args),
+    safeFetch: (...args: unknown[]) => mocks.safeFetch(...args),
+  };
+});
+
+vi.mock('@adcp/sdk/auth', () => ({
+  runAuthDiagnosis: (...args: unknown[]) => mocks.runAuthDiagnosis(...args),
+}));
+
+import {
+  __setAuthGraderProcessRunnerForTests,
+  createAuthGraderToolHandlers,
+} from '../../src/addie/mcp/auth-grader-tools.js';
+import {
+  __createInMemoryStore,
+  __resetRateLimitHistory,
+  __setRateLimitStore,
+} from '../../src/addie/mcp/tool-rate-limiter.js';
+
+const PUBLIC_AGENT_URL = 'https://agent.example.test/mcp';
+
+function gradeReport() {
+  return {
+    agent_url: PUBLIC_AGENT_URL,
+    harness_mode: 'black_box',
+    live_endpoint_warning: false,
+    contract_loaded: true,
+    positive: [],
+    negative: [],
+    passed: true,
+    passed_count: 0,
+    failed_count: 0,
+    skipped_count: 0,
+    total_duration_ms: 10,
+  };
+}
+
+function gradeResult() {
+  return { stdout: JSON.stringify(gradeReport()) };
+}
+
+function capabilityResponse(mode: 'either' | 'required' | 'forbidden' = 'required'): Response {
+  return new Response(JSON.stringify({
+    result: {
+      content: [{
+        text: JSON.stringify({ request_signing: { covers_content_digest: mode } }),
+      }],
+    },
+  }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitForCallCount(mock: ReturnType<typeof vi.fn>, count: number): Promise<void> {
+  for (let attempt = 0; attempt < 100 && mock.mock.calls.length < count; attempt++) {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+  expect(mock).toHaveBeenCalledTimes(count);
+}
+
+describe('hosted auth grader security boundaries', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    __setRateLimitStore(__createInMemoryStore());
+    await __resetRateLimitHistory();
+    mocks.validateFetchUrl.mockResolvedValue(undefined);
+    mocks.safeFetch.mockResolvedValue(capabilityResponse());
+    mocks.runAuthDiagnosis.mockResolvedValue({ agentUrl: PUBLIC_AGENT_URL, hypotheses: [] });
+    mocks.processRunner.mockResolvedValue(gradeResult());
+    __setAuthGraderProcessRunnerForTests(mocks.processRunner);
+  });
+
+  afterEach(() => {
+    __setAuthGraderProcessRunnerForTests(null);
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ['grade_agent_signing', { allow_http: true }],
+    ['grade_agent_signing', { allow_live_side_effects: true }],
+    ['diagnose_agent_auth', { allow_http: true }],
+  ])('rejects legacy true options before any URL, network, SDK, or process work for %s', async (toolName, extra) => {
+    const handler = createAuthGraderToolHandlers('caller-legacy').get(toolName)!;
+
+    const result = await handler({ agent_url: PUBLIC_AGENT_URL, ...extra });
+
+    expect(result).toMatch(/Hosted Addie cannot/);
+    expect(mocks.validateFetchUrl).not.toHaveBeenCalled();
+    expect(mocks.safeFetch).not.toHaveBeenCalled();
+    expect(mocks.runAuthDiagnosis).not.toHaveBeenCalled();
+    expect(mocks.processRunner).not.toHaveBeenCalled();
+  });
+
+  it('treats legacy false values as benign while forcing safe CLI and SDK options', async () => {
+    const handlers = createAuthGraderToolHandlers('caller-safe-options');
+
+    await handlers.get('grade_agent_signing')!({
+      agent_url: PUBLIC_AGENT_URL,
+      allow_http: false,
+      allow_live_side_effects: false,
+      content_digest_mode: 'required',
+    });
+    await handlers.get('diagnose_agent_auth')!({
+      agent_url: PUBLIC_AGENT_URL,
+      allow_http: false,
+    });
+
+    expect(mocks.processRunner).toHaveBeenCalledOnce();
+    const [args, options] = mocks.processRunner.mock.calls[0];
+    expect(args).toEqual(expect.arrayContaining([
+      'grade',
+      'request-signing',
+      PUBLIC_AGENT_URL,
+      '--skip-rate-abuse',
+    ]));
+    expect(args).not.toContain('--allow-http');
+    expect(args).not.toContain('--allow-live-side-effects');
+    const skips = String(args[args.indexOf('--skip') + 1]).split(',');
+    expect(skips).toEqual(expect.arrayContaining([
+      '016-replayed-nonce',
+      '020-rate-abuse',
+      '018-digest-covered-when-forbidden',
+    ]));
+    expect(options).toEqual({ timeout: 90_000, maxBuffer: 10 * 1024 * 1024 });
+    expect(mocks.runAuthDiagnosis).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_uri: PUBLIC_AGENT_URL }),
+      { allowPrivateIp: false, skipRefresh: true, skipToolCall: true },
+    );
+  });
+
+  it.each([
+    'http://public.example.test/mcp',
+    'https://user:secret@public.example.test/mcp',
+    'https://localhost/mcp',
+    'https://127.0.0.1/mcp',
+    'https://10.0.0.8/mcp',
+    'https://172.16.0.8/mcp',
+    'https://192.168.1.8/mcp',
+    'https://100.64.0.8/mcp',
+    'https://169.254.169.254/latest/meta-data',
+    'https://[::1]/mcp',
+    'https://[0:0:0:0:0:0:0:1]/mcp',
+    'https://[fe80::1]/mcp',
+    'https://[fc00::1]/mcp',
+    'https://[fd12::1]/mcp',
+    'https://[::ffff:127.0.0.1]/mcp',
+    'https://2130706433/mcp',
+    'https://0177.0.0.1/mcp',
+    'https://0x7f000001/mcp',
+    'https://agent.local/mcp',
+    'https://service.internal/mcp',
+    'https://metadata.google.internal/mcp',
+  ])('rejects a non-public target before DNS or either outbound sink: %s', async (agentUrl) => {
+    const handlers = createAuthGraderToolHandlers('system:addie');
+
+    const [grade, diagnosis] = await Promise.all([
+      handlers.get('grade_agent_signing')!({ agent_url: agentUrl }),
+      handlers.get('diagnose_agent_auth')!({ agent_url: agentUrl }),
+    ]);
+
+    expect(grade).toMatch(/public HTTPS|public network|credentials/);
+    expect(diagnosis).toMatch(/public HTTPS|public network|credentials/);
+    expect(mocks.validateFetchUrl).not.toHaveBeenCalled();
+    expect(mocks.safeFetch).not.toHaveBeenCalled();
+    expect(mocks.runAuthDiagnosis).not.toHaveBeenCalled();
+    expect(mocks.processRunner).not.toHaveBeenCalled();
+  });
+
+  it('rejects a hostname resolving to a private address before capability, SDK, or process sinks', async () => {
+    mocks.validateFetchUrl.mockRejectedValueOnce(new Error('private address'));
+    const handlers = createAuthGraderToolHandlers('caller-rebind');
+
+    const result = await handlers.get('grade_agent_signing')!({
+      agent_url: 'https://rebind.example.test/mcp',
+    });
+
+    expect(result).toContain('resolve only to public network addresses');
+    expect(mocks.safeFetch).not.toHaveBeenCalled();
+    expect(mocks.runAuthDiagnosis).not.toHaveBeenCalled();
+    expect(mocks.processRunner).not.toHaveBeenCalled();
+  });
+
+  it('uses pinned safeFetch with a 10-second signal and no redirects for the capability probe', async () => {
+    const timeoutSignal = new AbortController().signal;
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal);
+    mocks.safeFetch.mockResolvedValueOnce(capabilityResponse('required'));
+    const handler = createAuthGraderToolHandlers('caller-capability').get('grade_agent_signing')!;
+
+    await handler({ agent_url: PUBLIC_AGENT_URL });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(mocks.safeFetch).toHaveBeenCalledWith(PUBLIC_AGENT_URL, expect.objectContaining({
+      method: 'POST',
+      maxRedirects: 0,
+      signal: timeoutSignal,
+    }));
+    const request = mocks.safeFetch.mock.calls[0][1];
+    expect(JSON.parse(request.body)).toMatchObject({
+      method: 'tools/call',
+      params: { name: 'get_adcp_capabilities', arguments: {} },
+    });
+    const args = mocks.processRunner.mock.calls[0][0] as string[];
+    const skips = args[args.indexOf('--skip') + 1].split(',');
+    expect(skips).toEqual(expect.arrayContaining([
+      '016-replayed-nonce',
+      '020-rate-abuse',
+      '018-digest-covered-when-forbidden',
+    ]));
+  });
+
+  it('streams and cancels a capability response after the 64 KiB cap', async () => {
+    let cancelled = false;
+    const oversizedBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(64 * 1024));
+        controller.enqueue(new Uint8Array([1]));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    mocks.safeFetch.mockResolvedValueOnce(new Response(oversizedBody as unknown as BodyInit, { status: 200 }));
+    const handler = createAuthGraderToolHandlers('caller-cap').get('grade_agent_signing')!;
+
+    await handler({ agent_url: PUBLIC_AGENT_URL });
+
+    expect(cancelled).toBe(true);
+    expect(mocks.processRunner).toHaveBeenCalledOnce();
+    const args = mocks.processRunner.mock.calls[0][0] as string[];
+    expect(args[args.indexOf('--skip') + 1].split(',').sort()).toEqual([
+      '016-replayed-nonce',
+      '020-rate-abuse',
+    ]);
+  });
+
+  it('sheds a third concurrent child immediately and releases permits after completion', async () => {
+    const first = deferred<{ stdout: string }>();
+    const second = deferred<{ stdout: string }>();
+    mocks.processRunner
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise);
+    const firstRun = createAuthGraderToolHandlers('caller-one').get('grade_agent_signing')!({
+      agent_url: PUBLIC_AGENT_URL,
+      content_digest_mode: 'required',
+    });
+    const secondRun = createAuthGraderToolHandlers('caller-two').get('grade_agent_signing')!({
+      agent_url: PUBLIC_AGENT_URL,
+      content_digest_mode: 'required',
+    });
+    await waitForCallCount(mocks.processRunner, 2);
+
+    const overloaded = await createAuthGraderToolHandlers('caller-three').get('grade_agent_signing')!({
+      agent_url: PUBLIC_AGENT_URL,
+      content_digest_mode: 'required',
+    });
+    expect(overloaded).toMatch(/capacity is busy/);
+    expect(mocks.processRunner).toHaveBeenCalledTimes(2);
+
+    first.resolve(gradeResult());
+    second.resolve(gradeResult());
+    await Promise.all([firstRun, secondRun]);
+
+    mocks.processRunner.mockResolvedValueOnce(gradeResult());
+    const afterRelease = await createAuthGraderToolHandlers('caller-four').get('grade_agent_signing')!({
+      agent_url: PUBLIC_AGENT_URL,
+      content_digest_mode: 'required',
+    });
+    expect(afterRelease).toContain('Result:** PASS');
+    expect(mocks.processRunner).toHaveBeenCalledTimes(3);
+  });
+
+  it('releases a child-process permit when the runner rejects', async () => {
+    mocks.processRunner.mockRejectedValueOnce(new Error('child failed'));
+    const failed = await createAuthGraderToolHandlers('caller-failed').get('grade_agent_signing')!({
+      agent_url: PUBLIC_AGENT_URL,
+      content_digest_mode: 'required',
+    });
+    expect(failed).toContain('Error running RFC 9421 grader');
+
+    mocks.processRunner.mockResolvedValueOnce(gradeResult());
+    const retried = await createAuthGraderToolHandlers('caller-after-failure').get('grade_agent_signing')!({
+      agent_url: PUBLIC_AGENT_URL,
+      content_digest_mode: 'required',
+    });
+    expect(retried).toContain('Result:** PASS');
+  });
+
+  it('releases a child-process permit before handling malformed grader JSON', async () => {
+    mocks.processRunner.mockResolvedValueOnce({ stdout: '{not-json' });
+    const malformed = await createAuthGraderToolHandlers('caller-malformed').get('grade_agent_signing')!({
+      agent_url: PUBLIC_AGENT_URL,
+      content_digest_mode: 'required',
+    });
+    expect(malformed).toContain('Error running RFC 9421 grader');
+
+    mocks.processRunner.mockResolvedValueOnce(gradeResult());
+    const retried = await createAuthGraderToolHandlers('caller-after-malformed').get('grade_agent_signing')!({
+      agent_url: PUBLIC_AGENT_URL,
+      content_digest_mode: 'required',
+    });
+    expect(retried).toContain('Result:** PASS');
+  });
+
+  it('enforces the signing-grader per-user cap before spawning a fourth child', async () => {
+    const handler = createAuthGraderToolHandlers('caller-rate-limited').get('grade_agent_signing')!;
+    for (let i = 0; i < 3; i++) {
+      expect(await handler({ agent_url: PUBLIC_AGENT_URL, content_digest_mode: 'required' }))
+        .toContain('Result:** PASS');
+    }
+
+    const blocked = await handler({ agent_url: PUBLIC_AGENT_URL, content_digest_mode: 'required' });
+
+    expect(blocked).toMatch(/Rate limit exceeded.*grade_agent_signing/i);
+    expect(mocks.processRunner).toHaveBeenCalledTimes(3);
+  });
+
+  it('wires authenticated web and Slack identities into handler creation', () => {
+    const webSource = readFileSync(join(process.cwd(), 'server/src/routes/addie-chat.ts'), 'utf8');
+    const slackSource = readFileSync(join(process.cwd(), 'server/src/addie/bolt-app.ts'), 'utf8');
+
+    expect(webSource).toContain('createAuthGraderToolHandlers(userId)');
+    expect(slackSource).toContain(
+      'memberContext?.workos_user?.workos_user_id ?? `slack:${slackUserId}`',
+    );
+    expect(slackSource).toContain('createAuthGraderToolHandlers(authGraderCallerId)');
+  });
+});

--- a/server/tests/unit/auth-grader-tools.test.ts
+++ b/server/tests/unit/auth-grader-tools.test.ts
@@ -11,13 +11,16 @@ describe('auth grader tools', () => {
     expect(names).toEqual(['diagnose_agent_auth', 'grade_agent_signing']);
   });
 
-  it('declares allow_live_side_effects as opt-in (not required)', () => {
+  it('does not expose hosted private-network or live-side-effect escape hatches', () => {
     const grader = AUTH_GRADER_TOOLS.find((t) => t.name === 'grade_agent_signing');
+    const diagnosis = AUTH_GRADER_TOOLS.find((t) => t.name === 'diagnose_agent_auth');
     expect(grader).toBeDefined();
     expect(grader!.input_schema.required).toEqual(['agent_url']);
     const props = grader!.input_schema.properties as Record<string, unknown>;
-    expect(props.allow_live_side_effects).toBeDefined();
-    expect(props.allow_http).toBeDefined();
+    const diagnosisProps = diagnosis!.input_schema.properties as Record<string, unknown>;
+    expect(props.allow_live_side_effects).toBeUndefined();
+    expect(props.allow_http).toBeUndefined();
+    expect(diagnosisProps.allow_http).toBeUndefined();
   });
 
   it('exposes transport mcp/raw with mcp default (the schema declares enum, handler defaults absent → mcp)', () => {
@@ -30,24 +33,29 @@ describe('auth grader tools', () => {
   });
 
   it('rejects malformed agent URLs without invoking the grader', async () => {
-    const handlers = createAuthGraderToolHandlers();
+    const handlers = createAuthGraderToolHandlers('system:addie');
     const grader = handlers.get('grade_agent_signing')!;
     const out = await grader({ agent_url: 'not-a-url' });
     expect(out).toContain('Invalid agent URL');
   });
 
   it('rejects cloud-metadata SSRF targets', async () => {
-    const handlers = createAuthGraderToolHandlers();
+    const handlers = createAuthGraderToolHandlers('system:addie');
     const diag = handlers.get('diagnose_agent_auth')!;
-    const out = await diag({ agent_url: 'http://169.254.169.254/' });
-    expect(out).toContain('blocked');
+    const out = await diag({ agent_url: 'https://169.254.169.254/' });
+    expect(out).toContain('public network');
   });
 
   it('rejects non-http(s) protocols', async () => {
-    const handlers = createAuthGraderToolHandlers();
+    const handlers = createAuthGraderToolHandlers('system:addie');
     const grader = handlers.get('grade_agent_signing')!;
     const out = await grader({ agent_url: 'file:///etc/passwd' });
-    expect(out).toContain('HTTP or HTTPS');
+    expect(out).toContain('public HTTPS');
+  });
+
+  it('requires a stable nonempty caller ID', () => {
+    expect(() => createAuthGraderToolHandlers('')).toThrow(/stable caller ID/);
+    expect(() => createAuthGraderToolHandlers('   ')).toThrow(/stable caller ID/);
   });
 });
 

--- a/server/tests/unit/tool-rate-limiter.test.ts
+++ b/server/tests/unit/tool-rate-limiter.test.ts
@@ -233,6 +233,18 @@ describe('withToolRateLimit', () => {
     expect(result).toMatch(/overall Addie tool call limit/i);
   });
 
+  it('renders sub-hour workspace windows in minutes', async () => {
+    for (let i = 0; i < 12; i++) {
+      const wrapped = withToolRateLimit('grade_agent_signing', `workspace-user-${i}`, async () => 'ok');
+      expect(await wrapped({})).toBe('ok');
+    }
+
+    const blocked = withToolRateLimit('grade_agent_signing', 'workspace-user-13', async () => 'ok');
+    const result = await blocked({});
+    expect(result).toMatch(/workspace-wide grade_agent_signing limit \(12 per 10 minutes\)/i);
+    expect(result).not.toMatch(/0 hour/i);
+  });
+
   it('passes through system: users without rate checks', async () => {
     let calls = 0;
     const wrapped = withToolRateLimit('generate_perspective_illustration', 'system:addie', async () => {

--- a/server/tests/unit/tool-rate-limiter.test.ts
+++ b/server/tests/unit/tool-rate-limiter.test.ts
@@ -82,6 +82,25 @@ describe('checkToolRateLimit', () => {
     expect((await checkToolRateLimit('some_unknown_tool', 'u4')).ok).toBe(false);
   });
 
+  it('limits signing graders to three calls per user in ten minutes', async () => {
+    for (let i = 0; i < 3; i++) {
+      expect((await checkToolRateLimit('grade_agent_signing', 'grader-user')).ok).toBe(true);
+    }
+    const blocked = await checkToolRateLimit('grade_agent_signing', 'grader-user');
+    expect(blocked.ok).toBe(false);
+    expect(blocked.scope).toBe('per_tool');
+    expect((await checkToolRateLimit('grade_agent_signing', 'different-grader-user')).ok).toBe(true);
+  });
+
+  it('limits auth diagnosis to ten calls per user in ten minutes', async () => {
+    for (let i = 0; i < 10; i++) {
+      expect((await checkToolRateLimit('diagnose_agent_auth', 'diagnosis-user')).ok).toBe(true);
+    }
+    const blocked = await checkToolRateLimit('diagnose_agent_auth', 'diagnosis-user');
+    expect(blocked.ok).toBe(false);
+    expect(blocked.scope).toBe('per_tool');
+  });
+
   it('retryAfterMs is a positive value within the window bound', async () => {
     for (let i = 0; i < 10; i++) await checkToolRateLimit('generate_perspective_illustration', 'u-retry');
     const blocked = await checkToolRateLimit('generate_perspective_illustration', 'u-retry');
@@ -135,6 +154,15 @@ describe('checkToolRateLimit', () => {
     }
     expect(blockedAt).toBe(50);
     expect(blockedScope).toBe('workspace');
+  });
+
+  it('enforces the service-wide signing-grader cap across distinct users', async () => {
+    for (let i = 0; i < 12; i++) {
+      expect((await checkToolRateLimit('grade_agent_signing', `grader-${i}`)).ok).toBe(true);
+    }
+    const blocked = await checkToolRateLimit('grade_agent_signing', 'grader-13');
+    expect(blocked.ok).toBe(false);
+    expect(blocked.scope).toBe('workspace');
   });
 
   it('workspace cap does not apply to tools not listed in WORKSPACE_CAPS', async () => {


### PR DESCRIPTION
## Summary

- remove hosted Addie escape hatches for HTTP/private targets and live-side-effect signing vectors
- enforce credential-free public HTTPS targets and use the DNS-pinned SSRF-safe fetch path for capability probes
- always skip replay and rate-abuse live vectors, regardless of the bundled sandbox contract
- bound signing-grader child processes with stable caller identities, distributed rate caps, and a fail-fast two-process semaphore
- regenerate the Addie tool reference and add adversarial regression coverage

## Root cause

Both hosted auth-grader tools exposed `allow_http`, which mapped directly to the SDK/CLI private-network override. The signing grader also allowed callers to request live vectors and had no cross-request process bound; ordinary authenticated users could launch multiple long-lived child processes. Its custom capability probe preflight-resolved DNS and then used global `fetch`, leaving a DNS-rebinding gap.

## Impact

Hosted Addie now probes only public HTTPS agents. Trusted private development loops and explicit live-vector testing remain available through the local SDK CLI. Signing grades are capped at two concurrent children per server, with per-user and service-wide limits; excess work fails fast with a retry message.

## Validation

- final security expert review: clean
- final testing expert review: clean
- focused security/unit suites: 161/161 passed independently; 134/134 passed after rebase
- TypeScript no-emit: passed
- generated Addie tool reference check: passed (247 tools, 15 sets)
- Semgrep: 0 findings across 210 rules on changed runtime files
- diff/package/lock/dist scope checks: passed

No changeset is required because this is an operational Addie/server security fix with no protocol-package API change.
