### PR TITLE
fix(security): enforce network health admin boundary

### DIFF
--- a/server/src/db/network-health-db.ts
+++ b/server/src/db/network-health-db.ts
@@ -354,11 +354,18 @@ export async function getAlertHistory(
   return result.rows;
 }
 
-export async function resolveAlert(alertId: string): Promise<void> {
-  await query(
-    `UPDATE network_alert_history SET resolved_at = NOW() WHERE id = $1`,
-    [alertId]
+export async function resolveAlert(
+  orgId: string,
+  alertId: string
+): Promise<boolean> {
+  const result = await query<{ id: string }>(
+    `UPDATE network_alert_history
+     SET resolved_at = COALESCE(resolved_at, NOW())
+     WHERE org_id = $1 AND id = $2
+     RETURNING id`,
+    [orgId, alertId]
   );
+  return result.rows.length > 0;
 }
 
 // ─── Alert evaluation ───────────────────────────────────────────────────────

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -11,6 +11,7 @@ import { getPool } from "../db/client.js";
 import { createLogger } from "../logger.js";
 import { requireAuth, requireAdmin } from "../middleware/auth.js";
 import { serveHtmlWithConfig } from "../utils/html-config.js";
+import { registerNetworkHealthAdminPage } from "./network-health.js";
 import { getMemberContext, getWebMemberContext } from "../addie/member-context.js";
 import { getMemberCapabilities } from "../db/outbound-db.js";
 import { canEngageSlackUser } from "../addie/services/relationship-orchestrator.js";
@@ -109,12 +110,7 @@ export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
     });
   });
 
-  pageRouter.get("/network-health", requireAuth, requireAdmin, (req, res) => {
-    serveHtmlWithConfig(req, res, "admin-network-health.html").catch((err) => {
-      logger.error({ err }, "Error serving network health page");
-      res.status(500).send("Internal server error");
-    });
-  });
+  registerNetworkHealthAdminPage(pageRouter);
 
   // Redirects from old newsletter admin URLs
   pageRouter.get("/digest", (_req, res) => res.redirect(301, "/admin/newsletters/the_prompt"));

--- a/server/src/routes/network-health.ts
+++ b/server/src/routes/network-health.ts
@@ -1,8 +1,9 @@
 /**
  * Network health API routes.
  *
- * Org-scoped endpoints comparing brand.json declarations against crawl reality.
- * All API routes require authentication; write operations require admin.
+ * Platform-admin endpoints comparing brand.json declarations against crawl
+ * reality across organizations. Tenant-issued API keys must not reach this
+ * cross-organization surface.
  *
  * API:
  *   GET  /api/network-health                     — summary across all orgs (admin)
@@ -12,8 +13,8 @@
  *   GET  /api/network-health/:orgId/alerts       — alert rule config (webhook redacted)
  *   GET  /api/network-health/:orgId/alerts/history    — alert history
  *   GET  /api/network-health/:orgId/alerts/unresolved — unresolved alerts
- *   POST /api/network-health/:orgId/alerts       — configure alert thresholds (admin)
- *   POST /api/network-health/alerts/:alertId/resolve — resolve an alert (admin)
+ *   POST /api/network-health/:orgId/alerts       — configure alert thresholds
+ *   POST /api/network-health/:orgId/alerts/:alertId/resolve — resolve an alert
  *
  * Admin page:
  *   GET  /admin/network-health                   — dashboard
@@ -22,9 +23,10 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { createLogger } from '../logger.js';
-import { requireAuth, requireAdmin } from '../middleware/auth.js';
+import { requireGlobalAdmin } from '../middleware/auth.js';
 import * as db from '../db/network-health-db.js';
 import { isUuid } from '../utils/uuid.js';
+import { serveHtmlWithConfig } from '../utils/html-config.js';
 
 const logger = createLogger('network-health');
 
@@ -40,16 +42,28 @@ const alertRuleSchema = z.object({
   enabled: z.boolean().optional(),
 });
 
+/** Register the platform-admin dashboard page on the shared admin router. */
+export function registerNetworkHealthAdminPage(pageRouter: Router): void {
+  pageRouter.get('/network-health', ...requireGlobalAdmin, (req, res) => {
+    serveHtmlWithConfig(req, res, 'admin-network-health.html').catch((error) => {
+      logger.error({ error }, 'Error serving network health page');
+      res.status(500).send('Internal server error');
+    });
+  });
+}
+
 export function createNetworkHealthApiRouter(): Router {
   const apiRouter = Router();
 
-  // All API routes require authentication
-  apiRouter.use(requireAuth);
+  // This dashboard intentionally spans organizations. Keep the authorization
+  // boundary at router scope so new endpoints cannot accidentally inherit only
+  // authentication or tenant-admin access.
+  apiRouter.use(...requireGlobalAdmin);
 
   // ── Read API ───────────────────────────────────────────────────
 
-  // Summary across all tracked orgs (admin only)
-  apiRouter.get('/', requireAdmin, async (_req, res) => {
+  // Summary across all tracked orgs
+  apiRouter.get('/', async (_req, res) => {
     try {
       const summaries = await db.getNetworkSummaries();
       res.json({ networks: summaries });
@@ -143,10 +157,10 @@ export function createNetworkHealthApiRouter(): Router {
     }
   });
 
-  // ── Write API (admin only) ────────────────────────────────────
+  // ── Write API ─────────────────────────────────────────────────
 
   // Configure alert thresholds
-  apiRouter.post('/:orgId/alerts', requireAdmin, async (req, res) => {
+  apiRouter.post('/:orgId/alerts', async (req, res) => {
     try {
       const parsed = alertRuleSchema.safeParse(req.body);
       if (!parsed.success) {
@@ -170,14 +184,19 @@ export function createNetworkHealthApiRouter(): Router {
     }
   });
 
-  // Resolve an alert (must be before /:orgId routes to avoid capture)
-  apiRouter.post('/:orgId/alerts/:alertId/resolve', requireAdmin, async (req, res) => {
+  // Resolve an alert within the organization named by the route.
+  apiRouter.post('/:orgId/alerts/:alertId/resolve', async (req, res) => {
     try {
       const { alertId } = req.params;
       if (!isUuid(alertId)) {
         return res.status(400).json({ error: 'Invalid alert ID format' });
       }
-      await db.resolveAlert(alertId);
+      const resolved = await db.resolveAlert(req.params.orgId, alertId);
+      if (!resolved) {
+        // Use the same response for a missing alert and an alert owned by a
+        // different organization so the route does not disclose ownership.
+        return res.status(404).json({ error: 'Alert not found' });
+      }
       res.json({ ok: true });
     } catch (error) {
       logger.error({ error }, 'Error resolving alert');

--- a/server/tests/unit/network-health-db.test.ts
+++ b/server/tests/unit/network-health-db.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '../../src/db/client.js';
+import { resolveAlert } from '../../src/db/network-health-db.js';
+
+const mockedQuery = vi.mocked(query);
+
+describe('network-health alert resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('atomically binds the update to organization and alert ID', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ id: 'alert_1' }],
+      rowCount: 1,
+      command: 'UPDATE',
+      oid: 0,
+      fields: [],
+    });
+
+    await expect(resolveAlert('org_target', 'alert_1')).resolves.toBe(true);
+
+    const [sql, params] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('SET resolved_at = COALESCE(resolved_at, NOW())');
+    expect(sql).toContain('WHERE org_id = $1 AND id = $2');
+    expect(sql).toContain('RETURNING id');
+    expect(params).toEqual(['org_target', 'alert_1']);
+  });
+
+  it('returns false for a missing alert or organization mismatch', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [],
+      rowCount: 0,
+      command: 'UPDATE',
+      oid: 0,
+      fields: [],
+    });
+
+    await expect(resolveAlert('org_other', 'alert_1')).resolves.toBe(false);
+  });
+});

--- a/server/tests/unit/network-health-security.test.ts
+++ b/server/tests/unit/network-health-security.test.ts
@@ -1,0 +1,418 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  createValidation: vi.fn(),
+  loadSealedSession: vi.fn(),
+  checkPlatformBanForApiKey: vi.fn(),
+  checkPlatformBan: vi.fn(),
+  resolveEffectiveMembership: vi.fn(),
+  isWebUserAAOAdmin: vi.fn(),
+  poolQuery: vi.fn(),
+  getNetworkSummaries: vi.fn(),
+  getLatestReport: vi.fn(),
+  getReportHistory: vi.fn(),
+  getTrends: vi.fn(),
+  getAlertRule: vi.fn(),
+  getAlertHistory: vi.fn(),
+  getUnresolvedAlerts: vi.fn(),
+  upsertAlertRule: vi.fn(),
+  resolveAlert: vi.fn(),
+  serveHtmlWithConfig: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = 'sk_test_network_health_boundary';
+  process.env.WORKOS_CLIENT_ID = 'client_test_network_health_boundary';
+  process.env.WORKOS_COOKIE_PASSWORD =
+    'test-cookie-password-at-least-32-characters';
+  process.env.ADMIN_API_KEY = 'static-global-admin-key';
+  process.env.ADMIN_EMAILS = '';
+  delete process.env.DEV_USER_EMAIL;
+  delete process.env.DEV_USER_ID;
+});
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: class WorkOS {
+    apiKeys = { createValidation: mocks.createValidation };
+    userManagement = { loadSealedSession: mocks.loadSealedSession };
+  },
+}));
+
+vi.mock('../../src/db/bans-db.js', () => ({
+  bansDb: {
+    checkPlatformBanForApiKey: mocks.checkPlatformBanForApiKey,
+    checkPlatformBan: mocks.checkPlatformBan,
+  },
+}));
+
+vi.mock('../../src/db/org-filters.js', () => ({
+  resolveEffectiveMembership: mocks.resolveEffectiveMembership,
+}));
+
+vi.mock('../../src/db/client.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/db/client.js')>()),
+  getPool: () => ({ query: mocks.poolQuery }),
+}));
+
+vi.mock('../../src/addie/mcp/admin-tools.js', () => ({
+  isWebUserAAOAdmin: mocks.isWebUserAAOAdmin,
+}));
+
+vi.mock('../../src/db/network-health-db.js', () => ({
+  getNetworkSummaries: mocks.getNetworkSummaries,
+  getLatestReport: mocks.getLatestReport,
+  getReportHistory: mocks.getReportHistory,
+  getTrends: mocks.getTrends,
+  getAlertRule: mocks.getAlertRule,
+  getAlertHistory: mocks.getAlertHistory,
+  getUnresolvedAlerts: mocks.getUnresolvedAlerts,
+  upsertAlertRule: mocks.upsertAlertRule,
+  resolveAlert: mocks.resolveAlert,
+}));
+
+vi.mock('../../src/utils/html-config.js', () => ({
+  serveHtmlWithConfig: mocks.serveHtmlWithConfig,
+}));
+
+const { createNetworkHealthApiRouter, registerNetworkHealthAdminPage } = await import(
+  '../../src/routes/network-health.js'
+);
+const { stopAuthTimers } = await import('../../src/middleware/auth.js');
+const { csrfProtection } = await import('../../src/middleware/csrf.js');
+
+const ALERT_ID = '11111111-1111-4111-8111-111111111111';
+const CSRF_TOKEN = 'a'.repeat(64);
+
+function createApp() {
+  const app = express();
+  app.use(cookieParser());
+  app.use(csrfProtection);
+  app.use(express.json());
+  app.use('/api/network-health', createNetworkHealthApiRouter());
+  const pageRouter = express.Router();
+  registerNetworkHealthAdminPage(pageRouter);
+  app.use('/admin', pageRouter);
+  return app;
+}
+
+function validatedTenantKey(permission: 'admin:*' | 'admin:read') {
+  return {
+    apiKey: {
+      id: `key_${permission}`,
+      owner: { id: 'org_tenant' },
+      name: 'Tenant admin key',
+      permissions: [permission],
+    },
+  };
+}
+
+function expectNoNetworkHealthQuery() {
+  for (const dbCall of [
+    mocks.getNetworkSummaries,
+    mocks.getLatestReport,
+    mocks.getReportHistory,
+    mocks.getTrends,
+    mocks.getAlertRule,
+    mocks.getAlertHistory,
+    mocks.getUnresolvedAlerts,
+    mocks.upsertAlertRule,
+    mocks.resolveAlert,
+  ]) {
+    expect(dbCall).not.toHaveBeenCalled();
+  }
+}
+
+function configureSsoSession(isPlatformAdmin: boolean): void {
+  mocks.isWebUserAAOAdmin.mockResolvedValue(isPlatformAdmin);
+  mocks.loadSealedSession.mockReturnValue({
+    authenticate: vi.fn().mockResolvedValue({
+      authenticated: true,
+      accessToken: 'user-access-token',
+      user: {
+        id: isPlatformAdmin ? 'user_platform_admin' : 'user_non_admin',
+        email: isPlatformAdmin ? 'platform-admin@example.test' : 'user@example.test',
+        firstName: isPlatformAdmin ? 'Platform' : 'Regular',
+        lastName: isPlatformAdmin ? 'Admin' : 'User',
+        emailVerified: true,
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      },
+    }),
+  });
+}
+
+function withSsoAuth<T extends request.Test>(test: T, platformAdmin = false): T {
+  const session = platformAdmin ? 'platform-admin-session' : 'non-admin-session';
+  return test
+    .set('Cookie', `wos-session=${session}; csrf-token=${CSRF_TOKEN}`)
+    .set('X-CSRF-Token', CSRF_TOKEN) as T;
+}
+
+function withCsrf<T extends request.Test>(test: T): T {
+  return test
+    .set('Cookie', `csrf-token=${CSRF_TOKEN}`)
+    .set('X-CSRF-Token', CSRF_TOKEN) as T;
+}
+
+describe('network-health global authorization boundary', () => {
+  const app = createApp();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createValidation.mockImplementation(({ value }: { value: string }) =>
+      Promise.resolve(
+        validatedTenantKey(value.includes('read') ? 'admin:read' : 'admin:*'),
+      ),
+    );
+    mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: true });
+    mocks.checkPlatformBanForApiKey.mockResolvedValue({ banned: false });
+    mocks.checkPlatformBan.mockResolvedValue({ banned: false });
+    mocks.isWebUserAAOAdmin.mockResolvedValue(false);
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes('FROM users')) {
+        return Promise.resolve({
+          rows: [{ first_name: 'Regular', last_name: 'User' }],
+          rowCount: 1,
+        });
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+    mocks.getNetworkSummaries.mockResolvedValue([]);
+    mocks.getLatestReport.mockResolvedValue({ id: 'report_1' });
+    mocks.getReportHistory.mockResolvedValue([{ id: 'report_history_1' }]);
+    mocks.getTrends.mockResolvedValue([{ checked_at: '2026-01-01' }]);
+    mocks.getAlertRule.mockResolvedValue({
+      id: 'rule_1',
+      org_id: 'org_target',
+      enabled: true,
+      slack_webhook_url: 'https://hooks.slack.com/services/secret/path',
+    });
+    mocks.getAlertHistory.mockResolvedValue([{ id: 'alert_history_1' }]);
+    mocks.getUnresolvedAlerts.mockResolvedValue([{ id: 'alert_open_1' }]);
+    mocks.upsertAlertRule.mockResolvedValue({
+      id: 'rule_1',
+      org_id: 'org_target',
+      enabled: true,
+      slack_webhook_url: 'https://hooks.slack.com/services/secret/path',
+    });
+    mocks.resolveAlert.mockResolvedValue(true);
+    mocks.serveHtmlWithConfig.mockImplementation(
+      (_req: express.Request, res: express.Response) => {
+        res.status(200).send('Network health admin');
+        return Promise.resolve();
+      },
+    );
+  });
+
+  function endpointsFor(orgId: string) {
+    return [
+      { method: 'get', path: '/api/network-health' },
+      { method: 'get', path: `/api/network-health/${orgId}` },
+      { method: 'get', path: `/api/network-health/${orgId}/history` },
+      { method: 'get', path: `/api/network-health/${orgId}/trends` },
+      { method: 'get', path: `/api/network-health/${orgId}/alerts` },
+      { method: 'get', path: `/api/network-health/${orgId}/alerts/history` },
+      { method: 'get', path: `/api/network-health/${orgId}/alerts/unresolved` },
+      { method: 'post', path: `/api/network-health/${orgId}/alerts`, body: { enabled: true } },
+      {
+        method: 'post',
+        path: `/api/network-health/${orgId}/alerts/${ALERT_ID}/resolve`,
+        body: {},
+      },
+    ] as const;
+  }
+
+  const positiveEndpoints = [
+    { method: 'get', path: '/api/network-health', db: mocks.getNetworkSummaries, args: [] },
+    { method: 'get', path: '/api/network-health/org_target', db: mocks.getLatestReport, args: ['org_target'] },
+    { method: 'get', path: '/api/network-health/org_target/history', db: mocks.getReportHistory, args: ['org_target', 30] },
+    { method: 'get', path: '/api/network-health/org_target/trends', db: mocks.getTrends, args: ['org_target', 60] },
+    { method: 'get', path: '/api/network-health/org_target/alerts', db: mocks.getAlertRule, args: ['org_target'] },
+    { method: 'get', path: '/api/network-health/org_target/alerts/history', db: mocks.getAlertHistory, args: ['org_target', 50] },
+    { method: 'get', path: '/api/network-health/org_target/alerts/unresolved', db: mocks.getUnresolvedAlerts, args: ['org_target'] },
+    { method: 'post', path: '/api/network-health/org_target/alerts', body: { enabled: true }, db: mocks.upsertAlertRule },
+    {
+      method: 'post',
+      path: `/api/network-health/org_target/alerts/${ALERT_ID}/resolve`,
+      body: {},
+      db: mocks.resolveAlert,
+      args: ['org_target', ALERT_ID],
+    },
+  ] as const;
+
+  it.each([
+    ['admin:*', 'org_tenant'],
+    ['admin:*', 'org_foreign'],
+    ['admin:read', 'org_tenant'],
+    ['admin:read', 'org_foreign'],
+  ] as const)(
+    'rejects a tenant key with %s for %s before every network-health query',
+    async (permission, orgId) => {
+      for (const endpoint of endpointsFor(orgId)) {
+        vi.clearAllMocks();
+        mocks.createValidation.mockResolvedValue(validatedTenantKey(permission));
+        mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: true });
+        mocks.checkPlatformBanForApiKey.mockResolvedValue({ banned: false });
+
+        const response = await request(app)
+          [endpoint.method](endpoint.path)
+          .set('Authorization', `Bearer sk_tenant_${permission}`)
+          .send('body' in endpoint ? endpoint.body : undefined);
+
+        expect(response.status, endpoint.path).toBe(403);
+        expect(response.body.error, endpoint.path).toBe('global_admin_required');
+        expectNoNetworkHealthQuery();
+      }
+    },
+  );
+
+  it('rejects unauthenticated callers before every network-health query', async () => {
+    for (const endpoint of endpointsFor('org_target')) {
+      vi.clearAllMocks();
+      const response = await withCsrf(request(app)
+        [endpoint.method](endpoint.path)
+        .set('Accept', 'application/json')
+        .send('body' in endpoint ? endpoint.body : undefined));
+
+      expect(response.status, endpoint.path).toBe(401);
+      expectNoNetworkHealthQuery();
+    }
+  });
+
+  it('rejects an authenticated non-platform SSO user before every network-health query', async () => {
+    // Organization membership is deliberately not an authorization input for
+    // this platform-global surface; only platform-admin status is consulted.
+    configureSsoSession(false);
+    for (const endpoint of endpointsFor('org_target')) {
+      vi.clearAllMocks();
+      const test = request(app)[endpoint.method](endpoint.path).send(
+        'body' in endpoint ? endpoint.body : undefined,
+      );
+      const response = await withSsoAuth(test);
+
+      expect(response.status, endpoint.path).toBe(403);
+      expect(response.body.error, endpoint.path).toBe('Admin access required');
+      expectNoNetworkHealthQuery();
+    }
+  });
+
+  it('allows an SSO platform admin through every API path with exact scoped DB arguments', async () => {
+    configureSsoSession(true);
+    for (const endpoint of positiveEndpoints) {
+      vi.clearAllMocks();
+      const test = request(app)[endpoint.method](endpoint.path).send(
+        'body' in endpoint ? endpoint.body : undefined,
+      );
+      const response = await withSsoAuth(test, true);
+
+      expect(response.status, endpoint.path).toBe(200);
+      expect(endpoint.db, endpoint.path).toHaveBeenCalledOnce();
+      if ('args' in endpoint) {
+        expect(endpoint.db.mock.calls[0], endpoint.path).toEqual(endpoint.args);
+      } else {
+        expect(mocks.upsertAlertRule).toHaveBeenCalledWith(
+          expect.objectContaining({
+            org_id: 'org_target',
+            enabled: true,
+            created_by: 'platform-admin@example.test',
+          }),
+        );
+      }
+      if (endpoint.path.endsWith('/alerts')) {
+        expect(response.body.slack_webhook_url).toBeUndefined();
+        expect(response.body.slack_webhook_configured).toBe(true);
+      }
+    }
+  });
+
+  it('allows a global static admin to read the cross-organization summary', async () => {
+    const response = await request(app)
+      .get('/api/network-health')
+      .set('Authorization', 'Bearer static-global-admin-key');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ networks: [] });
+    expect(mocks.getNetworkSummaries).toHaveBeenCalledOnce();
+  });
+
+  it('binds alert resolution to both route organization and alert ID', async () => {
+    const response = await request(app)
+      .post(`/api/network-health/org_target/alerts/${ALERT_ID}/resolve`)
+      .set('Authorization', 'Bearer static-global-admin-key');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    expect(mocks.resolveAlert).toHaveBeenCalledWith('org_target', ALERT_ID);
+  });
+
+  it('returns the same 404 when the org-bound alert update finds no row', async () => {
+    mocks.resolveAlert.mockResolvedValue(false);
+
+    const response = await request(app)
+      .post(`/api/network-health/org_other/alerts/${ALERT_ID}/resolve`)
+      .set('Authorization', 'Bearer static-global-admin-key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'Alert not found' });
+    expect(mocks.resolveAlert).toHaveBeenCalledWith('org_other', ALERT_ID);
+  });
+
+  it('rejects malformed alert IDs without calling the update', async () => {
+    const response = await request(app)
+      .post('/api/network-health/org_target/alerts/not-a-uuid/resolve')
+      .set('Authorization', 'Bearer static-global-admin-key');
+
+    expect(response.status).toBe(400);
+    expect(mocks.resolveAlert).not.toHaveBeenCalled();
+  });
+
+  it.each(['admin:*', 'admin:read'] as const)(
+    'rejects a tenant key with %s before serving the admin page',
+    async (permission) => {
+      mocks.createValidation.mockResolvedValue(validatedTenantKey(permission));
+      const response = await request(app)
+        .get('/admin/network-health')
+        .set('Accept', 'text/html')
+        .set('Authorization', `Bearer sk_tenant_${permission}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('global_admin_required');
+      expect(mocks.serveHtmlWithConfig).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects a non-platform SSO user before serving the admin page', async () => {
+    configureSsoSession(false);
+    const response = await withSsoAuth(
+      request(app).get('/admin/network-health').set('Accept', 'application/json'),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mocks.serveHtmlWithConfig).not.toHaveBeenCalled();
+  });
+
+  it('allows SSO and static platform admins to serve the admin page', async () => {
+    configureSsoSession(true);
+    const ssoResponse = await withSsoAuth(
+      request(app).get('/admin/network-health').set('Accept', 'text/html'),
+      true,
+    );
+    expect(ssoResponse.status).toBe(200);
+    expect(mocks.serveHtmlWithConfig).toHaveBeenCalledOnce();
+
+    vi.clearAllMocks();
+    const staticResponse = await request(app)
+      .get('/admin/network-health')
+      .set('Accept', 'text/html')
+      .set('Authorization', 'Bearer static-global-admin-key');
+    expect(staticResponse.status).toBe(200);
+    expect(mocks.serveHtmlWithConfig).toHaveBeenCalledOnce();
+  });
+});
+
+afterAll(() => {
+  stopAuthTimers();
+});

--- a/server/tests/unit/network-health-security.test.ts
+++ b/server/tests/unit/network-health-security.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
-import cookieParser from 'cookie-parser';
 import request from 'supertest';
 
 const mocks = vi.hoisted(() => ({
@@ -88,7 +87,18 @@ const CSRF_TOKEN = 'a'.repeat(64);
 
 function createApp() {
   const app = express();
-  app.use(cookieParser());
+  // Authentication/CSRF behavior is under test, not cookie-parser itself.
+  // Inject the already-parsed cookie shape that production's global
+  // cookieParser middleware supplies so CodeQL does not mistake this isolated
+  // test application for a production cookie-authenticated server.
+  app.use((req, _res, next) => {
+    req.cookies = {};
+    const session = req.get('X-Test-Session');
+    const csrfCookie = req.get('X-Test-Csrf-Cookie');
+    if (session) req.cookies['wos-session'] = session;
+    if (csrfCookie) req.cookies['csrf-token'] = csrfCookie;
+    next();
+  });
   app.use(csrfProtection);
   app.use(express.json());
   app.use('/api/network-health', createNetworkHealthApiRouter());
@@ -147,13 +157,14 @@ function configureSsoSession(isPlatformAdmin: boolean): void {
 function withSsoAuth<T extends request.Test>(test: T, platformAdmin = false): T {
   const session = platformAdmin ? 'platform-admin-session' : 'non-admin-session';
   return test
-    .set('Cookie', `wos-session=${session}; csrf-token=${CSRF_TOKEN}`)
+    .set('X-Test-Session', session)
+    .set('X-Test-Csrf-Cookie', CSRF_TOKEN)
     .set('X-CSRF-Token', CSRF_TOKEN) as T;
 }
 
 function withCsrf<T extends request.Test>(test: T): T {
   return test
-    .set('Cookie', `csrf-token=${CSRF_TOKEN}`)
+    .set('X-Test-Csrf-Cookie', CSRF_TOKEN)
     .set('X-CSRF-Token', CSRF_TOKEN) as T;
 }
 


### PR DESCRIPTION
## Summary

- make the cross-organization network-health API and dashboard page platform-global-admin-only
- reject tenant-scoped WorkOS API keys before any report, alert, or page access
- bind alert resolution atomically to both the route organization and alert ID, returning a uniform 404 when no row matches
- add adversarial real-auth coverage for unauthenticated users, non-platform SSO users, tenant keys, SSO platform admins, and the static platform key

## Security findings addressed

- `codex-security/e7408e3c0a688491` — authenticated cross-organization network-health reads
- `codex-security/979a512ad5dbb710` — alert resolution not bound to the authorized organization

## Validation

- 35 focused authorization/database tests passed after rebasing onto `origin/main`
- server TypeScript no-emit check passed
- Semgrep: 0 findings across 210 rules on the changed runtime files
- `git diff --check`, package/lock guard, and dist guard passed
- independent security and testing expert reviews: CLEAN

Package metadata and generated `dist` files are unchanged.
