### PR TITLE
feat(registry): add moderated community mirror proposals

### DIFF
--- a/docs/governance/property/adagents.mdx
+++ b/docs/governance/property/adagents.mdx
@@ -297,6 +297,8 @@ A community mirror:
 - MUST carry at least one non-empty catalog array (`formats`/`properties`/`placements`/`collections`/`signals`) and SHOULD carry a **`catalog_etag`** cache validator (the validator enforces the array, not `catalog_etag`). A file with neither sales authorization nor catalog content is invalid.
 - Sets **`superseded_by`** once the platform publishes its own authoritative `adagents.json`. Buyer SDKs encountering `superseded_by` SHOULD re-fetch from the named URL rather than serving the stale mirror. The mirror SHOULD continue serving with `superseded_by` set for at least one minor release so buyer caches keyed on the mirror URL get an explicit migration signal.
 
+Community contributions use a review-before-publication workflow. Any authenticated organization can submit a conforming catalog with `PUT /api/registry/mirrors/{platform}`. Registry moderators and AgenticAdvertising.org administrators publish immediately; other callers receive `202 Accepted` with an opaque proposal ID, status URL, and content digest. Contributors can follow their proposals through `/api/registry/mirror-proposals`, while moderators approve or reject the exact reviewed digest from the same review surface. Approval returns `409 Conflict` if either the proposal content or its base public mirror changed after review. Pending proposals are stored separately and never appear at `/translated/<platform>/adagents.json` or in derived publisher records before approval.
+
 See the worked example at [`static/examples/adagents/community/meta.json`](https://github.com/adcontextprotocol/adcp/blob/main/static/examples/adagents/community/meta.json).
 
 ## URL Reference Pattern

--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -337,6 +337,8 @@ Authorization: Bearer <jwt>
 
 A valid user JWT proves identity, not entitlement. Endpoints gated on organization membership or admin role (most write endpoints) still return `403` if the authenticated user lacks the required standing.
 
+Community-mirror submissions are the exception to direct role rejection: `PUT /api/registry/mirrors/{platform}` accepts any authenticated organization. A registry moderator or AgenticAdvertising.org administrator publishes immediately; other callers create a pending proposal and receive `202 Accepted` plus `Location`, `status_url`, and `proposal_digest`. Review decisions must echo that digest, and approval fails if the public mirror changed since submission. Contributor proposals are limited to 1 MiB and 2,000 catalog items. This keeps community contribution open without allowing an organization credential to publish a global fallback catalog on another platform's behalf without bounded, revision-safe review.
+
 ### Authenticated endpoints
 
 These endpoints require a valid API key.

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -107,7 +107,7 @@ const TAG_DESCRIPTIONS: Record<string, string> = {
   "Change Feed": "Poll cursor-based registry change events for local sync.",
   "Lookups & Authorization": "Look up agents by domain or property, and validate ad-serving authorization.",
   "Validation Tools": "Validate publisher adagents.json files and generate compliant configurations.",
-  "Community Mirrors": "Publish, fetch, list, and retire catalog-only adagents.json mirrors for platforms that have not adopted AdCP.",
+  "Community Mirrors": "Propose, review, publish, fetch, list, and retire catalog-only adagents.json mirrors for platforms that have not adopted AdCP.",
   "Search": "Cross-entity search across brands, publishers, agents, and properties.",
   "Agent Probing": "Connect to live agents and inspect their capabilities, formats, and inventory.",
   "Brand Discovery": "Discover and crawl brand.json files across domains.",

--- a/server/src/creative-agent/index.ts
+++ b/server/src/creative-agent/index.ts
@@ -113,13 +113,10 @@ export function createCreativeAgentRouter(): Router {
       }
 
       const serialized = JSON.stringify(mirror.adagents_json);
-      // Use catalog_etag only when it is safe to embed in a quoted ETag header
-      // (no quotes / control chars); otherwise fall back to a content hash so a
-      // moderator-supplied token can't produce a malformed ETag.
-      const etagValue =
-        mirror.catalog_etag && /^[A-Za-z0-9_\-:.+=]+$/.test(mirror.catalog_etag)
-          ? mirror.catalog_etag
-          : createHash('sha256').update(serialized).digest('hex').slice(0, 32);
+      // HTTP cache validation must follow the served bytes. `catalog_etag` is
+      // provenance supplied with the catalog and may be reused accidentally;
+      // using it here could return 304 after the mirror content changed.
+      const etagValue = createHash('sha256').update(serialized).digest('hex').slice(0, 32);
       const etag = `"${etagValue}"`;
 
       res.setHeader('ETag', etag);

--- a/server/src/db/community-mirror-db.ts
+++ b/server/src/db/community-mirror-db.ts
@@ -2,9 +2,9 @@ import { query } from './client.js';
 import type { PoolClient } from 'pg';
 
 /**
- * A stored AAO catalog-only community mirror (#2176). The body is a
- * catalog-only adagents.json (authorized_agents: []) for a platform that has
- * not adopted AdCP, served at /translated/<platform>/adagents.json. One row
+ * A stored AgenticAdvertising.org catalog-only community mirror (#2176). The
+ * body is a catalog-only adagents.json (authorized_agents: []) for a platform
+ * that has not adopted AdCP, served at /translated/<platform>/adagents.json. One row
  * per platform; re-publishing the same platform updates the row in place.
  */
 export interface CommunityMirror {
@@ -33,6 +33,55 @@ export interface UpsertCommunityMirrorInput {
   superseded_by?: string | null;
   created_by_user_id?: string | null;
   created_by_email?: string | null;
+}
+
+export type CommunityMirrorProposalStatus = 'pending' | 'approved' | 'rejected';
+
+export interface CommunityMirrorProposal {
+  id: string;
+  platform: string;
+  adagents_json: Record<string, unknown>;
+  catalog_etag: string | null;
+  superseded_by: string | null;
+  proposal_digest: string;
+  base_mirror_digest: string | null;
+  status: CommunityMirrorProposalStatus;
+  proposed_by_user_id: string;
+  proposed_by_email: string | null;
+  proposed_by_organization_id: string | null;
+  proposed_at: string;
+  reviewed_by_user_id: string | null;
+  reviewed_at: string | null;
+  review_notes: string | null;
+  published_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CommunityMirrorProposalSummary {
+  id: string;
+  platform: string;
+  catalog_etag: string | null;
+  superseded_by: string | null;
+  proposal_digest: string;
+  base_mirror_digest: string | null;
+  status: CommunityMirrorProposalStatus;
+  proposed_at: string;
+  reviewed_at: string | null;
+  published_at: string | null;
+  updated_at: string;
+}
+
+export interface SubmitCommunityMirrorProposalInput {
+  platform: string;
+  adagents_json: Record<string, unknown>;
+  catalog_etag?: string | null;
+  superseded_by?: string | null;
+  proposal_digest: string;
+  base_mirror_digest?: string | null;
+  proposed_by_user_id: string;
+  proposed_by_email?: string | null;
+  proposed_by_organization_id?: string | null;
 }
 
 export class CommunityMirrorDatabase {
@@ -137,5 +186,152 @@ export class CommunityMirrorDatabase {
   async deleteByPlatformWithClient(client: PoolClient, platform: string): Promise<boolean> {
     const result = await client.query('DELETE FROM community_mirrors WHERE platform = $1', [platform]);
     return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * Create or refresh this caller's pending proposal for a platform. The
+   * partial unique indexes keep retries idempotent while preserving completed
+   * review records.
+   */
+  async submitProposal(input: SubmitCommunityMirrorProposalInput): Promise<CommunityMirrorProposal> {
+    const organizationId = input.proposed_by_organization_id ?? null;
+    const conflictTarget = organizationId
+      ? `(platform, proposed_by_organization_id)
+         WHERE status = 'pending' AND proposed_by_organization_id IS NOT NULL`
+      : `(platform, proposed_by_user_id)
+         WHERE status = 'pending' AND proposed_by_organization_id IS NULL`;
+    const result = await query<CommunityMirrorProposal>(
+      `INSERT INTO community_mirror_proposals
+         (platform, adagents_json, catalog_etag, superseded_by,
+          proposal_digest, base_mirror_digest,
+          proposed_by_user_id, proposed_by_email, proposed_by_organization_id)
+       VALUES ($1, $2::jsonb, $3, $4, $5, $6, $7, $8, $9)
+       ON CONFLICT ${conflictTarget} DO UPDATE SET
+         adagents_json = EXCLUDED.adagents_json,
+         catalog_etag = EXCLUDED.catalog_etag,
+         superseded_by = EXCLUDED.superseded_by,
+         proposal_digest = EXCLUDED.proposal_digest,
+         base_mirror_digest = EXCLUDED.base_mirror_digest,
+         proposed_by_user_id = EXCLUDED.proposed_by_user_id,
+         proposed_by_email = EXCLUDED.proposed_by_email,
+         proposed_at = NOW(),
+         reviewed_by_user_id = NULL,
+         reviewed_at = NULL,
+         review_notes = NULL,
+         published_at = NULL,
+         updated_at = NOW()
+       RETURNING *`,
+      [
+        input.platform,
+        JSON.stringify(input.adagents_json),
+        input.catalog_etag ?? null,
+        input.superseded_by ?? null,
+        input.proposal_digest,
+        input.base_mirror_digest ?? null,
+        input.proposed_by_user_id,
+        input.proposed_by_email ?? null,
+        organizationId,
+      ],
+    );
+    return result.rows[0];
+  }
+
+  async getProposalById(id: string): Promise<CommunityMirrorProposal | null> {
+    const result = await query<CommunityMirrorProposal>(
+      `SELECT * FROM community_mirror_proposals WHERE id = $1`,
+      [id],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  async getProposalByIdWithClient(client: PoolClient, id: string): Promise<CommunityMirrorProposal | null> {
+    const result = await client.query<CommunityMirrorProposal>(
+      `SELECT * FROM community_mirror_proposals WHERE id = $1 FOR UPDATE`,
+      [id],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  async listProposals(options: {
+    status?: CommunityMirrorProposalStatus;
+    proposedByUserId?: string;
+    proposedByOrganizationId?: string;
+    limit?: number;
+    offset?: number;
+  } = {}): Promise<{ proposals: CommunityMirrorProposalSummary[]; total: number }> {
+    const clauses: string[] = [];
+    const values: unknown[] = [];
+    const add = (clause: string, value: unknown) => {
+      values.push(value);
+      clauses.push(clause.replace('?', `$${values.length}`));
+    };
+    if (options.status) add('status = ?', options.status);
+    if (options.proposedByOrganizationId) {
+      add('proposed_by_organization_id = ?', options.proposedByOrganizationId);
+    } else if (options.proposedByUserId) {
+      add('proposed_by_user_id = ?', options.proposedByUserId);
+    }
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+    const limit = Math.min(Math.max(options.limit ?? 25, 1), 50);
+    const offset = Math.max(options.offset ?? 0, 0);
+    const listValues = [...values, limit, offset];
+    const [rows, count] = await Promise.all([
+      query<CommunityMirrorProposalSummary>(
+        `SELECT id, platform, catalog_etag, superseded_by, proposal_digest,
+                base_mirror_digest, status, proposed_at, reviewed_at,
+                published_at, updated_at
+           FROM community_mirror_proposals
+          ${where}
+          ORDER BY proposed_at DESC
+          LIMIT $${values.length + 1} OFFSET $${values.length + 2}`,
+        listValues,
+      ),
+      query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM community_mirror_proposals ${where}`,
+        values,
+      ),
+    ]);
+    return { proposals: rows.rows, total: parseInt(count.rows[0]?.count ?? '0', 10) };
+  }
+
+  async approveProposalWithClient(
+    client: PoolClient,
+    id: string,
+    reviewedByUserId: string,
+    reviewNotes?: string | null,
+  ): Promise<CommunityMirrorProposal | null> {
+    const result = await client.query<CommunityMirrorProposal>(
+      `UPDATE community_mirror_proposals
+          SET status = 'approved',
+              reviewed_by_user_id = $2,
+              reviewed_at = NOW(),
+              review_notes = $3,
+              published_at = NOW(),
+              updated_at = NOW()
+        WHERE id = $1 AND status = 'pending'
+        RETURNING *`,
+      [id, reviewedByUserId, reviewNotes ?? null],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  async rejectProposal(
+    id: string,
+    proposalDigest: string,
+    reviewedByUserId: string,
+    reviewNotes: string,
+  ): Promise<CommunityMirrorProposal | null> {
+    const result = await query<CommunityMirrorProposal>(
+      `UPDATE community_mirror_proposals
+          SET status = 'rejected',
+              reviewed_by_user_id = $3,
+              reviewed_at = NOW(),
+              review_notes = $4,
+              updated_at = NOW()
+        WHERE id = $1 AND status = 'pending' AND proposal_digest = $2
+        RETURNING *`,
+      [id, proposalDigest, reviewedByUserId, reviewNotes],
+    );
+    return result.rows[0] ?? null;
   }
 }

--- a/server/src/db/migrations/529_community_mirror_proposals.sql
+++ b/server/src/db/migrations/529_community_mirror_proposals.sql
@@ -1,0 +1,48 @@
+-- Community members may propose catalog-only mirrors, but only registry
+-- moderators or AgenticAdvertising.org administrators publish them. Keep the
+-- proposed document separate from community_mirrors so unreviewed catalog
+-- data can never leak into the public serving or publisher projection paths.
+CREATE TABLE IF NOT EXISTS community_mirror_proposals (
+  id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  platform                    TEXT NOT NULL CHECK (platform ~ '^[a-z0-9_-]{1,64}$'),
+  adagents_json               JSONB NOT NULL,
+  catalog_etag                TEXT,
+  superseded_by               TEXT,
+  proposal_digest             TEXT NOT NULL CHECK (proposal_digest ~ '^[a-f0-9]{64}$'),
+  base_mirror_digest          TEXT CHECK (base_mirror_digest IS NULL OR base_mirror_digest ~ '^[a-f0-9]{64}$'),
+  status                      TEXT NOT NULL DEFAULT 'pending'
+                                CHECK (status IN ('pending', 'approved', 'rejected')),
+  proposed_by_user_id         TEXT NOT NULL,
+  proposed_by_email           TEXT,
+  proposed_by_organization_id TEXT,
+  proposed_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  reviewed_by_user_id         TEXT,
+  reviewed_at                 TIMESTAMPTZ,
+  review_notes                TEXT,
+  published_at                TIMESTAMPTZ,
+  created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_community_mirror_proposals_review_queue
+  ON community_mirror_proposals (status, proposed_at DESC);
+
+-- Re-running a submission script updates that caller's pending proposal
+-- rather than filling the moderation queue with duplicates. Historical
+-- approved/rejected proposals remain append-only review records.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_community_mirror_proposals_pending_org
+  ON community_mirror_proposals (platform, proposed_by_organization_id)
+  WHERE status = 'pending' AND proposed_by_organization_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_community_mirror_proposals_pending_user
+  ON community_mirror_proposals (platform, proposed_by_user_id)
+  WHERE status = 'pending' AND proposed_by_organization_id IS NULL;
+
+DROP TRIGGER IF EXISTS update_community_mirror_proposals_updated_at
+  ON community_mirror_proposals;
+CREATE TRIGGER update_community_mirror_proposals_updated_at
+  BEFORE UPDATE ON community_mirror_proposals
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+COMMENT ON TABLE community_mirror_proposals IS
+  'Authenticated community submissions awaiting moderator review before publication as community mirrors';

--- a/server/src/routes/community-mirrors.ts
+++ b/server/src/routes/community-mirrors.ts
@@ -1,23 +1,28 @@
 /**
  * Community-mirror catalog lifecycle API (#2176).
  *
- * AAO publishes catalog-only adagents.json mirrors for platforms that have not
- * adopted AdCP (Meta, TikTok, …). These mirrors carry catalog content
- * (formats/properties/placements) and an empty `authorized_agents: []` — there
+ * AgenticAdvertising.org publishes catalog-only adagents.json mirrors for
+ * platforms that have not adopted AdCP (Meta, TikTok, …). These mirrors carry
+ * catalog content (formats/properties/placements) and an empty `authorized_agents: []` — there
  * is no sales agent to authorize. This router makes them first-class:
  *
  *   GET  /api/registry/mirrors            — list mirrors (public, with etags)
  *   GET  /api/registry/mirrors/:platform  — read one mirror (public)
- *   PUT  /api/registry/mirrors/:platform  — idempotent publish/upsert (moderator/admin)
+ *   PUT  /api/registry/mirrors/:platform  — publish for moderators, propose for other callers
+ *   GET  /api/registry/mirror-proposals   — review queue or caller's own proposals
+ *   POST /api/registry/mirror-proposals/:id/{approve,reject} — moderation
  *
  * The stored body is served at /translated/<platform>/adagents.json by the
  * creative agent. Mounted at /api/registry alongside catalog-api.ts.
  */
 
 import { Router } from 'express';
-import type { RequestHandler, Response } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
+import type { PoolClient } from 'pg';
+import { createHash } from 'node:crypto';
 import { z } from 'zod';
 import { CommunityMirrorDatabase } from '../db/community-mirror-db.js';
+import type { CommunityMirror, CommunityMirrorProposal } from '../db/community-mirror-db.js';
 import { PublisherDatabase } from '../db/publisher-db.js';
 import type { CatalogEventsDatabase } from '../db/catalog-events-db.js';
 import { getClient } from '../db/client.js';
@@ -26,10 +31,15 @@ import { isWebUserAAOAdmin } from '../addie/admin-status-lookup.js';
 import { validateAdagentsDocument } from '../services/adagents-schema-validator.js';
 import { registryReadRateLimiter, brandCreationRateLimiter } from '../middleware/rate-limit.js';
 import { createLogger } from '../logger.js';
+import { resolveCallerOrgId } from './helpers/resolve-caller-org.js';
 
 const logger = createLogger('community-mirrors');
 
 const PLATFORM_RE = /^[a-z0-9_-]{1,64}$/;
+const ProposalIdSchema = z.string().uuid();
+const ProposalDigestSchema = z.string().regex(/^[a-f0-9]{64}$/);
+const MAX_PROPOSAL_BYTES = 1024 * 1024;
+const MAX_PROPOSAL_CATALOG_ITEMS = 2000;
 
 const MirrorBodySchema = z
   .object({
@@ -69,14 +79,21 @@ export interface CommunityMirrorRouterConfig {
 }
 
 /**
- * Resolve the authenticated caller and confirm they may manage community
- * mirrors — a registry moderator or AAO admin (the static ADMIN_API_KEY
- * sentinel always passes). Returns the user id, or null after sending the
- * 401/403 response. `req.user` has no isAdmin field — admin status is resolved
- * via isWebUserAAOAdmin, not the request.
+ * Organization API keys represent an organization, not a human working-group
+ * member, so they intentionally submit proposals instead of passing this gate.
  */
-async function resolvePublisher(
-  req: { user?: { id?: string; email?: string } },
+async function canManageMirrors(userId: string): Promise<boolean> {
+  if (userId === 'admin_api_key') return true;
+  if (userId.startsWith('api_key_')) return false;
+  const [isOrganizationAdmin, isModerator] = await Promise.all([
+    isWebUserAAOAdmin(userId),
+    isRegistryModerator(userId),
+  ]);
+  return isOrganizationAdmin || isModerator;
+}
+
+async function resolveManager(
+  req: { user?: { id?: string } },
   res: Response
 ): Promise<string | null> {
   const userId = req.user?.id;
@@ -84,17 +101,39 @@ async function resolvePublisher(
     res.status(401).json({ error: 'Authentication required' });
     return null;
   }
-  if (userId !== 'admin_api_key') {
-    const [isAaoAdmin, isModerator] = await Promise.all([
-      isWebUserAAOAdmin(userId),
-      isRegistryModerator(userId),
-    ]);
-    if (!isAaoAdmin && !isModerator) {
-      res.status(403).json({ error: 'Only registry moderators or AAO admins can manage community mirrors' });
-      return null;
-    }
+  if (!(await canManageMirrors(userId))) {
+    res.status(403).json({
+      error: 'Only registry moderators or AgenticAdvertising.org administrators can manage community mirrors',
+    });
+    return null;
   }
   return userId;
+}
+
+async function callerOrganizationId(req: Request): Promise<string | null> {
+  const attached = (req as Request & { apiKey?: { organizationId?: string } }).apiKey?.organizationId;
+  return attached ?? resolveCallerOrgId(req);
+}
+
+function reviewedContentDigest(document: Record<string, unknown>): string {
+  const { last_updated: _lastUpdated, ...reviewedContent } = document;
+  return createHash('sha256').update(JSON.stringify(reviewedContent)).digest('hex');
+}
+
+function proposalDigest(document: Record<string, unknown>, baseMirrorDigest: string | null): string {
+  return createHash('sha256')
+    .update(`${baseMirrorDigest ?? 'no-public-mirror'}:${reviewedContentDigest(document)}`)
+    .digest('hex');
+}
+
+function proposalForResponse(proposal: CommunityMirrorProposal) {
+  const {
+    proposed_by_user_id: _proposedByUserId,
+    proposed_by_email: _proposedByEmail,
+    reviewed_by_user_id: _reviewedByUserId,
+    ...safe
+  } = proposal;
+  return safe;
 }
 
 export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig): Router {
@@ -106,6 +145,226 @@ export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig)
   const writeMiddleware: RequestHandler[] = authMiddleware
     ? [authMiddleware, brandCreationRateLimiter]
     : [brandCreationRateLimiter];
+  const authenticatedReadMiddleware: RequestHandler[] = authMiddleware
+    ? [authMiddleware, registryReadRateLimiter]
+    : [registryReadRateLimiter];
+
+  async function lockPlatform(client: PoolClient, platform: string): Promise<void> {
+    await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`community-mirror:${platform}`]);
+  }
+
+  async function publishWithClient(
+    client: PoolClient,
+    previousMirror: CommunityMirror | null,
+    input: {
+      platform: string;
+      adagentsJson: Record<string, unknown>;
+      catalogEtag: string | null;
+      supersededBy: string | null;
+      userId: string;
+      email: string | null;
+    },
+  ) {
+    const mirror = await mirrorDb.upsertWithClient(client, {
+      platform: input.platform,
+      adagents_json: input.adagentsJson,
+      catalog_etag: input.catalogEtag,
+      superseded_by: input.supersededBy,
+      created_by_user_id: input.userId,
+      created_by_email: input.email,
+    });
+    const publisherDomains = await publisherDb.replaceCommunityAdagentsCatalogWithClient(client, {
+      platform: input.platform,
+      manifest: input.adagentsJson,
+      previousManifest: previousMirror?.adagents_json ?? null,
+      catalogUrl: `/api/creative-agent/translated/${input.platform}/adagents.json`,
+      createdByUserId: input.userId,
+      createdByEmail: input.email,
+      eventsDb,
+    });
+    return { mirror, publisherDomains };
+  }
+
+  // ── Community proposal and moderation workflow ─────────────────
+  router.get('/mirror-proposals', ...authenticatedReadMiddleware, async (req, res) => {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Authentication required' });
+
+    const requestedStatus = req.query.status ? String(req.query.status) : undefined;
+    if (requestedStatus && !['pending', 'approved', 'rejected'].includes(requestedStatus)) {
+      return res.status(400).json({ error: 'Invalid proposal status' });
+    }
+    const isManager = await canManageMirrors(userId);
+    const organizationId = isManager ? null : await callerOrganizationId(req);
+    const limit = req.query.limit ? parseInt(String(req.query.limit), 10) : undefined;
+    const offset = req.query.offset ? parseInt(String(req.query.offset), 10) : undefined;
+    try {
+      const result = await mirrorDb.listProposals({
+        status: (requestedStatus ?? (isManager ? 'pending' : undefined)) as
+          | 'pending'
+          | 'approved'
+          | 'rejected'
+          | undefined,
+        proposedByOrganizationId: isManager ? undefined : organizationId ?? undefined,
+        proposedByUserId: isManager || organizationId ? undefined : userId,
+        limit: Number.isFinite(limit) ? limit : undefined,
+        offset: Number.isFinite(offset) ? offset : undefined,
+      });
+      return res.json(result);
+    } catch (err) {
+      logger.error({ err, userId }, 'Failed to list community mirror proposals');
+      return res.status(500).json({ error: 'Failed to list community mirror proposals' });
+    }
+  });
+
+  router.get('/mirror-proposals/:id', ...authenticatedReadMiddleware, async (req, res) => {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Authentication required' });
+    const proposalId = String(req.params.id);
+    if (!ProposalIdSchema.safeParse(proposalId).success) {
+      return res.status(400).json({ error: 'Invalid proposal identifier' });
+    }
+    try {
+      const proposal = await mirrorDb.getProposalById(proposalId);
+      if (!proposal) return res.status(404).json({ error: 'Community mirror proposal not found' });
+      const isManager = await canManageMirrors(userId);
+      const organizationId = isManager ? null : await callerOrganizationId(req);
+      const ownsProposal = organizationId
+        ? proposal.proposed_by_organization_id === organizationId
+        : proposal.proposed_by_user_id === userId;
+      if (!ownsProposal && !isManager) {
+        return res.status(404).json({ error: 'Community mirror proposal not found' });
+      }
+      return res.json({ proposal: proposalForResponse(proposal) });
+    } catch (err) {
+      logger.error({ err, proposalId }, 'Failed to read community mirror proposal');
+      return res.status(500).json({ error: 'Failed to read community mirror proposal' });
+    }
+  });
+
+  router.post('/mirror-proposals/:id/approve', ...writeMiddleware, async (req, res) => {
+    const managerId = await resolveManager(req, res);
+    if (!managerId) return;
+    const proposalId = String(req.params.id);
+    if (!ProposalIdSchema.safeParse(proposalId).success) {
+      return res.status(400).json({ error: 'Invalid proposal identifier' });
+    }
+    const review = z.object({
+      proposal_digest: ProposalDigestSchema,
+      review_notes: z.string().trim().max(2000).optional(),
+    }).safeParse(req.body ?? {});
+    if (!review.success) return res.status(400).json({ error: 'Invalid review body', details: review.error.issues });
+
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+      const proposal = await mirrorDb.getProposalByIdWithClient(client, proposalId);
+      if (!proposal) {
+        await client.query('ROLLBACK');
+        return res.status(404).json({ error: 'Community mirror proposal not found' });
+      }
+      if (proposal.status !== 'pending') {
+        await client.query('ROLLBACK');
+        return res.status(409).json({ error: `Community mirror proposal is already ${proposal.status}` });
+      }
+      if (proposal.proposal_digest !== review.data.proposal_digest) {
+        await client.query('ROLLBACK');
+        return res.status(409).json({
+          error: 'Proposal changed after review. Fetch the latest proposal and approve its new proposal_digest.',
+        });
+      }
+
+      await lockPlatform(client, proposal.platform);
+      const currentMirror = await mirrorDb.getByPlatformWithClient(client, proposal.platform);
+      const currentBaseDigest = currentMirror ? reviewedContentDigest(currentMirror.adagents_json) : null;
+      if (proposal.base_mirror_digest !== currentBaseDigest) {
+        await client.query('ROLLBACK');
+        return res.status(409).json({
+          error: 'The published mirror changed after this proposal was submitted. Resubmit against the current mirror.',
+        });
+      }
+
+      const { last_updated: _lastUpdated, authorized_agents: _authorizedAgents, ...proposalBody } =
+        proposal.adagents_json;
+      const adagentsJson = {
+        ...proposalBody,
+        authorized_agents: [],
+        last_updated: new Date().toISOString(),
+      };
+      const conformance = await validateAdagentsDocument(adagentsJson);
+      if (!conformance.valid) {
+        await client.query('ROLLBACK');
+        return res.status(400).json({
+          error: 'Proposed document no longer conforms to the adagents.json schema',
+          details: conformance.errors.slice(0, 20),
+        });
+      }
+
+      const { mirror, publisherDomains } = await publishWithClient(client, currentMirror, {
+        platform: proposal.platform,
+        adagentsJson,
+        catalogEtag: proposal.catalog_etag,
+        supersededBy: proposal.superseded_by,
+        userId: managerId,
+        email: req.user?.email ?? null,
+      });
+      await mirrorDb.approveProposalWithClient(client, proposalId, managerId, review.data.review_notes);
+      await client.query('COMMIT');
+      logger.info({ proposalId, platform: proposal.platform, by: managerId }, 'Approved community mirror proposal');
+      return res.json({
+        success: true,
+        proposal_id: proposalId,
+        platform: mirror.platform,
+        catalog_etag: mirror.catalog_etag,
+        superseded_by: mirror.superseded_by,
+        publisher_domains: publisherDomains,
+        updated_at: mirror.updated_at,
+      });
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => undefined);
+      logger.error({ err, proposalId }, 'Failed to approve community mirror proposal');
+      return res.status(500).json({ error: 'Failed to approve community mirror proposal' });
+    } finally {
+      client.release();
+    }
+  });
+
+  router.post('/mirror-proposals/:id/reject', ...writeMiddleware, async (req, res) => {
+    const managerId = await resolveManager(req, res);
+    if (!managerId) return;
+    const proposalId = String(req.params.id);
+    if (!ProposalIdSchema.safeParse(proposalId).success) {
+      return res.status(400).json({ error: 'Invalid proposal identifier' });
+    }
+    const review = z.object({
+      proposal_digest: ProposalDigestSchema,
+      review_notes: z.string().trim().min(1).max(2000),
+    }).safeParse(req.body);
+    if (!review.success) return res.status(400).json({ error: 'Invalid review body', details: review.error.issues });
+    try {
+      const proposal = await mirrorDb.rejectProposal(
+        proposalId,
+        review.data.proposal_digest,
+        managerId,
+        review.data.review_notes,
+      );
+      if (!proposal) {
+        const existing = await mirrorDb.getProposalById(proposalId);
+        if (!existing) return res.status(404).json({ error: 'Community mirror proposal not found' });
+        if (existing.status === 'pending') {
+          return res.status(409).json({
+            error: 'Proposal changed after review. Fetch the latest proposal and reject its new proposal_digest.',
+          });
+        }
+        return res.status(409).json({ error: `Community mirror proposal is already ${existing.status}` });
+      }
+      logger.info({ proposalId, platform: proposal.platform, by: managerId }, 'Rejected community mirror proposal');
+      return res.json({ success: true, proposal: proposalForResponse(proposal) });
+    } catch (err) {
+      logger.error({ err, proposalId }, 'Failed to reject community mirror proposal');
+      return res.status(500).json({ error: 'Failed to reject community mirror proposal' });
+    }
+  });
 
   // ── GET /api/registry/mirrors — list ────────────────────────────
   router.get('/mirrors', registryReadRateLimiter, async (req, res) => {
@@ -148,15 +407,26 @@ export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig)
     }
   });
 
-  // ── PUT /api/registry/mirrors/:platform — idempotent publish ────
+  // ── PUT /api/registry/mirrors/:platform — publish or propose ────
   router.put('/mirrors/:platform', ...writeMiddleware, async (req, res) => {
     const platform = String(req.params.platform).toLowerCase();
     if (!PLATFORM_RE.test(platform)) {
       return res.status(400).json({ error: 'Invalid platform identifier (expected ^[a-z0-9_-]{1,64}$)' });
     }
 
-    const userId = await resolvePublisher(req, res);
-    if (!userId) return;
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Authentication required' });
+    const isManager = await canManageMirrors(userId);
+    const organizationId = isManager ? null : await callerOrganizationId(req);
+    if (!isManager && !organizationId) {
+      return res.status(403).json({ error: 'Organization context is required to propose a community mirror' });
+    }
+    if (!isManager) {
+      const rawBody = (req as Request & { rawBody?: string }).rawBody ?? JSON.stringify(req.body ?? {});
+      if (Buffer.byteLength(rawBody, 'utf8') > MAX_PROPOSAL_BYTES) {
+        return res.status(413).json({ error: 'Community mirror proposals must not exceed 1 MiB' });
+      }
+    }
 
     const parsed = MirrorBodySchema.safeParse(req.body);
     if (!parsed.success) {
@@ -186,6 +456,15 @@ export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig)
         error: 'A community mirror must carry catalog content (formats, properties, placements, collections, or signals)',
       });
     }
+    if (!isManager) {
+      const catalogItemCount = [body.formats, body.properties, body.placements, body.collections, body.signals]
+        .reduce((total, items) => total + (Array.isArray(items) ? items.length : 0), 0);
+      if (catalogItemCount > MAX_PROPOSAL_CATALOG_ITEMS) {
+        return res.status(413).json({
+          error: `Community mirror proposals may contain at most ${MAX_PROPOSAL_CATALOG_ITEMS} catalog items`,
+        });
+      }
+    }
 
     // Assemble the served document: forced authorized_agents:[] + $schema.
     // authorized_agents is dropped so a mirror never asserts sales
@@ -200,7 +479,7 @@ export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig)
     };
 
     // Validate the fully-assembled document against the published adagents.json
-    // schema before persisting — AAO must never serve a mirror that a buyer SDK
+    // schema before persisting — the registry must never serve a mirror that a buyer SDK
     // validating against the schema would reject (e.g. a formats[] entry
     // missing required params).
     const conformance = await validateAdagentsDocument(adagentsJson);
@@ -211,26 +490,52 @@ export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig)
       });
     }
 
+    if (!isManager) {
+      try {
+        const currentMirror = await mirrorDb.getByPlatform(platform);
+        const baseMirrorDigest = currentMirror ? reviewedContentDigest(currentMirror.adagents_json) : null;
+        const digest = proposalDigest(adagentsJson, baseMirrorDigest);
+        const proposal = await mirrorDb.submitProposal({
+          platform,
+          adagents_json: adagentsJson,
+          catalog_etag: body.catalog_etag ?? null,
+          superseded_by: body.superseded_by ?? null,
+          proposal_digest: digest,
+          base_mirror_digest: baseMirrorDigest,
+          proposed_by_user_id: userId,
+          proposed_by_email: req.user?.email ?? null,
+          proposed_by_organization_id: organizationId,
+        });
+        logger.info({ platform, proposalId: proposal.id, by: userId }, 'Submitted community mirror proposal');
+        const statusUrl = `/api/registry/mirror-proposals/${proposal.id}`;
+        res.setHeader('Location', statusUrl);
+        return res.status(202).json({
+          success: true,
+          status: 'pending',
+          proposal_id: proposal.id,
+          proposal_digest: proposal.proposal_digest,
+          platform: proposal.platform,
+          status_url: statusUrl,
+          submitted_at: proposal.proposed_at,
+        });
+      } catch (err) {
+        logger.error({ err, platform }, 'Failed to submit community mirror proposal');
+        return res.status(500).json({ error: 'Failed to submit community mirror proposal' });
+      }
+    }
+
     const client = await getClient();
     try {
       await client.query('BEGIN');
+      await lockPlatform(client, platform);
       const previousMirror = await mirrorDb.getByPlatformWithClient(client, platform);
-      const mirror = await mirrorDb.upsertWithClient(client, {
+      const { mirror, publisherDomains } = await publishWithClient(client, previousMirror, {
         platform,
-        adagents_json: adagentsJson,
-        catalog_etag: body.catalog_etag ?? null,
-        superseded_by: body.superseded_by ?? null,
-        created_by_user_id: userId,
-        created_by_email: req.user?.email ?? null,
-      });
-      const publisher_domains = await publisherDb.replaceCommunityAdagentsCatalogWithClient(client, {
-        platform,
-        manifest: adagentsJson,
-        previousManifest: previousMirror?.adagents_json ?? null,
-        catalogUrl: `/api/creative-agent/translated/${platform}/adagents.json`,
-        createdByUserId: userId,
-        createdByEmail: req.user?.email ?? null,
-        eventsDb,
+        adagentsJson,
+        catalogEtag: body.catalog_etag ?? null,
+        supersededBy: body.superseded_by ?? null,
+        userId,
+        email: req.user?.email ?? null,
       });
       await client.query('COMMIT');
       logger.info({ platform, by: userId }, 'Published community mirror');
@@ -239,7 +544,7 @@ export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig)
         platform: mirror.platform,
         catalog_etag: mirror.catalog_etag,
         superseded_by: mirror.superseded_by,
-        publisher_domains,
+        publisher_domains: publisherDomains,
         updated_at: mirror.updated_at,
       });
     } catch (err) {
@@ -257,12 +562,13 @@ export function createCommunityMirrorRouter(config: CommunityMirrorRouterConfig)
     if (!PLATFORM_RE.test(platform)) {
       return res.status(400).json({ error: 'Invalid platform identifier (expected ^[a-z0-9_-]{1,64}$)' });
     }
-    const userId = await resolvePublisher(req, res);
+    const userId = await resolveManager(req, res);
     if (!userId) return;
 
     const client = await getClient();
     try {
       await client.query('BEGIN');
+      await lockPlatform(client, platform);
       const mirror = await mirrorDb.getByPlatformWithClient(client, platform);
       if (!mirror) {
         await client.query('ROLLBACK');

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -91,6 +91,13 @@ import {
   CommunityMirrorListResponseSchema,
   CommunityMirrorGetResponseSchema,
   CommunityMirrorPublishResponseSchema,
+  CommunityMirrorProposalSubmissionResponseSchema,
+  CommunityMirrorProposalListResponseSchema,
+  CommunityMirrorProposalGetResponseSchema,
+  CommunityMirrorProposalReviewRequestSchema,
+  CommunityMirrorProposalRejectRequestSchema,
+  CommunityMirrorProposalApprovalResponseSchema,
+  CommunityMirrorProposalDecisionResponseSchema,
   CommunityMirrorDeleteResponseSchema,
   CommunityMirrorPublishErrorSchema,
   AdagentsAuthorizedAgentSchema,
@@ -1784,6 +1791,101 @@ registry.registerPath({
 // Community Mirrors
 registry.registerPath({
   method: "get",
+  path: "/api/registry/mirror-proposals",
+  operationId: "listCommunityMirrorProposals",
+  summary: "List community mirror proposals",
+  description:
+    "List the caller's own community-mirror proposals. Registry moderators and AgenticAdvertising.org administrators see the review queue and may filter by status; their default is `pending`.",
+  tags: ["Community Mirrors"],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
+  request: {
+    query: z.object({
+      status: z.enum(["pending", "approved", "rejected"]).optional(),
+      limit: z.number().int().max(50).optional(),
+      offset: z.number().int().optional(),
+    }),
+  },
+  responses: {
+    200: { description: "Community mirror proposal list", content: { "application/json": { schema: CommunityMirrorProposalListResponseSchema } } },
+    400: { description: "Invalid status", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    429: { description: "Rate limit exceeded", content: { "application/json": { schema: RateLimitErrorSchema } } },
+    500: { description: "Failed to list proposals", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/registry/mirror-proposals/{id}",
+  operationId: "getCommunityMirrorProposal",
+  summary: "Get community mirror proposal",
+  description:
+    "Fetch a proposal owned by the caller. Registry moderators and AgenticAdvertising.org administrators may fetch any proposal.",
+  tags: ["Community Mirrors"],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
+  request: { params: z.object({ id: z.string().uuid() }) },
+  responses: {
+    200: { description: "Community mirror proposal", content: { "application/json": { schema: CommunityMirrorProposalGetResponseSchema } } },
+    400: { description: "Invalid proposal identifier", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    404: { description: "Proposal not found or not visible to the caller", content: { "application/json": { schema: ErrorSchema } } },
+    429: { description: "Rate limit exceeded", content: { "application/json": { schema: RateLimitErrorSchema } } },
+    500: { description: "Failed to read proposal", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/registry/mirror-proposals/{id}/approve",
+  operationId: "approveCommunityMirrorProposal",
+  summary: "Approve community mirror proposal",
+  description:
+    "Approve and atomically publish a pending proposal. Requires a registry moderator or AgenticAdvertising.org administrator.",
+  tags: ["Community Mirrors"],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: { required: true, content: { "application/json": { schema: CommunityMirrorProposalReviewRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Proposal approved and mirror published", content: { "application/json": { schema: CommunityMirrorProposalApprovalResponseSchema } } },
+    400: { description: "Invalid identifier, review body, or stale schema conformance", content: { "application/json": { schema: CommunityMirrorPublishErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Reviewer role required", content: { "application/json": { schema: ErrorSchema } } },
+    404: { description: "Proposal not found", content: { "application/json": { schema: ErrorSchema } } },
+    409: { description: "Proposal changed after review, its base mirror is stale, or it was already reviewed", content: { "application/json": { schema: ErrorSchema } } },
+    429: { description: "Rate limit exceeded", content: { "application/json": { schema: RateLimitErrorSchema } } },
+    500: { description: "Failed to approve proposal", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/registry/mirror-proposals/{id}/reject",
+  operationId: "rejectCommunityMirrorProposal",
+  summary: "Reject community mirror proposal",
+  description:
+    "Reject a pending proposal with reviewer notes. Requires a registry moderator or AgenticAdvertising.org administrator.",
+  tags: ["Community Mirrors"],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: { required: true, content: { "application/json": { schema: CommunityMirrorProposalRejectRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Proposal rejected", content: { "application/json": { schema: CommunityMirrorProposalDecisionResponseSchema } } },
+    400: { description: "Invalid identifier or review body", content: { "application/json": { schema: CommunityMirrorPublishErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Reviewer role required", content: { "application/json": { schema: ErrorSchema } } },
+    404: { description: "Proposal not found", content: { "application/json": { schema: ErrorSchema } } },
+    409: { description: "Proposal changed after review or was already reviewed", content: { "application/json": { schema: ErrorSchema } } },
+    429: { description: "Rate limit exceeded", content: { "application/json": { schema: RateLimitErrorSchema } } },
+    500: { description: "Failed to reject proposal", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/api/registry/mirrors",
   operationId: "listCommunityMirrors",
   summary: "List community mirrors",
@@ -1836,9 +1938,9 @@ registry.registerPath({
   method: "put",
   path: "/api/registry/mirrors/{platform}",
   operationId: "publishCommunityMirror",
-  summary: "Publish community mirror",
+  summary: "Publish or propose community mirror",
   description:
-    "Publish or update a catalog-only adagents.json community mirror. Requires a registry moderator or AgenticAdvertising.org admin. The service validates the assembled document against adagents.json, forces `authorized_agents: []`, regenerates `$schema` and `last_updated`, and updates derived publisher-domain catalog rows.",
+    "Submit a catalog-only adagents.json community mirror. Registry moderators and AgenticAdvertising.org administrators publish immediately; other authenticated organization callers create or refresh a pending proposal and receive HTTP 202. Contributor proposals are limited to 1 MiB and 2,000 catalog items. The service validates the assembled document against adagents.json, forces `authorized_agents: []`, and regenerates `$schema` and `last_updated`.",
   tags: ["Community Mirrors"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -1859,9 +1961,11 @@ registry.registerPath({
   },
   responses: {
     200: { description: "Community mirror published", content: { "application/json": { schema: CommunityMirrorPublishResponseSchema } } },
+    202: { description: "Community mirror proposal accepted for review", content: { "application/json": { schema: CommunityMirrorProposalSubmissionResponseSchema } } },
     400: { description: "Invalid platform, request body, or adagents.json conformance failure", content: { "application/json": { schema: CommunityMirrorPublishErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
-    403: { description: "Only registry moderators or AgenticAdvertising.org admins can manage community mirrors", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Organization context required for community proposals", content: { "application/json": { schema: ErrorSchema } } },
+    413: { description: "Proposal body or catalog item count exceeds the contributor limit", content: { "application/json": { schema: ErrorSchema } } },
     429: { description: "Rate limit exceeded", content: { "application/json": { schema: RateLimitErrorSchema } } },
     500: { description: "Failed to publish community mirror", content: { "application/json": { schema: ErrorSchema } } },
   },

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -260,6 +260,89 @@ export const CommunityMirrorPublishResponseSchema = z
   })
   .openapi("CommunityMirrorPublishResponse");
 
+const CommunityMirrorProposalIdSchema = z.string().uuid().openapi({
+  description: "Opaque identifier for the proposal.",
+  example: "4ec8bc86-6180-4d0e-aa72-9cbf402d3638",
+});
+
+const CommunityMirrorProposalDigestSchema = z.string().regex(/^[a-f0-9]{64}$/).openapi({
+  description: "SHA-256 digest that reviewers must echo when approving or rejecting this exact revision.",
+});
+
+export const CommunityMirrorProposalSchema = z
+  .object({
+    id: CommunityMirrorProposalIdSchema,
+    platform: CommunityMirrorPlatformSchema,
+    adagents_json: CommunityMirrorAdagentsJsonSchema,
+    catalog_etag: z.string().nullable(),
+    superseded_by: HttpsUrlSchema.nullable(),
+    proposal_digest: CommunityMirrorProposalDigestSchema,
+    base_mirror_digest: CommunityMirrorProposalDigestSchema.nullable().openapi({
+      description: "Digest of the public mirror state this proposal was reviewed against, or null when none existed.",
+    }),
+    status: z.enum(["pending", "approved", "rejected"]),
+    proposed_by_organization_id: z.string().nullable(),
+    proposed_at: z.string().datetime(),
+    reviewed_at: z.string().datetime().nullable(),
+    review_notes: z.string().nullable(),
+    published_at: z.string().datetime().nullable(),
+    created_at: z.string().datetime(),
+    updated_at: z.string().datetime(),
+  })
+  .openapi("CommunityMirrorProposal");
+
+export const CommunityMirrorProposalSummarySchema = CommunityMirrorProposalSchema.omit({
+  adagents_json: true,
+  proposed_by_organization_id: true,
+  review_notes: true,
+  created_at: true,
+}).openapi("CommunityMirrorProposalSummary");
+
+export const CommunityMirrorProposalSubmissionResponseSchema = z
+  .object({
+    success: z.literal(true),
+    status: z.literal("pending"),
+    proposal_id: CommunityMirrorProposalIdSchema,
+    proposal_digest: CommunityMirrorProposalDigestSchema,
+    platform: CommunityMirrorPlatformSchema,
+    status_url: z.string().openapi({ description: "Authenticated API path for fetching proposal status and content." }),
+    submitted_at: z.string().datetime(),
+  })
+  .openapi("CommunityMirrorProposalSubmissionResponse");
+
+export const CommunityMirrorProposalListResponseSchema = z
+  .object({
+    proposals: z.array(CommunityMirrorProposalSummarySchema),
+    total: z.number().int().nonnegative(),
+  })
+  .openapi("CommunityMirrorProposalListResponse");
+
+export const CommunityMirrorProposalGetResponseSchema = z
+  .object({ proposal: CommunityMirrorProposalSchema })
+  .openapi("CommunityMirrorProposalGetResponse");
+
+export const CommunityMirrorProposalReviewRequestSchema = z
+  .object({
+    proposal_digest: CommunityMirrorProposalDigestSchema,
+    review_notes: z.string().max(2000).optional(),
+  })
+  .openapi("CommunityMirrorProposalReviewRequest");
+
+export const CommunityMirrorProposalRejectRequestSchema = z
+  .object({
+    proposal_digest: CommunityMirrorProposalDigestSchema,
+    review_notes: z.string().min(1).max(2000),
+  })
+  .openapi("CommunityMirrorProposalRejectRequest");
+
+export const CommunityMirrorProposalApprovalResponseSchema = CommunityMirrorPublishResponseSchema.extend({
+  proposal_id: CommunityMirrorProposalIdSchema,
+}).openapi("CommunityMirrorProposalApprovalResponse");
+
+export const CommunityMirrorProposalDecisionResponseSchema = z
+  .object({ success: z.literal(true), proposal: CommunityMirrorProposalSchema })
+  .openapi("CommunityMirrorProposalDecisionResponse");
+
 export const CommunityMirrorPublishErrorSchema = z
   .object({
     error: z.string(),

--- a/server/tests/integration/community-mirrors.test.ts
+++ b/server/tests/integration/community-mirrors.test.ts
@@ -13,12 +13,17 @@ vi.hoisted(() => {
 
 // Mutable identity for the authenticated caller so a re-publish can come from a
 // different user (used to assert created_by_* is preserved).
-const authState = vi.hoisted(() => ({ userId: 'user_test_mirrors', email: 'mirrors@test.com' }));
+const authState = vi.hoisted(() => ({
+  userId: 'user_test_mirrors',
+  email: 'mirrors@test.com',
+  organizationId: null as string | null,
+}));
 
 vi.mock('../../src/middleware/auth.js', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('../../src/middleware/auth.js');
-  const pass = (req: { user: unknown }, _res: unknown, next: () => void) => {
+  const pass = (req: { user: unknown; apiKey?: unknown }, _res: unknown, next: () => void) => {
     req.user = { id: authState.userId, email: authState.email };
+    req.apiKey = authState.organizationId ? { organizationId: authState.organizationId } : undefined;
     next();
   };
   return { ...actual, requireAuth: pass, requireAdmin: (_r: unknown, _s: unknown, n: () => void) => n() };
@@ -148,6 +153,7 @@ describe('Community-mirror lifecycle — /api/registry/mirrors + /translated', (
     await pool.query('DELETE FROM catalog_properties WHERE created_by = $1', [`community_adagents:${PLATFORM}`]);
     await pool.query('DELETE FROM discovered_properties WHERE publisher_domain = ANY($1::text[])', [[PUBLISHER_DOMAIN, REMOVED_PUBLISHER_DOMAIN]]);
     await pool.query('DELETE FROM publishers WHERE domain = ANY($1::text[])', [[PUBLISHER_DOMAIN, REMOVED_PUBLISHER_DOMAIN]]);
+    await pool.query('DELETE FROM community_mirror_proposals WHERE platform LIKE $1', [PLATFORM_LIKE]);
     await pool.query('DELETE FROM community_mirrors WHERE platform LIKE $1', [PLATFORM_LIKE]);
   }
 
@@ -175,12 +181,13 @@ describe('Community-mirror lifecycle — /api/registry/mirrors + /translated', (
     isWebUserAAOAdmin.mockResolvedValue(false);
     authState.userId = 'user_test_mirrors';
     authState.email = 'mirrors@test.com';
+    authState.organizationId = null;
     await clear();
   });
 
   it('publishes a catalog-only mirror (authorized_agents forced to [])', async () => {
     const res = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
-    expect(res.status).toBe(200);
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.platform).toBe(PLATFORM);
     expect(res.body.catalog_etag).toBe('test-etag-1');
@@ -339,7 +346,7 @@ describe('Community-mirror lifecycle — /api/registry/mirrors + /translated', (
     isRegistryModerator.mockResolvedValue(false);
     isWebUserAAOAdmin.mockResolvedValue(true);
     const res = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
-    expect(res.status).toBe(200);
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
   });
 
   it('re-publish is idempotent — updates in place, no duplicate row', async () => {
@@ -406,6 +413,39 @@ describe('Community-mirror lifecycle — /api/registry/mirrors + /translated', (
     expect((await pool.query('SELECT 1 FROM discovered_properties WHERE publisher_domain = $1', [REMOVED_PUBLISHER_DOMAIN])).rows).toHaveLength(0);
   });
 
+  it('serializes concurrent publications so the final projection matches the final mirror', async () => {
+    const [first, second] = await Promise.all([
+      request(app)
+        .put(`/api/registry/mirrors/${PLATFORM}`)
+        .send(publishBody({ catalog_etag: 'concurrent-a', properties: [MINIMAL_PROPERTY] })),
+      request(app)
+        .put(`/api/registry/mirrors/${PLATFORM}`)
+        .send(publishBody({ catalog_etag: 'concurrent-b', properties: [REMOVED_PROPERTY] })),
+    ]);
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+
+    const mirror = await pool.query<{ adagents_json: { properties: Array<{ publisher_domain: string }> } }>(
+      'SELECT adagents_json FROM community_mirrors WHERE platform = $1',
+      [PLATFORM],
+    );
+    const finalDomains = mirror.rows[0].adagents_json.properties.map((property) => property.publisher_domain);
+    const projected = await pool.query<{ domain: string }>(
+      'SELECT domain FROM publishers WHERE domain = ANY($1::text[]) ORDER BY domain',
+      [[PUBLISHER_DOMAIN, REMOVED_PUBLISHER_DOMAIN]],
+    );
+    expect(projected.rows.map((row) => row.domain)).toEqual([...finalDomains].sort());
+    const projectedProperties = await pool.query<{ publisher_domain: string }>(
+      `SELECT DISTINCT publisher_domain
+         FROM discovered_properties
+        WHERE publisher_domain = ANY($1::text[])
+          AND source_type = 'community'
+        ORDER BY publisher_domain`,
+      [[PUBLISHER_DOMAIN, REMOVED_PUBLISHER_DOMAIN]],
+    );
+    expect(projectedProperties.rows.map((row) => row.publisher_domain)).toEqual([...finalDomains].sort());
+  });
+
   it('preserves created_by_* across a re-publish by a different user', async () => {
     authState.userId = 'creator-A';
     await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody({ catalog_etag: 'v1' }));
@@ -439,11 +479,244 @@ describe('Community-mirror lifecycle — /api/registry/mirrors + /translated', (
     expect(res.status).toBe(400);
   });
 
-  it('rejects a non-moderator, non-admin caller (403)', async () => {
+  it('queues a valid non-moderator submission for review without publishing it', async () => {
     isRegistryModerator.mockResolvedValue(false);
     isWebUserAAOAdmin.mockResolvedValue(false);
+    authState.userId = 'api_key_test_mirrors';
+    authState.organizationId = 'org_test_mirrors';
     const res = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(202);
+    expect(res.body).toMatchObject({
+      success: true,
+      status: 'pending',
+      proposal_id: expect.any(String),
+      proposal_digest: expect.stringMatching(/^[a-f0-9]{64}$/),
+      platform: PLATFORM,
+      status_url: `/api/registry/mirror-proposals/${res.body.proposal_id}`,
+    });
+    expect(res.headers.location).toBe(res.body.status_url);
+    expect((await pool.query('SELECT 1 FROM community_mirrors WHERE platform = $1', [PLATFORM])).rows).toHaveLength(0);
+    expect((await pool.query('SELECT 1 FROM publishers WHERE domain = $1', [PUBLISHER_DOMAIN])).rows).toHaveLength(0);
+
+    const mine = await request(app).get('/api/registry/mirror-proposals');
+    expect(mine.status).toBe(200);
+    expect(mine.body.total).toBe(1);
+    expect(mine.body.proposals[0]).toMatchObject({
+      id: res.body.proposal_id,
+      platform: PLATFORM,
+      status: 'pending',
+      proposal_digest: res.body.proposal_digest,
+    });
+    expect(mine.body.proposals[0]).not.toHaveProperty('adagents_json');
+    expect(mine.body.proposals[0]).not.toHaveProperty('proposed_by_email');
+  });
+
+  it('updates an organization\'s pending proposal in place on retry', async () => {
+    isRegistryModerator.mockResolvedValue(false);
+    authState.userId = 'api_key_test_mirrors';
+    authState.organizationId = 'org_test_mirrors';
+    const first = await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({ catalog_etag: 'proposal-v1' }));
+    const second = await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({ catalog_etag: 'proposal-v2' }));
+
+    expect(second.status).toBe(202);
+    expect(second.body.proposal_id).toBe(first.body.proposal_id);
+    expect(second.body.proposal_digest).not.toBe(first.body.proposal_digest);
+    const rows = await pool.query(
+      'SELECT catalog_etag FROM community_mirror_proposals WHERE platform = $1',
+      [PLATFORM],
+    );
+    expect(rows.rows).toEqual([{ catalog_etag: 'proposal-v2' }]);
+  });
+
+  it('refuses approval when a contributor changed the proposal after review', async () => {
+    isRegistryModerator.mockResolvedValue(false);
+    authState.userId = 'api_key_test_mirrors';
+    authState.organizationId = 'org_test_mirrors';
+    const reviewed = await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({ catalog_etag: 'reviewed-v1' }));
+    const changed = await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({ catalog_etag: 'changed-v2', formats: [{ ...MINIMAL_FORMAT, display_name: 'Changed' }] }));
+    expect(changed.body.proposal_id).toBe(reviewed.body.proposal_id);
+
+    authState.userId = 'user_registry_moderator';
+    authState.organizationId = null;
+    isRegistryModerator.mockResolvedValue(true);
+    const staleApproval = await request(app)
+      .post(`/api/registry/mirror-proposals/${reviewed.body.proposal_id}/approve`)
+      .send({ proposal_digest: reviewed.body.proposal_digest });
+
+    expect(staleApproval.status).toBe(409);
+    expect(staleApproval.body.error).toMatch(/changed after review/i);
+    expect((await pool.query('SELECT 1 FROM community_mirrors WHERE platform = $1', [PLATFORM])).rows).toHaveLength(0);
+  });
+
+  it('refuses approval when the public mirror changed after proposal submission', async () => {
+    isRegistryModerator.mockResolvedValue(false);
+    authState.userId = 'api_key_test_mirrors';
+    authState.organizationId = 'org_test_mirrors';
+    const submitted = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+
+    authState.userId = 'user_registry_moderator';
+    authState.organizationId = null;
+    isRegistryModerator.mockResolvedValue(true);
+    await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({ catalog_etag: 'newer-public-state' }));
+    const staleApproval = await request(app)
+      .post(`/api/registry/mirror-proposals/${submitted.body.proposal_id}/approve`)
+      .send({ proposal_digest: submitted.body.proposal_digest });
+
+    expect(staleApproval.status).toBe(409);
+    expect(staleApproval.body.error).toMatch(/published mirror changed/i);
+    const mirror = await pool.query('SELECT catalog_etag FROM community_mirrors WHERE platform = $1', [PLATFORM]);
+    expect(mirror.rows).toEqual([{ catalog_etag: 'newer-public-state' }]);
+  });
+
+  it('changes the review digest when identical content is rebased onto a newer public mirror', async () => {
+    isRegistryModerator.mockResolvedValue(false);
+    authState.userId = 'api_key_test_mirrors';
+    authState.organizationId = 'org_test_mirrors';
+    const original = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+
+    authState.userId = 'user_registry_moderator';
+    authState.organizationId = null;
+    isRegistryModerator.mockResolvedValue(true);
+    await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({ catalog_etag: 'new-public-base', formats: [{ ...MINIMAL_FORMAT, display_name: 'Live' }] }));
+
+    authState.userId = 'api_key_test_mirrors';
+    authState.organizationId = 'org_test_mirrors';
+    isRegistryModerator.mockResolvedValue(false);
+    const rebased = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+    expect(rebased.body.proposal_id).toBe(original.body.proposal_id);
+    expect(rebased.body.proposal_digest).not.toBe(original.body.proposal_digest);
+
+    authState.userId = 'user_registry_moderator';
+    authState.organizationId = null;
+    isRegistryModerator.mockResolvedValue(true);
+    const staleApproval = await request(app)
+      .post(`/api/registry/mirror-proposals/${original.body.proposal_id}/approve`)
+      .send({ proposal_digest: original.body.proposal_digest });
+    expect(staleApproval.status).toBe(409);
+    expect(staleApproval.body.error).toMatch(/changed after review/i);
+  });
+
+  it('scopes proposal list and detail reads to the submitting organization', async () => {
+    isRegistryModerator.mockResolvedValue(false);
+    authState.userId = 'api_key_test_mirrors';
+    authState.organizationId = 'org_test_mirrors';
+    const submitted = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+
+    authState.userId = 'api_key_other_org';
+    authState.organizationId = 'org_other';
+    const list = await request(app).get('/api/registry/mirror-proposals');
+    const detail = await request(app).get(`/api/registry/mirror-proposals/${submitted.body.proposal_id}`);
+    expect(list.status).toBe(200);
+    expect(list.body.total).toBe(0);
+    expect(detail.status).toBe(404);
+  });
+
+  it('requires organization context and caps contributor proposal bodies at 1 MiB', async () => {
+    isRegistryModerator.mockResolvedValue(false);
+    authState.userId = 'user_without_org';
+    authState.organizationId = null;
+    const noOrg = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+    expect(noOrg.status).toBe(403);
+    expect(noOrg.body.error).toMatch(/organization context/i);
+
+    authState.userId = 'api_key_test_mirrors';
+    authState.organizationId = 'org_test_mirrors';
+    const oversized = await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({ contributor_notes: 'x'.repeat(1024 * 1024) }));
+    expect(oversized.status).toBe(413);
+  });
+
+  it('lets a moderator approve and atomically publish a pending proposal', async () => {
+    isRegistryModerator.mockResolvedValue(false);
+    authState.userId = 'api_key_test_mirrors';
+    authState.organizationId = 'org_test_mirrors';
+    const submitted = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+
+    authState.userId = 'user_registry_moderator';
+    authState.organizationId = null;
+    isRegistryModerator.mockResolvedValue(true);
+    const approved = await request(app)
+      .post(`/api/registry/mirror-proposals/${submitted.body.proposal_id}/approve`)
+      .send({
+        proposal_digest: submitted.body.proposal_digest,
+        review_notes: 'Catalog checked against platform documentation.',
+      });
+
+    expect(approved.status).toBe(200);
+    expect(approved.body).toMatchObject({
+      success: true,
+      proposal_id: submitted.body.proposal_id,
+      platform: PLATFORM,
+      publisher_domains: [PUBLISHER_DOMAIN],
+    });
+    const proposal = await pool.query(
+      'SELECT status, reviewed_by_user_id, published_at FROM community_mirror_proposals WHERE id = $1',
+      [submitted.body.proposal_id],
+    );
+    expect(proposal.rows[0]).toMatchObject({
+      status: 'approved',
+      reviewed_by_user_id: 'user_registry_moderator',
+      published_at: expect.any(Date),
+    });
+    expect((await pool.query('SELECT 1 FROM community_mirrors WHERE platform = $1', [PLATFORM])).rows).toHaveLength(1);
+    expect((await pool.query('SELECT 1 FROM publishers WHERE domain = $1', [PUBLISHER_DOMAIN])).rows).toHaveLength(1);
+
+    const repeated = await request(app)
+      .post(`/api/registry/mirror-proposals/${submitted.body.proposal_id}/approve`)
+      .send({ proposal_digest: submitted.body.proposal_digest });
+    expect(repeated.status).toBe(409);
+    expect(repeated.body.error).toMatch(/already approved/i);
+  });
+
+  it('does not let a non-moderator approve another proposal', async () => {
+    isRegistryModerator.mockResolvedValue(false);
+    authState.userId = 'api_key_test_mirrors';
+    authState.organizationId = 'org_test_mirrors';
+    const submitted = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+
+    const approved = await request(app)
+      .post(`/api/registry/mirror-proposals/${submitted.body.proposal_id}/approve`)
+      .send({});
+    expect(approved.status).toBe(403);
+    expect((await pool.query('SELECT 1 FROM community_mirrors WHERE platform = $1', [PLATFORM])).rows).toHaveLength(0);
+  });
+
+  it('lets a moderator reject a pending proposal without publishing it', async () => {
+    isRegistryModerator.mockResolvedValue(false);
+    authState.userId = 'api_key_test_mirrors';
+    authState.organizationId = 'org_test_mirrors';
+    const submitted = await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody());
+
+    authState.userId = 'user_registry_moderator';
+    authState.organizationId = null;
+    isRegistryModerator.mockResolvedValue(true);
+    const rejected = await request(app)
+      .post(`/api/registry/mirror-proposals/${submitted.body.proposal_id}/reject`)
+      .send({
+        proposal_digest: submitted.body.proposal_digest,
+        review_notes: 'Source evidence needs updating.',
+      });
+
+    expect(rejected.status).toBe(200);
+    expect(rejected.body.proposal).toMatchObject({
+      id: submitted.body.proposal_id,
+      status: 'rejected',
+      review_notes: 'Source evidence needs updating.',
+    });
+    expect((await pool.query('SELECT 1 FROM community_mirrors WHERE platform = $1', [PLATFORM])).rows).toHaveLength(0);
   });
 
   it('returns 404 for an unknown mirror', async () => {
@@ -459,16 +732,36 @@ describe('Community-mirror lifecycle — /api/registry/mirrors + /translated', (
     expect(served.headers['content-type']).toMatch(/^application\/json/);
     expect(served.headers['access-control-allow-origin']).toBe('*');
     expect(served.headers['x-content-type-options']).toBe('nosniff');
-    expect(served.headers['etag']).toBe('"serve-etag"');
+    expect(served.headers['etag']).toMatch(/^"[0-9a-f]{32}"$/);
+    expect(served.headers['etag']).not.toBe('"serve-etag"');
     expect(served.body.authorized_agents).toEqual([]);
 
     const revalidate = await request(app)
       .get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`)
-      .set('If-None-Match', '"serve-etag"');
-    expect(revalidate.status).toBe(304);
+      .set('If-None-Match', served.headers['etag']);
+    expect(revalidate.status, JSON.stringify(revalidate.body)).toBe(304);
   });
 
-  it('falls back to a content-hash ETag when catalog_etag is absent', async () => {
+  it('changes the HTTP ETag when content changes even if catalog_etag is reused', async () => {
+    await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody({ catalog_etag: 'reused-token' }));
+    const first = await request(app).get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`);
+
+    await request(app)
+      .put(`/api/registry/mirrors/${PLATFORM}`)
+      .send(publishBody({
+        catalog_etag: 'reused-token',
+        formats: [{ ...MINIMAL_FORMAT, display_name: 'Updated display name' }],
+      }));
+    const second = await request(app)
+      .get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`)
+      .set('If-None-Match', first.headers['etag']);
+
+    expect(second.status).toBe(200);
+    expect(second.headers['etag']).not.toBe(first.headers['etag']);
+    expect(second.body.formats[0].display_name).toBe('Updated display name');
+  });
+
+  it('uses a content-hash ETag when catalog_etag is absent', async () => {
     await request(app).put(`/api/registry/mirrors/${PLATFORM}`).send(publishBody({ catalog_etag: undefined }));
     const served = await request(app).get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`);
     expect(served.status).toBe(200);
@@ -477,7 +770,7 @@ describe('Community-mirror lifecycle — /api/registry/mirrors + /translated', (
     const revalidate = await request(app)
       .get(`/api/creative-agent/translated/${PLATFORM}/adagents.json`)
       .set('If-None-Match', served.headers['etag']);
-    expect(revalidate.status).toBe(304);
+    expect(revalidate.status, JSON.stringify(revalidate.body)).toBe(304);
   });
 
   it('serving carries superseded_by in the body and advertises it via a Link header', async () => {

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -1475,22 +1475,27 @@ components:
       required:
         - url
       additionalProperties: {}
-    CommunityMirrorListResponse:
+    CommunityMirrorProposalListResponse:
       type: object
       properties:
-        mirrors:
+        proposals:
           type: array
           items:
-            $ref: "#/components/schemas/CommunityMirrorSummary"
+            $ref: "#/components/schemas/CommunityMirrorProposalSummary"
         total:
           type: integer
           minimum: 0
       required:
-        - mirrors
+        - proposals
         - total
-    CommunityMirrorSummary:
+    CommunityMirrorProposalSummary:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
+          description: Opaque identifier for the proposal.
+          example: 4ec8bc86-6180-4d0e-aa72-9cbf402d3638
         platform:
           type: string
           pattern: ^[a-z0-9_-]{1,64}$
@@ -1505,14 +1510,50 @@ components:
             - string
             - "null"
           pattern: ^https:\/\/
-          description: HTTPS successor document URL, when this mirror has been superseded.
+          description: HTTPS URL.
+        proposal_digest:
+          type: string
+          pattern: ^[a-f0-9]{64}$
+          description: SHA-256 digest that reviewers must echo when approving or rejecting this exact revision.
+        base_mirror_digest:
+          type:
+            - string
+            - "null"
+          pattern: ^[a-f0-9]{64}$
+          description: Digest of the public mirror state this proposal was reviewed against, or null when none existed.
+        status:
+          type: string
+          enum:
+            - pending
+            - approved
+            - rejected
+        proposed_at:
+          type: string
+          format: date-time
+        reviewed_at:
+          type:
+            - string
+            - "null"
+          format: date-time
+        published_at:
+          type:
+            - string
+            - "null"
+          format: date-time
         updated_at:
           type: string
           format: date-time
       required:
+        - id
         - platform
         - catalog_etag
         - superseded_by
+        - proposal_digest
+        - base_mirror_digest
+        - status
+        - proposed_at
+        - reviewed_at
+        - published_at
         - updated_at
     RateLimitError:
       type: object
@@ -1526,14 +1567,28 @@ components:
           description: Seconds to wait before retrying.
       required:
         - error
-    CommunityMirrorGetResponse:
+    CommunityMirrorProposalGetResponse:
       type: object
       properties:
+        proposal:
+          $ref: "#/components/schemas/CommunityMirrorProposal"
+      required:
+        - proposal
+    CommunityMirrorProposal:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Opaque identifier for the proposal.
+          example: 4ec8bc86-6180-4d0e-aa72-9cbf402d3638
         platform:
           type: string
           pattern: ^[a-z0-9_-]{1,64}$
           description: Lowercase platform identifier, normalized by the service.
           example: example_platform
+        adagents_json:
+          $ref: "#/components/schemas/CommunityMirrorAdagentsJson"
         catalog_etag:
           type:
             - string
@@ -1543,9 +1598,44 @@ components:
             - string
             - "null"
           pattern: ^https:\/\/
-          description: HTTPS successor document URL, when this mirror has been superseded.
-        adagents_json:
-          $ref: "#/components/schemas/CommunityMirrorAdagentsJson"
+          description: HTTPS URL.
+        proposal_digest:
+          type: string
+          pattern: ^[a-f0-9]{64}$
+          description: SHA-256 digest that reviewers must echo when approving or rejecting this exact revision.
+        base_mirror_digest:
+          type:
+            - string
+            - "null"
+          pattern: ^[a-f0-9]{64}$
+          description: Digest of the public mirror state this proposal was reviewed against, or null when none existed.
+        status:
+          type: string
+          enum:
+            - pending
+            - approved
+            - rejected
+        proposed_by_organization_id:
+          type:
+            - string
+            - "null"
+        proposed_at:
+          type: string
+          format: date-time
+        reviewed_at:
+          type:
+            - string
+            - "null"
+          format: date-time
+        review_notes:
+          type:
+            - string
+            - "null"
+        published_at:
+          type:
+            - string
+            - "null"
+          format: date-time
         created_at:
           type: string
           format: date-time
@@ -1553,10 +1643,19 @@ components:
           type: string
           format: date-time
       required:
+        - id
         - platform
+        - adagents_json
         - catalog_etag
         - superseded_by
-        - adagents_json
+        - proposal_digest
+        - base_mirror_digest
+        - status
+        - proposed_by_organization_id
+        - proposed_at
+        - reviewed_at
+        - review_notes
+        - published_at
         - created_at
         - updated_at
     CommunityMirrorAdagentsJson:
@@ -1620,6 +1719,18 @@ components:
       required:
         - authorized_agents
       additionalProperties: {}
+    CommunityMirrorProposalApprovalResponse:
+      allOf:
+        - $ref: "#/components/schemas/CommunityMirrorPublishResponse"
+        - type: object
+          properties:
+            proposal_id:
+              type: string
+              format: uuid
+              description: Opaque identifier for the proposal.
+              example: 4ec8bc86-6180-4d0e-aa72-9cbf402d3638
+          required:
+            - proposal_id
     CommunityMirrorPublishResponse:
       type: object
       properties:
@@ -1668,6 +1779,155 @@ components:
           description: Validation details for request-body parse failures or adagents.json conformance errors.
       required:
         - error
+    CommunityMirrorProposalReviewRequest:
+      type: object
+      properties:
+        proposal_digest:
+          type: string
+          pattern: ^[a-f0-9]{64}$
+          description: SHA-256 digest that reviewers must echo when approving or rejecting this exact revision.
+        review_notes:
+          type: string
+          maxLength: 2000
+      required:
+        - proposal_digest
+    CommunityMirrorProposalDecisionResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        proposal:
+          $ref: "#/components/schemas/CommunityMirrorProposal"
+      required:
+        - success
+        - proposal
+    CommunityMirrorProposalRejectRequest:
+      type: object
+      properties:
+        proposal_digest:
+          type: string
+          pattern: ^[a-f0-9]{64}$
+          description: SHA-256 digest that reviewers must echo when approving or rejecting this exact revision.
+        review_notes:
+          type: string
+          minLength: 1
+          maxLength: 2000
+      required:
+        - proposal_digest
+        - review_notes
+    CommunityMirrorListResponse:
+      type: object
+      properties:
+        mirrors:
+          type: array
+          items:
+            $ref: "#/components/schemas/CommunityMirrorSummary"
+        total:
+          type: integer
+          minimum: 0
+      required:
+        - mirrors
+        - total
+    CommunityMirrorSummary:
+      type: object
+      properties:
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+        catalog_etag:
+          type:
+            - string
+            - "null"
+        superseded_by:
+          type:
+            - string
+            - "null"
+          pattern: ^https:\/\/
+          description: HTTPS successor document URL, when this mirror has been superseded.
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - platform
+        - catalog_etag
+        - superseded_by
+        - updated_at
+    CommunityMirrorGetResponse:
+      type: object
+      properties:
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+        catalog_etag:
+          type:
+            - string
+            - "null"
+        superseded_by:
+          type:
+            - string
+            - "null"
+          pattern: ^https:\/\/
+          description: HTTPS successor document URL, when this mirror has been superseded.
+        adagents_json:
+          $ref: "#/components/schemas/CommunityMirrorAdagentsJson"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - platform
+        - catalog_etag
+        - superseded_by
+        - adagents_json
+        - created_at
+        - updated_at
+    CommunityMirrorProposalSubmissionResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        status:
+          type: string
+          enum:
+            - pending
+        proposal_id:
+          type: string
+          format: uuid
+          description: Opaque identifier for the proposal.
+          example: 4ec8bc86-6180-4d0e-aa72-9cbf402d3638
+        proposal_digest:
+          type: string
+          pattern: ^[a-f0-9]{64}$
+          description: SHA-256 digest that reviewers must echo when approving or rejecting this exact revision.
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+        status_url:
+          type: string
+          description: Authenticated API path for fetching proposal status and content.
+        submitted_at:
+          type: string
+          format: date-time
+      required:
+        - success
+        - status
+        - proposal_id
+        - proposal_digest
+        - platform
+        - status_url
+        - submitted_at
     CommunityMirrorPublishRequest:
       anyOf:
         - type: object
@@ -7068,6 +7328,266 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CreateAdagentsResponse"
+  /api/registry/mirror-proposals:
+    get:
+      operationId: listCommunityMirrorProposals
+      summary: List community mirror proposals
+      description: List the caller's own community-mirror proposals. Registry moderators and AgenticAdvertising.org administrators see the review queue and may filter by status; their default is `pending`.
+      tags:
+        - Community Mirrors
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - pending
+              - approved
+              - rejected
+          required: false
+          name: status
+          in: query
+        - schema:
+            type: integer
+            maximum: 50
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Community mirror proposal list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorProposalListResponse"
+        "400":
+          description: Invalid status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to list proposals
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/mirror-proposals/{id}:
+    get:
+      operationId: getCommunityMirrorProposal
+      summary: Get community mirror proposal
+      description: Fetch a proposal owned by the caller. Registry moderators and AgenticAdvertising.org administrators may fetch any proposal.
+      tags:
+        - Community Mirrors
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Community mirror proposal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorProposalGetResponse"
+        "400":
+          description: Invalid proposal identifier
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Proposal not found or not visible to the caller
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to read proposal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/mirror-proposals/{id}/approve:
+    post:
+      operationId: approveCommunityMirrorProposal
+      summary: Approve community mirror proposal
+      description: Approve and atomically publish a pending proposal. Requires a registry moderator or AgenticAdvertising.org administrator.
+      tags:
+        - Community Mirrors
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommunityMirrorProposalReviewRequest"
+      responses:
+        "200":
+          description: Proposal approved and mirror published
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorProposalApprovalResponse"
+        "400":
+          description: Invalid identifier, review body, or stale schema conformance
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorPublishError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Reviewer role required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Proposal not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Proposal changed after review, its base mirror is stale, or it was already reviewed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to approve proposal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/mirror-proposals/{id}/reject:
+    post:
+      operationId: rejectCommunityMirrorProposal
+      summary: Reject community mirror proposal
+      description: Reject a pending proposal with reviewer notes. Requires a registry moderator or AgenticAdvertising.org administrator.
+      tags:
+        - Community Mirrors
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommunityMirrorProposalRejectRequest"
+      responses:
+        "200":
+          description: Proposal rejected
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorProposalDecisionResponse"
+        "400":
+          description: Invalid identifier or review body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorPublishError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Reviewer role required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Proposal not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Proposal changed after review or was already reviewed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to reject proposal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/registry/mirrors:
     get:
       operationId: listCommunityMirrors
@@ -7159,8 +7679,8 @@ paths:
                 $ref: "#/components/schemas/Error"
     put:
       operationId: publishCommunityMirror
-      summary: Publish community mirror
-      description: "Publish or update a catalog-only adagents.json community mirror. Requires a registry moderator or AgenticAdvertising.org admin. The service validates the assembled document against adagents.json, forces `authorized_agents: []`, regenerates `$schema` and `last_updated`, and updates derived publisher-domain catalog rows."
+      summary: Publish or propose community mirror
+      description: "Submit a catalog-only adagents.json community mirror. Registry moderators and AgenticAdvertising.org administrators publish immediately; other authenticated organization callers create or refresh a pending proposal and receive HTTP 202. Contributor proposals are limited to 1 MiB and 2,000 catalog items. The service validates the assembled document against adagents.json, forces `authorized_agents: []`, and regenerates `$schema` and `last_updated`."
       tags:
         - Community Mirrors
       security:
@@ -7189,6 +7709,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CommunityMirrorPublishResponse"
+        "202":
+          description: Community mirror proposal accepted for review
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorProposalSubmissionResponse"
         "400":
           description: Invalid platform, request body, or adagents.json conformance failure
           content:
@@ -7202,7 +7728,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "403":
-          description: Only registry moderators or AgenticAdvertising.org admins can manage community mirrors
+          description: Organization context required for community proposals
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: Proposal body or catalog item count exceeds the contributor limit
           content:
             application/json:
               schema:
@@ -12028,7 +12560,7 @@ tags:
   - name: Validation Tools
     description: Validate publisher adagents.json files and generate compliant configurations.
   - name: Community Mirrors
-    description: Publish, fetch, list, and retire catalog-only adagents.json mirrors for platforms that have not adopted AdCP.
+    description: Propose, review, publish, fetch, list, and retire catalog-only adagents.json mirrors for platforms that have not adopted AdCP.
   - name: Search
     description: Cross-entity search across brands, publishers, agents, and properties.
   - name: Agent Probing


### PR DESCRIPTION
## Summary

Adds a moderated proposal workflow for community `adagents.json` mirrors so organization API keys can submit catalogs without publishing global fallback data directly.
Review decisions are bound to both the exact proposal content and its public-mirror base revision, while per-platform locks keep the mirror and derived publisher/property projections consistent.
Proposal APIs use organization scoping, opaque IDs, bounded summary responses, payload limits, and content-derived HTTP ETags, with corresponding documentation, schema, migration, OpenAPI, and integration-test updates.

## Validation

The fresh-schema community-mirror suite passed 35/35 alongside typecheck, migration validation, OpenAPI generation, expert reviews, and pre-push checks; the full server unit hook reached 4,716 passing tests but 9 unrelated C2PA tests could not load the locally installed x86-64 Linux native module on this arm64 Mac.
