### PR TITLE
fix(security): restrict billing portal access

### DIFF
--- a/server/src/addie/mcp/billing-tools.ts
+++ b/server/src/addie/mcp/billing-tools.ts
@@ -34,7 +34,6 @@ import { recordEvent } from '../../db/person-events-db.js';
 import {
   canManageOrganizationBilling,
 } from '../../billing/billing-authorization.js';
-import { resolveUserOrgMembership } from '../../utils/resolve-user-org-membership.js';
 import { getWorkos } from '../../auth/workos-client.js';
 
 const logger = createLogger('addie-billing-tools');
@@ -627,6 +626,10 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
       // MemberContext is cached for conversational continuity. Financial
       // authorization is not: resolve the current active role for this exact
       // org immediately before reading the billing account or calling Stripe.
+      // Load the canonical resolver only on this privileged path: it imports
+      // auth middleware for the dev-user bypass, whose WorkOS constructor must
+      // not run while unrelated billing tools are being initialized.
+      const { resolveUserOrgMembership } = await import('../../utils/resolve-user-org-membership.js');
       const membership = await resolveUserOrgMembership(getWorkos(), workosUserId, orgId);
       if (!canManageOrganizationBilling(membership, orgId)) {
         return JSON.stringify({

--- a/server/src/addie/mcp/billing-tools.ts
+++ b/server/src/addie/mcp/billing-tools.ts
@@ -31,6 +31,11 @@ import {
   getRelationshipBySlackId,
 } from '../../db/relationship-db.js';
 import { recordEvent } from '../../db/person-events-db.js';
+import {
+  canManageOrganizationBilling,
+} from '../../billing/billing-authorization.js';
+import { resolveUserOrgMembership } from '../../utils/resolve-user-org-membership.js';
+import { getWorkos } from '../../auth/workos-client.js';
 
 const logger = createLogger('addie-billing-tools');
 const orgDb = new OrganizationDatabase();
@@ -207,9 +212,9 @@ on file (set via the dashboard or invite-acceptance flow).`,
   },
   {
     name: 'get_billing_portal',
-    description: `Get a link to the Stripe Customer Portal where the member can view invoices, download receipts, update payment methods, and manage their subscription.
-Use this when a member asks about receipts, invoices, billing history, payment methods, or subscription management.
-The member must be signed in.`,
+    description: `Get a link to the Stripe Customer Portal where an organization owner or admin can view invoices, download receipts, update payment methods, and manage the subscription.
+Use this when an owner or admin asks about receipts, invoices, billing history, payment methods, or subscription management.
+The user must be signed in and have an active owner or admin role in the selected organization.`,
     input_schema: {
       type: 'object' as const,
       properties: {},
@@ -600,7 +605,7 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
     }
   });
 
-  // Get billing portal link for existing members
+  // Get billing portal link for active organization billing managers
   handlers.set('get_billing_portal', async (_input) => {
     const orgId = memberContext?.organization?.workos_organization_id;
     if (!orgId) {
@@ -611,6 +616,25 @@ export function createBillingToolHandlers(memberContext?: MemberContext | null):
     }
 
     try {
+      const workosUserId = memberContext?.workos_user?.workos_user_id;
+      if (!workosUserId) {
+        return JSON.stringify({
+          success: false,
+          error: 'You need to be signed in with a linked account to access billing.',
+        });
+      }
+
+      // MemberContext is cached for conversational continuity. Financial
+      // authorization is not: resolve the current active role for this exact
+      // org immediately before reading the billing account or calling Stripe.
+      const membership = await resolveUserOrgMembership(getWorkos(), workosUserId, orgId);
+      if (!canManageOrganizationBilling(membership, orgId)) {
+        return JSON.stringify({
+          success: false,
+          error: 'Only organization owners and admins can manage billing.',
+        });
+      }
+
       const org = await orgDb.getOrganization(orgId);
       const stripeCustomerId = org?.stripe_customer_id;
 

--- a/server/src/billing/active-subscription-guard.ts
+++ b/server/src/billing/active-subscription-guard.ts
@@ -15,6 +15,8 @@
 import { OrganizationDatabase, TIER_PRESERVING_STATUSES } from '../db/organization-db.js';
 import { createCustomerPortalSession } from './stripe-client.js';
 import { createLogger } from '../logger.js';
+import { canManageOrganizationBilling } from './billing-authorization.js';
+import type { UserOrgMembership } from '../utils/resolve-user-org-membership.js';
 
 const logger = createLogger('active-subscription-guard');
 
@@ -62,6 +64,8 @@ export interface BlockOptions {
    * over the org's subscription, payment method, and cancellation.
    */
   customerPortalReturnUrl?: string;
+  /** Active membership used to authorize billing-management access. */
+  requesterMembership?: Pick<UserOrgMembership, 'organizationId' | 'role' | 'status'>;
 }
 
 /**
@@ -71,11 +75,10 @@ export interface BlockOptions {
  *
  * @param orgId    workos_organization_id of the org being billed
  * @param orgDb    OrganizationDatabase instance (DI for testing)
- * @param options.customerPortalReturnUrl  When provided, the 409 includes a
- *   single-use Stripe Customer Portal URL the requester can follow to
- *   manage the existing subscription. Omit on routes where the requester
- *   does not have admin authority over the org (e.g., invite acceptance
- *   for a not-yet-member or a `member`-role user).
+ * @param options.customerPortalReturnUrl  When provided alongside an active
+ *   owner/admin membership for this exact org, the 409 includes a single-use
+ *   Stripe Customer Portal URL. Missing, inactive, mismatched, or ordinary
+ *   member authorization suppresses portal creation.
  */
 export async function blockIfActiveSubscription(
   orgId: string,
@@ -88,7 +91,10 @@ export async function blockIfActiveSubscription(
   }
 
   let portalUrl: string | undefined;
-  if (options.customerPortalReturnUrl) {
+  if (
+    options.customerPortalReturnUrl
+    && canManageOrganizationBilling(options.requesterMembership, orgId)
+  ) {
     const org = await orgDb.getOrganization(orgId);
     if (org?.stripe_customer_id) {
       try {

--- a/server/src/billing/billing-authorization.ts
+++ b/server/src/billing/billing-authorization.ts
@@ -1,0 +1,25 @@
+import type {
+  MembershipRole,
+  UserOrgMembership,
+} from '../utils/resolve-user-org-membership.js';
+
+export type BillingManagerRole = Extract<MembershipRole, 'owner' | 'admin'>;
+
+/** Billing management can change payment methods, tiers, and cancellation. */
+export function isBillingManagerRole(role: unknown): role is BillingManagerRole {
+  return role === 'owner' || role === 'admin';
+}
+
+/**
+ * Bind billing-management authority to an active membership in the exact org
+ * being managed. The organization match is intentionally repeated here so a
+ * filtered WorkOS response containing a row for another org fails closed.
+ */
+export function canManageOrganizationBilling(
+  membership: Pick<UserOrgMembership, 'organizationId' | 'role' | 'status'> | null | undefined,
+  organizationId: string,
+): boolean {
+  return membership?.organizationId === organizationId
+    && membership.status === 'active'
+    && isBillingManagerRole(membership.role);
+}

--- a/server/src/routes/billing-public.ts
+++ b/server/src/routes/billing-public.ts
@@ -53,6 +53,7 @@ import {
 import { COMPANY_TYPE_VALUES } from "../config/company-types.js";
 import { notifyInvoiceSent } from "../notifications/billing.js";
 import { WorkOS } from "@workos-inc/node";
+import { resolveUserOrgMembership } from "../utils/resolve-user-org-membership.js";
 
 const logger = createLogger("billing-public-routes");
 const orgDb = new OrganizationDatabase();
@@ -286,30 +287,21 @@ export function createPublicBillingRouter(): Router {
         });
       }
 
-      const isDevUserInvoice =
-        isDevModeEnabled() &&
-        Object.values(DEV_USERS).some((du) => du.id === user.id) &&
-        orgId.startsWith("org_dev_");
-
-      if (!isDevUserInvoice) {
-        const membership = await workos?.userManagement.listOrganizationMemberships({
-          userId: user.id,
-          organizationId: orgId,
+      const membership = await resolveUserOrgMembership(workos, user.id, orgId);
+      if (!membership) {
+        return res.status(403).json({
+          error: "Access denied",
+          message: "You are not a member of this organization",
         });
-        if (!membership?.data?.length) {
-          return res.status(403).json({
-            error: "Access denied",
-            message: "You are not a member of this organization",
-          });
-        }
       }
 
       // Refuse if the org already has an active subscription. Tier changes go
       // through the Stripe Customer Portal, not this intake route. The
-      // requester is an authenticated member of the org (verified above), so
-      // it's safe to surface the portal URL.
+      // Ordinary members may still request an invoice, but only an active
+      // owner/admin membership may receive a billing-management portal URL.
       const activeBlock = await blockIfActiveSubscription(orgId, orgDb, {
         customerPortalReturnUrl: `${req.protocol}://${req.get('host')}/dashboard/membership`,
+        requesterMembership: membership,
       });
       if (activeBlock) {
         return res.status(activeBlock.status).json(activeBlock.body);
@@ -425,11 +417,18 @@ export function createPublicBillingRouter(): Router {
       // pass that early check before either has minted a sub.
       const intake = await withOrgIntakeLock<
         | { kind: 'block'; block: ActiveSubscriptionBlock }
+        | { kind: 'forbidden' }
         | { kind: 'invoiceFailed' }
         | { kind: 'success'; invoiceResult: NonNullable<Awaited<ReturnType<typeof createAndSendInvoice>>> }
       >(orgId, async () => {
+        // Re-resolve inside the lock: a membership can be revoked or
+        // downgraded after the early check while the request waits. Never use
+        // that stale snapshot to mint a billing-management portal session.
+        const currentMembership = await resolveUserOrgMembership(workos, user.id, orgId);
+        if (!currentMembership) return { kind: 'forbidden' };
         const racedBlock = await blockIfActiveSubscription(orgId, orgDb, {
           customerPortalReturnUrl: `${req.protocol}://${req.get('host')}/dashboard/membership`,
+          requesterMembership: currentMembership,
         });
         if (racedBlock) return { kind: 'block', block: racedBlock };
         const invoiceResult = await createAndSendInvoice(invoiceData);
@@ -439,6 +438,12 @@ export function createPublicBillingRouter(): Router {
 
       if (intake.kind === 'block') {
         return res.status(intake.block.status).json(intake.block.body);
+      }
+      if (intake.kind === 'forbidden') {
+        return res.status(403).json({
+          error: 'Access denied',
+          message: 'You are no longer a member of this organization',
+        });
       }
       if (intake.kind === 'invoiceFailed') {
         return res.status(500).json({
@@ -522,9 +527,16 @@ export function createPublicBillingRouter(): Router {
           });
         }
 
-        // Validate that the requested product is available for this org type.
-        // This endpoint handles membership checkout only; event and sponsorship
-        // purchases use separate flows.
+        const membership = await resolveUserOrgMembership(workos, user.id, orgId);
+        if (!membership) {
+          return res.status(403).json({
+            error: "Access denied",
+            message: "You are not a member of this organization",
+          });
+        }
+
+        // Product discovery can call Stripe, so authorize the exact active org
+        // membership first. Ordinary members remain eligible for checkout.
         const customerType = org.is_personal ? 'individual' : 'company';
         const eligibleProducts = await getProductsForCustomer({
           customerType,
@@ -537,25 +549,16 @@ export function createPublicBillingRouter(): Router {
           });
         }
 
-        // Dev mode: skip WorkOS membership check for dev orgs
-        const isDevUserCheckout =
-          isDevModeEnabled() &&
-          Object.values(DEV_USERS).some((du) => du.id === user.id) &&
-          orgId.startsWith("org_dev_");
-        if (!isDevUserCheckout) {
-          // Check user membership in organization
-          const membership =
-            await workos?.userManagement.listOrganizationMemberships({
-              userId: user.id,
-              organizationId: orgId,
-            });
-
-          if (!membership?.data?.length) {
-            return res.status(403).json({
-              error: "Access denied",
-              message: "You are not a member of this organization",
-            });
-          }
+        // Product discovery is an awaited Stripe-backed operation. Re-resolve
+        // afterwards so a membership revoked or downgraded while it was in
+        // flight cannot carry stale billing-management authority into the
+        // active-subscription guard.
+        const currentMembership = await resolveUserOrgMembership(workos, user.id, orgId);
+        if (!currentMembership) {
+          return res.status(403).json({
+            error: "Access denied",
+            message: "You are no longer a member of this organization",
+          });
         }
 
         const host = req.get("host");
@@ -563,11 +566,12 @@ export function createPublicBillingRouter(): Router {
         const baseUrl = `${protocol}://${host}`;
 
         // Refuse if the org already has an active subscription. Tier changes go
-        // through the Stripe Customer Portal, not this checkout intake. The
-        // requester is a verified org member, so the portal URL is safe to
-        // include.
+        // through the Stripe Customer Portal, not this checkout intake.
+        // Ordinary members may still start checkout, but only an active
+        // owner/admin membership may receive a billing-management portal URL.
         const activeBlock = await blockIfActiveSubscription(orgId, orgDb, {
           customerPortalReturnUrl: `${baseUrl}/dashboard/membership`,
+          requesterMembership: currentMembership,
         });
         if (activeBlock) {
           return res.status(activeBlock.status).json(activeBlock.body);

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -46,6 +46,7 @@ import { getOrgAdminEmails } from "../utils/org-admins.js";
 import { emailPrefsDb } from "../db/email-preferences-db.js";
 import { performCreateOrganization } from "../services/organization-bootstrap.js";
 import { collectWorkOSPages } from "../services/workos-pagination.js";
+import { canManageOrganizationBilling } from "../billing/billing-authorization.js";
 
 const logger = createLogger("organization-routes");
 
@@ -1674,12 +1675,14 @@ export function createOrganizationsRouter(): Router {
       const user = req.user!;
       const { orgId } = req.params;
 
-      // Verify user is member of this organization
+      // The Stripe Customer Portal can change payment methods, tiers, and
+      // cancellation. Bind that authority to an active owner/admin role in
+      // this exact organization before any database or Stripe work.
       const membership = await resolveUserOrgMembership(workos, user.id, orgId);
-      if (!membership) {
+      if (!canManageOrganizationBilling(membership, orgId)) {
         return res.status(403).json({
           error: 'Access denied',
-          message: 'You are not a member of this organization',
+          message: 'Only organization owners and admins can manage billing',
         });
       }
 
@@ -1708,6 +1711,17 @@ export function createOrganizationsRouter(): Router {
           error: 'No subscription on file',
           message: 'The billing portal manages an existing subscription. Start one from the membership page first.',
           membership_url: '/dashboard/membership',
+        });
+      }
+
+      // Re-resolve immediately before the first operation that can call
+      // Stripe. A cached/earlier owner role must not survive a concurrent
+      // demotion or membership revocation.
+      const currentMembership = await resolveUserOrgMembership(workos, user.id, orgId);
+      if (!canManageOrganizationBilling(currentMembership, orgId)) {
+        return res.status(403).json({
+          error: 'Access denied',
+          message: 'Only organization owners and admins can manage billing',
         });
       }
 

--- a/server/tests/integration/billing-portal-gate.test.ts
+++ b/server/tests/integration/billing-portal-gate.test.ts
@@ -4,8 +4,8 @@
  * Stripe portal session (Sabarish opened it four times before realizing
  * the portal can't initiate a subscription).
  *
- * Confirms the gate refuses NULL but allows past_due / canceled / etc., where
- * the portal IS the right tool to recover the subscription.
+ * Confirms the gate refuses NULL, limits billing management to active
+ * owner/admin roles, and allows recoverable subscription statuses.
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
@@ -137,6 +137,16 @@ describe('POST /api/organizations/:orgId/billing/portal — subscription_status 
 
   beforeEach(async () => {
     await cleanup(pool);
+    mockListMemberships.mockReset();
+    mockListMemberships.mockResolvedValue({
+      data: [{
+        id: 'om_test',
+        userId: TEST_USER_ID,
+        organizationId: TEST_ORG,
+        role: { slug: 'owner' },
+        status: 'active',
+      }],
+    });
     mockCreatePortalSession.mockClear();
     mockCreatePortalSession.mockResolvedValue('https://billing.stripe.com/p/session/x');
   });
@@ -149,6 +159,71 @@ describe('POST /api/organizations/:orgId/billing/portal — subscription_status 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('No subscription on file');
     expect(res.body.membership_url).toBe('/dashboard/membership');
+    expect(mockCreatePortalSession).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['ordinary member', { organizationId: TEST_ORG, role: 'member', status: 'active' }],
+    ['inactive owner', { organizationId: TEST_ORG, role: 'owner', status: 'inactive' }],
+    ['owner from another organization', { organizationId: 'org_other', role: 'owner', status: 'active' }],
+  ])('denies %s before any Stripe call', async (_label, membership) => {
+    await seedOrg(pool, { subscriptionStatus: 'active' });
+    mockListMemberships.mockResolvedValue({
+      data: [{
+        id: 'om_denied',
+        userId: TEST_USER_ID,
+        organizationId: membership.organizationId,
+        role: { slug: membership.role },
+        status: membership.status,
+      }],
+    });
+
+    const res = await request(app).post(`/api/organizations/${TEST_ORG}/billing/portal`).send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Access denied');
+    expect(mockCreatePortalSession).not.toHaveBeenCalled();
+  });
+
+  it.each(['owner', 'admin'])('allows an active %s to manage billing', async (role) => {
+    await seedOrg(pool, { subscriptionStatus: 'active' });
+    mockListMemberships.mockResolvedValue({
+      data: [{
+        id: `om_${role}`,
+        userId: TEST_USER_ID,
+        organizationId: TEST_ORG,
+        role: { slug: role },
+        status: 'active',
+      }],
+    });
+
+    const res = await request(app).post(`/api/organizations/${TEST_ORG}/billing/portal`).send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.portal_url).toBe('https://billing.stripe.com/p/session/x');
+    expect(mockCreatePortalSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies when an owner is demoted before the Stripe operation', async () => {
+    await seedOrg(pool, { subscriptionStatus: 'active' });
+    const membership = (role: string) => ({
+      data: [{
+        id: `om_${role}`,
+        userId: TEST_USER_ID,
+        organizationId: TEST_ORG,
+        role: { slug: role },
+        status: 'active',
+      }],
+    });
+    mockListMemberships
+      .mockReset()
+      .mockResolvedValueOnce(membership('owner'))
+      .mockResolvedValueOnce(membership('member'));
+
+    const res = await request(app).post(`/api/organizations/${TEST_ORG}/billing/portal`).send({});
+
+    expect(res.status).toBe(403);
+    expect(mockListMemberships).toHaveBeenCalledTimes(2);
     expect(mockCreatePortalSession).not.toHaveBeenCalled();
   });
 

--- a/server/tests/unit/active-subscription-guard.test.ts
+++ b/server/tests/unit/active-subscription-guard.test.ts
@@ -33,6 +33,14 @@ function makeOrgDb(opts: {
 }
 
 const PORTAL_RETURN_URL = 'https://app/dashboard/membership';
+const ownerPortalOptions = {
+  customerPortalReturnUrl: PORTAL_RETURN_URL,
+  requesterMembership: {
+    organizationId: 'org_x',
+    role: 'owner' as const,
+    status: 'active' as const,
+  },
+};
 
 describe('blockIfActiveSubscription', () => {
   beforeEach(() => {
@@ -41,19 +49,19 @@ describe('blockIfActiveSubscription', () => {
 
   it('returns null when org has no subscription info', async () => {
     const orgDb = makeOrgDb({ info: null });
-    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+    const result = await blockIfActiveSubscription('org_x', orgDb, ownerPortalOptions);
     expect(result).toBeNull();
   });
 
   it('returns null when subscription status is "none"', async () => {
     const orgDb = makeOrgDb({ info: { status: 'none' } });
-    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+    const result = await blockIfActiveSubscription('org_x', orgDb, ownerPortalOptions);
     expect(result).toBeNull();
   });
 
   it('returns null when subscription is canceled', async () => {
     const orgDb = makeOrgDb({ info: { status: 'canceled' } });
-    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+    const result = await blockIfActiveSubscription('org_x', orgDb, ownerPortalOptions);
     expect(result).toBeNull();
   });
 
@@ -64,7 +72,7 @@ describe('blockIfActiveSubscription', () => {
     });
     mockCreatePortal.mockResolvedValueOnce('https://billing.stripe.com/p/session/x');
 
-    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+    const result = await blockIfActiveSubscription('org_x', orgDb, ownerPortalOptions);
 
     expect(result).not.toBeNull();
     expect(result!.body.existing_subscription.status).toBe('past_due');
@@ -72,7 +80,7 @@ describe('blockIfActiveSubscription', () => {
 
   it('returns null when subscription is unpaid (recoverable by re-subscribing)', async () => {
     const orgDb = makeOrgDb({ info: { status: 'unpaid' } });
-    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+    const result = await blockIfActiveSubscription('org_x', orgDb, ownerPortalOptions);
     expect(result).toBeNull();
   });
 
@@ -91,7 +99,14 @@ describe('blockIfActiveSubscription', () => {
       },
     });
 
-    const result = await blockIfActiveSubscription('org_triton', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+    const result = await blockIfActiveSubscription('org_triton', orgDb, {
+      customerPortalReturnUrl: PORTAL_RETURN_URL,
+      requesterMembership: {
+        organizationId: 'org_triton',
+        role: 'owner',
+        status: 'active',
+      },
+    });
 
     expect(result).not.toBeNull();
     expect(result!.status).toBe(409);
@@ -108,6 +123,26 @@ describe('blockIfActiveSubscription', () => {
     expect(mockCreatePortal).toHaveBeenCalledWith('cus_triton', PORTAL_RETURN_URL);
   });
 
+  it('allows an active admin membership to create the portal URL', async () => {
+    mockCreatePortal.mockResolvedValueOnce('https://billing.stripe.com/p/session/admin');
+    const orgDb = makeOrgDb({
+      info: { status: 'active' },
+      org: { stripe_customer_id: 'cus_x' },
+    });
+
+    const result = await blockIfActiveSubscription('org_x', orgDb, {
+      customerPortalReturnUrl: PORTAL_RETURN_URL,
+      requesterMembership: {
+        organizationId: 'org_x',
+        role: 'admin',
+        status: 'active',
+      },
+    });
+
+    expect(result?.body.customer_portal_url).toBe('https://billing.stripe.com/p/session/admin');
+    expect(mockCreatePortal).toHaveBeenCalledWith('cus_x', PORTAL_RETURN_URL);
+  });
+
   it('blocks when subscription is trialing', async () => {
     const orgDb = makeOrgDb({
       info: { status: 'trialing', amount_cents: 25050 },
@@ -115,7 +150,7 @@ describe('blockIfActiveSubscription', () => {
     });
     mockCreatePortal.mockResolvedValueOnce(null);
 
-    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+    const result = await blockIfActiveSubscription('org_x', orgDb, ownerPortalOptions);
 
     expect(result).not.toBeNull();
     expect(result!.body.existing_subscription.status).toBe('trialing');
@@ -127,7 +162,7 @@ describe('blockIfActiveSubscription', () => {
       org: { stripe_customer_id: null },
     });
 
-    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+    const result = await blockIfActiveSubscription('org_x', orgDb, ownerPortalOptions);
 
     expect(result).not.toBeNull();
     // $250.50 must render with cents — toLocaleString defaults drop them.
@@ -144,7 +179,7 @@ describe('blockIfActiveSubscription', () => {
       org: { stripe_customer_id: null },
     });
 
-    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+    const result = await blockIfActiveSubscription('org_x', orgDb, ownerPortalOptions);
 
     expect(result).not.toBeNull();
     expect(result!.body.message).toContain('Membership (an active tier)');
@@ -169,13 +204,33 @@ describe('blockIfActiveSubscription', () => {
     expect(mockCreatePortal).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['member role', { organizationId: 'org_x', role: 'member' as const, status: 'active' as const }],
+    ['inactive membership', { organizationId: 'org_x', role: 'owner' as const, status: 'inactive' as const }],
+    ['mismatched organization', { organizationId: 'org_other', role: 'owner' as const, status: 'active' as const }],
+  ])('does not create a portal for %s', async (_label, requesterMembership) => {
+    const orgDb = makeOrgDb({
+      info: { status: 'active', amount_cents: 1000000 },
+      org: { stripe_customer_id: 'cus_x' },
+    });
+
+    const result = await blockIfActiveSubscription('org_x', orgDb, {
+      customerPortalReturnUrl: PORTAL_RETURN_URL,
+      requesterMembership,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.body.customer_portal_url).toBeUndefined();
+    expect(mockCreatePortal).not.toHaveBeenCalled();
+  });
+
   it('omits customer_portal_url when org has no Stripe customer id', async () => {
     const orgDb = makeOrgDb({
       info: { status: 'active', amount_cents: 5000 },
       org: { stripe_customer_id: null },
     });
 
-    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+    const result = await blockIfActiveSubscription('org_x', orgDb, ownerPortalOptions);
 
     expect(result).not.toBeNull();
     expect(result!.body.customer_portal_url).toBeUndefined();
@@ -191,7 +246,7 @@ describe('blockIfActiveSubscription', () => {
       org: { stripe_customer_id: 'cus_x' },
     });
 
-    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+    const result = await blockIfActiveSubscription('org_x', orgDb, ownerPortalOptions);
 
     expect(result).not.toBeNull();
     expect(result!.body.customer_portal_url).toBeUndefined();
@@ -208,7 +263,7 @@ describe('blockIfActiveSubscription', () => {
       org: { stripe_customer_id: null },
     });
 
-    const result = await blockIfActiveSubscription('org_x', orgDb, { customerPortalReturnUrl: PORTAL_RETURN_URL });
+    const result = await blockIfActiveSubscription('org_x', orgDb, ownerPortalOptions);
 
     expect(result).not.toBeNull();
     expect(result!.body.message).toContain('aao_membership_builder_3000');

--- a/server/tests/unit/billing-public-portal-authorization.test.ts
+++ b/server/tests/unit/billing-public-portal-authorization.test.ts
@@ -1,0 +1,319 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+process.env.WORKOS_API_KEY ||= 'sk_test_billing_auth';
+process.env.WORKOS_CLIENT_ID ||= 'client_test_billing_auth';
+process.env.WORKOS_COOKIE_PASSWORD ||= 'test-cookie-password-32chars-minimum';
+
+const {
+  mockListMemberships,
+  mockGetOrganization,
+  mockGetSubscriptionInfo,
+  mockGetCurrentAgreement,
+  mockUpdateOrganization,
+  mockGetProducts,
+  mockCreatePortal,
+  mockCreateInvoice,
+  mockCreateCheckout,
+  mockGetAcceptedReferral,
+  mockWithOrgIntakeLock,
+} = vi.hoisted(() => ({
+  mockListMemberships: vi.fn(),
+  mockGetOrganization: vi.fn(),
+  mockGetSubscriptionInfo: vi.fn(),
+  mockGetCurrentAgreement: vi.fn(),
+  mockUpdateOrganization: vi.fn(),
+  mockGetProducts: vi.fn(),
+  mockCreatePortal: vi.fn(),
+  mockCreateInvoice: vi.fn(),
+  mockCreateCheckout: vi.fn(),
+  mockGetAcceptedReferral: vi.fn(),
+  mockWithOrgIntakeLock: vi.fn(),
+}));
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: class {
+    userManagement = {
+      listOrganizationMemberships: mockListMemberships,
+    };
+  },
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  DEV_USERS: {},
+  isDevModeEnabled: () => false,
+  requireAuth: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = {
+      id: 'user_billing',
+      email: 'billing@example.test',
+      firstName: 'Billing',
+      lastName: 'Tester',
+      emailVerified: true,
+      is_admin: false,
+    };
+    next();
+  },
+}));
+
+vi.mock('../../src/db/organization-db.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../src/db/organization-db.js')>();
+  return {
+    ...original,
+    OrganizationDatabase: class {
+      getOrganization = mockGetOrganization;
+      getSubscriptionInfo = mockGetSubscriptionInfo;
+      getCurrentAgreementByType = mockGetCurrentAgreement;
+      updateOrganization = mockUpdateOrganization;
+    },
+  };
+});
+
+vi.mock('../../src/billing/stripe-client.js', () => ({
+  getProductsForCustomer: mockGetProducts,
+  createAndSendInvoice: mockCreateInvoice,
+  getInvoiceableProducts: vi.fn(),
+  createCheckoutSession: mockCreateCheckout,
+  createCoupon: vi.fn(),
+  getPendingInvoices: vi.fn(),
+  createStripeCustomer: vi.fn(),
+  createCustomerSession: vi.fn(),
+  createCustomerPortalSession: mockCreatePortal,
+}));
+
+vi.mock('../../src/billing/org-intake-lock.js', () => ({
+  withOrgIntakeLock: mockWithOrgIntakeLock,
+}));
+
+vi.mock('../../src/db/referral-codes-db.js', () => ({
+  getReferralCode: vi.fn(),
+  redeemReferralCodeForInvoice: vi.fn(),
+  getAcceptedReferralForOrg: mockGetAcceptedReferral,
+  acceptReferralCode: vi.fn(),
+}));
+
+vi.mock('../../src/notifications/billing.js', () => ({
+  notifyInvoiceSent: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { createPublicBillingRouter } = await import('../../src/routes/billing-public.js');
+
+const ORG_ID = 'org_billing';
+const ACTIVE_SUBSCRIPTION = {
+  status: 'active',
+  product_name: 'Company Membership',
+  amount_cents: 300000,
+};
+
+function membership(
+  role: 'owner' | 'admin' | 'member',
+  options: { status?: 'active' | 'inactive'; organizationId?: string } = {},
+) {
+  return {
+    id: `om_${role}`,
+    userId: 'user_billing',
+    organizationId: options.organizationId ?? ORG_ID,
+    role: { slug: role },
+    status: options.status ?? 'active',
+  };
+}
+
+function membershipPage(...rows: ReturnType<typeof membership>[]) {
+  return { data: rows };
+}
+
+const invoiceBody = {
+  orgId: ORG_ID,
+  lookupKey: 'aao_company_standard',
+  agreement_version: 'v1',
+  billingAddress: {
+    line1: '100 Main Street',
+    city: 'New York',
+    state: 'NY',
+    postal_code: '10001',
+    country: 'US',
+  },
+};
+
+const checkoutBody = {
+  orgId: ORG_ID,
+  priceId: 'price_company_standard',
+};
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(createPublicBillingRouter());
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetOrganization.mockResolvedValue({
+    workos_organization_id: ORG_ID,
+    name: 'Acme Corp',
+    is_personal: false,
+    stripe_customer_id: 'cus_billing',
+    subscription_status: null,
+    pending_agreement_version: null,
+    agreement_version: null,
+  });
+  mockGetCurrentAgreement.mockResolvedValue({ version: 'v1' });
+  mockUpdateOrganization.mockResolvedValue(undefined);
+  mockGetProducts.mockResolvedValue([{
+    lookup_key: 'aao_company_standard',
+    price_id: 'price_company_standard',
+    display_name: 'Company Membership',
+    amount_cents: 300000,
+    currency: 'usd',
+  }]);
+  mockCreatePortal.mockResolvedValue('https://billing.stripe.test/portal');
+  mockCreateInvoice.mockResolvedValue({
+    invoiceId: 'in_test',
+    invoiceUrl: 'https://invoice.stripe.test/in_test',
+  });
+  mockCreateCheckout.mockResolvedValue({
+    sessionId: 'cs_test',
+    url: 'https://checkout.stripe.test/cs_test',
+  });
+  mockGetAcceptedReferral.mockResolvedValue(null);
+  mockWithOrgIntakeLock.mockImplementation(async (_orgId: string, fn: () => Promise<unknown>) => fn());
+});
+
+describe.each([
+  ['invoice request', '/invoice-request', invoiceBody],
+  ['checkout session', '/checkout-session', checkoutBody],
+] as const)('%s portal authorization', (_label, path, body) => {
+  it('returns a portal-free 409 to an ordinary member with an active subscription', async () => {
+    mockListMemberships.mockResolvedValue(membershipPage(membership('member')));
+    mockGetSubscriptionInfo.mockResolvedValue(ACTIVE_SUBSCRIPTION);
+
+    const response = await request(createApp()).post(path).send(body);
+
+    expect(response.status).toBe(409);
+    expect(response.body.error).toBe('Active subscription exists');
+    expect(response.body).not.toHaveProperty('customer_portal_url');
+    expect(mockCreatePortal).not.toHaveBeenCalled();
+    expect(mockCreateInvoice).not.toHaveBeenCalled();
+    expect(mockCreateCheckout).not.toHaveBeenCalled();
+  });
+
+  it.each(['owner', 'admin'] as const)('returns a portal URL to an active %s', async (role) => {
+    mockListMemberships.mockResolvedValue(membershipPage(membership(role)));
+    mockGetSubscriptionInfo.mockResolvedValue(ACTIVE_SUBSCRIPTION);
+
+    const response = await request(createApp()).post(path).send(body);
+
+    expect(response.status).toBe(409);
+    expect(response.body.customer_portal_url).toBe('https://billing.stripe.test/portal');
+    expect(mockCreatePortal).toHaveBeenCalledWith(
+      'cus_billing',
+      expect.stringContaining('/dashboard/membership'),
+    );
+  });
+
+  it.each([
+    ['inactive owner', membership('owner', { status: 'inactive' })],
+    ['owner for another org', membership('owner', { organizationId: 'org_other' })],
+  ])('rejects an %s before any Stripe call', async (_case, row) => {
+    mockListMemberships.mockResolvedValue(membershipPage(row));
+
+    const response = await request(createApp()).post(path).send(body);
+
+    expect(response.status).toBe(403);
+    expect(mockGetSubscriptionInfo).not.toHaveBeenCalled();
+    expect(mockGetProducts).not.toHaveBeenCalled();
+    expect(mockCreatePortal).not.toHaveBeenCalled();
+    expect(mockCreateInvoice).not.toHaveBeenCalled();
+    expect(mockCreateCheckout).not.toHaveBeenCalled();
+  });
+});
+
+describe('invoice request in-lock authorization', () => {
+  it('fails closed when membership is revoked while waiting for the lock', async () => {
+    mockListMemberships
+      .mockResolvedValueOnce(membershipPage(membership('owner')))
+      .mockResolvedValueOnce(membershipPage());
+    mockGetSubscriptionInfo.mockResolvedValueOnce(null);
+
+    const response = await request(createApp()).post('/invoice-request').send(invoiceBody);
+
+    expect(response.status).toBe(403);
+    expect(mockListMemberships).toHaveBeenCalledTimes(2);
+    expect(mockCreateInvoice).not.toHaveBeenCalled();
+    expect(mockCreatePortal).not.toHaveBeenCalled();
+  });
+
+  it('preserves member intake but suppresses the raced portal after an owner downgrade', async () => {
+    mockListMemberships
+      .mockResolvedValueOnce(membershipPage(membership('owner')))
+      .mockResolvedValueOnce(membershipPage(membership('member')));
+    mockGetSubscriptionInfo
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(ACTIVE_SUBSCRIPTION);
+
+    const response = await request(createApp()).post('/invoice-request').send(invoiceBody);
+
+    expect(response.status).toBe(409);
+    expect(response.body).not.toHaveProperty('customer_portal_url');
+    expect(mockCreateInvoice).not.toHaveBeenCalled();
+    expect(mockCreatePortal).not.toHaveBeenCalled();
+  });
+
+  it('lets an ordinary member reach the existing invoice success path when no subscription is active', async () => {
+    mockListMemberships.mockResolvedValue(membershipPage(membership('member')));
+    mockGetSubscriptionInfo.mockResolvedValue(null);
+
+    const response = await request(createApp()).post('/invoice-request').send(invoiceBody);
+
+    expect(response.status).toBe(200);
+    expect(response.body.invoiceId).toBe('in_test');
+    expect(mockCreateInvoice).toHaveBeenCalledTimes(1);
+    expect(mockCreatePortal).not.toHaveBeenCalled();
+  });
+});
+
+describe('checkout member intake', () => {
+  it('fails closed when membership is revoked during product discovery', async () => {
+    mockListMemberships
+      .mockResolvedValueOnce(membershipPage(membership('owner')))
+      .mockResolvedValueOnce(membershipPage());
+
+    const response = await request(createApp()).post('/checkout-session').send(checkoutBody);
+
+    expect(response.status).toBe(403);
+    expect(mockListMemberships).toHaveBeenCalledTimes(2);
+    expect(mockGetProducts).toHaveBeenCalledTimes(1);
+    expect(mockGetSubscriptionInfo).not.toHaveBeenCalled();
+    expect(mockCreatePortal).not.toHaveBeenCalled();
+    expect(mockCreateCheckout).not.toHaveBeenCalled();
+  });
+
+  it('suppresses the portal when an owner is downgraded during product discovery', async () => {
+    mockListMemberships
+      .mockResolvedValueOnce(membershipPage(membership('owner')))
+      .mockResolvedValueOnce(membershipPage(membership('member')));
+    mockGetSubscriptionInfo.mockResolvedValue(ACTIVE_SUBSCRIPTION);
+
+    const response = await request(createApp()).post('/checkout-session').send(checkoutBody);
+
+    expect(response.status).toBe(409);
+    expect(response.body).not.toHaveProperty('customer_portal_url');
+    expect(mockListMemberships).toHaveBeenCalledTimes(2);
+    expect(mockCreatePortal).not.toHaveBeenCalled();
+    expect(mockCreateCheckout).not.toHaveBeenCalled();
+  });
+
+  it('lets an ordinary member reach the existing checkout success path when no subscription is active', async () => {
+    mockListMemberships.mockResolvedValue(membershipPage(membership('member')));
+    mockGetSubscriptionInfo.mockResolvedValue(null);
+
+    const response = await request(createApp()).post('/checkout-session').send(checkoutBody);
+
+    expect(response.status).toBe(200);
+    expect(response.body.sessionId).toBe('cs_test');
+    expect(mockListMemberships).toHaveBeenCalledTimes(2);
+    expect(mockCreateCheckout).toHaveBeenCalledTimes(1);
+    expect(mockCreatePortal).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/billing-tool-lockdown.test.ts
+++ b/server/tests/unit/billing-tool-lockdown.test.ts
@@ -9,16 +9,34 @@
  * agent-supplied address become the Stripe customer of record, which
  * cross-contaminated two distinct organizations (Triton/Encypher, Apr 2026).
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
 process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+
+const { mockCreatePortalSession, mockListMemberships } = vi.hoisted(() => ({
+  mockCreatePortalSession: vi.fn(),
+  mockListMemberships: vi.fn(),
+}));
+
+vi.mock('../../src/billing/stripe-client.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/billing/stripe-client.js')>()),
+  createCustomerPortalSession: mockCreatePortalSession,
+}));
+
+vi.mock('../../src/auth/workos-client.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/auth/workos-client.js')>()),
+  getWorkos: () => ({
+    userManagement: { listOrganizationMemberships: mockListMemberships },
+  }),
+}));
 
 const {
   BILLING_TOOLS,
   createBillingToolHandlers,
 } = await import('../../src/addie/mcp/billing-tools.js');
 const { ADMIN_TOOLS } = await import('../../src/addie/mcp/admin-tools.js');
+const { OrganizationDatabase } = await import('../../src/db/organization-db.js');
 
 function getToolSchema(name: string, source: typeof BILLING_TOOLS | typeof ADMIN_TOOLS) {
   const tool = source.find((t) => t.name === name);
@@ -78,6 +96,104 @@ describe('send_invoice / confirm_send_invoice tools', () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/sign(?:ed)? in/i);
   });
+});
+
+describe('get_billing_portal tool', () => {
+  beforeEach(() => {
+    mockCreatePortalSession.mockReset();
+    mockListMemberships.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function memberContext(role: 'owner' | 'admin' | 'member' = 'member') {
+    return {
+      is_mapped: true,
+      is_member: true,
+      workos_user: { workos_user_id: 'user_123', email: 'member@example.test' },
+      organization: {
+        workos_organization_id: 'org_123',
+        name: 'Acme Corp',
+        subscription_status: 'active',
+        is_personal: false,
+        membership_tier: 'company_standard',
+      },
+      org_membership: { role, member_count: 3, joined_at: null },
+    };
+  }
+
+  function liveMembership(opts: {
+    role?: 'owner' | 'admin' | 'member';
+    status?: 'active' | 'inactive';
+    organizationId?: string;
+  } = {}) {
+    return {
+      id: 'om_live',
+      userId: 'user_123',
+      organizationId: opts.organizationId ?? 'org_123',
+      role: { slug: opts.role ?? 'member' },
+      status: opts.status ?? 'active',
+    };
+  }
+
+  it('denies an ordinary live organization member before any Stripe call', async () => {
+    mockListMemberships.mockResolvedValue({ data: [liveMembership()] });
+    const handlers = createBillingToolHandlers({
+      ...memberContext('owner'), // stale cached owner must not authorize
+    });
+
+    const result = JSON.parse(await handlers.get('get_billing_portal')!({}));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/owners and admins/i);
+    expect(mockCreatePortalSession).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['inactive owner', liveMembership({ role: 'owner', status: 'inactive' })],
+    ['owner in another organization', liveMembership({ role: 'owner', organizationId: 'org_other' })],
+  ])('denies %s before any Stripe call', async (_label, membership) => {
+    mockListMemberships.mockResolvedValue({ data: [membership] });
+    const handlers = createBillingToolHandlers(memberContext('owner'));
+
+    const result = JSON.parse(await handlers.get('get_billing_portal')!({}));
+
+    expect(result.success).toBe(false);
+    expect(mockCreatePortalSession).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when live role resolution fails', async () => {
+    mockListMemberships.mockRejectedValue(new Error('WorkOS unavailable'));
+    const handlers = createBillingToolHandlers(memberContext('owner'));
+
+    const result = JSON.parse(await handlers.get('get_billing_portal')!({}));
+
+    expect(result.success).toBe(false);
+    expect(mockCreatePortalSession).not.toHaveBeenCalled();
+  });
+
+  it.each(['owner', 'admin'] as const)(
+    'allows a live %s even when cached context is stale',
+    async (role) => {
+      mockListMemberships.mockResolvedValue({ data: [liveMembership({ role })] });
+      vi.spyOn(OrganizationDatabase.prototype, 'getOrganization').mockResolvedValueOnce({
+        workos_organization_id: 'org_123',
+        stripe_customer_id: 'cus_123',
+      } as never);
+      mockCreatePortalSession.mockResolvedValueOnce('https://billing.stripe.test/session');
+      const handlers = createBillingToolHandlers(memberContext('member'));
+
+      const result = JSON.parse(await handlers.get('get_billing_portal')!({}));
+
+      expect(result.success).toBe(true);
+      expect(mockCreatePortalSession).toHaveBeenCalledWith(
+        'cus_123',
+        'https://agenticadvertising.org/dashboard/membership',
+      );
+    },
+  );
 });
 
 describe('send_payment_request admin tool', () => {


### PR DESCRIPTION
## Summary

- require an active exact-organization `owner` or `admin` role before issuing Stripe Customer Portal sessions
- live-recheck WorkOS authorization at direct, Addie, invoice-lock, and checkout post-discovery boundaries to close cached-role and TOCTOU gaps
- preserve ordinary-member invoice and checkout intake while returning active-subscription responses without privileged portal URLs

## Security impact

Stripe Customer Portal sessions can change payment methods, subscriptions, and cancellation state. Previously any organization member could obtain one directly or through Addie, invoice, and checkout paths. This change centralizes billing-manager authorization, fails closed for inactive/mismatched/revoked memberships, and keeps invite flows portal-free.

## Validation

- 4,947 server unit tests passed; 30 skipped
- 49 focused billing authorization tests passed
- TypeScript build passed
- Semgrep: 0 findings across changed files
- `git diff --check` passed
- changeset protocol-scope check passed
- independent security review: CLEAN
- independent testing review: CLEAN

Database-backed billing portal assertions are included and will run in CI; the local environment did not provide `DATABASE_URL`.
