### PR TITLE
fix(security): enforce Slack knowledge ACLs

### DIFF
--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -46,7 +46,7 @@ import { getPool } from '../db/client.js';
 import { linkDomain } from '../db/organization-domains-db.js';
 import {
   isKnowledgeReady,
-  createKnowledgeToolHandlers,
+  createSlackKnowledgeRequestTools,
   createUserScopedBookmarkHandler,
 } from './mcp/knowledge-search.js';
 import { registerBaselineTools } from './register-baseline-tools.js';
@@ -1035,6 +1035,16 @@ async function createUserScopedTools(
   let allTools = [...MEMBER_TOOLS];
   const allHandlers = new Map(memberHandlers);
 
+  const slackKnowledge = createSlackKnowledgeRequestTools(
+    slackUserId
+      ? { kind: 'slack-user', slackUserId }
+      : { kind: 'public-only' },
+  );
+  allTools.push(...slackKnowledge.tools);
+  for (const [name, handler] of slackKnowledge.handlers) {
+    allHandlers.set(name, handler);
+  }
+
   // Re-register Google Docs tools with user context for per-user rate
   // limiting (see tool-rate-limiter.ts). The boot-time registration
   // remains as a fallback; this per-request copy shadows whenever
@@ -1247,19 +1257,6 @@ async function createUserScopedTools(
   // Override bookmark_resource handler with user-scoped version (for attribution)
   if (slackUserId) {
     allHandlers.set('bookmark_resource', createUserScopedBookmarkHandler(slackUserId));
-  }
-
-  // Override Slack search handlers with user-scoped versions (for private channel access control)
-  if (slackUserId) {
-    const userScopedKnowledgeHandlers = createKnowledgeToolHandlers(slackUserId);
-    const searchSlackHandler = userScopedKnowledgeHandlers.get('search_slack');
-    const getChannelActivityHandler = userScopedKnowledgeHandlers.get('get_channel_activity');
-    if (searchSlackHandler) {
-      allHandlers.set('search_slack', searchSlackHandler);
-    }
-    if (getChannelActivityHandler) {
-      allHandlers.set('get_channel_activity', getChannelActivityHandler);
-    }
   }
 
   // Remove enrollment tools in public channels (covers all handler paths,

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.2';
+export const CODE_VERSION = '2026.08.3';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -27,7 +27,9 @@ import {
   isKnowledgeReady,
   KNOWLEDGE_TOOLS,
   createKnowledgeToolHandlers,
+  createSlackKnowledgeRequestTools,
   createUserScopedBookmarkHandler,
+  isSlackKnowledgeTool,
 } from './mcp/knowledge-search.js';
 import {
   BILLING_TOOLS,
@@ -185,8 +187,10 @@ export async function initializeAddie(): Promise<void> {
   await initializeKnowledgeSearch();
 
   // Register knowledge tools
-  const knowledgeHandlers = createKnowledgeToolHandlers();
-  for (const tool of KNOWLEDGE_TOOLS) {
+  const knowledgeHandlers = createKnowledgeToolHandlers({
+    slackAccess: { kind: 'public-only' },
+  });
+  for (const tool of KNOWLEDGE_TOOLS.filter((tool) => !isSlackKnowledgeTool(tool))) {
     const handler = knowledgeHandlers.get(tool.name);
     if (handler) {
       claudeClient.registerTool(tool, handler);
@@ -350,6 +354,16 @@ async function createUserScopedTools(
   const allTools = [...MEMBER_TOOLS];
   const allHandlers = new Map(memberHandlers);
 
+  const slackKnowledge = createSlackKnowledgeRequestTools(
+    slackUserId
+      ? { kind: 'slack-user', slackUserId }
+      : { kind: 'public-only' },
+  );
+  allTools.push(...slackKnowledge.tools);
+  for (const [name, handler] of slackKnowledge.handlers) {
+    allHandlers.set(name, handler);
+  }
+
   // Add billing tools (for membership signup assistance)
   // Skip in channel mentions to prevent enrollment pitching
   if (!options?.isChannelMention) {
@@ -494,19 +508,6 @@ async function createUserScopedTools(
   // Override bookmark_resource handler with user-scoped version (for attribution)
   if (slackUserId) {
     allHandlers.set('bookmark_resource', createUserScopedBookmarkHandler(slackUserId));
-  }
-
-  // Override Slack search handlers with user-scoped versions (for private channel access control)
-  if (slackUserId) {
-    const userScopedKnowledgeHandlers = createKnowledgeToolHandlers(slackUserId);
-    const searchSlackHandler = userScopedKnowledgeHandlers.get('search_slack');
-    const getChannelActivityHandler = userScopedKnowledgeHandlers.get('get_channel_activity');
-    if (searchSlackHandler) {
-      allHandlers.set('search_slack', searchSlackHandler);
-    }
-    if (getChannelActivityHandler) {
-      allHandlers.set('get_channel_activity', getChannelActivityHandler);
-    }
   }
 
   return {

--- a/server/src/addie/mcp/knowledge-search.ts
+++ b/server/src/addie/mcp/knowledge-search.ts
@@ -364,6 +364,20 @@ export const KNOWLEDGE_TOOLS: AddieTool[] = [
   },
 ];
 
+/** Slack history tools must only be installed with an explicit request scope. */
+export const SLACK_KNOWLEDGE_TOOL_NAMES = new Set([
+  'search_slack',
+  'get_channel_activity',
+]);
+
+export function isSlackKnowledgeTool(tool: AddieTool): boolean {
+  return SLACK_KNOWLEDGE_TOOL_NAMES.has(tool.name);
+}
+
+export type SlackKnowledgeAccess =
+  | { kind: 'public-only' }
+  | { kind: 'slack-user'; slackUserId: string };
+
 /**
  * Extract a smart excerpt that shows content around query matches
  * instead of just the first N characters
@@ -479,21 +493,39 @@ function extractSmartExcerpt(content: string, query: string, maxLength: number =
 
 /**
  * Tool handlers
- * @param slackUserId - Optional Slack user ID for access control on private channels
+ * @param options.slackAccess - Explicit Slack-history access scope. Missing access
+ *   context defaults to public-only; it never grants access to every channel.
  * @param options.anonymous - When true, restrict resource sources to curated/rss
  *   and strip Addie-generated notes. Anonymous web/MCP callers should pass true
  *   so attacker-controlled URLs queued via `bookmark_resource` (Slack-authenticated
  *   path) cannot become a prompt-injection vector for unauthenticated sessions.
  */
 export function createKnowledgeToolHandlers(
-  slackUserId?: string,
-  options: { anonymous?: boolean } = {}
+  options: {
+    anonymous?: boolean;
+    slackAccess?: SlackKnowledgeAccess;
+  } = {}
 ): Map<
   string,
   (input: Record<string, unknown>) => Promise<string>
 > {
   const handlers = new Map<string, (input: Record<string, unknown>) => Promise<string>>();
   const anonymous = options.anonymous === true;
+  const slackUserId = options.slackAccess?.kind === 'slack-user'
+    ? options.slackAccess.slackUserId
+    : undefined;
+
+  const resolveAccessiblePrivateChannelIds = async (): Promise<string[]> => {
+    if (!slackUserId) return [];
+    try {
+      return await getAccessiblePrivateChannelIds(slackUserId);
+    } catch (error) {
+      // The Slack client currently also fails closed, but this boundary must
+      // stay safe if its implementation changes or a test double rejects.
+      logger.warn({ error, slackUserId }, 'Addie: Failed to resolve Slack channel permissions');
+      return [];
+    }
+  };
 
   handlers.set('search_docs', async (input) => {
     const startTime = Date.now();
@@ -672,10 +704,7 @@ ${excerpt}`;
 
       // Get accessible private channel IDs for access filtering
       // This ensures search results don't leak private channel content
-      let accessiblePrivateChannelIds: string[] | undefined;
-      if (slackUserId) {
-        accessiblePrivateChannelIds = await getAccessiblePrivateChannelIds(slackUserId);
-      }
+      const accessiblePrivateChannelIds = await resolveAccessiblePrivateChannelIds();
 
       // Search local database with optional channel filter and access control
       const localResults = await addieDb.searchSlackMessages(searchQuery, {
@@ -720,24 +749,30 @@ ${excerpt}`;
     const limit = input.limit as number | undefined;
 
     try {
+      const accessiblePrivateChannelIds = await resolveAccessiblePrivateChannelIds();
+      let requestedPrivateChannelName: string | undefined;
+
       // Check access if we have user context
       if (slackUserId) {
         const accessResult = await findChannelWithAccess(channel, slackUserId);
         if (accessResult && !accessResult.hasAccess) {
           return `Cannot access #${accessResult.channel.name}: ${accessResult.reason || 'Access denied'}.\n\nPrivate channel activity is only accessible to channel members.`;
         }
-        // If it's a private channel and not indexed, inform the user
-        if (accessResult && accessResult.channel.is_private) {
-          const messages = await addieDb.getChannelActivity(channel, { days, limit });
-          if (messages.length === 0) {
-            return `No indexed activity found for private channel #${accessResult.channel.name}.\n\nPrivate channels are indexed but may not have historical data. Recent messages should appear after they are sent.`;
-          }
+        if (accessResult?.channel.is_private) {
+          requestedPrivateChannelName = accessResult.channel.name;
         }
       }
 
-      const messages = await addieDb.getChannelActivity(channel, { days, limit });
+      const messages = await addieDb.getChannelActivity(channel, {
+        days,
+        limit,
+        accessiblePrivateChannelIds,
+      });
 
       if (messages.length === 0) {
+        if (requestedPrivateChannelName) {
+          return `No indexed activity found for private channel #${requestedPrivateChannelName}.\n\nPrivate channels are indexed but may not have historical data. Recent messages should appear after they are sent.`;
+        }
         return `No recent activity found in channels matching "${channel}".\n\nThis could mean:\n- The channel name might be different (try partial matches like "technical" for "technical-standards-wg")\n- No messages in the last ${days ?? 30} days\n- The channel may not be indexed yet`;
       }
 
@@ -942,6 +977,25 @@ ${addieNotesBlock}`;
   });
 
   return handlers;
+}
+
+/**
+ * Build the two Slack-history tools as an atomic request-scoped unit. Keeping
+ * definitions and handlers together prevents a routed tool definition from
+ * falling back to a shared-client handler with a different caller's scope.
+ */
+export function createSlackKnowledgeRequestTools(slackAccess: SlackKnowledgeAccess): {
+  tools: AddieTool[];
+  handlers: Map<string, (input: Record<string, unknown>) => Promise<string>>;
+} {
+  const allHandlers = createKnowledgeToolHandlers({ slackAccess });
+  const tools = KNOWLEDGE_TOOLS.filter(isSlackKnowledgeTool);
+  const handlers = new Map<string, (input: Record<string, unknown>) => Promise<string>>();
+  for (const tool of tools) {
+    const handler = allHandlers.get(tool.name);
+    if (handler) handlers.set(tool.name, handler);
+  }
+  return { tools, handlers };
 }
 
 /**

--- a/server/src/addie/register-baseline-tools.ts
+++ b/server/src/addie/register-baseline-tools.ts
@@ -14,6 +14,7 @@ import {
   initializeKnowledgeSearch,
   KNOWLEDGE_TOOLS,
   createKnowledgeToolHandlers,
+  isSlackKnowledgeTool,
 } from "./mcp/knowledge-search.js";
 import {
   BILLING_TOOLS,
@@ -60,7 +61,13 @@ function registerToolsFromMap(
 export async function registerBaselineTools(client: AddieClaudeClient): Promise<void> {
   await initializeKnowledgeSearch();
 
-  registerToolsFromMap(client, KNOWLEDGE_TOOLS, createKnowledgeToolHandlers());
+  // Slack history is request-scoped because private-channel visibility depends
+  // on the current caller. Never install these handlers on the shared client.
+  registerToolsFromMap(
+    client,
+    KNOWLEDGE_TOOLS.filter((tool) => !isSlackKnowledgeTool(tool)),
+    createKnowledgeToolHandlers({ slackAccess: { kind: 'public-only' } }),
+  );
   registerToolsFromMap(client, BILLING_TOOLS, createBillingToolHandlers());
   registerToolsFromMap(client, SCHEMA_TOOLS, createSchemaToolHandlers());
   registerToolsFromMap(client, DIRECTORY_TOOLS, createDirectoryToolHandlers());

--- a/server/src/db/addie-db.ts
+++ b/server/src/db/addie-db.ts
@@ -450,8 +450,8 @@ export class AddieDatabase {
    * Search Slack messages stored locally using PostgreSQL full-text search
    *
    * @param accessiblePrivateChannelIds - List of private channel IDs the user has access to.
-   *   If provided, results will only include public channels OR private channels in this list.
-   *   If not provided (undefined), no access filtering is applied (use for internal/admin queries).
+   *   Results only include public channels OR private channels in this list.
+   *   Omitting this value fails closed to public-only results.
    */
   async searchSlackMessages(searchQuery: string, options: {
     limit?: number;
@@ -460,7 +460,7 @@ export class AddieDatabase {
   } = {}): Promise<SlackSearchResult[]> {
     const limit = options.limit ?? 10;
     const channel = options.channel;
-    const accessiblePrivateChannelIds = options.accessiblePrivateChannelIds;
+    const accessiblePrivateChannelIds = options.accessiblePrivateChannelIds ?? [];
 
     // Build dynamic query with optional filters
     const params: (string | number | string[])[] = [searchQuery, limit];
@@ -474,29 +474,24 @@ export class AddieDatabase {
       paramIndex++;
     }
 
-    // Access control filter for private channels
-    // Only include messages from:
-    // 1. Public channels (those without a working group - tracked via slack_channel_id)
-    // 2. Private channels the user has access to (in accessiblePrivateChannelIds)
-    let accessFilter = '';
-    if (accessiblePrivateChannelIds !== undefined) {
-      if (accessiblePrivateChannelIds.length > 0) {
-        // Include public channels (not in any working group) OR accessible private channels
-        accessFilter = `AND (
+    // Indexed private channels are linked to working groups. Missing ACL
+    // context is deliberately equivalent to an empty allowlist rather than
+    // unrestricted access.
+    let accessFilter: string;
+    if (accessiblePrivateChannelIds.length > 0) {
+      accessFilter = `AND (
           NOT EXISTS (
             SELECT 1 FROM working_groups wg
             WHERE wg.slack_channel_id = addie_knowledge.slack_channel_id
           )
           OR slack_channel_id = ANY($${paramIndex}::text[])
         )`;
-        params.push(accessiblePrivateChannelIds);
-      } else {
-        // User has no private channel access - only show public channels
-        accessFilter = `AND NOT EXISTS (
+      params.push(accessiblePrivateChannelIds);
+    } else {
+      accessFilter = `AND NOT EXISTS (
           SELECT 1 FROM working_groups wg
           WHERE wg.slack_channel_id = addie_knowledge.slack_channel_id
         )`;
-      }
     }
 
     const result = await query<SlackSearchResult>(
@@ -539,6 +534,7 @@ export class AddieDatabase {
   async getChannelActivity(channel: string, options: {
     days?: number;
     limit?: number;
+    accessiblePrivateChannelIds?: string[];
   } = {}): Promise<Array<{
     text: string;
     channel_name: string;
@@ -548,6 +544,24 @@ export class AddieDatabase {
   }>> {
     const days = Math.min(options.days ?? 30, 90);
     const limit = Math.min(options.limit ?? 25, 50);
+    const accessiblePrivateChannelIds = options.accessiblePrivateChannelIds ?? [];
+    const params: (string | number | string[])[] = [`%${channel}%`, days, limit];
+    let accessFilter: string;
+    if (accessiblePrivateChannelIds.length > 0) {
+      accessFilter = `AND (
+         NOT EXISTS (
+           SELECT 1 FROM working_groups wg
+           WHERE wg.slack_channel_id = addie_knowledge.slack_channel_id
+         )
+         OR slack_channel_id = ANY($4::text[])
+       )`;
+      params.push(accessiblePrivateChannelIds);
+    } else {
+      accessFilter = `AND NOT EXISTS (
+         SELECT 1 FROM working_groups wg
+         WHERE wg.slack_channel_id = addie_knowledge.slack_channel_id
+       )`;
+    }
 
     const result = await query<{
       text: string;
@@ -568,9 +582,10 @@ export class AddieDatabase {
          AND LOWER(slack_channel_name) LIKE LOWER($1)
          AND slack_ts IS NOT NULL
          AND TO_TIMESTAMP(slack_ts::numeric) >= NOW() - INTERVAL '1 day' * $2
+         ${accessFilter}
        ORDER BY slack_ts::numeric DESC
        LIMIT $3`,
-      [`%${channel}%`, days, limit]
+      params
     );
     return result.rows;
   }
@@ -1573,4 +1588,3 @@ export interface ConfigVersionInfo {
   avg_rating: number | null;
   source_synthesis_run_ids: number[] | null;
 }
-

--- a/server/src/mcp/chat-tool.ts
+++ b/server/src/mcp/chat-tool.ts
@@ -105,7 +105,10 @@ function getChatClient(): AddieClaudeClient {
     // callers here are treated as anonymous — handlers are scoped to exclude
     // user-bookmarked URLs and strip Addie-generated notes that could carry
     // prompt-injection text from arbitrary fetched content.
-    const knowledgeHandlers = createKnowledgeToolHandlers(undefined, { anonymous: true });
+    const knowledgeHandlers = createKnowledgeToolHandlers({
+      anonymous: true,
+      slackAccess: { kind: 'public-only' },
+    });
     for (const tool of KNOWLEDGE_TOOLS) {
       if (ANONYMOUS_SAFE_KNOWLEDGE_TOOLS.has(tool.name)) {
         const handler = knowledgeHandlers.get(tool.name);

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -30,6 +30,8 @@ import {
   initializeKnowledgeSearch,
   KNOWLEDGE_TOOLS,
   createKnowledgeToolHandlers,
+  createSlackKnowledgeRequestTools,
+  isSlackKnowledgeTool,
 } from "../addie/mcp/knowledge-search.js";
 import { ANONYMOUS_SAFE_KNOWLEDGE_TOOLS } from "../mcp/chat-tool.js";
 import {
@@ -332,8 +334,13 @@ async function initializeChatClient(): Promise<void> {
   // user-submitted resources and strips Addie-generated notes) and full
   // (for the authenticated-only set). The split happens at handler-creation
   // time because handler closures don't carry per-call scope.
-  const anonymousKnowledgeHandlers = createKnowledgeToolHandlers(undefined, { anonymous: true });
-  const authedKnowledgeHandlers = createKnowledgeToolHandlers();
+  const anonymousKnowledgeHandlers = createKnowledgeToolHandlers({
+    anonymous: true,
+    slackAccess: { kind: 'public-only' },
+  });
+  const authedKnowledgeHandlers = createKnowledgeToolHandlers({
+    slackAccess: { kind: 'public-only' },
+  });
 
   // Register anonymous-safe knowledge tools globally — search_docs, get_doc,
   // search_repos, search_resources, get_recent_news. All read-only over public
@@ -361,6 +368,7 @@ async function initializeChatClient(): Promise<void> {
   // restricted handler globally, authenticated users get the full handler
   // via this per-request override.
   for (const tool of KNOWLEDGE_TOOLS) {
+    if (isSlackKnowledgeTool(tool)) continue;
     const handler = authedKnowledgeHandlers.get(tool.name);
     if (!handler) continue;
     if (ANONYMOUS_SAFE_KNOWLEDGE_TOOLS.has(tool.name)) {
@@ -767,6 +775,19 @@ export async function prepareRequestWithMemberTools(
     ...createBillingToolHandlers(memberContext),
     ...createImageToolHandlers(linkedSlackUserId, threadExternalId),
   ]);
+
+  // Slack history is always request-scoped. A linked Slack identity may see
+  // its allowed private channels; an authenticated-but-unlinked web user gets
+  // an explicit public-only scope.
+  const slackKnowledge = createSlackKnowledgeRequestTools(
+    linkedSlackUserId
+      ? { kind: 'slack-user', slackUserId: linkedSlackUserId }
+      : { kind: 'public-only' },
+  );
+  allTools.push(...slackKnowledge.tools);
+  for (const [name, handler] of slackKnowledge.handlers) {
+    combinedHandlers.set(name, handler);
+  }
 
   // Certification tools (for authenticated users)
   if (userId) {

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -13,6 +13,8 @@ import {
   initializeKnowledgeSearch,
   KNOWLEDGE_TOOLS,
   createKnowledgeToolHandlers,
+  createSlackKnowledgeRequestTools,
+  isSlackKnowledgeTool,
 } from "../addie/mcp/knowledge-search.js";
 import {
   DIRECTORY_TOOLS,
@@ -106,8 +108,10 @@ async function initializeTavusClient(): Promise<void> {
     }
     claudeClient = new AddieClaudeClient(apiKey, AddieModelConfig.voice);
     await initializeKnowledgeSearch();
-    const knowledgeHandlers = createKnowledgeToolHandlers();
-    for (const tool of KNOWLEDGE_TOOLS) {
+    const knowledgeHandlers = createKnowledgeToolHandlers({
+      slackAccess: { kind: 'public-only' },
+    });
+    for (const tool of KNOWLEDGE_TOOLS.filter((tool) => !isSlackKnowledgeTool(tool))) {
       const handler = knowledgeHandlers.get(tool.name);
       if (handler) claudeClient.registerTool(tool, handler);
     }
@@ -231,6 +235,16 @@ async function buildVoiceRequestTools(
     ...createEscalationToolHandlers(memberContext, linkedSlackUserId, threadId),
     ...createBillingToolHandlers(memberContext),
   ]);
+
+  const slackKnowledge = createSlackKnowledgeRequestTools(
+    linkedSlackUserId
+      ? { kind: 'slack-user', slackUserId: linkedSlackUserId }
+      : { kind: 'public-only' },
+  );
+  allTools.push(...slackKnowledge.tools);
+  for (const [name, handler] of slackKnowledge.handlers) {
+    combinedHandlers.set(name, handler);
+  }
 
   // Schema tools
   allTools.push(...SCHEMA_TOOLS);

--- a/server/tests/unit/addie-chat-object-authorization.test.ts
+++ b/server/tests/unit/addie-chat-object-authorization.test.ts
@@ -22,6 +22,12 @@ const mocks = vi.hoisted(() => ({
   initializeKnowledgeSearch: vi.fn().mockResolvedValue(undefined),
   getProgress: vi.fn(),
   getAttemptForUser: vi.fn(),
+  memberContext: {
+    is_mapped: false,
+    is_member: false,
+    slack_linked: false,
+  } as Record<string, unknown>,
+  createSlackKnowledgeRequestTools: vi.fn(() => ({ tools: [], handlers: new Map() })),
 }));
 
 vi.mock('express-rate-limit', () => ({
@@ -72,6 +78,8 @@ vi.mock('../../src/addie/mcp/knowledge-search.js', () => ({
   initializeKnowledgeSearch: mocks.initializeKnowledgeSearch,
   KNOWLEDGE_TOOLS: [],
   createKnowledgeToolHandlers: () => new Map(),
+  createSlackKnowledgeRequestTools: mocks.createSlackKnowledgeRequestTools,
+  isSlackKnowledgeTool: () => false,
 }));
 
 vi.mock('../../src/mcp/chat-tool.js', () => ({
@@ -177,11 +185,7 @@ vi.mock('../../src/utils/anthropic-retry.js', () => ({
 }));
 
 vi.mock('../../src/addie/member-context.js', () => ({
-  getWebMemberContext: vi.fn().mockResolvedValue({
-    is_mapped: false,
-    is_member: false,
-    slack_linked: false,
-  }),
+  getWebMemberContext: vi.fn(() => Promise.resolve(mocks.memberContext)),
   formatMemberContextForPrompt: vi.fn().mockReturnValue(null),
 }));
 
@@ -229,6 +233,7 @@ import {
   getChatClaudeClient,
   resolveCompletionModuleId,
   resolveThreadCertificationProgress,
+  prepareRequestWithMemberTools,
 } from '../../src/routes/addie-chat.js';
 import { issueAnonymousSessionCapability } from '../../src/routes/helpers/anonymous-session-capability.js';
 
@@ -291,6 +296,11 @@ describe('Addie chat conversation object authorization', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.authenticated = true;
+    mocks.memberContext = {
+      is_mapped: false,
+      is_member: false,
+      slack_linked: false,
+    };
     mocks.getThreadByExternalId.mockResolvedValue({
       thread_id: 'thread_victim',
       channel: 'web',
@@ -378,6 +388,28 @@ describe('Addie chat conversation object authorization', () => {
 
     expect(resolved).toBe('S6');
     expect(mocks.getAttemptForUser).toHaveBeenCalledWith(attemptId, 'user_attacker');
+  });
+
+  it('builds authenticated unlinked web Slack tools with an explicit public-only scope', async () => {
+    await prepareRequestWithMemberTools('hello', 'user_attacker', 'thread-web', true);
+
+    expect(mocks.createSlackKnowledgeRequestTools).toHaveBeenCalledWith({ kind: 'public-only' });
+  });
+
+  it('builds linked web Slack tools with the member Slack identity', async () => {
+    mocks.memberContext = {
+      is_mapped: true,
+      is_member: true,
+      slack_linked: true,
+      slack_user: { slack_user_id: 'U_LINKED' },
+    };
+
+    await prepareRequestWithMemberTools('hello', 'user_attacker', 'thread-web', true);
+
+    expect(mocks.createSlackKnowledgeRequestTools).toHaveBeenCalledWith({
+      kind: 'slack-user',
+      slackUserId: 'U_LINKED',
+    });
   });
 
   it('allows an anonymous caller to continue a thread with its signed owner capability', async () => {

--- a/server/tests/unit/addie-db-slack-acl.test.ts
+++ b/server/tests/unit/addie-db-slack-acl.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '../../src/db/client.js';
+import { AddieDatabase } from '../../src/db/addie-db.js';
+
+const queryMock = vi.mocked(query);
+
+const rows = [
+  { id: 1, text: 'public update', channel_name: 'public-room', username: 'public-user', permalink: 'https://slack/public', created_at: new Date() },
+  { id: 2, text: 'allowed update', channel_name: 'private-allowed', username: 'allowed-user', permalink: 'https://slack/allowed', created_at: new Date() },
+  { id: 3, text: 'denied update', channel_name: 'private-denied', username: 'denied-user', permalink: 'https://slack/denied', created_at: new Date() },
+];
+
+describe('AddieDatabase Slack knowledge ACL', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    queryMock.mockImplementation(async (sql, params = []) => {
+      const statement = String(sql);
+      const allowed = params.find(Array.isArray) as string[] | undefined;
+      const channelPattern = statement.includes('TO_TIMESTAMP(slack_ts::numeric)')
+        ? String(params[0] ?? '').replaceAll('%', '').toLowerCase()
+        : '';
+      const visible = rows.filter((row) => {
+        if (channelPattern && !row.channel_name.includes(channelPattern)) return false;
+        if (row.channel_name === 'public-room') return true;
+        if (row.channel_name === 'private-allowed') return allowed?.includes('C_ALLOWED') === true;
+        return allowed?.includes('C_DENIED') === true;
+      });
+      return { rows: visible, rowCount: visible.length } as never;
+    });
+  });
+
+  it('defaults Slack search to public-only and excludes denied private rows', async () => {
+    const db = new AddieDatabase();
+    const result = await db.searchSlackMessages('update');
+
+    expect(result.map((row) => row.channel_name)).toEqual(['public-room']);
+    const [sql, params] = queryMock.mock.calls[0];
+    expect(String(sql)).toContain('NOT EXISTS');
+    expect(String(sql)).not.toContain('ANY(');
+    expect(params).toEqual(['update', 10]);
+  });
+
+  it('returns public and explicitly allowed private search rows only', async () => {
+    const db = new AddieDatabase();
+    const result = await db.searchSlackMessages('update', {
+      accessiblePrivateChannelIds: ['C_ALLOWED'],
+    });
+
+    expect(result.map((row) => row.channel_name)).toEqual(['public-room', 'private-allowed']);
+    expect(result.map((row) => row.channel_name)).not.toContain('private-denied');
+    const [sql, params] = queryMock.mock.calls[0];
+    expect(String(sql)).toContain('slack_channel_id = ANY($3::text[])');
+    expect(params).toEqual(['update', 10, ['C_ALLOWED']]);
+  });
+
+  it('defaults broad channel activity to public-only', async () => {
+    const db = new AddieDatabase();
+    const result = await db.getChannelActivity('');
+
+    expect(result.map((row) => row.channel_name)).toEqual(['public-room']);
+    const [sql, params] = queryMock.mock.calls[0];
+    expect(String(sql)).toContain('NOT EXISTS');
+    expect(String(sql)).not.toContain('ANY(');
+    expect(params).toEqual(['%%', 30, 25]);
+  });
+
+  it('filters broad and partial channel activity to public plus allowed private rows', async () => {
+    const db = new AddieDatabase();
+    const broad = await db.getChannelActivity('', {
+      accessiblePrivateChannelIds: ['C_ALLOWED'],
+    });
+    const partial = await db.getChannelActivity('private', {
+      accessiblePrivateChannelIds: ['C_ALLOWED'],
+    });
+
+    expect(broad.map((row) => row.channel_name)).toEqual(['public-room', 'private-allowed']);
+    expect(partial.map((row) => row.channel_name)).toEqual(['private-allowed']);
+    expect(partial.map((row) => row.channel_name)).not.toContain('private-denied');
+    const [sql, params] = queryMock.mock.calls[1];
+    expect(String(sql)).toContain('slack_channel_id = ANY($4::text[])');
+    expect(params).toEqual(['%private%', 30, 25, ['C_ALLOWED']]);
+  });
+});

--- a/server/tests/unit/knowledge-baseline-registration.test.ts
+++ b/server/tests/unit/knowledge-baseline-registration.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+
+const registerTool = vi.fn();
+
+vi.mock('../../src/addie/mcp/knowledge-search.js', () => ({
+  initializeKnowledgeSearch: vi.fn().mockResolvedValue(undefined),
+  KNOWLEDGE_TOOLS: [
+    { name: 'search_docs', input_schema: {} },
+    { name: 'search_slack', input_schema: {} },
+    { name: 'get_channel_activity', input_schema: {} },
+  ],
+  createKnowledgeToolHandlers: () => new Map([
+    ['search_docs', vi.fn()],
+    ['search_slack', vi.fn()],
+    ['get_channel_activity', vi.fn()],
+  ]),
+  isSlackKnowledgeTool: (tool: { name: string }) =>
+    tool.name === 'search_slack' || tool.name === 'get_channel_activity',
+}));
+
+vi.mock('../../src/addie/mcp/billing-tools.js', () => ({ BILLING_TOOLS: [], createBillingToolHandlers: () => new Map() }));
+vi.mock('../../src/addie/mcp/schema-tools.js', () => ({ SCHEMA_TOOLS: [], createSchemaToolHandlers: () => new Map() }));
+vi.mock('../../src/addie/mcp/directory-tools.js', () => ({ DIRECTORY_TOOLS: [], createDirectoryToolHandlers: () => new Map() }));
+vi.mock('../../src/addie/mcp/brand-tools.js', () => ({ BRAND_TOOLS: [], createBrandToolHandlers: () => new Map() }));
+vi.mock('../../src/addie/mcp/brand-canonical-tools.js', () => ({ BRAND_CANONICAL_TOOLS: [], createBrandCanonicalToolHandlers: () => new Map() }));
+vi.mock('../../src/addie/mcp/property-tools.js', () => ({ PROPERTY_TOOLS: [], createPropertyToolHandlers: () => new Map() }));
+
+import type { AddieClaudeClient } from '../../src/addie/claude-client.js';
+import { registerBaselineTools } from '../../src/addie/register-baseline-tools.js';
+
+describe('Slack knowledge global registration', () => {
+  it('does not install Slack search or activity on the shared baseline client', async () => {
+    const client = { registerTool } as unknown as AddieClaudeClient;
+    await registerBaselineTools(client);
+
+    const registeredNames = registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(registeredNames).toContain('search_docs');
+    expect(registeredNames).not.toContain('search_slack');
+    expect(registeredNames).not.toContain('get_channel_activity');
+  });
+
+  it('keeps every shared-client registration site structurally scoped', () => {
+    const baseline = readFileSync(new URL('../../src/addie/register-baseline-tools.ts', import.meta.url), 'utf8');
+    const legacy = readFileSync(new URL('../../src/addie/handler.ts', import.meta.url), 'utf8');
+    const web = readFileSync(new URL('../../src/routes/addie-chat.ts', import.meta.url), 'utf8');
+    const voice = readFileSync(new URL('../../src/routes/tavus.ts', import.meta.url), 'utf8');
+
+    expect(baseline).toContain('KNOWLEDGE_TOOLS.filter((tool) => !isSlackKnowledgeTool(tool))');
+    expect(legacy).toContain('KNOWLEDGE_TOOLS.filter((tool) => !isSlackKnowledgeTool(tool))');
+    expect(web).toContain('if (isSlackKnowledgeTool(tool)) continue;');
+    expect(voice).toContain('KNOWLEDGE_TOOLS.filter((tool) => !isSlackKnowledgeTool(tool))');
+    expect(web).toContain('const slackKnowledge = createSlackKnowledgeRequestTools(');
+    expect(web).toContain("? { kind: 'slack-user', slackUserId: linkedSlackUserId }");
+    expect(web).toContain("  : { kind: 'public-only' }");
+    expect(web).toContain('allTools.push(...slackKnowledge.tools);');
+    expect(voice).toContain('const slackKnowledge = createSlackKnowledgeRequestTools(');
+    expect(voice).toContain("? { kind: 'slack-user', slackUserId: linkedSlackUserId }");
+    expect(voice).toContain("  : { kind: 'public-only' }");
+    expect(voice).toContain('allTools.push(...slackKnowledge.tools);');
+  });
+});

--- a/server/tests/unit/knowledge-search-slack-acl.test.ts
+++ b/server/tests/unit/knowledge-search-slack-acl.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  searchSlackMessages: vi.fn(),
+  getChannelActivity: vi.fn(),
+  getAccessiblePrivateChannelIds: vi.fn(),
+  findChannelWithAccess: vi.fn(),
+}));
+
+vi.mock('../../src/db/addie-db.js', () => ({
+  AddieDatabase: class {
+    searchSlackMessages = mocks.searchSlackMessages;
+    getChannelActivity = mocks.getChannelActivity;
+  },
+}));
+
+vi.mock('../../src/slack/client.js', () => ({
+  getAccessiblePrivateChannelIds: mocks.getAccessiblePrivateChannelIds,
+  findChannelWithAccess: mocks.findChannelWithAccess,
+}));
+
+import {
+  createKnowledgeToolHandlers,
+  createSlackKnowledgeRequestTools,
+} from '../../src/addie/mcp/knowledge-search.js';
+
+describe('Slack knowledge handler scopes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.searchSlackMessages.mockResolvedValue([]);
+    mocks.getChannelActivity.mockResolvedValue([]);
+    mocks.getAccessiblePrivateChannelIds.mockResolvedValue(['C_ALLOWED']);
+    mocks.findChannelWithAccess.mockResolvedValue(null);
+  });
+
+  it('treats missing access context as public-only', async () => {
+    const handlers = createKnowledgeToolHandlers();
+    await handlers.get('search_slack')!({ query: 'roadmap' });
+    await handlers.get('get_channel_activity')!({ channel: 'general' });
+
+    expect(mocks.searchSlackMessages).toHaveBeenCalledWith('roadmap', expect.objectContaining({
+      accessiblePrivateChannelIds: [],
+    }));
+    expect(mocks.getChannelActivity).toHaveBeenCalledWith('general', expect.objectContaining({
+      accessiblePrivateChannelIds: [],
+    }));
+    expect(mocks.getAccessiblePrivateChannelIds).not.toHaveBeenCalled();
+  });
+
+  it('passes a linked Slack user private-channel allowlist to search and activity', async () => {
+    const handlers = createKnowledgeToolHandlers({
+      slackAccess: { kind: 'slack-user', slackUserId: 'U_LINKED' },
+    });
+    await handlers.get('search_slack')!({ query: 'roadmap' });
+    await handlers.get('get_channel_activity')!({ channel: 'working-group' });
+
+    expect(mocks.getAccessiblePrivateChannelIds).toHaveBeenCalledWith('U_LINKED');
+    expect(mocks.searchSlackMessages).toHaveBeenCalledWith('roadmap', expect.objectContaining({
+      accessiblePrivateChannelIds: ['C_ALLOWED'],
+    }));
+    expect(mocks.getChannelActivity).toHaveBeenCalledWith('working-group', expect.objectContaining({
+      accessiblePrivateChannelIds: ['C_ALLOWED'],
+    }));
+  });
+
+  it('builds both routed definitions and handlers with the same explicit scope', async () => {
+    const publicOnly = createSlackKnowledgeRequestTools({ kind: 'public-only' });
+    expect(publicOnly.tools.map((tool) => tool.name)).toEqual([
+      'search_slack',
+      'get_channel_activity',
+    ]);
+    expect([...publicOnly.handlers.keys()]).toEqual([
+      'search_slack',
+      'get_channel_activity',
+    ]);
+    await publicOnly.handlers.get('search_slack')!({ query: 'roadmap' });
+    expect(mocks.searchSlackMessages).toHaveBeenLastCalledWith('roadmap', expect.objectContaining({
+      accessiblePrivateChannelIds: [],
+    }));
+
+    const linked = createSlackKnowledgeRequestTools({
+      kind: 'slack-user',
+      slackUserId: 'U_LINKED',
+    });
+    await linked.handlers.get('get_channel_activity')!({ channel: 'working-group' });
+    expect(mocks.getChannelActivity).toHaveBeenLastCalledWith('working-group', expect.objectContaining({
+      accessiblePrivateChannelIds: ['C_ALLOWED'],
+    }));
+  });
+
+  it('fails permission lookup errors closed to public-only', async () => {
+    mocks.getAccessiblePrivateChannelIds.mockRejectedValue(new Error('permission DB unavailable'));
+    const handlers = createKnowledgeToolHandlers({
+      slackAccess: { kind: 'slack-user', slackUserId: 'U_LINKED' },
+    });
+
+    await handlers.get('search_slack')!({ query: 'roadmap' });
+    await handlers.get('get_channel_activity')!({ channel: 'working-group' });
+
+    expect(mocks.searchSlackMessages).toHaveBeenCalledWith('roadmap', expect.objectContaining({
+      accessiblePrivateChannelIds: [],
+    }));
+    expect(mocks.getChannelActivity).toHaveBeenCalledWith('working-group', expect.objectContaining({
+      accessiblePrivateChannelIds: [],
+    }));
+  });
+
+  it('denies an explicitly requested private channel before querying indexed content', async () => {
+    mocks.findChannelWithAccess.mockResolvedValue({
+      channel: { id: 'C_DENIED', name: 'private-denied', is_private: true },
+      hasAccess: false,
+      reason: 'not a member',
+    });
+    const handlers = createKnowledgeToolHandlers({
+      slackAccess: { kind: 'slack-user', slackUserId: 'U_LINKED' },
+    });
+
+    const searchResult = await handlers.get('search_slack')!({ query: 'roadmap', channel: 'private-denied' });
+    const activityResult = await handlers.get('get_channel_activity')!({ channel: 'private-denied' });
+
+    expect(searchResult).toContain('Cannot search #private-denied');
+    expect(activityResult).toContain('Cannot access #private-denied');
+    expect(mocks.searchSlackMessages).not.toHaveBeenCalled();
+    expect(mocks.getChannelActivity).not.toHaveBeenCalled();
+  });
+
+  it('formats activity identities and permalinks only from ACL-filtered rows', async () => {
+    mocks.getChannelActivity.mockResolvedValue([{
+      text: 'Allowed decision',
+      channel_name: 'private-allowed',
+      username: 'allowed-user',
+      permalink: 'https://slack/allowed',
+      created_at: new Date('2026-07-30T12:00:00Z'),
+    }]);
+    const handlers = createKnowledgeToolHandlers({
+      slackAccess: { kind: 'slack-user', slackUserId: 'U_LINKED' },
+    });
+
+    const result = await handlers.get('get_channel_activity')!({ channel: 'private' });
+
+    expect(result).toContain('@allowed-user');
+    expect(result).toContain('https://slack/allowed');
+    expect(result).not.toContain('denied-user');
+    expect(result).not.toContain('https://slack/denied');
+  });
+});


### PR DESCRIPTION
## Summary

- remove Slack history tools from shared/global Addie clients and install them only with an explicit request-scoped caller identity
- make missing, unlinked, and permission-error contexts public-only instead of unrestricted
- enforce private-channel allowlists in SQL for both search and channel activity before ordering, limiting, and response aggregation
- advance the current Addie configuration version to `2026.08.3`

## Security impact

Authenticated web and voice callers previously inherited Slack knowledge handlers created without Slack identity. In that state, `undefined` disabled private-channel filtering, and channel activity had no row-level ACL at all. This could expose private working-group messages, participants, and permalinks.

The new discriminated access scope binds linked callers to their Slack allowlist and treats every absent/error context as public-only. Slack, legacy, web, and Tavus paths now install atomic request-scoped tool definitions and handlers.

## Rebase integration

The branch is rebased onto current `main`. The conflict resolution preserves the newer certification and signed anonymous-thread tests, adds the Slack ACL cases alongside them, and increments the latest August Addie configuration version rather than restoring the old July value.

## Validation

- exact-lockfile TypeScript typecheck: passed after rebase
- focused Slack ACL/routing suite: 30/30 passed after rebase
- `git diff --check`: passed

## Follow-up

Private/public classification currently depends on retaining the indexed channel's `working_groups.slack_channel_id` mapping. Persisting privacy-at-index or cleaning stale rows during channel remaps is separate lifecycle hardening and is not introduced by this change.
