### PR TITLE
fix(test): handle GET discovery probe in sdk-safe-fetch MCP fixture

### DIFF
--- a/tests/sdk-safe-fetch.test.ts
+++ b/tests/sdk-safe-fetch.test.ts
@@ -147,6 +147,10 @@ describe('SDK safe fetch adapter', () => {
         res.writeHead(404).end();
         return;
       }
+      if (req.method === 'GET') {
+        res.writeHead(405, { Allow: 'POST, DELETE' }).end();
+        return;
+      }
       if (req.headers.authorization !== 'Bearer fresh-token') {
         res.writeHead(401, {
           'www-authenticate': `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`,


### PR DESCRIPTION
Closes #6120

## Summary

`@adcp/sdk` 12.x's `SingleAgentClient.discoverMCPEndpoint` sends a GET probe to the MCP endpoint before the OAuth flow begins. The test server in `sdk-safe-fetch.test.ts` only had a path guard and an auth guard — the auth guard fired on GET, returning 401 to the discovery probe. The SDK does not treat 401 as "this path speaks MCP protocol"; a stateless `StreamableHTTPServerTransport` should return 405 (no SSE sessions), which is the signal the SDK looks for to confirm MCP capability.

**Fix:** add a `GET → 405 (Allow: POST, DELETE)` handler between the path guard and the auth guard. POST traffic is unchanged, so the OAuth refresh path and all existing assertions remain intact.

This matches production behavior: the training-agent router already returns 405 for GET on `/mcp` paths. The test fixture was written against the pre-v12 SDK behavior (where 401 was sufficient) and was never passing on main.

## Changes

- `tests/sdk-safe-fetch.test.ts` — insert GET→405 handler in local MCP test server before auth guard

No changeset needed: test-only change, no protocol package surface affected.

## Pre-PR review

**code-reviewer:** Approved — qualifies for the low-entropy Execute gate. Single-file change, purely test infrastructure, no product/spec judgment. Fix is deterministic (405 for GET on stateless MCP transport is normative MCP behavior). All 1025 tests pass via precommit hook.

---
_Triage-managed PR — opened by the adcp issue-triage routine for [#6120](https://github.com/adcontextprotocol/adcp/issues/6120)._

---
_Generated by [Claude Code](https://claude.ai/code/session_013edyQTGxosRhqYpR9cQskq)_