### PR TITLE
fix(tests): register exact MCP path in sdk-safe-fetch fixture (closes #6120)

### DIFF
--- a/tests/sdk-safe-fetch.test.ts
+++ b/tests/sdk-safe-fetch.test.ts
@@ -147,6 +147,10 @@ describe('SDK safe fetch adapter', () => {
         res.writeHead(404).end();
         return;
       }
+      if (req.method === 'GET') {
+        res.writeHead(405, { Allow: 'POST, DELETE' }).end();
+        return;
+      }
       if (req.headers.authorization !== 'Bearer fresh-token') {
         res.writeHead(401, {
           'www-authenticate': `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`,


### PR DESCRIPTION
## Summary

`tests/sdk-safe-fetch.test.ts > runs a real SDK OAuth refresh and MCP discovery without ambient fetch` fails deterministically on main, which blocks every contributor's pre-commit hook (the hook runs `test:unit`).

**Root cause:** the `@adcp/sdk` bump from 9.6.2 → 12.1.1 (#6017) pulled in a new MCP client (`@modelcontextprotocol/client` 2.0.0-beta.4) whose `discoverMCPEndpoint` probing now issues a GET request to the candidate MCP endpoint — both via the `Client`'s `"auto"` version-negotiation probe and via the SSE listening channel opened in `_startOrAuthSse`. This happens before, or independently of, the POST-based JSON-RPC `initialize` exchange.

The local test server in the fixture only had a path guard and an auth guard. The auth guard fires unconditionally (before any method check), so an unauthenticated GET probe got a `401` back. The SDK's discovery loop does not treat `401` as confirmation that "this path speaks MCP protocol" the way it treats a clean `405` from a stateless transport (a `StreamableHTTPServerTransport` with no `sessionIdGenerator` — i.e. no SSE sessions — correctly answers GET with 405). With neither candidate URL (`/mcp`, `/mcp/`) ever confirmed, discovery exhausts its list and throws:

```
Error: Failed to discover MCP endpoint. Tried:
  1. http://127.0.0.1:<port>/mcp
  2. http://127.0.0.1:<port>/mcp/
None responded to MCP protocol.
```

**Fix:** add a `GET → 405 (Allow: POST, DELETE)` handler in the test's local MCP server, ahead of the auth guard. This matches how a real stateless `StreamableHTTPServerTransport` (and the production training-agent router) already answers GET on `/mcp`. POST traffic — and with it the OAuth refresh + MCP discovery assertions the test exists to verify — is untouched.

The fixture's `agent_uri` (`${origin}/mcp`) already matched exactly what discovery tries first; the fix is purely about giving the GET probe a spec-correct response, not about path registration.

## Changes

- `tests/sdk-safe-fetch.test.ts` — insert `GET → 405` handler before the auth guard in the local MCP test server.

## Test plan

- [x] `npx vitest run tests/sdk-safe-fetch.test.ts --pool=threads` — 9/9 pass
- [x] `npx vitest run --dir tests/ --pool=threads` (full `test:unit`) — 66 files / 1026 tests pass
- [x] Committed via the repo's real pre-commit hook (not bypassed) — full `precommit` chain (test:unit, dynamic-imports lint, callapi-state-change lint, server-unit, typecheck) ran clean

Closes #6120

🤖 Generated with [Claude Code](https://claude.com/claude-code)