### PR TITLE
fix(addie): contain queue panel overflow so long issue titles truncate

### DIFF
--- a/server/public/secretariat.html
+++ b/server/public/secretariat.html
@@ -197,13 +197,18 @@
     /* Queues dashboard */
     .queue-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(min(420px, 100%), 1fr));
       gap: var(--space-5);
     }
     .queue-panel {
       border: var(--border-1) solid var(--color-gray-200);
       border-radius: var(--radius-md);
       padding: var(--space-5);
+      /* Grid children default to min-width:auto, which lets long unbreakable
+         issue titles widen the track and paint across neighboring panels.
+         min-width:0 restores shrinkability so the ellipsis chain below works. */
+      min-width: 0;
+      overflow: hidden;
     }
     .queue-panel-header {
       display: flex;
@@ -216,7 +221,7 @@
     .queue-count { font-size: var(--text-3xl); font-weight: var(--font-bold); color: var(--color-brand); }
     .queue-freshness { margin-top: var(--space-2); font-size: var(--text-sm); color: var(--color-text-secondary); }
     .queue-freshness-stale { color: var(--color-warning); }
-    .queue-items { display: grid; gap: var(--space-1); }
+    .queue-items { display: grid; grid-template-columns: minmax(0, 1fr); gap: var(--space-1); }
     .queue-item-row {
       display: flex;
       justify-content: space-between;
@@ -225,10 +230,22 @@
       padding: var(--space-2) 0;
       border-bottom: var(--border-1) solid var(--color-gray-100);
       font-size: var(--text-sm);
+      min-width: 0;
     }
     .queue-item-row:last-child { border-bottom: none; }
+    .queue-item-row > a {
+      /* The anchor wrapping title + tags must itself be shrinkable, or the
+         title span's ellipsis never engages (flex min-width:auto default). */
+      flex: 1 1 auto;
+      min-width: 0;
+      display: flex;
+      align-items: baseline;
+      gap: var(--space-1_5);
+      overflow: hidden;
+    }
     .queue-item-title {
       color: var(--color-text-heading);
+      min-width: 0;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -236,6 +253,7 @@
     .queue-item-meta { color: var(--color-text-muted); font-size: var(--text-xs); white-space: nowrap; }
     .queue-tag {
       display: inline-block;
+      flex-shrink: 0;
       padding: 1px var(--space-1_5);
       border-radius: var(--radius-sm);
       font-size: var(--text-xs);


### PR DESCRIPTION
## Summary

The Queues dashboard shipped with an ellipsis rule that never engaged: grid and flex children default to `min-width: auto`, so unbreakable issue titles (underscore-heavy identifiers like `report_plan_outcome…`) propagated their min-content width up the chain — title span → anchor → item row → items grid → panel → queue grid — and painted across neighboring panels (maintainer screenshot).

CSS-only fix at every level of the chain: `min-width: 0` + `overflow: hidden` on panels (with a comment explaining the trap), `minmax(0, 1fr)` on the items grid, the title anchor made a shrinkable flex container, `flex-shrink: 0` on P0/P1 tags, and `minmax(min(420px, 100%), 1fr)` so panels can't exceed narrow viewports.

## Test plan
- [x] CSS-only; no JS/API changes; full precommit suite on commit.
- [ ] Post-deploy: titles ellipsize in-panel, no cross-panel bleed, tags visible, narrow widths hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)