### PR TITLE
fix(server): align report_usage validation errors

### DIFF
--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -7958,8 +7958,12 @@ export async function handleReportUsage(args: ToolArgs, ctx: TrainingContext) {
   const sessionScopeReq = withUsageAccountScope(req as unknown as Record<string, unknown>) as unknown as ToolArgs;
   const session = await getSession(sessionKeyFromArgs(sessionScopeReq, ctx.mode, ctx.userId, ctx.moduleId));
 
-  if (!req.reporting_period || !req.usage?.length) {
-    return { errors: [{ code: 'INVALID_USAGE_DATA', message: 'reporting_period and at least one usage record are required.' }] };
+  if (!req.reporting_period) {
+    return { errors: [{ code: 'INVALID_REQUEST', message: 'reporting_period is required.', field: 'reporting_period' }] };
+  }
+
+  if (!req.usage?.length) {
+    return { errors: [{ code: 'INVALID_REQUEST', message: 'At least one usage record is required.', field: 'usage' }] };
   }
 
   if (session.usageRecords.length + req.usage.length > MAX_USAGE_RECORDS_PER_SESSION) {

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -5294,17 +5294,20 @@ describe('report_usage handler', () => {
     expect(result.rejected).toBeUndefined();
   });
 
-  it('returns error when reporting_period is missing', async () => {
+  it('returns INVALID_REQUEST when reporting_period is missing', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { result, isError } = await simulateCallTool(server, 'report_usage', {
       usage: [{ account, vendor_cost: 100, currency: 'USD' }],
     });
 
     expect(isError).toBe(true);
-    expect(result.code).toBe('INVALID_USAGE_DATA');
+    expect(result).toMatchObject({
+      code: 'INVALID_REQUEST',
+      field: 'reporting_period',
+    });
   });
 
-  it('returns error when usage array is empty', async () => {
+  it('returns INVALID_REQUEST when usage array is empty', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { result, isError } = await simulateCallTool(server, 'report_usage', {
       reporting_period: period,
@@ -5312,7 +5315,10 @@ describe('report_usage handler', () => {
     });
 
     expect(isError).toBe(true);
-    expect(result.code).toBe('INVALID_USAGE_DATA');
+    expect(result).toMatchObject({
+      code: 'INVALID_REQUEST',
+      field: 'usage',
+    });
   });
 
   it('returns NOT_FOUND for unknown creative_id', async () => {


### PR DESCRIPTION
## Summary

- Return `INVALID_REQUEST` when `report_usage` is missing its top-level `reporting_period`.
- Return `INVALID_REQUEST` when `usage` is absent or empty.
- Include the specific top-level field in each error while preserving `INVALID_USAGE_DATA` for individual record validation failures.

## Why

Follow-up to #5982. The canonical error description now distinguishes malformed top-level requests (`INVALID_REQUEST`) from invalid records inside an otherwise well-formed request (`INVALID_USAGE_DATA`), but the training agent still used the record-level code for both top-level cases.

## Impact

This changes only training-agent error classification and diagnostics. It does not change the protocol schema or require a protocol changeset.

## Validation

- `./node_modules/.bin/vitest run server/tests/unit/training-agent.test.ts --config server/vitest.config.ts -t "report_usage handler"`
- `./node_modules/.bin/tsc --project server/tsconfig.json --noEmit`
- `git diff --check`
