### PR TITLE
fix(dev): support npm 11 workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,9 +224,21 @@
   "devEngines": {
     "packageManager": {
       "name": "npm",
-      "version": "^10.9.4",
+      "version": ">=10.9.4 <12",
       "onFail": "error"
     }
+  },
+  "allowScripts": {
+    "@contentauth/c2pa-node@0.6.3": true,
+    "@scarf/scarf": false,
+    "esbuild@0.28.1": true,
+    "fsevents@2.3.3": true,
+    "keytar@7.9.0": true,
+    "msw@2.15.0": true,
+    "protobufjs@7.5.8": true,
+    "puppeteer@24.3.1": true,
+    "puppeteer@25.3.0": true,
+    "sharp@0.33.5": true
   },
   "overrides": {
     "webpack-dev-server": "^5.2.2",


### PR DESCRIPTION
## Summary

- accept npm 10.9.4 and npm 11 while keeping npm 10.9.4 as the preferred package manager
- add a version-pinned npm 11 lifecycle-script allowlist for dependencies whose install steps the project needs
- explicitly deny the Scarf telemetry install script under npm 11

## Root cause and impact

Conductor inherited Node 26/npm 11 from the local non-interactive shell, but `devEngines.packageManager` only accepted npm 10. New workspace setup therefore stopped before dependencies could install. Simply widening the range was insufficient because npm 11's lifecycle-script policy withheld required native install steps.

This change makes npm 11 a tested compatibility target and preserves required native installs without granting unversioned script trust. npm 10 remains supported and ignores the npm 11-only `allowScripts` policy.

## Validation

- clean `npm ci` with npm 11.17.0
- `npm approve-scripts --allow-scripts-pending --json` reports no pending scripts
- npm 10.9.7 and npm 11.17.0 both accept the package and resolve dry-run installs without lockfile changes
- C2PA native wiring tests: 8/8 pass
- repository pre-push storyboard matrices: current and 3.0 compatibility tracks green across all six tenants
- broad unit suite reached 5,105+ passing tests in each run; three unrelated route tests intermittently returned 404 under parallel shared state and each passed immediately in isolated reruns
- changeset protocol-scope check passes; no changeset required for this operational-only fix

## Follow-ups

Dependency upgrades remain separate. Dependabot PR #6142 covers the current minor/patch batch but needs its Stripe 22.4 type break separated or adapted; #5993 and #6079 are bounded review-ready upgrades. Major Slack Bolt PR #6023 should remain separate.
