### PR TITLE
fix(ci): authorize triage commands from event association

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -3,15 +3,15 @@ name: Slash Command Dispatch
 # Routes `/<command>` comments on issues and PRs to dedicated handler
 # workflows via repository_dispatch events. Uses peter-evans/slash-command-
 # dispatch so we get:
-#   - Built-in permission checks (only OWNER / MEMBER / COLLABORATOR trigger)
+#   - Event-level permission checks (only OWNER / MEMBER / COLLABORATOR trigger)
 #   - Reactions on the triggering comment (eyes on ack, +1 on success, -1 on fail)
 #   - Clean separation: this workflow routes, downstream handlers do the work
 #
 # Required repo secret:
 #   TRIAGE_DISPATCH_PAT  — Personal Access Token with `repo` scope (or fine-
-#                         grained: contents:write, issues:write, pull-requests:write
-#                         on this repo). GITHUB_TOKEN cannot fire
-#                         repository_dispatch events.
+#                         grained contents:write on this repo). It is used only
+#                         to fire repository_dispatch events; the signed event
+#                         payload gates callers and GITHUB_TOKEN adds reactions.
 #
 # Current commands:
 #   /triage [modifier]  — fire the triage routine on this issue. Modifiers
@@ -23,23 +23,33 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   dispatch:
     name: Dispatch slash command
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    # Skip bot-authored comments always.
+    # Trust GitHub's signed author_association value instead of asking the
+    # dispatch PAT to resolve repository permissions. Fine-grained PATs without
+    # org membership read access resolve even owners as permission "none".
     if: >-
       github.event.comment.user.type != 'Bot' &&
-      !endsWith(github.event.comment.user.login, '[bot]')
+      !endsWith(github.event.comment.user.login, '[bot]') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
     steps:
       - name: Slash command dispatch
         uses: peter-evans/slash-command-dispatch@v5
         with:
           token: ${{ secrets.TRIAGE_DISPATCH_PAT }}
+          reaction-token: ${{ github.token }}
           commands: |
             triage
-          permission: write
+          # Caller authorization is enforced by the job-level association gate.
+          permission: none
           reactions: true
           issue-type: both

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -36,6 +36,7 @@ jobs:
     if: >-
       github.event.comment.user.type != 'Bot' &&
       !endsWith(github.event.comment.user.login, '[bot]') &&
+      startsWith(github.event.comment.body, '/triage') &&
       (
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -3,7 +3,7 @@ name: Slash Command Dispatch
 # Routes `/<command>` comments on issues and PRs to dedicated handler
 # workflows via repository_dispatch events. Uses peter-evans/slash-command-
 # dispatch so we get:
-#   - Event-level permission checks (only OWNER / MEMBER / COLLABORATOR trigger)
+#   - Event association plus repository-write permission checks
 #   - Reactions on the triggering comment (eyes on ack, +1 on success, -1 on fail)
 #   - Clean separation: this workflow routes, downstream handlers do the work
 #
@@ -31,9 +31,8 @@ jobs:
     name: Dispatch slash command
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    # Trust GitHub's signed author_association value instead of asking the
-    # dispatch PAT to resolve repository permissions. Fine-grained PATs without
-    # org membership read access resolve even owners as permission "none".
+    # Reject outsiders before spending a runner. The first step below then
+    # preserves the stricter write-or-higher repository permission boundary.
     if: >-
       github.event.comment.user.type != 'Bot' &&
       !endsWith(github.event.comment.user.login, '[bot]') &&
@@ -43,14 +42,33 @@ jobs:
         github.event.comment.author_association == 'COLLABORATOR'
       )
     steps:
+      - name: Resolve caller repository permission
+        id: caller
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          permission=$(gh api \
+            "repos/${REPOSITORY}/collaborators/${COMMENTER}/permission" \
+            --jq '.permission')
+          echo "permission=${permission}" >> "$GITHUB_OUTPUT"
+          case "$permission" in
+            write|maintain|admin) echo "allowed=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "allowed=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
       - name: Slash command dispatch
+        if: steps.caller.outputs.allowed == 'true'
         uses: peter-evans/slash-command-dispatch@v5
         with:
           token: ${{ secrets.TRIAGE_DISPATCH_PAT }}
           reaction-token: ${{ github.token }}
           commands: |
             triage
-          # Caller authorization is enforced by the job-level association gate.
+          # Caller authorization is enforced before the action. The PAT is used
+          # only for repository_dispatch, not permission lookup or reactions.
           permission: none
           reactions: true
           issue-type: both

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -24,6 +24,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   dispatch:


### PR DESCRIPTION
## What changed

- reject outsiders using GitHub's signed `author_association` event field
- resolve trusted callers' repository permission with the scoped workflow token
- use the dispatch PAT only for `repository_dispatch`
- use the scoped `GITHUB_TOKEN` for issue-comment reactions

## Root cause

`peter-evans/slash-command-dispatch` used the dispatch PAT to query the commenter's repository permission. The fine-grained PAT lacks organization membership-read access, so even repository writers resolved to permission `none`. Reactions failed separately because the default `GITHUB_TOKEN` had not been granted issue/PR write permission.

## Impact

Fresh `/triage` commands from callers with repository `write`, `maintain`, or `admin` permission dispatch normally again. Read-only organization members, outsiders, and bot comments remain blocked.

## Validation

- `actionlint .github/workflows/slash-command-dispatch.yml`
- parsed the workflow and asserted the association prefilter, write-or-higher permission resolver, dispatch gate, token separation, and reaction permissions
- `git diff --check`
