### PR TITLE
fix(ci): dispatch triage with Secretariat App

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -16,10 +16,6 @@ name: Claude Issue Triage
 # Required repo secrets:
 #   CLAUDE_ROUTINE_TRIAGE_URL    — full /fire URL including routine ID
 #   CLAUDE_ROUTINE_TRIAGE_TOKEN  — bearer token for that routine
-#   TRIAGE_DISPATCH_PAT          — PAT for reaction on the /triage-triggering
-#                                  comment (same secret as slash-command-dispatch.yml)
-#
-# Token last rotated: 2026-04-23 — rotate every 90 days.
 
 on:
   issues:
@@ -31,8 +27,8 @@ on:
 
 permissions:
   contents: read
-  issues: read
-  pull-requests: read
+  issues: write
+  pull-requests: write
 
 concurrency:
   group: claude-triage-${{ github.event.issue.number || github.event.client_payload.github.payload.issue.number }}
@@ -270,7 +266,7 @@ jobs:
         if: steps.ctx.outputs.kind == 'manual' && success() && steps.ctx.outputs.comment_id != ''
         uses: peter-evans/create-or-update-comment@v5
         with:
-          token: ${{ secrets.TRIAGE_DISPATCH_PAT }}
+          token: ${{ github.token }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ steps.ctx.outputs.comment_id }}
           reactions: "+1"
@@ -279,7 +275,7 @@ jobs:
         if: steps.ctx.outputs.kind == 'manual' && failure() && steps.ctx.outputs.comment_id != ''
         uses: peter-evans/create-or-update-comment@v5
         with:
-          token: ${{ secrets.TRIAGE_DISPATCH_PAT }}
+          token: ${{ github.token }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ steps.ctx.outputs.comment_id }}
           reactions: "-1"

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -7,11 +7,10 @@ name: Slash Command Dispatch
 #   - Reactions on the triggering comment (eyes on ack, +1 on success, -1 on fail)
 #   - Clean separation: this workflow routes, downstream handlers do the work
 #
-# Required repo secret:
-#   TRIAGE_DISPATCH_PAT  — Personal Access Token with `repo` scope (or fine-
-#                         grained contents:write on this repo). It is used only
-#                         to fire repository_dispatch events; the signed event
-#                         payload gates callers and GITHUB_TOKEN adds reactions.
+# Required repo secrets:
+#   SECRETARIAT_APP_ID / SECRETARIAT_APP_PRIVATE_KEY — mint a short-lived App
+#                         token for repository_dispatch. GITHUB_TOKEN resolves
+#                         caller permissions and adds reactions.
 #
 # Current commands:
 #   /triage [modifier]  — fire the triage routine on this issue. Modifiers
@@ -43,6 +42,15 @@ jobs:
         github.event.comment.author_association == 'COLLABORATOR'
       )
     steps:
+      - name: Mint Secretariat App token
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ secrets.SECRETARIAT_APP_ID }}
+          private-key: ${{ secrets.SECRETARIAT_APP_PRIVATE_KEY }}
+          owner: adcontextprotocol
+          repositories: adcp
+
       - name: Resolve caller repository permission
         id: caller
         env:
@@ -64,12 +72,12 @@ jobs:
         if: steps.caller.outputs.allowed == 'true'
         uses: peter-evans/slash-command-dispatch@v5
         with:
-          token: ${{ secrets.TRIAGE_DISPATCH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           reaction-token: ${{ github.token }}
           commands: |
             triage
-          # Caller authorization is enforced before the action. The PAT is used
-          # only for repository_dispatch, not permission lookup or reactions.
+          # Caller authorization is enforced before the action. The App token
+          # is used only for dispatch, not permission lookup or reactions.
           permission: none
           reactions: true
           issue-type: both

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -50,6 +50,8 @@ jobs:
           private-key: ${{ secrets.SECRETARIAT_APP_PRIVATE_KEY }}
           owner: adcontextprotocol
           repositories: adcp
+          permission-contents: write
+          permission-pull-requests: read
 
       - name: Resolve caller repository permission
         id: caller


### PR DESCRIPTION
## What changed

- mint a short-lived Secretariat GitHub App installation token for `/triage` repository dispatch
- limit the App token to contents-write and pull-request-read on this repository
- remove both workflows' dependency on `TRIAGE_DISPATCH_PAT`
- use each workflow's scoped built-in token for caller permission checks and reactions

## Why

The legacy dispatch PAT was expired. Rotating it to a human OAuth credential authenticated but coupled triage to that user's shared REST rate-limit bucket, causing the live smoke test to fail when the bucket was exhausted. The Secretariat App is the repository's automation trust surface and receives an independent, short-lived installation token per run.

## Impact

`/triage` no longer depends on a manually rotated human credential. The existing write-or-higher caller authorization remains unchanged, and downstream success/failure reactions no longer fail on the retired PAT.

## Validation

- `actionlint .github/workflows/slash-command-dispatch.yml`
- `actionlint .github/workflows/claude-issue-triage.yml` (only pre-existing SC2129 style findings)
- parsed the workflow and asserted App-token minting, caller authorization, token separation, and removal of the PAT dependency
- `git diff --check`
