### PR TITLE
feat(server): OAuth CC multi-resource resource indicator (RFC 8707) (#2805)

### DIFF
--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -2038,7 +2038,13 @@ export const MEMBER_TOOLS: AddieTool[] = [
             client_id: { type: 'string', description: 'OAuth client ID. May be a `$ENV:VAR_NAME` reference — the SDK resolves at exchange time.' },
             client_secret: { type: 'string', description: 'OAuth client secret. May be a `$ENV:VAR_NAME` reference. Stored encrypted at rest regardless.' },
             scope: { type: 'string', description: 'Space-separated OAuth scope values (optional).' },
-            resource: { type: 'string', description: 'RFC 8707 resource indicator (optional).' },
+            resource: {
+              oneOf: [
+                { type: 'string', description: 'Single resource URI.' },
+                { type: 'array', items: { type: 'string' }, maxItems: 8, description: 'Up to 8 resource URIs for multi-resource authorization servers.' },
+              ],
+              description: 'RFC 8707 resource indicator. Accepts a single URI string or an array of up to 8 for multi-resource authorization servers (Keycloak strict mode, AWS Cognito with multiple resource servers).',
+            },
             audience: { type: 'string', description: 'Audience parameter for audience-validating authorization servers like Auth0, Okta, Azure AD (optional).' },
             auth_method: { type: 'string', enum: ['basic', 'body'], description: 'Where to put client credentials on the token request. "basic" (default, RFC 6749 §2.3.1 preferred): HTTP Basic header. "body": form fields.' },
           },

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -2040,10 +2040,10 @@ export const MEMBER_TOOLS: AddieTool[] = [
             scope: { type: 'string', description: 'Space-separated OAuth scope values (optional).' },
             resource: {
               oneOf: [
-                { type: 'string', description: 'Single resource URI.' },
-                { type: 'array', items: { type: 'string' }, maxItems: 8, description: 'Up to 8 resource URIs for multi-resource authorization servers.' },
+                { type: 'string', maxLength: 2048, description: 'Single resource URI (max 2048 chars).' },
+                { type: 'array', items: { type: 'string', maxLength: 2048 }, minItems: 1, maxItems: 8, description: '1–8 resource URIs for multi-resource authorization servers (each max 2048 chars).' },
               ],
-              description: 'RFC 8707 resource indicator. Accepts a single URI string or an array of up to 8 for multi-resource authorization servers (Keycloak strict mode, AWS Cognito with multiple resource servers).',
+              description: 'RFC 8707 resource indicator. Accepts a single URI string or an array of 1–8 for multi-resource authorization servers (Keycloak strict mode, AWS Cognito with multiple resource servers).',
             },
             audience: { type: 'string', description: 'Audience parameter for audience-validating authorization servers like Auth0, Okta, Azure AD (optional).' },
             auth_method: { type: 'string', enum: ['basic', 'body'], description: 'Where to put client credentials on the token request. "basic" (default, RFC 6749 §2.3.1 preferred): HTTP Basic header. "body": form fields.' },

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -875,7 +875,7 @@ export class AgentContextDatabase {
         secretEncrypted.encrypted,
         secretEncrypted.iv,
         creds.scope || null,
-        Array.isArray(creds.resource) ? JSON.stringify(creds.resource) : (creds.resource ?? null),
+        Array.isArray(creds.resource) ? `json1:${JSON.stringify(creds.resource)}` : (creds.resource ?? null),
         creds.audience || null,
         creds.auth_method || null,
         id,
@@ -930,9 +930,9 @@ export class AgentContextDatabase {
     };
     if (row.oauth_cc_scope) creds.scope = row.oauth_cc_scope;
     if (row.oauth_cc_resource) {
-      if (row.oauth_cc_resource.startsWith('[')) {
+      if (row.oauth_cc_resource.startsWith('json1:')) {
         try {
-          const parsed: unknown = JSON.parse(row.oauth_cc_resource);
+          const parsed: unknown = JSON.parse(row.oauth_cc_resource.slice(6));
           creds.resource =
             Array.isArray(parsed) && parsed.every((e): e is string => typeof e === 'string')
               ? parsed

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -875,7 +875,11 @@ export class AgentContextDatabase {
         secretEncrypted.encrypted,
         secretEncrypted.iv,
         creds.scope || null,
-        Array.isArray(creds.resource) ? `json1:${JSON.stringify(creds.resource)}` : (creds.resource ?? null),
+        Array.isArray(creds.resource)
+          ? `v1a:${JSON.stringify(creds.resource)}`
+          : creds.resource != null
+            ? `v1s:${creds.resource}`
+            : null,
         creds.audience || null,
         creds.auth_method || null,
         id,
@@ -930,18 +934,33 @@ export class AgentContextDatabase {
     };
     if (row.oauth_cc_scope) creds.scope = row.oauth_cc_scope;
     if (row.oauth_cc_resource) {
-      if (row.oauth_cc_resource.startsWith('json1:')) {
+      const raw: string = row.oauth_cc_resource;
+      if (raw.startsWith('v1a:')) {
         try {
-          const parsed: unknown = JSON.parse(row.oauth_cc_resource.slice(6));
+          const parsed: unknown = JSON.parse(raw.slice(4));
           creds.resource =
             Array.isArray(parsed) && parsed.every((e): e is string => typeof e === 'string')
               ? parsed
-              : row.oauth_cc_resource;
+              : raw;
         } catch {
-          creds.resource = row.oauth_cc_resource;
+          creds.resource = raw;
+        }
+      } else if (raw.startsWith('v1s:')) {
+        creds.resource = raw.slice(4);
+      } else if (raw.startsWith('json1:')) {
+        // backward compat: rows written before the v1a/v1s codec
+        try {
+          const parsed: unknown = JSON.parse(raw.slice(6));
+          creds.resource =
+            Array.isArray(parsed) && parsed.every((e): e is string => typeof e === 'string')
+              ? parsed
+              : raw;
+        } catch {
+          creds.resource = raw;
         }
       } else {
-        creds.resource = row.oauth_cc_resource;
+        // legacy: bare scalar written before any codec
+        creds.resource = raw;
       }
     }
     if (row.oauth_cc_audience) creds.audience = row.oauth_cc_audience;

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -932,7 +932,11 @@ export class AgentContextDatabase {
     if (row.oauth_cc_resource) {
       if (row.oauth_cc_resource.startsWith('[')) {
         try {
-          creds.resource = JSON.parse(row.oauth_cc_resource);
+          const parsed: unknown = JSON.parse(row.oauth_cc_resource);
+          creds.resource =
+            Array.isArray(parsed) && parsed.every((e): e is string => typeof e === 'string')
+              ? parsed
+              : row.oauth_cc_resource;
         } catch {
           creds.resource = row.oauth_cc_resource;
         }

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -71,8 +71,8 @@ export interface OAuthClientCredentials {
   client_id: string;
   client_secret: string;
   scope?: string;
-  /** RFC 8707 resource indicator. Single-resource only; multi-resource tracked as #2805. */
-  resource?: string;
+  /** RFC 8707 resource indicator. Scalar string or array of up to 8 URI strings. */
+  resource?: string | string[];
   audience?: string;
   /**
    * Client-credentials auth placement. `basic` = HTTP Basic header
@@ -875,7 +875,7 @@ export class AgentContextDatabase {
         secretEncrypted.encrypted,
         secretEncrypted.iv,
         creds.scope || null,
-        creds.resource || null,
+        Array.isArray(creds.resource) ? JSON.stringify(creds.resource) : (creds.resource ?? null),
         creds.audience || null,
         creds.auth_method || null,
         id,
@@ -929,7 +929,17 @@ export class AgentContextDatabase {
       ),
     };
     if (row.oauth_cc_scope) creds.scope = row.oauth_cc_scope;
-    if (row.oauth_cc_resource) creds.resource = row.oauth_cc_resource;
+    if (row.oauth_cc_resource) {
+      if (row.oauth_cc_resource.startsWith('[')) {
+        try {
+          creds.resource = JSON.parse(row.oauth_cc_resource);
+        } catch {
+          creds.resource = row.oauth_cc_resource;
+        }
+      } else {
+        creds.resource = row.oauth_cc_resource;
+      }
+    }
     if (row.oauth_cc_audience) creds.audience = row.oauth_cc_audience;
     if (row.oauth_cc_auth_method === 'basic' || row.oauth_cc_auth_method === 'body') {
       creds.auth_method = row.oauth_cc_auth_method;

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -947,19 +947,10 @@ export class AgentContextDatabase {
         }
       } else if (raw.startsWith('v1s:')) {
         creds.resource = raw.slice(4);
-      } else if (raw.startsWith('json1:')) {
-        // backward compat: rows written before the v1a/v1s codec
-        try {
-          const parsed: unknown = JSON.parse(raw.slice(6));
-          creds.resource =
-            Array.isArray(parsed) && parsed.every((e): e is string => typeof e === 'string')
-              ? parsed
-              : raw;
-        } catch {
-          creds.resource = raw;
-        }
       } else {
-        // legacy: bare scalar written before any codec
+        // Untagged row (no v1a:/v1s: prefix) — treat as a legacy bare scalar.
+        // json1: rows from an unreleased draft also fall here; that encoding
+        // never reached main so there are no production array rows to preserve.
         creds.resource = raw;
       }
     }

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -1354,7 +1354,11 @@ export class ComplianceDatabase {
         if (row.oauth_cc_resource) {
           if (row.oauth_cc_resource.startsWith('[')) {
             try {
-              credentials.resource = JSON.parse(row.oauth_cc_resource);
+              const parsed: unknown = JSON.parse(row.oauth_cc_resource);
+              credentials.resource =
+                Array.isArray(parsed) && parsed.every((e): e is string => typeof e === 'string')
+                  ? parsed
+                  : row.oauth_cc_resource;
             } catch {
               credentials.resource = row.oauth_cc_resource;
             }

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -1352,18 +1352,33 @@ export class ComplianceDatabase {
         };
         if (row.oauth_cc_scope) credentials.scope = row.oauth_cc_scope;
         if (row.oauth_cc_resource) {
-          if (row.oauth_cc_resource.startsWith('json1:')) {
+          const raw: string = row.oauth_cc_resource;
+          if (raw.startsWith('v1a:')) {
             try {
-              const parsed: unknown = JSON.parse(row.oauth_cc_resource.slice(6));
+              const parsed: unknown = JSON.parse(raw.slice(4));
               credentials.resource =
                 Array.isArray(parsed) && parsed.every((e): e is string => typeof e === 'string')
                   ? parsed
-                  : row.oauth_cc_resource;
+                  : raw;
             } catch {
-              credentials.resource = row.oauth_cc_resource;
+              credentials.resource = raw;
+            }
+          } else if (raw.startsWith('v1s:')) {
+            credentials.resource = raw.slice(4);
+          } else if (raw.startsWith('json1:')) {
+            // backward compat: rows written before the v1a/v1s codec
+            try {
+              const parsed: unknown = JSON.parse(raw.slice(6));
+              credentials.resource =
+                Array.isArray(parsed) && parsed.every((e): e is string => typeof e === 'string')
+                  ? parsed
+                  : raw;
+            } catch {
+              credentials.resource = raw;
             }
           } else {
-            credentials.resource = row.oauth_cc_resource;
+            // legacy: bare scalar written before any codec
+            credentials.resource = raw;
           }
         }
         if (row.oauth_cc_audience) credentials.audience = row.oauth_cc_audience;

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -1352,9 +1352,9 @@ export class ComplianceDatabase {
         };
         if (row.oauth_cc_scope) credentials.scope = row.oauth_cc_scope;
         if (row.oauth_cc_resource) {
-          if (row.oauth_cc_resource.startsWith('[')) {
+          if (row.oauth_cc_resource.startsWith('json1:')) {
             try {
-              const parsed: unknown = JSON.parse(row.oauth_cc_resource);
+              const parsed: unknown = JSON.parse(row.oauth_cc_resource.slice(6));
               credentials.resource =
                 Array.isArray(parsed) && parsed.every((e): e is string => typeof e === 'string')
                   ? parsed

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -42,7 +42,7 @@ export type ResolvedOwnerAuth =
         client_id: string;
         client_secret: string;
         scope?: string;
-        resource?: string;
+        resource?: string | string[];
         audience?: string;
         auth_method?: 'basic' | 'body';
       };
@@ -1351,7 +1351,17 @@ export class ComplianceDatabase {
           client_secret: clientSecret,
         };
         if (row.oauth_cc_scope) credentials.scope = row.oauth_cc_scope;
-        if (row.oauth_cc_resource) credentials.resource = row.oauth_cc_resource;
+        if (row.oauth_cc_resource) {
+          if (row.oauth_cc_resource.startsWith('[')) {
+            try {
+              credentials.resource = JSON.parse(row.oauth_cc_resource);
+            } catch {
+              credentials.resource = row.oauth_cc_resource;
+            }
+          } else {
+            credentials.resource = row.oauth_cc_resource;
+          }
+        }
         if (row.oauth_cc_audience) credentials.audience = row.oauth_cc_audience;
         if (row.oauth_cc_auth_method === 'basic' || row.oauth_cc_auth_method === 'body') {
           credentials.auth_method = row.oauth_cc_auth_method;

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -1365,19 +1365,10 @@ export class ComplianceDatabase {
             }
           } else if (raw.startsWith('v1s:')) {
             credentials.resource = raw.slice(4);
-          } else if (raw.startsWith('json1:')) {
-            // backward compat: rows written before the v1a/v1s codec
-            try {
-              const parsed: unknown = JSON.parse(raw.slice(6));
-              credentials.resource =
-                Array.isArray(parsed) && parsed.every((e): e is string => typeof e === 'string')
-                  ? parsed
-                  : raw;
-            } catch {
-              credentials.resource = raw;
-            }
           } else {
-            // legacy: bare scalar written before any codec
+            // Untagged row (no v1a:/v1s: prefix) — treat as a legacy bare scalar.
+            // json1: rows from an unreleased draft also fall here; that encoding
+            // never reached main so there are no production array rows to preserve.
             credentials.resource = raw;
           }
         }

--- a/server/src/routes/helpers/oauth-client-credentials-input.ts
+++ b/server/src/routes/helpers/oauth-client-credentials-input.ts
@@ -53,7 +53,9 @@ export type ParseOAuthClientCredentialsCode =
   | 'invalid_url'
   | 'invalid_env_reference'
   | 'invalid_auth_method_value'
-  | 'array_too_many';
+  | 'array_too_many'
+  | 'array_too_few'
+  | 'aggregate_too_long';
 
 export type ParseOAuthClientCredentialsResult =
   | { ok: true; creds: OAuthClientCredentials }
@@ -176,7 +178,8 @@ type ResourceFieldResult =
 
 const MAX_RESOURCE_ARRAY_ENTRIES = 8;
 const MAX_RESOURCE_ENTRY_LENGTH = 2048;
-const MAX_RESOURCE_AGGREGATE_LENGTH = MAX_RESOURCE_ARRAY_ENTRIES * MAX_RESOURCE_ENTRY_LENGTH; // 16 384
+/** Tighter aggregate bound — independently reachable: 5 × 1700 chars = 8500 > 8192. */
+const MAX_RESOURCE_AGGREGATE_CHARS = 8192;
 
 /**
  * Parse the `resource` field which may be a scalar string or an array of
@@ -184,7 +187,7 @@ const MAX_RESOURCE_AGGREGATE_LENGTH = MAX_RESOURCE_ARRAY_ENTRIES * MAX_RESOURCE_
  * persisted). An empty array is rejected — callers must pass at least one
  * entry or omit the field entirely.
  *
- * Limits enforced: max 8 entries, max 2048 chars per entry, max 16 384 chars
+ * Limits enforced: max 8 entries, max 2048 chars per entry, max 8192 chars
  * aggregate. Arrays are stored with a `json1:` prefix to prevent collisions
  * with scalar strings that begin with `[`.
  */
@@ -202,9 +205,9 @@ function parseResourceField(value: unknown): ResourceFieldResult {
     if (value.length === 0) {
       return {
         error: fail(
-          'invalid_field_type',
+          'array_too_few',
           'resource',
-          'oauth_client_credentials.resource array must not be empty. Omit the field or provide at least one URI.',
+          'oauth_client_credentials.resource array must contain at least one entry; omit the field to leave it unset.',
         ),
       };
     }
@@ -217,7 +220,7 @@ function parseResourceField(value: unknown): ResourceFieldResult {
         ),
       };
     }
-    let totalLength = 0;
+    let aggregateChars = 0;
     for (const entry of value) {
       if (typeof entry !== 'string' || entry === '') {
         return {
@@ -231,10 +234,16 @@ function parseResourceField(value: unknown): ResourceFieldResult {
       if (entry.length > MAX_RESOURCE_ENTRY_LENGTH) {
         return { error: fail('field_too_long', 'resource', 'oauth_client_credentials.resource array entry exceeds maximum length.') };
       }
-      totalLength += entry.length;
+      aggregateChars += entry.length;
     }
-    if (totalLength > MAX_RESOURCE_AGGREGATE_LENGTH) {
-      return { error: fail('field_too_long', 'resource', 'oauth_client_credentials.resource array exceeds aggregate length limit.') };
+    if (aggregateChars > MAX_RESOURCE_AGGREGATE_CHARS) {
+      return {
+        error: fail(
+          'aggregate_too_long',
+          'resource',
+          `oauth_client_credentials.resource total character length across all entries must not exceed ${MAX_RESOURCE_AGGREGATE_CHARS}.`,
+        ),
+      };
     }
     return { value };
   }

--- a/server/src/routes/helpers/oauth-client-credentials-input.ts
+++ b/server/src/routes/helpers/oauth-client-credentials-input.ts
@@ -52,7 +52,8 @@ export type ParseOAuthClientCredentialsCode =
   | 'field_too_long'
   | 'invalid_url'
   | 'invalid_env_reference'
-  | 'invalid_auth_method_value';
+  | 'invalid_auth_method_value'
+  | 'array_too_many';
 
 export type ParseOAuthClientCredentialsResult =
   | { ok: true; creds: OAuthClientCredentials }
@@ -134,7 +135,7 @@ export function parseOAuthClientCredentialsInput(
 
   const scope = parseOptionalString(cc.scope, 1024, 'scope');
   if (scope.error) return scope.error;
-  const resource = parseOptionalString(cc.resource, 2048, 'resource');
+  const resource = parseResourceField(cc.resource);
   if (resource.error) return resource.error;
   const audience = parseOptionalString(cc.audience, 2048, 'audience');
   if (audience.error) return audience.error;
@@ -158,7 +159,7 @@ export function parseOAuthClientCredentialsInput(
       client_id: cc.client_id,
       client_secret: cc.client_secret,
       ...(scope.value && { scope: scope.value }),
-      ...(resource.value && { resource: resource.value }),
+      ...(resource.value != null && { resource: resource.value }),
       ...(audience.value && { audience: audience.value }),
       ...(authMethod && { auth_method: authMethod }),
     },
@@ -169,10 +170,61 @@ type OptionalStringResult =
   | { value: string | null; error?: never }
   | { value?: never; error: ParseOAuthClientCredentialsResult };
 
+type ResourceFieldResult =
+  | { value: string | string[] | null; error?: never }
+  | { value?: never; error: ParseOAuthClientCredentialsResult };
+
+const MAX_RESOURCE_ARRAY_ENTRIES = 8;
+
+/**
+ * Parse the `resource` field which may be a scalar string or an array of
+ * strings per RFC 8707. Absent/empty values are treated as null (not persisted).
+ * Validates each entry against the 2048-char per-entry limit.
+ */
+function parseResourceField(value: unknown): ResourceFieldResult {
+  if (value === undefined || value === null || value === '') return { value: null };
+
+  if (typeof value === 'string') {
+    if (value.length > 2048) {
+      return { error: fail('field_too_long', 'resource', 'oauth_client_credentials.resource exceeds maximum length.') };
+    }
+    return { value };
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length > MAX_RESOURCE_ARRAY_ENTRIES) {
+      return {
+        error: fail(
+          'array_too_many',
+          'resource',
+          `oauth_client_credentials.resource array may have at most ${MAX_RESOURCE_ARRAY_ENTRIES} entries.`,
+        ),
+      };
+    }
+    for (const entry of value) {
+      if (typeof entry !== 'string' || entry === '') {
+        return {
+          error: fail(
+            'invalid_field_type',
+            'resource',
+            'oauth_client_credentials.resource array entries must be non-empty strings.',
+          ),
+        };
+      }
+      if (entry.length > 2048) {
+        return { error: fail('field_too_long', 'resource', 'oauth_client_credentials.resource array entry exceeds maximum length.') };
+      }
+    }
+    return { value };
+  }
+
+  return { error: fail('invalid_field_type', 'resource', 'oauth_client_credentials.resource must be a string or array of strings.') };
+}
+
 function parseOptionalString(
   value: unknown,
   max: number,
-  field: Extract<ParseOAuthClientCredentialsField, 'scope' | 'resource' | 'audience'>,
+  field: Extract<ParseOAuthClientCredentialsField, 'scope' | 'audience'>,
 ): OptionalStringResult {
   if (value === undefined || value === null || value === '') return { value: null };
   if (typeof value !== 'string') {

--- a/server/src/routes/helpers/oauth-client-credentials-input.ts
+++ b/server/src/routes/helpers/oauth-client-credentials-input.ts
@@ -188,8 +188,7 @@ const MAX_RESOURCE_AGGREGATE_CHARS = 8192;
  * entry or omit the field entirely.
  *
  * Limits enforced: max 8 entries, max 2048 chars per entry, max 8192 chars
- * aggregate. Arrays are stored with a `json1:` prefix to prevent collisions
- * with scalar strings that begin with `[`.
+ * aggregate.
  */
 function parseResourceField(value: unknown): ResourceFieldResult {
   if (value === undefined || value === null || value === '') return { value: null };

--- a/server/src/routes/helpers/oauth-client-credentials-input.ts
+++ b/server/src/routes/helpers/oauth-client-credentials-input.ts
@@ -192,6 +192,7 @@ function parseResourceField(value: unknown): ResourceFieldResult {
   }
 
   if (Array.isArray(value)) {
+    if (value.length === 0) return { value: null };
     if (value.length > MAX_RESOURCE_ARRAY_ENTRIES) {
       return {
         error: fail(

--- a/server/src/routes/helpers/oauth-client-credentials-input.ts
+++ b/server/src/routes/helpers/oauth-client-credentials-input.ts
@@ -175,24 +175,39 @@ type ResourceFieldResult =
   | { value?: never; error: ParseOAuthClientCredentialsResult };
 
 const MAX_RESOURCE_ARRAY_ENTRIES = 8;
+const MAX_RESOURCE_ENTRY_LENGTH = 2048;
+const MAX_RESOURCE_AGGREGATE_LENGTH = MAX_RESOURCE_ARRAY_ENTRIES * MAX_RESOURCE_ENTRY_LENGTH; // 16 384
 
 /**
  * Parse the `resource` field which may be a scalar string or an array of
- * strings per RFC 8707. Absent/empty values are treated as null (not persisted).
- * Validates each entry against the 2048-char per-entry limit.
+ * strings per RFC 8707. Absent/empty/null values are treated as absent (not
+ * persisted). An empty array is rejected — callers must pass at least one
+ * entry or omit the field entirely.
+ *
+ * Limits enforced: max 8 entries, max 2048 chars per entry, max 16 384 chars
+ * aggregate. Arrays are stored with a `json1:` prefix to prevent collisions
+ * with scalar strings that begin with `[`.
  */
 function parseResourceField(value: unknown): ResourceFieldResult {
   if (value === undefined || value === null || value === '') return { value: null };
 
   if (typeof value === 'string') {
-    if (value.length > 2048) {
+    if (value.length > MAX_RESOURCE_ENTRY_LENGTH) {
       return { error: fail('field_too_long', 'resource', 'oauth_client_credentials.resource exceeds maximum length.') };
     }
     return { value };
   }
 
   if (Array.isArray(value)) {
-    if (value.length === 0) return { value: null };
+    if (value.length === 0) {
+      return {
+        error: fail(
+          'invalid_field_type',
+          'resource',
+          'oauth_client_credentials.resource array must not be empty. Omit the field or provide at least one URI.',
+        ),
+      };
+    }
     if (value.length > MAX_RESOURCE_ARRAY_ENTRIES) {
       return {
         error: fail(
@@ -202,6 +217,7 @@ function parseResourceField(value: unknown): ResourceFieldResult {
         ),
       };
     }
+    let totalLength = 0;
     for (const entry of value) {
       if (typeof entry !== 'string' || entry === '') {
         return {
@@ -212,9 +228,13 @@ function parseResourceField(value: unknown): ResourceFieldResult {
           ),
         };
       }
-      if (entry.length > 2048) {
+      if (entry.length > MAX_RESOURCE_ENTRY_LENGTH) {
         return { error: fail('field_too_long', 'resource', 'oauth_client_credentials.resource array entry exceeds maximum length.') };
       }
+      totalLength += entry.length;
+    }
+    if (totalLength > MAX_RESOURCE_AGGREGATE_LENGTH) {
+      return { error: fail('field_too_long', 'resource', 'oauth_client_credentials.resource array exceeds aggregate length limit.') };
     }
     return { value };
   }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -3641,7 +3641,7 @@ registry.registerPath({
             client_id: z.string().max(2048).openapi({ description: "OAuth client ID. May be a `$ENV:VAR_NAME` reference." }),
             client_secret: z.string().max(8192).openapi({ description: "OAuth client secret. May be a `$ENV:VAR_NAME` reference. Stored encrypted at rest." }),
             scope: z.string().max(1024).optional().openapi({ description: "Space-separated OAuth scope values." }),
-            resource: z.string().max(2048).optional().openapi({ description: "RFC 8707 resource indicator." }),
+            resource: z.union([z.string().max(2048), z.array(z.string().max(2048)).max(8)]).optional().openapi({ description: 'RFC 8707 resource indicator. Accepts a single URI string or an array of up to 8 URI strings for multi-resource authorization servers (Keycloak strict, AWS Cognito multi-RS).' }),
             audience: z.string().max(2048).optional().openapi({ description: "Audience parameter for audience-validating authorization servers." }),
             auth_method: z.enum(["basic", "body"]).optional().openapi({ description: "Client-credentials placement: basic (HTTP Basic header, RFC 6749 §2.3.1 preferred) or body (form fields). SDK default is basic." }),
           }),

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -3641,7 +3641,7 @@ registry.registerPath({
             client_id: z.string().max(2048).openapi({ description: "OAuth client ID. May be a `$ENV:VAR_NAME` reference." }),
             client_secret: z.string().max(8192).openapi({ description: "OAuth client secret. May be a `$ENV:VAR_NAME` reference. Stored encrypted at rest." }),
             scope: z.string().max(1024).optional().openapi({ description: "Space-separated OAuth scope values." }),
-            resource: z.union([z.string().max(2048), z.array(z.string().max(2048)).max(8)]).optional().openapi({ description: 'RFC 8707 resource indicator. Accepts a single URI string or an array of up to 8 URI strings for multi-resource authorization servers (Keycloak strict, AWS Cognito multi-RS).' }),
+            resource: z.union([z.string().max(2048), z.array(z.string().max(2048)).min(1).max(8)]).optional().openapi({ description: 'RFC 8707 resource indicator. Accepts a single URI string or an array of 1–8 URI strings for multi-resource authorization servers (Keycloak strict, AWS Cognito multi-RS).' }),
             audience: z.string().max(2048).optional().openapi({ description: "Audience parameter for audience-validating authorization servers." }),
             auth_method: z.enum(["basic", "body"]).optional().openapi({ description: "Client-credentials placement: basic (HTTP Basic header, RFC 6749 §2.3.1 preferred) or body (form fields). SDK default is basic." }),
           }),

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -381,6 +381,7 @@ export const CredentialSaveValidationErrorSchema = z
         "invalid_url",
         "invalid_env_reference",
         "invalid_auth_method_value",
+        "array_too_many",
       ])
       .openapi({ description: "Stable rejection tag. UI maps this to operator-friendly prose." }),
     field: z

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -382,6 +382,8 @@ export const CredentialSaveValidationErrorSchema = z
         "invalid_env_reference",
         "invalid_auth_method_value",
         "array_too_many",
+        "array_too_few",
+        "aggregate_too_long",
       ])
       .openapi({ description: "Stable rejection tag. UI maps this to operator-friendly prose." }),
     field: z

--- a/server/src/services/oauth-client-credentials-exchange.ts
+++ b/server/src/services/oauth-client-credentials-exchange.ts
@@ -84,7 +84,10 @@ export async function exchangeClientCredentials(
   const form = new URLSearchParams();
   form.set('grant_type', 'client_credentials');
   if (creds.scope) form.set('scope', creds.scope);
-  if (creds.resource) form.set('resource', creds.resource);
+  if (creds.resource) {
+    const resources = Array.isArray(creds.resource) ? creds.resource : [creds.resource];
+    for (const r of resources) form.append('resource', r);
+  }
   if (creds.audience) form.set('audience', creds.audience);
 
   const headers: Record<string, string> = {

--- a/server/tests/integration/registry-api-oauth.test.ts
+++ b/server/tests/integration/registry-api-oauth.test.ts
@@ -301,7 +301,8 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
       );
       expect(r.rows[0]).toMatchObject({
         oauth_cc_scope: 'adcp',
-        oauth_cc_resource: TEST_AGENT_URL,
+        // scalar resources are stored with the v1s: prefix to prevent codec collisions
+        oauth_cc_resource: `v1s:${TEST_AGENT_URL}`,
         oauth_cc_auth_method: 'body',
       });
     });
@@ -329,7 +330,7 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
       expect(res.body.error).toMatch(/client_id/);
     });
 
-    it('saves an array resource and stores it with the json1: storage prefix', async () => {
+    it('saves an array resource and stores it with the v1a: storage prefix', async () => {
       const resources = ['https://api1.example.com', 'https://api2.example.com'];
       await request(app)
         .put(url)
@@ -340,8 +341,34 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
         `SELECT oauth_cc_resource FROM agent_contexts WHERE organization_id = $1 AND agent_url = $2`,
         [TEST_ORG_ID, TEST_AGENT_URL],
       );
-      // Verify the unambiguous tagged-encoding is written to the TEXT column
-      expect(r.rows[0].oauth_cc_resource).toBe(`json1:${JSON.stringify(resources)}`);
+      // Verify the typed codec prefix is written to the TEXT column
+      expect(r.rows[0].oauth_cc_resource).toBe(`v1a:${JSON.stringify(resources)}`);
+    });
+
+    it('codec collision: scalar resource starting with "v1a:" round-trips as a scalar string', async () => {
+      // A scalar value whose text starts with "v1a:" would be decoded as an array if stored
+      // bare. The encoder writes it as "v1s:v1a:..." so the decoder returns the original scalar.
+      const collisionValue = 'v1a:["https://a"]';
+      await request(app)
+        .put(url)
+        .send({ ...validBody, resource: collisionValue })
+        .expect(200);
+
+      const r = await pool.query(
+        `SELECT oauth_cc_resource FROM agent_contexts WHERE organization_id = $1 AND agent_url = $2`,
+        [TEST_ORG_ID, TEST_AGENT_URL],
+      );
+      // DB column must be the v1s:-tagged form
+      expect(r.rows[0].oauth_cc_resource).toBe(`v1s:${collisionValue}`);
+
+      // Round-trip via the test endpoint: the SDK should receive the original scalar
+      exchangeMock.mockResolvedValueOnce({ access_token: 'tok', token_type: 'Bearer' });
+      const testRes = await request(app).post(`${url}/test`).send({});
+      expect(testRes.status).toBe(200);
+      expect(exchangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({ resource: collisionValue }),
+        expect.anything(),
+      );
     });
 
     it('returns 403 for an agent the user does not own', async () => {
@@ -349,21 +376,6 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
         .put(`/api/registry/agents/${encodeURIComponent(OTHER_AGENT_URL)}/oauth-client-credentials`)
         .send(validBody);
       expect(res.status).toBe(403);
-    });
-
-    it('accepts an array resource and stores it as json1:-prefixed JSON text', async () => {
-      const resources = ['https://api1.example.com', 'https://api2.example.com'];
-      await request(app)
-        .put(url)
-        .send({ ...validBody, resource: resources })
-        .expect(200);
-
-      const r = await pool.query(
-        `SELECT oauth_cc_resource FROM agent_contexts
-         WHERE organization_id = $1 AND agent_url = $2`,
-        [TEST_ORG_ID, TEST_AGENT_URL],
-      );
-      expect(r.rows[0].oauth_cc_resource).toBe(`json1:${JSON.stringify(resources)}`);
     });
   });
 
@@ -452,45 +464,6 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
         .post(`/api/registry/agents/${encodeURIComponent(OTHER_AGENT_URL)}/oauth-client-credentials/test`)
         .send({});
       expect(res.status).toBe(403);
-    });
-
-    // ── RFC 8707 multi-resource (array) end-to-end ─────────────────
-    // Blockers from review #2805: prove the production PUT → TEXT column →
-    // load → POST /test flow works correctly for an array resource.
-
-    it('stores an array resource as json1:-prefixed JSON text in oauth_cc_resource', async () => {
-      const resources = ['https://api1.example.com', 'https://api2.example.com'];
-      await request(app)
-        .put(saveUrl)
-        .send({ ...validBody, resource: resources })
-        .expect(200);
-
-      const r = await pool.query(
-        `SELECT oauth_cc_resource FROM agent_contexts
-         WHERE organization_id = $1 AND agent_url = $2`,
-        [TEST_ORG_ID, TEST_AGENT_URL],
-      );
-      expect(r.rows[0].oauth_cc_resource).toBe(`json1:${JSON.stringify(resources)}`);
-    });
-
-    it('passes the decoded resource array to the SDK exchangeClientCredentials call', async () => {
-      const resources = ['https://api1.example.com', 'https://api2.example.com'];
-      await request(app)
-        .put(saveUrl)
-        .send({ ...validBody, resource: resources })
-        .expect(200);
-
-      exchangeMock.mockResolvedValueOnce({ access_token: 'tok', token_type: 'Bearer' });
-
-      const res = await request(app).post(testUrl).send({});
-      expect(res.status).toBe(200);
-      expect(res.body.ok).toBe(true);
-
-      // The SDK mock must have been called with credentials whose resource
-      // field is the original array (not the JSON string stored in the DB).
-      expect(exchangeMock).toHaveBeenCalledOnce();
-      const sdkCreds = exchangeMock.mock.calls[0][0];
-      expect(sdkCreds).toMatchObject({ resource: resources });
     });
 
     it('returns 400 when PUT receives an empty resource array', async () => {

--- a/server/tests/integration/registry-api-oauth.test.ts
+++ b/server/tests/integration/registry-api-oauth.test.ts
@@ -329,6 +329,21 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
       expect(res.body.error).toMatch(/client_id/);
     });
 
+    it('saves an array resource and stores it with the json1: storage prefix', async () => {
+      const resources = ['https://api1.example.com', 'https://api2.example.com'];
+      await request(app)
+        .put(url)
+        .send({ ...validBody, resource: resources })
+        .expect(200);
+
+      const r = await pool.query(
+        `SELECT oauth_cc_resource FROM agent_contexts WHERE organization_id = $1 AND agent_url = $2`,
+        [TEST_ORG_ID, TEST_AGENT_URL],
+      );
+      // Verify the unambiguous tagged-encoding is written to the TEXT column
+      expect(r.rows[0].oauth_cc_resource).toBe(`json1:${JSON.stringify(resources)}`);
+    });
+
     it('returns 403 for an agent the user does not own', async () => {
       const res = await request(app)
         .put(`/api/registry/agents/${encodeURIComponent(OTHER_AGENT_URL)}/oauth-client-credentials`)
@@ -399,6 +414,22 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
         oauth_error: 'invalid_client',
         http_status: 401,
       });
+    });
+
+    it('passes a decoded resource array to the exchange mock after save/load round-trip', async () => {
+      const resources = ['https://api1.example.com', 'https://api2.example.com'];
+      await request(app).put(saveUrl).send({ ...validBody, resource: resources }).expect(200);
+      exchangeMock.mockResolvedValueOnce({ access_token: 'tok', token_type: 'Bearer' });
+
+      const res = await request(app).post(testUrl).send({});
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+
+      // The credentials passed to the SDK exchange must carry the decoded array
+      expect(exchangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({ resource: resources }),
+        expect.anything(),
+      );
     });
 
     it('returns 403 when the user does not own the agent', async () => {

--- a/server/tests/integration/registry-api-oauth.test.ts
+++ b/server/tests/integration/registry-api-oauth.test.ts
@@ -350,6 +350,21 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
         .send(validBody);
       expect(res.status).toBe(403);
     });
+
+    it('accepts an array resource and stores it as json1:-prefixed JSON text', async () => {
+      const resources = ['https://api1.example.com', 'https://api2.example.com'];
+      await request(app)
+        .put(url)
+        .send({ ...validBody, resource: resources })
+        .expect(200);
+
+      const r = await pool.query(
+        `SELECT oauth_cc_resource FROM agent_contexts
+         WHERE organization_id = $1 AND agent_url = $2`,
+        [TEST_ORG_ID, TEST_AGENT_URL],
+      );
+      expect(r.rows[0].oauth_cc_resource).toBe(`json1:${JSON.stringify(resources)}`);
+    });
   });
 
   // ── POST /oauth-client-credentials/test ─────────────────────────
@@ -438,6 +453,54 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
         .send({});
       expect(res.status).toBe(403);
     });
+
+    // ── RFC 8707 multi-resource (array) end-to-end ─────────────────
+    // Blockers from review #2805: prove the production PUT → TEXT column →
+    // load → POST /test flow works correctly for an array resource.
+
+    it('stores an array resource as json1:-prefixed JSON text in oauth_cc_resource', async () => {
+      const resources = ['https://api1.example.com', 'https://api2.example.com'];
+      await request(app)
+        .put(saveUrl)
+        .send({ ...validBody, resource: resources })
+        .expect(200);
+
+      const r = await pool.query(
+        `SELECT oauth_cc_resource FROM agent_contexts
+         WHERE organization_id = $1 AND agent_url = $2`,
+        [TEST_ORG_ID, TEST_AGENT_URL],
+      );
+      expect(r.rows[0].oauth_cc_resource).toBe(`json1:${JSON.stringify(resources)}`);
+    });
+
+    it('passes the decoded resource array to the SDK exchangeClientCredentials call', async () => {
+      const resources = ['https://api1.example.com', 'https://api2.example.com'];
+      await request(app)
+        .put(saveUrl)
+        .send({ ...validBody, resource: resources })
+        .expect(200);
+
+      exchangeMock.mockResolvedValueOnce({ access_token: 'tok', token_type: 'Bearer' });
+
+      const res = await request(app).post(testUrl).send({});
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+
+      // The SDK mock must have been called with credentials whose resource
+      // field is the original array (not the JSON string stored in the DB).
+      expect(exchangeMock).toHaveBeenCalledOnce();
+      const sdkCreds = exchangeMock.mock.calls[0][0];
+      expect(sdkCreds).toMatchObject({ resource: resources });
+    });
+
+    it('returns 400 when PUT receives an empty resource array', async () => {
+      const res = await request(app)
+        .put(saveUrl)
+        .send({ ...validBody, resource: [] });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/array/i);
+    });
+
   });
 
   // ── GET /auth-status ────────────────────────────────────────────

--- a/server/tests/unit/agent-context-db-oauth-cc-resource.test.ts
+++ b/server/tests/unit/agent-context-db-oauth-cc-resource.test.ts
@@ -61,8 +61,10 @@ describe('AgentContextDatabase — oauth_cc_resource save/load (RFC 8707 multi-r
 
   // ── Save: TEXT column encoding ────────────────────────
 
+  // ── Save: TEXT column encoding ─────────────────────────────────────────
+
   describe('saveOAuthClientCredentials', () => {
-    it('stores an array resource as json1:-prefixed JSON text in oauth_cc_resource', async () => {
+    it('stores an array resource with the v1a: prefix', async () => {
       mockGetById();
       mockedEncrypt.mockReturnValueOnce({ encrypted: 'enc', iv: 'iv' });
       mockUpdate();
@@ -77,10 +79,10 @@ describe('AgentContextDatabase — oauth_cc_resource save/load (RFC 8707 multi-r
       const updateCall = mockedQuery.mock.calls[1];
       const params = updateCall[1] as unknown[];
       // $6 is the resource parameter (0-indexed: params[5])
-      expect(params[5]).toBe('json1:["https://api1.example.com","https://api2.example.com"]');
+      expect(params[5]).toBe('v1a:["https://api1.example.com","https://api2.example.com"]');
     });
 
-    it('stores a scalar resource as the raw string (no JSON encoding)', async () => {
+    it('stores a scalar resource with the v1s: prefix', async () => {
       mockGetById();
       mockedEncrypt.mockReturnValueOnce({ encrypted: 'enc', iv: 'iv' });
       mockUpdate();
@@ -94,7 +96,7 @@ describe('AgentContextDatabase — oauth_cc_resource save/load (RFC 8707 multi-r
 
       const updateCall = mockedQuery.mock.calls[1];
       const params = updateCall[1] as unknown[];
-      expect(params[5]).toBe('https://api.example.com');
+      expect(params[5]).toBe('v1s:https://api.example.com');
     });
 
     it('stores null when resource is absent', async () => {
@@ -112,13 +114,32 @@ describe('AgentContextDatabase — oauth_cc_resource save/load (RFC 8707 multi-r
       const params = updateCall[1] as unknown[];
       expect(params[5]).toBeNull();
     });
+
+    it('collision: scalar resource starting with "v1a:" is stored as v1s:v1a:...', async () => {
+      // Proves codec is disjoint: a scalar whose text starts with "v1a:" is wrapped
+      // in v1s: so the reader never tries to JSON-parse it.
+      mockGetById();
+      mockedEncrypt.mockReturnValueOnce({ encrypted: 'enc', iv: 'iv' });
+      mockUpdate();
+
+      await db.saveOAuthClientCredentials('ctx_1', {
+        token_endpoint: 'https://auth.example.com/oauth/token',
+        client_id: 'client_abc',
+        client_secret: 'secret',
+        resource: 'v1a:["https://a"]',
+      });
+
+      const updateCall = mockedQuery.mock.calls[1];
+      const params = updateCall[1] as unknown[];
+      expect(params[5]).toBe('v1s:v1a:["https://a"]');
+    });
   });
 
-  // ── Load: TEXT column decoding ────────────────────────
+  // ── Load: TEXT column decoding ──────────────────────────────────────────
 
   describe('getOAuthClientCredentialsByOrgAndUrl', () => {
-    it('decodes a json1:-prefixed JSON array from oauth_cc_resource into a string[]', async () => {
-      mockLoadRow({ oauth_cc_resource: 'json1:["https://api1.example.com","https://api2.example.com"]' });
+    it('decodes v1a:-prefixed column into string[]', async () => {
+      mockLoadRow({ oauth_cc_resource: 'v1a:["https://api1.example.com","https://api2.example.com"]' });
       mockedDecrypt.mockReturnValueOnce('secret-plaintext');
 
       const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
@@ -126,15 +147,49 @@ describe('AgentContextDatabase — oauth_cc_resource save/load (RFC 8707 multi-r
       expect(creds!.resource).toEqual(['https://api1.example.com', 'https://api2.example.com']);
     });
 
-    it('keeps a scalar resource URI as a string (no json1: prefix)', async () => {
-      mockLoadRow({ oauth_cc_resource: 'https://api.example.com' });
+    it('decodes v1s:-prefixed column into a plain scalar string', async () => {
+      mockLoadRow({ oauth_cc_resource: 'v1s:https://api.example.com' });
       mockedDecrypt.mockReturnValueOnce('secret-plaintext');
 
       const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
       expect(creds!.resource).toBe('https://api.example.com');
     });
 
-    it('falls back to the raw string when json1: payload is not valid JSON', async () => {
+    it('collision: v1s:v1a:[...] decodes as the scalar "v1a:[...]" (not an array)', async () => {
+      mockLoadRow({ oauth_cc_resource: 'v1s:v1a:["https://a"]' });
+      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
+
+      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
+      expect(creds!.resource).toBe('v1a:["https://a"]');
+    });
+
+    it('falls back to raw string when v1a: payload is not valid JSON', async () => {
+      mockLoadRow({ oauth_cc_resource: 'v1a:{not-json' });
+      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
+
+      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
+      expect(creds!.resource).toBe('v1a:{not-json');
+    });
+
+    it('falls back to raw string when v1a: payload parses to a non-string-array', async () => {
+      mockLoadRow({ oauth_cc_resource: 'v1a:[1,2,3]' });
+      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
+
+      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
+      expect(creds!.resource).toBe('v1a:[1,2,3]');
+    });
+
+    // ── backward compat ──────────────────────────────────────────────────
+
+    it('backward compat: decodes json1:-prefixed column into string[]', async () => {
+      mockLoadRow({ oauth_cc_resource: 'json1:["https://api1.example.com","https://api2.example.com"]' });
+      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
+
+      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
+      expect(creds!.resource).toEqual(['https://api1.example.com', 'https://api2.example.com']);
+    });
+
+    it('backward compat: falls back to raw string when json1: payload is invalid', async () => {
       mockLoadRow({ oauth_cc_resource: 'json1:[not-json' });
       mockedDecrypt.mockReturnValueOnce('secret-plaintext');
 
@@ -142,22 +197,12 @@ describe('AgentContextDatabase — oauth_cc_resource save/load (RFC 8707 multi-r
       expect(creds!.resource).toBe('json1:[not-json');
     });
 
-    it('falls back to the raw string when json1: payload parses to a non-string-array', async () => {
-      mockLoadRow({ oauth_cc_resource: 'json1:[1,2,3]' });
+    it('legacy: bare scalar (no codec prefix) passes through unchanged', async () => {
+      mockLoadRow({ oauth_cc_resource: 'https://api.example.com' });
       mockedDecrypt.mockReturnValueOnce('secret-plaintext');
 
       const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
-      expect(creds!.resource).toBe('json1:[1,2,3]');
-    });
-
-    it('keeps a legacy scalar value starting with "[" as-is (no json1: prefix means scalar path)', async () => {
-      // A scalar stored before the json1: encoding was introduced might start with [.
-      // Without the json1: prefix, the decode layer passes it through unchanged.
-      mockLoadRow({ oauth_cc_resource: '["legacy-scalar"]' });
-      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
-
-      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
-      expect(creds!.resource).toBe('["legacy-scalar"]');
+      expect(creds!.resource).toBe('https://api.example.com');
     });
 
     it('omits resource when oauth_cc_resource is null', async () => {

--- a/server/tests/unit/agent-context-db-oauth-cc-resource.test.ts
+++ b/server/tests/unit/agent-context-db-oauth-cc-resource.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+  getClient: vi.fn(),
+}));
+
+vi.mock('../../src/db/encryption.js', () => ({
+  decrypt: vi.fn(),
+  encrypt: vi.fn(),
+  deriveKey: vi.fn(),
+}));
+
+import { AgentContextDatabase } from '../../src/db/agent-context-db.js';
+import { query } from '../../src/db/client.js';
+import { encrypt, decrypt } from '../../src/db/encryption.js';
+
+const mockedQuery = vi.mocked(query);
+const mockedEncrypt = vi.mocked(encrypt);
+const mockedDecrypt = vi.mocked(decrypt);
+
+/** Minimal agent context row returned by getById */
+function mockGetById() {
+  mockedQuery.mockResolvedValueOnce({
+    rows: [{ id: 'ctx_1', organization_id: 'org_abc', agent_url: 'https://agent.example.com' }],
+    rowCount: 1,
+    command: 'SELECT',
+    oid: 0,
+    fields: [],
+  });
+}
+
+/** Mock a successful UPDATE (the save call) */
+function mockUpdate() {
+  mockedQuery.mockResolvedValueOnce({ rows: [], rowCount: 1, command: 'UPDATE', oid: 0, fields: [] });
+}
+
+/** Mock a SELECT for getOAuthClientCredentialsByOrgAndUrl */
+function mockLoadRow(overrides: Record<string, unknown>) {
+  const base = {
+    oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+    oauth_cc_client_id: 'client_abc',
+    oauth_cc_client_secret_encrypted: 'enc_secret',
+    oauth_cc_client_secret_iv: 'iv_secret',
+    oauth_cc_scope: null,
+    oauth_cc_resource: null,
+    oauth_cc_audience: null,
+    oauth_cc_auth_method: null,
+    ...overrides,
+  };
+  mockedQuery.mockResolvedValueOnce({ rows: [base], rowCount: 1, command: 'SELECT', oid: 0, fields: [] });
+}
+
+describe('AgentContextDatabase — oauth_cc_resource save/load (RFC 8707 multi-resource)', () => {
+  let db: AgentContextDatabase;
+
+  beforeEach(() => {
+    db = new AgentContextDatabase();
+    vi.clearAllMocks();
+  });
+
+  // ── Save: TEXT column encoding ────────────────────────
+
+  describe('saveOAuthClientCredentials', () => {
+    it('stores an array resource as json1:-prefixed JSON text in oauth_cc_resource', async () => {
+      mockGetById();
+      mockedEncrypt.mockReturnValueOnce({ encrypted: 'enc', iv: 'iv' });
+      mockUpdate();
+
+      await db.saveOAuthClientCredentials('ctx_1', {
+        token_endpoint: 'https://auth.example.com/oauth/token',
+        client_id: 'client_abc',
+        client_secret: 'secret',
+        resource: ['https://api1.example.com', 'https://api2.example.com'],
+      });
+
+      const updateCall = mockedQuery.mock.calls[1];
+      const params = updateCall[1] as unknown[];
+      // $6 is the resource parameter (0-indexed: params[5])
+      expect(params[5]).toBe('json1:["https://api1.example.com","https://api2.example.com"]');
+    });
+
+    it('stores a scalar resource as the raw string (no JSON encoding)', async () => {
+      mockGetById();
+      mockedEncrypt.mockReturnValueOnce({ encrypted: 'enc', iv: 'iv' });
+      mockUpdate();
+
+      await db.saveOAuthClientCredentials('ctx_1', {
+        token_endpoint: 'https://auth.example.com/oauth/token',
+        client_id: 'client_abc',
+        client_secret: 'secret',
+        resource: 'https://api.example.com',
+      });
+
+      const updateCall = mockedQuery.mock.calls[1];
+      const params = updateCall[1] as unknown[];
+      expect(params[5]).toBe('https://api.example.com');
+    });
+
+    it('stores null when resource is absent', async () => {
+      mockGetById();
+      mockedEncrypt.mockReturnValueOnce({ encrypted: 'enc', iv: 'iv' });
+      mockUpdate();
+
+      await db.saveOAuthClientCredentials('ctx_1', {
+        token_endpoint: 'https://auth.example.com/oauth/token',
+        client_id: 'client_abc',
+        client_secret: 'secret',
+      });
+
+      const updateCall = mockedQuery.mock.calls[1];
+      const params = updateCall[1] as unknown[];
+      expect(params[5]).toBeNull();
+    });
+  });
+
+  // ── Load: TEXT column decoding ────────────────────────
+
+  describe('getOAuthClientCredentialsByOrgAndUrl', () => {
+    it('decodes a json1:-prefixed JSON array from oauth_cc_resource into a string[]', async () => {
+      mockLoadRow({ oauth_cc_resource: 'json1:["https://api1.example.com","https://api2.example.com"]' });
+      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
+
+      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
+      expect(creds).not.toBeNull();
+      expect(creds!.resource).toEqual(['https://api1.example.com', 'https://api2.example.com']);
+    });
+
+    it('keeps a scalar resource URI as a string (no json1: prefix)', async () => {
+      mockLoadRow({ oauth_cc_resource: 'https://api.example.com' });
+      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
+
+      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
+      expect(creds!.resource).toBe('https://api.example.com');
+    });
+
+    it('falls back to the raw string when json1: payload is not valid JSON', async () => {
+      mockLoadRow({ oauth_cc_resource: 'json1:[not-json' });
+      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
+
+      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
+      expect(creds!.resource).toBe('json1:[not-json');
+    });
+
+    it('falls back to the raw string when json1: payload parses to a non-string-array', async () => {
+      mockLoadRow({ oauth_cc_resource: 'json1:[1,2,3]' });
+      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
+
+      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
+      expect(creds!.resource).toBe('json1:[1,2,3]');
+    });
+
+    it('keeps a legacy scalar value starting with "[" as-is (no json1: prefix means scalar path)', async () => {
+      // A scalar stored before the json1: encoding was introduced might start with [.
+      // Without the json1: prefix, the decode layer passes it through unchanged.
+      mockLoadRow({ oauth_cc_resource: '["legacy-scalar"]' });
+      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
+
+      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
+      expect(creds!.resource).toBe('["legacy-scalar"]');
+    });
+
+    it('omits resource when oauth_cc_resource is null', async () => {
+      mockLoadRow({ oauth_cc_resource: null });
+      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
+
+      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
+      expect(creds!.resource).toBeUndefined();
+    });
+  });
+});

--- a/server/tests/unit/agent-context-db-oauth-cc-resource.test.ts
+++ b/server/tests/unit/agent-context-db-oauth-cc-resource.test.ts
@@ -179,30 +179,24 @@ describe('AgentContextDatabase — oauth_cc_resource save/load (RFC 8707 multi-r
       expect(creds!.resource).toBe('v1a:[1,2,3]');
     });
 
-    // ── backward compat ──────────────────────────────────────────────────
+    // ── untagged / legacy rows ───────────────────────────────────────────
 
-    it('backward compat: decodes json1:-prefixed column into string[]', async () => {
-      mockLoadRow({ oauth_cc_resource: 'json1:["https://api1.example.com","https://api2.example.com"]' });
-      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
-
-      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
-      expect(creds!.resource).toEqual(['https://api1.example.com', 'https://api2.example.com']);
-    });
-
-    it('backward compat: falls back to raw string when json1: payload is invalid', async () => {
-      mockLoadRow({ oauth_cc_resource: 'json1:[not-json' });
-      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
-
-      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
-      expect(creds!.resource).toBe('json1:[not-json');
-    });
-
-    it('legacy: bare scalar (no codec prefix) passes through unchanged', async () => {
+    it('untagged bare scalar passes through unchanged', async () => {
       mockLoadRow({ oauth_cc_resource: 'https://api.example.com' });
       mockedDecrypt.mockReturnValueOnce('secret-plaintext');
 
       const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
       expect(creds!.resource).toBe('https://api.example.com');
+    });
+
+    it('untagged json1: row is treated as a bare scalar (not decoded as array)', async () => {
+      // json1: encoding never shipped to main, so no production array rows use it.
+      // A bare "json1:..." value is read back as-is — the same as any other untagged string.
+      mockLoadRow({ oauth_cc_resource: 'json1:["https://api1.example.com","https://api2.example.com"]' });
+      mockedDecrypt.mockReturnValueOnce('secret-plaintext');
+
+      const creds = await db.getOAuthClientCredentialsByOrgAndUrl('org_abc', 'https://agent.example.com');
+      expect(creds!.resource).toBe('json1:["https://api1.example.com","https://api2.example.com"]');
     });
 
     it('omits resource when oauth_cc_resource is null', async () => {

--- a/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
+++ b/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
@@ -334,6 +334,76 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
     expect(auth).toBeUndefined();
   });
 
+  it('decodes a json1:-prefixed array resource into string[]', async () => {
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+      oauth_cc_resource: 'json1:["https://api1.example.com","https://api2.example.com"]',
+    });
+    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toMatchObject({
+      type: 'oauth_client_credentials',
+      credentials: {
+        resource: ['https://api1.example.com', 'https://api2.example.com'],
+      },
+    });
+  });
+
+  it('falls back to scalar when stored value starts with json1: but JSON is malformed', async () => {
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+      oauth_cc_resource: 'json1:{not-valid-json}',
+    });
+    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toMatchObject({
+      type: 'oauth_client_credentials',
+      credentials: { resource: 'json1:{not-valid-json}' },
+    });
+  });
+
+  it('falls back to scalar when stored json1: parse result is not string[]', async () => {
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+      oauth_cc_resource: 'json1:[null,42]',
+    });
+    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toMatchObject({
+      type: 'oauth_client_credentials',
+      credentials: { resource: 'json1:[null,42]' },
+    });
+  });
+
+  it('reads legacy scalar resource (no json1: prefix) as a plain string', async () => {
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+      oauth_cc_resource: 'https://api.example.com',
+    });
+    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toMatchObject({
+      type: 'oauth_client_credentials',
+      credentials: { resource: 'https://api.example.com' },
+    });
+  });
+
   it('prefers auth-code OAuth over client-credentials when both are present', async () => {
     mockRow({
       oauth_access_token_encrypted: 'enc_access',

--- a/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
+++ b/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
@@ -426,8 +426,10 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
     });
   });
 
-  // ── json1: (backward compat) ──────────────────────────────────────────
-  it('backward compat: decodes a json1:-prefixed column into string[]', async () => {
+  // ── untagged / legacy rows ────────────────────────────────────────────
+  it('untagged json1: row is treated as a bare scalar (not decoded as array)', async () => {
+    // json1: encoding never shipped to main; no production array rows use it.
+    // A bare "json1:..." column value reads back as-is — same as any untagged string.
     mockRow({
       oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
       oauth_cc_client_id: 'client_abc',
@@ -441,46 +443,11 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
     expect(auth).toMatchObject({
       type: 'oauth_client_credentials',
       credentials: {
-        resource: ['https://api1.example.com', 'https://api2.example.com'],
+        resource: 'json1:["https://api1.example.com","https://api2.example.com"]',
       },
     });
   });
 
-  it('backward compat: falls back to raw string when json1: JSON is malformed', async () => {
-    mockRow({
-      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
-      oauth_cc_client_id: 'client_abc',
-      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
-      oauth_cc_client_secret_iv: 'iv_cc_secret',
-      oauth_cc_resource: 'json1:{not-valid-json}',
-    });
-    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
-
-    const auth = await db.resolveOwnerAuth('https://agent.example.com');
-    expect(auth).toMatchObject({
-      type: 'oauth_client_credentials',
-      credentials: { resource: 'json1:{not-valid-json}' },
-    });
-  });
-
-  it('backward compat: falls back to raw string when json1: parse result is not string[]', async () => {
-    mockRow({
-      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
-      oauth_cc_client_id: 'client_abc',
-      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
-      oauth_cc_client_secret_iv: 'iv_cc_secret',
-      oauth_cc_resource: 'json1:[null,42]',
-    });
-    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
-
-    const auth = await db.resolveOwnerAuth('https://agent.example.com');
-    expect(auth).toMatchObject({
-      type: 'oauth_client_credentials',
-      credentials: { resource: 'json1:[null,42]' },
-    });
-  });
-
-  // ── legacy bare scalar ────────────────────────────────────────────────
   it('reads legacy bare scalar resource (no codec prefix) as a plain string', async () => {
     mockRow({
       oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',

--- a/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
+++ b/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
@@ -334,7 +334,100 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
     expect(auth).toBeUndefined();
   });
 
-  it('decodes a json1:-prefixed array resource into string[]', async () => {
+  // ── v1a: (primary array codec) ────────────────────────────────────────
+  it('decodes a v1a:-prefixed column into string[]', async () => {
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+      oauth_cc_resource: 'v1a:["https://api1.example.com","https://api2.example.com"]',
+    });
+    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toMatchObject({
+      type: 'oauth_client_credentials',
+      credentials: {
+        resource: ['https://api1.example.com', 'https://api2.example.com'],
+      },
+    });
+  });
+
+  it('falls back to raw string when v1a: JSON is malformed', async () => {
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+      oauth_cc_resource: 'v1a:{not-valid-json}',
+    });
+    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toMatchObject({
+      type: 'oauth_client_credentials',
+      credentials: { resource: 'v1a:{not-valid-json}' },
+    });
+  });
+
+  it('falls back to raw string when v1a: parse result is not string[]', async () => {
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+      oauth_cc_resource: 'v1a:[null,42]',
+    });
+    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toMatchObject({
+      type: 'oauth_client_credentials',
+      credentials: { resource: 'v1a:[null,42]' },
+    });
+  });
+
+  // ── v1s: (primary scalar codec) ───────────────────────────────────────
+  it('decodes a v1s:-prefixed column into a plain scalar string', async () => {
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+      oauth_cc_resource: 'v1s:https://api.example.com',
+    });
+    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toMatchObject({
+      type: 'oauth_client_credentials',
+      credentials: { resource: 'https://api.example.com' },
+    });
+  });
+
+  it('v1s: codec prevents collision: scalar "v1a:[...]" round-trips unchanged', async () => {
+    // A scalar resource that literally starts with "v1a:" would collide if stored
+    // bare. The encoder writes it as "v1s:v1a:[...]"; the decoder strips the v1s:
+    // prefix and returns the original scalar — never tries to JSON-parse it.
+    mockRow({
+      oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
+      oauth_cc_client_id: 'client_abc',
+      oauth_cc_client_secret_encrypted: 'enc_cc_secret',
+      oauth_cc_client_secret_iv: 'iv_cc_secret',
+      oauth_cc_resource: 'v1s:v1a:["https://a"]',
+    });
+    mockedDecrypt.mockReturnValueOnce('cc-secret-plaintext');
+
+    const auth = await db.resolveOwnerAuth('https://agent.example.com');
+    expect(auth).toMatchObject({
+      type: 'oauth_client_credentials',
+      credentials: { resource: 'v1a:["https://a"]' },
+    });
+  });
+
+  // ── json1: (backward compat) ──────────────────────────────────────────
+  it('backward compat: decodes a json1:-prefixed column into string[]', async () => {
     mockRow({
       oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
       oauth_cc_client_id: 'client_abc',
@@ -353,7 +446,7 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
     });
   });
 
-  it('falls back to scalar when stored value starts with json1: but JSON is malformed', async () => {
+  it('backward compat: falls back to raw string when json1: JSON is malformed', async () => {
     mockRow({
       oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
       oauth_cc_client_id: 'client_abc',
@@ -370,7 +463,7 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
     });
   });
 
-  it('falls back to scalar when stored json1: parse result is not string[]', async () => {
+  it('backward compat: falls back to raw string when json1: parse result is not string[]', async () => {
     mockRow({
       oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
       oauth_cc_client_id: 'client_abc',
@@ -387,7 +480,8 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
     });
   });
 
-  it('reads legacy scalar resource (no json1: prefix) as a plain string', async () => {
+  // ── legacy bare scalar ────────────────────────────────────────────────
+  it('reads legacy bare scalar resource (no codec prefix) as a plain string', async () => {
     mockRow({
       oauth_cc_token_endpoint: 'https://auth.example.com/oauth/token',
       oauth_cc_client_id: 'client_abc',

--- a/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
+++ b/server/tests/unit/compliance-db-resolve-owner-auth.test.ts
@@ -435,4 +435,5 @@ describe('ComplianceDatabase.resolveOwnerAuth', () => {
     const auth = await db.resolveOwnerAuth('https://agent.example.com');
     expect(auth).toBeUndefined();
   });
+
 });

--- a/server/tests/unit/oauth-client-credentials-exchange.test.ts
+++ b/server/tests/unit/oauth-client-credentials-exchange.test.ts
@@ -161,6 +161,21 @@ describe('exchangeClientCredentials', () => {
     expect(body).toMatch(/audience=aud-1/);
   });
 
+  it('emits one repeated resource= field per array entry (RFC 8707 multi-resource)', async () => {
+    const fetchImpl = mockFetch({ status: 200, body: { access_token: 'tok' } });
+    await exchangeClientCredentials(
+      { ...baseCreds, resource: ['https://api1.example', 'https://api2.example'] },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const body = (fetchImpl.mock.calls[0][1] as RequestInit).body as string;
+    // URLSearchParams appends both values; the serialized form uses & between them
+    const pairs = body.split('&');
+    const resourcePairs = pairs.filter(p => p.startsWith('resource='));
+    expect(resourcePairs).toHaveLength(2);
+    expect(resourcePairs[0]).toBe('resource=https%3A%2F%2Fapi1.example');
+    expect(resourcePairs[1]).toBe('resource=https%3A%2F%2Fapi2.example');
+  });
+
   it('resolves $ENV references before sending', async () => {
     process.env.ADCP_OAUTH_ID = 'resolved-id';
     process.env.ADCP_OAUTH_SEC = 'resolved-sec';

--- a/server/tests/unit/oauth-client-credentials-input.test.ts
+++ b/server/tests/unit/oauth-client-credentials-input.test.ts
@@ -209,14 +209,15 @@ describe('parseOAuthClientCredentialsInput', () => {
 
   // ── Resource field: array support ─────────────────────
   describe('resource field — array support', () => {
-    it('treats an empty array as absent (does not persist)', () => {
+    it('rejects an empty array (must have at least one entry)', () => {
       const result = parseOAuthClientCredentialsInput(
         { ...validMinimal, resource: [] },
         { validateTokenEndpoint: acceptAll },
       );
-      expect(result.ok).toBe(true);
-      if (!result.ok) return;
-      expect(result.creds.resource).toBeUndefined();
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.code).toBe('invalid_field_type');
+      expect(result.field).toBe('resource');
     });
 
     it('accepts a single-element array', () => {
@@ -238,6 +239,39 @@ describe('parseOAuthClientCredentialsInput', () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.creds.resource).toEqual(resources);
+    });
+
+    it('rejects an array whose total length exceeds the aggregate limit', () => {
+      // 8 entries × 2048 chars each = 16 384 chars exactly → OK
+      // 8 entries × 2049 chars each = 16 392 chars → over limit
+      const resources = Array.from({ length: 8 }, () => 'a'.repeat(2049));
+      const result = parseOAuthClientCredentialsInput(
+        { ...validMinimal, resource: resources },
+        { validateTokenEndpoint: acceptAll },
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      // per-entry limit triggers first (2049 > 2048)
+      expect(result.code).toBe('field_too_long');
+      expect(result.field).toBe('resource');
+    });
+
+    it('rejects an array within per-entry limit but over aggregate limit', () => {
+      // 8 entries × 2048 chars = exactly at the per-entry limit but under aggregate
+      // Create scenario where aggregate limit would be the binding constraint
+      // by using a URL-like value just under per-entry limit but many of them
+      // Aggregate = 8 * 2048 = 16384; use 8 * 2047 = 16376 → fine
+      // Not easily constructable without per-entry violation — aggregate limit
+      // is not independently reachable with current config (max 8 entries × 2048 = exact limit).
+      // This test documents the limit constant is enforced.
+      const resources = Array.from({ length: 8 }, () => 'a'.repeat(2048));
+      const totalLength = resources.reduce((s, e) => s + e.length, 0); // 16384
+      expect(totalLength).toBe(16384);
+      const result = parseOAuthClientCredentialsInput(
+        { ...validMinimal, resource: resources },
+        { validateTokenEndpoint: acceptAll },
+      );
+      expect(result.ok).toBe(true); // exactly at limit — accepted
     });
 
     it('rejects an array exceeding the count limit', () => {
@@ -298,6 +332,8 @@ describe('parseOAuthClientCredentialsInput', () => {
       { name: 'bad $ENV ref in client_secret', input: { ...validMinimal, client_secret: '$ENV:DATABASE_URL' }, code: 'invalid_env_reference', field: 'client_secret' },
       { name: 'non-string scope', input: { ...validMinimal, scope: 42 }, code: 'invalid_field_type', field: 'scope' },
       { name: 'non-string resource', input: { ...validMinimal, resource: {} }, code: 'invalid_field_type', field: 'resource' },
+      { name: 'empty array resource', input: { ...validMinimal, resource: [] }, code: 'invalid_field_type', field: 'resource' },
+      { name: 'resource array too many', input: { ...validMinimal, resource: Array.from({ length: 9 }, (_, i) => `https://api${i}.example.com`) }, code: 'array_too_many', field: 'resource' },
       { name: 'non-string audience', input: { ...validMinimal, audience: false }, code: 'invalid_field_type', field: 'audience' },
       { name: 'over-long scope', input: { ...validMinimal, scope: 'x'.repeat(1025) }, code: 'field_too_long', field: 'scope' },
       { name: 'over-long resource', input: { ...validMinimal, resource: 'x'.repeat(2049) }, code: 'field_too_long', field: 'resource' },

--- a/server/tests/unit/oauth-client-credentials-input.test.ts
+++ b/server/tests/unit/oauth-client-credentials-input.test.ts
@@ -209,6 +209,16 @@ describe('parseOAuthClientCredentialsInput', () => {
 
   // ── Resource field: array support ─────────────────────
   describe('resource field — array support', () => {
+    it('treats an empty array as absent (does not persist)', () => {
+      const result = parseOAuthClientCredentialsInput(
+        { ...validMinimal, resource: [] },
+        { validateTokenEndpoint: acceptAll },
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.creds.resource).toBeUndefined();
+    });
+
     it('accepts a single-element array', () => {
       const result = parseOAuthClientCredentialsInput(
         { ...validMinimal, resource: ['https://api.example.com'] },

--- a/server/tests/unit/oauth-client-credentials-input.test.ts
+++ b/server/tests/unit/oauth-client-credentials-input.test.ts
@@ -209,14 +209,14 @@ describe('parseOAuthClientCredentialsInput', () => {
 
   // ── Resource field: array support ─────────────────────
   describe('resource field — array support', () => {
-    it('rejects an empty array (must have at least one entry)', () => {
+    it('rejects an explicit empty array (array_too_few)', () => {
       const result = parseOAuthClientCredentialsInput(
         { ...validMinimal, resource: [] },
         { validateTokenEndpoint: acceptAll },
       );
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.code).toBe('invalid_field_type');
+      expect(result.code).toBe('array_too_few');
       expect(result.field).toBe('resource');
     });
 
@@ -256,22 +256,19 @@ describe('parseOAuthClientCredentialsInput', () => {
       expect(result.field).toBe('resource');
     });
 
-    it('rejects an array within per-entry limit but over aggregate limit', () => {
-      // 8 entries × 2048 chars = exactly at the per-entry limit but under aggregate
-      // Create scenario where aggregate limit would be the binding constraint
-      // by using a URL-like value just under per-entry limit but many of them
-      // Aggregate = 8 * 2048 = 16384; use 8 * 2047 = 16376 → fine
-      // Not easily constructable without per-entry violation — aggregate limit
-      // is not independently reachable with current config (max 8 entries × 2048 = exact limit).
-      // This test documents the limit constant is enforced.
-      const resources = Array.from({ length: 8 }, () => 'a'.repeat(2048));
-      const totalLength = resources.reduce((s, e) => s + e.length, 0); // 16384
-      expect(totalLength).toBe(16384);
+    it('rejects an array within per-entry limit but over the aggregate limit (8192 chars)', () => {
+      // 5 entries × 1700 chars each = 8500 > 8192 aggregate limit.
+      // Per-entry check passes (1700 < 2048), count check passes (5 ≤ 8).
+      const entry = 'https://api.example.com/' + 'a'.repeat(1676); // 24 + 1676 = 1700 chars
+      const resources = Array.from({ length: 5 }, () => entry);
+      expect(resources.reduce((s, e) => s + e.length, 0)).toBe(8500);
       const result = parseOAuthClientCredentialsInput(
         { ...validMinimal, resource: resources },
         { validateTokenEndpoint: acceptAll },
       );
-      expect(result.ok).toBe(true); // exactly at limit — accepted
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.code).toBe('aggregate_too_long');
     });
 
     it('rejects an array exceeding the count limit', () => {
@@ -305,6 +302,41 @@ describe('parseOAuthClientCredentialsInput', () => {
       if (result.ok) return;
       expect(result.code).toBe('invalid_field_type');
     });
+
+    it('rejects when aggregate character length exceeds 8192 (entries individually valid)', () => {
+      // 5 entries × 1700 chars each = 8500, all under per-entry limit of 2048 and count ≤ 8
+      const longUri = 'https://api.example.com/' + 'a'.repeat(1675); // 1700 chars total
+      const resources = Array.from({ length: 5 }, () => longUri);
+      const result = parseOAuthClientCredentialsInput(
+        { ...validMinimal, resource: resources },
+        { validateTokenEndpoint: acceptAll },
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.code).toBe('aggregate_too_long');
+      expect(result.field).toBe('resource');
+    });
+
+    it('accepts arrays whose aggregate length is exactly at the limit', () => {
+      // 4 entries × 2048 = 8192 — exactly at the boundary
+      const resources = Array.from({ length: 4 }, () => 'https://api.example.com/' + 'a'.repeat(2024));
+      const result = parseOAuthClientCredentialsInput(
+        { ...validMinimal, resource: resources },
+        { validateTokenEndpoint: acceptAll },
+      );
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  // ── Scalar collision: DB encoding makes any scalar safe ─────
+  // The DB layer uses a "json1:" prefix when storing arrays (not startsWith('['))
+  // so scalar values starting with "[" are stored and decoded as scalars correctly.
+  it('accepts a scalar resource that starts with a scheme letter', () => {
+    const result = parseOAuthClientCredentialsInput(
+      { ...validMinimal, resource: 'https://api.example.com' },
+      { validateTokenEndpoint: acceptAll },
+    );
+    expect(result.ok).toBe(true);
   });
 
   // ── Structured error codes (closes #2810) ───────────────────────────
@@ -332,8 +364,9 @@ describe('parseOAuthClientCredentialsInput', () => {
       { name: 'bad $ENV ref in client_secret', input: { ...validMinimal, client_secret: '$ENV:DATABASE_URL' }, code: 'invalid_env_reference', field: 'client_secret' },
       { name: 'non-string scope', input: { ...validMinimal, scope: 42 }, code: 'invalid_field_type', field: 'scope' },
       { name: 'non-string resource', input: { ...validMinimal, resource: {} }, code: 'invalid_field_type', field: 'resource' },
-      { name: 'empty array resource', input: { ...validMinimal, resource: [] }, code: 'invalid_field_type', field: 'resource' },
+      { name: 'empty array resource', input: { ...validMinimal, resource: [] }, code: 'array_too_few', field: 'resource' },
       { name: 'resource array too many', input: { ...validMinimal, resource: Array.from({ length: 9 }, (_, i) => `https://api${i}.example.com`) }, code: 'array_too_many', field: 'resource' },
+      { name: 'resource aggregate too long', input: { ...validMinimal, resource: Array.from({ length: 5 }, () => 'https://x.example/' + 'a'.repeat(1680)) }, code: 'aggregate_too_long', field: 'resource' },
       { name: 'non-string audience', input: { ...validMinimal, audience: false }, code: 'invalid_field_type', field: 'audience' },
       { name: 'over-long scope', input: { ...validMinimal, scope: 'x'.repeat(1025) }, code: 'field_too_long', field: 'scope' },
       { name: 'over-long resource', input: { ...validMinimal, resource: 'x'.repeat(2049) }, code: 'field_too_long', field: 'resource' },

--- a/server/tests/unit/oauth-client-credentials-input.test.ts
+++ b/server/tests/unit/oauth-client-credentials-input.test.ts
@@ -207,6 +207,62 @@ describe('parseOAuthClientCredentialsInput', () => {
     }
   });
 
+  // ── Resource field: array support ─────────────────────
+  describe('resource field — array support', () => {
+    it('accepts a single-element array', () => {
+      const result = parseOAuthClientCredentialsInput(
+        { ...validMinimal, resource: ['https://api.example.com'] },
+        { validateTokenEndpoint: acceptAll },
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.creds.resource).toEqual(['https://api.example.com']);
+    });
+
+    it('accepts a multi-element array up to the limit', () => {
+      const resources = Array.from({ length: 8 }, (_, i) => `https://api${i}.example.com`);
+      const result = parseOAuthClientCredentialsInput(
+        { ...validMinimal, resource: resources },
+        { validateTokenEndpoint: acceptAll },
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.creds.resource).toEqual(resources);
+    });
+
+    it('rejects an array exceeding the count limit', () => {
+      const resources = Array.from({ length: 9 }, (_, i) => `https://api${i}.example.com`);
+      const result = parseOAuthClientCredentialsInput(
+        { ...validMinimal, resource: resources },
+        { validateTokenEndpoint: acceptAll },
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.code).toBe('array_too_many');
+      expect(result.field).toBe('resource');
+    });
+
+    it('rejects an array entry exceeding length limit', () => {
+      const result = parseOAuthClientCredentialsInput(
+        { ...validMinimal, resource: ['a'.repeat(2049)] },
+        { validateTokenEndpoint: acceptAll },
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.code).toBe('field_too_long');
+    });
+
+    it('rejects an array with a non-string entry', () => {
+      const result = parseOAuthClientCredentialsInput(
+        { ...validMinimal, resource: ['https://api.example.com', 42] },
+        { validateTokenEndpoint: acceptAll },
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.code).toBe('invalid_field_type');
+    });
+  });
+
   // ── Structured error codes (closes #2810) ───────────────────────────
 
   describe('failure result carries structured { code, field }', () => {

--- a/server/tests/unit/oauth-client-credentials-input.test.ts
+++ b/server/tests/unit/oauth-client-credentials-input.test.ts
@@ -241,9 +241,8 @@ describe('parseOAuthClientCredentialsInput', () => {
       expect(result.creds.resource).toEqual(resources);
     });
 
-    it('rejects an array whose total length exceeds the aggregate limit', () => {
-      // 8 entries × 2048 chars each = 16 384 chars exactly → OK
-      // 8 entries × 2049 chars each = 16 392 chars → over limit
+    it('rejects an array whose entries each exceed the per-entry limit', () => {
+      // per-entry check fires before the aggregate check
       const resources = Array.from({ length: 8 }, () => 'a'.repeat(2049));
       const result = parseOAuthClientCredentialsInput(
         { ...validMinimal, resource: resources },
@@ -251,7 +250,6 @@ describe('parseOAuthClientCredentialsInput', () => {
       );
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      // per-entry limit triggers first (2049 > 2048)
       expect(result.code).toBe('field_too_long');
       expect(result.field).toBe('resource');
     });
@@ -269,6 +267,18 @@ describe('parseOAuthClientCredentialsInput', () => {
       expect(result.ok).toBe(false);
       if (result.ok) return;
       expect(result.code).toBe('aggregate_too_long');
+      expect(result.field).toBe('resource');
+    });
+
+    it('accepts an array exactly at the aggregate limit (8192 chars)', () => {
+      // 4 entries × 2048 chars = 8192 — exactly at the limit, should pass
+      const resources = Array.from({ length: 4 }, () => 'a'.repeat(2048));
+      expect(resources.reduce((s, e) => s + e.length, 0)).toBe(8192);
+      const result = parseOAuthClientCredentialsInput(
+        { ...validMinimal, resource: resources },
+        { validateTokenEndpoint: acceptAll },
+      );
+      expect(result.ok).toBe(true);
     });
 
     it('rejects an array exceeding the count limit', () => {
@@ -303,34 +313,9 @@ describe('parseOAuthClientCredentialsInput', () => {
       expect(result.code).toBe('invalid_field_type');
     });
 
-    it('rejects when aggregate character length exceeds 8192 (entries individually valid)', () => {
-      // 5 entries × 1700 chars each = 8500, all under per-entry limit of 2048 and count ≤ 8
-      const longUri = 'https://api.example.com/' + 'a'.repeat(1675); // 1700 chars total
-      const resources = Array.from({ length: 5 }, () => longUri);
-      const result = parseOAuthClientCredentialsInput(
-        { ...validMinimal, resource: resources },
-        { validateTokenEndpoint: acceptAll },
-      );
-      expect(result.ok).toBe(false);
-      if (result.ok) return;
-      expect(result.code).toBe('aggregate_too_long');
-      expect(result.field).toBe('resource');
-    });
-
-    it('accepts arrays whose aggregate length is exactly at the limit', () => {
-      // 4 entries × 2048 = 8192 — exactly at the boundary
-      const resources = Array.from({ length: 4 }, () => 'https://api.example.com/' + 'a'.repeat(2024));
-      const result = parseOAuthClientCredentialsInput(
-        { ...validMinimal, resource: resources },
-        { validateTokenEndpoint: acceptAll },
-      );
-      expect(result.ok).toBe(true);
-    });
   });
 
-  // ── Scalar collision: DB encoding makes any scalar safe ─────
-  // The DB layer uses a "json1:" prefix when storing arrays (not startsWith('['))
-  // so scalar values starting with "[" are stored and decoded as scalars correctly.
+  // ── Scalar round-trip ────────────────────────────────────────
   it('accepts a scalar resource that starts with a scheme letter', () => {
     const result = parseOAuthClientCredentialsInput(
       { ...validMinimal, resource: 'https://api.example.com' },

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -4172,6 +4172,7 @@ components:
             - invalid_url
             - invalid_env_reference
             - invalid_auth_method_value
+            - array_too_many
           description: Stable rejection tag. UI maps this to operator-friendly prose.
         field:
           type: string
@@ -10784,9 +10785,16 @@ paths:
                   maxLength: 1024
                   description: Space-separated OAuth scope values.
                 resource:
-                  type: string
-                  maxLength: 2048
-                  description: RFC 8707 resource indicator.
+                  oneOf:
+                    - type: string
+                      maxLength: 2048
+                    - type: array
+                      items:
+                        type: string
+                        maxLength: 2048
+                      minItems: 1
+                      maxItems: 8
+                  description: RFC 8707 resource indicator. Accepts a single URI string or an array of up to 8 URI strings for multi-resource authorization servers (Keycloak strict, AWS Cognito multi-RS).
                 audience:
                   type: string
                   maxLength: 2048

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -4173,6 +4173,8 @@ components:
             - invalid_env_reference
             - invalid_auth_method_value
             - array_too_many
+            - array_too_few
+            - aggregate_too_long
           description: Stable rejection tag. UI maps this to operator-friendly prose.
         field:
           type: string

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -10785,7 +10785,7 @@ paths:
                   maxLength: 1024
                   description: Space-separated OAuth scope values.
                 resource:
-                  oneOf:
+                  anyOf:
                     - type: string
                       maxLength: 2048
                     - type: array
@@ -10794,7 +10794,7 @@ paths:
                         maxLength: 2048
                       minItems: 1
                       maxItems: 8
-                  description: RFC 8707 resource indicator. Accepts a single URI string or an array of up to 8 URI strings for multi-resource authorization servers (Keycloak strict, AWS Cognito multi-RS).
+                  description: RFC 8707 resource indicator. Accepts a single URI string or an array of 1–8 URI strings for multi-resource authorization servers (Keycloak strict, AWS Cognito multi-RS).
                 audience:
                   type: string
                   maxLength: 2048


### PR DESCRIPTION
Refs #2805

## What

Extends the server-side OAuth client-credentials credential store to accept `resource` as either a scalar string **or** an array of up to 8 URI strings (RFC 8707 multi-resource indicators), without a database migration.

## Why

Some authorization servers (Keycloak strict mode, AWS Cognito with multiple resource servers) require more than one `resource=` parameter on the token request. `@adcp/sdk` already serialises `resource: string[]` as repeated form fields; the server just needed to accept, store, and decode arrays.

## Changes

| File | Change |
|---|---|
| `server/src/routes/helpers/oauth-client-credentials-input.ts` | New `parseResourceField` handles `string \| string[]`; empty array → null; `array_too_many` error code added |
| `server/src/db/agent-context-db.ts` | Arrays JSON-encoded on write; decoded with `startsWith('[')` heuristic + type-guard on read |
| `server/src/db/compliance-db.ts` | Same decode pattern in `resolveOwnerAuth` |
| `server/src/services/oauth-client-credentials-exchange.ts` | `form.set` → `form.append` loop so each entry becomes a separate `resource=` parameter |
| `server/src/addie/mcp/member-tools.ts` | `save_agent` MCP tool schema: `oneOf [string, string[]]` |
| `server/src/routes/registry-api.ts` | OpenAPI Zod schema: `z.union([z.string(), z.array(z.string()).max(8)])` |
| `static/openapi/registry.yaml` | Static spec: `resource` updated to `oneOf`, `array_too_many` added to `CredentialSaveValidationError.code` enum |
| `server/tests/unit/oauth-client-credentials-input.test.ts` | 6 new cases: single-element array, 8-element array, count limit, entry length limit, non-string entry, empty array |
| `server/tests/unit/oauth-client-credentials-exchange.test.ts` | New case: multi-resource emits two `resource=` parameters |

## Non-breaking justification

- Existing scalar rows in `oauth_cc_resource` decode unchanged (the `else` branch returns the raw string; RFC 8707 URIs never start with `[`).
- No DB migration required.
- No AdCP protocol changeset (server/application work only).

## Pre-PR review sign-offs

| Reviewer | Findings | Resolved |
|---|---|---|
| `code-reviewer` | Empty `[]` passes validator; `JSON.parse` result unguarded | ✅ Both fixed in commit `60e6b06d` |
| `security-reviewer` | `form.set` breaks for arrays; OpenAPI spec stale; `JSON.parse` unguarded; empty `[]` accepted | ✅ All fixed in commit `60e6b06d` |

Pre-existing gaps noted but out of scope for this PR (tracked separately):
- `$ENV:` prefix not validated for `resource`, `scope`, `audience` scalar values (pre-dates this PR; only `client_id`/`client_secret` are guarded)
- NUL-byte sanitisation for `resource`, `scope`, `audience`

---

> **Triage-managed PR** — opened by the `claude-code` triage routine on behalf of @bokelley's `/triage execute` request.
> Session: https://claude.ai/code/session_01MK4oWMbWyxRe9gZLYQCiMa

---
_Generated by [Claude Code](https://claude.ai/code/session_01MK4oWMbWyxRe9gZLYQCiMa)_