### PR TITLE
feat(schemas): two-tier discriminated union for Format.assets[] items

### DIFF
--- a/.changeset/two-tier-format-assets-discriminator.md
+++ b/.changeset/two-tier-format-assets-discriminator.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Restructure `Format.assets[]` oneOf from a flat 16-variant union to a two-tier discriminated union. Outer discriminator on `item_type` ("individual" | "repeatable_group"); inner discriminator on `asset_type` for the 15 individual-asset variants. Adds `discriminator.propertyName` hints at both tiers and direct `required` constraints on each variant so codegen tools (openapi-generator, quicktype) produce proper discriminated-union types. Wire-payload acceptance set is unchanged.

--- a/scripts/oneof-discriminators.baseline.json
+++ b/scripts/oneof-discriminators.baseline.json
@@ -191,11 +191,6 @@
       "variants": 3,
       "note": "0:[exemplars] | 1:[evaluator_id] | 2:[agent_url]"
     },
-    "core/format.json##/properties/assets/items/oneOf": {
-      "kind": "dangerous",
-      "variants": 16,
-      "note": "shared-required=[∅]; 0:req=[∅] | 1:req=[∅] | 2:req=[∅] | 3:req=[∅] | 4:req=[∅] | 5:req=[∅] | 6:req=[∅] | 7:req=[∅] | 8:req=[∅] | 9:req=[∅] | 10:req=[∅] | 11:req=[∅] | 12:req=[∅] | 13:req=[∅] | 14:req=[∅] | 15:req=[item_type,asset_group_id,required,min_count,max_count,assets]"
-    },
     "core/format.json##/properties/renders/items/oneOf": {
       "kind": "narrowable",
       "variants": 2,

--- a/static/schemas/source/core/format.json
+++ b/static/schemas/source/core/format.json
@@ -206,154 +206,181 @@
       "type": "array",
       "description": "Array of all assets supported for this format. Each asset is identified by its asset_id, which must be used as the key in creative manifests. Use the 'required' boolean on each asset to indicate whether it's mandatory.",
       "items": {
+        "discriminator": { "propertyName": "item_type" },
         "oneOf": [
           {
-            "title": "IndividualImageAsset",
-            "description": "Image asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+            "type": "object",
+            "description": "Individual asset slot",
             "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "image" },
-              "requirements": { "$ref": "/schemas/core/requirements/image-asset-requirements.json" }
-            }
-          },
-          {
-            "title": "IndividualVideoAsset",
-            "description": "Video asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "video" },
-              "requirements": { "$ref": "/schemas/core/requirements/video-asset-requirements.json" }
-            }
-          },
-          {
-            "title": "IndividualAudioAsset",
-            "description": "Audio asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "audio" },
-              "requirements": { "$ref": "/schemas/core/requirements/audio-asset-requirements.json" }
-            }
-          },
-          {
-            "title": "IndividualTextAsset",
-            "description": "Text asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "text" },
-              "requirements": { "$ref": "/schemas/core/requirements/text-asset-requirements.json" }
-            }
-          },
-          {
-            "title": "IndividualMarkdownAsset",
-            "description": "Markdown asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "markdown" },
-              "requirements": { "$ref": "/schemas/core/requirements/markdown-asset-requirements.json" }
-            }
-          },
-          {
-            "title": "IndividualHtmlAsset",
-            "description": "HTML asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "html" },
-              "requirements": { "$ref": "/schemas/core/requirements/html-asset-requirements.json" }
-            }
-          },
-          {
-            "title": "IndividualCssAsset",
-            "description": "CSS asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "css" },
-              "requirements": { "$ref": "/schemas/core/requirements/css-asset-requirements.json" }
-            }
-          },
-          {
-            "title": "IndividualJavaScriptAsset",
-            "description": "JavaScript asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "javascript" },
-              "requirements": { "$ref": "/schemas/core/requirements/javascript-asset-requirements.json" }
-            }
-          },
-          {
-            "title": "IndividualZipAsset",
-            "description": "Zip-bundled asset (HTML5 banner bundles, etc.)",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "zip" }
-            }
-          },
-          {
-            "title": "IndividualVastAsset",
-            "description": "VAST asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "vast" },
-              "requirements": { "$ref": "/schemas/core/requirements/vast-asset-requirements.json" }
-            }
-          },
-          {
-            "title": "IndividualDaastAsset",
-            "description": "DAAST asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "daast" },
-              "requirements": { "$ref": "/schemas/core/requirements/daast-asset-requirements.json" }
-            }
-          },
-          {
-            "title": "IndividualUrlAsset",
-            "description": "URL asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "url" },
-              "requirements": { "$ref": "/schemas/core/requirements/url-asset-requirements.json" }
-            }
-          },
-          {
-            "title": "IndividualWebhookAsset",
-            "description": "Webhook asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "webhook" },
-              "requirements": { "$ref": "/schemas/core/requirements/webhook-asset-requirements.json" }
-            }
-          },
-          {
-            "title": "IndividualBriefAsset",
-            "description": "Brief asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "brief" }
-            }
-          },
-          {
-            "title": "IndividualCatalogAsset",
-            "description": "Catalog asset",
-            "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
-            "properties": {
-              "item_type": { "const": "individual" },
-              "asset_type": { "const": "catalog" },
-              "requirements": { "$ref": "/schemas/core/requirements/catalog-requirements.json" }
-            }
+              "item_type": { "type": "string", "const": "individual" }
+            },
+            "required": ["item_type"],
+            "discriminator": { "propertyName": "asset_type" },
+            "oneOf": [
+              {
+                "title": "IndividualImageAsset",
+                "description": "Image asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "image" },
+                  "requirements": { "$ref": "/schemas/core/requirements/image-asset-requirements.json" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualVideoAsset",
+                "description": "Video asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "video" },
+                  "requirements": { "$ref": "/schemas/core/requirements/video-asset-requirements.json" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualAudioAsset",
+                "description": "Audio asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "audio" },
+                  "requirements": { "$ref": "/schemas/core/requirements/audio-asset-requirements.json" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualTextAsset",
+                "description": "Text asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "text" },
+                  "requirements": { "$ref": "/schemas/core/requirements/text-asset-requirements.json" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualMarkdownAsset",
+                "description": "Markdown asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "markdown" },
+                  "requirements": { "$ref": "/schemas/core/requirements/markdown-asset-requirements.json" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualHtmlAsset",
+                "description": "HTML asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "html" },
+                  "requirements": { "$ref": "/schemas/core/requirements/html-asset-requirements.json" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualCssAsset",
+                "description": "CSS asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "css" },
+                  "requirements": { "$ref": "/schemas/core/requirements/css-asset-requirements.json" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualJavaScriptAsset",
+                "description": "JavaScript asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "javascript" },
+                  "requirements": { "$ref": "/schemas/core/requirements/javascript-asset-requirements.json" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualZipAsset",
+                "description": "Zip-bundled asset (HTML5 banner bundles, etc.)",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "zip" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualVastAsset",
+                "description": "VAST asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "vast" },
+                  "requirements": { "$ref": "/schemas/core/requirements/vast-asset-requirements.json" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualDaastAsset",
+                "description": "DAAST asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "daast" },
+                  "requirements": { "$ref": "/schemas/core/requirements/daast-asset-requirements.json" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualUrlAsset",
+                "description": "URL asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "url" },
+                  "requirements": { "$ref": "/schemas/core/requirements/url-asset-requirements.json" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualWebhookAsset",
+                "description": "Webhook asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "webhook" },
+                  "requirements": { "$ref": "/schemas/core/requirements/webhook-asset-requirements.json" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualBriefAsset",
+                "description": "Brief asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "brief" }
+                },
+                "required": ["asset_type"]
+              },
+              {
+                "title": "IndividualCatalogAsset",
+                "description": "Catalog asset",
+                "allOf": [{ "$ref": "#/$defs/baseIndividualAsset" }],
+                "properties": {
+                  "item_type": { "const": "individual" },
+                  "asset_type": { "const": "catalog" },
+                  "requirements": { "$ref": "/schemas/core/requirements/catalog-requirements.json" }
+                },
+                "required": ["asset_type"]
+              }
+            ]
           },
           {
             "title": "RepeatableGroupAsset",


### PR DESCRIPTION
## Summary

Closes #3935.

Restructures `Format.assets[]` from a flat 16-variant `oneOf` to a two-tier discriminated union so codegen tools (openapi-generator, quicktype) can produce proper discriminated-union types instead of a large `any`-typed union.

### What changed

**`static/schemas/source/core/format.json`** — `assets.items` restructured:

- **Outer tier**: `discriminator: { propertyName: "item_type" }` with two branches:
  - `"individual"` — carries an inner `oneOf` over 15 asset types
  - `"repeatable_group"` — the existing group shape
- **Inner tier (individual)**: `discriminator: { propertyName: "asset_type" }` over all 15 variants (`image`, `video`, `audio`, `text`, `markdown`, `html`, `css`, `javascript`, `zip`, `vast`, `daast`, `url`, `webhook`, `brief`, `catalog`)
- **Inner tier (group assets)**: `discriminator: { propertyName: "asset_type" }` over 13 group variants
- Each variant carries `required: ["asset_type"]` directly (required by `audit-oneof.mjs`'s one-hop resolver — redundant with `allOf` inheritance but necessary for the audit tool)

**`scripts/oneof-discriminators.baseline.json`** — Removes the `dangerous` entry for `core/format.json##/properties/assets/items/oneOf` (was: 16 variants, all `req=[∅]`). The restructured paths are now classified `discriminated` by the audit tool and are not tracked in the baseline.

**`.changeset/two-tier-format-assets-discriminator.md`** — `minor` bump for `adcontextprotocol`.

### Non-breaking

The wire-payload acceptance set is unchanged. `discriminator.propertyName` is an OAS 3.1 tooling hint — Ajv ignores it at validation time and validates each `oneOf` branch normally. All payloads accepted before this change are accepted after; none that were rejected are now accepted.

### Test results

All schema-relevant gates pass:
- `test:json-schema` — 284 blocks validated ✓
- `test:schemas` — 20/20 ✓
- `test:composed` — 132/132 ✓
- `test:oneof-discriminators` — no new undiscriminated oneOf (✓ 56 ⚠ 46 ✗ 24)
- `build` — clean ✓
- `typecheck` — clean ✓
- `test:unit` — 1026/1026 ✓

> **Note on precommit hook**: The `precommit:server-unit` suite (~285s) exceeds its 240s timeout in this remote execution environment (slower CPUs than the hook was calibrated for). All 5183 tests pass when run directly (`358 passed, 30 skipped`). This is a pre-existing environment constraint, not a regression — CI will verify on normal hardware.

### Pre-PR review sign-offs

Two expert agents were consulted before implementation and their caveats incorporated:

- **ad-tech-protocol-expert** ✓ — Approved with three caveats: (1) add `"type": "object"` to the individual wrapper, (2) run `--update` on the baseline, (3) `minor` changeset. All three incorporated.
- **adtech-product-expert** ✓ — Approved; confirmed non-breaking, backward-compatible, correct changeset tier.

---

<!-- triage-managed-pr: issue=3935 session=https://claude.ai/code/session_01WrJsbX2pgzs7beqSSAGRdH -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrJsbX2pgzs7beqSSAGRdH)_