### PR TITLE
fix(security): Bad HTML filtering regexp

### DIFF
--- a/server/tests/unit/addie/brand-canonical-tools.test.ts
+++ b/server/tests/unit/addie/brand-canonical-tools.test.ts
@@ -574,7 +574,7 @@ describe('buildNotificationEmail (HTML escaping)', () => {
     });
 
     // Raw injected sequences MUST NOT appear unescaped in the HTML body.
-    expect(email.html).not.toMatch(/<script>/);
+    expect(email.html).not.toMatch(/<script>/i);
     expect(email.html).not.toContain('house"injected".com');
     expect(email.html).not.toContain('evil"\'<x>');
     // Escaped versions MUST be present.


### PR DESCRIPTION
Potential fix for [https://github.com/adcontextprotocol/adcp/security/code-scanning/1325](https://github.com/adcontextprotocol/adcp/security/code-scanning/1325)

Use a case-insensitive regex for the script-tag check in the HTML-escaping test.

Best fix (minimal functional change): in `server/tests/unit/addie/brand-canonical-tools.test.ts`, update the assertion at line 577 from `/<script>/` to `/<script>/i`. This preserves the original intent (ensure no raw script tag appears) while correctly covering uppercase/mixed-case HTML tag variants. No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
