### PR TITLE
Reject legacy bidding fields for `new_packages` in update-media-buy-request schema

### DIFF
--- a/static/schemas/source/media-buy/update-media-buy-request.json
+++ b/static/schemas/source/media-buy/update-media-buy-request.json
@@ -41,6 +41,33 @@
                 ]
               }
             }
+          },
+          "new_packages": {
+            "items": {
+              "not": {
+                "anyOf": [
+                  { "required": ["bid_price"] },
+                  {
+                    "properties": {
+                      "optimization_goals": {
+                        "contains": {
+                          "properties": {
+                            "target": {
+                              "properties": {
+                                "kind": { "enum": ["cost_per", "per_ad_spend"] }
+                              },
+                              "required": ["kind"]
+                            }
+                          },
+                          "required": ["target"]
+                        }
+                      }
+                    },
+                    "required": ["optimization_goals"]
+                  }
+                ]
+              }
+            }
           }
         }
       }

--- a/tests/composed-schema-validation.test.cjs
+++ b/tests/composed-schema-validation.test.cjs
@@ -770,6 +770,50 @@ async function runTests() {
   );
 
   await testSchemaRejection(
+    '/schemas/media-buy/update-media-buy-request.json',
+    {
+      idempotency_key: 'ambiguous-new-package-bid-001',
+      account: { account_id: 'acc_test_001' },
+      media_buy_id: 'mb_bidding_001',
+      bidding: { max_bid: 5 },
+      new_packages: [
+        {
+          product_id: 'display_standard',
+          pricing_option_id: 'cpm_auction',
+          budget: 10000,
+          bid_price: 4
+        }
+      ]
+    },
+    'Media-buy bidding rejects an inheriting new package with legacy bid_price'
+  );
+
+  await testSchemaRejection(
+    '/schemas/media-buy/update-media-buy-request.json',
+    {
+      idempotency_key: 'ambiguous-new-package-goal-01',
+      account: { account_id: 'acc_test_001' },
+      media_buy_id: 'mb_bidding_002',
+      bidding: { max_bid: 5 },
+      new_packages: [
+        {
+          product_id: 'display_standard',
+          pricing_option_id: 'cpm_auction',
+          budget: 10000,
+          optimization_goals: [
+            {
+              kind: 'event',
+              event_sources: [{ event_source_id: 'purchases', event_type: 'purchase' }],
+              target: { kind: 'cost_per', value: 25 }
+            }
+          ]
+        }
+      ]
+    },
+    'Media-buy bidding rejects an inheriting new package with a legacy monetary goal target'
+  );
+
+  await testSchemaRejection(
     '/schemas/media-buy/create-media-buy-request.json',
     {
       idempotency_key: 'fixed-missing-budget-001',


### PR DESCRIPTION
### Motivation

- Keep `update-media-buy-request` schema consistent with `create-media-buy-request` by preventing ambiguous/legacy bidding fields on newly added packages.

### Description

- Add validation to `static/schemas/source/media-buy/update-media-buy-request.json` to forbid `bid_price` on `new_packages` items.
- Add validation to `new_packages` items to reject `optimization_goals` whose `target.kind` is `cost_per` or `per_ad_spend` to disallow legacy monetary goal targets.
- Update `tests/composed-schema-validation.test.cjs` with two new `testSchemaRejection` cases that assert rejections for `new_packages` containing `bid_price` and a legacy monetary `target` respectively.

### Testing

- Ran the composed schema validation tests in `tests/composed-schema-validation.test.cjs` which include the two new `testSchemaRejection` cases, and they succeeded.
- Ran the full schema validation suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a70b90a391c832bae608ab4855018da)