### PR TITLE
fix(docs): publish default 3.1 routes

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -67,617 +67,6 @@
   "navigation": {
     "versions": [
       {
-        "version": "3.0",
-        "groups": [
-          {
-            "group": "Getting Started",
-            "pages": [
-              "dist/docs/3.0.22/intro",
-              "dist/docs/3.0.22/quickstart"
-            ]
-          },
-          {
-            "group": "Building with AdCP",
-            "expanded": false,
-            "pages": [
-              "dist/docs/3.0.22/building/index",
-              "dist/docs/3.0.22/building/schemas-and-sdks",
-              {
-                "group": "AdCP 3.x",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/reference/whats-new-in-v3",
-                  "dist/docs/3.0.22/reference/whats-new-in-3-1",
-                  "dist/docs/3.0.22/reference/migration/v3-readiness",
-                  "dist/docs/3.0.22/reference/migration/index",
-                  "dist/docs/3.0.22/reference/migration/prerelease-upgrades",
-                  "dist/docs/3.0.22/reference/migration/channels",
-                  "dist/docs/3.0.22/reference/migration/pricing",
-                  "dist/docs/3.0.22/reference/migration/geo-targeting",
-                  "dist/docs/3.0.22/reference/migration/creatives",
-                  "dist/docs/3.0.22/reference/migration/creative-transformers",
-                  "dist/docs/3.0.22/reference/migration/catalogs",
-                  "dist/docs/3.0.22/reference/migration/optimization-goals",
-                  "dist/docs/3.0.22/reference/migration/brand-identity",
-                  "dist/docs/3.0.22/reference/migration/signals",
-                  "dist/docs/3.0.22/reference/migration/audiences",
-                  "dist/docs/3.0.22/reference/migration/attribution",
-                  "dist/docs/3.0.22/reference/migration/media-buy-status"
-                ]
-              },
-              "dist/docs/3.0.22/protocol/architecture",
-              "dist/docs/3.0.22/protocol/design-principles",
-              "dist/docs/3.0.22/protocol/capabilities-explorer",
-              "dist/docs/3.0.22/spec-guidelines",
-              "dist/docs/3.0.22/protocol/required-tasks",
-              "dist/docs/3.0.22/protocol/calling-an-agent",
-              "dist/docs/3.0.22/protocol/format-references",
-              "dist/docs/3.0.22/protocol/snapshot-and-log",
-              {
-                "group": "Concepts",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/building/concepts/index",
-                  "dist/docs/3.0.22/building/concepts/protocol-comparison",
-                  "dist/docs/3.0.22/building/concepts/adcp-vs-openrtb",
-                  "dist/docs/3.0.22/building/concepts/how-agents-communicate",
-                  "dist/docs/3.0.22/building/concepts/security-model",
-                  "dist/docs/3.0.22/building/concepts/industry-landscape"
-                ]
-              },
-              {
-                "group": "Build by layer",
-                "pages": [
-                  {
-                    "group": "L4 — Business logic",
-                    "pages": [
-                      "dist/docs/3.0.22/building/by-layer/L4/index",
-                      "dist/docs/3.0.22/building/by-layer/L4/choose-your-sdk",
-                      "dist/docs/3.0.22/building/by-layer/L4/build-an-agent",
-                      "dist/docs/3.0.22/building/by-layer/L4/build-a-caller",
-                      "dist/docs/3.0.22/building/by-layer/L4/migrate-from-hand-rolled"
-                    ]
-                  },
-                  {
-                    "group": "L3 — Protocol semantics",
-                    "expanded": false,
-                    "pages": [
-                      "dist/docs/3.0.22/building/by-layer/L3/index",
-                      "dist/docs/3.0.22/building/by-layer/L3/task-lifecycle",
-                      "dist/docs/3.0.22/building/by-layer/L3/async-operations",
-                      "dist/docs/3.0.22/building/by-layer/L3/webhooks",
-                      "dist/docs/3.0.22/building/by-layer/L3/error-handling",
-                      "dist/docs/3.0.22/building/by-layer/L3/comply-test-controller"
-                    ]
-                  },
-                  {
-                    "group": "L2 — Auth & registry",
-                    "expanded": false,
-                    "pages": [
-                      "dist/docs/3.0.22/building/by-layer/L2/index",
-                      "dist/docs/3.0.22/building/by-layer/L2/authentication",
-                      "dist/docs/3.0.22/building/by-layer/L2/account-state",
-                      "dist/docs/3.0.22/building/by-layer/L2/accounts-and-agents",
-                      "dist/docs/3.0.22/building/by-layer/L2/context-sessions"
-                    ]
-                  },
-                  {
-                    "group": "L1 — Identity & signing",
-                    "expanded": false,
-                    "pages": [
-                      "dist/docs/3.0.22/building/by-layer/L1/index",
-                      "dist/docs/3.0.22/building/by-layer/L1/security",
-                      "dist/docs/3.0.22/building/by-layer/L1/request-signing",
-                      "dist/docs/3.0.22/building/by-layer/L1/webhook-verifier-tuning"
-                    ]
-                  },
-                  {
-                    "group": "L0 — Wire & transport",
-                    "expanded": false,
-                    "pages": [
-                      "dist/docs/3.0.22/building/by-layer/L0/index",
-                      "dist/docs/3.0.22/building/by-layer/L0/schemas",
-                      "dist/docs/3.0.22/building/by-layer/L0/mcp-guide",
-                      "dist/docs/3.0.22/building/by-layer/L0/a2a-guide",
-                      "dist/docs/3.0.22/building/by-layer/L0/a2a-response-format",
-                      "dist/docs/3.0.22/protocol/get_adcp_capabilities",
-                      "dist/docs/3.0.22/building/by-layer/L0/mcp-response-extraction",
-                      "dist/docs/3.0.22/building/by-layer/L0/a2a-response-extraction"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Cross-cutting",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/building/cross-cutting/sdk-stack",
-                  "dist/docs/3.0.22/building/cross-cutting/version-adaptation",
-                  "dist/docs/3.0.22/building/cross-cutting/known-ambiguities"
-                ]
-              },
-              {
-                "group": "Verification & trust",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/building/verification/conformance",
-                  "dist/docs/3.0.22/building/verification/compliance-catalog",
-                  "dist/docs/3.0.22/building/verification/storyboards-vs-scenarios",
-                  "dist/docs/3.0.22/building/verification/how-grading-works",
-                  "dist/docs/3.0.22/building/verification/validate-your-agent",
-                  "dist/docs/3.0.22/building/verification/validate-with-mock-fixtures",
-                  "dist/docs/3.0.22/building/verification/addie-socket-mode",
-                  "dist/docs/3.0.22/building/verification/grading",
-                  "dist/docs/3.0.22/building/verification/get-test-ready",
-                  "dist/docs/3.0.22/building/verification/aao-verified"
-                ]
-              },
-              {
-                "group": "Operating",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/building/operating/operating-an-agent",
-                  "dist/docs/3.0.22/building/operating/orchestrator-design",
-                  "dist/docs/3.0.22/building/operating/transport-errors",
-                  "dist/docs/3.0.22/building/operating/seller-integration",
-                  "dist/docs/3.0.22/building/operating/storyboard-troubleshooting"
-                ]
-              },
-              {
-                "group": "Accounts",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/accounts/overview",
-                  "dist/docs/3.0.22/accounts/tasks/sync_accounts",
-                  "dist/docs/3.0.22/accounts/tasks/list_accounts",
-                  "dist/docs/3.0.22/accounts/tasks/report_usage",
-                  "dist/docs/3.0.22/accounts/tasks/sync_governance",
-                  "dist/docs/3.0.22/accounts/tasks/get_account_financials"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Protocol",
-            "expanded": false,
-            "pages": [
-              {
-                "group": "Media Buy",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/media-buy/index",
-                  "dist/docs/3.0.22/media-buy/commerce-media",
-                  {
-                    "group": "Concepts",
-                    "pages": [
-                      "dist/docs/3.0.22/media-buy/product-discovery/index",
-                      "dist/docs/3.0.22/media-buy/product-discovery/brief-expectations",
-                      "dist/docs/3.0.22/media-buy/product-discovery/example-briefs",
-                      "dist/docs/3.0.22/media-buy/product-discovery/media-products",
-                      "dist/docs/3.0.22/media-buy/product-discovery/collections-and-installments",
-                      "dist/docs/3.0.22/media-buy/product-discovery/refinement",
-                      "dist/docs/3.0.22/media-buy/media-buys/index",
-                      "dist/docs/3.0.22/media-buy/media-buys/lifecycle",
-                      "dist/docs/3.0.22/media-buy/media-buys/optimization-reporting",
-                      "dist/docs/3.0.22/media-buy/media-buys/policy-compliance",
-                      "dist/docs/3.0.22/media-buy/creatives/index",
-                      "dist/docs/3.0.22/media-buy/conversion-tracking/index",
-                      "dist/docs/3.0.22/media-buy/advanced-topics/pricing-models",
-                      "dist/docs/3.0.22/media-buy/advanced-topics/targeting",
-                      "dist/docs/3.0.22/media-buy/advanced-topics/accountability",
-                      "dist/docs/3.0.22/media-buy/advanced-topics/billing-authority"
-                    ]
-                  },
-                  {
-                    "group": "Building",
-                    "pages": [
-                      "dist/docs/3.0.22/media-buy/capability-discovery/index",
-                      "dist/docs/3.0.22/media-buy/capability-discovery/implementing-standard-formats",
-                      "dist/docs/3.0.22/media-buy/advanced-topics/agentic-execution-engine",
-                      "dist/docs/3.0.22/media-buy/advanced-topics/accounts-and-security",
-                      "dist/docs/3.0.22/media-buy/advanced-topics/sandbox"
-                    ]
-                  },
-                  {
-                    "group": "Reference",
-                    "expanded": false,
-                    "pages": [
-                      "dist/docs/3.0.22/media-buy/specification",
-                      "dist/docs/3.0.22/media-buy/task-reference/index",
-                      "dist/docs/3.0.22/media-buy/task-reference/get_products",
-                      "dist/docs/3.0.22/media-buy/task-reference/create_media_buy",
-                      "dist/docs/3.0.22/media-buy/task-reference/sync_catalogs",
-                      "dist/docs/3.0.22/media-buy/task-reference/get_media_buys",
-                      "dist/docs/3.0.22/media-buy/task-reference/get_media_buy_delivery",
-                      "dist/docs/3.0.22/media-buy/task-reference/update_media_buy",
-                      "dist/docs/3.0.22/media-buy/task-reference/provide_performance_feedback",
-                      "dist/docs/3.0.22/media-buy/task-reference/sync_event_sources",
-                      "dist/docs/3.0.22/media-buy/task-reference/log_event",
-                      "dist/docs/3.0.22/media-buy/task-reference/sync_audiences"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Creative",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/creative/index",
-                  {
-                    "group": "Concepts",
-                    "pages": [
-                      "dist/docs/3.0.22/creative/key-concepts",
-                      "dist/docs/3.0.22/creative/ai-creative-overview",
-                      "dist/docs/3.0.22/creative/generative-creative",
-                      "dist/docs/3.0.22/creative/creative-libraries",
-                      "dist/docs/3.0.22/creative/catalogs",
-                      "dist/docs/3.0.22/creative/catalog-schemas"
-                    ]
-                  },
-                  {
-                    "group": "Building Creative Agents",
-                    "pages": [
-                      "dist/docs/3.0.22/creative/implementing-creative-agents",
-                      "dist/docs/3.0.22/creative/buyer-attached-inputs",
-                      "dist/docs/3.0.22/creative/sales-agent-creative-capabilities",
-                      "dist/docs/3.0.22/creative/multi-agent-orchestration",
-                      "dist/docs/3.0.22/creative/creative-manifests",
-                      "dist/docs/3.0.22/creative/private-assets"
-                    ]
-                  },
-                  {
-                    "group": "Formats and Assets",
-                    "pages": [
-                      "dist/docs/3.0.22/creative/formats",
-                      "dist/docs/3.0.22/creative/canonical-formats",
-                      "dist/docs/3.0.22/creative/asset-types",
-                      "dist/docs/3.0.22/creative/published-post-reference-creatives",
-                      "dist/docs/3.0.22/creative/template-format-ids",
-                      "dist/docs/3.0.22/creative/universal-macros"
-                    ]
-                  },
-                  {
-                    "group": "Channel Guides",
-                    "pages": [
-                      "dist/docs/3.0.22/creative/channels/video",
-                      "dist/docs/3.0.22/creative/channels/ctv",
-                      "dist/docs/3.0.22/creative/channels/broadcast",
-                      "dist/docs/3.0.22/creative/channels/display",
-                      "dist/docs/3.0.22/creative/channels/audio",
-                      "dist/docs/3.0.22/creative/channels/dooh",
-                      "dist/docs/3.0.22/creative/channels/carousels",
-                      "dist/docs/3.0.22/creative/channels/social-native"
-                    ]
-                  },
-                  {
-                    "group": "Compliance",
-                    "pages": [
-                      "dist/docs/3.0.22/creative/accessibility",
-                      "dist/docs/3.0.22/creative/provenance"
-                    ]
-                  },
-                  {
-                    "group": "Reference",
-                    "expanded": false,
-                    "pages": [
-                      "dist/docs/3.0.22/creative/specification",
-                      "dist/docs/3.0.22/creative/task-reference/build_creative",
-                      "dist/docs/3.0.22/creative/task-reference/preview_creative",
-                      "dist/docs/3.0.22/creative/task-reference/preview_creative-advanced",
-                      "dist/docs/3.0.22/creative/task-reference/list_creative_formats",
-                      "dist/docs/3.0.22/creative/task-reference/list_transformers",
-                      "dist/docs/3.0.22/creative/task-reference/list_creatives",
-                      "dist/docs/3.0.22/creative/task-reference/sync_creatives",
-                      "dist/docs/3.0.22/creative/task-reference/get_creative_delivery"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Governance",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/governance/overview",
-                  "dist/docs/3.0.22/governance/rfc-process",
-                  "dist/docs/3.0.22/governance/embedded-human-judgment",
-                  "dist/docs/3.0.22/governance/policy-registry",
-                  "dist/docs/3.0.22/governance/policy-registry-sync",
-                  "dist/docs/3.0.22/governance/policy-attribution",
-                  "dist/docs/3.0.22/governance/annex-iii-obligations",
-                  "dist/docs/3.0.22/governance/working-group-charter",
-                  {
-                    "group": "Property Governance",
-                    "pages": [
-                      "dist/docs/3.0.22/governance/property/index",
-                      "dist/docs/3.0.22/governance/property/adagents",
-                      "dist/docs/3.0.22/governance/property/managed-networks",
-                      "dist/docs/3.0.22/governance/property/authorized-properties",
-                      "dist/docs/3.0.22/governance/property/specification",
-                      {
-                        "group": "Tasks",
-                        "pages": [
-                          "dist/docs/3.0.22/governance/property/tasks/index",
-                          "dist/docs/3.0.22/governance/property/tasks/property_lists",
-                          "dist/docs/3.0.22/governance/property/tasks/validate_property_delivery"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Collection Governance",
-                    "pages": [
-                      "dist/docs/3.0.22/governance/collection/index",
-                      "dist/docs/3.0.22/governance/collection/tasks/collection_lists"
-                    ]
-                  },
-                  {
-                    "group": "Content Standards",
-                    "pages": [
-                      "dist/docs/3.0.22/governance/content-standards/index",
-                      "dist/docs/3.0.22/governance/content-standards/artifacts",
-                      "dist/docs/3.0.22/governance/content-standards/implementation-guide",
-                      {
-                        "group": "Tasks",
-                        "pages": [
-                          "dist/docs/3.0.22/governance/content-standards/tasks/list_content_standards",
-                          "dist/docs/3.0.22/governance/content-standards/tasks/get_content_standards",
-                          "dist/docs/3.0.22/governance/content-standards/tasks/create_content_standards",
-                          "dist/docs/3.0.22/governance/content-standards/tasks/update_content_standards",
-                          "dist/docs/3.0.22/governance/content-standards/tasks/calibrate_content",
-                          "dist/docs/3.0.22/governance/content-standards/tasks/get_media_buy_artifacts",
-                          "dist/docs/3.0.22/governance/content-standards/tasks/validate_content_delivery"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Creative Governance",
-                    "pages": [
-                      "dist/docs/3.0.22/governance/creative/index",
-                      "dist/docs/3.0.22/governance/creative/get_creative_features",
-                      "dist/docs/3.0.22/governance/creative/provenance-verification"
-                    ]
-                  },
-                  {
-                    "group": "Campaign Governance",
-                    "pages": [
-                      "dist/docs/3.0.22/governance/campaign/index",
-                      "dist/docs/3.0.22/governance/campaign/responsibilities",
-                      "dist/docs/3.0.22/governance/campaign/safety-model",
-                      "dist/docs/3.0.22/governance/campaign/specification",
-                      "dist/docs/3.0.22/governance/campaign/audit-trail",
-                      {
-                        "group": "Tasks",
-                        "pages": [
-                          "dist/docs/3.0.22/governance/campaign/tasks/index",
-                          "dist/docs/3.0.22/governance/campaign/tasks/sync_plans",
-                          "dist/docs/3.0.22/governance/campaign/tasks/report_plan_outcome",
-                          "dist/docs/3.0.22/governance/campaign/tasks/check_governance",
-                          "dist/docs/3.0.22/governance/campaign/tasks/get_plan_audit_logs"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Sponsored Intelligence",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/sponsored-intelligence/overview",
-                  "dist/docs/3.0.22/sponsored-intelligence/monetizing-ai",
-                  {
-                    "group": "Concepts",
-                    "pages": [
-                      "dist/docs/3.0.22/sponsored-intelligence/product-spectrum",
-                      "dist/docs/3.0.22/sponsored-intelligence/networks",
-                      "dist/docs/3.0.22/sponsored-intelligence/workflow",
-                      "dist/docs/3.0.22/sponsored-intelligence/measurement"
-                    ]
-                  },
-                  {
-                    "group": "SI Chat Protocol",
-                    "pages": [
-                      "dist/docs/3.0.22/sponsored-intelligence/si-chat-protocol",
-                      "dist/docs/3.0.22/sponsored-intelligence/implementing-si-agents",
-                      "dist/docs/3.0.22/sponsored-intelligence/implementing-si-hosts"
-                    ]
-                  },
-                  {
-                    "group": "Reference",
-                    "expanded": false,
-                    "pages": [
-                      "dist/docs/3.0.22/sponsored-intelligence/specification",
-                      "dist/docs/3.0.22/sponsored-intelligence/tasks/index",
-                      "dist/docs/3.0.22/sponsored-intelligence/tasks/si_get_offering",
-                      "dist/docs/3.0.22/sponsored-intelligence/tasks/si_initiate_session",
-                      "dist/docs/3.0.22/sponsored-intelligence/tasks/si_send_message",
-                      "dist/docs/3.0.22/sponsored-intelligence/tasks/si_terminate_session"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Brand",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/brand-protocol/index",
-                  "dist/docs/3.0.22/brand-protocol/key-concepts",
-                  "dist/docs/3.0.22/brand-protocol/walkthrough-rights-licensing",
-                  "dist/docs/3.0.22/brand-protocol/for-advertisers",
-                  "dist/docs/3.0.22/brand-protocol/for-rights-holders",
-                  "dist/docs/3.0.22/brand-protocol/seller-setup",
-                  "dist/docs/3.0.22/brand-protocol/brand-json",
-                  "dist/docs/3.0.22/brand-protocol/building-a-brand-agent",
-                  "dist/docs/3.0.22/brand-protocol/ui-guidance",
-                  {
-                    "group": "Tasks",
-                    "pages": [
-                      "dist/docs/3.0.22/brand-protocol/tasks/get_brand_identity",
-                      "dist/docs/3.0.22/brand-protocol/tasks/verify_brand_claim",
-                      "dist/docs/3.0.22/brand-protocol/tasks/verify_brand_claims",
-                      "dist/docs/3.0.22/brand-protocol/tasks/get_rights",
-                      "dist/docs/3.0.22/brand-protocol/tasks/acquire_rights",
-                      "dist/docs/3.0.22/brand-protocol/tasks/update_rights"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Signals",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/signals/overview",
-                  "dist/docs/3.0.22/signals/key-concepts",
-                  "dist/docs/3.0.22/signals/ecosystem",
-                  "dist/docs/3.0.22/signals/data-providers",
-                  {
-                    "group": "Reference",
-                    "expanded": false,
-                    "pages": [
-                      "dist/docs/3.0.22/signals/specification",
-                      "dist/docs/3.0.22/signals/tasks/get_signals",
-                      "dist/docs/3.0.22/signals/tasks/activate_signal"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Trusted Match",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/trusted-match/index",
-                  "dist/docs/3.0.22/trusted-match/ai-mediation",
-                  "dist/docs/3.0.22/trusted-match/buyer-guide",
-                  "dist/docs/3.0.22/trusted-match/execution-gap",
-                  "dist/docs/3.0.22/trusted-match/context-and-identity",
-                  "dist/docs/3.0.22/trusted-match/specification",
-                  "dist/docs/3.0.22/trusted-match/router-architecture",
-                  "dist/docs/3.0.22/trusted-match/privacy-architecture",
-                  "dist/docs/3.0.22/trusted-match/data-protection-roles",
-                  "dist/docs/3.0.22/trusted-match/migration-from-axe",
-                  {
-                    "group": "Surface Guides",
-                    "pages": [
-                      "dist/docs/3.0.22/trusted-match/surfaces/web",
-                      "dist/docs/3.0.22/trusted-match/surfaces/ctv",
-                      "dist/docs/3.0.22/trusted-match/surfaces/mobile",
-                      "dist/docs/3.0.22/trusted-match/surfaces/retail-media",
-                      "dist/docs/3.0.22/trusted-match/surfaces/ai-assistants"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "group": "FAQ",
-            "pages": [
-              "dist/docs/3.0.22/faq"
-            ]
-          },
-          {
-            "group": "Trust & Security",
-            "expanded": false,
-            "pages": [
-              "dist/docs/3.0.22/trust",
-              "dist/docs/3.0.22/verification/overview",
-              "dist/docs/3.0.22/ai-disclosure",
-              "dist/docs/3.0.22/reference/privacy-considerations",
-              "dist/docs/3.0.22/reference/known-limitations"
-            ]
-          },
-          {
-            "group": "Reference",
-            "expanded": false,
-            "pages": [
-              {
-                "group": "Registry API",
-                "openapi": {
-                  "source": "https://agenticadvertising.org/openapi/registry.yaml",
-                  "directory": "dist/docs/3.0.21/registry/api-reference"
-                },
-                "pages": [
-                  "dist/docs/3.0.22/registry/index",
-                  "dist/docs/3.0.22/registry/registering-an-agent",
-                  "dist/docs/3.0.22/registry/maintaining-your-agent"
-                ]
-              },
-              "dist/docs/3.0.22/reference/gmsf-reference",
-              "dist/docs/3.0.22/reference/media-channel-taxonomy",
-              "dist/docs/3.0.22/measurement/taxonomy",
-              "dist/docs/3.0.22/reference/roadmap",
-              "dist/docs/3.0.22/reference/versions",
-              "dist/docs/3.0.22/reference/versioning",
-              "dist/docs/3.0.22/reference/specification-lifecycle",
-              "dist/docs/3.0.22/reference/url-canonicalization",
-              "dist/docs/3.0.22/reference/verifying-protocol-tarballs",
-              "dist/docs/3.0.22/reference/test-vectors/index",
-              "dist/docs/3.0.22/reference/experimental-status",
-              "dist/docs/3.0.22/reference/schema-extensions",
-              "dist/docs/3.0.22/reference/v2-sunset",
-              "dist/docs/3.0.22/reference/release-notes",
-              "dist/docs/3.0.22/reference/changelog",
-              "dist/docs/3.0.22/reference/implementor-faq",
-              "dist/docs/3.0.22/reference/glossary",
-              "dist/docs/3.0.22/community/working-group",
-              "dist/docs/3.0.22/community/joining-slack"
-            ]
-          },
-          {
-            "group": "Certification",
-            "expanded": false,
-            "pages": [
-              "dist/docs/3.0.22/learning/overview",
-              "dist/docs/3.0.22/learning/instructional-design",
-              "dist/docs/3.0.22/learning/failure-mode-scope",
-              {
-                "group": "Basics (free)",
-                "pages": [
-                  "dist/docs/3.0.22/learning/foundations/a1-agentic-advertising",
-                  "dist/docs/3.0.22/learning/foundations/a2-protocol-architecture",
-                  "dist/docs/3.0.22/learning/foundations/a2b-testing-your-first-agent",
-                  "dist/docs/3.0.22/learning/foundations/a3-ecosystem-governance"
-                ]
-              },
-              {
-                "group": "Role tracks",
-                "pages": [
-                  "dist/docs/3.0.22/learning/tracks/publisher",
-                  "dist/docs/3.0.22/learning/tracks/buyer",
-                  "dist/docs/3.0.22/learning/tracks/platform"
-                ]
-              },
-              {
-                "group": "Specialist modules",
-                "pages": [
-                  "dist/docs/3.0.22/learning/specialist/media-buy",
-                  "dist/docs/3.0.22/learning/specialist/creative",
-                  "dist/docs/3.0.22/learning/specialist/signals",
-                  "dist/docs/3.0.22/learning/specialist/governance",
-                  "dist/docs/3.0.22/learning/specialist/sponsored-intelligence",
-                  "dist/docs/3.0.22/learning/specialist/security"
-                ]
-              },
-              {
-                "group": "Policies",
-                "expanded": false,
-                "pages": [
-                  "dist/docs/3.0.22/learning/policies/nondiscrimination",
-                  "dist/docs/3.0.22/learning/policies/learner-records",
-                  "dist/docs/3.0.22/learning/policies/recertification",
-                  "dist/docs/3.0.22/learning/policies/complaints",
-                  "dist/docs/3.0.22/learning/policies/conflict-of-interest",
-                  "dist/docs/3.0.22/learning/policies/intellectual-property",
-                  "dist/docs/3.0.22/learning/policies/personnel-qualifications",
-                  "dist/docs/3.0.22/learning/policies/refund"
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      {
         "version": "3.1",
         "tag": "Latest",
         "groups": [
@@ -1321,6 +710,617 @@
           }
         ],
         "default": true
+      },
+      {
+        "version": "3.0",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "dist/docs/3.0.22/intro",
+              "dist/docs/3.0.22/quickstart"
+            ]
+          },
+          {
+            "group": "Building with AdCP",
+            "expanded": false,
+            "pages": [
+              "dist/docs/3.0.22/building/index",
+              "dist/docs/3.0.22/building/schemas-and-sdks",
+              {
+                "group": "AdCP 3.x",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/reference/whats-new-in-v3",
+                  "dist/docs/3.0.22/reference/whats-new-in-3-1",
+                  "dist/docs/3.0.22/reference/migration/v3-readiness",
+                  "dist/docs/3.0.22/reference/migration/index",
+                  "dist/docs/3.0.22/reference/migration/prerelease-upgrades",
+                  "dist/docs/3.0.22/reference/migration/channels",
+                  "dist/docs/3.0.22/reference/migration/pricing",
+                  "dist/docs/3.0.22/reference/migration/geo-targeting",
+                  "dist/docs/3.0.22/reference/migration/creatives",
+                  "dist/docs/3.0.22/reference/migration/creative-transformers",
+                  "dist/docs/3.0.22/reference/migration/catalogs",
+                  "dist/docs/3.0.22/reference/migration/optimization-goals",
+                  "dist/docs/3.0.22/reference/migration/brand-identity",
+                  "dist/docs/3.0.22/reference/migration/signals",
+                  "dist/docs/3.0.22/reference/migration/audiences",
+                  "dist/docs/3.0.22/reference/migration/attribution",
+                  "dist/docs/3.0.22/reference/migration/media-buy-status"
+                ]
+              },
+              "dist/docs/3.0.22/protocol/architecture",
+              "dist/docs/3.0.22/protocol/design-principles",
+              "dist/docs/3.0.22/protocol/capabilities-explorer",
+              "dist/docs/3.0.22/spec-guidelines",
+              "dist/docs/3.0.22/protocol/required-tasks",
+              "dist/docs/3.0.22/protocol/calling-an-agent",
+              "dist/docs/3.0.22/protocol/format-references",
+              "dist/docs/3.0.22/protocol/snapshot-and-log",
+              {
+                "group": "Concepts",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/building/concepts/index",
+                  "dist/docs/3.0.22/building/concepts/protocol-comparison",
+                  "dist/docs/3.0.22/building/concepts/adcp-vs-openrtb",
+                  "dist/docs/3.0.22/building/concepts/how-agents-communicate",
+                  "dist/docs/3.0.22/building/concepts/security-model",
+                  "dist/docs/3.0.22/building/concepts/industry-landscape"
+                ]
+              },
+              {
+                "group": "Build by layer",
+                "pages": [
+                  {
+                    "group": "L4 — Business logic",
+                    "pages": [
+                      "dist/docs/3.0.22/building/by-layer/L4/index",
+                      "dist/docs/3.0.22/building/by-layer/L4/choose-your-sdk",
+                      "dist/docs/3.0.22/building/by-layer/L4/build-an-agent",
+                      "dist/docs/3.0.22/building/by-layer/L4/build-a-caller",
+                      "dist/docs/3.0.22/building/by-layer/L4/migrate-from-hand-rolled"
+                    ]
+                  },
+                  {
+                    "group": "L3 — Protocol semantics",
+                    "expanded": false,
+                    "pages": [
+                      "dist/docs/3.0.22/building/by-layer/L3/index",
+                      "dist/docs/3.0.22/building/by-layer/L3/task-lifecycle",
+                      "dist/docs/3.0.22/building/by-layer/L3/async-operations",
+                      "dist/docs/3.0.22/building/by-layer/L3/webhooks",
+                      "dist/docs/3.0.22/building/by-layer/L3/error-handling",
+                      "dist/docs/3.0.22/building/by-layer/L3/comply-test-controller"
+                    ]
+                  },
+                  {
+                    "group": "L2 — Auth & registry",
+                    "expanded": false,
+                    "pages": [
+                      "dist/docs/3.0.22/building/by-layer/L2/index",
+                      "dist/docs/3.0.22/building/by-layer/L2/authentication",
+                      "dist/docs/3.0.22/building/by-layer/L2/account-state",
+                      "dist/docs/3.0.22/building/by-layer/L2/accounts-and-agents",
+                      "dist/docs/3.0.22/building/by-layer/L2/context-sessions"
+                    ]
+                  },
+                  {
+                    "group": "L1 — Identity & signing",
+                    "expanded": false,
+                    "pages": [
+                      "dist/docs/3.0.22/building/by-layer/L1/index",
+                      "dist/docs/3.0.22/building/by-layer/L1/security",
+                      "dist/docs/3.0.22/building/by-layer/L1/request-signing",
+                      "dist/docs/3.0.22/building/by-layer/L1/webhook-verifier-tuning"
+                    ]
+                  },
+                  {
+                    "group": "L0 — Wire & transport",
+                    "expanded": false,
+                    "pages": [
+                      "dist/docs/3.0.22/building/by-layer/L0/index",
+                      "dist/docs/3.0.22/building/by-layer/L0/schemas",
+                      "dist/docs/3.0.22/building/by-layer/L0/mcp-guide",
+                      "dist/docs/3.0.22/building/by-layer/L0/a2a-guide",
+                      "dist/docs/3.0.22/building/by-layer/L0/a2a-response-format",
+                      "dist/docs/3.0.22/protocol/get_adcp_capabilities",
+                      "dist/docs/3.0.22/building/by-layer/L0/mcp-response-extraction",
+                      "dist/docs/3.0.22/building/by-layer/L0/a2a-response-extraction"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Cross-cutting",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/building/cross-cutting/sdk-stack",
+                  "dist/docs/3.0.22/building/cross-cutting/version-adaptation",
+                  "dist/docs/3.0.22/building/cross-cutting/known-ambiguities"
+                ]
+              },
+              {
+                "group": "Verification & trust",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/building/verification/conformance",
+                  "dist/docs/3.0.22/building/verification/compliance-catalog",
+                  "dist/docs/3.0.22/building/verification/storyboards-vs-scenarios",
+                  "dist/docs/3.0.22/building/verification/how-grading-works",
+                  "dist/docs/3.0.22/building/verification/validate-your-agent",
+                  "dist/docs/3.0.22/building/verification/validate-with-mock-fixtures",
+                  "dist/docs/3.0.22/building/verification/addie-socket-mode",
+                  "dist/docs/3.0.22/building/verification/grading",
+                  "dist/docs/3.0.22/building/verification/get-test-ready",
+                  "dist/docs/3.0.22/building/verification/aao-verified"
+                ]
+              },
+              {
+                "group": "Operating",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/building/operating/operating-an-agent",
+                  "dist/docs/3.0.22/building/operating/orchestrator-design",
+                  "dist/docs/3.0.22/building/operating/transport-errors",
+                  "dist/docs/3.0.22/building/operating/seller-integration",
+                  "dist/docs/3.0.22/building/operating/storyboard-troubleshooting"
+                ]
+              },
+              {
+                "group": "Accounts",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/accounts/overview",
+                  "dist/docs/3.0.22/accounts/tasks/sync_accounts",
+                  "dist/docs/3.0.22/accounts/tasks/list_accounts",
+                  "dist/docs/3.0.22/accounts/tasks/report_usage",
+                  "dist/docs/3.0.22/accounts/tasks/sync_governance",
+                  "dist/docs/3.0.22/accounts/tasks/get_account_financials"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Protocol",
+            "expanded": false,
+            "pages": [
+              {
+                "group": "Media Buy",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/media-buy/index",
+                  "dist/docs/3.0.22/media-buy/commerce-media",
+                  {
+                    "group": "Concepts",
+                    "pages": [
+                      "dist/docs/3.0.22/media-buy/product-discovery/index",
+                      "dist/docs/3.0.22/media-buy/product-discovery/brief-expectations",
+                      "dist/docs/3.0.22/media-buy/product-discovery/example-briefs",
+                      "dist/docs/3.0.22/media-buy/product-discovery/media-products",
+                      "dist/docs/3.0.22/media-buy/product-discovery/collections-and-installments",
+                      "dist/docs/3.0.22/media-buy/product-discovery/refinement",
+                      "dist/docs/3.0.22/media-buy/media-buys/index",
+                      "dist/docs/3.0.22/media-buy/media-buys/lifecycle",
+                      "dist/docs/3.0.22/media-buy/media-buys/optimization-reporting",
+                      "dist/docs/3.0.22/media-buy/media-buys/policy-compliance",
+                      "dist/docs/3.0.22/media-buy/creatives/index",
+                      "dist/docs/3.0.22/media-buy/conversion-tracking/index",
+                      "dist/docs/3.0.22/media-buy/advanced-topics/pricing-models",
+                      "dist/docs/3.0.22/media-buy/advanced-topics/targeting",
+                      "dist/docs/3.0.22/media-buy/advanced-topics/accountability",
+                      "dist/docs/3.0.22/media-buy/advanced-topics/billing-authority"
+                    ]
+                  },
+                  {
+                    "group": "Building",
+                    "pages": [
+                      "dist/docs/3.0.22/media-buy/capability-discovery/index",
+                      "dist/docs/3.0.22/media-buy/capability-discovery/implementing-standard-formats",
+                      "dist/docs/3.0.22/media-buy/advanced-topics/agentic-execution-engine",
+                      "dist/docs/3.0.22/media-buy/advanced-topics/accounts-and-security",
+                      "dist/docs/3.0.22/media-buy/advanced-topics/sandbox"
+                    ]
+                  },
+                  {
+                    "group": "Reference",
+                    "expanded": false,
+                    "pages": [
+                      "dist/docs/3.0.22/media-buy/specification",
+                      "dist/docs/3.0.22/media-buy/task-reference/index",
+                      "dist/docs/3.0.22/media-buy/task-reference/get_products",
+                      "dist/docs/3.0.22/media-buy/task-reference/create_media_buy",
+                      "dist/docs/3.0.22/media-buy/task-reference/sync_catalogs",
+                      "dist/docs/3.0.22/media-buy/task-reference/get_media_buys",
+                      "dist/docs/3.0.22/media-buy/task-reference/get_media_buy_delivery",
+                      "dist/docs/3.0.22/media-buy/task-reference/update_media_buy",
+                      "dist/docs/3.0.22/media-buy/task-reference/provide_performance_feedback",
+                      "dist/docs/3.0.22/media-buy/task-reference/sync_event_sources",
+                      "dist/docs/3.0.22/media-buy/task-reference/log_event",
+                      "dist/docs/3.0.22/media-buy/task-reference/sync_audiences"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Creative",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/creative/index",
+                  {
+                    "group": "Concepts",
+                    "pages": [
+                      "dist/docs/3.0.22/creative/key-concepts",
+                      "dist/docs/3.0.22/creative/ai-creative-overview",
+                      "dist/docs/3.0.22/creative/generative-creative",
+                      "dist/docs/3.0.22/creative/creative-libraries",
+                      "dist/docs/3.0.22/creative/catalogs",
+                      "dist/docs/3.0.22/creative/catalog-schemas"
+                    ]
+                  },
+                  {
+                    "group": "Building Creative Agents",
+                    "pages": [
+                      "dist/docs/3.0.22/creative/implementing-creative-agents",
+                      "dist/docs/3.0.22/creative/buyer-attached-inputs",
+                      "dist/docs/3.0.22/creative/sales-agent-creative-capabilities",
+                      "dist/docs/3.0.22/creative/multi-agent-orchestration",
+                      "dist/docs/3.0.22/creative/creative-manifests",
+                      "dist/docs/3.0.22/creative/private-assets"
+                    ]
+                  },
+                  {
+                    "group": "Formats and Assets",
+                    "pages": [
+                      "dist/docs/3.0.22/creative/formats",
+                      "dist/docs/3.0.22/creative/canonical-formats",
+                      "dist/docs/3.0.22/creative/asset-types",
+                      "dist/docs/3.0.22/creative/published-post-reference-creatives",
+                      "dist/docs/3.0.22/creative/template-format-ids",
+                      "dist/docs/3.0.22/creative/universal-macros"
+                    ]
+                  },
+                  {
+                    "group": "Channel Guides",
+                    "pages": [
+                      "dist/docs/3.0.22/creative/channels/video",
+                      "dist/docs/3.0.22/creative/channels/ctv",
+                      "dist/docs/3.0.22/creative/channels/broadcast",
+                      "dist/docs/3.0.22/creative/channels/display",
+                      "dist/docs/3.0.22/creative/channels/audio",
+                      "dist/docs/3.0.22/creative/channels/dooh",
+                      "dist/docs/3.0.22/creative/channels/carousels",
+                      "dist/docs/3.0.22/creative/channels/social-native"
+                    ]
+                  },
+                  {
+                    "group": "Compliance",
+                    "pages": [
+                      "dist/docs/3.0.22/creative/accessibility",
+                      "dist/docs/3.0.22/creative/provenance"
+                    ]
+                  },
+                  {
+                    "group": "Reference",
+                    "expanded": false,
+                    "pages": [
+                      "dist/docs/3.0.22/creative/specification",
+                      "dist/docs/3.0.22/creative/task-reference/build_creative",
+                      "dist/docs/3.0.22/creative/task-reference/preview_creative",
+                      "dist/docs/3.0.22/creative/task-reference/preview_creative-advanced",
+                      "dist/docs/3.0.22/creative/task-reference/list_creative_formats",
+                      "dist/docs/3.0.22/creative/task-reference/list_transformers",
+                      "dist/docs/3.0.22/creative/task-reference/list_creatives",
+                      "dist/docs/3.0.22/creative/task-reference/sync_creatives",
+                      "dist/docs/3.0.22/creative/task-reference/get_creative_delivery"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Governance",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/governance/overview",
+                  "dist/docs/3.0.22/governance/rfc-process",
+                  "dist/docs/3.0.22/governance/embedded-human-judgment",
+                  "dist/docs/3.0.22/governance/policy-registry",
+                  "dist/docs/3.0.22/governance/policy-registry-sync",
+                  "dist/docs/3.0.22/governance/policy-attribution",
+                  "dist/docs/3.0.22/governance/annex-iii-obligations",
+                  "dist/docs/3.0.22/governance/working-group-charter",
+                  {
+                    "group": "Property Governance",
+                    "pages": [
+                      "dist/docs/3.0.22/governance/property/index",
+                      "dist/docs/3.0.22/governance/property/adagents",
+                      "dist/docs/3.0.22/governance/property/managed-networks",
+                      "dist/docs/3.0.22/governance/property/authorized-properties",
+                      "dist/docs/3.0.22/governance/property/specification",
+                      {
+                        "group": "Tasks",
+                        "pages": [
+                          "dist/docs/3.0.22/governance/property/tasks/index",
+                          "dist/docs/3.0.22/governance/property/tasks/property_lists",
+                          "dist/docs/3.0.22/governance/property/tasks/validate_property_delivery"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Collection Governance",
+                    "pages": [
+                      "dist/docs/3.0.22/governance/collection/index",
+                      "dist/docs/3.0.22/governance/collection/tasks/collection_lists"
+                    ]
+                  },
+                  {
+                    "group": "Content Standards",
+                    "pages": [
+                      "dist/docs/3.0.22/governance/content-standards/index",
+                      "dist/docs/3.0.22/governance/content-standards/artifacts",
+                      "dist/docs/3.0.22/governance/content-standards/implementation-guide",
+                      {
+                        "group": "Tasks",
+                        "pages": [
+                          "dist/docs/3.0.22/governance/content-standards/tasks/list_content_standards",
+                          "dist/docs/3.0.22/governance/content-standards/tasks/get_content_standards",
+                          "dist/docs/3.0.22/governance/content-standards/tasks/create_content_standards",
+                          "dist/docs/3.0.22/governance/content-standards/tasks/update_content_standards",
+                          "dist/docs/3.0.22/governance/content-standards/tasks/calibrate_content",
+                          "dist/docs/3.0.22/governance/content-standards/tasks/get_media_buy_artifacts",
+                          "dist/docs/3.0.22/governance/content-standards/tasks/validate_content_delivery"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Creative Governance",
+                    "pages": [
+                      "dist/docs/3.0.22/governance/creative/index",
+                      "dist/docs/3.0.22/governance/creative/get_creative_features",
+                      "dist/docs/3.0.22/governance/creative/provenance-verification"
+                    ]
+                  },
+                  {
+                    "group": "Campaign Governance",
+                    "pages": [
+                      "dist/docs/3.0.22/governance/campaign/index",
+                      "dist/docs/3.0.22/governance/campaign/responsibilities",
+                      "dist/docs/3.0.22/governance/campaign/safety-model",
+                      "dist/docs/3.0.22/governance/campaign/specification",
+                      "dist/docs/3.0.22/governance/campaign/audit-trail",
+                      {
+                        "group": "Tasks",
+                        "pages": [
+                          "dist/docs/3.0.22/governance/campaign/tasks/index",
+                          "dist/docs/3.0.22/governance/campaign/tasks/sync_plans",
+                          "dist/docs/3.0.22/governance/campaign/tasks/report_plan_outcome",
+                          "dist/docs/3.0.22/governance/campaign/tasks/check_governance",
+                          "dist/docs/3.0.22/governance/campaign/tasks/get_plan_audit_logs"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Sponsored Intelligence",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/sponsored-intelligence/overview",
+                  "dist/docs/3.0.22/sponsored-intelligence/monetizing-ai",
+                  {
+                    "group": "Concepts",
+                    "pages": [
+                      "dist/docs/3.0.22/sponsored-intelligence/product-spectrum",
+                      "dist/docs/3.0.22/sponsored-intelligence/networks",
+                      "dist/docs/3.0.22/sponsored-intelligence/workflow",
+                      "dist/docs/3.0.22/sponsored-intelligence/measurement"
+                    ]
+                  },
+                  {
+                    "group": "SI Chat Protocol",
+                    "pages": [
+                      "dist/docs/3.0.22/sponsored-intelligence/si-chat-protocol",
+                      "dist/docs/3.0.22/sponsored-intelligence/implementing-si-agents",
+                      "dist/docs/3.0.22/sponsored-intelligence/implementing-si-hosts"
+                    ]
+                  },
+                  {
+                    "group": "Reference",
+                    "expanded": false,
+                    "pages": [
+                      "dist/docs/3.0.22/sponsored-intelligence/specification",
+                      "dist/docs/3.0.22/sponsored-intelligence/tasks/index",
+                      "dist/docs/3.0.22/sponsored-intelligence/tasks/si_get_offering",
+                      "dist/docs/3.0.22/sponsored-intelligence/tasks/si_initiate_session",
+                      "dist/docs/3.0.22/sponsored-intelligence/tasks/si_send_message",
+                      "dist/docs/3.0.22/sponsored-intelligence/tasks/si_terminate_session"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Brand",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/brand-protocol/index",
+                  "dist/docs/3.0.22/brand-protocol/key-concepts",
+                  "dist/docs/3.0.22/brand-protocol/walkthrough-rights-licensing",
+                  "dist/docs/3.0.22/brand-protocol/for-advertisers",
+                  "dist/docs/3.0.22/brand-protocol/for-rights-holders",
+                  "dist/docs/3.0.22/brand-protocol/seller-setup",
+                  "dist/docs/3.0.22/brand-protocol/brand-json",
+                  "dist/docs/3.0.22/brand-protocol/building-a-brand-agent",
+                  "dist/docs/3.0.22/brand-protocol/ui-guidance",
+                  {
+                    "group": "Tasks",
+                    "pages": [
+                      "dist/docs/3.0.22/brand-protocol/tasks/get_brand_identity",
+                      "dist/docs/3.0.22/brand-protocol/tasks/verify_brand_claim",
+                      "dist/docs/3.0.22/brand-protocol/tasks/verify_brand_claims",
+                      "dist/docs/3.0.22/brand-protocol/tasks/get_rights",
+                      "dist/docs/3.0.22/brand-protocol/tasks/acquire_rights",
+                      "dist/docs/3.0.22/brand-protocol/tasks/update_rights"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Signals",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/signals/overview",
+                  "dist/docs/3.0.22/signals/key-concepts",
+                  "dist/docs/3.0.22/signals/ecosystem",
+                  "dist/docs/3.0.22/signals/data-providers",
+                  {
+                    "group": "Reference",
+                    "expanded": false,
+                    "pages": [
+                      "dist/docs/3.0.22/signals/specification",
+                      "dist/docs/3.0.22/signals/tasks/get_signals",
+                      "dist/docs/3.0.22/signals/tasks/activate_signal"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Trusted Match",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/trusted-match/index",
+                  "dist/docs/3.0.22/trusted-match/ai-mediation",
+                  "dist/docs/3.0.22/trusted-match/buyer-guide",
+                  "dist/docs/3.0.22/trusted-match/execution-gap",
+                  "dist/docs/3.0.22/trusted-match/context-and-identity",
+                  "dist/docs/3.0.22/trusted-match/specification",
+                  "dist/docs/3.0.22/trusted-match/router-architecture",
+                  "dist/docs/3.0.22/trusted-match/privacy-architecture",
+                  "dist/docs/3.0.22/trusted-match/data-protection-roles",
+                  "dist/docs/3.0.22/trusted-match/migration-from-axe",
+                  {
+                    "group": "Surface Guides",
+                    "pages": [
+                      "dist/docs/3.0.22/trusted-match/surfaces/web",
+                      "dist/docs/3.0.22/trusted-match/surfaces/ctv",
+                      "dist/docs/3.0.22/trusted-match/surfaces/mobile",
+                      "dist/docs/3.0.22/trusted-match/surfaces/retail-media",
+                      "dist/docs/3.0.22/trusted-match/surfaces/ai-assistants"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "group": "FAQ",
+            "pages": [
+              "dist/docs/3.0.22/faq"
+            ]
+          },
+          {
+            "group": "Trust & Security",
+            "expanded": false,
+            "pages": [
+              "dist/docs/3.0.22/trust",
+              "dist/docs/3.0.22/verification/overview",
+              "dist/docs/3.0.22/ai-disclosure",
+              "dist/docs/3.0.22/reference/privacy-considerations",
+              "dist/docs/3.0.22/reference/known-limitations"
+            ]
+          },
+          {
+            "group": "Reference",
+            "expanded": false,
+            "pages": [
+              {
+                "group": "Registry API",
+                "openapi": {
+                  "source": "https://agenticadvertising.org/openapi/registry.yaml",
+                  "directory": "dist/docs/3.0.21/registry/api-reference"
+                },
+                "pages": [
+                  "dist/docs/3.0.22/registry/index",
+                  "dist/docs/3.0.22/registry/registering-an-agent",
+                  "dist/docs/3.0.22/registry/maintaining-your-agent"
+                ]
+              },
+              "dist/docs/3.0.22/reference/gmsf-reference",
+              "dist/docs/3.0.22/reference/media-channel-taxonomy",
+              "dist/docs/3.0.22/measurement/taxonomy",
+              "dist/docs/3.0.22/reference/roadmap",
+              "dist/docs/3.0.22/reference/versions",
+              "dist/docs/3.0.22/reference/versioning",
+              "dist/docs/3.0.22/reference/specification-lifecycle",
+              "dist/docs/3.0.22/reference/url-canonicalization",
+              "dist/docs/3.0.22/reference/verifying-protocol-tarballs",
+              "dist/docs/3.0.22/reference/test-vectors/index",
+              "dist/docs/3.0.22/reference/experimental-status",
+              "dist/docs/3.0.22/reference/schema-extensions",
+              "dist/docs/3.0.22/reference/v2-sunset",
+              "dist/docs/3.0.22/reference/release-notes",
+              "dist/docs/3.0.22/reference/changelog",
+              "dist/docs/3.0.22/reference/implementor-faq",
+              "dist/docs/3.0.22/reference/glossary",
+              "dist/docs/3.0.22/community/working-group",
+              "dist/docs/3.0.22/community/joining-slack"
+            ]
+          },
+          {
+            "group": "Certification",
+            "expanded": false,
+            "pages": [
+              "dist/docs/3.0.22/learning/overview",
+              "dist/docs/3.0.22/learning/instructional-design",
+              "dist/docs/3.0.22/learning/failure-mode-scope",
+              {
+                "group": "Basics (free)",
+                "pages": [
+                  "dist/docs/3.0.22/learning/foundations/a1-agentic-advertising",
+                  "dist/docs/3.0.22/learning/foundations/a2-protocol-architecture",
+                  "dist/docs/3.0.22/learning/foundations/a2b-testing-your-first-agent",
+                  "dist/docs/3.0.22/learning/foundations/a3-ecosystem-governance"
+                ]
+              },
+              {
+                "group": "Role tracks",
+                "pages": [
+                  "dist/docs/3.0.22/learning/tracks/publisher",
+                  "dist/docs/3.0.22/learning/tracks/buyer",
+                  "dist/docs/3.0.22/learning/tracks/platform"
+                ]
+              },
+              {
+                "group": "Specialist modules",
+                "pages": [
+                  "dist/docs/3.0.22/learning/specialist/media-buy",
+                  "dist/docs/3.0.22/learning/specialist/creative",
+                  "dist/docs/3.0.22/learning/specialist/signals",
+                  "dist/docs/3.0.22/learning/specialist/governance",
+                  "dist/docs/3.0.22/learning/specialist/sponsored-intelligence",
+                  "dist/docs/3.0.22/learning/specialist/security"
+                ]
+              },
+              {
+                "group": "Policies",
+                "expanded": false,
+                "pages": [
+                  "dist/docs/3.0.22/learning/policies/nondiscrimination",
+                  "dist/docs/3.0.22/learning/policies/learner-records",
+                  "dist/docs/3.0.22/learning/policies/recertification",
+                  "dist/docs/3.0.22/learning/policies/complaints",
+                  "dist/docs/3.0.22/learning/policies/conflict-of-interest",
+                  "dist/docs/3.0.22/learning/policies/intellectual-property",
+                  "dist/docs/3.0.22/learning/policies/personnel-qualifications",
+                  "dist/docs/3.0.22/learning/policies/refund"
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
         "version": "2.5",

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -79,6 +79,15 @@ const defaultVersion = (navigation.versions.find(v => v.default) || navigation.v
 const pageOwners = new Map();
 const crossVersionDuplicates = [];
 
+test('default version is first in the versions array', () => {
+  if (navigation.versions[0].version !== defaultVersion) {
+    throw new Error(
+      `Default version "${defaultVersion}" must be first; Mintlify can omit its ` +
+      `file-backed routes when an archived version precedes it.`
+    );
+  }
+});
+
 for (const versionEntry of navigation.versions) {
   const { version, groups } = versionEntry;
   log(`Version: ${version}`);


### PR DESCRIPTION
## What changed

- move AdCP 3.1 to the first position in Mintlify's version navigation while preserving it as the default and `Latest` version
- add a regression assertion that the default documentation version must be first

## Root cause

The 3.1 GA navigation marked AdCP 3.1 as the default but left archived 3.0 first in the versions array. The production deployment redirected `/` to `/docs/intro`, but Mintlify omitted the file-backed 3.1 routes from the published sitemap, so that destination returned 404. Archived pages and generated API-reference pages continued to publish.

Before the 3.1 GA flip, the live/default 3.0 entry was first and the unversioned `/docs/**` routes published correctly. This restores that ordering invariant for 3.1 without changing any version's navigation contents.

## Validation

- docs expert: lands-well, no blocker
- code reviewer: ready to push
- Mintlify navigation validation: 18/18 passed
- unit tests: 66 files / 1,026 tests passed
- dynamic-import lint: 7/7 passed
- `callApi` state-change lint: 10/10 passed
- TypeScript typecheck passed
- pre-push version, changeset-scope, schema-link, and docs-navigation gates passed

No protocol release surface changed, so no changeset is required.
