### PR TITLE
fix(docs): restore live version sentinel

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -67,8 +67,8 @@
   "navigation": {
     "versions": [
       {
-        "version": "3.1",
-        "tag": "Latest",
+        "version": "latest",
+        "tag": "3.1",
         "groups": [
           {
             "group": "Getting Started",

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -88,6 +88,32 @@ test('default version is first in the versions array', () => {
   }
 });
 
+test('one latest version owns the live docs tree', () => {
+  const liveVersions = navigation.versions.filter(versionEntry =>
+    collectPages(versionEntry.groups).some(page => page.startsWith('docs/'))
+  );
+  const expectedTag = JSON.parse(
+    fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8')
+  ).version.split('.').slice(0, 2).join('.');
+
+  if (liveVersions.length !== 1) {
+    throw new Error(`Expected one live docs owner, found ${liveVersions.length}`);
+  }
+
+  const [liveVersion] = liveVersions;
+  if (liveVersion !== navigation.versions[0] || !liveVersion.default) {
+    throw new Error('The live docs owner must be the first and default version');
+  }
+  if (liveVersion.version !== 'latest') {
+    throw new Error('The live docs owner must use Mintlify version "latest"');
+  }
+  if (liveVersion.tag !== expectedTag) {
+    throw new Error(
+      `Live docs tag "${liveVersion.tag}" must match package release "${expectedTag}"`
+    );
+  }
+});
+
 for (const versionEntry of navigation.versions) {
   const { version, groups } = versionEntry;
   log(`Version: ${version}`);


### PR DESCRIPTION
## What changed

- identify the single live/default Mintlify version as `latest`
- retain the release-facing label as the `3.1` tag
- assert that exactly one version owns `docs/**`, and that it is first, default, and named `latest`

## Why

PR #6186 proved that ordering was not sufficient. Its Mintlify deployment completed successfully and reached production under a new deployment ID, but `/docs/intro` and `/docs/quickstart` still returned 404. The production sitemap continued to contain all archived `dist/docs/**` pages and generated API pages while omitting every file-backed current `docs/**` page.

The deployed API page navigation contains `/docs/intro`, but Mintlify falls back to the filename title (`Intro`) instead of the MDX frontmatter title and does not publish the route. This indicates the live `docs/**` files are not being resolved for the semantic-version entry.

This is an intentionally instrumented emergency experiment: restore Mintlify's `latest` live-version identifier without restoring the former duplicate live tree. Static validation protects the single-owner invariant; production HTTP checks remain the proof of success. If the deployed route remains 404, this change should be rolled back and escalated to Mintlify with both deployment IDs.

## Validation

- Mintlify navigation validation: 19/19 passed
- pre-push version, changeset-scope, schema-link, and docs-navigation gates passed
- code-review expert: recommends this as the smallest plausible empirical fix
- docs expert: correctly notes the sentinel behavior is undocumented, so post-deploy verification is required

No protocol release surface changed, so no changeset is required.
