### PR TITLE
fix(docs): restore documentation front door

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -67,8 +67,8 @@
   "navigation": {
     "versions": [
       {
-        "version": "latest",
-        "tag": "3.1",
+        "version": "3.1",
+        "tag": "Latest",
         "groups": [
           {
             "group": "Getting Started",
@@ -1563,6 +1563,14 @@
     }
   },
   "redirects": [
+    {
+      "source": "/docs/intro",
+      "destination": "/dist/docs/3.1.2/intro"
+    },
+    {
+      "source": "/docs/quickstart",
+      "destination": "/dist/docs/3.1.2/quickstart"
+    },
     {
       "source": "/docs/governance/content-standards/overview",
       "destination": "/docs/governance/content-standards/index"

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -88,11 +88,11 @@ test('default version is first in the versions array', () => {
   }
 });
 
-test('one latest version owns the live docs tree', () => {
+test('one release-labeled version owns the live docs tree', () => {
   const liveVersions = navigation.versions.filter(versionEntry =>
     collectPages(versionEntry.groups).some(page => page.startsWith('docs/'))
   );
-  const expectedTag = JSON.parse(
+  const expectedVersion = JSON.parse(
     fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8')
   ).version.split('.').slice(0, 2).join('.');
 
@@ -104,13 +104,13 @@ test('one latest version owns the live docs tree', () => {
   if (liveVersion !== navigation.versions[0] || !liveVersion.default) {
     throw new Error('The live docs owner must be the first and default version');
   }
-  if (liveVersion.version !== 'latest') {
-    throw new Error('The live docs owner must use Mintlify version "latest"');
-  }
-  if (liveVersion.tag !== expectedTag) {
+  if (liveVersion.version !== expectedVersion) {
     throw new Error(
-      `Live docs tag "${liveVersion.tag}" must match package release "${expectedTag}"`
+      `Live docs version "${liveVersion.version}" must match package release "${expectedVersion}"`
     );
+  }
+  if (liveVersion.tag !== 'Latest') {
+    throw new Error('The live docs owner must carry the "Latest" tag');
   }
 });
 
@@ -212,6 +212,25 @@ for (const versionEntry of navigation.versions) {
 test('page files belong to only one version', () => {
   if (crossVersionDuplicates.length > 0) {
     throw new Error(`Pages referenced across versions:\n      ${crossVersionDuplicates.join('\n      ')}`);
+  }
+});
+
+test('emergency front-door redirects target published snapshot files', () => {
+  const expectedRedirects = new Map([
+    ['/docs/intro', '/dist/docs/3.1.2/intro'],
+    ['/docs/quickstart', '/dist/docs/3.1.2/quickstart']
+  ]);
+
+  for (const [source, destination] of expectedRedirects) {
+    const matches = docsConfig.redirects.filter(redirect => redirect.source === source);
+    if (matches.length !== 1 || matches[0].destination !== destination) {
+      throw new Error(`${source} must redirect exactly once to ${destination}`);
+    }
+
+    const filePath = path.join(rootDir, destination.slice(1));
+    if (!fs.existsSync(`${filePath}.mdx`) && !fs.existsSync(`${filePath}.md`)) {
+      throw new Error(`Redirect destination file does not exist: ${destination}`);
+    }
   }
 });
 


### PR DESCRIPTION
## What changed

- restore the supported AdCP `3.1` / `Latest` version labeling after the `latest` experiment failed
- redirect `/docs/intro` and `/docs/quickstart` to their immutable, published 3.1.2 snapshot pages
- validate the single live-tree owner and both emergency redirect destinations

## Scope

This is a bounded outage mitigation, not a full repair of Mintlify's live-file ingestion. It restores the two documentation front-door URLs, including the `/` redirect destination. Other file-backed `/docs/**` routes may still return 404 until Mintlify resolves the ingestion failure.

Both snapshot destinations currently return HTTP 200 and their files are immutable release artifacts already checked into the repository. The redirects do not modify those artifacts.

## Evidence

- PR #6186 deployed with 3.1 first/default; live files remained omitted
- PR #6187 deployed with a sole `latest` live owner; API navigation confirmed that config was active, but live files remained omitted
- `/dist/docs/3.1.2/intro` and `/dist/docs/3.1.2/quickstart` return HTTP 200

## Validation

- docs expert: safe as a bounded emergency mitigation, no blocker
- code reviewer: accepts as narrow intro/quickstart restoration; correctly notes it is not a full-site fix
- Mintlify navigation validation: 20/20 passed
- pre-push version, changeset-scope, schema-link, and docs-navigation gates passed

No protocol release surface changed, so no changeset is required.
