### PR TITLE
fix(docs): restore AAO admin guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2839,6 +2839,11 @@
       "permanent": false
     },
     {
+      "source": "/docs/aao/aao-admins",
+      "destination": "/dist/docs/3.1.2/aao/aao-admins",
+      "permanent": false
+    },
+    {
       "source": "/docs/aao/users",
       "destination": "/dist/docs/3.1.2/aao/users",
       "permanent": false

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -236,6 +236,12 @@ test('temporary snapshot redirects cover every available live page', () => {
     }
   }
 
+  // This file is linked by Addie but intentionally omitted from navigation.
+  expectedRedirects.set(
+    '/docs/aao/aao-admins',
+    '/dist/docs/3.1.2/aao/aao-admins'
+  );
+
   const expectedUncoveredPages = ['docs/protocol/sync_agent_notification_configs'];
   if (JSON.stringify(uncoveredPages) !== JSON.stringify(expectedUncoveredPages)) {
     throw new Error(


### PR DESCRIPTION
## Summary

- restore the final production-owned documentation route omitted from navigation
- redirect `/docs/aao/aao-admins` temporarily to its immutable 3.1.2 snapshot
- cover the non-navigation Addie-linked fallback in docs validation

This completes owned-link coverage after #6189 while leaving generated API routes untouched.

## Validation

- `node tests/docs-nav-validation.test.cjs`
- required pre-push storyboard matrix
