### PR TITLE
fix(spec): backport 3.1.x maintenance milestone

### DIFF
--- a/.changeset/3-1-x-maintenance-milestone.md
+++ b/.changeset/3-1-x-maintenance-milestone.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add audience dependency-impairment conformance coverage and clarify `list_accounts` as the recommended cold-start recovery read for buyer-declared accounts.

--- a/docs/accounts/overview.mdx
+++ b/docs/accounts/overview.mdx
@@ -246,6 +246,7 @@ The introspection model — "the caller asks the authorization-enforcing party w
      or receive account_id out-of-band (seller-defined)
    Buyer-declared account (require_operator_auth: false):
      sync_accounts({ accounts: [{ brand, operator, billing, billing_entity? }] }) → status, billing terms
+     list_accounts() → recover acknowledged brand/operator accounts after a cold start (SHOULD be exposed)
 
 6. Execute
    Protocol tasks use the account reference to apply correct rates and terms
@@ -269,12 +270,12 @@ The Accounts Protocol operates with four party types. See [Accounts and agents](
 
 ## Tasks
 
-**Account discovery (normative).** Every agent accepting accounts MUST expose at least one of `list_accounts` (upstream-managed account-id namespaces) or `sync_accounts` (buyer-declared accounts, `require_operator_auth: false`). A seller-defined account-id namespace MAY omit both account-discovery tasks only when account IDs are supplied out-of-band and no account settings are managed through AdCP. An agent MAY implement both; for account-id namespaces, `sync_accounts` is settings-update only in 3.0.x unless a future explicit capability declares account-id provisioning. See [Required tasks by protocol](/docs/protocol/required-tasks#any-agent-accepting-accounts).
+**Account discovery (normative).** Every agent accepting accounts MUST expose at least one of `list_accounts` (upstream-managed account-id namespaces) or `sync_accounts` (buyer-declared accounts, `require_operator_auth: false`). A seller-defined account-id namespace MAY omit both account-discovery tasks only when account IDs are supplied out-of-band and no account settings are managed through AdCP. Buyer-declared-account sellers SHOULD expose `list_accounts` in addition to `sync_accounts`: a stateless buyer cannot recover its acknowledged portfolio by re-running `sync_accounts` when the lost state is the set of `(brand, operator, sandbox)` natural keys needed to construct that request. For account-id namespaces, `sync_accounts` is settings-update only in 3.0.x unless a future explicit capability declares account-id provisioning. See [Required tasks by protocol](/docs/protocol/required-tasks#any-agent-accepting-accounts).
 
 | Task | Purpose |
 |------|--------|
 | [`sync_accounts`](/docs/accounts/tasks/sync_accounts) | Declare brand/operator pairs and billing; provision accounts (buyer-declared accounts, `require_operator_auth: false`); optionally update settings for existing accounts when the seller exposes settings-update mode |
-| [`list_accounts`](/docs/accounts/tasks/list_accounts) | Discover existing accounts (upstream-managed account-id namespaces); poll status on pending accounts |
+| [`list_accounts`](/docs/accounts/tasks/list_accounts) | Discover existing accounts in upstream-managed namespaces; recover acknowledged buyer-declared accounts after a cold start; poll status on pending accounts |
 | [`get_account_financials`](/docs/accounts/tasks/get_account_financials) | Query spend, credit, and invoice status for operator-billed accounts |
 | [`sync_governance`](/docs/accounts/tasks/sync_governance) | Sync governance agent endpoints to accounts for seller-side validation |
 | [`report_usage`](/docs/accounts/tasks/report_usage) | Inform vendor agents how their services were consumed after delivery |

--- a/docs/building/by-layer/L2/accounts-and-agents.mdx
+++ b/docs/building/by-layer/L2/accounts-and-agents.mdx
@@ -385,6 +385,8 @@ Some sellers use `account_id` without exposing an account discovery surface. In 
 
 The agent manages the buying relationship. It calls `sync_accounts` to tell the seller who's advertising, who's operating on the brand's behalf, and who's paying. The seller provisions accounts and responds with status — the account IDs are a byproduct of the declaration, not something the buyer needs to know upfront.
 
+Buyer-declared-account sellers SHOULD also expose `list_accounts` as the recovery read for stateless buyers. Replaying `sync_accounts` is not a cold-start recovery mechanism when the buyer has lost the `(brand, operator, sandbox)` natural keys required to compose that replay. `list_accounts` returns the relationships the seller already acknowledged; it does not change the natural-key contract or make the seller-issued `account_id` mandatory on later calls.
+
 **Typical sellers:** Traditional publishers, retail media networks, DSPs — anywhere the buying relationship is established programmatically.
 
 `sync_accounts` is the declaration tool. Each entry is a set of flags that tells the seller what the buyer needs:
@@ -419,6 +421,7 @@ On individual media buys, an `invoice_recipient` can override the account defaul
    - **Sandbox (buyer-declared)**: pass the natural key with `sandbox: true` (declared via `sync_accounts`)
    - **Sandbox (account-id namespace)**: pass `{ "account_id": "test_acc_001" }` (pre-existing test account, discovered via `list_accounts` or supplied out-of-band)
 4. When anything changes (billing model, new brand, new operator), call `sync_accounts` again
+5. After a cold start, call `list_accounts` to recover previously acknowledged relationships when the seller exposes the recommended read surface
 
 The agent may be directly responsible for billing when `billing` is `"agent"`. When `billing` is `"operator"` or `"advertiser"`, the agent facilitates but is not the invoiced party. The seller may require human approval before activating accounts.
 

--- a/docs/protocol/required-tasks.mdx
+++ b/docs/protocol/required-tasks.mdx
@@ -115,12 +115,12 @@ Brand agents MUST declare `brand` in `supported_protocols`.
 | Task | Requirement | Notes |
 |------|------------|-------|
 | `sync_accounts` | Conditional | Buyer-declared accounts (`require_operator_auth: false`) — buyer declares brand/operator pairs; account-id namespaces may use this only for settings updates unless a future explicit capability declares provisioning |
-| `list_accounts` | Conditional | Account-id namespaces (`require_operator_auth: true`) — buyer discovers seller-assigned accounts; singleton credentials SHOULD still return one row so SDKs can auto-select |
+| `list_accounts` | Conditional / recommended | Account-id namespaces (`require_operator_auth: true`) MUST expose it when a credential can access multiple accounts and SHOULD return a singleton otherwise. Buyer-declared-account sellers (`require_operator_auth: false`) SHOULD expose it as the cold-start recovery read for stateless buyers. |
 | `sync_governance` | Conditional | Required when the buyer uses campaign governance |
 | `report_usage` | Conditional | Required when the agent charges for services |
 | `get_account_financials` | Optional | Financial summary per account |
 
-Agents MUST implement at least one of `sync_accounts` or `list_accounts` depending on their account model. An agent MAY implement both (e.g., ad networks that use buyer-declared accounts on the buyer side and account-id namespaces with underlying platforms).
+Agents MUST implement at least one of `sync_accounts` or `list_accounts` depending on their account model. An agent MAY implement both. Buyer-declared-account sellers SHOULD implement both: `sync_accounts` establishes the relationship, while `list_accounts` lets a stateless buyer recover the seller's acknowledged `(brand, operator, sandbox)` portfolio without already possessing the natural keys it lost.
 
 **Reference**: [Accounts Protocol](/docs/accounts/overview)
 

--- a/server/src/training-agent/audience-handlers.ts
+++ b/server/src/training-agent/audience-handlers.ts
@@ -43,13 +43,16 @@ interface AudienceInput {
   consent_basis?: string;
 }
 
+export type TrainingAudienceStatus = 'processing' | 'ready' | 'too_small' | 'suspended';
+
 interface AudienceState {
   audienceId: string;
   name: string;
   sellerId: string;
   uploadedCount: number;
   matchedCount: number;
-  status: 'processing' | 'ready' | 'too_small';
+  status: TrainingAudienceStatus;
+  statusReason?: string;
   audienceType: string;
   createdAt: string;
   lastSyncedAt: string;
@@ -84,6 +87,23 @@ export function findAudienceAnywhere(audienceId: string): AudienceState | undefi
  *  rather than silently accepting phantom ids. */
 export function findAudienceInSession(sessionKey: string, audienceId: string): AudienceState | undefined {
   return audienceStore.get(sessionKey)?.get(audienceId) ?? findAudienceAnywhere(audienceId);
+}
+
+/** Apply a deterministic lifecycle transition for comply_test_controller.
+ * Returns the prior state, or undefined when the audience is unknown. */
+export function forceAudienceStatusInSession(
+  sessionKey: string,
+  audienceId: string,
+  status: TrainingAudienceStatus,
+  reason?: string,
+): { previous: TrainingAudienceStatus; current: TrainingAudienceStatus } | undefined {
+  const audience = findAudienceInSession(sessionKey, audienceId);
+  if (!audience) return undefined;
+  const previous = audience.status;
+  audience.status = status;
+  audience.statusReason = status === 'suspended' ? reason : undefined;
+  audience.lastSyncedAt = new Date().toISOString();
+  return { previous, current: status };
 }
 
 /** Exported for testing */
@@ -170,6 +190,7 @@ export async function handleSyncAudiences(args: ToolArgs, ctx: TrainingContext) 
       seller_id: a.sellerId,
       action: 'unchanged',
       status: a.status,
+      ...(a.statusReason && { reason: a.statusReason }),
       uploaded_count: 0,
       total_uploaded_count: a.uploadedCount,
       matched_count: a.matchedCount,

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -41,6 +41,11 @@ import { verifyGovernanceToken, mintRevokedDemoToken, mintWrongAudDemoToken } fr
 import { emitAccountNotificationWebhook } from './webhooks.js';
 import { buildCatalog } from './product-factory.js';
 import { getAllSignals } from './signal-providers.js';
+import {
+  findAudienceInSession,
+  forceAudienceStatusInSession,
+  type TrainingAudienceStatus,
+} from './audience-handlers.js';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -55,6 +60,21 @@ const CREATIVE_TRANSITIONS: Record<string, string[]> = {
   rejected: ['processing'],
   archived: ['approved'],
 };
+
+const AUDIENCE_TRANSITIONS: Record<string, string[]> = {
+  processing: ['ready', 'too_small', 'suspended'],
+  ready: ['processing', 'too_small', 'suspended'],
+  too_small: ['processing', 'ready', 'suspended'],
+  suspended: ['processing', 'ready'],
+};
+
+const AUDIENCE_IMPAIRMENT_REASONS = new Set([
+  'policy_violation',
+  'consent_expired',
+  'ttl_expired',
+  'pii_audit_failed',
+  'seller_removed',
+]);
 
 const ACCOUNT_TRANSITIONS: Record<string, string[]> = {
   pending_approval: ['active', 'rejected'],
@@ -270,6 +290,65 @@ function propagateCreativeImpairment(
   }
 }
 
+function packageAudienceIds(pkg: PackageState): string[] {
+  const targeting = pkg.targeting;
+  if (!targeting) return [];
+  return [
+    ...(Array.isArray(targeting.audience_include) ? targeting.audience_include : []),
+    ...(Array.isArray(targeting.audience_exclude) ? targeting.audience_exclude : []),
+  ];
+}
+
+/** Propagate an audience suspension/recovery to every dependent package. */
+function propagateAudienceImpairment(
+  session: SessionState,
+  audienceId: string,
+  prev: string,
+  next: string,
+  reason?: string,
+): void {
+  const isOfflineTransition = next === 'suspended' && prev !== 'suspended';
+  const isOnlineTransition = next !== 'suspended' && prev === 'suspended';
+  if (!isOfflineTransition && !isOnlineTransition) return;
+
+  for (const mb of session.mediaBuys.values()) {
+    const dependentPackages = mb.packages
+      .filter(pkg => packageAudienceIds(pkg).includes(audienceId))
+      .map(pkg => pkg.packageId);
+    if (dependentPackages.length === 0) continue;
+
+    if (isOfflineTransition) {
+      const existing = (mb.impairments ?? []).find(
+        i => i.resourceType === 'audience' && i.resourceId === audienceId,
+      );
+      if (existing) continue;
+      const reasonCode = reason && AUDIENCE_IMPAIRMENT_REASONS.has(reason)
+        ? reason
+        : 'policy_violation';
+      mb.impairments = [
+        ...(mb.impairments ?? []),
+        {
+          impairmentId: `imp_${randomUUID().replace(/-/g, '')}`,
+          resourceType: 'audience',
+          resourceId: audienceId,
+          packageIds: dependentPackages,
+          transition: { from: prev, to: 'suspended' },
+          reasonCode,
+          ...(reason && !AUDIENCE_IMPAIRMENT_REASONS.has(reason) && { reason }),
+          observedAt: new Date().toISOString(),
+        },
+      ];
+      mb.updatedAt = new Date().toISOString();
+    } else {
+      const before = mb.impairments?.length ?? 0;
+      mb.impairments = (mb.impairments ?? []).filter(
+        i => !(i.resourceType === 'audience' && i.resourceId === audienceId),
+      );
+      if (mb.impairments.length !== before) mb.updatedAt = new Date().toISOString();
+    }
+  }
+}
+
 function validateTransition(
   transitions: Record<string, string[]>,
   terminalSet: Set<string>,
@@ -407,6 +486,39 @@ function recordCreativeWebhookActivity(
 
 function createStore(session: SessionState, sessionKey: string, principal?: string): TestControllerStore {
   return {
+    async forceAudienceStatus(audienceId, status, reason) {
+      const audience = findAudienceInSession(sessionKey, audienceId);
+      if (!audience) {
+        throw new TestControllerError('NOT_FOUND', `Audience ${audienceId} not found`, null);
+      }
+
+      const prev = audience.status;
+      if (prev === status) {
+        return { success: true, previous_state: prev, current_state: status, message: `Audience ${audienceId} is already ${status}` };
+      }
+      validateTransition(AUDIENCE_TRANSITIONS, new Set(), prev, status, 'audience');
+      if (status === 'suspended' && !reason) {
+        throw new TestControllerError('INVALID_PARAMS', 'reason is required when audience status = suspended', prev);
+      }
+
+      const transition = forceAudienceStatusInSession(
+        sessionKey,
+        audienceId,
+        status as TrainingAudienceStatus,
+        reason,
+      );
+      if (!transition) {
+        throw new TestControllerError('NOT_FOUND', `Audience ${audienceId} not found`, null);
+      }
+      propagateAudienceImpairment(session, audienceId, transition.previous, transition.current, reason);
+      return {
+        success: true,
+        previous_state: transition.previous,
+        current_state: transition.current,
+        message: `Audience ${audienceId} transitioned from ${transition.previous} to ${transition.current}`,
+      };
+    },
+
     async forceCreativeStatus(creativeId, status, rejectionReason) {
       const creative = session.creatives.get(creativeId);
       if (!creative) {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -456,16 +456,36 @@ function validateTargeting(t: unknown, pathLabel: string): { targeting?: Package
   const pl = validateListRef(src.property_list, `${pathLabel}.property_list`);
   const cl = validateListRef(src.collection_list, `${pathLabel}.collection_list`);
   const cle = validateListRef(src.collection_list_exclude, `${pathLabel}.collection_list_exclude`);
+  const validateAudienceIds = (value: unknown, field: string): string[] | undefined => {
+    if (value === undefined) return undefined;
+    if (!Array.isArray(value)) {
+      errors.push({ code: 'VALIDATION_ERROR', message: `${pathLabel}.${field}: must be an array of audience IDs`, field: `${pathLabel}.${field}` });
+      return undefined;
+    }
+    const ids: string[] = [];
+    for (let i = 0; i < value.length; i++) {
+      if (typeof value[i] !== 'string' || value[i].length === 0) {
+        errors.push({ code: 'VALIDATION_ERROR', message: `${pathLabel}.${field}[${i}]: must be a non-empty audience ID`, field: `${pathLabel}.${field}[${i}]` });
+      } else {
+        ids.push(value[i]);
+      }
+    }
+    return ids;
+  };
+  const audienceInclude = validateAudienceIds(src.audience_include, 'audience_include');
+  const audienceExclude = validateAudienceIds(src.audience_exclude, 'audience_exclude');
   if (pl.error) errors.push(pl.error);
   if (cl.error) errors.push(cl.error);
   if (cle.error) errors.push(cle.error);
   if (errors.length) return { errors };
-  if (!pl.ref && !cl.ref && !cle.ref) return { errors: [] };
+  if (!pl.ref && !cl.ref && !cle.ref && !audienceInclude && !audienceExclude) return { errors: [] };
   return {
     targeting: {
       ...(pl.ref && { property_list: pl.ref }),
       ...(cl.ref && { collection_list: cl.ref }),
       ...(cle.ref && { collection_list_exclude: cle.ref }),
+      ...(audienceInclude && { audience_include: audienceInclude }),
+      ...(audienceExclude && { audience_exclude: audienceExclude }),
     },
     errors: [],
   };
@@ -5884,19 +5904,21 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       }
     }
 
-    // Recompute open impairments: a creative-impairment is cleared when no
-    // package on the buy still references it. Recovery via assignment swap
-    // is the canonical clearing path (the buyer replaces a rejected creative
-    // with an approved sibling), so the same-buy union of all package
-    // creativeAssignments is the authoritative dependency set.
+    // Recompute open impairments when package dependencies change. Creative
+    // bindings use creativeAssignments; audience bindings use the targeting
+    // overlay include/exclude arrays.
     if (mb.impairments?.length) {
       const stillReferenced = new Set<string>();
+      const stillReferencedAudiences = new Set<string>();
       for (const pkg of mb.packages) {
         for (const cid of pkg.creativeAssignments) stillReferenced.add(cid);
+        for (const audienceId of pkg.targeting?.audience_include ?? []) stillReferencedAudiences.add(audienceId);
+        for (const audienceId of pkg.targeting?.audience_exclude ?? []) stillReferencedAudiences.add(audienceId);
       }
       const before = mb.impairments.length;
       mb.impairments = mb.impairments.filter(
-        i => i.resourceType !== 'creative' || stillReferenced.has(i.resourceId),
+        i => (i.resourceType !== 'creative' || stillReferenced.has(i.resourceId))
+          && (i.resourceType !== 'audience' || stillReferencedAudiences.has(i.resourceId)),
       );
       if (mb.impairments.length !== before) {
         mb.updatedAt = now;
@@ -6023,6 +6045,7 @@ export async function handleGetAdcpCapabilities(args: ToolArgs, ctx: TrainingCon
   const wholesaleProfile = wholesaleCapabilityProfile(ctx);
   const complianceScenarios = [
     'force_creative_status',
+    'force_audience_status',
     'force_account_status',
     'force_media_buy_status',
     'force_create_media_buy_arm',

--- a/server/src/training-agent/tenants/comply.ts
+++ b/server/src/training-agent/tenants/comply.ts
@@ -232,6 +232,9 @@ export function buildSalesComplyConfig(): ComplyControllerConfig {
       // toggles creative.status and propagates to dependent media buys'
       // impairments[] via the v5 store's propagateCreativeImpairment.
       creative_status: cast(forceAdapter('force_creative_status')),
+      // Audience sibling: suspends a synced audience and propagates the
+      // resulting impairment to packages that target it.
+      audience_status: cast(forceAdapter('force_audience_status')),
       upstream_unavailable: cast(forceAdapter('force_upstream_unavailable')),
     },
     simulate: {

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -462,6 +462,8 @@ export interface PackageTargeting {
   property_list?: ListReference;
   collection_list?: ListReference;
   collection_list_exclude?: ListReference;
+  audience_include?: string[];
+  audience_exclude?: string[];
 }
 
 /** A single asset slot inside a creative manifest (e.g., headline, hero_image). */

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -171,6 +171,7 @@ describe('comply_test_controller', () => {
       // training-agent wrapper) without coupling to enumeration order.
       expect(scenarios).toEqual(expect.arrayContaining([
         'force_creative_status',
+        'force_audience_status',
         'force_account_status',
         'force_media_buy_status',
         'force_session_status',
@@ -196,7 +197,7 @@ describe('comply_test_controller', () => {
       ]));
       // Catch silent drift in either direction (entries removed, or new ones
       // not yet documented in this assertion).
-      expect(scenarios.length).toBe(21);
+      expect(scenarios.length).toBe(22);
       // Dedup invariant — see SCENARIO_ENUM dedup in the wrapper.
       expect(new Set(scenarios).size).toBe(scenarios.length);
     });

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -35,6 +35,7 @@ import {
 } from '../../src/training-agent/governance-handlers.js';
 import { clearAccountStore } from '../../src/training-agent/account-handlers.js';
 import { TrainingSalesPlatform } from '../../src/training-agent/v6-sales-platform.js';
+import { clearAudienceStore } from '../../src/training-agent/audience-handlers.js';
 
 // Valid channels per the enum schema at static/schemas/source/enums/channels.json
 const VALID_CHANNELS = [
@@ -2406,10 +2407,12 @@ describe('create_media_buy handler', () => {
   beforeEach(() => {
     invalidateCache();
     clearSessions();
+    clearAudienceStore();
   });
 
   afterEach(() => {
     clearSessions();
+    clearAudienceStore();
   });
 
   function getFirstProductAndPricing(): { productId: string; pricingOptionId: string } {
@@ -3364,6 +3367,90 @@ describe('create_media_buy handler', () => {
 
     expect(result.errors).toBeUndefined();
     expect(typeof result.media_buy_id).toBe('string');
+  });
+
+  it('propagates a forced audience suspension to media-buy health and clears it on recovery', async () => {
+    const { productId, pricingOptionId } = getFirstProductAndPricing();
+    const account = {
+      brand: { domain: 'audience-impairment.example' },
+      operator: 'pinnacle-agency.example',
+      sandbox: true,
+    };
+    const audienceId = 'audience_impairment_test';
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+
+    await simulateCallTool(server, 'sync_audiences', {
+      account,
+      audiences: [{
+        audience_id: audienceId,
+        name: 'Audience impairment test',
+        audience_type: 'crm',
+        add: [{
+          external_id: 'audience-member-1',
+          hashed_email: 'a000000000000000000000000000000000000000000000000000000000000201',
+        }],
+      }],
+    });
+
+    const { result: baselineReady } = await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      scenario: 'force_audience_status',
+      params: { audience_id: audienceId, status: 'ready' },
+    });
+    expect(baselineReady).toMatchObject({ success: true, current_state: 'ready' });
+
+    const { result: created } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'audience-impairment.example' },
+      start_time: 'asap',
+      end_time: '2099-11-30T23:59:59Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 5000,
+        targeting_overlay: { audience_include: [audienceId] },
+      }],
+    });
+    const mediaBuyId = created.media_buy_id as string;
+    const packageId = (created.packages as Array<Record<string, unknown>>)[0].package_id as string;
+
+    const { result: suspended } = await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      scenario: 'force_audience_status',
+      params: { audience_id: audienceId, status: 'suspended', reason: 'consent_expired' },
+    });
+    expect(suspended).toMatchObject({ success: true, current_state: 'suspended' });
+
+    const { result: impairedRead } = await simulateCallTool(server, 'get_media_buys', {
+      account,
+      media_buy_ids: [mediaBuyId],
+    });
+    const impairedBuy = (impairedRead.media_buys as Array<Record<string, unknown>>)[0];
+    expect(impairedBuy.health).toBe('impaired');
+    expect(impairedBuy.impairments).toEqual([
+      expect.objectContaining({
+        resource_type: 'audience',
+        resource_id: audienceId,
+        package_ids: [packageId],
+        transition: { from: 'ready', to: 'suspended' },
+        reason_code: 'consent_expired',
+      }),
+    ]);
+
+    const { result: restored } = await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      scenario: 'force_audience_status',
+      params: { audience_id: audienceId, status: 'ready' },
+    });
+    expect(restored).toMatchObject({ success: true, current_state: 'ready' });
+
+    const { result: recoveredRead } = await simulateCallTool(server, 'get_media_buys', {
+      account,
+      media_buy_ids: [mediaBuyId],
+    });
+    const recoveredBuy = (recoveredRead.media_buys as Array<Record<string, unknown>>)[0];
+    expect(recoveredBuy.health).toBe('ok');
+    expect(recoveredBuy.impairments).toEqual([]);
   });
 
   it('rejects targeting_overlay.audience_exclude referencing an unregistered audience_id', async () => {
@@ -8355,6 +8442,7 @@ describe('get_adcp_capabilities handler', () => {
     const scenarios = complianceTesting.scenarios as string[];
     expect(scenarios).toEqual(expect.arrayContaining([
       'force_creative_status',
+      'force_audience_status',
       'force_account_status',
       'force_media_buy_status',
       'force_create_media_buy_arm',

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -21,6 +21,7 @@ requires_scenarios:
   - media_buy_seller/inline_creatives_without_sync
   - media_buy_seller/create_media_buy_async
   - media_buy_seller/dependency_impairment
+  - media_buy_seller/dependency_impairment_audience
   - media_buy_seller/dependency_impairment_cardinality
 
 narrative: |

--- a/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_audience.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_audience.yaml
@@ -1,0 +1,317 @@
+id: media_buy_seller/dependency_impairment_audience
+version: "1.0.0"
+title: "Audience dependency impairment — suspension propagates to media buy health"
+category: media_buy_seller
+summary: "Syncs an audience, targets it from a package, forces ready → suspended, verifies an audience impairment, then restores ready and verifies recovery."
+track: media_buy
+
+required_tools:
+  - sync_audiences
+  - create_media_buy
+  - get_media_buys
+  - comply_test_controller
+
+requires_capability:
+  path: media_buy.propagation_surfaces
+  contains: "snapshot"
+
+narrative: |
+  Audience status is a serving dependency, not catalog decoration. When a
+  seller suspends an audience targeted by a non-terminal media buy, every
+  affected package must surface an audience impairment and the buy's health
+  must become impaired. When the audience returns to a serviceable state, the
+  impairment must clear.
+
+  This is the audience sibling of dependency_impairment. It is additive and
+  capability-gated: sellers without audience_targeting, snapshot propagation,
+  sync_audiences, or the force_audience_status controller adapter grade the
+  unsupported path not-applicable rather than inheriting a new wire contract.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - audience_targeting
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    Seller advertises media_buy.audience_targeting, snapshot propagation, and
+    a sandbox comply_test_controller with force_audience_status.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "audience_impairment_display"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+  pricing_options:
+    - product_id: "audience_impairment_display"
+      pricing_option_id: "audience_impairment_cpm"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 2.00
+
+phases:
+  - id: setup
+    title: "Sync an audience and target it from a media buy"
+    requires_capability:
+      path: media_buy.audience_targeting
+      present: true
+    steps:
+      - id: sync_audience
+        title: "Register the audience"
+        task: sync_audiences
+        schema_ref: "media-buy/sync-audiences-request.json"
+        response_schema_ref: "media-buy/sync-audiences-response.json"
+        doc_ref: "/media-buy/task-reference/sync_audiences"
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          audiences:
+            - audience_id: "acme_impairment_audience"
+              name: "Acme impairment audience"
+              audience_type: "crm"
+              add:
+                - external_id: "acme-impairment-001"
+                  hashed_email: "a000000000000000000000000000000000000000000000000000000000000101"
+                - external_id: "acme-impairment-002"
+                  hashed_email: "a000000000000000000000000000000000000000000000000000000000000102"
+          idempotency_key: "$generate:uuid_v4#dependency_impairment_audience_sync"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-audiences-response.json"
+          - check: field_value
+            path: "audiences[0].audience_id"
+            value: "acme_impairment_audience"
+            description: "Seller echoes the registered audience ID"
+
+      - id: force_audience_ready_baseline
+        title: "Establish a serviceable audience baseline"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          scenario: "force_audience_status"
+          params:
+            audience_id: "acme_impairment_audience"
+            status: "ready"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Controller establishes the ready baseline"
+          - check: field_value
+            path: "current_state"
+            allowed_values: ["ready"]
+            description: "Audience is ready before the buy is created"
+
+      - id: create_audience_buy
+        title: "Create a buy targeting the synced audience"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "asap"
+          end_time: "2099-11-30T23:59:59Z"
+          packages:
+            - product_id: "audience_impairment_display"
+              budget: 5000
+              pricing_option_id: "audience_impairment_cpm"
+              targeting_overlay:
+                audience_include:
+                  - "acme_impairment_audience"
+          idempotency_key: "$generate:uuid_v4#dependency_impairment_audience_create"
+        context_outputs:
+          - path: "media_buy_id"
+            key: "media_buy_id"
+          - path: "packages[0].package_id"
+            key: "package_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Seller creates the audience-targeted buy"
+
+  - id: baseline_healthy
+    title: "Establish the healthy baseline"
+    requires_capability:
+      path: media_buy.audience_targeting
+      present: true
+    steps:
+      - id: get_buy_healthy
+        title: "Read the healthy buy"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json"
+          - check: field_value
+            path: "media_buys[0].health"
+            allowed_values: ["ok"]
+            description: "Buy starts healthy while the audience is serviceable"
+          - check: field_value_or_absent
+            path: "media_buys[0].impairments"
+            value: []
+            description: "No impairment is open at baseline"
+
+  - id: suspend_audience
+    title: "Suspend the targeted audience"
+    requires_capability:
+      path: media_buy.audience_targeting
+      present: true
+    steps:
+      - id: force_audience_suspended
+        title: "Force the audience offline"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          scenario: "force_audience_status"
+          params:
+            audience_id: "acme_impairment_audience"
+            status: "suspended"
+            reason: "consent_expired"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Controller applies the audience suspension"
+          - check: field_value
+            path: "current_state"
+            allowed_values: ["suspended"]
+            description: "Audience is now suspended"
+
+  - id: verify_impaired
+    title: "Verify audience impairment propagation"
+    requires_capability:
+      path: media_buy.audience_targeting
+      present: true
+    steps:
+      - id: get_buy_impaired
+        title: "Read the impaired buy"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json"
+          - check: field_value
+            path: "media_buys[0].health"
+            allowed_values: ["impaired"]
+            description: "Buy health becomes impaired"
+          - check: field_contains
+            path: "media_buys[0].impairments[*]"
+            value:
+              resource_type: "audience"
+              resource_id: "acme_impairment_audience"
+              package_ids:
+                - "$context.package_id"
+              transition:
+                to: "suspended"
+              reason_code: "consent_expired"
+            description: "Impairment identifies the suspended audience and affected package"
+
+  - id: recover_audience
+    title: "Restore the audience and verify recovery"
+    requires_capability:
+      path: media_buy.audience_targeting
+      present: true
+    steps:
+      - id: force_audience_ready
+        title: "Return the audience to ready"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          scenario: "force_audience_status"
+          params:
+            audience_id: "acme_impairment_audience"
+            status: "ready"
+        validations:
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Controller restores the audience"
+          - check: field_value
+            path: "current_state"
+            allowed_values: ["ready"]
+            description: "Audience is serviceable again"
+
+      - id: get_buy_recovered
+        title: "Read the recovered buy"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json"
+          - check: field_value
+            path: "media_buys[0].health"
+            allowed_values: ["ok"]
+            description: "Buy health returns to ok"
+          - check: field_value_or_absent
+            path: "media_buys[0].impairments"
+            value: []
+            description: "Audience impairment is cleared"


### PR DESCRIPTION
## Summary

Backport #6198 to the 3.1.x maintenance line for v3.1.10.

- adds the capability-gated audience dependency-impairment storyboard and training-agent lifecycle adapter
- clarifies `list_accounts` as the recommended cold-start recovery read for buyer-declared accounts
- carries a patch changeset so this joins the already-merged Retina catalog backport in v3.1.10

## Validation

- clean cherry-pick of main merge `a2e7888ba0bef5ffac3a12a3bb412a52dfcf99a2`
- Changesets patch-scope validation
- compliance authoring lints and development build
- 552 focused training-agent/controller tests passed

The same implementation passed the complete mainline suite and both current and 3.0 compatibility storyboard matrices in #6198.

(cherry picked from commit a2e7888ba0bef5ffac3a12a3bb412a52dfcf99a2)
