### PR TITLE
docs(compliance): SHOULD on runner session reuse and 404-as-terminal (#6204)

### DIFF
--- a/.changeset/runner-session-lifecycle-should.md
+++ b/.changeset/runner-session-lifecycle-should.md
@@ -1,0 +1,16 @@
+---
+"adcontextprotocol": patch
+---
+
+compliance: SHOULD-level session-lifecycle guidance for conformance runners
+
+Adds a `session_lifecycle` block to `runner-output-contract.yaml` (per the
+#6204 triage): runners SHOULD establish one MCP session per storyboard and
+reuse it across that storyboard's steps, SHOULD close sessions gracefully at
+storyboard end, and SHOULD treat an HTTP 404 on a known-terminated session id
+as terminal rather than retryable. A fresh streamable-HTTP session per call
+spends 4-5 protocol round trips on handshake alone (~5x per-step wall time,
+attributed to the agent under test rather than the runner), and orphaned
+GET-stream reconnects against expired sessions generate silent 4xx volume
+that is easily misread as rate limiting. Guidance only — no wire or schema
+change; the session-per-storyboard implementation lands in `adcp-client`.

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -604,6 +604,21 @@ validation_result:
                               # capability v{expires_after_version};
                               # promoted at v{runner_capability_version}]".
 
+session_lifecycle:
+  description: |
+    Transport session hygiene for streamable-HTTP MCP agents. Runners SHOULD
+    establish one MCP session per storyboard and reuse it across that
+    storyboard's steps, matching how production buyer agents operate: a fresh
+    session per call spends 4-5 protocol round trips on handshake alone
+    (initialize, initialized, tools/list, call, close), multiplying per-step
+    wall time ~5x and attributing runner-side session overhead to the agent
+    under test. Runners SHOULD close sessions gracefully at storyboard end,
+    and SHOULD treat an HTTP 404 on a known-terminated session id as terminal
+    rather than retryable — the streamable-HTTP session layer answers
+    expired-session requests 404 without an agent-visible error, so reconnect
+    loops against dead sessions generate silent 4xx volume that is easily
+    misread as rate limiting.
+
 request:
   description: |
     Exact request the runner sent, per transport. Runners MUST redact secrets


### PR DESCRIPTION
Implements the `runner-output-contract.yaml` follow-on from the #6204 triage ("Add one SHOULD on session reuse across steps and 404-as-terminal. Patch-eligible; no changeset.").

Adds a `session_lifecycle` guidance block: runners SHOULD establish one MCP session per storyboard and reuse it across steps (a fresh session per call spends 4–5 round trips on handshake, ~5× per-step wall time, and attributes runner overhead to the agent under test), SHOULD close sessions gracefully, and SHOULD treat expired-session 404s as terminal rather than retryable (the streamable-HTTP session layer answers them silently, so reconnect loops read as rate limiting).

Evidence for the numbers is in #6204. YAML strict-parses clean (`yaml.safe_load`). The core session-per-storyboard fix lands in `adcp-client` per the triage's sibling-repo item.