### PR TITLE
fix(addie): reset daily cost cap at UTC midnight instead of rolling 24h

### DIFF
--- a/server/src/addie/claude-cost-tracker.ts
+++ b/server/src/addie/claude-cost-tracker.ts
@@ -7,11 +7,20 @@
  * compromised account can keep a session running that stays under
  * the tool-call cap while steadily burning dollars on Claude.
  *
- * This module enforces a rolling 24-hour USD budget per user at the
- * claude-client boundary. Callers check the cap at entry, record
- * cost on completion. Like `tool-rate-limiter.ts`, it uses a
+ * This module enforces a calendar-day (UTC midnight) USD budget per
+ * user at the claude-client boundary. Callers check the cap at entry,
+ * record cost on completion. Like `tool-rate-limiter.ts`, it uses a
  * dependency-injection seam so unit tests don't need a Postgres
  * connection.
+ *
+ * Calendar-day, not rolling 24h (#6048): the cap was originally a
+ * rolling 24h window (`NOW() - interval`), which caused a real
+ * incident — `formatCapExceededMessage()` tells users "try again
+ * tomorrow", but a user capped at 6pm was still blocked at 8am the
+ * next morning because only 14 of the required 24 hours had elapsed.
+ * Rolling windows are right for abuse/API-cost defense; human-facing
+ * "daily" quotas need to reset at a fixed calendar boundary, matching
+ * how every ad-tech daily budget/frequency cap already works.
  *
  * System users (automated pipelines — newsletter, registry review)
  * are exempt by literal allowlist (see `./system-identities.ts`).
@@ -20,6 +29,14 @@
  * amortized across the workspace.
  *
  * Known trade-offs:
+ *
+ * - **Midnight burst.** A calendar-day boundary (vs. the old rolling
+ *   window) lets a user spend up to ~2x the daily budget in the few
+ *   seconds straddling UTC midnight (max out at 23:59:59, fresh budget
+ *   at 00:00:00). Acceptable given the caps are small in absolute
+ *   terms ($3-$25) and this is cost-defense against runaway/abusive
+ *   sessions, not hard billing enforcement — every calendar-day ad
+ *   budget or frequency cap has this same edge at its reset boundary.
  *
  * - **Check/record race.** The flow is `check → Claude call → record`,
  *   which is TOCTOU. N concurrent requests from one user can all see
@@ -53,7 +70,19 @@ import type { MemberContext } from './member-context.js';
 const logger = createLogger('addie-cost-tracker');
 
 const MICROS_PER_DOLLAR = 1_000_000;
-const WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/** Start of the current UTC calendar day, as an epoch-ms cutoff. */
+function utcMidnightCutoffMs(now: number = Date.now()): number {
+  const d = new Date(now);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}
+
+/** Milliseconds from now until the next UTC calendar-day boundary. */
+function msUntilNextUtcMidnight(now: number = Date.now()): number {
+  const d = new Date(now);
+  const nextMidnight = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1);
+  return nextMidnight - now;
+}
 
 /**
  * Slack sharing metadata may be this old when choosing a public-community
@@ -106,11 +135,11 @@ export type UserTier = CappedTier | 'aao_team';
 
 export interface CostCheckResult {
   ok: boolean;
-  /** Cents spent in the trailing 24h for the user (rounded from micros). */
+  /** Cents spent in the current UTC calendar day for the user (rounded from micros). */
   spentCents?: number;
   /** Remaining USD in the budget, floored to 2 decimals. 0 when blocked. */
   remainingUsd?: number;
-  /** Milliseconds until the oldest in-window charge falls out. */
+  /** Milliseconds until the daily cap resets at the next UTC midnight. */
   retryAfterMs?: number;
   /** The tier threshold that applies. */
   tier?: UserTier;
@@ -127,8 +156,8 @@ export interface CostCheckResult {
  * inject an in-memory store.
  */
 export interface CostTrackerStore {
-  /** Sum of cost_usd_micros for `key` recorded in the last `windowMs`. */
-  sumInWindow(key: string, windowMs: number): Promise<{ totalMicros: number; firstAtMs: number | null }>;
+  /** Sum of cost_usd_micros for `key` recorded since the start of the current UTC calendar day. */
+  sumSinceUtcMidnight(key: string): Promise<{ totalMicros: number }>;
   /** Persist one charge. */
   record(key: string, costMicros: number, model: string, usage: ClaudeUsage): Promise<void>;
   claimCertificationLease(key: string, leaseId: string): Promise<boolean>;
@@ -139,18 +168,22 @@ export interface CostTrackerStore {
 }
 
 class PostgresStore implements CostTrackerStore {
-  async sumInWindow(key: string, windowMs: number): Promise<{ totalMicros: number; firstAtMs: number | null }> {
-    const result = await query<{ total_micros: string | null; first_at: Date | null }>(
-      `SELECT COALESCE(SUM(cost_usd_micros), 0)::text AS total_micros, MIN(recorded_at) AS first_at
+  async sumSinceUtcMidnight(key: string): Promise<{ totalMicros: number }> {
+    // Computes the UTC-midnight cutoff from Postgres's own NOW(), not the
+    // app server's clock — `record()` below also timestamps via NOW(), so
+    // the cutoff and the recorded charges share one clock. Comparing an
+    // app-computed epoch-ms cutoff against DB-clock timestamps would let
+    // clock skew misplace a charge relative to the boundary — precisely
+    // the class of bug #6048 was about.
+    const result = await query<{ total_micros: string | null }>(
+      `SELECT COALESCE(SUM(cost_usd_micros), 0)::text AS total_micros
        FROM addie_token_cost_events
-       WHERE scope_key = $1 AND recorded_at > NOW() - ($2::bigint || ' milliseconds')::interval`,
-      [key, String(windowMs)],
+       WHERE scope_key = $1
+         AND recorded_at >= (date_trunc('day', NOW() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')`,
+      [key],
     );
     const row = result.rows[0];
-    return {
-      totalMicros: Number(row.total_micros ?? 0),
-      firstAtMs: row.first_at ? row.first_at.getTime() : null,
-    };
+    return { totalMicros: Number(row.total_micros ?? 0) };
   }
 
   async record(key: string, costMicros: number, model: string, usage: ClaudeUsage): Promise<void> {
@@ -202,11 +235,11 @@ class InMemoryStore implements CostTrackerStore {
   private readonly events = new Map<string, Array<{ atMs: number; micros: number }>>();
   private readonly certificationLeases = new Map<string, string>();
 
-  async sumInWindow(key: string, windowMs: number): Promise<{ totalMicros: number; firstAtMs: number | null }> {
-    const cutoff = Date.now() - windowMs;
-    const recent = (this.events.get(key) ?? []).filter(e => e.atMs > cutoff);
+  async sumSinceUtcMidnight(key: string): Promise<{ totalMicros: number }> {
+    const cutoff = utcMidnightCutoffMs();
+    const recent = (this.events.get(key) ?? []).filter(e => e.atMs >= cutoff);
     const totalMicros = recent.reduce((acc, e) => acc + e.micros, 0);
-    return { totalMicros, firstAtMs: recent.length > 0 ? recent[0].atMs : null };
+    return { totalMicros };
   }
 
   async record(key: string, costMicros: number): Promise<void> {
@@ -258,16 +291,28 @@ export async function checkCostCap(
   const baseBudgetMicros = DAILY_BUDGET_MICROS[tier];
   const reserveMicros = Math.max(0, options?.certificationReserveUsd ?? 0) * MICROS_PER_DOLLAR;
   const budgetMicros = baseBudgetMicros + reserveMicros;
-  const { totalMicros, firstAtMs } = await store.sumInWindow(userId, WINDOW_MS);
+  const { totalMicros } = await store.sumSinceUtcMidnight(userId);
   const remainingMicros = Math.max(0, budgetMicros - totalMicros);
   const usedCertificationReserve = reserveMicros > 0 && totalMicros >= baseBudgetMicros;
 
-  if (totalMicros >= budgetMicros && firstAtMs !== null) {
+  if (totalMicros >= budgetMicros) {
+    // #6048 secondary risk: a Slack caller without a resolved WorkOS
+    // mapping is forced to `member_free` ($5/day) by
+    // `resolveUserTierFromDb` regardless of their real subscription
+    // tier, so a paying member can hit a cap 5x tighter than expected.
+    // Log it so an unmapped-identity cap-exceeded is diagnosable from
+    // the scope key alone, without re-deriving this from an escalation.
+    if (tier === 'member_free' && userId.startsWith('slack:')) {
+      logger.warn(
+        { userId, tier, spentCents: Math.round(totalMicros / 10_000) },
+        'Slack user hit member_free cost cap on an unmapped scope key — real tier could not be resolved from WorkOS',
+      );
+    }
     return {
       ok: false,
       spentCents: Math.round(totalMicros / 10_000),
       remainingUsd: 0,
-      retryAfterMs: Math.max(0, firstAtMs + WINDOW_MS - Date.now()),
+      retryAfterMs: msUntilNextUtcMidnight(),
       tier,
       usedCertificationReserve,
     };

--- a/server/tests/unit/claude-cost-tracker.test.ts
+++ b/server/tests/unit/claude-cost-tracker.test.ts
@@ -272,13 +272,15 @@ describe('resolveUserTier', () => {
   });
 });
 
-describe('rolling 24h window semantics', () => {
-  // Meat of the "rolling daily budget" invariant — charges older than
-  // 24h fall out of the sum. Uses fake timers so we can fast-forward
-  // through the window without a real DB TTL.
+describe('calendar-day (UTC midnight) reset semantics', () => {
+  // #6048 — the daily budget resets at UTC midnight, not 24h after the
+  // triggering charge. A user capped at 6pm UTC must be unblocked at
+  // the next UTC midnight, not at 6pm the following day. Uses fake
+  // timers so we can fast-forward across the boundary without a real
+  // DB TTL.
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-04-22T12:00:00Z'));
+    vi.setSystemTime(new Date('2026-04-22T18:00:00Z'));
     __setCostTrackerStore(__createInMemoryCostStore());
   });
 
@@ -286,31 +288,33 @@ describe('rolling 24h window semantics', () => {
     vi.useRealTimers();
   });
 
-  it('expires charges older than 24h so the cap resets on their anniversary', async () => {
-    // Record a big charge that exhausts the anonymous cap at T0.
-    // Opus is $15/M-token input, so 200_001 tokens = just over $3.
+  it('stays blocked until UTC midnight even if 24h has not elapsed since the charge', async () => {
     const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 15) + 1;
-    await recordCost('u-roll', 'claude-opus-4-7', { input_tokens: tokensToExceedCap, output_tokens: 0 });
-    expect((await checkCostCap('u-roll', 'anonymous')).ok).toBe(false);
+    await recordCost('u-cal', 'claude-opus-4-7', { input_tokens: tokensToExceedCap, output_tokens: 0 });
+    expect((await checkCostCap('u-cal', 'anonymous')).ok).toBe(false);
 
-    // At T+23h the charge is still in-window — still blocked.
-    vi.advanceTimersByTime(23 * 60 * 60 * 1000);
-    expect((await checkCostCap('u-roll', 'anonymous')).ok).toBe(false);
-
-    // At T+24h+1ms the original charge has aged out. The cap has
-    // fresh headroom and the user is allowed again.
-    vi.advanceTimersByTime(60 * 60 * 1000 + 1);
-    const result = await checkCostCap('u-roll', 'anonymous');
+    // 14h later (08:00 UTC the next day) is well short of 24h since
+    // the charge, but past UTC midnight — the cap must have reset.
+    vi.setSystemTime(new Date('2026-04-23T08:00:00Z'));
+    const result = await checkCostCap('u-cal', 'anonymous');
     expect(result.ok).toBe(true);
     expect(result.spentCents).toBe(0);
   });
 
-  it('retryAfterMs counts down as individual charges age out (not fixed to a daily boundary)', async () => {
-    // Three separate charges 30 min apart. When the cap trips on
-    // the third, `retryAfterMs` reflects the OLDEST charge's
-    // remaining time — not a fixed midnight or similar boundary.
-    // Each charge ~$1 (a third of the anonymous cap), so all three
-    // together push past $3.
+  it('stays capped right up to 23:59:59.999 UTC on the day of the charge', async () => {
+    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 15) + 1;
+    await recordCost('u-cal2', 'claude-opus-4-7', { input_tokens: tokensToExceedCap, output_tokens: 0 });
+
+    vi.setSystemTime(new Date('2026-04-22T23:59:59.999Z'));
+    expect((await checkCostCap('u-cal2', 'anonymous')).ok).toBe(false);
+
+    vi.setSystemTime(new Date('2026-04-23T00:00:00.000Z'));
+    expect((await checkCostCap('u-cal2', 'anonymous')).ok).toBe(true);
+  });
+
+  it('retryAfterMs reflects time until the next UTC midnight, not a per-charge anniversary', async () => {
+    // At 18:00 UTC, next midnight is 6h away regardless of when
+    // within today's window the charges landed.
     const perChargeTokens = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 15 / 3) + 1;
     await recordCost('u-slide', 'claude-opus-4-7', { input_tokens: perChargeTokens, output_tokens: 0 });
     vi.advanceTimersByTime(30 * 60 * 1000);
@@ -320,10 +324,20 @@ describe('rolling 24h window semantics', () => {
 
     const result = await checkCostCap('u-slide', 'anonymous');
     expect(result.ok).toBe(false);
-    // Oldest charge is ~60 min old → retry in ~23h.
+    // Now is 19:00 UTC (18:00 + two 30min advances) → 5h to midnight.
     const retryHours = (result.retryAfterMs ?? 0) / 3_600_000;
-    expect(retryHours).toBeGreaterThan(22.9);
-    expect(retryHours).toBeLessThan(23.1);
+    expect(retryHours).toBeGreaterThan(4.9);
+    expect(retryHours).toBeLessThan(5.1);
+  });
+
+  it('does not count a charge from a previous UTC day toward today\'s budget', async () => {
+    await recordCost('u-yesterday', 'claude-opus-4-7', { input_tokens: 10_000_000, output_tokens: 0 });
+    expect((await checkCostCap('u-yesterday', 'anonymous')).ok).toBe(false);
+
+    vi.setSystemTime(new Date('2026-04-23T00:00:01.000Z'));
+    const result = await checkCostCap('u-yesterday', 'anonymous');
+    expect(result.ok).toBe(true);
+    expect(result.spentCents).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- Addie's daily conversation cost cap used a rolling 24h window (`recorded_at > NOW() - interval`), but the user-facing message says "try again tomorrow" — implying a calendar reset that never happened. A user capped at 6pm was still blocked at 8am the next day (only 14 of the required 24h elapsed). Fixes #6048.
- Switched the reset boundary to UTC midnight, computed inside Postgres (`date_trunc('day', NOW() AT TIME ZONE 'UTC')`) so the cutoff and the `recorded_at` timestamps it's compared against share one clock — an app-clock cutoff compared against DB-clock timestamps would reintroduce the same class of boundary bug this issue was about.
- `retryAfterMs` now counts down to the next UTC midnight instead of a per-charge "24h anniversary."
- Root cause was **not** a regression from the #2946–#2969 cost-cap PRs as the issue speculated — the rolling window is original behavior from #2946, unchanged since.
- Secondary risk mitigation: added a warn log when an unmapped-WorkOS-identity Slack user (`slack:<id>` scope key) hits the `member_free` tier cap, so it's diagnosable from logs that they may be getting a tighter cap ($5/day) than their real subscription tier warrants, instead of requiring a support escalation to notice.
- Documented an accepted tradeoff of the calendar-day boundary: a user can spend up to ~2x budget in the seconds straddling UTC midnight. Judged acceptable given caps are small ($3–$25) and this is abuse-defense, not billing enforcement — now called out explicitly in the module's "Known trade-offs" docstring.

## Test plan
- [x] `npx tsc --project server/tsconfig.json --noEmit` — clean
- [x] `npx vitest run server/tests/unit/claude-cost-tracker.test.ts server/tests/unit/claude-cost-tier-resolution.test.ts server/tests/unit/claude-client-cost-gate.test.ts` — 50/50 pass. Rewrote the cost-tracker test suite's rolling-window block into a calendar-day-semantics block (mid-window unblock at midnight, exact 23:59:59.999/00:00:00 boundary, `retryAfterMs` correctness, no cross-day bleed).
- [x] Live-verified against a real local Postgres (migrated via `npm run db:migrate`), exercising `PostgresStore` directly rather than the in-memory DI store the unit tests use: backdated-yesterday charge excluded, today's charge blocks with `retryAfterMs` accurate to the millisecond, exact-midnight inclusive boundary, and the new Slack-unmapped warn log fires as designed.
- [x] `code-reviewer` and `security-reviewer` agents run; findings addressed (app/DB clock-skew fix, midnight-burst tradeoff documented).
- [x] `node scripts/check-changeset-protocol-scope.cjs origin/main` — passed, no changeset needed (server-only Addie change).

## Risks / follow-ups
- The unmapped-Slack-identity tier gap (Slack users without a linked WorkOS account always resolve to `member_free`) is now observable via logs but not fixed — that's a separate, larger identity-resolution feature, out of scope here.