### PR TITLE
fix(addie): avoid unreliable GitHub issue draft links

### DIFF
--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -948,6 +948,11 @@ const GITHUB_BODY_MAX_CHARS = 4000;
 const GITHUB_COMMENT_MAX_CHARS = 1000;
 const GITHUB_MAX_COMMENTS = 10;
 const GITHUB_DIFF_MAX_CHARS = 12000;
+// Keep generated issue links below a conservative cross-client URL ceiling.
+// This reduces the risk of Slack splitting a query string or GitHub clearing
+// an oversized prefill. Longer drafts still get a complete copyable preview
+// and a short link that pre-fills the title only.
+const GITHUB_PREFILL_URL_MAX_CHARS = 2000;
 
 type ParsedRepo =
   | { ok: true; org: string; repo: string }
@@ -6512,29 +6517,36 @@ export function createMemberToolHandlers(
       params.set('labels', labels.join(','));
     }
 
-    const issueUrl = `https://github.com/${org}/${repo}/issues/new?${params.toString()}`;
+    const newIssueUrl = `https://github.com/${org}/${repo}/issues/new`;
+    const issueUrl = `${newIssueUrl}?${params.toString()}`;
 
-    // Check URL length - browsers/GitHub have practical limits (~8000 chars)
+    // Avoid body-prefilled links that are likely to be truncated or rejected
+    // across browsers, Slack clients, and Addie's streamed responses.
     const urlLength = issueUrl.length;
-    const URL_LENGTH_WARNING_THRESHOLD = 6000;
-    const URL_LENGTH_MAX = 8000;
 
     // Build response with the draft details and link
     let response = `## GitHub Issue Draft\n\n`;
 
-    if (urlLength > URL_LENGTH_MAX) {
-      // URL too long - provide manual instructions instead
-      response += `⚠️ **Issue body is too long for a pre-filled URL.**\n\n`;
-      response += `Please create the issue manually:\n`;
-      response += `1. Go to https://github.com/${org}/${repo}/issues/new\n`;
-      response += `2. Copy the title and body from the preview below\n\n`;
+    if (urlLength > GITHUB_PREFILL_URL_MAX_CHARS) {
+      response += `⚠️ **This draft is too long for a reliable pre-filled link.**\n\n`;
+      const shortParams = new URLSearchParams();
+      shortParams.set('title', title);
+      if (labels.length > 0) {
+        shortParams.set('labels', labels.join(','));
+      }
+      const titlePrefillUrl = `${newIssueUrl}?${shortParams.toString()}`;
+
+      if (titlePrefillUrl.length <= GITHUB_PREFILL_URL_MAX_CHARS) {
+        response += `**👉 [Open GitHub with the title pre-filled](${titlePrefillUrl})**\n\n`;
+        response += `Copy the body from the preview below, then submit the issue.\n\n`;
+      } else {
+        response += `Please create the issue manually:\n`;
+        response += `1. Go to ${newIssueUrl}\n`;
+        response += `2. Copy the title and body from the preview below\n\n`;
+      }
     } else {
       response += `I've drafted a GitHub issue for you. Click the link below to create it:\n\n`;
       response += `**👉 [Create Issue on GitHub](${issueUrl})**\n\n`;
-
-      if (urlLength > URL_LENGTH_WARNING_THRESHOLD) {
-        response += `⚠️ _Note: The issue body is quite long. If the link doesn't work, you may need to shorten it or copy/paste manually._\n\n`;
-      }
     }
 
     response += `---\n\n`;

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -518,6 +518,13 @@ describe('createMemberToolHandlers', () => {
       expect(result).toContain('Test Issue');
       expect(result).toContain('This is a test issue body');
       expect(result).toContain('bug');
+
+      const href = result.match(/\[Create Issue on GitHub\]\(([^)]+)\)/)?.[1];
+      expect(href).toBeDefined();
+      const url = new URL(href!);
+      expect(url.searchParams.get('title')).toBe('Test Issue');
+      expect(url.searchParams.get('body')).toBe('This is a test issue body');
+      expect(url.searchParams.get('labels')).toBe('bug');
     });
 
     it('uses default repo when not specified', async () => {
@@ -532,35 +539,47 @@ describe('createMemberToolHandlers', () => {
       expect(result).toContain('adcontextprotocol/adcp');
     });
 
-    it('warns when URL is very long', async () => {
+    it('omits the body from the pre-filled URL when the encoded URL exceeds 2,000 chars', async () => {
       const handlers = createMemberToolHandlers(null);
       const handler = handlers.get('draft_github_issue')!;
 
-      // Create a body that will exceed warning threshold (6000 chars)
-      const longBody = 'x'.repeat(6000);
+      // URL encoding makes the final URL longer than the raw issue body.
+      const longBody = 'multi word body\n'.repeat(150);
 
       const result = await handler({
         title: 'Test Issue',
         body: longBody,
       });
 
-      expect(result).toContain('quite long');
+      expect(result).toContain('too long for a reliable pre-filled link');
+      expect(result).toContain('Open GitHub with the title pre-filled');
+      expect(result).toContain('Copy the body from the preview below');
+      expect(result).toContain(longBody);
+      const href = result.match(/\[Open GitHub with the title pre-filled\]\(([^)]+)\)/)?.[1];
+      expect(href).toBeDefined();
+      expect(new URL(href!).searchParams.get('body')).toBeNull();
     });
 
-    it('provides manual instructions when URL exceeds max length', async () => {
+    it('uses the body-prefilled link at 2,000 chars and falls back at 2,001', async () => {
       const handlers = createMemberToolHandlers(null);
       const handler = handlers.get('draft_github_issue')!;
+      const title = 'Boundary';
+      const urlForBody = (body: string) => {
+        const params = new URLSearchParams({ title, body });
+        return `https://github.com/adcontextprotocol/adcp/issues/new?${params.toString()}`;
+      };
+      const emptyUrlLength = urlForBody('').length;
+      const bodyAtLimit = 'x'.repeat(2000 - emptyUrlLength);
 
-      // Create a body that will exceed max (8000 chars)
-      const veryLongBody = 'x'.repeat(8000);
+      expect(urlForBody(bodyAtLimit)).toHaveLength(2000);
+      expect(urlForBody(`${bodyAtLimit}x`)).toHaveLength(2001);
 
-      const result = await handler({
-        title: 'Test Issue',
-        body: veryLongBody,
-      });
+      const atLimit = await handler({ title, body: bodyAtLimit });
+      const overLimit = await handler({ title, body: `${bodyAtLimit}x` });
 
-      expect(result).toContain('too long for a pre-filled URL');
-      expect(result).toContain('create the issue manually');
+      expect(atLimit).toContain('[Create Issue on GitHub]');
+      expect(overLimit).not.toContain('[Create Issue on GitHub]');
+      expect(overLimit).toContain('[Open GitHub with the title pre-filled]');
     });
 
     it('accepts adcp-client as a valid repo', async () => {


### PR DESCRIPTION
## What changed

- cap body-prefilled GitHub issue URLs at a conservative 2,000 characters
- fall back to a short title-and-label-prefilled link for longer drafts
- keep the complete issue body in the copyable preview
- add URL round-trip and exact 2,000/2,001 boundary coverage

## Why

`draft_github_issue` previously treated URLs up to 8,000 characters as safe. Long query strings could be split by Slack delivery or briefly hydrate and then clear on GitHub, leaving users with a broken issue-submission flow.

The new fallback avoids presenting an unreliable body-prefilled link while still minimizing manual work: GitHub opens with the title and labels populated, and the user copies only the body.

## Validation

- `npx vitest run tests/addie/member-tools.test.ts server/tests/unit/addie/slack-blocks.test.ts --pool=threads` — 88 passed
- `npx vitest run --config server/vitest.config.ts tests/unit/working-group-document-privacy.test.ts tests/unit/portrait-object-authorization.test.ts` — 25 passed
- general unit suite during pre-commit — 1,030 passed
- `npm run typecheck` — passed
- expert code, test, and user-workflow reviews — approved
