### PR TITLE
feat(content-standards): deprecate inline asset credentials

### DIFF
--- a/.changeset/deprecate-inline-asset-credentials.md
+++ b/.changeset/deprecate-inline-asset-credentials.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Deprecate inline provider credentials in secured artifact access. Signed URLs are now the recommended default for one-off delivery, while credential-free workload identity remains available for established relationships and bounded bearer tokens remain available for origins that require them.
+
+Document the AdCP 3.2 migration path and require secret-safe handling of legacy credentials, bearer tokens, and complete signed URLs during the compatibility window. The deprecated `service_account.credentials` field remains schema-valid throughout 3.x and is removed in 4.0.

--- a/.changeset/deprecate-inline-asset-credentials.md
+++ b/.changeset/deprecate-inline-asset-credentials.md
@@ -4,4 +4,4 @@
 
 Deprecate inline provider credentials in secured artifact access. Signed URLs are now the recommended default for one-off delivery, while credential-free workload identity remains available for established relationships and bounded bearer tokens remain available for origins that require them.
 
-Document the AdCP 3.2 migration path and require secret-safe handling of legacy credentials, bearer tokens, and complete signed URLs during the compatibility window. The deprecated `service_account.credentials` field remains schema-valid throughout 3.x and is removed in 4.0.
+Document the AdCP 3.2 migration path and require secret-safe handling of legacy credentials, bearer tokens, and complete signed URLs during the compatibility window. The deprecated `service_account.credentials` field remains schema-valid throughout 3.x and is eligible for removal in 4.0 or later once the six-month notice and full-release-cycle policy gates are satisfied.

--- a/docs.json
+++ b/docs.json
@@ -105,6 +105,7 @@
                   "docs/reference/migration/audiences",
                   "docs/reference/migration/attribution",
                   "docs/reference/migration/media-buy-status",
+                  "docs/reference/migration/asset-access",
                   "docs/reference/migration/cross-role-governance-enforcement"
                 ]
               },

--- a/docs/governance/content-standards/artifacts.mdx
+++ b/docs/governance/content-standards/artifacts.mdx
@@ -235,11 +235,11 @@ For one-off access, place the complete pre-signed URL in the asset's `url` and m
 }
 ```
 
-The URL itself is a bearer capability. Producers should scope it to one asset and the shortest practical access window. Consumers must redact the complete URL from logs, traces, error messages, and model context because providers may place credential material in either its path or query string.
+The URL itself is a bearer capability. Producers should scope it to one asset and the shortest practical access window under a documented maximum TTL. Consumers must redact the complete URL from logs, traces, errors, metrics, analytics, model context, and durable storage because providers may place credential material in either its path or query string. Do not forward a signed URL outside its intended recipient or trust boundary.
 
 ### Workload identity
 
-For ongoing partnerships, the asset origin can authorize an identity already controlled by the consumer. At fetch time, the consumer uses its normal cloud credential chain, such as GCP Application Default Credentials or AWS SigV4. No credential is sent in the artifact.
+For ongoing partnerships, the asset origin can authorize an identity already controlled by the component that performs the asset fetch. At fetch time, that component uses its normal cloud credential chain, such as GCP Application Default Credentials or AWS SigV4. No credential is sent in the artifact. If an orchestrator forwards an artifact to a governance agent, it must either fetch the asset itself or arrange out-of-band authorization for the governance agent's identity.
 
 ```json
 {
@@ -252,7 +252,7 @@ For ongoing partnerships, the asset origin can authorize an identity already con
 }
 ```
 
-The `service_account.credentials` field is deprecated in AdCP 3.2 and removed in 4.0. Existing 3.x consumers must continue accepting the field during the compatibility window, treat any value as secret, and keep it out of logs and model context. New producers must omit it.
+The `service_account.credentials` field is deprecated in AdCP 3.2. Its presence denotes only the legacy inline-credential form, not workload-identity authorization. Consumers must continue parsing and validating the field for 3.x wire compatibility, but must not activate received credentials automatically. They may process the legacy form only for a peer explicitly allowlisted for legacy compatibility; otherwise they must reject or quarantine it. New producers must omit it. The field is eligible for removal in 4.0 or later only after the six-month notice and full-release-cycle gates in the deprecation policy are satisfied.
 
 ### Bearer tokens
 
@@ -269,11 +269,17 @@ When neither signed URLs nor pre-configured workload identity is available, atta
 }
 ```
 
-Send the token only in the `Authorization` header when fetching that asset. Never log it, retain it beyond the access window, or place it in model context.
+Send the token only in the `Authorization` header to the HTTPS origin authorized for that asset. Never forward the header across redirects. Redact the token from logs, traces, errors, metrics, analytics, model context, and durable storage.
 
 For artifacts with many assets, prefer signed URLs or pre-configured workload identity rather than repeating bearer tokens throughout the payload.
 
 The asset `url` may differ from the artifact's canonical or published URL. For example, a published article at `https://news.pinnacle.example/article/123` might have assets served from `https://assets.pinnacle.example/secured/...`.
+
+### Safe fetching
+
+Treat every asset URL and its access metadata as untrusted input. Consumers must require HTTPS and, after DNS resolution and after every redirect, reject loopback, link-local, metadata-service, private, and other locally disallowed destinations unless a specific destination was explicitly approved during authenticated onboarding. Access metadata alone must never select an ambient credential: workload identity is limited to the pre-authorized origin and resource prefix, and bearer tokens are limited to the authorized origin.
+
+Fail closed on authorization or destination-check failures. Do not retry by switching among signed URLs, workload identity, bearer tokens, or legacy inline credentials. Temporary encrypted caching of signed URLs, tokens, or legacy credentials must end no later than both the credential expiry and the consumer's configured maximum lifetime.
 
 ### Access methods at a glance
 

--- a/docs/governance/content-standards/artifacts.mdx
+++ b/docs/governance/content-standards/artifacts.mdx
@@ -209,57 +209,42 @@ This is separate from assets because it's about the artifact container, not the 
 
 ## Secured Asset Access
 
-Many assets aren't publicly accessible - AI-generated images, private conversations, paywalled content. The artifact schema supports authenticated access.
+Many assets aren't publicly accessible—AI-generated images, private conversations, and paywalled content are common examples. The artifact schema supports three access methods without requiring every consumer to understand cloud IAM.
 
-### Pre-Configuration (Recommended)
+### Choosing an access method
 
-For ongoing partnerships, configure access once during onboarding rather than per-request:
+Use the simplest method that fits the relationship:
 
-1. **Service account sharing** - Grant the verification agent access to your cloud storage
-2. **OAuth client credentials** - Set up machine-to-machine authentication
-3. **API key exchange** - Share long-lived API keys during setup
+1. **Use `signed_url` by default** for one-off asset delivery. The consumer performs an ordinary HTTPS `GET`; no additional authentication integration is required.
+2. **Use `service_account` for established, higher-volume relationships** where the asset origin has already authorized a workload identity controlled by the consumer.
+3. **Use `bearer_token` only when the origin cannot support either option.** Tokens must be short-lived and scoped to the individual asset.
 
-This happens during the activation phase when the seller first receives content standards from a buyer.
+Never place long-lived API keys, service-account private keys, cloud access keys, or other standing credentials in an artifact payload.
 
-### Per-Asset Authentication
+### Signed URLs (recommended)
 
-When pre-configured identity access isn't possible, attach a short-lived, asset-scoped token to individual assets:
+For one-off access, place the complete pre-signed URL in the asset's `url` and mark the access method:
 
 ```json
 {
-  "type": "image",
-  "url": "https://cdn.openai.com/secured/img_abc123.png",
+  "type": "video",
+  "url": "https://assets.streamhaus.example/video/scene-14.mp4?expires=...&signature=...",
   "access": {
-    "method": "bearer_token",
-    "token": "eyJhbGciOiJIUzI1NiIs..."
+    "method": "signed_url"
   }
 }
 ```
 
-**Note on token size**: For artifacts with many assets, per-asset tokens can significantly increase payload size. Consider:
+The URL itself is a bearer capability. Producers should scope it to one asset and the shortest practical access window. Consumers must redact the complete URL from logs, traces, error messages, and model context because providers may place credential material in either its path or query string.
 
-1. **Pre-configured access** - Set up service account access once during onboarding
-2. **Shared token reference** - Define tokens at the artifact level and reference by ID
-3. **Signed URLs** - Use pre-signed URLs where the URL itself is the credential
+### Workload identity
 
-The `url` field is the access URL - it may differ from the artifact's canonical/published URL. For example, a published article at `https://news.example.com/article/123` might have assets served from `https://cdn.example.com/secured/...`.
-
-### Access Methods
-
-| Method | Use Case |
-|--------|----------|
-| `bearer_token` | Short-lived, asset-scoped OAuth2 token in the Authorization header. The only method that carries a live secret in the payload — treat it as a secret (never log it or place it in model context). |
-| `service_account` | Identity-based access. The seller pre-authorizes the caller's own service account; **no credentials are transmitted**. |
-| `signed_url` | Pre-signed URL — the URL itself is the (time-limited) credential. |
-
-### Service Account Access
-
-`service_account` is **identity-based** — no credentials are sent in the response. During onboarding the seller grants the buyer's (or verification agent's) own service account read access to the asset store; at fetch time the client authenticates with that identity using the cloud provider's normal credential chain (GCP Application Default Credentials, AWS SigV4).
-
-For GCP:
+For ongoing partnerships, the asset origin can authorize an identity already controlled by the consumer. At fetch time, the consumer uses its normal cloud credential chain, such as GCP Application Default Credentials or AWS SigV4. No credential is sent in the artifact.
 
 ```json
 {
+  "type": "audio",
+  "url": "https://storage.streamhaus.example/episodes/42/segment-3.mp3",
   "access": {
     "method": "service_account",
     "provider": "gcp"
@@ -267,34 +252,38 @@ For GCP:
 }
 ```
 
-For AWS:
+The `service_account.credentials` field is deprecated in AdCP 3.2 and removed in 4.0. Existing 3.x consumers must continue accepting the field during the compatibility window, treat any value as secret, and keep it out of logs and model context. New producers must omit it.
+
+### Bearer tokens
+
+When neither signed URLs nor pre-configured workload identity is available, attach a short-lived, asset-scoped token:
 
 ```json
 {
+  "type": "image",
+  "url": "https://assets.streamhaus.example/images/frame-382.png",
   "access": {
-    "method": "service_account",
-    "provider": "aws"
+    "method": "bearer_token",
+    "token": "short-lived-asset-token"
   }
 }
 ```
 
-**Never place service-account keys, private keys, or access secrets in a response payload** — they would travel across agent transport, logs, and model context. Identity-based access keeps secrets off the wire entirely.
+Send the token only in the `Authorization` header when fetching that asset. Never log it, retain it beyond the access window, or place it in model context.
 
-### Pre-Signed URLs
+For artifacts with many assets, prefer signed URLs or pre-configured workload identity rather than repeating bearer tokens throughout the payload.
 
-For one-off access without sharing credentials:
+The asset `url` may differ from the artifact's canonical or published URL. For example, a published article at `https://news.pinnacle.example/article/123` might have assets served from `https://assets.pinnacle.example/secured/...`.
 
-```json
-{
-  "type": "video",
-  "url": "https://storage.googleapis.com/bucket/video.mp4?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=...&X-Goog-Signature=...",
-  "access": {
-    "method": "signed_url"
-  }
-}
-```
+### Access methods at a glance
 
-The URL itself contains the credentials - no additional authentication needed.
+| Method | Use Case |
+|--------|----------|
+| `signed_url` | Recommended default for one-off access. Ordinary HTTPS fetch; the complete URL is a time-limited secret. |
+| `service_account` | Credential-free workload identity for a pre-configured relationship. No keys or access secrets appear in the payload. |
+| `bearer_token` | Compatibility path for origins requiring an Authorization header. The token must be short-lived, asset-scoped, and handled as a secret. |
+
+See [Migrating secured asset access for AdCP 3.2](/docs/reference/migration/asset-access) for producer and consumer changes.
 
 ## Property Identifier Types
 

--- a/docs/reference/migration/asset-access.mdx
+++ b/docs/reference/migration/asset-access.mdx
@@ -1,0 +1,119 @@
+---
+title: "Migrating secured asset access (3.2)"
+description: "Stop embedding cloud credentials in artifact payloads and choose signed URLs, workload identity, or bounded bearer tokens in AdCP 3.2."
+"og:title": "AdCP — Migrating secured asset access"
+testable: true
+---
+
+# Migrating secured asset access (3.2)
+
+AdCP 3.2 deprecates `assets[].access.credentials` on the `service_account` access method. The method itself remains supported: it now unambiguously means that the asset origin has authorized a workload identity already controlled by the consumer. No provider credential crosses the AdCP payload.
+
+For most integrations, use a short-lived signed URL. It gives consumers one interoperable operation—an ordinary HTTPS `GET`—without cloud-provider setup.
+
+## Choose the simplest path
+
+| Situation | Access method |
+|-----------|---------------|
+| One-off delivery or no prior identity relationship | `signed_url` (recommended) |
+| Established cloud-IAM relationship and repeated access | `service_account` without `credentials` |
+| Origin requires an Authorization header | Short-lived, asset-scoped `bearer_token` |
+
+Do not place long-lived API keys, private keys, cloud access keys, or other standing credentials in any artifact field.
+
+## Before: inline provider credentials
+
+This legacy shape remains schema-valid during the 3.x compatibility window, but new producers must not emit it:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/latest/content-standards/artifact.json",
+  "property_rid": "property_streamhaus_001",
+  "artifact_id": "episode_42_segment_3",
+  "assets": [
+    {
+      "type": "audio",
+      "url": "https://storage.streamhaus.example/episodes/42/segment-3.mp3",
+      "access": {
+        "method": "service_account",
+        "provider": "gcp",
+        "credentials": {
+          "type": "service_account",
+          "private_key": "legacy-secret-redacted"
+        }
+      }
+    }
+  ]
+}
+```
+
+Consumers receiving this legacy field must treat its complete value as secret. Do not log it, copy it into traces or error messages, persist it beyond the access window, or place it in model context.
+
+## After: signed URL (recommended)
+
+Issue a URL scoped to one asset and the shortest practical access window:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/latest/content-standards/artifact.json",
+  "property_rid": "property_streamhaus_001",
+  "artifact_id": "episode_42_segment_3",
+  "assets": [
+    {
+      "type": "audio",
+      "url": "https://assets.streamhaus.example/episodes/42/segment-3.mp3?expires=1786003200&signature=redacted",
+      "access": {
+        "method": "signed_url"
+      }
+    }
+  ]
+}
+```
+
+The complete URL is a bearer capability. Consumers must redact it from logs and model context because providers may place credential material in either its path or query string. No additional Authorization header is sent.
+
+## Alternative: pre-authorized workload identity
+
+For an established relationship, authorize the consumer's identity out of band and omit `credentials`:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/latest/content-standards/artifact.json",
+  "property_rid": "property_streamhaus_001",
+  "artifact_id": "episode_42_segment_3",
+  "assets": [
+    {
+      "type": "audio",
+      "url": "https://storage.streamhaus.example/episodes/42/segment-3.mp3",
+      "access": {
+        "method": "service_account",
+        "provider": "gcp"
+      }
+    }
+  ]
+}
+```
+
+The consumer uses its normal provider credential chain at fetch time. The payload does not assert which principal is authorized, and the asset origin remains responsible for authorization.
+
+## Producer checklist
+
+- Prefer `signed_url` unless the parties already maintain an identity-based access relationship.
+- Scope signed URLs and bearer tokens to one asset and the shortest practical access window.
+- Omit `service_account.credentials` in all new payloads.
+- Never copy consumer-owned provider credentials into an artifact.
+
+## Consumer checklist
+
+- Continue accepting legacy `service_account.credentials` throughout 3.x, but isolate and redact it as secret material.
+- Never infer authorization from an identity string in the payload; authorization is enforced by the asset origin.
+- Remove cached URLs, tokens, and legacy credentials when their access window closes.
+- Expect `service_account.credentials` to be rejected after adopting AdCP 4.0.
+
+## Related
+
+- [Content artifacts](/docs/governance/content-standards/artifacts#secured-asset-access)
+- [AdCP versioning and deprecation policy](/docs/reference/versioning#deprecation-policy)
+- [Issue #5698](https://github.com/adcontextprotocol/adcp/issues/5698) — 3.2 deprecation
+- [Issue #5699](https://github.com/adcontextprotocol/adcp/issues/5699) — 4.0 removal
+- [Issue #6224](https://github.com/adcontextprotocol/adcp/issues/6224) — 4.0 extensible access-method design

--- a/docs/reference/migration/asset-access.mdx
+++ b/docs/reference/migration/asset-access.mdx
@@ -7,7 +7,7 @@ testable: true
 
 # Migrating secured asset access (3.2)
 
-AdCP 3.2 deprecates `assets[].access.credentials` on the `service_account` access method. The method itself remains supported: it now unambiguously means that the asset origin has authorized a workload identity already controlled by the consumer. No provider credential crosses the AdCP payload.
+AdCP 3.2 deprecates `assets[].access.credentials` on the `service_account` access method. Without that legacy field, the method means that the asset origin has authorized a workload identity already controlled by the component that performs the asset fetch. No provider credential crosses the AdCP payload.
 
 For most integrations, use a short-lived signed URL. It gives consumers one interoperable operation—an ordinary HTTPS `GET`—without cloud-provider setup.
 
@@ -27,7 +27,7 @@ This legacy shape remains schema-valid during the 3.x compatibility window, but 
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/content-standards/artifact.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/content-standards/artifact.json",
   "property_rid": "property_streamhaus_001",
   "artifact_id": "episode_42_segment_3",
   "assets": [
@@ -47,7 +47,7 @@ This legacy shape remains schema-valid during the 3.x compatibility window, but 
 }
 ```
 
-Consumers receiving this legacy field must treat its complete value as secret. Do not log it, copy it into traces or error messages, persist it beyond the access window, or place it in model context.
+Presence of this field denotes only the deprecated legacy form; it is not workload-identity authorization. Consumers must continue parsing and validating it for 3.x wire compatibility, but must not activate received credentials automatically. Process it only for a peer explicitly allowlisted for legacy compatibility; otherwise reject or quarantine it. Redact the complete value from logs, traces, errors, metrics, analytics, model context, and durable storage.
 
 ## After: signed URL (recommended)
 
@@ -55,7 +55,7 @@ Issue a URL scoped to one asset and the shortest practical access window:
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/content-standards/artifact.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/content-standards/artifact.json",
   "property_rid": "property_streamhaus_001",
   "artifact_id": "episode_42_segment_3",
   "assets": [
@@ -70,7 +70,7 @@ Issue a URL scoped to one asset and the shortest practical access window:
 }
 ```
 
-The complete URL is a bearer capability. Consumers must redact it from logs and model context because providers may place credential material in either its path or query string. No additional Authorization header is sent.
+The complete URL is a bearer capability. Consumers must redact it from logs, traces, errors, metrics, analytics, model context, and durable storage because providers may place credential material in either its path or query string. No additional Authorization header is sent, and the URL must not be forwarded outside the intended recipient trust boundary.
 
 ## Alternative: pre-authorized workload identity
 
@@ -78,7 +78,7 @@ For an established relationship, authorize the consumer's identity out of band a
 
 ```json
 {
-  "$schema": "https://adcontextprotocol.org/schemas/latest/content-standards/artifact.json",
+  "$schema": "https://adcontextprotocol.org/schemas/v3/content-standards/artifact.json",
   "property_rid": "property_streamhaus_001",
   "artifact_id": "episode_42_segment_3",
   "assets": [
@@ -94,21 +94,28 @@ For an established relationship, authorize the consumer's identity out of band a
 }
 ```
 
-The consumer uses its normal provider credential chain at fetch time. The payload does not assert which principal is authorized, and the asset origin remains responsible for authorization.
+The component that fetches the asset uses its normal provider credential chain at fetch time. The payload does not assert which principal is authorized, and the asset origin remains responsible for authorization. An intermediary must either fetch the asset itself or arrange out-of-band authorization for the downstream component that will fetch it.
+
+## Fetch safely
+
+Treat every asset URL and access object as untrusted. Require HTTPS and validate the resolved destination before the first request and after every redirect. Reject loopback, link-local, metadata-service, private, and locally disallowed destinations unless a specific destination was explicitly approved during authenticated onboarding.
+
+Never select or attach ambient credentials based only on `access.method`, `provider`, or the supplied URL. Bind workload credentials out of band to an allowed origin and resource prefix. Send bearer tokens only to the authorized origin, never forward an Authorization header across redirects, and fail closed rather than falling back to another access method.
 
 ## Producer checklist
 
 - Prefer `signed_url` unless the parties already maintain an identity-based access relationship.
-- Scope signed URLs and bearer tokens to one asset and the shortest practical access window.
+- Scope signed URLs and bearer tokens to one asset and the shortest practical access window under a documented maximum TTL.
 - Omit `service_account.credentials` in all new payloads.
 - Never copy consumer-owned provider credentials into an artifact.
 
 ## Consumer checklist
 
-- Continue accepting legacy `service_account.credentials` throughout 3.x, but isolate and redact it as secret material.
+- Continue parsing and validating legacy `service_account.credentials` throughout 3.x. Process it only for an explicitly allowlisted legacy peer; otherwise reject or quarantine it.
 - Never infer authorization from an identity string in the payload; authorization is enforced by the asset origin.
-- Remove cached URLs, tokens, and legacy credentials when their access window closes.
-- Expect `service_account.credentials` to be rejected after adopting AdCP 4.0.
+- Keep any temporary encrypted cache no longer than both the credential expiry and a configured maximum lifetime.
+- Do not fall back between supplied credentials, workload identity, bearer tokens, and signed URLs after an authorization failure.
+- Expect `service_account.credentials` to become removable in AdCP 4.0 or later, once the deprecation-policy notice and release-cycle gates are satisfied.
 
 ## Related
 

--- a/docs/reference/migration/index.mdx
+++ b/docs/reference/migration/index.mdx
@@ -13,6 +13,10 @@ This page covers every breaking change when upgrading from AdCP 2.x to 3.0, with
 **Upgrading from 3.0 to 3.1?** Use the [3.0 to 3.1 migration guide](/docs/reference/migration/3-0-to-3-1). This page is for the breaking v2.x to 3.0 upgrade.
 </Info>
 
+<Info>
+**Preparing for 3.2?** See [Migrating secured asset access](/docs/reference/migration/asset-access) to replace inline provider credentials with signed URLs or pre-authorized workload identity.
+</Info>
+
 <Warning>
 **v2 is unsupported as of 3.0 GA and fully deprecated on August 1, 2026 (UTC).** See the [v2 sunset page](/docs/reference/v2-sunset) for the full timeline, AAO registry policy, and why v2 is not safe for interoperable production.
 </Warning>
@@ -124,6 +128,14 @@ During migration, sellers can accept both v2 and v3 traffic and buyers can route
   </Card>
   <Card title="Attribution" icon="link" href="/docs/reference/migration/attribution">
     Integer days to structured `Duration` objects
+  </Card>
+</CardGroup>
+
+## 3.2 migration guides
+
+<CardGroup cols={2}>
+  <Card title="Secured asset access" icon="key" href="/docs/reference/migration/asset-access">
+    Replace inline provider credentials with signed URLs or pre-authorized workload identity
   </Card>
 </CardGroup>
 

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -13,6 +13,12 @@ Authoritative version-by-version release record for AdCP, with cumulative change
 
 **Status:** In development — minor release targeting the 3.2.0 milestone. Stable wire shapes remain backward compatible; explicitly experimental surfaces may carry noticed changes under the [experimental-status contract](/docs/reference/experimental-status).
 
+### Inline asset-access credentials deprecated (#5698)
+
+`service_account.credentials` in secured content-artifact access is deprecated. New producers must omit it. For one-off delivery, use an asset-scoped, short-lived signed URL; established integrations may use the fetching component's pre-authorized workload identity, and origins that require an Authorization header may use a short-lived, asset-scoped bearer token.
+
+The legacy field remains schema-valid for 3.x wire compatibility. Consumers must not activate received credentials automatically: they may process the legacy form only for an explicitly allowlisted peer and otherwise must reject or quarantine it. The field is eligible for removal in 4.0 or later only after both deprecation-policy gates are satisfied: at least six months from publication of this notice and at least one full release cycle. See [Migrating secured asset access](/docs/reference/migration/asset-access) and [#5699](https://github.com/adcontextprotocol/adcp/issues/5699) for removal tracking.
+
 ### Cross-role governance enforcement
 
 **Breaking-change notice for an experimental surface. The implementation may merge during 3.2 development; the beta-to-GA period provides the six-week notice window before production availability.**

--- a/static/schemas/source/content-standards/artifact.json
+++ b/static/schemas/source/content-standards/artifact.json
@@ -283,26 +283,26 @@
   "$defs": {
     "asset_access": {
       "type": "object",
-      "description": "Access instructions for a secured asset URL. Producers SHOULD use `signed_url` for one-off delivery unless the parties already have an identity-based access relationship. New producers MUST NOT carry long-lived credentials in this object; consumers continue accepting the deprecated legacy field during the 3.x compatibility window.",
+      "description": "Access instructions for a secured asset URL. Producers SHOULD use `signed_url` for one-off delivery unless the parties already have an identity-based access relationship. New producers MUST NOT emit `service_account.credentials`; `bearer_token` is the explicit short-lived credential path. Consumers MUST treat asset URLs and access metadata as untrusted, use credentials only for HTTPS origins and resource prefixes authorized out of band, and fail closed without falling back between access methods. The deprecated legacy field remains parseable during the 3.x compatibility window but MUST NOT be activated automatically.",
       "discriminator": {
         "propertyName": "method"
       },
       "oneOf": [
         {
           "type": "object",
-          "description": "Short-lived bearer-token access for origins that cannot use signed URLs or pre-configured workload identity. The token is a live secret and must be scoped to the asset.",
+          "description": "Short-lived bearer-token access for origins that cannot use signed URLs or pre-configured workload identity. The token is a live secret and must be scoped to the asset. Consumers MUST send it only to the HTTPS origin authorized for that asset and MUST NOT forward the Authorization header across redirects.",
           "properties": {
             "method": { "type": "string", "const": "bearer_token" },
             "token": {
               "type": "string",
-              "description": "Short-lived, asset-scoped bearer token for the Authorization header. Producers MUST NOT issue a standing or broadly scoped credential here. Consumers MUST treat the token as a secret and MUST NOT log it, persist it beyond the access window, or place it in model context."
+              "description": "Short-lived, asset-scoped bearer token for the Authorization header. Producers MUST NOT issue a standing or broadly scoped credential here. Consumers MUST redact the token from logs, traces, errors, metrics, analytics, model context, and durable storage. Any temporary encrypted cache MUST be bounded by the credential expiry and the consumer's configured maximum lifetime."
             }
           },
           "required": ["method", "token"]
         },
         {
           "type": "object",
-          "description": "Credential-free workload-identity access. The asset origin authorizes an identity already controlled by the consumer, such as a GCP service account or AWS IAM role, through out-of-band onboarding. No provider key or access secret crosses the AdCP payload.",
+          "description": "Credential-free workload-identity access. The asset origin authorizes an identity already controlled by the component that performs the asset fetch, such as a GCP service account or AWS IAM role, through authenticated out-of-band onboarding. The consumer MUST use workload credentials only for the pre-authorized HTTPS origin and resource prefix; the payload's method, provider, and URL are not authorization. No provider key or access secret crosses the AdCP payload.",
           "properties": {
             "method": { "type": "string", "const": "service_account" },
             "provider": {
@@ -313,7 +313,7 @@
             "credentials": {
               "type": "object",
               "deprecated": true,
-              "description": "Deprecated in AdCP 3.2 and removed in 4.0. Legacy integrations may still supply provider credentials here during the compatibility window, but new producers MUST omit this field. Consumers MUST treat any value as secret and MUST NOT log it, persist it beyond the access window, or place it in model context. Use the consumer's pre-authorized workload identity or `signed_url` instead.",
+              "description": "Deprecated in AdCP 3.2 and eligible for removal in 4.0 or later only after the deprecation-policy notice and release-cycle gates are satisfied. Presence denotes the legacy inline-credential form, not workload-identity authorization. New producers MUST omit this field. Consumers MUST NOT activate received credentials automatically; they may process them only for an explicitly allowlisted legacy peer and otherwise MUST reject or quarantine them. Consumers MUST redact the complete value from logs, traces, errors, metrics, analytics, model context, and durable storage. Use the consumer's pre-authorized workload identity or `signed_url` instead.",
               "additionalProperties": true
             }
           },
@@ -321,7 +321,7 @@
         },
         {
           "type": "object",
-          "description": "Recommended default for one-off access. The asset `url` is a time-limited bearer capability and requires no additional authentication. Producers SHOULD scope it to one asset and the shortest practical access window. Consumers MUST treat the complete URL as a secret and MUST NOT place it in logs or model context.",
+          "description": "Recommended default for one-off access. The asset `url` is a time-limited bearer capability and requires no additional authentication. Producers SHOULD scope it to one asset and the shortest practical access window under their documented maximum TTL. Consumers MUST redact the complete URL from logs, traces, errors, metrics, analytics, model context, and durable storage, and MUST NOT forward it outside the intended recipient trust boundary.",
           "properties": {
             "method": { "type": "string", "const": "signed_url" }
           },

--- a/static/schemas/source/content-standards/artifact.json
+++ b/static/schemas/source/content-standards/artifact.json
@@ -283,26 +283,26 @@
   "$defs": {
     "asset_access": {
       "type": "object",
-      "description": "Authentication for accessing secured asset URLs",
+      "description": "Access instructions for a secured asset URL. Producers SHOULD use `signed_url` for one-off delivery unless the parties already have an identity-based access relationship. New producers MUST NOT carry long-lived credentials in this object; consumers continue accepting the deprecated legacy field during the 3.x compatibility window.",
       "discriminator": {
         "propertyName": "method"
       },
       "oneOf": [
         {
           "type": "object",
-          "description": "Bearer token authentication",
+          "description": "Short-lived bearer-token access for origins that cannot use signed URLs or pre-configured workload identity. The token is a live secret and must be scoped to the asset.",
           "properties": {
             "method": { "type": "string", "const": "bearer_token" },
             "token": {
               "type": "string",
-              "description": "OAuth2 bearer token for Authorization header"
+              "description": "Short-lived, asset-scoped bearer token for the Authorization header. Producers MUST NOT issue a standing or broadly scoped credential here. Consumers MUST treat the token as a secret and MUST NOT log it, persist it beyond the access window, or place it in model context."
             }
           },
           "required": ["method", "token"]
         },
         {
           "type": "object",
-          "description": "Service account authentication (GCP, AWS)",
+          "description": "Credential-free workload-identity access. The asset origin authorizes an identity already controlled by the consumer, such as a GCP service account or AWS IAM role, through out-of-band onboarding. No provider key or access secret crosses the AdCP payload.",
           "properties": {
             "method": { "type": "string", "const": "service_account" },
             "provider": {
@@ -312,7 +312,8 @@
             },
             "credentials": {
               "type": "object",
-              "description": "Service account credentials",
+              "deprecated": true,
+              "description": "Deprecated in AdCP 3.2 and removed in 4.0. Legacy integrations may still supply provider credentials here during the compatibility window, but new producers MUST omit this field. Consumers MUST treat any value as secret and MUST NOT log it, persist it beyond the access window, or place it in model context. Use the consumer's pre-authorized workload identity or `signed_url` instead.",
               "additionalProperties": true
             }
           },
@@ -320,7 +321,7 @@
         },
         {
           "type": "object",
-          "description": "Pre-signed URL (credentials embedded in URL)",
+          "description": "Recommended default for one-off access. The asset `url` is a time-limited bearer capability and requires no additional authentication. Producers SHOULD scope it to one asset and the shortest practical access window. Consumers MUST treat the complete URL as a secret and MUST NOT place it in logs or model context.",
           "properties": {
             "method": { "type": "string", "const": "signed_url" }
           },

--- a/static/schemas/source/trusted-match/context-match-request.json
+++ b/static/schemas/source/trusted-match/context-match-request.json
@@ -60,7 +60,7 @@
     },
     "artifact": {
       "$ref": "/schemas/content-standards/artifact.json",
-      "description": "Full content artifact adjacent to this ad opportunity. Same schema used for content standards evaluation. The publisher sends the artifact when they want the buyer to evaluate the full content. Contractual protections govern buyer use. TEE deployment upgrades contractual trust to cryptographic verification. Publishers MUST NOT include asset access credentials (bearer tokens, service accounts) — the router fans out to multiple buyer agents. For secured assets, use signed URLs with short expiry. Routers MUST strip access fields from artifacts before forwarding."
+      "description": "Full content artifact adjacent to this ad opportunity. Same schema used for content standards evaluation. The publisher sends the artifact when they want the buyer to evaluate the full content. Contractual protections govern buyer use. TEE deployment upgrades contractual trust to cryptographic verification. Because the router fans out to multiple buyer agents, publishers MUST NOT include bearer tokens, service-account credentials, or signed URLs in this artifact. Routers MUST remove every asset `access` object and remove or replace every credential-bearing asset `url` before forwarding; only public asset URLs that recipients can resolve independently may remain."
     },
     "artifact_refs": {
       "type": "array",

--- a/tests/asset-access-deprecation.test.cjs
+++ b/tests/asset-access-deprecation.test.cjs
@@ -1,0 +1,39 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const schemaPath = path.join(
+  __dirname,
+  '../static/schemas/source/content-standards/artifact.json'
+);
+const artifactSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+const accessBranches = artifactSchema.$defs.asset_access.oneOf;
+
+function branch(method) {
+  return accessBranches.find(
+    (candidate) => candidate.properties?.method?.const === method
+  );
+}
+
+test('deprecates only inline service-account credentials', () => {
+  const serviceAccount = branch('service_account');
+
+  assert.ok(serviceAccount, 'service_account access remains supported');
+  assert.equal(serviceAccount.properties.credentials.deprecated, true);
+  assert.ok(!serviceAccount.properties.authorized_principal);
+  assert.deepEqual(serviceAccount.required, ['method', 'provider']);
+});
+
+test('keeps the three 3.2 access pathways available', () => {
+  assert.deepEqual(
+    accessBranches.map((candidate) => candidate.properties.method.const),
+    ['bearer_token', 'service_account', 'signed_url']
+  );
+});
+
+test('documents signed URLs as the recommended one-off path', () => {
+  assert.match(branch('signed_url').description, /Recommended default/);
+  assert.match(branch('bearer_token').description, /Short-lived/);
+  assert.match(branch('service_account').description, /Credential-free/);
+});

--- a/tests/asset-access-deprecation.test.cjs
+++ b/tests/asset-access-deprecation.test.cjs
@@ -8,6 +8,15 @@ const schemaPath = path.join(
   '../static/schemas/source/content-standards/artifact.json'
 );
 const artifactSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+const trustedMatchSchema = JSON.parse(
+  fs.readFileSync(
+    path.join(
+      __dirname,
+      '../static/schemas/source/trusted-match/context-match-request.json'
+    ),
+    'utf8'
+  )
+);
 const accessBranches = artifactSchema.$defs.asset_access.oneOf;
 
 function branch(method) {
@@ -36,4 +45,22 @@ test('documents signed URLs as the recommended one-off path', () => {
   assert.match(branch('signed_url').description, /Recommended default/);
   assert.match(branch('bearer_token').description, /Short-lived/);
   assert.match(branch('service_account').description, /Credential-free/);
+});
+
+test('fails closed at credential and recipient trust boundaries', () => {
+  assert.match(artifactSchema.$defs.asset_access.description, /fail closed/);
+  assert.match(branch('bearer_token').description, /MUST NOT forward/);
+  assert.match(
+    branch('service_account').description,
+    /authenticated out-of-band onboarding/
+  );
+  assert.match(branch('signed_url').description, /MUST NOT forward/);
+  assert.match(
+    branch('service_account').properties.credentials.description,
+    /MUST NOT activate/
+  );
+  assert.match(
+    trustedMatchSchema.properties.artifact.description,
+    /MUST NOT include bearer tokens, service-account credentials, or signed URLs/
+  );
 });

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -243,6 +243,7 @@ test('temporary snapshot redirects cover every available live page', () => {
   );
 
   const expectedUncoveredPages = [
+    'docs/reference/migration/asset-access',
     'docs/reference/migration/cross-role-governance-enforcement',
     'docs/protocol/sync_agent_notification_configs',
   ];


### PR DESCRIPTION
## Summary

- deprecate inline `service_account.credentials` while keeping legacy 3.x payloads schema-valid
- recommend signed URLs as the default one-off asset-access path
- preserve credential-free workload identity and bounded bearer-token access
- define safe-fetch, redirect, credential-binding, and trusted-match fan-out boundaries
- add a tested 3.2 migration guide and focused regression coverage

## Why

Standing cloud credentials embedded in artifact responses can flow through agent transport, logs, traces, and model context. AdCP 3.2 needs to stop new producers from emitting that pattern without breaking existing 3.x consumers before the 4.0 removal window.

This change deliberately does not add `authorized_principal`: payload metadata is not proof of authorization. The broader extensible and identity-bound access-method design is tracked in #6224, while removal of the deprecated field remains tracked in #5699.

## Developer impact

- New producers should use short-lived signed URLs unless an identity-based relationship is already configured.
- Existing consumers must continue parsing and validating legacy inline credentials during 3.x, but may process them only for explicitly allowlisted legacy peers.
- `service_account` remains available without `credentials` for pre-authorized workload identity.
- Origins requiring an Authorization header can continue using short-lived, asset-scoped bearer tokens.
- Removal is eligible in 4.0 or later only after the six-month notice and full-release-cycle policy gates are satisfied.

## Validation

- `npm run test:schemas`
- `node --test tests/asset-access-deprecation.test.cjs`
- `npm run test:json-schema -- --file docs/reference/migration/asset-access.mdx`
- `npm run test:docs-nav`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- `npx --yes @changesets/cli@^2.31.0 status --since=origin/main`
- GitHub CI: all required checks passing, including CodeQL, security scans, build, integration tests, and current/3.0 storyboard matrices

Closes #5698.
