### PR TITLE
fix(addie): recover production response failures

### DIFF
--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -29,6 +29,7 @@ import type {
 } from '@slack/bolt/dist/Assistant';
 import type { Router } from 'express';
 import { createLogger } from '../logger.js';
+import { deliverAndRecordDirectMessage } from './direct-message-delivery.js';
 
 const logger = createLogger('addie-bolt-app');
 import { sanitizeSpeakerName } from './prompts.js';
@@ -3628,21 +3629,70 @@ async function handleDirectMessage(
   // 2. Regular DMs: response threads to the user's message (Slack shows
   //    threaded DM replies inline, so UX is unchanged)
   const replyThreadTs = event.thread_ts || event.ts;
-  let responseTs: string | undefined;
-  try {
-    const postResult = await boltApp.client.chat.postMessage({
-      channel: channelId,
-      text: wrapUrlsForSlack(outputValidation.sanitized),
-      thread_ts: replyThreadTs,
-    });
-    responseTs = postResult.ts;
-  } catch (error) {
-    logger.error({ error }, 'Addie Bolt: Failed to send DM response');
-  }
+
+  const assistantFlagged = response.flagged || outputValidation.flagged;
+  const flagReason = [response.flag_reason, outputValidation.reason].filter(Boolean).join('; ');
+  const boltClient = boltApp.client;
+  const assistantMessage = {
+    thread_id: thread.thread_id,
+    role: 'assistant' as const,
+    content: outputValidation.sanitized,
+    tools_used: response.tools_used,
+    tool_calls: response.tool_executions?.map(exec => ({
+      name: exec.tool_name,
+      input: exec.parameters,
+      result: exec.result,
+      duration_ms: exec.duration_ms,
+      is_error: exec.is_error,
+    })),
+    model: AddieModelConfig.chat,
+    latency_ms: Date.now() - startTime,
+    tokens_input: response.usage?.input_tokens,
+    tokens_output: response.usage?.output_tokens,
+    flagged: assistantFlagged,
+    flag_reason: flagReason || undefined,
+    timing: response.timing ? {
+      system_prompt_ms: response.timing.system_prompt_ms,
+      total_llm_ms: response.timing.total_llm_ms,
+      total_tool_ms: response.timing.total_tool_execution_ms,
+      iterations: response.timing.iterations,
+    } : undefined,
+    tokens_cache_creation: response.usage?.cache_creation_input_tokens,
+    tokens_cache_read: response.usage?.cache_read_input_tokens,
+    active_rule_ids: response.active_rule_ids,
+  };
+  const delivery = await deliverAndRecordDirectMessage({
+    channelId,
+    userId,
+    threadId: thread.thread_id,
+    assistantMessage,
+    userMessageFlagged,
+    assistantFlagged,
+    flagReason: [inputValidation.reason, flagReason].filter(Boolean).join('; '),
+    dependencies: {
+      postMessage: () => boltClient.chat.postMessage({
+        channel: channelId,
+        text: wrapUrlsForSlack(outputValidation.sanitized),
+        thread_ts: replyThreadTs,
+      }),
+      addMessage: (message) => threadService.addMessage(message),
+      flagThread: (threadId, reason) => threadService.flagThread(threadId, reason),
+    },
+  });
 
   // If no permanent thread existed, save the user's message ts as the permanent
   // thread so the orchestrator will continue in this same thread later.
-  if (!permThreadTs) {
+  if (delivery.permanentFailure) {
+    try {
+      const rel = cachedRel ?? await relationshipDb.getRelationshipBySlackId(userId);
+      if (rel?.slack_dm_channel_id === channelId) {
+        await relationshipDb.clearSlackDmThread(rel.id, channelId);
+        logger.info({ userId, channelId }, 'Addie Bolt: Cleared unwritable permanent DM thread');
+      }
+    } catch (error) {
+      logger.debug({ error, userId }, 'Addie Bolt: Could not clear unwritable permanent thread');
+    }
+  } else if (!permThreadTs) {
     try {
       const rel = cachedRel ?? await relationshipDb.getRelationshipBySlackId(userId);
       if (rel && !rel.slack_dm_thread_ts) {
@@ -3651,55 +3701,6 @@ async function handleDirectMessage(
       }
     } catch (error) {
       logger.debug({ error, userId }, 'Addie Bolt: Could not save permanent thread');
-    }
-  }
-
-  // Log assistant response to unified thread
-  const assistantFlagged = response.flagged || outputValidation.flagged;
-  const flagReason = [response.flag_reason, outputValidation.reason].filter(Boolean).join('; ');
-
-  try {
-    await threadService.addMessage({
-      thread_id: thread.thread_id,
-      role: 'assistant',
-      content: outputValidation.sanitized,
-      tools_used: response.tools_used,
-      tool_calls: response.tool_executions?.map(exec => ({
-        name: exec.tool_name,
-        input: exec.parameters,
-        result: exec.result,
-        duration_ms: exec.duration_ms,
-        is_error: exec.is_error,
-      })),
-      model: AddieModelConfig.chat,
-      latency_ms: Date.now() - startTime,
-      tokens_input: response.usage?.input_tokens,
-      tokens_output: response.usage?.output_tokens,
-      flagged: assistantFlagged,
-      flag_reason: flagReason || undefined,
-      timing: response.timing ? {
-        system_prompt_ms: response.timing.system_prompt_ms,
-        total_llm_ms: response.timing.total_llm_ms,
-        total_tool_ms: response.timing.total_tool_execution_ms,
-        iterations: response.timing.iterations,
-      } : undefined,
-      tokens_cache_creation: response.usage?.cache_creation_input_tokens,
-      tokens_cache_read: response.usage?.cache_read_input_tokens,
-      active_rule_ids: response.active_rule_ids,
-    });
-  } catch (error) {
-    logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to save assistant message');
-  }
-
-  // Flag the thread if any message was flagged
-  if (userMessageFlagged || assistantFlagged) {
-    try {
-      await threadService.flagThread(
-        thread.thread_id,
-        [inputValidation.reason, flagReason].filter(Boolean).join('; ')
-      );
-    } catch (error) {
-      logger.error({ error, threadId: thread.thread_id }, 'Addie Bolt: Failed to flag thread');
     }
   }
 
@@ -3717,14 +3718,14 @@ async function handleDirectMessage(
     tools_used: response.tools_used,
     model: AddieModelConfig.chat,
     latency_ms: Date.now() - startTime,
-    flagged: userMessageFlagged || assistantFlagged,
-    flag_reason: [inputValidation.reason, flagReason].filter(Boolean).join('; ') || undefined,
+    delivery_status: delivery.delivered ? 'delivered' : 'failed',
+    flagged: userMessageFlagged || assistantFlagged || !delivery.delivered,
+    flag_reason: [
+      inputValidation.reason,
+      flagReason,
+      delivery.delivered ? undefined : `Slack delivery failed: ${delivery.errorCode ?? 'unknown_error'}`,
+    ].filter(Boolean).join('; ') || undefined,
   });
-
-  logger.info(
-    { userId, channelId, latencyMs: Date.now() - startTime },
-    'Addie Bolt: DM response sent'
-  );
 }
 
 /**

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -867,6 +867,8 @@ export class AddieClaudeClient {
       };
     }
     let iteration = 0;
+    let retriedEmptyPostToolResponse = false;
+    let hasExecutedCustomTool = false;
 
     while (iteration < maxIterations) {
       iteration++;
@@ -880,7 +882,7 @@ export class AddieClaudeClient {
             model: effectiveModel,
             max_tokens: 4096,
             system: systemBlocks,
-            tools: [
+            tools: retriedEmptyPostToolResponse ? [] : [
               ...customTools,
               // Add web search tool via beta API
               ...(this.webSearchEnabled ? [{
@@ -924,6 +926,18 @@ export class AddieClaudeClient {
         inputTokens: response.usage?.input_tokens,
         outputTokens: response.usage?.output_tokens,
       }, 'Addie: Claude response received');
+
+      // The empty-response recovery call is intentionally text-only. Defend
+      // against a malformed provider response that nevertheless contains a
+      // tool request: discard it instead of risking a duplicate mutation.
+      if (retriedEmptyPostToolResponse && response.stop_reason === 'tool_use') {
+        logger.warn({ iteration }, 'Addie: Ignoring tool use from text-only recovery');
+        response = {
+          ...response,
+          stop_reason: 'end_turn',
+          content: [],
+        };
+      }
 
       // Check for web search results in the response (can appear even with end_turn)
       const earlyWebSearchResults = response.content.filter((c) => c.type === 'web_search_tool_result');
@@ -982,6 +996,14 @@ export class AddieClaudeClient {
           .map(block => block.type === 'text' ? block.text : '')
           .join('\n\n')
           .trim();
+        // Anthropic can occasionally return an empty end_turn immediately
+        // after a tool result. Resampling the unchanged post-tool turn once is
+        // safe because no assistant response has reached the caller yet.
+        if (!rawText && hasExecutedCustomTool && !retriedEmptyPostToolResponse && iteration < maxIterations) {
+          retriedEmptyPostToolResponse = true;
+          logger.warn({ iteration, toolsUsed }, 'Addie: Retrying empty response after tool use');
+          continue;
+        }
         const emptyResponse = applyResponsePipelineWithEmptyMonitoring(userMessage, rawText, toolExecutions);
         const text = emptyResponse.text;
 
@@ -1162,6 +1184,7 @@ export class AddieClaudeClient {
           if (block.type !== 'tool_use') continue;
 
           const toolName = block.name;
+          hasExecutedCustomTool = true;
           const toolInput = block.input as Record<string, unknown>;
           const toolUseId = block.id;
           const startTime = Date.now();
@@ -1470,6 +1493,7 @@ export class AddieClaudeClient {
     }
     const maxIterations = options?.maxIterations ?? 10;
     let iteration = 0;
+    let retriedEmptyPostToolResponse = false;
 
     try {
       while (iteration < maxIterations) {
@@ -1494,7 +1518,7 @@ export class AddieClaudeClient {
               model: effectiveModel,
               max_tokens: 4096,
               system: systemBlocks,
-              tools: customTools,
+              tools: retriedEmptyPostToolResponse ? [] : customTools,
               messages,
             });
 
@@ -1503,10 +1527,12 @@ export class AddieClaudeClient {
               if (event.type === 'content_block_delta') {
                 const delta = event.delta;
                 if ('text' in delta && delta.text) {
-                  hasYieldedContent = true;
                   textChunks.push(delta.text);
-                  fullText += delta.text;
-                  yield { type: 'text', text: delta.text };
+                  if (!retriedEmptyPostToolResponse) {
+                    hasYieldedContent = true;
+                    fullText += delta.text;
+                    yield { type: 'text', text: delta.text };
+                  }
                 }
               } else if (event.type === 'message_stop') {
                 // Get the final message
@@ -1626,6 +1652,26 @@ export class AddieClaudeClient {
           outputTokens: currentResponse.usage?.output_tokens,
         }, 'Addie Stream: Claude response received');
 
+        // The recovery iteration has no tools. If the provider still returns
+        // a tool_use block, ignore it rather than executing a mutation twice.
+        if (retriedEmptyPostToolResponse && currentResponse.stop_reason === 'tool_use') {
+          logger.warn({ iteration }, 'Addie Stream: Ignoring tool use from text-only recovery');
+          currentResponse = {
+            ...currentResponse,
+            stop_reason: 'end_turn',
+            content: [],
+          };
+        } else if (retriedEmptyPostToolResponse) {
+          const recoveredText = textChunks.join('') || currentResponse.content
+            .filter((block): block is Anthropic.Beta.BetaTextBlock => block.type === 'text')
+            .map((block) => block.text)
+            .join('');
+          if (recoveredText) {
+            fullText += recoveredText;
+            yield { type: 'text', text: recoveredText };
+          }
+        }
+
         // Build the final usage block + charge the user's cost
         // budget (#2790). Both stream terminal paths (end_turn and
         // no-tool-blocks) share this; kept inline as a local const
@@ -1649,6 +1695,20 @@ export class AddieClaudeClient {
 
         // Done - no tool use
         if (currentResponse.stop_reason === 'end_turn') {
+          const iterationText = currentResponse.content
+            .filter((block): block is Anthropic.Beta.BetaTextBlock => block.type === 'text')
+            .map(block => block.text)
+            .join('\n\n')
+            .trim();
+
+          // No deltas were emitted for this iteration, so retrying the same
+          // post-tool turn once cannot duplicate text in streaming clients.
+          if (!iterationText && toolExecutions.length > 0 && !retriedEmptyPostToolResponse && iteration < maxIterations) {
+            retriedEmptyPostToolResponse = true;
+            logger.warn({ iteration, toolsUsed }, 'Addie Stream: Retrying empty response after tool use');
+            continue;
+          }
+
           totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
 
           // Run both detectors against the post-pipeline text — same as the

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.07.6';
+export const CODE_VERSION = '2026.08.1';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/direct-message-delivery.ts
+++ b/server/src/addie/direct-message-delivery.ts
@@ -1,0 +1,105 @@
+import { createLogger } from '../logger.js';
+import type { CreateMessageInput } from './thread-service.js';
+import { getSlackApiErrorCode, isPermanentDmDeliveryError } from './slack-api-errors.js';
+
+const logger = createLogger('addie-dm-delivery');
+
+export interface DirectMessageDeliveryDependencies {
+  postMessage: () => Promise<{ ts?: string }>;
+  addMessage: (input: CreateMessageInput) => Promise<unknown>;
+  flagThread: (threadId: string, reason: string) => Promise<unknown>;
+}
+
+export interface DirectMessageDeliveryInput {
+  channelId: string;
+  userId: string;
+  threadId: string;
+  assistantMessage: CreateMessageInput;
+  userMessageFlagged: boolean;
+  assistantFlagged: boolean;
+  flagReason: string;
+  dependencies: DirectMessageDeliveryDependencies;
+}
+
+export interface DirectMessageDeliveryResult {
+  delivered: boolean;
+  responseTs?: string;
+  errorCode: string | null;
+  permanentFailure: boolean;
+}
+
+/**
+ * Deliver a prepared DM response and keep persistence aligned with what the
+ * user actually saw. Failed deliveries retain tool executions as an internal
+ * assistant marker so later turns know not to repeat completed mutations.
+ */
+export async function deliverAndRecordDirectMessage(
+  input: DirectMessageDeliveryInput,
+): Promise<DirectMessageDeliveryResult> {
+  const { dependencies } = input;
+  let delivered = false;
+  let responseTs: string | undefined;
+  let errorCode: string | null = null;
+  let permanentFailure = false;
+
+  try {
+    const result = await dependencies.postMessage();
+    responseTs = result.ts;
+    delivered = true;
+  } catch (error) {
+    errorCode = getSlackApiErrorCode(error);
+    permanentFailure = isPermanentDmDeliveryError(error);
+    if (permanentFailure) {
+      logger.warn(
+        { slackError: errorCode, channelId: input.channelId, userId: input.userId },
+        'Addie Bolt: DM channel does not allow responses',
+      );
+    } else {
+      logger.error({ error }, 'Addie Bolt: Failed to send DM response');
+    }
+  }
+
+  if (delivered) {
+    try {
+      await dependencies.addMessage(input.assistantMessage);
+    } catch (error) {
+      logger.error({ error, threadId: input.threadId }, 'Addie Bolt: Failed to save assistant message');
+    }
+  } else if (input.assistantMessage.tool_calls?.length) {
+    const deliveryLabel = errorCode ?? 'unknown_error';
+    try {
+      await dependencies.addMessage({
+        ...input.assistantMessage,
+        role: 'assistant',
+        content: `[Internal delivery note: Slack delivery failed (${deliveryLabel}). The recorded tool executions completed, but the user did not receive the assistant response. Do not repeat successful actions unless the user explicitly asks.]`,
+        content_sanitized: undefined,
+        flagged: true,
+        flag_reason: `Slack delivery failed: ${deliveryLabel}`,
+      });
+    } catch (error) {
+      logger.error({ error, threadId: input.threadId }, 'Addie Bolt: Failed to save undelivered tool audit');
+    }
+  }
+
+  const hasUndeliveredToolAudit = !delivered && !!input.assistantMessage.tool_calls?.length;
+  if (input.userMessageFlagged || (delivered && input.assistantFlagged) || hasUndeliveredToolAudit) {
+    try {
+      const threadFlagReason = [
+        input.userMessageFlagged || (delivered && input.assistantFlagged) ? input.flagReason : undefined,
+        hasUndeliveredToolAudit ? `Slack delivery failed: ${errorCode ?? 'unknown_error'}` : undefined,
+      ].filter(Boolean).join('; ');
+      await dependencies.flagThread(input.threadId, threadFlagReason);
+    } catch (error) {
+      logger.error({ error, threadId: input.threadId }, 'Addie Bolt: Failed to flag thread');
+    }
+  }
+
+  if (delivered) {
+    logger.info(
+      { userId: input.userId, channelId: input.channelId, responseTs },
+      'Addie Bolt: DM response sent',
+    );
+  }
+
+  return { delivered, responseTs, errorCode, permanentFailure };
+}

--- a/server/src/addie/security.ts
+++ b/server/src/addie/security.ts
@@ -368,6 +368,7 @@ export function logInteraction(log: AddieInteractionLog): void {
       userId: log.user_id,
       channelId: log.channel_id,
       latencyMs: log.latency_ms,
+      deliveryStatus: log.delivery_status,
       toolsUsed: log.tools_used,
       flagged: log.flagged,
       flagReason: log.flag_reason,

--- a/server/src/addie/slack-api-errors.ts
+++ b/server/src/addie/slack-api-errors.ts
@@ -1,0 +1,17 @@
+const PERMANENT_DM_DELIVERY_ERRORS = new Set([
+  'restricted_action_read_only_channel',
+]);
+
+/** Extract Slack's API error name from @slack/web-api platform errors. */
+export function getSlackApiErrorCode(error: unknown): string | null {
+  if (!error || typeof error !== 'object' || !('data' in error)) return null;
+  const data = error.data;
+  if (!data || typeof data !== 'object' || !('error' in data)) return null;
+  return typeof data.error === 'string' ? data.error : null;
+}
+
+/** Errors where retrying or escalating cannot make the current DM writable. */
+export function isPermanentDmDeliveryError(error: unknown): boolean {
+  const code = getSlackApiErrorCode(error);
+  return code !== null && PERMANENT_DM_DELIVERY_ERRORS.has(code);
+}

--- a/server/src/addie/types.ts
+++ b/server/src/addie/types.ts
@@ -80,6 +80,7 @@ export interface AddieInteractionLog {
   tools_used: string[];
   model: string;
   latency_ms: number;
+  delivery_status?: 'delivered' | 'failed';
   flagged: boolean;
   flag_reason?: string;
 }

--- a/server/src/db/relationship-db.ts
+++ b/server/src/db/relationship-db.ts
@@ -411,6 +411,16 @@ export async function setSlackDmThread(personId: string, channelId: string, thre
   );
 }
 
+/** Clear permanent Slack DM coordinates after Slack marks the channel unwritable. */
+export async function clearSlackDmThread(personId: string, channelId: string): Promise<void> {
+  await query(
+    `UPDATE person_relationships
+     SET slack_dm_channel_id = NULL, slack_dm_thread_ts = NULL, updated_at = NOW()
+     WHERE id = $1 AND slack_dm_channel_id = $2`,
+    [personId, channelId]
+  );
+}
+
 /** Mark a person as opted out of all proactive outreach. */
 export async function setOptedOut(personId: string, optedOut: boolean): Promise<void> {
   await query(

--- a/server/tests/unit/addie-empty-response-fallback.test.ts
+++ b/server/tests/unit/addie-empty-response-fallback.test.ts
@@ -52,6 +52,40 @@ const emptyEndTurn = {
   },
 };
 
+const toolUseTurn = {
+  stop_reason: 'tool_use',
+  content: [{
+    type: 'tool_use',
+    id: 'toolu_1',
+    name: 'get_github_issue',
+    input: { issue_number: 42 },
+  }],
+  usage: { input_tokens: 10, output_tokens: 5 },
+};
+
+const recoveredEndTurn = {
+  stop_reason: 'end_turn',
+  content: [{ type: 'text', text: 'Issue 42 is open.' }],
+  usage: { input_tokens: 12, output_tokens: 6 },
+};
+
+const mixedRecoveryToolUseTurn = {
+  ...toolUseTurn,
+  content: [
+    { type: 'text', text: 'I updated it again.' },
+    ...toolUseTurn.content,
+  ],
+};
+
+const webSearchResultOnlyEndTurn = {
+  stop_reason: 'end_turn',
+  content: [
+    { type: 'server_tool_use', id: 'srv_1', name: 'web_search', input: { query: 'AdCP issue 42' } },
+    { type: 'web_search_tool_result', tool_use_id: 'srv_1', content: [] },
+  ],
+  usage: { input_tokens: 10, output_tokens: 5 },
+};
+
 function makeEmptyStream() {
   return {
     async *[Symbol.asyncIterator]() {
@@ -61,12 +95,36 @@ function makeEmptyStream() {
   };
 }
 
+function makeStream(message: typeof toolUseTurn | typeof emptyEndTurn | typeof recoveredEndTurn | typeof mixedRecoveryToolUseTurn) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const block of message.content) {
+        if (block.type === 'text') {
+          yield { type: 'content_block_delta', delta: { type: 'text_delta', text: block.text } };
+        }
+      }
+    },
+    finalMessage: vi.fn().mockResolvedValue(message),
+  };
+}
+
+const getGithubIssue = vi.fn().mockResolvedValue('{"number":42,"state":"open"}');
+const githubIssueTools = {
+  tools: [{
+    name: 'get_github_issue',
+    description: 'Get an issue',
+    input_schema: { type: 'object' as const, properties: {} },
+  }],
+  handlers: new Map([['get_github_issue', getGithubIssue]]),
+};
+
 describe('Addie empty-response fallback (#4430)', () => {
   beforeEach(() => {
     mocks.createMessage.mockReset();
     mocks.streamMessage.mockReset();
     mocks.notifySystemError.mockReset();
     mocks.notifyToolError.mockReset();
+    getGithubIssue.mockClear();
   });
 
   it('returns fallback text and sends monitoring for non-streaming empty responses', async () => {
@@ -114,5 +172,173 @@ describe('Addie empty-response fallback (#4430)', () => {
       source: 'addie-empty-response',
       errorMessage: expect.stringContaining('processMessageStream'),
     }));
+  });
+
+  it('resamples once after a tool returns an empty non-streaming completion', async () => {
+    mocks.createMessage
+      .mockResolvedValueOnce(toolUseTurn)
+      .mockResolvedValueOnce(emptyEndTurn)
+      .mockResolvedValueOnce(recoveredEndTurn);
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const response = await client.processMessage(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      undefined,
+      { uncapped: true, threadId: 'thread-recovered' },
+    );
+
+    expect(response.text).toBe('Issue 42 is open.');
+    expect(response.timing?.iterations).toBe(3);
+    expect(getGithubIssue).toHaveBeenCalledOnce();
+    expect(mocks.notifySystemError).not.toHaveBeenCalled();
+  });
+
+  it('does not discard server-managed search results by entering custom-tool recovery', async () => {
+    mocks.createMessage.mockResolvedValueOnce(webSearchResultOnlyEndTurn);
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const response = await client.processMessage(
+      'search for issue 42',
+      undefined,
+      undefined,
+      undefined,
+      { uncapped: true, threadId: 'thread-web-search-empty' },
+    );
+
+    expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(mocks.createMessage).toHaveBeenCalledOnce();
+    expect(mocks.notifySystemError).toHaveBeenCalledOnce();
+  });
+
+  it('resamples once after a tool returns an empty streaming completion', async () => {
+    mocks.streamMessage
+      .mockReturnValueOnce(makeStream(toolUseTurn))
+      .mockReturnValueOnce(makeStream(emptyEndTurn))
+      .mockReturnValueOnce(makeStream(recoveredEndTurn));
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const events: StreamEvent[] = [];
+
+    for await (const event of client.processMessageStream(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      { uncapped: true, threadId: 'thread-stream-recovered' },
+    )) {
+      events.push(event);
+    }
+
+    const text = events
+      .filter((event): event is Extract<StreamEvent, { type: 'text' }> => event.type === 'text')
+      .map(event => event.text)
+      .join('');
+    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    expect(text).toBe('Issue 42 is open.');
+    expect(done?.response.text).toBe('Issue 42 is open.');
+    expect(done?.response.timing?.iterations).toBe(3);
+    expect(getGithubIssue).toHaveBeenCalledOnce();
+    expect(mocks.notifySystemError).not.toHaveBeenCalled();
+  });
+
+  it('falls back after the one non-streaming post-tool resample is also empty', async () => {
+    mocks.createMessage
+      .mockResolvedValueOnce(toolUseTurn)
+      .mockResolvedValueOnce(emptyEndTurn)
+      .mockResolvedValueOnce(emptyEndTurn);
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const response = await client.processMessage(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      undefined,
+      { uncapped: true, threadId: 'thread-recovery-exhausted' },
+    );
+
+    expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(response.flagged).toBe(true);
+    expect(response.timing?.iterations).toBe(3);
+    expect(getGithubIssue).toHaveBeenCalledOnce();
+    expect(mocks.createMessage).toHaveBeenCalledTimes(3);
+    expect(mocks.createMessage.mock.calls[2][0].tools).toEqual([]);
+    expect(mocks.notifySystemError).toHaveBeenCalledOnce();
+  });
+
+  it('falls back after the one streaming post-tool resample is also empty', async () => {
+    mocks.streamMessage
+      .mockReturnValueOnce(makeStream(toolUseTurn))
+      .mockReturnValueOnce(makeStream(emptyEndTurn))
+      .mockReturnValueOnce(makeStream(emptyEndTurn));
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const events: StreamEvent[] = [];
+    for await (const event of client.processMessageStream(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      { uncapped: true, threadId: 'thread-stream-recovery-exhausted' },
+    )) {
+      events.push(event);
+    }
+
+    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    expect(done?.response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(done?.response.flagged).toBe(true);
+    expect(done?.response.timing?.iterations).toBe(3);
+    expect(getGithubIssue).toHaveBeenCalledOnce();
+    expect(mocks.streamMessage).toHaveBeenCalledTimes(3);
+    expect(mocks.streamMessage.mock.calls[2][0].tools).toEqual([]);
+    expect(mocks.notifySystemError).toHaveBeenCalledOnce();
+  });
+
+  it('never repeats a tool emitted by a malformed non-streaming recovery response', async () => {
+    mocks.createMessage
+      .mockResolvedValueOnce(toolUseTurn)
+      .mockResolvedValueOnce(emptyEndTurn)
+      .mockResolvedValueOnce(mixedRecoveryToolUseTurn);
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const response = await client.processMessage(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      undefined,
+      { uncapped: true, threadId: 'thread-recovery-tool-rejected' },
+    );
+
+    expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(response.text).not.toContain('updated it again');
+    expect(getGithubIssue).toHaveBeenCalledOnce();
+    expect(mocks.notifySystemError).toHaveBeenCalledOnce();
+  });
+
+  it('never repeats a tool emitted by a malformed streaming recovery response', async () => {
+    mocks.streamMessage
+      .mockReturnValueOnce(makeStream(toolUseTurn))
+      .mockReturnValueOnce(makeStream(emptyEndTurn))
+      .mockReturnValueOnce(makeStream(mixedRecoveryToolUseTurn));
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const events: StreamEvent[] = [];
+    for await (const event of client.processMessageStream(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      { uncapped: true, threadId: 'thread-stream-recovery-tool-rejected' },
+    )) {
+      events.push(event);
+    }
+
+    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    expect(done?.response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    const streamedText = events
+      .filter((event): event is Extract<StreamEvent, { type: 'text' }> => event.type === 'text')
+      .map((event) => event.text)
+      .join('');
+    expect(streamedText).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(getGithubIssue).toHaveBeenCalledOnce();
+    expect(mocks.notifySystemError).toHaveBeenCalledOnce();
   });
 });

--- a/server/tests/unit/direct-message-delivery.test.ts
+++ b/server/tests/unit/direct-message-delivery.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const log = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('../../src/logger.js', () => ({
+  createLogger: vi.fn(() => log),
+}));
+
+import { deliverAndRecordDirectMessage } from '../../src/addie/direct-message-delivery.js';
+
+function makeInput(overrides: { userMessageFlagged?: boolean; assistantFlagged?: boolean } = {}) {
+  const postMessage = vi.fn();
+  const addMessage = vi.fn().mockResolvedValue(undefined);
+  const flagThread = vi.fn().mockResolvedValue(undefined);
+  return {
+    input: {
+      channelId: 'D123',
+      userId: 'U123',
+      threadId: 'thread-1',
+      assistantMessage: {
+        thread_id: 'thread-1',
+        role: 'assistant' as const,
+        content: 'Done.',
+        tools_used: ['update_profile'],
+        tool_calls: [{ name: 'update_profile', input: { name: 'Ari' }, result: 'updated' }],
+      },
+      userMessageFlagged: overrides.userMessageFlagged ?? false,
+      assistantFlagged: overrides.assistantFlagged ?? true,
+      flagReason: 'assistant output flagged',
+      dependencies: { postMessage, addMessage, flagThread },
+    },
+    postMessage,
+    addMessage,
+    flagThread,
+  };
+}
+
+describe('direct-message delivery orchestration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('records a replayable internal tool marker when a DM is permanently read-only', async () => {
+    const fixture = makeInput();
+    fixture.postMessage.mockRejectedValue({
+      data: { error: 'restricted_action_read_only_channel' },
+    });
+
+    const result = await deliverAndRecordDirectMessage(fixture.input);
+
+    expect(result).toMatchObject({ delivered: false, permanentFailure: true, errorCode: 'restricted_action_read_only_channel' });
+    expect(fixture.addMessage).toHaveBeenCalledOnce();
+    expect(fixture.addMessage).toHaveBeenCalledWith(expect.objectContaining({
+      role: 'assistant',
+      tool_calls: fixture.input.assistantMessage.tool_calls,
+      flag_reason: 'Slack delivery failed: restricted_action_read_only_channel',
+    }));
+    expect(fixture.flagThread).toHaveBeenCalledWith('thread-1', 'Slack delivery failed: restricted_action_read_only_channel');
+    expect(log.warn).toHaveBeenCalledOnce();
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it('records tool executions and logs an error for transient delivery failures', async () => {
+    const fixture = makeInput();
+    fixture.postMessage.mockRejectedValue({ data: { error: 'ratelimited' } });
+
+    const result = await deliverAndRecordDirectMessage(fixture.input);
+
+    expect(result).toMatchObject({ delivered: false, permanentFailure: false, errorCode: 'ratelimited' });
+    expect(fixture.addMessage).toHaveBeenCalledWith(expect.objectContaining({ role: 'assistant' }));
+    expect(fixture.flagThread).toHaveBeenCalledWith('thread-1', 'Slack delivery failed: ratelimited');
+    expect(log.error).toHaveBeenCalledOnce();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('persists and flags a successfully delivered assistant response', async () => {
+    const fixture = makeInput();
+    fixture.postMessage.mockResolvedValue({ ts: '123.456' });
+
+    const result = await deliverAndRecordDirectMessage(fixture.input);
+
+    expect(result).toMatchObject({ delivered: true, responseTs: '123.456', permanentFailure: false });
+    expect(fixture.addMessage).toHaveBeenCalledWith(fixture.input.assistantMessage);
+    expect(fixture.flagThread).toHaveBeenCalledWith('thread-1', 'assistant output flagged');
+    expect(log.info).toHaveBeenCalledOnce();
+  });
+
+  it('still flags a rejected inbound user message when delivery fails', async () => {
+    const fixture = makeInput({ userMessageFlagged: true, assistantFlagged: false });
+    fixture.postMessage.mockRejectedValue(new Error('network failed'));
+
+    await deliverAndRecordDirectMessage(fixture.input);
+
+    expect(fixture.flagThread).toHaveBeenCalledWith(
+      'thread-1',
+      'assistant output flagged; Slack delivery failed: unknown_error',
+    );
+  });
+
+  it('does not persist or assistant-flag an undelivered plain response', async () => {
+    const fixture = makeInput({ assistantFlagged: true });
+    fixture.input.assistantMessage.tools_used = [];
+    fixture.input.assistantMessage.tool_calls = [];
+    fixture.postMessage.mockRejectedValue(new Error('network failed'));
+
+    const result = await deliverAndRecordDirectMessage(fixture.input);
+
+    expect(result.delivered).toBe(false);
+    expect(fixture.addMessage).not.toHaveBeenCalled();
+    expect(fixture.flagThread).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/slack-api-errors.test.ts
+++ b/server/tests/unit/slack-api-errors.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { getSlackApiErrorCode, isPermanentDmDeliveryError } from '../../src/addie/slack-api-errors.js';
+
+describe('Slack API error classification', () => {
+  it('recognizes read-only conversations as permanent DM delivery failures', () => {
+    const error = {
+      code: 'slack_webapi_platform_error',
+      data: { ok: false, error: 'restricted_action_read_only_channel' },
+    };
+
+    expect(getSlackApiErrorCode(error)).toBe('restricted_action_read_only_channel');
+    expect(isPermanentDmDeliveryError(error)).toBe(true);
+  });
+
+  it('leaves transient and malformed failures unclassified', () => {
+    expect(isPermanentDmDeliveryError({ data: { error: 'ratelimited' } })).toBe(false);
+    expect(isPermanentDmDeliveryError(new Error('network failed'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Recover once when Claude returns no user-visible text after successful custom tool execution, with tools disabled during recovery.
- Preserve replay-safe delivery state when Slack rejects a DM because the channel is read-only, and clear stale DM coordinates.
- Add focused regression coverage and advance the Addie code version.

## Why

Production alerts showed successful tool executions followed by empty responses, plus Slack DM delivery failures in read-only channels. The recovery path must not repeat side effects, and failed delivery must leave enough state for a later turn to respond safely.

## Impact

Addie now makes one text-only recovery attempt after an empty custom-tool response, refuses recovery tool calls, records delivery-safe audit context, and distinguishes permanent Slack channel failures from transient errors.

## Validation

- 1,037 general unit tests passed
- 5,273 server unit tests passed; 30 skipped
- targeted regression suites: 16 tests passed
- TypeScript typecheck passed
- version and changeset policy checks passed