### PR TITLE
fix(media-buy): close vendor metric accountability loop

### DIFF
--- a/.changeset/vendor-metric-accountability-readback.md
+++ b/.changeset/vendor-metric-accountability-readback.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Close the metric-accountability loop in the reference seller and conformance suite. Package commitments are seller-stamped and read back, vendor values and deferrals are reconciled per package, and unified `missing_metrics` reports overdue standard or vendor commitments. Packages without a snapshot fall back to current product reporting capabilities, while metrics not yet measurable in the current window stay out of the gap list.

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -136,6 +136,54 @@ function getOrCreateDeliveryAccumulator(session: SessionState, mediaBuyId: strin
   return cumulative;
 }
 
+type VendorMetricIdentity = {
+  vendor: { domain: string; brand_id?: string };
+  metric_id: string;
+};
+
+function normalizeVendorMetricIdentity(value: unknown): VendorMetricIdentity | null {
+  if (!isRecord(value) || !isRecord(value.vendor)) return null;
+  if (typeof value.vendor.domain !== 'string' || value.vendor.domain.length === 0) return null;
+  if (typeof value.metric_id !== 'string' || value.metric_id.length === 0) return null;
+  return {
+    vendor: {
+      domain: value.vendor.domain,
+      ...(typeof value.vendor.brand_id === 'string' && { brand_id: value.vendor.brand_id }),
+    },
+    metric_id: value.metric_id,
+  };
+}
+
+function normalizeVendorMetricIdentities(value: unknown): VendorMetricIdentity[] | null {
+  if (!Array.isArray(value)) return null;
+  const normalized = value.map(normalizeVendorMetricIdentity);
+  return normalized.every((entry): entry is VendorMetricIdentity => entry !== null) ? normalized : null;
+}
+
+function validatePackageMetricMap(
+  value: unknown,
+  mb: MediaBuyState,
+  field: string,
+  requireValue: boolean,
+): string | null {
+  if (value === undefined) return null;
+  if (!isRecord(value)) return `${field} must be an object keyed by package_id`;
+  const packageIds = new Set(mb.packages.map(pkg => pkg.packageId));
+  for (const [packageId, entries] of Object.entries(value)) {
+    if (!packageIds.has(packageId)) return `${field}.${packageId} references an unknown package_id`;
+    if (normalizeVendorMetricIdentities(entries) === null) {
+      return `${field}.${packageId} must contain valid vendor/metric_id entries`;
+    }
+    if (
+      requireValue
+      && (entries as unknown[]).some(entry => !isRecord(entry) || typeof entry.value !== 'number' || !Number.isFinite(entry.value))
+    ) {
+      return `${field}.${packageId} entries require a finite numeric value`;
+    }
+  }
+  return null;
+}
+
 function applyExtendedDeliveryParams(cumulative: ComplyDeliveryAccumulator, params: Record<string, unknown>) {
   if (typeof params.is_final === 'boolean') cumulative.isFinal = params.is_final;
   if (typeof params.finalized_at === 'string') cumulative.finalizedAt = params.finalized_at;
@@ -148,6 +196,22 @@ function applyExtendedDeliveryParams(cumulative: ComplyDeliveryAccumulator, para
   if (params.viewability && typeof params.viewability === 'object' && !Array.isArray(params.viewability)) {
     cumulative.viewability = params.viewability as ComplyDeliveryAccumulator['viewability'];
   }
+  if (Array.isArray(params.not_yet_measurable_vendor_metrics)) {
+    cumulative.deferredVendorMetrics = normalizeVendorMetricIdentities(params.not_yet_measurable_vendor_metrics) ?? [];
+  }
+  if (isRecord(params.vendor_metric_values_by_package)) {
+    cumulative.vendorMetricValuesByPackage = Object.fromEntries(
+      Object.entries(params.vendor_metric_values_by_package).map(([packageId, values]) => [packageId, values as unknown[]]),
+    );
+  }
+  if (isRecord(params.not_yet_measurable_vendor_metrics_by_package)) {
+    cumulative.deferredVendorMetricsByPackage = Object.fromEntries(
+      Object.entries(params.not_yet_measurable_vendor_metrics_by_package).map(([packageId, values]) => [
+        packageId,
+        normalizeVendorMetricIdentities(values) ?? [],
+      ]),
+    );
+  }
 }
 
 function extendedDeliverySnapshot(cumulative: ComplyDeliveryAccumulator): Record<string, unknown> {
@@ -159,6 +223,9 @@ function extendedDeliverySnapshot(cumulative: ComplyDeliveryAccumulator): Record
     ...(cumulative.frequency !== undefined ? { frequency: cumulative.frequency } : {}),
     ...(cumulative.reachWindow ? { reach_window: cumulative.reachWindow } : {}),
     ...(cumulative.viewability ? { viewability: cumulative.viewability } : {}),
+    ...(cumulative.deferredVendorMetrics ? { not_yet_measurable_vendor_metrics: cumulative.deferredVendorMetrics } : {}),
+    ...(cumulative.vendorMetricValuesByPackage ? { vendor_metric_values_by_package: cumulative.vendorMetricValuesByPackage } : {}),
+    ...(cumulative.deferredVendorMetricsByPackage ? { not_yet_measurable_vendor_metrics_by_package: cumulative.deferredVendorMetricsByPackage } : {}),
   };
 }
 
@@ -188,6 +255,7 @@ function normalizeSeedPackage(pkg: Record<string, unknown>, mbStart: string, mbE
     context: isRecord(pkg.context) ? pkg.context : undefined,
     legacyOmitProductId: !hasProductId,
     optimizationGoals: Array.isArray(pkg.optimizationGoals) ? pkg.optimizationGoals as PackageState['optimizationGoals'] : Array.isArray(pkg.optimization_goals) ? pkg.optimization_goals as PackageState['optimizationGoals'] : undefined,
+    committedMetrics: Array.isArray(pkg.committedMetrics) ? pkg.committedMetrics as PackageState['committedMetrics'] : Array.isArray(pkg.committed_metrics) ? pkg.committed_metrics as PackageState['committedMetrics'] : undefined,
   };
 }
 
@@ -1167,20 +1235,33 @@ export async function handleComplyTestController(args: ToolArgs, ctx: TrainingCo
     return { success: true, message: `Creative format "${formatId}" seeded — list_creative_formats will use the seeded catalog process-wide` };
   }
 
-  // Pre-capture extended simulate_delivery fields before the SDK dispatcher strips
-  // unknown params. The SDK's TestControllerStore.simulateDelivery interface can lag
-  // this repo's controller schema, so rawArgs remains the compatibility path for
-  // new delivery metrics until the SDK accepts them natively.
+  // Validate local simulate_delivery extensions before dispatch. Persist them
+  // only after the SDK confirms success so a rejected simulation cannot leave
+  // values or deferrals behind in session state.
   if (scenario === 'simulate_delivery') {
     const params = (rawArgs.params ?? {}) as Record<string, unknown>;
     const mediaBuyId = params.media_buy_id as string | undefined;
-    const vendorMetricValues = params.vendor_metric_values;
     const mb = mediaBuyId ? findMediaBuy(session, mediaBuyId) : undefined;
     if (mb) {
-      const cumulative = getOrCreateDeliveryAccumulator(session, mediaBuyId!, mb.currency);
-      applyExtendedDeliveryParams(cumulative, params);
-      if (Array.isArray(vendorMetricValues) && vendorMetricValues.length > 0) {
-        cumulative.vendorMetricValues = vendorMetricValues;
+      if (
+        mb.packages.length > 1
+        && (params.vendor_metric_values !== undefined || params.not_yet_measurable_vendor_metrics !== undefined)
+      ) {
+        return {
+          success: false,
+          error: 'INVALID_PARAMS',
+          error_detail: 'Multi-package buys require package-scoped vendor metric values and deferrals',
+        };
+      }
+      if (
+        params.not_yet_measurable_vendor_metrics !== undefined
+        && normalizeVendorMetricIdentities(params.not_yet_measurable_vendor_metrics) === null
+      ) {
+        return { success: false, error: 'INVALID_PARAMS', error_detail: 'not_yet_measurable_vendor_metrics must contain valid vendor/metric_id entries' };
+      }
+      for (const field of ['vendor_metric_values_by_package', 'not_yet_measurable_vendor_metrics_by_package'] as const) {
+        const error = validatePackageMetricMap(params[field], mb, field, field === 'vendor_metric_values_by_package');
+        if (error) return { success: false, error: 'INVALID_PARAMS', error_detail: error };
       }
     }
   }
@@ -1197,6 +1278,12 @@ export async function handleComplyTestController(args: ToolArgs, ctx: TrainingCo
     const params = (rawArgs.params ?? {}) as Record<string, unknown>;
     const mediaBuyId = params.media_buy_id as string | undefined;
     const cumulative = mediaBuyId ? getDeliverySimulation(session, mediaBuyId) : undefined;
+    if (cumulative) {
+      applyExtendedDeliveryParams(cumulative, params);
+      if (Array.isArray(params.vendor_metric_values)) {
+        cumulative.vendorMetricValues = params.vendor_metric_values;
+      }
+    }
     const simulatedExtras: Record<string, unknown> = {};
     if (params.reach !== undefined) simulatedExtras.reach = params.reach;
     if (params.frequency !== undefined) simulatedExtras.frequency = params.frequency;
@@ -1205,6 +1292,15 @@ export async function handleComplyTestController(args: ToolArgs, ctx: TrainingCo
     if (params.is_final !== undefined) simulatedExtras.is_final = params.is_final;
     if (params.finalized_at !== undefined) simulatedExtras.finalized_at = params.finalized_at;
     if (params.measurement_window !== undefined) simulatedExtras.measurement_window = params.measurement_window;
+    if (params.not_yet_measurable_vendor_metrics !== undefined) {
+      simulatedExtras.not_yet_measurable_vendor_metrics = params.not_yet_measurable_vendor_metrics;
+    }
+    if (params.vendor_metric_values_by_package !== undefined) {
+      simulatedExtras.vendor_metric_values_by_package = params.vendor_metric_values_by_package;
+    }
+    if (params.not_yet_measurable_vendor_metrics_by_package !== undefined) {
+      simulatedExtras.not_yet_measurable_vendor_metrics_by_package = params.not_yet_measurable_vendor_metrics_by_package;
+    }
     if (Object.keys(simulatedExtras).length > 0 || cumulative) {
       const response = sdkResponse as unknown as Record<string, unknown>;
       return {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -6178,7 +6178,7 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
   }
   const durationMs = end.getTime() - start.getTime();
   const elapsed = durationMs > 0
-    ? Math.max(0, Math.min(1, (now.getTime() - start.getTime()) / durationMs))
+    ? Math.max(0, Math.min(1, (reportingEnd.getTime() - start.getTime()) / durationMs))
     : 0;
 
   // Read simulated delivery upfront so vendor_metric_values can be spread into

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -289,6 +289,12 @@ interface PackageInput {
   creative_assignments?: Array<{ creative_id?: string }>;
   creatives?: InlineCreativeInput[];
   context?: Record<string, unknown>;
+  committed_metrics?: Array<{
+    scope: 'standard' | 'vendor';
+    metric_id: string;
+    vendor?: { domain: string; brand_id?: string };
+    qualifier?: Record<string, unknown>;
+  }>;
 }
 
 interface CreativeAssignmentInput {
@@ -794,12 +800,21 @@ interface VendorMetricRefView {
   scope?: unknown;
 }
 
+interface CommittedMetricProposalView extends VendorMetricRefView {
+  scope?: 'standard' | 'vendor';
+  metric_id?: string;
+  vendor?: { domain?: string; brand_id?: string };
+  qualifier?: Record<string, unknown>;
+  committed_at?: string;
+}
+
 interface VendorMetricOptimizationView {
   supported_metrics?: VendorMetricRefView[];
 }
 
 interface ReportingCapabilitiesView {
   vendor_metrics?: VendorMetricRefView[];
+  available_metrics?: string[];
 }
 
 interface MeasurementCatalogView {
@@ -815,6 +830,120 @@ function vendorMetricKey(entry: VendorMetricRefView | undefined): string | null 
   }
   const brandId = typeof entry?.vendor?.brand_id === 'string' ? entry.vendor.brand_id : '';
   return `${domain.toLowerCase()}|${brandId}|${metricId}`;
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+function committedMetricKey(entry: CommittedMetricProposalView): string | null {
+  if (entry.scope === 'vendor') {
+    const vendorKey = vendorMetricKey(entry);
+    return vendorKey ? `vendor|${vendorKey}` : null;
+  }
+  if (entry.scope !== 'standard' || typeof entry.metric_id !== 'string' || entry.metric_id.length === 0) return null;
+  return `standard|${entry.metric_id}|${canonicalJson(entry.qualifier ?? {})}`;
+}
+
+function validateCommittedMetricProposals(
+  metrics: CommittedMetricProposalView[] | undefined,
+  product: Product,
+  fieldPrefix: string,
+): TaskError | null {
+  if (!metrics?.length) return null;
+  const reporting = product.reporting_capabilities as ReportingCapabilitiesView | undefined;
+  const availableMetrics = new Set(reporting?.available_metrics ?? []);
+  const vendorMetrics = reporting?.vendor_metrics ?? [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < metrics.length; i++) {
+    const metric = metrics[i]!;
+    const key = committedMetricKey(metric);
+    if (!key) {
+      return {
+        code: 'VALIDATION_ERROR',
+        message: 'committed_metrics entries require a valid scope and metric identity',
+        field: `${fieldPrefix}[${i}]`,
+      };
+    }
+    if (seen.has(key)) {
+      return {
+        code: 'VALIDATION_ERROR',
+        message: 'committed_metrics entries must be unique by scope, metric identity, and qualifier',
+        field: `${fieldPrefix}[${i}]`,
+      };
+    }
+    seen.add(key);
+
+    if (metric.scope === 'standard' && !availableMetrics.has(metric.metric_id!)) {
+      return {
+        code: 'TERMS_REJECTED',
+        message: `committed standard metric "${metric.metric_id}" is not in the product's reporting_capabilities.available_metrics`,
+        field: `${fieldPrefix}[${i}].metric_id`,
+      };
+    }
+    if (
+      metric.scope === 'vendor'
+      && !vendorMetrics.some(candidate => vendorMetricKey(candidate) === vendorMetricKey(metric))
+    ) {
+      return {
+        code: 'TERMS_REJECTED',
+        message: `committed vendor metric "${metric.metric_id}" is not in the product's reporting_capabilities.vendor_metrics`,
+        field: `${fieldPrefix}[${i}].metric_id`,
+      };
+    }
+  }
+  return null;
+}
+
+function hasOwnMetric(metrics: Record<string, unknown>, metricId: string): boolean {
+  return Object.prototype.hasOwnProperty.call(metrics, metricId) && metrics[metricId] !== undefined;
+}
+
+function standardMetricIsDelivered(
+  metric: CommittedMetricProposalView,
+  delivery: Record<string, unknown>,
+): boolean {
+  const metricId = metric.metric_id!;
+  const qualifier = metric.qualifier;
+  if (qualifier && Object.keys(qualifier).length > 0) {
+    if (
+      metricId === 'viewability'
+      && typeof qualifier.viewability_standard === 'string'
+      && isRecord(delivery.viewability)
+    ) {
+      return delivery.viewability.standard === qualifier.viewability_standard;
+    }
+    // A qualified commitment is satisfied only by a delivery path that makes
+    // the same qualifier observable. The reference seller currently exposes
+    // only viewability.standard at package grain.
+    return false;
+  }
+  if (hasOwnMetric(delivery, metricId)) return true;
+  switch (metricId) {
+    case 'ctr':
+      return hasOwnMetric(delivery, 'clicks') && hasOwnMetric(delivery, 'impressions');
+    case 'cost_per_click':
+    case 'cpm':
+      return hasOwnMetric(delivery, 'spend') && hasOwnMetric(delivery, metricId === 'cpm' ? 'impressions' : 'clicks');
+    case 'cost_per_completed_view':
+      return hasOwnMetric(delivery, 'spend') && hasOwnMetric(delivery, 'completed_views');
+    case 'roas':
+      return hasOwnMetric(delivery, 'conversion_value') && hasOwnMetric(delivery, 'spend');
+    case 'cost_per_acquisition':
+      return hasOwnMetric(delivery, 'conversions') && hasOwnMetric(delivery, 'spend');
+    case 'engagement_rate':
+      return hasOwnMetric(delivery, 'engagements') && hasOwnMetric(delivery, 'impressions');
+    default:
+      return false;
+  }
 }
 
 function vendorCatalogKey(entry: VendorMetricRefView | undefined): string | null {
@@ -5542,6 +5671,7 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   }
 
   // Validate all packages and collect errors before returning
+  const confirmedAt = new Date().toISOString();
   const errors: TaskError[] = [];
   const createdPackages: PackageState[] = [];
   const inlineCreativesToPersist: InlineCreativeInput[] = [];
@@ -5558,6 +5688,16 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     const product = productMap.get(pkg.product_id);
     if (!product) {
       errors.push({ code: 'PRODUCT_NOT_FOUND', message: `${pkgLabel}: Product not found: ${pkg.product_id}` });
+      continue;
+    }
+
+    const committedMetricError = validateCommittedMetricProposals(
+      pkg.committed_metrics,
+      product,
+      `packages[${i}].committed_metrics`,
+    );
+    if (committedMetricError) {
+      errors.push(committedMetricError);
       continue;
     }
 
@@ -5685,6 +5825,12 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     const optimizationGoals = Array.isArray(rawGoals)
       ? (rawGoals as unknown[]).filter((g): g is Record<string, unknown> => typeof g === 'object' && g !== null)
       : undefined;
+    const committedMetrics = Array.isArray(pkg.committed_metrics)
+      ? pkg.committed_metrics.map(metric => ({
+        ...metric,
+        committed_at: confirmedAt,
+      }))
+      : undefined;
     const rawCreativeAssignments = Array.isArray(pkg.creative_assignments) ? pkg.creative_assignments : [];
     const creativeAssignments: string[] = [];
     for (let j = 0; j < rawCreativeAssignments.length; j++) {
@@ -5728,6 +5874,7 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       targeting: targetingResult.targeting,
       ...(isRecord(pkg.context) && { context: pkg.context }),
       ...(optimizationGoals && optimizationGoals.length > 0 && { optimizationGoals }),
+      ...(committedMetrics && committedMetrics.length > 0 && { committedMetrics }),
     });
   }
 
@@ -5743,7 +5890,7 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   const mediaBuyId = typeof requestedMediaBuyId === 'string' && /^[A-Za-z0-9._-]{1,128}$/.test(requestedMediaBuyId)
     ? requestedMediaBuyId
     : `mb_${randomUUID().slice(0, 8)}`;
-  const now = new Date().toISOString();
+  const now = confirmedAt;
   const resolvedStart = buyStart === 'asap' ? now : buyStart;
   persistInlineCreatives(
     session,
@@ -5835,6 +5982,7 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       ...packageReadinessFields(pkg, session),
       ...(pkg.targeting && { targeting_overlay: pkg.targeting }),
       ...(pkg.context && { context: pkg.context }),
+      ...(pkg.committedMetrics && { committed_metrics: pkg.committedMetrics }),
       creative_assignments: pkg.creativeAssignments.map(creativeId => ({ creative_id: creativeId })),
     })),
     ...(isRecord(req.context) && { context: req.context }),
@@ -5972,6 +6120,7 @@ export async function handleGetMediaBuys(args: ToolArgs, ctx: TrainingContext): 
             })),
             ...(pkg.targeting && { targeting_overlay: pkg.targeting }),
             ...(pkg.context && { context: pkg.context }),
+            ...(pkg.committedMetrics && { committed_metrics: pkg.committedMetrics }),
             ...(pkg.canceledAt && {
               cancellation: {
                 canceled_at: pkg.canceledAt,
@@ -6007,6 +6156,7 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
   const session = await getSession(sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId));
   const catalog = getCatalog();
   const productMap = new Map(catalog.map(cp => [cp.product.product_id, cp.product]));
+  overlaySeededProducts(session, productMap);
   const mediaBuyId = req.media_buy_id || req.media_buy_ids?.[0] || '';
   const mb = session.mediaBuys.get(mediaBuyId) ?? getComplianceMediaBuy(mediaBuyId);
 
@@ -6019,6 +6169,13 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
   const now = new Date();
   const start = new Date(mb.startTime);
   const end = new Date(mb.endTime);
+  const reportingStart = req.start_date ? new Date(`${req.start_date}T00:00:00.000Z`) : start;
+  const reportingEnd = req.end_date ? new Date(`${req.end_date}T23:59:59.999Z`) : now;
+  if (req.start_date && req.end_date && reportingStart.getTime() > reportingEnd.getTime()) {
+    return {
+      errors: [{ code: 'INVALID_REQUEST', message: 'start_date must be on or before end_date', field: 'start_date' }],
+    };
+  }
   const durationMs = end.getTime() - start.getTime();
   const elapsed = durationMs > 0
     ? Math.max(0, Math.min(1, (now.getTime() - start.getTime()) / durationMs))
@@ -6129,6 +6286,91 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
       }
       : {};
 
+    const reporting = product?.reporting_capabilities as ReportingCapabilitiesView | undefined;
+    const fallbackMetrics: CommittedMetricProposalView[] = [
+      ...(reporting?.available_metrics ?? []).map(metricId => ({ scope: 'standard' as const, metric_id: metricId })),
+      ...(reporting?.vendor_metrics ?? []).flatMap(metric => {
+        const domain = metric.vendor?.domain;
+        const metricId = metric.metric_id;
+        if (typeof domain !== 'string' || typeof metricId !== 'string') return [];
+        return [{
+          scope: 'vendor' as const,
+          vendor: {
+            domain,
+            ...(typeof metric.vendor?.brand_id === 'string' && { brand_id: metric.vendor.brand_id }),
+          },
+          metric_id: metricId,
+        }];
+      }),
+    ];
+    // An explicit package snapshot is authoritative even when it contains no
+    // vendor rows. Only packages without a snapshot fall back to the product's
+    // current reporting capabilities.
+    const auditMetrics: CommittedMetricProposalView[] = pkg.committedMetrics !== undefined
+      ? pkg.committedMetrics
+      : fallbackMetrics;
+    const eligibleAuditMetrics = auditMetrics.filter(metric => (
+      metric.committed_at === undefined
+      || new Date(metric.committed_at).getTime() < reportingEnd.getTime()
+    ));
+    const auditVendorKeys = new Set(
+      auditMetrics
+        .filter(metric => metric.scope === 'vendor')
+        .map(metric => vendorMetricKey(metric))
+        .filter((key): key is string => key !== null),
+    );
+    const rawDeferredVendorMetrics = simDelivery?.deferredVendorMetricsByPackage?.[pkg.packageId]
+      ?? (mb.packages.length === 1 ? simDelivery?.deferredVendorMetrics : undefined)
+      ?? [];
+    const deferredVendorKeys = new Set(
+      rawDeferredVendorMetrics
+        .map(metric => vendorMetricKey(metric))
+        .filter((key): key is string => key !== null),
+    );
+    const rawVendorMetricValues = simDelivery?.vendorMetricValuesByPackage?.[pkg.packageId]
+      ?? (mb.packages.length === 1 ? simDelivery?.vendorMetricValues : undefined)
+      ?? [];
+    const vendorMetricValues = rawVendorMetricValues
+      .filter((value): value is Record<string, unknown> => isRecord(value))
+      .filter(value => {
+        const key = vendorMetricKey(value as VendorMetricRefView);
+        return key !== null && auditVendorKeys.has(key);
+      });
+    const deliveredVendorKeys = new Set(
+      vendorMetricValues
+        .map(value => vendorMetricKey(value as VendorMetricRefView))
+        .filter((key): key is string => key !== null),
+    );
+    const packageDeliveryMetrics: Record<string, unknown> = {
+      spend,
+      impressions,
+      clicks,
+      ...audioMetrics,
+      ...byCreative,
+      ...(vendorMetricValues.length > 0 && { vendor_metric_values: vendorMetricValues }),
+    };
+    const missingMetrics = eligibleAuditMetrics.reduce<Array<Record<string, unknown>>>((missing, metric) => {
+      if (metric.scope === 'standard') {
+        if (!standardMetricIsDelivered(metric, packageDeliveryMetrics)) {
+          missing.push({
+            scope: 'standard' as const,
+            metric_id: metric.metric_id!,
+            ...(metric.qualifier && { qualifier: metric.qualifier }),
+          });
+        }
+        return missing;
+      }
+      const key = vendorMetricKey(metric);
+      if (key !== null && !deliveredVendorKeys.has(key) && !deferredVendorKeys.has(key)) {
+        missing.push({
+          scope: 'vendor' as const,
+          vendor: metric.vendor!,
+          metric_id: metric.metric_id!,
+        });
+      }
+      return missing;
+    }, []);
+
     if (isAudioVideo && impressions > 0) {
       totalCompletedViews += Math.round(impressions * completionRate);
       totalViews += Math.round(impressions * 0.9);
@@ -6139,11 +6381,7 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
 
     return {
       package_id: pkg.packageId,
-      spend,
-      impressions,
-      clicks,
-      ...audioMetrics,
-      ...byCreative,
+      ...packageDeliveryMetrics,
       pricing_model: pricingModel,
       model: pricingModel, // #1525: alias for @adcp/sdk < 4.11.0
       rate,
@@ -6153,13 +6391,7 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
       ...(includeThreeOneFields(ctx) && simDelivery?.measurementWindow ? { measurement_window: simDelivery.measurementWindow } : {}),
       paused: false,
       delivery_status: elapsed >= 1 ? 'completed' as const : 'delivering' as const,
-      // vendor_metric_values are media-buy-scoped in simulate_delivery, so they
-      // propagate to all active packages. Multi-package buys will echo the same
-      // array across packages — known training-agent limitation, acceptable for
-      // single-package storyboard scenarios.
-      ...(simDelivery?.vendorMetricValues?.length
-        ? { vendor_metric_values: simDelivery.vendorMetricValues }
-        : {}),
+      ...(auditMetrics.length > 0 ? { missing_metrics: missingMetrics } : {}),
     };
   });
 
@@ -6266,8 +6498,8 @@ export async function handleGetMediaBuyDelivery(args: ToolArgs, ctx: TrainingCon
 
   return {
     reporting_period: {
-      start: mb.startTime,
-      end: now.toISOString(),
+      start: reportingStart.toISOString(),
+      end: reportingEnd.toISOString(),
     },
     currency: mb.currency,
     media_buy_deliveries: [{
@@ -7148,6 +7380,7 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     ...packageReadinessFields(pkg, session),
     ...(pkg.targeting && { targeting_overlay: pkg.targeting }),
     ...(pkg.context && { context: pkg.context }),
+    ...(pkg.committedMetrics && { committed_metrics: pkg.committedMetrics }),
     creative_assignments: pkg.creativeAssignments.map(creativeId => ({ creative_id: creativeId })),
     ...(pkg.canceledAt && {
       cancellation: { canceled_at: pkg.canceledAt, canceled_by: pkg.canceledBy, reason: pkg.cancellationReason },

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -221,6 +221,18 @@ export interface ComplyDeliveryAccumulator {
   };
   /** vendor_metric_values injected via comply_test_controller simulate_delivery. */
   vendorMetricValues?: unknown[];
+  /** Package-scoped vendor values, keyed by package_id. */
+  vendorMetricValuesByPackage?: Record<string, unknown[]>;
+  /** Committed vendor metrics whose value is not yet measurable in this window. */
+  deferredVendorMetrics?: Array<{
+    vendor: { domain: string; brand_id?: string };
+    metric_id: string;
+  }>;
+  /** Package-scoped measurement deferrals, keyed by package_id. */
+  deferredVendorMetricsByPackage?: Record<string, Array<{
+    vendor: { domain: string; brand_id?: string };
+    metric_id: string;
+  }>>;
 }
 
 export interface ComplyBudgetSimulation {
@@ -478,6 +490,14 @@ export interface PackageState {
    *  what the buyer actually requested (e.g., only surface reach + frequency
    *  when a reach goal was requested). */
   optimizationGoals?: Array<Record<string, unknown>>;
+  /** Seller-stamped reporting contract captured when the package is confirmed. */
+  committedMetrics?: Array<{
+    scope: 'standard' | 'vendor';
+    metric_id: string;
+    vendor?: { domain: string; brand_id?: string };
+    qualifier?: Record<string, unknown>;
+    committed_at: string;
+  }>;
 }
 
 export interface ListReference {

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -1583,6 +1583,71 @@ describe('comply_test_controller', () => {
       expect((result as any).cumulative.impressions).toBe(8000);
     });
 
+    it('rejects malformed package-scoped vendor inputs without creating delivery state', async () => {
+      const mediaBuyId = await createMediaBuy(server);
+      const { result } = await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'simulate_delivery',
+        params: {
+          media_buy_id: mediaBuyId,
+          vendor_metric_values_by_package: {
+            unknown_package: [{ vendor: { domain: 'attentionvendor.example' }, metric_id: 'attention_units', value: 4.2 }],
+          },
+        },
+        account: ACCOUNT,
+        brand: BRAND,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('INVALID_PARAMS');
+
+      const { result: missingValue } = await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'simulate_delivery',
+        params: {
+          media_buy_id: mediaBuyId,
+          vendor_metric_values_by_package: {
+            'pkg-0': [{ vendor: { domain: 'attentionvendor.example' }, metric_id: 'attention_units' }],
+          },
+        },
+        account: ACCOUNT,
+        brand: BRAND,
+      });
+      expect(missingValue.success).toBe(false);
+      expect(missingValue.error).toBe('INVALID_PARAMS');
+
+      const sessionKey = sessionKeyFromArgs({ account: ACCOUNT }, DEFAULT_CTX.mode, DEFAULT_CTX.userId, DEFAULT_CTX.moduleId);
+      const session = await getSession(sessionKey);
+      expect(session.complyExtensions.deliverySimulations.has(mediaBuyId)).toBe(false);
+    });
+
+    it('does not persist deferred metrics from a rejected simulation', async () => {
+      const mediaBuyId = await createMediaBuyWithCreatives(server);
+      const firstMetric = { vendor: { domain: 'attentionvendor.example' }, metric_id: 'attention_units' };
+      const rejectedMetric = { vendor: { domain: 'attentionvendor.example' }, metric_id: 'post_flight_brand_lift' };
+      await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'simulate_delivery',
+        params: { media_buy_id: mediaBuyId, not_yet_measurable_vendor_metrics: [firstMetric] },
+        account: ACCOUNT,
+        brand: BRAND,
+      });
+      await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'force_media_buy_status',
+        params: { media_buy_id: mediaBuyId, status: 'completed' },
+        account: ACCOUNT,
+        brand: BRAND,
+      });
+      const { result: rejected } = await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'simulate_delivery',
+        params: { media_buy_id: mediaBuyId, not_yet_measurable_vendor_metrics: [rejectedMetric] },
+        account: ACCOUNT,
+        brand: BRAND,
+      });
+      expect(rejected.success).toBe(false);
+      expect(rejected.error).toBe('INVALID_STATE');
+
+      const sessionKey = sessionKeyFromArgs({ account: ACCOUNT }, DEFAULT_CTX.mode, DEFAULT_CTX.userId, DEFAULT_CTX.moduleId);
+      const session = await getSession(sessionKey);
+      expect(session.complyExtensions.deliverySimulations.get(mediaBuyId)?.deferredVendorMetrics).toEqual([firstMetric]);
+    });
+
     it('injects reach_window and viewability metrics into delivery reporting', async () => {
       const mediaBuyId = await createMediaBuy(server);
 

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -4506,6 +4506,264 @@ describe('create_media_buy handler', () => {
     )).toBe(true);
   });
 
+  it('reconciles committed vendor metrics per package and defers future-window gaps', async () => {
+    const account = { brand: { domain: 'vendor-audit.example' }, operator: 'vendor-audit.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const metrics = [
+      { vendor: { domain: 'attentionvendor.example' }, metric_id: 'attention_units' },
+      { vendor: { domain: 'attentionvendor.example' }, metric_id: 'post_flight_brand_lift' },
+    ];
+
+    await seedVendorMetricProduct(server, account, 'vendor_audit_product', {
+      delivery_type: 'non_guaranteed',
+      channels: ['display'],
+      reporting_capabilities: {
+        available_metrics: ['impressions', 'clicks', 'spend'],
+        measurement_windows: [
+          { window_id: 'live', duration_days: 0, expected_availability_days: 0 },
+          { window_id: 'post_flight', duration_days: 0, expected_availability_days: 14, is_guarantee_basis: true },
+        ],
+        vendor_metrics: metrics,
+      },
+    });
+
+    const { result: created } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'vendor-audit.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [
+        {
+          product_id: 'vendor_audit_product',
+          pricing_option_id: 'vendor_audit_product_cpm',
+          budget: 1000,
+          bid_price: 5,
+          committed_metrics: metrics.slice(0, 2).map(metric => ({ scope: 'vendor', ...metric })),
+        },
+        {
+          product_id: 'vendor_audit_product',
+          pricing_option_id: 'vendor_audit_product_cpm',
+          budget: 1000,
+          bid_price: 5,
+          committed_metrics: [{ scope: 'vendor', ...metrics[0] }],
+        },
+      ],
+    });
+
+    const mediaBuyId = created.media_buy_id as string;
+    const createdPackages = created.packages as Array<{ committed_metrics: Array<{ committed_at: string }> }>;
+    expect(mediaBuyId).toBeDefined();
+    expect(createdPackages[0]!.committed_metrics[0]!.committed_at).toBe(created.confirmed_at);
+
+    const { result: ambiguousSimulation } = await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      scenario: 'simulate_delivery',
+      params: {
+        media_buy_id: mediaBuyId,
+        vendor_metric_values: [{ ...metrics[0], value: 4.2 }],
+      },
+    });
+    expect(ambiguousSimulation.success).toBe(false);
+    expect(ambiguousSimulation.error).toBe('INVALID_PARAMS');
+
+    const { result: simulated } = await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      brand: { domain: 'vendor-audit.example' },
+      scenario: 'simulate_delivery',
+      params: {
+        media_buy_id: mediaBuyId,
+        impressions: 10_000,
+        measurement_window: 'live',
+        vendor_metric_values_by_package: {
+          'pkg-0': [{
+            ...metrics[0],
+            value: 4.2,
+            unit: 'score',
+            measurable_impressions: 9_000,
+          }],
+        },
+        not_yet_measurable_vendor_metrics_by_package: {
+          'pkg-0': [metrics[1]],
+        },
+      },
+    });
+    expect(simulated.success).toBe(true);
+
+    const { result: delivery } = await simulateCallTool(server, 'get_media_buy_delivery', {
+      account,
+      brand: { domain: 'vendor-audit.example' },
+      media_buy_ids: [mediaBuyId],
+      end_date: '2027-06-30',
+    });
+    const packages = (delivery.media_buy_deliveries as Array<{ by_package: Array<Record<string, unknown>> }>)[0]!.by_package;
+
+    expect(packages[0]!.vendor_metric_values).toEqual([expect.objectContaining({ metric_id: 'attention_units' })]);
+    expect(packages[0]!.missing_metrics).toEqual([]);
+    expect(packages[1]!.vendor_metric_values).toBeUndefined();
+    expect(packages[1]!.missing_metrics).toEqual([{
+      scope: 'vendor',
+      vendor: { domain: 'attentionvendor.example' },
+      metric_id: 'attention_units',
+    }]);
+
+    const { result: readback } = await simulateCallTool(server, 'get_media_buys', {
+      account,
+      media_buy_ids: [mediaBuyId],
+    });
+    const readbackPackages = (readback.media_buys as Array<{ packages: Array<Record<string, unknown>> }>)[0]!.packages;
+    expect(readbackPackages[0]!.committed_metrics).toEqual(createdPackages[0]!.committed_metrics);
+  });
+
+  it('falls back to product reporting capabilities when no committed snapshot exists', async () => {
+    const account = { brand: { domain: 'vendor-fallback.example' }, operator: 'vendor-fallback.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const metric = { vendor: { domain: 'attentionvendor.example' }, metric_id: 'attention_units' };
+    await seedVendorMetricProduct(server, account, 'vendor_fallback_product', {
+      delivery_type: 'non_guaranteed',
+      channels: ['display'],
+      reporting_capabilities: {
+        available_metrics: ['impressions', 'clicks', 'spend'],
+        vendor_metrics: [metric],
+      },
+    });
+    const { result: created } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'vendor-fallback.example' },
+      start_time: 'asap',
+      end_time: '2099-07-01T00:00:00Z',
+      packages: [{
+        product_id: 'vendor_fallback_product',
+        pricing_option_id: 'vendor_fallback_product_cpm',
+        budget: 1000,
+        bid_price: 5,
+      }],
+    });
+    const mediaBuyId = created.media_buy_id as string;
+    expect((created.packages as Array<Record<string, unknown>>)[0]!.committed_metrics).toBeUndefined();
+
+    const { result: delivery } = await simulateCallTool(server, 'get_media_buy_delivery', {
+      account,
+      media_buy_ids: [mediaBuyId],
+      end_date: '2099-01-01',
+    });
+    const packageDelivery = (delivery.media_buy_deliveries as Array<{ by_package: Array<Record<string, unknown>> }>)[0]!.by_package[0]!;
+    expect(packageDelivery.missing_metrics).toContainEqual({ scope: 'vendor', ...metric });
+  });
+
+  it('keeps missing_metrics honest for mixed standard and vendor commitments', async () => {
+    const account = { brand: { domain: 'mixed-metric-audit.example' }, operator: 'mixed-metric-audit.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const vendorMetric = { vendor: { domain: 'attentionvendor.example' }, metric_id: 'attention_units' };
+    await seedVendorMetricProduct(server, account, 'mixed_metric_audit_product', {
+      delivery_type: 'non_guaranteed',
+      channels: ['display'],
+      reporting_capabilities: {
+        available_metrics: ['impressions', 'spend', 'conversion_value'],
+        vendor_metrics: [vendorMetric],
+      },
+    });
+    const { result: created } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'mixed-metric-audit.example' },
+      start_time: 'asap',
+      end_time: '2099-07-01T00:00:00Z',
+      packages: [{
+        product_id: 'mixed_metric_audit_product',
+        pricing_option_id: 'mixed_metric_audit_product_cpm',
+        budget: 1000,
+        bid_price: 5,
+        committed_metrics: [
+          { scope: 'standard', metric_id: 'conversion_value' },
+          { scope: 'vendor', ...vendorMetric },
+        ],
+      }],
+    });
+    const mediaBuyId = created.media_buy_id as string;
+    await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      scenario: 'simulate_delivery',
+      params: {
+        media_buy_id: mediaBuyId,
+        vendor_metric_values: [{ ...vendorMetric, value: 4.2 }],
+      },
+    });
+
+    const { result: delivery } = await simulateCallTool(server, 'get_media_buy_delivery', {
+      account,
+      media_buy_ids: [mediaBuyId],
+      end_date: '2099-01-01',
+    });
+    const packageDelivery = (delivery.media_buy_deliveries as Array<{ by_package: Array<Record<string, unknown>> }>)[0]!.by_package[0]!;
+    expect(packageDelivery.vendor_metric_values).toEqual([{ ...vendorMetric, value: 4.2 }]);
+    expect(packageDelivery.missing_metrics).toEqual([{ scope: 'standard', metric_id: 'conversion_value' }]);
+  });
+
+  it('applies the strict committed_at reporting-period boundary', async () => {
+    const account = { brand: { domain: 'metric-boundary.example' }, operator: 'metric-boundary.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const committedAt = '2026-06-30T23:59:59.999Z';
+    const metric = { vendor: { domain: 'attentionvendor.example' }, metric_id: 'attention_units' };
+    await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      scenario: 'seed_media_buy',
+      params: {
+        media_buy_id: 'metric_boundary_buy',
+        fixture: {
+          status: 'active',
+          currency: 'USD',
+          start_time: '2026-01-01T00:00:00Z',
+          end_time: '2026-12-31T23:59:59Z',
+          packages: [{
+            package_id: 'metric_boundary_package',
+            budget: 1000,
+            committed_metrics: [{ scope: 'vendor', ...metric, committed_at: committedAt }],
+          }],
+        },
+      },
+    });
+
+    const read = async (end_date: string) => {
+      const { result } = await simulateCallTool(server, 'get_media_buy_delivery', {
+        account,
+        media_buy_ids: ['metric_boundary_buy'],
+        start_date: '2026-01-01',
+        end_date,
+      });
+      return (result.media_buy_deliveries as Array<{ by_package: Array<Record<string, unknown>> }>)[0]!.by_package[0]!;
+    };
+    expect((await read('2026-06-30')).missing_metrics).toEqual([]);
+    expect((await read('2026-07-01')).missing_metrics).toEqual([{ scope: 'vendor', ...metric }]);
+  });
+
+  it('rejects standalone committed metrics outside product reporting capabilities', async () => {
+    const account = { brand: { domain: 'unsupported-commitment.example' }, operator: 'unsupported-commitment.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    await seedVendorMetricProduct(server, account, 'unsupported_commitment_product', {
+      delivery_type: 'non_guaranteed',
+      channels: ['display'],
+      reporting_capabilities: { available_metrics: ['impressions', 'spend'], vendor_metrics: [] },
+    });
+    const { result } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'unsupported-commitment.example' },
+      start_time: 'asap',
+      end_time: '2099-07-01T00:00:00Z',
+      packages: [{
+        product_id: 'unsupported_commitment_product',
+        pricing_option_id: 'unsupported_commitment_product_cpm',
+        budget: 1000,
+        bid_price: 5,
+        committed_metrics: [{
+          scope: 'vendor',
+          vendor: { domain: 'attentionvendor.example' },
+          metric_id: 'attention_units',
+        }],
+      }],
+    });
+    expect(result.code).toBe('TERMS_REJECTED');
+    expect(result.field).toBe('packages[0].committed_metrics[0].metric_id');
+  });
+
   it('rejects vendor_metric optimization_goal whose metric is not in supported_metrics', async () => {
     const { productId, pricingOptionId } = findProductWithVendorMetric();
     const account = { brand: { domain: 'phantom-vendor-goal.example' }, operator: 'phantom-vendor-goal.example' };

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -4735,6 +4735,40 @@ describe('create_media_buy handler', () => {
     expect((await read('2026-07-01')).missing_metrics).toEqual([{ scope: 'vendor', ...metric }]);
   });
 
+  it('uses a requested end_date as the delivery pacing cutoff', async () => {
+    const account = { brand: { domain: 'delivery-period.example' }, operator: 'delivery-period.example', sandbox: true };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      scenario: 'seed_media_buy',
+      params: {
+        media_buy_id: 'delivery_period_buy',
+        fixture: {
+          status: 'active',
+          currency: 'USD',
+          start_time: '2026-01-01T00:00:00Z',
+          end_time: '2026-12-31T23:59:59Z',
+          packages: [{ package_id: 'delivery_period_package', budget: 1000 }],
+        },
+      },
+    });
+
+    const read = async (end_date: string) => {
+      const { result } = await simulateCallTool(server, 'get_media_buy_delivery', {
+        account,
+        media_buy_ids: ['delivery_period_buy'],
+        end_date,
+      });
+      return (result.media_buy_deliveries as Array<{ by_package: Array<Record<string, number>> }>)[0]!.by_package[0]!;
+    };
+    const firstQuarter = await read('2026-03-31');
+    const firstHalf = await read('2026-06-30');
+
+    expect(firstQuarter.spend).toBeLessThan(firstHalf.spend);
+    expect(firstQuarter.impressions).toBeLessThan(firstHalf.impressions);
+    expect(firstQuarter.clicks).toBeLessThan(firstHalf.clicks);
+  });
+
   it('rejects standalone committed metrics outside product reporting capabilities', async () => {
     const account = { brand: { domain: 'unsupported-commitment.example' }, operator: 'unsupported-commitment.example', sandbox: true };
     const server = createTrainingAgentServer(DEFAULT_CTX);

--- a/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_accountability.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/vendor_metric_accountability.yaml
@@ -1,9 +1,14 @@
 id: media_buy_seller/vendor_metric_accountability
 version: "1.0.0"
-title: "End-to-end vendor-metric accountability: declaration → filter → emission"
+title: "End-to-end vendor-metric accountability: declaration → commitment → delivery audit"
 category: media_buy_seller
-summary: "Buyer discovers products that declare a vendor metric, creates a media buy, and verifies vendor-metric values appear in the delivery report."
+summary: "Buyer commits vendor metrics on two packages, then verifies one clean package, one overdue gap, and one not-yet-measurable omission."
 track: reporting
+
+requires_capability:
+  path: media_buy.features.committed_metrics_supported
+  equals: true
+
 required_tools:
   - get_products
   - create_media_buy
@@ -25,18 +30,17 @@ narrative: |
        match (filter-not-fail; do not return an error). At least one of `vendor`
        or `metric_id` must be pinned per entry.
 
-    3. `by_package[].vendor_metric_values` on `get_media_buy_delivery` — reported
-       values for each declared vendor metric. One row per `(vendor.domain,
-       vendor.brand_id, metric_id)` per reporting period. Sellers MUST
-       de-duplicate before emission.
+    3. `package.committed_metrics` and `by_package[].missing_metrics` — the
+       seller stamps the binding vendor-metric contract at confirmation, emits
+       values only for the matching package contract, and reports overdue
+       omissions as `{ scope: "vendor", vendor, metric_id }`. Metrics that are
+       not yet measurable in the current window MUST NOT be reported missing.
 
   This storyboard exercises that contract end to end. It uses
   comply_test_controller to seed a product with vendor metrics declared and to
-  inject delivery data with vendor_metric_values, then asserts the schema-level
-  contract on the delivery response.
-
-  Item 3 of the originating issue (#3501) — whether vendor-metric emission
-  failures need a dedicated hint kind — is deferred to a follow-up adcp-client PR.
+  inject delivery data with vendor_metric_values, then asserts all three audit
+  outcomes required by #3519: a populated commitment is clean, an overdue
+  commitment is missing, and a future commitment is omitted from the gap list.
 
 agent:
   interaction_model: media_buy_seller
@@ -73,10 +77,21 @@ fixtures:
           - impressions
           - clicks
           - spend
+        measurement_windows:
+          - window_id: "live"
+            duration_days: 0
+            expected_availability_days: 0
+          - window_id: "post_flight"
+            duration_days: 0
+            expected_availability_days: 14
+            is_guarantee_basis: true
         vendor_metrics:
           - vendor:
               domain: "attentionvendor.example"
             metric_id: "attention_units"
+          - vendor:
+              domain: "attentionvendor.example"
+            metric_id: "post_flight_brand_lift"
   pricing_options:
     - product_id: "display_premium_vendor_metrics"
       pricing_option_id: "cpm_standard_vendor"
@@ -171,10 +186,10 @@ phases:
   - id: create_media_buy
     title: "Commit the media buy on the matched product"
     narrative: |
-      The buyer commits a media buy on the vendor-metric-capable product. The
-      product's `vendor_metrics` declaration carries forward as the vendor
-      reporting contract for the resulting buy — no additional field is required
-      on `create_media_buy` itself.
+      The buyer creates two packages on the same vendor-metric-capable product.
+      Package 0 commits attention plus a post-flight metric; package 1 commits
+      the same attention metric. The seller stamps both package contracts with
+      `committed_at`, allowing the report to prove package-scoped isolation.
     steps:
       - id: create_media_buy
         title: "Create media buy"
@@ -185,9 +200,8 @@ phases:
         comply_scenario: create_media_buy
         stateful: true
         expected: |
-          The buy succeeds. The product's vendor_metrics declaration carries
-          forward as the vendor reporting contract — no additional field is
-          required on the buy itself.
+          The buy succeeds with two packages. Each response package echoes the
+          seller-stamped committed_metrics contract used for delivery audit.
         sample_request:
           brand:
             domain: "acmeoutdoor.example"
@@ -201,23 +215,61 @@ phases:
             - product_id: "$context.product_id"
               pricing_option_id: "$context.pricing_option_id"
               budget: 12000
+              committed_metrics:
+                - scope: "vendor"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_units"
+                - scope: "vendor"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "post_flight_brand_lift"
+            - product_id: "$context.product_id"
+              pricing_option_id: "$context.pricing_option_id"
+              budget: 8000
+              committed_metrics:
+                - scope: "vendor"
+                  vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_units"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_vendor_metric_accountability_create"
         context_outputs:
           - path: "media_buy_id"
             key: "media_buy_id"
+          - path: "confirmed_at"
+            key: "confirmed_at"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
           - check: field_present
             path: "media_buy_id"
             description: "Seller returns a media_buy_id"
+          - check: field_value
+            path: "packages[0].committed_metrics[0].metric_id"
+            value: "attention_units"
+            description: "Clean-package attention commitment is stamped into the binding contract"
+          - check: field_value
+            path: "packages[0].committed_metrics[1].metric_id"
+            value: "post_flight_brand_lift"
+            description: "Future metric is present in the contract even though it is not measurable yet"
+          - check: field_present
+            path: "packages[0].committed_metrics[0].committed_at"
+            description: "Seller stamps the commitment time used by delivery reconciliation"
+          - check: field_value
+            path: "packages[0].committed_metrics[0].committed_at"
+            value: "$context.confirmed_at"
+            description: "Day-1 commitment time equals the media buy confirmed_at timestamp"
+          - check: field_value
+            path: "packages[1].committed_metrics[0].metric_id"
+            value: "attention_units"
+            description: "Breach package commits the same metric, proving values are package-scoped"
 
   - id: simulate_and_validate_vendor_metrics
     title: "Simulate delivery with vendor-metric values and validate emission"
     narrative: |
       Inject simulated delivery via the test controller, including
-      vendor_metric_values, then call get_media_buy_delivery and check that
-      `by_package[].vendor_metric_values` carries the injected entries.
+      vendor_metric_values and the explicit current-window deferral, then call
+      get_media_buy_delivery and reconcile each package independently.
 
       The semantic uniqueness key for each vendor metric row is
       `(vendor.domain, vendor.brand_id, metric_id)`. Since brand_id is optional
@@ -243,13 +295,20 @@ phases:
             reported_spend:
               amount: 960.00
               currency: "USD"
-            vendor_metric_values:
-              - vendor:
-                  domain: "attentionvendor.example"
-                metric_id: "attention_units"
-                value: 4.2
-                unit: "score"
-                measurable_impressions: 72000
+            measurement_window: "live"
+            vendor_metric_values_by_package:
+              pkg-0:
+                - vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "attention_units"
+                  value: 4.2
+                  unit: "score"
+                  measurable_impressions: 72000
+            not_yet_measurable_vendor_metrics_by_package:
+              pkg-0:
+                - vendor:
+                    domain: "attentionvendor.example"
+                  metric_id: "post_flight_brand_lift"
         validations:
           - check: field_value
             path: "success"
@@ -257,7 +316,7 @@ phases:
             description: "Delivery simulation succeeds"
 
       - id: get_delivery_with_vendor_metrics
-        title: "Get delivery report and assert vendor_metric_values are present"
+        title: "Get delivery report and assert clean, missing, and deferred outcomes"
         task: get_media_buy_delivery
         schema_ref: "media-buy/get-media-buy-delivery-request.json"
         response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
@@ -265,11 +324,11 @@ phases:
         comply_scenario: reporting_flow
         stateful: true
         expected: |
-          Return delivery metrics with vendor_metric_values populated in
-          by_package[0]. The entry must carry vendor.domain, metric_id, and
-          value matching the injected data. measurable_impressions is the
-          coverage denominator — buyers compute coverage rate as
-          measurable_impressions / impressions.
+          Package 0 reports attention_units and has an empty missing_metrics:
+          the populated metric is not flagged, and post_flight_brand_lift is
+          omitted because it is not yet measurable. Package 1 reports
+          attention_units in missing_metrics because its package-scoped value is
+          overdue and absent from vendor_metric_values.
         sample_request:
           account:
             brand:
@@ -292,6 +351,32 @@ phases:
           - check: field_present
             path: "media_buy_deliveries[0].by_package[0].vendor_metric_values[0].value"
             description: "Each vendor_metric_value entry carries a value"
+          - check: field_value
+            path: "media_buy_deliveries[0].by_package[0].vendor_metric_values[0].value"
+            value: 4.2
+            description: "Clean package reports the exact injected vendor value"
           - check: field_present
             path: "media_buy_deliveries[0].by_package[0].vendor_metric_values[0].measurable_impressions"
             description: "Coverage denominator is present — buyers can compute vendor measurement coverage rate"
+          - check: field_present
+            path: "media_buy_deliveries[0].by_package[0].missing_metrics"
+            description: "Clean package returns an explicit audit result"
+          - check: field_value
+            path: "media_buy_deliveries[0].by_package[0].missing_metrics"
+            value: []
+            description: "Populated attention is not missing and future brand lift is excluded until measurable"
+          - check: field_absent
+            path: "media_buy_deliveries[0].by_package[1].vendor_metric_values"
+            description: "Package-scoped simulated attention does not leak into the second package"
+          - check: field_value
+            path: "media_buy_deliveries[0].by_package[1].missing_metrics[0].scope"
+            value: "vendor"
+            description: "Overdue vendor commitment uses the unified vendor-scope missing_metrics arm"
+          - check: field_value
+            path: "media_buy_deliveries[0].by_package[1].missing_metrics[0].vendor.domain"
+            value: "attentionvendor.example"
+            description: "Missing row preserves the committed vendor identity"
+          - check: field_value
+            path: "media_buy_deliveries[0].by_package[1].missing_metrics[0].metric_id"
+            value: "attention_units"
+            description: "Same-key package without a scoped value is reported missing"

--- a/static/schemas/source/compliance/comply-test-controller-request.json
+++ b/static/schemas/source/compliance/comply-test-controller-request.json
@@ -799,6 +799,60 @@
           },
           "additionalProperties": true
         },
+        "vendor_metric_values": {
+          "type": "array",
+          "description": "Vendor-defined metric values to inject into the next delivery report. Used by simulate_delivery. The reference seller reconciles these rows against each package's seller-stamped committed_metrics contract.",
+          "items": {
+            "$ref": "/schemas/core/vendor-metric-value.json"
+          }
+        },
+        "vendor_metric_values_by_package": {
+          "type": "object",
+          "description": "Package-scoped vendor-defined values to inject, keyed by package_id. Used by simulate_delivery for multi-package buys. Sellers MUST use this form whenever more than one package could carry the same vendor/metric_id key; the legacy media-buy-scoped vendor_metric_values form is unambiguous only for a single-package buy.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "/schemas/core/vendor-metric-value.json"
+            }
+          }
+        },
+        "not_yet_measurable_vendor_metrics": {
+          "type": "array",
+          "description": "Committed vendor metrics that are not yet measurable for the simulated measurement window. Used by simulate_delivery to prove that a future metric is omitted from missing_metrics until its measurement window matures.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "vendor": {
+                "$ref": "/schemas/core/brand-ref.json"
+              },
+              "metric_id": {
+                "$ref": "/schemas/core/vendor-metric-id.json"
+              }
+            },
+            "required": ["vendor", "metric_id"],
+            "additionalProperties": false
+          }
+        },
+        "not_yet_measurable_vendor_metrics_by_package": {
+          "type": "object",
+          "description": "Package-scoped committed vendor metrics that are not yet measurable for the simulated window, keyed by package_id. Used by simulate_delivery for multi-package buys so a deferral on one package never suppresses another package's overdue gap.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "vendor": {
+                  "$ref": "/schemas/core/brand-ref.json"
+                },
+                "metric_id": {
+                  "$ref": "/schemas/core/vendor-metric-id.json"
+                }
+              },
+              "required": ["vendor", "metric_id"],
+              "additionalProperties": false
+            }
+          }
+        },
         "spend_percentage": {
           "type": "number",
           "minimum": 0,


### PR DESCRIPTION
## Summary

- persist seller-stamped per-package metric commitments and expose them on readback
- reconcile unified standard and vendor `missing_metrics`, including product capability fallback
- isolate simulated vendor values and deferrals by package and make controller updates success-atomic
- capability-gate and strengthen the vendor metric accountability storyboard

## Why

Vendor metric commitments had no reliable in-band audit path. The reference seller also treated simulated vendor values as media-buy scoped, which could leak one package's value into another package carrying the same metric key.

This closes the accountability loop while preserving the unified `missing_metrics` schema introduced after the original issue proposal.

## Impact

Buyers can read back the binding reporting contract and identify overdue standard or vendor metrics per package. Sellers that do not advertise `media_buy.features.committed_metrics_supported` are not evaluated by the optional conformance scenario.

## Validation

- `npm run typecheck`
- affected server unit suites: 623 passing tests
- `npm run test:schemas`: 27 passing validations
- `npm run build:schemas`
- `npm run build:compliance`
- storyboard sample-request, response, and context-output lints
- current and AdCP 3.0 compatibility storyboard matrices across all tenants

The repository pre-commit hook's full server suite exceeded its local 240-second timeout under workspace load; no assertion failure was reported. The scoped suites and all other gates above passed.

Closes #3519
