### PR TITLE
fix(dashboard): correct broken aao-verified doc links, remove stale live hint

### DIFF
--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -2285,7 +2285,7 @@
         } else if (status === 'opted_out') {
           hint = 'Compliance monitoring is opted out for this agent — no badges will issue. Re-enable monitoring to be eligible.';
         } else if (status === 'passing' && declaredSpecialisms.length === 0) {
-          hint = 'Storyboards are passing, but your agent isn\'t declaring any specialisms in <code>get_adcp_capabilities</code> — without that declaration, AAO doesn\'t know which badges to issue. <a href="/docs/building/aao-verified#declare-specialisms" target="_blank" rel="noopener">How to declare specialisms</a>.';
+          hint = 'Storyboards are passing, but your agent isn\'t declaring any specialisms in <code>get_adcp_capabilities</code> — without that declaration, AAO doesn\'t know which badges to issue. <a href="/docs/building/verification/aao-verified#declare-specialisms" target="_blank" rel="noopener">How to declare specialisms</a>.';
         } else if (status === 'passing') {
           if (tierEligibleSentence) {
             hint = `Storyboards are passing. ${tierEligibleSentence}. Your badge should issue ${nextCheckCopy}.`;
@@ -2296,10 +2296,10 @@
           }
         } else if (status === 'failing' || status === 'degraded') {
           hint = declaredSpecialisms.length === 0
-            ? 'Storyboards are failing — fix the failing storyboards in this card to earn AAO Verified (Spec). <a href="/docs/building/aao-verified" target="_blank" rel="noopener">Learn more</a>.'
-            : 'Some declared specialisms are failing — fix the failing storyboards in this card to earn AAO Verified (Spec). <a href="/docs/building/aao-verified" target="_blank" rel="noopener">Learn more</a>.';
+            ? 'Storyboards are failing — fix the failing storyboards in this card to earn AAO Verified (Spec). <a href="/docs/building/verification/aao-verified" target="_blank" rel="noopener">Learn more</a>.'
+            : 'Some declared specialisms are failing — fix the failing storyboards in this card to earn AAO Verified (Spec). <a href="/docs/building/verification/aao-verified" target="_blank" rel="noopener">Learn more</a>.';
         } else {
-          hint = `Compliance check will run ${nextCheckCopy}. Earn AAO Verified (Spec) by declaring specialisms in <code>get_adcp_capabilities</code> and passing their storyboards. <a href="/docs/building/aao-verified" target="_blank" rel="noopener">Learn more</a>.`;
+          hint = `Compliance check will run ${nextCheckCopy}. Earn AAO Verified (Spec) by declaring specialisms in <code>get_adcp_capabilities</code> and passing their storyboards. <a href="/docs/building/verification/aao-verified" target="_blank" rel="noopener">Learn more</a>.`;
         }
 
         const renderSpecialismChip = (s) => {
@@ -2442,12 +2442,6 @@
           </div>`;
       }).join('');
 
-      // Surface the (Live) upgrade path inline when no badge holds it yet.
-      const hasLive = badges.some(b => Array.isArray(b.verification_modes) && b.verification_modes.includes('live'));
-      const liveHint = hasLive
-        ? ''
-        : '<div class="verification-eligibility-hint">Want <strong>(Live)</strong> too? Once AAO\'s canonical-campaign runner ships in 3.1, agents that flow real production traffic will earn the <strong>(Live)</strong> qualifier on the same badge — same URL, no embed swap. <a href="/docs/building/aao-verified#verified-live" target="_blank" rel="noopener">Learn more</a>.</div>';
-
       // Header count: "1 badge" / "N badges" / "N badges across M roles"
       // The "across M roles" suffix only appears when at least one role
       // has parallel-version badges (i.e. distinctRoleCount < badges.length).
@@ -2465,7 +2459,6 @@
             <span style="font-weight: normal; text-transform: none; letter-spacing: 0;">${badgeCountSummary}</span>
           </div>
           ${rowsHtml}
-          ${liveHint}
           ${buildNoticesSectionHtml(cs)}
         </div>`;
     }


### PR DESCRIPTION
Closes #6231

Four hint-text links in the agent dashboard pointed to `/docs/building/aao-verified`, which returns 404 — the page lives at `/docs/building/verification/aao-verified`. This PR corrects all four hrefs and removes a stale `(Live)` hint block that had become permanently dead code.

**Non-breaking justification:** this is a pure `server/public/` HTML fix — link paths and dead JS variable removal. No schema, protocol, or API surface is touched; no changeset is needed.

## Changes

**`server/public/dashboard-agents.html`**

1. **Lines 2288, 2299, 2300, 2302** — four `href` values updated from `/docs/building/aao-verified[#anchor]` to `/docs/building/verification/aao-verified[#anchor]`. The `#declare-specialisms` anchor in hunk 1 remains valid (`## Declare specialisms` at line 94 of the target MDX, which Mintlify slugifies correctly).

2. **Lines 2445–2449 + 2468** — removed the stale `(Live)` upgrade hint block entirely. Three independent reasons:
   - `hasLive` checked `verification_modes.includes('live')` — permanently `false` because the badge-issuance path only writes `'spec'` or `'sandbox'`, never `'live'`. The hint rendered on every badge load unconditionally.
   - The `href` pointed to `#verified-live`, an anchor that no longer exists in the target page (the reframe to "(Sandbox)" removed it).
   - The copy ("ships in 3.1") references a roadmap milestone that has since shipped under different terminology.

## Pre-PR review

- **code-reviewer:** approved — no blockers. Nit: the `false` branch of the `failing`/`degraded` ternary (line 2300) was verified as already correct in the diff context; touching it is a no-op. (`out of scope` per reviewer.)
- **docs-expert:** approved after confirming working-copy line 2299 reads `aao-verified` (correct). Verified `docs/building/verification/aao-verified.mdx` exists, `#declare-specialisms` anchor is valid, and all stale references are absent post-patch.

> **Triage-managed PR.** This bot does not currently iterate on review comments or PR conversation threads (only on the source issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 6231` → fix → push.
> - **Or request a new first draft PR:** comment `/triage execute` on the source issue only when no triage-managed PR is already open. Triage does not update existing PRs.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.

Session: https://claude.ai/code/session_014EKuiUMS3Ei2Kh8ZSqqTSr

---
_Generated by [Claude Code](https://claude.ai/code/session_014EKuiUMS3Ei2Kh8ZSqqTSr)_