### PR TITLE
docs(prebid): make TMP a peer to RTD in Prebid.js

### DIFF
--- a/docs/trusted-match/surfaces/web.mdx
+++ b/docs/trusted-match/surfaces/web.mdx
@@ -173,7 +173,21 @@ For each active package, the publisher creates a GAM line item targeting `adcp_p
 
 ## Prebid Integration
 
-The TMP Prebid module is a Real-Time Data (RTD) module that replaces vendor-specific RTD modules. It is defined by the [TMP Prebid proposal](/specs/prebid-tmp-proposal) and follows the standard Prebid RTD module interface. It handles the full flow:
+The first TMP integration can be delivered as a Real-Time Data (RTD) submodule
+that follows Prebid's established RTD interface. This is the **present-day
+compatibility profile**: it provides a practical route to a pilot and can
+replace vendor-specific RTD modules without waiting for a new Prebid.js module
+boundary.
+
+The [TMP Prebid proposal](/specs/prebid-tmp-proposal) defines the **target
+architecture**: a dedicated optional TMP module that is a peer to RTD, rather
+than an RTD submodule. Moving from the bridge to that peer changes Prebid.js
+registration and configuration ownership, but not the TMP wire protocol,
+split-request privacy model, router, or local join described below. Publishers
+should follow the configuration for the implementation included in their
+Prebid.js build.
+
+Both profiles handle the full flow:
 
 1. **On auction init**: Send Context Match request to the TMP router for each placement on the page.
 2. **On context match response**: Store offers and targeting signals.

--- a/specs/prebid-tmp-proposal.md
+++ b/specs/prebid-tmp-proposal.md
@@ -1,4 +1,4 @@
-# Proposal: TMP as Core Prebid Infrastructure
+# Proposal: TMP as a Peer to RTD in Prebid
 
 ## Problem
 
@@ -45,11 +45,12 @@ API returns data that gets injected into:
 - **No standard protocol.** Vendors define their own request/response formats.
   Switching vendors means rewriting the integration.
 
-### What TMP can replace
+### What can migrate to TMP
 
 Of the 61 modules, approximately 38 (contextual + audience + brand safety + bid
 enrichment) follow the "fetch data, enrich request" pattern that TMP
-standardizes. Specifically:
+standardizes. Those integrations are migration candidates; introducing TMP
+does not remove or subsume the RTD framework. Specifically:
 
 | TMP operation | Replaces | How |
 |---|---|---|
@@ -64,10 +65,23 @@ JavaScript runtime.
 
 ## Proposal
 
-Make TMP (Trusted Match Protocol) a core Prebid capability — configured via
-`pbjs.setConfig()` in Prebid.js and via YAML in Prebid Server. Publishers
-register TMP providers the same way they register bidder adapters: declare them,
-configure endpoints, done.
+Add TMP (Trusted Match Protocol) as an optional Prebid.js module **alongside**
+the existing RTD module, and as a module in Prebid Server. In Prebid.js, TMP
+owns its protocol-specific lifecycle, privacy separation, temporal
+decorrelation, and local join. It does not register as an RTD data provider and
+does not change RTD's provider contract. Publishers include the TMP module in
+their build and configure it with `pbjs.setConfig()`. Prebid Server operators
+configure the corresponding module via YAML.
+
+This peer architecture preserves a clean boundary:
+
+- **RTD remains RTD.** Existing `realTimeData.dataProviders` configuration and
+  RTD submodules continue to work unchanged.
+- **TMP remains TMP.** Top-level `tmp` configuration is consumed only by the
+  TMP module, whose two-request flow cannot be represented safely as a single
+  RTD provider callback.
+- **Publishers can run both.** A publisher can compare or migrate an existing
+  RTD integration without changing auction-wide RTD behavior.
 
 TMP is an open protocol (part of AdCP) that standardizes what RTD modules do
 today. It defines two operations:
@@ -79,6 +93,13 @@ The publisher joins the results locally. The buyer never sees both context and
 identity for the same impression.
 
 ## What changes in Prebid.js
+
+Prebid.js gains an optional TMP module at the same architectural level as the
+RTD module. A distribution must include that module (for example, through the
+publisher's normal custom-build module list) before the `tmp` configuration is
+used. TMP may use the same auction lifecycle hook points as RTD, but it does
+not call RTD's submodule registration API or appear in
+`realTimeData.dataProviders`.
 
 ### Configuration
 
@@ -101,7 +122,9 @@ pbjs.setConfig({
 });
 ```
 
-No module installation. No `pbjs.que.push`. Just config.
+The publisher includes the TMP module in its Prebid.js build once, then uses
+top-level configuration. No vendor-specific RTD submodule is required for each
+TMP provider.
 
 ### Per-ad-unit configuration
 
@@ -141,16 +164,16 @@ var adUnits = [{
 
 See [Impression ID Substitution](/docs/trusted-match/surfaces/web#impression-id-substitution) for the full rationale, the `enableTIDs` reuse optimization, and the GAM creative URL pattern.
 
-The `@adcp/client/tmp` package handles steps 1, 3, and 4 as pure functions. Prebid
-handles the HTTP calls, timing, and ad unit targeting — exactly what Prebid is
-good at.
+The `@adcp/client/tmp` package handles steps 1, 3, and 4 as pure functions. The
+Prebid.js TMP module handles the HTTP calls, timing, and ad unit targeting. The
+RTD module is neither a dependency nor an intermediary.
 
 ### Dependency: `@adcp/client/tmp`
 
 - Zero dependencies, under 3KB gzipped
 - Tree-shakeable — only the functions Prebid uses get bundled
 - Types + pure functions — no network calls, no side effects
-- Prebid already supports npm dependencies for core modules
+- Prebid already supports npm dependencies for optional modules
 - Ed25519 request signing is handled by `@adcp/client/tmp` when a signing
   key is configured (see [Request signing](#request-signing) below for the
   requirements that apply to both Prebid.js and PBS)
@@ -329,7 +352,7 @@ endpoint accepts `ContextMatchRequest` and returns `ContextMatchResponse`.
 Scope3's existing contextual targeting, content classification, and enrichment
 signals map directly to TMP offers and signals.
 
-### Step 2: Publisher switches config
+### Step 2: Publisher enables the TMP peer module and switches config
 
 Before (Scope3 RTD module):
 ```javascript
@@ -345,7 +368,7 @@ pbjs.setConfig({
 });
 ```
 
-After (TMP core):
+After (TMP module, configured alongside rather than through RTD):
 ```javascript
 pbjs.setConfig({
   tmp: {
@@ -357,8 +380,10 @@ pbjs.setConfig({
 });
 ```
 
-The publisher's router configuration includes Scope3 as a provider. No
-per-vendor module needed.
+The publisher's router configuration includes Scope3 as a provider. The
+publisher's Prebid.js build includes the single TMP module; no per-vendor RTD
+submodule is needed. During migration, the `realTimeData` and `tmp` top-level
+configuration blocks may coexist for an A/B comparison.
 
 ### Step 3: Deprecate Scope3 RTD module
 
@@ -370,10 +395,12 @@ same config — no new Prebid modules needed.
 
 ### Fewer modules to maintain
 
-One TMP adapter in Prebid core replaces up to 38 vendor RTD modules (the
-contextual, audience, brand safety, and bid enrichment categories). Each vendor
-becomes a provider endpoint in config. New vendors don't require new Prebid
-modules, PRs, or releases.
+One optional TMP peer module provides a migration path for up to 38 vendor RTD
+modules (the contextual, audience, brand safety, and bid enrichment
+categories). Each migrated vendor becomes a provider endpoint in the
+publisher's router configuration. New TMP providers don't require new Prebid
+modules, PRs, or releases. RTD stays available for integrations that have not
+migrated or do not fit TMP.
 
 ### Smaller payloads
 
@@ -437,7 +464,8 @@ function resolveImpressionId(adUnit) {
   return ulid();
 }
 
-// Register as a Prebid subsystem
+// Initialize from the dedicated TMP module. This is not an RTD submodule:
+// it does not register through realTimeData or dataProviders.
 function init(config, userConsent) {
   const { router, propertyRid, propertyType, identity, temporalDelay, timeout } = config.tmp;
 
@@ -624,5 +652,6 @@ func (m *Module) HandleAuctionHook(ctx context.Context, payload modules.AuctionP
 4. **Scope3 TMP endpoint** — Scope3 ships TMP-compatible endpoint.
 5. **Publisher pilot** — One publisher runs TMP via Prebid alongside existing
    Scope3 RTD module, A/B comparison.
-6. **Prebid core merge** — Prebid team adapts reference adapters to their
-   codebase standards and merges.
+6. **Prebid module merge** — Prebid team adapts the reference adapters to their
+   codebase standards and merges TMP as an optional peer to RTD, not as an RTD
+   provider or an always-on core subsystem.

--- a/specs/prebid-tmp-proposal.md
+++ b/specs/prebid-tmp-proposal.md
@@ -63,7 +63,7 @@ Human Security), client-side device detection (51Degrees, WURFL), auction
 timeout control, and proprietary client-side engines that require their own
 JavaScript runtime.
 
-## Proposal
+## Proposal: target architecture
 
 Add TMP (Trusted Match Protocol) as an optional Prebid.js module **alongside**
 the existing RTD module, and as a module in Prebid Server. In Prebid.js, TMP
@@ -83,6 +83,15 @@ This peer architecture preserves a clean boundary:
 - **Publishers can run both.** A publisher can compare or migrate an existing
   RTD integration without changing auction-wide RTD behavior.
 
+This is the **target architecture**, not a claim that the dedicated peer module
+already exists in Prebid.js. The pragmatic first integration may ship as a TMP
+RTD submodule so it can use Prebid's established RTD interface while the peer
+module is proposed, reviewed, and implemented. That compatibility profile is a
+bridge: it registers through RTD and uses `realTimeData.dataProviders`; it MUST
+preserve TMP's separate Context Match and Identity Match requests and local
+join. Once the peer module is available, publishers move the same protocol flow
+to top-level `tmp` configuration. The wire protocol and router do not change.
+
 TMP is an open protocol (part of AdCP) that standardizes what RTD modules do
 today. It defines two operations:
 
@@ -100,6 +109,37 @@ publisher's normal custom-build module list) before the `tmp` configuration is
 used. TMP may use the same auction lifecycle hook points as RTD, but it does
 not call RTD's submodule registration API or appear in
 `realTimeData.dataProviders`.
+
+### Present-day compatibility profile
+
+Before that peer module lands, an implementation MAY expose TMP as an RTD
+submodule. This is the near-term integration described in the current web
+surface guide. It is intentionally a concession to the existing Prebid.js
+extension surface, not the final ownership boundary. Implementers must not
+infer from the RTD registration that TMP collapses its context and identity
+paths into a conventional single vendor-enrichment request.
+
+The compatibility form is:
+
+```javascript
+pbjs.setConfig({
+  realTimeData: {
+    dataProviders: [{
+      name: 'tmp',
+      params: {
+        router: 'https://tmp.publisher.example.com',
+        propertyRid: '01916f3a-9c4e-7000-8000-000000000010',
+        propertyType: 'website',
+        timeout: 50
+      }
+    }]
+  }
+});
+```
+
+The next configuration block describes the target peer module. Documentation
+for either implementation must identify its profile so publishers know which
+module their build contains.
 
 ### Configuration
 
@@ -164,9 +204,11 @@ var adUnits = [{
 
 See [Impression ID Substitution](/docs/trusted-match/surfaces/web#impression-id-substitution) for the full rationale, the `enableTIDs` reuse optimization, and the GAM creative URL pattern.
 
-The `@adcp/client/tmp` package handles steps 1, 3, and 4 as pure functions. The
-Prebid.js TMP module handles the HTTP calls, timing, and ad unit targeting. The
-RTD module is neither a dependency nor an intermediary.
+The `@adcp/client/tmp` package handles steps 1, 3, and 4 as pure functions. In
+the target architecture, the Prebid.js TMP module handles the HTTP calls,
+timing, and ad unit targeting, and RTD is neither a dependency nor an
+intermediary. In the bridge profile, the TMP RTD submodule temporarily owns
+those responsibilities while preserving the same protocol behavior.
 
 ### Dependency: `@adcp/client/tmp`
 
@@ -368,7 +410,7 @@ pbjs.setConfig({
 });
 ```
 
-After (TMP module, configured alongside rather than through RTD):
+Target state (TMP peer module, configured alongside rather than through RTD):
 ```javascript
 pbjs.setConfig({
   tmp: {
@@ -383,7 +425,9 @@ pbjs.setConfig({
 The publisher's router configuration includes Scope3 as a provider. The
 publisher's Prebid.js build includes the single TMP module; no per-vendor RTD
 submodule is needed. During migration, the `realTimeData` and `tmp` top-level
-configuration blocks may coexist for an A/B comparison.
+configuration blocks may coexist for an A/B comparison. Before the peer module
+lands, the TMP RTD bridge can provide the same wire behavior, but its temporary
+configuration remains inside `realTimeData.dataProviders`.
 
 ### Step 3: Deprecate Scope3 RTD module
 
@@ -464,8 +508,8 @@ function resolveImpressionId(adUnit) {
   return ulid();
 }
 
-// Initialize from the dedicated TMP module. This is not an RTD submodule:
-// it does not register through realTimeData or dataProviders.
+// Target architecture: initialize from the dedicated TMP peer module.
+// A present-day RTD bridge wraps this lifecycle through the RTD interface.
 function init(config, userConsent) {
   const { router, propertyRid, propertyType, identity, temporalDelay, timeout } = config.tmp;
 
@@ -647,11 +691,14 @@ func (m *Module) HandleAuctionHook(ctx context.Context, payload modules.AuctionP
    the TMP schemas shipping in AdCP 3.0.
 2. **Reference adapters** — Working Prebid.js and Prebid Server adapters that
    the Prebid team can review and adapt.
-3. **Prebid proposal submission** — Submit to Prebid.org with working code,
-   performance benchmarks (payload size, latency), and Scope3 migration plan.
-4. **Scope3 TMP endpoint** — Scope3 ships TMP-compatible endpoint.
-5. **Publisher pilot** — One publisher runs TMP via Prebid alongside existing
+3. **RTD bridge** — If needed for an initial pilot, ship a compatibility RTD
+   submodule that preserves TMP's split-request and local-join invariants.
+4. **Prebid proposal submission** — Submit the peer-module architecture to
+   Prebid.org with working code, performance benchmarks (payload size,
+   latency), and Scope3 migration plan.
+5. **Scope3 TMP endpoint** — Scope3 ships TMP-compatible endpoint.
+6. **Publisher pilot** — One publisher runs TMP via Prebid alongside existing
    Scope3 RTD module, A/B comparison.
-6. **Prebid module merge** — Prebid team adapts the reference adapters to their
+7. **Prebid module merge** — Prebid team adapts the reference adapters to their
    codebase standards and merges TMP as an optional peer to RTD, not as an RTD
    provider or an always-on core subsystem.


### PR DESCRIPTION
### Motivation
- Clarify the Prebid integration strategy so the Trusted Match Protocol (TMP) is an optional, peer-level module rather than a core subsystem or an RTD provider.
- Preserve the existing RTD framework while providing a migration path for contextual/audience RTD modules to adopt TMP where appropriate.
- Reduce ambiguity around build, configuration, and ownership boundaries so publishers can run RTD and TMP side-by-side during migration and comparison.

### Description
- Rewrote `specs/prebid-tmp-proposal.md` to reframe TMP as an optional Prebid.js module that coexists with, and does not subsume, the RTD system and to update the doc title to `TMP as a Peer to RTD in Prebid`.
- Added explicit guidance that publishers must include the TMP module in their Prebid.js build and that TMP consumes top-level `tmp` config rather than registering via `realTimeData.dataProviders`.
- Clarified migration steps and examples so `realTimeData` and `tmp` configurations may coexist for A/B comparisons and migration, and updated the Prebid Server and reference-adapter commentary accordingly.
- Small editorial changes to the dependency note (`@adcp/client/tmp`) and the rollout timeline to reflect that TMP is an optional peer module, not a core RTD replacement.

### Testing
- Ran `git diff --check` which succeeded with no whitespace errors.
- Ran `node scripts/check-pr-title.cjs "docs(prebid): make TMP a peer to RTD in Prebid.js"` which returned success for the PR title format.
- Confirmed the working tree and commit with `git status --short --branch` and `git commit` completion, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a73d5824774832b8cc99fc4de8d05cf)