### PR TITLE
feat(certification): improve chat reliability and outcomes

### DIFF
--- a/server/public/admin-certification.html
+++ b/server/public/admin-certification.html
@@ -346,6 +346,21 @@
       <!-- Overview metrics -->
       <div class="metrics-grid" id="metrics-grid"></div>
 
+      <div class="section" id="model-outcomes-section" style="display:none;">
+        <h2>Certification outcomes by model</h2>
+        <table id="model-outcomes-table">
+          <thead><tr>
+            <th>Model</th><th>Module</th>
+            <th class="text-right">Completed turns</th>
+            <th class="text-right">Interrupted</th>
+            <th class="text-right">Evidence</th>
+            <th class="text-right">Modules</th>
+            <th class="text-right">Credentials</th>
+          </tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+
       <!-- Credentials by tier -->
       <div class="section">
         <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px;">
@@ -494,6 +509,12 @@
 
         // Metrics cards
         const grid = document.getElementById('metrics-grid');
+        const experience = data.experience || {};
+        const credentialLatency = experience.avg_credential_latency_seconds == null
+          ? '—'
+          : experience.avg_credential_latency_seconds < 60
+            ? `${experience.avg_credential_latency_seconds}s`
+            : `${Math.round(experience.avg_credential_latency_seconds / 60)}m`;
         grid.innerHTML = `
           <div class="metric-card">
             <div class="metric-label">Total learners</div>
@@ -519,7 +540,62 @@
             <div class="metric-value">${data.totals.stuck_attempts}</div>
             <div class="metric-sub">Blocking learners</div>
           </div>` : ''}
+          <div class="metric-card">
+            <div class="metric-label">Turn completion</div>
+            <div class="metric-value">${experience.completion_rate || 0}%</div>
+            <div class="metric-sub">Last ${experience.window_days || 30} days</div>
+          </div>
+          <div class="metric-card">
+            <div class="metric-label">Interrupted turns</div>
+            <div class="metric-value">${experience.interruption_rate || 0}%</div>
+            <div class="metric-sub">${experience.recovery_rate || 0}% recovered after retry</div>
+          </div>
+          <div class="metric-card">
+            <div class="metric-label">Resume sessions</div>
+            <div class="metric-value">${experience.resume_sessions || 0}</div>
+            <div class="metric-sub">${experience.resume_completion_rate || 0}% reached module completion</div>
+          </div>
+          <div class="metric-card">
+            <div class="metric-label">Capacity protection</div>
+            <div class="metric-value">${experience.reserve_turns || 0}</div>
+            <div class="metric-sub">${experience.capacity_blocks || 0} blocked turns</div>
+          </div>
+          <div class="metric-card">
+            <div class="metric-label">Contributions submitted</div>
+            <div class="metric-value">${experience.contributions_submitted || 0}</div>
+            <div class="metric-sub">${experience.contribution_submit_rate || 0}% of drafts</div>
+          </div>
+          <div class="metric-card">
+            <div class="metric-label">Credential issue time</div>
+            <div class="metric-value">${credentialLatency}</div>
+            <div class="metric-sub">${experience.credential_action_resolution_rate || 0}% of action blocks resolved</div>
+          </div>
+          <div class="metric-card">
+            <div class="metric-label">Evidence → completion</div>
+            <div class="metric-value">${experience.evidence_completion_rate || 0}%</div>
+            <div class="metric-sub">Validated module completions only</div>
+          </div>
         `;
+
+        const modelOutcomes = experience.model_outcomes || [];
+        const modelSection = document.getElementById('model-outcomes-section');
+        const modelBody = document.querySelector('#model-outcomes-table tbody');
+        if (modelOutcomes.length > 0) {
+          modelSection.style.display = '';
+          modelBody.innerHTML = modelOutcomes.map(outcome => `
+            <tr>
+              <td>${escapeHtml(outcome.model)}</td>
+              <td>${escapeHtml(outcome.module_id || '—')}</td>
+              <td class="text-right">${Number(outcome.turns_completed) || 0}</td>
+              <td class="text-right">${Number(outcome.turns_interrupted) || 0}</td>
+              <td class="text-right">${Number(outcome.evidence_complete) || 0}</td>
+              <td class="text-right">${Number(outcome.modules_completed) || 0}</td>
+              <td class="text-right">${Number(outcome.credentials_issued) || 0}</td>
+            </tr>`).join('');
+        } else {
+          modelSection.style.display = 'none';
+          modelBody.innerHTML = '';
+        }
 
         // Credentials by tier
         const credBody = document.querySelector('#credentials-table tbody');

--- a/server/public/certification.html
+++ b/server/public/certification.html
@@ -941,6 +941,27 @@
       color: var(--color-success-700);
       margin: 0;
     }
+
+    .module-resume-state {
+      margin-top: var(--space-2);
+      color: var(--color-text-secondary);
+      font-size: var(--text-xs);
+    }
+
+    .contributions-section {
+      max-width: 900px;
+      margin: 0 auto var(--space-8);
+    }
+
+    .contribution-item {
+      display: flex;
+      justify-content: space-between;
+      gap: var(--space-3);
+      padding: var(--space-3);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      margin-top: var(--space-2);
+    }
   </style>
 </head>
 <body>
@@ -996,6 +1017,12 @@
       </div>
     </div>
 
+    <div id="contributions-section" class="contributions-section" style="display: none;">
+      <h2>My protocol contributions</h2>
+      <p style="color: var(--color-text-secondary);">Questions that became concrete proposals while you learned.</p>
+      <div id="contributions-list"></div>
+    </div>
+
     <!-- Earned credentials are rendered inline in tier cards -->
   </div>
 
@@ -1008,6 +1035,7 @@
         certifications: [],
         credentials: [],
         myCredentials: [],
+        contributions: [],
         moduleDetails: {},
         isAuthenticated: false,
         isMember: false,
@@ -1055,6 +1083,7 @@
           var authFetches = [
             fetch('/api/me/certification/progress').then(function(r) { return r.ok ? r.json() : null; }),
             fetch('/api/me/certification/credentials').then(function(r) { return r.ok ? r.json() : null; }),
+            fetch('/api/me/certification/contributions').then(function(r) { return r.ok ? r.json() : null; }),
           ];
 
           var authResults = await Promise.all(authFetches);
@@ -1065,6 +1094,9 @@
           }
           if (authResults[1]) {
             state.myCredentials = authResults[1].credentials || [];
+          }
+          if (authResults[2]) {
+            state.contributions = authResults[2].contributions || [];
           }
         }
 
@@ -1361,6 +1393,7 @@
         renderHeaderActions();
         renderTiers();
         renderLearningPath();
+        renderContributions();
       }
 
       function renderHeaderActions() {
@@ -1376,7 +1409,16 @@
         var hasAnyProgress = state.progress.length > 0;
         if (hasAnyProgress && startBtn) {
           startBtn.textContent = 'Pick up where you left off';
-          startBtn.href = '/chat?topic=certification&action=continue';
+          var active = state.progress.find(function(p) { return p.status === 'in_progress'; });
+          if (active) {
+            startBtn.href = '#';
+            startBtn.onclick = function(event) {
+              event.preventDefault();
+              window.startModule(active.module_id);
+            };
+          } else {
+            startBtn.href = '/chat?topic=certification&action=continue';
+          }
           // Hide placement option for returning learners
           if (assessBtn) assessBtn.style.display = 'none';
         }
@@ -1568,6 +1610,47 @@
         container.innerHTML = html;
       }
 
+      function renderContributions() {
+        var section = document.getElementById('contributions-section');
+        var list = document.getElementById('contributions-list');
+        if (!section || !list || !state.contributions.length) return;
+        section.style.display = '';
+        list.innerHTML = state.contributions.map(function(item) {
+          var url = item.github_issue_url || item.draft_url;
+          try {
+            var parsedUrl = new URL(url);
+            url = parsedUrl.protocol === 'https:' && parsedUrl.hostname === 'github.com' ? parsedUrl.href : '';
+          } catch (e) { url = ''; }
+          var action = item.status === 'submitted' ? 'View issue' : 'Open draft';
+          return '<div class="contribution-item">' +
+            '<div><strong>' + esc(item.title) + '</strong><div class="module-resume-state">' +
+            esc(item.repository) + (item.module_id ? ' · ' + esc(item.module_id) : '') + '</div></div>' +
+            '<div>' + (url ? '<a href="' + esc(url).replace(/"/g, '&quot;') + '" target="_blank" rel="noopener">' + action + '</a>' : '') +
+            (item.status === 'drafted' ? ' <button class="btn-start btn-start-secondary contribution-confirm" data-id="' + esc(item.id) + '">Confirm submitted</button>' : '') + '</div>' +
+            '</div>';
+        }).join('');
+        list.querySelectorAll('.contribution-confirm').forEach(function(button) {
+          button.addEventListener('click', async function() {
+            var issueUrl = window.prompt('Paste the GitHub issue URL you submitted:');
+            if (!issueUrl) return;
+            var response = await fetch('/api/me/certification/contributions/' + encodeURIComponent(button.dataset.id) + '/confirm', {
+              method: 'POST',
+              credentials: 'include',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ issue_url: issueUrl }),
+            });
+            var result = await response.json().catch(function() { return {}; });
+            if (!response.ok) {
+              window.alert(result.error || 'Unable to verify that issue.');
+              return;
+            }
+            var index = state.contributions.findIndex(function(item) { return item.id === button.dataset.id; });
+            if (index >= 0) state.contributions[index] = result.contribution;
+            renderContributions();
+          });
+        });
+      }
+
       function renderAssessmentDisclosure(mod, status) {
         var isTestedOut = status === 'tested_out';
         var prog = state.progress.find(function(p) { return p.module_id === mod.id; });
@@ -1615,6 +1698,7 @@
 
       function renderModule(mod) {
         var status = getModuleStatus(mod.id, mod.is_free, mod.prerequisites);
+        var prog = state.progress.find(function(p) { return p.module_id === mod.id; });
         var canStart = status === 'available' || status === 'in_progress';
         var isLocked = status === 'locked';
         var isComplete = status === 'completed' || status === 'tested_out';
@@ -1649,6 +1733,13 @@
           html += '    <button class="btn-start btn-start-secondary" disabled>Locked</button>';
         }
         html += '  </div>';
+        if (status === 'in_progress' && prog && prog.experience && prog.experience.checkpoint) {
+          var checkpoint = prog.experience.checkpoint;
+          var saved = new Date(checkpoint.saved_at).toLocaleString();
+          html += '<div class="module-resume-state">Progress saved ' + esc(saved) +
+            ' · ' + checkpoint.demonstrations_verified.length + ' of ' +
+            checkpoint.required_demonstrations + ' demonstrations verified</div>';
+        }
         if (isComplete && state.isAuthenticated) {
           html += renderAssessmentDisclosure(mod, status);
         }
@@ -1716,11 +1807,31 @@
           return;
         }
 
-        try {
-          await fetch('/api/me/certification/modules/' + moduleId + '/start', { method: 'POST' });
-        } catch (e) { /* continue anyway */ }
+        var prog = state.progress.find(function(p) { return p.module_id === moduleId; });
+        if (prog && prog.status === 'in_progress') {
+          try {
+            var response = await fetch('/api/me/certification/modules/' + encodeURIComponent(moduleId) + '/resume', {
+              method: 'POST',
+              credentials: 'include',
+            });
+            if (response.ok) {
+              var experience = await response.json();
+              var target = '/chat?topic=certification&module=' + encodeURIComponent(moduleId) + '&action=resume';
+              if (experience.resume_conversation_id) {
+                target += '&conversation=' + encodeURIComponent(experience.resume_conversation_id);
+              }
+              window.location.href = target;
+              return;
+            }
+          } catch (e) { /* fall through to checkpoint-based recovery */ }
+          window.location.href = '/chat?topic=certification&module=' + encodeURIComponent(moduleId) + '&action=resume';
+          return;
+        }
 
-        window.location.href = '/chat?topic=certification&module=' + moduleId;
+        // Let Addie's start tool create progress and bind it to the new chat
+        // thread atomically. Pre-starting here produced orphaned modules with
+        // no reliable conversation to resume.
+        window.location.href = '/chat?topic=certification&module=' + encodeURIComponent(moduleId);
       };
 
       window.loadAssessmentDetails = async function(modId, detailsEl) {

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -811,6 +811,45 @@
       animation: slideUp 0.3s ease;
     }
 
+    .certification-status,
+    .reply-recovery {
+      margin-top: var(--space-3);
+      padding: var(--space-3);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      background: var(--color-bg-subtle);
+    }
+
+    .certification-status__title,
+    .reply-recovery__title {
+      color: var(--color-text-heading);
+      font-weight: 600;
+      margin-bottom: var(--space-1);
+    }
+
+    .certification-status__detail,
+    .reply-recovery__detail {
+      color: var(--color-text-secondary);
+      font-size: 13px;
+    }
+
+    .reply-recovery__action {
+      margin-top: var(--space-3);
+      padding: var(--space-2) var(--space-3);
+      border: 0;
+      border-radius: var(--radius-md);
+      background: var(--color-brand);
+      color: white;
+      cursor: pointer;
+      font: inherit;
+      font-weight: 600;
+    }
+
+    .reply-recovery__action:disabled {
+      cursor: wait;
+      opacity: 0.6;
+    }
+
     @keyframes slideUp {
       from { opacity: 0; transform: translate(-50%, 20px); }
       to { opacity: 1; transform: translate(-50%, 0); }
@@ -3622,7 +3661,7 @@
 
       // Switch to a different conversation
       async function switchToConversation(newConversationId, channel = 'web') {
-        if (newConversationId === conversationId && channel === currentChannel) return;
+        if (newConversationId === conversationId && channel === currentChannel) return true;
         clearAttachments();
 
         conversationId = newConversationId;
@@ -3668,6 +3707,15 @@
               lastAssistantContent = msg.content || '';
             }
           });
+          if (data.recoverable_turn) {
+            showReplyRecovery({
+              message: data.recoverable_turn.message,
+              attachments: [],
+              messageSource: data.recoverable_turn.message_source || 'typed',
+              clientRequestId: data.recoverable_turn.client_request_id,
+              certification: null,
+            });
+          }
 
           // Handle read-only mode for Slack/video threads
           if (data.read_only) {
@@ -3675,15 +3723,16 @@
           } else {
             setReadOnlyMode(false);
           }
+          closeMobileSidebar();
+          return true;
         } catch (error) {
           console.error('Failed to load conversation:', error);
           removeActiveTab(newConversationId);
           switchToHome();
           showError('Failed to load conversation');
+          closeMobileSidebar();
+          return false;
         }
-
-        // Close sidebar on mobile
-        closeMobileSidebar();
       }
 
       // Set read-only mode for the chat input
@@ -4859,16 +4908,97 @@
       // Reset to null after each send so subsequent typed messages get 'typed'.
       let pendingMessageSource = null;
 
+      function appendCertificationStatus(contentDiv, certification) {
+        if (!certification) return;
+
+        const panel = document.createElement('div');
+        panel.className = 'certification-status';
+        const title = document.createElement('div');
+        title.className = 'certification-status__title';
+        const detail = document.createElement('div');
+        detail.className = 'certification-status__detail';
+
+        if (certification.status === 'completed') {
+          title.textContent = `${certification.title || certification.module_id} complete`;
+          if (certification.credential?.state === 'processing') {
+            detail.textContent = 'Your digital credential is being issued. We’ll show the share link when it is ready.';
+          } else if (certification.credential?.state === 'action_required') {
+            detail.textContent = certification.credential?.action === 'provide_name'
+              ? 'Your completion is saved. Tell Addie the name you want on your credential to finish issuance.'
+              : 'Your completion is saved, but credential issuance needs support review. The certification team can reconcile it without repeating your assessment.';
+          } else if (certification.credential?.state === 'issued') {
+            detail.textContent = 'Your completion and credential are confirmed.';
+          } else {
+            detail.textContent = 'Your completion is confirmed.';
+          }
+        } else if (certification.status === 'evidence_complete') {
+          title.textContent = 'Evidence checkpoint saved';
+          detail.textContent = 'Your demonstrations are saved. Addie will validate the remaining completion requirements.';
+        } else {
+          title.textContent = 'Progress saved';
+          const checkpoint = certification.checkpoint;
+          detail.textContent = checkpoint
+            ? `${checkpoint.demonstrations_verified.length} of ${checkpoint.required_demonstrations} demonstrations verified.`
+            : 'You can safely continue from this conversation.';
+        }
+
+        panel.append(title, detail);
+        const credentialUrl = certification.credential?.url;
+        if (certification.credential?.state === 'issued' && credentialUrl
+            && /^(https:\/\/|\/)/i.test(credentialUrl)) {
+          const link = document.createElement('a');
+          link.href = credentialUrl;
+          link.target = '_blank';
+          link.rel = 'noopener noreferrer';
+          link.textContent = 'View credential';
+          link.style.display = 'block';
+          link.style.marginTop = '8px';
+          panel.appendChild(link);
+        }
+        contentDiv.appendChild(panel);
+      }
+
+      function showReplyRecovery(options) {
+        const messageDiv = addMessage('', 'assistant');
+        const contentDiv = messageDiv.querySelector('.message-content');
+        const panel = document.createElement('div');
+        panel.className = 'reply-recovery';
+
+        const title = document.createElement('div');
+        title.className = 'reply-recovery__title';
+        title.textContent = 'Reply interrupted — your progress is safe';
+        const detail = document.createElement('div');
+        detail.className = 'reply-recovery__detail';
+        detail.textContent = options.certification
+          ? 'Addie saved the completed work and can continue without repeating it.'
+          : 'Addie can continue this turn without adding your message twice.';
+        const retryButton = document.createElement('button');
+        retryButton.type = 'button';
+        retryButton.className = 'reply-recovery__action';
+        retryButton.textContent = 'Continue reply';
+        retryButton.addEventListener('click', async () => {
+          retryButton.disabled = true;
+          await sendMessage({ ...options, retry: true });
+          if (messageDiv.parentNode) messageDiv.remove();
+        });
+
+        panel.append(title, detail, retryButton);
+        contentDiv.appendChild(panel);
+        appendCertificationStatus(contentDiv, options.certification);
+      }
+
       // Send message with streaming
-      async function sendMessage() {
-        const message = chatInput.value.trim();
-        const attachmentsToSend = pendingAttachments.slice();
+      async function sendMessage(sendOptions = {}) {
+        const retrying = sendOptions.retry === true;
+        const message = retrying ? sendOptions.message : chatInput.value.trim();
+        const attachmentsToSend = retrying ? (sendOptions.attachments || []) : pendingAttachments.slice();
         if ((!message && attachmentsToSend.length === 0) || isLoading || !isReady || isReadOnly) {
-          pendingMessageSource = null;
+          if (!retrying) pendingMessageSource = null;
           return;
         }
 
-        const messageSource = pendingMessageSource || 'typed';
+        const messageSource = retrying ? sendOptions.messageSource : (pendingMessageSource || 'typed');
+        const clientRequestId = sendOptions.clientRequestId || crypto.randomUUID();
         pendingMessageSource = null;
 
         isLoading = true;
@@ -4882,15 +5012,15 @@
         // Request notification permission on first message
         requestNotificationPermission();
 
-        // Add user message
-        addMessage(message, 'user', null, attachmentsToSend);
-
-        // Clear input
-        chatInput.value = '';
-        pendingAttachments = [];
-        renderAttachmentTray();
-        updateSendButton();
-        autoResize();
+        if (!retrying) {
+          // The retry reuses the visible and persisted user turn.
+          addMessage(message, 'user', null, attachmentsToSend);
+          chatInput.value = '';
+          pendingAttachments = [];
+          renderAttachmentTray();
+          updateSendButton();
+          autoResize();
+        }
 
         // Track if this is a new conversation
         const isNewConversation = !conversationId;
@@ -4914,17 +5044,25 @@
               message_source: messageSource,
               organization_id: getSelectedOrganizationId(),
               attachments: buildAttachmentPayload(attachmentsToSend),
+              client_request_id: clientRequestId,
+              retry: retrying,
             }),
           });
 
           if (!response.ok) {
             // Surface server error messages (e.g., rate limit "daily limit reached")
             let errorMsg = 'Failed to send message';
+            let errorCode = '';
             try {
               const errorData = await response.json();
               if (errorData.message) errorMsg = errorData.message;
+              if (errorData.error) errorCode = errorData.error;
             } catch (e) { /* ignore parse errors */ }
-            throw new Error(errorMsg);
+            const httpError = new Error(errorMsg);
+            httpError.httpStatus = response.status;
+            httpError.serverCode = errorCode;
+            httpError.recoverable = errorCode === 'turn_in_progress';
+            throw httpError;
           }
 
           // Show remaining message count for anonymous users (when running low)
@@ -4946,6 +5084,7 @@
           let newConversationId = null;
           let sawDone = false;
           let streamFailure = null;
+          let pendingCertification = null;
 
           // Helper to process SSE lines (uses closure for currentEventType)
           const processLines = (lines) => {
@@ -4988,6 +5127,7 @@
                   sawDone = true;
                   messageId = data.message_id;
                   conversationId = data.conversation_id;
+                  pendingCertification = data.certification || null;
 
                   // Store SI session data - will open modal after stream is completely done
                   if (data.si_session && data.si_session.session_id) {
@@ -5002,7 +5142,10 @@
                   }
                 } else if (currentEventType === 'stream_error') {
                   streamFailure = data.reason || 'Reply interrupted';
-                  throw new Error(streamFailure);
+                  const streamError = new Error(streamFailure);
+                  streamError.recoverable = data.recoverable === true;
+                  streamError.certification = data.certification || null;
+                  throw streamError;
                 } else if (currentEventType === 'error') {
                   throw new Error(data.error || 'Unknown error');
                 }
@@ -5036,11 +5179,15 @@
           }
 
           if (!sawDone) {
-            throw new Error(streamFailure || 'Reply did not complete');
+            const incompleteError = new Error(streamFailure || 'Reply did not complete');
+            incompleteError.recoverable = Boolean(conversationId);
+            incompleteError.certification = pendingCertification;
+            throw incompleteError;
           }
 
           // Finalize the message with feedback UI
           finalizeStreamingMessage(messageDiv, contentDiv, fullContent, messageId);
+          appendCertificationStatus(contentDiv, pendingCertification);
           if (messageId) lastAssistantMessageId = messageId;
           lastAssistantContent = fullContent;
 
@@ -5088,12 +5235,30 @@
           scheduleLoadThreads();
 
         } catch (error) {
-          console.error('Error sending message:', error);
-          // Remove the streaming message and show error
+          // Network EOFs do not carry an SSE error event, but once the server
+          // assigned a conversation the same client request can be continued.
+          if (!error.recoverable && !error.httpStatus && conversationId && clientRequestId) {
+            error.recoverable = true;
+          }
+          if (error.recoverable) {
+            console.warn('Addie reply interrupted; offering a safe continuation:', error.message);
+          } else {
+            console.error('Error sending message:', error);
+          }
           if (messageDiv.parentNode) {
             messageDiv.remove();
           }
-          showError('Failed to send message. Please try again.');
+          if (error.recoverable) {
+            showReplyRecovery({
+              message,
+              attachments: attachmentsToSend,
+              messageSource,
+              clientRequestId,
+              certification: error.certification,
+            });
+          } else {
+            showError(error.message || 'Failed to send message. Please try again.');
+          }
 
           // Clear loading state on error
           if (conversationId) {
@@ -5155,7 +5320,7 @@
         }
       });
 
-      sendButton.addEventListener('click', sendMessage);
+      sendButton.addEventListener('click', () => sendMessage());
 
       // Suggested prompts
       suggestedPrompts.addEventListener('click', (e) => {
@@ -5259,23 +5424,49 @@
       }
 
       // Check for prompt in query string (e.g., ?prompt=Try%20AdCP)
-      // Also handles certification deep links: ?topic=certification&module=A1
+      // Also handles certification deep links and exact conversation resume.
       function checkQueryPrompt() {
         const params = new URLSearchParams(window.location.search);
         let prompt = params.get('prompt');
+        let resumeConversationId = null;
+        let resumeModuleId = null;
 
         // Synthesize prompt from certification deep link params
         if (!prompt && params.get('topic') === 'certification') {
           const moduleId = params.get('module');
           const action = params.get('action');
+          const requestedConversationId = params.get('conversation');
           if (action === 'assess') {
             prompt = 'I\'d like to assess my AdCP knowledge level. Run a placement assessment to figure out which certification modules I can skip and where I should focus.';
+          } else if (action === 'resume' && moduleId && /^[a-z0-9-]{1,16}$/i.test(moduleId)
+              && requestedConversationId && /^[0-9a-f-]{36}$/i.test(requestedConversationId)) {
+            resumeConversationId = requestedConversationId;
+            resumeModuleId = moduleId;
+          } else if (action === 'resume' && moduleId) {
+            prompt = `Continue module ${moduleId} from my saved checkpoint`;
           } else if (moduleId) {
             prompt = `Start module ${moduleId}`;
           }
         }
 
-        if (prompt && prompt.trim()) {
+        if (resumeConversationId) {
+          const waitForResume = setInterval(async () => {
+            if (isReady && isAuthenticated) {
+              clearInterval(waitForResume);
+              addActiveTab(resumeConversationId, `Certification ${resumeModuleId}`, 'web');
+              const resumed = await switchToConversation(resumeConversationId, 'web');
+              if (resumed) {
+                await authFetch(`/api/me/certification/modules/${encodeURIComponent(resumeModuleId)}/resumed`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ conversation_id: resumeConversationId }),
+                });
+                window.history.replaceState({}, '', window.location.pathname);
+              }
+            }
+          }, 100);
+          setTimeout(() => clearInterval(waitForResume), 10000);
+        } else if (prompt && prompt.trim()) {
           // Wait for Addie to be ready before sending
           const waitForReady = setInterval(() => {
             if (isReady) {

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -20,7 +20,14 @@ import { withRetry, isRetryableError, RetriesExhaustedError, type RetryConfig } 
 import { formatTokenCount, getConversationTokenLimit, buildDroppedMessagesSummary, type MessageTurn } from '../utils/token-limiter.js';
 import { notifySystemError, notifyToolError } from './error-notifier.js';
 import { ToolError } from './tool-error.js';
-import { checkCostCap, recordCost, formatCapExceededMessage, type UserTier } from './claude-cost-tracker.js';
+import {
+  checkCostCap,
+  recordCost,
+  releaseCertificationReserve,
+  renewCertificationReserve,
+  formatCapExceededMessage,
+  type UserTier,
+} from './claude-cost-tracker.js';
 import { EMPTY_RESPONSE_FALLBACK, applyResponsePipeline, stripBannedRituals, hasPersonaCollapse } from './response-postprocess.js';
 import type { AddieInputAttachment } from './chat-attachments.js';
 
@@ -434,6 +441,8 @@ export interface ProcessMessageOptions {
   costScope?: {
     userId: string;
     tier: UserTier;
+    /** Bounded extra daily budget available only while a certification module is active. */
+    certificationReserveUsd?: number;
   };
   /**
    * Explicit opt-out for system / router callers that shouldn't
@@ -501,6 +510,9 @@ export interface AddieResponse {
     cache_creation_input_tokens?: number;
     cache_read_input_tokens?: number;
   };
+  capacity?: {
+    certification_reserve_used: boolean;
+  };
 }
 
 /**
@@ -520,6 +532,8 @@ export type StreamEvent =
       type: 'stream_error';
       reason: string;
       deltasBeforeError: number;
+      tool_executions: ToolExecution[];
+      certification_reserve_used: boolean;
     }
   | { type: 'done'; response: AddieResponse }
   | { type: 'error'; error: string };
@@ -738,7 +752,8 @@ export class AddieClaudeClient {
         options.costScope.tier,
       );
       if (!capResult.ok) {
-        const message = formatCapExceededMessage(capResult);
+        const message = formatCapExceededMessage(capResult)
+          + (options.costScope.certificationReserveUsd ? ' Your certification progress is saved.' : '');
         logger.warn(
           {
             userId: options.costScope.userId,
@@ -1364,13 +1379,20 @@ export class AddieClaudeClient {
     // contract as `processMessage` — yield a `done` event with the
     // friendly cap-exceeded text and return early instead of firing
     // another billable Claude call.
+    let certificationReserveUsed = false;
+    let certificationLeaseId: string | undefined;
+    let certificationLeaseHeartbeat: ReturnType<typeof setInterval> | undefined;
     if (options?.costScope) {
       const capResult = await checkCostCap(
         options.costScope.userId,
         options.costScope.tier,
+        { certificationReserveUsd: options.costScope.certificationReserveUsd },
       );
+      certificationReserveUsed = capResult.usedCertificationReserve === true;
+      certificationLeaseId = capResult.certificationLeaseId;
       if (!capResult.ok) {
-        const message = formatCapExceededMessage(capResult);
+        const message = formatCapExceededMessage(capResult)
+          + (options.costScope.certificationReserveUsd ? ' Your certification progress is saved.' : '');
         logger.warn(
           {
             userId: options.costScope.userId,
@@ -1392,12 +1414,20 @@ export class AddieClaudeClient {
         };
         return;
       }
+      if (certificationLeaseId) {
+        certificationLeaseHeartbeat = setInterval(() => {
+          void renewCertificationReserve(options.costScope?.userId, certificationLeaseId);
+        }, 30_000);
+      }
     }
 
     const toolsUsed: string[] = [];
     const toolExecutions: ToolExecution[] = [];
     let executionSequence = 0;
     let fullText = '';
+    let streamErrorEmitted = false;
+
+    try {
 
     // Timing metrics
     const timingStart = Date.now();
@@ -1495,7 +1525,6 @@ export class AddieClaudeClient {
     let iteration = 0;
     let retriedEmptyPostToolResponse = false;
 
-    try {
       while (iteration < maxIterations) {
         iteration++;
 
@@ -1576,10 +1605,13 @@ export class AddieClaudeClient {
                               errorMsg.includes('rate') ? 'Rate limited' :
                               errorMsg.includes('timeout') ? 'Request timed out' :
                               'Connection broke mid-reply';
+                streamErrorEmitted = true;
                 yield {
                   type: 'stream_error',
                   reason,
                   deltasBeforeError: textChunks.length,
+                  tool_executions: [...toolExecutions],
+                  certification_reserve_used: certificationReserveUsed,
                 };
               }
               // Not retryable or already yielded content - rethrow original error
@@ -1748,6 +1780,7 @@ export class AddieClaudeClient {
                 iterations: iteration,
               },
               usage: streamUsage,
+              capacity: { certification_reserve_used: certificationReserveUsed },
             },
           };
           return;
@@ -1785,6 +1818,7 @@ export class AddieClaudeClient {
                   iterations: iteration,
                 },
                 usage: streamUsage,
+                capacity: { certification_reserve_used: certificationReserveUsed },
               },
             };
             return;
@@ -1968,11 +2002,23 @@ export class AddieClaudeClient {
             iterations: maxIterations,
           },
           usage: maxIterUsage,
+          capacity: { certification_reserve_used: certificationReserveUsed },
         },
       };
     } catch (error) {
       logger.error({ error }, 'Addie Stream: Error during streaming');
-      yield { type: 'error', error: error instanceof Error ? error.message : 'Unknown error' };
+      if (!streamErrorEmitted) {
+        yield {
+          type: 'stream_error',
+          reason: error instanceof Error ? error.message : 'Unknown error',
+          deltasBeforeError: fullText.length > 0 ? 1 : 0,
+          tool_executions: [...toolExecutions],
+          certification_reserve_used: certificationReserveUsed,
+        };
+      }
+    } finally {
+      if (certificationLeaseHeartbeat) clearInterval(certificationLeaseHeartbeat);
+      await releaseCertificationReserve(options?.costScope?.userId, certificationLeaseId);
     }
   }
 

--- a/server/src/addie/claude-cost-tracker.ts
+++ b/server/src/addie/claude-cost-tracker.ts
@@ -42,6 +42,7 @@
  *   intentionally triggers truncation to make responses "free".
  */
 
+import { randomUUID } from 'crypto';
 import { createLogger } from '../logger.js';
 import { query } from '../db/client.js';
 import { TIER_PRESERVING_STATUSES } from '../db/organization-db.js';
@@ -113,6 +114,12 @@ export interface CostCheckResult {
   retryAfterMs?: number;
   /** The tier threshold that applies. */
   tier?: UserTier;
+  /** True when the normal tier cap was exceeded but a bounded certification reserve allowed the call. */
+  usedCertificationReserve?: boolean;
+  /** Cross-replica lease held while a reserve-eligible completion call runs. */
+  certificationLeaseId?: string;
+  /** Another completion call already owns the reserve lease. */
+  reserveBusy?: boolean;
 }
 
 /**
@@ -124,6 +131,9 @@ export interface CostTrackerStore {
   sumInWindow(key: string, windowMs: number): Promise<{ totalMicros: number; firstAtMs: number | null }>;
   /** Persist one charge. */
   record(key: string, costMicros: number, model: string, usage: ClaudeUsage): Promise<void>;
+  claimCertificationLease(key: string, leaseId: string): Promise<boolean>;
+  renewCertificationLease(key: string, leaseId: string): Promise<boolean>;
+  releaseCertificationLease(key: string, leaseId: string): Promise<void>;
   /** Test-only: clear all state. */
   reset(): Promise<void>;
 }
@@ -151,6 +161,38 @@ class PostgresStore implements CostTrackerStore {
     );
   }
 
+  async claimCertificationLease(key: string, leaseId: string): Promise<boolean> {
+    const result = await query(
+      `INSERT INTO certification_completion_leases (scope_key, lease_id, expires_at)
+       VALUES ($1, $2, NOW() + INTERVAL '10 minutes')
+       ON CONFLICT (scope_key) DO UPDATE SET
+         lease_id = EXCLUDED.lease_id,
+         expires_at = EXCLUDED.expires_at,
+         created_at = NOW()
+       WHERE certification_completion_leases.expires_at < NOW()
+       RETURNING lease_id`,
+      [key, leaseId],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async releaseCertificationLease(key: string, leaseId: string): Promise<void> {
+    await query(
+      `DELETE FROM certification_completion_leases WHERE scope_key = $1 AND lease_id = $2`,
+      [key, leaseId],
+    );
+  }
+
+  async renewCertificationLease(key: string, leaseId: string): Promise<boolean> {
+    const result = await query(
+      `UPDATE certification_completion_leases
+       SET expires_at = NOW() + INTERVAL '10 minutes'
+       WHERE scope_key = $1 AND lease_id = $2`,
+      [key, leaseId],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
   async reset(): Promise<void> {
     await query(`TRUNCATE addie_token_cost_events`);
   }
@@ -158,6 +200,7 @@ class PostgresStore implements CostTrackerStore {
 
 class InMemoryStore implements CostTrackerStore {
   private readonly events = new Map<string, Array<{ atMs: number; micros: number }>>();
+  private readonly certificationLeases = new Map<string, string>();
 
   async sumInWindow(key: string, windowMs: number): Promise<{ totalMicros: number; firstAtMs: number | null }> {
     const cutoff = Date.now() - windowMs;
@@ -172,8 +215,23 @@ class InMemoryStore implements CostTrackerStore {
     this.events.set(key, existing);
   }
 
+  async claimCertificationLease(key: string, leaseId: string): Promise<boolean> {
+    if (this.certificationLeases.has(key)) return false;
+    this.certificationLeases.set(key, leaseId);
+    return true;
+  }
+
+  async releaseCertificationLease(key: string, leaseId: string): Promise<void> {
+    if (this.certificationLeases.get(key) === leaseId) this.certificationLeases.delete(key);
+  }
+
+  async renewCertificationLease(key: string, leaseId: string): Promise<boolean> {
+    return this.certificationLeases.get(key) === leaseId;
+  }
+
   async reset(): Promise<void> {
     this.events.clear();
+    this.certificationLeases.clear();
   }
 }
 
@@ -191,14 +249,18 @@ let store: CostTrackerStore = new PostgresStore();
 export async function checkCostCap(
   userId: string | null | undefined,
   tier: UserTier,
+  options?: { certificationReserveUsd?: number },
 ): Promise<CostCheckResult> {
   if (!userId) return { ok: true };
   if (SYSTEM_USER_IDS.has(userId)) return { ok: true };
   if (tier === 'aao_team') return { ok: true, tier };
 
-  const budgetMicros = DAILY_BUDGET_MICROS[tier];
+  const baseBudgetMicros = DAILY_BUDGET_MICROS[tier];
+  const reserveMicros = Math.max(0, options?.certificationReserveUsd ?? 0) * MICROS_PER_DOLLAR;
+  const budgetMicros = baseBudgetMicros + reserveMicros;
   const { totalMicros, firstAtMs } = await store.sumInWindow(userId, WINDOW_MS);
   const remainingMicros = Math.max(0, budgetMicros - totalMicros);
+  const usedCertificationReserve = reserveMicros > 0 && totalMicros >= baseBudgetMicros;
 
   if (totalMicros >= budgetMicros && firstAtMs !== null) {
     return {
@@ -207,7 +269,22 @@ export async function checkCostCap(
       remainingUsd: 0,
       retryAfterMs: Math.max(0, firstAtMs + WINDOW_MS - Date.now()),
       tier,
+      usedCertificationReserve,
     };
+  }
+
+  let certificationLeaseId: string | undefined;
+  if (reserveMicros > 0 && usedCertificationReserve) {
+    certificationLeaseId = randomUUID();
+    if (!await store.claimCertificationLease(userId, certificationLeaseId)) {
+      return {
+        ok: false,
+        spentCents: Math.round(totalMicros / 10_000),
+        remainingUsd: remainingMicros / MICROS_PER_DOLLAR,
+        tier,
+        reserveBusy: true,
+      };
+    }
   }
 
   return {
@@ -215,7 +292,34 @@ export async function checkCostCap(
     spentCents: Math.round(totalMicros / 10_000),
     remainingUsd: remainingMicros / MICROS_PER_DOLLAR,
     tier,
+    usedCertificationReserve,
+    certificationLeaseId,
   };
+}
+
+export async function releaseCertificationReserve(
+  userId: string | null | undefined,
+  leaseId: string | undefined,
+): Promise<void> {
+  if (!userId || !leaseId) return;
+  try {
+    await store.releaseCertificationLease(userId, leaseId);
+  } catch (error) {
+    logger.error({ error, userId }, 'Failed to release certification completion lease');
+  }
+}
+
+export async function renewCertificationReserve(
+  userId: string | null | undefined,
+  leaseId: string | undefined,
+): Promise<boolean> {
+  if (!userId || !leaseId) return false;
+  try {
+    return await store.renewCertificationLease(userId, leaseId);
+  } catch (error) {
+    logger.error({ error, userId }, 'Failed to renew certification completion lease');
+    return false;
+  }
 }
 
 /**
@@ -249,19 +353,28 @@ export async function recordCost(
  * understands what happened.
  */
 export function formatCapExceededMessage(result: CostCheckResult): string {
+  if (result.reserveBusy) {
+    return 'A certification completion reply is already processing. Please wait a moment and reload this conversation.';
+  }
   const tier = result.tier ?? 'anonymous';
+  const retryHours = result.retryAfterMs == null
+    ? null
+    : Math.max(1, Math.ceil(result.retryAfterMs / (60 * 60 * 1000)));
+  const retryMessage = retryHours == null
+    ? 'Please try again when your rolling daily limit resets.'
+    : `Please try again in about ${retryHours} ${retryHours === 1 ? 'hour' : 'hours'}.`;
   if (tier === 'aao_team') {
     return 'AAO team usage is uncapped.';
   }
   if (tier === 'public_community') {
     return (
       `Public Addie discussions have reached today's community conversation capacity. ` +
-      `Please try again tomorrow or ping the AgenticAdvertising.org team if the discussion is time-sensitive.`
+      `${retryMessage} Ping the AgenticAdvertising.org team if the discussion is time-sensitive.`
     );
   }
   return (
     `You've reached your daily conversation limit with Addie. ` +
-    `Please try again tomorrow. ` +
+    `${retryMessage} ` +
     (tier === 'member_paid'
       ? 'Ping the AgenticAdvertising.org team if you need a higher ceiling for legitimate work.'
       : 'Upgrade your membership at https://agenticadvertising.org/dashboard/membership for a higher daily limit.')

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -38,6 +38,7 @@ import {
   NAME_REQUIRED_MARKER,
   ensureCertifierCredential,
 } from '../../services/certification-credential-issuance.js';
+import { linkCertificationModuleThread } from '../../services/certification-experience.js';
 
 export { NAME_REQUIRED_MARKER };
 
@@ -1847,7 +1848,11 @@ export function createCertificationToolHandlers(
         return `Module ${moduleId} is already ${existingMod.status.replace('_', ' ')}. You can proceed to the next module or use get_learner_progress to check your overall progress.`;
       }
 
-      await certDb.startModule(userId, moduleId);
+      if (options?.threadId) {
+        await certDb.startModule(userId, moduleId, options.threadId);
+      } else {
+        await certDb.startModule(userId, moduleId);
+      }
       if (options?.trainingModuleContext) {
         options.trainingModuleContext.moduleId = moduleId;
       }
@@ -2435,7 +2440,11 @@ export function createCertificationToolHandlers(
       }
 
       // Start the module and create an attempt
-      await certDb.startModule(userId, moduleId);
+      if (options?.threadId) {
+        await certDb.startModule(userId, moduleId, options.threadId);
+      } else {
+        await certDb.startModule(userId, moduleId);
+      }
       const attempt = await certDb.createAttempt(userId, mod.track_id, options?.threadId, moduleId);
       if (options?.trainingModuleContext) {
         options.trainingModuleContext.moduleId = moduleId;
@@ -2862,6 +2871,7 @@ export function createCertificationToolHandlers(
         demonstration_evidence: demonstrationEvidence,
         notes: enrichedNotes,
       });
+      await linkCertificationModuleThread(userId, moduleId, options?.threadId);
 
       const demoCount = demonstrationsVerified.length;
       return `Teaching checkpoint saved for ${moduleId}. Phase: ${currentPhase}. Covered ${conceptsCovered.length} concepts, ${conceptsRemaining.length} remaining. Demonstrations verified: ${demoCount}.`;

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -142,6 +142,10 @@ import {
   guardPersonalWorkspaceDomainSelection,
   type PersonalWorkspaceDomainSelectionResult,
 } from '../../services/org-selection-guard.js';
+import {
+  recordCertificationExperienceEvent,
+  upsertCertificationContribution,
+} from '../../services/certification-experience.js';
 
 const logger = createLogger('addie-member-tools');
 const complianceTarget = hostedComplianceTarget();
@@ -2365,7 +2369,8 @@ async function callApi(
  */
 export function createMemberToolHandlers(
   memberContext: MemberContext | null,
-  slackUserId?: string
+  slackUserId?: string,
+  certificationModuleContext?: { moduleId?: string },
 ): Map<string, (input: Record<string, unknown>) => Promise<string>> {
   const handlers = new Map<string, (input: Record<string, unknown>) => Promise<string>>();
 
@@ -6485,6 +6490,43 @@ export function createMemberToolHandlers(
   // ============================================
   // GITHUB ISSUE DRAFTING
   // ============================================
+  const activeCertification = () => {
+    const userId = memberContext?.workos_user?.workos_user_id;
+    if (!userId || !certificationModuleContext?.moduleId) return null;
+    return { userId, moduleId: certificationModuleContext.moduleId };
+  };
+
+  const trackCertificationContribution = async (input: {
+    repository: string;
+    title: string;
+    status: 'drafted' | 'submitted';
+    draftUrl?: string;
+    issueNumber?: number;
+    issueUrl?: string;
+  }) => {
+    const active = activeCertification();
+    if (!active) return;
+    try {
+      await upsertCertificationContribution({
+        userId: active.userId,
+        moduleId: active.moduleId,
+        ...input,
+      });
+      await recordCertificationExperienceEvent({
+        userId: active.userId,
+        moduleId: active.moduleId,
+        eventType: input.status === 'submitted' ? 'contribution_submitted' : 'contribution_drafted',
+        metadata: {
+          repository: input.repository,
+          title: input.title,
+          issue_number: input.issueNumber ?? null,
+        },
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to track certification contribution');
+    }
+  };
+
   handlers.set('draft_github_issue', async (input) => {
     const title = input.title as string;
     let body = input.body as string;
@@ -6526,6 +6568,7 @@ export function createMemberToolHandlers(
 
     // Build response with the draft details and link
     let response = `## GitHub Issue Draft\n\n`;
+    let reliableDraftUrl = issueUrl;
 
     if (urlLength > GITHUB_PREFILL_URL_MAX_CHARS) {
       response += `⚠️ **This draft is too long for a reliable pre-filled link.**\n\n`;
@@ -6535,6 +6578,9 @@ export function createMemberToolHandlers(
         shortParams.set('labels', labels.join(','));
       }
       const titlePrefillUrl = `${newIssueUrl}?${shortParams.toString()}`;
+      reliableDraftUrl = titlePrefillUrl.length <= GITHUB_PREFILL_URL_MAX_CHARS
+        ? titlePrefillUrl
+        : newIssueUrl;
 
       if (titlePrefillUrl.length <= GITHUB_PREFILL_URL_MAX_CHARS) {
         response += `**👉 [Open GitHub with the title pre-filled](${titlePrefillUrl})**\n\n`;
@@ -6559,6 +6605,13 @@ export function createMemberToolHandlers(
     response += `\n**Body:**\n\n${body}\n\n`;
     response += `---\n\n`;
     response += `_Note: You'll need to be signed in to GitHub to create the issue. Feel free to edit the title, body, or labels before submitting._`;
+
+    await trackCertificationContribution({
+      repository: `${org}/${repo}`,
+      title,
+      status: 'drafted',
+      draftUrl: reliableDraftUrl,
+    });
 
     return response;
   });
@@ -6647,6 +6700,13 @@ export function createMemberToolHandlers(
           });
           if (retryResponse.ok) {
             const issue = await retryResponse.json() as { html_url: string; number: number };
+            await trackCertificationContribution({
+              repository: `${org}/${repo}`,
+              title,
+              status: 'submitted',
+              issueNumber: issue.number,
+              issueUrl: issue.html_url,
+            });
             return `Issue created: [#${issue.number}](${issue.html_url})`;
           }
         }
@@ -6655,6 +6715,13 @@ export function createMemberToolHandlers(
 
       const issue = await response.json() as { html_url: string; number: number };
       logger.info({ issueUrl: issue.html_url, repo }, 'create_github_issue: Issue created');
+      await trackCertificationContribution({
+        repository: `${org}/${repo}`,
+        title,
+        status: 'submitted',
+        issueNumber: issue.number,
+        issueUrl: issue.html_url,
+      });
       return `Issue created: [#${issue.number}](${issue.html_url})`;
     } catch (error) {
       logger.error({ error, repo }, 'create_github_issue: Failed to create issue');

--- a/server/src/addie/thread-service.ts
+++ b/server/src/addie/thread-service.ts
@@ -9,6 +9,7 @@
  * - chat-routes.ts (Web conversations)
  */
 
+import { randomUUID } from 'crypto';
 import { query, getPool } from '../db/client.js';
 import { createLogger } from '../logger.js';
 
@@ -159,6 +160,12 @@ export interface CreateMessageInput {
   // How the user initiated this message. Only populated on role='user' rows.
   // NULL on rows predating migration 451 (2026-04-28).
   message_source?: 'typed' | 'cta_chip' | 'voice' | 'paste' | 'email' | 'unknown';
+  // Browser-generated turn identity used to make a retry idempotent.
+  client_request_id?: string;
+  delivery_status?: 'completed' | 'interrupted';
+  /** Internal web-turn fencing: terminal status and message commit atomically. */
+  client_turn_lease_id?: string;
+  finalize_client_turn_status?: 'completed' | 'interrupted';
 }
 
 export interface ThreadMessage {
@@ -217,10 +224,24 @@ export interface ThreadMessage {
   user_id: string | null;
   user_display_name: string | null;
   message_source: 'typed' | 'cta_chip' | 'voice' | 'paste' | 'email' | 'unknown' | null;
+  client_request_id: string | null;
+  delivery_status: 'completed' | 'interrupted';
 }
 
 export interface ThreadWithMessages extends Thread {
   messages: ThreadMessage[];
+}
+
+export type ClientTurnClaimResult = {
+  state: 'claimed' | 'processing' | 'completed' | 'not_retryable';
+  leaseId?: string;
+};
+
+export class StaleClientTurnLeaseError extends Error {
+  constructor() {
+    super('Client turn lease is no longer owned by this worker');
+    this.name = 'StaleClientTurnLeaseError';
+  }
 }
 
 export interface ThreadSummary {
@@ -352,6 +373,24 @@ export class ThreadService {
     return result.rows[0] || null;
   }
 
+  /** Permanently attach a browser-owned anonymous thread to its signed-in user. */
+  async claimAnonymousThread(
+    threadId: string,
+    anonymousOwnerId: string,
+    workosUserId: string,
+    userDisplayName?: string,
+  ): Promise<Thread | null> {
+    const result = await query<Thread>(
+      `UPDATE addie_threads
+       SET user_type = 'workos', user_id = $3,
+           user_display_name = COALESCE($4, user_display_name), updated_at = NOW()
+       WHERE thread_id = $1 AND user_type = 'anonymous' AND user_id = $2
+       RETURNING *`,
+      [threadId, anonymousOwnerId, workosUserId, userDisplayName ?? null],
+    );
+    return result.rows[0] ?? null;
+  }
+
   /**
    * Update thread context (e.g., when user switches channels in Slack)
    */
@@ -463,6 +502,22 @@ export class ThreadService {
       // ordering in getThreadMessages.
       await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [input.thread_id]);
 
+      if (input.client_turn_lease_id && input.client_request_id && input.finalize_client_turn_status) {
+        const finalized = await client.query(
+          `UPDATE addie_chat_turns
+           SET status = $4, lease_expires_at = NULL, updated_at = NOW()
+           WHERE thread_id = $1 AND client_request_id = $2
+             AND lease_id = $3 AND status = 'processing'`,
+          [
+            input.thread_id,
+            input.client_request_id,
+            input.client_turn_lease_id,
+            input.finalize_client_turn_status,
+          ],
+        );
+        if ((finalized.rowCount ?? 0) === 0) throw new StaleClientTurnLeaseError();
+      }
+
       const seqResult = await client.query<{ next_seq: number }>(
         `SELECT COALESCE(MAX(sequence_number), 0) + 1 as next_seq
          FROM addie_thread_messages WHERE thread_id = $1`,
@@ -479,8 +534,9 @@ export class ThreadService {
           timing_system_prompt_ms, timing_total_llm_ms, timing_total_tool_ms,
           processing_iterations, tokens_cache_creation, tokens_cache_read, active_rule_ids,
           router_decision, config_version_id, email_message_id,
-          user_id, user_display_name, message_source
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
+          user_id, user_display_name, message_source,
+          client_request_id, delivery_status
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29)
         RETURNING *`,
         [
           input.thread_id,
@@ -510,6 +566,8 @@ export class ThreadService {
           input.user_id ?? null,
           input.user_display_name != null ? stripNullBytesString(input.user_display_name) : null,
           input.message_source ?? null,
+          input.client_request_id ?? null,
+          input.delivery_status ?? 'completed',
         ]
       );
 
@@ -557,6 +615,125 @@ export class ThreadService {
       [threadId]
     );
     return result.rows;
+  }
+
+  /**
+   * Return all attempts associated with one browser turn. The caller has
+   * already authorized access to the parent thread before using this method.
+   */
+  async getMessagesByClientRequestId(
+    threadId: string,
+    clientRequestId: string,
+  ): Promise<ThreadMessage[]> {
+    const result = await query<ThreadMessage>(
+      `SELECT * FROM addie_thread_messages
+       WHERE thread_id = $1 AND client_request_id = $2
+       ORDER BY sequence_number ASC`,
+      [threadId, clientRequestId],
+    );
+    return result.rows;
+  }
+
+  /**
+   * Atomically claim the right to execute one browser turn. A retry may only
+   * transition an interrupted (or expired) turn back to processing.
+   */
+  async claimClientTurn(
+    threadId: string,
+    clientRequestId: string,
+    retry: boolean,
+  ): Promise<ClientTurnClaimResult> {
+    const leaseId = randomUUID();
+    if (!retry) {
+      const inserted = await query(
+        `INSERT INTO addie_chat_turns
+           (thread_id, client_request_id, status, lease_id, lease_expires_at)
+         VALUES ($1, $2, 'processing', $3, NOW() + INTERVAL '2 minutes')
+         ON CONFLICT DO NOTHING
+         RETURNING status`,
+        [threadId, clientRequestId, leaseId],
+      );
+      if ((inserted.rowCount ?? 0) > 0) return { state: 'claimed', leaseId };
+    } else {
+      const reclaimed = await query(
+        `UPDATE addie_chat_turns
+         SET status = 'processing', lease_id = $3,
+             lease_expires_at = NOW() + INTERVAL '2 minutes', updated_at = NOW()
+         WHERE thread_id = $1 AND client_request_id = $2
+           AND (status = 'interrupted'
+             OR (status = 'processing' AND lease_expires_at < NOW()))
+         RETURNING status`,
+        [threadId, clientRequestId, leaseId],
+      );
+      if ((reclaimed.rowCount ?? 0) > 0) return { state: 'claimed', leaseId };
+    }
+
+    const current = await query<{ status: 'processing' | 'interrupted' | 'completed' }>(
+      `SELECT status FROM addie_chat_turns
+       WHERE thread_id = $1 AND client_request_id = $2`,
+      [threadId, clientRequestId],
+    );
+    const status = current.rows[0]?.status;
+    if (status === 'processing') return { state: 'processing' };
+    if (status === 'completed') return { state: 'completed' };
+    return { state: 'not_retryable' };
+  }
+
+  async renewClientTurnLease(
+    threadId: string,
+    clientRequestId: string,
+    leaseId: string,
+  ): Promise<boolean> {
+    const result = await query(
+      `UPDATE addie_chat_turns
+       SET lease_expires_at = NOW() + INTERVAL '2 minutes', updated_at = NOW()
+       WHERE thread_id = $1 AND client_request_id = $2
+         AND lease_id = $3 AND status = 'processing'`,
+      [threadId, clientRequestId, leaseId],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async setClientTurnStatus(
+    threadId: string,
+    clientRequestId: string,
+    leaseId: string,
+    status: 'interrupted' | 'completed',
+  ): Promise<boolean> {
+    const result = await query(
+      `UPDATE addie_chat_turns
+       SET status = $4, lease_expires_at = NULL, updated_at = NOW()
+       WHERE thread_id = $1 AND client_request_id = $2
+         AND lease_id = $3 AND status = 'processing'`,
+      [threadId, clientRequestId, leaseId, status],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async getRecoverableClientTurn(threadId: string): Promise<{
+    client_request_id: string;
+    content: string;
+    message_source: CreateMessageInput['message_source'] | null;
+  } | null> {
+    const result = await query<{
+      client_request_id: string;
+      content: string;
+      message_source: CreateMessageInput['message_source'] | null;
+    }>(
+      `SELECT turn.client_request_id::text, message.content, message.message_source
+       FROM addie_chat_turns turn
+       JOIN addie_thread_messages message
+         ON message.thread_id = turn.thread_id
+        AND message.client_request_id = turn.client_request_id
+        AND message.role = 'user'
+       WHERE turn.thread_id = $1
+         AND (turn.status = 'interrupted'
+           OR (turn.status = 'processing' AND turn.lease_expires_at < NOW()))
+       ORDER BY turn.updated_at DESC
+       LIMIT 1`,
+      [threadId],
+    );
+    return result.rows[0] ?? null;
   }
 
   /**

--- a/server/src/config/models.ts
+++ b/server/src/config/models.ts
@@ -60,6 +60,15 @@ export const AddieModelConfig = {
   chat: process.env.ADDIE_ANTHROPIC_MODEL || ModelConfig.primary,
 
   /**
+   * Model for active certification sessions. Kept separate so curriculum
+   * adherence can be A/B tested without changing general Addie traffic.
+   * Override: ADDIE_CERTIFICATION_MODEL (falls back to chat/Sonnet)
+   */
+  certification: process.env.ADDIE_CERTIFICATION_MODEL
+    || process.env.ADDIE_ANTHROPIC_MODEL
+    || ModelConfig.primary,
+
+  /**
    * Model for anonymous web chat.
    *
    * Defaults to Sonnet (`primary`). Anonymous traffic exposes Addie's worst

--- a/server/src/db/migrations/535_certification_experience_reliability.sql
+++ b/server/src/db/migrations/535_certification_experience_reliability.sql
@@ -1,0 +1,74 @@
+-- Certification experience reliability and outcome tracking.
+--
+-- client_request_id makes web-chat retries safe for the learner: the original
+-- user turn is stored once, while assistant attempts can be retained as an
+-- interrupted audit trail and followed by a completed retry.
+ALTER TABLE addie_thread_messages
+  ADD COLUMN IF NOT EXISTS client_request_id UUID,
+  ADD COLUMN IF NOT EXISTS delivery_status TEXT NOT NULL DEFAULT 'completed';
+
+ALTER TABLE addie_thread_messages
+  DROP CONSTRAINT IF EXISTS addie_thread_messages_delivery_status_check;
+
+ALTER TABLE addie_thread_messages
+  ADD CONSTRAINT addie_thread_messages_delivery_status_check
+  CHECK (delivery_status IN ('completed', 'interrupted'));
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_addie_thread_user_client_request
+  ON addie_thread_messages(thread_id, client_request_id)
+  WHERE role = 'user' AND client_request_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_addie_thread_assistant_client_request
+  ON addie_thread_messages(thread_id, client_request_id, created_at DESC)
+  WHERE role = 'assistant' AND client_request_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS certification_experience_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workos_user_id TEXT NOT NULL,
+  module_id TEXT REFERENCES certification_modules(id) ON DELETE SET NULL,
+  addie_thread_id TEXT,
+  event_type TEXT NOT NULL,
+  client_request_id UUID,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cert_experience_event_request_once
+  ON certification_experience_events(workos_user_id, event_type, client_request_id)
+  WHERE client_request_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_cert_experience_event_type_created
+  ON certification_experience_events(event_type, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cert_experience_user_created
+  ON certification_experience_events(workos_user_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS certification_contributions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workos_user_id TEXT NOT NULL,
+  module_id TEXT REFERENCES certification_modules(id) ON DELETE SET NULL,
+  repository TEXT NOT NULL,
+  title TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'drafted'
+    CHECK (status IN ('drafted', 'submitted')),
+  draft_url TEXT,
+  github_issue_number INTEGER,
+  github_issue_url TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (workos_user_id, repository, title)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cert_contributions_user_updated
+  ON certification_contributions(workos_user_id, updated_at DESC);
+
+-- The provider ID tells us issuance succeeded, but historically we did not
+-- preserve when it succeeded. Keep that timestamp so credential latency is a
+-- real operational metric rather than an inference from a chat response.
+ALTER TABLE user_credentials
+  ADD COLUMN IF NOT EXISTS certifier_issued_at TIMESTAMPTZ;
+
+UPDATE user_credentials
+SET certifier_issued_at = awarded_at
+WHERE certifier_public_id IS NOT NULL
+  AND certifier_issued_at IS NULL;

--- a/server/src/db/migrations/536_certification_experience_hardening.sql
+++ b/server/src/db/migrations/536_certification_experience_hardening.sql
@@ -1,0 +1,44 @@
+-- Harden certification chat retries and experience metrics after the initial
+-- reliability rollout. A turn lease makes client_request_id an execution
+-- idempotency key, not merely a message-storage dedupe key.
+CREATE TABLE IF NOT EXISTS addie_chat_turns (
+  thread_id UUID NOT NULL REFERENCES addie_threads(thread_id) ON DELETE CASCADE,
+  client_request_id UUID NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('processing', 'interrupted', 'completed')),
+  lease_id UUID NOT NULL,
+  lease_expires_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (thread_id, client_request_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_addie_chat_turns_expired_processing
+  ON addie_chat_turns(lease_expires_at)
+  WHERE status = 'processing';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_one_completed_assistant_per_request
+  ON addie_thread_messages(thread_id, client_request_id)
+  WHERE role = 'assistant'
+    AND delivery_status = 'completed'
+    AND client_request_id IS NOT NULL;
+
+-- Loading the same checkpoint repeatedly is one resume session, not several
+-- successful resumes. COALESCE also deduplicates modules without a checkpoint.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cert_resume_once_per_checkpoint
+  ON certification_experience_events (
+    workos_user_id,
+    module_id,
+    addie_thread_id,
+    COALESCE(metadata->>'checkpoint_saved_at', '')
+  )
+  WHERE event_type = 'module_resumed';
+
+-- Only one cross-replica call may consume a learner's certification reserve
+-- at a time. Normal tier-cap concurrency remains governed by the existing
+-- rate limit; this protects the extra last-mile budget specifically.
+CREATE TABLE IF NOT EXISTS certification_completion_leases (
+  scope_key TEXT PRIMARY KEY,
+  lease_id UUID NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -16,7 +16,7 @@ import { createLogger } from "../logger.js";
 import { CachedPostgresStore } from "../middleware/pg-rate-limit-store.js";
 import { optionalAuth } from "../middleware/auth.js";
 import { serveHtmlWithConfig } from "../utils/html-config.js";
-import { AddieClaudeClient, type RequestTools } from "../addie/claude-client.js";
+import { AddieClaudeClient, type AddieResponse, type RequestTools } from "../addie/claude-client.js";
 import { sanitizeSpeakerName } from "../addie/prompts.js";
 import { resolveUserTierFromDb } from "../addie/claude-cost-tracker.js";
 import {
@@ -112,6 +112,11 @@ import {
 import { WorkingGroupDatabase } from "../db/working-group-db.js";
 import { siRetriever, type RetrievedSIAgent } from "../addie/services/si-retriever.js";
 import { AddieModelConfig } from "../config/models.js";
+import {
+  getCertificationExperienceForClientRequest,
+  getCertificationModuleExperience,
+  recordCertificationExperienceEvent,
+} from "../services/certification-experience.js";
 import {
   getWebMemberContext,
   formatMemberContextForPrompt,
@@ -260,7 +265,7 @@ export function ensureNonEmptyAssistantResponse(
  * Merge per-request member tools with cached authenticated-only tools,
  * and select model + iteration limits based on auth status.
  */
-export function buildTieredAccess(memberTools: RequestTools, isAuth: boolean) {
+export function buildTieredAccess(memberTools: RequestTools, isAuth: boolean, isCertification = false) {
   let requestTools = memberTools;
   if (isAuth && authenticatedOnlyTools) {
     // Per-request member tools (with memberContext) must override cached auth tools
@@ -275,9 +280,11 @@ export function buildTieredAccess(memberTools: RequestTools, isAuth: boolean) {
     };
   }
   const processOptions = isAuth
-    ? {}
+    ? (isCertification ? { modelOverride: AddieModelConfig.certification } : {})
     : { modelOverride: AddieModelConfig.anonymousChat, maxIterations: ANONYMOUS_MAX_ITERATIONS };
-  const effectiveModel = isAuth ? AddieModelConfig.chat : AddieModelConfig.anonymousChat;
+  const effectiveModel = isAuth
+    ? (isCertification ? AddieModelConfig.certification : AddieModelConfig.chat)
+    : AddieModelConfig.anonymousChat;
   return { requestTools, processOptions, effectiveModel };
 }
 
@@ -520,7 +527,56 @@ export interface PreparedRequest {
   siRetrievalTimeMs: number | null;
   siAgents: RetrievedSIAgent[];
   hasCertificationContext: boolean;
+  hasThreadCertificationContext: boolean;
+  certificationModuleContext: { moduleId?: string };
+  certificationProgress: certDb.LearnerProgress[];
   threadExternalId: string;
+}
+
+export function resolveThreadCertificationProgress(
+  progress: Array<Pick<certDb.LearnerProgress, 'module_id' | 'status' | 'addie_thread_id' | 'completed_at'>>,
+  threadExternalId: string,
+  threadId?: string,
+) {
+  const matches = progress.filter(item =>
+    Boolean(item.addie_thread_id)
+    && (item.addie_thread_id === threadExternalId || item.addie_thread_id === threadId),
+  );
+  return matches.find(item => item.status === 'in_progress') ?? matches[0];
+}
+
+export async function resolveCompletionModuleId(
+  execution: { tool_name: string; parameters?: Record<string, unknown> } | undefined,
+  userId: string | null | undefined,
+  threadContextModuleId: string | undefined,
+): Promise<string | undefined> {
+  const explicitModuleId = execution?.parameters?.module_id;
+  if (typeof explicitModuleId === 'string') {
+    return explicitModuleId.toUpperCase();
+  }
+
+  if (execution?.tool_name !== 'complete_certification_exam' || !userId) {
+    return threadContextModuleId;
+  }
+
+  const attemptId = execution.parameters?.attempt_id;
+  if (typeof attemptId !== 'string') {
+    return threadContextModuleId;
+  }
+
+  // The exam tool accepts a module ID as a recovery shorthand. Otherwise use
+  // the owned attempt as the authoritative source; its module can differ from
+  // the thread's previously active teaching context.
+  const normalizedAttemptId = attemptId.toUpperCase();
+  if (/^[A-Z]{1,2}[0-9]+$/.test(normalizedAttemptId)) {
+    return normalizedAttemptId;
+  }
+  if (!uuidValidate(attemptId)) {
+    return threadContextModuleId;
+  }
+
+  const attempt = await certDb.getAttemptForUser(attemptId, userId);
+  return attempt?.module_id?.toUpperCase() ?? threadContextModuleId;
 }
 
 interface SiSessionData {
@@ -649,10 +705,22 @@ export async function prepareRequestWithMemberTools(
   // Add certification module state so Addie remembers active modules
   // even when conversation history is trimmed
   let hasCertificationContext = false;
+  let hasThreadCertificationContext = false;
+  let certificationModuleId: string | undefined;
+  let certificationProgress: certDb.LearnerProgress[] = [];
   if (memberContext?.workos_user?.workos_user_id) {
     try {
       const progress = await certDb.getProgress(memberContext.workos_user.workos_user_id);
+      certificationProgress = progress;
       const inProgress = progress.filter(p => p.status === 'in_progress');
+      const threadProgress = resolveThreadCertificationProgress(progress, threadExternalId, threadId);
+      const recentlyCompleted = threadProgress?.status === 'completed'
+        && threadProgress.completed_at
+        && Date.now() - new Date(threadProgress.completed_at).getTime() < 24 * 60 * 60 * 1000;
+      certificationModuleId = threadProgress?.status === 'in_progress' || recentlyCompleted
+        ? threadProgress.module_id
+        : undefined;
+      hasThreadCertificationContext = threadProgress?.status === 'in_progress';
       const certContext = await buildCertificationContext(inProgress, memberContext.workos_user.workos_user_id);
       if (certContext) {
         contextSections.push(certContext);
@@ -664,6 +732,9 @@ export async function prepareRequestWithMemberTools(
   }
 
   const requestContext = contextSections.join('\n\n');
+  const trainingModuleContext: { moduleId?: string } = {
+    moduleId: certificationModuleId,
+  };
 
   // Anonymous users get no per-request tools (saves tokens and prevents data leakage)
   if (!isAuthenticated) {
@@ -675,6 +746,9 @@ export async function prepareRequestWithMemberTools(
       siRetrievalTimeMs,
       siAgents: siRetrievalResult.agents,
       hasCertificationContext: false,
+      hasThreadCertificationContext: false,
+      certificationModuleContext: trainingModuleContext,
+      certificationProgress,
       threadExternalId,
     };
   }
@@ -684,14 +758,9 @@ export async function prepareRequestWithMemberTools(
 
   // Create per-request tools (same tools as Slack, minus Slack-specific ones)
   // Re-register billing with memberContext so org-scoped operations work (overrides baseline)
-  const trainingModuleContext: { moduleId?: string } = {
-    moduleId: memberContext?.certification?.status === 'in_progress'
-      ? memberContext.certification.module_id ?? undefined
-      : undefined,
-  };
   const allTools = [...MEMBER_TOOLS, ...SI_HOST_TOOLS, ...ADCP_TOOLS, ...ESCALATION_TOOLS, ...BILLING_TOOLS, ...IMAGE_TOOLS];
   const combinedHandlers = new Map([
-    ...createMemberToolHandlers(memberContext),
+    ...createMemberToolHandlers(memberContext, undefined, trainingModuleContext),
     ...createSiHostToolHandlers(() => memberContext, () => threadExternalId),
     ...createAdcpToolHandlers(memberContext, trainingModuleContext),
     ...createEscalationToolHandlers(memberContext, linkedSlackUserId, threadId),
@@ -797,6 +866,9 @@ export async function prepareRequestWithMemberTools(
     siRetrievalTimeMs,
     siAgents: siRetrievalResult.agents,
     hasCertificationContext,
+    hasThreadCertificationContext,
+    certificationModuleContext: trainingModuleContext,
+    certificationProgress,
     threadExternalId,
   };
 }
@@ -962,6 +1034,15 @@ export function createAddieChatRouter(options?: {
         if (!thread || !canAccessWebThread(req, thread)) {
           return res.status(404).json({ error: "Conversation not found" });
         }
+        if (req.user?.id && thread.user_type === 'anonymous') {
+          const anonymousOwnerId = readAnonymousThreadOwner(req);
+          thread = anonymousOwnerId
+            ? await threadService.claimAnonymousThread(
+                thread.thread_id, anonymousOwnerId, req.user.id, req.user.firstName ?? undefined,
+              )
+            : null;
+          if (!thread) return res.status(404).json({ error: "Conversation not found" });
+        }
       }
 
       // Get conversation history for context
@@ -999,7 +1080,10 @@ export function createAddieChatRouter(options?: {
       // data so they are reconstructed as proper tool_use/tool_result API blocks.
       // Token-aware trimming in processMessage handles length; no hard slice here.
       const contextMessages = threadMessages
-        .filter((m) => m.role === 'user' || m.role === 'assistant')
+        .filter((m) =>
+          (m.role === 'user' || m.role === 'assistant')
+          && m.delivery_status !== 'interrupted',
+        )
         .map((m) => ({
           user: m.role === 'assistant' ? 'Addie' : (m.user_display_name || 'User'),
           text: m.content,
@@ -1011,7 +1095,12 @@ export function createAddieChatRouter(options?: {
       const isAuth = !!req.user;
 
       // Prepare message with member context and per-request tools
-      const { messageToProcess, requestContext, requestTools: memberTools, hasCertificationContext } = await prepareRequestWithMemberTools(
+      const {
+        messageToProcess,
+        requestContext,
+        requestTools: memberTools,
+        hasThreadCertificationContext,
+      } = await prepareRequestWithMemberTools(
         inputValidation.sanitized,
         req.user?.id,
         externalId,
@@ -1019,7 +1108,11 @@ export function createAddieChatRouter(options?: {
         thread.thread_id,
         typeof organization_id === 'string' ? organization_id : null
       );
-      const { requestTools, processOptions, effectiveModel } = buildTieredAccess(memberTools, isAuth);
+      const { requestTools, processOptions, effectiveModel } = buildTieredAccess(
+        memberTools,
+        isAuth,
+        hasThreadCertificationContext,
+      );
 
       // Cost-cap scope (#2790 / #2945 f/u). Authenticated callers key
       // off the WorkOS user ID and resolve their tier from
@@ -1044,7 +1137,9 @@ export function createAddieChatRouter(options?: {
           userDisplayName: displayName || undefined,
           currentSpeakerName: displayName || undefined,
           inputAttachments: attachments,
-          costScope: authedScope ?? { userId: `anon:${hashIp(req.ip)}`, tier: 'anonymous' as const },
+          costScope: authedScope
+            ? authedScope
+            : { userId: `anon:${hashIp(req.ip)}`, tier: 'anonymous' as const },
         });
       } catch (error) {
         // Provide user-friendly error message based on error type
@@ -1170,9 +1265,12 @@ export function createAddieChatRouter(options?: {
 
     // Track connection state
     let connectionClosed = false;
+    let heartbeat: ReturnType<typeof setInterval> | null = null;
+    let claimedTurn: { threadId: string; clientRequestId: string; leaseId: string } | null = null;
+    let terminalResponse: AddieResponse | undefined;
 
     // Handle client disconnect
-    req.on("close", () => {
+    res.on("close", () => {
       connectionClosed = true;
       logger.debug("Addie Chat Stream: Client disconnected");
     });
@@ -1197,8 +1295,26 @@ export function createAddieChatRouter(options?: {
         });
       }
 
-      const { message, conversation_id, user_name, message_source: rawMessageSourceStream, attachments: rawAttachmentsStream, organization_id } = req.body;
+      const {
+        message,
+        conversation_id,
+        user_name,
+        message_source: rawMessageSourceStream,
+        attachments: rawAttachmentsStream,
+        organization_id,
+        client_request_id,
+        retry,
+      } = req.body;
       const attachments = validateChatAttachments(rawAttachmentsStream);
+      const clientRequestId = typeof client_request_id === 'string' ? client_request_id : null;
+      const retryRequested = retry === true;
+
+      if (clientRequestId && !uuidValidate(clientRequestId)) {
+        return res.status(400).json({ error: 'client_request_id must be a valid UUID' });
+      }
+      if (retryRequested && !clientRequestId) {
+        return res.status(400).json({ error: 'client_request_id is required when retry is true' });
+      }
 
       if (typeof message !== "string" || (!message.trim() && attachments.length === 0)) {
         return res.status(400).json({ error: "Message is required" });
@@ -1272,6 +1388,67 @@ export function createAddieChatRouter(options?: {
         if (!thread || !canAccessWebThread(req, thread)) {
           return res.status(404).json({ error: "Conversation not found" });
         }
+        if (req.user?.id && thread.user_type === 'anonymous') {
+          const anonymousOwnerId = readAnonymousThreadOwner(req);
+          thread = anonymousOwnerId
+            ? await threadService.claimAnonymousThread(
+                thread.thread_id, anonymousOwnerId, req.user.id, req.user.firstName ?? undefined,
+              )
+            : null;
+          if (!thread) return res.status(404).json({ error: "Conversation not found" });
+        }
+      }
+
+      const requestMessages = clientRequestId
+        ? await threadService.getMessagesByClientRequestId(thread.thread_id, clientRequestId)
+        : [];
+      const existingUserMessage = requestMessages.find(m => m.role === 'user');
+      const completedAssistantMessage = [...requestMessages]
+        .reverse()
+        .find(m => m.role === 'assistant' && m.delivery_status === 'completed');
+
+      if (existingUserMessage && existingUserMessage.content !== messageForStorage) {
+        return res.status(409).json({
+          error: 'client_request_id conflict',
+          message: 'That retry identifier belongs to a different message. Please send this as a new turn.',
+        });
+      }
+      if (retryRequested && !existingUserMessage) {
+        return res.status(409).json({
+          error: 'Original turn not found',
+          message: 'The original turn is no longer available to retry. Please send it as a new message.',
+        });
+      }
+
+      // The message uniqueness constraint prevents duplicate storage; this
+      // lease prevents duplicate model/tool execution while a turn is active.
+      if (!completedAssistantMessage && clientRequestId) {
+        const claim = await threadService.claimClientTurn(
+          thread.thread_id,
+          clientRequestId,
+          retryRequested,
+        );
+        if (claim.state !== 'claimed') {
+          const messages = claim.state === 'completed'
+            ? await threadService.getMessagesByClientRequestId(thread.thread_id, clientRequestId)
+            : [];
+          const completed = [...messages].reverse().find(
+            m => m.role === 'assistant' && m.delivery_status === 'completed',
+          );
+          if (completed) {
+            return res.status(409).json({
+              error: 'turn_already_completed',
+              message: 'This reply has already completed. Reload the conversation to view it.',
+            });
+          }
+          return res.status(409).json({
+            error: claim.state === 'processing' ? 'turn_in_progress' : 'turn_not_retryable',
+            message: claim.state === 'processing'
+              ? 'This reply is still being generated. Please wait a moment and reload.'
+              : 'Only an interrupted reply can be continued with this retry identifier.',
+          });
+        }
+        claimedTurn = { threadId: thread.thread_id, clientRequestId, leaseId: claim.leaseId! };
       }
 
       // Do not commit the SSE response until ownership has been checked.
@@ -1280,28 +1457,60 @@ export function createAddieChatRouter(options?: {
       res.setHeader("Connection", "keep-alive");
       res.setHeader("X-Accel-Buffering", "no");
       res.flushHeaders();
+      heartbeat = setInterval(() => {
+        if (!connectionClosed) res.write(': keep-alive\n\n');
+        const turn = claimedTurn;
+        if (turn) {
+          void threadService.renewClientTurnLease(
+            turn.threadId,
+            turn.clientRequestId,
+            turn.leaseId,
+          ).catch(error => logger.error({ error }, 'Failed to renew chat turn lease'));
+        }
+      }, 15_000);
 
       // Send conversation_id immediately so client can track it
       sendEvent("meta", { conversation_id: externalId });
+
+      // A browser may retry after losing the final SSE packet even though the
+      // assistant response committed. Replay the authoritative stored result
+      // instead of sampling the model or executing tools again.
+      if (completedAssistantMessage) {
+        const certification = userId && clientRequestId
+          ? await getCertificationExperienceForClientRequest(userId, clientRequestId)
+          : null;
+        sendEvent('text', { text: completedAssistantMessage.content, replayed: true });
+        sendEvent('done', {
+          conversation_id: externalId,
+          message_id: completedAssistantMessage.message_id,
+          replayed: true,
+          certification,
+        });
+        res.end();
+        return;
+      }
 
       // Get conversation history
       const threadMessages = await threadService.getThreadMessages(thread.thread_id, { limit: 100 });
 
       // Save user message
-      await threadService.addMessage({
-        thread_id: thread.thread_id,
-        role: 'user',
-        content: messageForStorage,
-        content_sanitized: inputValidation.sanitized,
-        flagged: inputValidation.flagged,
-        flag_reason: inputValidation.reason,
-        user_id: userId || undefined,
-        user_display_name: displayName || undefined,
-        message_source: messageSourceStream,
-      });
+      if (!existingUserMessage) {
+        await threadService.addMessage({
+          thread_id: thread.thread_id,
+          role: 'user',
+          content: messageForStorage,
+          content_sanitized: inputValidation.sanitized,
+          flagged: inputValidation.flagged,
+          flag_reason: inputValidation.reason,
+          user_id: userId || undefined,
+          user_display_name: displayName || undefined,
+          message_source: messageSourceStream,
+          client_request_id: clientRequestId || undefined,
+        });
+      }
 
       // Record inbound message in the relationship system
-      if (userId) {
+      if (userId && !existingUserMessage) {
         try {
           const personId = await relationshipDb.resolvePersonId({ workos_user_id: userId });
           await relationshipDb.recordPersonMessage(personId, 'web');
@@ -1321,7 +1530,11 @@ export function createAddieChatRouter(options?: {
       // Build context messages, passing tool calls as structured data
       // Token-aware trimming in processMessageStream handles length; no hard slice here.
       const contextMessages = threadMessages
-        .filter((m) => m.role === 'user' || m.role === 'assistant')
+        .filter((m) =>
+          (m.role === 'user' || m.role === 'assistant')
+          && (m.delivery_status !== 'interrupted'
+            || (retryRequested && m.client_request_id === clientRequestId)),
+        )
         .map((m) => ({
           user: m.role === 'assistant' ? 'Addie' : (m.user_display_name || 'User'),
           text: m.content,
@@ -1333,19 +1546,57 @@ export function createAddieChatRouter(options?: {
       const isAuth = !!req.user;
 
       // Prepare message with member context and per-request tools
-      const { messageToProcess, requestContext, requestTools: memberTools, siAgents, hasCertificationContext: hasCertCtx } = await prepareRequestWithMemberTools(
-        inputValidation.sanitized,
+      const messageForModel = retryRequested
+        ? 'Continue the interrupted reply from the stored tool results. Do not repeat any completed action. Give the learner the result and next step.'
+        : inputValidation.sanitized;
+      const {
+        messageToProcess,
+        requestContext,
+        requestTools: memberTools,
+        siAgents,
+        hasThreadCertificationContext: hasThreadCertCtx,
+        certificationModuleContext,
+        certificationProgress,
+      } = await prepareRequestWithMemberTools(
+        messageForModel,
         req.user?.id,
         externalId,
         isAuth,
         thread.thread_id,
         typeof organization_id === 'string' ? organization_id : null
       );
-      const { requestTools, processOptions, effectiveModel } = buildTieredAccess(memberTools, isAuth);
+      const { requestTools, processOptions, effectiveModel } = buildTieredAccess(memberTools, isAuth, hasThreadCertCtx);
+      const preTurnCertification = userId && certificationModuleContext.moduleId
+        ? await getCertificationModuleExperience(userId, certificationModuleContext.moduleId)
+        : null;
+      const completionReserveEligible = hasThreadCertCtx
+        && (retryRequested
+          || preTurnCertification?.status === 'evidence_complete'
+          || preTurnCertification?.checkpoint?.current_phase === 'assessment');
+      if (userId && hasThreadCertCtx) {
+        await recordCertificationExperienceEvent({
+          userId,
+          moduleId: certificationModuleContext.moduleId,
+          threadId: externalId,
+          eventType: 'chat_turn_started',
+          clientRequestId,
+          metadata: { model: effectiveModel, retry: retryRequested },
+        });
+        if (retryRequested) {
+          await recordCertificationExperienceEvent({
+            userId,
+            moduleId: certificationModuleContext.moduleId,
+            threadId: externalId,
+            eventType: 'chat_turn_retry_requested',
+            clientRequestId,
+            metadata: { model: effectiveModel },
+          });
+        }
+      }
 
       // Stream the response — certification sessions get more conversation history
       let fullText = '';
-      let response;
+      let response: AddieResponse | undefined;
       const toolsUsed: string[] = [];
 
       // Cost cap — see matching block in the non-streaming path.
@@ -1355,22 +1606,23 @@ export function createAddieChatRouter(options?: {
 
       for await (const event of activeChatClient.processMessageStream(messageToProcess, contextMessages, requestTools, {
         ...processOptions,
+        ...(completionReserveEligible ? { maxIterations: 3, maxMessages: 12 } : {}),
         requestContext,
         threadId: thread.thread_id,
-          userDisplayName: displayName || undefined,
-          currentSpeakerName: displayName || undefined,
-          inputAttachments: attachments,
-          ...(streamAuthedScope
-          ? { costScope: streamAuthedScope }
+        userDisplayName: displayName || undefined,
+        currentSpeakerName: displayName || undefined,
+        inputAttachments: attachments,
+        ...(streamAuthedScope
+          ? { costScope: {
+              ...streamAuthedScope,
+              ...(completionReserveEligible ? { certificationReserveUsd: 1 } : {}),
+            } }
           : externalId
             ? { costScope: { userId: `anon:${externalId}`, tier: 'anonymous' as const } }
             : {}),
       })) {
-        // Break early if client disconnected (still save partial response below)
-        if (connectionClosed) {
-          logger.info("Addie Chat Stream: Breaking loop due to client disconnect");
-          break;
-        }
+        // Deliberately keep consuming after a disconnect. The completed result
+        // is persisted and the same client_request_id can replay it on reconnect.
 
         if (event.type === 'text') {
           fullText += event.text;
@@ -1387,30 +1639,121 @@ export function createAddieChatRouter(options?: {
             reason: event.reason,
           });
         } else if (event.type === 'stream_error') {
-          // Mid-stream upstream failure after partial delivery (#4797). Forward
-          // to the SSE client so it can render a Retry affordance, then end
-          // the response. The underlying throw on the next iteration is caught
-          // by the outer handler — persistence is already skipped because we
-          // never reach addMessage on this path. The partial fullText is
-          // discarded by virtue of returning here.
+          // Mid-stream upstream failure after partial delivery (#4797). Save a
+          // non-displayable audit attempt (including completed tool results),
+          // then give the browser an idempotent continuation affordance. The
+          // partial prose is deliberately excluded from future history.
           logger.warn(
             { reason: event.reason, deltasBeforeError: event.deltasBeforeError, fullTextLength: fullText.length },
             'Addie Chat Stream: Stream interrupted mid-reply — discarding partial turn'
           );
+          const moduleId = certificationModuleContext.moduleId;
+          const certification = userId && moduleId
+            ? await getCertificationModuleExperience(userId, moduleId)
+            : null;
+          await threadService.addMessage({
+            thread_id: thread.thread_id,
+            role: 'assistant',
+            content: 'Reply interrupted before completion. The learner can safely retry this turn.',
+            tools_used: event.tool_executions.map(execution => execution.tool_name),
+            tool_calls: event.tool_executions.map(execution => ({
+              name: execution.tool_name,
+              input: execution.parameters,
+              result: execution.result,
+              duration_ms: execution.duration_ms,
+              is_error: execution.is_error,
+            })),
+            model: effectiveModel,
+            flagged: true,
+            flag_reason: `stream_interrupted: ${event.reason}`,
+            client_request_id: clientRequestId || undefined,
+            delivery_status: 'interrupted',
+            client_turn_lease_id: claimedTurn?.leaseId,
+            finalize_client_turn_status: claimedTurn ? 'interrupted' : undefined,
+          });
+          claimedTurn = null;
+          if (userId && moduleId) {
+            await recordCertificationExperienceEvent({
+              userId,
+              moduleId,
+              threadId: externalId,
+              eventType: 'chat_turn_interrupted',
+              clientRequestId,
+              metadata: {
+                reason: event.reason,
+                tools_executed: event.tool_executions.map(execution => execution.tool_name),
+                model: effectiveModel,
+              },
+            });
+          }
           sendEvent("stream_error", {
             reason: event.reason,
             deltasBeforeError: event.deltasBeforeError,
             recoverable: true,
+            certification,
           });
           res.end();
           return;
         } else if (event.type === 'done') {
           response = event.response;
+          terminalResponse = event.response;
         } else if (event.type === 'error') {
-          sendEvent("error", { error: event.error });
+          if (claimedTurn) {
+            await threadService.addMessage({
+              thread_id: claimedTurn.threadId,
+              role: 'assistant',
+              content: 'Reply interrupted before completion. The learner can safely retry this turn.',
+              flagged: true,
+              flag_reason: `stream_interrupted: ${event.error}`,
+              client_request_id: claimedTurn.clientRequestId,
+              delivery_status: 'interrupted',
+              client_turn_lease_id: claimedTurn.leaseId,
+              finalize_client_turn_status: 'interrupted',
+            });
+            claimedTurn = null;
+          }
+          sendEvent("stream_error", { error: event.error, recoverable: true });
           res.end();
           return;
         }
+      }
+
+      if (!response) {
+        const moduleId = certificationModuleContext.moduleId;
+        const certification = userId && moduleId
+          ? await getCertificationModuleExperience(userId, moduleId)
+          : null;
+        await threadService.addMessage({
+          thread_id: thread.thread_id,
+          role: 'assistant',
+          content: 'Reply interrupted before completion. The learner can safely retry this turn.',
+          tools_used: toolsUsed.length > 0 ? toolsUsed : undefined,
+          model: effectiveModel,
+          flagged: true,
+          flag_reason: 'stream_interrupted: ended_without_done',
+          client_request_id: clientRequestId || undefined,
+          delivery_status: 'interrupted',
+          client_turn_lease_id: claimedTurn?.leaseId,
+          finalize_client_turn_status: claimedTurn ? 'interrupted' : undefined,
+        });
+        claimedTurn = null;
+        if (userId && moduleId) {
+          await recordCertificationExperienceEvent({
+            userId,
+            moduleId,
+            threadId: externalId,
+            eventType: 'chat_turn_interrupted',
+            clientRequestId,
+            metadata: { reason: 'ended_without_done', model: effectiveModel },
+          });
+        }
+        sendEvent('stream_error', {
+          reason: 'Reply ended before completion',
+          recoverable: true,
+          certification,
+        });
+        res.end();
+        return;
       }
 
       const finalStreamText = fullText.trim() ? fullText : response?.text;
@@ -1468,7 +1811,130 @@ export function createAddieChatRouter(options?: {
         tokens_cache_read: response?.usage?.cache_read_input_tokens,
         active_rule_ids: response?.active_rule_ids,
         config_version_id: response?.config_version_id,
+        client_request_id: clientRequestId || undefined,
+        delivery_status: 'completed',
+        client_turn_lease_id: claimedTurn?.leaseId,
+        finalize_client_turn_status: claimedTurn ? 'completed' : undefined,
       });
+      claimedTurn = null;
+
+      const completionExecution = response?.tool_executions?.find(execution =>
+        execution.tool_name === 'complete_certification_module'
+        || execution.tool_name === 'complete_certification_exam');
+      const activeModuleId = await resolveCompletionModuleId(
+        completionExecution,
+        userId,
+        certificationModuleContext.moduleId,
+      );
+      const preCompletionProgress = activeModuleId
+        ? certificationProgress.find(item => item.module_id === activeModuleId)
+        : undefined;
+      const certification = userId && activeModuleId
+        ? await getCertificationModuleExperience(userId, activeModuleId)
+        : null;
+      if (userId && activeModuleId) {
+        // A module can begin during this turn, so it was not present in the
+        // pre-model member context. Backfill the matching start event once the
+        // tool has bound the module to the thread.
+        if (!hasThreadCertCtx) {
+          await recordCertificationExperienceEvent({
+            userId,
+            moduleId: activeModuleId,
+            threadId: externalId,
+            eventType: 'chat_turn_started',
+            clientRequestId,
+            metadata: { model: effectiveModel, module_started_during_turn: true },
+          });
+        }
+        const capacityBlocked = response?.flag_reason === 'cost_cap_exceeded';
+        await recordCertificationExperienceEvent({
+          userId,
+          moduleId: activeModuleId,
+          threadId: externalId,
+          eventType: capacityBlocked ? 'capacity_blocked' : 'chat_turn_completed',
+          clientRequestId,
+          metadata: { model: effectiveModel, latency_ms: latencyMs },
+        });
+        if (response?.capacity?.certification_reserve_used) {
+          await recordCertificationExperienceEvent({
+            userId,
+            moduleId: activeModuleId,
+            threadId: externalId,
+            eventType: 'completion_reserve_used',
+            clientRequestId,
+            metadata: { model: effectiveModel },
+          });
+        }
+        if (certification?.status === 'evidence_complete') {
+          await recordCertificationExperienceEvent({
+            userId,
+            moduleId: activeModuleId,
+            threadId: externalId,
+            eventType: 'module_evidence_complete',
+            clientRequestId,
+            metadata: { model: effectiveModel },
+          });
+        }
+        // Tool invocation alone is not success: completion tools return normal
+        // explanatory text when a server-side gate rejects the attempt.
+        if (completionExecution
+            && certification?.status === 'completed'
+            && preCompletionProgress?.status !== 'completed'
+            && preCompletionProgress?.status !== 'tested_out') {
+          const completedAt = new Date().toISOString();
+          await recordCertificationExperienceEvent({
+            userId,
+            moduleId: activeModuleId,
+            threadId: externalId,
+            eventType: 'module_completed',
+            clientRequestId,
+            metadata: { completed_at: completedAt, model: effectiveModel },
+          });
+          if (certification?.credential.state === 'issued') {
+            await recordCertificationExperienceEvent({
+              userId,
+              moduleId: activeModuleId,
+              threadId: externalId,
+              eventType: 'credential_issued',
+              clientRequestId,
+              metadata: { module_completed_at: completedAt, model: effectiveModel },
+            });
+          } else if (certification?.credential.state === 'processing') {
+            await recordCertificationExperienceEvent({
+              userId,
+              moduleId: activeModuleId,
+              threadId: externalId,
+              eventType: 'credential_processing',
+              clientRequestId,
+              metadata: { module_completed_at: completedAt, model: effectiveModel },
+            });
+          } else if (certification?.credential.state === 'action_required') {
+            await recordCertificationExperienceEvent({
+              userId,
+              moduleId: activeModuleId,
+              threadId: externalId,
+              eventType: 'credential_action_required',
+              clientRequestId,
+              metadata: { module_completed_at: completedAt, model: effectiveModel },
+            });
+          }
+        }
+        if (!completionExecution
+            && certification?.credential.state === 'issued'
+            && preTurnCertification?.credential.state !== 'issued') {
+          await recordCertificationExperienceEvent({
+            userId,
+            moduleId: activeModuleId,
+            threadId: externalId,
+            eventType: 'credential_issued',
+            clientRequestId,
+            metadata: {
+              resolved_previous_state: preTurnCertification?.credential.state ?? null,
+              model: effectiveModel,
+            },
+          });
+        }
+      }
 
       // Check for SI session started (from connect_to_si_agent tool)
       const siSession = withSiAnonymousCapability(
@@ -1484,6 +1950,7 @@ export function createAddieChatRouter(options?: {
         timing: response?.timing,
         usage: response?.usage,
         latency_ms: latencyMs,
+        certification,
         si_session: siSession,
         si_agents: !siSession && siAgents.length > 0 ? siAgents.map(a => ({
           slug: a.slug,
@@ -1495,6 +1962,32 @@ export function createAddieChatRouter(options?: {
       res.end();
     } catch (error) {
       logger.error({ err: error }, "Addie Chat Stream: Error handling message");
+      if (claimedTurn) {
+        try {
+          await threadService.addMessage({
+            thread_id: claimedTurn.threadId,
+            role: 'assistant',
+            content: 'Reply interrupted before completion. The learner can safely retry this turn.',
+            tools_used: terminalResponse?.tool_executions?.map(execution => execution.tool_name),
+            tool_calls: terminalResponse?.tool_executions?.map(execution => ({
+              name: execution.tool_name,
+              input: execution.parameters,
+              result: execution.result,
+              duration_ms: execution.duration_ms,
+              is_error: execution.is_error,
+            })),
+            flagged: true,
+            flag_reason: 'stream_interrupted: route_error',
+            client_request_id: claimedTurn.clientRequestId,
+            delivery_status: 'interrupted',
+            client_turn_lease_id: claimedTurn.leaseId,
+            finalize_client_turn_status: 'interrupted',
+          });
+          claimedTurn = null;
+        } catch (statusError) {
+          logger.error({ statusError }, 'Failed to release interrupted chat turn lease');
+        }
+      }
       if (!res.headersSent) {
         if (error instanceof ChatAttachmentValidationError) {
           return res.status(error.statusCode).json({ error: ATTACHMENT_VALIDATION_CLIENT_MESSAGE });
@@ -1505,9 +1998,11 @@ export function createAddieChatRouter(options?: {
         logger.warn({ reason: error.message }, "Addie Chat Stream: Invalid attachment");
         sendEvent("error", { error: ATTACHMENT_VALIDATION_CLIENT_MESSAGE });
       } else {
-        sendEvent("error", { error: "Internal server error" });
+        sendEvent("stream_error", { error: "Internal server error", recoverable: true });
       }
       res.end();
+    } finally {
+      if (heartbeat) clearInterval(heartbeat);
     }
   });
 
@@ -1726,9 +2221,12 @@ export function createAddieChatRouter(options?: {
       const limit = Number.isSafeInteger(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 200) : 100;
       const offset = Number.isSafeInteger(requestedOffset) ? Math.min(requestedOffset, 10_000) : 0;
 
-      const threadMessages = await threadService.getThreadMessages(thread.thread_id, { limit, offset });
+      const [threadMessages, recoverableTurn] = await Promise.all([
+        threadService.getThreadMessages(thread.thread_id, { limit, offset }),
+        channel === 'web' ? threadService.getRecoverableClientTurn(thread.thread_id) : Promise.resolve(null),
+      ]);
       const messages: ConversationMessage[] = threadMessages
-        .filter((m) => m.role === 'user' || m.role === 'assistant')
+        .filter((m) => (m.role === 'user' || m.role === 'assistant') && m.delivery_status !== 'interrupted')
         .map((m) => ({
           role: m.role as 'user' | 'assistant',
           content: m.content,
@@ -1748,6 +2246,11 @@ export function createAddieChatRouter(options?: {
         limit,
         offset,
         messages,
+        recoverable_turn: recoverableTurn ? {
+          client_request_id: recoverableTurn.client_request_id,
+          message: recoverableTurn.content,
+          message_source: recoverableTurn.message_source ?? 'typed',
+        } : null,
         read_only: channel === 'slack' || channel === 'video',
       });
     } catch (error) {

--- a/server/src/routes/certification.ts
+++ b/server/src/routes/certification.ts
@@ -18,6 +18,13 @@ import {
   CredentialRecoveryConflictError,
   ensureCertifierCredential,
 } from '../services/certification-credential-issuance.js';
+import {
+  confirmCertificationContribution,
+  getCertificationContributions,
+  getCertificationExperienceMetrics,
+  getCertificationModuleExperience,
+  recordCertificationExperienceEvent,
+} from '../services/certification-experience.js';
 
 const logger = createLogger('certification-routes');
 
@@ -335,10 +342,101 @@ export function createCertificationRouters() {
         certDb.getPublicUserCredentials(userId),
       ]);
 
-      res.json({ progress, trackProgress, certifications, credentials });
+      const experiences = await Promise.all(
+        progress
+          .filter(item => item.status === 'in_progress')
+          .map(item => getCertificationModuleExperience(userId, item.module_id)),
+      );
+      const experienceByModule = new Map(
+        experiences.filter(Boolean).map(experience => [experience!.module_id, experience]),
+      );
+      res.json({
+        progress: progress.map(item => ({
+          ...item,
+          experience: experienceByModule.get(item.module_id) ?? null,
+        })),
+        trackProgress,
+        certifications,
+        credentials,
+      });
     } catch (error) {
       logger.error({ error }, 'Failed to get certification progress');
       res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  // GET /api/me/certification/modules/:id/experience — authoritative learner-facing state
+  userRouter.get('/certification/modules/:id/experience', async (req, res) => {
+    try {
+      const experience = await getCertificationModuleExperience(req.user!.id, req.params.id.toUpperCase());
+      if (!experience) return res.status(404).json({ error: 'Module not found' });
+      res.json(experience);
+    } catch (error) {
+      logger.error({ error, moduleId: req.params.id }, 'Failed to get module experience');
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  // POST /api/me/certification/modules/:id/resume — resolve a true resume target
+  userRouter.post('/certification/modules/:id/resume', async (req, res) => {
+    try {
+      const moduleId = req.params.id.toUpperCase();
+      const experience = await getCertificationModuleExperience(req.user!.id, moduleId);
+      if (!experience || (experience.status !== 'in_progress' && experience.status !== 'evidence_complete')) {
+        return res.status(409).json({ error: 'Module is not in progress' });
+      }
+      res.json(experience);
+    } catch (error) {
+      logger.error({ error, moduleId: req.params.id }, 'Failed to resume module');
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  // Count a resume only after the chat UI successfully loaded the stored thread.
+  userRouter.post('/certification/modules/:id/resumed', async (req, res) => {
+    try {
+      const moduleId = req.params.id.toUpperCase();
+      const conversationId = typeof req.body?.conversation_id === 'string'
+        ? req.body.conversation_id
+        : null;
+      const experience = await getCertificationModuleExperience(req.user!.id, moduleId);
+      if (!conversationId || !experience || experience.resume_conversation_id !== conversationId) {
+        return res.status(409).json({ error: 'Resume target does not match current module progress' });
+      }
+      await recordCertificationExperienceEvent({
+        userId: req.user!.id,
+        moduleId,
+        threadId: conversationId,
+        eventType: 'module_resumed',
+        metadata: { checkpoint_saved_at: experience.checkpoint?.saved_at ?? null },
+      });
+      res.json({ success: true });
+    } catch (error) {
+      logger.error({ error, moduleId: req.params.id }, 'Failed to confirm module resume');
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  userRouter.get('/certification/contributions', async (req, res) => {
+    try {
+      res.json({ contributions: await getCertificationContributions(req.user!.id) });
+    } catch (error) {
+      logger.error({ error }, 'Failed to get certification contributions');
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  userRouter.post('/certification/contributions/:id/confirm', async (req, res) => {
+    try {
+      const issueUrl = typeof req.body?.issue_url === 'string' ? req.body.issue_url.trim() : '';
+      if (!issueUrl) return res.status(400).json({ error: 'GitHub issue URL is required' });
+      const contribution = await confirmCertificationContribution(req.user!.id, req.params.id, issueUrl);
+      if (!contribution) return res.status(404).json({ error: 'Contribution not found' });
+      res.json({ contribution });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to verify contribution';
+      logger.warn({ error, contributionId: req.params.id }, 'Failed to confirm certification contribution');
+      res.status(422).json({ error: message });
     }
   });
 
@@ -1079,8 +1177,11 @@ export function createCertificationRouters() {
   // GET /api/admin/certification/overview — aggregate metrics
   adminRouter.get('/overview', async (_req, res) => {
     try {
-      const metrics = await certDb.getAdminOverviewMetrics();
-      res.json(metrics);
+      const [metrics, experience] = await Promise.all([
+        certDb.getAdminOverviewMetrics(),
+        getCertificationExperienceMetrics(),
+      ]);
+      res.json({ ...metrics, experience });
     } catch (error) {
       logger.error({ error }, 'Failed to get admin overview metrics');
       res.status(500).json({ error: 'Internal server error' });

--- a/server/src/services/certification-credential-issuance.ts
+++ b/server/src/services/certification-credential-issuance.ts
@@ -148,7 +148,11 @@ async function persistProviderState(
   const result = await client.query(
     `UPDATE user_credentials
         SET certifier_public_id = COALESCE($4, certifier_public_id),
-            certifier_badge_url = COALESCE($5, certifier_badge_url)
+            certifier_badge_url = COALESCE($5, certifier_badge_url),
+            certifier_issued_at = CASE
+              WHEN $4::text IS NOT NULL THEN COALESCE(certifier_issued_at, NOW())
+              ELSE certifier_issued_at
+            END
       WHERE workos_user_id = $1
         AND credential_id = $2
         AND certifier_credential_id = $3

--- a/server/src/services/certification-experience.ts
+++ b/server/src/services/certification-experience.ts
@@ -1,0 +1,532 @@
+import { query } from '../db/client.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('certification-experience');
+
+export type CertificationExperienceEventType =
+  | 'chat_turn_started'
+  | 'chat_turn_completed'
+  | 'chat_turn_interrupted'
+  | 'chat_turn_retry_requested'
+  | 'completion_reserve_used'
+  | 'capacity_blocked'
+  | 'module_resumed'
+  | 'module_evidence_complete'
+  | 'module_completed'
+  | 'credential_processing'
+  | 'credential_action_required'
+  | 'credential_issued'
+  | 'contribution_drafted'
+  | 'contribution_submitted';
+
+export interface CertificationModuleExperience {
+  module_id: string;
+  title: string;
+  status: 'not_started' | 'in_progress' | 'evidence_complete' | 'completed';
+  resume_conversation_id: string | null;
+  checkpoint: {
+    saved_at: string;
+    current_phase: string;
+    concepts_covered: string[];
+    concepts_remaining: string[];
+    demonstrations_verified: string[];
+    required_demonstrations: number;
+  } | null;
+  credential: {
+    state: 'not_earned' | 'action_required' | 'processing' | 'issued';
+    action: 'provide_name' | 'contact_support' | null;
+    name: string | null;
+    url: string | null;
+  };
+}
+
+export interface CertificationContribution {
+  id: string;
+  module_id: string | null;
+  repository: string;
+  title: string;
+  status: 'drafted' | 'submitted';
+  draft_url: string | null;
+  github_issue_number: number | null;
+  github_issue_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function criterionIds(exerciseDefinitions: unknown): string[] {
+  if (!Array.isArray(exerciseDefinitions)) return [];
+  const ids: string[] = [];
+  for (const exercise of exerciseDefinitions) {
+    if (!exercise || typeof exercise !== 'object') continue;
+    const criteria = (exercise as { success_criteria?: unknown }).success_criteria;
+    if (!Array.isArray(criteria)) continue;
+    for (const criterion of criteria) {
+      if (criterion && typeof criterion === 'object' && typeof (criterion as { id?: unknown }).id === 'string') {
+        ids.push((criterion as { id: string }).id);
+      }
+    }
+  }
+  return ids;
+}
+
+/** Analytics must never block the learner path. */
+export async function recordCertificationExperienceEvent(input: {
+  userId: string;
+  moduleId?: string | null;
+  threadId?: string | null;
+  eventType: CertificationExperienceEventType;
+  clientRequestId?: string | null;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  try {
+    await query(
+      `INSERT INTO certification_experience_events
+         (workos_user_id, module_id, addie_thread_id, event_type, client_request_id, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT DO NOTHING`,
+      [
+        input.userId,
+        input.moduleId ?? null,
+        input.threadId ?? null,
+        input.eventType,
+        input.clientRequestId ?? null,
+        JSON.stringify(input.metadata ?? {}),
+      ],
+    );
+  } catch (error) {
+    logger.error({ error, eventType: input.eventType }, 'Failed to record certification experience event');
+  }
+}
+
+export async function linkCertificationModuleThread(
+  userId: string,
+  moduleId: string,
+  threadId: string | undefined,
+): Promise<void> {
+  if (!threadId) return;
+  await query(
+    `UPDATE learner_progress
+     SET addie_thread_id = $3, updated_at = NOW()
+     WHERE workos_user_id = $1 AND module_id = $2 AND status = 'in_progress'`,
+    [userId, moduleId, threadId],
+  );
+}
+
+export async function getCertificationModuleExperience(
+  userId: string,
+  moduleId: string,
+): Promise<CertificationModuleExperience | null> {
+  const result = await query<{
+    module_id: string;
+    title: string;
+    progress_status: 'in_progress' | 'completed' | 'tested_out' | null;
+    exercise_definitions: unknown;
+    addie_thread_id: string | null;
+    resume_conversation_id: string | null;
+    checkpoint_saved_at: string | null;
+    current_phase: string | null;
+    concepts_covered: string[] | null;
+    concepts_remaining: string[] | null;
+    demonstrations_verified: string[] | null;
+    preliminary_scores: Record<string, number> | null;
+  }>(
+    `SELECT m.id AS module_id, m.title, lp.status AS progress_status,
+            m.exercise_definitions, lp.addie_thread_id,
+            COALESCE(t.external_id, lp.addie_thread_id) AS resume_conversation_id,
+            tc.created_at::text AS checkpoint_saved_at, tc.current_phase,
+            tc.concepts_covered, tc.concepts_remaining,
+            tc.demonstrations_verified, tc.preliminary_scores
+     FROM certification_modules m
+     LEFT JOIN learner_progress lp
+       ON lp.module_id = m.id AND lp.workos_user_id = $1
+     LEFT JOIN LATERAL (
+       SELECT * FROM teaching_checkpoints
+       WHERE workos_user_id = $1 AND module_id = m.id
+       ORDER BY created_at DESC LIMIT 1
+     ) tc ON TRUE
+     LEFT JOIN addie_threads t
+       ON t.thread_id::text = lp.addie_thread_id OR t.external_id = lp.addie_thread_id
+     WHERE m.id = $2`,
+    [userId, moduleId],
+  );
+  const row = result.rows[0];
+  if (!row) return null;
+
+  const requiredIds = criterionIds(row.exercise_definitions);
+  const verified = row.demonstrations_verified ?? [];
+  const evidenceComplete = requiredIds.every(id => verified.includes(id)) && !!row.preliminary_scores;
+  let status: CertificationModuleExperience['status'] = 'not_started';
+  if (row.progress_status === 'completed' || row.progress_status === 'tested_out') status = 'completed';
+  else if (row.progress_status === 'in_progress' && evidenceComplete) status = 'evidence_complete';
+  else if (row.progress_status === 'in_progress') status = 'in_progress';
+
+  const credentialResult = await query<{
+    name: string;
+    all_requirements_met: boolean;
+    user_credential_id: string | null;
+    certifier_group_id: string | null;
+    certifier_credential_id: string | null;
+    certifier_public_id: string | null;
+    certifier_issuance_state: string | null;
+    has_credential_name: boolean;
+  }>(
+    `SELECT cc.name,
+            NOT EXISTS (
+              SELECT 1 FROM unnest(cc.required_modules) required_module
+              WHERE NOT EXISTS (
+                SELECT 1 FROM learner_progress completed
+                WHERE completed.workos_user_id = $1
+                  AND completed.module_id = required_module
+                  AND completed.status IN ('completed', 'tested_out')
+              )
+            ) AS all_requirements_met,
+            uc.id AS user_credential_id, cc.certifier_group_id,
+            uc.certifier_credential_id, uc.certifier_public_id,
+            uc.certifier_issuance_state,
+            NULLIF(TRIM(COALESCE(u.first_name, '')), '') IS NOT NULL AS has_credential_name
+     FROM certification_credentials cc
+     LEFT JOIN user_credentials uc
+       ON uc.credential_id = cc.id AND uc.workos_user_id = $1
+     LEFT JOIN users u ON u.workos_user_id = $1
+     WHERE $2 = ANY(cc.required_modules)
+     ORDER BY cc.tier ASC
+     LIMIT 1`,
+    [userId, moduleId],
+  );
+  const credentialRow = credentialResult.rows[0];
+  let credentialState: CertificationModuleExperience['credential']['state'] = 'not_earned';
+  let credentialAction: CertificationModuleExperience['credential']['action'] = null;
+  let credentialUrl: string | null = null;
+  if (credentialRow?.all_requirements_met) {
+    const issued = Boolean(credentialRow.user_credential_id) && (
+      credentialRow.certifier_group_id === null
+      || Boolean(credentialRow.certifier_credential_id && credentialRow.certifier_public_id)
+    );
+    const processing = ['creating', 'draft_created', 'issuing'].includes(
+      credentialRow.certifier_issuance_state ?? '',
+    );
+    credentialState = issued ? 'issued' : processing ? 'processing' : 'action_required';
+    if (credentialState === 'action_required') {
+      credentialAction = credentialRow.certifier_group_id !== null && !credentialRow.has_credential_name
+        ? 'provide_name'
+        : 'contact_support';
+    }
+    if (credentialRow.certifier_public_id) {
+      credentialUrl = `https://credsverse.com/credentials/${credentialRow.certifier_public_id}`;
+    }
+  }
+
+  return {
+    module_id: row.module_id,
+    title: row.title,
+    status,
+    resume_conversation_id: row.resume_conversation_id,
+    checkpoint: row.checkpoint_saved_at ? {
+      saved_at: row.checkpoint_saved_at,
+      current_phase: row.current_phase ?? 'teaching',
+      concepts_covered: row.concepts_covered ?? [],
+      concepts_remaining: row.concepts_remaining ?? [],
+      demonstrations_verified: verified,
+      required_demonstrations: requiredIds.length,
+    } : null,
+    credential: {
+      state: credentialState,
+      action: credentialAction,
+      name: credentialRow?.name ?? null,
+      url: credentialUrl,
+    },
+  };
+}
+
+export async function getCertificationExperienceForClientRequest(
+  userId: string,
+  clientRequestId: string,
+): Promise<CertificationModuleExperience | null> {
+  const result = await query<{ module_id: string }>(
+    `SELECT module_id
+     FROM certification_experience_events
+     WHERE workos_user_id = $1 AND client_request_id = $2 AND module_id IS NOT NULL
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [userId, clientRequestId],
+  );
+  const moduleId = result.rows[0]?.module_id;
+  return moduleId ? getCertificationModuleExperience(userId, moduleId) : null;
+}
+
+export async function upsertCertificationContribution(input: {
+  userId: string;
+  moduleId?: string | null;
+  repository: string;
+  title: string;
+  status: 'drafted' | 'submitted';
+  draftUrl?: string | null;
+  issueNumber?: number | null;
+  issueUrl?: string | null;
+}): Promise<void> {
+  await query(
+    `INSERT INTO certification_contributions
+       (workos_user_id, module_id, repository, title, status, draft_url,
+        github_issue_number, github_issue_url)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     ON CONFLICT (workos_user_id, repository, title) DO UPDATE SET
+       module_id = COALESCE(EXCLUDED.module_id, certification_contributions.module_id),
+       status = CASE WHEN EXCLUDED.status = 'submitted' THEN 'submitted'
+                     ELSE certification_contributions.status END,
+       draft_url = COALESCE(EXCLUDED.draft_url, certification_contributions.draft_url),
+       github_issue_number = COALESCE(EXCLUDED.github_issue_number, certification_contributions.github_issue_number),
+       github_issue_url = COALESCE(EXCLUDED.github_issue_url, certification_contributions.github_issue_url),
+       updated_at = NOW()`,
+    [
+      input.userId, input.moduleId ?? null, input.repository, input.title, input.status,
+      input.draftUrl ?? null, input.issueNumber ?? null, input.issueUrl ?? null,
+    ],
+  );
+}
+
+export async function getCertificationContributions(userId: string): Promise<CertificationContribution[]> {
+  const result = await query<CertificationContribution>(
+    `SELECT id, module_id, repository, title, status, draft_url,
+            github_issue_number, github_issue_url, created_at::text, updated_at::text
+     FROM certification_contributions
+     WHERE workos_user_id = $1
+     ORDER BY updated_at DESC
+     LIMIT 50`,
+    [userId],
+  );
+  return result.rows;
+}
+
+export async function confirmCertificationContribution(
+  userId: string,
+  contributionId: string,
+  issueUrl: string,
+): Promise<CertificationContribution | null> {
+  const existing = await query<CertificationContribution>(
+    `SELECT * FROM certification_contributions WHERE id = $1 AND workos_user_id = $2`,
+    [contributionId, userId],
+  );
+  const contribution = existing.rows[0];
+  if (!contribution) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(issueUrl);
+  } catch {
+    throw new Error('Enter the full GitHub issue URL.');
+  }
+  const parts = parsed.pathname.split('/').filter(Boolean);
+  const issueNumber = Number(parts[3]);
+  if (parsed.protocol !== 'https:' || parsed.hostname !== 'github.com'
+      || parts[2] !== 'issues' || !Number.isSafeInteger(issueNumber) || issueNumber < 1
+      || `${parts[0]}/${parts[1]}` !== contribution.repository) {
+    throw new Error(`Enter an issue URL from ${contribution.repository}.`);
+  }
+
+  const response = await fetch(
+    `https://api.github.com/repos/${contribution.repository}/issues/${issueNumber}`,
+    { headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'adcp-certification' } },
+  );
+  if (!response.ok) throw new Error('That GitHub issue could not be verified.');
+  const issue = await response.json() as {
+    title?: string;
+    html_url?: string;
+    pull_request?: unknown;
+  };
+  if (issue.pull_request || issue.title?.trim() !== contribution.title.trim()
+      || issue.html_url !== parsed.href.replace(/\/$/, '')) {
+    throw new Error('The issue repository and title must match the saved contribution draft.');
+  }
+
+  const updated = await query<CertificationContribution>(
+    `UPDATE certification_contributions
+     SET status = 'submitted', github_issue_number = $3,
+         github_issue_url = $4, updated_at = NOW()
+     WHERE id = $1 AND workos_user_id = $2
+     RETURNING *`,
+    [contributionId, userId, issueNumber, issue.html_url],
+  );
+  await recordCertificationExperienceEvent({
+    userId,
+    moduleId: contribution.module_id,
+    eventType: 'contribution_submitted',
+    metadata: { repository: contribution.repository, title: contribution.title, issue_number: issueNumber },
+  });
+  return updated.rows[0] ?? null;
+}
+
+export async function getCertificationExperienceMetrics(): Promise<{
+  window_days: number;
+  turns_started: number;
+  turns_completed: number;
+  turns_interrupted: number;
+  retries_requested: number;
+  recovered_turns: number;
+  recovery_rate: number;
+  capacity_blocks: number;
+  reserve_turns: number;
+  resume_sessions: number;
+  resume_completion_rate: number;
+  evidence_completion_rate: number;
+  credential_actions_required: number;
+  credential_action_resolution_rate: number;
+  contributions_drafted: number;
+  contributions_submitted: number;
+  completion_rate: number;
+  interruption_rate: number;
+  contribution_submit_rate: number;
+  avg_credential_latency_seconds: number | null;
+  model_outcomes: Array<{
+    model: string;
+    module_id: string | null;
+    turns_started: number;
+    turns_completed: number;
+    turns_interrupted: number;
+    evidence_complete: number;
+    modules_completed: number;
+    credentials_issued: number;
+  }>;
+}> {
+  const result = await query<Record<string, string | null>>(
+    `WITH event_metrics AS (
+       SELECT
+         COUNT(*) FILTER (WHERE event.event_type = 'chat_turn_started') AS turns_started,
+         COUNT(*) FILTER (WHERE event.event_type = 'chat_turn_completed') AS turns_completed,
+         COUNT(*) FILTER (WHERE event.event_type = 'chat_turn_interrupted') AS turns_interrupted,
+         COUNT(*) FILTER (WHERE event.event_type = 'chat_turn_retry_requested') AS retries_requested,
+         COUNT(*) FILTER (WHERE event.event_type = 'capacity_blocked') AS capacity_blocks,
+         COUNT(*) FILTER (WHERE event.event_type = 'completion_reserve_used') AS reserve_turns,
+         COUNT(*) FILTER (WHERE event.event_type = 'module_resumed') AS resume_sessions,
+         COUNT(*) FILTER (WHERE event.event_type = 'module_resumed' AND EXISTS (
+           SELECT 1 FROM certification_experience_events completed
+           WHERE completed.workos_user_id = event.workos_user_id
+             AND completed.module_id = event.module_id
+             AND completed.event_type = 'module_completed'
+             AND completed.created_at >= event.created_at
+         )) AS resume_completions,
+         COUNT(*) FILTER (WHERE event.event_type = 'module_evidence_complete') AS evidence_checkpoints,
+         COUNT(*) FILTER (WHERE event.event_type = 'module_evidence_complete' AND EXISTS (
+           SELECT 1 FROM certification_experience_events completed
+           WHERE completed.workos_user_id = event.workos_user_id
+             AND completed.module_id = event.module_id
+             AND completed.event_type = 'module_completed'
+             AND completed.created_at >= event.created_at
+         )) AS evidence_completions,
+         COUNT(*) FILTER (WHERE event.event_type = 'credential_action_required') AS credential_actions_required,
+         COUNT(*) FILTER (WHERE event.event_type = 'credential_action_required' AND EXISTS (
+           SELECT 1 FROM certification_experience_events issued
+           WHERE issued.workos_user_id = event.workos_user_id
+             AND issued.module_id = event.module_id
+             AND issued.event_type = 'credential_issued'
+             AND issued.created_at >= event.created_at
+         )) AS credential_actions_resolved
+       FROM certification_experience_events event
+       WHERE event.created_at > NOW() - INTERVAL '30 days'
+     ), recovery_metrics AS (
+       SELECT COUNT(DISTINCT retry.client_request_id) AS recovered_turns
+       FROM certification_experience_events retry
+       WHERE retry.event_type = 'chat_turn_retry_requested'
+         AND retry.client_request_id IS NOT NULL
+         AND retry.created_at > NOW() - INTERVAL '30 days'
+         AND EXISTS (
+           SELECT 1 FROM certification_experience_events completed
+           WHERE completed.workos_user_id = retry.workos_user_id
+             AND completed.client_request_id = retry.client_request_id
+             AND completed.event_type = 'chat_turn_completed'
+         )
+     ), contribution_metrics AS (
+       SELECT COUNT(*) AS contributions_drafted,
+              COUNT(*) FILTER (WHERE status = 'submitted') AS contributions_submitted
+       FROM certification_contributions
+       WHERE created_at > NOW() - INTERVAL '30 days'
+     ), credential_metrics AS (
+       SELECT ROUND(AVG(EXTRACT(EPOCH FROM (certifier_issued_at - awarded_at))))
+                AS avg_credential_latency_seconds
+       FROM user_credentials
+       WHERE certifier_issued_at > NOW() - INTERVAL '30 days'
+     )
+     SELECT e.turns_started::text, e.turns_completed::text,
+            e.turns_interrupted::text, e.retries_requested::text,
+            r.recovered_turns::text, e.capacity_blocks::text,
+            e.reserve_turns::text, e.resume_sessions::text,
+            e.resume_completions::text, e.evidence_checkpoints::text,
+            e.evidence_completions::text, e.credential_actions_required::text,
+            e.credential_actions_resolved::text,
+            c.contributions_drafted::text, c.contributions_submitted::text,
+            g.avg_credential_latency_seconds::text
+     FROM event_metrics e CROSS JOIN recovery_metrics r
+       CROSS JOIN contribution_metrics c CROSS JOIN credential_metrics g`,
+  );
+  const row = result.rows[0] ?? {};
+  const number = (key: string) => Number(row[key] ?? 0);
+  const started = number('turns_started');
+  const interrupted = number('turns_interrupted');
+  const drafted = number('contributions_drafted');
+  const completed = number('turns_completed');
+  const submitted = number('contributions_submitted');
+  const retries = number('retries_requested');
+  const recovered = number('recovered_turns');
+  const resumes = number('resume_sessions');
+  const evidence = number('evidence_checkpoints');
+  const credentialActions = number('credential_actions_required');
+  const modelResult = await query<{
+    model: string;
+    module_id: string | null;
+    turns_started: string;
+    turns_completed: string;
+    turns_interrupted: string;
+    evidence_complete: string;
+    modules_completed: string;
+    credentials_issued: string;
+  }>(
+    `SELECT metadata->>'model' AS model, module_id,
+            COUNT(*) FILTER (WHERE event_type = 'chat_turn_started')::text AS turns_started,
+            COUNT(*) FILTER (WHERE event_type = 'chat_turn_completed')::text AS turns_completed,
+            COUNT(*) FILTER (WHERE event_type = 'chat_turn_interrupted')::text AS turns_interrupted,
+            COUNT(*) FILTER (WHERE event_type = 'module_evidence_complete')::text AS evidence_complete,
+            COUNT(*) FILTER (WHERE event_type = 'module_completed')::text AS modules_completed,
+            COUNT(*) FILTER (WHERE event_type = 'credential_issued')::text AS credentials_issued
+     FROM certification_experience_events
+     WHERE created_at > NOW() - INTERVAL '30 days'
+       AND metadata ? 'model'
+     GROUP BY metadata->>'model', module_id
+     ORDER BY COUNT(*) DESC`,
+  );
+  return {
+    window_days: 30,
+    turns_started: started,
+    turns_completed: completed,
+    turns_interrupted: interrupted,
+    retries_requested: retries,
+    recovered_turns: recovered,
+    recovery_rate: retries > 0 ? Math.round((recovered / retries) * 1000) / 10 : 0,
+    capacity_blocks: number('capacity_blocks'),
+    reserve_turns: number('reserve_turns'),
+    resume_sessions: resumes,
+    resume_completion_rate: resumes > 0
+      ? Math.round((number('resume_completions') / resumes) * 1000) / 10 : 0,
+    evidence_completion_rate: evidence > 0
+      ? Math.round((number('evidence_completions') / evidence) * 1000) / 10 : 0,
+    credential_actions_required: credentialActions,
+    credential_action_resolution_rate: credentialActions > 0
+      ? Math.round((number('credential_actions_resolved') / credentialActions) * 1000) / 10 : 0,
+    contributions_drafted: drafted,
+    contributions_submitted: submitted,
+    completion_rate: started > 0 ? Math.round((completed / started) * 1000) / 10 : 0,
+    interruption_rate: started > 0 ? Math.round((interrupted / started) * 1000) / 10 : 0,
+    contribution_submit_rate: drafted > 0 ? Math.round((submitted / drafted) * 1000) / 10 : 0,
+    avg_credential_latency_seconds: row.avg_credential_latency_seconds === null
+      ? null
+      : Number(row.avg_credential_latency_seconds),
+    model_outcomes: modelResult.rows.map(outcome => ({
+      model: outcome.model,
+      module_id: outcome.module_id,
+      turns_started: Number(outcome.turns_started),
+      turns_completed: Number(outcome.turns_completed),
+      turns_interrupted: Number(outcome.turns_interrupted),
+      evidence_complete: Number(outcome.evidence_complete),
+      modules_completed: Number(outcome.modules_completed),
+      credentials_issued: Number(outcome.credentials_issued),
+    })),
+  };
+}

--- a/server/src/services/certification-experience.ts
+++ b/server/src/services/certification-experience.ts
@@ -1,7 +1,9 @@
+import { resolveGitHubToken } from '../addie/jobs/github-app-token.js';
 import { query } from '../db/client.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('certification-experience');
+const GITHUB_VERIFICATION_TIMEOUT_MS = 10_000;
 
 export type CertificationExperienceEventType =
   | 'chat_turn_started'
@@ -323,16 +325,38 @@ export async function confirmCertificationContribution(
     throw new Error(`Enter an issue URL from ${contribution.repository}.`);
   }
 
-  const response = await fetch(
-    `https://api.github.com/repos/${contribution.repository}/issues/${issueNumber}`,
-    { headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'adcp-certification' } },
-  );
-  if (!response.ok) throw new Error('That GitHub issue could not be verified.');
-  const issue = await response.json() as {
+  const token = await resolveGitHubToken();
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'adcp-certification',
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  let response: Response;
+  try {
+    response = await fetch(
+      `https://api.github.com/repos/${contribution.repository}/issues/${issueNumber}`,
+      { headers, signal: AbortSignal.timeout(GITHUB_VERIFICATION_TIMEOUT_MS) },
+    );
+  } catch {
+    throw new Error('That GitHub issue could not be verified. Please try again.');
+  }
+  if (!response.ok && (response.status === 429
+      || response.headers.get('x-ratelimit-remaining') === '0'
+      || (response.status === 403 && response.headers.has('retry-after')))) {
+    throw new Error('GitHub verification is temporarily rate limited. Please try again in a few minutes.');
+  }
+  if (!response.ok) throw new Error('That GitHub issue could not be verified. Please try again.');
+  let issue: {
     title?: string;
     html_url?: string;
     pull_request?: unknown;
   };
+  try {
+    issue = await response.json() as typeof issue;
+  } catch {
+    throw new Error('That GitHub issue could not be verified. Please try again.');
+  }
   if (issue.pull_request || issue.title?.trim() !== contribution.title.trim()
       || issue.html_url !== parsed.href.replace(/\/$/, '')) {
     throw new Error('The issue repository and title must match the saved contribution draft.');

--- a/server/tests/unit/addie-chat-object-authorization.test.ts
+++ b/server/tests/unit/addie-chat-object-authorization.test.ts
@@ -9,11 +9,19 @@ const mocks = vi.hoisted(() => ({
   authenticated: true,
   getThreadByExternalId: vi.fn(),
   getThreadMessages: vi.fn(),
+  getMessagesByClientRequestId: vi.fn(),
+  claimClientTurn: vi.fn(),
+  renewClientTurnLease: vi.fn(),
+  setClientTurnStatus: vi.fn(),
+  getRecoverableClientTurn: vi.fn(),
+  claimAnonymousThread: vi.fn(),
   addMessage: vi.fn(),
   addMessageFeedback: vi.fn(),
   processMessage: vi.fn(),
   processMessageStream: vi.fn(),
   initializeKnowledgeSearch: vi.fn().mockResolvedValue(undefined),
+  getProgress: vi.fn(),
+  getAttemptForUser: vi.fn(),
 }));
 
 vi.mock('express-rate-limit', () => ({
@@ -47,6 +55,12 @@ vi.mock('../../src/addie/thread-service.js', () => ({
   getThreadService: () => ({
     getThreadByExternalId: mocks.getThreadByExternalId,
     getThreadMessages: mocks.getThreadMessages,
+    getMessagesByClientRequestId: mocks.getMessagesByClientRequestId,
+    claimClientTurn: mocks.claimClientTurn,
+    renewClientTurnLease: mocks.renewClientTurnLease,
+    setClientTurnStatus: mocks.setClientTurnStatus,
+    getRecoverableClientTurn: mocks.getRecoverableClientTurn,
+    claimAnonymousThread: mocks.claimAnonymousThread,
     addMessage: mocks.addMessage,
     addMessageFeedback: mocks.addMessageFeedback,
     getOrCreateThread: vi.fn(),
@@ -179,7 +193,14 @@ vi.mock('../../src/addie/services/si-retriever.js', () => ({
 }));
 
 vi.mock('../../src/db/certification-db.js', () => ({
-  getProgress: vi.fn().mockResolvedValue([]),
+  getProgress: mocks.getProgress,
+  getAttemptForUser: mocks.getAttemptForUser,
+}));
+
+vi.mock('../../src/services/certification-experience.js', () => ({
+  getCertificationExperienceForClientRequest: vi.fn().mockResolvedValue(null),
+  getCertificationModuleExperience: vi.fn().mockResolvedValue(null),
+  recordCertificationExperienceEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../src/db/working-group-db.js', () => ({
@@ -206,6 +227,8 @@ vi.mock('../../src/db/person-events-db.js', () => ({
 import {
   createAddieChatRouter,
   getChatClaudeClient,
+  resolveCompletionModuleId,
+  resolveThreadCertificationProgress,
 } from '../../src/routes/addie-chat.js';
 import { issueAnonymousSessionCapability } from '../../src/routes/helpers/anonymous-session-capability.js';
 
@@ -279,11 +302,31 @@ describe('Addie chat conversation object authorization', () => {
       { role: 'user', content: 'Earlier question', user_display_name: 'Attacker' },
       { role: 'assistant', content: 'Earlier answer' },
     ]);
+    mocks.getMessagesByClientRequestId.mockResolvedValue([]);
+    mocks.claimClientTurn.mockResolvedValue({ state: 'claimed', leaseId: 'lease-1' });
+    mocks.renewClientTurnLease.mockResolvedValue(true);
+    mocks.setClientTurnStatus.mockResolvedValue(undefined);
+    mocks.getRecoverableClientTurn.mockResolvedValue(null);
+    mocks.claimAnonymousThread.mockImplementation(async (
+      _threadId: string,
+      _ownerId: string,
+      workosUserId: string,
+      userDisplayName?: string,
+    ) => ({
+      thread_id: 'thread_anonymous',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: workosUserId,
+      user_display_name: userDisplayName,
+    }));
     mocks.addMessage.mockImplementation(async (message: { role: string }) => ({
       ...message,
       message_id: message.role === 'assistant' ? 'message_assistant' : 'message_user',
     }));
     mocks.processMessage.mockResolvedValue(successfulModelResponse());
+    mocks.getProgress.mockResolvedValue([]);
+    mocks.getAttemptForUser.mockResolvedValue(null);
     mocks.addMessageFeedback.mockResolvedValue(true);
     mocks.processMessageStream.mockImplementation(async function* () {
       yield { type: 'text', text: 'Allowed response' };
@@ -308,6 +351,33 @@ describe('Addie chat conversation object authorization', () => {
     expect(mocks.getThreadMessages).not.toHaveBeenCalled();
     expect(mocks.addMessage).not.toHaveBeenCalled();
     expect(mocks.processMessage).not.toHaveBeenCalled();
+  });
+
+  it('resolves an ordinary learner-progress module from its bound conversation', () => {
+    const resolved = resolveThreadCertificationProgress([
+      { module_id: 'S6', status: 'in_progress', addie_thread_id: 'other-thread', completed_at: null },
+      { module_id: 'A1', status: 'completed', addie_thread_id: 'conversation-a1', completed_at: new Date().toISOString() },
+      { module_id: 'A2', status: 'in_progress', addie_thread_id: 'conversation-a1', completed_at: null },
+    ], 'conversation-a1', 'internal-thread-a1');
+
+    expect(resolved?.module_id).toBe('A2');
+  });
+
+  it('attributes capstone completion to the attempt module instead of stale thread context', async () => {
+    const attemptId = '36ad6e65-7a1c-45bb-ab7f-86b05ae3b718';
+    mocks.getAttemptForUser.mockResolvedValue({
+      id: attemptId,
+      workos_user_id: 'user_attacker',
+      module_id: 'S6',
+    });
+
+    const resolved = await resolveCompletionModuleId({
+      tool_name: 'complete_certification_exam',
+      parameters: { attempt_id: attemptId },
+    }, 'user_attacker', 'A2');
+
+    expect(resolved).toBe('S6');
+    expect(mocks.getAttemptForUser).toHaveBeenCalledWith(attemptId, 'user_attacker');
   });
 
   it('allows an anonymous caller to continue a thread with its signed owner capability', async () => {
@@ -335,6 +405,32 @@ describe('Addie chat conversation object authorization', () => {
     expect(mocks.getThreadMessages).toHaveBeenCalledWith('thread_anonymous', { limit: 100 });
     expect(mocks.addMessage).toHaveBeenCalledTimes(2);
     expect(mocks.processMessage).toHaveBeenCalledOnce();
+  });
+
+  it('claims a browser-owned anonymous thread when that learner signs in', async () => {
+    const ownerId = 'anonymous-owner';
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_anonymous',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'anonymous',
+      user_id: ownerId,
+    });
+    const capability = issueAnonymousSessionCapability('addie-web-thread-owner', ownerId);
+
+    const response = await request(mountChatRouter())
+      .post('/')
+      .set('Cookie', `addie-anonymous-owner=${capability}`)
+      .send({
+        message: 'Continue after signing in',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      });
+
+    expect(response.status).toBe(200);
+    expect(mocks.claimAnonymousThread).toHaveBeenCalledWith(
+      'thread_anonymous', ownerId, 'user_attacker', 'Attacker',
+    );
+    expect(mocks.getThreadMessages).toHaveBeenCalledWith('thread_anonymous', { limit: 100 });
   });
 
   it('denies an authenticated caller access to an anonymous thread before effects', async () => {
@@ -427,6 +523,108 @@ describe('Addie chat conversation object authorization', () => {
     expect(mocks.addMessage).toHaveBeenCalledTimes(2);
     expect(mocks.processMessage).not.toHaveBeenCalled();
     expect(mocks.processMessageStream).toHaveBeenCalledOnce();
+  });
+
+  it('replays a completed client request without duplicating messages, tools, or model work', async () => {
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+    mocks.getMessagesByClientRequestId.mockResolvedValue([
+      {
+        message_id: 'message_user',
+        role: 'user',
+        content: 'Complete my module',
+        delivery_status: 'completed',
+      },
+      {
+        message_id: 'message_assistant',
+        role: 'assistant',
+        content: 'Module complete and saved.',
+        delivery_status: 'completed',
+      },
+    ]);
+
+    const response = await request(mountChatRouter())
+      .post('/stream')
+      .send({
+        message: 'Complete my module',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+        client_request_id: 'e6c3ffbe-bbf4-4ae5-a32f-713e05af4b68',
+        retry: true,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('Module complete and saved.');
+    expect(response.text).toContain('"replayed":true');
+    expect(mocks.getThreadMessages).not.toHaveBeenCalled();
+    expect(mocks.addMessage).not.toHaveBeenCalled();
+    expect(mocks.processMessageStream).not.toHaveBeenCalled();
+  });
+
+  it('rejects a duplicate request while the original turn owns the execution lease', async () => {
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+    mocks.getMessagesByClientRequestId.mockResolvedValue([{
+      message_id: 'message_user',
+      role: 'user',
+      content: 'Complete my module',
+      delivery_status: 'completed',
+    }]);
+    mocks.claimClientTurn.mockResolvedValue({ state: 'processing' });
+
+    const response = await request(mountChatRouter())
+      .post('/stream')
+      .send({
+        message: 'Complete my module',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+        client_request_id: 'e6c3ffbe-bbf4-4ae5-a32f-713e05af4b68',
+        retry: true,
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body.error).toBe('turn_in_progress');
+    expect(mocks.addMessage).not.toHaveBeenCalled();
+    expect(mocks.processMessageStream).not.toHaveBeenCalled();
+  });
+
+  it('marks a stream that ends without done as interrupted and recoverable', async () => {
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+    mocks.processMessageStream.mockImplementation(async function* () {
+      yield { type: 'text', text: 'Partial response' };
+    });
+
+    const response = await request(mountChatRouter())
+      .post('/stream')
+      .send({
+        message: 'Continue assessment',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+        client_request_id: 'e6c3ffbe-bbf4-4ae5-a32f-713e05af4b68',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('Reply ended before completion');
+    expect(response.text).toContain('"recoverable":true');
+    expect(mocks.addMessage).toHaveBeenCalledWith(expect.objectContaining({
+      role: 'assistant',
+      delivery_status: 'interrupted',
+      client_turn_lease_id: 'lease-1',
+      finalize_client_turn_status: 'interrupted',
+    }));
   });
 
   it('denies cross-user feedback before attempting a message update', async () => {

--- a/server/tests/unit/addie-chat-org-selection.test.ts
+++ b/server/tests/unit/addie-chat-org-selection.test.ts
@@ -16,6 +16,7 @@ const threadMocks = vi.hoisted(() => ({
   getThreadByExternalId: vi.fn(),
   getOrCreateThread: vi.fn(),
   getThreadMessages: vi.fn(),
+  getRecoverableClientTurn: vi.fn(),
   addMessage: vi.fn(),
   addMessageFeedback: vi.fn(),
 }));
@@ -126,6 +127,7 @@ describe('mounted Addie web-thread ownership', () => {
       message_count: 0,
     });
     threadMocks.getThreadMessages.mockReset().mockResolvedValue([]);
+    threadMocks.getRecoverableClientTurn.mockReset().mockResolvedValue(null);
     threadMocks.addMessage.mockReset().mockResolvedValue({
       message_id: '33333333-3333-4333-8333-333333333333',
     });

--- a/server/tests/unit/certification-contribution-verification.test.ts
+++ b/server/tests/unit/certification-contribution-verification.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { query, resolveGitHubToken } = vi.hoisted(() => ({
+  query: vi.fn(),
+  resolveGitHubToken: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({ query }));
+vi.mock('../../src/addie/jobs/github-app-token.js', () => ({ resolveGitHubToken }));
+
+import { confirmCertificationContribution } from '../../src/services/certification-experience.js';
+
+const contribution = {
+  id: 'contribution-1',
+  module_id: 'module-1',
+  repository: 'adcontextprotocol/adcp',
+  title: 'Clarify the certification guide',
+  status: 'drafted',
+  draft_url: null,
+  github_issue_number: null,
+  github_issue_url: null,
+  created_at: '2026-08-06T00:00:00.000Z',
+  updated_at: '2026-08-06T00:00:00.000Z',
+};
+
+describe('certification contribution verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    query.mockResolvedValue({ rows: [contribution] });
+    resolveGitHubToken.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('bounds the GitHub request and turns timeouts into a retryable error', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new DOMException('The operation timed out', 'TimeoutError'),
+    );
+
+    await expect(confirmCertificationContribution(
+      'user-1',
+      contribution.id,
+      'https://github.com/adcontextprotocol/adcp/issues/123',
+    )).rejects.toThrow('That GitHub issue could not be verified. Please try again.');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.github.com/repos/adcontextprotocol/adcp/issues/123',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+  });
+
+  it('uses the configured GitHub credential and explains rate-limit failures', async () => {
+    resolveGitHubToken.mockResolvedValue('github-token');
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: new Headers({ 'x-ratelimit-remaining': '0' }),
+    } as Response);
+
+    await expect(confirmCertificationContribution(
+      'user-1',
+      contribution.id,
+      'https://github.com/adcontextprotocol/adcp/issues/123',
+    )).rejects.toThrow('GitHub verification is temporarily rate limited. Please try again in a few minutes.');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.github.com/repos/adcontextprotocol/adcp/issues/123',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer github-token' }),
+      }),
+    );
+  });
+
+  it('explains GitHub secondary rate-limit failures', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: new Headers({ 'retry-after': '60' }),
+    } as Response);
+
+    await expect(confirmCertificationContribution(
+      'user-1',
+      contribution.id,
+      'https://github.com/adcontextprotocol/adcp/issues/123',
+    )).rejects.toThrow('GitHub verification is temporarily rate limited. Please try again in a few minutes.');
+  });
+
+  it('turns response-body timeouts into a retryable error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: vi.fn().mockRejectedValue(new DOMException('The operation timed out', 'TimeoutError')),
+    } as unknown as Response);
+
+    await expect(confirmCertificationContribution(
+      'user-1',
+      contribution.id,
+      'https://github.com/adcontextprotocol/adcp/issues/123',
+    )).rejects.toThrow('That GitHub issue could not be verified. Please try again.');
+  });
+
+  it('accepts a successful response that consumes the last rate-limit request', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'x-ratelimit-remaining': '0' }),
+      json: vi.fn().mockResolvedValue({
+        title: contribution.title,
+        html_url: 'https://github.com/adcontextprotocol/adcp/issues/123',
+      }),
+    } as unknown as Response);
+
+    await expect(confirmCertificationContribution(
+      'user-1',
+      contribution.id,
+      'https://github.com/adcontextprotocol/adcp/issues/123',
+    )).resolves.toEqual(contribution);
+  });
+});

--- a/server/tests/unit/claude-client-stream-error.test.ts
+++ b/server/tests/unit/claude-client-stream-error.test.ts
@@ -122,16 +122,13 @@ describe('processMessageStream — mid-stream upstream failure (#4797)', () => {
     const evt = streamErrorEvents[0] as Extract<StreamEvent, { type: 'stream_error' }>;
     expect(evt.reason).toBe('API is busy');
     expect(evt.deltasBeforeError).toBe(1);
+    expect(evt.tool_executions).toEqual([]);
+    expect(evt.certification_reserve_used).toBe(false);
 
-    // The underlying error is wrapped into a final `error` event by
-    // processMessageStream's outer catch (claude-client.ts:1730). The
-    // consumer-side throw happens in bolt-app's event-loop branch that
-    // re-raises on `error`; addie-chat/tavus return/break on the
-    // `stream_error` event instead. Either path lands persistence in
-    // the discard branch.
+    // The recoverable terminal event is emitted exactly once. It carries the
+    // completed tool receipts, so consumers do not need a second error event.
     const errorEvents = events.filter(e => e.type === 'error');
-    expect(errorEvents).toHaveLength(1);
-    expect((errorEvents[0] as { type: 'error'; error: string }).error).toMatch(/overloaded/);
+    expect(errorEvents).toHaveLength(0);
   });
 
   it('orders stream_error after text deltas (consumer can render in-place recovery)', async () => {

--- a/server/tests/unit/claude-cost-tracker.test.ts
+++ b/server/tests/unit/claude-cost-tracker.test.ts
@@ -3,6 +3,7 @@ import {
   checkCostCap,
   recordCost,
   formatCapExceededMessage,
+  releaseCertificationReserve,
   resolveUserTier,
   buildSlackCostOptions,
   DAILY_BUDGET_USD,
@@ -36,6 +37,45 @@ describe('checkCostCap', () => {
     expect(result.ok).toBe(true);
     expect(result.remainingUsd).toBe(DAILY_BUDGET_USD.member_free);
     expect(result.spentCents).toBe(0);
+  });
+
+  it('uses a bounded certification reserve after the normal tier budget', async () => {
+    // $5.50 exceeds the free-member budget but stays within a $1 completion reserve.
+    await recordCost('u-certification', 'claude-sonnet-4-6', {
+      input_tokens: 1_833_334,
+      output_tokens: 0,
+    });
+
+    expect((await checkCostCap('u-certification', 'member_free')).ok).toBe(false);
+    const withReserve = await checkCostCap('u-certification', 'member_free', {
+      certificationReserveUsd: 1,
+    });
+    expect(withReserve.ok).toBe(true);
+    expect(withReserve.usedCertificationReserve).toBe(true);
+    expect(withReserve.remainingUsd).toBeCloseTo(0.5, 4);
+  });
+
+  it('admits only one concurrent completion-reserve call per user', async () => {
+    await recordCost('u-reserve-lease', 'claude-sonnet-4-6', {
+      input_tokens: 1_833_334,
+      output_tokens: 0,
+    });
+    const first = await checkCostCap('u-reserve-lease', 'member_free', {
+      certificationReserveUsd: 1,
+    });
+    const concurrent = await checkCostCap('u-reserve-lease', 'member_free', {
+      certificationReserveUsd: 1,
+    });
+
+    expect(first.ok).toBe(true);
+    expect(first.certificationLeaseId).toBeTruthy();
+    expect(concurrent.ok).toBe(false);
+    expect(concurrent.reserveBusy).toBe(true);
+
+    await releaseCertificationReserve('u-reserve-lease', first.certificationLeaseId);
+    expect((await checkCostCap('u-reserve-lease', 'member_free', {
+      certificationReserveUsd: 1,
+    })).ok).toBe(true);
   });
 
   it('blocks the call that crosses the daily budget', async () => {
@@ -180,7 +220,7 @@ describe('formatCapExceededMessage', () => {
       tier: 'member_free',
     });
     expect(msg).toContain('daily conversation limit');
-    expect(msg).toContain('try again tomorrow');
+    expect(msg).toContain('try again in about 1 hour');
     expect(msg).toContain('/dashboard/membership');
     expect(msg).toContain('Upgrade');
     expect(msg).not.toContain('$5.50');

--- a/tests/certification-experience-ui.test.cjs
+++ b/tests/certification-experience-ui.test.cjs
@@ -1,0 +1,33 @@
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { resolve } = require('node:path');
+const test = require('node:test');
+
+const chatHtml = readFileSync(resolve(__dirname, '../server/public/chat.html'), 'utf8');
+const certificationHtml = readFileSync(resolve(__dirname, '../server/public/certification.html'), 'utf8');
+const adminHtml = readFileSync(resolve(__dirname, '../server/public/admin-certification.html'), 'utf8');
+
+test('certification retry preserves one client turn and exposes a recovery action', () => {
+  assert.match(chatHtml, /client_request_id:\s*clientRequestId/);
+  assert.match(chatHtml, /retry:\s*retrying/);
+  assert.match(chatHtml, /Reply interrupted — your progress is safe/);
+  assert.match(chatHtml, /Continue reply/);
+  assert.match(chatHtml, /data\.recoverable_turn/);
+  assert.match(chatHtml, /if \(!retrying\) \{\s*\/\/ The retry reuses/);
+});
+
+test('certification continue opens the authoritative saved conversation', () => {
+  assert.match(certificationHtml, /\/certification\/modules\/['"]? \+ encodeURIComponent\(moduleId\) \+ ['"]\/resume/);
+  assert.match(certificationHtml, /experience\.resume_conversation_id/);
+  assert.match(chatHtml, /switchToConversation\(resumeConversationId, 'web'\)/);
+  assert.match(chatHtml, /\/resumed`/);
+  assert.match(chatHtml, /Continue module \$\{moduleId\} from my saved checkpoint/);
+});
+
+test('learner and admin surfaces expose outcome tracking', () => {
+  assert.match(certificationHtml, /My protocol contributions/);
+  assert.match(certificationHtml, /demonstrations verified/);
+  assert.match(adminHtml, /Turn completion/);
+  assert.match(adminHtml, /Credential issue time/);
+  assert.match(adminHtml, /Contributions submitted/);
+});


### PR DESCRIPTION
Improves the certification chat experience with durable retries and resume, atomic turn leases, completion-capacity protection, verified contributions, clearer credential recovery, and configurable model selection.  
Adds success instrumentation and an admin dashboard for turn recovery, resume-to-completion, evidence and credential outcomes, capacity blocks, contributions, and model-by-module performance.  
The root cause was that certification progress, streaming delivery, and terminal state were handled independently, allowing interrupted or concurrent requests to lose context or misattribute outcomes.  
Validated with expert security, learning-design, and concurrency reviews; focused tests, migration checks, TypeScript and production Docker builds, local migration 536, and real-browser learner/admin UI checks all pass (the full precommit server suite hit its 240-second host-load timeout, and its lone reported test passed independently).
