### PR TITLE
feat(reporting): extend reporting-frequency for measured channels; surface print guide in nav

### DIFF
--- a/.changeset/extend-reporting-frequency-measured-channels.md
+++ b/.changeset/extend-reporting-frequency-measured-channels.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Extend `reporting-frequency` with `weekly`, `quarterly`, and `post_campaign` to match audience-currency publication cadences in measured channels (OOH, radio, print), with guidance that a product's declared cadence gates mid-flight optimization eligibility. Surface the print channel guide in docs navigation.

--- a/docs.json
+++ b/docs.json
@@ -351,6 +351,7 @@
                       "docs/creative/channels/display",
                       "docs/creative/channels/audio",
                       "docs/creative/channels/dooh",
+                      "docs/creative/channels/print",
                       "docs/creative/channels/carousels",
                       "docs/creative/channels/social-native"
                     ]
@@ -2304,6 +2305,11 @@
     {
       "source": "/docs/creative/channels/dooh",
       "destination": "/dist/docs/3.1.2/creative/channels/dooh",
+      "permanent": false
+    },
+    {
+      "source": "/docs/creative/channels/print",
+      "destination": "/dist/docs/3.1.2/creative/channels/print",
       "permanent": false
     },
     {

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -270,7 +270,12 @@ Publishers declare supported reporting frequencies in the product's `reporting_c
 
 - **`hourly`**: Receive notifications every hour during campaign flight (optional, consider cost/complexity)
 - **`daily`**: Receive notifications once per day (most common, recommended for Phase 1)
+- **`weekly`**: Receive notifications once per week — the native cadence for audience-currency channels reporting weekly increments (OOH, radio)
 - **`monthly`**: Receive notifications once per month (timezone specified by publisher)
+- **`quarterly`**: Receive notifications once per quarter — matches quarterly measurement-currency publication cycles
+- **`post_campaign`**: A single report after the flight ends — for channels where delivery is only knowable in arrears
+
+A product's declared frequencies are an optimization-eligibility signal: buyers should not mid-flight-optimize against a channel whose data arrives quarterly or post-campaign.
 
 **Cost Consideration:** Hourly webhooks generate 24x more traffic than daily. Large buyer-seller pairs may prefer offline reporting mechanisms (see below) for cost efficiency.
 

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -27,7 +27,7 @@ Retrieve comprehensive delivery metrics and performance data for media buy repor
 | `start_date` | string | No | Report start date (YYYY-MM-DD), inclusive. Omit for campaign lifetime data. Only accepted when product supports `date_range`. |
 | `end_date` | string | No | Report end date (YYYY-MM-DD), **exclusive**. Omit for campaign lifetime data. Only accepted when product supports `date_range`. |
 | `reporting_dimensions` | object | No | Request dimensional breakdowns within `by_package`. Include a key as an empty object (e.g., `"device_type": {}`) to activate with defaults. Keys: `geo`, `device_type`, `device_platform`, `audience`, `placement`. Each accepts optional `limit` (defaults to 25 for geo, audience, placement) and `sort_by` (sort-metric enum, default: `spend`). Geo requires `geo_level` (one per request); include `system` for metro/postal levels when requesting a specific system. Unsupported dimensions are silently omitted; malformed requests return a validation error. |
-| `time_granularity` | string | No | Per-window slice granularity for pull recovery, matching `reporting_webhook.reporting_frequency` vocabulary (`hourly`, `daily`, `monthly`). When set, the response includes `windows[]` slices shape-aligned with webhook fires at the same granularity. Capability-scoped — value MUST be in the product's `reporting_capabilities.windowed_pull_granularities`. See [Windowed pull recovery](#windowed-pull-recovery). |
+| `time_granularity` | string | No | Per-window slice granularity for pull recovery, matching `reporting_webhook.reporting_frequency` vocabulary (`hourly`, `daily`, `weekly`, `monthly`, `quarterly`, `post_campaign`). When set, the response includes `windows[]` slices shape-aligned with webhook fires at the same granularity. Capability-scoped — value MUST be in the product's `reporting_capabilities.windowed_pull_granularities`. See [Windowed pull recovery](#windowed-pull-recovery). |
 | `include_window_breakdown` | boolean | No | When `true` (and `time_granularity` is set), include the `windows[]` array on each media buy. Defaults to `false`. Ignored when `time_granularity` is omitted. |
 
 > **Date Range Behavior**: The date range is **start-inclusive, end-exclusive**. For example, `start_date: "2026-01-01"` and `end_date: "2026-01-02"` returns delivery data for January 1st only (from `2026-01-01 00:00:00` up to, but not including, `2026-01-02 00:00:00`). To get a full week of data (Jan 1-7), use `end_date: "2026-01-08"`.
@@ -781,7 +781,7 @@ This is optional. Sellers that support item-level reporting populate `by_catalog
 
 ## Windowed pull recovery
 
-`reporting_webhook` fires at the buyer's chosen `reporting_frequency` (hourly, daily, monthly). When a receiver is offline long enough for transport retries to expire, the buyer loses per-window detail unless GET can reproduce the same slices. `time_granularity` + `include_window_breakdown` close that gap.
+`reporting_webhook` fires at the buyer's chosen `reporting_frequency` (hourly through post_campaign). When a receiver is offline long enough for transport retries to expire, the buyer loses per-window detail unless GET can reproduce the same slices. `time_granularity` + `include_window_breakdown` close that gap.
 
 ### Capability check
 

--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -220,7 +220,7 @@ Configure automated delivery reporting for this media buy:
 |-----------|------|----------|-------------|
 | `url` | string | Yes | Webhook endpoint URL |
 | `authentication` | object | Yes | Auth config with `schemes` and `credentials` |
-| `reporting_frequency` | string | Yes | `hourly`, `daily`, or `monthly` |
+| `reporting_frequency` | string | Yes | `hourly`, `daily`, `weekly`, `monthly`, `quarterly`, or `post_campaign` |
 | `requested_metrics` | string[] | No | Specific metrics to include (defaults to all) |
 | `token` | string | No | Client token for validation (min 16 chars) |
 

--- a/static/schemas/source/enums/reporting-frequency.json
+++ b/static/schemas/source/enums/reporting-frequency.json
@@ -2,11 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/enums/reporting-frequency.json",
   "title": "Reporting Frequency",
-  "description": "Available frequencies for delivery reports and metrics updates",
+  "description": "Available frequencies for delivery reports and metrics updates. Weekly and quarterly match audience-currency publication cycles in measured channels (e.g. weekly OOH/radio increments, quarterly circulation updates); post_campaign is a single report after the flight ends. Buyers should treat a product's declared frequencies as an optimization-eligibility signal — mid-flight optimization is not meaningful against data that arrives quarterly or post-campaign.",
   "type": "string",
   "enum": [
     "hourly",
     "daily",
-    "monthly"
+    "weekly",
+    "monthly",
+    "quarterly",
+    "post_campaign"
   ]
 }


### PR DESCRIPTION
## Summary

Two small, additive changes that measured/physical channels (OOH, radio, print) sit on, converged in review on #6138 and #6140:

- **`reporting-frequency` gains `weekly`, `quarterly`, `post_campaign`.** These are the publication cadences of audience-currency channels: weekly OOH/radio increments (Geopath, RAJAR), quarterly measurement-cycle updates (Geopath DEC), and flights only reconcilable in arrears. The enum description and `optimization-reporting` docs now state the eligibility principle from the #6138 thread: a product's declared cadence gates mid-flight optimization — nothing should optimize against data that arrives quarterly.
- **`docs/creative/channels/print` is added to navigation** (plus the matching snapshot redirect). The page has shipped since the collection/installment work (#1642) but has never been reachable from `docs.json` nav.

Doc value lists (`update_media_buy`, `get_media_buy_delivery`, `optimization-reporting`) updated to match the enum. Changeset included (minor).

## Notes

- Purely additive; no existing value or behavior changes.
- The MUST-level normative sentence proposed on #6138 (cadence as optimization-eligibility gate) is expressed here as guidance prose; promoting it to a normative statement can ride the WG review of the static-OOH channel work (#6140, spec draft in #6146).

Refs #6138, #6140

🤖 Generated with [Claude Code](https://claude.com/claude-code)