### PR TITLE
fix(compliance): build creative assets from seller formats

### DIFF
--- a/.changeset/fix-dynamic-creative-assets.md
+++ b/.changeset/fix-dynamic-creative-assets.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix the creative-fate compliance storyboard to build creative assets from the required slots declared by the seller's selected product format. Clarify that runners must resolve context substitutions recursively before sending requests.

--- a/docs/creative/task-reference/sync_creatives.mdx
+++ b/docs/creative/task-reference/sync_creatives.mdx
@@ -156,11 +156,13 @@ Implementations that acknowledge a creative on the synchronous success branch bu
 | `format_kind`       | CanonicalFormatKind | Yes for 3.2 authoring | Portable canonical format path. Pair with `format_option_ref` when exact routing is required. |
 | `format_id`         | FormatId            | Deprecated | Named-format compatibility path for older 3.x peers; mutually exclusive with `format_kind`. |
 | `format_option_ref` | FormatOptionRef     | No          | Optional structured reference to a product or publisher format option. Required when the target product has multiple options with the same `format_kind`. |
-| `assets`            | object              | Yes         | Assets keyed by role (e.g., `{video: {...}, thumbnail: {...}}`). Catalogs are included as assets with `asset_type: "catalog"`. See [Catalogs](/docs/creative/catalogs). |
+| `assets`            | object              | Yes         | Assets keyed by the selected format's slot name (`asset_group_id` for canonical formats). Catalogs are included as assets with `asset_type: "catalog"`. See [Catalogs](/docs/creative/catalogs). |
 | `localization`      | object \| null       | No          | Sync-only explicit source and target locale variants. Requires `get_adcp_capabilities.creative.localization`. An object replaces the complete locale set; null removes it. Omission preserves existing localization only when source assets are exactly unchanged. |
 | `tags`              | string[]            | No          | Searchable tags for creative organization                          |
 
 New 3.2 integrations use `format_kind` with `format_option_ref` when routing depends on a product's declared option. A compatibility implementation may accept the legacy branch from an older peer, but never mixes both shapes.
+
+Before uploading, buyers MUST verify each creative manifest against the target product's canonical `format_options[]`. The manifest MUST include every asset slot that the selected format option declares as required, keyed by that slot's `asset_group_id`.
 
 ### Native localization
 
@@ -926,7 +928,7 @@ Poll `tasks/get` or wait for the webhook. The completion artifact carries the `c
 
 ## Best practices
 
-1. **Use upsert semantics** - Same `creative_id` updates existing creative rather than creating duplicates. This allows iterative creative development. Note: updates are blocked for creatives in active delivery (see #7).
+1. **Use upsert semantics** - Same `creative_id` updates existing creative rather than creating duplicates. This allows iterative creative development. Note: updates are blocked for creatives in active delivery (see #6).
 
 2. **Rehearse seller acceptance first** - Use `dry_run: true` when you need to catch upload, upsert, assignment, account, policy, or format errors before mutating the seller's creative library. Use `validate_input` earlier in the workflow only for manifest-structure preflight or multi-target product comparison.
 
@@ -936,9 +938,7 @@ Poll `tasks/get` or wait for the webhook. The completion artifact carries the `c
 
 5. **Brand identity** - For generative creatives, validate brand identity schema before syncing to avoid processing failures.
 
-6. **Check format support** - Verify the manifest against the product's canonical `format_options[]` before uploading.
-
-7. **Active delivery protection** - Creatives assigned to active, non-paused packages cannot be updated or deleted via `delete_missing`. Pause the package first, unassign the creative via `update_media_buy`, or create a new creative with a different `creative_id`.
+6. **Active delivery protection** - Creatives assigned to active, non-paused packages cannot be updated or deleted via `delete_missing`. Pause the package first, unassign the creative via `update_media_buy`, or create a new creative with a different `creative_id`.
 
 ## Related tasks
 

--- a/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
@@ -91,6 +91,8 @@ phases:
             key: "format_kind"
           - path: "products[0].format_options[0].format_option_id"
             key: "format_option_id"
+          - path: "products[0].format_options[0].params"
+            key: "format_params"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -172,12 +174,7 @@ phases:
                 scope: "product"
                 format_option_id: "$context.format_option_id"
               assets:
-                image:
-                  asset_type: "image"
-                  url: "https://cdn.pinnacle-agency.example/acme-reuse-banner.png"
-                  width: 300
-                  height: 250
-                  mime_type: "image/png"
+                $build_assets_from_format: "$context.format_params"
           assignments:
             - creative_id: "acme_reuse_banner_001"
               package_id: "$context.package_id"
@@ -373,9 +370,10 @@ phases:
       - id: reassign_creative
         title: "Assign the original creative_id to the new package"
         narrative: |
-          Reference the original creative by creative_id only (no assets, no re-upload)
-          and assign it to the new package. The seller resolves the creative_id from
-          the library; if the creative was evaporated on cancel, this call fails.
+          Reference the original creative by creative_id and resubmit the source assets
+          required by the selected product format, then assign it to the new package.
+          The seller resolves the creative_id from the library; if the creative was
+          evaporated on cancel, this call fails.
         task: sync_creatives
         schema_ref: "creative/sync-creatives-request.json"
         response_schema_ref: "creative/sync-creatives-response.json"
@@ -400,13 +398,12 @@ phases:
             # leaving `creatives: undefined` which fails pre-flight zod.
             - creative_id: "acme_reuse_banner_001"
               name: "Reassigned creative"
-              format_kind: "image"
+              format_kind: "$context.format_kind"
+              format_option_ref:
+                scope: "product"
+                format_option_id: "$context.format_option_id"
               assets:
-                image:
-                  asset_type: "image"
-                  url: "https://test-assets.adcontextprotocol.org/acme-outdoor/banner_300x250.jpg"
-                  width: 300
-                  height: 250
+                $build_assets_from_format: "$context.format_params"
           assignments:
             - creative_id: "acme_reuse_banner_001"
               package_id: "$context.second_package_id"

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -639,6 +639,20 @@
 #   case where the SDK's per-task request builder discards a body field
 #   from `sample_request`, use `context_inputs:` (above) as the
 #   post-builder injection path.
+#
+#   Creative asset expansion: an `assets` object MAY contain the reserved
+#   `$build_assets_from_format` key with a `$context.<name>` value. The context
+#   value MUST be either canonical `FormatOption.params` captured from
+#   `get_products` or a legacy `FormatId` resolved against formats captured from
+#   `list_creative_formats`. Before request-schema validation or transport, the
+#   runner MUST replace the entire directive-bearing `assets` object with an
+#   asset map keyed by each required slot's canonical `asset_group_id` or legacy
+#   `asset_id`. Values come from the storyboard's test kit and MUST satisfy the
+#   slot contract. Image slots use an `assets.images[]` fixture satisfying the
+#   declared dimensions; URL slots use `assets.click_url`. If any required slot
+#   cannot be populated, the runner
+#   MUST fail the step before transport with `unresolved_substitution` rather
+#   than sending the directive or an incomplete manifest.
 # sample_response: object (optional — example expected response; also surfaces in published docs)
 #
 # auth: "none" | object (optional — overrides the transport's default credentials for this step)
@@ -2296,11 +2310,10 @@
 # --- Unresolved substitution behavior ---
 #
 # When a storyboard references a substitution variable the runner cannot
-# resolve — most commonly {{runner.webhook_base}} or {{runner.webhook_url:<id>}}
-# on a run with no webhook receiver configured — the runner MUST NOT ship the
-# literal `{{...}}` token to the agent under test. Shipping unresolved
-# substitutions is a conformance bug on the runner side, not a grading signal
-# about the agent.
+# resolve — whether a `$context.*` token or a `{{...}}` token, including tokens
+# nested in object properties or array elements — the runner MUST NOT ship the
+# literal token to the agent under test. Shipping unresolved substitutions is a
+# conformance bug on the runner side, not a grading signal about the agent.
 #
 # Runners MUST resolve substitutions at one of two preflight points:
 #   1. Before the storyboard run starts — if any step references an unresolvable
@@ -2311,4 +2324,4 @@
 #      (e.g., {{prior_step.<id>.task_id}}) fails to resolve, grade the
 #      step as failed with `unresolved_substitution`.
 #
-# Neither path may ship a literal `{{...}}` token on the wire.
+# Neither path may ship a literal `$context.*` or `{{...}}` token on the wire.


### PR DESCRIPTION
## Summary
- build creative manifests from the required slots declared by the selected seller format
- resubmit valid source assets when testing creative fate after cancellation
- require recursive pre-wire resolution for nested `$context.*` substitutions
- document required canonical creative asset keys

Closes #6237.
Closes #6238.

## Validation
- compliance build and targeted storyboard lints
- full pre-commit protocol/server suites (1,037 protocol tests; 5,281 server tests)
- current compliance storyboard matrix across all six tenants
- released 3.0.22 compatibility storyboard matrix across all six tenants
- docs navigation validation