### PR TITLE
fix(ci): skip Husky for changesets commit

### DIFF
--- a/.changeset/stabilize-changesets-release-commit.md
+++ b/.changeset/stabilize-changesets-release-commit.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Prevent automated release pull request commits from rerunning local pre-commit hooks after release workflow validation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,7 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          HUSKY: '0'
 
       - name: Sign local protocol tarball if needed
         if: steps.changesets.outputs.published == 'true' || steps.release-artifacts.outputs.has_release_artifacts == 'true'

--- a/tests/release-workflow-immutability.test.cjs
+++ b/tests/release-workflow-immutability.test.cjs
@@ -24,6 +24,7 @@ function extractStep(name) {
 
 const releaseRelevance = extractStep('Detect release-relevant push');
 const artifactDetection = extractStep('Detect committed release artifacts');
+const changesetsStep = extractStep('Create Release Pull Request or Tag Release');
 const uploadStep = extractStep('Upload protocol tarball to GitHub Release');
 
 assert(
@@ -39,6 +40,11 @@ assert(
 assert(
   artifactDetection.includes('grep -Eq "^dist/(schemas|compliance)/${VERSION}/|^dist/protocol/${VERSION}[.]" <<< "${changed_files}"'),
   'Release artifact detection must be based on artifact paths changed by the triggering commit.'
+);
+
+assert(
+  changesetsStep.includes("HUSKY: '0'"),
+  'Changesets automation must not rerun local pre-commit hooks while creating its release commit.'
 );
 
 assert(


### PR DESCRIPTION
## Summary
- prevent `changesets/action` release commits from invoking Husky local pre-commit hooks
- preserve all workflow validations, PR checks, publication verification, and artifact signing
- add a release-workflow invariant test and patch changeset

## Why
The post-merge Release run for #6127 failed twice at the changesets commit. The commit inherited Husky, reran the full pre-commit suite, and the redundant server-unit phase was killed by its 240-second timeout even though the normal Build Check had already passed that suite.

Failed run: https://github.com/adcontextprotocol/adcp/actions/runs/31102432337

## Validation
- `npm run test:release-workflow`
- full local pre-commit hook: 1,037 unit tests, dynamic-import lint, call-shape lint, and TypeScript checking
- changeset protocol-scope and pre-push checks
- code/CI expert review: no findings
- security expert review: no findings