### PR TITLE
feat(compliance): add capabilities_response_schema_invalid notice + capability_pointer field

### DIFF
--- a/.changeset/capabilities-response-schema-invalid-notice.md
+++ b/.changeset/capabilities-response-schema-invalid-notice.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add the `capabilities_response_schema_invalid` canonical notice code and a `capability_pointer` (RFC 6901) optional notice field to the runner output contract, so a schema-invalid `get_adcp_capabilities` response is reported once as a root cause ahead of the track results instead of fanning out into unrelated-looking track failures.

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -26,7 +26,7 @@
 # --- Schema definition ---
 
 id: runner_output_contract
-version: "2.8.0"
+version: "2.9.0"
 title: "Runner output contract"
 summary: "Required failure-detail shape that AdCP storyboard runners MUST emit so implementors can self-diagnose validation failures."
 
@@ -1102,6 +1102,23 @@ notice:
                               # Lets consumers link the notice to the
                               # exact capability flag without parsing the
                               # message string.
+    - capability_pointer      # RFC 6901 JSON Pointer to the location in the
+                              # agent's `get_adcp_capabilities` response that
+                              # motivated the notice
+                              # (e.g., "/account/supported_billing",
+                              # "/specialisms/0"). Use this when the notice
+                              # originates from schema validation, whose
+                              # errors are already RFC 6901, or when the
+                              # location is an array element that has no
+                              # unambiguous dotted form. Same pointer
+                              # convention as `validation_result.json_pointer`
+                              # above.
+                              #
+                              # Distinct from `capability_path`, which names
+                              # the capability flag: an emitter MAY set both,
+                              # and when it does `capability_pointer` MUST
+                              # resolve to the node named by `capability_path`
+                              # or to a position within it.
     - reference_url           # optional spec or issue URL with more context
                               # (e.g., the upstream issue tracking the
                               # deprecation, or the relevant section in
@@ -1150,6 +1167,33 @@ notice:
         field was material to the scenario's intent. Agents should
         declare all spec-defined fields they support in their
         inputSchema.
+    capabilities_response_schema_invalid:
+      severity: info
+      spec_source: protocol/get-adcp-capabilities-response.json
+      message_template: |
+        The agent's `get_adcp_capabilities` response failed schema
+        validation at {capability_pointer}. Track results are computed
+        against a capabilities response the runner could not trust, so
+        failures in dependent steps may share this single root cause.
+        Fix this first, then re-read the track results.
+      notes: |
+        Emitted on `run_summary.notices` when the runner validates the
+        agent's capabilities response and validation fails. One notice per
+        failing validation error, each carrying its own
+        `capability_pointer`, so a response with three violations produces
+        three notices rather than one aggregate. Because these share a
+        `code`, consumers dedupe them by (`code`, `capability_pointer`)
+        per the run_summary.notices rule below.
+
+        The runner MUST still execute and report the storyboards it would
+        otherwise have run. This notice explains the results, it does not
+        replace them, and suppressing downstream failures would hide
+        genuine defects behind a preflight line.
+
+        This code covers schema-invalid capabilities responses only. A
+        capabilities response that is schema-valid but stale, cached, or
+        otherwise unrepresentative is a different condition and MUST NOT
+        reuse this code (see adcontextprotocol/adcp#6206).
 
 cascade_rules:
   description: |
@@ -1370,9 +1414,13 @@ run_summary:
                                   # emit the same code on step_result.notices
                                   # AND run_summary.notices when an advisory
                                   # is both step-specific and run-wide;
-                                  # consumers dedupe by `code`. See the
-                                  # notice block above for shape and
-                                  # canonical_codes.
+                                  # consumers dedupe by `code`, or by
+                                  # (`code`, `capability_pointer`) when
+                                  # `capability_pointer` is present, since a
+                                  # code that reports one location per
+                                  # occurrence emits several notices sharing
+                                  # that code. See the notice block above for
+                                  # shape and canonical_codes.
     - validations_advisory_failed # count of validation_result entries with
                                   # passed: false and severity: advisory.
                                   # These do NOT contribute to steps_failed


### PR DESCRIPTION
Part A of #6254. Adds the canonical notice code so a runner can name the root cause once, ahead of the track results, when a schema-invalid `get_adcp_capabilities` response would otherwise fan out into N unrelated-looking track failures.

Two documented repros, both costing hours of triage: #6242 (`account` block missing `supported_billing`, `sandbox` typed as an object — 10 steps failed across three tracks) and #6206 (one uncached `context.correlation_id` presented as five unrelated problems).

### What's here

**`capabilities_response_schema_invalid`** in `canonical_codes`. `severity: info`, following `input_schema_field_stripped` — the closest peer, also `info`, also carrying no `capability_path`. The `notes` block keeps the Part B constraint explicit: the runner MUST still execute and report every storyboard it would otherwise have run. The notice explains the results, it does not replace them, and suppressing downstream failures would hide genuine defects behind a preflight line.

One notice per failing validation error, each with its own pointer, rather than one aggregate. The "affects N storyboards" count is omitted per the triage, since it needs a dry-run pass.

Per your instruction, the notes also scope the code away from #6206: a capabilities response that is schema-valid but stale or cached is a different condition and must not reuse this code.

**`capability_pointer`** (RFC 6901) as a new entry in `optional_fields`, per Option 2.

### On the open question

The doc comment says a notice **MAY carry both**, because they answer different questions rather than being two spellings of one. `capability_path` names the capability flag that motivated the notice; `capability_pointer` locates a position in the response document. This new code often has no meaningful flag at all — a wrong type inside a block, or an array element — while the existing codes carry a flag with no validation pointer. "Exactly one" would force a false choice on leaf fields where both are genuinely available.

It also states that a consumer MUST NOT reject a notice for carrying only one, and that when both are present they MUST refer to the same location.

### Scope

Documentation-only change to the conformance harness contract; no schema, no storyboard, no runner code. No changeset, per the triage. Part B (pre-execution validation in the `@adcp/sdk` runner that emits this notice) is a separate change in `adcp-client`.

Checked before filing: `runner-output-contract.yaml` is excluded from `lint-universal-storyboard-doc-parity` as a fixture, `server/tests/unit/compliance-notices.test.ts` asserts specific existing codes rather than enumerating them, and the file parses.
