### PR TITLE
fix(compliance): backport dynamic creative assets to 3.1.x

### DIFF
--- a/.changeset/fix-dynamic-creative-assets.md
+++ b/.changeset/fix-dynamic-creative-assets.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix the creative-fate compliance storyboard to build creative assets from the required slots declared by the seller's selected product format. Clarify that runners must resolve context substitutions recursively before sending requests.

--- a/docs/creative/task-reference/sync_creatives.mdx
+++ b/docs/creative/task-reference/sync_creatives.mdx
@@ -162,10 +162,12 @@ Implementations that acknowledge a creative on the synchronous success branch bu
 | `format_id`         | FormatId            | Conditional | Legacy named-format path. Structured object with `agent_url` and `id`. Required when `format_kind` is omitted; mutually exclusive with `format_kind`. |
 | `format_kind`       | CanonicalFormatKind | Conditional | 3.1+ canonical-format path. Required when `format_id` is omitted; mutually exclusive with `format_id`. |
 | `format_option_ref` | FormatOptionRef     | No          | Optional structured reference to a product or publisher format option. Required when the target product has multiple options with the same `format_kind`. |
-| `assets`            | object              | Yes         | Assets keyed by role (e.g., `{video: {...}, thumbnail: {...}}`). Catalogs are included as assets with `asset_type: "catalog"`. See [Catalogs](/docs/creative/catalogs). |
+| `assets`            | object              | Yes         | Assets keyed by the selected format's slot name (`asset_id` for legacy named formats; `asset_group_id` for canonical formats). Catalogs are included as assets with `asset_type: "catalog"`. See [Catalogs](/docs/creative/catalogs). |
 | `tags`              | string[]            | No          | Searchable tags for creative organization                          |
 
 Provide either the legacy `format_id` or the canonical `format_kind` path, never both. New 3.1+ integrations should prefer `format_kind` with `format_option_ref` when routing depends on a product's declared format option.
+
+Before uploading, buyers MUST verify each creative manifest against the selected seller-declared format. For a legacy `format_id`, resolve the definition with `list_creative_formats`; the manifest MUST include every required asset keyed by its exact `asset_id`. For a canonical `format_kind`, validate against the target product's `format_options[]` and key required slots by `asset_group_id`.
 
 ### Promoting a build_creative variant
 
@@ -833,7 +835,7 @@ Poll `tasks/get` or wait for the webhook. The completion artifact carries the `c
 
 ## Best practices
 
-1. **Use upsert semantics** - Same `creative_id` updates existing creative rather than creating duplicates. This allows iterative creative development. Note: updates are blocked for creatives in active delivery (see #7).
+1. **Use upsert semantics** - Same `creative_id` updates existing creative rather than creating duplicates. This allows iterative creative development. Note: updates are blocked for creatives in active delivery (see #6).
 
 2. **Rehearse seller acceptance first** - Use `dry_run: true` when you need to catch upload, upsert, assignment, account, policy, or format errors before mutating the seller's creative library. Use `validate_input` earlier in the workflow only for manifest-structure preflight or multi-target product comparison.
 
@@ -843,9 +845,7 @@ Poll `tasks/get` or wait for the webhook. The completion artifact carries the `c
 
 5. **Brand identity** - For generative creatives, validate brand identity schema before syncing to avoid processing failures.
 
-6. **Check format support** - Use `list_creative_formats` to verify product supports your creative formats before uploading.
-
-7. **Active delivery protection** - Creatives assigned to active, non-paused packages cannot be updated or deleted via `delete_missing`. Pause the package first, unassign the creative via `update_media_buy`, or create a new creative with a different `creative_id`.
+6. **Active delivery protection** - Creatives assigned to active, non-paused packages cannot be updated or deleted via `delete_missing`. Pause the package first, unassign the creative via `update_media_buy`, or create a new creative with a different `creative_id`.
 
 ## Related tasks
 

--- a/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
@@ -6,6 +6,7 @@ summary: "Validates that canceling a media buy releases package-creative assignm
 track: media_buy
 required_tools:
   - get_products
+  - list_creative_formats
   - create_media_buy
   - update_media_buy
   - sync_creatives
@@ -87,10 +88,8 @@ phases:
             key: "product_id"
           - path: "products[0].pricing_options[0].pricing_option_id"
             key: "pricing_option_id"
-          - path: "products[0].format_ids[0].agent_url"
-            key: "format_agent_url"
-          - path: "products[0].format_ids[0].id"
-            key: "format_id"
+          - path: "products[0].format_ids[0]"
+            key: "format_ref"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -100,6 +99,41 @@ phases:
           - check: field_present
             path: "products[0].pricing_options[0].fixed_price"
             description: "The captured pricing option is fixed-price; fixed-price storyboards do not send bid_price"
+
+      - id: list_selected_format
+        title: "Resolve the selected product format"
+        task: list_creative_formats
+        schema_ref: "creative/list-creative-formats-request.json"
+        response_schema_ref: "creative/list-creative-formats-response.json"
+        doc_ref: "/creative/task-reference/list_creative_formats"
+        comply_scenario: creative_lifecycle
+        stateful: false
+        expected: |
+          Return the format definition referenced by the selected product, including
+          every required asset slot the buyer must provide to sync_creatives.
+        sample_request:
+          format_ids:
+            - "$context.format_ref"
+          context:
+            correlation_id: "creative_fate--list_selected_format"
+        # Older SDK request builders discard list_creative_formats filters. Inject
+        # after request construction so the selected FormatId reaches the seller.
+        context_inputs:
+          - key: format_ref
+            inject_at: "format_ids[0]"
+        context_outputs:
+          - path: "formats"
+            key: "formats"
+        validations:
+          - check: response_schema
+            description: "Response matches list-creative-formats-response.json schema"
+          - check: field_present
+            path: "formats[0]"
+            description: "The product's selected format resolves to a seller-declared format"
+          - check: field_value
+            path: "formats[0].format_id"
+            value: "$context.format_ref"
+            description: "The returned format matches the product's selected format_id"
 
       - id: create_buy
         title: "Create the initial media buy"
@@ -167,16 +201,9 @@ phases:
           creatives:
             - creative_id: "acme_reuse_banner_001"
               name: "Acme Outdoor reuse banner"
-              format_id:
-                agent_url: "$context.format_agent_url"
-                id: "$context.format_id"
+              format_id: "$context.format_ref"
               assets:
-                image:
-                  asset_type: "image"
-                  url: "https://cdn.pinnacle-agency.example/acme-reuse-banner.png"
-                  width: 300
-                  height: 250
-                  mime_type: "image/png"
+                $build_assets_from_format: "$context.format_ref"
           assignments:
             - creative_id: "acme_reuse_banner_001"
               package_id: "$context.package_id"
@@ -372,9 +399,10 @@ phases:
       - id: reassign_creative
         title: "Assign the original creative_id to the new package"
         narrative: |
-          Reference the original creative by creative_id only (no assets, no re-upload)
-          and assign it to the new package. The seller resolves the creative_id from
-          the library; if the creative was evaporated on cancel, this call fails.
+          Reference the original creative by creative_id and resubmit the source assets
+          required by the selected product format, then assign it to the new package.
+          The seller resolves the creative_id from the library; if the creative was
+          evaporated on cancel, this call fails.
         task: sync_creatives
         schema_ref: "creative/sync-creatives-request.json"
         response_schema_ref: "creative/sync-creatives-response.json"
@@ -399,15 +427,9 @@ phases:
             # leaving `creatives: undefined` which fails pre-flight zod.
             - creative_id: "acme_reuse_banner_001"
               name: "Reassigned creative"
-              format_id:
-                agent_url: "https://your-platform.example.com"
-                id: "display_300x250"
+              format_id: "$context.format_ref"
               assets:
-                image:
-                  asset_type: "image"
-                  url: "https://test-assets.adcontextprotocol.org/acme-outdoor/banner_300x250.jpg"
-                  width: 300
-                  height: 250
+                $build_assets_from_format: "$context.format_ref"
           assignments:
             - creative_id: "acme_reuse_banner_001"
               package_id: "$context.second_package_id"

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -639,6 +639,20 @@
 #   case where the SDK's per-task request builder discards a body field
 #   from `sample_request`, use `context_inputs:` (above) as the
 #   post-builder injection path.
+#
+#   Creative asset expansion: an `assets` object MAY contain the reserved
+#   `$build_assets_from_format` key with a `$context.<name>` value. The context
+#   value MUST be either canonical `FormatOption.params` captured from
+#   `get_products` or a legacy `FormatId` resolved against formats captured from
+#   `list_creative_formats`. Before request-schema validation or transport, the
+#   runner MUST replace the entire directive-bearing `assets` object with an
+#   asset map keyed by each required slot's canonical `asset_group_id` or legacy
+#   `asset_id`. Values come from the storyboard's test kit and MUST satisfy the
+#   slot contract. Image slots use an `assets.images[]` fixture satisfying the
+#   declared dimensions; URL slots use `assets.click_url`. If any required slot
+#   cannot be populated, the runner MUST fail the step before transport with
+#   `unresolved_substitution` rather than sending the directive or an incomplete
+#   manifest.
 # sample_response: object (optional — example expected response; also surfaces in published docs)
 #
 # auth: "none" | object (optional — overrides the transport's default credentials for this step)
@@ -2296,11 +2310,10 @@
 # --- Unresolved substitution behavior ---
 #
 # When a storyboard references a substitution variable the runner cannot
-# resolve — most commonly {{runner.webhook_base}} or {{runner.webhook_url:<id>}}
-# on a run with no webhook receiver configured — the runner MUST NOT ship the
-# literal `{{...}}` token to the agent under test. Shipping unresolved
-# substitutions is a conformance bug on the runner side, not a grading signal
-# about the agent.
+# resolve — whether a `$context.*` token or a `{{...}}` token, including tokens
+# nested in object properties or array elements — the runner MUST NOT ship the
+# literal token to the agent under test. Shipping unresolved substitutions is a
+# conformance bug on the runner side, not a grading signal about the agent.
 #
 # Runners MUST resolve substitutions at one of two preflight points:
 #   1. Before the storyboard run starts — if any step references an unresolvable
@@ -2311,4 +2324,4 @@
 #      (e.g., {{prior_step.<id>.task_id}}) fails to resolve, grade the
 #      step as failed with `unresolved_substitution`.
 #
-# Neither path may ship a literal `{{...}}` token on the wire.
+# Neither path may ship a literal `$context.*` or `{{...}}` token on the wire.


### PR DESCRIPTION
## Summary
- resolve the selected product FormatId through list_creative_formats
- build both sync_creatives payloads from every seller-required legacy asset_id slot
- document fail-closed recursive runner substitution semantics

## Validation
- all 206 storyboard lint tests pass
- compliance bundle build passes
- all six storyboard tenant matrices pass their gates
- changeset scope check passes

Backport of #6244. Fixes #6237 and #6238 for the 3.1.x release line.