### PR TITLE
fix(certification): revalidate membership before paid completion

### DIFF
--- a/docs/learning/policies/recertification.mdx
+++ b/docs/learning/policies/recertification.mdx
@@ -39,6 +39,19 @@ Delta assessment is available only when a written rationale maps the new criteri
 5. Learners receive a notification explaining the change, required delta work, deadline, and escalation path.
 6. Delta completion is recorded in the learner record and retained under the [learner records policy](/docs/learning/policies/learner-records).
 
+## Access-entitlement review
+
+If a credential may have been earned without the required AgenticAdvertising.org membership, treat the record as an audit candidate rather than automatically revoking it. Program leadership must establish the learner's effective membership at the module-completion and credential-award timestamps using subscription history, inherited-membership evidence, and certification audit records.
+
+Until that review is complete, the credential remains valid and no learner-facing allegation is made. The review outcome must be one of:
+
+- **Valid:** evidence shows the required membership was active at the relevant timestamps;
+- **Grandfathered:** entitlement cannot be proven, but program leadership decides to preserve the credential and records the rationale;
+- **Annotated:** the competency evidence remains valid but the credential record needs a non-punitive administrative note;
+- **Revoked:** evidence establishes that required access was absent and program leadership approves revocation under the complaints and appeals process.
+
+Every annotation or revocation requires a human decision, an immutable audit entry, notice to the learner, and an appeal path. Automated audits may identify candidates, but must not change credential state.
+
 ## Effective dates and targeting
 
 For any protocol-change update, the curriculum change record must define these dates before engineering targets learners:

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.1';
+export const CODE_VERSION = '2026.08.2';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/jobs/certification-recovery.ts
+++ b/server/src/addie/jobs/certification-recovery.ts
@@ -107,6 +107,34 @@ export async function runCertificationRecoveryJob(
         throw new Error('Passed attempt has no numeric scores to reconcile');
       }
 
+      // Recovery is still a paid completion mutation. Do not reconcile a
+      // historical passed attempt automatically after entitlement has ended;
+      // those cases require the human-reviewed historical audit path.
+      const module = await certDb.getModule(moduleId);
+      if (!module) {
+        throw new Error(`Certification module ${moduleId} was not found`);
+      }
+      if (!module.is_free && !(await certDb.hasEffectiveMembershipForUser(attempt.workos_user_id))) {
+        const escalation = await createEscalation({
+          workos_user_id: attempt.workos_user_id,
+          user_display_name: candidate.name,
+          user_email: candidate.email,
+          category: 'needs_human_action',
+          priority: 'high',
+          summary: `Historical entitlement review required for certification attempt ${candidate.id}`,
+          addie_context: [
+            `Certification recovery found passed module ${moduleId}, but the learner does not currently have active membership.`,
+            `Do not reconcile or revoke automatically; establish entitlement at the attempt timestamp under the certification access-entitlement review policy.`,
+          ].join(' '),
+          dedup_key: `certification-recovery-entitlement:${candidate.id}`,
+        });
+        result.escalated += 1;
+        const notified = await notifyEscalation(escalation, candidate.id, moduleId);
+        if (notified === true) result.notified += 1;
+        if (notified === 'no_channel') result.skipped_no_channel += 1;
+        continue;
+      }
+
       await certDb.reconcilePassedAttemptModule(attempt, moduleId, scores);
       const awarded = await certDb.checkAndAwardCredentials(attempt.workos_user_id);
       if (awarded.length > 0) {

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -609,8 +609,15 @@ function formatUtcDate(value: string | null): string {
 async function checkAndFormatCredentials(
   userId: string,
   memberContext: MemberContext | null,
+  allowPaidCredentials: boolean,
 ): Promise<string[]> {
-  const awarded = await certDb.checkAndAwardCredentials(userId);
+  const awarded = await certDb.checkAndAwardCredentials(
+    userId,
+    { maxTier: allowPaidCredentials ? Number.POSITIVE_INFINITY : 1 },
+  );
+
+  const creds = await certDb.getCredentials();
+  const credMap = new Map(creds.map(c => [c.id, c]));
 
   // Pick up the "awarded earlier, never issued to Certifier" backlog so a
   // post-set_my_name retry actually finalizes the certificate. Bounded to a
@@ -625,6 +632,7 @@ async function checkAndFormatCredentials(
     .filter(c =>
       !c.certifier_credential_id &&
       !awarded.includes(c.credential_id) &&
+      (allowPaidCredentials || (credMap.get(c.credential_id)?.tier ?? Number.POSITIVE_INFINITY) <= 1) &&
       (now - new Date(c.awarded_at).getTime()) < RETRY_WINDOW_MS,
     )
     .map(c => c.credential_id);
@@ -632,8 +640,6 @@ async function checkAndFormatCredentials(
   const toProcess = [...new Set([...awarded, ...deferred])];
   if (toProcess.length === 0) return [];
 
-  const creds = await certDb.getCredentials();
-  const credMap = new Map(creds.map(c => [c.id, c]));
   const lines: string[] = [''];
   let nameRequired = false;
   for (const credId of toProcess) {
@@ -1973,6 +1979,14 @@ export function createCertificationToolHandlers(
       const unavailable = unavailableSpecialistMessage(moduleId);
       if (unavailable) return notCompleted(moduleId, 'state', unavailable);
 
+      const mod = await certDb.getModule(moduleId);
+      if (!mod) return notCompleted(moduleId, 'state', `Module ${moduleId} was not found.`);
+
+      const hasMembership = await ensureMembership();
+      if (!mod.is_free && !hasMembership) {
+        return notCompleted(moduleId, 'state', membershipRequiredMessage(moduleId, memberContext));
+      }
+
       // Verify module is in-progress before allowing completion
       const progress = await certDb.getProgress(userId);
       const moduleProgress = progress.find(p => p.module_id === moduleId);
@@ -1983,7 +1997,7 @@ export function createCertificationToolHandlers(
           'Congratulate them warmly — they earned this. Do NOT share any scores or percentages with the learner.',
         ];
         try {
-          lines.push(...await checkAndFormatCredentials(userId, memberContext));
+          lines.push(...await checkAndFormatCredentials(userId, memberContext, hasMembership));
         } catch (credError) {
           logger.error({ error: credError }, 'Failed to check credential eligibility');
         }
@@ -1995,7 +2009,6 @@ export function createCertificationToolHandlers(
       const scores = input.scores as Record<string, number>;
       if (!scores || typeof scores !== 'object') return 'Scores are required to complete a module.';
 
-      const mod = await certDb.getModule(moduleId);
       const ac = mod?.assessment_criteria as certDb.AssessmentCriteria | undefined;
 
       // Validate scores against assessment criteria (range, dimensions, floor, threshold)
@@ -2061,7 +2074,7 @@ export function createCertificationToolHandlers(
 
       // Auto-check and award credentials
       try {
-        lines.push(...await checkAndFormatCredentials(userId, memberContext));
+        lines.push(...await checkAndFormatCredentials(userId, memberContext, hasMembership));
       } catch (credError) {
         logger.error({ error: credError }, 'Failed to check credential eligibility');
       }
@@ -2091,7 +2104,8 @@ export function createCertificationToolHandlers(
       const retrySeconds = Math.max(1, Math.ceil((rate.retryAfterMs ?? 60000) / 1000));
       return `Rate limit exceeded on check_credentials. Try again in ~${retrySeconds} seconds.`;
     }
-    const lines = await checkAndFormatCredentials(userId, memberContext);
+    const hasMembership = await ensureMembership();
+    const lines = await checkAndFormatCredentials(userId, memberContext, hasMembership);
     if (lines.length === 0) {
       return 'No new credentials to issue. Your existing credentials are unchanged.';
     }
@@ -2248,7 +2262,8 @@ export function createCertificationToolHandlers(
         const mod = moduleMap.get(id);
         return mod && !mod.is_free;
       });
-      if (paidModules.length > 0 && !(await ensureMembership())) {
+      const hasMembership = await ensureMembership();
+      if (paidModules.length > 0 && !hasMembership) {
         return membershipRequiredMessage(paidModules[0], memberContext);
       }
 
@@ -2281,7 +2296,7 @@ export function createCertificationToolHandlers(
 
       // Check for newly earned credentials
       try {
-        lines.push(...await checkAndFormatCredentials(userId, memberContext));
+        lines.push(...await checkAndFormatCredentials(userId, memberContext, hasMembership));
       } catch (credError) {
         logger.error({ error: credError }, 'Failed to check credential eligibility after test-out');
       }
@@ -2590,6 +2605,10 @@ export function createCertificationToolHandlers(
             return 'This exam attempt is already completed, but I could not find the capstone module needed to reconcile credential issuance. Ask an admin to run the certification repair from the admin dashboard.';
           }
 
+          if (!(await ensureMembership())) {
+            return notCompleted(capstoneMod.id, 'state', membershipRequiredMessage(capstoneMod.id, memberContext));
+          }
+
           const completedScores = asNumberRecord(attempt.scores);
           if (!completedScores) {
             return notCompleted(capstoneMod.id, 'state', `This capstone attempt is already passed, but its recorded scores are missing. Ask an admin to use Certification > Attempts needing attention for attempt ${attempt.id}.`);
@@ -2607,7 +2626,7 @@ export function createCertificationToolHandlers(
           lines.push('The capstone was already recorded, so I rechecked module completion and credential issuance.');
 
           try {
-            lines.push(...await checkAndFormatCredentials(userId, memberContext));
+            lines.push(...await checkAndFormatCredentials(userId, memberContext, true));
           } catch (credError) {
             logger.error({ error: credError, userId, attemptId: attempt.id }, 'Failed to reconcile credentials for already-passed capstone');
             return notCompleted(capstoneMod.id, 'state', `This capstone attempt is already passed, but credential issuance failed during reconciliation. Ask an admin to use Certification > Attempts needing attention for attempt ${attempt.id}.`);
@@ -2636,6 +2655,9 @@ export function createCertificationToolHandlers(
       const capstoneId = capstoneMod.id;
       const unavailable = unavailableSpecialistMessage(capstoneId);
       if (unavailable) return notCompleted(capstoneId, 'state', unavailable);
+      if (!(await ensureMembership())) {
+        return notCompleted(capstoneId, 'state', membershipRequiredMessage(capstoneId, memberContext));
+      }
       const deltaDef = getDeltaForModule(capstoneId) ?? null;
       const deltaStatus = deltaDef
         ? await certDb.getDeltaStatus(deltaDef, userId)
@@ -2758,7 +2780,7 @@ export function createCertificationToolHandlers(
 
         // Auto-award credentials (including specialist)
         try {
-          lines.push(...await checkAndFormatCredentials(userId, memberContext));
+          lines.push(...await checkAndFormatCredentials(userId, memberContext, true));
         } catch (credError) {
           logger.error({ error: credError }, 'Failed to check credential eligibility');
         }
@@ -2818,6 +2840,12 @@ export function createCertificationToolHandlers(
       const userId = getUserId();
       if (!userId) return 'User not authenticated.';
 
+      const mod = await certDb.getModule(moduleId);
+      if (!mod) return `Module ${moduleId} was not found.`;
+      if (!mod.is_free && !(await ensureMembership())) {
+        return membershipRequiredMessage(moduleId, memberContext);
+      }
+
       // Validate module is in-progress before saving checkpoint
       const progress = await certDb.getProgress(userId);
       const modProgress = progress.find(p => p.module_id === moduleId);
@@ -2841,7 +2869,6 @@ export function createCertificationToolHandlers(
 
       // Validate demonstration IDs and evidence keys are real criteria for this module
       if (demonstrationsVerified.length || (demonstrationEvidence && Object.keys(demonstrationEvidence).length > 0)) {
-        const mod = await certDb.getModule(moduleId);
         if (demonstrationsVerified.length) {
           const invalid = validateDemonstrationIds(mod, demonstrationsVerified);
           if (invalid.length > 0) {

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -609,12 +609,9 @@ function formatUtcDate(value: string | null): string {
 async function checkAndFormatCredentials(
   userId: string,
   memberContext: MemberContext | null,
-  allowPaidCredentials: boolean,
 ): Promise<string[]> {
-  const awarded = await certDb.checkAndAwardCredentials(
-    userId,
-    { maxTier: allowPaidCredentials ? Number.POSITIVE_INFINITY : 1 },
-  );
+  const allowPaidCredentials = await certDb.hasEffectiveMembershipForUser(userId);
+  const awarded = await certDb.checkAndAwardCredentials(userId);
 
   const creds = await certDb.getCredentials();
   const credMap = new Map(creds.map(c => [c.id, c]));
@@ -645,6 +642,12 @@ async function checkAndFormatCredentials(
   for (const credId of toProcess) {
     const cred = credMap.get(credId);
     if (cred) {
+      // External issuance is its own authorization boundary. Recheck directly
+      // before each paid badge call so membership ending during assessment or
+      // an earlier network request cannot reuse a stale positive decision.
+      if (cred.tier > 1 && !(await certDb.hasEffectiveMembershipForUser(userId))) {
+        continue;
+      }
       const result = await issueCertifierBadge(userId, credId, cred, memberContext);
       if (result === NAME_REQUIRED_MARKER) {
         nameRequired = true;
@@ -1585,9 +1588,20 @@ export function createCertificationToolHandlers(
    * trigger that surfaces the latent state — they never see the drift.
    */
   const ensureMembership = async (): Promise<boolean> => {
-    if (memberContext?.is_member) return true;
     const orgId = memberContext?.organization?.workos_organization_id;
-    if (!orgId || !stripe) return false;
+    const userId = getUserId();
+    if (!userId) return false;
+
+    // This is an authorization boundary, so do not trust the conversation's
+    // captured member context or the normal five-minute membership cache. Use
+    // the same user-level resolver as background issuance so membership via a
+    // second organization is handled consistently.
+    if (await certDb.hasEffectiveMembershipForUser(userId)) {
+      memberContext = memberContext ? { ...memberContext, is_member: true } : memberContext;
+      return true;
+    }
+    if (!orgId) return false;
+    if (!stripe) return false;
 
     const result = await attemptStripeReconciliation(orgId, {
       pool: getPool(),
@@ -1595,19 +1609,24 @@ export function createCertificationToolHandlers(
       logger,
     });
 
-    if (!result.healed) return false;
+    if (!result.healed && result.reason !== 'already_entitled') return false;
+
+    // Lazy reconciliation accepts a broader set of Stripe states for billing
+    // continuity. Certification uses the canonical membership rule (active,
+    // not canceled), so refresh and re-resolve instead of trusting `healed`.
+    const isMember = await certDb.hasEffectiveMembershipForUser(userId);
 
     if (memberContext?.organization) {
       memberContext = {
         ...memberContext,
-        is_member: true,
+        is_member: isMember,
         organization: {
           ...memberContext.organization,
-          subscription_status: result.subscriptionStatus,
+          ...(result.healed && { subscription_status: result.subscriptionStatus }),
         },
       };
     }
-    return true;
+    return isMember;
   };
 
   // ----- list_certification_tracks -----
@@ -1997,7 +2016,7 @@ export function createCertificationToolHandlers(
           'Congratulate them warmly — they earned this. Do NOT share any scores or percentages with the learner.',
         ];
         try {
-          lines.push(...await checkAndFormatCredentials(userId, memberContext, hasMembership));
+          lines.push(...await checkAndFormatCredentials(userId, memberContext));
         } catch (credError) {
           logger.error({ error: credError }, 'Failed to check credential eligibility');
         }
@@ -2074,7 +2093,7 @@ export function createCertificationToolHandlers(
 
       // Auto-check and award credentials
       try {
-        lines.push(...await checkAndFormatCredentials(userId, memberContext, hasMembership));
+        lines.push(...await checkAndFormatCredentials(userId, memberContext));
       } catch (credError) {
         logger.error({ error: credError }, 'Failed to check credential eligibility');
       }
@@ -2104,8 +2123,12 @@ export function createCertificationToolHandlers(
       const retrySeconds = Math.max(1, Math.ceil((rate.retryAfterMs ?? 60000) / 1000));
       return `Rate limit exceeded on check_credentials. Try again in ~${retrySeconds} seconds.`;
     }
-    const hasMembership = await ensureMembership();
-    const lines = await checkAndFormatCredentials(userId, memberContext, hasMembership);
+    // A deferred badge retry is also an entitlement recovery point. Give a
+    // Stripe-active organization with stale local state the same lazy-heal
+    // opportunity as the paid learning gates. The issuance path still
+    // revalidates membership immediately before every paid badge call.
+    await ensureMembership();
+    const lines = await checkAndFormatCredentials(userId, memberContext);
     if (lines.length === 0) {
       return 'No new credentials to issue. Your existing credentials are unchanged.';
     }
@@ -2296,7 +2319,7 @@ export function createCertificationToolHandlers(
 
       // Check for newly earned credentials
       try {
-        lines.push(...await checkAndFormatCredentials(userId, memberContext, hasMembership));
+        lines.push(...await checkAndFormatCredentials(userId, memberContext));
       } catch (credError) {
         logger.error({ error: credError }, 'Failed to check credential eligibility after test-out');
       }
@@ -2626,7 +2649,7 @@ export function createCertificationToolHandlers(
           lines.push('The capstone was already recorded, so I rechecked module completion and credential issuance.');
 
           try {
-            lines.push(...await checkAndFormatCredentials(userId, memberContext, true));
+            lines.push(...await checkAndFormatCredentials(userId, memberContext));
           } catch (credError) {
             logger.error({ error: credError, userId, attemptId: attempt.id }, 'Failed to reconcile credentials for already-passed capstone');
             return notCompleted(capstoneMod.id, 'state', `This capstone attempt is already passed, but credential issuance failed during reconciliation. Ask an admin to use Certification > Attempts needing attention for attempt ${attempt.id}.`);
@@ -2780,7 +2803,7 @@ export function createCertificationToolHandlers(
 
         // Auto-award credentials (including specialist)
         try {
-          lines.push(...await checkAndFormatCredentials(userId, memberContext, true));
+          lines.push(...await checkAndFormatCredentials(userId, memberContext));
         } catch (credError) {
           logger.error({ error: credError }, 'Failed to check credential eligibility');
         }

--- a/server/src/db/certification-db.ts
+++ b/server/src/db/certification-db.ts
@@ -11,6 +11,7 @@ import {
 } from '../certification/s2-canonical-formats-delta.js';
 import { S2_DELTA_DEFINITION, type DeltaDefinition } from '../config/recertification-deltas.js';
 import { getDeltaRelease } from './system-settings-db.js';
+import { resolveEffectiveMembership } from './org-filters.js';
 
 const logger = createLogger('certification-db');
 
@@ -1111,7 +1112,34 @@ export async function recordAdminCredentialReissueEvent(input: {
  * Check and auto-award any credentials the user has become eligible for.
  * Returns a list of newly awarded credential IDs.
  */
-export async function checkAndAwardCredentials(userId: string): Promise<string[]> {
+export async function hasEffectiveMembershipForUser(userId: string): Promise<boolean> {
+  const orgs = await query<{ workos_organization_id: string }>(
+    `SELECT DISTINCT workos_organization_id
+     FROM organization_memberships
+     WHERE workos_user_id = $1`,
+    [userId],
+  );
+  const memberships = await Promise.all(
+    orgs.rows.map(row => resolveEffectiveMembership(row.workos_organization_id)),
+  );
+  return memberships.some(membership => membership.is_member);
+}
+
+export async function checkAndAwardCredentials(
+  userId: string,
+  options: { maxTier?: number } = {},
+): Promise<string[]> {
+  // Callers at an interactive membership boundary can pass an explicit cap
+  // after performing Stripe lazy reconciliation. Background and admin callers
+  // intentionally fall back to the canonical persisted membership resolver so
+  // they cannot bypass the paid-tier gate by calling this low-level function.
+  let maxTier = options.maxTier;
+  if (maxTier === undefined) {
+    if (!(await hasEffectiveMembershipForUser(userId))) {
+      maxTier = 1;
+    }
+  }
+
   const [credentials, existing] = await Promise.all([
     getCredentials(),
     getUserCredentials(userId),
@@ -1121,6 +1149,7 @@ export async function checkAndAwardCredentials(userId: string): Promise<string[]
 
   // Process in tier order so prerequisites are checked correctly
   for (const credential of credentials) {
+    if (maxTier !== undefined && credential.tier > maxTier) continue;
     if (heldSet.has(credential.id)) continue;
 
     const { eligible } = await checkCredentialEligibility(userId, credential.id);

--- a/server/src/db/certification-db.ts
+++ b/server/src/db/certification-db.ts
@@ -11,7 +11,7 @@ import {
 } from '../certification/s2-canonical-formats-delta.js';
 import { S2_DELTA_DEFINITION, type DeltaDefinition } from '../config/recertification-deltas.js';
 import { getDeltaRelease } from './system-settings-db.js';
-import { resolveEffectiveMembership } from './org-filters.js';
+import { invalidateMembershipCache, resolveEffectiveMembership } from './org-filters.js';
 
 const logger = createLogger('certification-db');
 
@@ -1119,9 +1119,12 @@ export async function hasEffectiveMembershipForUser(userId: string): Promise<boo
      WHERE workos_user_id = $1`,
     [userId],
   );
-  const memberships = await Promise.all(
-    orgs.rows.map(row => resolveEffectiveMembership(row.workos_organization_id)),
-  );
+  const memberships = await Promise.all(orgs.rows.map(row => {
+    // Credential award/issuance is an authorization boundary. Force a fresh
+    // canonical lookup instead of accepting the normal five-minute cache.
+    invalidateMembershipCache(row.workos_organization_id);
+    return resolveEffectiveMembership(row.workos_organization_id);
+  }));
   return memberships.some(membership => membership.is_member);
 }
 
@@ -1133,12 +1136,15 @@ export async function checkAndAwardCredentials(
   // after performing Stripe lazy reconciliation. Background and admin callers
   // intentionally fall back to the canonical persisted membership resolver so
   // they cannot bypass the paid-tier gate by calling this low-level function.
-  let maxTier = options.maxTier;
-  if (maxTier === undefined) {
-    if (!(await hasEffectiveMembershipForUser(userId))) {
-      maxTier = 1;
-    }
-  }
+  const membershipMaxTier = await hasEffectiveMembershipForUser(userId)
+    ? Number.POSITIVE_INFINITY
+    : 1;
+  // A caller may narrow authorization (for example, free-only issuance), but
+  // it may never widen the fresh canonical membership decision.
+  const requestedMaxTier = Number.isNaN(options.maxTier)
+    ? 1
+    : options.maxTier ?? Number.POSITIVE_INFINITY;
+  const maxTier = Math.min(requestedMaxTier, membershipMaxTier);
 
   const [credentials, existing] = await Promise.all([
     getCredentials(),

--- a/server/src/routes/certification.ts
+++ b/server/src/routes/certification.ts
@@ -1107,12 +1107,17 @@ export function createCertificationRouters() {
 
   // POST /api/admin/certification/backfill-badges — retry Certifier for credentials missing data
   let backfillInProgress = false;
-  adminRouter.post('/backfill-badges', async (_req, res) => {
+  adminRouter.post('/backfill-badges', async (req, res) => {
     if (backfillInProgress) {
       return res.status(409).json({ error: 'Backfill already in progress' });
     }
     backfillInProgress = true;
     try {
+      const requestedCursor = req.body?.cursor;
+      if (requestedCursor != null && !isUuid(requestedCursor)) {
+        return res.status(400).json({ error: 'cursor must be a valid UUID' });
+      }
+
       const { isCertifierConfigured } = await import('../services/certifier-client.js');
 
       if (!isCertifierConfigured()) {
@@ -1146,12 +1151,13 @@ export function createCertificationRouters() {
       let examined = 0;
       let processed = 0;
       const errors: string[] = [];
-      let cursor: string | null = null;
+      let cursor: string | null = requestedCursor ?? null;
+      const MAX_EXAMINED = 500;
 
       // Keyset pagination prevents inactive paid rows (which intentionally
       // retain a null badge URL) from occupying the same LIMIT 50 forever and
       // starving eligible rows later in the result set.
-      while (processed < 50) {
+      while (processed < 50 && examined < MAX_EXAMINED) {
         const page: { rows: BadgeBackfillRow[] } = await query<BadgeBackfillRow>(
           `SELECT uc.id, uc.workos_user_id, uc.credential_id, cc.tier,
                   uc.certifier_credential_id, uc.certifier_public_id
@@ -1198,12 +1204,19 @@ export function createCertificationRouters() {
         if (page.rows.length < 50) break;
       }
 
+      // A cursor lets operators resume after the per-request scan bound. This
+      // prevents a large inactive backlog from creating an unbounded admin
+      // request while still allowing later eligible rows to be reached.
+      const hasMore = processed >= 50 || examined >= MAX_EXAMINED;
+
       res.json({
         total: examined,
         updated,
         skipped_inactive: skippedInactive,
         errors,
         credentialsAwarded,
+        has_more: hasMore,
+        next_cursor: hasMore ? cursor : null,
       });
     } catch (error) {
       logger.error({ error }, 'Failed to backfill badges');

--- a/server/src/routes/certification.ts
+++ b/server/src/routes/certification.ts
@@ -1137,9 +1137,10 @@ export function createCertificationRouters() {
       // Then: backfill badges for credentials missing them
       const needsBadgeUrl = await query<{
         id: string; workos_user_id: string; credential_id: string;
+        tier: number;
         certifier_credential_id: string | null; certifier_public_id: string | null;
       }>(
-        `SELECT uc.id, uc.workos_user_id, uc.credential_id,
+        `SELECT uc.id, uc.workos_user_id, uc.credential_id, cc.tier,
                 uc.certifier_credential_id, uc.certifier_public_id
          FROM user_credentials uc
          JOIN certification_credentials cc ON cc.id = uc.credential_id
@@ -1149,10 +1150,15 @@ export function createCertificationRouters() {
       );
 
       let updated = 0;
+      let skippedInactive = 0;
       const errors: string[] = [];
 
       for (const row of needsBadgeUrl.rows) {
         try {
+          if (row.tier > 1 && !(await certDb.hasEffectiveMembershipForUser(row.workos_user_id))) {
+            skippedInactive++;
+            continue;
+          }
           const result = await ensureCertifierCredential({
             userId: row.workos_user_id,
             credentialId: row.credential_id,
@@ -1165,7 +1171,13 @@ export function createCertificationRouters() {
         }
       }
 
-      res.json({ total: needsBadgeUrl.rows.length, updated, errors, credentialsAwarded });
+      res.json({
+        total: needsBadgeUrl.rows.length,
+        updated,
+        skipped_inactive: skippedInactive,
+        errors,
+        credentialsAwarded,
+      });
     } catch (error) {
       logger.error({ error }, 'Failed to backfill badges');
       res.status(500).json({ error: 'Internal server error' });

--- a/server/src/routes/certification.ts
+++ b/server/src/routes/certification.ts
@@ -1135,44 +1135,71 @@ export function createCertificationRouters() {
       }
 
       // Then: backfill badges for credentials missing them
-      const needsBadgeUrl = await query<{
+      type BadgeBackfillRow = {
         id: string; workos_user_id: string; credential_id: string;
         tier: number;
         certifier_credential_id: string | null; certifier_public_id: string | null;
-      }>(
-        `SELECT uc.id, uc.workos_user_id, uc.credential_id, cc.tier,
-                uc.certifier_credential_id, uc.certifier_public_id
-         FROM user_credentials uc
-         JOIN certification_credentials cc ON cc.id = uc.credential_id
-         WHERE uc.certifier_badge_url IS NULL
-           AND cc.certifier_group_id IS NOT NULL
-         LIMIT 50`
-      );
+      };
 
       let updated = 0;
       let skippedInactive = 0;
+      let examined = 0;
+      let processed = 0;
       const errors: string[] = [];
+      let cursor: string | null = null;
 
-      for (const row of needsBadgeUrl.rows) {
-        try {
-          if (row.tier > 1 && !(await certDb.hasEffectiveMembershipForUser(row.workos_user_id))) {
-            skippedInactive++;
-            continue;
+      // Keyset pagination prevents inactive paid rows (which intentionally
+      // retain a null badge URL) from occupying the same LIMIT 50 forever and
+      // starving eligible rows later in the result set.
+      while (processed < 50) {
+        const page: { rows: BadgeBackfillRow[] } = await query<BadgeBackfillRow>(
+          `SELECT uc.id, uc.workos_user_id, uc.credential_id, cc.tier,
+                  uc.certifier_credential_id, uc.certifier_public_id
+           FROM user_credentials uc
+           JOIN certification_credentials cc ON cc.id = uc.credential_id
+           WHERE uc.certifier_badge_url IS NULL
+             AND cc.certifier_group_id IS NOT NULL
+             AND ($1::uuid IS NULL OR uc.id > $1::uuid)
+           ORDER BY uc.id
+           LIMIT 50`,
+          [cursor],
+        );
+        if (page.rows.length === 0) break;
+
+        for (const row of page.rows as BadgeBackfillRow[]) {
+          cursor = row.id;
+          examined++;
+          let counted = false;
+          try {
+            if (row.tier > 1) {
+              const active = await certDb.hasEffectiveMembershipForUser(row.workos_user_id);
+              if (!active) {
+                skippedInactive++;
+                continue;
+              }
+            }
+            processed++;
+            counted = true;
+            const result = await ensureCertifierCredential({
+              userId: row.workos_user_id,
+              credentialId: row.credential_id,
+            });
+            if (result.badgeUrl) updated++;
+          } catch (err) {
+            // Membership lookup failures also consume one unit of the bounded
+            // batch, while known-inactive rows do not.
+            if (!counted) processed++;
+            const msg = err instanceof Error ? err.message : String(err);
+            errors.push(`${row.credential_id}/${row.workos_user_id}: ${msg}`);
+            logger.error({ error: err, row }, 'Backfill failed for credential');
           }
-          const result = await ensureCertifierCredential({
-            userId: row.workos_user_id,
-            credentialId: row.credential_id,
-          });
-          if (result.badgeUrl) updated++;
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          errors.push(`${row.credential_id}/${row.workos_user_id}: ${msg}`);
-          logger.error({ error: err, row }, 'Backfill failed for credential');
+          if (processed >= 50) break;
         }
+        if (page.rows.length < 50) break;
       }
 
       res.json({
-        total: needsBadgeUrl.rows.length,
+        total: examined,
         updated,
         skipped_inactive: skippedInactive,
         errors,
@@ -1451,6 +1478,13 @@ export function createCertificationRouters() {
         if (!moduleId) {
           return res.status(409).json({ error: 'Attempt has no capstone module to reconcile' });
         }
+        const module = await certDb.getModule(moduleId);
+        if (!module) {
+          return res.status(409).json({ error: 'Attempt capstone module was not found' });
+        }
+        if (!module.is_free && !(await certDb.hasEffectiveMembershipForUser(attempt.workos_user_id))) {
+          return res.status(409).json({ error: 'Active membership is required to reconcile this paid attempt' });
+        }
 
         const warnings: string[] = [];
         try {
@@ -1484,6 +1518,16 @@ export function createCertificationRouters() {
         scoreValues.reduce((sum, s) => sum + s, 0) / scoreValues.length
       );
       const passing = scoreValues.every(s => s >= 70) && overallScore >= 70;
+
+      if (passing && attempt.module_id) {
+        const module = await certDb.getModule(attempt.module_id);
+        if (!module) {
+          return res.status(409).json({ error: 'Attempt module was not found' });
+        }
+        if (!module.is_free && !(await certDb.hasEffectiveMembershipForUser(attempt.workos_user_id))) {
+          return res.status(409).json({ error: 'Active membership is required to complete this paid attempt' });
+        }
+      }
 
       let updated;
       try {
@@ -1562,6 +1606,9 @@ export function createCertificationRouters() {
       const mod = await certDb.getModule(moduleId);
       if (!mod) {
         return res.status(404).json({ error: 'Module not found' });
+      }
+      if (!mod.is_free && !(await certDb.hasEffectiveMembershipForUser(userId))) {
+        return res.status(409).json({ error: 'Active membership is required to complete this paid module' });
       }
 
       const scoreResult = validateModuleCompletionScores(effectiveScores, mod.assessment_criteria);

--- a/server/tests/unit/admin-certification-badge-backfill.test.ts
+++ b/server/tests/unit/admin-certification-badge-backfill.test.ts
@@ -135,4 +135,68 @@ describe('admin certification badge backfill', () => {
     expect(response.body.errors).toHaveLength(50);
     expect(mocks.ensureCertifierCredential).toHaveBeenCalledTimes(50);
   });
+
+  it('bounds inactive-row scanning and resumes from the returned cursor', async () => {
+    const inactive = Array.from({ length: 500 }, (_, index) => ({
+      id: uuid(index + 1),
+      workos_user_id: `inactive_${index}`,
+      credential_id: 'practitioner',
+      tier: 2,
+      certifier_credential_id: null,
+      certifier_public_id: null,
+    }));
+    const eligible = {
+      id: uuid(501),
+      workos_user_id: 'free_after_bound',
+      credential_id: 'basics',
+      tier: 1,
+      certifier_credential_id: null,
+      certifier_public_id: null,
+    };
+    const allRows = [...inactive, eligible];
+    mocks.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('SELECT DISTINCT workos_user_id FROM learner_progress')) return { rows: [] };
+      if (sql.includes('FROM user_credentials uc')) {
+        const cursor = params?.[0];
+        const start = cursor == null
+          ? 0
+          : allRows.findIndex(row => row.id === cursor) + 1;
+        return { rows: allRows.slice(start, start + 50) };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+    const app = express();
+    app.use(express.json());
+    app.use('/api/admin/certification', createCertificationRouters().adminRouter);
+
+    const first = await request(app)
+      .post('/api/admin/certification/backfill-badges')
+      .send({});
+
+    expect(first.status).toBe(200);
+    expect(first.body).toMatchObject({
+      total: 500,
+      updated: 0,
+      skipped_inactive: 500,
+      has_more: true,
+      next_cursor: uuid(500),
+    });
+    expect(mocks.ensureCertifierCredential).not.toHaveBeenCalled();
+
+    const second = await request(app)
+      .post('/api/admin/certification/backfill-badges')
+      .send({ cursor: first.body.next_cursor });
+
+    expect(second.status).toBe(200);
+    expect(second.body).toMatchObject({
+      total: 1,
+      updated: 1,
+      has_more: false,
+      next_cursor: null,
+    });
+    expect(mocks.ensureCertifierCredential).toHaveBeenCalledWith({
+      userId: 'free_after_bound',
+      credentialId: 'basics',
+    });
+  });
 });

--- a/server/tests/unit/admin-certification-badge-backfill.test.ts
+++ b/server/tests/unit/admin-certification-badge-backfill.test.ts
@@ -1,0 +1,138 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  checkAndAwardCredentials: vi.fn(),
+  hasEffectiveMembershipForUser: vi.fn(),
+  ensureCertifierCredential: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY ??= 'sk_test_mock_key';
+  process.env.WORKOS_CLIENT_ID ??= 'client_mock_id';
+  process.env.WORKOS_COOKIE_PASSWORD ??= 'test-cookie-password-at-least-32-chars-long';
+});
+
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
+  const passThrough = (_req: any, _res: any, next: any) => next();
+  return {
+    ...(await importOriginal<typeof import('../../src/middleware/auth.js')>()),
+    requireAuth: passThrough,
+    requireGlobalAdmin: [passThrough],
+    optionalAuth: passThrough,
+  };
+});
+
+vi.mock('../../src/db/client.js', () => ({
+  query: mocks.query,
+}));
+
+vi.mock('../../src/db/certification-db.js', () => ({
+  checkAndAwardCredentials: mocks.checkAndAwardCredentials,
+  hasEffectiveMembershipForUser: mocks.hasEffectiveMembershipForUser,
+}));
+
+vi.mock('../../src/services/certifier-client.js', () => ({
+  isCertifierConfigured: () => true,
+}));
+
+vi.mock('../../src/services/certification-credential-issuance.js', () => ({
+  CertifierNotConfiguredError: class extends Error {},
+  CredentialNameRequiredError: class extends Error {},
+  CredentialNotEarnedError: class extends Error {},
+  CredentialRecoveryConflictError: class extends Error {},
+  ensureCertifierCredential: mocks.ensureCertifierCredential,
+}));
+
+import { createCertificationRouters } from '../../src/routes/certification.js';
+
+function uuid(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
+}
+
+describe('admin certification badge backfill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const inactive = Array.from({ length: 50 }, (_, index) => ({
+      id: uuid(index + 1),
+      workos_user_id: `inactive_${index}`,
+      credential_id: 'practitioner',
+      tier: 2,
+      certifier_credential_id: null,
+      certifier_public_id: null,
+    }));
+    const eligible = [{
+      id: uuid(51),
+      workos_user_id: 'free_learner',
+      credential_id: 'basics',
+      tier: 1,
+      certifier_credential_id: null,
+      certifier_public_id: null,
+    }];
+
+    mocks.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('SELECT DISTINCT workos_user_id FROM learner_progress')) {
+        return { rows: [] };
+      }
+      if (sql.includes('FROM user_credentials uc')) {
+        return { rows: params?.[0] === null ? inactive : eligible };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+    mocks.hasEffectiveMembershipForUser.mockResolvedValue(false);
+    mocks.ensureCertifierCredential.mockResolvedValue({ badgeUrl: 'https://badge.example.test/basics' });
+  });
+
+  it('paginates past inactive paid rows instead of starving eligible badges', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/admin/certification', createCertificationRouters().adminRouter);
+
+    const response = await request(app)
+      .post('/api/admin/certification/backfill-badges')
+      .send({});
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      total: 51,
+      updated: 1,
+      skipped_inactive: 50,
+    });
+    expect(mocks.ensureCertifierCredential).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureCertifierCredential).toHaveBeenCalledWith({
+      userId: 'free_learner',
+      credentialId: 'basics',
+    });
+  });
+
+  it('counts each failed issuance once when enforcing the 50-item batch cap', async () => {
+    const eligible = Array.from({ length: 50 }, (_, index) => ({
+      id: uuid(index + 1),
+      workos_user_id: `free_${index}`,
+      credential_id: 'basics',
+      tier: 1,
+      certifier_credential_id: null,
+      certifier_public_id: null,
+    }));
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT DISTINCT workos_user_id FROM learner_progress')) return { rows: [] };
+      if (sql.includes('FROM user_credentials uc')) return { rows: eligible };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+    mocks.ensureCertifierCredential.mockRejectedValue(new Error('provider unavailable'));
+    const app = express();
+    app.use(express.json());
+    app.use('/api/admin/certification', createCertificationRouters().adminRouter);
+
+    const response = await request(app)
+      .post('/api/admin/certification/backfill-badges')
+      .send({});
+
+    expect(response.status).toBe(200);
+    expect(response.body.total).toBe(50);
+    expect(response.body.errors).toHaveLength(50);
+    expect(mocks.ensureCertifierCredential).toHaveBeenCalledTimes(50);
+  });
+});

--- a/server/tests/unit/admin-certification-module-completion-route.test.ts
+++ b/server/tests/unit/admin-certification-module-completion-route.test.ts
@@ -7,6 +7,7 @@ const mockCertDb = vi.hoisted(() => ({
   getLatestCheckpointForThread: vi.fn(),
   adminCompleteModule: vi.fn(),
   checkAndAwardCredentials: vi.fn(),
+  hasEffectiveMembershipForUser: vi.fn(),
 }));
 
 vi.hoisted(() => {
@@ -36,6 +37,7 @@ import { createCertificationRouters } from '../../src/routes/certification.js';
 
 const moduleFixture = {
   id: 'A1',
+  is_free: true,
   assessment_criteria: {
     passing_threshold: 70,
     dimensions: [
@@ -69,6 +71,7 @@ describe('admin certification module completion route', () => {
     vi.clearAllMocks();
     mockCertDb.getModule.mockResolvedValue(moduleFixture);
     mockCertDb.checkAndAwardCredentials.mockResolvedValue([]);
+    mockCertDb.hasEffectiveMembershipForUser.mockResolvedValue(true);
   });
 
   it('refuses to write without a checkpoint for the supplied Addie thread', async () => {
@@ -170,6 +173,23 @@ describe('admin certification module completion route', () => {
 
     expect(response.status).toBe(409);
     expect(response.body.error).toContain('>20 points');
+    expect(mockCertDb.adminCompleteModule).not.toHaveBeenCalled();
+  });
+
+  it('refuses to admin-complete a paid module for an inactive learner', async () => {
+    mockCertDb.getModule.mockResolvedValue({ ...moduleFixture, id: 'B1', is_free: false });
+    mockCertDb.hasEffectiveMembershipForUser.mockResolvedValue(false);
+    const app = buildApp();
+
+    const response = await request(app)
+      .post('/api/admin/certification/learners/user_learner/modules/B1/complete')
+      .send({
+        addie_thread_id: 'thread_123',
+        scores: { protocol_mastery: 82, practical_application: 80 },
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body.error).toContain('Active membership');
     expect(mockCertDb.adminCompleteModule).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/unit/certification-attempt-recovery.test.ts
+++ b/server/tests/unit/certification-attempt-recovery.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   completeAttempt: vi.fn(),
   completeModule: vi.fn(),
   checkAndAwardCredentials: vi.fn(),
+  hasEffectiveMembershipForUser: vi.fn(),
   query: vi.fn(),
 }));
 
@@ -33,6 +34,7 @@ vi.mock('../../src/db/certification-db.js', () => ({
   completeAttempt: mocks.completeAttempt,
   completeModule: mocks.completeModule,
   checkAndAwardCredentials: mocks.checkAndAwardCredentials,
+  hasEffectiveMembershipForUser: mocks.hasEffectiveMembershipForUser,
 }));
 
 vi.mock('../../src/db/client.js', () => ({
@@ -61,6 +63,7 @@ describe('certification attempt recovery', () => {
     mocks.getTracks.mockResolvedValue([]);
     mocks.getDeltaStatus.mockResolvedValue({ active: false, status: 'not_required' });
     mocks.checkAndAwardCredentials.mockResolvedValue([]);
+    mocks.hasEffectiveMembershipForUser.mockResolvedValue(true);
   });
 
   it('surfaces an in-progress specialist attempt across handler sessions', async () => {

--- a/server/tests/unit/certification-checkpoint-handler.test.ts
+++ b/server/tests/unit/certification-checkpoint-handler.test.ts
@@ -27,6 +27,7 @@ describe('checkpoint_teaching_progress handler', () => {
     }));
     mocks.getModule.mockResolvedValue({
       id: 'A1',
+      is_free: true,
       assessment_criteria: null,
       exercise_definitions: null,
     });
@@ -80,6 +81,7 @@ describe('checkpoint_teaching_progress handler', () => {
   it('splits comma-separated demonstration IDs before validation', async () => {
     mocks.getModule.mockResolvedValue({
       id: 'A1',
+      is_free: true,
       exercise_definitions: [{
         success_criteria: [
           { id: 'a1_ex1_sc0', text: 'First criterion' },

--- a/server/tests/unit/certification-credential-tier-gate.test.ts
+++ b/server/tests/unit/certification-credential-tier-gate.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  resolveEffectiveMembership: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  getClient: vi.fn(),
+  query: mocks.query,
+}));
+
+vi.mock('../../src/db/org-filters.js', () => ({
+  resolveEffectiveMembership: mocks.resolveEffectiveMembership,
+}));
+
+import { checkAndAwardCredentials } from '../../src/db/certification-db.js';
+
+const basics = {
+  id: 'basics',
+  tier: 1,
+  name: 'AdCP Basics',
+  required_modules: [],
+  requires_credential: null,
+  requires_any_track_complete: false,
+  sort_order: 1,
+};
+const practitioner = {
+  ...basics,
+  id: 'practitioner',
+  tier: 2,
+  name: 'AdCP Practitioner',
+  sort_order: 2,
+};
+
+describe('credential tier award gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: false });
+    mocks.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('FROM organization_memberships')) {
+        return { rows: [{ workos_organization_id: 'org_free' }] };
+      }
+      if (sql.includes('FROM certification_credentials ORDER BY')) {
+        return { rows: [basics, practitioner] };
+      }
+      if (sql.includes('FROM user_credentials WHERE workos_user_id') && sql.includes('ORDER BY awarded_at')) {
+        return { rows: [] };
+      }
+      if (sql.includes('FROM certification_credentials WHERE id')) {
+        return { rows: [params?.[0] === 'basics' ? basics : practitioner] };
+      }
+      if (sql.includes('INSERT INTO user_credentials')) {
+        return { rows: [{ workos_user_id: 'user_free', credential_id: params?.[1] }] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+  });
+
+  it('awards the free credential without evaluating or issuing paid tiers', async () => {
+    const awarded = await checkAndAwardCredentials('user_free', { maxTier: 1 });
+
+    expect(awarded).toEqual(['basics']);
+    expect(mocks.query).not.toHaveBeenCalledWith(
+      expect.stringContaining('FROM certification_credentials WHERE id'),
+      ['practitioner'],
+    );
+  });
+
+  it('defaults background award calls to the free tier for inactive learners', async () => {
+    const awarded = await checkAndAwardCredentials('user_free');
+
+    expect(mocks.resolveEffectiveMembership).toHaveBeenCalledWith('org_free');
+    expect(awarded).toEqual(['basics']);
+    expect(mocks.query).not.toHaveBeenCalledWith(
+      expect.stringContaining('FROM certification_credentials WHERE id'),
+      ['practitioner'],
+    );
+  });
+});

--- a/server/tests/unit/certification-credential-tier-gate.test.ts
+++ b/server/tests/unit/certification-credential-tier-gate.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   query: vi.fn(),
   resolveEffectiveMembership: vi.fn(),
+  invalidateMembershipCache: vi.fn(),
 }));
 
 vi.mock('../../src/db/client.js', () => ({
@@ -12,9 +13,12 @@ vi.mock('../../src/db/client.js', () => ({
 
 vi.mock('../../src/db/org-filters.js', () => ({
   resolveEffectiveMembership: mocks.resolveEffectiveMembership,
+  invalidateMembershipCache: mocks.invalidateMembershipCache,
 }));
 
 import { checkAndAwardCredentials } from '../../src/db/certification-db.js';
+
+let orgRows: Array<{ workos_organization_id: string }>;
 
 const basics = {
   id: 'basics',
@@ -36,10 +40,11 @@ const practitioner = {
 describe('credential tier award gate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    orgRows = [{ workos_organization_id: 'org_free' }];
     mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: false });
     mocks.query.mockImplementation(async (sql: string, params?: unknown[]) => {
       if (sql.includes('FROM organization_memberships')) {
-        return { rows: [{ workos_organization_id: 'org_free' }] };
+        return { rows: orgRows };
       }
       if (sql.includes('FROM certification_credentials ORDER BY')) {
         return { rows: [basics, practitioner] };
@@ -76,5 +81,59 @@ describe('credential tier award gate', () => {
       expect.stringContaining('FROM certification_credentials WHERE id'),
       ['practitioner'],
     );
+  });
+
+  it('allows the default background path to award paid tiers for an active member', async () => {
+    mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: true });
+
+    const awarded = await checkAndAwardCredentials('user_member');
+
+    expect(mocks.invalidateMembershipCache).toHaveBeenCalledWith('org_free');
+    expect(awarded).toEqual(['basics', 'practitioner']);
+  });
+
+  it('does not let an explicit unlimited caller cap bypass inactive membership', async () => {
+    const awarded = await checkAndAwardCredentials('user_free', {
+      maxTier: Number.POSITIVE_INFINITY,
+    });
+
+    expect(awarded).toEqual(['basics']);
+    expect(mocks.query).not.toHaveBeenCalledWith(
+      expect.stringContaining('FROM certification_credentials WHERE id'),
+      ['practitioner'],
+    );
+  });
+
+  it('recognizes membership through any of a learner\'s organizations', async () => {
+    orgRows = [
+      { workos_organization_id: 'org_inactive' },
+      { workos_organization_id: 'org_active' },
+    ];
+    mocks.resolveEffectiveMembership.mockImplementation(async (orgId: string) => ({
+      is_member: orgId === 'org_active',
+    }));
+
+    const awarded = await checkAndAwardCredentials('user_multi_org');
+
+    expect(awarded).toEqual(['basics', 'practitioner']);
+    expect(mocks.invalidateMembershipCache).toHaveBeenCalledWith('org_inactive');
+    expect(mocks.invalidateMembershipCache).toHaveBeenCalledWith('org_active');
+  });
+
+  it('limits a learner with no organization to the free tier', async () => {
+    orgRows = [];
+
+    const awarded = await checkAndAwardCredentials('user_no_org');
+
+    expect(awarded).toEqual(['basics']);
+    expect(mocks.resolveEffectiveMembership).not.toHaveBeenCalled();
+  });
+
+  it('treats a NaN caller cap as free-only', async () => {
+    mocks.resolveEffectiveMembership.mockResolvedValue({ is_member: true });
+
+    const awarded = await checkAndAwardCredentials('user_member', { maxTier: Number.NaN });
+
+    expect(awarded).toEqual(['basics']);
   });
 });

--- a/server/tests/unit/certification-deferred-badge-membership.test.ts
+++ b/server/tests/unit/certification-deferred-badge-membership.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  hasEffectiveMembershipForUser: vi.fn(),
+  checkAndAwardCredentials: vi.fn(),
+  getCredentials: vi.fn(),
+  getUserCredentials: vi.fn(),
+  ensureCertifierCredential: vi.fn(),
+  attemptStripeReconciliation: vi.fn(),
+}));
+
+vi.mock('../../src/db/certification-db.js', () => ({
+  hasEffectiveMembershipForUser: mocks.hasEffectiveMembershipForUser,
+  checkAndAwardCredentials: mocks.checkAndAwardCredentials,
+  getCredentials: mocks.getCredentials,
+  getUserCredentials: mocks.getUserCredentials,
+}));
+
+vi.mock('../../src/addie/mcp/tool-rate-limiter.js', () => ({
+  checkToolRateLimit: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+vi.mock('../../src/billing/stripe-client.js', () => ({ stripe: {} }));
+
+vi.mock('../../src/billing/lazy-reconcile.js', () => ({
+  attemptStripeReconciliation: mocks.attemptStripeReconciliation,
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  getPool: vi.fn(() => ({})),
+}));
+
+vi.mock('../../src/services/certification-credential-issuance.js', () => ({
+  CertifierNotConfiguredError: class extends Error {},
+  CredentialNameRequiredError: class extends Error {},
+  NAME_REQUIRED_MARKER: 'NAME_REQUIRED',
+  ensureCertifierCredential: mocks.ensureCertifierCredential,
+}));
+
+import { createCertificationToolHandlers } from '../../src/addie/mcp/certification-tools.js';
+
+describe('deferred certification badge membership gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasEffectiveMembershipForUser.mockResolvedValue(false);
+    mocks.checkAndAwardCredentials.mockResolvedValue([]);
+    mocks.getCredentials.mockResolvedValue([{
+      id: 'practitioner',
+      name: 'AdCP Practitioner',
+      tier: 2,
+      certifier_group_id: 'group_paid',
+    }]);
+    mocks.getUserCredentials.mockResolvedValue([{
+      credential_id: 'practitioner',
+      certifier_credential_id: null,
+      awarded_at: new Date().toISOString(),
+    }]);
+    mocks.attemptStripeReconciliation.mockResolvedValue({
+      healed: false,
+      reason: 'no_stripe_customer',
+    });
+  });
+
+  it('does not issue a recently deferred paid badge after membership ends', async () => {
+    const handlers = createCertificationToolHandlers({
+      is_member: true,
+      workos_user: {
+        workos_user_id: 'user_lapsed',
+        email: 'learner@example.test',
+      },
+    } as any);
+
+    const result = await handlers.get('check_credentials')?.({});
+
+    expect(result).toContain('No new credentials to issue');
+    expect(mocks.hasEffectiveMembershipForUser).toHaveBeenCalledWith('user_lapsed');
+    expect(mocks.ensureCertifierCredential).not.toHaveBeenCalled();
+  });
+
+  it('lazy-heals a Stripe-active member before issuing a deferred paid badge', async () => {
+    mocks.hasEffectiveMembershipForUser
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+    mocks.attemptStripeReconciliation.mockResolvedValue({
+      healed: true,
+      reason: 'healed_from_stripe',
+      subscriptionStatus: 'active',
+    });
+    mocks.ensureCertifierCredential.mockResolvedValue({
+      credentialId: 'certifier-credential-id',
+      publicId: 'certifier-public-id',
+      badgeUrl: 'https://badge.example.test/practitioner',
+      outcome: 'issued',
+    });
+    const handlers = createCertificationToolHandlers({
+      is_member: false,
+      workos_user: {
+        workos_user_id: 'user_healed',
+        email: 'learner@example.test',
+      },
+      organization: {
+        workos_organization_id: 'org_healed',
+        is_personal: false,
+      },
+    } as any);
+
+    const result = await handlers.get('check_credentials')?.({});
+
+    expect(mocks.attemptStripeReconciliation).toHaveBeenCalledWith(
+      'org_healed',
+      expect.any(Object),
+    );
+    expect(mocks.ensureCertifierCredential).toHaveBeenCalledWith({
+      userId: 'user_healed',
+      credentialId: 'practitioner',
+    });
+    expect(result).toContain('Credential earned: AdCP Practitioner!');
+  });
+});

--- a/server/tests/unit/certification-membership-revalidation.test.ts
+++ b/server/tests/unit/certification-membership-revalidation.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  completeAttempt: vi.fn(),
+  completeModule: vi.fn(),
+  getAttemptForUser: vi.fn(),
+  getModule: vi.fn(),
+  getProgress: vi.fn(),
+  saveTeachingCheckpoint: vi.fn(),
+}));
+
+vi.mock('../../src/db/certification-db.js', () => ({
+  S2_CANONICAL_FORMATS_MODULE_ID: 'S2',
+  completeAttempt: mocks.completeAttempt,
+  completeModule: mocks.completeModule,
+  getAttemptForUser: mocks.getAttemptForUser,
+  getModule: mocks.getModule,
+  getProgress: mocks.getProgress,
+  saveTeachingCheckpoint: mocks.saveTeachingCheckpoint,
+}));
+
+import { createCertificationToolHandlers, NOT_COMPLETED_SENTINEL } from '../../src/addie/mcp/certification-tools.js';
+
+const nonmemberContext = {
+  is_member: false,
+  workos_user: { workos_user_id: 'user_nonmember' },
+  organization: { is_personal: true },
+} as any;
+
+describe('certification membership revalidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getModule.mockResolvedValue({
+      id: 'B1',
+      is_free: false,
+      format: 'lesson',
+      assessment_criteria: null,
+      exercise_definitions: [],
+    });
+    mocks.getProgress.mockResolvedValue([{ module_id: 'B1', status: 'in_progress' }]);
+  });
+
+  it('blocks completion of an in-progress paid module after membership ends', async () => {
+    const handler = createCertificationToolHandlers(nonmemberContext).get('complete_certification_module');
+
+    const result = await handler?.({ module_id: 'B1', scores: { knowledge: 90 } });
+
+    expect(result).toContain(NOT_COMPLETED_SENTINEL);
+    expect(result).toContain('requires AgenticAdvertising.org membership');
+    expect(mocks.completeModule).not.toHaveBeenCalled();
+  });
+
+  it('blocks paid-module checkpoints after membership ends', async () => {
+    const handler = createCertificationToolHandlers(nonmemberContext).get('checkpoint_teaching_progress');
+
+    const result = await handler?.({ module_id: 'B1', current_phase: 'teaching' });
+
+    expect(result).toContain('requires AgenticAdvertising.org membership');
+    expect(mocks.saveTeachingCheckpoint).not.toHaveBeenCalled();
+    expect(mocks.getProgress).not.toHaveBeenCalled();
+  });
+
+  it('blocks completion of an in-progress specialist exam after membership ends', async () => {
+    const attemptId = '123e4567-e89b-42d3-a456-426614174000';
+    mocks.getAttemptForUser.mockResolvedValue({
+      id: attemptId,
+      workos_user_id: 'user_nonmember',
+      module_id: 'S1',
+      track_id: 'S',
+      status: 'in_progress',
+      started_at: '2026-01-01T00:00:00.000Z',
+    });
+    mocks.getModule.mockResolvedValue({
+      id: 'S1',
+      is_free: false,
+      format: 'capstone',
+      assessment_criteria: null,
+      exercise_definitions: [],
+    });
+    const handler = createCertificationToolHandlers(nonmemberContext).get('complete_certification_exam');
+
+    const result = await handler?.({ attempt_id: attemptId, scores: { knowledge: 90 } });
+
+    expect(result).toContain(NOT_COMPLETED_SENTINEL);
+    expect(result).toContain('requires AgenticAdvertising.org membership');
+    expect(mocks.completeAttempt).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/certification-membership-revalidation.test.ts
+++ b/server/tests/unit/certification-membership-revalidation.test.ts
@@ -3,20 +3,36 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   completeAttempt: vi.fn(),
   completeModule: vi.fn(),
+  reconcilePassedAttemptModule: vi.fn(),
   getAttemptForUser: vi.fn(),
   getModule: vi.fn(),
   getProgress: vi.fn(),
   saveTeachingCheckpoint: vi.fn(),
+  hasEffectiveMembershipForUser: vi.fn(),
+  attemptStripeReconciliation: vi.fn(),
 }));
 
 vi.mock('../../src/db/certification-db.js', () => ({
   S2_CANONICAL_FORMATS_MODULE_ID: 'S2',
   completeAttempt: mocks.completeAttempt,
   completeModule: mocks.completeModule,
+  reconcilePassedAttemptModule: mocks.reconcilePassedAttemptModule,
   getAttemptForUser: mocks.getAttemptForUser,
   getModule: mocks.getModule,
   getProgress: mocks.getProgress,
   saveTeachingCheckpoint: mocks.saveTeachingCheckpoint,
+  hasEffectiveMembershipForUser: mocks.hasEffectiveMembershipForUser,
+}));
+
+vi.mock('../../src/billing/stripe-client.js', () => ({ stripe: {} }));
+
+vi.mock('../../src/billing/lazy-reconcile.js', () => ({
+  attemptStripeReconciliation: mocks.attemptStripeReconciliation,
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  getPool: vi.fn(() => ({})),
+  query: vi.fn(),
 }));
 
 import { createCertificationToolHandlers, NOT_COMPLETED_SENTINEL } from '../../src/addie/mcp/certification-tools.js';
@@ -30,6 +46,8 @@ const nonmemberContext = {
 describe('certification membership revalidation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.hasEffectiveMembershipForUser.mockReset();
+    mocks.attemptStripeReconciliation.mockReset();
     mocks.getModule.mockResolvedValue({
       id: 'B1',
       is_free: false,
@@ -38,6 +56,9 @@ describe('certification membership revalidation', () => {
       exercise_definitions: [],
     });
     mocks.getProgress.mockResolvedValue([{ module_id: 'B1', status: 'in_progress' }]);
+    mocks.saveTeachingCheckpoint.mockResolvedValue({});
+    mocks.hasEffectiveMembershipForUser.mockResolvedValue(false);
+    mocks.attemptStripeReconciliation.mockResolvedValue({ healed: false, reason: 'no_stripe_customer' });
   });
 
   it('blocks completion of an in-progress paid module after membership ends', async () => {
@@ -84,5 +105,91 @@ describe('certification membership revalidation', () => {
     expect(result).toContain(NOT_COMPLETED_SENTINEL);
     expect(result).toContain('requires AgenticAdvertising.org membership');
     expect(mocks.completeAttempt).not.toHaveBeenCalled();
+  });
+
+  it('blocks reconciliation of an already-passed paid exam after membership ends', async () => {
+    const attemptId = '123e4567-e89b-42d3-a456-426614174001';
+    mocks.getAttemptForUser.mockResolvedValue({
+      id: attemptId,
+      workos_user_id: 'user_nonmember',
+      module_id: 'S1',
+      track_id: 'S',
+      status: 'passed',
+      passing: true,
+      scores: { protocol_mastery: 90 },
+      started_at: '2026-01-01T00:00:00.000Z',
+    });
+    mocks.getModule.mockResolvedValue({
+      id: 'S1',
+      is_free: false,
+      format: 'capstone',
+      assessment_criteria: null,
+      exercise_definitions: [],
+    });
+    const handler = createCertificationToolHandlers(nonmemberContext).get('complete_certification_exam');
+
+    const result = await handler?.({ attempt_id: attemptId, scores: { protocol_mastery: 90 } });
+
+    expect(result).toContain(NOT_COMPLETED_SENTINEL);
+    expect(result).toContain('requires AgenticAdvertising.org membership');
+    expect(mocks.reconcilePassedAttemptModule).not.toHaveBeenCalled();
+  });
+
+  it('force-refreshes and rejects a stale positive member context', async () => {
+    const staleMemberContext = {
+      is_member: true,
+      workos_user: { workos_user_id: 'user_stale' },
+      organization: { workos_organization_id: 'org_stale', is_personal: false },
+    } as any;
+    const handler = createCertificationToolHandlers(staleMemberContext).get('checkpoint_teaching_progress');
+
+    const result = await handler?.({ module_id: 'B1', current_phase: 'teaching' });
+
+    expect(mocks.hasEffectiveMembershipForUser).toHaveBeenCalledWith('user_stale');
+    expect(result).toContain('requires AgenticAdvertising.org membership');
+    expect(mocks.saveTeachingCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it('allows a canonical active membership after Stripe lazy reconciliation', async () => {
+    const orgContext = {
+      is_member: false,
+      workos_user: { workos_user_id: 'user_healed' },
+      organization: { workos_organization_id: 'org_healed', is_personal: false },
+    } as any;
+    mocks.hasEffectiveMembershipForUser
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    mocks.attemptStripeReconciliation.mockResolvedValue({
+      healed: true,
+      reason: 'healed_from_stripe',
+      subscriptionStatus: 'active',
+    });
+    const handler = createCertificationToolHandlers(orgContext).get('checkpoint_teaching_progress');
+
+    const result = await handler?.({ module_id: 'B1', current_phase: 'teaching' });
+
+    expect(mocks.attemptStripeReconciliation).toHaveBeenCalled();
+    expect(mocks.hasEffectiveMembershipForUser).toHaveBeenCalledTimes(2);
+    expect(mocks.saveTeachingCheckpoint).toHaveBeenCalled();
+    expect(result).toContain('checkpoint saved');
+  });
+
+  it('rejects a lazy-healed status that canonical membership does not accept', async () => {
+    const orgContext = {
+      is_member: false,
+      workos_user: { workos_user_id: 'user_past_due' },
+      organization: { workos_organization_id: 'org_past_due', is_personal: false },
+    } as any;
+    mocks.attemptStripeReconciliation.mockResolvedValue({
+      healed: true,
+      reason: 'healed_from_stripe',
+      subscriptionStatus: 'past_due',
+    });
+    const handler = createCertificationToolHandlers(orgContext).get('checkpoint_teaching_progress');
+
+    const result = await handler?.({ module_id: 'B1', current_phase: 'teaching' });
+
+    expect(result).toContain('requires AgenticAdvertising.org membership');
+    expect(mocks.saveTeachingCheckpoint).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/unit/certification-recovery-membership.test.ts
+++ b/server/tests/unit/certification-recovery-membership.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getStuckAttempts: vi.fn(),
+  getAttempt: vi.fn(),
+  getModule: vi.fn(),
+  hasEffectiveMembershipForUser: vi.fn(),
+  reconcilePassedAttemptModule: vi.fn(),
+  checkAndAwardCredentials: vi.fn(),
+  hasEligibleMissingCredentialForModule: vi.fn(),
+  createEscalation: vi.fn(),
+  getEscalationChannel: vi.fn(),
+}));
+
+vi.mock('../../src/db/certification-db.js', () => ({
+  getStuckAttempts: mocks.getStuckAttempts,
+  getAttempt: mocks.getAttempt,
+  getModule: mocks.getModule,
+  hasEffectiveMembershipForUser: mocks.hasEffectiveMembershipForUser,
+  reconcilePassedAttemptModule: mocks.reconcilePassedAttemptModule,
+  checkAndAwardCredentials: mocks.checkAndAwardCredentials,
+  hasEligibleMissingCredentialForModule: mocks.hasEligibleMissingCredentialForModule,
+}));
+
+vi.mock('../../src/db/escalation-db.js', () => ({
+  createEscalation: mocks.createEscalation,
+  markNotificationSent: vi.fn(),
+}));
+
+vi.mock('../../src/db/system-settings-db.js', () => ({
+  getEscalationChannel: mocks.getEscalationChannel,
+}));
+
+vi.mock('../../src/slack/client.js', () => ({
+  sendChannelMessage: vi.fn(),
+}));
+
+import { runCertificationRecoveryJob } from '../../src/addie/jobs/certification-recovery.js';
+
+const attempt = {
+  id: 'attempt_1',
+  workos_user_id: 'user_inactive',
+  module_id: 'S1',
+  status: 'passed',
+  passing: true,
+  scores: { protocol_mastery: 90 },
+};
+
+describe('certification recovery membership gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getStuckAttempts.mockResolvedValue([{
+      ...attempt,
+      name: 'Learner',
+      email: 'learner@example.test',
+    }]);
+    mocks.getAttempt.mockResolvedValue(attempt);
+    mocks.getModule.mockResolvedValue({ id: 'S1', is_free: false });
+    mocks.hasEffectiveMembershipForUser.mockResolvedValue(false);
+    mocks.createEscalation.mockResolvedValue({
+      id: 42,
+      workos_user_id: 'user_inactive',
+      notification_message_ts: null,
+    });
+    mocks.getEscalationChannel.mockResolvedValue({ channel_id: null });
+  });
+
+  it('does not reconcile paid completion and opens an entitlement review when membership is inactive', async () => {
+    const result = await runCertificationRecoveryJob();
+
+    expect(result.scanned).toBe(1);
+    expect(mocks.hasEffectiveMembershipForUser).toHaveBeenCalledWith('user_inactive');
+    expect(mocks.reconcilePassedAttemptModule).not.toHaveBeenCalled();
+    expect(mocks.checkAndAwardCredentials).not.toHaveBeenCalled();
+    expect(mocks.hasEligibleMissingCredentialForModule).not.toHaveBeenCalled();
+    expect(mocks.createEscalation).toHaveBeenCalledWith(expect.objectContaining({
+      dedup_key: 'certification-recovery-entitlement:attempt_1',
+      category: 'needs_human_action',
+    }));
+    expect(result.escalated).toBe(1);
+    expect(result.skipped_no_channel).toBe(1);
+  });
+});

--- a/server/tests/unit/certification-specialist-catalog.test.ts
+++ b/server/tests/unit/certification-specialist-catalog.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   createAttempt: vi.fn(),
   getAttemptForUser: vi.fn(),
   getModulesForTrack: vi.fn(),
+  hasEffectiveMembershipForUser: vi.fn(),
 }));
 
 vi.mock('../../src/db/certification-db.js', () => ({
@@ -49,6 +50,7 @@ describe('specialist certification catalog', () => {
       status: 'in_progress',
       started_at: new Date().toISOString(),
     });
+    mocks.hasEffectiveMembershipForUser.mockResolvedValue(true);
   });
 
   it('advertises S6 as a specialist module and labels S5 unavailable', () => {

--- a/tests/addie/certification-recovery-job.test.ts
+++ b/tests/addie/certification-recovery-job.test.ts
@@ -5,7 +5,9 @@ const {
   mockCreateEscalation,
   mockGetAttempt,
   mockGetEscalationChannel,
+  mockGetModule,
   mockGetStuckAttempts,
+  mockHasEffectiveMembershipForUser,
   mockHasEligibleMissingCredentialForModule,
   mockMarkNotificationSent,
   mockReconcilePassedAttemptModule,
@@ -15,7 +17,9 @@ const {
   mockCreateEscalation: vi.fn<any>(),
   mockGetAttempt: vi.fn<any>(),
   mockGetEscalationChannel: vi.fn<any>(),
+  mockGetModule: vi.fn<any>(),
   mockGetStuckAttempts: vi.fn<any>(),
+  mockHasEffectiveMembershipForUser: vi.fn<any>(),
   mockHasEligibleMissingCredentialForModule: vi.fn<any>(),
   mockMarkNotificationSent: vi.fn<any>(),
   mockReconcilePassedAttemptModule: vi.fn<any>(),
@@ -25,7 +29,9 @@ const {
 vi.mock('../../server/src/db/certification-db.js', () => ({
   checkAndAwardCredentials: (...args: unknown[]) => mockCheckAndAwardCredentials(...args),
   getAttempt: (...args: unknown[]) => mockGetAttempt(...args),
+  getModule: (...args: unknown[]) => mockGetModule(...args),
   getStuckAttempts: (...args: unknown[]) => mockGetStuckAttempts(...args),
+  hasEffectiveMembershipForUser: (...args: unknown[]) => mockHasEffectiveMembershipForUser(...args),
   hasEligibleMissingCredentialForModule: (...args: unknown[]) => mockHasEligibleMissingCredentialForModule(...args),
   reconcilePassedAttemptModule: (...args: unknown[]) => mockReconcilePassedAttemptModule(...args),
 }));
@@ -78,7 +84,9 @@ beforeEach(() => {
   mockCreateEscalation.mockReset();
   mockGetAttempt.mockReset();
   mockGetEscalationChannel.mockReset();
+  mockGetModule.mockReset();
   mockGetStuckAttempts.mockReset();
+  mockHasEffectiveMembershipForUser.mockReset();
   mockHasEligibleMissingCredentialForModule.mockReset();
   mockMarkNotificationSent.mockReset();
   mockReconcilePassedAttemptModule.mockReset();
@@ -86,6 +94,8 @@ beforeEach(() => {
 
   mockGetStuckAttempts.mockResolvedValue([stuckAttempt()]);
   mockGetAttempt.mockResolvedValue(fullAttempt());
+  mockGetModule.mockResolvedValue({ id: 'module_a', is_free: false });
+  mockHasEffectiveMembershipForUser.mockResolvedValue(true);
   mockCheckAndAwardCredentials.mockResolvedValue([]);
   mockHasEligibleMissingCredentialForModule.mockResolvedValue(false);
   mockReconcilePassedAttemptModule.mockResolvedValue(undefined);


### PR DESCRIPTION
## What changed

- revalidate effective membership before paid-module checkpoints, module completion, test-out, and specialist exam completion
- gate already-passed reconciliation paths and tier 2/3 credential awards while preserving free tier 1 issuance
- apply the same guard to background/admin award checks and deferred badge backfills
- preserve Stripe lazy reconciliation for interactive learners whose local membership state is stale
- document a human-reviewed entitlement audit policy before annotation or revocation
- add regression coverage for membership ending after paid learning has started

## Why

Issue #6052 identified A3 access as suspicious, but A3 is intentionally free. The investigation exposed a different gap: membership was checked when paid learning started, but not at later mutation and issuance boundaries. Existing progress could therefore be completed after membership ended.

## Impact

Inactive learners retain access to the free Basics tier, but cannot mutate paid progress or receive Practitioner/Specialist credentials and deferred badges. Existing credentials are not automatically changed; historical candidates remain subject to human review.

## Validation

- certification unit suite: 65 passed
- TypeScript typecheck: passed
- repository unit suite: 5,392 passed, 30 skipped; one unrelated Slack signature test failed under the combined run and passed immediately when rerun alone (13/13)
- push-time version, changeset, and docs-navigation checks: passed

Fixes #6274
