### PR TITLE
fix(compliance): grade missing creative fixtures not applicable

### DIFF
--- a/.changeset/grade-missing-creative-fixtures-not-applicable.md
+++ b/.changeset/grade-missing-creative-fixtures-not-applicable.md
@@ -1,0 +1,10 @@
+---
+"adcontextprotocol": patch
+---
+
+Grade creative-asset fixture coverage gaps as `not_applicable` instead of
+failing the seller, require semantic text-slot matching, and add common image
+fixtures for 970x250, 300x600, 336x280, and 1080x1920 formats. Storyboards that
+previously stopped on a missing common-size fixture can now execute and produce
+real behavioral signal; valid formats the runner still cannot synthesize no
+longer count against the agent under test.

--- a/.changeset/grade-missing-creative-fixtures-not-applicable.md
+++ b/.changeset/grade-missing-creative-fixtures-not-applicable.md
@@ -2,9 +2,10 @@
 "adcontextprotocol": patch
 ---
 
-Grade creative-asset fixture coverage gaps as `not_applicable` instead of
-failing the seller, require semantic text-slot matching, and add common image
-fixtures for 970x250, 300x600, 336x280, and 1080x1920 formats. Storyboards that
-previously stopped on a missing common-size fixture can now execute and produce
-real behavioral signal; valid formats the runner still cannot synthesize no
-longer count against the agent under test.
+Grade creative-asset fixture coverage gaps as `not_applicable` with the new
+canonical `fixture_unavailable` skip reason instead of failing the seller,
+require explicit text-slot mappings, and add common image fixtures for 970x250,
+300x600, 336x280, and 1080x1920 formats. Storyboards that previously stopped on
+a missing common-size fixture can now execute and produce real behavioral
+signal; valid formats the runner still cannot synthesize no longer count
+against the agent under test.

--- a/static/compliance/source/test-kits/acme-outdoor.yaml
+++ b/static/compliance/source/test-kits/acme-outdoor.yaml
@@ -120,6 +120,34 @@ assets:
       mime_type: "image/jpeg"
       description: "Wide skyscraper hero — vertical trail scene"
 
+    - id: "hero_970x250"
+      url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-970x250.jpg"
+      width: 970
+      height: 250
+      mime_type: "image/jpeg"
+      description: "Billboard hero — panoramic mountain expedition"
+
+    - id: "hero_300x600"
+      url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-300x600.jpg"
+      width: 300
+      height: 600
+      mime_type: "image/jpeg"
+      description: "Half-page hero — vertical climbing scene"
+
+    - id: "hero_336x280"
+      url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-336x280.jpg"
+      width: 336
+      height: 280
+      mime_type: "image/jpeg"
+      description: "Large rectangle hero — trail camp at sunrise"
+
+    - id: "hero_1080x1920"
+      url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-1080x1920.jpg"
+      width: 1080
+      height: 1920
+      mime_type: "image/jpeg"
+      description: "Full-screen portrait hero — hiker approaching a summit"
+
     - id: "hero_master"
       url: "https://test-assets.adcontextprotocol.org/acme-outdoor/hero-master.jpg"
       width: 1200

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -26,7 +26,7 @@
 # --- Schema definition ---
 
 id: runner_output_contract
-version: "2.7.0"
+version: "2.8.0"
 title: "Runner output contract"
 summary: "Required failure-detail shape that AdCP storyboard runners MUST emit so implementors can self-diagnose validation failures."
 
@@ -809,7 +809,8 @@ skip_result:
     - reason                  # not_applicable | no_phases |
                               # prerequisite_failed | missing_tool |
                               # missing_test_controller |
-                              # unsatisfied_contract | peer_branch_taken |
+                              # fixture_unavailable | unsatisfied_contract |
+                              # peer_branch_taken |
                               # peer_substituted | requirement_unmet
     - detail                  # human-readable explanation citing the
                               # declared supported_protocols / specialisms
@@ -847,6 +848,19 @@ skip_result:
     missing_test_controller: |
       The storyboard requires comply_test_controller and the agent did not
       advertise it. Applies only to deterministic_testing phases.
+    fixture_unavailable: |
+      The item was selected and the agent declared the tested pathway, but the
+      runner's test kit cannot synthesize a valid input satisfying the agent's
+      declared contract. The storyboard grades not_applicable; this reason MUST
+      NOT produce a failed validation, increment failed-step counts, or cascade
+      prerequisite_failed to downstream phases. detail MUST begin with
+      `creative_asset_fixture_unavailable:` and name the unavailable slot id,
+      asset type, and any unsatisfied constraint.
+
+      This reason is runner-owned and distinct from `not_applicable` (an agent
+      capability/applicability gate evaluated false) and
+      `unsatisfied_contract` (a declared harness contract was required but not
+      in scope, which follows that contract's fail-or-skip semantics).
     unsatisfied_contract: |
       A test-kit harness contract (e.g., signed-requests-runner) is not in
       scope for this grading run. detail MUST cite the contract key. Per
@@ -1153,7 +1167,9 @@ cascade_rules:
     collapsed. Steps that skip with `peer_substituted` do NOT trigger the
     cascade — the `provides_state_for` mechanism already waived it (see
     `skip_result.reasons.peer_substituted`). Steps that skip with
-    `not_applicable`, `missing_tool`, or `missing_test_controller` do NOT
+    `fixture_unavailable` never trigger the cascade because the runner-owned
+    coverage gap grades the entire storyboard not_applicable. Steps that skip
+    with `not_applicable`, `missing_tool`, or `missing_test_controller` do NOT
     trigger the cascade when the `sole_stateful_step_exemption` below applies.
     A stateful step's genuine failure or `peer_branch_taken` skip does NOT
     cascade onto a sibling phase that shares its `branch_set.id` under `any_of`

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -662,7 +662,7 @@
 #   unsupported asset type, an unknown text-slot semantic, or no image fixture
 #   satisfying the declared dimensions — the runner MUST stop before transport
 #   and grade the storyboard `not_applicable` with `skip_result.reason:
-#   unsatisfied_contract`. The diagnostic detail MUST begin with
+#   fixture_unavailable`. The diagnostic detail MUST begin with
 #   `creative_asset_fixture_unavailable:` and name the slot id, asset type, and
 #   any unsatisfied constraint. This is a runner/test-kit coverage gap, not a
 #   grading signal about the agent, and MUST NOT contribute to failed steps.
@@ -1989,7 +1989,7 @@
 #       directive whose valid captured format cannot be satisfied by the
 #       runner's test-kit assets is not an unresolved substitution: it uses the
 #       storyboard-level not_applicable disposition with `skip_result.reason:
-#       unsatisfied_contract` at step preflight. This runner-owned coverage gap
+#       fixture_unavailable` at step preflight. This runner-owned coverage gap
 #       MUST NOT count as a failed step.
 #
 #       Output shape: runner-output-contract.yaml > validation_result, with
@@ -2382,7 +2382,7 @@
 # captures the seller's valid format contract. If the format context exists but
 # the runner's test kit cannot synthesize every required slot, the runner MUST
 # apply a storyboard-level `not_applicable` disposition with
-# `skip_result.reason: unsatisfied_contract` at step preflight, not the
+# `skip_result.reason: fixture_unavailable` at step preflight, not the
 # failed-step disposition from point 2. If the format context itself is absent
 # because its producer failed or was skipped, point 2 and the normal
 # prerequisite cascade still apply.

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -649,10 +649,27 @@
 #   asset map keyed by each required slot's canonical `asset_group_id` or legacy
 #   `asset_id`. Values come from the storyboard's test kit and MUST satisfy the
 #   slot contract. Image slots use an `assets.images[]` fixture satisfying the
-#   declared dimensions; URL slots use `assets.click_url`. If any required slot
-#   cannot be populated, the runner
-#   MUST fail the step before transport with `unresolved_substitution` rather
-#   than sending the directive or an incomplete manifest.
+#   declared dimensions; URL slots use `assets.click_url`; text slots use
+#   `assets.text` only through an explicit runner-maintained mapping from the
+#   exact declared `asset_group_id` or legacy `asset_id` to a fixture category
+#   (for example, `headlines`, `descriptions`, or `cta`). Runners MUST NOT infer
+#   text semantics from a slot-id substring or populate an unmapped slot (for
+#   example, `legal`, `disclaimer`, or `alt_text`) from an arbitrary fallback
+#   category.
+#
+#   Asset-fixture coverage exception: when the captured format is valid but the
+#   runner cannot populate a required slot from the test kit — including an
+#   unsupported asset type, an unknown text-slot semantic, or no image fixture
+#   satisfying the declared dimensions — the runner MUST stop before transport
+#   and grade the storyboard `not_applicable` with `skip_result.reason:
+#   unsatisfied_contract`. The diagnostic detail MUST begin with
+#   `creative_asset_fixture_unavailable:` and name the slot id, asset type, and
+#   any unsatisfied constraint. This is a runner/test-kit coverage gap, not a
+#   grading signal about the agent, and MUST NOT contribute to failed steps.
+#   A malformed directive, or missing format context caused by a prior agent
+#   step failing or being skipped, follows the ordinary harness-error or
+#   prerequisite-failure path instead; this exception MUST NOT conceal agent
+#   behavior that the storyboard actually observed.
 # sample_response: object (optional — example expected response; also surfaces in published docs)
 #
 # auth: "none" | object (optional — overrides the transport's default credentials for this step)
@@ -1968,7 +1985,12 @@
 #       ran). The step grades as failed. Also used at preflight when a
 #       substitution is statically unresolvable (e.g., {{runner.webhook_url:*}}
 #       on a run with no webhook receiver) to grade the entire storyboard
-#       not_applicable before execution.
+#       not_applicable before execution. A `$build_assets_from_format`
+#       directive whose valid captured format cannot be satisfied by the
+#       runner's test-kit assets is not an unresolved substitution: it uses the
+#       storyboard-level not_applicable disposition with `skip_result.reason:
+#       unsatisfied_contract` at step preflight. This runner-owned coverage gap
+#       MUST NOT count as a failed step.
 #
 #       Output shape: runner-output-contract.yaml > validation_result, with
 #       check: unresolved_substitution, expected: the unresolved token string,
@@ -2354,5 +2376,15 @@
 #   2. Before individual step execution — if a later-computed substitution
 #      (e.g., {{prior_step.<id>.task_id}}) fails to resolve, grade the
 #      step as failed with `unresolved_substitution`.
+#
+# Exception for runner-owned creative-asset coverage: a
+# `$build_assets_from_format` directive can only be resolved after a prior step
+# captures the seller's valid format contract. If the format context exists but
+# the runner's test kit cannot synthesize every required slot, the runner MUST
+# apply a storyboard-level `not_applicable` disposition with
+# `skip_result.reason: unsatisfied_contract` at step preflight, not the
+# failed-step disposition from point 2. If the format context itself is absent
+# because its producer failed or was skipped, point 2 and the normal
+# prerequisite cascade still apply.
 #
 # Neither path may ship a literal `$context.*` or `{{...}}` token on the wire.


### PR DESCRIPTION
## Summary

- grade valid creative formats the runner cannot synthesize as a storyboard
  coverage gap instead of a seller failure
- add the canonical `fixture_unavailable` skip reason with a stable
  `creative_asset_fixture_unavailable:` diagnostic prefix and no failure
  cascade
- require explicit exact slot-ID-to-text-fixture mappings, forbidding substring
  inference and arbitrary text fallback
- add 970x250, 300x600, 336x280, and 1080x1920 image fixtures to the Acme
  Outdoor test kit

## Why

`$build_assets_from_format` currently supports only a narrow set of asset
fixtures. A seller can declare a valid video, audio, HTML, VAST, text, or image
slot that the runner cannot populate; the runner then fails before transport
and attributes the harness limitation to the seller. Because the affected call
is a setup step, one coverage gap cascades across the remaining
`creative_fate_after_cancellation` phases.

The corrected boundary is explicit: if the valid captured format exists but
the test kit cannot synthesize it, the storyboard is not applicable and emits
`fixture_unavailable`. If the format context is absent because an earlier
agent step failed or was skipped, the ordinary prerequisite/failure cascade
still applies.

The SDK implementation is tracked separately in
adcontextprotocol/adcp-client#2465. Directive expansion paths that bypass the
runner remain tracked in adcontextprotocol/adcp-client#2459.

## Impact

Common image formats become executable immediately. Other valid formats no
longer receive false-negative seller grades when the runner lacks a suitable
fixture. No AdCP task request or response schema changes.

## Validation

- `npm run build:compliance`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- `git diff --check origin/main..codex/6269-fixture-coverage-v2`

Closes #6269.
