### PR TITLE
fix(compliance): preflight fixture gaps safely

### DIFF
--- a/.changeset/grade-missing-creative-fixtures-not-applicable.md
+++ b/.changeset/grade-missing-creative-fixtures-not-applicable.md
@@ -4,7 +4,9 @@
 
 Grade creative-asset fixture coverage gaps as `not_applicable` with the new
 canonical `fixture_unavailable` skip reason instead of failing the seller,
-require explicit text-slot mappings, and add common image fixtures for 970x250,
+preflight future directives before intervening side effects, preserve the skip
+as non-failing untested coverage in registry aggregation, require explicit
+text-slot mappings, and add common image fixtures for 970x250,
 300x600, 336x280, and 1080x1920 formats. Storyboards that previously stopped on
 a missing common-size fixture can now execute and produce real behavioral
 signal; valid formats the runner still cannot synthesize no longer count

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -626,6 +626,18 @@ function effectiveRunStatus(result: ComplianceResult): {
   const hasCoverageGapSkip = hasFixtureUnavailable || result.tracks
     .filter((track: TrackResult) => track.status === 'skip')
     .some(trackHasCoverageGapSkip);
+  const hasGenuineFailure = activeTracks.some((track: TrackResult) => track.status === 'fail') ||
+    result.overall_status === 'failing' ||
+    result.overall_status === 'auth_required' ||
+    result.overall_status === 'unreachable';
+  if (hasGenuineFailure) {
+    return {
+      overall_status: mapOverallStatus(result.overall_status),
+      tracks_passed: result.summary.tracks_passed,
+      tracks_failed: result.summary.tracks_failed,
+      tracks_partial: result.summary.tracks_partial,
+    };
+  }
   if (hasFixtureUnavailable) {
     return {
       overall_status: 'partial',

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -685,7 +685,10 @@ export function deriveStoryboardStatuses(
     },
     scenario: string,
   ): boolean => {
-    if (step.skip_reason === 'not_applicable') return true;
+    if (
+      step.skip_reason === 'not_applicable' ||
+      step.skip_reason === 'fixture_unavailable'
+    ) return true;
 
     // `@adcp/sdk` emits a single synthetic `missing_tool` phase when a
     // storyboard's `required_tools` gate is unmet. That means the storyboard is

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -541,6 +541,9 @@ export function isNonExecutableCoverageGapScenario(scenario: {
 }): boolean {
   const steps = Array.isArray(scenario.steps) ? scenario.steps : [];
   const scenarioId = typeof scenario.scenario === 'string' ? scenario.scenario : '';
+  if (steps.some(
+    (step) => step.skipped && step.skip_reason === 'fixture_unavailable',
+  )) return true;
   return steps.length > 0 && steps.every((step) => {
     if (!step?.skipped) return false;
     return step.skip_reason === 'peer_branch_taken' ||
@@ -590,6 +593,14 @@ function trackHasCoverageGapSkip(track: TrackResult): boolean {
   return false;
 }
 
+function trackHasFixtureUnavailableSkip(track: TrackResult): boolean {
+  return track.scenarios.some((scenario) =>
+    (scenario.steps ?? []).some((step) =>
+      step.skipped && step.skip_reason === 'fixture_unavailable'
+    )
+  );
+}
+
 /**
  * Derive the effective overall status and track counters from a ComplianceResult.
  *
@@ -611,9 +622,10 @@ function effectiveRunStatus(result: ComplianceResult): {
   // e.g. a signals-only agent skipping controller-gated media-buy pagination
   // storyboards with `missing_test_controller` — are expected and must not
   // degrade an otherwise all-pass run (#5429, regression of #5328).
-  const hasCoverageGapSkip = result.tracks
-    .filter((t: TrackResult) => t.status === 'skip')
-    .some(trackHasCoverageGapSkip);
+  const hasCoverageGapSkip = result.tracks.some((track: TrackResult) =>
+    trackHasFixtureUnavailableSkip(track) ||
+    (track.status === 'skip' && trackHasCoverageGapSkip(track))
+  );
   if (
     !hasCoverageGapSkip &&
     activeTracks.length > 0 &&

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -530,6 +530,28 @@ function isRunnerApplicabilitySkip(step: {
   }
 }
 
+export function isNonExecutableCoverageGapScenario(scenario: {
+  scenario?: unknown;
+  steps?: Array<{
+    skipped?: boolean;
+    skip_reason?: string;
+    step_id?: unknown;
+    requirement?: unknown;
+  }>;
+}): boolean {
+  const steps = Array.isArray(scenario.steps) ? scenario.steps : [];
+  const scenarioId = typeof scenario.scenario === 'string' ? scenario.scenario : '';
+  return steps.length > 0 && steps.every((step) => {
+    if (!step?.skipped) return false;
+    return step.skip_reason === 'peer_branch_taken' ||
+      step.skip_reason === 'peer_substituted' ||
+      step.skip_reason === 'missing_test_controller' ||
+      step.skip_reason === 'fixture_unavailable' ||
+      (step.skip_reason === 'requirement_unmet' && step.requirement === 'controller') ||
+      isRunnerApplicabilitySkip(step, scenarioId);
+  });
+}
+
 function skipReasonIsCoverageGap(
   reason: string | undefined,
   step?: {

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -533,6 +533,7 @@ function isRunnerApplicabilitySkip(step: {
 export function isNonExecutableCoverageGapScenario(scenario: {
   scenario?: unknown;
   steps?: Array<{
+    passed?: boolean;
     skipped?: boolean;
     skip_reason?: string;
     step_id?: unknown;
@@ -541,7 +542,8 @@ export function isNonExecutableCoverageGapScenario(scenario: {
 }): boolean {
   const steps = Array.isArray(scenario.steps) ? scenario.steps : [];
   const scenarioId = typeof scenario.scenario === 'string' ? scenario.scenario : '';
-  if (steps.some(
+  const hasGenuineFailure = steps.some((step) => !step.skipped && step.passed === false);
+  if (!hasGenuineFailure && steps.some(
     (step) => step.skipped && step.skip_reason === 'fixture_unavailable',
   )) return true;
   return steps.length > 0 && steps.every((step) => {

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -622,10 +622,18 @@ function effectiveRunStatus(result: ComplianceResult): {
   // e.g. a signals-only agent skipping controller-gated media-buy pagination
   // storyboards with `missing_test_controller` — are expected and must not
   // degrade an otherwise all-pass run (#5429, regression of #5328).
-  const hasCoverageGapSkip = result.tracks.some((track: TrackResult) =>
-    trackHasFixtureUnavailableSkip(track) ||
-    (track.status === 'skip' && trackHasCoverageGapSkip(track))
-  );
+  const hasFixtureUnavailable = result.tracks.some(trackHasFixtureUnavailableSkip);
+  const hasCoverageGapSkip = hasFixtureUnavailable || result.tracks
+    .filter((track: TrackResult) => track.status === 'skip')
+    .some(trackHasCoverageGapSkip);
+  if (hasFixtureUnavailable) {
+    return {
+      overall_status: 'partial',
+      tracks_passed: result.summary.tracks_passed,
+      tracks_failed: result.summary.tracks_failed,
+      tracks_partial: result.summary.tracks_partial,
+    };
+  }
   if (
     !hasCoverageGapSkip &&
     activeTracks.length > 0 &&

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -654,6 +654,7 @@ export function deriveStoryboardStatuses(
     stepLessPhasesPassed: number;
     stepLessPhasesTotal: number;
     controllerSkipped: number;
+    fixtureUnavailable: boolean;
     failureCount: number;
     skippedCount: number;
     firstFailure: FirstFailure | null;
@@ -719,6 +720,7 @@ export function deriveStoryboardStatuses(
           stepLessPhasesPassed: 0,
           stepLessPhasesTotal: 0,
           controllerSkipped: 0,
+          fixtureUnavailable: false,
           failureCount: 0,
           skippedCount: 0,
           firstFailure: null,
@@ -743,6 +745,9 @@ export function deriveStoryboardStatuses(
       let phaseSawNeutralApplicabilitySkip = false;
       for (const step of s.steps) {
         if (step.skipped) {
+          if (step.skip_reason === 'fixture_unavailable') {
+            agg.fixtureUnavailable = true;
+          }
           if (isBranchSkip(step)) {
             continue;
           }
@@ -789,6 +794,19 @@ export function deriveStoryboardStatuses(
       if (hasExplicitIds) {
         entries.push({ storyboard_id: sbId, status: 'untested', steps_passed: 0, steps_total: 0 });
       }
+      continue;
+    }
+
+    // Fixture availability is a whole-storyboard preflight disposition. The
+    // producer step that captured the format may already have passed, but that
+    // partial execution is not evidence that the seller behavior was tested.
+    if (agg.fixtureUnavailable) {
+      entries.push({
+        storyboard_id: sbId,
+        status: 'untested',
+        steps_passed: 0,
+        steps_total: 0,
+      });
       continue;
     }
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -35,6 +35,7 @@ import {
 import {
   comply,
   complianceResultToDbInput,
+  isNonExecutableCoverageGapScenario,
   classifyCapabilityResolutionError,
   presentCapabilityResolutionError,
   computeSpecialismStatus,
@@ -8030,35 +8031,6 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           steps_total: 0,
         };
         const serializedStoryboardStatus = serializeStoryboardRunStatus(storyboardStatus);
-        const isRunnerApplicabilitySkip = (scenarioId: string, step: {
-          skip_reason?: string;
-          step_id?: unknown;
-          requirement?: unknown;
-        }): boolean => {
-          switch (step.skip_reason) {
-            case 'capability_unsupported':
-              return true;
-            case 'missing_test_kit_contract':
-              return scenarioId === 'idempotency/rate_limit_replay_invariant' &&
-                step.step_id === 'expect_rate_limit_not_replayed';
-            case 'requirement_unmet':
-              return step.requirement === 'webhook_receiver';
-            default:
-              return false;
-          }
-        };
-        const isControllerCoverageGapScenario = (scenario: { scenario?: unknown; steps?: any[] }): boolean => {
-          const steps = Array.isArray(scenario.steps) ? scenario.steps : [];
-          const scenarioId = typeof scenario.scenario === 'string' ? scenario.scenario : '';
-          return steps.length > 0 && steps.every((step) => {
-            if (!step?.skipped) return false;
-            return step.skip_reason === 'peer_branch_taken' ||
-              step.skip_reason === 'peer_substituted' ||
-              step.skip_reason === 'missing_test_controller' ||
-              (step.skip_reason === 'requirement_unmet' && step.requirement === 'controller') ||
-              isRunnerApplicabilitySkip(scenarioId, step);
-          });
-        };
         const uiDiagnostics = (dbInput.step_diagnostics ?? []).map((diagnostic) => ({
           run_id: run.id,
           agent_url: agentUrl,
@@ -8082,7 +8054,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
                   t.scenarios.filter((s) => s.scenario === step.comply_scenario),
                 )
               : [];
-            const executableScenarios = matchingScenarios.filter((s) => !isControllerCoverageGapScenario(s));
+            const executableScenarios = matchingScenarios.filter(
+              (s) => !isNonExecutableCoverageGapScenario(s),
+            );
 
             const passed = executableScenarios.length > 0
               ? executableScenarios.every((s) => s.overall_passed)

--- a/server/tests/unit/compliance-testing-effective-run-status.test.ts
+++ b/server/tests/unit/compliance-testing-effective-run-status.test.ts
@@ -183,7 +183,7 @@ describe('complianceResultToDbInput — effectiveRunStatus', () => {
       {
         track: 'creative',
         label: 'Creative',
-        status: 'skip',
+        status: 'silent',
         duration_ms: 1000,
         skipped_scenarios: [],
         observations: [],
@@ -192,6 +192,11 @@ describe('complianceResultToDbInput — effectiveRunStatus', () => {
             scenario: 'creative_fate_after_cancellation/sync_creative_with_assignment',
             overall_passed: true,
             steps: [
+              {
+                step: 'Capture the seller format contract',
+                passed: true,
+                duration_ms: 0,
+              },
               {
                 step: 'Runner cannot synthesize the required creative asset',
                 passed: true,
@@ -216,7 +221,7 @@ describe('complianceResultToDbInput — effectiveRunStatus', () => {
       expect.objectContaining({ track: 'core', has_coverage_gap_skip: false }),
       expect.objectContaining({
         track: 'creative',
-        status: 'skip',
+        status: 'silent',
         has_coverage_gap_skip: true,
       }),
     ]);

--- a/server/tests/unit/compliance-testing-effective-run-status.test.ts
+++ b/server/tests/unit/compliance-testing-effective-run-status.test.ts
@@ -183,7 +183,7 @@ describe('complianceResultToDbInput — effectiveRunStatus', () => {
       {
         track: 'creative',
         label: 'Creative',
-        status: 'silent',
+        status: 'pass',
         duration_ms: 1000,
         skipped_scenarios: [],
         observations: [],
@@ -208,7 +208,7 @@ describe('complianceResultToDbInput — effectiveRunStatus', () => {
           },
         ],
       },
-    ] as any);
+    ] as any, 'passing');
 
     const out = complianceResultToDbInput(
       result as any,
@@ -221,7 +221,7 @@ describe('complianceResultToDbInput — effectiveRunStatus', () => {
       expect.objectContaining({ track: 'core', has_coverage_gap_skip: false }),
       expect.objectContaining({
         track: 'creative',
-        status: 'silent',
+        status: 'pass',
         has_coverage_gap_skip: true,
       }),
     ]);

--- a/server/tests/unit/compliance-testing-effective-run-status.test.ts
+++ b/server/tests/unit/compliance-testing-effective-run-status.test.ts
@@ -227,6 +227,46 @@ describe('complianceResultToDbInput — effectiveRunStatus', () => {
     ]);
   });
 
+  it('keeps a genuine seller failure above a concurrent runner fixture gap', () => {
+    const fixtureTrack = {
+      track: 'creative',
+      label: 'Creative',
+      status: 'pass',
+      duration_ms: 1000,
+      skipped_scenarios: [],
+      observations: [],
+      scenarios: [
+        {
+          scenario: 'creative_fate_after_cancellation/fixture_preflight',
+          overall_passed: true,
+          steps: [
+            { step: 'Capture format', passed: true, duration_ms: 0 },
+            {
+              step: 'Fixture unavailable',
+              passed: true,
+              skipped: true,
+              skip_reason: 'fixture_unavailable',
+              duration_ms: 0,
+            },
+          ],
+        },
+      ],
+    };
+    const result = makeResult([
+      makeTrack('fail'),
+      fixtureTrack,
+    ] as any, 'failing');
+
+    const out = complianceResultToDbInput(
+      result as any,
+      'https://agent.example.com/mcp',
+      'production',
+    );
+
+    expect(out.overall_status).toBe('failing');
+    expect(out.tracks_failed).toBe(1);
+  });
+
   it('does not promote when all tracks are skipped (no active tracks)', () => {
     const result = makeResult([makeTrack('skip'), makeTrack('skip')], 'partial');
     const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');

--- a/server/tests/unit/compliance-testing-effective-run-status.test.ts
+++ b/server/tests/unit/compliance-testing-effective-run-status.test.ts
@@ -177,6 +177,51 @@ describe('complianceResultToDbInput — effectiveRunStatus', () => {
     ]);
   });
 
+  it('keeps runner fixture gaps non-failing but coverage-incomplete', () => {
+    const result = makeResult([
+      makeTrack('silent'),
+      {
+        track: 'creative',
+        label: 'Creative',
+        status: 'skip',
+        duration_ms: 1000,
+        skipped_scenarios: [],
+        observations: [],
+        scenarios: [
+          {
+            scenario: 'creative_fate_after_cancellation/sync_creative_with_assignment',
+            overall_passed: true,
+            steps: [
+              {
+                step: 'Runner cannot synthesize the required creative asset',
+                passed: true,
+                skipped: true,
+                skip_reason: 'fixture_unavailable',
+                duration_ms: 0,
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    const out = complianceResultToDbInput(
+      result as any,
+      'https://agent.example.com/mcp',
+      'production',
+    );
+
+    expect(out.overall_status).toBe('partial');
+    expect(out.tracks_json).toEqual([
+      expect.objectContaining({ track: 'core', has_coverage_gap_skip: false }),
+      expect.objectContaining({
+        track: 'creative',
+        status: 'skip',
+        has_coverage_gap_skip: true,
+      }),
+    ]);
+  });
+
   it('does not promote when all tracks are skipped (no active tracks)', () => {
     const result = makeResult([makeTrack('skip'), makeTrack('skip')], 'partial');
     const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');

--- a/server/tests/unit/derive-storyboard-statuses.test.ts
+++ b/server/tests/unit/derive-storyboard-statuses.test.ts
@@ -229,6 +229,38 @@ describe('deriveStoryboardStatuses', () => {
     });
   });
 
+  it('treats an unavailable runner fixture and any legacy cascade as untested', () => {
+    const result = makeResult([
+      {
+        scenario: 'creative_fate_after_cancellation/sync_creative_with_assignment',
+        passed: true,
+        steps: [
+          {
+            passed: true,
+            skipped: true,
+            skip_reason: 'fixture_unavailable',
+            step: 'Runner cannot synthesize the required creative asset',
+          },
+          {
+            passed: true,
+            skipped: true,
+            skip_reason: 'prerequisite_failed',
+            step: 'Observe creative state',
+          },
+        ],
+      },
+    ]);
+
+    const [entry] = deriveStoryboardStatuses(result);
+
+    expect(entry).toEqual({
+      storyboard_id: 'creative_fate_after_cancellation',
+      status: 'untested',
+      steps_passed: 0,
+      steps_total: 0,
+    });
+  });
+
   it('treats storyboard-level required-tool skips as untested', () => {
     const result = makeResult([
       {

--- a/server/tests/unit/derive-storyboard-statuses.test.ts
+++ b/server/tests/unit/derive-storyboard-statuses.test.ts
@@ -85,13 +85,28 @@ describe('deriveStoryboardStatuses', () => {
     expect(isNonExecutableCoverageGapScenario({
       scenario: 'creative_fate_after_cancellation/fixture_preflight',
       steps: [
-        { skipped: false },
+        { passed: true, skipped: false },
         {
           skipped: true,
           skip_reason: 'fixture_unavailable',
         },
       ],
     })).toBe(true);
+  });
+
+  it('keeps fixture-gap UI scenarios executable when a real step also failed', () => {
+    expect(isNonExecutableCoverageGapScenario({
+      scenario: 'creative_fate_after_cancellation/fixture_preflight',
+      steps: [
+        { passed: true },
+        {
+          passed: true,
+          skipped: true,
+          skip_reason: 'fixture_unavailable',
+        },
+        { passed: false },
+      ],
+    })).toBe(false);
   });
 
   it('emits one entry per storyboard the runner produced data for', () => {

--- a/server/tests/unit/derive-storyboard-statuses.test.ts
+++ b/server/tests/unit/derive-storyboard-statuses.test.ts
@@ -232,6 +232,16 @@ describe('deriveStoryboardStatuses', () => {
   it('treats an unavailable runner fixture and any legacy cascade as untested', () => {
     const result = makeResult([
       {
+        scenario: 'creative_fate_after_cancellation/get_products_brief',
+        passed: true,
+        steps: [
+          {
+            passed: true,
+            step: 'Capture the seller format contract',
+          },
+        ],
+      },
+      {
         scenario: 'creative_fate_after_cancellation/sync_creative_with_assignment',
         passed: true,
         steps: [

--- a/server/tests/unit/derive-storyboard-statuses.test.ts
+++ b/server/tests/unit/derive-storyboard-statuses.test.ts
@@ -84,10 +84,13 @@ describe('deriveStoryboardStatuses', () => {
   it('classifies fixture-only UI scenarios as non-executable coverage gaps', () => {
     expect(isNonExecutableCoverageGapScenario({
       scenario: 'creative_fate_after_cancellation/fixture_preflight',
-      steps: [{
-        skipped: true,
-        skip_reason: 'fixture_unavailable',
-      }],
+      steps: [
+        { skipped: false },
+        {
+          skipped: true,
+          skip_reason: 'fixture_unavailable',
+        },
+      ],
     })).toBe(true);
   });
 

--- a/server/tests/unit/derive-storyboard-statuses.test.ts
+++ b/server/tests/unit/derive-storyboard-statuses.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { deriveStoryboardStatuses } from '../../src/addie/services/compliance-testing.js';
+import {
+  deriveStoryboardStatuses,
+  isNonExecutableCoverageGapScenario,
+} from '../../src/addie/services/compliance-testing.js';
 import type { ComplianceResult } from '@adcp/sdk/testing';
 
 /**
@@ -78,6 +81,16 @@ function makeResult(
 }
 
 describe('deriveStoryboardStatuses', () => {
+  it('classifies fixture-only UI scenarios as non-executable coverage gaps', () => {
+    expect(isNonExecutableCoverageGapScenario({
+      scenario: 'creative_fate_after_cancellation/fixture_preflight',
+      steps: [{
+        skipped: true,
+        skip_reason: 'fixture_unavailable',
+      }],
+    })).toBe(true);
+  });
+
   it('emits one entry per storyboard the runner produced data for', () => {
     const result = makeResult([
       { scenario: 'signal_owned/capability_discovery', passed: true, steps: [{ passed: true }] },

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -662,7 +662,14 @@
 #   unsupported asset type, an unknown text-slot semantic, or no image fixture
 #   satisfying the declared dimensions — the runner MUST stop before transport
 #   and grade the storyboard `not_applicable` with `skip_result.reason:
-#   fixture_unavailable`. The diagnostic detail MUST begin with
+#   fixture_unavailable`. As soon as the referenced format context is captured,
+#   the runner MUST preflight every remaining `$build_assets_from_format`
+#   directive that uses it before executing any intervening side-effecting
+#   step. On this disposition, the runner MUST terminate the storyboard without
+#   executing its remaining phases or emitting `prerequisite_failed` cascades.
+#   This early whole-storyboard preflight prevents a later fixture gap from
+#   leaving behind state such as an active media buy. The diagnostic detail MUST
+#   begin with
 #   `creative_asset_fixture_unavailable:` and name the slot id, asset type, and
 #   any unsatisfied constraint. This is a runner/test-kit coverage gap, not a
 #   grading signal about the agent, and MUST NOT contribute to failed steps.
@@ -1989,8 +1996,10 @@
 #       directive whose valid captured format cannot be satisfied by the
 #       runner's test-kit assets is not an unresolved substitution: it uses the
 #       storyboard-level not_applicable disposition with `skip_result.reason:
-#       fixture_unavailable` at step preflight. This runner-owned coverage gap
-#       MUST NOT count as a failed step.
+#       fixture_unavailable` at the earliest preflight after the referenced
+#       format is captured and before any intervening side-effecting step. The
+#       runner terminates the remaining storyboard without prerequisite
+#       cascades. This runner-owned coverage gap MUST NOT count as a failed step.
 #
 #       Output shape: runner-output-contract.yaml > validation_result, with
 #       check: unresolved_substitution, expected: the unresolved token string,
@@ -2382,9 +2391,12 @@
 # captures the seller's valid format contract. If the format context exists but
 # the runner's test kit cannot synthesize every required slot, the runner MUST
 # apply a storyboard-level `not_applicable` disposition with
-# `skip_result.reason: fixture_unavailable` at step preflight, not the
-# failed-step disposition from point 2. If the format context itself is absent
-# because its producer failed or was skipped, point 2 and the normal
+# `skip_result.reason: fixture_unavailable` at the earliest preflight after the
+# referenced format is captured, not wait until the directive-bearing step.
+# This preflight MUST occur before any intervening side-effecting step. The
+# runner then terminates the remaining storyboard without executing later
+# phases or emitting `prerequisite_failed` cascades. If the format context itself
+# is absent because its producer failed or was skipped, point 2 and the normal
 # prerequisite cascade still apply.
 #
 # Neither path may ship a literal `$context.*` or `{{...}}` token on the wire.


### PR DESCRIPTION
## Summary

- treat canonical `fixture_unavailable` skips as non-failing, untested storyboard coverage in registry aggregation
- preserve them as coverage-incomplete so they cannot promote an unexecuted track
- require future creative-asset directives to preflight immediately after format capture and before intervening side effects
- terminate the remaining storyboard without prerequisite cascades when the runner cannot synthesize a valid fixture

## Why this follows #6276

Independent protocol and code-review audits after #6276 merged found two downstream gaps: the registry consumer would count the new reason as a seller failure, and deferred expansion could discover an unavailable fixture only after creating a media buy. This follow-up closes both gaps before the SDK implementation lands.

## Validation

- `npx vitest run server/tests/unit/derive-storyboard-statuses.test.ts server/tests/unit/compliance-testing-effective-run-status.test.ts` (110 tests passed across configured projects)
- `npm run build:compliance`
- `git diff --check origin/main..codex/6269-fixture-followup`

Follow-up to #6276 and #6269. Blocks adcontextprotocol/adcp-client#2475 until merged.