### PR TITLE
fix(compliance): run hosted grader on sdk rc.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.1.1",
       "dependencies": {
         "@adcp/sdk": "12.1.1",
+        "@adcp/sdk-compliance": "npm:@adcp/sdk@13.0.0-rc.9",
         "@anthropic-ai/sdk": "^0.115.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.8.0",
@@ -172,6 +173,131 @@
         "redis": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@adcp/sdk-compliance": {
+      "name": "@adcp/sdk",
+      "version": "13.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-13.0.0-rc.9.tgz",
+      "integrity": "sha512-7Cg0ZxdxzrV7kc4BeplxR9eRebV4V1PNqURKuDEyPwHxaF/vqOlt00957jUmIkXjWjje6c3PSoNlW4EKwfbvtA==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        ".",
+        "packages/*"
+      ],
+      "dependencies": {
+        "@modelcontextprotocol/client": "2.0.0",
+        "@modelcontextprotocol/node": "2.0.0",
+        "@modelcontextprotocol/server": "2.0.0",
+        "@types/ws": "^8.18.1",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
+        "fast-check": "^3.23.2",
+        "jose": "^6.2.2",
+        "secure-json-parse": "^4.1.0",
+        "structured-headers": "2.0.2",
+        "tldts": "^7.0.29",
+        "undici": "^6.27.0",
+        "ws": "^8.21.0",
+        "yaml": "^2.7.1"
+      },
+      "bin": {
+        "adcp": "bin/adcp.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@a2a-js/sdk": "^0.3.13",
+        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@opentelemetry/api": "^1.0.0",
+        "pg": "^8.0.0",
+        "redis": "^4.6.0 || ^5.0.0",
+        "zod": "^4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adcp/sdk-compliance/node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@adcp/sdk-compliance/node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@adcp/sdk-compliance/node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adcp/sdk-compliance/node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@adcp/sdk-compliance/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@adcp/sdk/node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
   },
   "dependencies": {
     "@adcp/sdk": "12.1.1",
+    "@adcp/sdk-compliance": "npm:@adcp/sdk@13.0.0-rc.9",
     "@anthropic-ai/sdk": "^0.115.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.8.0",

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -6,20 +6,23 @@
  */
 
 import {
+  SAMPLE_BRIEFS,
+  getBriefsByVertical,
+  type ComplyOptions as StableComplyOptions,
+} from '@adcp/sdk/testing';
+import {
   setAgentTesterLogger,
   comply as sdkComply,
   loadComplianceIndex as sdkLoadComplianceIndex,
   testCapabilityDiscovery,
+  CapabilityResolutionError,
   type ComplyOptions,
   type ComplianceResult,
   type ComplianceTrack,
   type TrackResult,
   type AdvisoryObservation,
   type SampleBrief,
-  SAMPLE_BRIEFS,
-  getBriefsByVertical,
-  CapabilityResolutionError,
-} from '@adcp/sdk/testing';
+} from '@adcp/sdk-compliance/testing';
 import {
   hostedComplianceTarget,
   hostedAuthProbeTaskForProfile,
@@ -47,6 +50,29 @@ import type {
 
 const logger = createLogger('addie-compliance-testing');
 const DEFAULT_TARGET_DISCOVERY_TIMEOUT_MS = 10_000;
+
+// The application remains on the stable SDK while hosted grading consumes the
+// release candidate. These helpers only add transport/cache options that are
+// structurally identical across both versions; keep the cast at this boundary
+// rather than forcing the RC's expanded types into stable-SDK helper signatures.
+// Remove the package alias and these adapters when the application moves to SDK 13.
+function withComplianceSdkTransport(options: ComplyOptions): ComplyOptions {
+  return withSdkSafeTransport(options as unknown as StableComplyOptions) as unknown as ComplyOptions;
+}
+
+function withHostedRcOptions(
+  options: ComplyOptions,
+  target: HostedComplianceTarget,
+  probeTask?: string,
+  apiKey?: string,
+): ComplyOptions {
+  return withHostedComplianceRunOptions(
+    options as unknown as StableComplyOptions,
+    target,
+    probeTask,
+    apiKey,
+  ) as unknown as ComplyOptions;
+}
 
 export interface ComplianceTargetSelection {
   target: HostedComplianceTarget;
@@ -122,12 +148,12 @@ export async function comply(
   options: ComplyOptions,
   target: HostedComplianceTarget,
 ): Promise<ComplianceResult> {
-  const safeOptions = withSdkSafeTransport(options);
+  const safeOptions = withComplianceSdkTransport(options);
   const authDefaults = await hostedAuthDefaultsForRun(agentUrl, safeOptions);
   const result = await sdkComply(
     agentUrl,
-    withSdkSafeTransport(
-      withHostedComplianceRunOptions(safeOptions, target, authDefaults.probeTask, authDefaults.apiKey),
+    withComplianceSdkTransport(
+      withHostedRcOptions(safeOptions, target, authDefaults.probeTask, authDefaults.apiKey),
     ),
   );
   result.adcp_version ??= target.version;
@@ -137,7 +163,7 @@ export async function comply(
 
 export function loadComplianceIndex(target: HostedComplianceTarget, options: ComplyOptions = {}) {
   return sdkLoadComplianceIndex(
-    withSdkSafeTransport(withHostedComplianceRunOptions(options, target)),
+    withComplianceSdkTransport(withHostedRcOptions(options, target)),
   );
 }
 
@@ -152,7 +178,7 @@ export async function selectComplianceTargetForAgentSelection(
   mode: 'preferred' | 'canonical' = 'preferred',
 ): Promise<ComplianceTargetSelection> {
   try {
-    const safeOptions = withSdkSafeTransport(options);
+    const safeOptions = withComplianceSdkTransport(options);
     const discovery = await withTimeout(
       testCapabilityDiscovery(agentUrl, safeOptions),
       complianceTargetDiscoveryTimeoutMs(safeOptions),

--- a/tests/addie/compliance-sdk-rc-transport.test.ts
+++ b/tests/addie/compliance-sdk-rc-transport.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  safeFetch: vi.fn(),
+}));
+
+vi.mock('../../server/src/utils/url-security.js', async () => {
+  const actual = await vi.importActual<typeof import('../../server/src/utils/url-security.js')>(
+    '../../server/src/utils/url-security.js',
+  );
+  mocks.safeFetch.mockImplementation(actual.safeFetch);
+  return {
+    ...actual,
+    safeFetch: mocks.safeFetch,
+  };
+});
+
+import {
+  comply,
+  defaultComplianceTarget,
+} from '../../server/src/addie/services/compliance-testing.js';
+
+describe('hosted compliance SDK transport', () => {
+  it('runs rc.9 compliance requests through the SSRF-safe fetch boundary', async () => {
+    const result = await comply(
+      'http://127.0.0.1:1/mcp',
+      { allow_http: true, timeout_ms: 1_000 },
+      defaultComplianceTarget(),
+    );
+
+    expect(result.overall_status).toBe('unreachable');
+    expect(mocks.safeFetch).toHaveBeenCalled();
+    expect(mocks.safeFetch.mock.calls.some(([url]) => String(url).startsWith('http://127.0.0.1:1'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- keep the application on the stable `@adcp/sdk@12.1.1` surface
- add an isolated `@adcp/sdk-compliance` alias pinned to `@adcp/sdk@13.0.0-rc.9`
- route hosted compliance execution, capability discovery, and compliance-index loading through rc.9
- keep the stable/RC type compatibility cast at the hosted-grader boundary

## Why

The rc.9 SDK contains the creative-fixture and unexpanded-directive fixes needed to verify #6267 and consume the completed #6269 work. Moving the entire application to SDK 13 currently requires a broad, unrelated API/schema migration, so this change upgrades only the hosted grader.

## Impact

After deployment, scheduled heartbeats and owner/admin compliance runs use rc.9. The rest of the application and training-agent implementation remain on the stable SDK.

## Validation

- `npm run typecheck`
- `npm run build`
- 48 hosted-compliance server unit tests
- 10 compliance adapter/version tests
- `npm run test:sdk-shims`

No changeset: this is an application/runtime dependency change, not a published AdCP protocol package change.
