### PR TITLE
fix(registry): restore public agent discovery

### DIFF
--- a/server/public/agents.html
+++ b/server/public/agents.html
@@ -558,6 +558,10 @@
         return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
+    function agentToolCount(agent) {
+        return Number(agent?.health?.tools_count ?? agent?.capabilities?.tools_count) || 0;
+    }
+
     window.addEventListener('DOMContentLoaded', async () => {
         handleRoute();
         window.addEventListener('hashchange', handleRoute);
@@ -692,7 +696,7 @@
 
         container.innerHTML = filtered.map(agent => {
             const agentSlug = agent.name.toLowerCase().replace(/\s+/g, '-');
-            const toolCount = agent.capabilities?.tools_count || 0;
+            const toolCount = agentToolCount(agent);
 
             let metaHtml = `
                 <div class="meta-item">
@@ -1079,7 +1083,7 @@
                     <details>
                         <summary class="detail-section__summary">
                             <span class="detail-section__arrow">&#9654;</span>
-                            Tools (${Number(agentWithCaps?.capabilities?.tools_count) || 0})
+                            Tools (${agentToolCount(agentWithCaps)})
                         </summary>
                         <div id="tools-section" class="detail-section__content"><div class="loading">Loading tools...</div></div>
                     </details>
@@ -1149,7 +1153,8 @@
             const allAgents = data.agents || data;
             const agentWithCaps = allAgents.find(a => a.url === agent.url);
 
-            if (!agentWithCaps || !agentWithCaps.capabilities || agentWithCaps.capabilities.tools_count === 0) {
+            const toolCount = agentToolCount(agentWithCaps);
+            if (toolCount === 0) {
                 section.innerHTML = `<div class="property-section-small">No tools discovered yet.</div>`;
                 return;
             }
@@ -1159,8 +1164,8 @@
             if (tools.length === 0) {
                 section.innerHTML = `
                     <div class="tools-summary">
-                        <span class="tools-summary__count">Total tools: ${agentWithCaps.capabilities.tools_count}</span>
-                        <p class="tools-summary__desc">This agent exposes ${agentWithCaps.capabilities.tools_count} tools via ${agent.protocol || 'mcp'} protocol.</p>
+                        <span class="tools-summary__count">Total tools: ${toolCount}</span>
+                        <p class="tools-summary__desc">This agent exposes ${toolCount} tools via ${agent.protocol || 'mcp'} protocol.</p>
                     </div>
                 `;
                 return;
@@ -1168,8 +1173,8 @@
 
             let html = `
                 <div class="tools-summary">
-                    <span class="tools-summary__count">Total tools: ${tools.length}</span>
-                    <p class="tools-summary__desc">This agent exposes ${tools.length} tools via ${agent.protocol || 'mcp'} protocol.</p>
+                    <span class="tools-summary__count">Total tools: ${toolCount}</span>
+                    <p class="tools-summary__desc">This agent exposes ${toolCount} tools via ${agent.protocol || 'mcp'} protocol.</p>
                 </div>
                 <div class="tools-list">
             `;
@@ -1199,41 +1204,22 @@
 
     async function fetchPublishers(agent) {
         try {
-            const response = await fetch(`/mcp`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    jsonrpc: '2.0',
-                    id: 1,
-                    method: 'tools/call',
-                    params: {
-                        name: 'get_properties_for_agent',
-                        arguments: { agent_url: agent.url }
-                    }
-                })
-            });
+            const response = await fetch(`/api/public/agent-publishers?url=${encodeURIComponent(agent.url)}`);
             const data = await response.json();
-            const content = data?.result?.content?.[0];
-            const text = content?.resource?.text || content?.text;
-            if (!text) {
-                document.getElementById('publishers-section').innerHTML = '<div style="color: var(--color-text-muted); font-size: var(--text-sm);">No publisher data available.</div>';
-                return;
-            }
-            const result = JSON.parse(text);
-
             const section = document.getElementById('publishers-section');
 
-            if (result.error) {
+            if (!response.ok || data.error) {
+                const message = data.error?.message || data.message || data.error || 'Unknown error';
                 section.innerHTML = `<div class="tool-error-box">
-                    <strong>Error:</strong> ${escapeHtml(result.error)}
+                    <strong>Error:</strong> ${escapeHtml(message)}
                 </div>`;
                 return;
             }
 
-            if (result.properties && result.properties.length > 0) {
-                const verified = result.properties.filter(p => p.verified === true);
-                const unverified = result.properties.filter(p => p.verified === false);
-                const unchecked = result.properties.filter(p => p.verified === undefined);
+            if (data.properties && data.properties.length > 0) {
+                const verified = data.properties.filter(p => p.verified === true);
+                const unverified = data.properties.filter(p => p.verified === false);
+                const unchecked = data.properties.filter(p => p.verified === undefined);
 
                 let html = '';
 
@@ -1323,7 +1309,7 @@
         section.innerHTML = '<div class="loading">Loading formats...</div>';
 
         try {
-            const response = await fetch(`/api/public/agent-products?url=${encodeURIComponent(agent.url)}`);
+            const response = await fetch(`/api/public/agent-formats?url=${encodeURIComponent(agent.url)}`);
             const data = await response.json();
 
             if (!response.ok || data.error) {
@@ -1331,13 +1317,11 @@
                 return;
             }
 
-            const formats = (data.products || []).flatMap(product =>
-                (product.format_options || []).map(option => ({
-                    name: option.display_name || option.label || option.format_option_id || option.format_kind,
-                    format: option,
-                    description: product.description
-                }))
-            );
+            const formats = (data.formats || []).map(entry => ({
+                name: entry.capability_id || entry.format?.display_name || entry.format?.format_kind,
+                format: entry.format || entry,
+                description: entry.description
+            }));
 
             if (formats.length === 0) {
                 section.innerHTML = '<div class="property-section-small">No creative formats available</div>';
@@ -1372,42 +1356,24 @@
         section.innerHTML = '<div class="loading">Loading products...</div>';
 
         try {
-            const response = await fetch(`/mcp`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    jsonrpc: '2.0',
-                    id: 1,
-                    method: 'tools/call',
-                    params: {
-                        name: 'get_products_for_agent',
-                        arguments: { agent_url: agent.url, params: {} }
-                    }
-                })
-            });
+            const response = await fetch(`/api/public/agent-products?url=${encodeURIComponent(agent.url)}`);
             const data = await response.json();
 
-            if (data.error) {
-                section.innerHTML = `<div class="property-section-small">Unable to fetch products: ${escapeHtml(data.error.message || 'Unknown error')}</div>`;
-                return;
-            }
-
-            const result = JSON.parse(data.result.content[0].resource.text);
-
-            if (result.error) {
-                const isValidationError = result.error.includes('does not match') || result.error.includes('Input should be');
+            if (!response.ok || data.error) {
+                const message = data.error?.message || data.message || data.error || 'Unknown error';
+                const isValidationError = message.includes('does not match') || message.includes('Input should be');
                 section.innerHTML = `
                     <div class="agent-params-required">
                         <div class="agent-params-required__title">${isValidationError ? 'Agent requires parameters' : 'Agent error'}</div>
                         <div class="agent-params-required__desc">
-                            ${isValidationError ? 'This agent requires specific targeting criteria (brief, brand_manifest, etc.) and does not support browsing public products.' : escapeHtml(result.error)}
+                            ${isValidationError ? 'This agent requires specific targeting criteria (brief, brand_manifest, etc.) and does not support browsing public products.' : escapeHtml(message)}
                         </div>
                     </div>
                 `;
                 return;
             }
 
-            const products = result.products || [];
+            const products = data.products || [];
 
             if (products.length === 0) {
                 section.innerHTML = '<div class="property-section-small">No public products available (may require targeting)</div>';
@@ -1418,11 +1384,10 @@
             products.forEach(product => {
                 html += `
                     <div class="product-card">
-                        <div class="product-card__name">${escapeHtml(product.name || product.id || 'Unnamed Product')}</div>
+                        <div class="product-card__name">${escapeHtml(product.name || product.product_id || 'Unnamed Product')}</div>
                         ${product.description ? `<div class="product-card__desc">${escapeHtml(product.description)}</div>` : ''}
-                        ${product.inventory_type ? `<div class="product-card__meta"><strong>Type:</strong> ${escapeHtml(product.inventory_type)}</div>` : ''}
-                        ${product.price ? `<div class="product-card__meta"><strong>Price:</strong> ${escapeHtml(String(product.price.amount))} ${escapeHtml(product.price.currency)}</div>` : ''}
-                        ${product.publisher_domain ? `<div class="product-card__meta"><strong>Publisher:</strong> ${escapeHtml(product.publisher_domain)}</div>` : ''}
+                        ${product.property_type ? `<div class="product-card__meta"><strong>Type:</strong> ${escapeHtml(product.property_type)}</div>` : ''}
+                        ${product.base_rate !== undefined && product.base_rate !== null ? `<div class="product-card__meta"><strong>Price:</strong> ${escapeHtml(String(product.base_rate))} ${escapeHtml(product.currency || '')}</div>` : ''}
                     </div>
                 `;
             });

--- a/server/public/agents.html
+++ b/server/public/agents.html
@@ -558,6 +558,15 @@
         return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
+    function safeHttpsUrl(value) {
+        try {
+            const parsed = new URL(String(value));
+            return parsed.protocol === 'https:' ? parsed.href : null;
+        } catch {
+            return null;
+        }
+    }
+
     function agentToolCount(agent) {
         return Number(agent?.health?.tools_count ?? agent?.capabilities?.tools_count) || 0;
     }
@@ -1159,7 +1168,7 @@
                 return;
             }
 
-            const tools = agentWithCaps.capabilities.tools || [];
+            const tools = agentWithCaps?.capabilities?.tools || [];
 
             if (tools.length === 0) {
                 section.innerHTML = `
@@ -1237,9 +1246,9 @@
                                             ${p.country ? ` | <strong>Country:</strong> ${escapeHtml(p.country)}` : ''}
                                         </div>
                                     </div>
-                                    <a href="${escapeHtml(p.verification_url)}" target="_blank" rel="noopener noreferrer" class="publisher-verify-link" title="View adagents.json">
+                                    ${safeHttpsUrl(p.verification_url) ? `<a href="${escapeHtml(safeHttpsUrl(p.verification_url))}" target="_blank" rel="noopener noreferrer" class="publisher-verify-link" title="View adagents.json">
                                         Verified
-                                    </a>
+                                    </a>` : '<span class="publisher-verify-link">Verified</span>'}
                                 </div>
                                 ${p.description ? `<div class="property-section-small" style="margin-top: var(--space-2);">${escapeHtml(p.description)}</div>` : ''}
                                 ${p.tags && p.tags.length > 0 ? `
@@ -1268,7 +1277,7 @@
                                         <div class="publisher-domain">${escapeHtml(p.identifier || p.domain || 'Unknown')}</div>
                                         <div class="property-section-small" style="margin-top: var(--space-1);">${escapeHtml(p.type || 'domain')}</div>
                                     </div>
-                                    ${p.verification_url ? `<a href="${escapeHtml(p.verification_url)}" target="_blank" rel="noopener noreferrer" class="publisher-verify-link publisher-verify-link--error" title="Check adagents.json">
+                                    ${safeHttpsUrl(p.verification_url) ? `<a href="${escapeHtml(safeHttpsUrl(p.verification_url))}" target="_blank" rel="noopener noreferrer" class="publisher-verify-link publisher-verify-link--error" title="Check adagents.json">
                                         Check
                                     </a>` : ''}
                                 </div>
@@ -1519,7 +1528,7 @@
                         <div><strong>Canonical kind:</strong> ${escapeHtml(format.format?.format_kind || '')}</div>
                         <div><strong>Operations:</strong> ${escapeHtml((format.operations || []).join(', '))}</div>
                         ${width && height ? `<div><strong>Dimensions:</strong> ${escapeHtml(String(width))}&times;${escapeHtml(String(height))}px</div>` : ''}
-                        ${params.min_width || params.min_height ? `<div><strong>Responsive:</strong> Yes (${params.min_width || 0}&times;${params.min_height || 0} to ${params.max_width || width}&times;${params.max_height || height})</div>` : ''}
+                        ${params.min_width || params.min_height ? `<div><strong>Responsive:</strong> Yes (${escapeHtml(String(params.min_width || 0))}&times;${escapeHtml(String(params.min_height || 0))} to ${escapeHtml(String(params.max_width || width || 0))}&times;${escapeHtml(String(params.max_height || height || 0))})</div>` : ''}
                     </div>
                 </div>
             </div>

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -9147,14 +9147,6 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
       }
     });
 
-    // GET /api/public/agent-publishers - Deprecated: listAuthorizedProperties was removed from AdCP SDK
-    this.app.get('/api/public/agent-publishers', async (_req, res) => {
-      return res.status(501).json({
-        error: 'Not Implemented',
-        message: 'The list_authorized_properties task is no longer supported in the current SDK version',
-      });
-    });
-
     // Note: Member profile routes are in routes/member-profiles.ts (mounted in setupRoutes)
 
     // Note: Account management routes are in routes/admin/accounts.ts

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -9678,7 +9678,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
       if (formats.length === 0) {
         try {
-          const legacyResult = await capabilityClient.executeTask("list_creative_formats", {});
+          const legacyResult = await capabilityClient.executeTask(
+            "list_creative_formats",
+            {},
+            undefined,
+            { timeout: PUBLIC_AGENT_TIMEOUT_MS },
+          );
           if (!legacyResult.success) {
             throw new Error(legacyResult.error || "Legacy creative format discovery failed");
           }
@@ -9729,7 +9734,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         agent_uri: url,
         protocol: "mcp",
       }, publicAgentTransportOptions());
-      const result = await client.executeTask("list_authorized_properties", {});
+      const result = await client.executeTask(
+        "list_authorized_properties",
+        {},
+        undefined,
+        { timeout: PUBLIC_AGENT_TIMEOUT_MS },
+      );
       if (!result.success) {
         throw new Error(result.error || "Publisher discovery failed");
       }
@@ -9776,7 +9786,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         protocol: "mcp",
       }, publicAgentTransportOptions());
 
-      const result = await client.getProducts({ buying_mode: 'wholesale' });
+      const result = await client.getProducts(
+        { buying_mode: 'wholesale' },
+        undefined,
+        { timeout: PUBLIC_AGENT_TIMEOUT_MS },
+      );
       const products = (result.data?.products || []).slice(0, PUBLIC_AGENT_MAX_ITEMS);
 
       const payload = {

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -144,6 +144,7 @@ import { getDevUser, isDevModeEnabled } from "../middleware/auth.js";
 import { OrganizationDatabase, hasApiAccess, resolveMembershipTier } from "../db/organization-db.js";
 import { resolveCallerOrgId } from "./helpers/resolve-caller-org.js";
 import { canonicalizeAgentUrl, PublisherDatabase } from "../db/publisher-db.js";
+import { buildCreativeCapabilities } from "../creative-agent/task-handlers.js";
 import {
   AuthorizationSnapshotDatabase,
   EvidenceValidationError,
@@ -2174,11 +2175,24 @@ registry.registerPath({
   path: "/api/public/agent-formats",
   operationId: "getAgentFormats",
   summary: "Get creative-agent format capabilities",
-  description: "Fetch get_adcp_capabilities creative.supported_formats[] from a creative agent.",
+  description: "Fetch get_adcp_capabilities creative.supported_formats[] from a creative agent, falling back to the deprecated list_creative_formats catalog for 3.1-compatible agents.",
   tags: ["Agent Probing"],
   request: { query: z.object({ url: z.string() }) },
   responses: {
     200: { description: "Canonical creative capabilities", content: { "application/json": { schema: z.object({ success: z.boolean(), formats: z.array(z.unknown()) }) } } },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/public/agent-publishers",
+  operationId: "getAgentPublishers",
+  summary: "Get agent publisher properties",
+  description: "Fetch public list_authorized_properties data from a sales agent.",
+  tags: ["Agent Probing"],
+  request: { query: z.object({ url: z.string() }) },
+  responses: {
+    200: { description: "Publisher properties", content: { "application/json": { schema: z.object({ success: z.boolean(), properties: z.array(z.unknown()) }) } } },
   },
 });
 
@@ -5937,6 +5951,13 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
               if (h.stats_json) {
                 enrichedAgent.stats = h.stats_json;
               }
+              // The health snapshot comes from the latest tools/list probe;
+              // the capability catalog can lag on a separate crawl cadence.
+              // Keep the legacy capabilities count fresh for consumers that
+              // have not yet moved to health.tools_count.
+              if (enrichedAgent.capabilities && h.tools_count != null) {
+                enrichedAgent.capabilities.tools_count = h.tools_count;
+              }
             }
           }
 
@@ -9519,9 +9540,38 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         agent_uri: url,
         protocol: "mcp",
       }], withSdkSafeTransport({})).agent("creative-capability-discovery");
-      const result = await capabilityClient.getAdcpCapabilities({}, undefined, { timeout: 10_000 });
-      const creative = (result.data as Record<string, unknown> | undefined)?.creative as Record<string, unknown> | undefined;
-      const formats = Array.isArray(creative?.supported_formats) ? creative.supported_formats : [];
+      let formats: unknown[] = [];
+      let capabilityError: unknown;
+
+      try {
+        const result = await capabilityClient.getAdcpCapabilities({}, undefined, { timeout: 10_000 });
+        const creative = (result.data as Record<string, unknown> | undefined)?.creative as Record<string, unknown> | undefined;
+        formats = Array.isArray(creative?.supported_formats) ? creative.supported_formats : [];
+      } catch (error) {
+        capabilityError = error;
+        logger.debug({ err: error, url }, "Canonical creative capability discovery failed; trying legacy formats");
+      }
+
+      if (formats.length === 0) {
+        try {
+          const legacyResult = await capabilityClient.executeTask("list_creative_formats", {});
+          if (!legacyResult.success) {
+            throw new Error(legacyResult.error || "Legacy creative format discovery failed");
+          }
+          const legacyData = legacyResult.data as unknown;
+          const legacyFormats = Array.isArray(legacyData)
+            ? legacyData
+            : legacyData && typeof legacyData === "object" && Array.isArray((legacyData as Record<string, unknown>).formats)
+              ? (legacyData as { formats: unknown[] }).formats
+              : [];
+          formats = buildCreativeCapabilities(
+            legacyFormats.filter((entry): entry is Record<string, unknown> => Boolean(entry && typeof entry === "object" && !Array.isArray(entry))),
+          );
+        } catch (error) {
+          if (capabilityError) throw error;
+          logger.debug({ err: error, url }, "Legacy creative format discovery failed");
+        }
+      }
 
       return res.json({
         success: true,
@@ -9535,6 +9585,49 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       }
 
       return res.status(502).json({ error: "Failed to fetch formats" });
+    }
+  });
+
+  router.get("/public/agent-publishers", async (req, res) => {
+    const { url } = req.query;
+
+    if (!url || typeof url !== "string") {
+      return res.status(400).json({ error: "URL is required" });
+    }
+
+    try {
+      const client = new SingleAgentClient({
+        id: "publisher-discovery",
+        name: "publisher-discovery-client",
+        agent_uri: url,
+        protocol: "mcp",
+      }, withSdkSafeTransport({}));
+      const result = await client.executeTask("list_authorized_properties", {});
+      if (!result.success) {
+        throw new Error(result.error || "Publisher discovery failed");
+      }
+      const data = result.data as unknown;
+      const properties = Array.isArray(data)
+        ? data
+        : data && typeof data === "object" && Array.isArray((data as Record<string, unknown>).properties)
+          ? (data as { properties: unknown[] }).properties
+          : data && typeof data === "object" && Array.isArray((data as Record<string, unknown>).publisher_domains)
+            ? (data as { publisher_domains: string[] }).publisher_domains.map(domain => ({
+                identifier: domain,
+                domain,
+                type: "domain",
+              }))
+            : [];
+
+      return res.json({ success: true, properties });
+    } catch (error) {
+      logger.warn({ err: error, url }, "Agent publishers fetch failed");
+
+      if (error instanceof Error && error.name === "TimeoutError") {
+        return res.status(504).json({ error: "Connection timeout", message: "Agent did not respond within the timeout period" });
+      }
+
+      return res.status(502).json({ error: "Failed to fetch publishers" });
     }
   });
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -112,7 +112,7 @@ import { CatalogDatabase } from "../db/catalog-db.js";
 import type { AdAgentsManager } from "../adagents-manager.js";
 import type { HealthChecker } from "../health.js";
 import type { CrawlerService } from "../crawler.js";
-import type { CapabilityDiscovery } from "../capabilities.js";
+import { sanitizeCreativeCapabilities, type CapabilityDiscovery } from "../capabilities.js";
 import { aaoHostedBrandJsonUrl, aaoHostedAdagentsJsonUrl, expectedAdagentsJsonUrl } from "../config/aao.js";
 import { canonicalTargetUri } from "@adcp/sdk/signing";
 import { fetchBrandContext, fetchBrandData, isBrandfetchConfigured, ENRICHMENT_CACHE_MAX_AGE_MS } from "../services/brandfetch.js";
@@ -710,6 +710,27 @@ registry.registerPath({
     200: { description: "API discovery information", content: { "application/json": { schema: z.object({ name: z.string(), version: z.string(), documentation: z.string(), openapi: z.string(), endpoints: z.record(z.string(), z.string()) }) } } },
   },
 });
+
+const PublicAgentProxyErrorResponses = {
+  400: { description: "Missing agent URL", content: { "application/json": { schema: ErrorSchema } } },
+  429: {
+    description: "Rate limit exceeded",
+    content: {
+      "application/json": {
+        schema: z.object({
+          error: z.string(),
+          message: z.string(),
+          retryAfter: z.number().int().optional(),
+        }),
+      },
+    },
+  },
+  502: { description: "Agent discovery failed", content: { "application/json": { schema: ErrorSchema } } },
+  504: {
+    description: "Connection timeout",
+    content: { "application/json": { schema: z.object({ error: z.string(), message: z.string() }) } },
+  },
+} as const;
 
 registry.registerPath({
   method: "get",
@@ -2180,6 +2201,7 @@ registry.registerPath({
   request: { query: z.object({ url: z.string() }) },
   responses: {
     200: { description: "Canonical creative capabilities", content: { "application/json": { schema: z.object({ success: z.boolean(), formats: z.array(z.unknown()) }) } } },
+    ...PublicAgentProxyErrorResponses,
   },
 });
 
@@ -2193,6 +2215,7 @@ registry.registerPath({
   request: { query: z.object({ url: z.string() }) },
   responses: {
     200: { description: "Publisher properties", content: { "application/json": { schema: z.object({ success: z.boolean(), properties: z.array(z.unknown()) }) } } },
+    ...PublicAgentProxyErrorResponses,
   },
 });
 
@@ -2206,6 +2229,7 @@ registry.registerPath({
   request: { query: z.object({ url: z.string() }) },
   responses: {
     200: { description: "Products", content: { "application/json": { schema: z.object({ success: z.boolean(), products: z.array(z.unknown()) }) } } },
+    ...PublicAgentProxyErrorResponses,
   },
 });
 
@@ -9526,7 +9550,105 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     }
   });
 
-  router.get("/public/agent-formats", async (req, res) => {
+  const PUBLIC_AGENT_RESPONSE_BYTES = 1024 * 1024;
+  const PUBLIC_AGENT_OUTPUT_BYTES = 512 * 1024;
+  const PUBLIC_AGENT_TIMEOUT_MS = 10_000;
+  const PUBLIC_AGENT_MAX_ITEMS = 200;
+
+  function publicAgentTransportOptions() {
+    return withSdkSafeTransport({
+      transport: {
+        maxResponseBytes: PUBLIC_AGENT_RESPONSE_BYTES,
+        requestTimeoutMs: PUBLIC_AGENT_TIMEOUT_MS,
+      },
+    });
+  }
+
+  function boundedString(value: unknown, maxLength: number): string | undefined {
+    return typeof value === "string" && value.length > 0
+      ? value.slice(0, maxLength)
+      : undefined;
+  }
+
+  function assertPublicAgentOutputSize(payload: unknown): void {
+    if (Buffer.byteLength(JSON.stringify(payload), "utf8") > PUBLIC_AGENT_OUTPUT_BYTES) {
+      throw new Error("Public agent discovery payload exceeds output limit");
+    }
+  }
+
+  function normalizePublicProperties(rawProperties: unknown[]): Array<Record<string, unknown>> {
+    return rawProperties.slice(0, PUBLIC_AGENT_MAX_ITEMS).flatMap(value => {
+      if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+      const property = value as Record<string, unknown>;
+      const identifier = boundedString(property.identifier, 512);
+      const domain = boundedString(property.domain, 253);
+      if (!identifier && !domain) return [];
+
+      const tags = Array.isArray(property.tags)
+        ? property.tags
+          .slice(0, 20)
+          .map(tag => boundedString(tag, 64))
+          .filter((tag): tag is string => Boolean(tag))
+        : undefined;
+
+      return [{
+        ...(identifier && { identifier }),
+        ...(domain && { domain }),
+        type: boundedString(property.type, 64) ?? "domain",
+        ...(boundedString(property.country, 64) && { country: boundedString(property.country, 64) }),
+        ...(boundedString(property.description, 2_000) && { description: boundedString(property.description, 2_000) }),
+        ...(tags?.length && { tags }),
+        // Verification is registry-owned. Never trust peer-supplied verified,
+        // verification_url, or verification_error fields on this proxy.
+      }];
+    });
+  }
+
+  function projectLegacyFormatsForPublicDiscovery(legacyFormats: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+    return legacyFormats.slice(0, PUBLIC_AGENT_MAX_ITEMS).flatMap((legacyFormat, index) => {
+      const reviewedProjection = buildCreativeCapabilities([legacyFormat]);
+      if (reviewedProjection.length > 0) return reviewedProjection;
+
+      const formatId = legacyFormat.format_id && typeof legacyFormat.format_id === "object"
+        ? boundedString((legacyFormat.format_id as Record<string, unknown>).id, 256)
+        : undefined;
+      const rawAssets = Array.isArray(legacyFormat.assets) ? legacyFormat.assets : [];
+      const assets = rawAssets.filter((asset): asset is Record<string, unknown> =>
+        Boolean(asset && typeof asset === "object" && !Array.isArray(asset))
+      );
+      const imageAsset = assets.find(asset => asset.asset_type === "image");
+      const requirements = imageAsset?.requirements && typeof imageAsset.requirements === "object"
+        ? imageAsset.requirements as Record<string, unknown>
+        : undefined;
+      const minWidth = requirements?.min_width;
+      const maxWidth = requirements?.max_width;
+      const minHeight = requirements?.min_height;
+      const maxHeight = requirements?.max_height;
+      const hasFixedImageSize = typeof minWidth === "number"
+        && minWidth === maxWidth
+        && typeof minHeight === "number"
+        && minHeight === maxHeight;
+
+      // The legacy `type: display` catalog shape used by 3.1 sellers does
+      // not carry the optional `canonical` annotation. A concrete image
+      // asset is enough to project it safely for this read-only UI.
+      if (!imageAsset) return [];
+      const stableId = (formatId ?? `legacy_${index + 1}`)
+        .replace(/[^a-zA-Z0-9_-]/g, "_")
+        .slice(0, 256);
+      return [{
+        capability_id: `preview_${stableId}`,
+        operations: ["preview"],
+        ...(boundedString(legacyFormat.name, 512) && { description: boundedString(legacyFormat.name, 512) }),
+        format: {
+          format_kind: "image",
+          params: hasFixedImageSize ? { width: minWidth, height: minHeight } : {},
+        },
+      }];
+    });
+  }
+
+  router.get("/public/agent-formats", registryReadRateLimiter, async (req, res) => {
     const { url } = req.query;
 
     if (!url || typeof url !== "string") {
@@ -9539,14 +9661,16 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         name: "Creative capability discovery",
         agent_uri: url,
         protocol: "mcp",
-      }], withSdkSafeTransport({})).agent("creative-capability-discovery");
+      }], publicAgentTransportOptions()).agent("creative-capability-discovery");
       let formats: unknown[] = [];
       let capabilityError: unknown;
 
       try {
         const result = await capabilityClient.getAdcpCapabilities({}, undefined, { timeout: 10_000 });
-        const creative = (result.data as Record<string, unknown> | undefined)?.creative as Record<string, unknown> | undefined;
-        formats = Array.isArray(creative?.supported_formats) ? creative.supported_formats : [];
+        const creative = (result.data as Record<string, unknown> | undefined)?.creative;
+        formats = creative
+          ? (await sanitizeCreativeCapabilities(creative)).supported_formats
+          : [];
       } catch (error) {
         capabilityError = error;
         logger.debug({ err: error, url }, "Canonical creative capability discovery failed; trying legacy formats");
@@ -9564,19 +9688,22 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             : legacyData && typeof legacyData === "object" && Array.isArray((legacyData as Record<string, unknown>).formats)
               ? (legacyData as { formats: unknown[] }).formats
               : [];
-          formats = buildCreativeCapabilities(
+          const projectedFormats = projectLegacyFormatsForPublicDiscovery(
             legacyFormats.filter((entry): entry is Record<string, unknown> => Boolean(entry && typeof entry === "object" && !Array.isArray(entry))),
           );
+          formats = (await sanitizeCreativeCapabilities({ supported_formats: projectedFormats })).supported_formats;
         } catch (error) {
           if (capabilityError) throw error;
           logger.debug({ err: error, url }, "Legacy creative format discovery failed");
         }
       }
 
-      return res.json({
+      const payload = {
         success: true,
         formats,
-      });
+      };
+      assertPublicAgentOutputSize(payload);
+      return res.json(payload);
     } catch (error) {
       logger.warn({ err: error, url }, "Agent formats fetch failed");
 
@@ -9588,7 +9715,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     }
   });
 
-  router.get("/public/agent-publishers", async (req, res) => {
+  router.get("/public/agent-publishers", registryReadRateLimiter, async (req, res) => {
     const { url } = req.query;
 
     if (!url || typeof url !== "string") {
@@ -9601,13 +9728,13 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         name: "publisher-discovery-client",
         agent_uri: url,
         protocol: "mcp",
-      }, withSdkSafeTransport({}));
+      }, publicAgentTransportOptions());
       const result = await client.executeTask("list_authorized_properties", {});
       if (!result.success) {
         throw new Error(result.error || "Publisher discovery failed");
       }
       const data = result.data as unknown;
-      const properties = Array.isArray(data)
+      const rawProperties = Array.isArray(data)
         ? data
         : data && typeof data === "object" && Array.isArray((data as Record<string, unknown>).properties)
           ? (data as { properties: unknown[] }).properties
@@ -9618,8 +9745,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
                 type: "domain",
               }))
             : [];
+      const properties = normalizePublicProperties(rawProperties);
 
-      return res.json({ success: true, properties });
+      const payload = { success: true, properties };
+      assertPublicAgentOutputSize(payload);
+      return res.json(payload);
     } catch (error) {
       logger.warn({ err: error, url }, "Agent publishers fetch failed");
 
@@ -9631,7 +9761,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     }
   });
 
-  router.get("/public/agent-products", async (req, res) => {
+  router.get("/public/agent-products", registryReadRateLimiter, async (req, res) => {
     const { url } = req.query;
 
     if (!url || typeof url !== "string") {
@@ -9644,27 +9774,29 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         name: "products-discovery-client",
         agent_uri: url,
         protocol: "mcp",
-      }, withSdkSafeTransport({}));
+      }, publicAgentTransportOptions());
 
       const result = await client.getProducts({ buying_mode: 'wholesale' });
-      const products = result.data?.products || [];
+      const products = (result.data?.products || []).slice(0, PUBLIC_AGENT_MAX_ITEMS);
 
-      return res.json({
+      const payload = {
         success: true,
         products: products.map((p: any) => ({
-          product_id: p.product_id,
-          name: p.name,
-          description: p.description,
-          property_type: p.property_type,
-          property_name: p.property_name,
-          pricing_model: p.pricing_model,
+          product_id: boundedString(p.product_id, 512),
+          name: boundedString(p.name, 512),
+          description: boundedString(p.description, 2_000),
+          property_type: boundedString(p.property_type, 128),
+          property_name: boundedString(p.property_name, 512),
+          pricing_model: boundedString(p.pricing_model, 128),
           base_rate: p.base_rate,
-          currency: p.currency,
-          format_options: p.format_options,
-          delivery_channels: p.delivery_channels,
-          targeting_capabilities: p.targeting_capabilities,
+          currency: boundedString(p.currency, 16),
+          format_options: Array.isArray(p.format_options) ? p.format_options.slice(0, 50) : undefined,
+          delivery_channels: Array.isArray(p.delivery_channels) ? p.delivery_channels.slice(0, 50) : undefined,
+          targeting_capabilities: Array.isArray(p.targeting_capabilities) ? p.targeting_capabilities.slice(0, 100) : undefined,
         })),
-      });
+      };
+      assertPublicAgentOutputSize(payload);
+      return res.json(payload);
     } catch (error) {
       logger.warn({ err: error, url }, "Agent products fetch failed");
 

--- a/server/tests/unit/public-agent-discovery-proxies.test.ts
+++ b/server/tests/unit/public-agent-discovery-proxies.test.ts
@@ -107,7 +107,12 @@ describe('public agent discovery proxies', () => {
     const response = await request(app).get('/api/public/agent-formats?url=https://creative.example.com/mcp');
 
     expect(response.status).toBe(200);
-    expect(sdkMocks.agentExecuteTask).toHaveBeenCalledWith('list_creative_formats', {});
+    expect(sdkMocks.agentExecuteTask).toHaveBeenCalledWith(
+      'list_creative_formats',
+      {},
+      undefined,
+      { timeout: 10_000 },
+    );
     expect(response.body.formats).toEqual([{
       capability_id: 'preview_display_300x250',
       operations: ['preview'],
@@ -196,7 +201,12 @@ describe('public agent discovery proxies', () => {
     const response = await request(app).get('/api/public/agent-publishers?url=https://sales.example.com/mcp');
 
     expect(response.status).toBe(200);
-    expect(sdkMocks.singleExecuteTask).toHaveBeenCalledWith('list_authorized_properties', {});
+    expect(sdkMocks.singleExecuteTask).toHaveBeenCalledWith(
+      'list_authorized_properties',
+      {},
+      undefined,
+      { timeout: 10_000 },
+    );
     expect(response.body).toEqual({
       success: true,
       properties: [{

--- a/server/tests/unit/public-agent-discovery-proxies.test.ts
+++ b/server/tests/unit/public-agent-discovery-proxies.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const sdkMocks = vi.hoisted(() => ({
+  getAdcpCapabilities: vi.fn(),
+  agentExecuteTask: vi.fn(),
+  getProducts: vi.fn(),
+  singleExecuteTask: vi.fn(),
+}));
+
+vi.mock('@adcp/sdk', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@adcp/sdk');
+  return {
+    ...actual,
+    AdCPClient: class {
+      agent() {
+        return {
+          getAdcpCapabilities: sdkMocks.getAdcpCapabilities,
+          executeTask: sdkMocks.agentExecuteTask,
+        };
+      }
+    },
+    SingleAgentClient: class {
+      getProducts = sdkMocks.getProducts;
+      executeTask = sdkMocks.singleExecuteTask;
+    },
+  };
+});
+
+import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/routes/registry-api.js';
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  const passAuth: import('express').RequestHandler = (_req, _res, next) => next();
+  const config = {
+    brandManager: {} as RegistryApiConfig['brandManager'],
+    brandDb: {} as RegistryApiConfig['brandDb'],
+    propertyDb: {} as RegistryApiConfig['propertyDb'],
+    adagentsManager: {} as RegistryApiConfig['adagentsManager'],
+    healthChecker: {} as RegistryApiConfig['healthChecker'],
+    crawler: {} as RegistryApiConfig['crawler'],
+    capabilityDiscovery: {} as RegistryApiConfig['capabilityDiscovery'],
+    registryRequestsDb: {
+      trackRequest: async () => {},
+      markResolved: async () => true,
+    },
+    requireAuth: passAuth,
+    optionalAuth: passAuth,
+  };
+  app.use('/api', createRegistryApiRouter(config));
+  return app;
+}
+
+describe('public agent discovery proxies', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  it('returns canonical creative capabilities without calling the legacy fallback', async () => {
+    const capability = {
+      capability_id: 'preview_display',
+      operations: ['preview'],
+      format: { format_kind: 'display', params: { width: 300, height: 250 } },
+    };
+    sdkMocks.getAdcpCapabilities.mockResolvedValue({
+      data: { creative: { supported_formats: [capability] } },
+    });
+
+    const response = await request(app).get('/api/public/agent-formats?url=https://creative.example.com/mcp');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true, formats: [capability] });
+    expect(sdkMocks.agentExecuteTask).not.toHaveBeenCalled();
+  });
+
+  it('projects legacy list_creative_formats data when canonical capabilities are empty', async () => {
+    sdkMocks.getAdcpCapabilities.mockResolvedValue({
+      data: { creative: { supported_formats: [] } },
+    });
+    sdkMocks.agentExecuteTask.mockResolvedValue({
+      success: true,
+      data: {
+        formats: [{
+          format_id: { agent_url: 'https://creative.example.com', id: 'display_300x250' },
+          canonical: { kind: 'display' },
+          renders: [{ dimensions: { width: 300, height: 250 } }],
+        }],
+      },
+    });
+
+    const response = await request(app).get('/api/public/agent-formats?url=https://creative.example.com/mcp');
+
+    expect(response.status).toBe(200);
+    expect(sdkMocks.agentExecuteTask).toHaveBeenCalledWith('list_creative_formats', {});
+    expect(response.body.formats).toEqual([{
+      capability_id: 'preview_display_300x250',
+      operations: ['preview'],
+      format: { format_kind: 'display', params: { width: 300, height: 250 } },
+    }]);
+  });
+
+  it('returns a gateway error when legacy format discovery fails', async () => {
+    sdkMocks.getAdcpCapabilities.mockRejectedValue(new Error('capability discovery failed'));
+    sdkMocks.agentExecuteTask.mockResolvedValue({
+      success: false,
+      error: 'legacy discovery failed',
+    });
+
+    const response = await request(app).get('/api/public/agent-formats?url=https://creative.example.com/mcp');
+
+    expect(response.status).toBe(502);
+    expect(response.body).toEqual({ error: 'Failed to fetch formats' });
+  });
+
+  it('normalizes publisher_domains from list_authorized_properties', async () => {
+    sdkMocks.singleExecuteTask.mockResolvedValue({
+      success: true,
+      data: { publisher_domains: ['publisher.example.com'] },
+    });
+
+    const response = await request(app).get('/api/public/agent-publishers?url=https://sales.example.com/mcp');
+
+    expect(response.status).toBe(200);
+    expect(sdkMocks.singleExecuteTask).toHaveBeenCalledWith('list_authorized_properties', {});
+    expect(response.body).toEqual({
+      success: true,
+      properties: [{
+        identifier: 'publisher.example.com',
+        domain: 'publisher.example.com',
+        type: 'domain',
+      }],
+    });
+  });
+
+  it('returns a gateway error when publisher discovery fails', async () => {
+    sdkMocks.singleExecuteTask.mockResolvedValue({
+      success: false,
+      error: 'publisher discovery failed',
+    });
+
+    const response = await request(app).get('/api/public/agent-publishers?url=https://sales.example.com/mcp');
+
+    expect(response.status).toBe(502);
+    expect(response.body).toEqual({ error: 'Failed to fetch publishers' });
+  });
+
+  it('returns the public product fields consumed by the registry UI', async () => {
+    sdkMocks.getProducts.mockResolvedValue({
+      data: {
+        products: [{
+          product_id: 'homepage',
+          name: 'Homepage display',
+          description: 'Premium placement',
+          property_type: 'website',
+          property_name: 'Example Publisher',
+          pricing_model: 'cpm',
+          base_rate: 12,
+          currency: 'USD',
+          format_options: [],
+          private_field: 'do not expose',
+        }],
+      },
+    });
+
+    const response = await request(app).get('/api/public/agent-products?url=https://sales.example.com/mcp');
+
+    expect(response.status).toBe(200);
+    expect(response.body.products).toEqual([{
+      product_id: 'homepage',
+      name: 'Homepage display',
+      description: 'Premium placement',
+      property_type: 'website',
+      property_name: 'Example Publisher',
+      pricing_model: 'cpm',
+      base_rate: 12,
+      currency: 'USD',
+      format_options: [],
+    }]);
+  });
+});

--- a/server/tests/unit/public-agent-discovery-proxies.test.ts
+++ b/server/tests/unit/public-agent-discovery-proxies.test.ts
@@ -7,6 +7,7 @@ const sdkMocks = vi.hoisted(() => ({
   agentExecuteTask: vi.fn(),
   getProducts: vi.fn(),
   singleExecuteTask: vi.fn(),
+  clientOptions: [] as unknown[],
 }));
 
 vi.mock('@adcp/sdk', async () => {
@@ -14,6 +15,9 @@ vi.mock('@adcp/sdk', async () => {
   return {
     ...actual,
     AdCPClient: class {
+      constructor(_agents: unknown, options: unknown) {
+        sdkMocks.clientOptions.push(options);
+      }
       agent() {
         return {
           getAdcpCapabilities: sdkMocks.getAdcpCapabilities,
@@ -22,6 +26,9 @@ vi.mock('@adcp/sdk', async () => {
       }
     },
     SingleAgentClient: class {
+      constructor(_agent: unknown, options: unknown) {
+        sdkMocks.clientOptions.push(options);
+      }
       getProducts = sdkMocks.getProducts;
       executeTask = sdkMocks.singleExecuteTask;
     },
@@ -58,6 +65,7 @@ describe('public agent discovery proxies', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    sdkMocks.clientOptions.length = 0;
     app = buildApp();
   });
 
@@ -65,7 +73,7 @@ describe('public agent discovery proxies', () => {
     const capability = {
       capability_id: 'preview_display',
       operations: ['preview'],
-      format: { format_kind: 'display', params: { width: 300, height: 250 } },
+      format: { format_kind: 'image', params: { width: 300, height: 250 } },
     };
     sdkMocks.getAdcpCapabilities.mockResolvedValue({
       data: { creative: { supported_formats: [capability] } },
@@ -75,6 +83,9 @@ describe('public agent discovery proxies', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ success: true, formats: [capability] });
+    expect(sdkMocks.clientOptions[0]).toMatchObject({
+      transport: { maxResponseBytes: 1024 * 1024, requestTimeoutMs: 10_000 },
+    });
     expect(sdkMocks.agentExecuteTask).not.toHaveBeenCalled();
   });
 
@@ -87,7 +98,7 @@ describe('public agent discovery proxies', () => {
       data: {
         formats: [{
           format_id: { agent_url: 'https://creative.example.com', id: 'display_300x250' },
-          canonical: { kind: 'display' },
+          canonical: { kind: 'image' },
           renders: [{ dimensions: { width: 300, height: 250 } }],
         }],
       },
@@ -100,8 +111,67 @@ describe('public agent discovery proxies', () => {
     expect(response.body.formats).toEqual([{
       capability_id: 'preview_display_300x250',
       operations: ['preview'],
-      format: { format_kind: 'display', params: { width: 300, height: 250 } },
+      format: { format_kind: 'image', params: { width: 300, height: 250 } },
     }]);
+  });
+
+  it('projects a 3.1 display catalog without optional canonical annotations', async () => {
+    sdkMocks.getAdcpCapabilities.mockResolvedValue({
+      data: { creative: { supported_formats: [] } },
+    });
+    sdkMocks.agentExecuteTask.mockResolvedValue({
+      success: true,
+      data: {
+        formats: [{
+          format_id: { agent_url: 'https://sales.example.com', id: 'display_300x250' },
+          name: 'Medium Rectangle',
+          type: 'display',
+          assets: [{
+            asset_type: 'image',
+            requirements: {
+              min_width: 300,
+              max_width: 300,
+              min_height: 250,
+              max_height: 250,
+            },
+          }],
+        }],
+      },
+    });
+
+    const response = await request(app).get('/api/public/agent-formats?url=https://sales.example.com/mcp');
+
+    expect(response.status).toBe(200);
+    expect(response.body.formats).toEqual([{
+      capability_id: 'preview_display_300x250',
+      operations: ['preview'],
+      description: 'Medium Rectangle',
+      format: { format_kind: 'image', params: { width: 300, height: 250 } },
+    }]);
+  });
+
+  it('drops hostile legacy format parameters before they reach the registry UI', async () => {
+    sdkMocks.getAdcpCapabilities.mockResolvedValue({
+      data: { creative: { supported_formats: [] } },
+    });
+    sdkMocks.agentExecuteTask.mockResolvedValue({
+      success: true,
+      data: {
+        formats: [{
+          format_id: { agent_url: 'https://creative.example.com', id: 'hostile' },
+          canonical: {
+            kind: 'image',
+            parameters: { min_width: '<img src=x onerror=alert(1)>' },
+          },
+        }],
+      },
+    });
+
+    const response = await request(app).get('/api/public/agent-formats?url=https://creative.example.com/mcp');
+
+    expect(response.status).toBe(200);
+    expect(response.body.formats).toEqual([]);
+    expect(JSON.stringify(response.body)).not.toContain('onerror');
   });
 
   it('returns a gateway error when legacy format discovery fails', async () => {
@@ -147,6 +217,32 @@ describe('public agent discovery proxies', () => {
 
     expect(response.status).toBe(502);
     expect(response.body).toEqual({ error: 'Failed to fetch publishers' });
+  });
+
+  it('strips peer-supplied publisher verification state and unsafe links', async () => {
+    sdkMocks.singleExecuteTask.mockResolvedValue({
+      success: true,
+      data: {
+        properties: [{
+          identifier: 'publisher.example.com',
+          domain: 'publisher.example.com',
+          type: 'domain',
+          verified: true,
+          verification_url: 'javascript:alert(1)',
+          verification_error: '<img src=x onerror=alert(1)>',
+          private_field: 'do not expose',
+        }],
+      },
+    });
+
+    const response = await request(app).get('/api/public/agent-publishers?url=https://sales.example.com/mcp');
+
+    expect(response.status).toBe(200);
+    expect(response.body.properties).toEqual([{
+      identifier: 'publisher.example.com',
+      domain: 'publisher.example.com',
+      type: 'domain',
+    }]);
   });
 
   it('returns the public product fields consumed by the registry UI', async () => {

--- a/server/tests/unit/public-agent-registry-ui.test.ts
+++ b/server/tests/unit/public-agent-registry-ui.test.ts
@@ -13,5 +13,12 @@ describe('public agent registry UI', () => {
 
   it('prefers the latest health tool count over stale capability metadata', () => {
     expect(agentsHtml).toContain('agent?.health?.tools_count ?? agent?.capabilities?.tools_count');
+    expect(agentsHtml).toContain('agentWithCaps?.capabilities?.tools || []');
+  });
+
+  it('allowlists verification links and escapes responsive format dimensions', () => {
+    expect(agentsHtml).toContain("parsed.protocol === 'https:'");
+    expect(agentsHtml).not.toContain('href="${escapeHtml(p.verification_url)}"');
+    expect(agentsHtml).toContain('escapeHtml(String(params.min_width || 0))');
   });
 });

--- a/server/tests/unit/public-agent-registry-ui.test.ts
+++ b/server/tests/unit/public-agent-registry-ui.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const agentsHtml = readFileSync(new URL('../../public/agents.html', import.meta.url), 'utf8');
+
+describe('public agent registry UI', () => {
+  it('uses the public discovery proxy routes instead of the removed MCP helpers', () => {
+    expect(agentsHtml).toContain('/api/public/agent-products?url=');
+    expect(agentsHtml).toContain('/api/public/agent-formats?url=');
+    expect(agentsHtml).toContain('/api/public/agent-publishers?url=');
+    expect(agentsHtml).not.toContain("fetch(`/mcp`");
+  });
+
+  it('prefers the latest health tool count over stale capability metadata', () => {
+    expect(agentsHtml).toContain('agent?.health?.tools_count ?? agent?.capabilities?.tools_count');
+  });
+});

--- a/server/tests/unit/registry-agent-tool-count.test.ts
+++ b/server/tests/unit/registry-agent-tool-count.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const AGENT_URL = 'https://sales.example.com/mcp';
+
+vi.mock('../../src/db/agent-snapshot-db.js', () => ({
+  AgentSnapshotDatabase: class {
+    bulkGetCapabilities() {
+      return Promise.resolve(new Map([[AGENT_URL, {
+        discovered_tools_json: Array.from({ length: 5 }, (_, index) => `stale_tool_${index}`),
+        inferred_type: 'sales',
+      }]]));
+    }
+
+    bulkGetHealth() {
+      return Promise.resolve(new Map([[AGENT_URL, {
+        online: true,
+        checked_at: new Date('2026-08-08T00:00:00Z'),
+        tools_count: 10,
+      }]]));
+    }
+  },
+}));
+
+import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/routes/registry-api.js';
+
+function buildApp(): express.Express {
+  const app = express();
+  const passAuth: import('express').RequestHandler = (_req, _res, next) => next();
+  const config = {
+    brandManager: {} as RegistryApiConfig['brandManager'],
+    brandDb: {} as RegistryApiConfig['brandDb'],
+    propertyDb: {} as RegistryApiConfig['propertyDb'],
+    adagentsManager: {} as RegistryApiConfig['adagentsManager'],
+    healthChecker: {} as RegistryApiConfig['healthChecker'],
+    crawler: {
+      getFederatedIndex: () => ({
+        listAllAgents: vi.fn().mockResolvedValue([{
+          name: 'Example Sales Agent',
+          url: AGENT_URL,
+          type: 'sales',
+          protocol: 'mcp',
+        }]),
+      }),
+    } as unknown as RegistryApiConfig['crawler'],
+    capabilityDiscovery: {} as RegistryApiConfig['capabilityDiscovery'],
+    registryRequestsDb: {
+      trackRequest: async () => {},
+      markResolved: async () => true,
+    },
+    requireAuth: passAuth,
+    optionalAuth: passAuth,
+  };
+  app.use('/api', createRegistryApiRouter(config));
+  return app;
+}
+
+describe('public registry tool count enrichment', () => {
+  it('uses the fresher health count for legacy capability consumers', async () => {
+    const response = await request(buildApp())
+      .get('/api/registry/agents?health=true&capabilities=true');
+
+    expect(response.status).toBe(200);
+    expect(response.body.agents[0]).toMatchObject({
+      health: { tools_count: 10 },
+      capabilities: { tools_count: 10 },
+    });
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -8229,7 +8229,7 @@ paths:
     get:
       operationId: getAgentFormats
       summary: Get creative-agent format capabilities
-      description: Fetch get_adcp_capabilities creative.supported_formats[] from a creative agent.
+      description: Fetch get_adcp_capabilities creative.supported_formats[] from a creative agent, falling back to the deprecated list_creative_formats catalog for 3.1-compatible agents.
       tags:
         - Agent Probing
       parameters:
@@ -8254,6 +8254,35 @@ paths:
                 required:
                   - success
                   - formats
+  /api/public/agent-publishers:
+    get:
+      operationId: getAgentPublishers
+      summary: Get agent publisher properties
+      description: Fetch public list_authorized_properties data from a sales agent.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: url
+          in: query
+      responses:
+        "200":
+          description: Publisher properties
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  properties:
+                    type: array
+                    items: {}
+                required:
+                  - success
+                  - properties
   /api/public/agent-products:
     get:
       operationId: getAgentProducts

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -8254,6 +8254,48 @@ paths:
                 required:
                   - success
                   - formats
+        "400":
+          description: Missing agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                  retryAfter:
+                    type: integer
+                required:
+                  - error
+                  - message
+        "502":
+          description: Agent discovery failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Connection timeout
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
   /api/public/agent-publishers:
     get:
       operationId: getAgentPublishers
@@ -8283,6 +8325,48 @@ paths:
                 required:
                   - success
                   - properties
+        "400":
+          description: Missing agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                  retryAfter:
+                    type: integer
+                required:
+                  - error
+                  - message
+        "502":
+          description: Agent discovery failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Connection timeout
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
   /api/public/agent-products:
     get:
       operationId: getAgentProducts
@@ -8312,6 +8396,48 @@ paths:
                 required:
                   - success
                   - products
+        "400":
+          description: Missing agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                  retryAfter:
+                    type: integer
+                required:
+                  - error
+                  - message
+        "502":
+          description: Agent discovery failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Connection timeout
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
   /api/public/validate-publisher:
     get:
       operationId: validatePublisher

--- a/tests/sdk-safe-fetch-callsites.test.ts
+++ b/tests/sdk-safe-fetch-callsites.test.ts
@@ -31,12 +31,21 @@ describe('hosted SDK safe-fetch call sites', () => {
     expect(registryApiSource).toContain(
       '}], withSdkSafeTransport({})).agent("creative-capability-discovery")',
     );
+    expect(registryApiSource).toContain(
+      '}], publicAgentTransportOptions()).agent("creative-capability-discovery")',
+    );
+    expect(registryApiSource).toContain('return withSdkSafeTransport({');
+    expect(registryApiSource).toContain('maxResponseBytes: PUBLIC_AGENT_RESPONSE_BYTES');
+    expect(registryApiSource).toContain('requestTimeoutMs: PUBLIC_AGENT_TIMEOUT_MS');
     expect(httpSource).toContain(
       'new CreativeAgentClient(withSdkSafeTransport({ agentUrl: url }))',
     );
     expect(registryApiSource.split(
       '}], withSdkSafeTransport({})).agent("creative-capability-discovery")',
-    )).toHaveLength(3);
+    )).toHaveLength(2);
+    expect(registryApiSource.split(
+      '}], publicAgentTransportOptions()).agent("creative-capability-discovery")',
+    )).toHaveLength(2);
     expect(httpSource.split('}, withSdkSafeTransport({}));')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

- route anonymous registry product, format, and publisher discovery through server-side public proxies
- normalize canonical capability and legacy discovery responses for the public agent detail view
- prefer the latest health snapshot tool count in both the API and UI
- add regression coverage for the proxy routes, UI endpoint wiring, and stale capability counts

Closes #6229
Closes #6268

## Validation

- `npm run typecheck`
- `npm run test:openapi`
- `npm run test:server-unit` (380 files, 5,469 passed, 30 skipped)
- root unit suite via pre-commit (66 files, 1,037 passed)
- targeted registry tests (3 files, 9 passed)
- `git diff origin/main... --check`

## Release

No changeset: registry application/runtime-only fix; no protocol release surface changed.