### PR TITLE
fix(registry): add synchronous brand recrawl

### DIFF
--- a/server/public/admin-brands.html
+++ b/server/public/admin-brands.html
@@ -662,6 +662,7 @@
           </td>
           <td>
             <button class="btn-icon" onclick="viewBrand('${encodeURIComponent(brand.domain)}')" title="View Details">View</button>
+            <button class="btn-icon" data-action="force-brand-crawl" data-domain="${escapeHtml(brand.domain)}" title="Fetch live brand.json and refresh registry evidence">Re-crawl</button>
             <button class="btn-icon" onclick="openSetParentModal('${encodeURIComponent(brand.domain)}', '${escapeHtml(brand.house_domain || '')}')" title="Set Parent">Parent</button>
             ${subCount > 0 || !brand.house_domain ? `<button class="btn-icon" onclick="expandHouse('${encodeURIComponent(brand.domain)}')" title="Discover sub-brands via AI">Expand</button>` : ''}
             ${brand.source === 'hosted' ? `<button class="btn-icon" onclick="deleteBrand('${encodeURIComponent(brand.domain)}')" title="Delete">Delete</button>` : ''}
@@ -680,6 +681,44 @@
       };
       return labels[source] || source;
     }
+
+    async function forceBrandCrawl(button, domain) {
+      if (!confirm(`Fetch and validate the live brand.json for ${domain}?`)) return;
+
+      const originalText = button.textContent;
+      button.disabled = true;
+      button.textContent = 'Crawling...';
+      try {
+        const response = await fetch(`/api/registry/brand/${encodeURIComponent(domain)}/force-crawl`, {
+          method: 'POST',
+        });
+        const result = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(result.error || 'Brand crawl failed');
+        }
+
+        if (result.brand_json_found) {
+          const outcome = result.promoted ? 'Live brand.json evidence was adopted.' : 'Live brand.json evidence is current.';
+          alert(`${outcome}\nStored source type: ${result.new_source_type}.`);
+        } else {
+          alert('The crawl completed, but no valid live brand.json was found. Existing registry data was preserved.');
+        }
+      } catch (error) {
+        alert('Error: ' + error.message);
+        return;
+      } finally {
+        button.disabled = false;
+        button.textContent = originalText;
+      }
+
+      await loadBrands();
+    }
+
+    document.getElementById('brandsTableBody').addEventListener('click', (event) => {
+      const button = event.target.closest('[data-action="force-brand-crawl"]');
+      if (!button) return;
+      forceBrandCrawl(button, button.dataset.domain);
+    });
 
     // Research Modal
     function openResearchModal() {

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -4,7 +4,7 @@ import { sanitizeAdagentsProperty } from "./discovery/property-index-guard.js";
 import { FederatedIndexService } from "./federated-index.js";
 import type { DiscoveredAgent } from "./db/federated-index-db.js";
 import { AdAgentsManager, type AdAgentsValidationResult } from "./adagents-manager.js";
-import { BrandManager } from "./brand-manager.js";
+import { BrandManager, type BrandValidationResult } from "./brand-manager.js";
 import { BrandDatabase } from "./db/brand-db.js";
 import { PublisherDatabase, adagentsChangedFields, canonicalizeAgentUrl, type AdagentsManifest, type AdagentsAuthorizedAgent } from "./db/publisher-db.js";
 import { canonicalizePublisherDomain } from "./services/publisher-domain.js";
@@ -367,9 +367,23 @@ export class CrawlerService {
   /**
    * Scan a single domain for brand.json and upsert discovered/verified brand data.
    */
-  async scanBrandForDomain(domain: string): Promise<void> {
+  async scanBrandForDomain(domain: string): Promise<{
+    found: boolean;
+    valid: boolean;
+    variant: BrandValidationResult['variant'] | null;
+    manifestPersisted: boolean;
+  }> {
     const result = await this.brandManager.validateDomain(domain, { skipCache: true });
-    if (!result.valid || !result.raw_data) return;
+    if (!result.valid || !result.raw_data) {
+      return {
+        found: result.status_code !== undefined && result.status_code !== 404,
+        valid: false,
+        variant: result.variant ?? null,
+        manifestPersisted: false,
+      };
+    }
+
+    let manifestPersisted = false;
 
     if (result.variant === 'authoritative_location') {
       const data = result.raw_data as { authoritative_location: string };
@@ -394,6 +408,7 @@ export class CrawlerService {
       const manifest = result.variant === 'house_portfolio' || result.variant === 'brand_canonical'
         ? this.stripLegacyCompatibilityMetadata(result.raw_data as Record<string, unknown>)
         : undefined;
+      manifestPersisted = Boolean(manifest);
       await this.brandDb.upsertDiscoveredBrand({
         domain,
         brand_name: brandName,
@@ -407,6 +422,13 @@ export class CrawlerService {
         await this.upsertBrandProperties(domain, result.raw_data as Record<string, unknown>);
       }
     }
+
+    return {
+      found: true,
+      valid: true,
+      variant: result.variant ?? null,
+      manifestPersisted,
+    };
   }
 
   /**

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -389,21 +389,19 @@ export class CrawlerService {
       const data = result.raw_data as { authoritative_location: string };
       try {
         const url = new URL(data.authoritative_location);
-        if (url.hostname === AAO_HOST &&
-            url.pathname === `/brands/${domain}/brand.json`) {
-          const hosted = await this.brandDb.getHostedBrandByDomain(domain);
-          if (hosted) {
-            // A valid pointer at the publisher's origin is terminal origin
-            // evidence even when ownership was already verified. Persisting
-            // source_type + last_validated prevents publisher-page reads from
-            // scheduling this same brand crawl every debounce interval.
-            await this.brandDb.updateHostedBrand(hosted.id, {
-              domain_verified: true,
-              origin_validated: true,
-            });
-            if (!hosted.domain_verified) {
-              log.debug({ domain }, 'Brand verified');
-            }
+        const hosted = await this.brandDb.getHostedBrandByDomain(domain);
+        if (hosted) {
+          const pointsToAaoHostedBrand = url.hostname === AAO_HOST &&
+            url.pathname === `/brands/${domain}/brand.json`;
+          // Any valid pointer read from the publisher's origin is terminal
+          // origin evidence, including central hosting on a third-party CDN.
+          // Only the exact AAO-hosted pointer may also promote ownership.
+          await this.brandDb.updateHostedBrand(hosted.id, {
+            ...(pointsToAaoHostedBrand ? { domain_verified: true } : {}),
+            origin_validated: true,
+          });
+          if (pointsToAaoHostedBrand && !hosted.domain_verified) {
+            log.debug({ domain }, 'Brand verified');
           }
         }
       } catch {

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -392,9 +392,18 @@ export class CrawlerService {
         if (url.hostname === AAO_HOST &&
             url.pathname === `/brands/${domain}/brand.json`) {
           const hosted = await this.brandDb.getHostedBrandByDomain(domain);
-          if (hosted && !hosted.domain_verified) {
-            await this.brandDb.updateHostedBrand(hosted.id, { domain_verified: true });
-            log.debug({ domain }, 'Brand verified');
+          if (hosted) {
+            // A valid pointer at the publisher's origin is terminal origin
+            // evidence even when ownership was already verified. Persisting
+            // source_type + last_validated prevents publisher-page reads from
+            // scheduling this same brand crawl every debounce interval.
+            await this.brandDb.updateHostedBrand(hosted.id, {
+              domain_verified: true,
+              origin_validated: true,
+            });
+            if (!hosted.domain_verified) {
+              log.debug({ domain }, 'Brand verified');
+            }
           }
         }
       } catch {

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -290,7 +290,7 @@ export interface ListBrandsOptions {
   // response round-trip: ?source=hosted returns rows a verified owner
   // registered, ?source=brand_json returns crawler-discovered rows with a
   // live /.well-known/brand.json, etc.
-  source?: 'hosted' | 'brand_json' | 'community' | 'enriched';
+  source?: 'hosted' | 'brand_json' | 'community' | 'enriched' | 'stub';
   has_manifest?: boolean;
   house_domain?: string;
   search?: string;
@@ -697,7 +697,8 @@ export class BrandDatabase {
    * not a self-reference). See issue #3467.
    */
   async upsertDiscoveredBrand(input: UpsertDiscoveredBrandInput): Promise<DiscoveredBrand> {
-    const canonicalDomain = input.domain.toLowerCase();
+    const canonicalDomain = canonicalizeBrandDomain(input.domain);
+    assertValidBrandDomain(canonicalDomain);
     const canonicalHouseDomain = validateHouseDomainArg(input.house_domain, canonicalDomain);
     const sanitized = sanitizeBrandManifest(input.brand_manifest);
     const persistedManifest = input.classification
@@ -1053,6 +1054,7 @@ export class BrandDatabase {
     brand_json: number;
     community: number;
     enriched: number;
+    stub: number;
     houses: number;
     sub_brands: number;
     with_manifest: number;
@@ -1082,20 +1084,22 @@ export class BrandDatabase {
       brand_json: string;
       community: string;
       enriched: string;
+      stub: string;
       houses: string;
       sub_brands: string;
       with_manifest: string;
     }>(
       // Bucket counts use the same predicates as the response labels in
       // getAllBrandsForRegistry, so stats round-trip with the four ?source
-      // filter values. hosted+brand_json+community+enriched (excluding
-      // 'stub') reconciles to total.
+      // filter values. hosted+brand_json+community+enriched+stub
+      // reconciles to total.
       `SELECT
         COUNT(*) AS total,
         COUNT(*) FILTER (WHERE ${OWNER_HOSTED_SQL}) AS hosted,
         COUNT(*) FILTER (WHERE brands.source_type = 'brand_json' AND NOT ${OWNER_HOSTED_SQL}) AS brand_json,
         COUNT(*) FILTER (WHERE brands.source_type = 'community' AND NOT ${OWNER_HOSTED_SQL}) AS community,
         COUNT(*) FILTER (WHERE brands.source_type = 'enriched' AND NOT ${OWNER_HOSTED_SQL}) AS enriched,
+        COUNT(*) FILTER (WHERE brands.source_type = 'stub' AND NOT ${OWNER_HOSTED_SQL}) AS stub,
         COUNT(*) FILTER (WHERE keller_type IN ('master', 'independent') OR keller_type IS NULL) AS houses,
         COUNT(*) FILTER (WHERE keller_type IN ('sub_brand', 'endorsed')) AS sub_brands,
         COUNT(*) FILTER (WHERE ${HAS_MANIFEST_SQL}) AS with_manifest
@@ -1111,6 +1115,7 @@ export class BrandDatabase {
       brand_json: parseInt(row.brand_json, 10),
       community: parseInt(row.community, 10),
       enriched: parseInt(row.enriched, 10),
+      stub: parseInt(row.stub, 10),
       houses: parseInt(row.houses, 10),
       sub_brands: parseInt(row.sub_brands, 10),
       with_manifest: parseInt(row.with_manifest, 10),
@@ -1131,7 +1136,8 @@ export class BrandDatabase {
     input: UpsertDiscoveredBrandInput,
     editor: { user_id: string; email?: string; name?: string }
   ): Promise<DiscoveredBrand> {
-    const canonicalDomain = input.domain.toLowerCase();
+    const canonicalDomain = canonicalizeBrandDomain(input.domain);
+    assertValidBrandDomain(canonicalDomain);
     const canonicalHouseDomain = validateHouseDomainArg(input.house_domain, canonicalDomain);
     const sanitizedManifest = sanitizeBrandManifest(input.brand_manifest);
 

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -233,6 +233,8 @@ export interface CreateHostedBrandInput {
 export interface UpdateHostedBrandInput {
   brand_json?: Record<string, unknown>;
   domain_verified?: boolean;
+  /** Mark a successful live origin read as terminal brand.json evidence. */
+  origin_validated?: boolean;
   verification_token?: string;
   is_public?: boolean;
   workos_organization_id?: string;
@@ -424,6 +426,10 @@ export class BrandDatabase {
     if (input.domain_verified !== undefined) {
       updates.push(`domain_verified = $${paramIndex++}`);
       values.push(input.domain_verified);
+    }
+    if (input.origin_validated === true) {
+      updates.push(`source_type = 'brand_json'`);
+      updates.push(`last_validated = NOW()`);
     }
     if (input.verification_token !== undefined) {
       updates.push(`verification_token = $${paramIndex++}`);

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -896,8 +896,8 @@ registry.registerPath({
       search: z.string().optional(),
       limit: z.string().optional().openapi({ type: 'integer', example: 100 }),
       offset: z.string().optional().openapi({ type: 'integer', example: 0 }),
-      source: z.enum(['hosted', 'brand_json', 'enriched', 'community']).optional().openapi({
-        description: 'Filter by source. Values match the per-brand source field in the response: hosted = registered by domain owner via /api/brands; brand_json = crawler-discovered with a live /.well-known/brand.json; enriched = Brandfetch-sourced; community = manually contributed.',
+      source: z.enum(['hosted', 'brand_json', 'enriched', 'community', 'stub']).optional().openapi({
+        description: 'Filter by source. Values match the per-brand source field in the response: hosted = registered by domain owner via /api/brands; brand_json = crawler-discovered with a live /.well-known/brand.json; enriched = Brandfetch-sourced; community = manually contributed; stub = organization-derived placeholder awaiting stronger evidence.',
       }),
     }),
   },
@@ -914,6 +914,7 @@ registry.registerPath({
               brand_json: z.number().int(),
               community: z.number().int(),
               enriched: z.number().int(),
+              stub: z.number().int(),
               houses: z.number().int(),
               sub_brands: z.number().int(),
               with_manifest: z.number().int(),
@@ -1021,8 +1022,8 @@ function storedBrandJsonVariant(
 function resolvedStoredBrandSource(brand: {
   workos_organization_id?: string;
   domain_verified?: boolean;
-  source_type: 'brand_json' | 'community' | 'enriched';
-}): 'hosted' | 'brand_json' | 'community' | 'enriched' {
+  source_type: 'brand_json' | 'community' | 'enriched' | 'stub';
+}): 'hosted' | 'brand_json' | 'community' | 'enriched' | 'stub' {
   return brand.workos_organization_id && brand.domain_verified === true
     ? 'hosted'
     : brand.source_type;
@@ -1038,6 +1039,7 @@ const RESOLVED_BRAND_SOURCE_PRIORITY: Record<ResolvedBrandResponse["source"], nu
   brand_json: 2,
   community: 3,
   enriched: 4,
+  stub: 5,
 };
 
 function storedBrandResolutionResponse(
@@ -1710,6 +1712,21 @@ const PublisherAdagentsRevalidationResultSchema = z.object({
   manager_domain: z.string().optional(),
 });
 
+const BrandForceCrawlResultSchema = z.object({
+  domain: z.string(),
+  previous_source: z.enum(["hosted", "brand_json", "community", "enriched", "stub"]).nullable(),
+  new_source: z.enum(["hosted", "brand_json", "community", "enriched", "stub"]).nullable(),
+  previous_source_type: z.enum(["brand_json", "community", "enriched", "stub"]).nullable(),
+  new_source_type: z.enum(["brand_json", "community", "enriched", "stub"]).nullable(),
+  promoted: z.boolean().openapi({
+    description: "True when the crawl replaced lower-trust stored evidence with live brand.json evidence.",
+  }),
+  brand_json_found: z.boolean(),
+  live_variant: z.enum(["authoritative_location", "house_redirect", "brand_agent", "house_portfolio", "brand_canonical"]).nullable(),
+  has_manifest: z.boolean(),
+  checked_at: z.string().datetime(),
+});
+
 registry.registerPath({
   method: "post",
   path: "/api/registry/publisher/{domain}/adagents/revalidate",
@@ -1743,6 +1760,40 @@ registry.registerPath({
         },
       },
     },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/registry/brand/{domain}/force-crawl",
+  operationId: "forceBrandCrawl",
+  summary: "Force a synchronous brand.json crawl",
+  description:
+    "Admin-only support endpoint that fetches a domain's live `/.well-known/brand.json`, persists valid origin evidence, and returns the before/after state. A verified owner remains labeled `source: hosted` because that field describes identity provenance; `new_source_type: brand_json` and `promoted: true` confirm that live origin evidence was adopted.\n\n**Rate limits:** 5 minutes per domain, 30 requests per user per hour.",
+  tags: ["Brand Discovery"],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
+  request: {
+    params: z.object({
+      domain: z.string().openapi({ example: "brand.example" }),
+    }),
+  },
+  responses: {
+    200: { description: "Synchronous crawl result", content: { "application/json": { schema: BrandForceCrawlResultSchema } } },
+    400: { description: "Invalid domain format, private IP, or unresolvable domain", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    403: { description: "Admin access required", content: { "application/json": { schema: ErrorSchema } } },
+    429: {
+      description: "Rate limit exceeded",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.string(),
+            retry_after: z.number().int(),
+          }),
+        },
+      },
+    },
+    500: { description: "Crawl failed", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -8539,7 +8590,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       // but never landed a brand_manifest. We were treating those rows
       // as "already crawled" and refusing to retry — leaving publishers
       // who actually serve a brand.json forever marked as missing one.
-      const brandNeverCrawled = !brandRow || !brandRow.has_brand_manifest;
+      const verifiedOwnerNeedsOriginEvidence = Boolean(
+        brandRow?.workos_organization_id
+        && brandRow.domain_verified === true
+        && brandRow.source_type !== 'brand_json'
+      );
+      const brandNeverCrawled = !brandRow || !brandRow.has_brand_manifest || verifiedOwnerNeedsOriginEvidence;
       // Bypass the per-domain auto-crawl debounce when the brand row is
       // stale-without-manifest for >1h. Without this, a heavily-trafficked
       // publisher whose brand.json went live AFTER our first crawl gets
@@ -10870,6 +10926,58 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     } catch (error) {
       logger.error({ error, path: req.path }, "Failed to revalidate publisher adagents.json");
       return res.status(500).json({ error: "Failed to revalidate publisher adagents.json" });
+    }
+  });
+
+  router.post("/registry/brand/:domain/force-crawl", authMiddleware, async (req, res) => {
+    try {
+      if (!req.user && !isStaticAdminRequest(req)) {
+        return res.status(401).json({ error: "Authentication required" });
+      }
+      if (!(await isRegistryAdminRequest(req))) {
+        return res.status(403).json({ error: "Admin access required" });
+      }
+
+      const rawDomain = typeof req.params.domain === 'string'
+        ? extractDomain(req.params.domain)
+        : '';
+      if (!rawDomain || !isValidDomain(rawDomain)) {
+        return res.status(400).json({ error: "Invalid domain" });
+      }
+
+      const normalizedDomain = await validateAndRateLimitCrawl(
+        req,
+        res,
+        rawDomain,
+        rawDomain,
+      );
+      if (!normalizedDomain) return;
+
+      const previous = await brandDb.getDiscoveredBrandByDomain(normalizedDomain);
+      const crawlResult = await crawler.scanBrandForDomain(normalizedDomain);
+      const current = await brandDb.getDiscoveredBrandByDomain(normalizedDomain);
+
+      const previousSource = previous ? resolvedStoredBrandSource(previous) : null;
+      const newSource = current ? resolvedStoredBrandSource(current) : null;
+      const promoted = previous?.source_type !== 'brand_json'
+        && current?.source_type === 'brand_json'
+        && crawlResult.valid;
+
+      return res.json({
+        domain: normalizedDomain,
+        previous_source: previousSource,
+        new_source: newSource,
+        previous_source_type: previous?.source_type ?? null,
+        new_source_type: current?.source_type ?? null,
+        promoted,
+        brand_json_found: crawlResult.valid,
+        live_variant: crawlResult.variant,
+        has_manifest: current?.has_brand_manifest ?? false,
+        checked_at: new Date().toISOString(),
+      });
+    } catch (error) {
+      logger.error({ error, path: req.path }, "Failed to force brand.json crawl");
+      return res.status(500).json({ error: "Failed to force brand.json crawl" });
     }
   });
 

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -8952,6 +8952,14 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       // adagents.json" / "you have a brand.json" — this block exposes
       // that signal so the client doesn't have to derive it from a
       // cocktail of nullable flags.
+      const brandOriginCrawlInFlight = autoCrawlTriggered && verifiedOwnerNeedsOriginEvidence;
+      const brandFileStatus = brandOriginCrawlInFlight
+        ? 'checking'
+        : brandRow?.has_brand_manifest
+          ? 'present'
+          : autoCrawlTriggered
+            ? 'checking'
+            : 'unknown';
       const files = {
         adagents_json: {
           status: cachedSourceType === 'community' && cachedAdagentsManifest
@@ -8975,12 +8983,8 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           // without a manifest from a prior failed crawl). `unknown`
           // = row exists with no manifest and we didn't re-trigger
           // (debounced).
-          status: brandRow?.has_brand_manifest
-            ? 'present'
-            : autoCrawlTriggered
-              ? 'checking'
-              : 'unknown',
-          name: brandRow?.has_brand_manifest ? brandRow.brand_name : undefined,
+          status: brandFileStatus,
+          name: brandFileStatus === 'present' ? brandRow?.brand_name : undefined,
         } as { status: 'present' | 'unknown' | 'checking'; name?: string },
       };
 

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -617,8 +617,8 @@ export const ResolvedBrandSchema = z
     }),
     brand_agent_url: z.string().optional(),
     brand_manifest: z.record(z.string(), z.unknown()).optional(),
-    source: z.enum(["hosted", "brand_json", "community", "enriched"]).openapi({
-      description: "Provenance of the selected record, not relationship authorization. Deterministic precedence is `hosted` > `brand_json` > `community` > `enriched`; normal reads prefer the durable stored winner on a source tie, while `fresh=true` lets a successful live origin read win a tie. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment.",
+    source: z.enum(["hosted", "brand_json", "community", "enriched", "stub"]).openapi({
+      description: "Provenance of the selected record, not relationship authorization. Deterministic precedence is `hosted` > `brand_json` > `community` > `enriched` > `stub`; normal reads prefer the durable stored winner on a source tie, while `fresh=true` lets a successful live origin read win a tie. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment. `stub`: a minimal organization-derived placeholder awaiting stronger evidence.",
     }),
     live_brand_json: LiveBrandJsonValidationSchema.optional().openapi({
       description: "This request's origin-validation diagnostics when `fresh=true` falls back to a stored registry record. Presence means the response is stored evidence, not a successful live-origin read.",
@@ -684,7 +684,7 @@ export const BrandRegistryItemSchema = z
   .object({
     domain: z.string().openapi({ example: "acmecorp.com" }),
     brand_name: z.string().optional().openapi({ example: "Acme Corp" }),
-    source: z.enum(["hosted", "brand_json", "community", "enriched"]),
+    source: z.enum(["hosted", "brand_json", "community", "enriched", "stub"]),
     has_manifest: z.boolean(),
     verified: z.boolean(),
     house_domain: z.string().optional(),

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -580,7 +580,7 @@ export interface DiscoveredBrand {
   brand_agent_capabilities?: string[];
   has_brand_manifest: boolean;
   brand_manifest?: Record<string, unknown>;
-  source_type: 'brand_json' | 'community' | 'enriched';
+  source_type: 'brand_json' | 'community' | 'enriched' | 'stub';
   review_status?: 'pending' | 'approved';
   discovered_at: Date;
   last_validated?: Date;
@@ -621,7 +621,7 @@ export interface ResolvedBrand {
   migration_warnings?: Array<{ field: string; message: string; suggestion?: string }>;
   brand_agent_url?: string;
   brand_manifest?: Record<string, unknown>;
-  source: 'hosted' | 'brand_json' | 'community' | 'enriched';
+  source: 'hosted' | 'brand_json' | 'community' | 'enriched' | 'stub';
 }
 
 /**

--- a/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
+++ b/server/tests/integration/registry-publisher-brand-json-hydration.test.ts
@@ -97,6 +97,7 @@ const PUB_BRAND_ONLY = `${DOMAIN_PREFIX}sasha${DOMAIN_SUFFIX}`;
 const PUB_AAO_HOSTED = `${DOMAIN_PREFIX}aao-hosted${DOMAIN_SUFFIX}`;
 const PUB_COMMUNITY = `${DOMAIN_PREFIX}community-catalog${DOMAIN_SUFFIX}`;
 const COMMUNITY_PLATFORM = 'test-community-publisher';
+const VERIFIED_OWNER_ORG = 'org_test_verified_owner_origin_evidence';
 const TEST_DATABASE_URL = process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test';
 
 describe('Registry publisher endpoint — brand.json hydration', () => {
@@ -122,6 +123,7 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     await pool.query('DELETE FROM catalog_properties WHERE created_by = $1', [`community_adagents:${COMMUNITY_PLATFORM}`]);
     await pool.query('DELETE FROM hosted_properties WHERE publisher_domain LIKE $1', [DOMAIN_LIKE]);
     await pool.query('DELETE FROM brands WHERE domain LIKE $1', [DOMAIN_LIKE]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [VERIFIED_OWNER_ORG]);
     await pool.query(
       'DELETE FROM discovered_properties WHERE publisher_domain LIKE $1',
       [DOMAIN_LIKE]
@@ -284,6 +286,33 @@ describe('Registry publisher endpoint — brand.json hydration', () => {
     // Name is suppressed when there's no real manifest — the
     // domain-literal placeholder is misleading.
     expect(res.body.files.brand_json.name).toBeUndefined();
+  });
+
+  it('re-triggers brand crawl for a verified owner whose manifest lacks origin evidence', async () => {
+    const domain = `verified-owner-${Date.now()}.registry-baseline.example`;
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, $2, NOW(), NOW())`,
+      [VERIFIED_OWNER_ORG, 'Verified Owner Test'],
+    );
+    await brandDb.upsertDiscoveredBrand({
+      domain,
+      brand_name: 'Verified Owner',
+      source_type: 'community',
+      has_brand_manifest: true,
+      brand_manifest: { name: 'Verified Owner' },
+    });
+    await pool.query(
+      `UPDATE brands
+          SET workos_organization_id = $2, domain_verified = TRUE
+        WHERE domain = $1`,
+      [domain, VERIFIED_OWNER_ORG],
+    );
+
+    const res = await request(app).get(`/api/registry/publisher?domain=${encodeURIComponent(domain)}`);
+    expect(res.status).toBe(200);
+    expect(res.body.auto_crawl_triggered).toBe(true);
+    expect(res.body.files.brand_json.status).toBe('checking');
   });
 
   it('reports hosting.mode=none when no adagents.json is configured', async () => {

--- a/server/tests/unit/brand-db-house-domain-validation.test.ts
+++ b/server/tests/unit/brand-db-house-domain-validation.test.ts
@@ -61,6 +61,17 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
   });
 
   describe('upsertDiscoveredBrand', () => {
+    it('rejects malformed primary domains before writing', async () => {
+      await expect(
+        db.upsertDiscoveredBrand({
+          domain: "x')-alert(1)-('",
+          brand_name: 'Attacker',
+          source_type: 'community',
+        }),
+      ).rejects.toThrow(/not a valid brand domain/i);
+      expect(mocks.query).not.toHaveBeenCalled();
+    });
+
     it('strips caller-supplied classification.confidence and brand_context from brand_manifest', async () => {
       mocks.query.mockResolvedValueOnce({
         rows: [{ domain: 'attacker.example', brand_names: '[]', brand_manifest: null, discovered_at: new Date(), last_validated: new Date() }],

--- a/server/tests/unit/crawler-brand-json.test.ts
+++ b/server/tests/unit/crawler-brand-json.test.ts
@@ -112,4 +112,43 @@ describe('CrawlerService brand.json ingestion', () => {
       source_type: 'brand_json',
     }));
   });
+
+  it('persists terminal origin evidence for an already-verified hosted pointer', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const updateHostedBrand = vi.fn().mockResolvedValue(undefined);
+    Object.assign(ctx, {
+      brandManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: true,
+          errors: [],
+          warnings: [],
+          domain: 'hosted.example',
+          url: 'https://hosted.example/.well-known/brand.json',
+          variant: 'authoritative_location',
+          raw_data: {
+            authoritative_location: 'https://agenticadvertising.org/brands/hosted.example/brand.json',
+          },
+        }),
+      },
+      brandDb: {
+        getHostedBrandByDomain: vi.fn().mockResolvedValue({
+          id: 'brand_hosted',
+          domain_verified: true,
+        }),
+        updateHostedBrand,
+      },
+    });
+
+    await expect(ctx.scanBrandForDomain('hosted.example')).resolves.toEqual({
+      found: true,
+      valid: true,
+      variant: 'authoritative_location',
+      manifestPersisted: false,
+    });
+    expect(updateHostedBrand).toHaveBeenCalledWith('brand_hosted', {
+      domain_verified: true,
+      origin_validated: true,
+    });
+  });
 });

--- a/server/tests/unit/crawler-brand-json.test.ts
+++ b/server/tests/unit/crawler-brand-json.test.ts
@@ -151,4 +151,42 @@ describe('CrawlerService brand.json ingestion', () => {
       origin_validated: true,
     });
   });
+
+  it('persists terminal origin evidence for a third-party hosted pointer without promoting ownership', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const updateHostedBrand = vi.fn().mockResolvedValue(undefined);
+    Object.assign(ctx, {
+      brandManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: true,
+          errors: [],
+          warnings: [],
+          domain: 'hosted.example',
+          url: 'https://hosted.example/.well-known/brand.json',
+          variant: 'authoritative_location',
+          raw_data: {
+            authoritative_location: 'https://cdn.provider.example/brands/hosted.json',
+          },
+        }),
+      },
+      brandDb: {
+        getHostedBrandByDomain: vi.fn().mockResolvedValue({
+          id: 'brand_hosted',
+          domain_verified: true,
+        }),
+        updateHostedBrand,
+      },
+    });
+
+    await expect(ctx.scanBrandForDomain('hosted.example')).resolves.toEqual({
+      found: true,
+      valid: true,
+      variant: 'authoritative_location',
+      manifestPersisted: false,
+    });
+    expect(updateHostedBrand).toHaveBeenCalledWith('brand_hosted', {
+      origin_validated: true,
+    });
+  });
 });

--- a/server/tests/unit/crawler-brand-json.test.ts
+++ b/server/tests/unit/crawler-brand-json.test.ts
@@ -31,7 +31,7 @@ describe('CrawlerService brand.json ingestion', () => {
       upsertBrandProperties,
     });
 
-    await ctx.scanBrandForDomain('leaf.example');
+    const result = await ctx.scanBrandForDomain('leaf.example');
 
     expect(upsertDiscoveredBrand).toHaveBeenCalledWith({
       domain: 'leaf.example',
@@ -46,5 +46,70 @@ describe('CrawlerService brand.json ingestion', () => {
       source_type: 'brand_json',
     });
     expect(upsertBrandProperties).toHaveBeenCalledWith('leaf.example', canonical);
+    expect(result).toEqual({
+      found: true,
+      valid: true,
+      variant: 'brand_canonical',
+      manifestPersisted: true,
+    });
   }, 30_000);
+
+  it('reports the live attempt as invalid instead of inferring success from stored state', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const upsertDiscoveredBrand = vi.fn();
+    Object.assign(ctx, {
+      brandManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: false,
+          errors: [{ field: '$', message: 'Not found', severity: 'error' }],
+          warnings: [],
+          domain: 'missing.example',
+          url: 'https://missing.example/.well-known/brand.json',
+          status_code: 404,
+        }),
+      },
+      brandDb: { upsertDiscoveredBrand },
+    });
+
+    await expect(ctx.scanBrandForDomain('missing.example')).resolves.toEqual({
+      found: false,
+      valid: false,
+      variant: null,
+      manifestPersisted: false,
+    });
+    expect(upsertDiscoveredBrand).not.toHaveBeenCalled();
+  });
+
+  it('reports a valid redirect without claiming that a full manifest was persisted', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const upsertDiscoveredBrand = vi.fn().mockResolvedValue(undefined);
+    Object.assign(ctx, {
+      brandManager: {
+        validateDomain: vi.fn().mockResolvedValue({
+          valid: true,
+          errors: [],
+          warnings: [],
+          domain: 'redirect.example',
+          url: 'https://redirect.example/.well-known/brand.json',
+          variant: 'house_redirect',
+          raw_data: { house: 'house.example' },
+        }),
+      },
+      brandDb: { upsertDiscoveredBrand },
+    });
+
+    await expect(ctx.scanBrandForDomain('redirect.example')).resolves.toEqual({
+      found: true,
+      valid: true,
+      variant: 'house_redirect',
+      manifestPersisted: false,
+    });
+    expect(upsertDiscoveredBrand).toHaveBeenCalledWith(expect.objectContaining({
+      domain: 'redirect.example',
+      has_brand_manifest: false,
+      source_type: 'brand_json',
+    }));
+  });
 });

--- a/server/tests/unit/registry-brand-force-crawl-route.test.ts
+++ b/server/tests/unit/registry-brand-force-crawl-route.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const validateCrawlDomainMock = vi.fn();
+const isWebUserAAOAdminMock = vi.fn();
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY || 'sk_test_registry_brand_force_crawl';
+  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID || 'client_test_registry_brand_force_crawl';
+});
+
+vi.mock('../../src/utils/url-security.js', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../src/utils/url-security.js');
+  return {
+    ...actual,
+    validateCrawlDomain: (domain: string) => validateCrawlDomainMock(domain),
+  };
+});
+
+vi.mock('../../src/addie/admin-status-lookup.js', () => ({
+  isWebUserAAOAdmin: (userId: string) => isWebUserAAOAdminMock(userId),
+}));
+
+import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/routes/registry-api.js';
+
+const ORIGINAL_ADMIN_EMAILS = process.env.ADMIN_EMAILS;
+
+function brand(overrides: Record<string, unknown>) {
+  return {
+    id: 'brand-1',
+    domain: 'brand.example',
+    has_brand_manifest: true,
+    source_type: 'community',
+    discovered_at: new Date('2026-08-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function buildApp(options: {
+  user?: { id: string; email: string; isAdmin?: boolean };
+  scanBrandForDomain: ReturnType<typeof vi.fn>;
+  getDiscoveredBrandByDomain: ReturnType<typeof vi.fn>;
+}) {
+  const app = express();
+  app.use(express.json());
+
+  const requireAuth: import('express').RequestHandler = (req, _res, next) => {
+    if (options.user) req.user = options.user as typeof req.user;
+    next();
+  };
+
+  app.use('/api', createRegistryApiRouter({
+    brandManager: {} as RegistryApiConfig['brandManager'],
+    brandDb: { getDiscoveredBrandByDomain: options.getDiscoveredBrandByDomain } as RegistryApiConfig['brandDb'],
+    propertyDb: {} as RegistryApiConfig['propertyDb'],
+    adagentsManager: {} as RegistryApiConfig['adagentsManager'],
+    healthChecker: {} as RegistryApiConfig['healthChecker'],
+    crawler: { scanBrandForDomain: options.scanBrandForDomain } as RegistryApiConfig['crawler'],
+    capabilityDiscovery: {} as RegistryApiConfig['capabilityDiscovery'],
+    registryRequestsDb: {
+      trackRequest: async () => {},
+      markResolved: async () => true,
+    },
+    requireAuth,
+    optionalAuth: requireAuth,
+  }));
+
+  return app;
+}
+
+describe('POST /api/registry/brand/:domain/force-crawl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ADMIN_EMAILS;
+    validateCrawlDomainMock.mockImplementation(async (domain: string) => domain.toLowerCase().trim());
+    isWebUserAAOAdminMock.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ADMIN_EMAILS === undefined) delete process.env.ADMIN_EMAILS;
+    else process.env.ADMIN_EMAILS = ORIGINAL_ADMIN_EMAILS;
+  });
+
+  it('synchronously adopts live brand.json evidence and reports raw promotion', async () => {
+    const getDiscoveredBrandByDomain = vi.fn()
+      .mockResolvedValueOnce(brand({
+        source_type: 'community',
+        workos_organization_id: 'org_brand',
+        domain_verified: true,
+      }))
+      .mockResolvedValueOnce(brand({
+        source_type: 'brand_json',
+        workos_organization_id: 'org_brand',
+        domain_verified: true,
+      }));
+    const scanBrandForDomain = vi.fn().mockResolvedValue({
+      found: true,
+      valid: true,
+      variant: 'brand_canonical',
+      manifestPersisted: true,
+    });
+
+    const response = await request(buildApp({
+      user: { id: 'admin_user', email: 'admin@example.com', isAdmin: true },
+      scanBrandForDomain,
+      getDiscoveredBrandByDomain,
+    }))
+      .post('/api/registry/brand/Brand.Example/force-crawl')
+      .send();
+
+    expect(response.status).toBe(200);
+    expect(validateCrawlDomainMock).toHaveBeenCalledWith('brand.example');
+    expect(scanBrandForDomain).toHaveBeenCalledWith('brand.example');
+    expect(response.body).toMatchObject({
+      domain: 'brand.example',
+      previous_source: 'hosted',
+      new_source: 'hosted',
+      previous_source_type: 'community',
+      new_source_type: 'brand_json',
+      promoted: true,
+      brand_json_found: true,
+      live_variant: 'brand_canonical',
+      has_manifest: true,
+    });
+  });
+
+  it('reports a stub without claiming promotion when no valid brand.json exists', async () => {
+    const existing = brand({ source_type: 'stub', has_brand_manifest: false });
+    const getDiscoveredBrandByDomain = vi.fn().mockResolvedValue(existing);
+    const scanBrandForDomain = vi.fn().mockResolvedValue({
+      found: false,
+      valid: false,
+      variant: null,
+      manifestPersisted: false,
+    });
+
+    const response = await request(buildApp({
+      user: { id: 'admin_user', email: 'admin@example.com', isAdmin: true },
+      scanBrandForDomain,
+      getDiscoveredBrandByDomain,
+    }))
+      .post('/api/registry/brand/missing.example/force-crawl')
+      .send();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      promoted: false,
+      brand_json_found: false,
+      previous_source: 'stub',
+      new_source: 'stub',
+      previous_source_type: 'stub',
+      new_source_type: 'stub',
+      live_variant: null,
+    });
+  });
+
+  it('does not treat a stale stored brand_json row as a successful live crawl', async () => {
+    const existing = brand({ source_type: 'brand_json', has_brand_manifest: true });
+    const response = await request(buildApp({
+      user: { id: 'admin_user', email: 'admin@example.com', isAdmin: true },
+      scanBrandForDomain: vi.fn().mockResolvedValue({
+        found: false,
+        valid: false,
+        variant: null,
+        manifestPersisted: false,
+      }),
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(existing),
+    }))
+      .post('/api/registry/brand/stale.example/force-crawl')
+      .send();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      previous_source_type: 'brand_json',
+      new_source_type: 'brand_json',
+      promoted: false,
+      brand_json_found: false,
+      live_variant: null,
+      has_manifest: true,
+    });
+  });
+
+  it('reports a valid live redirect even when no full manifest is persisted', async () => {
+    const getDiscoveredBrandByDomain = vi.fn()
+      .mockResolvedValueOnce(brand({ source_type: 'community', has_brand_manifest: false }))
+      .mockResolvedValueOnce(brand({ source_type: 'brand_json', has_brand_manifest: false }));
+    const response = await request(buildApp({
+      user: { id: 'admin_user', email: 'admin@example.com', isAdmin: true },
+      scanBrandForDomain: vi.fn().mockResolvedValue({
+        found: true,
+        valid: true,
+        variant: 'house_redirect',
+        manifestPersisted: false,
+      }),
+      getDiscoveredBrandByDomain,
+    }))
+      .post('/api/registry/brand/redirect.example/force-crawl')
+      .send();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      previous_source_type: 'community',
+      new_source_type: 'brand_json',
+      promoted: true,
+      brand_json_found: true,
+      live_variant: 'house_redirect',
+      has_manifest: false,
+    });
+  });
+
+  it('rejects authenticated non-admin callers before crawling', async () => {
+    const getDiscoveredBrandByDomain = vi.fn();
+    const scanBrandForDomain = vi.fn();
+
+    const response = await request(buildApp({
+      user: { id: 'member_user', email: 'member@example.com' },
+      scanBrandForDomain,
+      getDiscoveredBrandByDomain,
+    }))
+      .post('/api/registry/brand/example.com/force-crawl')
+      .send();
+
+    expect(response.status).toBe(403);
+    expect(scanBrandForDomain).not.toHaveBeenCalled();
+    expect(getDiscoveredBrandByDomain).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/runtime-xss-regressions.test.ts
+++ b/server/tests/unit/runtime-xss-regressions.test.ts
@@ -22,6 +22,15 @@ function loadSafePerspectiveExternalUrl(): (value: unknown) => string | null {
 }
 
 describe('runtime XSS regressions', () => {
+  it('uses delegated data attributes for the admin brand re-crawl action', () => {
+    const source = readPublicFile('admin-brands.html');
+
+    expect(source).toContain('data-action="force-brand-crawl"');
+    expect(source).toContain('data-domain="${escapeHtml(brand.domain)}"');
+    expect(source).not.toMatch(/onclick="forceBrandCrawl\(/);
+    expect(source).toContain("button.dataset.domain");
+  });
+
   it('renders community mirror proposal JSON and organization IDs as escaped text', () => {
     const source = readPublicFile('admin-community-mirrors.html');
     const rendererSource = section(source, 'function escapeHtml(value)', 'async function fetchJson(url)');

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -144,7 +144,8 @@ components:
             - brand_json
             - community
             - enriched
-          description: "Provenance of the selected record, not relationship authorization. Deterministic precedence is `hosted` > `brand_json` > `community` > `enriched`; normal reads prefer the durable stored winner on a source tie, while `fresh=true` lets a successful live origin read win a tie. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment."
+            - stub
+          description: "Provenance of the selected record, not relationship authorization. Deterministic precedence is `hosted` > `brand_json` > `community` > `enriched` > `stub`; normal reads prefer the durable stored winner on a source tie, while `fresh=true` lets a successful live origin read win a tie. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment. `stub`: a minimal organization-derived placeholder awaiting stronger evidence."
         live_brand_json:
           type: object
           properties:
@@ -223,6 +224,7 @@ components:
             - brand_json
             - community
             - enriched
+            - stub
         has_manifest:
           type: boolean
         verified:
@@ -5425,9 +5427,10 @@ paths:
               - brand_json
               - enriched
               - community
-            description: "Filter by source. Values match the per-brand source field in the response: hosted = registered by domain owner via /api/brands; brand_json = crawler-discovered with a live /.well-known/brand.json; enriched = Brandfetch-sourced; community = manually contributed."
+              - stub
+            description: "Filter by source. Values match the per-brand source field in the response: hosted = registered by domain owner via /api/brands; brand_json = crawler-discovered with a live /.well-known/brand.json; enriched = Brandfetch-sourced; community = manually contributed; stub = organization-derived placeholder awaiting stronger evidence."
           required: false
-          description: "Filter by source. Values match the per-brand source field in the response: hosted = registered by domain owner via /api/brands; brand_json = crawler-discovered with a live /.well-known/brand.json; enriched = Brandfetch-sourced; community = manually contributed."
+          description: "Filter by source. Values match the per-brand source field in the response: hosted = registered by domain owner via /api/brands; brand_json = crawler-discovered with a live /.well-known/brand.json; enriched = Brandfetch-sourced; community = manually contributed; stub = organization-derived placeholder awaiting stronger evidence."
           name: source
           in: query
       responses:
@@ -5455,6 +5458,8 @@ paths:
                         type: integer
                       enriched:
                         type: integer
+                      stub:
+                        type: integer
                       houses:
                         type: integer
                       sub_brands:
@@ -5467,6 +5472,7 @@ paths:
                       - brand_json
                       - community
                       - enriched
+                      - stub
                       - houses
                       - sub_brands
                       - with_manifest
@@ -7189,6 +7195,148 @@ paths:
                 required:
                   - error
                   - retry_after
+  /api/registry/brand/{domain}/force-crawl:
+    post:
+      operationId: forceBrandCrawl
+      summary: Force a synchronous brand.json crawl
+      description: |-
+        Admin-only support endpoint that fetches a domain's live `/.well-known/brand.json`, persists valid origin evidence, and returns the before/after state. A verified owner remains labeled `source: hosted` because that field describes identity provenance; `new_source_type: brand_json` and `promoted: true` confirm that live origin evidence was adopted.
+
+        **Rate limits:** 5 minutes per domain, 30 requests per user per hour.
+      tags:
+        - Brand Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            example: brand.example
+          required: true
+          name: domain
+          in: path
+      responses:
+        "200":
+          description: Synchronous crawl result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  previous_source:
+                    type:
+                      - string
+                      - "null"
+                    enum:
+                      - hosted
+                      - brand_json
+                      - community
+                      - enriched
+                      - stub
+                      - null
+                  new_source:
+                    type:
+                      - string
+                      - "null"
+                    enum:
+                      - hosted
+                      - brand_json
+                      - community
+                      - enriched
+                      - stub
+                      - null
+                  previous_source_type:
+                    type:
+                      - string
+                      - "null"
+                    enum:
+                      - brand_json
+                      - community
+                      - enriched
+                      - stub
+                      - null
+                  new_source_type:
+                    type:
+                      - string
+                      - "null"
+                    enum:
+                      - brand_json
+                      - community
+                      - enriched
+                      - stub
+                      - null
+                  promoted:
+                    type: boolean
+                    description: True when the crawl replaced lower-trust stored evidence with live brand.json evidence.
+                  brand_json_found:
+                    type: boolean
+                  live_variant:
+                    type:
+                      - string
+                      - "null"
+                    enum:
+                      - authoritative_location
+                      - house_redirect
+                      - brand_agent
+                      - house_portfolio
+                      - brand_canonical
+                      - null
+                  has_manifest:
+                    type: boolean
+                  checked_at:
+                    type: string
+                    format: date-time
+                required:
+                  - domain
+                  - previous_source
+                  - new_source
+                  - previous_source_type
+                  - new_source_type
+                  - promoted
+                  - brand_json_found
+                  - live_variant
+                  - has_manifest
+                  - checked_at
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Admin access required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                required:
+                  - error
+                  - retry_after
+        "500":
+          description: Crawl failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/registry/publisher/authorization:
     get:
       operationId: lookupPublisherAgentAuthorization


### PR DESCRIPTION
## Summary
- add an admin-only synchronous brand.json re-crawl endpoint and admin registry action
- report the live crawl attempt separately from stored provenance, including redirects and stubs
- retry origin discovery for verified owners that still have lower-trust evidence
- validate discovered-brand domains at the DB boundary and avoid inline admin handlers

## Validation
- code-review expert: passed after addressing live-result, stub, and auto-crawl findings
- security-review expert: passed after eliminating stored-XSS sink and validating write boundaries
- pre-commit: 1,038 root tests + 5,484 server tests passed; typecheck passed
- focused registry/UI tests: 45 passed
- OpenAPI generation/check passed
- local integration suite could not start because the shared test DB has a pre-existing migration 533 filename collision; clean CI will run it

## Notes
- no changeset: app/runtime-only change
- public `source: hosted` remains ownership provenance; raw `source_type: brand_json` records origin evidence

Closes #6055