### PR TITLE
fix(admin): add domain verification recovery

### DIFF
--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -3495,13 +3495,13 @@
           badges.push(`<span class="domain-badge ${escapeHtml(d.source || 'manual')}">${d.source === 'workos' ? 'WorkOS' : 'Manual'}</span>`);
 
           return `
-            <li class="domain-item" data-domain="${escapedDomain}" style="display: flex; justify-content: space-between; align-items: center; padding: var(--space-2) 0; border-bottom: 1px solid var(--color-border);">
+            <li class="domain-item" data-domain="${escapedDomain}" data-primary="${d.is_primary ? 'true' : 'false'}" style="display: flex; justify-content: space-between; align-items: center; padding: var(--space-2) 0; border-bottom: 1px solid var(--color-border);">
               <div class="domain-info">
                 <span class="domain-name" style="font-weight: var(--font-medium);">${escapedDomain}</span>
                 <span style="margin-left: var(--space-2);">${badges.join(' ')}</span>
               </div>
               <div class="domain-actions" style="display: flex; gap: var(--space-2);">
-                ${!d.verified ? `<button class="btn btn-sm btn-primary" data-action="verify">Verify</button>` : ''}
+                ${!d.verified ? `<button class="btn btn-sm btn-primary" data-action="verify">Force Re-check</button>` : ''}
                 ${!d.is_primary ? `<button class="btn btn-sm btn-secondary" data-action="set-primary">Set Primary</button>` : ''}
                 <button class="btn btn-sm btn-secondary" data-action="remove" style="color: var(--color-error-600);" title="Remove domain">&times;</button>
               </div>
@@ -3528,10 +3528,11 @@
       if (!domainItem) return;
 
       const domain = domainItem.dataset.domain;
+      const isPrimary = domainItem.dataset.primary === 'true';
       const action = btn.dataset.action;
 
       if (action === 'verify') {
-        verifyDomain(domain, btn);
+        verifyDomain(domain, isPrimary, btn);
       } else if (action === 'set-primary') {
         setDomainPrimary(domain, btn);
       } else if (action === 'remove') {
@@ -3539,7 +3540,7 @@
       }
     }
 
-    async function verifyDomain(domain, btn) {
+    async function verifyDomain(domain, isPrimary, btn) {
       const originalText = btn ? btn.textContent : '';
       if (btn) {
         btn.disabled = true;
@@ -3547,10 +3548,8 @@
       }
 
       try {
-        const response = await fetch(`/api/admin/organizations/${accountId}/domains`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ domain: domain.toLowerCase() })
+        const response = await fetch(`/api/admin/organizations/${accountId}/domains/${encodeURIComponent(domain.toLowerCase())}/verify`, {
+          method: 'POST'
         });
 
         if (!response.ok) {
@@ -3559,13 +3558,42 @@
             return;
           }
           const data = await response.json().catch(() => ({}));
-          throw new Error(data.error || 'Failed to verify domain');
+          if (data.error === 'still_pending') {
+            const workosReference = data.workos_domain_id
+              ? `\nWorkOS domain ID: ${data.workos_domain_id}`
+              : '';
+            const attestation = prompt(
+              `WorkOS still reports ${domain} as pending.${workosReference}\n\nTo mark it verified manually, enter an attestation note confirming how you checked the DNS record. Cancel to stop.`
+            );
+            if (attestation === null) return;
+            if (!attestation.trim()) {
+              throw new Error('An attestation note is required to mark the domain verified manually.');
+            }
+            if (!confirm(`Mark ${domain} verified manually? This bypasses the pending WorkOS DNS result.`)) return;
+
+            const overrideResponse = await fetch(`/api/admin/organizations/${accountId}/domains/${encodeURIComponent(domain.toLowerCase())}/override-verification`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                is_primary: isPrimary,
+                verification_attestation: attestation.trim()
+              })
+            });
+            const overrideData = await overrideResponse.json().catch(() => ({}));
+            if (!overrideResponse.ok) {
+              throw new Error(overrideData.message || overrideData.error || 'Failed to mark domain verified');
+            }
+            location.reload();
+            return;
+          }
+          throw new Error(data.message || data.error || 'Failed to verify domain');
         }
 
         location.reload();
       } catch (error) {
         console.error('Error verifying domain:', error);
         alert('Error: ' + error.message);
+      } finally {
         if (btn) {
           btn.disabled = false;
           btn.textContent = originalText;

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -5419,7 +5419,7 @@ export class HTTPServer {
 
 
     // GET /api/admin/audit-logs - Get audit log entries
-    this.app.get('/api/admin/audit-logs', requireAuth, requireAdmin, async (req, res) => {
+    this.app.get('/api/admin/audit-logs', ...requireGlobalAdmin, async (req, res) => {
       try {
         const {
           organization_id,

--- a/server/src/routes/admin/domains.ts
+++ b/server/src/routes/admin/domains.ts
@@ -13,7 +13,12 @@ import {
   unlinkDomainAndReselectPrimary,
 } from "../../db/organization-domains-db.js";
 import { createLogger } from "../../logger.js";
-import { requireAuth, requireAdmin, requireGlobalAdmin } from "../../middleware/auth.js";
+import {
+  requireAuth,
+  requireAdmin,
+  requireGlobalAdmin,
+  refuseAnyApiKeyOnGlobalAdmin,
+} from "../../middleware/auth.js";
 import { SlackDatabase } from "../../db/slack-db.js";
 import { enrichOrganization } from "../../services/enrichment.js";
 import { trackBackground } from "../../services/brand-enrichment.js";
@@ -1630,6 +1635,7 @@ export function setupDomainRoutes(
                 error: "still_pending",
                 message: "WorkOS could not find the DNS TXT verification record yet.",
                 state: initialState,
+                workos_domain_id: entry.id,
                 dns_record_name: recordName,
                 verification_token: entry.verificationToken ?? null,
               });
@@ -1643,6 +1649,7 @@ export function setupDomainRoutes(
             error: "still_pending",
             message: "WorkOS has not confirmed the DNS record yet.",
             state: verifiedState,
+            workos_domain_id: entry.id,
           });
         }
 
@@ -1674,8 +1681,218 @@ export function setupDomainRoutes(
     }
   );
 
+  // POST /api/admin/organizations/:orgId/domains/:domain/override-verification
+  // High-trust recovery path for a WorkOS challenge that remains pending after
+  // an administrator has independently confirmed the DNS record. Unlike the
+  // tenant-scoped add/re-check routes, this bypasses WorkOS ownership proof and
+  // therefore must remain restricted to global administrators.
+  apiRouter.post(
+    "/organizations/:orgId/domains/:domain/override-verification",
+    ...requireGlobalAdmin,
+    async (req, res) => {
+      const { orgId } = req.params;
+      if (!workos) {
+        return res.status(503).json({ error: "WorkOS not configured" });
+      }
+
+      let normalizedDomain: string;
+      try {
+        normalizedDomain = canonicalizeBrandDomain(req.params.domain);
+        assertClaimableBrandDomain(normalizedDomain);
+      } catch (error) {
+        logger.warn({ error, rawDomain: req.params.domain }, "Manual domain override rejected invalid domain");
+        return res.status(400).json({
+          error: "invalid_domain",
+          message: "The domain is malformed or cannot be claimed.",
+        });
+      }
+
+      const attestation = typeof req.body?.verification_attestation === "string"
+        ? req.body.verification_attestation.trim()
+        : "";
+      if (!attestation) {
+        return res.status(400).json({
+          error: "verification_attestation_required",
+          message: "An attestation note is required to manually mark a pending WorkOS domain verified.",
+        });
+      }
+      if (attestation.length > 2000) {
+        return res.status(400).json({
+          error: "verification_attestation_too_long",
+          message: "The attestation note must be 2,000 characters or fewer.",
+        });
+      }
+
+      const pool = getPool();
+      const actorId = req.user?.authWorkosUserId ?? req.user?.id;
+      if (!actorId) {
+        return res.status(500).json({ error: "Unable to identify the acting administrator" });
+      }
+
+      try {
+        const orgResult = await pool.query(
+          `SELECT name, is_personal FROM organizations WHERE workos_organization_id = $1`,
+          [orgId],
+        );
+        if (orgResult.rows.length === 0) {
+          return res.status(404).json({ error: "Organization not found" });
+        }
+        if (orgResult.rows[0].is_personal) {
+          return res.status(400).json({
+            error: "Invalid operation",
+            message: "Domains cannot be verified for individual (personal) organizations",
+          });
+        }
+
+        const workosOrg = await workos.organizations.getOrganization(orgId);
+        const existingDomain = workosOrg.domains.find(
+          d => d.domain.toLowerCase() === normalizedDomain,
+        );
+        if (!existingDomain) {
+          return res.status(404).json({
+            error: "no_challenge",
+            message: "No WorkOS domain challenge exists for this organization and domain.",
+          });
+        }
+
+        const beforeState = String(existingDomain.state);
+        const alreadyVerified = beforeState === "verified" || beforeState === "legacy_verified";
+        const wantsPrimary = req.body?.is_primary === true;
+        const auditDetails = {
+          domain: normalizedDomain,
+          workos_domain_id: existingDomain.id,
+          before_state: beforeState,
+          requested_after_state: "verified",
+          verification_attestation: attestation,
+          acting_workos_user_id: actorId,
+          admin_email: req.user?.email ?? null,
+        };
+        const writeAudit = async (
+          action: string,
+          outcome: "attempted" | "succeeded" | "failed",
+          error?: unknown,
+        ) => {
+          await pool.query(
+            `INSERT INTO registry_audit_log (
+               workos_organization_id, workos_user_id, action,
+               resource_type, resource_id, details
+             ) VALUES ($1, $2, $3, 'organization_domain', $4, $5)`,
+            [
+              orgId,
+              actorId,
+              action,
+              normalizedDomain,
+              JSON.stringify({
+                ...auditDetails,
+                outcome,
+                after_state: outcome === "succeeded" ? "verified" : beforeState,
+                error: error instanceof Error ? error.message : (error ? String(error) : null),
+              }),
+            ],
+          );
+        };
+
+        const syncLocalVerifiedState = async () => {
+          await upsertWorkosDomain({
+            orgId,
+            domain: normalizedDomain,
+            verified: true,
+            isPrimary: wantsPrimary,
+          });
+          if (wantsPrimary) {
+            await setPrimaryDomain({ orgId, domain: normalizedDomain });
+          }
+          const linkResult = await linkContactsByDomain(normalizedDomain, orgId, actorId);
+          invalidateMemberContextCache();
+          return linkResult;
+        };
+
+        if (alreadyVerified) {
+          const linkResult = await syncLocalVerifiedState();
+          await writeAudit("domain_verification_override_reconciled", "succeeded");
+          return res.json({
+            success: true,
+            domain: normalizedDomain,
+            state: beforeState,
+            already_verified: true,
+            contacts_linked: linkResult.contactsLinked,
+          });
+        }
+
+        await writeAudit("domain_verification_override_attempted", "attempted");
+
+        const updatedDomains = workosOrg.domains.map(d => {
+          const state = String(d.state);
+          return {
+            domain: d.domain,
+            state: d.domain.toLowerCase() === normalizedDomain
+              ? DomainDataState.Verified
+              : (state === "verified" || state === "legacy_verified"
+                ? DomainDataState.Verified
+                : DomainDataState.Pending),
+          };
+        });
+
+        try {
+          await workos.organizations.updateOrganization({
+            organization: orgId,
+            domainData: updatedDomains,
+          });
+        } catch (workosError) {
+          try {
+            await writeAudit("domain_verification_override_failed", "failed", workosError);
+          } catch (auditError) {
+            logger.error(
+              { err: auditError, workosError, orgId, domain: normalizedDomain },
+              "Manual domain override failed and failure audit could not be recorded",
+            );
+          }
+          logger.error({ err: workosError, orgId, domain: normalizedDomain }, "Manual domain override failed in WorkOS");
+          return res.status(502).json({
+            error: "workos_error",
+            message: "Failed to override domain verification in WorkOS.",
+          });
+        }
+
+        try {
+          await writeAudit("domain_verification_override_succeeded", "succeeded");
+        } catch (auditError) {
+          logger.error(
+            { err: auditError, orgId, domain: normalizedDomain },
+            "Manual domain override succeeded but its completion audit failed",
+          );
+          return res.status(500).json({
+            error: "audit_log_failed",
+            message: "WorkOS accepted the override, but its completion audit could not be recorded. Escalate before retrying.",
+          });
+        }
+
+        const linkResult = await syncLocalVerifiedState();
+
+        logger.warn(
+          { orgId, domain: normalizedDomain, actor: actorId, workosDomainId: existingDomain.id },
+          "Global administrator manually overrode WorkOS domain verification",
+        );
+        return res.json({
+          success: true,
+          domain: normalizedDomain,
+          state: "verified",
+          already_verified: false,
+          contacts_linked: linkResult.contactsLinked,
+        });
+      } catch (error) {
+        logger.error({ err: error, orgId, domain: normalizedDomain }, "Manual domain verification override failed");
+        return res.status(500).json({
+          error: "internal_error",
+          message: "Unable to complete the manual domain verification override.",
+        });
+      }
+    },
+  );
+
   // POST /api/admin/organizations/:orgId/domains - Add a domain to an organization
-  // Writes to WorkOS first, then local DB is updated via webhook (or immediately for consistency)
+  // Adds a pending WorkOS challenge. Only WorkOS verification or the dedicated
+  // global-admin override route may transition a domain to verified.
   apiRouter.post(
     "/organizations/:orgId/domains",
     requireAuth,
@@ -1693,14 +1910,15 @@ export function setupDomainRoutes(
           return res.status(500).json({ error: "WorkOS not configured" });
         }
 
-        const normalizedDomain = domain.toLowerCase().trim().replace(/^www\./, '');
-
-        // Validate domain format
-        const domainRegex = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z]{2,})+$/;
-        if (!domainRegex.test(normalizedDomain)) {
+        let normalizedDomain: string;
+        try {
+          normalizedDomain = canonicalizeBrandDomain(domain);
+          assertClaimableBrandDomain(normalizedDomain);
+        } catch (error) {
+          logger.warn({ error, rawDomain: domain }, "Organization domain add rejected invalid domain");
           return res.status(400).json({
-            error: "Invalid domain format",
-            message: `"${normalizedDomain}" is not a valid domain. Expected format: "example.com" or "sub.example.com"`,
+            error: "invalid_domain",
+            message: "The domain is malformed or cannot be claimed.",
           });
         }
 
@@ -1739,6 +1957,9 @@ export function setupDomainRoutes(
           if (existingOrg.workos_organization_id !== orgId) {
             // Allow admins to reassign domains from personal orgs to corporate orgs
             if (existingOrg.is_personal) {
+              // This mutates a second organization, so tenant-scoped admin
+              // keys may not use the platform WorkOS credential to perform it.
+              if (refuseAnyApiKeyOnGlobalAdmin(req, res)) return;
               logger.info(
                 { orgId, domain: normalizedDomain, fromOrg: existingOrg.workos_organization_id, fromOrgName: existingOrg.org_name },
                 "Reassigning domain from personal org to corporate org"
@@ -1774,7 +1995,7 @@ export function setupDomainRoutes(
               });
             }
           }
-          // Domain already belongs to this org - but need to verify it if not already
+          // Domain already belongs to this org - sync its current WorkOS challenge state.
           // Skip this check if we just reassigned from a personal org (domain was deleted)
           if (!reassigningFromPersonalOrgId) {
             if (existingOrg.verified) {
@@ -1784,10 +2005,11 @@ export function setupDomainRoutes(
                 domain: normalizedDomain,
               });
             }
-            // Domain exists but not verified - continue to verify it
-            logger.info({ orgId, domain: normalizedDomain }, "Domain exists but not verified, proceeding to verify");
+            logger.info({ orgId, domain: normalizedDomain }, "Domain exists but is not yet verified in WorkOS");
           }
         }
+
+        let workosVerified = false;
 
         // Add to WorkOS first - this is the source of truth
         try {
@@ -1797,28 +2019,20 @@ export function setupDomainRoutes(
           const existingDomain = workosOrg.domains.find(d => d.domain.toLowerCase() === normalizedDomain);
 
           if (existingDomain) {
-            // Domain already exists - just verify it if not already verified
-            if (existingDomain.state !== 'verified') {
-              const updatedDomains = workosOrg.domains.map(d => ({
-                domain: d.domain,
-                state: d.domain.toLowerCase() === normalizedDomain ? DomainDataState.Verified : (d.state === 'verified' ? DomainDataState.Verified : DomainDataState.Pending)
-              }));
-              await workos.organizations.updateOrganization({
-                organization: orgId,
-                domainData: updatedDomains,
-              });
-            }
-            // If already verified, no WorkOS update needed
+            const existingDomainState = String(existingDomain.state);
+            workosVerified = existingDomainState === "verified" || existingDomainState === "legacy_verified";
           } else {
-            // Domain doesn't exist - add it
+            // A new domain starts pending. WorkOS owns the verification transition.
             const existingDomains = workosOrg.domains.map(d => ({
               domain: d.domain,
-              state: d.state === 'verified' ? DomainDataState.Verified : DomainDataState.Pending
+              state: d.state === "verified" || String(d.state) === "legacy_verified"
+                ? DomainDataState.Verified
+                : DomainDataState.Pending,
             }));
 
             await workos.organizations.updateOrganization({
               organization: orgId,
-              domainData: [...existingDomains, { domain: normalizedDomain, state: DomainDataState.Verified }],
+              domainData: [...existingDomains, { domain: normalizedDomain, state: DomainDataState.Pending }],
             });
           }
         } catch (workosErr) {
@@ -1847,16 +2061,16 @@ export function setupDomainRoutes(
         const wantsPrimary = is_primary === true;
 
         // Insert/update local DB immediately (webhook will also do this, but
-        // for immediate consistency). Admin tool already pushed this domain
-        // to WorkOS above, so source='workos' reflects upstream truth.
+        // for immediate consistency). source='workos' reflects upstream truth;
+        // pending challenges remain unverified locally until WorkOS confirms.
         await upsertWorkosDomain({
           orgId,
           domain: normalizedDomain,
-          verified: true,
-          isPrimary: wantsPrimary,
+          verified: workosVerified,
+          isPrimary: wantsPrimary && workosVerified,
         });
 
-        if (wantsPrimary) {
+        if (wantsPrimary && workosVerified) {
           // Atomic-flip across the org's rows and sync email_domain. No
           // requireSource — admin override.
           await setPrimaryDomain({ orgId, domain: normalizedDomain });
@@ -1871,14 +2085,15 @@ export function setupDomainRoutes(
           );
         }
 
-        logger.info({ orgId, domain: normalizedDomain, isPrimary: is_primary }, "Added domain to organization via WorkOS");
+        logger.info(
+          { orgId, domain: normalizedDomain, isPrimary: is_primary, verified: workosVerified },
+          "Added domain to organization via WorkOS",
+        );
 
         // Link any existing unmapped email contacts with this domain to the org
-        const linkResult = await linkContactsByDomain(
-          normalizedDomain,
-          orgId,
-          req.user?.id
-        );
+        const linkResult = workosVerified
+          ? await linkContactsByDomain(normalizedDomain, orgId, req.user?.id)
+          : { contactsLinked: 0 };
 
         if (linkResult.contactsLinked > 0) {
           logger.info(
@@ -1890,7 +2105,8 @@ export function setupDomainRoutes(
         res.json({
           success: true,
           domain: normalizedDomain,
-          is_primary: is_primary || false,
+          verified: workosVerified,
+          is_primary: wantsPrimary && workosVerified,
           synced_to_workos: true,
           contacts_linked: linkResult.contactsLinked,
         });

--- a/server/tests/unit/admin-domain-verification-recovery.test.ts
+++ b/server/tests/unit/admin-domain-verification-recovery.test.ts
@@ -1,0 +1,424 @@
+import express, {
+  type NextFunction,
+  type Request,
+  type Response,
+} from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkOS } from "@workos-inc/node";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  upsertWorkosDomain: vi.fn(),
+  setPrimaryDomain: vi.fn(),
+  linkContactsByDomain: vi.fn(),
+  invalidateMemberContextCache: vi.fn(),
+}));
+
+vi.mock("../../src/db/client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/db/client.js")>()),
+  getPool: () => ({ query: mocks.query }),
+}));
+
+vi.mock("../../src/db/organization-domains-db.js", () => ({
+  linkDomain: vi.fn(),
+  setPrimaryDomain: mocks.setPrimaryDomain,
+  upsertWorkosDomain: mocks.upsertWorkosDomain,
+  unlinkDomainAndReselectPrimary: vi.fn(),
+}));
+
+vi.mock("../../src/db/contacts-db.js", () => ({
+  linkContactsByDomain: mocks.linkContactsByDomain,
+}));
+
+vi.mock("../../src/addie/index.js", () => ({
+  invalidateMemberContextCache: mocks.invalidateMemberContextCache,
+}));
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  requireAuth: (req: Request, _res: Response, next: NextFunction) => {
+    req.user = {
+      id: "admin_user",
+      authWorkosUserId: "credential_admin",
+      email: "admin@example.com",
+      firstName: "Admin",
+      lastName: "User",
+    } as typeof req.user;
+    next();
+  },
+  requireAdmin: (_req: Request, _res: Response, next: NextFunction) => next(),
+  refuseAnyApiKeyOnGlobalAdmin: (req: Request, res: Response) => {
+    if (!req.get("x-test-tenant-api-key")) return false;
+    res.status(403).json({ error: "global_admin_required" });
+    return true;
+  },
+  requireGlobalAdmin: [
+    (req: Request, _res: Response, next: NextFunction) => {
+      req.user = {
+        id: "admin_user",
+        authWorkosUserId: "credential_admin",
+        email: "admin@example.com",
+        firstName: "Admin",
+        lastName: "User",
+      } as typeof req.user;
+      next();
+    },
+    (req: Request, res: Response, next: NextFunction) => {
+      if (req.get("x-test-tenant-api-key")) {
+        return res.status(403).json({ error: "global_admin_required" });
+      }
+      next();
+    },
+    (_req: Request, _res: Response, next: NextFunction) => next(),
+  ],
+}));
+
+import { setupDomainRoutes } from "../../src/routes/admin/domains.js";
+
+const ORG_ID = "org_company";
+const DOMAIN = "asterio.ai";
+
+function domainEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "domain_asterio",
+    domain: DOMAIN,
+    state: "pending",
+    verificationPrefix: "_workos",
+    verificationToken: "dns-token",
+    ...overrides,
+  };
+}
+
+function buildApp(workos: WorkOS) {
+  const app = express();
+  const router = express.Router();
+  app.use(express.json());
+  setupDomainRoutes(router, { workos });
+  app.use("/api/admin", router);
+  return app;
+}
+
+function mockWorkos(domains: ReturnType<typeof domainEntry>[]) {
+  return {
+    organizations: {
+      getOrganization: vi.fn().mockResolvedValue({ id: ORG_ID, domains }),
+      updateOrganization: vi.fn().mockResolvedValue({ id: ORG_ID, domains }),
+    },
+    organizationDomains: {
+      verifyOrganizationDomain: vi.fn(),
+    },
+  } as unknown as WorkOS;
+}
+
+function mockExistingPendingDomainQueries() {
+  mocks.query.mockImplementation(async (sql: string) => {
+    if (sql.includes("SELECT name, is_personal")) {
+      return { rows: [{ name: "Asterio", is_personal: false }] };
+    }
+    if (sql.includes("FROM organization_domains od")) {
+      return {
+        rows: [
+          {
+            workos_organization_id: ORG_ID,
+            verified: false,
+            org_name: "Asterio",
+            is_personal: false,
+          },
+        ],
+      };
+    }
+    return { rows: [], rowCount: 1 };
+  });
+}
+
+function mockOrganizationWithoutDomainQueries() {
+  mocks.query.mockImplementation(async (sql: string) => {
+    if (sql.includes("SELECT name, is_personal")) {
+      return { rows: [{ name: "Asterio", is_personal: false }] };
+    }
+    if (sql.includes("FROM organization_domains od")) {
+      return { rows: [] };
+    }
+    return { rows: [], rowCount: 1 };
+  });
+}
+
+function mockDomainOwnedByPersonalOrganization() {
+  mocks.query.mockImplementation(async (sql: string) => {
+    if (sql.includes("SELECT name, is_personal")) {
+      return { rows: [{ name: "Asterio", is_personal: false }] };
+    }
+    if (sql.includes("FROM organization_domains od")) {
+      return {
+        rows: [
+          {
+            workos_organization_id: "org_personal_victim",
+            verified: false,
+            org_name: "Personal workspace",
+            is_personal: true,
+          },
+        ],
+      };
+    }
+    return { rows: [], rowCount: 1 };
+  });
+}
+
+describe("admin WorkOS domain verification recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.upsertWorkosDomain.mockResolvedValue(undefined);
+    mocks.setPrimaryDomain.mockResolvedValue(undefined);
+    mocks.linkContactsByDomain.mockResolvedValue({ contactsLinked: 0 });
+  });
+
+  it("surfaces the WorkOS domain ID when a force re-check remains pending", async () => {
+    const workos = mockWorkos([domainEntry()]);
+    vi.mocked(
+      workos.organizationDomains.verifyOrganizationDomain
+    ).mockRejectedValue({ status: 422 });
+
+    const response = await request(buildApp(workos))
+      .post(`/api/admin/organizations/${ORG_ID}/domains/${DOMAIN}/verify`)
+      .send();
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      error: "still_pending",
+      workos_domain_id: "domain_asterio",
+      verification_token: "dns-token",
+    });
+  });
+
+  it("requires an attestation before manually overriding a pending domain", async () => {
+    mockExistingPendingDomainQueries();
+    const workos = mockWorkos([domainEntry()]);
+
+    const response = await request(buildApp(workos))
+      .post(
+        `/api/admin/organizations/${ORG_ID}/domains/${DOMAIN}/override-verification`
+      )
+      .send({ is_primary: true });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      error: "verification_attestation_required",
+    });
+    expect(workos.organizations.updateOrganization).not.toHaveBeenCalled();
+    expect(
+      mocks.query.mock.calls.some(([sql]) =>
+        String(sql).includes("registry_audit_log")
+      )
+    ).toBe(false);
+  });
+
+  it("writes immutable attempt and success audits with the acting credential", async () => {
+    mockExistingPendingDomainQueries();
+    const workos = mockWorkos([
+      domainEntry(),
+      domainEntry({
+        id: "domain_verified",
+        domain: "verified.example",
+        state: "verified",
+      }),
+      domainEntry({
+        id: "domain_legacy",
+        domain: "legacy.example",
+        state: "legacy_verified",
+      }),
+    ]);
+
+    const response = await request(buildApp(workos))
+      .post(
+        `/api/admin/organizations/${ORG_ID}/domains/${DOMAIN}/override-verification`
+      )
+      .send({
+        is_primary: true,
+        verification_attestation:
+          "Confirmed the published TXT value with dig from two resolvers.",
+      });
+
+    expect(response.status).toBe(200);
+    expect(workos.organizations.updateOrganization).toHaveBeenCalledWith({
+      organization: ORG_ID,
+      domainData: [
+        { domain: DOMAIN, state: "verified" },
+        { domain: "verified.example", state: "verified" },
+        { domain: "legacy.example", state: "verified" },
+      ],
+    });
+    const auditCalls = mocks.query.mock.calls.filter(([sql]) =>
+      String(sql).includes("INSERT INTO registry_audit_log")
+    );
+    expect(auditCalls).toHaveLength(2);
+    expect(auditCalls.map(([, values]) => values[2])).toEqual([
+      "domain_verification_override_attempted",
+      "domain_verification_override_succeeded",
+    ]);
+    for (const [, values] of auditCalls) {
+      expect(values[0]).toBe(ORG_ID);
+      expect(values[1]).toBe("credential_admin");
+      expect(values[3]).toBe(DOMAIN);
+      expect(JSON.parse(values[4])).toMatchObject({
+        domain: DOMAIN,
+        workos_domain_id: "domain_asterio",
+        before_state: "pending",
+        requested_after_state: "verified",
+        verification_attestation:
+          "Confirmed the published TXT value with dig from two resolvers.",
+        acting_workos_user_id: "credential_admin",
+      });
+    }
+    expect(mocks.upsertWorkosDomain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: ORG_ID,
+        domain: DOMAIN,
+        verified: true,
+      })
+    );
+  });
+
+  it("rejects tenant-scoped API keys before the override handler runs", async () => {
+    mockExistingPendingDomainQueries();
+    const workos = mockWorkos([domainEntry()]);
+
+    const response = await request(buildApp(workos))
+      .post(
+        `/api/admin/organizations/${ORG_ID}/domains/${DOMAIN}/override-verification`
+      )
+      .set("x-test-tenant-api-key", "true")
+      .send({ verification_attestation: "DNS checked." });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("global_admin_required");
+    expect(workos.organizations.getOrganization).not.toHaveBeenCalled();
+  });
+
+  it("appends a failure audit when WorkOS rejects the override", async () => {
+    mockExistingPendingDomainQueries();
+    const workos = mockWorkos([domainEntry()]);
+    vi.mocked(workos.organizations.updateOrganization).mockRejectedValue(
+      new Error("WorkOS unavailable")
+    );
+
+    const response = await request(buildApp(workos))
+      .post(
+        `/api/admin/organizations/${ORG_ID}/domains/${DOMAIN}/override-verification`
+      )
+      .send({
+        verification_attestation: "Confirmed the TXT record independently.",
+      });
+
+    expect(response.status).toBe(502);
+    const auditCalls = mocks.query.mock.calls.filter(([sql]) =>
+      String(sql).includes("INSERT INTO registry_audit_log")
+    );
+    expect(auditCalls.map(([, values]) => values[2])).toEqual([
+      "domain_verification_override_attempted",
+      "domain_verification_override_failed",
+    ]);
+    expect(JSON.parse(auditCalls[1][1][4])).toMatchObject({
+      outcome: "failed",
+      before_state: "pending",
+      after_state: "pending",
+      error: "WorkOS unavailable",
+    });
+    expect(mocks.upsertWorkosDomain).not.toHaveBeenCalled();
+  });
+
+  it("reconciles local state when a retry finds WorkOS already verified", async () => {
+    mockExistingPendingDomainQueries();
+    const workos = mockWorkos([domainEntry({ state: "verified" })]);
+
+    const response = await request(buildApp(workos))
+      .post(
+        `/api/admin/organizations/${ORG_ID}/domains/${DOMAIN}/override-verification`
+      )
+      .send({
+        is_primary: true,
+        verification_attestation:
+          "Retry after a local synchronization failure.",
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      success: true,
+      already_verified: true,
+      state: "verified",
+    });
+    expect(workos.organizations.updateOrganization).not.toHaveBeenCalled();
+    expect(mocks.upsertWorkosDomain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: ORG_ID,
+        domain: DOMAIN,
+        verified: true,
+        isPrimary: true,
+      })
+    );
+    const auditCall = mocks.query.mock.calls.find(
+      ([, values]) =>
+        values?.[2] === "domain_verification_override_reconciled"
+    );
+    expect(auditCall).toBeDefined();
+  });
+
+  it("rejects a public-suffix domain before creating or overriding a challenge", async () => {
+    const workos = mockWorkos([]);
+
+    const response = await request(buildApp(workos))
+      .post(
+        `/api/admin/organizations/${ORG_ID}/domains/co.uk/override-verification`
+      )
+      .send({ verification_attestation: "DNS checked." });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("invalid_domain");
+    expect(workos.organizations.getOrganization).not.toHaveBeenCalled();
+  });
+
+  it("adds a new domain as pending and does not grant domain-linked access", async () => {
+    mockOrganizationWithoutDomainQueries();
+    const workos = mockWorkos([]);
+
+    const response = await request(buildApp(workos))
+      .post(`/api/admin/organizations/${ORG_ID}/domains`)
+      .send({ domain: DOMAIN, is_primary: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      success: true,
+      domain: DOMAIN,
+      verified: false,
+      is_primary: false,
+      contacts_linked: 0,
+    });
+    expect(workos.organizations.updateOrganization).toHaveBeenCalledWith({
+      organization: ORG_ID,
+      domainData: [{ domain: DOMAIN, state: "pending" }],
+    });
+    expect(mocks.upsertWorkosDomain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: ORG_ID,
+        domain: DOMAIN,
+        verified: false,
+        isPrimary: false,
+      })
+    );
+    expect(mocks.linkContactsByDomain).not.toHaveBeenCalled();
+  });
+
+  it("refuses a tenant key before reassigning a domain from another personal org", async () => {
+    mockDomainOwnedByPersonalOrganization();
+    const workos = mockWorkos([]);
+
+    const response = await request(buildApp(workos))
+      .post(`/api/admin/organizations/${ORG_ID}/domains`)
+      .set("x-test-tenant-api-key", "true")
+      .send({ domain: DOMAIN });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("global_admin_required");
+    expect(workos.organizations.getOrganization).not.toHaveBeenCalled();
+    expect(workos.organizations.updateOrganization).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/admin-domain-verification-ui.test.ts
+++ b/server/tests/unit/admin-domain-verification-ui.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("admin account domain verification recovery UI", () => {
+  const source = readFileSync(
+    join(process.cwd(), "server/public/admin-account-detail.html"),
+    "utf8"
+  );
+  const httpSource = readFileSync(
+    join(process.cwd(), "server/src/http.ts"),
+    "utf8"
+  );
+
+  it("uses the WorkOS re-check endpoint for pending domains", () => {
+    expect(source).toContain('data-action="verify">Force Re-check</button>');
+    expect(source).toContain(
+      "/domains/${encodeURIComponent(domain.toLowerCase())}/verify"
+    );
+  });
+
+  it("requires a second-step attested override when WorkOS remains pending", () => {
+    expect(source).toContain("data.error === 'still_pending'");
+    expect(source).toContain("data.workos_domain_id");
+    expect(source).toContain("verification_attestation: attestation.trim()");
+    expect(source).toContain("/override-verification");
+    expect(source).toContain("} finally {");
+  });
+
+  it("keeps immutable domain override attestations behind the global-admin gate", () => {
+    expect(httpSource).toContain(
+      "this.app.get('/api/admin/audit-logs', ...requireGlobalAdmin"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- wire force recheck and a globally gated, attested verification override
- append immutable attempted, succeeded, failed, and reconciled audit entries
- make ordinary domain adds pending-only and close cross-tenant admin boundaries

## Validation

- `npx vitest run --config server/vitest.config.ts tests/unit/admin-domain-verification-recovery.test.ts tests/unit/admin-domain-verification-ui.test.ts` (12 passed)
- `npm run typecheck`
- pre-commit: 381/382 test files and 5,486/5,487 tests passed; the sole unrelated robots.txt failure passed immediately in isolation (8/8)
- no changeset: admin runtime/UI only

Closes #6050