### PR TITLE
docs(testing): explain sandbox account discovery

### DIFF
--- a/docs/building/operating/storyboard-troubleshooting.mdx
+++ b/docs/building/operating/storyboard-troubleshooting.mdx
@@ -20,6 +20,18 @@ The storyboard's `sample_request` references a hardcoded ID (`test-product`, `te
 
 See [Compliance test controller — Scenarios](/docs/building/by-layer/L3/comply-test-controller#scenarios) for the full seed contract. Agents that return `UNKNOWN_SCENARIO` on a seed call grade the storyboard `not_applicable` — they are not penalized for missing sandbox surface, but they cannot pass storyboards that depend on pre-seeded state.
 
+## Ambiguous sandbox account discovery
+
+```
+× Discover sandbox accounts for media buy: list_accounts returned multiple matching accounts (acct-a, acct-b); provide media_buy_account_id/account_id to disambiguate
+```
+
+The runner is resolving an account-id namespace (`account.require_operator_auth: true`) and the credential can see more than one plausible sandbox account. It cannot safely choose an `account_id` for later media-buy calls.
+
+**Fix:** Prefer a dedicated compliance credential bound to one sandbox account. If the credential must expose a roster, return enough brand data for exactly one active sandbox row to match the selected test kit's `brand.house.domain`. Do not set `require_operator_auth: false` as a workaround unless the seller genuinely uses buyer-declared natural keys (`brand` + `operator`); that flag is a buyer-facing account-model promise, not a runner hint.
+
+When a valid `account` capability block is present, merely exposing `list_accounts` does not opt a buyer-declared seller into account-ID discovery. Leave `require_operator_auth` false or absent, and support `sync_accounts` with `sandbox: true`, when the buyer declares accounts. If the whole `account` block is absent or could not be read, the runner may retain its legacy `list_accounts` discovery heuristic. See [Get test-ready — Pick your sandbox bootstrap path](/docs/building/verification/get-test-ready).
+
 ## Signature challenge missing on 401
 
 ```

--- a/docs/building/verification/get-test-ready.mdx
+++ b/docs/building/verification/get-test-ready.mdx
@@ -56,6 +56,10 @@ The runner must obtain a sandbox account before it can do anything. Your `requir
 
 **Account-id namespaces (`require_operator_auth: true`).** Accounts must be pre-provisioned by a human on your side or by an upstream platform. The runner calls `list_accounts` with a sandbox filter to discover pre-existing test accounts. If your credential is bound to exactly one sandbox account, return that singleton. Publish a short note telling operators how to request one — include the contact, the expected turnaround, and what credentials they'll receive.
 
+<Note>
+When your response includes the `account` capability block, its `require_operator_auth` flag — not the presence of `list_accounts` — selects the account model. Keep the flag `false` (or omit the flag, since `false` is its schema default) for buyer-declared natural-key accounts even if your agent also exposes `list_accounts`. Do not omit the entire `account` block: without account capability data, runners may retain a legacy `list_accounts` discovery heuristic. Set the flag to `true` only when callers must use seller-assigned account IDs. In that mode, the sandbox credential must expose one unambiguous account for the storyboard brand; if it exposes a roster, make sure exactly one row matches the test kit's `brand.house.domain`. Do not advertise `false` merely to bypass an ambiguous roster — that tells buyers the wrong account model.
+</Note>
+
 Full details and examples: [Sandbox mode](/docs/media-buy/advanced-topics/sandbox).
 
 ## Step 3 — Implement the compliance test controller


### PR DESCRIPTION
## Summary

- explain that `require_operator_auth` selects account resolution when the account capability block is present
- document the exact ambiguous-roster diagnostic and safe remediation
- warn against publishing a false account model as a runner workaround

## Validation

- `npm run test:docs-nav` (20 passed)
- independent code/docs review approved
- no fixture needed: adcp-client#2488 removed the operator-equals-brand restriction and tests an agency-operated account directly
- no changeset: non-normative docs only

Refs #6242