### PR TITLE
fix(community): route Slack CTA through workspace invite

### DIFF
--- a/server/public/slack-cta.js
+++ b/server/public/slack-cta.js
@@ -1,0 +1,14 @@
+(function initSlackCta(global) {
+  'use strict';
+
+  global.resolveSlackCta = function resolveSlackCta(options) {
+    const inviteUrl = global.safeExternalHttpUrl(options?.inviteUrl);
+    const channelUrl = global.safeExternalHttpUrl(options?.channelUrl);
+    const opensChannel = options?.isLinkedToSlack === true && Boolean(channelUrl);
+
+    return {
+      url: opensChannel ? channelUrl : (inviteUrl || channelUrl),
+      label: opensChannel ? 'Open Slack Channel' : 'Join Slack Workspace',
+    };
+  };
+})(window);

--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -28,6 +28,7 @@
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
   <script src="/perspective-url.js"></script>
   <script src="/external-url.js"></script>
+  <script src="/slack-cta.js"></script>
   <style>
     body {
       background: var(--color-bg-page);
@@ -1182,7 +1183,7 @@
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
               <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/>
             </svg>
-            Join Slack Channel
+            <span id="slackBtnLabel">Join Slack Workspace</span>
           </a>
           <a id="manageBtn" class="btn btn-secondary" href="#" style="display: none;">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -1441,6 +1442,8 @@
     let isMember = false;
     let isLeader = false;
     let isAdmin = false;
+    let isLinkedToSlack = false;
+    let slackInviteUrl = '';
     let currentSlug = '';
     let postsData = [];
 
@@ -1490,6 +1493,8 @@
           const config = await response.json();
           currentUser = config.user || null;
           isAdmin = config.user?.isAdmin || false;
+          isLinkedToSlack = config.user?.isLinkedToSlack === true;
+          slackInviteUrl = safeExternalHttpUrl(config.slackInviteUrl);
         }
       } catch (err) {
         console.debug('Auth check failed:', err);
@@ -1605,10 +1610,15 @@
       }
 
       // Slack button
-      const slackChannelUrl = safeExternalHttpUrl(currentGroup.slack_channel_url);
-      if (slackChannelUrl) {
+      const slackCta = resolveSlackCta({
+        inviteUrl: slackInviteUrl,
+        channelUrl: currentGroup.slack_channel_url,
+        isLinkedToSlack,
+      });
+      if (slackCta.url) {
         const slackBtn = document.getElementById('slackBtn');
-        slackBtn.href = slackChannelUrl;
+        slackBtn.href = slackCta.url;
+        document.getElementById('slackBtnLabel').textContent = slackCta.label;
         slackBtn.rel = 'noopener noreferrer';
         slackBtn.style.display = 'inline-flex';
       }

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -54,6 +54,7 @@ import { syncSlackUsers, getSyncStatus, tryAutoLinkWebsiteUserToSlack } from "./
 import { isSlackConfigured, testSlackConnection } from "./slack/client.js";
 import { handleSlashCommand } from "./slack/commands.js";
 import { getCompanyDomain, getGoogleEmailAliases } from "./utils/email-domain.js";
+import { hasActiveSlackLink } from "./utils/slack-linkage.js";
 import { isUuid } from "./utils/uuid.js";
 import { resolveUserNameWithFallbacks, sanitizeName } from "./utils/resolve-user-name.js";
 import { scrubCommunityAuthorizedAgents } from "./utils/community-adagents.js";
@@ -61,7 +62,7 @@ import { formatPerspectiveUrlAsMarkdownDestination, normalizePerspectiveExternal
 import { requireAuth, requireAdmin, requireGlobalAdmin, optionalAuth, invalidateSessionCache, isDevModeEnabled, getDevUser, getAvailableDevUsers, getDevSessionCookieName, encodeDevSessionCookie, DEV_USERS, type DevUserConfig } from "./middleware/auth.js";
 import { invitationRateLimiter, brandCreationRateLimiter, notificationRateLimiter, emailPrefsRateLimiter, adminContentWriteRateLimiter, newsletterSubscribeRateLimiter, newsletterConfirmRateLimiter } from "./middleware/rate-limit.js";
 import { findOrCreateUserByEmail } from "./auth/workos-client.js";
-import { sendNewsletterConfirmation } from "./notifications/email.js";
+import { sendNewsletterConfirmation, SLACK_INVITE_URL } from "./notifications/email.js";
 import { getPerspectiveWithIllustration, getIllustrationData } from "./db/illustration-db.js";
 import { getAssetData as getPerspectiveAssetData } from "./db/perspective-asset-db.js";
 import { generatePerspectiveCard, compositePerspectiveCard } from "./services/perspective-cards.js";
@@ -2374,6 +2375,13 @@ export class HTTPServer {
       if (req.user) {
         await enrichUserWithMembership(req.user as any);
         await enrichUserWithAdmin(req.user as any);
+        let isLinkedToSlack = false;
+        try {
+          const slackMapping = await new SlackDatabase().getByWorkosUserId(req.user.id);
+          isLinkedToSlack = hasActiveSlackLink(slackMapping);
+        } catch (err) {
+          logger.warn({ err, userId: req.user.id }, 'Unable to resolve Slack linkage for public config');
+        }
         user = {
           id: req.user.id,
           email: req.user.email,
@@ -2381,11 +2389,13 @@ export class HTTPServer {
           lastName: req.user.lastName,
           isAdmin: !!(req.user as any).isAdmin,
           isMember: !!(req.user as any).isMember,
+          isLinkedToSlack,
         };
       }
 
       res.json({
         authEnabled: AUTH_ENABLED,
+        slackInviteUrl: SLACK_INVITE_URL,
         user,
       });
     });

--- a/server/src/utils/slack-linkage.ts
+++ b/server/src/utils/slack-linkage.ts
@@ -1,0 +1,11 @@
+import type { SlackUserMapping } from '../slack/types.js';
+
+export function hasActiveSlackLink(
+  mapping: Pick<SlackUserMapping, 'slack_user_id' | 'mapping_status' | 'slack_is_deleted'> | null,
+): boolean {
+  return Boolean(
+    mapping?.slack_user_id
+    && mapping.mapping_status === 'mapped'
+    && !mapping.slack_is_deleted
+  );
+}

--- a/server/tests/unit/public-external-url-sinks.test.ts
+++ b/server/tests/unit/public-external-url-sinks.test.ts
@@ -5,12 +5,26 @@ import { describe, expect, it } from 'vitest';
 
 const publicRoot = join(process.cwd(), 'server/public');
 const guardSource = readFileSync(join(publicRoot, 'external-url.js'), 'utf8');
+const slackCtaSource = readFileSync(join(publicRoot, 'slack-cta.js'), 'utf8');
 
 function loadGuard(): (value: unknown) => string {
   const context = vm.createContext({ window: {}, URL });
   vm.runInContext(guardSource, context);
   return (context.window as { safeExternalHttpUrl: (value: unknown) => string })
     .safeExternalHttpUrl;
+}
+
+function loadSlackCta(): (options: {
+  inviteUrl?: unknown;
+  channelUrl?: unknown;
+  isLinkedToSlack?: boolean;
+}) => { url: string; label: string } {
+  const context = vm.createContext({ window: {}, URL });
+  vm.runInContext(guardSource, context);
+  vm.runInContext(slackCtaSource, context);
+  return (context.window as {
+    resolveSlackCta: ReturnType<typeof loadSlackCta>;
+  }).resolveSlackCta;
 }
 
 describe('public external URL navigation guard', () => {
@@ -54,6 +68,48 @@ describe('public external URL navigation guard', () => {
     const source = readFileSync(join(publicRoot, 'admin-account-detail.html'), 'utf8');
     expect(source).toContain('linkedInSignalRow(a.enrichment.linkedin_url)');
     expect(source).toContain('getSafeLinkedInUrl(value)');
+  });
+
+  it('routes Slack CTAs by actual Slack linkage with safe fallbacks', () => {
+    const resolveSlackCta = loadSlackCta();
+    const inviteUrl = 'https://join.slack.com/t/agenticads/shared_invite/example';
+    const channelUrl = 'https://app.slack.com/client/workspace/channel';
+
+    expect(resolveSlackCta({ inviteUrl, channelUrl })).toEqual({
+      url: inviteUrl,
+      label: 'Join Slack Workspace',
+    });
+    expect(resolveSlackCta({ inviteUrl, channelUrl, isLinkedToSlack: false })).toEqual({
+      url: inviteUrl,
+      label: 'Join Slack Workspace',
+    });
+    expect(resolveSlackCta({ inviteUrl, channelUrl, isLinkedToSlack: true })).toEqual({
+      url: channelUrl,
+      label: 'Open Slack Channel',
+    });
+    expect(resolveSlackCta({ inviteUrl: 'javascript:alert(1)', channelUrl })).toEqual({
+      url: channelUrl,
+      label: 'Join Slack Workspace',
+    });
+    expect(resolveSlackCta({ inviteUrl, channelUrl: 'data:text/html,bad', isLinkedToSlack: true })).toEqual({
+      url: inviteUrl,
+      label: 'Join Slack Workspace',
+    });
+    expect(resolveSlackCta({ inviteUrl: '/relative', channelUrl: 'not a url' })).toEqual({
+      url: '',
+      label: 'Join Slack Workspace',
+    });
+  });
+
+  it('exposes Slack linkage and uses the shared CTA resolver', () => {
+    const source = readFileSync(join(publicRoot, 'working-groups/detail.html'), 'utf8');
+    const httpSource = readFileSync(join(process.cwd(), 'server/src/http.ts'), 'utf8');
+
+    expect(httpSource).toContain('slackInviteUrl: SLACK_INVITE_URL');
+    expect(httpSource).toContain('isLinkedToSlack,');
+    expect(source).toContain('isLinkedToSlack = config.user?.isLinkedToSlack === true');
+    expect(source).toContain('const slackCta = resolveSlackCta({');
+    expect(source).toContain('slackBtn.href = slackCta.url');
   });
 
   it.each([

--- a/server/tests/unit/slack-linkage.test.ts
+++ b/server/tests/unit/slack-linkage.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { hasActiveSlackLink } from '../../src/utils/slack-linkage.js';
+
+describe('hasActiveSlackLink', () => {
+  it('requires a mapped, non-deleted Slack account', () => {
+    expect(hasActiveSlackLink(null)).toBe(false);
+    expect(hasActiveSlackLink({
+      slack_user_id: 'U123',
+      mapping_status: 'unmapped',
+      slack_is_deleted: false,
+    })).toBe(false);
+    expect(hasActiveSlackLink({
+      slack_user_id: 'U123',
+      mapping_status: 'mapped',
+      slack_is_deleted: true,
+    })).toBe(false);
+    expect(hasActiveSlackLink({
+      slack_user_id: 'U123',
+      mapping_status: 'mapped',
+      slack_is_deleted: false,
+    })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- expose the existing public Slack invite and active Slack-linkage state through `/api/config`
- send unlinked and anonymous visitors to the workspace invite, while linked users open the group channel directly
- sanitize both destinations, provide safe fallbacks, and use destination-aware CTA labels
- treat deleted and unmapped Slack records as unlinked

## Validation

- `npx vitest run --config server/vitest.config.ts tests/unit/public-external-url-sinks.test.ts tests/unit/slack-linkage.test.ts` (27 passed)
- `npm run typecheck`
- independent code and security reviews approved
- no changeset: website/runtime behavior only

Closes #6049