### PR TITLE
fix(registry): scope agent auth to selected organization

### DIFF
--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1239,12 +1239,13 @@
     // Fetches compliance + history + auth for a single agent. Always returns
     // an object — on failure, loadError is populated so the renderer can
     // distinguish "server says unknown" from "we couldn't load".
-    async function fetchAgentState(agent) {
+    async function fetchAgentState(agent, organizationId) {
       const encoded = encodeURIComponent(agent.url);
+      const orgQuery = organizationId ? `?org=${encodeURIComponent(organizationId)}` : '';
       const endpoints = [
         `/api/registry/agents/${encoded}/compliance`,
         `/api/registry/agents/${encoded}/compliance/history?limit=10`,
-        `/api/registry/agents/${encoded}/auth-status`,
+        `/api/registry/agents/${encoded}/auth-status${orgQuery}`,
       ];
       const settled = await Promise.allSettled(
         endpoints.map(u => fetchWithRetry(u, { credentials: 'include' })),
@@ -1405,7 +1406,7 @@
               const agent = queue.shift();
               if (!agent) break;
               try {
-                const state = await fetchAgentState(agent);
+                const state = await fetchAgentState(agent, currentOrgId);
                 if (cancellation.cancelled) break;
                 agentCompliance.set(state.url, state);
                 swapAgentCard(state.url);
@@ -2496,7 +2497,7 @@
           checkbox.checked = !checkbox.checked;
           return;
         }
-        const state = await fetchAgentState({ url: agentUrl });
+        const state = await fetchAgentState({ url: agentUrl }, pageState.orgId);
         pageState.complianceMap.set(agentUrl, state);
         swapAgentCard(agentUrl);
       } catch {
@@ -2553,7 +2554,7 @@
       }
       if (auto) pageState.autoRetriedAgents.add(agentUrl);
       try {
-        const state = await fetchAgentState({ url: agentUrl });
+        const state = await fetchAgentState({ url: agentUrl }, pageState.orgId);
         pageState.complianceMap.set(agentUrl, state);
         // Clear any prior auto-retry marker UNLESS we hit another 429
         // — keeping the marker on a back-to-back 429 is what drives
@@ -2746,7 +2747,11 @@
       saveBtn.textContent = 'Saving...';
 
       try {
-        const body = { auth_token: authToken, auth_type: authType };
+        const body = {
+          auth_token: authToken,
+          auth_type: authType,
+          organization_id: pageState.orgId,
+        };
 
         const res = await fetch('/api/registry/agents/' + encodeURIComponent(agentUrl) + '/connect', {
           method: 'PUT',
@@ -2819,7 +2824,12 @@
       saveBtn.textContent = 'Saving...';
 
       try {
-        const body = { token_endpoint: tokenEndpoint, client_id: clientId, client_secret: clientSecret };
+        const body = {
+          token_endpoint: tokenEndpoint,
+          client_id: clientId,
+          client_secret: clientSecret,
+          organization_id: pageState.orgId,
+        };
         if (scope) body.scope = scope;
         if (resource) body.resource = resource;
         if (audience) body.audience = audience;
@@ -2990,6 +3000,7 @@
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
+          body: JSON.stringify({ organization_id: pageState.orgId }),
         });
         const data = await res.json().catch(() => ({}));
 
@@ -3055,7 +3066,7 @@
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'include',
-            body: JSON.stringify({}),
+            body: JSON.stringify({ organization_id: pageState.orgId }),
           });
           if (!connectRes.ok) {
             const data = await connectRes.json().catch(() => ({}));
@@ -3107,7 +3118,7 @@
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'include',
-            body: JSON.stringify({}),
+            body: JSON.stringify({ organization_id: pageState.orgId }),
           });
           if (!connectRes.ok) {
             const data = await connectRes.json().catch(() => ({}));
@@ -3249,6 +3260,7 @@
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ organization_id: pageState.orgId }),
         });
         const data = await res.json().catch(() => ({}));
 
@@ -3581,7 +3593,8 @@
 
         try {
           const storyboardStatusMapPromise = loadStoryboardStatusMap(agentUrl);
-          const res = await fetch('/api/registry/agents/' + encodeURIComponent(agentUrl) + '/applicable-storyboards', { credentials: 'include' });
+          const orgQuery = pageState.orgId ? '?org=' + encodeURIComponent(pageState.orgId) : '';
+          const res = await fetch('/api/registry/agents/' + encodeURIComponent(agentUrl) + '/applicable-storyboards' + orgQuery, { credentials: 'include' });
 
           if (res.ok) {
             const data = await res.json();
@@ -3900,7 +3913,7 @@
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'include',
-            body: JSON.stringify({ context, dry_run: true }),
+            body: JSON.stringify({ context, dry_run: true, organization_id: pageState.orgId }),
           });
           const result = await res.json();
           if (!res.ok) {
@@ -3994,6 +4007,7 @@
             method: 'POST',
             credentials: 'include',
             headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ organization_id: pageState.orgId }),
           });
 
           if (res.status === 429) {
@@ -4100,6 +4114,7 @@
             method: 'POST',
             credentials: 'include',
             headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ organization_id: pageState.orgId }),
           });
 
           if (res.status === 429) {

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -4518,6 +4518,18 @@ function parseRequestedOrganizationId(value: unknown):
   return { ok: true, organizationId: value };
 }
 
+function parseRequestedOrganizationQuery(query: Record<string, unknown>):
+  | { ok: true; organizationId: string | undefined }
+  | { ok: false } {
+  // Express's simple query parser preserves bracketed keys literally, so
+  // `?org[]=...` would otherwise look like an omitted `org`. Reject alternate
+  // object/array spellings rather than silently falling back to another org.
+  if (Object.keys(query).some(key => key !== "org" && (key.startsWith("org[") || key.startsWith("org.")))) {
+    return { ok: false };
+  }
+  return parseRequestedOrganizationId(query.org);
+}
+
 export function createRegistryApiRouters(config: RegistryApiConfig): { router: Router; v1AgentsRouter: Router } {
   const router = Router();
   const {
@@ -7455,7 +7467,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         has_oauth_client_credentials: false,
       };
 
-      const orgSelection = parseRequestedOrganizationId(req.query.org);
+      const orgSelection = parseRequestedOrganizationQuery(req.query);
       if (!orgSelection.ok) {
         return res.status(400).json({ error: "org must be a non-empty organization ID" });
       }
@@ -7804,7 +7816,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       return res.status(401).json({ error: "Authentication required" });
     }
 
-    const orgSelection = parseRequestedOrganizationId(req.query.org);
+    const orgSelection = parseRequestedOrganizationQuery(req.query);
     if (!orgSelection.ok) {
       return res.status(400).json({ error: "org must be a non-empty organization ID" });
     }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -10,7 +10,11 @@ import { once } from "node:events";
 import type { Request, RequestHandler } from "express";
 import { z } from "zod";
 import escapeHtml from "escape-html";
-import { findOwnerOrgForUser } from "../services/agent-ownership.js";
+import {
+  findOwnerOrgForUser,
+  isOrgOwnerOfAgent,
+  resolveOwnerOrgForUser,
+} from "../services/agent-ownership.js";
 import { AdCPClient, SingleAgentClient, exchangeClientCredentials, ClientCredentialsExchangeError } from "@adcp/sdk";
 import { runStoryboardStep, getComplianceStoryboardById, getFirstStepPreview, testCapabilityDiscovery, resolveStoryboardsForCapabilities, loadComplianceIndex, listAllComplianceStoryboards } from "@adcp/sdk/testing";
 import type { Agent, AgentType, AgentWithStats } from "../types.js";
@@ -3682,6 +3686,15 @@ registry.registerPath({
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL", example: "https%3A%2F%2Fvastlint.org%2Fmcp" }),
     }),
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            organization_id: z.string().optional().openapi({ description: "Selected organization ID. The caller must own the agent in this organization before its credentials are used." }),
+          }),
+        },
+      },
+    },
   },
   responses: {
     200: {
@@ -3750,6 +3763,9 @@ registry.registerPath({
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
     }),
+    query: z.object({
+      org: z.string().optional().openapi({ description: "Selected organization ID. Required to disambiguate an agent URL registered by multiple organizations." }),
+    }),
   },
   responses: {
     200: { description: "Auth status", content: { "application/json": { schema: AgentAuthStatusSchema } } },
@@ -3778,6 +3794,7 @@ registry.registerPath({
           schema: z.object({
             auth_token: z.string().max(4096).optional().openapi({ description: "Bearer or basic auth token" }),
             auth_type: z.enum(["bearer", "basic"]).optional().openapi({ description: "Auth type (default: bearer)" }),
+            organization_id: z.string().optional().openapi({ description: "Selected organization ID. The caller must own the agent in this organization." }),
           }),
         },
       },
@@ -3827,6 +3844,7 @@ registry.registerPath({
             resource: z.union([z.string().max(2048), z.array(z.string().max(2048)).min(1).max(8)]).optional().openapi({ description: 'RFC 8707 resource indicator. Accepts a single URI string or an array of 1–8 URI strings for multi-resource authorization servers (Keycloak strict, AWS Cognito multi-RS).' }),
             audience: z.string().max(2048).optional().openapi({ description: "Audience parameter for audience-validating authorization servers." }),
             auth_method: z.enum(["basic", "body"]).optional().openapi({ description: "Client-credentials placement: basic (HTTP Basic header, RFC 6749 §2.3.1 preferred) or body (form fields). SDK default is basic." }),
+            organization_id: z.string().optional().openapi({ description: "Selected organization ID. The caller must own the agent in this organization." }),
           }),
         },
       },
@@ -3869,6 +3887,15 @@ registry.registerPath({
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
     }),
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            organization_id: z.string().optional().openapi({ description: "Selected organization ID. The caller must own the agent in this organization." }),
+          }),
+        },
+      },
+    },
   },
   responses: {
     200: {
@@ -3916,6 +3943,9 @@ registry.registerPath({
   request: {
     params: z.object({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
+    }),
+    query: z.object({
+      org: z.string().optional().openapi({ description: "Selected organization ID. Required to disambiguate an agent URL registered by multiple organizations." }),
     }),
   },
   responses: {
@@ -4264,6 +4294,7 @@ registry.registerPath({
           schema: z.object({
             context: z.record(z.string(), z.unknown()).optional().openapi({ description: "Optional context object for the step" }),
             dry_run: z.boolean().optional().openapi({ description: "Dry run mode (default: true)" }),
+            organization_id: z.string().optional().openapi({ description: "Selected organization ID. The caller must own the agent in this organization." }),
           }),
         },
       },
@@ -4365,6 +4396,15 @@ registry.registerPath({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
       storyboardId: z.string(),
     }),
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            organization_id: z.string().optional().openapi({ description: "Selected organization ID. The caller must own the agent in this organization." }),
+          }),
+        },
+      },
+    },
   },
   responses: {
     200: {
@@ -4420,6 +4460,15 @@ registry.registerPath({
       encodedUrl: z.string().openapi({ description: "URL-encoded agent URL" }),
       storyboardId: z.string(),
     }),
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            organization_id: z.string().optional().openapi({ description: "Selected organization ID. The caller must own the agent in this organization." }),
+          }),
+        },
+      },
+    },
   },
   responses: {
     200: {
@@ -4452,6 +4501,21 @@ registry.registerPath({
 
 export function createRegistryApiRouter(config: RegistryApiConfig): Router {
   return createRegistryApiRouters(config).router;
+}
+
+function parseRequestedOrganizationId(value: unknown):
+  | { ok: true; organizationId: string | undefined }
+  | { ok: false } {
+  if (value === undefined) return { ok: true, organizationId: undefined };
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 255 ||
+    value !== value.trim()
+  ) {
+    return { ok: false };
+  }
+  return { ok: true, organizationId: value };
 }
 
 export function createRegistryApiRouters(config: RegistryApiConfig): { router: Router; v1AgentsRouter: Router } {
@@ -6830,6 +6894,10 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     try {
       const canonicalUrl = canonicalizeAgentUrl(agentUrl);
       if (!canonicalUrl) return null;
+      if (!(await isOrgOwnerOfAgent(orgId, userId, canonicalUrl))) {
+        logger.warn({ orgId, agentUrl: canonicalUrl }, "Refusing to create agent context outside owning organization");
+        return null;
+      }
       let context = await agentContextDb.getByOrgAndUrl(orgId, canonicalUrl);
       if (!context) {
         context = await agentContextDb.create({
@@ -7070,16 +7138,24 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         return res.status(401).json({ error: "Authentication required" });
       }
 
+      const orgSelection = parseRequestedOrganizationId(req.body?.organization_id);
+      if (!orgSelection.ok) {
+        return res.status(400).json({ error: "organization_id must be a non-empty organization ID" });
+      }
+      const ownerOrgId = await resolveOwnerOrgForUser(
+        req.user.id,
+        agentUrl,
+        orgSelection.organizationId,
+      );
+
       // Owner OR AAO admin. Admin escape hatch lets staff fix things for
       // any registered agent (mirrors how admin tools work elsewhere).
       // Dev-admin fallback is gated behind `isDevModeEnabled()` to match
       // `requireAdmin`'s pattern in middleware/auth.ts — in production
       // (no DEV_USER_EMAIL/DEV_USER_ID) this branch never fires.
       const isStaticAdmin = isStaticAdminRequest(req);
-      const [isOwner, isAaoAdmin] = await Promise.all([
-        verifyAgentOwnership(req.user.id, agentUrl),
-        isWebUserAAOAdmin(req.user.id),
-      ]);
+      const isOwner = ownerOrgId !== null;
+      const isAaoAdmin = await isWebUserAAOAdmin(req.user.id);
       const isDevAdmin = isDevModeEnabled() && getDevUser(req)?.isAdmin === true;
       if (!isOwner && !isAaoAdmin && !isDevAdmin && !isStaticAdmin) {
         return res.status(403).json({ error: "You do not have permission to refresh this agent" });
@@ -7118,7 +7194,6 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       // route still scopes auth to the caller's own org so an AAO admin
       // refreshing someone else's agent probes anonymously rather than
       // accidentally running with the owner's tokens.
-      const ownerOrgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
       let resolvedAuth: SdkAuth | undefined;
       if (ownerOrgId) {
         const auth = await resolveUserAgentAuth(agentContextDb, ownerOrgId, agentUrl, logger);
@@ -7370,18 +7445,6 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         return res.status(401).json({ error: "Authentication required" });
       }
 
-      // Verify ownership and get org ID in one query
-      const orgResult = await query(
-        `SELECT mp.workos_organization_id
-         FROM member_profiles mp
-         JOIN organization_memberships om
-           ON om.workos_organization_id = mp.workos_organization_id
-         WHERE mp.agents @> $1::jsonb
-           AND om.workos_user_id = $2
-         LIMIT 1`,
-        [JSON.stringify([{ url: agentUrl }]), req.user.id],
-      );
-
       const noAuthResponse = {
         has_auth: false,
         agent_context_id: null,
@@ -7392,11 +7455,15 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         has_oauth_client_credentials: false,
       };
 
-      if (orgResult.rows.length === 0) {
+      const orgSelection = parseRequestedOrganizationId(req.query.org);
+      if (!orgSelection.ok) {
+        return res.status(400).json({ error: "org must be a non-empty organization ID" });
+      }
+      const requestedOrgId = orgSelection.organizationId;
+      const orgId = await resolveOwnerOrgForUser(req.user.id, agentUrl, requestedOrgId);
+      if (!orgId) {
         return res.json(noAuthResponse);
       }
-
-      const orgId = orgResult.rows[0].workos_organization_id;
       const context = await agentContextDb.getByOrgAndUrl(orgId, agentUrl);
 
       if (!context) {
@@ -7470,23 +7537,15 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         authTokenToStore = normalized.stored;
       }
 
-      // Verify ownership and get org ID in a single query
-      const orgResult = await query(
-        `SELECT mp.workos_organization_id
-         FROM member_profiles mp
-         JOIN organization_memberships om
-           ON om.workos_organization_id = mp.workos_organization_id
-         WHERE mp.agents @> $1::jsonb
-           AND om.workos_user_id = $2
-         LIMIT 1`,
-        [JSON.stringify([{ url: agentUrl }]), req.user.id],
-      );
-
-      if (orgResult.rows.length === 0) {
+      const orgSelection = parseRequestedOrganizationId(req.body?.organization_id);
+      if (!orgSelection.ok) {
+        return res.status(400).json({ error: "organization_id must be a non-empty organization ID" });
+      }
+      const requestedOrgId = orgSelection.organizationId;
+      const orgId = await resolveOwnerOrgForUser(req.user.id, agentUrl, requestedOrgId);
+      if (!orgId) {
         return res.status(403).json({ error: "You do not have permission to modify this agent" });
       }
-
-      const orgId = orgResult.rows[0].workos_organization_id;
 
       // Get or create agent context
       let context = await agentContextDb.getByOrgAndUrl(orgId, agentUrl);
@@ -7566,20 +7625,15 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.status(400).json({ error: parsed.error, code: parsed.code, field: parsed.field });
         }
 
-        const orgResult = await query<{ workos_organization_id: string }>(
-          `SELECT mp.workos_organization_id
-           FROM member_profiles mp
-           JOIN organization_memberships om
-             ON om.workos_organization_id = mp.workos_organization_id
-           WHERE mp.agents @> $1::jsonb
-             AND om.workos_user_id = $2
-           LIMIT 1`,
-          [JSON.stringify([{ url: agentUrl }]), req.user.id],
-        );
-        if (orgResult.rows.length === 0) {
+        const orgSelection = parseRequestedOrganizationId(req.body?.organization_id);
+        if (!orgSelection.ok) {
+          return res.status(400).json({ error: "organization_id must be a non-empty organization ID" });
+        }
+        const requestedOrgId = orgSelection.organizationId;
+        const orgId = await resolveOwnerOrgForUser(req.user.id, agentUrl, requestedOrgId);
+        if (!orgId) {
           return res.status(403).json({ error: "You do not have permission to modify this agent" });
         }
-        const orgId = orgResult.rows[0].workos_organization_id;
 
         let context = await agentContextDb.getByOrgAndUrl(orgId, agentUrl);
         if (!context) {
@@ -7645,7 +7699,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.status(401).json({ error: "Authentication required" });
         }
 
-        const orgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
+        const orgSelection = parseRequestedOrganizationId(req.body?.organization_id);
+        if (!orgSelection.ok) {
+          return res.status(400).json({ error: "organization_id must be a non-empty organization ID" });
+        }
+        const requestedOrgId = orgSelection.organizationId;
+        const orgId = await resolveOwnerOrgForUser(req.user.id, agentUrl, requestedOrgId);
         if (!orgId) {
           return res.status(403).json({ error: "You do not have permission to test this agent" });
         }
@@ -7745,7 +7804,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       return res.status(401).json({ error: "Authentication required" });
     }
 
-    const orgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
+    const orgSelection = parseRequestedOrganizationId(req.query.org);
+    if (!orgSelection.ok) {
+      return res.status(400).json({ error: "org must be a non-empty organization ID" });
+    }
+    const requestedOrgId = orgSelection.organizationId;
+    const orgId = await resolveOwnerOrgForUser(req.user.id, agentUrl, requestedOrgId);
     if (!orgId) {
       return res.status(403).json({ error: "You do not have permission to test this agent" });
     }
@@ -7907,7 +7971,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.status(401).json({ error: "Authentication required" });
         }
 
-        const orgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
+        const orgSelection = parseRequestedOrganizationId(req.body?.organization_id);
+        if (!orgSelection.ok) {
+          return res.status(400).json({ error: "organization_id must be a non-empty organization ID" });
+        }
+        const requestedOrgId = orgSelection.organizationId;
+        const orgId = await resolveOwnerOrgForUser(req.user.id, agentUrl, requestedOrgId);
         if (!orgId) {
           return res.status(403).json({ error: "You do not have permission to test this agent" });
         }
@@ -8033,7 +8102,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.status(401).json({ error: "Authentication required" });
         }
 
-        const orgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
+        const orgSelection = parseRequestedOrganizationId(req.body?.organization_id);
+        if (!orgSelection.ok) {
+          return res.status(400).json({ error: "organization_id must be a non-empty organization ID" });
+        }
+        const requestedOrgId = orgSelection.organizationId;
+        const orgId = await resolveOwnerOrgForUser(req.user.id, agentUrl, requestedOrgId);
         if (!orgId) {
           return res.status(403).json({ error: "You do not have permission to test this agent" });
         }
@@ -8216,7 +8290,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           return res.status(401).json({ error: "Authentication required" });
         }
 
-        const orgId = await resolveAgentOwnerOrg(req.user.id, agentUrl);
+        const orgSelection = parseRequestedOrganizationId(req.body?.organization_id);
+        if (!orgSelection.ok) {
+          return res.status(400).json({ error: "organization_id must be a non-empty organization ID" });
+        }
+        const requestedOrgId = orgSelection.organizationId;
+        const orgId = await resolveOwnerOrgForUser(req.user.id, agentUrl, requestedOrgId);
         if (!orgId) {
           return res.status(403).json({ error: "You do not have permission to test this agent" });
         }

--- a/server/src/services/agent-ownership.ts
+++ b/server/src/services/agent-ownership.ts
@@ -1,23 +1,26 @@
 /**
  * Agent-ownership helpers — single source of truth for "who owns this agent."
  *
- * The query has two distinct semantic uses:
+ * The ownership relation has three distinct semantic uses:
  *
  *   1. `findOwnerOrgForUser(userId, agentUrl)` — "what org owns this agent
  *      for this user?" Returns the org_id (or null) for ANY org the user
  *      is a member of that has the agent in its member_profile. Used by
- *      route handlers gating per-agent operations (refresh, applicable-
- *      storyboards, run-storyboard) on ownership.
+ *      callers that only need to establish ownership by any organization.
  *
- *   2. `isOrgOwnerOfAgent(orgId, userId, agentUrl)` — "is THIS specific
+ *   2. `findSoleOwnerOrgForUser(userId, agentUrl)` — compatibility lookup
+ *      for credential-bearing routes whose caller omitted org context. It
+ *      succeeds only when exactly one organization matches.
+ *
+ *   3. `isOrgOwnerOfAgent(orgId, userId, agentUrl)` — "is THIS specific
  *      org the one that owns the agent for this user?" Tighter predicate
  *      than (1): requires the resolved org context to match the agent's
  *      owning org. Used by `evaluate_agent_quality`'s canonical-write
  *      gate where the calling-context org is known and must be confirmed
  *      as the owner (not "some org the user belongs to").
  *
- * Both queries join `member_profiles.agents` against `organization_memberships`
- * — the canonical ownership relation. The two-helper pattern exists because
+ * All queries join `member_profiles.agents` against `organization_memberships`
+ * — the canonical ownership relation. The shared helpers exist because
  * inlining the JOIN at every call site is a drift surface (PR #4250 review
  * flagged the duplication); a single shared helper keeps the predicate in
  * one place.
@@ -60,6 +63,36 @@ export async function findOwnerOrgForUser(
 }
 
 /**
+ * Resolve an owner only when the URL maps to exactly one organization for
+ * this user. Credential-bearing routes use this compatibility path when an
+ * older caller omits its organization selection. Multiple matches must fail
+ * closed: choosing either tenant would select the wrong encryption context.
+ */
+export async function findSoleOwnerOrgForUser(
+  userId: string,
+  agentUrl: string,
+): Promise<string | null> {
+  try {
+    const lookupAgentUrl = canonicalizeAgentUrl(agentUrl) ?? agentUrl;
+    const result = await query<{ workos_organization_id: string }>(
+      `SELECT DISTINCT mp.workos_organization_id
+       FROM member_profiles mp
+       JOIN organization_memberships om
+         ON om.workos_organization_id = mp.workos_organization_id
+       WHERE mp.agents @> $1::jsonb
+         AND om.workos_user_id = $2
+       LIMIT 2`,
+      [JSON.stringify([{ url: lookupAgentUrl }]), userId],
+    );
+    return result.rows.length === 1
+      ? result.rows[0].workos_organization_id
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Verify the given org is the org that owns the agent for the given user.
  * Tighter than `findOwnerOrgForUser` — requires the org_id in the calling
  * context (e.g., the resolved member-context organization) to match the
@@ -90,4 +123,28 @@ export async function isOrgOwnerOfAgent(
   } catch {
     return false;
   }
+}
+
+/**
+ * Resolve the owning organization for an agent operation, honoring an
+ * explicit dashboard organization when one was supplied.
+ *
+ * A user can belong to more than one organization that registers the same
+ * agent URL. In that case `findOwnerOrgForUser` is intentionally ambiguous;
+ * dashboard writes must instead stay inside the organization the user
+ * selected. The explicit path therefore fails closed when that organization
+ * does not own the agent, rather than silently falling back to another org.
+ */
+export async function resolveOwnerOrgForUser(
+  userId: string,
+  agentUrl: string,
+  requestedOrgId?: string,
+): Promise<string | null> {
+  if (requestedOrgId === undefined) {
+    return findSoleOwnerOrgForUser(userId, agentUrl);
+  }
+
+  return (await isOrgOwnerOfAgent(requestedOrgId, userId, agentUrl))
+    ? requestedOrgId
+    : null;
 }

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -26,6 +26,7 @@ const OTHER_USER_ID = `user_test_refresh_other_${RUN_SUFFIX}`;
 const ADMIN_USER_ID = `user_test_refresh_admin_${RUN_SUFFIX}`;
 const STATIC_ADMIN_USER_ID = 'admin_api_key';
 const TEST_ORG_ID = `org_test_refresh_${RUN_SUFFIX}`;
+const SECOND_ORG_ID = `org_test_refresh_second_${RUN_SUFFIX}`;
 // Each test that expects a 200 uses its own URL — the per-agent rate-limit
 // closure inside the router is stateful across test cases, so reusing one
 // URL would 429 the second hit. Unowned URL stays constant since no test
@@ -43,6 +44,8 @@ const ALL_OWNED_URLS = [
   ownedAgentUrl('badge-fanout'),
   ownedAgentUrl('static-admin'),
   ownedAgentUrl('applicable-oauth'),
+  ownedAgentUrl('selected-org-refresh'),
+  ownedAgentUrl('selected-org-challenge'),
 ];
 
 // Toggle which user the auth middleware stamps onto the request. Tests
@@ -214,6 +217,36 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
         JSON.stringify(ALL_OWNED_URLS.map(u => ({ url: u, name: 'Test agent' }))),
       ],
     );
+    await pool.query(
+      `INSERT INTO organizations (
+         workos_organization_id, name, membership_tier, subscription_status, created_at, updated_at
+       )
+       VALUES ($1, 'Second Refresh Org', 'company_standard', 'active', NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE
+         SET membership_tier = EXCLUDED.membership_tier,
+             subscription_status = EXCLUDED.subscription_status,
+             updated_at = NOW()`,
+      [SECOND_ORG_ID],
+    );
+    await pool.query(
+      `INSERT INTO organization_memberships (workos_organization_id, workos_user_id, email, role, created_at, updated_at)
+       VALUES ($1, $2, $3, 'admin', NOW(), NOW())
+       ON CONFLICT (workos_organization_id, workos_user_id) DO NOTHING`,
+      [SECOND_ORG_ID, OWNER_USER_ID, `${OWNER_USER_ID}@test.com`],
+    );
+    await pool.query(
+      `INSERT INTO member_profiles (workos_organization_id, display_name, slug, agents, created_at, updated_at)
+       VALUES ($1, 'Second Refresh Org', $2, $3::jsonb, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE SET agents = EXCLUDED.agents, updated_at = NOW()`,
+      [
+        SECOND_ORG_ID,
+        `test-refresh-second-${RUN_SUFFIX}`,
+        JSON.stringify([
+          { url: ownedAgentUrl('selected-org-refresh'), name: 'Shared refresh agent' },
+          { url: ownedAgentUrl('selected-org-challenge'), name: 'Shared challenge agent' },
+        ]),
+      ],
+    );
 
     server = new HTTPServer();
     await server.start(0);
@@ -229,9 +262,10 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
     await pool.query('DELETE FROM agent_compliance_runs WHERE agent_url = ANY($1)', [allUrls]);
     await pool.query('DELETE FROM agent_health_snapshot WHERE agent_url = ANY($1)', [allUrls]);
     await pool.query('DELETE FROM agent_capabilities_snapshot WHERE agent_url = ANY($1)', [allUrls]);
-    await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = $1', [TEST_ORG_ID]);
-    await pool.query('DELETE FROM organization_memberships WHERE workos_organization_id = $1', [TEST_ORG_ID]);
-    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    await pool.query('DELETE FROM agent_contexts WHERE organization_id = ANY($1)', [[TEST_ORG_ID, SECOND_ORG_ID]]);
+    await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = ANY($1)', [[TEST_ORG_ID, SECOND_ORG_ID]]);
+    await pool.query('DELETE FROM organization_memberships WHERE workos_organization_id = ANY($1)', [[TEST_ORG_ID, SECOND_ORG_ID]]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = ANY($1)', [[TEST_ORG_ID, SECOND_ORG_ID]]);
     await server?.stop();
     await closeDatabase();
   });
@@ -498,6 +532,66 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
     } finally {
       await pool.query('DELETE FROM agent_contexts WHERE id = $1', [context.id]);
     }
+  });
+
+  it('uses the selected org credentials when a shared agent is refreshed', async () => {
+    const agentUrl = ownedAgentUrl('selected-org-refresh');
+    const { AgentContextDatabase } = await import('../../src/db/agent-context-db.js');
+    const db = new AgentContextDatabase();
+    const context = await db.create({
+      organization_id: SECOND_ORG_ID,
+      agent_url: agentUrl,
+      created_by: OWNER_USER_ID,
+    });
+    const token = 'selected-org-bearer-do-not-use-in-prod';
+    await db.saveAuthToken(context.id, token, 'bearer');
+
+    try {
+      const res = await request(app)
+        .post(url(agentUrl))
+        .send({ organization_id: SECOND_ORG_ID });
+
+      expect(res.status).toBe(200);
+      expect(refreshSingleAgentMock).toHaveBeenCalledWith(
+        agentUrl,
+        expect.objectContaining({
+          auth: { type: 'bearer', token },
+          ownerOrgId: SECOND_ORG_ID,
+        }),
+      );
+    } finally {
+      await pool.query('DELETE FROM agent_contexts WHERE id = $1', [context.id]);
+    }
+  });
+
+  it('creates an OAuth challenge context in the selected org for a shared agent', async () => {
+    const agentUrl = ownedAgentUrl('selected-org-challenge');
+    testCapabilityDiscoveryMock.mockResolvedValueOnce({
+      profile: {
+        name: 'OAuth challenge agent',
+        tools: [],
+        supported_protocols: ['media_buy'],
+        specialisms: [],
+      },
+      steps: [{
+        step: 'Discover agent profile',
+        passed: false,
+        duration_ms: 1,
+        error: 'Agent requires OAuth authorization',
+      }],
+    });
+
+    const res = await request(app)
+      .get(`/api/registry/agents/${encodeURIComponent(agentUrl)}/applicable-storyboards`)
+      .query({ org: SECOND_ORG_ID });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({ needs_oauth: true });
+    const stored = await pool.query(
+      'SELECT organization_id FROM agent_contexts WHERE id = $1',
+      [res.body.agent_context_id],
+    );
+    expect(stored.rows).toEqual([{ organization_id: SECOND_ORG_ID }]);
   });
 
   it('fans out badge issuance for an owner refresh with a passing specialism', async () => {

--- a/server/tests/integration/registry-api-oauth.test.ts
+++ b/server/tests/integration/registry-api-oauth.test.ts
@@ -30,6 +30,7 @@ import { decrypt } from '../../src/db/encryption.js';
 const RUN_SUFFIX = Math.random().toString(36).slice(2, 8);
 const TEST_USER_ID = `user_test_oauth_${RUN_SUFFIX}`;
 const TEST_ORG_ID = `org_test_oauth_${RUN_SUFFIX}`;
+const SECOND_ORG_ID = `org_test_oauth_second_${RUN_SUFFIX}`;
 const TEST_AGENT_URL = 'https://agent.example.com';
 const OTHER_AGENT_URL = 'https://another-agent.example.com';
 
@@ -118,6 +119,27 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
        ON CONFLICT (workos_organization_id) DO UPDATE SET agents = EXCLUDED.agents, updated_at = NOW()`,
       [TEST_ORG_ID, JSON.stringify([{ url: TEST_AGENT_URL, name: 'Test agent' }])],
     );
+    // A second organization owned by the same user lets focused tests
+    // register the same URL in both orgs. It stays empty by default so the
+    // legacy URL-only test cases remain deterministic.
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, created_at, updated_at)
+       VALUES ($1, 'Second OAuth Integration Org', NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO NOTHING`,
+      [SECOND_ORG_ID],
+    );
+    await pool.query(
+      `INSERT INTO organization_memberships (workos_organization_id, workos_user_id, email, role, created_at, updated_at)
+       VALUES ($1, $2, 'oauth-int@test.com', 'admin', NOW(), NOW())
+       ON CONFLICT (workos_organization_id, workos_user_id) DO NOTHING`,
+      [SECOND_ORG_ID, TEST_USER_ID],
+    );
+    await pool.query(
+      `INSERT INTO member_profiles (workos_organization_id, display_name, slug, agents, created_at, updated_at)
+       VALUES ($1, 'Second OAuth Integration Org', 'test-oauth-integration-second', $2::jsonb, NOW(), NOW())
+       ON CONFLICT (workos_organization_id) DO UPDATE SET agents = EXCLUDED.agents, updated_at = NOW()`,
+      [SECOND_ORG_ID, JSON.stringify([])],
+    );
 
     server = new HTTPServer();
     await server.start(0);
@@ -126,10 +148,10 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
 
   afterAll(async () => {
     // Tear down in FK order.
-    await pool.query('DELETE FROM agent_contexts WHERE organization_id = $1', [TEST_ORG_ID]);
-    await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = $1', [TEST_ORG_ID]);
-    await pool.query('DELETE FROM organization_memberships WHERE workos_organization_id = $1', [TEST_ORG_ID]);
-    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    await pool.query('DELETE FROM agent_contexts WHERE organization_id = ANY($1)', [[TEST_ORG_ID, SECOND_ORG_ID]]);
+    await pool.query('DELETE FROM member_profiles WHERE workos_organization_id = ANY($1)', [[TEST_ORG_ID, SECOND_ORG_ID]]);
+    await pool.query('DELETE FROM organization_memberships WHERE workos_organization_id = ANY($1)', [[TEST_ORG_ID, SECOND_ORG_ID]]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = ANY($1)', [[TEST_ORG_ID, SECOND_ORG_ID]]);
     await server?.stop();
     await closeDatabase();
   });
@@ -137,7 +159,11 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
   beforeEach(async () => {
     // Clear saved credentials between tests so each case starts from a
     // known state. Also reset the SDK-exchange mock.
-    await pool.query('DELETE FROM agent_contexts WHERE organization_id = $1', [TEST_ORG_ID]);
+    await pool.query('DELETE FROM agent_contexts WHERE organization_id = ANY($1)', [[TEST_ORG_ID, SECOND_ORG_ID]]);
+    await pool.query(
+      'UPDATE member_profiles SET agents = $2::jsonb WHERE workos_organization_id = $1',
+      [SECOND_ORG_ID, JSON.stringify([])],
+    );
     exchangeMock.mockReset();
     // Reset the Postgres-backed rate-limit counter for brand:* keys. Both
     // save and test endpoints run through `brandCreationRateLimiter` (60/hr),
@@ -146,6 +172,13 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
     // within an hour eventually trigger 429 flakes.
     await pool.query("DELETE FROM rate_limit_hits WHERE key LIKE 'brand:%'");
   });
+
+  async function registerAgentInSecondOrg(): Promise<void> {
+    await pool.query(
+      'UPDATE member_profiles SET agents = $2::jsonb WHERE workos_organization_id = $1',
+      [SECOND_ORG_ID, JSON.stringify([{ url: TEST_AGENT_URL, name: 'Shared test agent' }])],
+    );
+  }
 
   // ── PUT /connect ────────────────────────────────────────────────
 
@@ -233,6 +266,54 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
       expect(res.status).toBe(200);
       expect(res.body.has_auth).toBe(false);
       expect(res.body.agent_context_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    });
+
+    it('creates the OAuth context in the explicitly selected organization', async () => {
+      await registerAgentInSecondOrg();
+      const res = await request(app)
+        .put(url)
+        .send({ organization_id: SECOND_ORG_ID });
+      expect(res.status).toBe(200);
+
+      const stored = await pool.query(
+        'SELECT organization_id FROM agent_contexts WHERE id = $1',
+        [res.body.agent_context_id],
+      );
+      expect(stored.rows).toEqual([{ organization_id: SECOND_ORG_ID }]);
+    });
+
+    it('does not fall back to another org when the selected org lacks ownership', async () => {
+      const res = await request(app)
+        .put(url)
+        .send({ organization_id: 'org_not_owned' });
+      expect(res.status).toBe(403);
+
+      const stored = await pool.query(
+        'SELECT id FROM agent_contexts WHERE organization_id = ANY($1)',
+        [[TEST_ORG_ID, SECOND_ORG_ID]],
+      );
+      expect(stored.rows).toHaveLength(0);
+    });
+
+    it('fails closed when organization is omitted and multiple orgs own the URL', async () => {
+      await registerAgentInSecondOrg();
+
+      const res = await request(app).put(url).send({});
+      expect(res.status).toBe(403);
+
+      const stored = await pool.query(
+        'SELECT id FROM agent_contexts WHERE organization_id = ANY($1)',
+        [[TEST_ORG_ID, SECOND_ORG_ID]],
+      );
+      expect(stored.rows).toHaveLength(0);
+    });
+
+    it('rejects a malformed selected organization instead of falling back', async () => {
+      const res = await request(app)
+        .put(url)
+        .send({ organization_id: [] });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/organization_id/);
     });
 
     it('returns 403 for an agent the user does not own', async () => {
@@ -495,6 +576,37 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
 
       const res = await request(app).get(statusUrl).expect(200);
       expect(res.body).toMatchObject({ has_auth: true, auth_type: 'bearer' });
+    });
+
+    it('reports auth only from the explicitly selected organization', async () => {
+      await registerAgentInSecondOrg();
+      await request(app)
+        .put(`/api/registry/agents/${encodeURIComponent(TEST_AGENT_URL)}/connect`)
+        .send({
+          auth_token: 'second-org-bearer',
+          auth_type: 'bearer',
+          organization_id: SECOND_ORG_ID,
+        })
+        .expect(200);
+
+      const secondOrg = await request(app)
+        .get(statusUrl)
+        .query({ org: SECOND_ORG_ID })
+        .expect(200);
+      expect(secondOrg.body).toMatchObject({ has_auth: true, auth_type: 'bearer' });
+
+      const firstOrg = await request(app)
+        .get(statusUrl)
+        .query({ org: TEST_ORG_ID })
+        .expect(200);
+      expect(firstOrg.body).toMatchObject({ has_auth: false, agent_context_id: null });
+    });
+
+    it('rejects a malformed org query instead of reading an arbitrary context', async () => {
+      const res = await request(app)
+        .get(`${statusUrl}?org[]=org_a`);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/org/);
     });
 
     it('canonicalizes the requested URL before ownership and auth-context lookup', async () => {

--- a/server/tests/integration/registry-api-oauth.test.ts
+++ b/server/tests/integration/registry-api-oauth.test.ts
@@ -602,12 +602,14 @@ describe('registry-api OAuth credential endpoints (integration)', () => {
       expect(firstOrg.body).toMatchObject({ has_auth: false, agent_context_id: null });
     });
 
-    it('rejects a malformed org query instead of reading an arbitrary context', async () => {
-      const res = await request(app)
-        .get(`${statusUrl}?org[]=org_a`);
-      expect(res.status).toBe(400);
-      expect(res.body.error).toMatch(/org/);
-    });
+    it.each(['org[]=org_a', 'org[0]=org_a', 'org.value=org_a'])(
+      'rejects malformed org query %s instead of reading an arbitrary context',
+      async (query) => {
+        const res = await request(app).get(`${statusUrl}?${query}`);
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/org/);
+      },
+    );
 
     it('canonicalizes the requested URL before ownership and auth-context lookup', async () => {
       await request(app)

--- a/server/tests/unit/agent-ownership.test.ts
+++ b/server/tests/unit/agent-ownership.test.ts
@@ -5,7 +5,11 @@ vi.mock('../../src/db/client.js', () => ({
 }));
 
 import { query } from '../../src/db/client.js';
-import { findOwnerOrgForUser, isOrgOwnerOfAgent } from '../../src/services/agent-ownership.js';
+import {
+  findOwnerOrgForUser,
+  isOrgOwnerOfAgent,
+  resolveOwnerOrgForUser,
+} from '../../src/services/agent-ownership.js';
 
 const queryMock = vi.mocked(query);
 
@@ -130,6 +134,62 @@ describe('agent-ownership', () => {
         JSON.stringify([{ url: 'https://agent.example.com/mcp' }]),
         'user_123',
       ]);
+    });
+  });
+
+  describe('resolveOwnerOrgForUser', () => {
+    it('uses the explicitly requested owning organization', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] } as never);
+
+      await expect(resolveOwnerOrgForUser(
+        'user_123',
+        'https://agent.example.com/mcp',
+        'org_selected',
+      )).resolves.toBe('org_selected');
+
+      expect(queryMock.mock.calls[0]?.[1]).toEqual([
+        'org_selected',
+        JSON.stringify([{ url: 'https://agent.example.com/mcp' }]),
+        'user_123',
+      ]);
+    });
+
+    it('fails closed when the requested organization does not own the agent', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [] } as never);
+
+      await expect(resolveOwnerOrgForUser(
+        'user_123',
+        'https://agent.example.com/mcp',
+        'org_wrong',
+      )).resolves.toBeNull();
+
+      expect(queryMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves a sole owner when no organization is requested', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [{ workos_organization_id: 'org_discovered' }] } as never);
+
+      await expect(resolveOwnerOrgForUser(
+        'user_123',
+        'https://agent.example.com/mcp',
+      )).resolves.toBe('org_discovered');
+    });
+
+    it('fails closed when an omitted organization has multiple owners', async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [
+          { workos_organization_id: 'org_a' },
+          { workos_organization_id: 'org_b' },
+        ],
+      } as never);
+
+      await expect(resolveOwnerOrgForUser(
+        'user_123',
+        'https://agent.example.com/mcp',
+      )).resolves.toBeNull();
+
+      expect(queryMock.mock.calls[0]?.[0]).toContain('SELECT DISTINCT');
+      expect(queryMock.mock.calls[0]?.[0]).toContain('LIMIT 2');
     });
   });
 

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -10972,6 +10972,15 @@ paths:
           description: URL-encoded agent URL
           name: encodedUrl
           in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization before its credentials are used.
       responses:
         "200":
           description: Snapshot refreshed
@@ -11121,6 +11130,13 @@ paths:
           description: URL-encoded agent URL
           name: encodedUrl
           in: path
+        - schema:
+            type: string
+            description: Selected organization ID. Required to disambiguate an agent URL registered by multiple organizations.
+          required: false
+          description: Selected organization ID. Required to disambiguate an agent URL registered by multiple organizations.
+          name: org
+          in: query
       responses:
         "200":
           description: Auth status
@@ -11180,6 +11196,9 @@ paths:
                     - bearer
                     - basic
                   description: "Auth type (default: bearer)"
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization.
       responses:
         "200":
           description: Connection result
@@ -11285,6 +11304,9 @@ paths:
                     - basic
                     - body
                   description: "Client-credentials placement: basic (HTTP Basic header, RFC 6749 §2.3.1 preferred) or body (form fields). SDK default is basic."
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization.
               required:
                 - token_endpoint
                 - client_id
@@ -11358,6 +11380,15 @@ paths:
           description: URL-encoded agent URL
           name: encodedUrl
           in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization.
       responses:
         "200":
           description: "Result of the token exchange. `ok: true` on 2xx from the AS; `ok: false` with a typed error otherwise (HTTP response itself is still 200 — the error payload carries the rejection kind so UI can branch on it)."
@@ -11460,6 +11491,13 @@ paths:
           description: URL-encoded agent URL
           name: encodedUrl
           in: path
+        - schema:
+            type: string
+            description: Selected organization ID. Required to disambiguate an agent URL registered by multiple organizations.
+          required: false
+          description: Selected organization ID. Required to disambiguate an agent URL registered by multiple organizations.
+          name: org
+          in: query
       responses:
         "200":
           description: Bundles the agent will be tested against, driven by its declared capabilities
@@ -12105,6 +12143,9 @@ paths:
                 dry_run:
                   type: boolean
                   description: "Dry run mode (default: true)"
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization.
       responses:
         "200":
           description: Step execution result
@@ -12233,6 +12274,15 @@ paths:
           required: true
           name: storyboardId
           in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization.
       responses:
         "200":
           description: Storyboard run result with annotated phases
@@ -12434,6 +12484,15 @@ paths:
           required: true
           name: storyboardId
           in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization.
       responses:
         "200":
           description: Side-by-side comparison results


### PR DESCRIPTION
## Summary
- bind dashboard OAuth, static auth, client credentials, refresh, and storyboard challenges to the selected organization
- fail closed when an omitted agent URL maps to multiple owned organizations, and reject malformed org selectors
- re-check exact ownership before creating OAuth contexts while preserving global any-org ownership checks
- add duplicate-owner, selected-org refresh, malformed-input, and OAuth-challenge regression coverage

Advances #6054. This intentionally does not close the issue: the commercial entitlement decision and production credential re-authorization/re-key remain separate operator actions.

## Validation
- `npx vitest run server/tests/unit/agent-ownership.test.ts` (13/13)
- `npm run typecheck`
- `npm run test:openapi`
- dashboard inline script syntax check
- code review: merge-ready
- security review: merge-ready

The Postgres integration suites are included for CI; this workspace has no local Postgres service on port 53198.