### PR TITLE
fix(compliance): expose storyboard verdicts and clarify partial tracks

### DIFF
--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -172,6 +172,11 @@
       font-size: var(--text-xs);
     }
     .agent-track-detail h4 { margin: 0 0 var(--space-2); font-size: var(--text-sm); }
+    .track-coverage-gap-note {
+      color: var(--color-warning-700);
+      font-size: var(--text-xs);
+      margin-top: var(--space-1);
+    }
     .track-scenario { padding: var(--space-1) 0; border-bottom: 1px solid var(--color-gray-200); }
     .track-scenario:last-child { border-bottom: none; }
     .track-scenario-name { font-weight: var(--font-semibold); }
@@ -3411,6 +3416,14 @@
       }
     });
 
+    function buildTrackCoverageGapNote(trackData) {
+      if (!trackData.has_coverage_gap_skip || trackData.status !== 'partial') return '';
+      return '<div class="track-coverage-gap-note">'
+        + 'Badge eligibility is storyboard-level. One or more storyboards in this track '
+        + 'have a coverage-gap skip and do not count as passing, even when every scenario that ran passed.'
+        + '</div>';
+    }
+
     // Track pill click — fetch history and show scenario details for that track
     document.addEventListener('click', async function(e) {
       const trackBtn = e.target.closest('.agent-track[data-track]');
@@ -3451,9 +3464,11 @@
             : trackData.status === 'partial' ? 'Partial' : trackData.status;
 
           let html = '<h4>' + escapeHtml(track) + ' — ' + escapeHtml(statusLabel) + '</h4>';
-          html += '<div>' + parseInt(trackData.passed_count, 10) + ' of ' + parseInt(trackData.scenario_count, 10) + ' scenarios passing';
+          html += '<div>' + Number(trackData.passed_count) + ' of ' + Number(trackData.scenario_count) + ' scenarios passing';
           if (trackData.duration_ms) html += ' (' + (trackData.duration_ms / 1000).toFixed(1) + 's)';
           html += '</div>';
+
+          html += buildTrackCoverageGapNote(trackData);
 
           if (trackData.scenarios) {
             for (const s of trackData.scenarios) {

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -6260,7 +6260,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           },
         });
       } catch (err) {
-        logger.warn({ err, agentUrl, userId }, "Owner membership lookup failed");
+        logger.error({ err, agentUrl, userId }, "Owner membership lookup failed");
         ownerMembership = {
           is_owner: false,
           membership_tier: null,
@@ -6271,9 +6271,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       }
 
       const encodedUrl = encodeURIComponent(agentUrl);
-      const storyboardStatusesForOwner = ownerMembership.is_owner
-        ? storyboardStatuses.map(s => serializeStoryboardStatus(s))
-        : [];
+      const serializedStoryboardStatuses = storyboardStatuses.map(s =>
+        serializeStoryboardStatus(s, { includeDiagnostics: ownerMembership.is_owner }),
+      );
 
       res.json({
         agent_url: agentUrl,
@@ -6295,11 +6295,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         check_interval_hours: metadata?.check_interval_hours ?? 12,
         declared_specialisms: declaredSpecialisms,
         specialism_status: specialismStatus,
-        // Owner-scoped: failing storyboard names and step counts for the
-        // dashboard hover states. Non-owners get an empty array so public
-        // registry consumers keep the same response shape without receiving
-        // implementation-level diagnostics.
-        storyboard_statuses: storyboardStatusesForOwner,
+        // Public per-storyboard verdicts and aggregate step counts explain
+        // storyboards_passing/storyboards_total. First-failure details stay
+        // owner-scoped; non-owner entries carry null scalar diagnostics and
+        // empty validation evidence.
+        storyboard_statuses: serializedStoryboardStatuses,
         // Advisory notices from the latest run. Forward-compat: unknown codes
         // and severities are passed through verbatim (runner-output-contract.yaml).
         notices,

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -797,9 +797,10 @@ export const AgentComplianceDetailSchema = z
       first_failed_step_title: z.string().nullable(),
       first_failed_step_task: z.string().nullable(),
       first_failure_message: z.string().nullable(),
+      first_failure_validations: z.array(z.any()).openapi({ description: "Validation evidence for the first failure. Populated only for owners and empty for other callers." }),
       last_tested_at: z.string().nullable(),
       last_passed_at: z.string().nullable(),
-    })).optional().openapi({ description: "Owner-scoped per-storyboard diagnostics used by the dashboard. Empty for non-owners." }),
+    })).optional().openapi({ description: "Public per-storyboard verdicts and aggregate step counts. First-failure diagnostic fields are populated only for owners; scalar diagnostics are null and validation evidence is empty for other callers." }),
     notices: z.array(z.any()).optional().openapi({ description: "Run-summary notices from the latest non-dry-run compliance run. Unknown codes/severities are preserved verbatim." }),
     observations: z.array(z.object({
       category: z.string(),

--- a/server/tests/integration/registry-api-compliance-verdict-source.test.ts
+++ b/server/tests/integration/registry-api-compliance-verdict-source.test.ts
@@ -3,7 +3,8 @@
  * GET /api/registry/agents/:encodedUrl/compliance.
  *
  * Pins the verdict_source / membership_tier / subscription_status /
- * is_api_access_tier scoping: those keys MUST exist on every response
+ * is_api_access_tier scoping and the public storyboard-status contract.
+ * The owner-only keys MUST exist on every response
  * (so non-owners can't detect ownership via Object.keys shape), but
  * carry null/false values for anonymous and cross-org callers. Only
  * an authenticated viewer whose org owns the agent sees populated
@@ -211,11 +212,12 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
       `INSERT INTO agent_compliance_step_diagnostics (
          run_id, agent_url, storyboard_id, phase_id, step_id, task,
          step_passed, duration_ms, request_url, request_jsonb,
-         response_status, response_jsonb, error_text
+         response_status, response_jsonb, error_text, failed_validations_jsonb
        ) VALUES (
          $1, $2, 'debug_storyboard', 'debug_phase', 'debug_step', 'get_products',
          false, 42, $2, '{"params":{"brief":"debug"}}'::jsonb,
-         200, '{"ok":false}'::jsonb, 'debug failure'
+         200, '{"ok":false}'::jsonb, 'debug failure',
+         '[{"field":"products","message":"must not be empty"}]'::jsonb
        )`,
       [complianceRunId, AGENT_URL],
     );
@@ -258,6 +260,29 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
     'is_api_access_tier',
   ] as const;
 
+  const expectPublicStoryboardStatus = (
+    body: Record<string, unknown>,
+    options: { includeDiagnostics?: boolean } = {},
+  ) => {
+    expect(body.storyboard_statuses).toEqual([
+      expect.objectContaining({
+        storyboard_id: 'debug_storyboard',
+        status: 'failing',
+        steps_passed: 1,
+        steps_total: 2,
+        first_failed_step_id: options.includeDiagnostics ? 'debug_step' : null,
+        first_failed_step_title: options.includeDiagnostics ? 'Debug step' : null,
+        first_failed_step_task: options.includeDiagnostics ? 'get_products' : null,
+        first_failure_message: options.includeDiagnostics ? 'debug failure' : null,
+        first_failure_validations: options.includeDiagnostics
+          ? [{ field: 'products', message: 'must not be empty' }]
+          : [],
+      }),
+    ]);
+    expect(body.storyboards_passing).toBe(0);
+    expect(body.storyboards_total).toBe(1);
+  };
+
   it('anonymous caller: shape is intact, owner-only fields are null/false', async () => {
     currentUserId = null;
     const res = await request(app).get(endpoint);
@@ -273,6 +298,7 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
     expect(res.body.membership_tier_label).toBeNull();
     expect(res.body.subscription_status).toBeNull();
     expect(res.body.is_api_access_tier).toBe(false);
+    expectPublicStoryboardStatus(res.body);
   });
 
   it('cross-org caller: shape is intact, owner-only fields are null/false', async () => {
@@ -287,6 +313,7 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
     expect(res.body.membership_tier_label).toBeNull();
     expect(res.body.subscription_status).toBeNull();
     expect(res.body.is_api_access_tier).toBe(false);
+    expectPublicStoryboardStatus(res.body);
   });
 
   it('owner caller: verdict_source + membership tier populated', async () => {
@@ -297,6 +324,7 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
     expect(res.body.membership_tier).toBe('company_standard');
     expect(res.body.subscription_status).toBe('active');
     expect(res.body.is_api_access_tier).toBe(true);
+    expectPublicStoryboardStatus(res.body, { includeDiagnostics: true });
   });
 
   it('owner of a free-tier org still sees verdict_source (is_owner is broader than is_api_access_tier)', async () => {

--- a/server/tests/unit/dashboard-track-coverage-gap.test.ts
+++ b/server/tests/unit/dashboard-track-coverage-gap.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { describe, expect, it } from 'vitest';
+
+const dashboardSource = readFileSync(
+  new URL('../../public/dashboard-agents.html', import.meta.url),
+  'utf8',
+);
+
+const helperStart = dashboardSource.indexOf('function buildTrackCoverageGapNote');
+const helperEnd = dashboardSource.indexOf('// Track pill click', helperStart);
+if (helperStart < 0 || helperEnd < 0) {
+  throw new Error('buildTrackCoverageGapNote helper not found');
+}
+const context = vm.createContext({});
+vm.runInContext(dashboardSource.slice(helperStart, helperEnd), context);
+const buildTrackCoverageGapNote = context.buildTrackCoverageGapNote as (
+  trackData: { has_coverage_gap_skip?: boolean; status?: string },
+) => string;
+
+describe('dashboard track coverage-gap guidance', () => {
+  it('explains partial tracks when coverage-gap skips block storyboard eligibility', () => {
+    const html = buildTrackCoverageGapNote({
+      has_coverage_gap_skip: true,
+      status: 'partial',
+    });
+
+    expect(html).toContain('class="track-coverage-gap-note"');
+    expect(html).toContain('Badge eligibility is storyboard-level.');
+    expect(html).toContain('do not count as passing');
+  });
+
+  it.each([
+    { has_coverage_gap_skip: false, status: 'partial' },
+    { has_coverage_gap_skip: true, status: 'pass' },
+    { has_coverage_gap_skip: true, status: 'fail' },
+  ])('omits the note for $status without a partial coverage gap', (trackData) => {
+    expect(buildTrackCoverageGapNote(trackData)).toBe('');
+  });
+
+  it('renders numeric scenario counts without string parsing', () => {
+    expect(dashboardSource).toContain('Number(trackData.passed_count)');
+    expect(dashboardSource).toContain('Number(trackData.scenario_count)');
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -3775,6 +3775,10 @@ components:
                 type:
                   - string
                   - "null"
+              first_failure_validations:
+                type: array
+                items: {}
+                description: Validation evidence for the first failure. Populated only for owners and empty for other callers.
               last_tested_at:
                 type:
                   - string
@@ -3797,9 +3801,10 @@ components:
               - first_failed_step_title
               - first_failed_step_task
               - first_failure_message
+              - first_failure_validations
               - last_tested_at
               - last_passed_at
-          description: Owner-scoped per-storyboard diagnostics used by the dashboard. Empty for non-owners.
+          description: Public per-storyboard verdicts and aggregate step counts. First-failure diagnostic fields are populated only for owners; scalar diagnostics are null and validation evidence is empty for other callers.
         notices:
           type: array
           items: {}


### PR DESCRIPTION
## Summary

- return public per-storyboard verdicts and aggregate counts from the compliance detail API
- keep first-failure diagnostics owner-only, with fail-closed redaction and explicit OpenAPI semantics
- explain PARTIAL tracks when storyboard-level coverage-gap skips block badge eligibility
- add owner/public integration coverage and behavioral dashboard tests

## Verification

- `npm run typecheck`
- `npm run build:openapi`
- `npx vitest run server/tests/unit/dashboard-track-coverage-gap.test.ts` (5/5)
- `git diff --check`
- code and security expert review: merge-ready
- integration suite deferred to CI because local Postgres is unavailable

Closes #6291
Closes #6292