### PR TITLE
fix(compliance): backport request-signing vector count cleanup to 3.1.x

### DIFF
--- a/.changeset/fix-request-signing-vector-counts.md
+++ b/.changeset/fix-request-signing-vector-counts.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Remove hard-coded request-signing conformance vector counts from the compliance runner header and request-signing documentation. The guidance now describes the vector directories without totals, so future fixture additions cannot make the prose stale. Comment and documentation text only — no schema, runner logic, or generated artifact is affected.

--- a/docs/building/by-layer/L1/request-signing.mdx
+++ b/docs/building/by-layer/L1/request-signing.mdx
@@ -708,10 +708,10 @@ For emergency rotation (key compromise), add the old `kid` to `revoked_kids` in 
 
 ### Conformance vectors
 
-The spec ships **39 test vectors** at `compliance/cache/3.0.0/test-vectors/request-signing/` (source at `static/compliance/source/test-vectors/request-signing/`):
+The spec ships request-signing test vectors at `compliance/cache/3.0.0/test-vectors/request-signing/` (source at `static/compliance/source/test-vectors/request-signing/`):
 
-- **12 positive vectors**: valid signed requests your verifier must accept (non-4xx)
-- **27 negative vectors**: invalid requests your verifier must reject with `401` and the correct error code
+- **Positive vectors**: valid signed requests your verifier must accept (non-4xx)
+- **Negative vectors**: invalid requests your verifier must reject with `401` and the correct error code
 
 ```bash
 # Debug a single vector

--- a/static/compliance/source/test-kits/signed-requests-runner.yaml
+++ b/static/compliance/source/test-kits/signed-requests-runner.yaml
@@ -3,7 +3,7 @@
 # Applies to: universal/signed-requests.yaml (gated on
 # `request_signing.supported: true` in get_adcp_capabilities).
 #
-# The signed-requests storyboard grades an agent's RFC 9421 verifier against 28
+# The signed-requests storyboard grades an agent's RFC 9421 verifier against
 # conformance vectors at /compliance/{version}/test-vectors/request-signing/.
 # Most vectors are pure black-box: the runner constructs a signed HTTP request,
 # sends it, and checks the response. Three negative vectors assert behavior that


### PR DESCRIPTION
## Summary

- remove stale hard-coded request-signing vector counts from the `3.1.x` implementer guide
- remove the incorrect total from the signed-requests runner header
- retain the stable-line wording and paths rather than importing `main`'s 3.2 profile guidance

## Why

`3.1.x` currently says the request-signing set contains 39 vectors in the guide and 28 vectors in the runner header. The branch actually contains 40 vectors (12 positive and 28 negative). Naming the positive and negative vector groups without totals prevents the prose from drifting again.

Backport of #6074.

## Validation

- `git diff --check origin/3.1.x...HEAD`
- `node scripts/check-changeset-protocol-scope.cjs origin/3.1.x --has-protocol-scoped-changes`
- `changeset status --since=origin/3.1.x`

The changeset is a patch. This changes comments and documentation only; runner behavior and generated release artifacts are unchanged.
