### PR TITLE
chore: retire AdCP v2 support

### DIFF
--- a/.changeset/retire-adcp-v2.md
+++ b/.changeset/retire-adcp-v2.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Mark all AdCP v2 schema releases as deprecated in discovery metadata after their end-of-life date while preserving the historical v2 and v2.5 aliases and pinned schema URLs.

--- a/.github/workflows/apps-web-check.yml
+++ b/.github/workflows/apps-web-check.yml
@@ -2,12 +2,12 @@ name: apps/web check
 
 on:
   pull_request:
-    branches: [main, develop, "3.0.x", "2.6.x"]
+    branches: [main, develop, "3.0.x"]
     paths:
       - "apps/web/**"
       - ".github/workflows/apps-web-check.yml"
   push:
-    branches: [main, develop, "3.0.x", "2.6.x"]
+    branches: [main, develop, "3.0.x"]
     paths:
       - "apps/web/**"
       - ".github/workflows/apps-web-check.yml"

--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -2,7 +2,7 @@ name: Check for Broken Links
 
 on:
   push:
-    branches: [ main, develop, '2.6.x' ]
+    branches: [ main, develop ]
     paths:
       - 'docs/**'
       - 'dist/docs/**'
@@ -15,7 +15,7 @@ on:
       - '.markdown-link-check.json'
       - '.github/workflows/broken-links.yml'
   pull_request:
-    branches: [ main, develop, '2.6.x' ]
+    branches: [ main, develop ]
     paths:
       - 'docs/**'
       - 'dist/docs/**'

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -2,9 +2,9 @@ name: Build Check
 
 on:
   pull_request:
-    branches: [main, develop, '3.1.x', '3.0.x', '2.6.x']
+    branches: [main, develop, '3.1.x', '3.0.x']
   push:
-    branches: [main, develop, '3.1.x', '3.0.x', '2.6.x']
+    branches: [main, develop, '3.1.x', '3.0.x']
 
 concurrency:
   group: build-check-${{ github.ref }}

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -2,7 +2,7 @@ name: Changeset Check
 
 on:
   pull_request:
-    branches: [main, '3.1.x', '3.0.x', '2.6.x', '2.5-maintenance']
+    branches: [main, '3.1.x', '3.0.x']
 
 jobs:
   pr-title:

--- a/.github/workflows/check-testable-snippets.yml
+++ b/.github/workflows/check-testable-snippets.yml
@@ -2,7 +2,7 @@ name: Check Testable Snippets
 
 on:
   pull_request:
-    branches: [main, '2.6.x']
+    branches: [main]
     paths:
       - 'docs/**/*.md'
       - 'docs/**/*.mdx'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,6 @@ on:
       - main
       - '3.1.x'
       - '3.0.x'
-      - '2.6.x'
-      # '2.5-maintenance' is security-only until 2026-08-01; remove after that
-      # date unless we extend the v2 support window.
-      - '2.5-maintenance'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,8 +9,7 @@ For comprehensive security guidance, see our [Security Documentation](https://do
 | Version | Supported          |
 | ------- | ------------------ |
 | 3.x     | :white_check_mark: |
-| 2.5     | :white_check_mark: (security-only until August 1, 2026 — see [v2 sunset](https://docs.adcontextprotocol.org/docs/reference/v2-sunset)) |
-| < 2.5   | :x:                |
+| < 3.0   | :x: (see [v2 sunset](https://docs.adcontextprotocol.org/docs/reference/v2-sunset)) |
 
 ## Reporting a Vulnerability
 

--- a/dist/schemas/index.json
+++ b/dist/schemas/index.json
@@ -537,7 +537,7 @@
       "version": "2.5.3",
       "stability": "stable",
       "prerelease": false,
-      "deprecated": false,
+      "deprecated": true,
       "path": "/schemas/2.5.3/",
       "index": "/schemas/2.5.3/index.json"
     },
@@ -545,7 +545,7 @@
       "version": "2.5.2",
       "stability": "stable",
       "prerelease": false,
-      "deprecated": false,
+      "deprecated": true,
       "path": "/schemas/2.5.2/",
       "index": "/schemas/2.5.2/index.json"
     },
@@ -553,7 +553,7 @@
       "version": "2.5.1",
       "stability": "stable",
       "prerelease": false,
-      "deprecated": false,
+      "deprecated": true,
       "path": "/schemas/2.5.1/",
       "index": "/schemas/2.5.1/index.json"
     },
@@ -561,7 +561,7 @@
       "version": "2.5.0",
       "stability": "stable",
       "prerelease": false,
-      "deprecated": false,
+      "deprecated": true,
       "path": "/schemas/2.5.0/",
       "index": "/schemas/2.5.0/index.json"
     }

--- a/docs.json
+++ b/docs.json
@@ -1329,7 +1329,7 @@
         ]
       },
       {
-        "version": "2.5",
+        "version": "2.5 (archived)",
         "groups": [
           {
             "group": "Getting Started",

--- a/docs/building/by-layer/L4/migrate-from-hand-rolled.mdx
+++ b/docs/building/by-layer/L4/migrate-from-hand-rolled.mdx
@@ -149,7 +149,7 @@ Two version axes you'll be juggling:
 
 ### Worked example: two buyers, mid-swap
 
-You're on step 3 (idempotency), buyer A is on AdCP 2.5, buyer B is on AdCP 3.0. You've adopted the SDK's controller, error envelopes, and idempotency cache for the accounts you've cut over. Buyer A is mid-flight to the SDK; buyer B is greenfield on the SDK.
+You're on step 3 (idempotency), buyer A is temporarily on end-of-life AdCP 2.5 while migrating, and buyer B is on AdCP 3.0. You've adopted the SDK's controller, error envelopes, and idempotency cache for the accounts you've cut over. Buyer A is mid-flight to the SDK; buyer B is greenfield on the SDK. This is a migration bridge, not a supported production endpoint state.
 
 Your inbound side: identify each peer's spec version up front (from the agent registry, the agent card, or the `adcp_version` field if present), pin `adcpVersion` on the agent / per call, and let the SDK adapt the wire shape. Example with `@adcp/sdk`:
 
@@ -207,7 +207,7 @@ If you fall back (rollback step 3 to your hand-rolled cache), buyer A still goes
 
 If your agent serves a frozen wire surface for a small set of named buyers and your engineers spend ~zero time on protocol maintenance, the migration ROI is low. Reasonable holds:
 
-- You're on AdCP 2.5, none of your buyers want 3.x, and you're willing to deprecate when they do.
+- You serve a frozen, supported 3.x wire surface and have a dated plan to adopt the current release before that surface reaches end of life.
 - Your conformance gap (from step 1) is small enough to fix in place without adopting the SDK.
 - You have a hard regulatory or operational reason for owning every layer end-to-end.
 

--- a/docs/building/cross-cutting/version-adaptation.mdx
+++ b/docs/building/cross-cutting/version-adaptation.mdx
@@ -15,6 +15,10 @@ Three versions move at the same time when you ship an AdCP agent or client:
 
 Official SDKs ship three concrete mechanisms so adopters don't carry the translation matrix in handler code. This page is the recipe per mechanism. For the conceptual background see the [SDK stack — Version adaptation section](/docs/building/cross-cutting/sdk-stack#version-adaptation). For the spec-side rules see [Versioning](/docs/reference/versioning).
 
+<Warning>
+AdCP v2.5 is end of life. The v2.5 examples below describe a temporary migration bridge for existing integrations, not a supported production configuration. New integrations must use v3.
+</Warning>
+
 ## Mechanism 1 — Pin the spec version per call
 
 Use this when you're a **client** talking to a peer that's pinned to an older (or newer beta) spec version. The SDK runs your request and the peer's response through adapter modules so your handler code stays on the canonical (current) shape.
@@ -159,10 +163,10 @@ This is the third mechanism rather than a fallback to the first: negotiation tel
 
 ## Putting it together
 
-A typical multi-version production setup:
+A supported multi-version production setup, with an optional migration-only bridge for an end-of-life v2.5 peer:
 
 1. **Server**: declare `supported_versions: ['3.0', '3.1']` in capabilities. The SDK accepts both on the wire and returns `VERSION_UNSUPPORTED` to anyone outside the set. (Only declare a version your handlers actually satisfy.)
-2. **Client (per peer)**: pin `adcpVersion` (e.g., `'v2.5'`) based on what the registry or peer's capabilities advertise. The client-side adapters translate the wire shape so your application code stays on the current spec.
+2. **Client (per peer)**: pin `adcpVersion` to a supported release based on what the registry or peer's capabilities advertise. Use `'v2.5'` only as a short-lived migration bridge for an existing end-of-life peer; the client-side adapters translate its wire shape so your application code stays on the current spec.
 3. **SDK upgrades**: bump the SDK on your schedule; switch to the new entry point per specialism over time; keep the rest on the legacy import until you're ready.
 
 The combined effect: **one handler codebase, three version axes, no fork.**

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -98,9 +98,9 @@ Yes. AdCP is open source under the [Apache 2.0 license](https://www.apache.org/l
 </Accordion>
 
 <Accordion title="How mature is the protocol?">
-AdCP is at **3.0.1 — General Availability**, with 3.0 released April 2026. The protocol is stable and production-ready. See [Release notes](/docs/reference/release-notes) for the full change log and [What's new in v3](/docs/reference/whats-new-in-v3) for the 2.5 → 3.0 migration summary.
+AdCP **3.1.12** is the current stable release. The protocol is stable and production-ready. See [Release notes](/docs/reference/release-notes) for the full change log and [What's new in v3](/docs/reference/whats-new-in-v3) for the 2.5 → 3.0 migration summary.
 
-The next major version (4.0) is targeted for early 2027. Under the [release cadence policy](/docs/reference/versioning#release-cadence), majors are at least 18 months apart, the previous major receives security patches for at least 12 months after successor GA, and deprecation notices are published at least 6 months before removal. See [Versioning & Governance](/docs/reference/versioning) for the full policy and 3.x stability guarantees. AdCP 2.5 remains security-patched until 2026-08-01 — see the [v2 sunset page](/docs/reference/v2-sunset) for the end-of-life timeline.
+The next major version (4.0) is targeted for early 2027. Under the [release cadence policy](/docs/reference/versioning#release-cadence), majors are at least 18 months apart, the previous major receives security patches for at least 12 months after successor GA, and deprecation notices are published at least 6 months before removal. See [Versioning & Governance](/docs/reference/versioning) for the full policy and 3.x stability guarantees. AdCP 2.5 reached end of life on 2026-08-01 and no longer receives security patches — see the [v2 sunset page](/docs/reference/v2-sunset).
 </Accordion>
 
 <Accordion title="I built against AdCP 2.5 — what changed?">

--- a/docs/reference/migration/index.mdx
+++ b/docs/reference/migration/index.mdx
@@ -18,7 +18,7 @@ This page covers every breaking change when upgrading from AdCP 2.x to 3.0, with
 </Info>
 
 <Warning>
-**v2 is unsupported as of 3.0 GA and fully deprecated on August 1, 2026 (UTC).** See the [v2 sunset page](/docs/reference/v2-sunset) for the full timeline, AAO registry policy, and why v2 is not safe for interoperable production.
+**v2 has been unsupported since 3.0 GA and reached end of life on August 1, 2026 (UTC).** See the [v2 sunset page](/docs/reference/v2-sunset) for the full timeline, AgenticAdvertising.org registry policy, and why v2 is not safe for interoperable production.
 </Warning>
 
 <Info>
@@ -88,11 +88,11 @@ These capabilities are new in v3. None existed in v2, so there's nothing to migr
 
 ## Running v2 and v3 side by side
 
-Dual-support is a temporary migration tool, not a long-term posture. After August 1, 2026, v3-only is the required configuration — see the [v2 sunset page](/docs/reference/v2-sunset).
+Dual-support is a temporary migration tool, not a supported production posture. Since August 1, 2026, v3-only has been the required configuration — see the [v2 sunset page](/docs/reference/v2-sunset).
 
 During migration, sellers can accept both v2 and v3 traffic and buyers can route to each seller on the correct version:
 
-1. **Check seller capabilities** — Call `get_adcp_capabilities` on each seller. A successful response means the seller supports v3; buyers declare their version via `adcp_major_version` and sellers advertise the versions they accept via `major_versions`. See [version negotiation](/docs/reference/versioning#version-negotiation) for the full flow. A seller that does not respond to `get_adcp_capabilities` is v2-only.
+1. **Check seller capabilities** — Call `get_adcp_capabilities` on each seller. A successful response means the seller supports v3; buyers declare their release via `adcp_version` and sellers advertise accepted releases via `adcp.supported_versions`. Through 3.x, buyers SHOULD also send the deprecated `adcp_major_version`, and sellers MUST continue advertising the deprecated `adcp.major_versions`, for compatibility with older peers. See [version negotiation](/docs/reference/versioning#version-negotiation) for the full flow. A seller that does not respond to `get_adcp_capabilities` is v2-only.
 2. **Branch by seller** — Route v3-capable sellers through your v3 integration and v2-only sellers through your existing v2 code.
 3. **Migrate incrementally** — Start with the rename changes (pricing fields, channel updates), then tackle structural changes (creative assignments, optimization goals), then adopt new capabilities (accounts, governance) as needed.
 

--- a/docs/reference/v2-sunset.mdx
+++ b/docs/reference/v2-sunset.mdx
@@ -1,44 +1,44 @@
 ---
-title: v2 Sunset
+title: v2 sunset
 sidebarTitle: v2 sunset
-description: "AdCP v2 is unsupported as of 3.0 GA. Security-only patches through August 1, 2026 (UTC); full deprecation thereafter. Begin migration to 3.0 now."
-"og:title": "AdCP — v2 Sunset"
+description: "AdCP v2 reached end of life on August 1, 2026 (UTC). It receives no patches and is not safe for interoperable production. Migrate to v3 now."
+"og:title": "AdCP — v2 sunset"
 ---
 
 <Warning>
-**AdCP v2 is not supported and is not safe for interoperable production on the AAO network.** v2 predates the accounts and governance protections that the AAO architecture committee considers essential for live multi-party campaigns. The last v2 release was 2.5.3 in January 2026. Begin migrating to [3.0](/docs/reference/whats-new-in-v3) now.
+**AdCP v2 is not supported and is not safe for interoperable production on the AgenticAdvertising.org network.** v2 predates the accounts and governance protections that the AgenticAdvertising.org architecture committee considers essential for live multi-party campaigns. The last v2 release was 2.5.3 in January 2026. Begin migrating to [3.0](/docs/reference/whats-new-in-v3) now.
 </Warning>
 
 ## Timeline
 
 | Date (UTC) | Event |
 |---|---|
-| **April 2026** (3.0 GA) | v2 no longer supported by AAO. Security-only patches begin. No feature work. |
+| **April 2026** (3.0 GA) | v2 no longer supported by AgenticAdvertising.org. Security-only patches begin. No feature work. |
 | **August 1, 2026** | v2 fully deprecated. No further patches. Reference documentation archived. |
 
-The v2 sunset is not tied to 4.0. v2 reaches end of life on its own schedule because 2.5 was an early, preliminary version — adoption remained small, and the architecture committee identified protections missing from v2 that cannot be backported without a major redesign. v2's shorter window is the documented exception to the [12-month previous-major support commitment](/docs/reference/versioning#support-window-for-previous-major); future majors will not invoke this exception.
+The v2 sunset was not tied to 4.0. v2 reached end of life on its own schedule because 2.5 was an early, preliminary version — adoption remained small, and the architecture committee identified protections missing from v2 that could not be backported without a major redesign. v2's shorter window is the documented exception to the [12-month previous-major support commitment](/docs/reference/versioning#support-window-for-previous-major); future majors will not invoke this exception.
 
 ## What "unsupported" means
 
 As of 3.0 GA:
 
 - **No feature work.** 2.5.3 is the last v2 release. No further minor or patch work in the 2.x line, other than security advisories.
-- **No AAO certification.** Certification requires v3.0 or later.
-- **Not verified in the AAO registry.** Verified seller and agent status requires v3.x. v2-only agents can be registered but cannot be verified.
+- **No AgenticAdvertising.org certification.** Certification requires v3.0 or later.
+- **Not verified in the AgenticAdvertising.org registry.** Verified seller and agent status requires v3.x. v2-only agents can be registered but cannot be verified.
 - **Frozen schemas.** v2 schemas are frozen as of 2.5.3 and remain at their existing schema URLs. No new fields, tasks, or protocols.
 
-After August 1, 2026 (UTC), v2 is fully deprecated: security patches stop and reference documentation is archived. The 2.5.3 schema URLs continue to resolve so existing integrations do not break silently, but those schemas receive no further updates.
+As of August 1, 2026 (UTC), v2 is fully deprecated: security patches have stopped and reference documentation is archived. The 2.5.3 schema URLs continue to resolve so existing integrations do not break silently, but those schemas receive no further updates.
 
 ## Why v2 is not safe for interoperable production
 
-v2 is missing protections that 3.0 treats as essential for live multi-party campaigns on the AAO network:
+v2 is missing protections that 3.0 treats as essential for live multi-party campaigns on the AgenticAdvertising.org network:
 
 - **No accounts protocol.** Buyers and sellers cannot negotiate account scope, operator authorization, or buyer identity resolution.
 - **No governance.** No structured content standards, audience bias validation, or property list governance.
 - **No campaign governance.** No signed proposals, approval workflow, or proposal lifecycle.
 - **Limited optimization and measurement.** No structured optimization goals, event source health, or streaming/audio delivery metrics.
 
-Running v2 on the AAO network means running without these protections. Private deployments with their own governance and identity layers are the operator's call — but the AAO network treats v2 as out of scope for supported production traffic.
+Running v2 on the AgenticAdvertising.org network means running without these protections. Private deployments with their own governance and identity layers are the operator's call — but the AgenticAdvertising.org network treats v2 as out of scope for supported production traffic.
 
 ## What to do
 
@@ -47,21 +47,21 @@ Running v2 on the AAO network means running without these protections. Private d
 1. Read [What's new in v3](/docs/reference/whats-new-in-v3).
 2. Work through the [v2→v3 migration guide](/docs/reference/migration).
 3. Validate with [storyboard testing](/docs/reference/migration/v3-readiness).
-4. Complete migration before August 1, 2026 (UTC).
+4. Complete migration as soon as possible; v2 no longer receives security patches.
 
 ### If you are a buyer integrating with v2 sellers
 
 1. Inventory which of your sellers are v2-only.
-2. Notify them of the August 1, 2026 (UTC) deprecation and share the [migration guide](/docs/reference/migration).
+2. Notify them that v2 is end of life and share the [migration guide](/docs/reference/migration).
 3. Shift traffic to v3 sellers as they become available.
 
-### If you use the AAO registry
+### If you use the AgenticAdvertising.org registry
 
 Verified seller and agent status requires v3.x. v2-only agents can be registered but are not eligible for verification. As the registry rolls out verified-default discovery, v2-only entries will not surface by default; endpoints that return unverified entries remain available for operators who need them.
 
 ## Dual-support during migration
 
-Sellers in mid-migration can temporarily support both versions using `get_adcp_capabilities` and the `major_versions` array — see [Running v2 and v3 side by side](/docs/reference/migration#running-v2-and-v3-side-by-side). Dual-support is a migration tool, not a long-term posture. After August 1, 2026 (UTC), v3-only is the required configuration.
+Sellers that still need a short migration bridge can support both versions using `get_adcp_capabilities`, `adcp_version`, and `adcp.supported_versions` — see [Running v2 and v3 side by side](/docs/reference/migration#running-v2-and-v3-side-by-side). Through 3.x, buyers SHOULD also send the deprecated `adcp_major_version`, and sellers MUST continue advertising the deprecated `adcp.major_versions`, for compatibility with older peers. Dual-support does not make v2 supported or safe; v3-only is the required production configuration.
 
 ## Related
 

--- a/docs/reference/versioning.mdx
+++ b/docs/reference/versioning.mdx
@@ -196,7 +196,7 @@ A patch release (`3.0.1`, `3.1.2`) changes only documentation, wording, validati
 
 ### Security fixes
 
-Security-relevant fixes are documented in release notes with a `security` label and land in the current release. Implementations SHOULD upgrade promptly after a security advisory. Older releases within 3.x do not receive routine backports; upgrading to the current release is the expected remediation path. The same posture applies to v2 during its security-only window — see the [v2 sunset page](/docs/reference/v2-sunset) for that timeline.
+Security-relevant fixes are documented in release notes with a `security` label and land in the current release. Implementations SHOULD upgrade promptly after a security advisory. Older releases within 3.x do not receive routine backports; upgrading to the current release is the expected remediation path. v2 no longer receives security fixes — see the [v2 sunset page](/docs/reference/v2-sunset).
 
 ### Breaking-change notice
 
@@ -238,7 +238,7 @@ When a new major ships, the prior major receives security patches for at least 1
 
 Deprecation windows do not reset when a deprecated feature is modified — the original removal date holds.
 
-The v2 sunset is the documented exception to this commitment: v2 predates this policy and lacks account and governance protections that cannot be backported. Its security-only window runs through August 1, 2026 — see the [v2 sunset page](/docs/reference/v2-sunset). Future majors will not invoke this exception.
+The v2 sunset is the documented exception to this commitment: v2 predates this policy and lacks account and governance protections that cannot be backported. Its security-only window ended August 1, 2026 — see the [v2 sunset page](/docs/reference/v2-sunset). Future majors will not invoke this exception.
 
 ### Planned releases
 

--- a/docs/reference/versions.mdx
+++ b/docs/reference/versions.mdx
@@ -13,10 +13,9 @@ description: "Every published AdCP version, its status, and its end-of-life date
 
 | Status | Versions | Wire pin | What it means |
 |---|---|---|---|
-| **Active** | 3.1 (current stable: 3.1.2) | `"3.1"` | Current production minor release. See [What's New in AdCP 3.1](/docs/reference/whats-new-in-3-1) for the feature set. |
-| **Maintained** | 3.0 (current stable: 3.0.21) | `"3.0"` | Supported previous minor for existing production integrations. Receives compatibility and security patches. |
-| **Security-only** | 2.5.0, 2.5.1, 2.5.3 | `"2.5"` | Security patches through **August 1, 2026 (UTC)**. Not safe for AAO-network production — see [v2 sunset](/docs/reference/v2-sunset). |
-| **End of life** | 2.0.0, 2.1.0 | — | No patches. Migrate to 3.0. |
+| **Active** | 3.1 (current stable: 3.1.12) | `"3.1"` | Current production minor release. See [What's New in AdCP 3.1](/docs/reference/whats-new-in-3-1) for the feature set. |
+| **Maintained** | 3.0 (current stable: 3.0.22) | `"3.0"` | Supported previous minor for existing production integrations. Receives compatibility and security patches. |
+| **End of life** | 2.0.0, 2.1.0, 2.5.0–2.5.3 | — | No patches. Migrate to 3.0. See [v2 sunset](/docs/reference/v2-sunset). |
 | **Planned** | 3.2, 4.0 | — | Targets in [planned releases](/docs/reference/versioning#planned-releases). |
 
 **Wire values are release-precision only.** Send `"3.1"` for the stable 3.1 line or `"3.0"` for the maintained 3.0 line. Do not send patch components like `"3.0.19"` or full semver pre-release values like `"3.1.0-rc.15"`. Historical prerelease pins such as `"3.1-rc.15"` remain valid only for agents that explicitly advertise those prerelease values. See [patches are not negotiated](/docs/reference/versioning#patches-are-not-negotiated).
@@ -32,11 +31,12 @@ description: "Every published AdCP version, its status, and its end-of-life date
 | 3.0.0 | 2026-04-22 | GA — stable baseline for the 3.x cycle. |
 | 3.0.1 through 3.0.10 | 2026-04-28 to 2026-05-10 | Patches. Wire-compatible with 3.0.0. |
 | 3.0.11 through 3.0.15 | 2026-05-11 to 2026-05-31 | Patches. Wire-compatible with 3.0.0. |
-| 3.0.16 through **3.0.21** | 2026-06-14 to 2026-07-08 | Patches. **3.0.21 is the latest stable patch.** Wire-compatible with 3.0.0. |
+| 3.0.16 through **3.0.22** | 2026-06-14 to 2026-07-24 | Patches. **3.0.22 is the latest stable patch.** Wire-compatible with 3.0.0. |
 | **3.1.0** | 2026-06-18 | GA — current production minor release. Use wire pin `"3.1"`. |
 | 3.1.1 | 2026-06-30 | Patch. Wire-compatible with 3.1.0. |
-| **3.1.2** | 2026-07-08 | Latest supported 3.1 patch. Wire-compatible with 3.1.0. |
+| 3.1.2 | 2026-07-08 | Patch. Wire-compatible with 3.1.0. |
 | 3.1.3 | 2026-07-13 | **Withdrawn. Do not use.** It added a stable schema field in a patch release and included an incorrect publisher-domain filter implementation. The artifacts remain available only for auditability. Use 3.1.2 instead. |
+| 3.1.4 through **3.1.12** | 2026-07-18 to 2026-08-08 | Patches. **3.1.12 is the latest stable patch.** Wire-compatible with 3.1.0. |
 
 Supported patches don't change the wire contract. Upgrading within 3.0.x is always safe, and 3.1 remains additive over 3.0. The withdrawn 3.1.3 release is not a supported patch or implementation target. For per-version detail, see [Release Notes](/docs/reference/release-notes) (curated narrative) and the [Changelog](/docs/reference/changelog) (full technical history).
 
@@ -48,28 +48,29 @@ Supported patches don't change the wire contract. Upgrading within 3.0.x is alwa
 | 3.0.0-beta.1 through rc.2 | 2026-01-26 to 2026-03-15 | Superseded. |
 | 3.0.0-rc.3 | 2026-04-01 | Superseded by GA. See [prerelease upgrade notes](/docs/reference/migration/prerelease-upgrades) if you adopted rc.3. |
 
-### 2.x — sunsetting
+### 2.x — end of life
 
 | Version | Released | Notes |
 |---|---|---|
 | 2.0.0 | 2025-10-15 | End of life. No patches. Migrate to 3.0. |
 | 2.1.0 | 2025-10-19 | End of life. No patches. Migrate to 3.0. |
-| 2.5.0 | 2025-11-22 | Security-only through Aug 1, 2026 (UTC). |
-| 2.5.1 | 2025-12-24 | Security-only through Aug 1, 2026 (UTC). |
-| 2.5.3 | January 2026 | Security-only through Aug 1, 2026 (UTC). **Last 2.x release.** |
+| 2.5.0 | 2025-11-22 | End of life. No patches. |
+| 2.5.1 | 2025-12-24 | End of life. No patches. |
+| 2.5.2 | 2026-01-07 | End of life. No patches. |
+| 2.5.3 | January 2026 | End of life. **Last 2.x release.** |
 
-After August 1, 2026 (UTC), the entire 2.x line is fully deprecated. The 2.x schema URLs continue to resolve so existing integrations don't break silently, but those schemas receive no further updates. See [v2 Sunset](/docs/reference/v2-sunset) for migration paths.
+The entire 2.x line has been fully deprecated since August 1, 2026 (UTC). The 2.x schema URLs continue to resolve so existing integrations don't break silently, but those schemas receive no further updates. See [v2 Sunset](/docs/reference/v2-sunset) for migration paths.
 
 ## FAQ
 
 ### What's "current"?
-For new production integrations, **3.1.2** is current; pin your integration to `"3.1"` (not `"3.1.2"`). Existing 3.0 integrations can remain pinned to `"3.0"` while they migrate. See [Version negotiation](/docs/reference/versioning#version-negotiation).
+For new production integrations, **3.1.12** is current; pin your integration to `"3.1"` (not `"3.1.12"`). Existing 3.0 integrations can remain pinned to `"3.0"` while they migrate. See [Version negotiation](/docs/reference/versioning#version-negotiation).
 
 ### What happened to 2.2, 2.3, 2.4, 2.6?
-The 2.x line skipped version numbers during its working-group cycle. Some appear as in-flight changelog entries but were never released — the changes were rolled forward into the next published version or deferred to 3.0. The five published 2.x releases are 2.0.0, 2.1.0, 2.5.0, 2.5.1, and 2.5.3.
+The 2.x line skipped version numbers during its working-group cycle. Some appear as in-flight changelog entries but were never released — the changes were rolled forward into the next published version or deferred to 3.0. The six published 2.x releases are 2.0.0, 2.1.0, 2.5.0, 2.5.1, 2.5.2, and 2.5.3.
 
 ### Can I still register a v2 agent?
-Yes — v2 agents can be registered in the AAO registry but cannot be AAO Verified. Certification and verified-default discovery require v3.x. See [v2 Sunset → If you use the AAO registry](/docs/reference/v2-sunset#if-you-use-the-aao-registry).
+Yes — v2 agents can be registered in the AgenticAdvertising.org registry but cannot be verified. Certification and verified-default discovery require v3.x. See [v2 Sunset → If you use the AgenticAdvertising.org registry](/docs/reference/v2-sunset#if-you-use-the-agenticadvertisingorg-registry).
 
 ### How long will 3.0 be supported?
 At least 12 months after 4.0 GA. See [Versioning → Support window for previous major](/docs/reference/versioning#support-window-for-previous-major).
@@ -83,7 +84,7 @@ Targeted for early 2027. 3.x is mid-cycle — see the [planned releases table](/
 |---|---|
 | Building a new production integration today | **3.1**. Pin `"3.1"` on the wire. |
 | Running an existing 3.0 integration | Stay on **3.0** while you migrate, or move to **3.1** when your SDK and validation are ready. |
-| Running a 2.5.x integration | Migrate to 3.0 before **Aug 1, 2026 (UTC)**. Start with the [migration guide](/docs/reference/migration). |
+| Running a 2.5.x integration | Upgrade now — out of support. Start with the [migration guide](/docs/reference/migration). |
 | Running a 2.0 or 2.1 integration | Upgrade now — out of support. |
 | Trying a post-3.1 unreleased feature | See [Release Notes](/docs/reference/release-notes), [Versioning & Governance](/docs/reference/versioning), and [experimental status](/docs/reference/experimental-status). |
 

--- a/scripts/build-schemas.cjs
+++ b/scripts/build-schemas.cjs
@@ -197,6 +197,13 @@ function getReleaseMetadata(version, knownVersions = []) {
       published: false,
     };
   }
+  if (String(version).startsWith('2.')) {
+    return {
+      stability: 'stable',
+      prerelease: false,
+      deprecated: true,
+    };
+  }
 
   const match = String(version).match(/^\d+\.\d+\.\d+(?:-([0-9A-Za-z.-]+))?$/);
   if (!match) {

--- a/server/src/schemas-middleware.ts
+++ b/server/src/schemas-middleware.ts
@@ -188,6 +188,9 @@ function releaseStatusMetadata(version: string): {
   if (status === "unpublished") {
     return { stability: "unpublished", deprecated: false, published: false };
   }
+  if (version.startsWith("2.")) {
+    return { deprecated: true };
+  }
   return {};
 }
 

--- a/server/tests/integration/schema-routing.test.ts
+++ b/server/tests/integration/schema-routing.test.ts
@@ -145,6 +145,12 @@ describe("/schemas HTTP routing", () => {
       if (!latestStableMajor2) return;
       const res = await request(app).get("/schemas/v2.5/adagents.json");
       expect(res.status).toBe(200);
+
+      const discovery = await request(app).get("/schemas/");
+      expect(discovery.body.versions).toContainEqual(expect.objectContaining({
+        version: latestStableMajor2,
+        deprecated: true,
+      }));
     });
 
     it("serves /schemas/v3/adagents.json via alias rewrite", async () => {

--- a/tests/artifact-cdn-worker.test.cjs
+++ b/tests/artifact-cdn-worker.test.cjs
@@ -95,6 +95,14 @@ async function loadWorker() {
 function env() {
   return {
     ARTIFACTS: new MockBucket([
+      object('schemas/2.5.3/index.json', '{"version":"2.5.3"}', {
+        contentType: 'application/json; charset=utf-8',
+        cacheControl: 'public, max-age=31536000, immutable',
+      }),
+      object('schemas/2.5.3/foo.json', '{"version":"2.5.3"}', {
+        contentType: 'application/json; charset=utf-8',
+        cacheControl: 'public, max-age=31536000, immutable',
+      }),
       object('schemas/3.0.12/index.json', '{"version":"3.0.12"}', {
         contentType: 'application/json; charset=utf-8',
         cacheControl: 'public, max-age=31536000, immutable',
@@ -587,8 +595,17 @@ describe('artifact CDN Worker', () => {
         deprecated: false,
         path: '/schemas/3.0.12/',
       },
+      {
+        version: '2.5.3',
+        stability: 'stable',
+        prerelease: false,
+        deprecated: true,
+        path: '/schemas/2.5.3/',
+      },
     ]);
     assert.deepEqual(body.aliases, [
+      { alias: 'v2', resolves_to: '2.5.3', path: '/schemas/v2/' },
+      { alias: 'v2.5', resolves_to: '2.5.3', path: '/schemas/v2.5/' },
       { alias: 'v3', resolves_to: '3.1.2', path: '/schemas/v3/' },
       { alias: 'v3.0', resolves_to: '3.0.12', path: '/schemas/v3.0/' },
       { alias: 'v3.1', resolves_to: '3.1.2', path: '/schemas/v3.1/' },
@@ -598,6 +615,25 @@ describe('artifact CDN Worker', () => {
       path: '/schemas/latest/',
       note: 'Development version, may differ from released versions',
     });
+  });
+
+  it('keeps deprecated v2 aliases resolvable', async () => {
+    const alias = await fetchPath('/schemas/v2.5/foo.json');
+    const discovery = await fetchPath('/schemas/');
+    const body = await discovery.json();
+
+    assert.equal(alias.status, 200);
+    assert.deepEqual(await alias.json(), { version: '2.5.3' });
+    assert.deepEqual(
+      body.versions.find((entry) => entry.version === '2.5.3'),
+      {
+        version: '2.5.3',
+        stability: 'stable',
+        prerelease: false,
+        deprecated: true,
+        path: '/schemas/2.5.3/',
+      },
+    );
   });
 
   it('applies release overrides consistently to compliance aliases', async () => {

--- a/tests/release-workflow-immutability.test.cjs
+++ b/tests/release-workflow-immutability.test.cjs
@@ -7,6 +7,15 @@ const assert = require('assert');
 const repoRoot = path.join(__dirname, '..');
 const workflowPath = path.join(repoRoot, '.github/workflows/release.yml');
 const workflow = fs.readFileSync(workflowPath, 'utf8');
+const eolReleaseBranches = ['2.5-maintenance', '2.6.x'];
+const activeWorkflowPaths = [
+  'apps-web-check.yml',
+  'broken-links.yml',
+  'build-check.yml',
+  'changeset-check.yml',
+  'check-testable-snippets.yml',
+  'release.yml',
+];
 const forwardMergeWorkflows = ['3.0', '3.1'].map((line) => ({
   line,
   source: fs.readFileSync(
@@ -26,6 +35,19 @@ const releaseRelevance = extractStep('Detect release-relevant push');
 const artifactDetection = extractStep('Detect committed release artifacts');
 const changesetsStep = extractStep('Create Release Pull Request or Tag Release');
 const uploadStep = extractStep('Upload protocol tarball to GitHub Release');
+
+for (const branch of eolReleaseBranches) {
+  for (const workflowName of activeWorkflowPaths) {
+    const source = fs.readFileSync(
+      path.join(repoRoot, '.github/workflows', workflowName),
+      'utf8'
+    );
+    assert(
+      !source.includes(branch),
+      `${workflowName} must not target end-of-life v2 branch ${branch}.`
+    );
+  }
+}
 
 assert(
   !releaseRelevance.includes('Release ${TAG} is missing ${asset}; running repair path.'),

--- a/tests/schema-release-status.test.ts
+++ b/tests/schema-release-status.test.ts
@@ -27,6 +27,21 @@ describe('schema release discovery status', () => {
     });
   });
 
+  it('marks v2 releases deprecated without removing them from aliases', () => {
+    expect(isSelectableRelease('2.5.3')).toBe(true);
+    expect(getReleaseMetadata('2.5.3')).toEqual({
+      stability: 'stable',
+      prerelease: false,
+      deprecated: true,
+    });
+
+    const discovery = buildRootSchemaDiscovery();
+    expect(discovery.aliases.v2).toBe('2.5.3');
+    expect(discovery.aliases['v2.5']).toBe('2.5.3');
+    expect(discovery.versions.find(({ version }: { version: string }) => version === '2.5.3'))
+      .toMatchObject({ deprecated: true });
+  });
+
   it('excludes non-selectable versions from stable aliases and latest', () => {
     const discovery = buildRootSchemaDiscovery();
     const withdrawn = discovery.versions.find(({ version }: { version: string }) => version === '3.1.3');

--- a/workers/artifact-cdn/src/index.js
+++ b/workers/artifact-cdn/src/index.js
@@ -461,6 +461,9 @@ function releaseStatusMetadata(version) {
   if (status === "unpublished") {
     return { stability: "unpublished", deprecated: false, published: false };
   }
+  if (version.startsWith("2.")) {
+    return { deprecated: true };
+  }
   return {};
 }
 


### PR DESCRIPTION
## Summary

- retire AdCP v2 release and CI branch support after the August 1, 2026 sunset
- mark v2 schema releases deprecated in discovery while preserving pinned schema URLs and the `v2`/`v2.5` aliases
- archive the v2.5 docs label and update sunset, migration, security, FAQ, and version guidance
- add regression coverage for EOL workflow branches and deprecated-but-addressable v2 schemas

## Why

AdCP v2's security-only window has ended. The repository still advertised 2.5 as supported, allowed dormant v2 branches to run publication workflows, and exposed v2 schema discovery entries as non-deprecated. That combination implied ongoing support and left a path for an accidental v2.6 release.

Historical artifacts remain available so existing pinned integrations do not break silently, but v2 is now consistently represented as end of life.

## Validation

- three independent expert reviews: protocol/versioning, documentation, and release automation
- `npx vitest run tests/schema-release-status.test.ts server/tests/integration/schema-routing.test.ts`
- `node --test --test-force-exit --test-timeout=30000 tests/artifact-cdn-worker.test.cjs`
- `npm run test:release-workflow`
- `npm run test:docs-nav`
- `npm run typecheck`
- changeset protocol scope and status checks
- pre-push version, changeset, docs-link, and Mintlify navigation checks
- isolated rerun of two unrelated full-suite flakes: 39/39 passed

The local full server-unit precommit run exceeded its 240-second wrapper and reported two unrelated order/load-sensitive failures; both failing files passed together in isolation. GitHub Actions is the authoritative full-suite run for this PR.
