### PR TITLE
docs(compliance): backport controller grading scope to 3.1.x

### DIFF
--- a/docs/building/by-layer/L3/comply-test-controller.mdx
+++ b/docs/building/by-layer/L3/comply-test-controller.mdx
@@ -7,11 +7,13 @@ description: "Optional sandbox tool that lets the storyboard runner walk full li
 # Compliance test controller
 
 <Note>
-**The compliance test controller is a dev/staging-only affordance, not a production-time concept.** AAO grading does NOT require or use it. The AAO compliance heartbeat drives storyboards against the seller's registered production URL with `account.sandbox: true` on every request, and the seller's prod stack is responsible for honoring the flag — no controller endpoint needed.
+**The compliance test controller is a dev/staging-only affordance, not a production-time concept.** AgenticAdvertising.org Verified (Sandbox) grading does not require or use it. The compliance heartbeat drives storyboards against the seller's registered production URL with `account.sandbox: true` on every request, and the seller's production stack is responsible for honoring the flag — no controller endpoint needed.
+
+Specialism certification under Verified (Spec) is different: any selected storyboard with `controller_seeding: true` requires a registered dev or staging endpoint that exposes the seed scenarios used by that storyboard. Sellers need only implement the scenarios required by the specialisms they certify; they do not need the full controller surface.
 
 Sellers MAY implement the controller in their dev or staging environment to support their own integration testing — walking lifecycle state machines deterministically, seeding fixtures, forcing transitions that would otherwise require waiting for real time. That's its purpose. It MUST NOT be exposed on production deployments (see [Sandbox gating](#sandbox-gating) below).
 
-Confused about how the controller relates to AAO Verified (Sandbox)? See [#4379](https://github.com/adcontextprotocol/adcp/issues/4379) for the framing decision: (Sandbox) attests "real production endpoint correctly handles sandbox-flagged traffic across the full storyboard suite." The controller is the developer-side affordance for *your* testing, not the AAO-side grading mechanism.
+Confused about how the controller relates to AgenticAdvertising.org Verified (Sandbox)? See [#4379](https://github.com/adcontextprotocol/adcp/issues/4379) for the framing decision: (Sandbox) attests "real production endpoint correctly handles sandbox-flagged traffic across the full storyboard suite." The controller is the developer-side affordance for deterministic testing and Verified (Spec) specialism fixtures, not the production grading mechanism.
 </Note>
 
 AdCP defines lifecycle state machines for accounts, creatives, media buys, SI sessions, and delivery reporting. Many transitions in these state machines are seller-initiated — creative approval, account suspension, budget depletion, delivery accrual. A storyboard runner can only exercise buyer-initiated flows, leaving seller-initiated transitions untested.

--- a/docs/building/operating/storyboard-troubleshooting.mdx
+++ b/docs/building/operating/storyboard-troubleshooting.mdx
@@ -16,7 +16,9 @@ Each section shows the error you'll see, what it means, and what to change in yo
 
 The storyboard's `sample_request` references a hardcoded ID (`test-product`, `test-pricing`, `campaign_hero_video`, `gov_acme_q2_2027`, etc.). The runner expects the agent to have that ID in its catalog before the mutating step runs.
 
-**Fix:** Implement `comply_test_controller` and honor the seed scenarios declared in the storyboard's `fixtures:` block. When `prerequisites.controller_seeding: true` is set, the runner auto-injects a fixtures phase that calls `seed_product`, `seed_pricing_option`, `seed_creative`, `seed_plan`, or `seed_media_buy` in foreign-key order before the main phases execute.
+**Fix:** On the dev or staging endpoint registered for Verified (Spec), implement `comply_test_controller` and honor the seed scenarios declared in the storyboard's `fixtures:` block. Do not expose the controller on the production endpoint used for Verified (Sandbox). When `prerequisites.controller_seeding: true` is set, the runner auto-injects a fixtures phase that calls `seed_product`, `seed_pricing_option`, `seed_creative`, `seed_plan`, or `seed_media_buy` in foreign-key order before the main phases execute.
+
+Implement only the scenarios your selected specialisms require. For example, `sales-non-guaranteed` needs `seed_product` and `seed_pricing_option`; it does not require the full controller surface unless another selected storyboard declares additional fixtures.
 
 See [Compliance test controller — Scenarios](/docs/building/by-layer/L3/comply-test-controller#scenarios) for the full seed contract. Agents that return `UNKNOWN_SCENARIO` on a seed call grade the storyboard `not_applicable` — they are not penalized for missing sandbox surface, but they cannot pass storyboards that depend on pre-seeded state.
 


### PR DESCRIPTION
Backports #6314 to the 3.1 maintenance branch.

Closes #6301 on the maintained 3.1 documentation surface.

## What changed
- distinguish production Verified (Sandbox) grading from dev/staging Verified (Spec) controller seeding
- clarify that only specialism-required fixture scenarios need to be implemented
- document the minimal `sales-non-guaranteed` controller surface

## Validation
- Mintlify navigation validation (21 checks)
- Mintlify broken-links validation
- docs copy test
- browser-facing owned-link validation
- `git diff --check`