### PR TITLE
fix(crawler): restrict probe auth to owning org

### DIFF
--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -137,7 +137,7 @@ export class CrawlerService {
    */
   private async resolveProbeAuth(agentUrl: string): Promise<SdkAuth | undefined> {
     try {
-      const ownerOrgId = await this.agentContextDb.findOrgWithSavedAuth(agentUrl);
+      const ownerOrgId = await this.agentContextDb.findOwnerOrgWithSavedAuth(agentUrl);
       if (!ownerOrgId) return undefined;
       const auth = await resolveUserAgentAuth(this.agentContextDb, ownerOrgId, agentUrl, log);
       return await adaptAuthForSdk(auth, { tokenEndpointLabel: `crawler:${agentUrl}` });

--- a/server/src/db/agent-context-db.ts
+++ b/server/src/db/agent-context-db.ts
@@ -322,35 +322,40 @@ export class AgentContextDatabase {
   }
 
   /**
-   * Find an organization that has saved any kind of auth (bearer, OAuth tokens,
-   * or OAuth client-credentials) for the given agent URL. Returns the most
-   * recently updated row's org id, or null if no credentials are saved by any
-   * org. Used by the periodic crawler so its probe runs with owner credentials
-   * when available — keeping a per-org-aware view of `oauth_required` instead
-   * of clobbering it back to `true` on every anonymous heartbeat. When multiple
-   * orgs have independently registered the same agent, the most recently
-   * updated set wins; that matches "freshly-rotated creds take precedence" and
-   * the periodic snapshot is a single shared row anyway.
+   * Find an owning organization that has saved any kind of auth (bearer, OAuth
+   * tokens, or OAuth client-credentials) for the given agent URL. Returns the
+   * most recently updated eligible row's org id, or null if no credentials are
+   * saved by an owning org. Used by the periodic crawler so its probe runs with owner
+   * credentials when available — keeping a per-org-aware view of
+   * `oauth_required` instead of clobbering it back to `true` on every anonymous
+   * heartbeat. A context is eligible only when the same organization registers
+   * the URL in `member_profiles.agents`; this prevents a stale or accidentally
+   * misrouted credential from another tenant from driving the shared probe.
+   * When multiple owning orgs have independently registered the same agent, the
+   * most recently updated set wins; the periodic snapshot is a single shared row.
    */
-  async findOrgWithSavedAuth(agentUrl: string): Promise<string | null> {
+  async findOwnerOrgWithSavedAuth(agentUrl: string): Promise<string | null> {
     const canonicalUrl = requireCanonicalAgentUrl(agentUrl);
     const result = await query<{ organization_id: string }>(
-      `SELECT organization_id
-       FROM agent_contexts
-       WHERE agent_url = $1
+      `SELECT ac.organization_id
+       FROM agent_contexts ac
+       JOIN member_profiles mp
+         ON mp.workos_organization_id = ac.organization_id
+        AND mp.agents @> $2::jsonb
+       WHERE ac.agent_url = $1
          AND (
-           (auth_token_encrypted IS NOT NULL
-            AND auth_token_iv IS NOT NULL)
-           OR (oauth_access_token_encrypted IS NOT NULL
-               AND oauth_access_token_iv IS NOT NULL)
-           OR (oauth_cc_token_endpoint IS NOT NULL
-               AND oauth_cc_client_id IS NOT NULL
-               AND oauth_cc_client_secret_encrypted IS NOT NULL
-               AND oauth_cc_client_secret_iv IS NOT NULL)
+           (ac.auth_token_encrypted IS NOT NULL
+            AND ac.auth_token_iv IS NOT NULL)
+           OR (ac.oauth_access_token_encrypted IS NOT NULL
+               AND ac.oauth_access_token_iv IS NOT NULL)
+           OR (ac.oauth_cc_token_endpoint IS NOT NULL
+               AND ac.oauth_cc_client_id IS NOT NULL
+               AND ac.oauth_cc_client_secret_encrypted IS NOT NULL
+               AND ac.oauth_cc_client_secret_iv IS NOT NULL)
          )
-       ORDER BY updated_at DESC
+       ORDER BY ac.updated_at DESC
        LIMIT 1`,
-      [canonicalUrl],
+      [canonicalUrl, JSON.stringify([{ url: canonicalUrl }])],
     );
     return result.rows[0]?.organization_id ?? null;
   }

--- a/server/tests/unit/agent-context-url-canonicalization.test.ts
+++ b/server/tests/unit/agent-context-url-canonicalization.test.ts
@@ -25,18 +25,21 @@ describe('AgentContextDatabase URL canonicalization', () => {
     await db.getAuthInfoByOrgAndUrl(ORG, VARIANT);
     await db.getOAuthTokensByOrgAndUrl(ORG, VARIANT);
     await db.getOAuthClientCredentialsByOrgAndUrl(ORG, VARIANT);
-    await db.findOrgWithSavedAuth(VARIANT);
+    await db.findOwnerOrgWithSavedAuth(VARIANT);
 
     expect(queryMock).toHaveBeenCalledTimes(5);
     for (const call of queryMock.mock.calls.slice(0, 4)) {
       expect(call[1]).toEqual([ORG, CANONICAL]);
     }
-    expect(queryMock.mock.calls[4][1]).toEqual([CANONICAL]);
+    expect(queryMock.mock.calls[4][1]).toEqual([
+      CANONICAL,
+      JSON.stringify([{ url: CANONICAL }]),
+    ]);
   });
 
   it('reports OAuth grants only when their ciphertext and IV are both present', async () => {
     await db.getByOrgAndUrl(ORG, VARIANT);
-    await db.findOrgWithSavedAuth(VARIANT);
+    await db.findOwnerOrgWithSavedAuth(VARIANT);
 
     const projectionSql = String(queryMock.mock.calls[0][0]);
     expect(projectionSql).toContain(
@@ -47,6 +50,9 @@ describe('AgentContextDatabase URL canonicalization', () => {
     );
 
     const savedAuthSql = String(queryMock.mock.calls[1][0]);
+    expect(savedAuthSql).toContain('JOIN member_profiles mp');
+    expect(savedAuthSql).toContain('mp.workos_organization_id = ac.organization_id');
+    expect(savedAuthSql).toContain('mp.agents @> $2::jsonb');
     expect(savedAuthSql).toContain('auth_token_iv IS NOT NULL');
     expect(savedAuthSql).toContain('oauth_access_token_iv IS NOT NULL');
     expect(savedAuthSql).toContain('oauth_cc_client_secret_iv IS NOT NULL');


### PR DESCRIPTION
Addresses the periodic-probe portion of #6054.

## What changed
- require a saved credential context to belong to an organization that actually registers the agent URL in `member_profiles.agents`
- keep newest-credential selection only among legitimate owning organizations
- rename the database lookup to make the ownership guarantee explicit

## Why
The crawler previously selected the most recently updated credential for an agent URL across every organization. A stale or misrouted cross-org credential could therefore drive the shared periodic probe and repeatedly produce 401s. This change makes the crawler use the same canonical ownership relation as the dashboard authorization paths.

## Security and tenant impact
No credentials are moved, decrypted, or rewritten. Non-owning contexts are excluded at query time. When an owning org has no saved auth, the existing anonymous fallback remains unchanged.

## Validation
- focused DB canonicalization/ownership tests: 4 passed
- focused ownership plus previously noisy Stripe test file: 27 passed
- TypeScript typecheck
- `git diff --check`
- full precommit run: 395/396 files and 5,649 tests passed; the unrelated `replace-subscription.test.ts` showed six cross-file-order failures, while that complete file passes when isolated alongside the changed test