### PR TITLE
fix(registry): bound high-fanout publisher reads

### DIFF
--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -18,7 +18,7 @@ import { AAO_UA_DISCOVERY } from "./config/user-agents.js";
 import { createLogger } from "./logger.js";
 import type { CatalogEventsDatabase, WriteEventInput } from "./db/catalog-events-db.js";
 import type { AgentInventoryProfilesDatabase, ProfileUpsertInput } from "./db/agent-inventory-profiles-db.js";
-import { query } from "./db/client.js";
+import { query, withDatabaseDeadline } from "./db/client.js";
 import { PropertyDatabase } from "./db/property-db.js";
 import { verifyHostedPropertyOrigin } from "./services/hosted-property-origin-verifier.js";
 import { insertTypeReclassification } from "./db/type-reclassification-log-db.js";
@@ -26,6 +26,12 @@ import { resolveUserAgentAuth } from "./routes/helpers/resolve-user-agent-auth.j
 import { adaptAuthForSdk, type SdkAuth } from "./services/sdk-auth-adapter.js";
 
 const log = createLogger('crawler');
+// Inventory profiles are a derived search projection, not the authorization
+// source of truth. Avoid a registry-wide property expansion for network agents
+// during a crawl; the publisher/auth rows have already been persisted by this
+// point. A dedicated aggregate profile query can replace this guard later.
+const INVENTORY_PROFILE_PUBLISHER_FANOUT_CAP = 1_000;
+const SINGLE_DOMAIN_CRAWL_DB_DEADLINE_MS = 60_000;
 
 function unknownClassificationProbeDue(
   snapshot: AgentCapabilitiesSnapshotRow | undefined,
@@ -92,6 +98,11 @@ export interface PublisherAdagentsRevalidationResult {
   manager_domain?: string;
 }
 
+export interface SingleDomainCrawlContext {
+  requestId?: string;
+  source?: string;
+}
+
 export class CrawlerService {
   private crawler: PropertyCrawler;
   private crawling: boolean = false;
@@ -155,6 +166,8 @@ export class CrawlerService {
 
     this.crawling = true;
 
+    try {
+
     // Filter out agents whose owners have paused monitoring
     const pausedUrls = await this.getPausedAgentUrls();
     const activeAgents = agents.filter(a => !pausedUrls.has(a.url));
@@ -215,13 +228,10 @@ export class CrawlerService {
       log.warn({ err }, 'Failed to fetch sales_candidate agents; proceeding without candidate probes');
     }
 
-    try {
       const result = await this.crawler.crawlAgents(agentInfos);
 
       this.lastCrawl = new Date();
       this.lastResult = result;
-      this.crawling = false;
-
       log.info({
         totalProperties: result.totalProperties,
         successfulAgents: result.successfulAgents,
@@ -289,8 +299,9 @@ export class CrawlerService {
       return result;
     } catch (error) {
       log.error({ err: error }, 'Crawl failed');
-      this.crawling = false;
       throw error;
+    } finally {
+      this.crawling = false;
     }
   }
 
@@ -1223,7 +1234,7 @@ export class CrawlerService {
       eventActor?: string;
       eventSource?: string;
     },
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       // The database writer locks this publisher and atomically compares,
       // caches, and emits the revision event. The returned fields gate the
@@ -1252,8 +1263,10 @@ export class CrawlerService {
           'Manager adagents.json changed; enqueued delegating publishers for re-validation',
         );
       }
+      return true;
     } catch (err) {
       log.warn({ domain, err: err instanceof Error ? err.message : err }, 'Publisher cache write failed');
+      return false;
     }
   }
 
@@ -1396,7 +1409,7 @@ export class CrawlerService {
     }
 
     const manifest = validation.raw_data as AdagentsManifest;
-    await this.cacheAdagentsManifest(
+    const cachePersisted = await this.cacheAdagentsManifest(
       domain,
       manifest,
       {
@@ -1409,6 +1422,9 @@ export class CrawlerService {
         eventSource: 'publisher_revalidation',
       },
     );
+    if (!cachePersisted) {
+      throw new Error(`Publisher cache write failed for ${domain}`);
+    }
     await this.federatedIndex.markPublisherHasValidAdagents(domain);
 
     for (const authorizedAgent of manifest.authorized_agents ?? []) {
@@ -1859,6 +1875,7 @@ export class CrawlerService {
     const agentUrlFilter = options.agentUrls ? new Set(options.agentUrls) : null;
     const profiles: ProfileUpsertInput[] = [];
     const emptyAgentUrls: string[] = [];
+    const preservedAgentUrls: string[] = [];
 
     for (const agent of agents) {
       if (agentUrlFilter && !agentUrlFilter.has(agent.url)) continue;
@@ -1866,6 +1883,18 @@ export class CrawlerService {
       const domains = await this.federatedIndex.getDomainsForAgent(agent.url);
       if (domains.length === 0) {
         if (agentUrlFilter) emptyAgentUrls.push(agent.url);
+        continue;
+      }
+      if (domains.length > INVENTORY_PROFILE_PUBLISHER_FANOUT_CAP) {
+        preservedAgentUrls.push(agent.url);
+        log.warn(
+          {
+            agent_url: agent.url,
+            publisher_count: domains.length,
+            publisher_fanout_cap: INVENTORY_PROFILE_PUBLISHER_FANOUT_CAP,
+          },
+          'Inventory profile refresh skipped for high-fanout agent',
+        );
         continue;
       }
 
@@ -1920,7 +1949,12 @@ export class CrawlerService {
         }
       }
       if (options.deleteStale !== false && !agentUrlFilter) {
-        const currentUrls = profiles.map(p => p.agent_url);
+        // A high-fanout profile was deliberately not recomputed, so preserve
+        // its last-known-good projection during full-crawl stale cleanup.
+        const currentUrls = [
+          ...profiles.map(p => p.agent_url),
+          ...preservedAgentUrls,
+        ];
         const staleDeleted = await this.profilesDb.deleteStaleProfiles(currentUrls);
         if (staleDeleted > 0) {
           log.info({ deleted: staleDeleted }, 'Stale inventory profiles cleaned up');
@@ -1940,28 +1974,78 @@ export class CrawlerService {
 
   // ── Single Domain Crawl ──────────────────────────────────────────
 
-  async crawlSingleDomain(domain: string): Promise<void> {
+  /**
+   * Atomically admit a fire-and-forget single-domain crawl.
+   *
+   * Returning null lets HTTP callers reject the request before emitting a
+   * misleading 202 while a full crawl owns the crawler. There is no await
+   * between this check and crawlSingleDomain's own admission check.
+   */
+  tryStartSingleDomainCrawl(
+    domain: string,
+    context: SingleDomainCrawlContext = {},
+  ): Promise<void> | null {
+    if (this.crawling) return null;
+    return this.crawlSingleDomain(domain, context);
+  }
+
+  async crawlSingleDomain(
+    domain: string,
+    context: SingleDomainCrawlContext = {},
+  ): Promise<void> {
+    const startedAt = Date.now();
+    let stage = 'admission';
+    const lifecycleContext = {
+      domain,
+      crawl_request_id: context.requestId,
+      crawl_source: context.source,
+    };
     if (this.crawling) {
-      log.warn({ domain }, 'Full crawl in progress, skipping single domain crawl');
-      return;
+      log.warn(
+        {
+          ...lifecycleContext,
+          crawl_status: 'skipped',
+          crawl_stage: stage,
+          reason: 'full_crawl_in_progress',
+          duration_ms: Date.now() - startedAt,
+        },
+        'Single domain crawl skipped',
+      );
+      throw Object.assign(new Error('Full crawl in progress; single-domain crawl deferred'), {
+        code: 'crawl_deferred',
+      });
     }
 
-    log.info({ domain }, 'Single domain crawl requested');
+    log.info(
+      { ...lifecycleContext, crawl_status: 'running', crawl_stage: stage },
+      'Single domain crawl started',
+    );
 
     try {
+      await withDatabaseDeadline(Date.now() + SINGLE_DOMAIN_CRAWL_DB_DEADLINE_MS, async () => {
+      stage = 'origin_validation';
       const validation = await this.adAgentsManager.validateDomain(domain);
 
       if (!validation.valid || !validation.raw_data?.authorized_agents) {
-        log.warn({ domain }, 'No valid adagents.json for domain');
         await this.recordFailedAdagentsFetch(domain, {
           statusCode: validation.status_code,
           responseBytes: validation.response_bytes,
           resolvedUrl: validation.resolved_url,
         });
+        log.warn(
+          {
+            ...lifecycleContext,
+            crawl_status: 'completed_invalid',
+            crawl_stage: stage,
+            duration_ms: Date.now() - startedAt,
+          },
+          'No valid adagents.json for domain',
+        );
         return;
       }
 
-      await this.cacheAdagentsManifest(
+      stage = 'publisher_cache_write';
+      const cachePersisted = await this.cacheAdagentsManifest(
         domain,
         validation.raw_data as AdagentsManifest,
         {
@@ -1974,7 +2058,11 @@ export class CrawlerService {
           eventSource: 'crawl_request',
         },
       );
+      if (!cachePersisted) {
+        throw new Error(`Publisher cache write failed for ${domain}`);
+      }
 
+      stage = 'authorization_projection';
       const affectedAgentUrls = new Set<string>();
       const existingAuthorizations = await this.federatedIndex.getAuthorizationsForDomain(domain);
       for (const auth of existingAuthorizations) {
@@ -2010,6 +2098,7 @@ export class CrawlerService {
       await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
 
       // Scan brand.json for this domain
+      stage = 'brand_scan';
       try {
         await this.scanBrandForDomain(domain);
       } catch (err) {
@@ -2017,14 +2106,33 @@ export class CrawlerService {
       }
 
       // Rebuild profiles for affected agents
+      stage = 'inventory_profile_refresh';
       await this.buildInventoryProfiles({
         agentUrls: [...affectedAgentUrls],
         deleteStale: false,
       });
 
-      log.info({ domain }, 'Single domain crawl complete');
+      log.info(
+        {
+          ...lifecycleContext,
+          crawl_status: 'completed',
+          crawl_stage: 'complete',
+          duration_ms: Date.now() - startedAt,
+        },
+        'Single domain crawl complete',
+      );
+      }, { readOnly: false });
     } catch (err) {
-      log.error({ domain, err }, 'Single domain crawl failed');
+      log.error(
+        {
+          ...lifecycleContext,
+          crawl_status: 'failed',
+          crawl_stage: stage,
+          duration_ms: Date.now() - startedAt,
+          err,
+        },
+        'Single domain crawl failed',
+      );
       throw err;
     }
   }

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -2306,6 +2306,9 @@ export class CrawlerService {
             await this.crawlSingleDomain(row.publisher_domain);
             return { row, ok: true as const };
           } catch (err) {
+            if (err instanceof Error && (err as Error & { code?: string }).code === 'crawl_deferred') {
+              return { row, ok: null };
+            }
             return {
               row,
               ok: false as const,
@@ -2321,9 +2324,14 @@ export class CrawlerService {
         if (result.ok) {
           await this.publisherDb.markRevalidationSucceeded(result.row.publisher_domain);
           succeeded++;
-        } else {
+        } else if (result.ok === false) {
           await this.publisherDb.markRevalidationFailed(result.row.publisher_domain, result.error);
           failed++;
+        } else {
+          log.info(
+            { publisherDomain: result.row.publisher_domain, reason: 'full_crawl_in_progress' },
+            'Manager revalidation deferred without advancing failure backoff',
+          );
         }
       }
 

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -176,7 +176,6 @@ export async function queryWithTimeout<T extends QueryResultRow = any>(
     ]);
     const result = await client.query<T>(text, params);
     await client.query('COMMIT');
-    transactionStarted = false;
     return result;
   } catch (error) {
     if (transactionStarted) {

--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -1,4 +1,5 @@
 import { Client, Pool, PoolClient, QueryResult, QueryResultRow } from "pg";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { DatabaseConfig } from "../config.js";
 import { createLogger } from "../logger.js";
 
@@ -8,6 +9,12 @@ const SLOW_QUERY_THRESHOLD_MS = 500;
 
 let pool: Pool | null = null;
 let poolConfig: DatabaseConfig | null = null;
+interface QueryDeadlineContext {
+  deadlineMs: number;
+  readOnly: boolean;
+}
+
+const queryDeadline = new AsyncLocalStorage<QueryDeadlineContext>();
 
 /** Callback invoked on pool-level errors (set via onPoolError). */
 let poolErrorCallback: ((err: Error) => void) | null = null;
@@ -103,6 +110,10 @@ export async function query<T extends QueryResultRow = any>(
   text: string,
   params?: any[]
 ): Promise<QueryResult<T>> {
+  const deadline = queryDeadline.getStore();
+  if (deadline !== undefined) {
+    return queryWithTimeout<T>(text, params, deadline.deadlineMs - Date.now());
+  }
   const p = getPool();
   const start = process.hrtime.bigint();
   try {
@@ -118,6 +129,64 @@ export async function query<T extends QueryResultRow = any>(
     if (durationMs > SLOW_QUERY_THRESHOLD_MS) {
       logger.warn({ duration_ms: Math.round(durationMs) }, "Slow database query");
     }
+  }
+}
+
+/** Apply one absolute datastore deadline to all query() calls in work. */
+export function withDatabaseDeadline<T>(
+  deadlineMs: number,
+  work: () => Promise<T>,
+  options: { readOnly?: boolean } = {},
+): Promise<T> {
+  return queryDeadline.run({ deadlineMs, readOnly: options.readOnly ?? true }, work);
+}
+
+/**
+ * Execute one query with server-enforced statement and lock deadlines.
+ *
+ * Use this for public read paths whose inputs can select unusually large
+ * registry fan-outs. The transaction-local settings ensure PostgreSQL stops
+ * the work at the same deadline as the caller instead of leaving an orphaned
+ * backend query consuming a pool slot.
+ */
+export async function queryWithTimeout<T extends QueryResultRow = any>(
+  text: string,
+  params: any[] | undefined,
+  timeoutMs: number,
+): Promise<QueryResult<T>> {
+  const inheritedDeadline = queryDeadline.getStore();
+  const deadlineMs = Math.min(
+    Date.now() + timeoutMs,
+    inheritedDeadline?.deadlineMs ?? Number.POSITIVE_INFINITY,
+  );
+  const client = await getClient();
+  let transactionStarted = false;
+  try {
+    const effectiveTimeoutMs = deadlineMs - Date.now();
+    if (effectiveTimeoutMs <= 0) {
+      throw Object.assign(new Error('Database query deadline exceeded'), { code: '57014' });
+    }
+    await client.query(inheritedDeadline?.readOnly === false ? 'BEGIN' : 'BEGIN READ ONLY');
+    transactionStarted = true;
+    await client.query("SELECT set_config('statement_timeout', $1, true)", [
+      `${effectiveTimeoutMs}ms`,
+    ]);
+    await client.query("SELECT set_config('lock_timeout', $1, true)", [
+      `${Math.min(effectiveTimeoutMs, 2_000)}ms`,
+    ]);
+    const result = await client.query<T>(text, params);
+    await client.query('COMMIT');
+    transactionStarted = false;
+    return result;
+  } catch (error) {
+    if (transactionStarted) {
+      await client.query('ROLLBACK').catch((rollbackError) => {
+        logger.warn({ err: rollbackError }, 'Timed query rollback failed');
+      });
+    }
+    throw error;
+  } finally {
+    client.release();
   }
 }
 

--- a/server/src/db/events-db.ts
+++ b/server/src/db/events-db.ts
@@ -547,14 +547,14 @@ export class EventsDatabase {
   async addInvites(eventId: string, emails: string[], invitedByUserId?: string): Promise<number> {
     if (emails.length === 0) return 0;
 
-    const values = emails.map((_, i) => `($1, $${i + 2}, $${emails.length + 2})`).join(', ');
-    const params: unknown[] = [eventId, ...emails.map(e => e.toLowerCase().trim()), invitedByUserId || null];
+    const normalizedEmails = emails.map(email => email.toLowerCase().trim());
 
     const result = await query(
       `INSERT INTO event_invites (event_id, email, invited_by_user_id)
-       VALUES ${values}
+       SELECT $1, invite.email, $3
+       FROM UNNEST($2::text[]) AS invite(email)
        ON CONFLICT (event_id, email) DO NOTHING`,
-      params
+      [eventId, normalizedEmails, invitedByUserId || null]
     );
     return result.rowCount || 0;
   }

--- a/server/src/db/federated-index-db.ts
+++ b/server/src/db/federated-index-db.ts
@@ -1,4 +1,4 @@
-import { query } from './client.js';
+import { query, queryWithTimeout } from './client.js';
 import { canonicalizePublisherDomain } from '../services/publisher-domain.js';
 
 /**
@@ -1003,6 +1003,93 @@ export class FederatedIndexDatabase {
        )
        SELECT * FROM deduped ORDER BY publisher_domain, property_type, name`,
       [agentUrl]
+    );
+    return result.rows.map(row => this.deserializeProperty(row));
+  }
+
+  /**
+   * Get an agent's authorized properties for one publisher domain.
+   *
+   * Publisher-facing reads must use this scoped form. Calling
+   * getPropertiesForAgent() and filtering in application code makes response
+   * time proportional to the agent's entire network. A network agent with
+   * thousands of publishers can otherwise turn a one-property publisher read
+   * into a registry-wide JSONB walk and sort.
+   */
+  async getPropertiesForAgentDomain(
+    agentUrl: string,
+    publisherDomain: string,
+  ): Promise<DiscoveredProperty[]> {
+    const canonicalDomain = canonicalizePublisherDomain(publisherDomain);
+    const result = await queryWithTimeout<DiscoveredProperty>(
+      `WITH unioned AS (
+         SELECT p.id, p.property_id, p.publisher_domain, p.property_type, p.name,
+                p.identifiers, p.tags, p.discovered_at, p.last_validated, p.expires_at,
+                0 AS src_priority
+           FROM discovered_properties p
+           JOIN agent_property_authorizations apa ON apa.property_id = p.id
+          WHERE apa.agent_url = $1
+            AND p.publisher_domain = $2
+         UNION ALL
+         SELECT
+           cp.property_rid AS id,
+           prop->>'property_id' AS property_id,
+           pub.domain AS publisher_domain,
+           prop->>'property_type' AS property_type,
+           prop->>'name' AS name,
+           CASE WHEN jsonb_typeof(prop->'identifiers') = 'array'
+                THEN prop->'identifiers'
+                ELSE '[]'::jsonb END AS identifiers,
+           COALESCE(
+             ARRAY(SELECT jsonb_array_elements_text(
+               CASE WHEN jsonb_typeof(prop->'tags') = 'array'
+                    THEN prop->'tags'
+                    ELSE '[]'::jsonb END
+             )),
+             ARRAY[]::text[]
+           ) AS tags,
+           cp.created_at AS discovered_at,
+           pub.last_validated AS last_validated,
+           pub.expires_at AS expires_at,
+           1 AS src_priority
+           FROM v_effective_agent_authorizations v
+           JOIN catalog_properties cp ON cp.property_rid = v.property_rid
+           JOIN publishers pub ON pub.domain = regexp_replace(cp.created_by, '^[^:]+:', '')
+                              AND pub.source_type = 'adagents_json'
+                              AND pub.domain = $2
+          CROSS JOIN LATERAL jsonb_array_elements(
+            CASE WHEN jsonb_typeof(pub.adagents_json->'properties') = 'array'
+                 THEN pub.adagents_json->'properties'
+                 ELSE '[]'::jsonb END
+          ) AS prop
+          WHERE v.agent_url_canonical = CASE WHEN $1 = '*' THEN '*' ELSE LOWER(RTRIM(BTRIM($1), '/')) END
+            AND v.publisher_domain = $2
+            AND v.property_rid IS NOT NULL
+            AND prop->>'property_id' IS NOT NULL
+            AND cp.property_id IS NOT NULL
+            AND prop->>'property_id' = cp.property_id
+            AND prop->>'name' IS NOT NULL
+            AND prop->>'property_type' IS NOT NULL
+            AND LOWER(REGEXP_REPLACE(
+                  REGEXP_REPLACE(
+                    BTRIM(COALESCE(NULLIF(prop->>'publisher_domain', ''), pub.domain)),
+                    '^https?://',
+                    '',
+                    'i'
+                  ),
+                  '[./]+$',
+                  ''
+                )) = pub.domain
+       ), deduped AS (
+         SELECT DISTINCT ON (publisher_domain, name, property_type)
+                id, property_id, publisher_domain, property_type, name,
+                identifiers, tags, discovered_at, last_validated, expires_at
+           FROM unioned
+          ORDER BY publisher_domain, name, property_type, src_priority
+       )
+       SELECT * FROM deduped ORDER BY publisher_domain, property_type, name`,
+      [agentUrl, canonicalDomain],
+      5_000,
     );
     return result.rows.map(row => this.deserializeProperty(row));
   }

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -8,6 +8,8 @@ import { createLogger } from '../logger.js';
 import type { PoolClient } from 'pg';
 
 const log = createLogger('publisher-db');
+const ADAGENTS_CACHE_LOCK_TIMEOUT_MS = 5_000;
+const ADAGENTS_CACHE_STATEMENT_TIMEOUT_MS = 30_000;
 
 /**
  * Property as it appears inside an adagents.json file. The manifest body is
@@ -1115,6 +1117,12 @@ export class PublisherDatabase {
     const collectionEvents: CollectionProjectionEvent[] = [];
     try {
       await client.query('BEGIN');
+      await client.query("SELECT set_config('lock_timeout', $1, true)", [
+        `${ADAGENTS_CACHE_LOCK_TIMEOUT_MS}ms`,
+      ]);
+      await client.query("SELECT set_config('statement_timeout', $1, true)", [
+        `${ADAGENTS_CACHE_STATEMENT_TIMEOUT_MS}ms`,
+      ]);
 
       // Serialize writers for one publisher, including first discovery where
       // no row exists yet. A row lock alone cannot prevent concurrent first

--- a/server/src/federated-index.ts
+++ b/server/src/federated-index.ts
@@ -443,6 +443,17 @@ export class FederatedIndexService {
   }
 
   /**
+   * Get an agent's properties for one publisher without walking the agent's
+   * full publisher network.
+   */
+  async getPropertiesForAgentDomain(
+    agentUrl: string,
+    publisherDomain: string,
+  ): Promise<DiscoveredProperty[]> {
+    return this.db.getPropertiesForAgentDomain(agentUrl, publisherDomain);
+  }
+
+  /**
    * Get all publisher domains for an agent (from properties).
    */
   async getPublisherDomainsForAgent(agentUrl: string): Promise<string[]> {

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -20,7 +20,7 @@ import { runStoryboardStep, getComplianceStoryboardById, getFirstStepPreview, te
 import type { Agent, AgentType, AgentWithStats } from "../types.js";
 import { isValidAgentType } from "../types.js";
 import { MemberDatabase } from "../db/member-db.js";
-import { query } from "../db/client.js";
+import { query, withDatabaseDeadline } from "../db/client.js";
 import { resolvePrimaryOrganization } from "../db/users-db.js";
 import * as manifestRefsDb from "../db/manifest-refs-db.js";
 import { isUuid } from "../utils/uuid.js";
@@ -463,6 +463,63 @@ function summarizePlacements(
 import { AAO_UA_COMPLIANCE } from "../config/user-agents.js";
 
 const logger = createLogger("registry-api");
+const PUBLISHER_LOOKUP_TIMEOUT_MS = 8_000;
+const PUBLISHER_LOOKUP_SLOW_PHASE_MS = 500;
+
+class PublisherLookupTimeoutError extends Error {
+  constructor(readonly phase: string) {
+    super(`Publisher lookup timed out during ${phase}`);
+    this.name = "PublisherLookupTimeoutError";
+  }
+}
+
+async function publisherLookupPhase<T>(
+  work: () => Promise<T>,
+  deadlineMs: number,
+  domain: string,
+  phase: string,
+): Promise<T> {
+  const startedAt = Date.now();
+  const remainingMs = deadlineMs - startedAt;
+  if (remainingMs <= 0) throw new PublisherLookupTimeoutError(phase);
+
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      withDatabaseDeadline(deadlineMs, work),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new PublisherLookupTimeoutError(phase)),
+          remainingMs,
+        );
+        timeout.unref();
+      }),
+    ]);
+  } catch (error) {
+    const code = error && typeof error === "object" && "code" in error
+      ? String(error.code)
+      : "";
+    const message = error instanceof Error ? error.message : "";
+    if (
+      code === "57014" // statement_timeout
+      || code === "55P03" // lock_timeout
+      || message.includes("timeout exceeded when trying to connect")
+    ) {
+      throw new PublisherLookupTimeoutError(phase);
+    }
+    throw error;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    const durationMs = Date.now() - startedAt;
+    if (durationMs >= PUBLISHER_LOOKUP_SLOW_PHASE_MS) {
+      logger.warn(
+        { domain, phase, duration_ms: durationMs },
+        "Slow publisher lookup phase",
+      );
+    }
+  }
+}
+
 const complianceTarget = hostedComplianceTarget();
 const complianceOptions = hostedComplianceOptions(complianceTarget);
 const badgeEligibilityMetadata = (eligibleVersions: readonly string[]) => ({
@@ -1687,6 +1744,14 @@ registry.registerPath({
   responses: {
     200: { description: "Publisher lookup result", content: { "application/json": { schema: PublisherLookupResultSchema } } },
     400: { description: "Missing domain", content: { "application/json": { schema: ErrorSchema } } },
+    503: {
+      description: "Publisher lookup exceeded its bounded read deadline",
+      content: { "application/json": { schema: z.object({
+        error: z.string(),
+        code: z.literal("publisher_lookup_timeout"),
+        retry_after: z.number().int(),
+      }) } },
+    },
   },
 });
 
@@ -1839,6 +1904,14 @@ registry.registerPath({
     },
     400: { description: "Missing domain or agent", content: { "application/json": { schema: ErrorSchema } } },
     404: { description: "No authorization record for this agent on this publisher", content: { "application/json": { schema: ErrorSchema } } },
+    503: {
+      description: "Publisher authorization lookup exceeded its bounded read deadline",
+      content: { "application/json": { schema: z.object({
+        error: z.string(),
+        code: z.literal("publisher_lookup_timeout"),
+        retry_after: z.number().int(),
+      }) } },
+    },
   },
 });
 
@@ -2988,7 +3061,7 @@ registry.registerPath({
   operationId: "requestCrawl",
   summary: "Request domain re-crawl",
   description:
-    "Trigger an immediate re-crawl of a publisher domain after updating adagents.json. The crawl runs asynchronously — returns 202 immediately.\n\n**Rate limits:** 5 minutes per domain, 30 requests per user per hour.",
+    "Trigger an immediate re-crawl of a publisher domain after updating adagents.json. The crawl runs asynchronously in the accepting process — returns 202 immediately. The response `crawl_request_id` correlates accepted, running, completed, skipped, and failed lifecycle logs; a 202 does not by itself mean the mirror write completed.\n\n**Rate limits:** 5 minutes per domain, 30 requests per user per hour.",
   tags: ["Agent Discovery"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -3010,12 +3083,27 @@ registry.registerPath({
           schema: z.object({
             message: z.literal("Crawl request accepted"),
             domain: z.string(),
+            crawl_request_id: z.string().uuid().openapi({
+              description: "Correlation ID for crawl lifecycle logs; acceptance is not completion.",
+            }),
           }),
         },
       },
     },
     400: { description: "Invalid domain format, private IP, or unresolvable domain", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    503: {
+      description: "A full crawl is active; the request was not accepted",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.string(),
+            code: z.literal("crawl_temporarily_unavailable"),
+            retry_after: z.number().int(),
+          }),
+        },
+      },
+    },
     429: {
       description: "Rate limit exceeded",
       content: {
@@ -8593,15 +8681,18 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       return res.status(400).json({ error: "Invalid include value; expected placements" });
     }
 
+    const lookupDeadlineMs = Date.now() + PUBLISHER_LOOKUP_TIMEOUT_MS;
+    let publisherLookupDomain = rawDomain;
     try {
       const domain = extractDomain(rawDomain);
+      publisherLookupDomain = domain;
       if (!isValidDomain(domain)) {
         return res.status(400).json({ error: "Invalid domain" });
       }
       const memberDb = new MemberDatabase();
       const federatedIndex = crawler.getFederatedIndex();
 
-      const [profile, properties, authorizations, adagentsValid, hostedProperty, brandRow, cachedAdagentsRow] = await Promise.all([
+      const [profile, properties, authorizations, adagentsValid, hostedProperty, brandRow, cachedAdagentsRow] = await publisherLookupPhase(() => Promise.all([
         memberDb.getProfileByDomain(domain),
         federatedIndex.getPropertiesForDomain(domain),
         federatedIndex.getAuthorizationsForDomain(domain),
@@ -8640,7 +8731,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
              FROM publishers WHERE domain = $1 LIMIT 1`,
           [domain],
         ).then(r => r.rows[0] ?? null),
-      ]);
+      ]), lookupDeadlineMs, domain, "initial_record_load");
       const cachedAdagentsManifest = cachedAdagentsRow?.adagents_json ?? null;
       const cachedAdagentsLastValidated = cachedAdagentsRow?.last_validated ?? null;
       const cachedHttpStatus = cachedAdagentsRow?.last_http_status ?? null;
@@ -8764,9 +8855,15 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         // already validated — any rewrite would mean a discrepancy.
         let crawlSafe = false;
         try {
-          const validated = await validateCrawlDomain(domain);
+          const validated = await publisherLookupPhase(
+            () => validateCrawlDomain(domain),
+            lookupDeadlineMs,
+            domain,
+            "auto_crawl_domain_validation",
+          );
           crawlSafe = validated === domain;
         } catch (err) {
+          if (err instanceof PublisherLookupTimeoutError) throw err;
           logger.debug({ err, domain }, 'Auto-crawl skipped — validateCrawlDomain rejected');
         }
         if (crawlSafe) {
@@ -8956,7 +9053,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         };
       });
 
-      const hostedBrand = await brandDb.getHostedBrandByDomain(domain);
+      const hostedBrand = await publisherLookupPhase(
+        () => brandDb.getHostedBrandByDomain(domain),
+        lookupDeadlineMs,
+        domain,
+        "hosted_brand_load",
+      );
       const brandManifest = hostedBrand?.brand_json
         ?? (brandRow?.brand_manifest as Record<string, unknown> | null | undefined)
         ?? null;
@@ -9029,15 +9131,21 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           ? authorizations.slice(0, PER_AGENT_ROLLUP_CAP)
           : authorizations;
       const agentPropertyCounts = new Map<string, number>();
-      await Promise.all(
-        agentsToRollup.map(async a => {
-          const agentProps = await federatedIndex.getPropertiesForAgent(a.agent_url);
-          const matching = agentProps.filter(
-            p => p.publisher_domain === domain && p.id && propertyDbIdSet.has(p.id),
-          );
-          agentPropertyCounts.set(a.agent_url, matching.length);
-        }),
-      );
+      await publisherLookupPhase(async () => {
+        const concurrency = 4;
+        for (let i = 0; i < agentsToRollup.length; i += concurrency) {
+          await Promise.all(agentsToRollup.slice(i, i + concurrency).map(async a => {
+            const agentProps = await federatedIndex.getPropertiesForAgentDomain(
+              a.agent_url,
+              domain,
+            );
+            const matching = agentProps.filter(
+              p => p.publisher_domain === domain && p.id && propertyDbIdSet.has(p.id),
+            );
+            agentPropertyCounts.set(a.agent_url, matching.length);
+          }));
+        }
+      }, lookupDeadlineMs, domain, "per_agent_property_rollup");
 
       // What-we-have summary. The page leads with "you have an
       // adagents.json" / "you have a brand.json" — this block exposes
@@ -9128,6 +9236,22 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         auto_crawl_triggered: autoCrawlTriggered || undefined,
       });
     } catch (error) {
+      if (error instanceof PublisherLookupTimeoutError) {
+        logger.warn(
+          {
+            domain: publisherLookupDomain,
+            phase: error.phase,
+            timeout_ms: PUBLISHER_LOOKUP_TIMEOUT_MS,
+          },
+          "Publisher lookup deadline exceeded",
+        );
+        res.setHeader("Retry-After", "5");
+        return res.status(503).json({
+          error: "Publisher lookup temporarily unavailable",
+          code: "publisher_lookup_timeout",
+          retry_after: 5,
+        });
+      }
       logger.error({ err: error, path: req.path }, "Publisher lookup failed");
       res.status(500).json({ error: "Publisher lookup failed" });
     }
@@ -9139,8 +9263,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     if (!rawDomain || !rawAgent) {
       return res.status(400).json({ error: "Missing required query params: domain, agent" });
     }
+    const lookupDeadlineMs = Date.now() + PUBLISHER_LOOKUP_TIMEOUT_MS;
+    let publisherLookupDomain = rawDomain;
     try {
       const domain = extractDomain(rawDomain);
+      publisherLookupDomain = domain;
       if (!isValidDomain(domain)) {
         return res.status(400).json({ error: "Invalid domain" });
       }
@@ -9152,10 +9279,10 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       }
       const federatedIndex = crawler.getFederatedIndex();
 
-      const [properties, authorizations] = await Promise.all([
+      const [properties, authorizations] = await publisherLookupPhase(() => Promise.all([
         federatedIndex.getPropertiesForDomain(domain),
         federatedIndex.getAuthorizationsForDomain(domain),
-      ]);
+      ]), lookupDeadlineMs, domain, "authorization_record_load");
 
       const auth = authorizations.find(a => canonicalizeAgentUrl(a.agent_url) === agentUrl);
       if (!auth) {
@@ -9170,7 +9297,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       const propertyDbIdSet = new Set(
         properties.map(p => p.id).filter((id): id is string => Boolean(id)),
       );
-      const agentProps = await federatedIndex.getPropertiesForAgent(agentUrl);
+      const agentProps = await publisherLookupPhase(
+        () => federatedIndex.getPropertiesForAgentDomain(agentUrl, domain),
+        lookupDeadlineMs,
+        domain,
+        "authorization_property_rollup",
+      );
       const matched = agentProps.filter(
         p => p.publisher_domain === domain && p.id && propertyDbIdSet.has(p.id),
       );
@@ -9195,6 +9327,22 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         unauthorized_properties: unauthorized,
       });
     } catch (error) {
+      if (error instanceof PublisherLookupTimeoutError) {
+        logger.warn(
+          {
+            domain: publisherLookupDomain,
+            phase: error.phase,
+            timeout_ms: PUBLISHER_LOOKUP_TIMEOUT_MS,
+          },
+          "Publisher authorization lookup deadline exceeded",
+        );
+        res.setHeader("Retry-After", "5");
+        return res.status(503).json({
+          error: "Publisher authorization lookup temporarily unavailable",
+          code: "publisher_lookup_timeout",
+          retry_after: 5,
+        });
+      }
       logger.error({ err: error, path: req.path }, "Publisher authorization lookup failed");
       return res.status(500).json({ error: "Publisher authorization lookup failed" });
     }
@@ -10994,6 +11142,19 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     return normalizedDomain;
   }
 
+  /** Release the reservation when synchronous crawler admission rejects. */
+  function releaseCrawlRateLimit(req: import('express').Request, rateLimitKey: string): void {
+    crawlRequestRateLimits.delete(rateLimitKey);
+    const memberId = req.user?.id || 'anonymous';
+    const memberState = memberCrawlCounts.get(memberId);
+    if (!memberState) return;
+    if (memberState.count <= 1) {
+      memberCrawlCounts.delete(memberId);
+    } else {
+      memberState.count--;
+    }
+  }
+
   if (!authMiddleware) throw new Error('requireAuth middleware is required for crawl-request endpoint');
 
   router.post("/registry/publisher/:domain/adagents/revalidate", authMiddleware, async (req, res) => {
@@ -11078,14 +11239,57 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
   router.post("/registry/crawl-request", authMiddleware, async (req, res) => {
     try {
-      const normalizedDomain = await validateAndRateLimitCrawl(req, res, req.body?.domain?.toLowerCase?.()?.trim?.() || '');
+      const rateLimitKey = req.body?.domain?.toLowerCase?.()?.trim?.() || '';
+      const normalizedDomain = await validateAndRateLimitCrawl(req, res, rateLimitKey);
       if (!normalizedDomain) return;
 
-      crawler.crawlSingleDomain(normalizedDomain).catch((err: Error) => {
-        logger.error({ err, domain: normalizedDomain }, "Crawl request failed");
+      const crawlRequestId = randomUUID();
+      const crawlTask = crawler.tryStartSingleDomainCrawl(normalizedDomain, {
+        requestId: crawlRequestId,
+        source: "api:crawl-request",
+      });
+      if (!crawlTask) {
+        releaseCrawlRateLimit(req, rateLimitKey);
+        logger.warn(
+          {
+            domain: normalizedDomain,
+            crawl_request_id: crawlRequestId,
+            crawl_status: "not_accepted",
+            reason: "full_crawl_in_progress",
+          },
+          "Crawl request not accepted",
+        );
+        res.setHeader("Retry-After", "5");
+        return res.status(503).json({
+          error: "A full crawl is in progress; retry the crawl request",
+          code: "crawl_temporarily_unavailable",
+          retry_after: 5,
+        });
+      }
+      logger.info(
+        {
+          domain: normalizedDomain,
+          crawl_request_id: crawlRequestId,
+          crawl_status: "accepted",
+        },
+        "Crawl request accepted",
+      );
+      crawlTask.catch((err: Error) => {
+        logger.debug(
+          {
+            err,
+            domain: normalizedDomain,
+            crawl_request_id: crawlRequestId,
+          },
+          "Accepted crawl task settled with error",
+        );
       });
 
-      return res.status(202).json({ message: "Crawl request accepted", domain: normalizedDomain });
+      return res.status(202).json({
+        message: "Crawl request accepted",
+        domain: normalizedDomain,
+        crawl_request_id: crawlRequestId,
+      });
     } catch (error) {
       logger.error({ error }, "Failed to process crawl request");
       return res.status(500).json({ error: "Failed to process crawl request" });

--- a/server/tests/integration/registry-reader-baseline-properties.test.ts
+++ b/server/tests/integration/registry-reader-baseline-properties.test.ts
@@ -25,7 +25,11 @@
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import type { Pool } from 'pg';
-import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import {
+  initializeDatabase,
+  closeDatabase,
+  withDatabaseDeadline,
+} from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import { FederatedIndexDatabase } from '../../src/db/federated-index-db.js';
 import { PropertyDatabase } from '../../src/db/property-db.js';
@@ -124,6 +128,11 @@ describe('Registry reader baseline — properties + publisher-side reads', () =>
       expect(props).toEqual([]);
     });
 
+    it('getPropertiesForAgentDomain returns [] for an unaffected empty domain', async () => {
+      const props = await fedDb.getPropertiesForAgentDomain(AGENT_X, PUB_A);
+      expect(props).toEqual([]);
+    });
+
     it('getPublisherDomainsForAgent returns [] for an unknown agent', async () => {
       const domains = await fedDb.getPublisherDomainsForAgent(AGENT_X);
       expect(domains).toEqual([]);
@@ -145,6 +154,24 @@ describe('Registry reader baseline — properties + publisher-side reads', () =>
     it('getAllPropertiesForRegistry filtered to our prefix returns []', async () => {
       const rows = await propDb.getAllPropertiesForRegistry({ search: DOMAIN_PREFIX });
       expect(rows).toEqual([]);
+    });
+
+    it('allows crawler-style writes under a bounded writable DB deadline', async () => {
+      await withDatabaseDeadline(
+        Date.now() + 5_000,
+        () => fedDb.upsertProperty({
+          property_id: 'deadline-write',
+          publisher_domain: PUB_A,
+          property_type: 'website',
+          name: 'Deadline Write Fixture',
+          identifiers: [{ type: 'domain', value: PUB_A }],
+        }),
+        { readOnly: false },
+      );
+
+      const properties = await fedDb.getPropertiesForDomain(PUB_A);
+      expect(properties).toHaveLength(1);
+      expect(properties[0].property_id).toBe('deadline-write');
     });
   });
 
@@ -194,6 +221,15 @@ describe('Registry reader baseline — properties + publisher-side reads', () =>
       expect(props.length).toBe(1);
       expect(props[0].publisher_domain).toBe(PUB_A);
       expect(props[0].name).toBe('Acme Homepage');
+    });
+
+    it('getPropertiesForAgentDomain returns only the requested publisher', async () => {
+      const props = await fedDb.getPropertiesForAgentDomain(AGENT_X, PUB_A);
+      expect(props).toHaveLength(1);
+      expect(props[0]).toMatchObject({
+        publisher_domain: PUB_A,
+        name: 'Acme Homepage',
+      });
     });
 
     it('getPublisherDomainsForAgent returns the publisher', async () => {

--- a/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
+++ b/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
@@ -96,6 +96,8 @@ import { HTTPServer } from '../../src/http.js';
 import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import { FederatedIndexDatabase } from '../../src/db/federated-index-db.js';
+import { FederatedIndexService } from '../../src/federated-index.js';
+import { CrawlerService } from '../../src/crawler.js';
 
 // `endpoint-` prefix scopes this file's fixtures away from the sibling
 // baseline files (prop-, auth-, mcp-) so concurrent file execution can't
@@ -223,6 +225,38 @@ describe('Registry reader baseline — public endpoints', () => {
     it('GET /api/registry/publisher returns 400 when domain query is missing', async () => {
       const res = await request(app).get('/api/registry/publisher');
       expect(res.status).toBe(400);
+    });
+
+    it('does not consume crawl rate limits when a full crawl rejects admission', async () => {
+      const admission = vi.spyOn(
+        CrawlerService.prototype,
+        'tryStartSingleDomainCrawl',
+      )
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce(Promise.resolve());
+
+      try {
+        const busy = await request(app)
+          .post('/api/registry/crawl-request')
+          .send({ domain: 'example.com' });
+        expect(busy.status).toBe(503);
+        expect(busy.headers['retry-after']).toBe('5');
+        expect(busy.body.code).toBe('crawl_temporarily_unavailable');
+
+        const admitted = await request(app)
+          .post('/api/registry/crawl-request')
+          .send({ domain: 'example.com' });
+        expect(admitted.status).toBe(202);
+        expect(admitted.body).toMatchObject({
+          message: 'Crawl request accepted',
+          domain: 'example.com',
+        });
+        expect(admitted.body.crawl_request_id).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+        );
+      } finally {
+        admission.mockRestore();
+      }
     });
   });
 
@@ -354,6 +388,29 @@ describe('Registry reader baseline — public endpoints', () => {
       });
     });
 
+    it('GET /api/registry/publisher returns a typed temporary error for a bounded DB timeout', async () => {
+      const timeoutError = Object.assign(new Error('statement timeout'), { code: '57014' });
+      const scopedRead = vi.spyOn(
+        FederatedIndexService.prototype,
+        'getPropertiesForAgentDomain',
+      ).mockRejectedValue(timeoutError);
+
+      try {
+        const res = await request(app).get(
+          `/api/registry/publisher?domain=${encodeURIComponent(PUB_A)}`
+        );
+        expect(res.status).toBe(503);
+        expect(res.headers['retry-after']).toBe('5');
+        expect(res.body).toEqual({
+          error: 'Publisher lookup temporarily unavailable',
+          code: 'publisher_lookup_timeout',
+          retry_after: 5,
+        });
+      } finally {
+        scopedRead.mockRestore();
+      }
+    });
+
     it('GET /api/registry/publisher reports publisher-wide auth as N of N', async () => {
       // Drop AGENT_X's property-level row so only the publisher-wide
       // authorization remains. The rollup should collapse to "all".
@@ -400,6 +457,29 @@ describe('Registry reader baseline — public endpoints', () => {
       expect(res.body.unauthorized_properties[0]).toMatchObject({
         name: 'Endpoint Mobile',
       });
+    });
+
+    it('GET /api/registry/publisher/authorization returns a typed temporary error for a lock timeout', async () => {
+      const timeoutError = Object.assign(new Error('lock timeout'), { code: '55P03' });
+      const scopedRead = vi.spyOn(
+        FederatedIndexService.prototype,
+        'getPropertiesForAgentDomain',
+      ).mockRejectedValue(timeoutError);
+
+      try {
+        const res = await request(app).get(
+          `/api/registry/publisher/authorization?domain=${encodeURIComponent(PUB_A)}&agent=${encodeURIComponent(AGENT_X)}`
+        );
+        expect(res.status).toBe(503);
+        expect(res.headers['retry-after']).toBe('5');
+        expect(res.body).toEqual({
+          error: 'Publisher authorization lookup temporarily unavailable',
+          code: 'publisher_lookup_timeout',
+          retry_after: 5,
+        });
+      } finally {
+        scopedRead.mockRestore();
+      }
     });
 
     it('GET /api/registry/publisher/authorization reports publisher-wide as N of N with no unauthorized list', async () => {

--- a/server/tests/integration/registry-reader-catalog-cutover.test.ts
+++ b/server/tests/integration/registry-reader-catalog-cutover.test.ts
@@ -226,6 +226,40 @@ describe('Registry reader catalog cutover — catalog seeds + override layer', (
       expect(props[0].tags).toEqual(['news']);
     });
 
+    it('getPropertiesForAgentDomain scopes a network agent to one catalog publisher', async () => {
+      await publisherDb.upsertAdagentsCache({
+        domain: PUB_A,
+        manifest: manifest(
+          [{
+            url: AGENT_Y,
+            authorization_type: 'inline_properties',
+            properties: [{
+              property_id: 'cutover-home-a',
+              property_type: 'website',
+              name: 'Acme Home',
+              identifiers: [{ type: 'domain', value: PUB_A }],
+            }],
+          }],
+          [{
+            property_id: 'cutover-home-a',
+            property_type: 'website',
+            name: 'Acme Home',
+            identifiers: [{ type: 'domain', value: PUB_A }],
+          }],
+        ),
+      });
+
+      const props = await fedDb.getPropertiesForAgentDomain(AGENT_Y, PUB_A);
+
+      expect(props).toHaveLength(1);
+      expect(props[0]).toMatchObject({
+        publisher_domain: PUB_A,
+        property_id: 'cutover-home-a',
+        name: 'Acme Home',
+      });
+      expect(props.some((property) => property.publisher_domain === PUB_B)).toBe(false);
+    });
+
     it('getPublisherDomainsForAgent surfaces catalog-only per-property rows', async () => {
       const domains = await fedDb.getPublisherDomainsForAgent(AGENT_Y);
       expect(domains).toContain(PUB_B);

--- a/server/tests/unit/crawler-format-kind-events.test.ts
+++ b/server/tests/unit/crawler-format-kind-events.test.ts
@@ -53,4 +53,38 @@ describe('CrawlerService canonical format-kind events', () => {
       ]),
     );
   });
+
+  it('preserves a high-fanout agent profile during full-crawl stale cleanup', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const normalAgent = 'https://normal.example.com/mcp';
+    const networkAgent = 'https://network.example.com/mcp';
+    const deleteStaleProfiles = vi.fn().mockResolvedValue(0);
+    const getPropertiesForAgent = vi.fn().mockResolvedValue([]);
+
+    Object.assign(ctx, {
+      federatedIndex: {
+        listAllAgents: vi.fn().mockResolvedValue([
+          { url: normalAgent },
+          { url: networkAgent },
+        ]),
+        getDomainsForAgent: vi.fn(async (agentUrl: string) => (
+          agentUrl === networkAgent
+            ? Array.from({ length: 1_001 }, (_, index) => `publisher-${index}.example`)
+            : ['publisher.example']
+        )),
+        getPropertiesForAgent,
+      },
+      profilesDb: {
+        upsertProfiles: vi.fn().mockImplementation(async (profiles: unknown[]) => profiles),
+        deleteStaleProfiles,
+      },
+    });
+
+    await ctx.buildInventoryProfiles();
+
+    expect(getPropertiesForAgent).toHaveBeenCalledTimes(1);
+    expect(getPropertiesForAgent).toHaveBeenCalledWith(normalAgent);
+    expect(deleteStaleProfiles).toHaveBeenCalledWith([normalAgent, networkAgent]);
+  });
 });

--- a/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
+++ b/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
@@ -30,13 +30,52 @@ describe('CrawlerService single-domain profile rebuild', () => {
         recordAgentFromAdagentsJson: vi.fn().mockResolvedValue(undefined),
         reconcileAdagentsAuthorizations: vi.fn().mockResolvedValue(undefined),
       },
-      cacheAdagentsManifest: vi.fn().mockResolvedValue(undefined),
+      cacheAdagentsManifest: vi.fn().mockResolvedValue(true),
       scanBrandForDomain: vi.fn().mockResolvedValue(undefined),
       buildInventoryProfiles: vi.fn().mockResolvedValue(new Map()),
     });
 
     return ctx;
   }
+
+  it('rejects visibly when a full crawl owns the crawler', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const validateDomain = vi.fn();
+    Object.assign(ctx, {
+      crawling: true,
+      adAgentsManager: { validateDomain },
+    });
+
+    await expect(ctx.crawlSingleDomain('publisher.example', {
+      requestId: 'crawl-request-id',
+      source: 'test',
+    })).rejects.toMatchObject({ code: 'crawl_deferred' });
+    expect(validateDomain).not.toHaveBeenCalled();
+  });
+
+  it('does not admit an HTTP-style crawl request while a full crawl is active', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const ctx = Object.create((CrawlerService as any).prototype);
+    Object.assign(ctx, { crawling: true });
+
+    expect(ctx.tryStartSingleDomainCrawl('publisher.example', {
+      requestId: 'crawl-request-id',
+      source: 'api:crawl-request',
+    })).toBeNull();
+  });
+
+  it('releases full-crawl ownership when setup fails', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const ctx = Object.create((CrawlerService as any).prototype);
+    Object.assign(ctx, {
+      crawling: false,
+      getPausedAgentUrls: vi.fn().mockRejectedValue(new Error('database unavailable')),
+    });
+
+    await expect(ctx.crawlAllAgents([])).rejects.toThrow('database unavailable');
+    expect(ctx.crawling).toBe(false);
+  });
 
   it('rebuilds profiles for agents removed from the prior manifest', async () => {
     const ctx = await makeCrawlerContext({
@@ -105,7 +144,7 @@ describe('CrawlerService single-domain profile rebuild', () => {
       publisherDb: {
         recordAdagentsValidationFailure: vi.fn().mockResolvedValue(undefined),
       },
-      cacheAdagentsManifest: vi.fn().mockResolvedValue(undefined),
+      cacheAdagentsManifest: vi.fn().mockResolvedValue(true),
       recordPropertiesForAgent: vi.fn().mockResolvedValue(undefined),
       fanOutPublisherPropertiesAuthorizations: vi.fn().mockResolvedValue(undefined),
       reconcileLegacyAdagentsAgents: vi.fn().mockResolvedValue(undefined),
@@ -170,7 +209,7 @@ describe('CrawlerService single-domain profile rebuild', () => {
         reconcileAdagentsAuthorizations: vi.fn().mockResolvedValue(undefined),
       },
       publisherDb: {},
-      cacheAdagentsManifest: vi.fn().mockResolvedValue(undefined),
+      cacheAdagentsManifest: vi.fn().mockResolvedValue(true),
       recordPropertiesForAgent: vi.fn().mockResolvedValue(undefined),
       fanOutPublisherPropertiesAuthorizations: vi.fn().mockResolvedValue(undefined),
       reconcileLegacyAdagentsAgents: vi.fn().mockResolvedValue(undefined),

--- a/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
+++ b/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
@@ -65,6 +65,34 @@ describe('CrawlerService single-domain profile rebuild', () => {
     })).toBeNull();
   });
 
+  it('does not advance manager revalidation failure backoff when a full crawl defers the item', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const deferredError = Object.assign(new Error('Full crawl in progress'), {
+      code: 'crawl_deferred',
+    });
+    const publisherDb = {
+      dequeueRevalidationBatch: vi.fn().mockResolvedValue([
+        { publisher_domain: 'publisher.example', manager_domain: 'manager.example', attempts: 0 },
+      ]),
+      markRevalidationSucceeded: vi.fn(),
+      markRevalidationFailed: vi.fn(),
+    };
+    Object.assign(ctx, {
+      managerRevalidationProcessing: false,
+      publisherDb,
+      crawlSingleDomain: vi.fn().mockRejectedValue(deferredError),
+    });
+
+    await expect(ctx.processManagerRevalidationQueue()).resolves.toEqual({
+      processed: 1,
+      succeeded: 0,
+      failed: 0,
+    });
+    expect(publisherDb.markRevalidationSucceeded).not.toHaveBeenCalled();
+    expect(publisherDb.markRevalidationFailed).not.toHaveBeenCalled();
+  });
+
   it('releases full-crawl ownership when setup fails', async () => {
     const { CrawlerService } = await import('../../src/crawler.js');
     const ctx = Object.create((CrawlerService as any).prototype);

--- a/server/tests/unit/db-client-checkout.test.ts
+++ b/server/tests/unit/db-client-checkout.test.ts
@@ -109,4 +109,101 @@ describe('db client checkout and health checks', () => {
     expect(pg.clientEnd).toHaveBeenCalledTimes(1);
     await db.closeDatabase();
   });
+
+  it('applies transaction-local deadlines and releases the client', async () => {
+    const pg = mockPg();
+    const release = vi.fn();
+    const query = vi.fn().mockResolvedValue({ rows: [{ value: 1 }] });
+    pg.poolConnect.mockResolvedValue({ query, release });
+
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    await expect(db.queryWithTimeout('SELECT $1 AS value', [1], 5_000))
+      .resolves.toEqual({ rows: [{ value: 1 }] });
+    expect(query.mock.calls[0]).toEqual(['BEGIN READ ONLY']);
+    const statementTimeout = Number.parseInt(query.mock.calls[1][1][0], 10);
+    expect(statementTimeout).toBeGreaterThan(0);
+    expect(statementTimeout).toBeLessThanOrEqual(5_000);
+    expect(query.mock.calls[2]).toEqual([
+      "SELECT set_config('lock_timeout', $1, true)",
+      ['2000ms'],
+    ]);
+    expect(query.mock.calls[3]).toEqual(['SELECT $1 AS value', [1]]);
+    expect(query.mock.calls[4]).toEqual(['COMMIT']);
+    expect(release).toHaveBeenCalledTimes(1);
+
+    await db.closeDatabase();
+  });
+
+  it('rolls back and releases the client after a timed query fails', async () => {
+    const pg = mockPg();
+    const release = vi.fn();
+    const timeoutError = Object.assign(new Error('statement timeout'), { code: '57014' });
+    const query = vi.fn().mockImplementation(async (text: string) => {
+      if (text === 'SELECT pg_sleep(10)') throw timeoutError;
+      return { rows: [] };
+    });
+    pg.poolConnect.mockResolvedValue({ query, release });
+
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    await expect(db.queryWithTimeout('SELECT pg_sleep(10)', undefined, 5_000))
+      .rejects.toBe(timeoutError);
+    expect(query).toHaveBeenLastCalledWith('ROLLBACK');
+    expect(query).not.toHaveBeenCalledWith('COMMIT');
+    expect(release).toHaveBeenCalledTimes(1);
+
+    await db.closeDatabase();
+  });
+
+  it('propagates a request deadline into ordinary query calls', async () => {
+    const pg = mockPg();
+    const release = vi.fn();
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    pg.poolConnect.mockResolvedValue({ query, release });
+
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    await db.withDatabaseDeadline(Date.now() + 1_000, () => db.query('SELECT 1'));
+
+    expect(pg.poolQuery).not.toHaveBeenCalled();
+    const statementTimeout = query.mock.calls.find(
+      ([text]) => text === "SELECT set_config('statement_timeout', $1, true)",
+    )?.[1]?.[0];
+    expect(Number.parseInt(statementTimeout, 10)).toBeGreaterThan(0);
+    expect(Number.parseInt(statementTimeout, 10)).toBeLessThanOrEqual(1_000);
+    expect(query).toHaveBeenCalledWith('SELECT 1', undefined);
+    expect(release).toHaveBeenCalledTimes(1);
+
+    await db.closeDatabase();
+  });
+
+  it('uses a writable transaction for deadline-bounded worker writes', async () => {
+    const pg = mockPg();
+    const release = vi.fn();
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    pg.poolConnect.mockResolvedValue({ query, release });
+
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    await db.withDatabaseDeadline(
+      Date.now() + 1_000,
+      () => db.query('UPDATE jobs SET status = $1', ['complete']),
+      { readOnly: false },
+    );
+
+    expect(query.mock.calls[0]).toEqual(['BEGIN']);
+    expect(query).toHaveBeenCalledWith(
+      'UPDATE jobs SET status = $1',
+      ['complete'],
+    );
+    expect(query).toHaveBeenCalledWith('COMMIT');
+    expect(release).toHaveBeenCalledTimes(1);
+
+    await db.closeDatabase();
+  });
 });

--- a/server/tests/unit/federated-index-publisher-scope.test.ts
+++ b/server/tests/unit/federated-index-publisher-scope.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+  queryWithTimeout: vi.fn(),
+}));
+
+import { queryWithTimeout } from '../../src/db/client.js';
+import { FederatedIndexDatabase } from '../../src/db/federated-index-db.js';
+
+const mockedQuery = vi.mocked(queryWithTimeout);
+const result = <T>(rows: T[]) => ({
+  rows,
+  rowCount: rows.length,
+  command: '',
+  oid: 0,
+  fields: [],
+});
+
+describe('FederatedIndexDatabase publisher-scoped agent properties', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pushes both the high-fanout agent and publisher into every query arm', async () => {
+    mockedQuery.mockResolvedValueOnce(result([{
+      id: 'property-rid',
+      property_id: 'site',
+      publisher_domain: 'publisher.example',
+      property_type: 'website',
+      name: 'Example Publisher',
+      identifiers: [{ type: 'domain', value: 'publisher.example' }],
+      tags: ['all'],
+    }]));
+
+    const db = new FederatedIndexDatabase();
+    const properties = await db.getPropertiesForAgentDomain(
+      'https://network-agent.example',
+      'HTTPS://PUBLISHER.EXAMPLE/',
+    );
+
+    expect(properties).toHaveLength(1);
+    expect(properties[0]).toMatchObject({
+      publisher_domain: 'publisher.example',
+      property_id: 'site',
+    });
+
+    const [sql, params, timeoutMs] = mockedQuery.mock.calls[0];
+    expect(sql).toContain('p.publisher_domain = $2');
+    expect(sql).toContain('pub.domain = $2');
+    expect(sql).toContain('v.publisher_domain = $2');
+    expect(params).toEqual([
+      'https://network-agent.example',
+      'publisher.example',
+    ]);
+    expect(timeoutMs).toBe(5_000);
+  });
+
+  it('returns an unaffected publisher without expanding unrelated agent data', async () => {
+    mockedQuery.mockResolvedValueOnce(result([]));
+
+    const db = new FederatedIndexDatabase();
+    await expect(db.getPropertiesForAgentDomain(
+      'https://sales-agent.example',
+      'control-publisher.example',
+    )).resolves.toEqual([]);
+
+    expect(mockedQuery).toHaveBeenCalledTimes(1);
+    expect(mockedQuery.mock.calls[0][1]).toEqual([
+      'https://sales-agent.example',
+      'control-publisher.example',
+    ]);
+  });
+});

--- a/server/tests/unit/publisher-db-adagents-timeout.test.ts
+++ b/server/tests/unit/publisher-db-adagents-timeout.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  getClient: vi.fn(),
+  query: vi.fn(),
+}));
+
+import { getClient } from '../../src/db/client.js';
+import { PublisherDatabase } from '../../src/db/publisher-db.js';
+
+const mockedGetClient = vi.mocked(getClient);
+const emptyResult = { rows: [], rowCount: 0, command: '', oid: 0, fields: [] };
+
+describe('PublisherDatabase adagents cache transaction deadlines', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets transaction-local lock and statement deadlines before taking the publisher lock', async () => {
+    const query = vi.fn().mockResolvedValue(emptyResult);
+    const release = vi.fn();
+    mockedGetClient.mockResolvedValue({ query, release } as never);
+
+    const db = new PublisherDatabase();
+    await db.upsertAdagentsCache({
+      domain: 'publisher.example',
+      manifest: { authorized_agents: [], properties: [], collections: [] },
+    });
+
+    const calls = query.mock.calls.map(([text, params]) => [text, params]);
+    expect(calls.slice(0, 4)).toEqual([
+      ['BEGIN', undefined],
+      ["SELECT set_config('lock_timeout', $1, true)", ['5000ms']],
+      ["SELECT set_config('statement_timeout', $1, true)", ['30000ms']],
+      ['SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', ['publisher.example']],
+    ]);
+    expect(query).toHaveBeenCalledWith('COMMIT');
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back and releases after advisory-lock timeout', async () => {
+    const lockError = Object.assign(new Error('canceling statement due to lock timeout'), {
+      code: '55P03',
+    });
+    const query = vi.fn().mockImplementation(async (text: string) => {
+      if (text.startsWith('SELECT pg_advisory_xact_lock')) throw lockError;
+      return emptyResult;
+    });
+    const release = vi.fn();
+    mockedGetClient.mockResolvedValue({ query, release } as never);
+
+    const db = new PublisherDatabase();
+    await expect(db.upsertAdagentsCache({
+      domain: 'publisher.example',
+      manifest: { authorized_agents: [] },
+    })).rejects.toBe(lockError);
+
+    expect(query).toHaveBeenCalledWith('ROLLBACK');
+    expect(query).not.toHaveBeenCalledWith('COMMIT');
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -7055,6 +7055,25 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "503":
+          description: Publisher lookup exceeded its bounded read deadline
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - publisher_lookup_timeout
+                  retry_after:
+                    type: integer
+                required:
+                  - error
+                  - code
+                  - retry_after
   /api/registry/publisher/{domain}/adagents/revalidate:
     post:
       operationId: revalidatePublisherAdagents
@@ -7424,6 +7443,25 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "503":
+          description: Publisher authorization lookup exceeded its bounded read deadline
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - publisher_lookup_timeout
+                  retry_after:
+                    type: integer
+                required:
+                  - error
+                  - code
+                  - retry_after
   /api/registry/validate/product-authorization:
     post:
       operationId: validateProductAuthorization
@@ -9703,7 +9741,7 @@ paths:
       operationId: requestCrawl
       summary: Request domain re-crawl
       description: |-
-        Trigger an immediate re-crawl of a publisher domain after updating adagents.json. The crawl runs asynchronously — returns 202 immediately.
+        Trigger an immediate re-crawl of a publisher domain after updating adagents.json. The crawl runs asynchronously in the accepting process — returns 202 immediately. The response `crawl_request_id` correlates accepted, running, completed, skipped, and failed lifecycle logs; a 202 does not by itself mean the mirror write completed.
 
         **Rate limits:** 5 minutes per domain, 30 requests per user per hour.
       tags:
@@ -9737,9 +9775,14 @@ paths:
                       - Crawl request accepted
                   domain:
                     type: string
+                  crawl_request_id:
+                    type: string
+                    format: uuid
+                    description: Correlation ID for crawl lifecycle logs; acceptance is not completion.
                 required:
                   - message
                   - domain
+                  - crawl_request_id
         "400":
           description: Invalid domain format, private IP, or unresolvable domain
           content:
@@ -9766,6 +9809,25 @@ paths:
                     description: Seconds to wait before retrying
                 required:
                   - error
+                  - retry_after
+        "503":
+          description: A full crawl is active; the request was not accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - crawl_temporarily_unavailable
+                  retry_after:
+                    type: integer
+                required:
+                  - error
+                  - code
                   - retry_after
   /api/registry/manager-revalidation-request:
     post:


### PR DESCRIPTION
## Summary

- scope publisher property reads to the requested publisher instead of expanding every publisher represented by each authorized agent
- bound publisher read phases, PostgreSQL statements/locks, and single-domain crawl work with typed temporary failures
- make crawl admission and lifecycle observable with correlated request IDs, and prevent full-crawl contention from being reported as successful completion
- preserve last-known-good high-fanout derived profiles while avoiding pathological rebuilds

## Root cause and production evidence

`GET /api/registry/publisher?domain=nofluffadvisory.com` authorized Interchange, then called the global `getPropertiesForAgent(agentUrl)` path and filtered by publisher in TypeScript. Interchange represented 6,844 publisher domains, so one publisher read expanded and sorted the entire agent inventory. Other Interchange publishers such as `07.gg` and `1000logos.net` exhibited the same timeout, while `scope3.com` and `example.com` did not traverse that high-fanout agent and returned normally.

The nofluff mirror rows for both authorized agents were updated at `2026-08-09T14:53:15.951Z`, confirming that core mirror persistence completed. However, the recrawl endpoint previously returned `202` before in-process work was admitted or completed, and had no durable terminal request status. The original accepted request therefore cannot be proven to have completed its full post-write lifecycle.

## Semantics

- Existing last-known-good registry data remains the source of truth for reads.
- A datastore deadline or lock timeout returns typed `503 registry_temporarily_unavailable` with `Retry-After` instead of hanging.
- A crawl request returns `202` only after synchronous admission to the single-domain worker. Full-crawl contention returns typed `503 crawl_temporarily_unavailable`; it is no longer falsely reported as accepted.
- Lifecycle logs distinguish admitted, completed, invalid, deferred, and failed requests by `crawl_request_id`.

## Tests

- focused registry/crawler unit tests: 26 passed
- public endpoint integration tests: 41 passed
- combined registry/crawl integration suites: 95 passed
- catalog scoped integration tests: 20 passed
- full pre-commit suite: 398 files, 5,667 passed, 30 skipped
- TypeScript typecheck and generated OpenAPI checks passed

No changeset is required: this is an operational server fix with no protocol release-surface change.

## Post-rollout verification

- verify bounded publisher GETs for `nofluffadvisory.com`, `07.gg`, and `1000logos.net`
- verify unaffected controls `scope3.com` and `example.com`
- issue one authenticated nofluff recrawl, capture `crawl_request_id`, and confirm mirror verification timestamps advance while reads remain bounded
- confirm both live authorizations (`sell.nofluffadvisory.com` and `interchange.io`) are reflected by the mirror
