### PR TITLE
fix(compliance): treat zero-step specialisms as untested

### DIFF
--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -1063,7 +1063,9 @@ export function computeSpecialismStatus(
       result[specialism] = 'untested';
       continue;
     }
-    if (sbStatus.status === 'passing') {
+    if (sbStatus.steps_total === 0) {
+      result[specialism] = 'untested';
+    } else if (sbStatus.status === 'passing') {
       result[specialism] = 'passing';
     } else if (sbStatus.status === 'failing' || sbStatus.status === 'partial') {
       result[specialism] = 'failing';

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -1026,6 +1026,7 @@ export interface VerificationResult {
     specialisms: string[];
     passing: string[];
     failing: string[];
+    untested: string[];
   }>;
 }
 
@@ -1115,10 +1116,13 @@ export function deriveVerificationStatus(
   for (const [role, specialisms] of protocolSpecialisms) {
     const passing: string[] = [];
     const failing: string[] = [];
+    const untested: string[] = [];
     for (const specialism of specialisms) {
       const info = SPECIALISM_CATALOG[specialism];
       const status = info ? statusMap.get(info.storyboard_id) : undefined;
-      if (status?.status === 'passing') {
+      if (status?.steps_total === 0) {
+        untested.push(specialism);
+      } else if (status?.status === 'passing') {
         passing.push(specialism);
       } else {
         failing.push(specialism);
@@ -1126,10 +1130,11 @@ export function deriveVerificationStatus(
     }
     roles.push({
       role,
-      verified: failing.length === 0 && passing.length > 0,
+      verified: failing.length === 0 && untested.length === 0 && passing.length > 0,
       specialisms,
       passing,
       failing,
+      untested,
     });
   }
 

--- a/server/src/services/badge-issuance.ts
+++ b/server/src/services/badge-issuance.ts
@@ -166,15 +166,19 @@ export async function processAgentBadges(
       if (existing.status === 'active') {
         await complianceDb.degradeBadge(agentUrl, roleResult.role, adcpVersion);
         result.degraded.push({ role: roleResult.role, adcp_version: adcpVersion });
-        logger.info({ agentUrl, role: roleResult.role, adcpVersion, failing: roleResult.failing }, 'Badge degraded');
+        logger.info({ agentUrl, role: roleResult.role, adcpVersion, failing: roleResult.failing, untested: roleResult.untested }, 'Badge degraded');
       } else if (existing.status === 'degraded') {
         const degradedAt = existing.updated_at;
         const hoursSinceDegraded = (Date.now() - degradedAt.getTime()) / (1000 * 60 * 60);
 
         if (hoursSinceDegraded >= 48) {
-          await complianceDb.revokeBadge(agentUrl, roleResult.role, adcpVersion, `Specialisms failing for 48+ hours: ${roleResult.failing.join(', ')}`);
-          result.revoked.push({ role: roleResult.role, reason: `Failing specialisms: ${roleResult.failing.join(', ')}`, adcp_version: adcpVersion });
-          logger.info({ agentUrl, role: roleResult.role, adcpVersion, failing: roleResult.failing }, 'Badge revoked after 48h grace');
+          const reason = [
+            roleResult.failing.length > 0 ? `Failing specialisms: ${roleResult.failing.join(', ')}` : undefined,
+            roleResult.untested.length > 0 ? `Untested specialisms: ${roleResult.untested.join(', ')}` : undefined,
+          ].filter(Boolean).join('; ');
+          await complianceDb.revokeBadge(agentUrl, roleResult.role, adcpVersion, `${reason} for 48+ hours`);
+          result.revoked.push({ role: roleResult.role, reason, adcp_version: adcpVersion });
+          logger.info({ agentUrl, role: roleResult.role, adcpVersion, failing: roleResult.failing, untested: roleResult.untested }, 'Badge revoked after 48h grace');
         } else {
           result.unchanged.push({ role: roleResult.role, adcp_version: adcpVersion });
         }

--- a/server/tests/unit/badge-issuance.test.ts
+++ b/server/tests/unit/badge-issuance.test.ts
@@ -163,6 +163,35 @@ describe('processAgentBadges — membership gating', () => {
     expect(result.revoked[0].reason).toMatch(/Failing specialisms/);
   });
 
+  it('reports a zero-step specialism as untested when revoking after the grace period', async () => {
+    const existing = [makeBadge('media-buy', 'degraded', 49 * 60 * 60 * 1000)];
+    const db = makeMockDb(existing);
+    const untestedStatus = {
+      ...makeStatus('sales_broadcast_tv', 'failing'),
+      steps_total: 0,
+    };
+
+    const result = await processAgentBadges(
+      db,
+      'https://example.com/mcp',
+      ['sales-broadcast-tv'],
+      [untestedStatus],
+      false,
+      'org_test',
+    );
+
+    expect(result.revoked).toEqual([expect.objectContaining({
+      role: 'media-buy',
+      reason: 'Untested specialisms: sales-broadcast-tv',
+    })]);
+    expect(db.revokeBadge).toHaveBeenCalledWith(
+      'https://example.com/mcp',
+      'media-buy',
+      '3.0',
+      'Untested specialisms: sales-broadcast-tv for 48+ hours',
+    );
+  });
+
   it('keeps a degraded badge unchanged within the 48-hour grace period', async () => {
     const existing = [makeBadge('media-buy', 'degraded', 10 * 60 * 60 * 1000)];
     const db = makeMockDb(existing);

--- a/server/tests/unit/specialism-status.test.ts
+++ b/server/tests/unit/specialism-status.test.ts
@@ -39,6 +39,14 @@ describe('computeSpecialismStatus', () => {
     expect(result).toEqual({ 'sales-broadcast-tv': 'untested' });
   });
 
+  it('returns untested for a legacy failing row with no executable steps', () => {
+    const result = computeSpecialismStatus(
+      ['sales-broadcast-tv'],
+      [{ storyboard_id: 'sales_broadcast_tv', status: 'failing', steps_passed: 0, steps_total: 0 }],
+    );
+    expect(result).toEqual({ 'sales-broadcast-tv': 'untested' });
+  });
+
   it('returns unknown for specialisms not in SPECIALISM_CATALOG', () => {
     const result = computeSpecialismStatus(
       ['some-future-specialism'],

--- a/server/tests/unit/verification-status.test.ts
+++ b/server/tests/unit/verification-status.test.ts
@@ -50,6 +50,23 @@ describe('deriveVerificationStatus', () => {
     expect(result.roles[0].failing).toEqual(['sales-non-guaranteed']);
   });
 
+  it('keeps a legacy zero-step row untested while denying badge eligibility', () => {
+    const declared = ['sales-non-guaranteed'];
+    const statuses: StoryboardStatusEntry[] = [{
+      storyboard_id: 'sales_non_guaranteed',
+      status: 'failing',
+      steps_passed: 0,
+      steps_total: 0,
+    }];
+    const result = deriveVerificationStatus(declared, statuses);
+
+    expect(result.verified).toBe(false);
+    expect(result.roles[0].verified).toBe(false);
+    expect(result.roles[0].passing).toEqual([]);
+    expect(result.roles[0].failing).toEqual([]);
+    expect(result.roles[0].untested).toEqual(['sales-non-guaranteed']);
+  });
+
   it('handles multiple protocols when specialisms from different protocols all pass', () => {
     const declared = ['sales-non-guaranteed', 'creative-template'];
     const statuses = [


### PR DESCRIPTION
Closes #6302

## Summary
- treat specialism storyboard results with `steps_total: 0` as untested, even when a legacy row says failing
- keep badge eligibility fail-closed while reporting zero-step specialisms as untested rather than failing
- preserve the existing dashboard handling for untested status; no client change is needed
- cover dashboard status, badge derivation, and badge revocation behavior with focused tests

## Validation
- 36 focused compliance/badge tests passed
- `npm run typecheck`
- `git diff --check`
- push policy checks
- full pre-commit: 5,655 passed; 3 unrelated cross-file-order failures in `replace-subscription.test.ts`; the full 23-test file passes in isolation