### PR TITLE
test(oauth): grade metadata vectors through SDK

### DIFF
--- a/tests/oauth-setup-vectors.test.cjs
+++ b/tests/oauth-setup-vectors.test.cjs
@@ -4,6 +4,9 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
+const {
+  gradeOAuthMetadataGraphVector,
+} = require('@adcp/sdk/testing');
 const yaml = require('js-yaml');
 
 const ROOT = path.join(__dirname, '..');
@@ -198,5 +201,15 @@ test('every advertised token endpoint in a positive vector has a passive GET fix
         `${vector.id} must probe advertised token endpoint ${tokenEndpoint}`,
       );
     }
+  }
+});
+
+test('installed SDK grades every OAuth metadata graph vector exactly', async (t) => {
+  for (const vector of [...vectors.positive, ...vectors.negative]) {
+    await t.test(vector.id, async () => {
+      const grade = await gradeOAuthMetadataGraphVector(vector);
+      assert.equal(grade.success, vector.expected_outcome.success);
+      assert.equal(grade.error_code, vector.expected_outcome.error_code);
+    });
   }
 });


### PR DESCRIPTION
Adds a consumer-contract test that grades every canonical OAuth metadata graph vector through the installed `@adcp/sdk` testing export. It asserts the exact success verdict and stable primary error code for each positive and negative vector, with named subtests for actionable CI failures. This ensures SDK rc.11 remains aligned with the protocol-owned conformance corpus. Validated by the full pre-commit suite, typecheck, and all 34 SDK vector cases.
