### PR TITLE
feat(registry): make publisher recrawls durable

### DIFF
--- a/docs/building/operating/support-recovery-runbooks.mdx
+++ b/docs/building/operating/support-recovery-runbooks.mdx
@@ -128,12 +128,45 @@ terminal `failed` request, correct the reported error category and submit a new
 crawl request after the per-domain rate-limit window; the old request remains
 as the audit record.
 
+Workers claim no more requests than they can start immediately. Each active
+publisher crawl holds a PostgreSQL shared global execution lock and an
+exclusive per-domain lock for the fetch/write lifecycle; the periodic full
+crawl holds the exclusive global lock. These session locks use dedicated
+connections outside the application pool, so crawl concurrency does not consume
+the connections needed by heartbeats, status reads, or mirror transactions. The
+locks prevent an expired or duplicate attempt from overwriting newer mirror
+state. The mirror transaction
+also verifies the current request lease token before committing. Publisher GET
+requests do not acquire these locks and continue to serve the last committed
+mirror state while crawling is delayed or unavailable.
+
+Dedicated lock-session operations are bounded at 10 seconds. The periodic full
+crawl may wait up to two minutes for the global lock, plus the 10-second
+database-operation margin. A missed keepalive or unlock deadline invalidates
+the lock and forcibly closes its dedicated connection so a wedged socket cannot
+hold a queue worker or request lease indefinitely.
+
+For the first deployment, use Fly's `immediate` strategy and leave
+`PUBLISHER_CRAWL_QUEUE_ENABLED=false`. Immediate replacement prevents an old
+image, which does not participate in the new PostgreSQL execution locks, from
+overlapping a new worker. After every machine runs the lock-participating image,
+set the gate to `true` and restart that image before accepting requests. Keep
+that consumer-capable image available for rollback; rolling back to an older
+image pauses queued work and removes status lookup until the new image is
+restored, but does not delete committed requests. Restore the normal rolling
+strategy only after every deployable image participates in these locks.
+
+Admission returns `crawl_queue_at_capacity` with `503` and `Retry-After` when
+10,000 active requests are already queued or running. This is backpressure, not
+acceptance; retry later rather than inserting or editing queue rows manually.
+
 Operational logs include `crawl_request_id`, attempt count,
-`accepted_to_terminal_ms`, queue depth, oldest-active age, and expired-lease
-count. A `Publisher crawl request queue requires attention` warning means a
-lease is expired or an active request is older than five minutes. Confirm that
-the worker process is healthy, then use the status endpoint to determine
-whether the request recovered before escalating.
+`accepted_to_terminal_ms`, queue depth, oldest-due lateness, reclaimed-lease
+count, and final-attempt lease expirations. A `Publisher crawl request queue
+requires attention` warning means a lease is expired or due work is more than
+five minutes late; requests intentionally waiting in retry backoff do not
+trigger it. Confirm that the worker process is healthy, then use the status
+endpoint to determine whether the request recovered before escalating.
 
 For brand manifests, use the same body shape:
 

--- a/docs/building/operating/support-recovery-runbooks.mdx
+++ b/docs/building/operating/support-recovery-runbooks.mdx
@@ -100,8 +100,40 @@ curl -X POST "https://agenticadvertising.org/api/registry/crawl-request" \
 Expected accepted response:
 
 ```json
-{ "message": "Crawl request accepted", "domain": "example.publisher" }
+{
+  "message": "Crawl request accepted",
+  "domain": "example.publisher",
+  "crawl_request_id": "8d127de4-5568-4756-b66c-dd9b0780fd8f"
+}
 ```
+
+Acceptance means the request was committed to the durable PostgreSQL queue; it
+does not mean the crawl has completed. Check the request with the same member
+or admin session:
+
+```bash
+CRAWL_REQUEST_ID="8d127de4-5568-4756-b66c-dd9b0780fd8f"
+curl "https://agenticadvertising.org/api/registry/crawl-request/$CRAWL_REQUEST_ID" \
+  -b "$SESSION_COOKIE"
+```
+
+The lifecycle is `queued` → `running` → `completed` or `invalid`. Transient
+failures move through `retrying`; full-crawl contention produces `deferred`
+without consuming an attempt. `failed` is terminal after the bounded retry
+budget. Request history is retained for 30 days.
+
+If a worker exits while a request is running, its two-minute lease expires and
+another worker reclaims the request. Do not manually change queue rows. For a
+terminal `failed` request, correct the reported error category and submit a new
+crawl request after the per-domain rate-limit window; the old request remains
+as the audit record.
+
+Operational logs include `crawl_request_id`, attempt count,
+`accepted_to_terminal_ms`, queue depth, oldest-active age, and expired-lease
+count. A `Publisher crawl request queue requires attention` warning means a
+lease is expired or an active request is older than five minutes. Confirm that
+the worker process is healthy, then use the status endpoint to determine
+whether the request recovered before escalating.
 
 For brand manifests, use the same body shape:
 

--- a/fly.toml
+++ b/fly.toml
@@ -12,7 +12,9 @@ primary_region = 'iad'
 [deploy]
   release_command = "node dist/db/migrate.js"
   release_command_timeout = "15m"
-  strategy = "rolling"
+  # One-time safety requirement for migration 540: old images do not
+  # participate in the new PostgreSQL crawl-execution locks.
+  strategy = "immediate"
 
 [processes]
   web = "node dist/index.js"
@@ -23,6 +25,9 @@ primary_region = 'iad'
   BASE_URL = "https://agenticadvertising.org"
   # Disabled - migrations now run via release_command
   RUN_MIGRATIONS = "false"
+  # Two-phase rollout gate. Enable only after every machine runs a
+  # lock-participating queue consumer; a Fly secret may override this value.
+  PUBLISHER_CRAWL_QUEUE_ENABLED = "false"
   # Use pre-cloned repos from Docker build, skip runtime git fetch.
   # Production image has no git binary — unsetting this degrades gracefully
   # (repos skip indexing) but does not crash.
@@ -90,4 +95,3 @@ primary_region = 'iad'
   memory = "4gb"
   cpu_kind = "performance"
   cpus = 2
-

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -1,4 +1,5 @@
 import type { Agent, FederatedAgent } from "./types.js";
+import type { Client } from "pg";
 import { PropertyCrawler, getPropertyIndex, type AgentInfo, type CrawlResult } from "@adcp/sdk";
 import { sanitizeAdagentsProperty } from "./discovery/property-index-guard.js";
 import { FederatedIndexService } from "./federated-index.js";
@@ -6,7 +7,14 @@ import type { DiscoveredAgent } from "./db/federated-index-db.js";
 import { AdAgentsManager, type AdAgentsValidationResult } from "./adagents-manager.js";
 import { BrandManager, type BrandValidationResult } from "./brand-manager.js";
 import { BrandDatabase } from "./db/brand-db.js";
-import { PublisherDatabase, adagentsChangedFields, canonicalizeAgentUrl, type AdagentsManifest, type AdagentsAuthorizedAgent } from "./db/publisher-db.js";
+import {
+  PublisherCrawlLeaseLostError,
+  PublisherDatabase,
+  adagentsChangedFields,
+  canonicalizeAgentUrl,
+  type AdagentsManifest,
+  type AdagentsAuthorizedAgent,
+} from "./db/publisher-db.js";
 import { canonicalizePublisherDomain } from "./services/publisher-domain.js";
 import { MemberDatabase } from "./db/member-db.js";
 import { CapabilityDiscovery } from "./capabilities.js";
@@ -18,7 +26,7 @@ import { AAO_UA_DISCOVERY } from "./config/user-agents.js";
 import { createLogger } from "./logger.js";
 import type { CatalogEventsDatabase, WriteEventInput } from "./db/catalog-events-db.js";
 import type { AgentInventoryProfilesDatabase, ProfileUpsertInput } from "./db/agent-inventory-profiles-db.js";
-import { query, withDatabaseDeadline } from "./db/client.js";
+import { getDedicatedClient, query, withDatabaseDeadline } from "./db/client.js";
 import { PropertyDatabase } from "./db/property-db.js";
 import { verifyHostedPropertyOrigin } from "./services/hosted-property-origin-verifier.js";
 import { insertTypeReclassification } from "./db/type-reclassification-log-db.js";
@@ -38,14 +46,18 @@ const log = createLogger('crawler');
 // point. A dedicated aggregate profile query can replace this guard later.
 const INVENTORY_PROFILE_PUBLISHER_FANOUT_CAP = 1_000;
 const SINGLE_DOMAIN_CRAWL_DB_DEADLINE_MS = 60_000;
-const PUBLISHER_CRAWL_QUEUE_BATCH_SIZE = 10;
 const PUBLISHER_CRAWL_QUEUE_CONCURRENCY = 4;
 const PUBLISHER_CRAWL_LEASE_MS = 2 * 60_000;
 const PUBLISHER_CRAWL_HEARTBEAT_MS = 30_000;
 const PUBLISHER_CRAWL_DEFER_MS = 30_000;
 const PUBLISHER_CRAWL_RETENTION_MS = 30 * 24 * 60 * 60_000;
+const CRAWL_EXECUTION_LOCK_OPERATION_TIMEOUT_MS = 10_000;
 
 export type SingleDomainCrawlOutcome = 'completed' | 'invalid';
+
+export function isPublisherCrawlQueueEnabled(): boolean {
+  return process.env.PUBLISHER_CRAWL_QUEUE_ENABLED === 'true';
+}
 
 function unknownClassificationProbeDue(
   snapshot: AgentCapabilitiesSnapshotRow | undefined,
@@ -115,6 +127,22 @@ export interface PublisherAdagentsRevalidationResult {
 export interface SingleDomainCrawlContext {
   requestId?: string;
   source?: string;
+  leaseToken?: string;
+  isLeaseValid?: () => boolean;
+}
+
+interface CrawlExecutionLock {
+  isValid(): boolean;
+  release(): Promise<void>;
+}
+
+class CrawlExecutionLockLostError extends Error {
+  readonly code = 'crawl_execution_lock_lost';
+
+  constructor() {
+    super('Crawl execution lock ownership was lost');
+    this.name = 'CrawlExecutionLockLostError';
+  }
 }
 
 export class CrawlerService {
@@ -123,6 +151,7 @@ export class CrawlerService {
   private lastCrawl: Date | null = null;
   private lastResult: CrawlResult | null = null;
   private intervalId: NodeJS.Timeout | null = null;
+  private fullCrawlLockRetryTimer: NodeJS.Timeout | null = null;
   private federatedIndex: FederatedIndexService;
   private adAgentsManager: AdAgentsManager;
   private brandManager: BrandManager;
@@ -137,6 +166,8 @@ export class CrawlerService {
   private profilesDb?: AgentInventoryProfilesDatabase;
   private crawlRequestsDb: PublisherCrawlRequestsDatabase;
   private publisherCrawlWorkerId: string;
+  private coordinateCrawlsAcrossInstances: boolean;
+  private crawlLockClientFactory?: () => Promise<Client>;
 
   constructor(options?: {
     eventsDb?: CatalogEventsDatabase;
@@ -158,9 +189,153 @@ export class CrawlerService {
     this.eventsDb = options?.eventsDb;
     this.profilesDb = options?.profilesDb;
     this.crawlRequestsDb = options?.crawlRequestsDb ?? new PublisherCrawlRequestsDatabase();
+    this.coordinateCrawlsAcrossInstances = true;
     this.publisherCrawlWorkerId = options?.crawlWorkerId
       ?? process.env.FLY_MACHINE_ID
       ?? `worker-${process.pid}-${Date.now().toString(36)}`;
+  }
+
+  private async tryAcquireCrawlExecutionLock(
+    domain?: string,
+    waitMs: number = 0,
+  ): Promise<CrawlExecutionLock | null> {
+    const client: Client = await (this.crawlLockClientFactory
+      ? this.crawlLockClientFactory()
+      : getDedicatedClient());
+    const globalKey = 'registry:crawl-execution';
+    const publisherKey = domain ? `registry:publisher:${canonicalizePublisherDomain(domain)}` : null;
+    let lockConnectionValid = true;
+    let keepaliveInFlight = false;
+    const onConnectionError = (error: Error) => {
+      if (!lockConnectionValid) return;
+      lockConnectionValid = false;
+      log.error({ error, domain }, 'Crawl execution lock connection failed; ownership lost');
+    };
+    const destroyConnection = (): void => {
+      if (!client.connection.stream.destroyed) client.connection.stream.destroy();
+    };
+    const runBounded = async <T>(
+      operation: () => Promise<T>,
+      label: string,
+      timeoutMs: number = CRAWL_EXECUTION_LOCK_OPERATION_TIMEOUT_MS,
+    ): Promise<T> => {
+      let timeout: NodeJS.Timeout | undefined;
+      const deadline = new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          const error = Object.assign(
+            new Error(`Crawl execution lock ${label} exceeded ${timeoutMs}ms`),
+            { code: 'crawl_lock_operation_timeout' },
+          );
+          onConnectionError(error);
+          destroyConnection();
+          reject(error);
+        }, timeoutMs);
+      });
+      try {
+        return await Promise.race([operation(), deadline]);
+      } finally {
+        if (timeout) clearTimeout(timeout);
+      }
+    };
+    const closeClient = async (): Promise<void> => {
+      try {
+        await runBounded(() => client.end(), 'connection close');
+      } catch {
+        destroyConnection();
+      }
+    };
+    client.on('error', onConnectionError);
+    try {
+      if (!domain && waitMs > 0) {
+        await runBounded(() => client.query("SELECT set_config('lock_timeout', $1, false)", [
+          `${Math.max(1, Math.min(waitMs, 300_000))}ms`,
+        ]), 'lock timeout setup');
+        await runBounded(
+          () => client.query('SELECT pg_advisory_lock(hashtextextended($1, 0))', [globalKey]),
+          'global lock acquisition',
+          Math.min(waitMs + CRAWL_EXECUTION_LOCK_OPERATION_TIMEOUT_MS, 310_000),
+        );
+      }
+      const global = !domain && waitMs > 0
+        ? { rows: [{ acquired: true }] }
+        : await runBounded(() => client.query<{ acquired: boolean }>(
+            domain
+              ? 'SELECT pg_try_advisory_lock_shared(hashtextextended($1, 0)) AS acquired'
+              : 'SELECT pg_try_advisory_lock(hashtextextended($1, 0)) AS acquired',
+            [globalKey],
+          ), 'global lock acquisition');
+      if (!global.rows[0]?.acquired) {
+        client.off('error', onConnectionError);
+        await closeClient();
+        return null;
+      }
+
+      if (publisherKey) {
+        const publisher = await runBounded(() => client.query<{ acquired: boolean }>(
+          'SELECT pg_try_advisory_lock(hashtextextended($1, 0)) AS acquired',
+          [publisherKey],
+        ), 'publisher lock acquisition');
+        if (!publisher.rows[0]?.acquired) {
+          await runBounded(
+            () => client.query('SELECT pg_advisory_unlock_shared(hashtextextended($1, 0))', [globalKey]),
+            'global lock release after contention',
+          );
+          client.off('error', onConnectionError);
+          await closeClient();
+          return null;
+        }
+      }
+
+      let released = false;
+      const keepalive = setInterval(() => {
+        if (keepaliveInFlight || !lockConnectionValid) return;
+        keepaliveInFlight = true;
+        runBounded(() => client.query('SELECT 1'), 'keepalive')
+          .catch((error) => onConnectionError(error instanceof Error ? error : new Error('Lock keepalive failed')))
+          .finally(() => { keepaliveInFlight = false; });
+      }, 15_000);
+      keepalive.unref();
+      return {
+        isValid: () => lockConnectionValid,
+        release: async () => {
+          if (released) return;
+          released = true;
+          clearInterval(keepalive);
+          try {
+            if (publisherKey) {
+              await runBounded(
+                () => client.query('SELECT pg_advisory_unlock(hashtextextended($1, 0))', [publisherKey]),
+                'publisher lock release',
+              );
+              await runBounded(
+                () => client.query('SELECT pg_advisory_unlock_shared(hashtextextended($1, 0))', [globalKey]),
+                'global lock release',
+              );
+            } else {
+              await runBounded(
+                () => client.query('SELECT pg_advisory_unlock(hashtextextended($1, 0))', [globalKey]),
+                'global lock release',
+              );
+              if (waitMs > 0) {
+                await runBounded(() => client.query('RESET lock_timeout'), 'lock timeout reset');
+              }
+            }
+          } catch (error) {
+            log.error({ error, domain }, 'Failed to release crawl execution lock; connection discarded');
+          } finally {
+            client.off('error', onConnectionError);
+            await closeClient();
+          }
+        },
+      };
+    } catch (error) {
+      client.off('error', onConnectionError);
+      await closeClient();
+      if (error && typeof error === 'object' && 'code' in error && error.code === '55P03') {
+        return null;
+      }
+      throw error;
+    }
   }
 
   /**
@@ -188,6 +363,30 @@ export class CrawlerService {
       log.debug('Crawl already in progress, skipping');
       return this.lastResult || this.emptyResult();
     }
+
+    const executionLock = this.coordinateCrawlsAcrossInstances
+      ? await this.tryAcquireCrawlExecutionLock(undefined, PUBLISHER_CRAWL_LEASE_MS)
+      : null;
+    if (this.coordinateCrawlsAcrossInstances && !executionLock) {
+      log.warn('Another crawl owns the global execution lock; retrying full crawl shortly');
+      if (!this.fullCrawlLockRetryTimer) {
+        this.fullCrawlLockRetryTimer = setTimeout(() => {
+          this.fullCrawlLockRetryTimer = null;
+          this.crawlAllAgents(agents).catch((err) => {
+            log.error({ err }, 'Full crawl execution-lock retry failed');
+          });
+        }, 30_000);
+        this.fullCrawlLockRetryTimer.unref();
+      }
+      return this.lastResult || this.emptyResult();
+    }
+    if (this.fullCrawlLockRetryTimer) {
+      clearTimeout(this.fullCrawlLockRetryTimer);
+      this.fullCrawlLockRetryTimer = null;
+    }
+    const assertExecutionLock = (): void => {
+      if (executionLock && !executionLock.isValid()) throw new CrawlExecutionLockLostError();
+    };
 
     this.crawling = true;
 
@@ -254,6 +453,7 @@ export class CrawlerService {
     }
 
       const result = await this.crawler.crawlAgents(agentInfos);
+      assertExecutionLock();
 
       this.lastCrawl = new Date();
       this.lastResult = result;
@@ -282,10 +482,12 @@ export class CrawlerService {
 
       // Snapshot pre-crawl state for diffing
       const preCrawlAgents = await this.snapshotAgentState();
+      assertExecutionLock();
 
       // Populate federated index from PropertyIndex and adagents.json files,
       // including any publisher-domain claims returned by sales_candidate probes.
-      const crawledDomains = await this.populateFederatedIndex(agents);
+      const crawledDomains = await this.populateFederatedIndex(agents, assertExecutionLock);
+      assertExecutionLock();
 
       // Promote or back off sales_candidates based on positive PropertyIndex evidence.
       // Absence of an error is not sufficient — the agent must have returned publisher-domain
@@ -293,6 +495,7 @@ export class CrawlerService {
       if (salesCandidates.length > 0) {
         const index = getPropertyIndex();
         for (const candidate of salesCandidates) {
+          assertExecutionLock();
           const auth = index.getAgentAuthorizations(candidate.agent_url);
           try {
             if (auth && auth.publisher_domains.length > 0) {
@@ -311,22 +514,35 @@ export class CrawlerService {
       }
 
       // Build and upsert inventory profiles
+      assertExecutionLock();
       const builtProfiles = await this.buildInventoryProfiles();
 
       // Diff and produce events (after profiles are built so discovery events include profile data)
+      assertExecutionLock();
       await this.produceEventsFromDiff(preCrawlAgents, builtProfiles);
 
       // Scan brand.json for all crawled domains + all hosted brand domains
       const hostedDomains = await this.brandDb.listAllHostedBrandDomains();
       const brandDomains = [...new Set([...crawledDomains, ...hostedDomains])];
-      await this.scanBrandsForDomains(brandDomains);
+      assertExecutionLock();
+      await this.scanBrandsForDomains(brandDomains, assertExecutionLock);
 
       return result;
     } catch (error) {
       log.error({ err: error }, 'Crawl failed');
+      if (error instanceof CrawlExecutionLockLostError && !this.fullCrawlLockRetryTimer) {
+        this.fullCrawlLockRetryTimer = setTimeout(() => {
+          this.fullCrawlLockRetryTimer = null;
+          this.crawlAllAgents(agents).catch((err) => {
+            log.error({ err }, 'Full crawl lock-loss retry failed');
+          });
+        }, 30_000);
+        this.fullCrawlLockRetryTimer.unref();
+      }
       throw error;
     } finally {
       this.crawling = false;
+      await executionLock?.release();
     }
   }
 
@@ -349,6 +565,10 @@ export class CrawlerService {
       clearInterval(this.intervalId);
       this.intervalId = null;
       log.info('Periodic crawl stopped');
+    }
+    if (this.fullCrawlLockRetryTimer) {
+      clearTimeout(this.fullCrawlLockRetryTimer);
+      this.fullCrawlLockRetryTimer = null;
     }
   }
 
@@ -403,13 +623,14 @@ export class CrawlerService {
   /**
    * Scan a single domain for brand.json and upsert discovered/verified brand data.
    */
-  async scanBrandForDomain(domain: string): Promise<{
+  async scanBrandForDomain(domain: string, assertExecutionLock?: () => void): Promise<{
     found: boolean;
     valid: boolean;
     variant: BrandValidationResult['variant'] | null;
     manifestPersisted: boolean;
   }> {
     const result = await this.brandManager.validateDomain(domain, { skipCache: true });
+    assertExecutionLock?.();
     if (!result.valid || !result.raw_data) {
       return {
         found: result.status_code !== undefined && result.status_code !== 404,
@@ -551,15 +772,20 @@ export class CrawlerService {
     }
   }
 
-  private async scanBrandsForDomains(domains: string[]): Promise<void> {
+  private async scanBrandsForDomains(
+    domains: string[],
+    assertExecutionLock?: () => void,
+  ): Promise<void> {
     const CONCURRENCY = 5;
     log.debug({ domainCount: domains.length }, 'Scanning brand.json');
 
     for (let i = 0; i < domains.length; i += CONCURRENCY) {
       await Promise.all(domains.slice(i, i + CONCURRENCY).map(async (domain) => {
         try {
-          await this.scanBrandForDomain(domain);
+          assertExecutionLock?.();
+          await this.scanBrandForDomain(domain, assertExecutionLock);
         } catch (err) {
+          if (err instanceof CrawlExecutionLockLostError) throw err;
           log.warn({ domain, err: err instanceof Error ? err.message : err }, 'Brand scan failed');
         }
       }));
@@ -597,7 +823,10 @@ export class CrawlerService {
    * This is called after the PropertyCrawler finishes to persist data to PostgreSQL.
    * Returns the set of domains that were crawled (for brand scanning).
    */
-  private async populateFederatedIndex(agents: Agent[]): Promise<Set<string>> {
+  private async populateFederatedIndex(
+    agents: Agent[],
+    assertExecutionLock: () => void = () => undefined,
+  ): Promise<Set<string>> {
     log.debug('Populating federated index');
     const index = getPropertyIndex();
 
@@ -626,6 +855,7 @@ export class CrawlerService {
 
         try {
           const validation = await this.adAgentsManager.validateDomain(pubConfig.domain);
+          assertExecutionLock();
           processedDomains.add(pubConfig.domain);
 
           if (validation.valid && validation.raw_data?.authorized_agents) {
@@ -647,6 +877,7 @@ export class CrawlerService {
 
             // Record agents
             for (const authorizedAgent of validation.raw_data.authorized_agents) {
+              assertExecutionLock();
               if (!authorizedAgent.url) continue;
 
               await this.federatedIndex.recordAgentFromAdagentsJson(
@@ -698,6 +929,7 @@ export class CrawlerService {
             });
           }
         } catch (err) {
+          if (err instanceof CrawlExecutionLockLostError) throw err;
           log.warn({ domain: pubConfig.domain, err: err instanceof Error ? err.message : err }, 'Publisher crawl failed');
         }
       }
@@ -715,6 +947,7 @@ export class CrawlerService {
         try {
           // Check if domain has valid adagents.json
           const validation = await this.adAgentsManager.validateDomain(domain);
+          assertExecutionLock();
           await this.federatedIndex.recordPublisherFromAgent(
             domain,
             agent.url,
@@ -739,6 +972,7 @@ export class CrawlerService {
             );
 
             for (const authorizedAgent of validation.raw_data.authorized_agents) {
+              assertExecutionLock();
               if (!authorizedAgent.url) continue;
 
               await this.federatedIndex.recordAgentFromAdagentsJson(
@@ -765,6 +999,7 @@ export class CrawlerService {
             await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
           }
         } catch (err) {
+          if (err instanceof CrawlExecutionLockLostError) throw err;
           log.error({ domain, err }, 'Failed to process domain');
         }
       }
@@ -784,6 +1019,7 @@ export class CrawlerService {
         for (const domain of auth.publisher_domains) {
           try {
             const validation = await this.adAgentsManager.validateDomain(domain);
+            assertExecutionLock();
             // Always write the agent_claim row so this discovered agent's authorization
             // edge is recorded even when the domain was already processed by step 1/2.
             await this.federatedIndex.recordPublisherFromAgent(domain, da.agent_url, validation.valid);
@@ -802,6 +1038,7 @@ export class CrawlerService {
               });
 
               for (const authorizedAgent of validation.raw_data.authorized_agents) {
+                assertExecutionLock();
                 if (!authorizedAgent.url) continue;
                 await this.federatedIndex.recordAgentFromAdagentsJson(
                   authorizedAgent.url, domain,
@@ -822,16 +1059,19 @@ export class CrawlerService {
               await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
             }
           } catch (err) {
+            if (err instanceof CrawlExecutionLockLostError) throw err;
             log.error({ domain, agentUrl: da.agent_url, err }, 'Failed to process DB-discovered sales agent domain');
           }
         }
       }
     } catch (err) {
+      if (err instanceof CrawlExecutionLockLostError) throw err;
       log.warn({ err }, 'Failed to process DB-discovered sales agents; skipping step 2b');
     }
 
     // Log stats
     try {
+      assertExecutionLock();
       const stats = await this.federatedIndex.getStats();
       log.info({
         agents: stats.discovered_agents,
@@ -1258,6 +1498,8 @@ export class CrawlerService {
       managerDomain?: string;
       eventActor?: string;
       eventSource?: string;
+      crawlRequestId?: string;
+      crawlRequestLeaseToken?: string;
     },
   ): Promise<boolean> {
     try {
@@ -1278,6 +1520,8 @@ export class CrawlerService {
           : 'pipeline:catalog_crawl',
         publisherEventActor: meta?.eventActor,
         publisherEventSource: meta?.eventSource,
+        crawlRequestId: meta?.crawlRequestId,
+        crawlRequestLeaseToken: meta?.crawlRequestLeaseToken,
       });
 
       // The writer atomically enqueues MANAGERDOMAIN dependants with the
@@ -1290,6 +1534,8 @@ export class CrawlerService {
       }
       return true;
     } catch (err) {
+      if (err instanceof CrawlExecutionLockLostError) throw err;
+      if (err instanceof PublisherCrawlLeaseLostError) throw err;
       log.warn({ domain, err: err instanceof Error ? err.message : err }, 'Publisher cache write failed');
       return false;
     }
@@ -1484,11 +1730,28 @@ export class CrawlerService {
     options: { force?: boolean } = {},
   ): Promise<PublisherAdagentsRevalidationResult> {
     const normalizedDomain = canonicalizePublisherDomain(domain);
+    const executionLock = this.coordinateCrawlsAcrossInstances
+      ? await this.tryAcquireCrawlExecutionLock(normalizedDomain)
+      : null;
+    if (this.coordinateCrawlsAcrossInstances && !executionLock) {
+      throw Object.assign(new Error('Another crawl owns this publisher'), {
+        code: 'crawl_deferred',
+      });
+    }
+    const assertExecutionLock = (): void => {
+      if (executionLock && !executionLock.isValid()) {
+        throw Object.assign(new Error('Publisher crawl execution lock was lost'), {
+          code: 'crawl_execution_lock_lost',
+        });
+      }
+    };
+    try {
     if (options.force) {
       log.info({ domain: normalizedDomain }, 'Force revalidation requested; live origin validation is always performed');
     }
     const checkedAt = new Date();
     const validation = await this.adAgentsManager.validateDomain(normalizedDomain);
+    assertExecutionLock();
     const persisted = await this.persistPublisherAdagentsValidation(
       normalizedDomain,
       validation,
@@ -1502,6 +1765,7 @@ export class CrawlerService {
     }
 
     if (persisted.affectedAgentUrls.size > 0) {
+      assertExecutionLock();
       await this.buildInventoryProfiles({
         agentUrls: [...persisted.affectedAgentUrls],
         deleteStale: false,
@@ -1509,6 +1773,9 @@ export class CrawlerService {
     }
 
     return this.summarizePublisherAdagentsRevalidation(normalizedDomain, validation, checkedAt);
+    } finally {
+      await executionLock?.release();
+    }
   }
 
   /**
@@ -2041,6 +2308,26 @@ export class CrawlerService {
       });
     }
 
+    const executionLock = this.coordinateCrawlsAcrossInstances
+      ? await this.tryAcquireCrawlExecutionLock(domain)
+      : null;
+    if (this.coordinateCrawlsAcrossInstances && !executionLock) {
+      throw Object.assign(new Error('Another crawl owns this publisher'), {
+        code: 'crawl_deferred',
+      });
+    }
+
+    const assertLease = (): void => {
+      if (executionLock && !executionLock.isValid()) {
+        throw Object.assign(new Error('Publisher crawl execution lock was lost'), {
+          code: 'crawl_execution_lock_lost',
+        });
+      }
+      if (context.isLeaseValid && !context.isLeaseValid()) {
+        throw Object.assign(new PublisherCrawlLeaseLostError(), { code: 'crawl_lease_lost' });
+      }
+    };
+
     log.info(
       { ...lifecycleContext, crawl_status: 'running', crawl_stage: stage },
       'Single domain crawl started',
@@ -2050,6 +2337,7 @@ export class CrawlerService {
       return await withDatabaseDeadline(Date.now() + SINGLE_DOMAIN_CRAWL_DB_DEADLINE_MS, async () => {
       stage = 'origin_validation';
       const validation = await this.adAgentsManager.validateDomain(domain);
+      assertLease();
 
       if (!validation.valid || !validation.raw_data?.authorized_agents) {
         await this.recordFailedAdagentsFetch(domain, {
@@ -2086,6 +2374,8 @@ export class CrawlerService {
           managerDomain: validation.manager_domain,
           eventActor: 'api:crawl-request',
           eventSource: 'crawl_request',
+          crawlRequestId: context.requestId,
+          crawlRequestLeaseToken: context.leaseToken,
         },
       );
       if (!cachePersisted) {
@@ -2093,6 +2383,7 @@ export class CrawlerService {
       }
 
       stage = 'authorization_projection';
+      assertLease();
       const affectedAgentUrls = new Set<string>();
       const existingAuthorizations = await this.federatedIndex.getAuthorizationsForDomain(domain);
       for (const auth of existingAuthorizations) {
@@ -2102,6 +2393,7 @@ export class CrawlerService {
 
       // Record agents and properties
       for (const authorizedAgent of validation.raw_data.authorized_agents) {
+        assertLease();
         if (!authorizedAgent.url) continue;
         affectedAgentUrls.add(canonicalizeAgentUrl(authorizedAgent.url) ?? authorizedAgent.url);
 
@@ -2126,6 +2418,7 @@ export class CrawlerService {
         }
       }
       await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
+      assertLease();
 
       // Scan brand.json for this domain
       stage = 'brand_scan';
@@ -2137,6 +2430,7 @@ export class CrawlerService {
 
       // Rebuild profiles for affected agents
       stage = 'inventory_profile_refresh';
+      assertLease();
       await this.buildInventoryProfiles({
         agentUrls: [...affectedAgentUrls],
         deleteStale: false,
@@ -2165,6 +2459,8 @@ export class CrawlerService {
         'Single domain crawl failed',
       );
       throw err;
+    } finally {
+      await executionLock?.release();
     }
   }
 
@@ -2186,6 +2482,10 @@ export class CrawlerService {
   private publisherCrawlLastHealthLogAt = 0;
 
   startPeriodicPublisherCrawlRequests(intervalSeconds: number = 5): void {
+    if (!isPublisherCrawlQueueEnabled()) {
+      log.info('Durable publisher crawl request queue disabled by rollout gate');
+      return;
+    }
     const run = () => {
       this.processPublisherCrawlRequestQueue().catch((err) => {
         log.error({ err }, 'Publisher crawl request queue tick failed');
@@ -2204,18 +2504,39 @@ export class CrawlerService {
     retried: number;
     failed: number;
     deferred: number;
+    lostLease: number;
   }> {
-    const stats = { claimed: 0, completed: 0, invalid: 0, retried: 0, failed: 0, deferred: 0 };
+    const stats = {
+      claimed: 0,
+      completed: 0,
+      invalid: 0,
+      retried: 0,
+      failed: 0,
+      deferred: 0,
+      lostLease: 0,
+    };
     if (this.publisherCrawlQueueProcessing || this.crawling) return stats;
 
     this.publisherCrawlQueueProcessing = true;
     try {
-      const requests = await this.crawlRequestsDb.claimDue(
+      const claim = await this.crawlRequestsDb.claimDue(
         this.publisherCrawlWorkerId,
-        PUBLISHER_CRAWL_QUEUE_BATCH_SIZE,
+        PUBLISHER_CRAWL_QUEUE_CONCURRENCY,
         PUBLISHER_CRAWL_LEASE_MS,
       );
+      const requests = claim.requests;
       stats.claimed = requests.length;
+      const reclaimed = requests.filter((request) => request.was_reclaimed).length;
+      if (reclaimed > 0 || claim.terminalizedExpired > 0) {
+        log.warn(
+          {
+            crawl_queue_reclaimed: reclaimed,
+            crawl_queue_terminalized_expired: claim.terminalizedExpired,
+            crawl_worker_id: this.publisherCrawlWorkerId,
+          },
+          'Publisher crawl request leases expired',
+        );
+      }
       if (requests.length === 0) {
         await this.maybeLogPublisherCrawlQueueHealth();
         await this.maybeRetainPublisherCrawlRequests();
@@ -2252,8 +2573,10 @@ export class CrawlerService {
 
   private async processClaimedPublisherCrawlRequest(
     request: ClaimedPublisherCrawlRequest,
-  ): Promise<'completed' | 'invalid' | 'retried' | 'failed' | 'deferred'> {
+  ): Promise<'completed' | 'invalid' | 'retried' | 'failed' | 'deferred' | 'lostLease'> {
     let heartbeatInFlight = false;
+    let leaseValid = true;
+    let leaseExpiresAtMs = request.lease_expires_at.getTime();
     const heartbeat = setInterval(() => {
       if (heartbeatInFlight) return;
       heartbeatInFlight = true;
@@ -2261,13 +2584,17 @@ export class CrawlerService {
         .heartbeat(request.id, request.lease_token, PUBLISHER_CRAWL_LEASE_MS)
         .then((renewed) => {
           if (!renewed) {
+            leaseValid = false;
             log.warn(
               { crawl_request_id: request.id, domain: request.publisher_domain },
               'Publisher crawl request lease was not renewed',
             );
+          } else {
+            leaseExpiresAtMs = Date.now() + PUBLISHER_CRAWL_LEASE_MS;
           }
         })
         .catch((err) => {
+          if (Date.now() >= leaseExpiresAtMs) leaseValid = false;
           log.warn(
             { err, crawl_request_id: request.id, domain: request.publisher_domain },
             'Publisher crawl request heartbeat failed',
@@ -2283,6 +2610,8 @@ export class CrawlerService {
       const outcome = await this.crawlSingleDomain(request.publisher_domain, {
         requestId: request.id,
         source: request.source,
+        leaseToken: request.lease_token,
+        isLeaseValid: () => leaseValid && Date.now() < leaseExpiresAtMs,
       });
       const recorded = await this.crawlRequestsDb.markCompleted(
         request.id,
@@ -2294,6 +2623,7 @@ export class CrawlerService {
           { crawl_request_id: request.id, domain: request.publisher_domain, crawl_status: outcome },
           'Publisher crawl request completion lost its lease',
         );
+        return 'lostLease';
       } else {
         log.info(
           {
@@ -2308,6 +2638,14 @@ export class CrawlerService {
       }
       return outcome;
     } catch (error) {
+      if (error instanceof PublisherCrawlLeaseLostError
+        || (error && typeof error === 'object' && 'code' in error && error.code === 'crawl_lease_lost')) {
+        log.warn(
+          { crawl_request_id: request.id, domain: request.publisher_domain },
+          'Publisher crawl request stopped after losing its lease',
+        );
+        return 'lostLease';
+      }
       const errorCode = error && typeof error === 'object' && 'code' in error
         && typeof error.code === 'string' && /^[a-zA-Z0-9_.:-]{1,100}$/.test(error.code)
         ? error.code
@@ -2318,12 +2656,13 @@ export class CrawlerService {
           ? 'Full crawl in progress; publisher crawl deferred'
           : 'Publisher crawl execution failed';
       if (errorCode === 'crawl_deferred') {
-        await this.crawlRequestsDb.markDeferred(
+        const deferred = await this.crawlRequestsDb.markDeferred(
           request.id,
           request.lease_token,
           PUBLISHER_CRAWL_DEFER_MS,
           errorMessage,
         );
+        if (!deferred) return 'lostLease';
         return 'deferred';
       }
 
@@ -2338,7 +2677,7 @@ export class CrawlerService {
           { crawl_request_id: request.id, domain: request.publisher_domain },
           'Publisher crawl request failure lost its lease',
         );
-        return 'retried';
+        return 'lostLease';
       }
       log[updated.status === 'failed' ? 'error' : 'warn'](
         {
@@ -2363,12 +2702,24 @@ export class CrawlerService {
   private async maybeRetainPublisherCrawlRequests(): Promise<void> {
     const now = Date.now();
     if (now - this.publisherCrawlLastRetentionAt < 60 * 60_000) return;
-    const deleted = await this.crawlRequestsDb.deleteTerminalBefore(
-      new Date(now - PUBLISHER_CRAWL_RETENTION_MS),
-    );
-    this.publisherCrawlLastRetentionAt = now;
+    const batchSize = 1_000;
+    let deleted = 0;
+    let lastBatch = 0;
+    for (let batch = 0; batch < 10; batch++) {
+      lastBatch = await this.crawlRequestsDb.deleteTerminalBefore(
+        new Date(now - PUBLISHER_CRAWL_RETENTION_MS),
+        batchSize,
+      );
+      deleted += lastBatch;
+      if (lastBatch < batchSize) break;
+    }
+    // A full final batch means more history may remain. Schedule another
+    // bounded drain in one minute instead of waiting an hour.
+    this.publisherCrawlLastRetentionAt = lastBatch === batchSize
+      ? now - 59 * 60_000
+      : now;
     if (deleted > 0) {
-      log.info({ deleted }, 'Expired publisher crawl request history removed');
+      log.info({ deleted, retention_backlog_remaining: lastBatch === batchSize }, 'Expired publisher crawl request history removed');
     }
   }
 
@@ -2377,16 +2728,17 @@ export class CrawlerService {
     if (now - this.publisherCrawlLastHealthLogAt < 60_000) return;
     const health = await this.crawlRequestsDb.getQueueHealth();
     this.publisherCrawlLastHealthLogAt = now;
-    const oldestActiveAgeMs = health.oldest_active_at
-      ? now - health.oldest_active_at.getTime()
+    const oldestDueLatenessMs = health.oldest_due_at
+      ? now - health.oldest_due_at.getTime()
       : 0;
     const context = {
       ...health,
-      oldest_active_at: health.oldest_active_at?.toISOString() ?? null,
-      oldest_active_age_ms: oldestActiveAgeMs,
+      oldest_due_at: health.oldest_due_at?.toISOString() ?? null,
+      oldest_due_lateness_ms: oldestDueLatenessMs,
+      oldest_running_at: health.oldest_running_at?.toISOString() ?? null,
       crawl_worker_id: this.publisherCrawlWorkerId,
     };
-    if (health.expired_leases > 0 || oldestActiveAgeMs > 5 * 60_000) {
+    if (health.expired_leases > 0 || oldestDueLatenessMs > 5 * 60_000) {
       log.warn(context, 'Publisher crawl request queue requires attention');
     } else {
       log.info(context, 'Publisher crawl request queue healthy');
@@ -2457,13 +2809,15 @@ export class CrawlerService {
 
       for (const { domain, valid } of results) {
         if (valid) {
-          found++;
           // Run full single-domain crawl to record agents/properties
+          let persisted = false;
           try {
-            await this.crawlSingleDomainForCatalog(domain);
+            persisted = await this.crawlSingleDomainForCatalog(domain);
           } catch (err) {
             log.error({ domain, err }, 'Catalog domain crawl failed for domain');
           }
+          if (!persisted) continue;
+          found++;
 
           // Mark as found in queue
           await query(
@@ -2666,15 +3020,28 @@ export class CrawlerService {
     }
   }
 
-  private async crawlSingleDomainForCatalog(domain: string): Promise<void> {
+  private async crawlSingleDomainForCatalog(domain: string): Promise<boolean> {
+    const executionLock = this.coordinateCrawlsAcrossInstances
+      ? await this.tryAcquireCrawlExecutionLock(domain)
+      : null;
+    if (this.coordinateCrawlsAcrossInstances && !executionLock) return false;
+    const assertExecutionLock = (): void => {
+      if (executionLock && !executionLock.isValid()) {
+        throw Object.assign(new Error('Publisher crawl execution lock was lost'), {
+          code: 'crawl_execution_lock_lost',
+        });
+      }
+    };
+    try {
     const validation = await this.adAgentsManager.validateDomain(domain);
+    assertExecutionLock();
     if (!validation.valid || !validation.raw_data?.authorized_agents) {
       await this.recordFailedAdagentsFetch(domain, {
         statusCode: validation.status_code,
         responseBytes: validation.response_bytes,
         resolvedUrl: validation.resolved_url,
       });
-      return;
+      return false;
     }
 
     await this.cacheAdagentsManifest(
@@ -2692,6 +3059,7 @@ export class CrawlerService {
     );
 
     for (const authorizedAgent of validation.raw_data.authorized_agents) {
+      assertExecutionLock();
       if (!authorizedAgent.url) continue;
 
       await this.federatedIndex.recordAgentFromAdagentsJson(
@@ -2715,7 +3083,10 @@ export class CrawlerService {
       }
     }
     await this.reconcileLegacyAdagentsAgents(domain, validation.raw_data as AdagentsManifest);
-
+    return true;
+    } finally {
+      await executionLock?.release();
+    }
   }
 
   private async processWithConcurrency<T, R>(
@@ -2724,17 +3095,25 @@ export class CrawlerService {
     fn: (item: T) => Promise<R>
   ): Promise<R[]> {
     const results: R[] = [];
+    const errors: unknown[] = [];
     let index = 0;
 
     async function worker() {
       while (index < items.length) {
         const i = index++;
-        results[i] = await fn(items[i]);
+        try {
+          results[i] = await fn(items[i]);
+        } catch (error) {
+          errors.push(error);
+        }
       }
     }
 
     const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
     await Promise.all(workers);
+    if (errors.length > 0) {
+      throw new AggregateError(errors, `${errors.length} publisher crawl worker(s) failed`);
+    }
     return results;
   }
 }

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -24,6 +24,12 @@ import { verifyHostedPropertyOrigin } from "./services/hosted-property-origin-ve
 import { insertTypeReclassification } from "./db/type-reclassification-log-db.js";
 import { resolveUserAgentAuth } from "./routes/helpers/resolve-user-agent-auth.js";
 import { adaptAuthForSdk, type SdkAuth } from "./services/sdk-auth-adapter.js";
+import {
+  PublisherCrawlRequestsDatabase,
+  type CreatePublisherCrawlRequestInput,
+  type PublisherCrawlRequest,
+  type ClaimedPublisherCrawlRequest,
+} from "./db/publisher-crawl-requests-db.js";
 
 const log = createLogger('crawler');
 // Inventory profiles are a derived search projection, not the authorization
@@ -32,6 +38,14 @@ const log = createLogger('crawler');
 // point. A dedicated aggregate profile query can replace this guard later.
 const INVENTORY_PROFILE_PUBLISHER_FANOUT_CAP = 1_000;
 const SINGLE_DOMAIN_CRAWL_DB_DEADLINE_MS = 60_000;
+const PUBLISHER_CRAWL_QUEUE_BATCH_SIZE = 10;
+const PUBLISHER_CRAWL_QUEUE_CONCURRENCY = 4;
+const PUBLISHER_CRAWL_LEASE_MS = 2 * 60_000;
+const PUBLISHER_CRAWL_HEARTBEAT_MS = 30_000;
+const PUBLISHER_CRAWL_DEFER_MS = 30_000;
+const PUBLISHER_CRAWL_RETENTION_MS = 30 * 24 * 60 * 60_000;
+
+export type SingleDomainCrawlOutcome = 'completed' | 'invalid';
 
 function unknownClassificationProbeDue(
   snapshot: AgentCapabilitiesSnapshotRow | undefined,
@@ -121,8 +135,15 @@ export class CrawlerService {
   private agentContextDb: AgentContextDatabase;
   private eventsDb?: CatalogEventsDatabase;
   private profilesDb?: AgentInventoryProfilesDatabase;
+  private crawlRequestsDb: PublisherCrawlRequestsDatabase;
+  private publisherCrawlWorkerId: string;
 
-  constructor(options?: { eventsDb?: CatalogEventsDatabase; profilesDb?: AgentInventoryProfilesDatabase }) {
+  constructor(options?: {
+    eventsDb?: CatalogEventsDatabase;
+    profilesDb?: AgentInventoryProfilesDatabase;
+    crawlRequestsDb?: PublisherCrawlRequestsDatabase;
+    crawlWorkerId?: string;
+  }) {
     this.crawler = new PropertyCrawler({ logLevel: (process.env.LOG_LEVEL as 'debug' | 'info' | 'warn' | 'error') || 'error', userAgent: AAO_UA_DISCOVERY });
     this.federatedIndex = new FederatedIndexService();
     this.adAgentsManager = new AdAgentsManager();
@@ -136,6 +157,10 @@ export class CrawlerService {
     this.agentContextDb = new AgentContextDatabase();
     this.eventsDb = options?.eventsDb;
     this.profilesDb = options?.profilesDb;
+    this.crawlRequestsDb = options?.crawlRequestsDb ?? new PublisherCrawlRequestsDatabase();
+    this.publisherCrawlWorkerId = options?.crawlWorkerId
+      ?? process.env.FLY_MACHINE_ID
+      ?? `worker-${process.pid}-${Date.now().toString(36)}`;
   }
 
   /**
@@ -1984,7 +2009,7 @@ export class CrawlerService {
   tryStartSingleDomainCrawl(
     domain: string,
     context: SingleDomainCrawlContext = {},
-  ): Promise<void> | null {
+  ): Promise<SingleDomainCrawlOutcome> | null {
     if (this.crawling) return null;
     return this.crawlSingleDomain(domain, context);
   }
@@ -1992,7 +2017,7 @@ export class CrawlerService {
   async crawlSingleDomain(
     domain: string,
     context: SingleDomainCrawlContext = {},
-  ): Promise<void> {
+  ): Promise<SingleDomainCrawlOutcome> {
     const startedAt = Date.now();
     let stage = 'admission';
     const lifecycleContext = {
@@ -2022,7 +2047,7 @@ export class CrawlerService {
     );
 
     try {
-      await withDatabaseDeadline(Date.now() + SINGLE_DOMAIN_CRAWL_DB_DEADLINE_MS, async () => {
+      return await withDatabaseDeadline(Date.now() + SINGLE_DOMAIN_CRAWL_DB_DEADLINE_MS, async () => {
       stage = 'origin_validation';
       const validation = await this.adAgentsManager.validateDomain(domain);
 
@@ -2032,6 +2057,11 @@ export class CrawlerService {
           responseBytes: validation.response_bytes,
           resolvedUrl: validation.resolved_url,
         });
+        if (this.isTransientPublisherAdagentsFailure(validation)) {
+          throw Object.assign(new Error('Publisher origin was temporarily unavailable'), {
+            code: 'crawl_origin_temporarily_unavailable',
+          });
+        }
         log.warn(
           {
             ...lifecycleContext,
@@ -2041,7 +2071,7 @@ export class CrawlerService {
           },
           'No valid adagents.json for domain',
         );
-        return;
+        return 'invalid' as const;
       }
 
       stage = 'publisher_cache_write';
@@ -2121,6 +2151,7 @@ export class CrawlerService {
         },
         'Single domain crawl complete',
       );
+      return 'completed' as const;
       }, { readOnly: false });
     } catch (err) {
       log.error(
@@ -2134,6 +2165,231 @@ export class CrawlerService {
         'Single domain crawl failed',
       );
       throw err;
+    }
+  }
+
+  // ── Durable Publisher Crawl Requests ─────────────────────────
+
+  async enqueuePublisherCrawlRequest(
+    input: CreatePublisherCrawlRequestInput,
+  ): Promise<PublisherCrawlRequest> {
+    return this.crawlRequestsDb.create(input);
+  }
+
+  async getPublisherCrawlRequest(id: string): Promise<PublisherCrawlRequest | null> {
+    return this.crawlRequestsDb.getById(id);
+  }
+
+  private publisherCrawlQueueIntervalId: NodeJS.Timeout | null = null;
+  private publisherCrawlQueueProcessing = false;
+  private publisherCrawlLastRetentionAt = 0;
+  private publisherCrawlLastHealthLogAt = 0;
+
+  startPeriodicPublisherCrawlRequests(intervalSeconds: number = 5): void {
+    const run = () => {
+      this.processPublisherCrawlRequestQueue().catch((err) => {
+        log.error({ err }, 'Publisher crawl request queue tick failed');
+      });
+    };
+    run();
+    this.publisherCrawlQueueIntervalId = setInterval(run, intervalSeconds * 1_000);
+    this.publisherCrawlQueueIntervalId.unref();
+    log.info({ intervalSeconds }, 'Durable publisher crawl request queue started');
+  }
+
+  async processPublisherCrawlRequestQueue(): Promise<{
+    claimed: number;
+    completed: number;
+    invalid: number;
+    retried: number;
+    failed: number;
+    deferred: number;
+  }> {
+    const stats = { claimed: 0, completed: 0, invalid: 0, retried: 0, failed: 0, deferred: 0 };
+    if (this.publisherCrawlQueueProcessing || this.crawling) return stats;
+
+    this.publisherCrawlQueueProcessing = true;
+    try {
+      const requests = await this.crawlRequestsDb.claimDue(
+        this.publisherCrawlWorkerId,
+        PUBLISHER_CRAWL_QUEUE_BATCH_SIZE,
+        PUBLISHER_CRAWL_LEASE_MS,
+      );
+      stats.claimed = requests.length;
+      if (requests.length === 0) {
+        await this.maybeLogPublisherCrawlQueueHealth();
+        await this.maybeRetainPublisherCrawlRequests();
+        return stats;
+      }
+
+      log.info(
+        {
+          crawl_queue_claimed: requests.length,
+          crawl_worker_id: this.publisherCrawlWorkerId,
+          oldest_request_age_ms: Math.max(...requests.map((request) => Date.now() - request.created_at.getTime())),
+        },
+        'Publisher crawl request batch claimed',
+      );
+
+      const results = await this.processWithConcurrency(
+        requests,
+        PUBLISHER_CRAWL_QUEUE_CONCURRENCY,
+        (request) => this.processClaimedPublisherCrawlRequest(request),
+      );
+      for (const result of results) stats[result]++;
+
+      log.info(
+        { ...stats, crawl_worker_id: this.publisherCrawlWorkerId },
+        'Publisher crawl request batch complete',
+      );
+      await this.maybeLogPublisherCrawlQueueHealth();
+      await this.maybeRetainPublisherCrawlRequests();
+      return stats;
+    } finally {
+      this.publisherCrawlQueueProcessing = false;
+    }
+  }
+
+  private async processClaimedPublisherCrawlRequest(
+    request: ClaimedPublisherCrawlRequest,
+  ): Promise<'completed' | 'invalid' | 'retried' | 'failed' | 'deferred'> {
+    let heartbeatInFlight = false;
+    const heartbeat = setInterval(() => {
+      if (heartbeatInFlight) return;
+      heartbeatInFlight = true;
+      this.crawlRequestsDb
+        .heartbeat(request.id, request.lease_token, PUBLISHER_CRAWL_LEASE_MS)
+        .then((renewed) => {
+          if (!renewed) {
+            log.warn(
+              { crawl_request_id: request.id, domain: request.publisher_domain },
+              'Publisher crawl request lease was not renewed',
+            );
+          }
+        })
+        .catch((err) => {
+          log.warn(
+            { err, crawl_request_id: request.id, domain: request.publisher_domain },
+            'Publisher crawl request heartbeat failed',
+          );
+        })
+        .finally(() => {
+          heartbeatInFlight = false;
+        });
+    }, PUBLISHER_CRAWL_HEARTBEAT_MS);
+    heartbeat.unref();
+
+    try {
+      const outcome = await this.crawlSingleDomain(request.publisher_domain, {
+        requestId: request.id,
+        source: request.source,
+      });
+      const recorded = await this.crawlRequestsDb.markCompleted(
+        request.id,
+        request.lease_token,
+        outcome,
+      );
+      if (!recorded) {
+        log.warn(
+          { crawl_request_id: request.id, domain: request.publisher_domain, crawl_status: outcome },
+          'Publisher crawl request completion lost its lease',
+        );
+      } else {
+        log.info(
+          {
+            crawl_request_id: request.id,
+            domain: request.publisher_domain,
+            crawl_status: outcome,
+            crawl_attempts: request.attempts,
+            accepted_to_terminal_ms: Date.now() - request.created_at.getTime(),
+          },
+          'Durable publisher crawl request reached terminal state',
+        );
+      }
+      return outcome;
+    } catch (error) {
+      const errorCode = error && typeof error === 'object' && 'code' in error
+        && typeof error.code === 'string' && /^[a-zA-Z0-9_.:-]{1,100}$/.test(error.code)
+        ? error.code
+        : 'crawl_failed';
+      const errorMessage = errorCode === 'crawl_origin_temporarily_unavailable'
+        ? 'Publisher origin was temporarily unavailable'
+        : errorCode === 'crawl_deferred'
+          ? 'Full crawl in progress; publisher crawl deferred'
+          : 'Publisher crawl execution failed';
+      if (errorCode === 'crawl_deferred') {
+        await this.crawlRequestsDb.markDeferred(
+          request.id,
+          request.lease_token,
+          PUBLISHER_CRAWL_DEFER_MS,
+          errorMessage,
+        );
+        return 'deferred';
+      }
+
+      const updated = await this.crawlRequestsDb.markFailedAttempt(
+        request.id,
+        request.lease_token,
+        errorCode,
+        errorMessage,
+      );
+      if (!updated) {
+        log.warn(
+          { crawl_request_id: request.id, domain: request.publisher_domain },
+          'Publisher crawl request failure lost its lease',
+        );
+        return 'retried';
+      }
+      log[updated.status === 'failed' ? 'error' : 'warn'](
+        {
+          crawl_request_id: request.id,
+          domain: request.publisher_domain,
+          crawl_status: updated.status,
+          crawl_attempts: updated.attempts,
+          max_attempts: updated.max_attempts,
+          error_code: updated.last_error_code,
+          accepted_to_outcome_ms: Date.now() - request.created_at.getTime(),
+        },
+        updated.status === 'failed'
+          ? 'Durable publisher crawl request exhausted retries'
+          : 'Durable publisher crawl request scheduled for retry',
+      );
+      return updated.status === 'failed' ? 'failed' : 'retried';
+    } finally {
+      clearInterval(heartbeat);
+    }
+  }
+
+  private async maybeRetainPublisherCrawlRequests(): Promise<void> {
+    const now = Date.now();
+    if (now - this.publisherCrawlLastRetentionAt < 60 * 60_000) return;
+    const deleted = await this.crawlRequestsDb.deleteTerminalBefore(
+      new Date(now - PUBLISHER_CRAWL_RETENTION_MS),
+    );
+    this.publisherCrawlLastRetentionAt = now;
+    if (deleted > 0) {
+      log.info({ deleted }, 'Expired publisher crawl request history removed');
+    }
+  }
+
+  private async maybeLogPublisherCrawlQueueHealth(): Promise<void> {
+    const now = Date.now();
+    if (now - this.publisherCrawlLastHealthLogAt < 60_000) return;
+    const health = await this.crawlRequestsDb.getQueueHealth();
+    this.publisherCrawlLastHealthLogAt = now;
+    const oldestActiveAgeMs = health.oldest_active_at
+      ? now - health.oldest_active_at.getTime()
+      : 0;
+    const context = {
+      ...health,
+      oldest_active_at: health.oldest_active_at?.toISOString() ?? null,
+      oldest_active_age_ms: oldestActiveAgeMs,
+      crawl_worker_id: this.publisherCrawlWorkerId,
+    };
+    if (health.expired_leases > 0 || oldestActiveAgeMs > 5 * 60_000) {
+      log.warn(context, 'Publisher crawl request queue requires attention');
+    } else {
+      log.info(context, 'Publisher crawl request queue healthy');
     }
   }
 

--- a/server/src/db/agent-inventory-profiles-db.ts
+++ b/server/src/db/agent-inventory-profiles-db.ts
@@ -155,6 +155,8 @@ export class AgentInventoryProfilesDatabase {
     let persistedProfiles: AgentInventoryProfile[] = [];
     try {
       await client.query('BEGIN');
+      await client.query("SELECT set_config('statement_timeout', '30000ms', true)");
+      await client.query("SELECT set_config('lock_timeout', '5000ms', true)");
       for (const input of inputs) {
         const sql = `INSERT INTO agent_inventory_profiles (
           agent_url, channels, property_types, markets, categories, tags,

--- a/server/src/db/migrations/540_publisher_crawl_requests.sql
+++ b/server/src/db/migrations/540_publisher_crawl_requests.sql
@@ -1,0 +1,56 @@
+-- Durable lifecycle for explicit publisher recrawl requests (#6325).
+--
+-- API admission persists a row before returning 202. Workers claim due rows
+-- with a bounded lease, perform origin/network work outside the transaction,
+-- then record a terminal outcome or schedule a bounded retry.
+
+CREATE TABLE publisher_crawl_requests (
+  id UUID PRIMARY KEY,
+  publisher_domain TEXT NOT NULL CHECK (char_length(publisher_domain) BETWEEN 1 AND 253),
+  source TEXT NOT NULL DEFAULT 'api:crawl-request' CHECK (char_length(source) BETWEEN 1 AND 100),
+  requester_type TEXT NOT NULL CHECK (requester_type IN ('user', 'static_admin')),
+  requested_by_user_id TEXT,
+  status TEXT NOT NULL DEFAULT 'queued' CHECK (
+    status IN ('queued', 'running', 'deferred', 'retrying', 'completed', 'invalid', 'failed')
+  ),
+  attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  max_attempts INTEGER NOT NULL DEFAULT 5 CHECK (max_attempts BETWEEN 1 AND 20),
+  available_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  lease_owner TEXT,
+  lease_token UUID,
+  lease_expires_at TIMESTAMPTZ,
+  heartbeat_at TIMESTAMPTZ,
+  last_attempted_at TIMESTAMPTZ,
+  last_error_code TEXT,
+  last_error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT publisher_crawl_requester_identity CHECK (
+    (requester_type = 'user' AND requested_by_user_id IS NOT NULL)
+    OR (requester_type = 'static_admin' AND requested_by_user_id IS NULL)
+  ),
+  CONSTRAINT publisher_crawl_lease_shape CHECK (
+    (status = 'running' AND lease_owner IS NOT NULL AND lease_token IS NOT NULL AND lease_expires_at IS NOT NULL)
+    OR (status <> 'running' AND lease_owner IS NULL AND lease_token IS NULL AND lease_expires_at IS NULL)
+  )
+);
+
+CREATE INDEX idx_publisher_crawl_requests_due
+  ON publisher_crawl_requests (available_at, created_at)
+  WHERE status IN ('queued', 'deferred', 'retrying');
+
+CREATE INDEX idx_publisher_crawl_requests_expired_lease
+  ON publisher_crawl_requests (lease_expires_at)
+  WHERE status = 'running';
+
+CREATE INDEX idx_publisher_crawl_requests_domain_created
+  ON publisher_crawl_requests (publisher_domain, created_at DESC);
+
+CREATE INDEX idx_publisher_crawl_requests_user_created
+  ON publisher_crawl_requests (requested_by_user_id, created_at DESC)
+  WHERE requested_by_user_id IS NOT NULL;
+
+COMMENT ON TABLE publisher_crawl_requests IS
+  'Durable, client-visible lifecycle for explicit publisher recrawls. Terminal rows are retained temporarily for status and audit, then removed by the worker retention sweep.';

--- a/server/src/db/migrations/540_publisher_crawl_requests.sql
+++ b/server/src/db/migrations/540_publisher_crawl_requests.sql
@@ -49,8 +49,15 @@ CREATE INDEX idx_publisher_crawl_requests_domain_created
   ON publisher_crawl_requests (publisher_domain, created_at DESC);
 
 CREATE INDEX idx_publisher_crawl_requests_user_created
-  ON publisher_crawl_requests (requested_by_user_id, created_at DESC)
-  WHERE requested_by_user_id IS NOT NULL;
+  ON publisher_crawl_requests (requester_type, requested_by_user_id, created_at DESC);
+
+CREATE INDEX idx_publisher_crawl_requests_active_status_available
+  ON publisher_crawl_requests (status, available_at, created_at)
+  WHERE status IN ('queued', 'running', 'deferred', 'retrying');
+
+CREATE INDEX idx_publisher_crawl_requests_terminal_completed
+  ON publisher_crawl_requests (completed_at, id)
+  WHERE status IN ('completed', 'invalid', 'failed');
 
 COMMENT ON TABLE publisher_crawl_requests IS
   'Durable, client-visible lifecycle for explicit publisher recrawls. Terminal rows are retained temporarily for status and audit, then removed by the worker retention sweep.';

--- a/server/src/db/publisher-crawl-requests-db.ts
+++ b/server/src/db/publisher-crawl-requests-db.ts
@@ -1,0 +1,412 @@
+import { getClient, query, withDatabaseDeadline } from './client.js';
+
+const CRAWL_REQUEST_DB_DEADLINE_MS = 5_000;
+
+export type PublisherCrawlRequestStatus =
+  | 'queued'
+  | 'running'
+  | 'deferred'
+  | 'retrying'
+  | 'completed'
+  | 'invalid'
+  | 'failed';
+
+export interface PublisherCrawlRequest {
+  id: string;
+  publisher_domain: string;
+  source: string;
+  requester_type: 'user' | 'static_admin';
+  requested_by_user_id: string | null;
+  status: PublisherCrawlRequestStatus;
+  attempts: number;
+  max_attempts: number;
+  available_at: Date;
+  lease_owner: string | null;
+  lease_token: string | null;
+  lease_expires_at: Date | null;
+  heartbeat_at: Date | null;
+  last_attempted_at: Date | null;
+  last_error_code: string | null;
+  last_error: string | null;
+  created_at: Date;
+  started_at: Date | null;
+  completed_at: Date | null;
+  updated_at: Date;
+}
+
+export interface ClaimedPublisherCrawlRequest extends PublisherCrawlRequest {
+  status: 'running';
+  lease_owner: string;
+  lease_token: string;
+  lease_expires_at: Date;
+}
+
+export class CrawlRequestRateLimitError extends Error {
+  constructor(
+    readonly scope: 'domain' | 'requester',
+    readonly retryAfterSeconds: number,
+  ) {
+    super(scope === 'domain'
+      ? 'Rate limit exceeded for this domain'
+      : 'Hourly crawl request limit exceeded');
+    this.name = 'CrawlRequestRateLimitError';
+  }
+}
+
+export interface CreatePublisherCrawlRequestInput {
+  id: string;
+  domain: string;
+  source: string;
+  requesterType: 'user' | 'static_admin';
+  requestedByUserId: string | null;
+  domainWindowMs?: number;
+  requesterWindowMs?: number;
+  requesterLimit?: number;
+}
+
+export interface PublisherCrawlQueueHealth {
+  queued: number;
+  running: number;
+  deferred: number;
+  retrying: number;
+  expired_leases: number;
+  oldest_active_at: Date | null;
+}
+
+function retryAfterSeconds(retryAt: Date): number {
+  return Math.max(1, Math.ceil((retryAt.getTime() - Date.now()) / 1_000));
+}
+
+export class PublisherCrawlRequestsDatabase {
+  /**
+   * Persist admission and enforce cross-instance limits in one transaction.
+   * Advisory transaction locks serialize both requester and domain limits
+   * across web instances without surviving the transaction.
+   */
+  async create(input: CreatePublisherCrawlRequestInput): Promise<PublisherCrawlRequest> {
+    const domainWindowMs = input.domainWindowMs ?? 5 * 60_000;
+    const requesterWindowMs = input.requesterWindowMs ?? 60 * 60_000;
+    const requesterLimit = input.requesterLimit ?? 30;
+    const client = await getClient();
+    let transactionStarted = false;
+    try {
+      await client.query('BEGIN');
+      transactionStarted = true;
+      await client.query("SELECT set_config('statement_timeout', '5000ms', true)");
+      await client.query("SELECT set_config('lock_timeout', '2000ms', true)");
+      const requesterKey = input.requesterType === 'user'
+        ? input.requestedByUserId
+        : 'static_admin';
+      await client.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [
+        `publisher-crawl-requester:${requesterKey}`,
+      ]);
+      await client.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [
+        `publisher-crawl-domain:${input.domain}`,
+      ]);
+
+      const domainLimit = await client.query<{ retry_at: Date }>(
+        `SELECT created_at + ($2::double precision * INTERVAL '1 millisecond') AS retry_at
+           FROM publisher_crawl_requests
+          WHERE publisher_domain = $1
+            AND created_at > NOW() - ($2::double precision * INTERVAL '1 millisecond')
+          ORDER BY created_at DESC
+          LIMIT 1`,
+        [input.domain, domainWindowMs],
+      );
+      if (domainLimit.rows[0]) {
+        throw new CrawlRequestRateLimitError('domain', retryAfterSeconds(domainLimit.rows[0].retry_at));
+      }
+
+      const requesterLimitResult = await client.query<{ request_count: string; retry_at: Date | null }>(
+        `SELECT COUNT(*)::text AS request_count,
+                MIN(created_at) + ($3::double precision * INTERVAL '1 millisecond') AS retry_at
+           FROM publisher_crawl_requests
+          WHERE requester_type = $1
+            AND requested_by_user_id IS NOT DISTINCT FROM $2
+            AND created_at > NOW() - ($3::double precision * INTERVAL '1 millisecond')`,
+        [input.requesterType, input.requestedByUserId, requesterWindowMs],
+      );
+      const requesterState = requesterLimitResult.rows[0];
+      if (Number(requesterState?.request_count ?? 0) >= requesterLimit) {
+        throw new CrawlRequestRateLimitError(
+          'requester',
+          requesterState?.retry_at ? retryAfterSeconds(requesterState.retry_at) : Math.ceil(requesterWindowMs / 1_000),
+        );
+      }
+
+      const inserted = await client.query<PublisherCrawlRequest>(
+        `INSERT INTO publisher_crawl_requests
+           (id, publisher_domain, source, requester_type, requested_by_user_id)
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING *`,
+        [input.id, input.domain, input.source, input.requesterType, input.requestedByUserId],
+      );
+      await client.query('COMMIT');
+      return inserted.rows[0];
+    } catch (error) {
+      if (transactionStarted) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async getById(id: string): Promise<PublisherCrawlRequest | null> {
+    return withDatabaseDeadline(
+      Date.now() + CRAWL_REQUEST_DB_DEADLINE_MS,
+      async () => {
+        const result = await query<PublisherCrawlRequest>(
+          'SELECT * FROM publisher_crawl_requests WHERE id = $1',
+          [id],
+        );
+        return result.rows[0] ?? null;
+      },
+    );
+  }
+
+  /** Claim due work, including expired leases, without waiting on peers. */
+  async claimDue(
+    workerId: string,
+    limit: number,
+    leaseMs: number,
+  ): Promise<ClaimedPublisherCrawlRequest[]> {
+    const client = await getClient();
+    let transactionStarted = false;
+    try {
+      await client.query('BEGIN');
+      transactionStarted = true;
+      await client.query("SELECT set_config('statement_timeout', '5000ms', true)");
+      await client.query("SELECT set_config('lock_timeout', '2000ms', true)");
+
+      // An expired final attempt is terminal; do not leave it permanently
+      // running merely because it is no longer eligible for another claim.
+      await client.query(
+        `UPDATE publisher_crawl_requests
+            SET status = 'failed',
+                completed_at = NOW(),
+                updated_at = NOW(),
+                lease_owner = NULL,
+                lease_token = NULL,
+                lease_expires_at = NULL,
+                heartbeat_at = NULL,
+                last_error_code = COALESCE(last_error_code, 'lease_expired'),
+                last_error = COALESCE(last_error, 'Worker lease expired after the final attempt')
+          WHERE status = 'running'
+            AND lease_expires_at <= NOW()
+            AND attempts >= max_attempts`,
+      );
+
+      const result = await client.query<ClaimedPublisherCrawlRequest>(
+        `WITH due AS (
+           SELECT id
+             FROM publisher_crawl_requests
+            WHERE attempts < max_attempts
+              AND (
+                (status IN ('queued', 'deferred', 'retrying') AND available_at <= NOW())
+                OR (status = 'running' AND lease_expires_at <= NOW())
+              )
+            ORDER BY available_at ASC, created_at ASC
+            FOR UPDATE SKIP LOCKED
+            LIMIT $2
+         )
+         UPDATE publisher_crawl_requests AS requests
+            SET status = 'running',
+                attempts = requests.attempts + 1,
+                lease_owner = $1,
+                lease_token = gen_random_uuid(),
+                lease_expires_at = NOW() + ($3::double precision * INTERVAL '1 millisecond'),
+                heartbeat_at = NOW(),
+                last_attempted_at = NOW(),
+                started_at = COALESCE(requests.started_at, NOW()),
+                completed_at = NULL,
+                updated_at = NOW()
+           FROM due
+          WHERE requests.id = due.id
+         RETURNING requests.*`,
+        [workerId, Math.max(1, Math.min(limit, 100)), leaseMs],
+      );
+      await client.query('COMMIT');
+      return result.rows;
+    } catch (error) {
+      if (transactionStarted) await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async heartbeat(id: string, leaseToken: string, leaseMs: number): Promise<boolean> {
+    return withDatabaseDeadline(
+      Date.now() + CRAWL_REQUEST_DB_DEADLINE_MS,
+      async () => {
+        const result = await query(
+          `UPDATE publisher_crawl_requests
+              SET heartbeat_at = NOW(),
+                  lease_expires_at = NOW() + ($3::double precision * INTERVAL '1 millisecond'),
+                  updated_at = NOW()
+            WHERE id = $1 AND status = 'running' AND lease_token = $2
+              AND lease_expires_at > NOW()`,
+          [id, leaseToken, leaseMs],
+        );
+        return (result.rowCount ?? 0) === 1;
+      },
+      { readOnly: false },
+    );
+  }
+
+  async markCompleted(
+    id: string,
+    leaseToken: string,
+    status: 'completed' | 'invalid',
+  ): Promise<boolean> {
+    return withDatabaseDeadline(
+      Date.now() + CRAWL_REQUEST_DB_DEADLINE_MS,
+      async () => {
+        const result = await query(
+          `UPDATE publisher_crawl_requests
+              SET status = $3,
+                  completed_at = NOW(),
+                  updated_at = NOW(),
+                  lease_owner = NULL,
+                  lease_token = NULL,
+                  lease_expires_at = NULL,
+                  heartbeat_at = NULL,
+                  last_error_code = CASE
+                    WHEN $3 = 'invalid' THEN 'publisher_manifest_invalid'
+                    ELSE NULL
+                  END,
+                  last_error = NULL
+            WHERE id = $1 AND status = 'running' AND lease_token = $2`,
+          [id, leaseToken, status],
+        );
+        return (result.rowCount ?? 0) === 1;
+      },
+      { readOnly: false },
+    );
+  }
+
+  /** Full-crawl contention is neutral: make the row due later and refund the claim attempt. */
+  async markDeferred(
+    id: string,
+    leaseToken: string,
+    delayMs: number,
+    reason: string,
+  ): Promise<boolean> {
+    return withDatabaseDeadline(
+      Date.now() + CRAWL_REQUEST_DB_DEADLINE_MS,
+      async () => {
+        const result = await query(
+          `UPDATE publisher_crawl_requests
+              SET status = 'deferred',
+                  attempts = GREATEST(attempts - 1, 0),
+                  available_at = NOW() + ($3::double precision * INTERVAL '1 millisecond'),
+                  updated_at = NOW(),
+                  lease_owner = NULL,
+                  lease_token = NULL,
+                  lease_expires_at = NULL,
+                  heartbeat_at = NULL,
+                  last_error_code = 'crawl_deferred',
+                  last_error = LEFT($4, 500)
+            WHERE id = $1 AND status = 'running' AND lease_token = $2`,
+          [id, leaseToken, delayMs, reason],
+        );
+        return (result.rowCount ?? 0) === 1;
+      },
+      { readOnly: false },
+    );
+  }
+
+  async markFailedAttempt(
+    id: string,
+    leaseToken: string,
+    errorCode: string,
+    errorMessage: string,
+  ): Promise<PublisherCrawlRequest | null> {
+    return withDatabaseDeadline(
+      Date.now() + CRAWL_REQUEST_DB_DEADLINE_MS,
+      async () => {
+        const result = await query<PublisherCrawlRequest>(
+          `UPDATE publisher_crawl_requests
+              SET status = CASE WHEN attempts >= max_attempts THEN 'failed' ELSE 'retrying' END,
+                  available_at = NOW() + CASE
+                    WHEN attempts <= 1 THEN INTERVAL '1 minute'
+                    WHEN attempts = 2 THEN INTERVAL '5 minutes'
+                    WHEN attempts = 3 THEN INTERVAL '30 minutes'
+                    ELSE INTERVAL '2 hours'
+                  END,
+                  completed_at = CASE WHEN attempts >= max_attempts THEN NOW() ELSE NULL END,
+                  updated_at = NOW(),
+                  lease_owner = NULL,
+                  lease_token = NULL,
+                  lease_expires_at = NULL,
+                  heartbeat_at = NULL,
+                  last_error_code = LEFT($3, 100),
+                  last_error = LEFT($4, 500)
+            WHERE id = $1 AND status = 'running' AND lease_token = $2
+            RETURNING *`,
+          [id, leaseToken, errorCode, errorMessage],
+        );
+        return result.rows[0] ?? null;
+      },
+      { readOnly: false },
+    );
+  }
+
+  async deleteTerminalBefore(retainAfter: Date, limit: number = 1_000): Promise<number> {
+    return withDatabaseDeadline(
+      Date.now() + CRAWL_REQUEST_DB_DEADLINE_MS,
+      async () => {
+        const result = await query(
+          `WITH expired AS (
+             SELECT id
+               FROM publisher_crawl_requests
+              WHERE status IN ('completed', 'invalid', 'failed')
+                AND completed_at < $1
+              ORDER BY completed_at ASC
+              LIMIT $2
+           )
+           DELETE FROM publisher_crawl_requests AS requests
+            USING expired
+            WHERE requests.id = expired.id`,
+          [retainAfter, Math.max(1, Math.min(limit, 10_000))],
+        );
+        return result.rowCount ?? 0;
+      },
+      { readOnly: false },
+    );
+  }
+
+  async getQueueHealth(): Promise<PublisherCrawlQueueHealth> {
+    return withDatabaseDeadline(Date.now() + CRAWL_REQUEST_DB_DEADLINE_MS, async () => {
+      const result = await query<{
+      queued: string;
+      running: string;
+      deferred: string;
+      retrying: string;
+      expired_leases: string;
+      oldest_active_at: Date | null;
+    }>(
+      `SELECT COUNT(*) FILTER (WHERE status = 'queued')::text AS queued,
+              COUNT(*) FILTER (WHERE status = 'running')::text AS running,
+              COUNT(*) FILTER (WHERE status = 'deferred')::text AS deferred,
+              COUNT(*) FILTER (WHERE status = 'retrying')::text AS retrying,
+              COUNT(*) FILTER (
+                WHERE status = 'running' AND lease_expires_at <= NOW()
+              )::text AS expired_leases,
+              MIN(created_at) FILTER (
+                WHERE status IN ('queued', 'running', 'deferred', 'retrying')
+              ) AS oldest_active_at
+         FROM publisher_crawl_requests`,
+    );
+      const row = result.rows[0];
+      return {
+        queued: Number(row.queued),
+        running: Number(row.running),
+        deferred: Number(row.deferred),
+        retrying: Number(row.retrying),
+        expired_leases: Number(row.expired_leases),
+        oldest_active_at: row.oldest_active_at,
+      };
+    });
+  }
+}

--- a/server/src/db/publisher-crawl-requests-db.ts
+++ b/server/src/db/publisher-crawl-requests-db.ts
@@ -39,6 +39,12 @@ export interface ClaimedPublisherCrawlRequest extends PublisherCrawlRequest {
   lease_owner: string;
   lease_token: string;
   lease_expires_at: Date;
+  was_reclaimed: boolean;
+}
+
+export interface ClaimPublisherCrawlRequestsResult {
+  requests: ClaimedPublisherCrawlRequest[];
+  terminalizedExpired: number;
 }
 
 export class CrawlRequestRateLimitError extends Error {
@@ -53,6 +59,13 @@ export class CrawlRequestRateLimitError extends Error {
   }
 }
 
+export class CrawlQueueCapacityError extends Error {
+  constructor(readonly capacity: number) {
+    super('Publisher crawl queue is at capacity');
+    this.name = 'CrawlQueueCapacityError';
+  }
+}
+
 export interface CreatePublisherCrawlRequestInput {
   id: string;
   domain: string;
@@ -62,6 +75,7 @@ export interface CreatePublisherCrawlRequestInput {
   domainWindowMs?: number;
   requesterWindowMs?: number;
   requesterLimit?: number;
+  activeQueueCapacity?: number;
 }
 
 export interface PublisherCrawlQueueHealth {
@@ -70,7 +84,8 @@ export interface PublisherCrawlQueueHealth {
   deferred: number;
   retrying: number;
   expired_leases: number;
-  oldest_active_at: Date | null;
+  oldest_due_at: Date | null;
+  oldest_running_at: Date | null;
 }
 
 function retryAfterSeconds(retryAt: Date): number {
@@ -87,6 +102,7 @@ export class PublisherCrawlRequestsDatabase {
     const domainWindowMs = input.domainWindowMs ?? 5 * 60_000;
     const requesterWindowMs = input.requesterWindowMs ?? 60 * 60_000;
     const requesterLimit = input.requesterLimit ?? 30;
+    const activeQueueCapacity = input.activeQueueCapacity ?? 10_000;
     const client = await getClient();
     let transactionStarted = false;
     try {
@@ -94,6 +110,17 @@ export class PublisherCrawlRequestsDatabase {
       transactionStarted = true;
       await client.query("SELECT set_config('statement_timeout', '5000ms', true)");
       await client.query("SELECT set_config('lock_timeout', '2000ms', true)");
+      await client.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [
+        'publisher-crawl-capacity',
+      ]);
+      const capacity = await client.query<{ active_count: string }>(
+        `SELECT COUNT(*)::text AS active_count
+           FROM publisher_crawl_requests
+          WHERE status IN ('queued', 'running', 'deferred', 'retrying')`,
+      );
+      if (Number(capacity.rows[0]?.active_count ?? 0) >= activeQueueCapacity) {
+        throw new CrawlQueueCapacityError(activeQueueCapacity);
+      }
       const requesterKey = input.requesterType === 'user'
         ? input.requestedByUserId
         : 'static_admin';
@@ -169,7 +196,7 @@ export class PublisherCrawlRequestsDatabase {
     workerId: string,
     limit: number,
     leaseMs: number,
-  ): Promise<ClaimedPublisherCrawlRequest[]> {
+  ): Promise<ClaimPublisherCrawlRequestsResult> {
     const client = await getClient();
     let transactionStarted = false;
     try {
@@ -180,7 +207,7 @@ export class PublisherCrawlRequestsDatabase {
 
       // An expired final attempt is terminal; do not leave it permanently
       // running merely because it is no longer eligible for another claim.
-      await client.query(
+      const expiredFinal = await client.query(
         `UPDATE publisher_crawl_requests
             SET status = 'failed',
                 completed_at = NOW(),
@@ -193,12 +220,15 @@ export class PublisherCrawlRequestsDatabase {
                 last_error = COALESCE(last_error, 'Worker lease expired after the final attempt')
           WHERE status = 'running'
             AND lease_expires_at <= NOW()
-            AND attempts >= max_attempts`,
+            AND attempts >= max_attempts
+            AND pg_try_advisory_xact_lock(
+              hashtextextended('publisher-crawl-fence:' || id::text, 0)
+            )`,
       );
 
       const result = await client.query<ClaimedPublisherCrawlRequest>(
-        `WITH due AS (
-           SELECT id
+        `WITH candidates AS MATERIALIZED (
+           SELECT id, status = 'running' AS was_reclaimed
              FROM publisher_crawl_requests
             WHERE attempts < max_attempts
               AND (
@@ -208,6 +238,12 @@ export class PublisherCrawlRequestsDatabase {
             ORDER BY available_at ASC, created_at ASC
             FOR UPDATE SKIP LOCKED
             LIMIT $2
+         ), due AS (
+           SELECT *
+             FROM candidates
+            WHERE pg_try_advisory_xact_lock(
+              hashtextextended('publisher-crawl-fence:' || id::text, 0)
+            )
          )
          UPDATE publisher_crawl_requests AS requests
             SET status = 'running',
@@ -222,11 +258,16 @@ export class PublisherCrawlRequestsDatabase {
                 updated_at = NOW()
            FROM due
           WHERE requests.id = due.id
-         RETURNING requests.*`,
+         RETURNING requests.*,
+                   COALESCE((SELECT due.was_reclaimed FROM due WHERE due.id = requests.id), false)
+                     AS was_reclaimed`,
         [workerId, Math.max(1, Math.min(limit, 100)), leaseMs],
       );
       await client.query('COMMIT');
-      return result.rows;
+      return {
+        requests: result.rows,
+        terminalizedExpired: expiredFinal.rowCount ?? 0,
+      };
     } catch (error) {
       if (transactionStarted) await client.query('ROLLBACK');
       throw error;
@@ -384,7 +425,8 @@ export class PublisherCrawlRequestsDatabase {
       deferred: string;
       retrying: string;
       expired_leases: string;
-      oldest_active_at: Date | null;
+      oldest_due_at: Date | null;
+      oldest_running_at: Date | null;
     }>(
       `SELECT COUNT(*) FILTER (WHERE status = 'queued')::text AS queued,
               COUNT(*) FILTER (WHERE status = 'running')::text AS running,
@@ -393,10 +435,12 @@ export class PublisherCrawlRequestsDatabase {
               COUNT(*) FILTER (
                 WHERE status = 'running' AND lease_expires_at <= NOW()
               )::text AS expired_leases,
-              MIN(created_at) FILTER (
-                WHERE status IN ('queued', 'running', 'deferred', 'retrying')
-              ) AS oldest_active_at
-         FROM publisher_crawl_requests`,
+              MIN(available_at) FILTER (
+                WHERE status IN ('queued', 'deferred', 'retrying') AND available_at <= NOW()
+              ) AS oldest_due_at,
+              MIN(last_attempted_at) FILTER (WHERE status = 'running') AS oldest_running_at
+         FROM publisher_crawl_requests
+        WHERE status IN ('queued', 'running', 'deferred', 'retrying')`,
     );
       const row = result.rows[0];
       return {
@@ -405,7 +449,8 @@ export class PublisherCrawlRequestsDatabase {
         deferred: Number(row.deferred),
         retrying: Number(row.retrying),
         expired_leases: Number(row.expired_leases),
-        oldest_active_at: row.oldest_active_at,
+        oldest_due_at: row.oldest_due_at,
+        oldest_running_at: row.oldest_running_at,
       };
     });
   }

--- a/server/src/db/publisher-db.ts
+++ b/server/src/db/publisher-db.ts
@@ -1,4 +1,4 @@
-import { getClient } from './client.js';
+import { getClient, query } from './client.js';
 import { uuidv7 } from './uuid.js';
 import { CollectionCatalogDatabase, type CollectionProjectionEvent } from './collection-catalog-db.js';
 import type { CatalogEventsDatabase, WriteEventInput } from './catalog-events-db.js';
@@ -147,6 +147,15 @@ export interface UpsertAdagentsCacheInput {
   collectionEventActor?: string;
   publisherEventActor?: string;
   publisherEventSource?: string;
+  crawlRequestId?: string;
+  crawlRequestLeaseToken?: string;
+}
+
+export class PublisherCrawlLeaseLostError extends Error {
+  constructor() {
+    super('Publisher crawl request lease is no longer current');
+    this.name = 'PublisherCrawlLeaseLostError';
+  }
 }
 
 export interface RecordAdagentsValidationFailureInput {
@@ -960,10 +969,8 @@ export class PublisherDatabase {
     resolvedUrl?: string;
   }): Promise<void> {
     const domain = canonicalizePublisherDomain(input.domain);
-    const client = await getClient();
-    try {
-      await client.query(
-        `INSERT INTO publishers
+    await query(
+      `INSERT INTO publishers
            (domain, source_type, last_http_status, last_response_bytes, resolved_url)
          VALUES ($1, 'community', $2, $3, $4)
          ON CONFLICT (domain) DO UPDATE SET
@@ -976,11 +983,8 @@ export class PublisherDatabase {
           clampHttpStatus(input.statusCode),
           input.responseBytes ?? null,
           truncateResolvedUrl(input.resolvedUrl),
-        ],
-      );
-    } finally {
-      client.release();
-    }
+      ],
+    );
   }
 
   /**
@@ -1128,6 +1132,28 @@ export class PublisherDatabase {
       // no row exists yet. A row lock alone cannot prevent concurrent first
       // crawls from both observing "missing" and emitting duplicate events.
       await client.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [domain]);
+      if (input.crawlRequestId || input.crawlRequestLeaseToken) {
+        if (!input.crawlRequestId || !input.crawlRequestLeaseToken) {
+          throw new PublisherCrawlLeaseLostError();
+        }
+        // Serialize the token check with claim/reclaim without row-locking
+        // the request. Heartbeats must remain able to extend the lease while
+        // a larger mirror transaction is committing.
+        await client.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [
+          `publisher-crawl-fence:${input.crawlRequestId}`,
+        ]);
+        const lease = await client.query(
+          `SELECT 1
+             FROM publisher_crawl_requests
+            WHERE id = $1
+              AND status = 'running'
+              AND lease_token = $2
+              AND lease_expires_at > NOW()
+            `,
+          [input.crawlRequestId, input.crawlRequestLeaseToken],
+        );
+        if (lease.rowCount !== 1) throw new PublisherCrawlLeaseLostError();
+      }
       const previousResult = await client.query<{ adagents_json: AdagentsManifest | null }>(
         `SELECT adagents_json FROM publishers WHERE domain = $1 FOR UPDATE`,
         [domain],

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -9704,6 +9704,11 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
       // Crawl catalog domains for adagents.json (demand-driven queue)
       this.crawler.startPeriodicCatalogCrawl(30); // Process queue every 30 minutes
 
+      // Drain durable explicit publisher recrawl requests. Admission is
+      // persisted by the web process before it returns 202; the worker claims
+      // requests with expiring leases so deploys and crashes cannot lose work.
+      this.crawler.startPeriodicPublisherCrawlRequests(5); // 5-second tick
+
       // Drain manager_revalidation_queue (#4200 item 2) — fan-out
       // re-validation when a manager rotates its adagents.json.
       this.crawler.startPeriodicManagerRevalidation(5); // 5-minute tick

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -11307,7 +11307,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         releaseCrawlRateLimit(req, rateLimitKey);
         if (error instanceof CrawlRequestRateLimitError) {
           return res.status(429).json({
-            error: error.message,
+            error: error.scope === 'domain'
+              ? 'Rate limit exceeded for this domain'
+              : 'Hourly crawl request limit exceeded',
             retry_after: error.retryAfterSeconds,
           });
         }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -116,6 +116,7 @@ import { CatalogDatabase } from "../db/catalog-db.js";
 import type { AdAgentsManager } from "../adagents-manager.js";
 import type { HealthChecker } from "../health.js";
 import type { CrawlerService } from "../crawler.js";
+import { isPublisherCrawlQueueEnabled } from "../crawler.js";
 import { sanitizeCreativeCapabilities, type CapabilityDiscovery } from "../capabilities.js";
 import { aaoHostedBrandJsonUrl, aaoHostedAdagentsJsonUrl, expectedAdagentsJsonUrl } from "../config/aao.js";
 import { canonicalTargetUri } from "@adcp/sdk/signing";
@@ -158,7 +159,10 @@ import {
 } from "../db/authorization-snapshot-db.js";
 import { createHash, randomUUID } from "crypto";
 import { createGzip, constants as zlibConstants } from "zlib";
-import { CrawlRequestRateLimitError } from "../db/publisher-crawl-requests-db.js";
+import {
+  CrawlQueueCapacityError,
+  CrawlRequestRateLimitError,
+} from "../db/publisher-crawl-requests-db.js";
 
 type PublisherBrandSummary = {
   name?: string;
@@ -1830,6 +1834,21 @@ registry.registerPath({
         },
       },
     },
+    503: {
+      description: "Publisher crawl is temporarily busy",
+      headers: z.object({
+        "Retry-After": z.string().openapi({ description: "Seconds to wait before retrying" }),
+      }),
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.string(),
+            code: z.literal("publisher_crawl_busy"),
+            retry_after: z.number().int().openapi({ description: "Seconds to wait before retrying" }),
+          }),
+        },
+      },
+    },
   },
 });
 
@@ -3095,11 +3114,14 @@ registry.registerPath({
     401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
     503: {
       description: "The durable crawl queue is temporarily unavailable; the request was not accepted",
+      headers: z.object({
+        "Retry-After": z.string().openapi({ description: "Seconds to wait before retrying" }),
+      }),
       content: {
         "application/json": {
           schema: z.object({
             error: z.string(),
-            code: z.literal("crawl_queue_unavailable"),
+            code: z.enum(["crawl_queue_unavailable", "crawl_queue_at_capacity"]),
             retry_after: z.number().int(),
           }),
         },
@@ -3156,7 +3178,21 @@ registry.registerPath({
     400: { description: "Invalid crawl request ID", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
     404: { description: "Crawl request not found", content: { "application/json": { schema: ErrorSchema } } },
-    503: { description: "Crawl status is temporarily unavailable", content: { "application/json": { schema: ErrorSchema } } },
+    503: {
+      description: "Crawl status is temporarily unavailable",
+      headers: z.object({
+        "Retry-After": z.string().openapi({ description: "Seconds to wait before retrying" }),
+      }),
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.string(),
+            code: z.literal("crawl_status_unavailable"),
+            retry_after: z.number().int(),
+          }),
+        },
+      },
+    },
   },
 });
 
@@ -11200,6 +11236,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
   if (!authMiddleware) throw new Error('requireAuth middleware is required for crawl-request endpoint');
 
   router.post("/registry/publisher/:domain/adagents/revalidate", authMiddleware, async (req, res) => {
+    let reservedDomain: string | null = null;
     try {
       if (!req.user && !isStaticAdminRequest(req)) {
         return res.status(401).json({ error: "Authentication required" });
@@ -11215,13 +11252,25 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         return res.status(400).json({ error: "Invalid domain" });
       }
 
-      const normalizedDomain = await validateAndRateLimitCrawl(req, res, rawDomain, rawDomain);
-      if (!normalizedDomain) return;
+      reservedDomain = await validateAndRateLimitCrawl(req, res, rawDomain, rawDomain);
+      if (!reservedDomain) return;
 
       const force = req.query.force === 'true' || req.query.force === '1';
-      const result = await crawler.revalidatePublisherAdagents(normalizedDomain, { force });
+      const result = await crawler.revalidatePublisherAdagents(reservedDomain, { force });
       return res.json(result);
     } catch (error) {
+      const errorCode = error instanceof Error
+        ? (error as Error & { code?: string }).code
+        : undefined;
+      if (errorCode === 'crawl_deferred' || errorCode === 'crawl_execution_lock_lost') {
+        if (reservedDomain) releaseCrawlRateLimit(req, reservedDomain);
+        res.setHeader('Retry-After', '5');
+        return res.status(503).json({
+          error: "Publisher crawl is temporarily busy",
+          code: "publisher_crawl_busy",
+          retry_after: 5,
+        });
+      }
       logger.error({ error, path: req.path }, "Failed to revalidate publisher adagents.json");
       return res.status(500).json({ error: "Failed to revalidate publisher adagents.json" });
     }
@@ -11280,6 +11329,14 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
   });
 
   router.post("/registry/crawl-request", authMiddleware, async (req, res) => {
+    if (!isPublisherCrawlQueueEnabled()) {
+      res.setHeader('Retry-After', '60');
+      return res.status(503).json({
+        error: 'Crawl queue is temporarily unavailable',
+        code: 'crawl_queue_unavailable',
+        retry_after: 60,
+      });
+    }
     const rateLimitKey = req.body?.domain?.toLowerCase?.()?.trim?.() || '';
     try {
       const normalizedDomain = await validateAndRateLimitCrawl(req, res, rateLimitKey);
@@ -11311,6 +11368,14 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
               ? 'Rate limit exceeded for this domain'
               : 'Hourly crawl request limit exceeded',
             retry_after: error.retryAfterSeconds,
+          });
+        }
+        if (error instanceof CrawlQueueCapacityError) {
+          res.setHeader('Retry-After', '60');
+          return res.status(503).json({
+            error: 'Crawl queue is temporarily at capacity',
+            code: 'crawl_queue_at_capacity',
+            retry_after: 60,
           });
         }
         throw error;

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -158,6 +158,7 @@ import {
 } from "../db/authorization-snapshot-db.js";
 import { createHash, randomUUID } from "crypto";
 import { createGzip, constants as zlibConstants } from "zlib";
+import { CrawlRequestRateLimitError } from "../db/publisher-crawl-requests-db.js";
 
 type PublisherBrandSummary = {
   name?: string;
@@ -3061,7 +3062,7 @@ registry.registerPath({
   operationId: "requestCrawl",
   summary: "Request domain re-crawl",
   description:
-    "Trigger an immediate re-crawl of a publisher domain after updating adagents.json. The crawl runs asynchronously in the accepting process — returns 202 immediately. The response `crawl_request_id` correlates accepted, running, completed, skipped, and failed lifecycle logs; a 202 does not by itself mean the mirror write completed.\n\n**Rate limits:** 5 minutes per domain, 30 requests per user per hour.",
+    "Persist a durable re-crawl request for a publisher domain after updating adagents.json. Returns 202 only after the request is committed to the queue. Use the returned `crawl_request_id` with the status endpoint to observe completion.\n\n**Rate limits:** 5 minutes per domain, 30 requests per user per hour.",
   tags: ["Agent Discovery"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -3084,7 +3085,7 @@ registry.registerPath({
             message: z.literal("Crawl request accepted"),
             domain: z.string(),
             crawl_request_id: z.string().uuid().openapi({
-              description: "Correlation ID for crawl lifecycle logs; acceptance is not completion.",
+              description: "Durable request ID for lifecycle logs and status lookup; acceptance is not completion.",
             }),
           }),
         },
@@ -3093,12 +3094,12 @@ registry.registerPath({
     400: { description: "Invalid domain format, private IP, or unresolvable domain", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
     503: {
-      description: "A full crawl is active; the request was not accepted",
+      description: "The durable crawl queue is temporarily unavailable; the request was not accepted",
       content: {
         "application/json": {
           schema: z.object({
             error: z.string(),
-            code: z.literal("crawl_temporarily_unavailable"),
+            code: z.literal("crawl_queue_unavailable"),
             retry_after: z.number().int(),
           }),
         },
@@ -3115,6 +3116,47 @@ registry.registerPath({
         },
       },
     },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/registry/crawl-request/{crawlRequestId}",
+  operationId: "getCrawlRequest",
+  summary: "Get publisher crawl request status",
+  description: "Return the durable lifecycle for a publisher recrawl. Requesters may read their own requests; registry administrators may read any request.",
+  tags: ["Agent Discovery"],
+  security: [{ bearerAuth: [] }, { oauth2: [] }],
+  request: {
+    params: z.object({
+      crawlRequestId: z.string().uuid(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Durable crawl request lifecycle",
+      content: {
+        "application/json": {
+          schema: z.object({
+            crawl_request_id: z.string().uuid(),
+            domain: z.string(),
+            status: z.enum(["queued", "running", "deferred", "retrying", "completed", "invalid", "failed"]),
+            attempts: z.number().int(),
+            max_attempts: z.number().int(),
+            requested_at: z.string().datetime(),
+            started_at: z.string().datetime().nullable(),
+            last_attempted_at: z.string().datetime().nullable(),
+            completed_at: z.string().datetime().nullable(),
+            next_attempt_at: z.string().datetime().nullable(),
+            last_error_code: z.string().nullable(),
+          }),
+        },
+      },
+    },
+    400: { description: "Invalid crawl request ID", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
+    404: { description: "Crawl request not found", content: { "application/json": { schema: ErrorSchema } } },
+    503: { description: "Crawl status is temporarily unavailable", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -11238,52 +11280,49 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
   });
 
   router.post("/registry/crawl-request", authMiddleware, async (req, res) => {
+    const rateLimitKey = req.body?.domain?.toLowerCase?.()?.trim?.() || '';
     try {
-      const rateLimitKey = req.body?.domain?.toLowerCase?.()?.trim?.() || '';
       const normalizedDomain = await validateAndRateLimitCrawl(req, res, rateLimitKey);
       if (!normalizedDomain) return;
 
-      const crawlRequestId = randomUUID();
-      const crawlTask = crawler.tryStartSingleDomainCrawl(normalizedDomain, {
-        requestId: crawlRequestId,
-        source: "api:crawl-request",
-      });
-      if (!crawlTask) {
+      const staticAdmin = isStaticAdminRequest(req);
+      if (!req.user && !staticAdmin) {
         releaseCrawlRateLimit(req, rateLimitKey);
-        logger.warn(
-          {
-            domain: normalizedDomain,
-            crawl_request_id: crawlRequestId,
-            crawl_status: "not_accepted",
-            reason: "full_crawl_in_progress",
-          },
-          "Crawl request not accepted",
-        );
-        res.setHeader("Retry-After", "5");
-        return res.status(503).json({
-          error: "A full crawl is in progress; retry the crawl request",
-          code: "crawl_temporarily_unavailable",
-          retry_after: 5,
-        });
+        return res.status(401).json({ error: "Authentication required" });
       }
+
+      const crawlRequestId = randomUUID();
+      try {
+        await crawler.enqueuePublisherCrawlRequest({
+          id: crawlRequestId,
+          domain: normalizedDomain,
+          source: "api:crawl-request",
+          requesterType: staticAdmin ? 'static_admin' : 'user',
+          requestedByUserId: staticAdmin ? null : req.user!.id,
+          domainWindowMs: CRAWL_RATE_LIMIT_MS,
+          requesterWindowMs: MEMBER_CRAWL_WINDOW_MS,
+          requesterLimit: MEMBER_CRAWL_LIMIT,
+        });
+      } catch (error) {
+        releaseCrawlRateLimit(req, rateLimitKey);
+        if (error instanceof CrawlRequestRateLimitError) {
+          return res.status(429).json({
+            error: error.message,
+            retry_after: error.retryAfterSeconds,
+          });
+        }
+        throw error;
+      }
+
       logger.info(
         {
           domain: normalizedDomain,
           crawl_request_id: crawlRequestId,
-          crawl_status: "accepted",
+          crawl_status: "queued",
+          source: "api:crawl-request",
         },
         "Crawl request accepted",
       );
-      crawlTask.catch((err: Error) => {
-        logger.debug(
-          {
-            err,
-            domain: normalizedDomain,
-            crawl_request_id: crawlRequestId,
-          },
-          "Accepted crawl task settled with error",
-        );
-      });
 
       return res.status(202).json({
         message: "Crawl request accepted",
@@ -11292,7 +11331,63 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       });
     } catch (error) {
       logger.error({ error }, "Failed to process crawl request");
-      return res.status(500).json({ error: "Failed to process crawl request" });
+      res.setHeader("Retry-After", "5");
+      return res.status(503).json({
+        error: "Crawl queue is temporarily unavailable",
+        code: "crawl_queue_unavailable",
+        retry_after: 5,
+      });
+    }
+  });
+
+  router.get("/registry/crawl-request/:crawlRequestId", authMiddleware, async (req, res) => {
+    try {
+      const crawlRequestId = req.params.crawlRequestId;
+      if (!isUuid(crawlRequestId)) {
+        return res.status(400).json({ error: "Invalid crawl request ID" });
+      }
+      const staticAdmin = isStaticAdminRequest(req);
+      if (!req.user && !staticAdmin) {
+        return res.status(401).json({ error: "Authentication required" });
+      }
+
+      const crawlRequest = await crawler.getPublisherCrawlRequest(crawlRequestId);
+      const ownsRequest = !!req.user
+        && crawlRequest?.requester_type === 'user'
+        && crawlRequest.requested_by_user_id === req.user.id;
+      if (!crawlRequest) {
+        return res.status(404).json({ error: "Crawl request not found" });
+      }
+      const canReadAnyRequest = staticAdmin
+        || (!ownsRequest && await isRegistryAdminRequest(req));
+      if (!ownsRequest && !canReadAnyRequest) {
+        return res.status(404).json({ error: "Crawl request not found" });
+      }
+
+      res.setHeader('Cache-Control', 'private, no-store');
+      return res.json({
+        crawl_request_id: crawlRequest.id,
+        domain: crawlRequest.publisher_domain,
+        status: crawlRequest.status,
+        attempts: crawlRequest.attempts,
+        max_attempts: crawlRequest.max_attempts,
+        requested_at: crawlRequest.created_at.toISOString(),
+        started_at: crawlRequest.started_at?.toISOString() ?? null,
+        last_attempted_at: crawlRequest.last_attempted_at?.toISOString() ?? null,
+        completed_at: crawlRequest.completed_at?.toISOString() ?? null,
+        next_attempt_at: crawlRequest.status === 'deferred' || crawlRequest.status === 'retrying'
+          ? crawlRequest.available_at.toISOString()
+          : null,
+        last_error_code: crawlRequest.last_error_code,
+      });
+    } catch (error) {
+      logger.error({ error, crawl_request_id: req.params.crawlRequestId }, "Failed to read crawl request");
+      res.setHeader('Retry-After', '5');
+      return res.status(503).json({
+        error: "Crawl status is temporarily unavailable",
+        code: "crawl_status_unavailable",
+        retry_after: 5,
+      });
     }
   });
 

--- a/server/tests/integration/publisher-crawl-requests-queue.test.ts
+++ b/server/tests/integration/publisher-crawl-requests-queue.test.ts
@@ -1,0 +1,201 @@
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Pool } from 'pg';
+import { closeDatabase, initializeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import {
+  CrawlRequestRateLimitError,
+  PublisherCrawlRequestsDatabase,
+} from '../../src/db/publisher-crawl-requests-db.js';
+
+describe('durable publisher crawl request queue', () => {
+  let pool: Pool;
+  let db: PublisherCrawlRequestsDatabase;
+  const ids: string[] = [];
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    db = new PublisherCrawlRequestsDatabase();
+  });
+
+  beforeEach(async () => {
+    if (ids.length > 0) {
+      await pool.query('DELETE FROM publisher_crawl_requests WHERE id = ANY($1::uuid[])', [[...ids]]);
+      ids.length = 0;
+    }
+  });
+
+  afterAll(async () => {
+    if (ids.length > 0) {
+      await pool.query('DELETE FROM publisher_crawl_requests WHERE id = ANY($1::uuid[])', [[...ids]]);
+    }
+    await closeDatabase();
+  });
+
+  async function enqueue(domain = `${randomUUID()}.example.com`) {
+    const id = randomUUID();
+    ids.push(id);
+    return db.create({
+      id,
+      domain,
+      source: 'test',
+      requesterType: 'user',
+      requestedByUserId: 'durable-crawl-test-user',
+    });
+  }
+
+  it('persists admission before exposing a queued request', async () => {
+    const created = await enqueue();
+    const stored = await db.getById(created.id);
+
+    expect(stored).toMatchObject({
+      id: created.id,
+      status: 'queued',
+      attempts: 0,
+      requested_by_user_id: 'durable-crawl-test-user',
+    });
+    expect(stored?.created_at).toBeInstanceOf(Date);
+  });
+
+  it('enforces the per-domain admission window across database clients', async () => {
+    const domain = `${randomUUID()}.example.com`;
+    await enqueue(domain);
+    const duplicateId = randomUUID();
+    ids.push(duplicateId);
+
+    await expect(db.create({
+      id: duplicateId,
+      domain,
+      source: 'test',
+      requesterType: 'user',
+      requestedByUserId: 'another-user',
+    })).rejects.toMatchObject<CrawlRequestRateLimitError>({
+      scope: 'domain',
+    });
+  });
+
+  it('serializes the per-requester hourly limit across different domains', async () => {
+    const firstId = randomUUID();
+    const secondId = randomUUID();
+    ids.push(firstId, secondId);
+    const create = (id: string) => db.create({
+      id,
+      domain: `${id}.example.com`,
+      source: 'test',
+      requesterType: 'user',
+      requestedByUserId: 'concurrent-limited-user',
+      requesterLimit: 1,
+    });
+
+    const outcomes = await Promise.allSettled([create(firstId), create(secondId)]);
+    expect(outcomes.filter((outcome) => outcome.status === 'fulfilled')).toHaveLength(1);
+    const rejected = outcomes.find((outcome) => outcome.status === 'rejected');
+    expect(rejected).toMatchObject({
+      status: 'rejected',
+      reason: { scope: 'requester' },
+    });
+  });
+
+  it('claims each request once when workers race', async () => {
+    const first = await enqueue();
+    const second = await enqueue();
+
+    const [workerA, workerB] = await Promise.all([
+      db.claimDue('worker-a', 1, 60_000),
+      db.claimDue('worker-b', 1, 60_000),
+    ]);
+
+    expect(workerA).toHaveLength(1);
+    expect(workerB).toHaveLength(1);
+    expect(new Set([workerA[0].id, workerB[0].id])).toEqual(new Set([first.id, second.id]));
+    expect(workerA[0].lease_token).not.toBe(workerB[0].lease_token);
+  });
+
+  it('reclaims an expired lease and rejects completion from the stale attempt', async () => {
+    const created = await enqueue();
+    const [firstClaim] = await db.claimDue('worker-a', 1, 60_000);
+    await pool.query(
+      `UPDATE publisher_crawl_requests SET lease_expires_at = NOW() - INTERVAL '1 second' WHERE id = $1`,
+      [created.id],
+    );
+
+    const [secondClaim] = await db.claimDue('worker-b', 1, 60_000);
+    expect(secondClaim.id).toBe(created.id);
+    expect(secondClaim.attempts).toBe(2);
+    expect(secondClaim.lease_token).not.toBe(firstClaim.lease_token);
+    await expect(db.markCompleted(created.id, firstClaim.lease_token, 'completed')).resolves.toBe(false);
+    await expect(db.markCompleted(created.id, secondClaim.lease_token, 'completed')).resolves.toBe(true);
+    await expect(db.getById(created.id)).resolves.toMatchObject({ status: 'completed', attempts: 2 });
+  });
+
+  it('defers full-crawl contention without consuming an attempt', async () => {
+    const created = await enqueue();
+    const [claim] = await db.claimDue('worker-a', 1, 60_000);
+    expect(claim.attempts).toBe(1);
+
+    await db.markDeferred(created.id, claim.lease_token, 30_000, 'full crawl in progress');
+    await expect(db.getById(created.id)).resolves.toMatchObject({
+      status: 'deferred',
+      attempts: 0,
+      last_error_code: 'crawl_deferred',
+    });
+  });
+
+  it('records an invalid publisher manifest as a terminal non-retry outcome', async () => {
+    const created = await enqueue();
+    const [claim] = await db.claimDue('worker-a', 1, 60_000);
+
+    await db.markCompleted(created.id, claim.lease_token, 'invalid');
+
+    await expect(db.getById(created.id)).resolves.toMatchObject({
+      status: 'invalid',
+      attempts: 1,
+      last_error_code: 'publisher_manifest_invalid',
+    });
+  });
+
+  it('retries failures and reaches a bounded terminal state', async () => {
+    const created = await enqueue();
+    await pool.query('UPDATE publisher_crawl_requests SET max_attempts = 2 WHERE id = $1', [created.id]);
+
+    const [firstClaim] = await db.claimDue('worker-a', 1, 60_000);
+    const retrying = await db.markFailedAttempt(
+      created.id,
+      firstClaim.lease_token,
+      'origin_timeout',
+      'origin timed out',
+    );
+    expect(retrying).toMatchObject({ status: 'retrying', attempts: 1 });
+
+    await pool.query('UPDATE publisher_crawl_requests SET available_at = NOW() WHERE id = $1', [created.id]);
+    const [secondClaim] = await db.claimDue('worker-b', 1, 60_000);
+    const failed = await db.markFailedAttempt(
+      created.id,
+      secondClaim.lease_token,
+      'origin_timeout',
+      'origin timed out again',
+    );
+    expect(failed).toMatchObject({ status: 'failed', attempts: 2 });
+    expect(failed?.completed_at).toBeInstanceOf(Date);
+  });
+
+  it('terminally fails a final attempt whose worker lease expires', async () => {
+    const created = await enqueue();
+    await pool.query('UPDATE publisher_crawl_requests SET max_attempts = 1 WHERE id = $1', [created.id]);
+    await db.claimDue('worker-a', 1, 60_000);
+    await pool.query(
+      `UPDATE publisher_crawl_requests SET lease_expires_at = NOW() - INTERVAL '1 second' WHERE id = $1`,
+      [created.id],
+    );
+
+    await db.claimDue('worker-b', 1, 60_000);
+    await expect(db.getById(created.id)).resolves.toMatchObject({
+      status: 'failed',
+      attempts: 1,
+      last_error_code: 'lease_expired',
+    });
+  });
+});

--- a/server/tests/integration/publisher-crawl-requests-queue.test.ts
+++ b/server/tests/integration/publisher-crawl-requests-queue.test.ts
@@ -4,14 +4,20 @@ import type { Pool } from 'pg';
 import { closeDatabase, initializeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import {
+  CrawlQueueCapacityError,
   CrawlRequestRateLimitError,
   PublisherCrawlRequestsDatabase,
 } from '../../src/db/publisher-crawl-requests-db.js';
+import {
+  PublisherCrawlLeaseLostError,
+  PublisherDatabase,
+} from '../../src/db/publisher-db.js';
 
 describe('durable publisher crawl request queue', () => {
   let pool: Pool;
   let db: PublisherCrawlRequestsDatabase;
   const ids: string[] = [];
+  const publisherDomains: string[] = [];
 
   beforeAll(async () => {
     pool = initializeDatabase({
@@ -26,11 +32,18 @@ describe('durable publisher crawl request queue', () => {
       await pool.query('DELETE FROM publisher_crawl_requests WHERE id = ANY($1::uuid[])', [[...ids]]);
       ids.length = 0;
     }
+    if (publisherDomains.length > 0) {
+      await pool.query('DELETE FROM publishers WHERE domain = ANY($1::text[])', [[...publisherDomains]]);
+      publisherDomains.length = 0;
+    }
   });
 
   afterAll(async () => {
     if (ids.length > 0) {
       await pool.query('DELETE FROM publisher_crawl_requests WHERE id = ANY($1::uuid[])', [[...ids]]);
+    }
+    if (publisherDomains.length > 0) {
+      await pool.query('DELETE FROM publishers WHERE domain = ANY($1::text[])', [[...publisherDomains]]);
     }
     await closeDatabase();
   });
@@ -58,6 +71,20 @@ describe('durable publisher crawl request queue', () => {
       requested_by_user_id: 'durable-crawl-test-user',
     });
     expect(stored?.created_at).toBeInstanceOf(Date);
+  });
+
+  it('rejects admission when the active queue reaches its global high-water mark', async () => {
+    await enqueue();
+    const id = randomUUID();
+    ids.push(id);
+    await expect(db.create({
+      id,
+      domain: `${id}.example.com`,
+      source: 'test',
+      requesterType: 'user',
+      requestedByUserId: 'capacity-test-user',
+      activeQueueCapacity: 1,
+    })).rejects.toBeInstanceOf(CrawlQueueCapacityError);
   });
 
   it('enforces the per-domain admission window across database clients', async () => {
@@ -108,32 +135,108 @@ describe('durable publisher crawl request queue', () => {
       db.claimDue('worker-b', 1, 60_000),
     ]);
 
-    expect(workerA).toHaveLength(1);
-    expect(workerB).toHaveLength(1);
-    expect(new Set([workerA[0].id, workerB[0].id])).toEqual(new Set([first.id, second.id]));
-    expect(workerA[0].lease_token).not.toBe(workerB[0].lease_token);
+    expect(workerA.requests).toHaveLength(1);
+    expect(workerB.requests).toHaveLength(1);
+    expect(new Set([workerA.requests[0].id, workerB.requests[0].id])).toEqual(new Set([first.id, second.id]));
+    expect(workerA.requests[0].lease_token).not.toBe(workerB.requests[0].lease_token);
   });
 
   it('reclaims an expired lease and rejects completion from the stale attempt', async () => {
     const created = await enqueue();
-    const [firstClaim] = await db.claimDue('worker-a', 1, 60_000);
+    const [firstClaim] = (await db.claimDue('worker-a', 1, 60_000)).requests;
     await pool.query(
       `UPDATE publisher_crawl_requests SET lease_expires_at = NOW() - INTERVAL '1 second' WHERE id = $1`,
       [created.id],
     );
 
-    const [secondClaim] = await db.claimDue('worker-b', 1, 60_000);
+    const [secondClaim] = (await db.claimDue('worker-b', 1, 60_000)).requests;
     expect(secondClaim.id).toBe(created.id);
     expect(secondClaim.attempts).toBe(2);
+    expect(secondClaim.was_reclaimed).toBe(true);
     expect(secondClaim.lease_token).not.toBe(firstClaim.lease_token);
     await expect(db.markCompleted(created.id, firstClaim.lease_token, 'completed')).resolves.toBe(false);
     await expect(db.markCompleted(created.id, secondClaim.lease_token, 'completed')).resolves.toBe(true);
     await expect(db.getById(created.id)).resolves.toMatchObject({ status: 'completed', attempts: 2 });
   });
 
+  it('fences a reclaimed stale attempt from committing publisher mirror data', async () => {
+    const domain = `${randomUUID()}.example.com`;
+    publisherDomains.push(domain);
+    const created = await enqueue(domain);
+    const [staleClaim] = (await db.claimDue('worker-a', 1, 60_000)).requests;
+    await pool.query(
+      `UPDATE publisher_crawl_requests SET lease_expires_at = NOW() - INTERVAL '1 second' WHERE id = $1`,
+      [created.id],
+    );
+    await db.claimDue('worker-b', 1, 60_000);
+
+    await expect(new PublisherDatabase().upsertAdagentsCache({
+      domain,
+      manifest: { authorized_agents: [] },
+      crawlRequestId: created.id,
+      crawlRequestLeaseToken: staleClaim.lease_token,
+    })).rejects.toBeInstanceOf(PublisherCrawlLeaseLostError);
+    const persisted = await pool.query(
+      'SELECT adagents_json FROM publishers WHERE domain = $1',
+      [domain],
+    );
+    expect(persisted.rowCount).toBe(0);
+  });
+
+  it('allows heartbeats while the commit fence prevents lease reclamation', async () => {
+    const created = await enqueue();
+    const [claim] = (await db.claimDue('worker-a', 1, 60_000)).requests;
+    const fenceClient = await pool.connect();
+    try {
+      await fenceClient.query('BEGIN');
+      await fenceClient.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [
+        `publisher-crawl-fence:${created.id}`,
+      ]);
+
+      await expect(db.heartbeat(created.id, claim.lease_token, 60_000)).resolves.toBe(true);
+      await pool.query(
+        `UPDATE publisher_crawl_requests SET lease_expires_at = NOW() - INTERVAL '1 second' WHERE id = $1`,
+        [created.id],
+      );
+      const fencedClaim = await db.claimDue('worker-b', 1, 60_000);
+      expect(fencedClaim.requests).toHaveLength(0);
+
+      await fenceClient.query('COMMIT');
+      const reclaimed = await db.claimDue('worker-b', 1, 60_000);
+      expect(reclaimed.requests).toHaveLength(1);
+      expect(reclaimed.requests[0].was_reclaimed).toBe(true);
+    } finally {
+      await fenceClient.query('ROLLBACK').catch(() => undefined);
+      fenceClient.release();
+    }
+  });
+
+  it('coordinates full and per-domain crawl execution across worker instances', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const firstWorker = Object.create((CrawlerService as any).prototype);
+    const secondWorker = Object.create((CrawlerService as any).prototype);
+    const pooledConnectionsBefore = pool.totalCount;
+    const domainLock = await firstWorker.tryAcquireCrawlExecutionLock('publisher.example');
+    expect(domainLock).not.toBeNull();
+    expect(pool.totalCount).toBe(pooledConnectionsBefore);
+
+    const sameDomain = await secondWorker.tryAcquireCrawlExecutionLock('publisher.example');
+    const fullCrawl = await secondWorker.tryAcquireCrawlExecutionLock();
+    const otherDomain = await secondWorker.tryAcquireCrawlExecutionLock('other.example');
+    expect(sameDomain).toBeNull();
+    expect(fullCrawl).toBeNull();
+    expect(otherDomain).not.toBeNull();
+
+    await otherDomain.release();
+    await domainLock.release();
+    const fullAfterRelease = await secondWorker.tryAcquireCrawlExecutionLock();
+    expect(fullAfterRelease).not.toBeNull();
+    await fullAfterRelease.release();
+  });
+
   it('defers full-crawl contention without consuming an attempt', async () => {
     const created = await enqueue();
-    const [claim] = await db.claimDue('worker-a', 1, 60_000);
+    const [claim] = (await db.claimDue('worker-a', 1, 60_000)).requests;
     expect(claim.attempts).toBe(1);
 
     await db.markDeferred(created.id, claim.lease_token, 30_000, 'full crawl in progress');
@@ -146,7 +249,7 @@ describe('durable publisher crawl request queue', () => {
 
   it('records an invalid publisher manifest as a terminal non-retry outcome', async () => {
     const created = await enqueue();
-    const [claim] = await db.claimDue('worker-a', 1, 60_000);
+    const [claim] = (await db.claimDue('worker-a', 1, 60_000)).requests;
 
     await db.markCompleted(created.id, claim.lease_token, 'invalid');
 
@@ -161,7 +264,7 @@ describe('durable publisher crawl request queue', () => {
     const created = await enqueue();
     await pool.query('UPDATE publisher_crawl_requests SET max_attempts = 2 WHERE id = $1', [created.id]);
 
-    const [firstClaim] = await db.claimDue('worker-a', 1, 60_000);
+    const [firstClaim] = (await db.claimDue('worker-a', 1, 60_000)).requests;
     const retrying = await db.markFailedAttempt(
       created.id,
       firstClaim.lease_token,
@@ -171,7 +274,7 @@ describe('durable publisher crawl request queue', () => {
     expect(retrying).toMatchObject({ status: 'retrying', attempts: 1 });
 
     await pool.query('UPDATE publisher_crawl_requests SET available_at = NOW() WHERE id = $1', [created.id]);
-    const [secondClaim] = await db.claimDue('worker-b', 1, 60_000);
+    const [secondClaim] = (await db.claimDue('worker-b', 1, 60_000)).requests;
     const failed = await db.markFailedAttempt(
       created.id,
       secondClaim.lease_token,
@@ -191,7 +294,8 @@ describe('durable publisher crawl request queue', () => {
       [created.id],
     );
 
-    await db.claimDue('worker-b', 1, 60_000);
+    const terminalized = await db.claimDue('worker-b', 1, 60_000);
+    expect(terminalized.terminalizedExpired).toBe(1);
     await expect(db.getById(created.id)).resolves.toMatchObject({
       status: 'failed',
       attempts: 1,

--- a/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
+++ b/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
@@ -227,13 +227,13 @@ describe('Registry reader baseline — public endpoints', () => {
       expect(res.status).toBe(400);
     });
 
-    it('does not consume crawl rate limits when a full crawl rejects admission', async () => {
+    it('does not consume crawl rate limits when durable queue admission fails', async () => {
       const admission = vi.spyOn(
         CrawlerService.prototype,
-        'tryStartSingleDomainCrawl',
+        'enqueuePublisherCrawlRequest',
       )
-        .mockReturnValueOnce(null)
-        .mockReturnValueOnce(Promise.resolve());
+        .mockRejectedValueOnce(new Error('database unavailable'))
+        .mockResolvedValueOnce({} as never);
 
       try {
         const busy = await request(app)
@@ -241,7 +241,7 @@ describe('Registry reader baseline — public endpoints', () => {
           .send({ domain: 'example.com' });
         expect(busy.status).toBe(503);
         expect(busy.headers['retry-after']).toBe('5');
-        expect(busy.body.code).toBe('crawl_temporarily_unavailable');
+        expect(busy.body.code).toBe('crawl_queue_unavailable');
 
         const admitted = await request(app)
           .post('/api/registry/crawl-request')
@@ -256,6 +256,64 @@ describe('Registry reader baseline — public endpoints', () => {
         );
       } finally {
         admission.mockRestore();
+      }
+    });
+
+    it('returns the durable lifecycle to the request owner', async () => {
+      const admission = vi.spyOn(
+        CrawlerService.prototype,
+        'enqueuePublisherCrawlRequest',
+      ).mockResolvedValue({} as never);
+      const statusLookup = vi.spyOn(
+        CrawlerService.prototype,
+        'getPublisherCrawlRequest',
+      );
+
+      try {
+        const admitted = await request(app)
+          .post('/api/registry/crawl-request')
+          .send({ domain: 'scope3.com' });
+        expect(admitted.status).toBe(202);
+        const requestInput = admission.mock.calls[0][0];
+        const now = new Date();
+        statusLookup.mockResolvedValue({
+          id: admitted.body.crawl_request_id,
+          publisher_domain: 'scope3.com',
+          source: 'api:crawl-request',
+          requester_type: 'user',
+          requested_by_user_id: requestInput.requestedByUserId,
+          status: 'completed',
+          attempts: 1,
+          max_attempts: 5,
+          available_at: now,
+          lease_owner: null,
+          lease_token: null,
+          lease_expires_at: null,
+          heartbeat_at: null,
+          last_attempted_at: now,
+          last_error_code: null,
+          last_error: null,
+          created_at: now,
+          started_at: now,
+          completed_at: now,
+          updated_at: now,
+        });
+
+        const status = await request(app)
+          .get(`/api/registry/crawl-request/${admitted.body.crawl_request_id}`);
+        expect(status.status).toBe(200);
+        expect(status.headers['cache-control']).toBe('private, no-store');
+        expect(status.body).toMatchObject({
+          crawl_request_id: admitted.body.crawl_request_id,
+          domain: 'scope3.com',
+          status: 'completed',
+          attempts: 1,
+          next_attempt_at: null,
+          last_error_code: null,
+        });
+      } finally {
+        admission.mockRestore();
+        statusLookup.mockRestore();
       }
     });
   });

--- a/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
+++ b/server/tests/integration/registry-reader-baseline-public-endpoints.test.ts
@@ -32,6 +32,7 @@ import type { Pool } from 'pg';
 vi.hoisted(() => {
   process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
   process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+  process.env.PUBLISHER_CRAWL_QUEUE_ENABLED = 'true';
 });
 
 // Bypass WorkOS auth — the registry feed requires `requireAuth`. Stamp
@@ -46,13 +47,30 @@ vi.hoisted(() => {
 const DEFAULT_TEST_USER_ID = 'user_test_registry_baseline_endpoints';
 const authState = vi.hoisted(() => ({
   optAuthUser: null as { id: string; email: string } | null,
+  requireAuthUser: {
+    id: 'user_test_registry_baseline_endpoints',
+    email: 'registry-baseline@test.com',
+  } as { id: string; email: string; isAdmin?: boolean } | null,
 }));
 vi.mock('../../src/middleware/auth.js', async () => {
   const actual = await vi.importActual<Record<string, unknown>>(
     '../../src/middleware/auth.js'
   );
-  const requireAuthPass = (req: { user: unknown }, _res: unknown, next: () => void) => {
-    req.user = { id: DEFAULT_TEST_USER_ID, email: 'registry-baseline@test.com' };
+  const requireAuthPass = (
+    req: { user: unknown; headers?: Record<string, unknown>; isStaticAdminApiKey?: boolean },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void,
+  ) => {
+    if (req.headers?.authorization === 'Bearer static-admin-test') {
+      req.isStaticAdminApiKey = true;
+      next();
+      return;
+    }
+    if (!authState.requireAuthUser) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+    req.user = authState.requireAuthUser;
     next();
   };
   const optAuthPass = (req: { user: unknown }, _res: unknown, next: () => void) => {
@@ -71,6 +89,10 @@ vi.mock('../../src/middleware/auth.js', async () => {
 
 function setOptAuthUser(user: { id: string; email: string } | null) {
   authState.optAuthUser = user;
+}
+
+function setRequireAuthUser(user: { id: string; email: string; isAdmin?: boolean } | null) {
+  authState.requireAuthUser = user;
 }
 
 vi.mock('../../src/middleware/csrf.js', async () => {
@@ -259,6 +281,25 @@ describe('Registry reader baseline — public endpoints', () => {
       }
     });
 
+    it('does not admit crawl requests while the rollout gate is disabled', async () => {
+      const admission = vi.spyOn(
+        CrawlerService.prototype,
+        'enqueuePublisherCrawlRequest',
+      );
+      process.env.PUBLISHER_CRAWL_QUEUE_ENABLED = 'false';
+      try {
+        const response = await request(app)
+          .post('/api/registry/crawl-request')
+          .send({ domain: 'example.com' });
+        expect(response.status).toBe(503);
+        expect(response.body.code).toBe('crawl_queue_unavailable');
+        expect(admission).not.toHaveBeenCalled();
+      } finally {
+        process.env.PUBLISHER_CRAWL_QUEUE_ENABLED = 'true';
+        admission.mockRestore();
+      }
+    });
+
     it('returns the durable lifecycle to the request owner', async () => {
       const admission = vi.spyOn(
         CrawlerService.prototype,
@@ -313,6 +354,69 @@ describe('Registry reader baseline — public endpoints', () => {
         });
       } finally {
         admission.mockRestore();
+        statusLookup.mockRestore();
+      }
+    });
+
+    it('enforces non-enumerating crawl-status ownership and both admin paths', async () => {
+      const requestId = '22222222-2222-4222-8222-222222222222';
+      const missingId = '33333333-3333-4333-8333-333333333333';
+      const now = new Date();
+      const statusLookup = vi.spyOn(
+        CrawlerService.prototype,
+        'getPublisherCrawlRequest',
+      ).mockImplementation(async (id) => id === missingId ? null : ({
+        id: requestId,
+        publisher_domain: 'scope3.com',
+        source: 'api:crawl-request',
+        requester_type: 'user',
+        requested_by_user_id: 'request-owner',
+        status: 'running',
+        attempts: 1,
+        max_attempts: 5,
+        available_at: now,
+        lease_owner: 'worker-1',
+        lease_token: '11111111-1111-4111-8111-111111111111',
+        lease_expires_at: new Date(now.getTime() + 60_000),
+        heartbeat_at: now,
+        last_attempted_at: now,
+        last_error_code: null,
+        last_error: null,
+        created_at: now,
+        started_at: now,
+        completed_at: null,
+        updated_at: now,
+      }));
+
+      try {
+        setRequireAuthUser(null);
+        const unauthenticated = await request(app)
+          .get(`/api/registry/crawl-request/${requestId}`);
+        expect(unauthenticated.status).toBe(401);
+
+        setRequireAuthUser({ id: 'different-user', email: 'different@example.com' });
+        const forbidden = await request(app)
+          .get(`/api/registry/crawl-request/${requestId}`);
+        const missing = await request(app)
+          .get(`/api/registry/crawl-request/${missingId}`);
+        expect(forbidden.status).toBe(404);
+        expect(forbidden.body).toEqual(missing.body);
+
+        setRequireAuthUser({ id: 'web-admin', email: 'admin@example.com', isAdmin: true });
+        const webAdmin = await request(app)
+          .get(`/api/registry/crawl-request/${requestId}`);
+        expect(webAdmin.status).toBe(200);
+
+        setRequireAuthUser(null);
+        const staticAdmin = await request(app)
+          .get(`/api/registry/crawl-request/${requestId}`)
+          .set('Authorization', 'Bearer static-admin-test');
+        expect(staticAdmin.status).toBe(200);
+      } finally {
+        setRequireAuthUser({
+          id: DEFAULT_TEST_USER_ID,
+          email: 'registry-baseline@test.com',
+        });
         statusLookup.mockRestore();
       }
     });

--- a/server/tests/unit/crawler-durable-request-queue.test.ts
+++ b/server/tests/unit/crawler-durable-request-queue.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest';
+
+function claimedRequest() {
+  const now = new Date();
+  return {
+    id: '8d127de4-5568-4756-b66c-dd9b0780fd8f',
+    publisher_domain: 'publisher.example',
+    source: 'api:crawl-request',
+    requester_type: 'user' as const,
+    requested_by_user_id: 'user-1',
+    status: 'running' as const,
+    attempts: 1,
+    max_attempts: 5,
+    available_at: now,
+    lease_owner: 'worker-1',
+    lease_token: '11111111-1111-4111-8111-111111111111',
+    lease_expires_at: new Date(now.getTime() + 60_000),
+    heartbeat_at: now,
+    last_attempted_at: now,
+    last_error_code: null,
+    last_error: null,
+    created_at: now,
+    started_at: now,
+    completed_at: null,
+    updated_at: now,
+  };
+}
+
+async function makeContext() {
+  const { CrawlerService } = await import('../../src/crawler.js');
+  const crawlRequestsDb = {
+    claimDue: vi.fn().mockResolvedValue([claimedRequest()]),
+    heartbeat: vi.fn().mockResolvedValue(true),
+    markCompleted: vi.fn().mockResolvedValue(true),
+    markDeferred: vi.fn().mockResolvedValue(true),
+    markFailedAttempt: vi.fn(),
+    deleteTerminalBefore: vi.fn().mockResolvedValue(0),
+    getQueueHealth: vi.fn().mockResolvedValue({
+      queued: 0,
+      running: 0,
+      deferred: 0,
+      retrying: 0,
+      expired_leases: 0,
+      oldest_active_at: null,
+    }),
+  };
+  const ctx = Object.create((CrawlerService as any).prototype);
+  Object.assign(ctx, {
+    crawling: false,
+    publisherCrawlQueueProcessing: false,
+    publisherCrawlLastRetentionAt: Date.now(),
+    publisherCrawlLastHealthLogAt: Date.now(),
+    publisherCrawlWorkerId: 'worker-1',
+    crawlRequestsDb,
+    crawlSingleDomain: vi.fn().mockResolvedValue('completed'),
+  });
+  return { ctx, crawlRequestsDb };
+}
+
+describe('CrawlerService durable publisher request worker', () => {
+  it('records a successful terminal outcome', async () => {
+    const { ctx, crawlRequestsDb } = await makeContext();
+
+    await expect(ctx.processPublisherCrawlRequestQueue()).resolves.toEqual({
+      claimed: 1,
+      completed: 1,
+      invalid: 0,
+      retried: 0,
+      failed: 0,
+      deferred: 0,
+    });
+    expect(crawlRequestsDb.markCompleted).toHaveBeenCalledWith(
+      claimedRequest().id,
+      claimedRequest().lease_token,
+      'completed',
+    );
+  });
+
+  it('records a publisher-invalid terminal outcome without retrying', async () => {
+    const { ctx, crawlRequestsDb } = await makeContext();
+    ctx.crawlSingleDomain.mockResolvedValue('invalid');
+
+    const result = await ctx.processPublisherCrawlRequestQueue();
+
+    expect(result.invalid).toBe(1);
+    expect(result.retried).toBe(0);
+    expect(crawlRequestsDb.markCompleted).toHaveBeenCalledWith(
+      claimedRequest().id,
+      claimedRequest().lease_token,
+      'invalid',
+    );
+  });
+
+  it('defers full-crawl contention without marking a failure', async () => {
+    const { ctx, crawlRequestsDb } = await makeContext();
+    ctx.crawlSingleDomain.mockRejectedValue(Object.assign(new Error('full crawl'), {
+      code: 'crawl_deferred',
+    }));
+
+    const result = await ctx.processPublisherCrawlRequestQueue();
+
+    expect(result.deferred).toBe(1);
+    expect(crawlRequestsDb.markDeferred).toHaveBeenCalledOnce();
+    expect(crawlRequestsDb.markFailedAttempt).not.toHaveBeenCalled();
+  });
+
+  it('schedules a retry for a transient execution failure', async () => {
+    const { ctx, crawlRequestsDb } = await makeContext();
+    ctx.crawlSingleDomain.mockRejectedValue(Object.assign(new Error('origin unavailable'), {
+      code: 'crawl_origin_temporarily_unavailable',
+    }));
+    crawlRequestsDb.markFailedAttempt.mockResolvedValue({ status: 'retrying' });
+
+    const result = await ctx.processPublisherCrawlRequestQueue();
+
+    expect(result.retried).toBe(1);
+    expect(crawlRequestsDb.markFailedAttempt).toHaveBeenCalledWith(
+      claimedRequest().id,
+      claimedRequest().lease_token,
+      'crawl_origin_temporarily_unavailable',
+      'Publisher origin was temporarily unavailable',
+    );
+  });
+});

--- a/server/tests/unit/crawler-durable-request-queue.test.ts
+++ b/server/tests/unit/crawler-durable-request-queue.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { CrawlerService } from '../../src/crawler.js';
 
 function claimedRequest() {
   const now = new Date();
@@ -15,6 +16,7 @@ function claimedRequest() {
     lease_owner: 'worker-1',
     lease_token: '11111111-1111-4111-8111-111111111111',
     lease_expires_at: new Date(now.getTime() + 60_000),
+    was_reclaimed: false,
     heartbeat_at: now,
     last_attempted_at: now,
     last_error_code: null,
@@ -27,9 +29,11 @@ function claimedRequest() {
 }
 
 async function makeContext() {
-  const { CrawlerService } = await import('../../src/crawler.js');
   const crawlRequestsDb = {
-    claimDue: vi.fn().mockResolvedValue([claimedRequest()]),
+    claimDue: vi.fn().mockResolvedValue({
+      requests: [claimedRequest()],
+      terminalizedExpired: 0,
+    }),
     heartbeat: vi.fn().mockResolvedValue(true),
     markCompleted: vi.fn().mockResolvedValue(true),
     markDeferred: vi.fn().mockResolvedValue(true),
@@ -41,7 +45,8 @@ async function makeContext() {
       deferred: 0,
       retrying: 0,
       expired_leases: 0,
-      oldest_active_at: null,
+      oldest_due_at: null,
+      oldest_running_at: null,
     }),
   };
   const ctx = Object.create((CrawlerService as any).prototype);
@@ -68,12 +73,14 @@ describe('CrawlerService durable publisher request worker', () => {
       retried: 0,
       failed: 0,
       deferred: 0,
+      lostLease: 0,
     });
     expect(crawlRequestsDb.markCompleted).toHaveBeenCalledWith(
       claimedRequest().id,
       claimedRequest().lease_token,
       'completed',
     );
+    expect(crawlRequestsDb.claimDue).toHaveBeenCalledWith('worker-1', 4, 120_000);
   });
 
   it('records a publisher-invalid terminal outcome without retrying', async () => {
@@ -120,5 +127,46 @@ describe('CrawlerService durable publisher request worker', () => {
       'crawl_origin_temporarily_unavailable',
       'Publisher origin was temporarily unavailable',
     );
+  });
+
+  it('reports a lost lease instead of a successful terminal outcome', async () => {
+    const { ctx, crawlRequestsDb } = await makeContext();
+    crawlRequestsDb.markCompleted.mockResolvedValue(false);
+
+    const result = await ctx.processPublisherCrawlRequestQueue();
+
+    expect(result.completed).toBe(0);
+    expect(result.lostLease).toBe(1);
+  });
+
+  it('drains sibling workers before releasing the batch guard after a transition error', async () => {
+    const { ctx, crawlRequestsDb } = await makeContext();
+    const first = claimedRequest();
+    const second = { ...claimedRequest(), id: '22222222-2222-4222-8222-222222222222' };
+    crawlRequestsDb.claimDue.mockResolvedValue({
+      requests: [first, second],
+      terminalizedExpired: 0,
+    });
+    let releaseSecond!: () => void;
+    const secondPending = new Promise<void>((resolve) => { releaseSecond = resolve; });
+    ctx.crawlSingleDomain
+      .mockRejectedValueOnce(new Error('crawl failed'))
+      .mockImplementationOnce(async () => {
+        await secondPending;
+        return 'completed';
+      });
+    crawlRequestsDb.markFailedAttempt.mockRejectedValueOnce(new Error('transition failed'));
+
+    const processing = ctx.processPublisherCrawlRequestQueue();
+    await vi.waitFor(() => expect(crawlRequestsDb.markFailedAttempt).toHaveBeenCalledOnce());
+    expect(ctx.publisherCrawlQueueProcessing).toBe(true);
+    releaseSecond();
+    await expect(processing).rejects.toThrow('publisher crawl worker(s) failed');
+    expect(crawlRequestsDb.markCompleted).toHaveBeenCalledWith(
+      second.id,
+      second.lease_token,
+      'completed',
+    );
+    expect(ctx.publisherCrawlQueueProcessing).toBe(false);
   });
 });

--- a/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
+++ b/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
+import { CrawlerService } from '../../src/crawler.js';
 
 describe('CrawlerService single-domain profile rebuild', () => {
   async function makeCrawlerContext(params: {
     existingAuthorizations: Array<{ agent_url: string; source: string }>;
     authorizedAgents: Array<{ url: string }>;
   }) {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const proto = (CrawlerService as any).prototype;
     const ctx = Object.create(proto);
 
@@ -39,7 +39,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
   }
 
   it('rejects visibly when a full crawl owns the crawler', async () => {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const ctx = Object.create((CrawlerService as any).prototype);
     const validateDomain = vi.fn();
     Object.assign(ctx, {
@@ -55,7 +54,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
   });
 
   it('does not admit an HTTP-style crawl request while a full crawl is active', async () => {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const ctx = Object.create((CrawlerService as any).prototype);
     Object.assign(ctx, { crawling: true });
 
@@ -66,7 +64,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
   });
 
   it('does not advance manager revalidation failure backoff when a full crawl defers the item', async () => {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const ctx = Object.create((CrawlerService as any).prototype);
     const deferredError = Object.assign(new Error('Full crawl in progress'), {
       code: 'crawl_deferred',
@@ -94,7 +91,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
   });
 
   it('releases full-crawl ownership when setup fails', async () => {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const ctx = Object.create((CrawlerService as any).prototype);
     Object.assign(ctx, {
       crawling: false,
@@ -103,6 +99,82 @@ describe('CrawlerService single-domain profile rebuild', () => {
 
     await expect(ctx.crawlAllAgents([])).rejects.toThrow('database unavailable');
     expect(ctx.crawling).toBe(false);
+  });
+
+  it('aborts a full crawl before persistence when its execution lock is lost', async () => {
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const release = vi.fn().mockResolvedValue(undefined);
+    const populateFederatedIndex = vi.fn();
+    Object.assign(ctx, {
+      crawling: false,
+      fullCrawlLockRetryTimer: null,
+      coordinateCrawlsAcrossInstances: true,
+      tryAcquireCrawlExecutionLock: vi.fn().mockResolvedValue({
+        isValid: () => false,
+        release,
+      }),
+      getPausedAgentUrls: vi.fn().mockResolvedValue(new Set()),
+      federatedIndex: {
+        listDiscoveredAgents: vi.fn().mockResolvedValue([]),
+        getSalesCandidatesForProbe: vi.fn().mockResolvedValue([]),
+      },
+      crawler: { crawlAgents: vi.fn().mockResolvedValue({}) },
+      populateFederatedIndex,
+    });
+
+    await expect(ctx.crawlAllAgents([])).rejects.toMatchObject({
+      code: 'crawl_execution_lock_lost',
+    });
+    expect(populateFederatedIndex).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
+    if (ctx.fullCrawlLockRetryTimer) clearTimeout(ctx.fullCrawlLockRetryTimer);
+  });
+
+  it('does not write catalog state when another crawl owns the domain lock', async () => {
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const validateDomain = vi.fn();
+    Object.assign(ctx, {
+      coordinateCrawlsAcrossInstances: true,
+      tryAcquireCrawlExecutionLock: vi.fn().mockResolvedValue(null),
+      adAgentsManager: { validateDomain },
+    });
+
+    await expect(ctx.crawlSingleDomainForCatalog('publisher.example')).resolves.toBe(false);
+    expect(validateDomain).not.toHaveBeenCalled();
+  });
+
+  it('forcibly closes a dedicated lock connection when unlock never resolves', async () => {
+    vi.useFakeTimers();
+    try {
+      const ctx = Object.create((CrawlerService as any).prototype);
+      const destroy = vi.fn();
+      const query = vi.fn()
+        .mockResolvedValueOnce({ rows: [{ acquired: true }] })
+        .mockResolvedValueOnce({ rows: [{ acquired: true }] })
+        .mockImplementationOnce(() => new Promise(() => undefined));
+      const client = {
+        query,
+        on: vi.fn(),
+        off: vi.fn(),
+        end: vi.fn().mockResolvedValue(undefined),
+        connection: { stream: { destroyed: false, destroy } },
+      };
+      Object.assign(ctx, {
+        crawlLockClientFactory: vi.fn().mockResolvedValue(client),
+      });
+
+      const lock = await ctx.tryAcquireCrawlExecutionLock('publisher.example');
+      expect(lock).not.toBeNull();
+
+      const release = lock.release();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await expect(release).resolves.toBeUndefined();
+      expect(destroy).toHaveBeenCalledOnce();
+      expect(client.end).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('rebuilds profiles for agents removed from the prior manifest', async () => {
@@ -139,7 +211,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
   });
 
   it('manual adagents revalidation persists a successful verdict and refreshed authorizations', async () => {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const proto = (CrawlerService as any).prototype;
     const ctx = Object.create(proto);
 
@@ -208,7 +279,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
   });
 
   it('manual adagents revalidation returns warnings for a valid manifest', async () => {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const proto = (CrawlerService as any).prototype;
     const ctx = Object.create(proto);
 
@@ -258,7 +328,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
   });
 
   it('manual adagents revalidation persists an invalid verdict and retires stale authorizations', async () => {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const proto = (CrawlerService as any).prototype;
     const ctx = Object.create(proto);
 
@@ -315,7 +384,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
   });
 
   it('manual adagents revalidation preserves cached state on transient fetch failures', async () => {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const proto = (CrawlerService as any).prototype;
     const ctx = Object.create(proto);
 
@@ -369,7 +437,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
   });
 
   it('manual adagents revalidation preserves cached state on access-denied origin responses', async () => {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const proto = (CrawlerService as any).prototype;
     const ctx = Object.create(proto);
 
@@ -423,7 +490,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
   });
 
   it('manual adagents revalidation preserves cached state on unparseable 200 responses', async () => {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const proto = (CrawlerService as any).prototype;
     const ctx = Object.create(proto);
 
@@ -477,7 +543,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
   });
 
   it('manual adagents revalidation preserves cached state when authoritative_location fetch is inconclusive', async () => {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const proto = (CrawlerService as any).prototype;
     const ctx = Object.create(proto);
 
@@ -531,7 +596,6 @@ describe('CrawlerService single-domain profile rebuild', () => {
   });
 
   it('manual adagents revalidation persists schema-invalid 200 responses as invalid', async () => {
-    const { CrawlerService } = await import('../../src/crawler.js');
     const proto = (CrawlerService as any).prototype;
     const ctx = Object.create(proto);
 

--- a/server/tests/unit/registry-publisher-adagents-revalidate-route.test.ts
+++ b/server/tests/unit/registry-publisher-adagents-revalidate-route.test.ts
@@ -175,6 +175,38 @@ describe('POST /api/registry/publisher/:domain/adagents/revalidate', () => {
     expect(revalidatePublisherAdagents).toHaveBeenCalledTimes(1);
   });
 
+  it('returns a retryable 503 and releases the rate-limit reservation on crawl contention', async () => {
+    const revalidatePublisherAdagents = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('crawl busy'), { code: 'crawl_deferred' }))
+      .mockResolvedValueOnce({
+        domain: 'busy.example',
+        adagents_valid: true,
+        checked_at: '2026-06-16T12:00:00.000Z',
+        status_code: 200,
+      });
+    const app = buildApp({
+      user: { id: 'admin_user', email: 'admin@example.com', isAdmin: true },
+      crawler: { revalidatePublisherAdagents },
+    });
+
+    const busy = await request(app)
+      .post('/api/registry/publisher/busy.example/adagents/revalidate')
+      .send();
+    const retry = await request(app)
+      .post('/api/registry/publisher/busy.example/adagents/revalidate')
+      .send();
+
+    expect(busy.status).toBe(503);
+    expect(busy.headers['retry-after']).toBe('5');
+    expect(busy.body).toEqual({
+      error: 'Publisher crawl is temporarily busy',
+      code: 'publisher_crawl_busy',
+      retry_after: 5,
+    });
+    expect(retry.status).toBe(200);
+    expect(revalidatePublisherAdagents).toHaveBeenCalledTimes(2);
+  });
+
   it('rejects authenticated non-admin callers', async () => {
     const revalidatePublisherAdagents = vi.fn();
     isWebUserAAOAdminMock.mockResolvedValue(false);

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -7219,6 +7219,33 @@ paths:
                 required:
                   - error
                   - retry_after
+        "503":
+          description: Publisher crawl is temporarily busy
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying
+              required: true
+              description: Seconds to wait before retrying
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - publisher_crawl_busy
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - code
+                  - retry_after
   /api/registry/brand/{domain}/force-crawl:
     post:
       operationId: forceBrandCrawl
@@ -9812,6 +9839,13 @@ paths:
                   - retry_after
         "503":
           description: The durable crawl queue is temporarily unavailable; the request was not accepted
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying
+              required: true
+              description: Seconds to wait before retrying
           content:
             application/json:
               schema:
@@ -9823,6 +9857,7 @@ paths:
                     type: string
                     enum:
                       - crawl_queue_unavailable
+                      - crawl_queue_at_capacity
                   retry_after:
                     type: integer
                 required:
@@ -9932,10 +9967,30 @@ paths:
                 $ref: "#/components/schemas/Error"
         "503":
           description: Crawl status is temporarily unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying
+              required: true
+              description: Seconds to wait before retrying
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - crawl_status_unavailable
+                  retry_after:
+                    type: integer
+                required:
+                  - error
+                  - code
+                  - retry_after
   /api/registry/manager-revalidation-request:
     post:
       operationId: requestManagerRevalidation

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -9741,7 +9741,7 @@ paths:
       operationId: requestCrawl
       summary: Request domain re-crawl
       description: |-
-        Trigger an immediate re-crawl of a publisher domain after updating adagents.json. The crawl runs asynchronously in the accepting process — returns 202 immediately. The response `crawl_request_id` correlates accepted, running, completed, skipped, and failed lifecycle logs; a 202 does not by itself mean the mirror write completed.
+        Persist a durable re-crawl request for a publisher domain after updating adagents.json. Returns 202 only after the request is committed to the queue. Use the returned `crawl_request_id` with the status endpoint to observe completion.
 
         **Rate limits:** 5 minutes per domain, 30 requests per user per hour.
       tags:
@@ -9778,7 +9778,7 @@ paths:
                   crawl_request_id:
                     type: string
                     format: uuid
-                    description: Correlation ID for crawl lifecycle logs; acceptance is not completion.
+                    description: Durable request ID for lifecycle logs and status lookup; acceptance is not completion.
                 required:
                   - message
                   - domain
@@ -9811,7 +9811,7 @@ paths:
                   - error
                   - retry_after
         "503":
-          description: A full crawl is active; the request was not accepted
+          description: The durable crawl queue is temporarily unavailable; the request was not accepted
           content:
             application/json:
               schema:
@@ -9822,13 +9822,120 @@ paths:
                   code:
                     type: string
                     enum:
-                      - crawl_temporarily_unavailable
+                      - crawl_queue_unavailable
                   retry_after:
                     type: integer
                 required:
                   - error
                   - code
                   - retry_after
+  /api/registry/crawl-request/{crawlRequestId}:
+    get:
+      operationId: getCrawlRequest
+      summary: Get publisher crawl request status
+      description: Return the durable lifecycle for a publisher recrawl. Requesters may read their own requests; registry administrators may read any request.
+      tags:
+        - Agent Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: crawlRequestId
+          in: path
+      responses:
+        "200":
+          description: Durable crawl request lifecycle
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  crawl_request_id:
+                    type: string
+                    format: uuid
+                  domain:
+                    type: string
+                  status:
+                    type: string
+                    enum:
+                      - queued
+                      - running
+                      - deferred
+                      - retrying
+                      - completed
+                      - invalid
+                      - failed
+                  attempts:
+                    type: integer
+                  max_attempts:
+                    type: integer
+                  requested_at:
+                    type: string
+                    format: date-time
+                  started_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                  last_attempted_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                  completed_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                  next_attempt_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                  last_error_code:
+                    type:
+                      - string
+                      - "null"
+                required:
+                  - crawl_request_id
+                  - domain
+                  - status
+                  - attempts
+                  - max_attempts
+                  - requested_at
+                  - started_at
+                  - last_attempted_at
+                  - completed_at
+                  - next_attempt_at
+                  - last_error_code
+        "400":
+          description: Invalid crawl request ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Crawl request not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Crawl status is temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/registry/manager-revalidation-request:
     post:
       operationId: requestManagerRevalidation


### PR DESCRIPTION
## Summary

- persist publisher recrawl requests in PostgreSQL before returning `202 Accepted`
- process requests with bounded claims, leases, heartbeats, retries, retention, and stale-worker protection
- fence mirror commits against lease loss and coordinate full/single-domain writers with dedicated PostgreSQL advisory-lock sessions
- expose owner/admin crawl status and queue health telemetry without coupling publisher reads to crawl execution
- bound database, lock-session, queue-worker, and publisher-read failure paths; serve last committed mirror state during crawl contention

## Semantics

`202 Accepted` means the request was durably committed, not that the crawl completed. Callers can poll `GET /api/registry/crawl-request/{id}`. Publisher reads do not acquire crawl locks and continue to return the last committed mirror state. Expired attempts cannot overwrite a newer attempt, and a wedged dedicated lock connection is forcibly closed after a bounded operation deadline.

Synchronous admin revalidation returns typed `503 publisher_crawl_busy` with `Retry-After` during contention and refunds its rate-limit reservation. Queue admission returns typed `503 crawl_queue_at_capacity` at 10,000 active requests.

## Validation

- `npm run precommit`: 1,039 tests plus typecheck passed
- focused durable crawler/revalidation tests: 29 passed
- durable queue integration tests in an isolated PostgreSQL schema: 13 passed, including atomic claim/reclaim/commit fencing
- public registry route integration suite in an isolated schema: 44 passed, including status authorization and unaffected-domain reads
- migration validation, OpenAPI generation/check, error-handling lint, dynamic-import lint, and typecheck passed
- current and 3.0 compatibility storyboard matrices passed for every tenant
- code, PostgreSQL/concurrency, and security expert reviews are clean after follow-up

## Rollout

Migration 540 creates the queue table and indexes. The first deployment uses Fly's `immediate` strategy with `PUBLISHER_CRAWL_QUEUE_ENABLED=false`, preventing an old non-lock-aware image from overlapping the new image. After every machine is confirmed on the new release, enable the gate and restart that image, then submit and poll the production recrawl. Restore rolling deploys only once all deployable images participate in the execution locks. Follow-up tracked in #6329.

Fixes #6325

