### PR TITLE
fix(deploy): complete durable crawl rollout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,13 +178,22 @@ jobs:
           set -eo pipefail
           echo "Waiting for all app machines to converge on the same image..."
 
+          # Verify the deployed value matches the checked-in kill-switch value.
+          # This keeps the gate useful for both queue enablement and an
+          # intentional emergency disablement.
+          expected_queue=$(sed -nE 's/^[[:space:]]*PUBLISHER_CRAWL_QUEUE_ENABLED[[:space:]]*=[[:space:]]*"(true|false)"[[:space:]]*$/\1/p' fly.toml)
+          if [ "$expected_queue" != "true" ] && [ "$expected_queue" != "false" ]; then
+            echo "::error::fly.toml must define PUBLISHER_CRAWL_QUEUE_ENABLED exactly once as \"true\" or \"false\""
+            exit 1
+          fi
+
           # `flyctl deploy` can return while an immediate replacement is still
           # transitioning through `replacing`. Require every web/worker machine
           # to be started and on one digest, but give Fly a bounded settle window.
           for attempt in $(seq 1 12); do
             if ! machines=$(flyctl machines list --json); then
               echo "attempt ${attempt}/12: Fly Machines API request failed"
-            elif ! summary=$(echo "$machines" | jq -ce '
+            elif ! summary=$(echo "$machines" | jq -ce --arg expected_queue "$expected_queue" '
                 if type != "array" then error("expected Fly machines JSON array") else . end |
                 [.[] | select(.config.metadata.fly_process_group == "web" or .config.metadata.fly_process_group == "worker")] |
                 {
@@ -192,7 +201,7 @@ jobs:
                   started: ([.[] | select(.state == "started")] | length),
                   web: ([.[] | select(.config.metadata.fly_process_group == "web")] | length),
                   worker: ([.[] | select(.config.metadata.fly_process_group == "worker")] | length),
-                  queue_enabled: ([.[] | select(.config.env.PUBLISHER_CRAWL_QUEUE_ENABLED == "true")] | length),
+                  queue_matching: ([.[] | select(.config.env.PUBLISHER_CRAWL_QUEUE_ENABLED == $expected_queue)] | length),
                   images: ([.[] | select(.state == "started") | .image_ref.digest] | unique)
                 }'); then
               echo "attempt ${attempt}/12: invalid Fly Machines API response"
@@ -201,14 +210,14 @@ jobs:
               started=$(echo "$summary" | jq -r '.started')
               web=$(echo "$summary" | jq -r '.web')
               worker=$(echo "$summary" | jq -r '.worker')
-              queue_enabled=$(echo "$summary" | jq -r '.queue_enabled')
+              queue_matching=$(echo "$summary" | jq -r '.queue_matching')
               image_count=$(echo "$summary" | jq -r '.images | length')
 
-              echo "attempt ${attempt}/12: total=${total} started=${started} web=${web} worker=${worker} queue_enabled=${queue_enabled} image_count=${image_count}"
+              echo "attempt ${attempt}/12: total=${total} started=${started} web=${web} worker=${worker} queue_expected=${expected_queue} queue_matching=${queue_matching} image_count=${image_count}"
               if [ "$web" -ge 2 ] && [ "$worker" -ge 1 ] && \
-                [ "$started" -eq "$total" ] && [ "$queue_enabled" -eq "$total" ] && \
+                [ "$started" -eq "$total" ] && [ "$queue_matching" -eq "$total" ] && \
                 [ "$image_count" -eq 1 ]; then
-                echo "✅ All ${started} web/worker machines are started on one image with the crawl queue enabled"
+                echo "✅ All ${started} web/worker machines are started on one image with crawl queue=${expected_queue}"
                 exit 0
               fi
             fi
@@ -320,12 +329,12 @@ jobs:
       - name: Setup Node.js for artifact build
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
 
       - name: Install dependencies for artifact build
         env:
-          PUPPETEER_SKIP_DOWNLOAD: 'true'
+          PUPPETEER_SKIP_DOWNLOAD: "true"
         run: npm ci
 
       - name: Publish latest artifacts to R2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,6 +97,23 @@ jobs:
       - name: Setup Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
 
+      - name: Reject publisher crawl queue secret override
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -eo pipefail
+          secrets=$(flyctl secrets list --json)
+          override_count=$(echo "$secrets" | jq -er '
+            if type == "array" then
+              [.[] | select((.Name // .name) == "PUBLISHER_CRAWL_QUEUE_ENABLED")] | length
+            else
+              error("expected Fly secrets JSON array")
+            end')
+          if [ "$override_count" -gt 0 ]; then
+            echo "::error::PUBLISHER_CRAWL_QUEUE_ENABLED is set as a Fly secret and would override fly.toml. Remove the secret before deploying."
+            exit 1
+          fi
+
       # flyctl deploy can fail for two very different reasons:
       #   1. The new image is broken (real failure — must block).
       #   2. Fly's machines API was unreachable during health-check polling
@@ -106,10 +123,9 @@ jobs:
       # was rate-limited from the earlier crashloop storm. The post-deploy
       # gates never ran. To distinguish, on failure we hit /health directly
       # — the same signal end users see — and only hard-fail if the app
-      # itself is unreachable. The "verify all machines on same image" gate
-      # below depends on the machines API, so it gates itself on
-      # `deploy_outcome != fallback-success`. The tenant smoke runs over
-      # plain HTTP and stays unconditional.
+      # itself is unreachable. The convergence gate below always remains
+      # mandatory: a public health response cannot prove every machine
+      # received the intended image and config.
       - name: Deploy
         id: deploy
         env:
@@ -153,10 +169,6 @@ jobs:
           exit 1
 
       - name: Verify all app machines are on same image
-        # Skipped on the fallback path because this gate also goes through
-        # the Fly machines API — if that's what timed out above, it'll time
-        # out again here.
-        if: steps.deploy.outputs.deploy_outcome != 'fallback-success'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
@@ -164,27 +176,49 @@ jobs:
           # surfaces as a real failure instead of being misread as
           # "no running web/worker machines."
           set -eo pipefail
-          echo "Checking that all app machines are running the same image..."
+          echo "Waiting for all app machines to converge on the same image..."
 
-          # Get image digests for started machines (web + worker process groups)
-          images=$(flyctl machines list --json | \
-            jq -r '[.[] | select((.config.metadata.fly_process_group == "web" or .config.metadata.fly_process_group == "worker") and .state == "started") | .image_ref.digest] | unique')
+          # `flyctl deploy` can return while an immediate replacement is still
+          # transitioning through `replacing`. Require every web/worker machine
+          # to be started and on one digest, but give Fly a bounded settle window.
+          for attempt in $(seq 1 12); do
+            if ! machines=$(flyctl machines list --json); then
+              echo "attempt ${attempt}/12: Fly Machines API request failed"
+            elif ! summary=$(echo "$machines" | jq -ce '
+                if type != "array" then error("expected Fly machines JSON array") else . end |
+                [.[] | select(.config.metadata.fly_process_group == "web" or .config.metadata.fly_process_group == "worker")] |
+                {
+                  total: length,
+                  started: ([.[] | select(.state == "started")] | length),
+                  web: ([.[] | select(.config.metadata.fly_process_group == "web")] | length),
+                  worker: ([.[] | select(.config.metadata.fly_process_group == "worker")] | length),
+                  queue_enabled: ([.[] | select(.config.env.PUBLISHER_CRAWL_QUEUE_ENABLED == "true")] | length),
+                  images: ([.[] | select(.state == "started") | .image_ref.digest] | unique)
+                }'); then
+              echo "attempt ${attempt}/12: invalid Fly Machines API response"
+            else
+              total=$(echo "$summary" | jq -r '.total')
+              started=$(echo "$summary" | jq -r '.started')
+              web=$(echo "$summary" | jq -r '.web')
+              worker=$(echo "$summary" | jq -r '.worker')
+              queue_enabled=$(echo "$summary" | jq -r '.queue_enabled')
+              image_count=$(echo "$summary" | jq -r '.images | length')
 
-          count=$(echo "$images" | jq 'length')
+              echo "attempt ${attempt}/12: total=${total} started=${started} web=${web} worker=${worker} queue_enabled=${queue_enabled} image_count=${image_count}"
+              if [ "$web" -ge 2 ] && [ "$worker" -ge 1 ] && \
+                [ "$started" -eq "$total" ] && [ "$queue_enabled" -eq "$total" ] && \
+                [ "$image_count" -eq 1 ]; then
+                echo "✅ All ${started} web/worker machines are started on one image with the crawl queue enabled"
+                exit 0
+              fi
+            fi
 
-          if [ "$count" -eq 0 ]; then
-            echo "❌ No running web/worker machines found"
-            flyctl machines list
-            exit 1
-          fi
+            if [ "$attempt" -lt 12 ]; then sleep 15; fi
+          done
 
-          if [ "$count" -ne 1 ]; then
-            echo "❌ Deploy split detected! Machines are running different images:"
-            flyctl machines list
-            exit 1
-          fi
-
-          echo "✅ All web/worker machines running the same image"
+          echo "❌ App machines did not converge within 180 seconds"
+          flyctl machines list
+          exit 1
 
       # Smoke each training-agent tenant URL after the rolling restart.
       # Catches production-only failures that don't surface in CI: SDK

--- a/fly.toml
+++ b/fly.toml
@@ -12,9 +12,7 @@ primary_region = 'iad'
 [deploy]
   release_command = "node dist/db/migrate.js"
   release_command_timeout = "15m"
-  # One-time safety requirement for migration 540: old images do not
-  # participate in the new PostgreSQL crawl-execution locks.
-  strategy = "immediate"
+  strategy = "rolling"
 
 [processes]
   web = "node dist/index.js"
@@ -25,9 +23,7 @@ primary_region = 'iad'
   BASE_URL = "https://agenticadvertising.org"
   # Disabled - migrations now run via release_command
   RUN_MIGRATIONS = "false"
-  # Two-phase rollout gate. Enable only after every machine runs a
-  # lock-participating queue consumer; a Fly secret may override this value.
-  PUBLISHER_CRAWL_QUEUE_ENABLED = "false"
+  PUBLISHER_CRAWL_QUEUE_ENABLED = "true"
   # Use pre-cloned repos from Docker build, skip runtime git fetch.
   # Production image has no git binary — unsetting this degrades gracefully
   # (repos skip indexing) but does not crash.


### PR DESCRIPTION
## Summary

- restore normal rolling Fly deployments after the lock-aware #6327 image reached production
- enable the PostgreSQL publisher crawl queue consumer
- reject a conflicting Fly secret override before deploy
- make machine convergence bounded and retryable, including on Fly API failures
- require two web machines, one worker, one image, and the queue flag on every machine

## Incident evidence

The first #6327 deployment applied migration 540 and completed Fly release v3442, but its single-snapshot verification ran while all three machines were transiently `replacing`. The public health endpoints recovered to 200 after the transition. This follow-up waits up to 180 seconds and does not allow `fallback-success` to bypass convergence.

## Validation

- precommit: 1,040 tests passed
- TypeScript typecheck passed
- `git diff --check` passed
- actionlint reports only pre-existing warnings outside the modified steps
- follow-up expert review clean after fail-closed secret and Machines API handling

Fixes #6329