### PR TITLE
Fix perspective 404 and admin escalation cleanup

### DIFF
--- a/server/src/db/escalation-db.ts
+++ b/server/src/db/escalation-db.ts
@@ -4,6 +4,7 @@
  */
 
 import { query } from './client.js';
+import type { PoolClient } from 'pg';
 import { createLogger } from '../logger.js';
 import { redactSupportSecrets } from '../services/support-redaction.js';
 
@@ -252,19 +253,21 @@ async function readOpenEscalationByDedupKey(dedupKey: string): Promise<Escalatio
 export async function resolveEscalationsForPerspective(
   perspectiveId: string,
   resolvedBy: string,
-  notes: string
+  notes: string,
+  client?: Pick<PoolClient, 'query'>
 ): Promise<number[]> {
-  const result = await query<{ id: number }>(
-    `UPDATE addie_escalations
-     SET status = 'resolved',
-         resolved_by = $2,
-         resolved_at = NOW(),
-         resolution_notes = $3,
-         updated_at = NOW()
-     WHERE perspective_id = $1 AND status = 'open'
-     RETURNING id`,
-    [perspectiveId, resolvedBy, notes]
-  );
+  const sql = `UPDATE addie_escalations
+               SET status = 'resolved',
+                   resolved_by = $2,
+                   resolved_at = NOW(),
+                   resolution_notes = $3,
+                   updated_at = NOW()
+               WHERE perspective_id = $1 AND status = 'open'
+               RETURNING id`;
+  const params = [perspectiveId, resolvedBy, notes];
+  const result = client
+    ? await client.query<{ id: number }>(sql, params)
+    : await query<{ id: number }>(sql, params);
   return result.rows.map(r => r.id);
 }
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -146,6 +146,7 @@ import { sendWelcomeEmail, sendUserSignupEmail, sendDuplicateSubscriptionNotice,
 import { emailPrefsDb } from "./db/email-preferences-db.js";
 import { pendingConfirmationsDb } from "./db/pending-confirmations-db.js";
 import { queuePerspectiveLink } from "./addie/services/content-curator.js";
+import { resolveEscalationsForPerspective } from "./db/escalation-db.js";
 import { serveHtmlWithMetaTags, enrichUserWithMembership, enrichUserWithAdmin } from "./utils/html-config.js";
 import { complete, isLLMConfigured } from "./utils/llm.js";
 import { notifyJoinRequest, notifyMemberAdded, notifySubscriptionThankYou } from "./slack/org-group-dm.js";
@@ -2930,6 +2931,11 @@ export class HTTPServer {
         );
         if (result.rows.length > 0) {
           article = result.rows[0];
+        } else {
+          // The article shell renders its own "Article Not Found" state after
+          // hydration. Preserve that UI while returning the correct HTTP
+          // status to crawlers and other clients.
+          res.status(404);
         }
       } catch (error) {
         logger.warn({ error, slug }, 'Failed to fetch article for meta tags');
@@ -6622,14 +6628,47 @@ export class HTTPServer {
         const { id } = req.params;
         if (!isUuid(id)) return res.status(400).json({ error: 'Invalid content ID' });
         const pool = getPool();
-        const result = await pool.query(
-          `DELETE FROM perspectives WHERE id = $1 RETURNING id, title`,
-          [id]
-        );
-        if (result.rows.length === 0) {
-          return res.status(404).json({ error: 'Content not found' });
+        const client = await pool.connect();
+        let deletedContent: { id: string; title: string };
+        let resolvedEscalationIds: number[];
+        try {
+          await client.query('BEGIN');
+          const existing = await client.query<{ id: string; title: string }>(
+            `SELECT id, title FROM perspectives WHERE id = $1 FOR UPDATE`,
+            [id]
+          );
+          if (existing.rows.length === 0) {
+            await client.query('ROLLBACK');
+            return res.status(404).json({ error: 'Content not found' });
+          }
+
+          resolvedEscalationIds = await resolveEscalationsForPerspective(
+            id,
+            req.user!.id,
+            'Auto-resolved: content deleted by admin',
+            client
+          );
+          const result = await client.query<{ id: string; title: string }>(
+            `DELETE FROM perspectives WHERE id = $1 RETURNING id, title`,
+            [id]
+          );
+          if (result.rows.length === 0) {
+            throw new Error('Perspective disappeared while holding its delete lock');
+          }
+          deletedContent = result.rows[0];
+          await client.query('COMMIT');
+        } catch (error) {
+          await client.query('ROLLBACK').catch(rollbackError => {
+            logger.warn({ err: rollbackError, contentId: id }, 'Failed to roll back admin content delete');
+          });
+          throw error;
+        } finally {
+          client.release();
         }
-        logger.info({ contentId: id, title: result.rows[0].title }, 'Admin deleted content');
+        logger.info(
+          { contentId: id, title: deletedContent.title, resolvedEscalationIds },
+          'Admin deleted content'
+        );
         res.json({ success: true });
       } catch (error) {
         logger.error({ err: error }, 'DELETE /api/admin/content/:id error');
@@ -6762,15 +6801,47 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
         if (status === 'published') {
           updates.push(`published_at = COALESCE(published_at, NOW())`);
         }
-        const result = await pool.query(
-          `UPDATE perspectives SET ${updates.join(', ')}, updated_at = NOW() WHERE id = $${values.length + 1} RETURNING *`,
-          [...values, id]
-        );
-        if (result.rows.length === 0) {
-          return res.status(404).json({ error: 'Content not found' });
+        const client = await pool.connect();
+        let updatedContent: Record<string, unknown>;
+        let resolvedEscalationIds: number[] = [];
+        try {
+          await client.query('BEGIN');
+          const existing = await client.query<{ id: string }>(
+            `SELECT id FROM perspectives WHERE id = $1 FOR UPDATE`,
+            [id]
+          );
+          if (existing.rows.length === 0) {
+            await client.query('ROLLBACK');
+            return res.status(404).json({ error: 'Content not found' });
+          }
+
+          const result = await client.query<Record<string, unknown>>(
+            `UPDATE perspectives SET ${updates.join(', ')}, updated_at = NOW() WHERE id = $${values.length + 1} RETURNING *`,
+            [...values, id]
+          );
+          if (result.rows.length === 0) {
+            throw new Error('Perspective disappeared while holding its status lock');
+          }
+          updatedContent = result.rows[0];
+          if (status === 'archived') {
+            resolvedEscalationIds = await resolveEscalationsForPerspective(
+              id,
+              req.user!.id,
+              'Auto-resolved: content archived by admin',
+              client
+            );
+          }
+          await client.query('COMMIT');
+        } catch (error) {
+          await client.query('ROLLBACK').catch(rollbackError => {
+            logger.warn({ err: rollbackError, contentId: id }, 'Failed to roll back admin content status update');
+          });
+          throw error;
+        } finally {
+          client.release();
         }
-        logger.info({ contentId: id, status }, 'Admin updated content status');
-        res.json(result.rows[0]);
+        logger.info({ contentId: id, status, resolvedEscalationIds }, 'Admin updated content status');
+        res.json(updatedContent);
       } catch (error) {
         logger.error({ err: error }, 'PUT /api/admin/content/:id/status error');
         res.status(500).json({ error: 'Failed to update status' });

--- a/server/tests/integration/content-my-content.test.ts
+++ b/server/tests/integration/content-my-content.test.ts
@@ -122,6 +122,7 @@ describe('My Content — body, admin scope, status, delete', () => {
   const ELIGIBLE_ORG_ID = 'org_my_content_professional';
   const INELIGIBLE_USER_ID = 'user_my_content_ineligible';
   const RATE_LIMIT_USER_ID = 'user_mc_ratelimit_test';
+  const ESCALATION_SUMMARY_PREFIX = 'mc-test-perspective-cleanup';
 
   async function ensureContentSubmissionEligibleUser(userId: string, email: string) {
     await pool.query(
@@ -190,6 +191,7 @@ describe('My Content — body, admin scope, status, delete', () => {
   }, 30000);
 
   afterAll(async () => {
+    await pool.query(`DELETE FROM addie_escalations WHERE summary LIKE $1`, [`${ESCALATION_SUMMARY_PREFIX}%`]);
     await pool.query(`DELETE FROM content_authors WHERE perspective_id IN (SELECT id FROM perspectives WHERE slug LIKE 'mc-test-%')`);
     await pool.query(`DELETE FROM perspectives WHERE slug LIKE 'mc-test-%'`);
     await pool.query(
@@ -217,6 +219,7 @@ describe('My Content — body, admin scope, status, delete', () => {
     adminState.isAdmin = false;
     authState.userId = USER_ID;
     authState.email = 'mc@example.com';
+    await pool.query(`DELETE FROM addie_escalations WHERE summary LIKE $1`, [`${ESCALATION_SUMMARY_PREFIX}%`]);
     await pool.query(`DELETE FROM content_authors WHERE perspective_id IN (SELECT id FROM perspectives WHERE slug LIKE 'mc-test-%')`);
     await pool.query(`DELETE FROM perspectives WHERE slug LIKE 'mc-test-%'`);
   });
@@ -814,6 +817,87 @@ describe('My Content — body, admin scope, status, delete', () => {
   });
 
   describe('DELETE /api/admin/content/:id', () => {
+    it('resolves linked open escalations before deleting the perspective', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-admin-delete-escalation',
+        title: 'delete and resolve escalation',
+        status: 'published',
+        proposerUserId: OTHER_USER_ID,
+      });
+      const escalation = await pool.query(
+        `INSERT INTO addie_escalations
+           (category, summary, status, perspective_id, perspective_slug)
+         VALUES ('needs_human_action', $1, 'open', $2, 'mc-test-admin-delete-escalation')
+         RETURNING id`,
+        [`${ESCALATION_SUMMARY_PREFIX}-delete`, id]
+      );
+
+      await request(app).delete(`/api/admin/content/${id}`).expect(200);
+
+      const result = await pool.query(
+        `SELECT status, resolved_by, resolution_notes, perspective_id
+         FROM addie_escalations WHERE id = $1`,
+        [escalation.rows[0].id]
+      );
+      expect(result.rows[0]).toMatchObject({
+        status: 'resolved',
+        resolved_by: USER_ID,
+        resolution_notes: 'Auto-resolved: content deleted by admin',
+        perspective_id: null,
+      });
+    });
+
+    it('rolls back escalation resolution when deleting the perspective fails', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-admin-delete-rollback',
+        title: 'failed delete keeps escalation open',
+        status: 'published',
+        proposerUserId: OTHER_USER_ID,
+      });
+      const escalation = await pool.query(
+        `INSERT INTO addie_escalations
+           (category, summary, status, perspective_id, perspective_slug)
+         VALUES ('needs_human_action', $1, 'open', $2, 'mc-test-admin-delete-rollback')
+         RETURNING id`,
+        [`${ESCALATION_SUMMARY_PREFIX}-delete-rollback`, id]
+      );
+
+      await pool.query(`
+        CREATE OR REPLACE FUNCTION mc_test_reject_perspective_delete()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+          IF OLD.slug = 'mc-test-admin-delete-rollback' THEN
+            RAISE EXCEPTION 'intentional perspective delete failure';
+          END IF;
+          RETURN OLD;
+        END;
+        $$;
+        DROP TRIGGER IF EXISTS mc_test_reject_perspective_delete ON perspectives;
+        CREATE TRIGGER mc_test_reject_perspective_delete
+          BEFORE DELETE ON perspectives
+          FOR EACH ROW EXECUTE FUNCTION mc_test_reject_perspective_delete();
+      `);
+
+      try {
+        await request(app).delete(`/api/admin/content/${id}`).expect(500);
+
+        const perspective = await pool.query(`SELECT id FROM perspectives WHERE id = $1`, [id]);
+        const escalationResult = await pool.query(
+          `SELECT status, resolved_by, resolved_at FROM addie_escalations WHERE id = $1`,
+          [escalation.rows[0].id]
+        );
+        expect(perspective.rows).toHaveLength(1);
+        expect(escalationResult.rows[0]).toMatchObject({
+          status: 'open',
+          resolved_by: null,
+          resolved_at: null,
+        });
+      } finally {
+        await pool.query(`DROP TRIGGER IF EXISTS mc_test_reject_perspective_delete ON perspectives`);
+        await pool.query(`DROP FUNCTION IF EXISTS mc_test_reject_perspective_delete()`);
+      }
+    });
+
     it('deletes linked content while preserving publication history', async () => {
       const id = await insertPerspective({
         slug: 'mc-test-admin-delete-linked',
@@ -861,6 +945,97 @@ describe('My Content — body, admin scope, status, delete', () => {
         await pool.query(`DELETE FROM weekly_digests WHERE id = $1`, [weeklyDigest.rows[0].id]);
         await pool.query(`DELETE FROM build_editions WHERE id = $1`, [buildEdition.rows[0].id]);
         await pool.query(`DELETE FROM moltbook_posts WHERE id = $1`, [moltbookPost.rows[0].id]);
+      }
+    });
+  });
+
+  describe('PUT /api/admin/content/:id/status', () => {
+    it('resolves linked open escalations when an admin archives content', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-admin-archive-escalation',
+        title: 'archive and resolve escalation',
+        status: 'published',
+        proposerUserId: OTHER_USER_ID,
+      });
+      const escalation = await pool.query(
+        `INSERT INTO addie_escalations
+           (category, summary, status, perspective_id, perspective_slug)
+         VALUES ('needs_human_action', $1, 'open', $2, 'mc-test-admin-archive-escalation')
+         RETURNING id`,
+        [`${ESCALATION_SUMMARY_PREFIX}-archive`, id]
+      );
+
+      const response = await request(app)
+        .put(`/api/admin/content/${id}/status`)
+        .send({ status: 'archived' })
+        .expect(200);
+
+      expect(response.body.status).toBe('archived');
+      const result = await pool.query(
+        `SELECT status, resolved_by, resolution_notes, perspective_id
+         FROM addie_escalations WHERE id = $1`,
+        [escalation.rows[0].id]
+      );
+      expect(result.rows[0]).toMatchObject({
+        status: 'resolved',
+        resolved_by: USER_ID,
+        resolution_notes: 'Auto-resolved: content archived by admin',
+        perspective_id: id,
+      });
+    });
+
+    it('rolls back the archive when escalation resolution fails', async () => {
+      const id = await insertPerspective({
+        slug: 'mc-test-admin-archive-rollback',
+        title: 'failed escalation cleanup keeps content published',
+        status: 'published',
+        proposerUserId: OTHER_USER_ID,
+      });
+      const escalation = await pool.query(
+        `INSERT INTO addie_escalations
+           (category, summary, status, perspective_id, perspective_slug)
+         VALUES ('needs_human_action', $1, 'open', $2, 'mc-test-admin-archive-rollback')
+         RETURNING id`,
+        [`${ESCALATION_SUMMARY_PREFIX}-archive-rollback`, id]
+      );
+
+      await pool.query(`
+        CREATE OR REPLACE FUNCTION mc_test_reject_escalation_resolution()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+          IF OLD.summary = 'mc-test-perspective-cleanup-archive-rollback'
+             AND NEW.status = 'resolved' THEN
+            RAISE EXCEPTION 'intentional escalation resolution failure';
+          END IF;
+          RETURN NEW;
+        END;
+        $$;
+        DROP TRIGGER IF EXISTS mc_test_reject_escalation_resolution ON addie_escalations;
+        CREATE TRIGGER mc_test_reject_escalation_resolution
+          BEFORE UPDATE ON addie_escalations
+          FOR EACH ROW EXECUTE FUNCTION mc_test_reject_escalation_resolution();
+      `);
+
+      try {
+        await request(app)
+          .put(`/api/admin/content/${id}/status`)
+          .send({ status: 'archived' })
+          .expect(500);
+
+        const perspective = await pool.query(`SELECT status FROM perspectives WHERE id = $1`, [id]);
+        const escalationResult = await pool.query(
+          `SELECT status, resolved_by, resolved_at FROM addie_escalations WHERE id = $1`,
+          [escalation.rows[0].id]
+        );
+        expect(perspective.rows[0].status).toBe('published');
+        expect(escalationResult.rows[0]).toMatchObject({
+          status: 'open',
+          resolved_by: null,
+          resolved_at: null,
+        });
+      } finally {
+        await pool.query(`DROP TRIGGER IF EXISTS mc_test_reject_escalation_resolution ON addie_escalations`);
+        await pool.query(`DROP FUNCTION IF EXISTS mc_test_reject_escalation_resolution()`);
       }
     });
   });

--- a/server/tests/unit/perspectives-crawlability.test.ts
+++ b/server/tests/unit/perspectives-crawlability.test.ts
@@ -215,6 +215,23 @@ describe('Perspectives crawlability routes', () => {
     expect(res.text).toContain('<pubDate>Mon, 01 Jun 2026 12:00:00 GMT</pubDate>');
   });
 
+  it('returns 404 for a missing published perspective while serving the article shell', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app())
+      .get('/perspectives/does-not-exist')
+      .set('Host', 'agenticadvertising.org');
+
+    expect(res.status).toBe(404);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.text).toContain('id="loadingState"');
+    expect(res.text).toContain('id="mainContent"');
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining("p.status = 'published'"),
+      ['does-not-exist']
+    );
+  });
+
   it('serves working group post canonical pages with server-rendered social meta tags', async () => {
     queryMock.mockResolvedValueOnce({
       rows: [{


### PR DESCRIPTION
## Summary

- return HTTP 404 for missing published perspective slugs while preserving the article shell's not-found UI
- resolve linked open escalations when admins archive or delete content
- make archive/delete and escalation cleanup atomic with row locks and a shared database transaction
- cover successful cleanup and both rollback directions with integration tests

## Root cause

The public HTML route always served the article shell with its default 200 status, even when the published perspective lookup returned no row. Separately, the admin archive and delete routes did not participate in the existing perspective escalation cleanup path. A delete also clears `perspective_id` through `ON DELETE SET NULL`, so cleanup after deletion can no longer identify the linked escalation.

## Impact

Missing perspective URLs now have correct crawler/client semantics. Admin cleanup no longer leaves open escalation records behind, and transaction boundaries prevent the UI and database from observing partial archive/delete outcomes.

Closes #5637.

## Validation

- `npm run typecheck`
- `npx vitest run --config server/vitest.config.ts server/tests/unit/perspectives-crawlability.test.ts` (9 passed)
- `DATABASE_URL=... npx vitest run --config server/vitest.config.ts server/tests/integration/content-my-content.test.ts` (43 passed)
- pre-commit general unit stage (1,040 passed) and source-boundary linters; full server-unit stage exceeded the local 240-second hook cap with no assertion failure observed before termination
- code and operations expert re-review clean after atomicity findings were addressed
