### PR TITLE
fix(auth): bound WorkOS Pipes requests

### DIFF
--- a/server/src/auth/workos-client.ts
+++ b/server/src/auth/workos-client.ts
@@ -4,9 +4,11 @@ import { createLogger } from '../logger.js';
 
 const logger = createLogger('workos-client');
 const OWNERLESS_PROMOTION_WORKOS_TIMEOUT_MS = 10_000;
+const PIPES_WORKOS_TIMEOUT_MS = 10_000;
 
 let _workos: WorkOS | null = null;
 let _ownerlessPromotionWorkos: WorkOS | null = null;
+let _pipesWorkos: WorkOS | null = null;
 let _clientId = '';
 
 /** Returns the shared WorkOS client. Constructed on first call; WORKOS_API_KEY and WORKOS_CLIENT_ID must be set by then. */
@@ -32,6 +34,25 @@ export function getOwnerlessPromotionWorkos(): WorkOS {
     });
   }
   return _ownerlessPromotionWorkos;
+}
+
+/**
+ * Returns a WorkOS client for interactive Pipes requests. Retries are disabled
+ * because the SDK timeout is per attempt; the bouncer must fail within the
+ * edge request budget instead of retrying for 40+ seconds.
+ */
+export function getPipesWorkos(): WorkOS {
+  if (!_pipesWorkos) {
+    if (!process.env.WORKOS_API_KEY) throw new Error('WORKOS_API_KEY environment variable is required');
+    if (!process.env.WORKOS_CLIENT_ID) throw new Error('WORKOS_CLIENT_ID environment variable is required');
+    _clientId = process.env.WORKOS_CLIENT_ID;
+    _pipesWorkos = new WorkOS(process.env.WORKOS_API_KEY, {
+      clientId: _clientId,
+      timeout: PIPES_WORKOS_TIMEOUT_MS,
+      maxRetries: 0,
+    });
+  }
+  return _pipesWorkos;
 }
 
 /**

--- a/server/src/services/pipes.ts
+++ b/server/src/services/pipes.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../logger.js';
-import { getWorkos } from '../auth/workos-client.js';
+import { getPipesWorkos } from '../auth/workos-client.js';
 
 const logger = createLogger('pipes');
 
@@ -11,7 +11,7 @@ export type PipesTokenResult =
   | { status: 'needs_reauthorization'; missingScopes: string[] };
 
 export async function getGitHubAccessToken(workosUserId: string): Promise<PipesTokenResult> {
-  const workos = getWorkos();
+  const workos = getPipesWorkos();
   const fetchToken = () =>
     workos.pipes.getAccessToken({ provider: GITHUB_PROVIDER, userId: workosUserId });
 
@@ -103,7 +103,7 @@ export async function resolveGitHubConnectUrl(
 }
 
 export async function getGitHubAuthorizeUrl(workosUserId: string, returnTo: string): Promise<string> {
-  const workos = getWorkos();
+  const workos = getPipesWorkos();
   let returnToHost = '';
   try {
     returnToHost = new URL(returnTo).host;
@@ -154,7 +154,7 @@ export type ConnectedAccountResult =
   | { status: 'unavailable'; reason: string };
 
 export async function getGitHubConnectedAccount(workosUserId: string): Promise<ConnectedAccountResult> {
-  const workos = getWorkos();
+  const workos = getPipesWorkos();
   try {
     const response = await workos.get(
       `/user_management/users/${encodeURIComponent(workosUserId)}/connected_accounts/${GITHUB_PROVIDER}`,
@@ -182,7 +182,7 @@ export type DisconnectResult =
   | { status: 'unavailable'; reason: string };
 
 export async function disconnectGitHub(workosUserId: string): Promise<DisconnectResult> {
-  const workos = getWorkos();
+  const workos = getPipesWorkos();
   try {
     await workos.delete(
       `/user_management/users/${encodeURIComponent(workosUserId)}/connected_accounts/${GITHUB_PROVIDER}`,

--- a/server/tests/unit/pipes-connected-account.test.ts
+++ b/server/tests/unit/pipes-connected-account.test.ts
@@ -7,7 +7,7 @@ const { mockGet, mockDelete, mockGetAccessToken } = vi.hoisted(() => ({
 }));
 
 vi.mock('../../src/auth/workos-client.js', () => ({
-  getWorkos: () => ({
+  getPipesWorkos: () => ({
     get: mockGet,
     delete: mockDelete,
     pipes: { getAccessToken: mockGetAccessToken },

--- a/server/tests/unit/pipes-resolve-connect-url.test.ts
+++ b/server/tests/unit/pipes-resolve-connect-url.test.ts
@@ -6,7 +6,7 @@ const { mockGetAccessToken, mockPost } = vi.hoisted(() => ({
 }));
 
 vi.mock('../../src/auth/workos-client.js', () => ({
-  getWorkos: () => ({
+  getPipesWorkos: () => ({
     pipes: { getAccessToken: mockGetAccessToken },
     post: mockPost,
   }),

--- a/server/tests/unit/workos-client-timeout.test.ts
+++ b/server/tests/unit/workos-client-timeout.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  constructWorkOS: vi.fn(),
+}));
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: class MockWorkOS {
+    constructor(apiKey: string, options: unknown) {
+      mocks.constructWorkOS(apiKey, options);
+    }
+  },
+}));
+
+describe('WorkOS client request budgets', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.constructWorkOS.mockReset();
+    vi.stubEnv('WORKOS_API_KEY', 'sk_test_timeout');
+    vi.stubEnv('WORKOS_CLIENT_ID', 'client_test_timeout');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('bounds interactive Pipes requests without automatic retries', async () => {
+    const { getPipesWorkos } = await import('../../src/auth/workos-client.js');
+
+    getPipesWorkos();
+    getPipesWorkos();
+
+    expect(mocks.constructWorkOS).toHaveBeenCalledOnce();
+    expect(mocks.constructWorkOS).toHaveBeenCalledWith('sk_test_timeout', {
+      clientId: 'client_test_timeout',
+      timeout: 10_000,
+      maxRetries: 0,
+    });
+  });
+
+  it('does not change retry or timeout policy for the general shared client', async () => {
+    const { getWorkos } = await import('../../src/auth/workos-client.js');
+
+    getWorkos();
+
+    expect(mocks.constructWorkOS).toHaveBeenCalledWith('sk_test_timeout', {
+      clientId: 'client_test_timeout',
+    });
+  });
+
+  it('makes one SDK attempt when retries are disabled', async () => {
+    const { WorkOS } = await vi.importActual<typeof import('@workos-inc/node')>(
+      '@workos-inc/node',
+    );
+    const fetchFn = vi.fn((...args: Parameters<typeof fetch>): ReturnType<typeof fetch> => {
+      const [, init] = args;
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          reject(error);
+        }, { once: true });
+      });
+    });
+    const client = new WorkOS('sk_test_timeout', {
+      clientId: 'client_test_timeout',
+      timeout: 10,
+      maxRetries: 0,
+      fetchFn,
+    });
+
+    await expect(client.get('/test-timeout', {})).rejects.toMatchObject({ status: 408 });
+    expect(fetchFn).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- isolate interactive WorkOS Pipes calls behind a dedicated client
- cap each Pipes request at 10 seconds and disable SDK automatic retries so edge requests fail predictably
- preserve the existing timeout/retry behavior for general WorkOS auth and membership traffic
- add constructor-policy and real SDK single-attempt timeout coverage

Fixes #5594

## Testing

- `npx vitest run --config server/vitest.config.ts server/tests/unit/workos-client-timeout.test.ts server/tests/unit/pipes-connected-account.test.ts server/tests/unit/pipes-resolve-connect-url.test.ts server/tests/unit/connect-github-bouncer.test.ts` (35 passed)
- `git diff --check origin/main...HEAD`

## Changeset

Not required: server-only behavior and tests; no published package surface changed.