### PR TITLE
fix(schema): align brand property type enums

### DIFF
--- a/.changeset/fix-brand-property-type-drift.md
+++ b/.changeset/fix-brand-property-type-drift.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Align brand property and verification schemas with the canonical property-type enum, including `linear_tv` and `ai_assistant`.

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -1222,6 +1222,7 @@ Properties are digital touchpoints associated with brands:
 ### Property types
 
 Matches AdCP property-type enum:
+
 - `website`
 - `mobile_app`
 - `ctv_app`
@@ -1229,7 +1230,9 @@ Matches AdCP property-type enum:
 - `dooh`
 - `podcast`
 - `radio`
+- `linear_tv`
 - `streaming_audio`
+- `ai_assistant`
 
 ### Property relationships
 

--- a/docs/brand-protocol/building-a-brand-agent.mdx
+++ b/docs/brand-protocol/building-a-brand-agent.mdx
@@ -205,7 +205,7 @@ type SubsidiaryRecord = {
 };
 
 type PropertyRecord = {
-  type: "website" | "mobile_app" | "ctv_app" | "desktop_app" | "dooh" | "podcast" | "radio" | "streaming_audio";
+  type: "website" | "mobile_app" | "ctv_app" | "desktop_app" | "dooh" | "podcast" | "radio" | "linear_tv" | "streaming_audio" | "ai_assistant";
   identifier: string;
   brand_id: string;
   relationship: "owned" | "direct" | "delegated" | "ad_network";
@@ -248,7 +248,7 @@ const ParentClaim = z.object({
 
 const PropertyClaim = z.object({
   property: z.object({
-    type: z.enum(["website", "mobile_app", "ctv_app", "desktop_app", "dooh", "podcast", "radio", "streaming_audio"]),
+    type: z.enum(["website", "mobile_app", "ctv_app", "desktop_app", "dooh", "podcast", "radio", "linear_tv", "streaming_audio", "ai_assistant"]),
     identifier: z.string().min(1),
     store: z.enum(["apple", "google", "amazon", "roku", "fire_tv", "samsung", "lg", "vizio", "other"]).optional(),
     region: z.string().optional(),

--- a/docs/brand-protocol/tasks/verify_brand_claim.mdx
+++ b/docs/brand-protocol/tasks/verify_brand_claim.mdx
@@ -255,7 +255,7 @@ Applicable statuses: `owned`, `transferring`, `disputed`, `not_ours`, `archived`
 
 | Field | Required | Notes |
 |---|---|---|
-| `property.type` | Yes | `website`, `mobile_app`, `ctv_app`, `desktop_app`, `dooh`, `podcast`, `radio`, `streaming_audio`. |
+| `property.type` | Yes | `website`, `mobile_app`, `ctv_app`, `desktop_app`, `dooh`, `podcast`, `radio`, `linear_tv`, `streaming_audio`, `ai_assistant`. |
 | `property.identifier` | Yes | Domain for websites/podcasts, bundle id for apps, etc. |
 | `property.store` | When type is an app | `apple`, `google`, `amazon`, `roku`, `fire_tv`, `samsung`, `lg`, `vizio`, `other`. |
 | `property.region` | No | Single ISO 3166-1 alpha-2 code (or `"global"`) — the region the caller cares about. The response's `details.regions` carries the full applicable set. |

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -381,8 +381,7 @@
       "description": "A digital property associated with a brand. Defaults to owned; use 'relationship' to declare direct, delegated, or ad_network properties. For delegated and network paths, these values match the delegation_type field in adagents.json, creating a bilateral verification chain: the operator declares the relationship here, the publisher confirms by setting the same delegation_type on the agent's authorization in their adagents.json. 'owned' is an inline ownership declaration with no adagents.json counterpart.",
       "properties": {
         "type": {
-          "type": "string",
-          "enum": ["website", "mobile_app", "ctv_app", "desktop_app", "dooh", "podcast", "radio", "streaming_audio"],
+          "$ref": "/schemas/enums/property-type.json",
           "description": "Property type"
         },
         "identifier": {

--- a/static/schemas/source/brand/verify-brand-claim-request.json
+++ b/static/schemas/source/brand/verify-brand-claim-request.json
@@ -95,8 +95,7 @@
               "description": "Shape matches brand.json properties[] entry.",
               "properties": {
                 "type": {
-                  "type": "string",
-                  "enum": ["website", "mobile_app", "ctv_app", "desktop_app", "dooh", "podcast", "radio", "streaming_audio"]
+                  "$ref": "/schemas/enums/property-type.json"
                 },
                 "identifier": { "type": "string" },
                 "store": {

--- a/static/schemas/source/brand/verify-brand-claims-request.json
+++ b/static/schemas/source/brand/verify-brand-claims-request.json
@@ -112,8 +112,7 @@
                   "description": "Shape matches brand.json properties[] entry.",
                   "properties": {
                     "type": {
-                      "type": "string",
-                      "enum": ["website", "mobile_app", "ctv_app", "desktop_app", "dooh", "podcast", "radio", "streaming_audio"]
+                      "$ref": "/schemas/enums/property-type.json"
                     },
                     "identifier": { "type": "string" },
                     "store": {

--- a/tests/schema-validation.test.cjs
+++ b/tests/schema-validation.test.cjs
@@ -351,6 +351,69 @@ async function runTests() {
     return true;
   });
 
+  await test('brand property schemas accept every canonical property type', async () => {
+    const compile = async relativePath => {
+      const testAjv = new Ajv({
+        allErrors: true,
+        verbose: true,
+        strict: false,
+        discriminator: true,
+        loadSchema: loadExternalSchema
+      });
+      addFormats(testAjv);
+      return testAjv.compileAsync(loadSchema(path.join(SCHEMA_BASE_DIR, relativePath)));
+    };
+
+    const validators = [
+      {
+        name: 'brand.json',
+        validate: await compile('brand.json'),
+        document: propertyType => ({
+          id: 'canonical_property_types',
+          names: [{ en: 'Canonical property types' }],
+          properties: [{ type: propertyType, identifier: 'property-id' }]
+        })
+      },
+      {
+        name: 'verify-brand-claim-request.json',
+        validate: await compile('brand/verify-brand-claim-request.json'),
+        document: propertyType => ({
+          claim_type: 'property',
+          claim: { property: { type: propertyType, identifier: 'property-id' } }
+        })
+      },
+      {
+        name: 'verify-brand-claims-request.json',
+        validate: await compile('brand/verify-brand-claims-request.json'),
+        document: propertyType => ({
+          claims: [{
+            claim_type: 'property',
+            claim: { property: { type: propertyType, identifier: 'property-id' } }
+          }]
+        })
+      }
+    ];
+
+    const canonicalPropertyTypes = loadSchema(
+      path.join(SCHEMA_BASE_DIR, 'enums/property-type.json')
+    ).enum;
+    for (const { name, validate, document } of validators) {
+      for (const propertyType of canonicalPropertyTypes) {
+        if (!validate(document(propertyType))) {
+          const errors = validate.errors
+            .map(error => `${error.instancePath} ${error.message}`)
+            .join('; ');
+          return `${name} rejected canonical property type ${propertyType}: ${errors}`;
+        }
+      }
+      if (validate(document('not_a_property_type'))) {
+        return `${name} accepted a non-canonical property type`;
+      }
+    }
+
+    return true;
+  });
+
   // Test 4B: Validate brand.json verifier ambiguity invariant
   await test('brand.json duplicate agent urls are verifier-ambiguous', () => {
     const manifest = {


### PR DESCRIPTION
## Summary

- replace stale inline brand property enums with the canonical property-type schema reference
- align single and bulk brand-claim verification schemas so `linear_tv` and `ai_assistant` validate consistently
- update protocol and implementation docs, including copyable TypeScript and Zod validators
- add bidirectional schema coverage for all canonical values and rejection of non-canonical values

Fixes #6330

## Testing

- `npm run build:schemas`
- `npm run test:schemas` (29 schema checks and 4 metadata checks passed)
- targeted snippet and JSON-schema validation for all three changed docs
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- `npx --yes @changesets/cli@^2.31.0 status --since=origin/main`
- `git diff --check origin/main...HEAD`

## Release

Includes a minor `adcontextprotocol` changeset because the published schemas gain two existing canonical enum values.