### PR TITLE
fix(registry): expose full-crawl queue deferrals

### DIFF
--- a/docs/building/operating/support-recovery-runbooks.mdx
+++ b/docs/building/operating/support-recovery-runbooks.mdx
@@ -128,14 +128,17 @@ terminal `failed` request, correct the reported error category and submit a new
 crawl request after the per-domain rate-limit window; the old request remains
 as the audit record.
 
-Workers claim no more requests than they can start immediately. Each active
-publisher crawl holds a PostgreSQL shared global execution lock and an
-exclusive per-domain lock for the fetch/write lifecycle; the periodic full
-crawl holds the exclusive global lock. These session locks use dedicated
-connections outside the application pool, so crawl concurrency does not consume
-the connections needed by heartbeats, status reads, or mirror transactions. The
-locks prevent an expired or duplicate attempt from overwriting newer mirror
-state. The mirror transaction
+Workers claim at most the configured crawl concurrency per tick. If a periodic
+full crawl is active, claimed requests are persisted as `deferred`, their claim
+attempt is refunded, and they become eligible again after 30 seconds. This
+makes contention visible without spending the retry budget or performing
+origin work. Each active publisher crawl holds a PostgreSQL shared global
+execution lock and an exclusive per-domain lock for the fetch/write lifecycle;
+the periodic full crawl holds the exclusive global lock. These session locks
+use dedicated connections outside the application pool, so crawl concurrency
+does not consume the connections needed by heartbeats, status reads, or mirror
+transactions. The locks prevent an expired or duplicate attempt from
+overwriting newer mirror state. The mirror transaction
 also verifies the current request lease token before committing. Publisher GET
 requests do not acquire these locks and continue to serve the last committed
 mirror state while crawling is delayed or unavailable.

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -2515,7 +2515,12 @@ export class CrawlerService {
       deferred: 0,
       lostLease: 0,
     };
-    if (this.publisherCrawlQueueProcessing || this.crawling) return stats;
+    // Claim even while an in-process full crawl is active. crawlSingleDomain()
+    // will take the existing contention path and persist the request as
+    // deferred without consuming an attempt. Returning here instead leaves
+    // accepted work invisibly queued for the entire full crawl and, if that
+    // crawl wedges, forever.
+    if (this.publisherCrawlQueueProcessing) return stats;
 
     this.publisherCrawlQueueProcessing = true;
     try {

--- a/server/tests/unit/crawler-durable-request-queue.test.ts
+++ b/server/tests/unit/crawler-durable-request-queue.test.ts
@@ -98,8 +98,9 @@ describe('CrawlerService durable publisher request worker', () => {
     );
   });
 
-  it('defers full-crawl contention without marking a failure', async () => {
+  it('claims and records deferred work while an in-process full crawl is active', async () => {
     const { ctx, crawlRequestsDb } = await makeContext();
+    ctx.crawling = true;
     ctx.crawlSingleDomain.mockRejectedValue(Object.assign(new Error('full crawl'), {
       code: 'crawl_deferred',
     }));
@@ -107,6 +108,7 @@ describe('CrawlerService durable publisher request worker', () => {
     const result = await ctx.processPublisherCrawlRequestQueue();
 
     expect(result.deferred).toBe(1);
+    expect(crawlRequestsDb.claimDue).toHaveBeenCalledOnce();
     expect(crawlRequestsDb.markDeferred).toHaveBeenCalledOnce();
     expect(crawlRequestsDb.markFailedAttempt).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- claim durable publisher crawl requests even while the worker's periodic full crawl is active
- persist those requests as `deferred`, refund the claim attempt, and retry after the existing 30-second contention delay
- document the observable contention lifecycle and add regression coverage

## Production evidence

After the durable PostgreSQL queue rollout, request `fec79840-2bd4-4b19-bcd9-6497bd5e2a75` for `nofluffadvisory.com` was accepted at `2026-08-10T07:43:36Z` but remained `queued` with zero attempts for more than 120 seconds.

The worker starts an immediate periodic full crawl before its durable queue tick. `processPublisherCrawlRequestQueue()` returned early whenever `this.crawling` was true, so it never claimed the request and never reached the existing `crawl_deferred` / `markDeferred` path. A long or wedged full crawl could therefore leave accepted work invisibly queued indefinitely.

This change removes only that early-return condition. `crawlSingleDomain()` still detects the active full crawl before origin work or advisory-lock acquisition, and the queue worker persists `deferred` without consuming retry budget.

## Performance

The queue remains bounded to the configured claim batch (currently four requests per five-second tick). During a full crawl, each claimed request performs only bounded queue-state database updates and is rescheduled after 30 seconds; it performs no publisher-origin request and acquires no crawl advisory lock.

## Validation

- `npm run precommit` (1,040 root tests; 5,687 server tests passed, 30 skipped; typecheck passed)
- focused durable queue suite: 6/6 passed
- independent code, database/performance, and security reviews found no blocker

Follow-up to #6327 and #6331.
