### PR TITLE
fix(training-agent): fail closed on comply sandbox gate

### DIFF
--- a/.changeset/restore-3-0-comply-sandbox-compat.md
+++ b/.changeset/restore-3-0-comply-sandbox-compat.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Restore frozen AdCP 3.0 storyboard compatibility with the fail-closed training-agent comply controller sandbox gate.

--- a/scripts/patch-3-0-compat-bundle.cjs
+++ b/scripts/patch-3-0-compat-bundle.cjs
@@ -48,6 +48,98 @@ function patchFile(filePath, transform, label) {
   return true;
 }
 
+// Frozen 3.0.x storyboards predate the explicit account.sandbox assertion
+// required by the current controller runtime. Add the assertion only to the
+// temporary compatibility copy so the lane continues to exercise 3.0
+// behavior through today's fail-closed reference implementation. Preserve an
+// explicit false value: live-account denial probes must remain denials.
+function indentation(line) {
+  return line.match(/^ */)?.[0].length ?? 0;
+}
+
+function blockEnd(lines, start, parentIndent) {
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^\s*(?:#.*)?$/.test(lines[i])) continue;
+    if (indentation(lines[i]) <= parentIndent) return i;
+  }
+  return lines.length;
+}
+
+function patchControllerSandboxAssertions(text) {
+  const newline = text.includes('\r\n') ? '\r\n' : '\n';
+  const lines = text.split(/\r?\n/);
+  const insertions = [];
+
+  for (let taskIndex = 0; taskIndex < lines.length; taskIndex += 1) {
+    const taskMatch = lines[taskIndex].match(/^(\s*)task:\s*["']?comply_test_controller["']?\s*(?:#.*)?$/);
+    if (!taskMatch) continue;
+
+    const taskIndent = taskMatch[1].length;
+    let stepStart = taskIndex;
+    while (stepStart > 0) {
+      const previous = lines[stepStart - 1];
+      if (!/^\s*(?:#.*)?$/.test(previous) && indentation(previous) < taskIndent) break;
+      stepStart -= 1;
+    }
+    const stepEnd = blockEnd(lines, taskIndex, taskIndent - 1);
+    const requestIndex = lines.findIndex((line, index) => (
+      index >= stepStart
+      && index < stepEnd
+      && indentation(line) === taskIndent
+      && /^\s*sample_request:\s*(?:#.*)?$/.test(line)
+    ));
+    if (requestIndex < 0) continue;
+
+    const requestEnd = blockEnd(lines, requestIndex, taskIndent);
+    const accountIndex = lines.findIndex((line, index) => (
+      index > requestIndex
+      && index < requestEnd
+      && indentation(line) === taskIndent + 2
+      && /^\s*account\s*:/.test(line)
+    ));
+
+    if (accountIndex < 0) {
+      insertions.push({
+        index: requestIndex + 1,
+        lines: [`${' '.repeat(taskIndent + 2)}account:`, `${' '.repeat(taskIndent + 4)}sandbox: true`],
+      });
+      continue;
+    }
+
+    // Only extend a block mapping (`account:`). Inline/null/scalar/array
+    // values are explicit malformed probes and must remain byte-for-byte.
+    if (!/^\s*account\s*:\s*(?:#.*)?$/.test(lines[accountIndex])) continue;
+    const accountEnd = blockEnd(lines, accountIndex, taskIndent + 2);
+    const hasSandbox = lines.some((line, index) => (
+      index > accountIndex
+      && index < accountEnd
+      && indentation(line) === taskIndent + 4
+      && /^\s*sandbox\s*:/.test(line)
+    ));
+    if (!hasSandbox) {
+      insertions.push({
+        index: accountIndex + 1,
+        lines: [`${' '.repeat(taskIndent + 4)}sandbox: true`],
+      });
+    }
+  }
+
+  for (const insertion of insertions.reverse()) {
+    lines.splice(insertion.index, 0, ...insertion.lines);
+  }
+  return lines.join(newline);
+}
+
+let sandboxAssertionFiles = 0;
+for (const yamlPath of walkYamlFiles(bundleDir)) {
+  if (patchFile(yamlPath, patchControllerSandboxAssertions)) {
+    sandboxAssertionFiles += 1;
+  }
+}
+if (sandboxAssertionFiles > 0) {
+  console.log(`Patched comply_test_controller sandbox assertions in ${sandboxAssertionFiles} 3.0 compatibility YAML file(s)`);
+}
+
 // Frozen 3.0.x storyboards authored concrete 2026/2027 active-window dates.
 // As wall-clock time advances those fixtures start failing calendar guards
 // before they can exercise the protocol behavior they were written for

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -1080,10 +1080,17 @@ export const COMPLY_TEST_CONTROLLER_TOOL = {
         type: 'object',
         description: 'Scenario-specific parameters. Call list_scenarios to see required and optional params per scenario. Omit for list_scenarios.',
       },
-      account: { type: 'object' },
+      account: {
+        type: 'object',
+        properties: {
+          sandbox: { type: 'boolean', const: true },
+        },
+        required: ['sandbox'],
+        additionalProperties: true,
+      },
       brand: { type: 'object' },
     },
-    required: ['scenario'],
+    required: ['scenario', 'account'],
   },
 };
 
@@ -1104,24 +1111,26 @@ export const COMPLY_TEST_CONTROLLER_TOOL = {
 export async function handleComplyTestController(args: ToolArgs, ctx: TrainingContext): Promise<object> {
   const rawArgs = args as Record<string, unknown>;
 
-  // Sandbox gate — spec: "If a comply_test_controller call references a
-  // non-sandbox account, the controller MUST return FORBIDDEN." The
-  // training agent is sandbox-only by deployment (the tool only lists on
-  // sandbox connections), so a caller hitting this endpoint is by
-  // definition in sandbox. Reject ONLY when the request explicitly
-  // declares `account.sandbox: false` (an attempt to target a named
-  // production account) — default-to-allow matches the storyboards
-  // (`deterministic_testing`, etc.) which don't include `account` at all
-  // on error-surface probes.
+  // Sandbox gate — the caller's assertion is required but is not itself an
+  // authorization grant. The training agent is sandbox-only, so requiring
+  // the explicit flag keeps this reference implementation fail-closed and
+  // aligned with the published comply_test_controller request schema.
   const account = rawArgs.account as { sandbox?: boolean } | undefined;
   const params = (rawArgs.params ?? {}) as Record<string, unknown>;
   const isLiveModeProbe = rawArgs.scenario === 'force_creative_status'
     && params.creative_id === 'comply-live-mode-probe-000';
-  if ((account && account.sandbox === false) || isLiveModeProbe) {
+  if (!account || account.sandbox !== true) {
     return {
       success: false,
       error: 'FORBIDDEN',
-      error_detail: 'comply_test_controller cannot target non-sandbox accounts',
+      error_detail: 'comply_test_controller requires account.sandbox: true',
+    };
+  }
+  if (isLiveModeProbe) {
+    return {
+      success: false,
+      error: 'FORBIDDEN',
+      error_detail: 'comply_test_controller is unavailable for live accounts',
     };
   }
 

--- a/server/src/training-agent/tenants/comply.ts
+++ b/server/src/training-agent/tenants/comply.ts
@@ -125,21 +125,19 @@ function simulateAdapter(scenario: string): AdapterShim {
  * .budget_spend, seed.product / .pricing_option / .media_buy / .creative.
  */
 /**
- * Extend the spec-canonical `TOOL_INPUT_SHAPE` with a top-level `account`
- * field. v5 storyboards send `account: { brand: { domain }, sandbox }` at
- * the top level — the v5 handler reads `account.brand.domain` for session
- * keying. The v6 first-class registration uses the spec-canonical shape
- * (no top-level `account` — spec routes account context through `context`)
- * which would strip the field. F10's `inputSchema` extension point lets us
- * accept the v5-vintage shape until storyboard fixtures migrate to spec.
+ * Extend the SDK's currently narrower `TOOL_INPUT_SHAPE` with the published
+ * request schema's required top-level sandbox account assertion. Storyboards
+ * send `account: { brand: { domain }, sandbox: true }`; the v5 handler also
+ * reads `account.brand.domain` for session keying. F10's `inputSchema`
+ * extension point preserves those canonical fields through v6 dispatch.
  */
 const SALES_COMPLY_INPUT_SCHEMA = {
   ...TOOL_INPUT_SHAPE,
   account: z.object({
     account_id: z.string().optional(),
     brand: z.object({ domain: z.string().optional() }).passthrough().optional(),
-    sandbox: z.boolean().optional(),
-  }).passthrough().optional(),
+    sandbox: z.literal(true),
+  }).passthrough(),
   brand: z.object({ domain: z.string().optional() }).passthrough().optional(),
   [TRAINING_PRINCIPAL_FIELD]: z.string().optional(),
 };

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -805,6 +805,7 @@ describe('tenant routing smoke', () => {
       const account = {
         brand: { domain: 'legacy-only-native-package.example' },
         operator: 'pinnacle-agency.example',
+        sandbox: true,
       };
       const productId = 'legacy_only_native_package';
       const pricingOptionId = 'legacy_only_native_package_cpm';

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import crypto from 'node:crypto';
+import { z } from 'zod';
 import {
   createTrainingAgentServer,
   invalidateCache,
@@ -13,6 +14,11 @@ import {
 import { MUTATING_TOOLS, clearIdempotencyCache } from '../../src/training-agent/idempotency.js';
 import type { TrainingContext } from '../../src/training-agent/types.js';
 import { clearAccountStore } from '../../src/training-agent/account-handlers.js';
+import {
+  buildCreativeComplyConfig,
+  buildGovernanceComplyConfig,
+  buildSalesComplyConfig,
+} from '../../src/training-agent/tenants/comply.js';
 
 const DEFAULT_CTX: TrainingContext = { mode: 'open' };
 const ACCOUNT = { brand: { domain: 'comply-test.example.com' }, operator: 'comply-tester', sandbox: true };
@@ -157,6 +163,12 @@ describe('comply_test_controller', () => {
       expect(toolNames).toContain('comply_test_controller');
       const controller = tools.find((tool: any) => tool.name === 'comply_test_controller') as any;
       expect(controller.inputSchema.properties.scenario.enum).toContain('force_get_products_arm');
+      expect(controller.inputSchema.required).toEqual(expect.arrayContaining(['scenario', 'account']));
+      expect(controller.inputSchema.properties.account.required).toContain('sandbox');
+      expect(controller.inputSchema.properties.account.properties.sandbox).toMatchObject({
+        type: 'boolean',
+        const: true,
+      });
     });
   });
 
@@ -1111,13 +1123,15 @@ describe('comply_test_controller', () => {
   });
 
   describe('sandbox gating', () => {
-    it('allows calls when sandbox is not specified', async () => {
+    it('rejects calls when sandbox is not specified', async () => {
       const { result } = await simulateCallTool(server, 'comply_test_controller', {
         scenario: 'list_scenarios',
         account: { brand: { domain: 'test.example.com' }, operator: 'tester' },
         brand: BRAND,
       });
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('FORBIDDEN');
+      expect(result.error_detail).toBe('comply_test_controller requires account.sandbox: true');
     });
 
     it('rejects calls with sandbox: false', async () => {
@@ -1130,12 +1144,67 @@ describe('comply_test_controller', () => {
       expect(result.error).toBe('FORBIDDEN');
     });
 
-    it('allows calls with no account', async () => {
+    it('rejects calls with no account', async () => {
       const { result } = await simulateCallTool(server, 'comply_test_controller', {
         scenario: 'list_scenarios',
         brand: BRAND,
       });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('FORBIDDEN');
+    });
+
+    it('allows calls with sandbox: true', async () => {
+      const { result } = await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'list_scenarios',
+        account: ACCOUNT,
+        brand: BRAND,
+      });
       expect(result.success).toBe(true);
+    });
+
+    it('reports live-account denial without contradicting the sandbox assertion', async () => {
+      const { result } = await simulateCallTool(server, 'comply_test_controller', {
+        scenario: 'force_creative_status',
+        params: { creative_id: 'comply-live-mode-probe-000', status: 'approved' },
+        account: ACCOUNT,
+        brand: BRAND,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('FORBIDDEN');
+      expect(result.error_detail).toBe('comply_test_controller is unavailable for live accounts');
+    });
+  });
+
+  describe('v6 tenant sandbox gating', () => {
+    it.each([
+      ['sales', buildSalesComplyConfig],
+      ['creative', buildCreativeComplyConfig],
+      ['governance', buildGovernanceComplyConfig],
+    ])('requires account.sandbox: true in the %s controller input schema', (_tenant, buildConfig) => {
+      const schema = z.object(buildConfig().inputSchema);
+      expect(schema.safeParse({ scenario: 'list_scenarios' }).success).toBe(false);
+      expect(schema.safeParse({ scenario: 'list_scenarios', account: { sandbox: false } }).success).toBe(false);
+      expect(schema.safeParse({ scenario: 'list_scenarios', account: { sandbox: true } }).success).toBe(true);
+    });
+
+    it('dispatches a sales controller adapter with an explicit sandbox account', async () => {
+      const config = buildSalesComplyConfig();
+      await expect((config.seed.product as any)({
+        product_id: 'v6_sandbox_gate_product',
+        fixture: {
+          name: 'V6 sandbox gate product',
+          description: 'Controller dispatch fixture',
+          delivery_type: 'guaranteed',
+          channels: ['display'],
+          format_ids: [{ id: 'display_300x250' }],
+        },
+      }, {
+        input: {
+          scenario: 'seed.product',
+          account: ACCOUNT,
+          brand: BRAND,
+        },
+      })).resolves.toBeUndefined();
     });
   });
 

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -129,15 +129,14 @@ async function simulateListTools(
 }
 
 /**
- * Auto-inject a fresh UUID v4 `idempotency_key` on mutating tools when the
- * test doesn't provide one. The idempotency middleware requires the key per
- * #2315; most tests in this file predate that requirement and don't care
- * about replay semantics — they just want the tool to run once.
+ * Apply protocol defaults that this broad legacy test file does not need to
+ * repeat at every call site: an explicit sandbox assertion for controller
+ * calls and a fresh UUID v4 `idempotency_key` for mutating tools.
  *
  * Tests that DO care (conflict / replay / expired / missing-key coverage)
  * pass an explicit `idempotency_key`, which this helper preserves.
  */
-function withIdempotencyKey(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
+function withTestProtocolDefaults(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
   let normalizedArgs = args;
   if (toolName === 'check_governance' && typeof args.tool === 'string' && args.payload) {
     const rawPayload = args.payload as Record<string, unknown>;
@@ -158,6 +157,18 @@ function withIdempotencyKey(toolName: string, args: Record<string, unknown>): Re
   if (toolName === 'validate_input' && args.adcp_version === undefined) {
     return { ...normalizedArgs, adcp_version: CURRENT_ADCP_VERSION };
   }
+  if (toolName === 'comply_test_controller') {
+    const account = normalizedArgs.account;
+    normalizedArgs = {
+      ...normalizedArgs,
+      account: account && typeof account === 'object' && !Array.isArray(account)
+        ? {
+            ...(account as Record<string, unknown>),
+            sandbox: (account as Record<string, unknown>).sandbox ?? true,
+          }
+        : { sandbox: true },
+    };
+  }
   if (!MUTATING_TOOLS.has(toolName)) return normalizedArgs;
   if (normalizedArgs.idempotency_key !== undefined) return normalizedArgs;
   return { ...normalizedArgs, idempotency_key: `test-${randomUUID()}` };
@@ -177,7 +188,7 @@ async function simulateCallTool(
     throw new Error('CallTool handler not found');
   }
   const response = await handler(
-    { method: 'tools/call', params: { name: toolName, arguments: withIdempotencyKey(toolName, args) } },
+    { method: 'tools/call', params: { name: toolName, arguments: withTestProtocolDefaults(toolName, args) } },
     {},
   );
   // Success responses carry the body on `structuredContent`; error / replay
@@ -213,7 +224,7 @@ async function simulateCallToolAsTask(
     throw new Error('CallTool handler not found');
   }
   return handler(
-    { method: 'tools/call', params: { name: toolName, arguments: withIdempotencyKey(toolName, args), task: taskParams } },
+    { method: 'tools/call', params: { name: toolName, arguments: withTestProtocolDefaults(toolName, args), task: taskParams } },
     {},
   );
 }
@@ -13886,7 +13897,7 @@ async function simulateCallToolRaw(
   const handler = requestHandlers.get('tools/call');
   if (!handler) throw new Error('CallTool handler not found');
   const response = await handler(
-    { method: 'tools/call', params: { name: toolName, arguments: withIdempotencyKey(toolName, args) } },
+    { method: 'tools/call', params: { name: toolName, arguments: withTestProtocolDefaults(toolName, args) } },
     {},
   );
   const text = response.content?.[0]?.text;

--- a/tests/patch-3-0-compat-bundle.test.cjs
+++ b/tests/patch-3-0-compat-bundle.test.cjs
@@ -7,6 +7,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
+const yaml = require('js-yaml');
 
 const repoRoot = path.resolve(__dirname, '..');
 const patchScript = path.join(repoRoot, 'scripts', 'patch-3-0-compat-bundle.cjs');
@@ -88,6 +89,77 @@ phases:
     execFileSync(process.execPath, [patchScript, dir], { cwd: repoRoot, encoding: 'utf8' });
     const output = fs.readFileSync(path.join(dir, 'universal', 'schema-validation.yaml'), 'utf8');
     assert.equal(output, input);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('3.0 compatibility patch adds missing controller sandbox assertions without weakening live probes', () => {
+  const dir = makeBundle('3.0.22', 'id: schema_validation\nphases: []\n');
+  const storyboardPath = path.join(dir, 'universal', 'deterministic-testing.yaml');
+  fs.writeFileSync(storyboardPath, `id: deterministic_testing
+phases:
+  - id: controller_validation
+    steps:
+      - id: missing_account
+        task: comply_test_controller
+        sample_request:
+          # Preserve this comment and numeric spelling exactly.
+          amount: 250.00
+          scenario: list_scenarios
+      - id: account_without_flag
+        task: comply_test_controller
+        sample_request:
+          account:
+            brand:
+              domain: example.com
+          scenario: force_account_status
+      - id: live_probe
+        task: comply_test_controller
+        sample_request:
+          account:
+            sandbox: false
+          scenario: force_creative_status
+      - id: null_account_probe
+        task: comply_test_controller
+        sample_request:
+          account: null
+          scenario: list_scenarios
+      - id: scalar_account_probe
+        task: comply_test_controller
+        sample_request:
+          account: invalid
+          scenario: list_scenarios
+      - id: array_account_probe
+        task: comply_test_controller
+        sample_request:
+          account: []
+          scenario: list_scenarios
+      - id: null_request_probe
+        task: comply_test_controller
+        sample_request: null
+      - id: unrelated
+        task: get_products
+        sample_request: {}
+`, 'utf8');
+
+  try {
+    execFileSync(process.execPath, [patchScript, dir], { cwd: repoRoot, encoding: 'utf8' });
+    const rawOutput = fs.readFileSync(storyboardPath, 'utf8');
+    const output = yaml.load(rawOutput);
+    const steps = output.phases[0].steps;
+    assert.equal(steps[0].sample_request.account.sandbox, true);
+    assert.equal(steps[1].sample_request.account.sandbox, true);
+    assert.equal(steps[1].sample_request.account.brand.domain, 'example.com');
+    assert.equal(steps[2].sample_request.account.sandbox, false);
+    assert.equal(steps[3].sample_request.account, null);
+    assert.equal(steps[4].sample_request.account, 'invalid');
+    assert.deepEqual(steps[5].sample_request.account, []);
+    assert.equal(steps[6].sample_request, null);
+    assert.deepEqual(steps[7].sample_request, {});
+    assert.match(rawOutput, /          # Preserve this comment and numeric spelling exactly\.\n          amount: 250\.00\n/);
+    assert.match(rawOutput, /        sample_request:\n          account:\n            sandbox: true\n          # Preserve this comment/);
+    assert.match(rawOutput, /          account:\n            sandbox: true\n            brand:\n/);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What changed

- require `account.sandbox: true` in the training-agent controller descriptor and fail closed at runtime when the account or flag is absent
- apply the same required literal-true contract to the sales, creative, and governance v6 tenant controller schemas
- preserve the live-account probe denial while returning an accurate diagnostic
- update broad legacy training-agent tests to supply the sandbox assertion and add regressions for general and tenant controller surfaces
- inject the assertion only into missing fields in temporary frozen-3.0 compatibility bundles, without normalizing malformed or explicit live-account probes

## Why

The published `comply_test_controller` request schema requires an explicit sandbox assertion, but the reference runtime only rejected `sandbox: false`. Missing account data therefore defaulted to allow, and the v6 tenant descriptors also advertised the field as optional. This made the canonical reference implementation weaker than the protocol contract.

Closes #3756.

## Validation

- controller unit suite: 70/70
- broad training-agent unit suite: 594/594
- TypeScript typecheck
- storyboard sample-request schema suite: 10/10
- frozen 3.0.22 storyboard matrix: all seven tenant tracks meet their clean/passed floors
- 3.0 compatibility patch regressions: 4/4
- Changesets protocol-scope/status checks
- independent code/security and protocol/runtime expert reviews: clean after fixes

The unrelated open-string `scenario` descriptor drift found during review is tracked separately in #6335.
