### PR TITLE
fix(registry): prevent full crawl starvation

### DIFF
--- a/docs/building/operating/support-recovery-runbooks.mdx
+++ b/docs/building/operating/support-recovery-runbooks.mdx
@@ -132,22 +132,30 @@ Workers claim at most the configured crawl concurrency per tick. If a periodic
 full crawl is active, claimed requests are persisted as `deferred`, their claim
 attempt is refunded, and they become eligible again after 30 seconds. This
 makes contention visible without spending the retry budget or performing
-origin work. Each active publisher crawl holds a PostgreSQL shared global
-execution lock and an exclusive per-domain lock for the fetch/write lifecycle;
-the periodic full crawl holds the exclusive global lock. These session locks
-use dedicated connections outside the application pool, so crawl concurrency
-does not consume the connections needed by heartbeats, status reads, or mirror
-transactions. The locks prevent an expired or duplicate attempt from
+origin work. On worker startup, the durable queue starts immediately and the
+initial full crawl waits a fixed 30 seconds. This gives already-due requests a
+bounded opportunity to run after a deploy. After that window, the full crawl
+holds an exclusive PostgreSQL intent lock while waiting for active publisher
+crawls, including across bounded execution-lock timeouts and retries. New
+publisher crawls therefore defer instead of starving the six-hour full crawl.
+Each active publisher crawl holds a PostgreSQL shared global execution lock and
+an exclusive per-domain lock for the fetch/write lifecycle; the periodic full
+crawl holds the exclusive global lock. These session locks use dedicated
+connections outside the application pool, so crawl concurrency does not consume
+the connections needed by heartbeats, status reads, or mirror transactions. A
+lost worker session releases its locks automatically. The locks prevent an
+expired or duplicate attempt from
 overwriting newer mirror state. The mirror transaction
 also verifies the current request lease token before committing. Publisher GET
 requests do not acquire these locks and continue to serve the last committed
 mirror state while crawling is delayed or unavailable.
 
-Dedicated lock-session operations are bounded at 10 seconds. The periodic full
-crawl may wait up to two minutes for the global lock, plus the 10-second
-database-operation margin. A missed keepalive or unlock deadline invalidates
-the lock and forcibly closes its dedicated connection so a wedged socket cannot
-hold a queue worker or request lease indefinitely.
+Routine dedicated lock-session operations are bounded at 10 seconds. Full-crawl
+intent acquisition may wait 10 seconds, with a 10-second socket-operation
+margin. The periodic full crawl may wait up to two minutes for the global lock,
+plus the same operation margin. A missed keepalive or unlock deadline
+invalidates the lock and forcibly closes its dedicated connection so a wedged
+socket cannot hold a queue worker or request lease indefinitely.
 
 For the first deployment, use Fly's `immediate` strategy and leave
 `PUBLISHER_CRAWL_QUEUE_ENABLED=false`. Immediate replacement prevents an old

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -294,7 +294,6 @@ export class CrawlerService {
             () => client.query('SELECT pg_advisory_unlock_shared(hashtextextended($1, 0))', [intentKey]),
             'shared intent lock release after contention',
           );
-          sharedIntentAcquired = false;
         }
         client.off('error', onConnectionError);
         await closeClient();
@@ -316,7 +315,6 @@ export class CrawlerService {
               () => client.query('SELECT pg_advisory_unlock_shared(hashtextextended($1, 0))', [intentKey]),
               'shared intent lock release after publisher contention',
             );
-            sharedIntentAcquired = false;
           }
           client.off('error', onConnectionError);
           await closeClient();
@@ -329,7 +327,6 @@ export class CrawlerService {
           () => client.query('SELECT pg_advisory_unlock_shared(hashtextextended($1, 0))', [intentKey]),
           'shared intent lock release after admission',
         );
-        sharedIntentAcquired = false;
       }
 
       let released = false;

--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -52,6 +52,7 @@ const PUBLISHER_CRAWL_HEARTBEAT_MS = 30_000;
 const PUBLISHER_CRAWL_DEFER_MS = 30_000;
 const PUBLISHER_CRAWL_RETENTION_MS = 30 * 24 * 60 * 60_000;
 const CRAWL_EXECUTION_LOCK_OPERATION_TIMEOUT_MS = 10_000;
+const FULL_CRAWL_INTENT_LOCK_WAIT_MS = 10_000;
 
 export type SingleDomainCrawlOutcome = 'completed' | 'invalid';
 
@@ -151,7 +152,12 @@ export class CrawlerService {
   private lastCrawl: Date | null = null;
   private lastResult: CrawlResult | null = null;
   private intervalId: NodeJS.Timeout | null = null;
+  private initialCrawlTimeoutId: NodeJS.Timeout | null = null;
   private fullCrawlLockRetryTimer: NodeJS.Timeout | null = null;
+  private fullCrawlIntentLock: CrawlExecutionLock | null = null;
+  private fullCrawlIntentLockAcquisition: Promise<CrawlExecutionLock | null> | null = null;
+  private fullCrawlCoordinationInProgress: boolean = false;
+  private crawlerSchedulersStopping: boolean = false;
   private federatedIndex: FederatedIndexService;
   private adAgentsManager: AdAgentsManager;
   private brandManager: BrandManager;
@@ -203,7 +209,9 @@ export class CrawlerService {
       ? this.crawlLockClientFactory()
       : getDedicatedClient());
     const globalKey = 'registry:crawl-execution';
+    const intentKey = 'registry:crawl-intent';
     const publisherKey = domain ? `registry:publisher:${canonicalizePublisherDomain(domain)}` : null;
+    let sharedIntentAcquired = false;
     let lockConnectionValid = true;
     let keepaliveInFlight = false;
     const onConnectionError = (error: Error) => {
@@ -246,6 +254,22 @@ export class CrawlerService {
     };
     client.on('error', onConnectionError);
     try {
+      // A publisher holds the shared intent lock only for its execution-lock
+      // admission handshake. Once a full crawl has queued for the exclusive
+      // intent lock, PostgreSQL prevents later publishers from bypassing it.
+      if (domain) {
+        const intent = await runBounded(() => client.query<{ acquired: boolean }>(
+          'SELECT pg_try_advisory_lock_shared(hashtextextended($1, 0)) AS acquired',
+          [intentKey],
+        ), 'shared intent lock acquisition');
+        if (!intent.rows[0]?.acquired) {
+          client.off('error', onConnectionError);
+          await closeClient();
+          return null;
+        }
+        sharedIntentAcquired = true;
+      }
+
       if (!domain && waitMs > 0) {
         await runBounded(() => client.query("SELECT set_config('lock_timeout', $1, false)", [
           `${Math.max(1, Math.min(waitMs, 300_000))}ms`,
@@ -265,6 +289,13 @@ export class CrawlerService {
             [globalKey],
           ), 'global lock acquisition');
       if (!global.rows[0]?.acquired) {
+        if (sharedIntentAcquired) {
+          await runBounded(
+            () => client.query('SELECT pg_advisory_unlock_shared(hashtextextended($1, 0))', [intentKey]),
+            'shared intent lock release after contention',
+          );
+          sharedIntentAcquired = false;
+        }
         client.off('error', onConnectionError);
         await closeClient();
         return null;
@@ -280,10 +311,25 @@ export class CrawlerService {
             () => client.query('SELECT pg_advisory_unlock_shared(hashtextextended($1, 0))', [globalKey]),
             'global lock release after contention',
           );
+          if (sharedIntentAcquired) {
+            await runBounded(
+              () => client.query('SELECT pg_advisory_unlock_shared(hashtextextended($1, 0))', [intentKey]),
+              'shared intent lock release after publisher contention',
+            );
+            sharedIntentAcquired = false;
+          }
           client.off('error', onConnectionError);
           await closeClient();
           return null;
         }
+      }
+
+      if (sharedIntentAcquired) {
+        await runBounded(
+          () => client.query('SELECT pg_advisory_unlock_shared(hashtextextended($1, 0))', [intentKey]),
+          'shared intent lock release after admission',
+        );
+        sharedIntentAcquired = false;
       }
 
       let released = false;
@@ -339,6 +385,160 @@ export class CrawlerService {
   }
 
   /**
+   * Announce a pending full crawl across worker instances before waiting for
+   * active publisher crawls. This lock deliberately survives execution-lock
+   * timeouts and retry gaps; session loss releases it automatically.
+   */
+  private async tryAcquireFullCrawlIntentLock(): Promise<CrawlExecutionLock | null> {
+    const client: Client = await (this.crawlLockClientFactory
+      ? this.crawlLockClientFactory()
+      : getDedicatedClient());
+    const intentKey = 'registry:crawl-intent';
+    let connectionValid = true;
+    let keepaliveInFlight = false;
+    let acquired = false;
+    const destroyConnection = (): void => {
+      if (!client.connection.stream.destroyed) client.connection.stream.destroy();
+    };
+    const onConnectionError = (error: Error) => {
+      if (!connectionValid) return;
+      connectionValid = false;
+      log.error({ error }, 'Full crawl intent lock connection failed; ownership lost');
+    };
+    const runBounded = async <T>(
+      operation: () => Promise<T>,
+      label: string,
+      timeoutMs: number = CRAWL_EXECUTION_LOCK_OPERATION_TIMEOUT_MS,
+    ): Promise<T> => {
+      let timeout: NodeJS.Timeout | undefined;
+      const deadline = new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          const error = Object.assign(
+            new Error(`Full crawl intent lock ${label} exceeded ${timeoutMs}ms`),
+            { code: 'crawl_intent_lock_operation_timeout' },
+          );
+          onConnectionError(error);
+          destroyConnection();
+          reject(error);
+        }, timeoutMs);
+      });
+      try {
+        return await Promise.race([operation(), deadline]);
+      } finally {
+        if (timeout) clearTimeout(timeout);
+      }
+    };
+    const closeClient = async (): Promise<void> => {
+      try {
+        await runBounded(() => client.end(), 'connection close');
+      } catch {
+        destroyConnection();
+      }
+    };
+
+    client.on('error', onConnectionError);
+    try {
+      await runBounded(() => client.query("SELECT set_config('lock_timeout', $1, false)", [
+        `${FULL_CRAWL_INTENT_LOCK_WAIT_MS}ms`,
+      ]), 'lock timeout setup');
+      await runBounded(
+        () => client.query('SELECT pg_advisory_lock(hashtextextended($1, 0))', [intentKey]),
+        'acquisition',
+        FULL_CRAWL_INTENT_LOCK_WAIT_MS + CRAWL_EXECUTION_LOCK_OPERATION_TIMEOUT_MS,
+      );
+      acquired = true;
+      await runBounded(() => client.query('RESET lock_timeout'), 'lock timeout reset');
+
+      let released = false;
+      const keepalive = setInterval(() => {
+        if (keepaliveInFlight || !connectionValid) return;
+        keepaliveInFlight = true;
+        runBounded(() => client.query('SELECT 1'), 'keepalive')
+          .catch((error) => onConnectionError(
+            error instanceof Error ? error : new Error('Intent lock keepalive failed'),
+          ))
+          .finally(() => { keepaliveInFlight = false; });
+      }, 15_000);
+      keepalive.unref();
+
+      return {
+        isValid: () => connectionValid,
+        release: async () => {
+          if (released) return;
+          released = true;
+          clearInterval(keepalive);
+          try {
+            if (connectionValid) {
+              await runBounded(
+                () => client.query('SELECT pg_advisory_unlock(hashtextextended($1, 0))', [intentKey]),
+                'release',
+              );
+            }
+          } catch (error) {
+            log.error({ error }, 'Failed to release full crawl intent lock; connection discarded');
+          } finally {
+            client.off('error', onConnectionError);
+            await closeClient();
+          }
+        },
+      };
+    } catch (error) {
+      client.off('error', onConnectionError);
+      await closeClient();
+      if (!acquired && error && typeof error === 'object' && 'code' in error && error.code === '55P03') {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private async ensureFullCrawlIntentLock(): Promise<boolean> {
+    if (this.fullCrawlIntentLock?.isValid()) return true;
+    if (this.fullCrawlIntentLock) {
+      await this.fullCrawlIntentLock.release();
+      this.fullCrawlIntentLock = null;
+    }
+    if (!this.fullCrawlIntentLockAcquisition) {
+      this.fullCrawlIntentLockAcquisition = (async () => {
+        const lock = await this.tryAcquireFullCrawlIntentLock();
+        if (!lock) return null;
+        if (this.crawlerSchedulersStopping) {
+          await lock.release();
+          return null;
+        }
+        this.fullCrawlIntentLock = lock;
+        return lock;
+      })();
+    }
+    const acquisition = this.fullCrawlIntentLockAcquisition;
+    try {
+      return (await acquisition) !== null;
+    } finally {
+      if (this.fullCrawlIntentLockAcquisition === acquisition) {
+        this.fullCrawlIntentLockAcquisition = null;
+      }
+    }
+  }
+
+  private async releaseFullCrawlIntentLock(): Promise<void> {
+    const lock = this.fullCrawlIntentLock;
+    this.fullCrawlIntentLock = null;
+    await lock?.release();
+  }
+
+  private scheduleFullCrawlLockRetry(agents: Agent[], reason: string): void {
+    if (this.fullCrawlLockRetryTimer || this.crawlerSchedulersStopping) return;
+    log.warn({ reason }, 'Full crawl coordination unavailable; retrying shortly');
+    this.fullCrawlLockRetryTimer = setTimeout(() => {
+      this.fullCrawlLockRetryTimer = null;
+      this.crawlAllAgents(agents).catch((err) => {
+        log.error({ err, reason }, 'Full crawl coordination retry failed');
+      });
+    }, 30_000);
+    this.fullCrawlLockRetryTimer.unref();
+  }
+
+  /**
    * Resolve any saved owner auth for an agent URL so probes don't get 401'd
    * by agents that gate discovery/health behind authentication. Returns
    * `undefined` when no org has registered credentials for the URL, which
@@ -359,38 +559,52 @@ export class CrawlerService {
   }
 
   async crawlAllAgents(agents: Agent[]): Promise<CrawlResult> {
-    if (this.crawling) {
+    if (this.crawlerSchedulersStopping) {
+      log.debug('Crawler schedulers are stopping; skipping full crawl');
+      return this.lastResult || this.emptyResult();
+    }
+    if (this.crawling || this.fullCrawlCoordinationInProgress) {
       log.debug('Crawl already in progress, skipping');
       return this.lastResult || this.emptyResult();
     }
 
-    const executionLock = this.coordinateCrawlsAcrossInstances
-      ? await this.tryAcquireCrawlExecutionLock(undefined, PUBLISHER_CRAWL_LEASE_MS)
-      : null;
-    if (this.coordinateCrawlsAcrossInstances && !executionLock) {
-      log.warn('Another crawl owns the global execution lock; retrying full crawl shortly');
-      if (!this.fullCrawlLockRetryTimer) {
-        this.fullCrawlLockRetryTimer = setTimeout(() => {
-          this.fullCrawlLockRetryTimer = null;
-          this.crawlAllAgents(agents).catch((err) => {
-            log.error({ err }, 'Full crawl execution-lock retry failed');
-          });
-        }, 30_000);
-        this.fullCrawlLockRetryTimer.unref();
-      }
-      return this.lastResult || this.emptyResult();
-    }
-    if (this.fullCrawlLockRetryTimer) {
-      clearTimeout(this.fullCrawlLockRetryTimer);
-      this.fullCrawlLockRetryTimer = null;
-    }
+    this.fullCrawlCoordinationInProgress = true;
+    let executionLock: CrawlExecutionLock | null = null;
+    let retainIntentForRetry = false;
+    let coordinating = true;
     const assertExecutionLock = (): void => {
       if (executionLock && !executionLock.isValid()) throw new CrawlExecutionLockLostError();
+      if (this.fullCrawlIntentLock && !this.fullCrawlIntentLock.isValid()) {
+        throw new CrawlExecutionLockLostError();
+      }
     };
 
-    this.crawling = true;
-
     try {
+      if (this.coordinateCrawlsAcrossInstances) {
+        const hasIntent = await this.ensureFullCrawlIntentLock();
+        if (!hasIntent) {
+          this.scheduleFullCrawlLockRetry(agents, 'intent_lock_contended');
+          return this.lastResult || this.emptyResult();
+        }
+        if (this.crawlerSchedulersStopping) return this.lastResult || this.emptyResult();
+        executionLock = await this.tryAcquireCrawlExecutionLock(undefined, PUBLISHER_CRAWL_LEASE_MS);
+        if (!executionLock) {
+          this.scheduleFullCrawlLockRetry(agents, 'execution_lock_contended');
+          retainIntentForRetry = !this.crawlerSchedulersStopping
+            && this.fullCrawlLockRetryTimer !== null
+            && (this.fullCrawlIntentLock?.isValid() ?? false);
+          return this.lastResult || this.emptyResult();
+        }
+        if (this.crawlerSchedulersStopping) return this.lastResult || this.emptyResult();
+        assertExecutionLock();
+      }
+      if (this.fullCrawlLockRetryTimer) {
+        clearTimeout(this.fullCrawlLockRetryTimer);
+        this.fullCrawlLockRetryTimer = null;
+      }
+
+      this.crawling = true;
+      coordinating = false;
 
     // Filter out agents whose owners have paused monitoring
     const pausedUrls = await this.getPausedAgentUrls();
@@ -530,37 +744,65 @@ export class CrawlerService {
       return result;
     } catch (error) {
       log.error({ err: error }, 'Crawl failed');
-      if (error instanceof CrawlExecutionLockLostError && !this.fullCrawlLockRetryTimer) {
-        this.fullCrawlLockRetryTimer = setTimeout(() => {
-          this.fullCrawlLockRetryTimer = null;
-          this.crawlAllAgents(agents).catch((err) => {
-            log.error({ err }, 'Full crawl lock-loss retry failed');
-          });
-        }, 30_000);
-        this.fullCrawlLockRetryTimer.unref();
+      if (error instanceof CrawlExecutionLockLostError || coordinating) {
+        this.scheduleFullCrawlLockRetry(
+          agents,
+          error instanceof CrawlExecutionLockLostError
+            ? 'execution_lock_lost'
+            : 'coordination_error',
+        );
+        retainIntentForRetry = !this.crawlerSchedulersStopping
+          && this.fullCrawlLockRetryTimer !== null
+          && (this.fullCrawlIntentLock?.isValid() ?? false);
       }
       throw error;
     } finally {
       this.crawling = false;
-      await executionLock?.release();
+      try {
+        await executionLock?.release();
+      } finally {
+        try {
+          if (!retainIntentForRetry) await this.releaseFullCrawlIntentLock();
+        } finally {
+          this.fullCrawlCoordinationInProgress = false;
+        }
+      }
     }
   }
 
-  startPeriodicCrawl(getAgents: () => Promise<Agent[]>, intervalMinutes: number = 60) {
+  startPeriodicCrawl(
+    getAgents: () => Promise<Agent[]>,
+    intervalMinutes: number = 60,
+    initialDelaySeconds: number = 0,
+  ) {
+    this.crawlerSchedulersStopping = false;
     const run = () =>
       getAgents()
         .then(agents => this.crawlAllAgents(agents))
         .catch(err => log.error({ err }, 'Periodic crawl failed'));
 
-    run();
+    if (initialDelaySeconds > 0) {
+      this.initialCrawlTimeoutId = setTimeout(() => {
+        this.initialCrawlTimeoutId = null;
+        run();
+      }, initialDelaySeconds * 1_000);
+      this.initialCrawlTimeoutId.unref();
+    } else {
+      run();
+    }
     this.intervalId = setInterval(run, intervalMinutes * 60 * 1000);
     // Background loop; never block process (or a vitest worker) exit.
     this.intervalId?.unref();
 
-    log.info({ intervalMinutes }, 'Periodic crawl started');
+    log.info({ intervalMinutes, initialDelaySeconds }, 'Periodic crawl started');
   }
 
   stopPeriodicCrawl() {
+    this.crawlerSchedulersStopping = true;
+    if (this.initialCrawlTimeoutId) {
+      clearTimeout(this.initialCrawlTimeoutId);
+      this.initialCrawlTimeoutId = null;
+    }
     if (this.intervalId) {
       clearInterval(this.intervalId);
       this.intervalId = null;
@@ -2481,10 +2723,10 @@ export class CrawlerService {
   private publisherCrawlLastRetentionAt = 0;
   private publisherCrawlLastHealthLogAt = 0;
 
-  startPeriodicPublisherCrawlRequests(intervalSeconds: number = 5): void {
+  startPeriodicPublisherCrawlRequests(intervalSeconds: number = 5): boolean {
     if (!isPublisherCrawlQueueEnabled()) {
       log.info('Durable publisher crawl request queue disabled by rollout gate');
-      return;
+      return false;
     }
     const run = () => {
       this.processPublisherCrawlRequestQueue().catch((err) => {
@@ -2495,6 +2737,14 @@ export class CrawlerService {
     this.publisherCrawlQueueIntervalId = setInterval(run, intervalSeconds * 1_000);
     this.publisherCrawlQueueIntervalId.unref();
     log.info({ intervalSeconds }, 'Durable publisher crawl request queue started');
+    return true;
+  }
+
+  stopPeriodicPublisherCrawlRequests(): void {
+    if (this.publisherCrawlQueueIntervalId) {
+      clearInterval(this.publisherCrawlQueueIntervalId);
+      this.publisherCrawlQueueIntervalId = null;
+    }
   }
 
   async processPublisherCrawlRequestQueue(): Promise<{
@@ -2765,6 +3015,13 @@ export class CrawlerService {
     log.info({ intervalMinutes }, 'Periodic catalog domain crawl started');
   }
 
+  stopPeriodicCatalogCrawl(): void {
+    if (this.catalogCrawlIntervalId) {
+      clearInterval(this.catalogCrawlIntervalId);
+      this.catalogCrawlIntervalId = null;
+    }
+  }
+
   async crawlCatalogDomains(): Promise<{ checked: number; found: number }> {
     if (this.catalogCrawling || this.crawling) {
       log.debug('Crawl already in progress, skipping catalog crawl');
@@ -2888,6 +3145,13 @@ export class CrawlerService {
     log.info({ intervalMinutes }, 'Periodic manager revalidation queue started');
   }
 
+  stopPeriodicManagerRevalidation(): void {
+    if (this.managerRevalidationIntervalId) {
+      clearInterval(this.managerRevalidationIntervalId);
+      this.managerRevalidationIntervalId = null;
+    }
+  }
+
   async processManagerRevalidationQueue(): Promise<{ processed: number; succeeded: number; failed: number }> {
     if (this.managerRevalidationProcessing) {
       log.debug('Manager revalidation already in progress, skipping tick');
@@ -2989,6 +3253,18 @@ export class CrawlerService {
       clearInterval(this.hostedReverifyIntervalId);
       this.hostedReverifyIntervalId = null;
     }
+  }
+
+  async stopPeriodicCrawlers(): Promise<void> {
+    this.stopPeriodicPublisherCrawlRequests();
+    this.stopPeriodicCrawl();
+    this.stopPeriodicCatalogCrawl();
+    this.stopPeriodicManagerRevalidation();
+    this.stopPeriodicHostedOriginReverification();
+    // Intent acquisition has a bounded deadline. Wait for it to settle so a
+    // late continuation cannot recreate a lock session after database drain.
+    await this.fullCrawlIntentLockAcquisition?.catch(() => null);
+    await this.releaseFullCrawlIntentLock();
   }
 
   async processHostedOriginReverification(): Promise<{ processed: number; lapsed: number }> {

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -866,6 +866,44 @@ export class HTTPServer {
   private app: express.Application;
   private server: Server | null = null;
   private isWorker: boolean = false;
+
+  private startWorkerCrawlers(): void {
+    // Drain durable explicit publisher recrawl requests first. Admission is
+    // persisted by the web process before it returns 202; the worker claims
+    // requests with expiring leases so deploys and crashes cannot lose work.
+    // The initial full crawl gets a fixed 30-second startup delay so already-
+    // due requests can run instead of being starved by consecutive deploys.
+    const publisherCrawlQueueStarted =
+      this.crawler.startPeriodicPublisherCrawlRequests(5); // 5-second tick
+
+    // Start periodic registry crawler for all registered agents. Re-fetches
+    // the agent list on every tick so newly registered agents are picked up
+    // without a restart. Sales agents drive publisher adagents.json
+    // discovery; signals/buying/creative agents still need health +
+    // capability snapshots on the same cycle. `viewerHasApiAccess` defaults
+    // to false — members_only agents are intentionally excluded from the
+    // periodic crawl (the public-facing registry surface is the target);
+    // owner-triggered probes for members_only agents go through
+    // POST /api/registry/agents/:encodedUrl/refresh. Fixes #4213.
+    logger.debug('Starting registry crawler');
+    this.crawler.startPeriodicCrawl(
+      () => this.agentService.listAgents(),
+      360,
+      publisherCrawlQueueStarted ? 30 : 0,
+    ); // Crawl every 6 hours
+
+    // Crawl catalog domains for adagents.json (demand-driven queue)
+    this.crawler.startPeriodicCatalogCrawl(30); // Process queue every 30 minutes
+
+    // Drain manager_revalidation_queue (#4200 item 2) — fan-out
+    // re-validation when a manager rotates its adagents.json.
+    this.crawler.startPeriodicManagerRevalidation(5); // 5-minute tick
+
+    // Re-verify AAO-hosted origins on a TTL so a transferred domain or a
+    // removed origin pointer lapses the owner lock (bind-on-verify, #5752),
+    // releasing the domain for re-claim.
+    this.crawler.startPeriodicHostedOriginReverification(60); // hourly tick
+  }
   private agentService: AgentService;
   private validator: AgentValidator;
   private healthChecker: HealthChecker;
@@ -9760,34 +9798,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
     logger.info({ isWorker }, 'Process role resolved');
 
     if (isWorker) {
-      // Start periodic registry crawler for all registered agents. Re-fetches
-      // the agent list on every tick so newly registered agents are picked up
-      // without a restart. Sales agents drive publisher adagents.json
-      // discovery; signals/buying/creative agents still need health +
-      // capability snapshots on the same cycle. `viewerHasApiAccess` defaults
-      // to false — members_only agents are intentionally excluded from the
-      // periodic crawl (the public-facing registry surface is the target);
-      // owner-triggered probes for members_only agents go through
-      // POST /api/registry/agents/:encodedUrl/refresh. Fixes #4213.
-      logger.debug('Starting registry crawler');
-      this.crawler.startPeriodicCrawl(() => this.agentService.listAgents(), 360); // Crawl every 6 hours
-
-      // Crawl catalog domains for adagents.json (demand-driven queue)
-      this.crawler.startPeriodicCatalogCrawl(30); // Process queue every 30 minutes
-
-      // Drain durable explicit publisher recrawl requests. Admission is
-      // persisted by the web process before it returns 202; the worker claims
-      // requests with expiring leases so deploys and crashes cannot lose work.
-      this.crawler.startPeriodicPublisherCrawlRequests(5); // 5-second tick
-
-      // Drain manager_revalidation_queue (#4200 item 2) — fan-out
-      // re-validation when a manager rotates its adagents.json.
-      this.crawler.startPeriodicManagerRevalidation(5); // 5-minute tick
-
-      // Re-verify AAO-hosted origins on a TTL so a transferred domain or a
-      // removed origin pointer lapses the owner lock (bind-on-verify, #5752),
-      // releasing the domain for re-claim.
-      this.crawler.startPeriodicHostedOriginReverification(60); // hourly tick
+      this.startWorkerCrawlers();
 
       // Register and start all scheduled jobs
       registerAllJobs();
@@ -9881,6 +9892,9 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
 
     // Only stop background services that were started on this machine
     if (this.isWorker) {
+      // Stop every crawler scheduler before awaiting other drains. In-flight
+      // durable work remains protected by its expiring database lease.
+      await this.crawler.stopPeriodicCrawlers();
       jobScheduler.stopAll();
 
       import('./scheduled/seat-request-reminders.js').then(({ stopSeatRequestReminders }) => {

--- a/server/tests/integration/publisher-crawl-requests-queue.test.ts
+++ b/server/tests/integration/publisher-crawl-requests-queue.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import type { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Client, type Pool } from 'pg';
 import { closeDatabase, initializeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import {
@@ -58,6 +58,12 @@ describe('durable publisher crawl request queue', () => {
       requesterType: 'user',
       requestedByUserId: 'durable-crawl-test-user',
     });
+  }
+
+  async function releaseLocks(...locks: Array<{ release(): Promise<void> } | null | undefined>) {
+    for (const lock of locks) {
+      await lock?.release().catch(() => undefined);
+    }
   }
 
   it('persists admission before exposing a queued request', async () => {
@@ -232,6 +238,86 @@ describe('durable publisher crawl request queue', () => {
     const fullAfterRelease = await secondWorker.tryAcquireCrawlExecutionLock();
     expect(fullAfterRelease).not.toBeNull();
     await fullAfterRelease.release();
+  });
+
+  it('retains full-crawl intent across execution-lock timeout and rejects later publishers', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const publisherWorker = Object.create((CrawlerService as any).prototype);
+    const fullWorker = Object.create((CrawlerService as any).prototype);
+    const laterPublisherWorker = Object.create((CrawlerService as any).prototype);
+    let activePublisher: { release(): Promise<void> } | null = null;
+    let fullIntent: ({ isValid(): boolean } & { release(): Promise<void> }) | null = null;
+    let retriedExecution: { release(): Promise<void> } | null = null;
+    try {
+      activePublisher = await publisherWorker.tryAcquireCrawlExecutionLock('active.example');
+      expect(activePublisher).not.toBeNull();
+
+      fullIntent = await fullWorker.tryAcquireFullCrawlIntentLock();
+      expect(fullIntent).not.toBeNull();
+      const timedOutExecution = await fullWorker.tryAcquireCrawlExecutionLock(undefined, 50);
+      expect(timedOutExecution).toBeNull();
+      expect(fullIntent.isValid()).toBe(true);
+
+      const laterPublisher = await laterPublisherWorker.tryAcquireCrawlExecutionLock('later.example');
+      expect(laterPublisher).toBeNull();
+
+      await activePublisher.release();
+      activePublisher = null;
+      retriedExecution = await fullWorker.tryAcquireCrawlExecutionLock(undefined, 1_000);
+      expect(retriedExecution).not.toBeNull();
+    } finally {
+      await releaseLocks(activePublisher, retriedExecution, fullIntent);
+    }
+  });
+
+  it('releases temporary publisher intent when the per-domain lock is contended', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const firstPublisher = Object.create((CrawlerService as any).prototype);
+    const secondPublisher = Object.create((CrawlerService as any).prototype);
+    const fullWorker = Object.create((CrawlerService as any).prototype);
+    let domainLock: { release(): Promise<void> } | null = null;
+    let fullIntent: { release(): Promise<void> } | null = null;
+    try {
+      domainLock = await firstPublisher.tryAcquireCrawlExecutionLock('same.example');
+      expect(domainLock).not.toBeNull();
+
+      const contended = await secondPublisher.tryAcquireCrawlExecutionLock('same.example');
+      expect(contended).toBeNull();
+      fullIntent = await fullWorker.tryAcquireFullCrawlIntentLock();
+      expect(fullIntent).not.toBeNull();
+    } finally {
+      await releaseLocks(domainLock, fullIntent);
+    }
+  });
+
+  it('releases full-crawl intent when its dedicated database session dies', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const fullWorker = Object.create((CrawlerService as any).prototype);
+    const publisherWorker = Object.create((CrawlerService as any).prototype);
+    let intentClient: Client | undefined;
+    fullWorker.crawlLockClientFactory = async () => {
+      intentClient = new Client({
+        connectionString: process.env.DATABASE_URL
+          || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+      });
+      await intentClient.connect();
+      return intentClient;
+    };
+    let fullIntent: ({ isValid(): boolean } & { release(): Promise<void> }) | null = null;
+    let publisher: { release(): Promise<void> } | null = null;
+    try {
+      fullIntent = await fullWorker.tryAcquireFullCrawlIntentLock();
+      expect(fullIntent).not.toBeNull();
+      await expect(publisherWorker.tryAcquireCrawlExecutionLock('blocked.example')).resolves.toBeNull();
+
+      (intentClient as any).connection.stream.destroy();
+      await vi.waitFor(() => expect(fullIntent?.isValid()).toBe(false));
+
+      publisher = await publisherWorker.tryAcquireCrawlExecutionLock('unblocked.example');
+      expect(publisher).not.toBeNull();
+    } finally {
+      await releaseLocks(publisher, fullIntent);
+    }
   });
 
   it('defers full-crawl contention without consuming an attempt', async () => {

--- a/server/tests/unit/crawler-periodic-startup.test.ts
+++ b/server/tests/unit/crawler-periodic-startup.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CrawlerService } from '../../src/crawler.js';
+
+function makeContext() {
+  const ctx = Object.create((CrawlerService as any).prototype);
+  Object.assign(ctx, {
+    intervalId: null,
+    initialCrawlTimeoutId: null,
+    fullCrawlLockRetryTimer: null,
+    publisherCrawlQueueIntervalId: null,
+    catalogCrawlIntervalId: null,
+    managerRevalidationIntervalId: null,
+    hostedReverifyIntervalId: null,
+    fullCrawlIntentLock: null,
+    crawlAllAgents: vi.fn().mockResolvedValue(undefined),
+  });
+  return ctx;
+}
+
+describe('CrawlerService periodic crawl startup', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('preserves the immediate initial crawl by default', async () => {
+    const ctx = makeContext();
+    const getAgents = vi.fn().mockResolvedValue([]);
+
+    ctx.startPeriodicCrawl(getAgents, 360);
+    await vi.runAllTicks();
+
+    expect(getAgents).toHaveBeenCalledOnce();
+    expect(ctx.crawlAllAgents).toHaveBeenCalledOnce();
+    ctx.stopPeriodicCrawl();
+  });
+
+  it('delays only the initial crawl for the bounded durable-queue startup window', async () => {
+    const ctx = makeContext();
+    const getAgents = vi.fn().mockResolvedValue([]);
+
+    ctx.startPeriodicCrawl(getAgents, 360, 30);
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(getAgents).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(getAgents).toHaveBeenCalledOnce();
+    expect(ctx.crawlAllAgents).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(360 * 60_000 - 30_000);
+    expect(getAgents).toHaveBeenCalledTimes(2);
+    expect(ctx.crawlAllAgents).toHaveBeenCalledTimes(2);
+    ctx.stopPeriodicCrawl();
+  });
+
+  it('cancels a pending initial crawl during shutdown', async () => {
+    const ctx = makeContext();
+    const getAgents = vi.fn().mockResolvedValue([]);
+
+    ctx.startPeriodicCrawl(getAgents, 360, 30);
+    ctx.stopPeriodicCrawl();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(getAgents).not.toHaveBeenCalled();
+  });
+
+  it('stops every crawler scheduler before worker shutdown', async () => {
+    const ctx = makeContext();
+    const tick = vi.fn();
+    ctx.initialCrawlTimeoutId = setTimeout(tick, 30_000);
+    ctx.intervalId = setInterval(tick, 30_000);
+    ctx.fullCrawlLockRetryTimer = setTimeout(tick, 30_000);
+    ctx.publisherCrawlQueueIntervalId = setInterval(tick, 5_000);
+    ctx.catalogCrawlIntervalId = setInterval(tick, 30_000);
+    ctx.managerRevalidationIntervalId = setInterval(tick, 30_000);
+    ctx.hostedReverifyIntervalId = setInterval(tick, 30_000);
+
+    await ctx.stopPeriodicCrawlers();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(tick).not.toHaveBeenCalled();
+    expect(ctx.initialCrawlTimeoutId).toBeNull();
+    expect(ctx.publisherCrawlQueueIntervalId).toBeNull();
+    expect(ctx.catalogCrawlIntervalId).toBeNull();
+    expect(ctx.managerRevalidationIntervalId).toBeNull();
+    expect(ctx.hostedReverifyIntervalId).toBeNull();
+  });
+
+  it('waits for and releases an intent lock acquired during shutdown', async () => {
+    const ctx = makeContext();
+    let resolveLock!: (lock: { isValid: () => boolean; release: () => Promise<void> }) => void;
+    const pendingLock = new Promise<{ isValid: () => boolean; release: () => Promise<void> }>(
+      (resolve) => { resolveLock = resolve; },
+    );
+    let resolveRelease!: () => void;
+    const releasePending = new Promise<void>((resolve) => { resolveRelease = resolve; });
+    const release = vi.fn().mockReturnValue(releasePending);
+    ctx.tryAcquireFullCrawlIntentLock = vi.fn().mockReturnValue(pendingLock);
+
+    const acquisition = ctx.ensureFullCrawlIntentLock();
+    const stopping = ctx.stopPeriodicCrawlers();
+    let stopped = false;
+    stopping.then(() => { stopped = true; });
+    await vi.runAllTicks();
+    expect(stopped).toBe(false);
+
+    resolveLock({ isValid: () => true, release });
+    await vi.waitFor(() => expect(release).toHaveBeenCalledOnce());
+    expect(stopped).toBe(false);
+    resolveRelease();
+    await stopping;
+    await expect(acquisition).resolves.toBe(false);
+
+    expect(ctx.fullCrawlIntentLock).toBeNull();
+  });
+});

--- a/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
+++ b/server/tests/unit/crawler-single-domain-profile-rebuild.test.ts
@@ -101,14 +101,114 @@ describe('CrawlerService single-domain profile rebuild', () => {
     expect(ctx.crawling).toBe(false);
   });
 
+  it('admits only one in-process full-crawl coordination attempt', async () => {
+    const ctx = Object.create((CrawlerService as any).prototype);
+    let resolveIntent!: (value: boolean) => void;
+    const intentPending = new Promise<boolean>((resolve) => { resolveIntent = resolve; });
+    const ensureFullCrawlIntentLock = vi.fn().mockReturnValue(intentPending);
+    const lastResult = { marker: 'last-result' };
+    Object.assign(ctx, {
+      crawling: false,
+      fullCrawlCoordinationInProgress: false,
+      crawlerSchedulersStopping: false,
+      coordinateCrawlsAcrossInstances: true,
+      fullCrawlIntentLock: null,
+      ensureFullCrawlIntentLock,
+      scheduleFullCrawlLockRetry: vi.fn(),
+      lastResult,
+    });
+
+    const first = ctx.crawlAllAgents([]);
+    await vi.waitFor(() => expect(ensureFullCrawlIntentLock).toHaveBeenCalledOnce());
+    await expect(ctx.crawlAllAgents([])).resolves.toBe(lastResult);
+    resolveIntent(false);
+    await expect(first).resolves.toBe(lastResult);
+
+    expect(ensureFullCrawlIntentLock).toHaveBeenCalledOnce();
+    expect(ctx.fullCrawlCoordinationInProgress).toBe(false);
+  });
+
+  it('does not open coordination sessions after crawler shutdown begins', async () => {
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const ensureFullCrawlIntentLock = vi.fn();
+    const lastResult = { marker: 'last-result' };
+    Object.assign(ctx, {
+      crawling: false,
+      fullCrawlCoordinationInProgress: false,
+      crawlerSchedulersStopping: true,
+      coordinateCrawlsAcrossInstances: true,
+      ensureFullCrawlIntentLock,
+      lastResult,
+    });
+
+    await expect(ctx.crawlAllAgents([])).resolves.toBe(lastResult);
+    expect(ensureFullCrawlIntentLock).not.toHaveBeenCalled();
+  });
+
+  it('retains full-crawl intent across an execution-lock timeout retry', async () => {
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const releaseIntent = vi.fn().mockResolvedValue(undefined);
+    const intentLock = { isValid: () => true, release: releaseIntent };
+    const lastResult = { marker: 'last-result' };
+    Object.assign(ctx, {
+      crawling: false,
+      fullCrawlCoordinationInProgress: false,
+      crawlerSchedulersStopping: false,
+      coordinateCrawlsAcrossInstances: true,
+      fullCrawlIntentLock: intentLock,
+      fullCrawlLockRetryTimer: null,
+      tryAcquireCrawlExecutionLock: vi.fn().mockResolvedValue(null),
+      lastResult,
+    });
+
+    await expect(ctx.crawlAllAgents([])).resolves.toBe(lastResult);
+
+    expect(ctx.fullCrawlIntentLock).toBe(intentLock);
+    expect(releaseIntent).not.toHaveBeenCalled();
+    expect(ctx.fullCrawlLockRetryTimer).not.toBeNull();
+    clearTimeout(ctx.fullCrawlLockRetryTimer);
+    ctx.fullCrawlLockRetryTimer = null;
+    await ctx.releaseFullCrawlIntentLock();
+  });
+
+  it('retains full-crawl intent when an execution retry timer already exists', async () => {
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const releaseIntent = vi.fn().mockResolvedValue(undefined);
+    const intentLock = { isValid: () => true, release: releaseIntent };
+    const existingRetryTimer = setTimeout(() => undefined, 60_000);
+    Object.assign(ctx, {
+      crawling: false,
+      fullCrawlCoordinationInProgress: false,
+      crawlerSchedulersStopping: false,
+      coordinateCrawlsAcrossInstances: true,
+      fullCrawlIntentLock: intentLock,
+      fullCrawlLockRetryTimer: existingRetryTimer,
+      tryAcquireCrawlExecutionLock: vi.fn().mockResolvedValue(null),
+    });
+
+    await ctx.crawlAllAgents([]);
+
+    expect(ctx.fullCrawlIntentLock).toBe(intentLock);
+    expect(ctx.fullCrawlLockRetryTimer).toBe(existingRetryTimer);
+    expect(releaseIntent).not.toHaveBeenCalled();
+    clearTimeout(existingRetryTimer);
+    ctx.fullCrawlLockRetryTimer = null;
+    await ctx.releaseFullCrawlIntentLock();
+  });
+
   it('aborts a full crawl before persistence when its execution lock is lost', async () => {
     const ctx = Object.create((CrawlerService as any).prototype);
     const release = vi.fn().mockResolvedValue(undefined);
+    const releaseIntent = vi.fn().mockResolvedValue(undefined);
     const populateFederatedIndex = vi.fn();
     Object.assign(ctx, {
       crawling: false,
       fullCrawlLockRetryTimer: null,
       coordinateCrawlsAcrossInstances: true,
+      fullCrawlIntentLock: {
+        isValid: () => true,
+        release: releaseIntent,
+      },
       tryAcquireCrawlExecutionLock: vi.fn().mockResolvedValue({
         isValid: () => false,
         release,
@@ -127,7 +227,10 @@ describe('CrawlerService single-domain profile rebuild', () => {
     });
     expect(populateFederatedIndex).not.toHaveBeenCalled();
     expect(release).toHaveBeenCalledOnce();
+    expect(releaseIntent).not.toHaveBeenCalled();
     if (ctx.fullCrawlLockRetryTimer) clearTimeout(ctx.fullCrawlLockRetryTimer);
+    await ctx.releaseFullCrawlIntentLock();
+    expect(releaseIntent).toHaveBeenCalledOnce();
   });
 
   it('does not write catalog state when another crawl owns the domain lock', async () => {
@@ -151,6 +254,8 @@ describe('CrawlerService single-domain profile rebuild', () => {
       const query = vi.fn()
         .mockResolvedValueOnce({ rows: [{ acquired: true }] })
         .mockResolvedValueOnce({ rows: [{ acquired: true }] })
+        .mockResolvedValueOnce({ rows: [{ acquired: true }] })
+        .mockResolvedValueOnce({ rows: [{ pg_advisory_unlock_shared: true }] })
         .mockImplementationOnce(() => new Promise(() => undefined));
       const client = {
         query,

--- a/server/tests/unit/http-crawler-lifecycle.test.ts
+++ b/server/tests/unit/http-crawler-lifecycle.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HTTPServer } from '../../src/http.js';
+import { jobScheduler } from '../../src/addie/jobs/scheduler.js';
+
+function makeCrawler(queueEnabled: boolean, calls: string[]) {
+  return {
+    startPeriodicPublisherCrawlRequests: vi.fn(() => {
+      calls.push('publisher-queue');
+      return queueEnabled;
+    }),
+    startPeriodicCrawl: vi.fn(() => calls.push('full-crawl')),
+    startPeriodicCatalogCrawl: vi.fn(),
+    startPeriodicManagerRevalidation: vi.fn(),
+    startPeriodicHostedOriginReverification: vi.fn(),
+    stopPeriodicCrawlers: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('HTTPServer crawler lifecycle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    { queueEnabled: true, expectedDelaySeconds: 30 },
+    { queueEnabled: false, expectedDelaySeconds: 0 },
+  ])('starts the publisher queue before the full crawl with delay $expectedDelaySeconds', ({ queueEnabled, expectedDelaySeconds }) => {
+    const calls: string[] = [];
+    const crawler = makeCrawler(queueEnabled, calls);
+    const server = Object.create((HTTPServer as any).prototype);
+    Object.assign(server, {
+      crawler,
+      agentService: { listAgents: vi.fn().mockResolvedValue([]) },
+    });
+
+    server.startWorkerCrawlers();
+
+    expect(calls).toEqual(['publisher-queue', 'full-crawl']);
+    expect(crawler.startPeriodicPublisherCrawlRequests).toHaveBeenCalledWith(5);
+    expect(crawler.startPeriodicCrawl).toHaveBeenCalledWith(expect.any(Function), 360, expectedDelaySeconds);
+  });
+
+  it('awaits crawler scheduler cleanup during worker shutdown', async () => {
+    const calls: string[] = [];
+    const crawler = makeCrawler(true, calls);
+    const stopAll = vi.spyOn(jobScheduler, 'stopAll').mockImplementation(() => undefined);
+    const server = Object.create((HTTPServer as any).prototype);
+    Object.assign(server, {
+      isWorker: true,
+      crawler,
+      server: null,
+    });
+
+    await server.stop();
+
+    expect(crawler.stopPeriodicCrawlers).toHaveBeenCalledOnce();
+    expect(stopAll).toHaveBeenCalledOnce();
+    expect(crawler.stopPeriodicCrawlers.mock.invocationCallOrder[0]).toBeLessThan(stopAll.mock.invocationCallOrder[0]);
+  });
+});


### PR DESCRIPTION
## Summary

- start the durable publisher crawl queue before the delayed startup full crawl
- coordinate publisher admission and full crawls with a PostgreSQL session advisory intent lock so pending full crawls stop new publisher admission without blocking active work
- bound intent/execution lock waits, preserve intent across retries, and clean up pending acquisitions during shutdown
- document the queue/fairness lifecycle and add telemetry-focused regression coverage

## Correctness and performance

Publisher crawls take one short shared intent-lock operation on their existing dedicated advisory-lock session. A pending or active full crawl uses one additional dedicated PostgreSQL session. Session death releases locks automatically; no queue table, migration, Redis dependency, or unbounded wait is introduced.

## Validation

- precommit hook: 5,705 passed, 30 skipped
- TypeScript typecheck
- focused crawler/lifecycle unit tests: 35 passed
- PostgreSQL durable queue integration tests: 16 passed
- auth-route isolation checks: 28 passed
- Stripe-link isolation checks: 9 passed
- database, security/concurrency, and code expert reviews: approved

Closes #6341