### PR TITLE
fix(schema): replace inline property-type enums with $ref in brand cluster

### DIFF
--- a/.changeset/brand-property-type-ref.md
+++ b/.changeset/brand-property-type-ref.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Replace inline property-type enums in brand.json, verify-brand-claim-request.json, and verify-brand-claims-request.json with $ref to enums/property-type.json. Adds linear_tv and ai_assistant to the brand property type surface. Completes the PR #6280 refactoring that missed the brand cluster.

--- a/docs/brand-protocol/brand-json.mdx
+++ b/docs/brand-protocol/brand-json.mdx
@@ -1221,7 +1221,7 @@ Properties are digital touchpoints associated with brands:
 
 ### Property types
 
-Matches AdCP property-type enum:
+Matches AdCP property-type enum (`enums/property-type.json`):
 - `website`
 - `mobile_app`
 - `ctv_app`
@@ -1229,7 +1229,9 @@ Matches AdCP property-type enum:
 - `dooh`
 - `podcast`
 - `radio`
+- `linear_tv`
 - `streaming_audio`
+- `ai_assistant`
 
 ### Property relationships
 

--- a/static/schemas/source/brand.json
+++ b/static/schemas/source/brand.json
@@ -381,8 +381,7 @@
       "description": "A digital property associated with a brand. Defaults to owned; use 'relationship' to declare direct, delegated, or ad_network properties. For delegated and network paths, these values match the delegation_type field in adagents.json, creating a bilateral verification chain: the operator declares the relationship here, the publisher confirms by setting the same delegation_type on the agent's authorization in their adagents.json. 'owned' is an inline ownership declaration with no adagents.json counterpart.",
       "properties": {
         "type": {
-          "type": "string",
-          "enum": ["website", "mobile_app", "ctv_app", "desktop_app", "dooh", "podcast", "radio", "streaming_audio"],
+          "$ref": "/schemas/enums/property-type.json",
           "description": "Property type"
         },
         "identifier": {

--- a/static/schemas/source/brand/verify-brand-claim-request.json
+++ b/static/schemas/source/brand/verify-brand-claim-request.json
@@ -95,8 +95,7 @@
               "description": "Shape matches brand.json properties[] entry.",
               "properties": {
                 "type": {
-                  "type": "string",
-                  "enum": ["website", "mobile_app", "ctv_app", "desktop_app", "dooh", "podcast", "radio", "streaming_audio"]
+                  "$ref": "/schemas/enums/property-type.json"
                 },
                 "identifier": { "type": "string" },
                 "store": {

--- a/static/schemas/source/brand/verify-brand-claims-request.json
+++ b/static/schemas/source/brand/verify-brand-claims-request.json
@@ -112,8 +112,7 @@
                   "description": "Shape matches brand.json properties[] entry.",
                   "properties": {
                     "type": {
-                      "type": "string",
-                      "enum": ["website", "mobile_app", "ctv_app", "desktop_app", "dooh", "podcast", "radio", "streaming_audio"]
+                      "$ref": "/schemas/enums/property-type.json"
                     },
                     "identifier": { "type": "string" },
                     "store": {

--- a/tests/brand-property-type-ref.test.cjs
+++ b/tests/brand-property-type-ref.test.cjs
@@ -1,0 +1,83 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
+
+const SCHEMA_BASE_DIR = path.join(__dirname, '../static/schemas/source');
+
+async function compile(schemaId) {
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: false,
+    discriminator: true,
+    loadSchema: async (uri) => {
+      if (!uri.startsWith('/schemas/')) throw new Error(`Cannot load: ${uri}`);
+      return JSON.parse(fs.readFileSync(path.join(SCHEMA_BASE_DIR, uri.replace('/schemas/', '')), 'utf8'));
+    }
+  });
+  addFormats(ajv);
+  return ajv.compileAsync(JSON.parse(fs.readFileSync(path.join(SCHEMA_BASE_DIR, schemaId.replace('/schemas/', '')), 'utf8')));
+}
+
+const ALL_PROPERTY_TYPES = [
+  'website', 'mobile_app', 'ctv_app', 'desktop_app', 'dooh',
+  'podcast', 'radio', 'linear_tv', 'streaming_audio', 'ai_assistant'
+];
+
+test('brand.json accepts all property types from enums/property-type.json', async () => {
+  const validate = await compile('/schemas/brand.json');
+  for (const pt of ALL_PROPERTY_TYPES) {
+    const brand = {
+      id: 'test_brand',
+      names: [{ en: 'Test Brand' }],
+      properties: [{
+        type: pt,
+        identifier: 'test.example'
+      }]
+    };
+    assert.equal(validate(brand), true, `brand.json rejects property type "${pt}": ${JSON.stringify(validate.errors)}`);
+  }
+});
+
+test('brand.json rejects invalid property type', async () => {
+  const validate = await compile('/schemas/brand.json');
+  const brand = {
+    id: 'test_brand',
+    names: [{ en: 'Test Brand' }],
+    properties: [{
+      type: 'invalid_type',
+      identifier: 'test.example'
+    }]
+  };
+  assert.equal(validate(brand), false);
+});
+
+test('verify-brand-claim-request accepts linear_tv and ai_assistant property types', async () => {
+  const validate = await compile('/schemas/brand/verify-brand-claim-request.json');
+  for (const pt of ['linear_tv', 'ai_assistant']) {
+    const request = {
+      claim_type: 'property',
+      claim: {
+        property: { type: pt, identifier: 'test.example' }
+      }
+    };
+    assert.equal(validate(request), true, `verify-brand-claim-request rejects "${pt}": ${JSON.stringify(validate.errors)}`);
+  }
+});
+
+test('verify-brand-claims-request accepts linear_tv and ai_assistant property types', async () => {
+  const validate = await compile('/schemas/brand/verify-brand-claims-request.json');
+  for (const pt of ['linear_tv', 'ai_assistant']) {
+    const request = {
+      claims: [{
+        claim_type: 'property',
+        claim: {
+          property: { type: pt, identifier: 'test.example' }
+        }
+      }]
+    };
+    assert.equal(validate(request), true, `verify-brand-claims-request rejects "${pt}": ${JSON.stringify(validate.errors)}`);
+  }
+});


### PR DESCRIPTION
Closes #6330

## Summary

- Replace inline `property.type` enum in `brand.json` with `$ref` to `enums/property-type.json`, matching the pattern already used by `core/property.json`
- Apply the same fix to `verify-brand-claim-request.json` and `verify-brand-claims-request.json` which had identical inline copies
- Adds `linear_tv` and `ai_assistant` to the brand property-type surface as a consequence of pointing at the canonical 10-value enum
- Update `brand-json.mdx` docs to list all 10 property types and reference the canonical enum file

## Root cause

`brand.json` (and the two verify-brand-claim schemas) defined `property.type` with a hardcoded 8-value enum instead of using `$ref`. When `linear_tv` and `ai_assistant` were added to `enums/property-type.json`, the brand cluster was missed. The inline copy drifted.

## Validation

- `node --test tests/brand-property-type-ref.test.cjs` — 4/4 pass: brand.json accepts all 10 property types, rejects invalid type, both verify-brand-claim variants accept the new values
- `npm run typecheck` — clean
- Full pre-commit suite (5700+ tests) — clean
- Pre-push hooks (changeset policy, version sync, docs validation) — all pass