### PR TITLE
fix(compliance): preserve controller skip cascades

### DIFF
--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -530,6 +530,40 @@ function isRunnerApplicabilitySkip(step: {
   }
 }
 
+type SkipEvidenceStep = {
+  skip_reason?: string;
+  details?: unknown;
+  error?: unknown;
+  warnings?: unknown;
+  skip?: { detail?: unknown };
+};
+
+const NO_SKIP_REASONS: ReadonlySet<string> = new Set();
+
+function prerequisiteCascadeSource(step: SkipEvidenceStep): { reason: string } | null {
+  if (step.skip_reason !== 'prerequisite_failed') return null;
+  const warning = Array.isArray(step.warnings)
+    ? step.warnings.find((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    : undefined;
+  const detail = firstString(step.skip?.detail, step.error, step.details, warning);
+  const match = detail?.match(/prior stateful step "([^"]+)" skipped \(([^)]+)\)/);
+  return match ? { reason: match[2] } : null;
+}
+
+function isApplicabilityCascade(
+  step: SkipEvidenceStep,
+  applicabilityReasons: ReadonlySet<string>,
+  nonApplicabilityReasons: ReadonlySet<string> = new Set(),
+): boolean {
+  const source = prerequisiteCascadeSource(step);
+  if (!source) return false;
+  // A controller absence is always runner-owned applicability, including
+  // cross-phase cascades where the originating step is not in this slice.
+  return source.reason === 'missing_test_controller' || (
+    applicabilityReasons.has(source.reason) && !nonApplicabilityReasons.has(source.reason)
+  );
+}
+
 export function isNonExecutableCoverageGapScenario(scenario: {
   scenario?: unknown;
   steps?: Array<{
@@ -538,6 +572,10 @@ export function isNonExecutableCoverageGapScenario(scenario: {
     skip_reason?: string;
     step_id?: unknown;
     requirement?: unknown;
+    details?: unknown;
+    error?: unknown;
+    warnings?: unknown;
+    skip?: { detail?: unknown };
   }>;
 }): boolean {
   const steps = Array.isArray(scenario.steps) ? scenario.steps : [];
@@ -548,12 +586,20 @@ export function isNonExecutableCoverageGapScenario(scenario: {
   )) return true;
   return steps.length > 0 && steps.every((step) => {
     if (!step?.skipped) return false;
-    return step.skip_reason === 'peer_branch_taken' ||
+    const isApplicabilitySkip = step.skip_reason === 'peer_branch_taken' ||
       step.skip_reason === 'peer_substituted' ||
       step.skip_reason === 'missing_test_controller' ||
       step.skip_reason === 'fixture_unavailable' ||
       (step.skip_reason === 'requirement_unmet' && step.requirement === 'controller') ||
+      isExplicitRequiresToolMissingSkip(step) ||
       isRunnerApplicabilitySkip(step, scenarioId);
+    if (isApplicabilitySkip) {
+      return true;
+    }
+    // This UI helper receives one phase without prior-phase provenance.
+    // Only controller absence is intrinsically safe to classify as N/A;
+    // other same-reason cascades stay visible as executable coverage gaps.
+    return isApplicabilityCascade(step, NO_SKIP_REASONS);
   });
 }
 
@@ -798,7 +844,8 @@ export function deriveStoryboardStatuses(
         }
         continue;
       }
-      let phaseSawNeutralApplicabilitySkip = false;
+      const phaseApplicabilityReasons = new Set<string>();
+      const phaseNonApplicabilityReasons = new Set<string>();
       for (const step of s.steps) {
         if (step.skipped) {
           if (step.skip_reason === 'fixture_unavailable') {
@@ -809,14 +856,18 @@ export function deriveStoryboardStatuses(
           }
           if (isControllerSkip(step)) {
             agg.controllerSkipped++;
+            phaseApplicabilityReasons.add('missing_test_controller');
             continue;
           }
           if (isNeutralApplicabilitySkip(step, String(s.scenario))) {
-            phaseSawNeutralApplicabilitySkip = true;
+            if (step.skip_reason) phaseApplicabilityReasons.add(step.skip_reason);
             continue;
           }
-          if (phaseSawNeutralApplicabilitySkip && isCascadeSkip(step)) {
+          if (isApplicabilityCascade(step, phaseApplicabilityReasons, phaseNonApplicabilityReasons)) {
             continue;
+          }
+          if (step.skip_reason !== 'prerequisite_failed' && step.skip_reason) {
+            phaseNonApplicabilityReasons.add(step.skip_reason);
           }
           if (isCascadeSkip(step)) {
             agg.skippedCount++;

--- a/server/tests/unit/derive-storyboard-statuses.test.ts
+++ b/server/tests/unit/derive-storyboard-statuses.test.ts
@@ -109,6 +109,147 @@ describe('deriveStoryboardStatuses', () => {
     })).toBe(false);
   });
 
+  it('classifies controller skips and their prerequisite cascades as non-executable', () => {
+    expect(isNonExecutableCoverageGapScenario({
+      scenario: 'stale_response_advisory/stale_response_forcing',
+      steps: [
+        {
+          passed: true,
+          skipped: true,
+          skip_reason: 'missing_test_controller',
+          step: 'Force upstream dependency unavailable',
+        },
+        {
+          passed: false,
+          skipped: true,
+          skip_reason: 'prerequisite_failed',
+          step: 'STALE_RESPONSE in errors[] on populated success response',
+          warnings: ['Skipped: prior stateful step "force_upstream_unavailable" skipped (missing_test_controller); state never materialized.'],
+        },
+      ],
+    })).toBe(true);
+  });
+
+  it('does not hide a genuine cascade after an unrelated controller skip', () => {
+    const result = makeResult([
+      {
+        scenario: 'mixed_roots/exercise',
+        passed: false,
+        steps: [
+          {
+            passed: true,
+            skipped: true,
+            skip_reason: 'missing_test_controller',
+            step: 'Controller setup',
+          },
+          {
+            passed: false,
+            step: 'Seller operation',
+            task: 'get_products',
+            error: 'Seller assertion failed',
+          },
+          {
+            passed: false,
+            skipped: true,
+            skip_reason: 'prerequisite_failed',
+            step: 'Dependent read',
+            warnings: ['Skipped: prior stateful step failed.'],
+          },
+        ],
+      },
+    ]);
+
+    expect(isNonExecutableCoverageGapScenario(result.tracks[0].scenarios[0])).toBe(false);
+    expect(deriveStoryboardStatuses(result)).toEqual([
+      {
+        storyboard_id: 'mixed_roots',
+        status: 'failing',
+        steps_passed: 0,
+        steps_total: 2,
+        failure_count: 1,
+        skipped_count: 1,
+        first_failed_step_id: 'seller_operation',
+        first_failed_step_title: 'Seller operation',
+        first_failed_step_task: 'get_products',
+        first_failure_message: 'Seller assertion failed',
+      },
+    ]);
+  });
+
+  it('does not hide a production missing-tool cascade after a neutral missing-tool skip', () => {
+    const result = makeResult([
+      {
+        scenario: 'mixed_missing_tools/exercise',
+        passed: false,
+        steps: [
+          {
+            passed: true,
+            skipped: true,
+            skip_reason: 'missing_tool',
+            step: 'Preview the creative',
+            task: 'preview_creative',
+            warnings: ['Required tool "preview_creative" not advertised; agent tools: [get_products].'],
+          },
+          {
+            passed: false,
+            skipped: true,
+            skip_reason: 'missing_tool',
+            step: 'Create media buy',
+            task: 'create_media_buy',
+            warnings: ['Agent did not advertise tool "create_media_buy"; agent tools: [get_products].'],
+          },
+          {
+            passed: false,
+            skipped: true,
+            skip_reason: 'prerequisite_failed',
+            step: 'Read media buy',
+            task: 'get_media_buys',
+            warnings: ['Skipped: prior stateful step "create_buy" skipped (missing_tool); state never materialized.'],
+          },
+        ],
+      },
+    ]);
+
+    expect(deriveStoryboardStatuses(result)).toEqual([
+      {
+        storyboard_id: 'mixed_missing_tools',
+        status: 'failing',
+        steps_passed: 0,
+        steps_total: 2,
+        failure_count: 1,
+        skipped_count: 1,
+        first_failed_step_id: 'create_media_buy',
+        first_failed_step_title: 'Create media buy',
+        first_failed_step_task: 'create_media_buy',
+        first_failure_message: 'Agent did not advertise tool "create_media_buy"; agent tools: [get_products].',
+      },
+    ]);
+  });
+
+  it('keeps same-reason cross-phase missing-tool cascades executable in the UI', () => {
+    expect(isNonExecutableCoverageGapScenario({
+      scenario: 'mixed_missing_tools/downstream_phase',
+      steps: [
+        {
+          passed: true,
+          skipped: true,
+          skip_reason: 'missing_tool',
+          step: 'Preview the creative',
+          task: 'preview_creative',
+          warnings: ['Required tool "preview_creative" not advertised; agent tools: [get_products].'],
+        },
+        {
+          passed: false,
+          skipped: true,
+          skip_reason: 'prerequisite_failed',
+          step: 'Read media buy',
+          task: 'get_media_buys',
+          warnings: ['Skipped: prior stateful step "create_buy" skipped (missing_tool); state never materialized.'],
+        },
+      ],
+    })).toBe(false);
+  });
+
   it('emits one entry per storyboard the runner produced data for', () => {
     const result = makeResult([
       { scenario: 'signal_owned/capability_discovery', passed: true, steps: [{ passed: true }] },
@@ -399,7 +540,6 @@ describe('deriveStoryboardStatuses', () => {
             skipped: true,
             skip_reason: 'missing_tool',
             step: 'Preview the display creative',
-            step_id: 'preview_display',
             task: 'preview_creative',
             warnings: ['Required tool "preview_creative" not advertised; agent tools: [build_creative].'],
           },
@@ -408,8 +548,8 @@ describe('deriveStoryboardStatuses', () => {
             skipped: true,
             skip_reason: 'prerequisite_failed',
             step: 'Build a VAST tag for the video creative',
-            step_id: 'build_video_tag',
             task: 'build_creative',
+            warnings: ['Skipped: prior stateful step "preview_display" skipped (missing_tool); state never materialized.'],
           },
         ],
       },

--- a/tests/addie/compliance-testing.test.ts
+++ b/tests/addie/compliance-testing.test.ts
@@ -45,7 +45,6 @@ describe('compliance result adapter', () => {
               steps: [
                 {
                   step: 'Force upstream dependency unavailable',
-                  step_id: 'force_upstream_unavailable',
                   task: 'comply_test_controller',
                   skipped: true,
                   skip_reason: 'missing_test_controller',
@@ -53,12 +52,11 @@ describe('compliance result adapter', () => {
                 },
                 {
                   step: 'STALE_RESPONSE in errors[] on populated success response',
-                  step_id: 'stale_response_wire_placement',
                   task: 'get_products',
                   skipped: true,
-                  skip_reason: 'missing_test_controller',
+                  skip_reason: 'prerequisite_failed',
                   passed: false,
-                  error: 'prior stateful step force_upstream_unavailable skipped; state never materialized',
+                  error: 'Skipped: prior stateful step "force_upstream_unavailable" skipped (missing_test_controller); state never materialized.',
                 },
               ],
             },


### PR DESCRIPTION
## Summary

- exclude controller-owned prerequisite cascades from hosted storyboard grading
- keep the UI classifier conservative where the SDK projection no longer carries source-step identity
- add production-shaped regression coverage for controller skips and same-reason missing-tool cases

## Root cause

The SDK correctly projected a missing controller as `missing_test_controller`, but projected its dependent step as `prerequisite_failed`. The hosted adapter excluded the root skip while still counting the dependent cascade in the grading denominator.

## Validation

- 49 focused compliance tests
- SDK runner capability-gate regression suite
- TypeScript typecheck
- full pre-commit suite: 5,709 passed, 30 skipped

Follow-up to #6320.