### PR TITLE
fix(compliance): gate per-agent billing phases

### DIFF
--- a/.changeset/skip-unavailable-agent-billing-gate.md
+++ b/.changeset/skip-unavailable-agent-billing-gate.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Skip the per-agent billing permission phases when a seller does not advertise agent billing, preventing capability-level `BILLING_NOT_SUPPORTED` responses from being graded as failures against the narrower `BILLING_NOT_PERMITTED_FOR_AGENT` contract.

--- a/static/compliance/source/test-kits/billing-gate-runner.yaml
+++ b/static/compliance/source/test-kits/billing-gate-runner.yaml
@@ -23,7 +23,9 @@
 # This kit is the coordination contract between the runner and a seller-under-
 # test that wants the per-agent-gate phases graded. Sellers that do not ship
 # a passthrough-only test caller leave `commercial_relationship` unset and
-# the per-agent phases grade `not_applicable`.
+# the per-agent phases grade `not_applicable`. Sellers whose
+# `account.supported_billing` omits `agent` also grade those phases
+# `not_applicable`: capability-level rejection is covered separately.
 
 id: billing_gate_runner
 applies_to:
@@ -44,10 +46,12 @@ description: |
 
     commercial_relationship — (optional) declares the calling buyer agent's
       onboarded commercial state with the seller. When set to
-      "passthrough_only", the runner submits `billing: "agent"` on the
-      per-agent-gate-reject phase and asserts BILLING_NOT_PERMITTED_FOR_AGENT
-      with the clamped error.details shape. When unset, both per-agent
-      phases grade `not_applicable`.
+      "passthrough_only" AND the seller advertises `"agent"` in
+      `account.supported_billing`, the runner submits `billing: "agent"` on
+      the per-agent-gate-reject phase and asserts
+      BILLING_NOT_PERMITTED_FOR_AGENT with the clamped error.details shape.
+      When the relationship is unset or agent billing is not supported,
+      both per-agent phases grade `not_applicable`.
 
   Establishing the commercial relationship is offline (the same posture as
   operator account creation): the seller-under-test records the test

--- a/static/compliance/source/universal/billing-gate-dispatch.yaml
+++ b/static/compliance/source/universal/billing-gate-dispatch.yaml
@@ -67,9 +67,10 @@ narrative: |
     field unset).
 
   - **`per_agent_gate_reject`** runs only when the test kit declares
-    `commercial_relationship: "passthrough_only"`. The runner submits
-    `billing: "agent"` (a value `supported_billing` accepts but the
-    per-agent record does not), and asserts
+    `commercial_relationship: "passthrough_only"` AND the seller's
+    `supported_billing` capability includes `"agent"`. The runner submits
+    `billing: "agent"` (a value the capability accepts but the per-agent
+    record does not), and asserts
     `BILLING_NOT_PERMITTED_FOR_AGENT` with the clamped
     `error.details` shape. The seller's `suggested_billing` value is
     captured into context for the recover phase.
@@ -119,9 +120,11 @@ prerequisites:
 
       commercial_relationship — (optional) declares whether the calling
         buyer agent is registered with the seller as passthrough-only.
-        When set to "passthrough_only", per_agent_gate_reject and
-        per_agent_gate_recover run. When unset or set to anything else,
-        both per-agent phases grade `not_applicable`.
+        When set to "passthrough_only" AND the seller advertises `"agent"`
+        in `account.supported_billing`, per_agent_gate_reject and
+        per_agent_gate_recover run. Sellers that do not offer agent billing
+        grade both phases `not_applicable`; they have no per-agent billing
+        permission boundary to exercise.
 
     Establishing the commercial relationship is offline — the
     seller-under-test records the test caller's commercial state in its
@@ -258,16 +261,22 @@ phases:
   - id: per_agent_gate_reject
     title: "Per-agent gate — BILLING_NOT_PERMITTED_FOR_AGENT (reject)"
     optional: true
+    requires_capability:
+      path: "account.supported_billing"
+      contains: "agent"
     skip_if: "test_kit.commercial_relationship != 'passthrough_only'"
     narrative: |
       The test kit declares the calling buyer agent is registered with
-      the seller as passthrough-only. The runner submits `billing:
-      "agent"` (which `supported_billing` accepts but the per-agent
-      record does not) and asserts the per-buyer-agent gate fires with
-      the clamped `error.details` shape. The seller's `suggested_billing`
-      value is captured into context for the recover phase, which
-      submits a new request (with a fresh idempotency_key) using the
-      suggested value.
+      the seller as passthrough-only, and the seller advertises `"agent"`
+      in `account.supported_billing`. The runner submits `billing: "agent"`
+      (which the capability accepts but the per-agent record does not) and
+      asserts the per-buyer-agent gate fires with the clamped
+      `error.details` shape. Sellers that do not offer agent billing skip
+      this phase as `not_applicable`: their rejection belongs to the
+      seller-wide `BILLING_NOT_SUPPORTED` capability gate instead. The
+      seller's `suggested_billing` value is captured into context for the
+      recover phase, which submits a new request (with a fresh
+      idempotency_key) using the suggested value.
 
     steps:
       - id: sync_accounts_passthrough_rejects_agent
@@ -360,6 +369,9 @@ phases:
   - id: per_agent_gate_recover
     title: "Per-agent gate — autonomous recovery via suggested_billing"
     optional: true
+    requires_capability:
+      path: "account.supported_billing"
+      contains: "agent"
     skip_if: "test_kit.commercial_relationship != 'passthrough_only'"
     narrative: |
       The runner submits a new request with the `billing` value the

--- a/tests/sdk-runner-capability-gates.test.cjs
+++ b/tests/sdk-runner-capability-gates.test.cjs
@@ -3,6 +3,9 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const YAML = require('yaml');
 
 const { runStoryboard } = require('@adcp/sdk/testing');
 
@@ -49,4 +52,76 @@ test('runStoryboard skips an equals-gated storyboard when the capability path is
   assert.equal(result.phases[0].phase_id, 'capability_unsupported');
   assert.equal(result.phases[0].steps[0].skip_reason, 'capability_unsupported');
   assert.match(result.phases[0].steps[0].error, /agent did not declare support/);
+});
+
+test('runStoryboard skips a contains-gated phase when the array omits the required value', async () => {
+  const storyboard = {
+    id: 'phase_contains_regression',
+    version: '1.0',
+    title: 'Phase contains regression',
+    category: 'error_compliance',
+    summary: 'Regression',
+    narrative: 'Regression',
+    agent: { interaction_model: 'single_agent', capabilities: [] },
+    caller: { role: 'buyer' },
+    phases: [
+      {
+        id: 'agent_billing',
+        title: 'Agent billing',
+        requires_capability: {
+          path: 'account.supported_billing',
+          contains: 'agent',
+        },
+        steps: [
+          {
+            id: 'noop',
+            title: 'Noop',
+            task: 'sync_accounts',
+            sample_request: { accounts: [] },
+          },
+        ],
+      },
+    ],
+  };
+
+  const result = await runStoryboard('https://agent.example/mcp', storyboard, {
+    _profile: {
+      tools: ['get_adcp_capabilities', 'sync_accounts'],
+      raw_capabilities: { account: { supported_billing: ['operator'] } },
+    },
+    agentTools: ['get_adcp_capabilities', 'sync_accounts'],
+  });
+
+  assert.equal(result.overall_passed, true);
+  assert.equal(result.skipped_count, 1);
+  assert.equal(result.phases[0].steps[0].skip_reason, 'not_applicable');
+  assert.match(result.phases[0].steps[0].error, /must contain "agent"/);
+});
+
+test('billing gate skips per-agent phases when agent billing is not supported', () => {
+  const storyboardPath = path.join(
+    __dirname,
+    '..',
+    'static',
+    'compliance',
+    'source',
+    'universal',
+    'billing-gate-dispatch.yaml'
+  );
+  const storyboard = YAML.parse(fs.readFileSync(storyboardPath, 'utf8'));
+  const perAgentPhases = storyboard.phases.filter(phase => phase.id.startsWith('per_agent_gate_'));
+
+  assert.deepEqual(
+    perAgentPhases.map(phase => [phase.id, phase.requires_capability]),
+    [
+      [
+        'per_agent_gate_reject',
+        { path: 'account.supported_billing', contains: 'agent' },
+      ],
+      [
+        'per_agent_gate_recover',
+        { path: 'account.supported_billing', contains: 'agent' },
+      ],
+    ]
+  );
 });


### PR DESCRIPTION
## What changed

- Gate both per-agent billing phases on `account.supported_billing` containing `agent`.
- Clarify the storyboard and runner-kit precondition.
- Add SDK-runtime and storyboard-structure regression coverage.

## Why

Sellers that only advertise operator billing have no per-agent billing permission boundary. The storyboard nevertheless sent `billing: agent` and expected `BILLING_NOT_PERMITTED_FOR_AGENT`, falsely failing the semantically correct capability-level `BILLING_NOT_SUPPORTED` response.

The phase-level `requires_capability` gate is enforced by the released SDK before dispatch and grades these phases `not_applicable` for sellers that do not offer agent billing.

Closes #6343.

## Validation

- `npm run test:sdk-runner-capability-gates`
- `npm run test:storyboard-test-kits`
- `npm run build:compliance`
- `git diff --check`
