### PR TITLE
fix(registry): render complete tool count

### DIFF
--- a/server/public/agents.html
+++ b/server/public/agents.html
@@ -568,7 +568,7 @@
     }
 
     function agentToolCount(agent) {
-        return Number(agent?.health?.tools_count ?? agent?.capabilities?.tools_count) || 0;
+        return Number(agent?.capabilities?.tools_count ?? agent?.health?.tools_count) || 0;
     }
 
     window.addEventListener('DOMContentLoaded', async () => {
@@ -980,7 +980,7 @@
                                 <div class="compliance-badge__title">${hasCoreTools ? 'AdCP sales agent' : 'Incomplete implementation'}</div>
                                 <div class="compliance-badge__subtitle">
                                     ${capLabels.length > 0 ? capLabels.join(' &middot; ') : 'Implements ' + coreImplemented.length + ' tools'}
-                                    &middot; ${coreImplemented.length + optionalImplemented.length} tools
+                                    &middot; ${agentToolCount(agentWithCaps)} tools
                                 </div>
                             </div>
                         </div>

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -6304,13 +6304,6 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
               if (h.stats_json) {
                 enrichedAgent.stats = h.stats_json;
               }
-              // The health snapshot comes from the latest tools/list probe;
-              // the capability catalog can lag on a separate crawl cadence.
-              // Keep the legacy capabilities count fresh for consumers that
-              // have not yet moved to health.tools_count.
-              if (enrichedAgent.capabilities && h.tools_count != null) {
-                enrichedAgent.capabilities.tools_count = h.tools_count;
-              }
             }
           }
 

--- a/server/tests/unit/public-agent-registry-ui.test.ts
+++ b/server/tests/unit/public-agent-registry-ui.test.ts
@@ -11,9 +11,11 @@ describe('public agent registry UI', () => {
     expect(agentsHtml).not.toContain("fetch(`/mcp`");
   });
 
-  it('prefers the latest health tool count over stale capability metadata', () => {
-    expect(agentsHtml).toContain('agent?.health?.tools_count ?? agent?.capabilities?.tools_count');
+  it('renders the complete discovered tool catalog count', () => {
+    expect(agentsHtml).toContain('agent?.capabilities?.tools_count ?? agent?.health?.tools_count');
     expect(agentsHtml).toContain('agentWithCaps?.capabilities?.tools || []');
+    expect(agentsHtml).toContain('&middot; ${agentToolCount(agentWithCaps)} tools');
+    expect(agentsHtml).not.toContain('${coreImplemented.length + optionalImplemented.length} tools');
   });
 
   it('allowlists verification links and escapes responsive format dimensions', () => {

--- a/server/tests/unit/registry-agent-tool-count.test.ts
+++ b/server/tests/unit/registry-agent-tool-count.test.ts
@@ -8,7 +8,7 @@ vi.mock('../../src/db/agent-snapshot-db.js', () => ({
   AgentSnapshotDatabase: class {
     bulkGetCapabilities() {
       return Promise.resolve(new Map([[AGENT_URL, {
-        discovered_tools_json: Array.from({ length: 5 }, (_, index) => `stale_tool_${index}`),
+        discovered_tools_json: Array.from({ length: 12 }, (_, index) => `tool_${index}`),
         inferred_type: 'sales',
       }]]));
     }
@@ -57,14 +57,14 @@ function buildApp(): express.Express {
 }
 
 describe('public registry tool count enrichment', () => {
-  it('uses the fresher health count for legacy capability consumers', async () => {
+  it('keeps the complete capability catalog count separate from the health snapshot', async () => {
     const response = await request(buildApp())
       .get('/api/registry/agents?health=true&capabilities=true');
 
     expect(response.status).toBe(200);
     expect(response.body.agents[0]).toMatchObject({
       health: { tools_count: 10 },
-      capabilities: { tools_count: 10 },
+      capabilities: { tools_count: 12 },
     });
   });
 });


### PR DESCRIPTION
Closes #6268.

## Summary

- render the registry badge from the complete capability tool count
- retain the health-reported tool count as separate diagnostic data
- cover the case where capability and health counts differ

## Validation

- `npx vitest run server/tests/unit/public-agent-registry-ui.test.ts server/tests/unit/registry-agent-tool-count.test.ts`
- `npm run typecheck`
- `git diff --check`

The full pre-commit run completed 5,703 tests and reported two unrelated failures. Both affected files passed immediately when rerun directly (39/39).
