### PR TITLE
fix(creative): deprecate legacy format pricing request

### DIFF
--- a/.changeset/deprecate-legacy-format-pricing.md
+++ b/.changeset/deprecate-legacy-format-pricing.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Deprecate the legacy `list_creative_formats` pricing request fields through 3.x and direct transformation and generation pricing discovery to `list_transformers`.

--- a/.changeset/remove-phantom-format-pricing.md
+++ b/.changeset/remove-phantom-format-pricing.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Remove the unimplementable pricing request fields from deprecated `list_creative_formats`; transformation and generation pricing is discovered through `list_transformers`.

--- a/.changeset/remove-phantom-format-pricing.md
+++ b/.changeset/remove-phantom-format-pricing.md
@@ -1,5 +1,0 @@
----
-"adcontextprotocol": patch
----
-
-Remove the unimplementable pricing request fields from deprecated `list_creative_formats`; transformation and generation pricing is discovered through `list_transformers`.

--- a/specs/creative-agent-pricing.md
+++ b/specs/creative-agent-pricing.md
@@ -177,9 +177,9 @@ rate card. For agents with predetermined rate cards, this typically contains a s
 option.
 
 **Two pricing discovery surfaces.** `list_creatives` carries `pricing_options` for
-ad servers and library agents. `list_creative_formats` carries `pricing_options` for
-transformation and generation agents where the format is the product. An agent MAY
-expose pricing on both.
+ad servers and library agents. The shipped protocol uses `list_transformers` for
+account-scoped transformation and generation pricing. An agent MAY expose pricing on
+both surfaces.
 
 **Schema: vendor pricing option**
 
@@ -296,15 +296,15 @@ so this field is always available for usage reporting.
   The sales agent is the buyer in the creative agent relationship.
 - **`sync_creatives`** — asset sync is about getting creatives into a library. Pricing is
   discovered via `list_creatives`, not during sync.
-- **`list_creative_formats`** — now carries `pricing_options` per format for transformation/generation agents.
+- **`list_transformers`** — carries account-scoped `pricing_options` per transformer for transformation/generation agents.
 
 ### Pricing models by interaction model
 
 | Interaction model | Pricing surface | Likely models |
 |---|---|---|
 | Transformation (free) | None | N/A — stateless, no pricing |
-| Transformation (paid) | `list_creative_formats` + `build_creative` response | per_unit, cpm, flat_fee |
-| Generation (AI) | `list_creative_formats` + `build_creative` response | per_unit, flat_fee, cpm |
+| Transformation (paid) | `list_transformers` + `build_creative` response | per_unit, cpm, flat_fee |
+| Generation (AI) | `list_transformers` + `build_creative` response | per_unit, flat_fee, cpm |
 | Ad server (pre-loaded) | `list_creatives` + `build_creative` response | cpm, flat_fee |
 | Sales agent with creative | `list_creatives` + `build_creative` response | cpm, percent_of_media |
 

--- a/static/schemas/source/creative/list-creative-formats-request.json
+++ b/static/schemas/source/creative/list-creative-formats-request.json
@@ -8,23 +8,6 @@
   "allOf": [
     {
       "$ref": "/schemas/core/version-envelope.json"
-    },
-    {
-      "if": {
-        "properties": {
-          "include_pricing": {
-            "const": true
-          }
-        },
-        "required": [
-          "include_pricing"
-        ]
-      },
-      "then": {
-        "required": [
-          "account"
-        ]
-      }
     }
   ],
   "properties": {
@@ -118,15 +101,6 @@
         "$ref": "/schemas/core/format-id.json"
       },
       "minItems": 1
-    },
-    "include_pricing": {
-      "type": "boolean",
-      "default": false,
-      "description": "Include pricing_options on each format. Used by transformation and generation agents that charge per format or per unit of work. Requires account. When false or omitted, pricing is not computed."
-    },
-    "account": {
-      "$ref": "/schemas/core/account-ref.json",
-      "description": "Account reference for pricing. When provided with include_pricing, the agent returns pricing_options from this account's rate card on each format."
     },
     "pagination": {
       "$ref": "/schemas/core/pagination-request.json"

--- a/static/schemas/source/creative/list-creative-formats-request.json
+++ b/static/schemas/source/creative/list-creative-formats-request.json
@@ -8,6 +8,23 @@
   "allOf": [
     {
       "$ref": "/schemas/core/version-envelope.json"
+    },
+    {
+      "if": {
+        "properties": {
+          "include_pricing": {
+            "const": true
+          }
+        },
+        "required": [
+          "include_pricing"
+        ]
+      },
+      "then": {
+        "required": [
+          "account"
+        ]
+      }
     }
   ],
   "properties": {
@@ -101,6 +118,17 @@
         "$ref": "/schemas/core/format-id.json"
       },
       "minItems": 1
+    },
+    "include_pricing": {
+      "type": "boolean",
+      "default": false,
+      "deprecated": true,
+      "description": "**DEPRECATED in 3.1. Removed at 4.0.** Use `list_transformers` with `include_pricing` and `account` for transformation and generation pricing. *Legacy 3.x behavior:* include `pricing_options` on each returned format. Requires `account`; when false or omitted, pricing is not computed. Agents supporting the 3.1 format-pricing surface MUST continue to honor this field through 3.x."
+    },
+    "account": {
+      "$ref": "/schemas/core/account-ref.json",
+      "deprecated": true,
+      "description": "**DEPRECATED for `list_creative_formats` in 3.1. Removed at 4.0.** Use the account-scoped `list_transformers` request instead. *Legacy 3.x behavior:* identifies the rate card used when `include_pricing` is true."
     },
     "pagination": {
       "$ref": "/schemas/core/pagination-request.json"

--- a/tests/list-creative-formats-pricing-surface.test.cjs
+++ b/tests/list-creative-formats-pricing-surface.test.cjs
@@ -13,8 +13,19 @@ const requestSchema = JSON.parse(
   )
 );
 
-test('list_creative_formats does not advertise the retired pricing surface', () => {
-  assert.equal(requestSchema.properties.include_pricing, undefined);
-  assert.equal(requestSchema.properties.account, undefined);
-  assert.doesNotMatch(JSON.stringify(requestSchema.allOf), /include_pricing|account/);
+const formatSchema = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, '../static/schemas/source/core/format.json'),
+    'utf8'
+  )
+);
+
+test('list_creative_formats retains deprecated pricing compatibility through 3.x', () => {
+  assert.equal(requestSchema.properties.include_pricing.deprecated, true);
+  assert.equal(requestSchema.properties.account.deprecated, true);
+  assert.match(requestSchema.properties.include_pricing.description, /Removed at 4\.0/);
+  assert.match(requestSchema.properties.include_pricing.description, /list_transformers/);
+  assert.match(JSON.stringify(requestSchema.allOf), /include_pricing/);
+  assert.match(JSON.stringify(requestSchema.allOf), /account/);
+  assert.equal(formatSchema.properties.pricing_options.deprecated, true);
 });

--- a/tests/list-creative-formats-pricing-surface.test.cjs
+++ b/tests/list-creative-formats-pricing-surface.test.cjs
@@ -1,0 +1,20 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const requestSchema = JSON.parse(
+  fs.readFileSync(
+    path.join(
+      __dirname,
+      '../static/schemas/source/creative/list-creative-formats-request.json'
+    ),
+    'utf8'
+  )
+);
+
+test('list_creative_formats does not advertise the retired pricing surface', () => {
+  assert.equal(requestSchema.properties.include_pricing, undefined);
+  assert.equal(requestSchema.properties.account, undefined);
+  assert.doesNotMatch(JSON.stringify(requestSchema.allOf), /include_pricing|account/);
+});


### PR DESCRIPTION
Closes #6353.

## Summary

- preserve the published 3.x `include_pricing` and pricing-only `account` request fields as deprecated compatibility surface
- document their 4.0 removal and direct new transformation/generation integrations to `list_transformers`
- align the original pricing design note with the shipped discovery model
- add a regression test covering the request deprecation, account conditional, and paired `format.pricing_options` response field

## Validation

- `node --test tests/list-creative-formats-pricing-surface.test.cjs`
- `npm run build`
- `npm run typecheck`
- full pre-commit gate before review correction: 402 files, 5,709 passed, 30 skipped
- `git diff --check`

## Review correction

The initial revision hard-removed the fields. Ladon correctly identified the existing 3.x compatibility guarantee on `format.pricing_options`; the current revision preserves both request fields and marks them deprecated through 3.x instead.
