### PR TITLE
fix(compliance): gate async media-buy forcing scenario

### DIFF
--- a/.changeset/gate-async-buy-controller-scenario.md
+++ b/.changeset/gate-async-buy-controller-scenario.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Gate the `create_media_buy` submitted-arm compliance storyboard on the seller advertising `force_create_media_buy_arm` under `compliance_testing.scenarios`. Sellers without that sandbox-only forcing capability now skip the whole storyboard before its independent downstream phase can incorrectly fail their otherwise conformant synchronous or provisional media-buy flow.

--- a/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async.yaml
@@ -4,6 +4,15 @@ title: "Seller returns submitted task envelope when create_media_buy goes async"
 category: media_buy_seller
 summary: "Verifies the AdCP-payload wire shape of the submitted-arm response from create_media_buy: status='submitted', task_id present, no media_buy_id and no packages on the envelope."
 track: media_buy
+
+# The submitted response arm is a production protocol path, but forcing a
+# seller into it is a sandbox-only compliance capability. Gate the entire
+# storyboard on the controller scenario advertisement so sellers that cannot
+# deterministically exercise this path skip before phase execution.
+requires_capability:
+  path: compliance_testing.scenarios
+  contains: force_create_media_buy_arm
+
 required_tools:
   - create_media_buy
   - comply_test_controller
@@ -33,9 +42,9 @@ narrative: |
   buys synchronously. To make this storyboard runnable across implementations, the test
   harness uses comply_test_controller force_create_media_buy_arm to drive the next
   create_media_buy call into the submitted arm. The directive is keyed to the caller's
-  authenticated sandbox account (account + principal pair); sellers that do not implement
-  the controller scenario return UNKNOWN_SCENARIO and the runner grades this storyboard
-  not_applicable rather than failed.
+  authenticated sandbox account (account + principal pair). The storyboard applies only
+  when get_adcp_capabilities advertises force_create_media_buy_arm under
+  compliance_testing.scenarios; other sellers skip before phase execution.
 
   Round-trip integrity. The deterministic task_id is captured from the controller
   response and reused as the expected task_id on the create_media_buy assertion, so the
@@ -68,11 +77,12 @@ caller:
 
 prerequisites:
   description: |
-    Seller exposes comply_test_controller in sandbox mode and supports
-    force_create_media_buy_arm. The directive is keyed to the caller's
-    authenticated sandbox account; without controller support, the storyboard
-    grades not_applicable — sellers cannot be deterministically driven into
-    the submitted arm by buyer-initiated requests alone.
+    Seller exposes comply_test_controller in sandbox mode and advertises
+    force_create_media_buy_arm under compliance_testing.scenarios. The
+    directive is keyed to the caller's authenticated sandbox account. Sellers
+    that omit the scenario grade not_applicable before phase execution because
+    buyer-initiated requests alone cannot deterministically drive the submitted
+    arm.
   test_kit: "test-kits/acme-outdoor.yaml"
   controller_seeding: true
 

--- a/tests/sdk-runner-capability-gates.test.cjs
+++ b/tests/sdk-runner-capability-gates.test.cjs
@@ -125,3 +125,62 @@ test('billing gate skips per-agent phases when agent billing is not supported', 
     ]
   );
 });
+
+test('create_media_buy async storyboard requires its advertised controller scenario', async () => {
+  const storyboardPath = path.join(
+    __dirname,
+    '..',
+    'static',
+    'compliance',
+    'source',
+    'protocols',
+    'media-buy',
+    'scenarios',
+    'create_media_buy_async.yaml'
+  );
+  const storyboard = YAML.parse(fs.readFileSync(storyboardPath, 'utf8'));
+
+  assert.deepEqual(storyboard.requires_capability, {
+    path: 'compliance_testing.scenarios',
+    contains: 'force_create_media_buy_arm',
+  });
+
+  const result = await runStoryboard('https://agent.example/mcp', storyboard, {
+    _profile: {
+      tools: ['get_adcp_capabilities', 'create_media_buy', 'comply_test_controller'],
+      raw_capabilities: {
+        compliance_testing: {
+          scenarios: ['force_account_status'],
+        },
+      },
+    },
+    agentTools: ['get_adcp_capabilities', 'create_media_buy', 'comply_test_controller'],
+  });
+
+  assert.equal(result.overall_passed, true);
+  assert.equal(result.skipped_count, 1);
+  assert.equal(result.phases[0].phase_id, 'capability_unsupported');
+  assert.equal(result.phases[0].steps[0].skip_reason, 'capability_unsupported');
+  assert.match(result.phases[0].steps[0].error, /force_create_media_buy_arm/);
+
+  // Strip executable work to isolate the affirmative gate path without
+  // dispatching the compliance controller over the network.
+  const advertisedResult = await runStoryboard(
+    'https://agent.example/mcp',
+    { ...storyboard, prerequisites: undefined, fixtures: undefined, phases: [] },
+    {
+      _profile: {
+        tools: ['get_adcp_capabilities', 'create_media_buy', 'comply_test_controller'],
+        raw_capabilities: {
+          compliance_testing: {
+            scenarios: ['force_create_media_buy_arm'],
+          },
+        },
+      },
+      agentTools: ['get_adcp_capabilities', 'create_media_buy', 'comply_test_controller'],
+    }
+  );
+
+  assert.equal(advertisedResult.overall_passed, true);
+  assert.equal(advertisedResult.phases[0].phase_id, 'no_phases');
+});


### PR DESCRIPTION
## Summary

- gate `media_buy_seller/create_media_buy_async` on `compliance_testing.scenarios` containing `force_create_media_buy_arm`
- skip sellers without the sandbox-only forcing scenario before any storyboard phase executes
- keep the production `submitted` response arm unchanged and avoid adding a public `supports_async_arm` capability
- add regression coverage for both omitted and advertised controller scenarios

## Root cause

The storyboard documented `force_create_media_buy_arm` as optional, but only discovered its absence inside the first stateful phase. The runner contract intentionally grades the following phase independently, so a seller using the conformant synchronous/provisional path could still fail the downstream `status: submitted` assertion.

The existing storyboard-level `requires_capability` predicate is the correct selection mechanism because sellers already advertise controller support under `compliance_testing.scenarios`.

## Impact

Sellers that do not advertise `force_create_media_buy_arm` now receive a non-failing whole-storyboard skip. Sellers that advertise it continue to exercise the real production submitted-task envelope.

## Validation

- `npm run test:sdk-runner-capability-gates`
- `npm run build:compliance`
- `npm run precommit`
- pre-push current and 3.0-compat storyboard matrices
- `git diff --check`

Closes #6345
