### PR TITLE
feat(creative): echo preview quality used

### DIFF
--- a/.changeset/echo-preview-quality-used.md
+++ b/.changeset/echo-preview-quality-used.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `quality_used` to successful `preview_creative` responses so buyers can detect render-quality downgrades before approval.

--- a/docs/creative/task-reference/preview_creative.mdx
+++ b/docs/creative/task-reference/preview_creative.mdx
@@ -239,6 +239,7 @@ Generate multiple preview variants by providing different contexts:
 ```typescript
 {
   response_type: "single";
+  quality_used?: "draft" | "production"; // Required when the request supplied quality
   previews: Preview[];       // One per input (or one default)
   interactive_url?: string;  // Optional sandbox for interactive formats
   expires_at?: string;       // Optional ISO 8601 expiration; omitted means no expiration
@@ -253,7 +254,11 @@ Generate multiple preview variants by providing different contexts:
   results: Array<{
     success: boolean;
     creative_id: string;
-    response?: { previews: Preview[]; expires_at?: string; };
+    quality_used?: "draft" | "production"; // Required when effective request supplied quality
+    response?: {
+      previews: Preview[];
+      expires_at?: string;
+    };
     errors?: Array<{ code: string; message: string; }>;
   }>;
 }
@@ -353,7 +358,9 @@ These formats have the widest gap between pre-flight and post-flight: a pre-flig
 
 ### Quality mismatch
 
-If the requested quality level is not supported, the agent renders at the best quality it can provide. The protocol does not require agents to support both levels, standardize per-capability quality discovery, or echo the actual quality used. Quality is therefore best-effort and not machine-verifiable in 3.x; if exact fidelity matters, verify the render by inspection before approval.
+If the requested quality level is not supported, the agent renders at the best quality it can provide and reports that tier in `quality_used`. When a single request supplies `quality`, the response MUST include `quality_used`. For batch mode, each successful result whose effective request supplied `quality`—either on the item or through the batch-level default—MUST include `quality_used`. Agents SHOULD report `quality_used` even when the request omitted `quality`, so buyers can record the renderer's default tier.
+
+Buyers MUST compare `quality_used` with the requested value before treating a preview as approval-ready. A mismatch is an explicit downgrade, not confirmation that the requested fidelity was honored. `quality_used` does not appear on variant-mode replay because that mode reproduces a historical execution rather than selecting a new render-quality tier. Agents are not required to support both quality levels or advertise per-capability quality discovery.
 
 ### Preview expiration and variant retention
 

--- a/server/src/creative-agent/task-handlers.ts
+++ b/server/src/creative-agent/task-handlers.ts
@@ -404,7 +404,7 @@ function renderSinglePreview(
   req: PreviewRequest,
   formats: Format[],
   baseUrl: string,
-): { previews: unknown[]; expires_at: string } {
+): { previews: unknown[]; quality_used: 'draft' | 'production'; expires_at: string } {
   if (!req.creative_manifest) {
     throw new PreviewCreativeNotFoundError(`Creative "${req.creative_id ?? 'unknown'}" was not found in this agent's creative library.`);
   }
@@ -464,7 +464,11 @@ function renderSinglePreview(
     };
   });
 
-  return { previews, expires_at: expiresAt.toISOString() };
+  return {
+    previews,
+    quality_used: req.quality ?? 'production',
+    expires_at: expiresAt.toISOString(),
+  };
 }
 
 export function handlePreviewCreative(args: Record<string, unknown>, formats: Format[], baseUrl: string): Record<string, unknown> {
@@ -503,10 +507,12 @@ export function handlePreviewCreative(args: Record<string, unknown>, formats: Fo
       }
       try {
         const result = renderSinglePreview(withBatchDefaults(args, req), formats, baseUrl);
+        const { quality_used, ...response } = result;
         return {
           success: true,
           creative_id: (req.creative_manifest?.creative_id as string) || req.creative_id || `batch_${i}`,
-          response: result,
+          quality_used,
+          response,
         };
       } catch (err) {
         return {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -9570,6 +9570,7 @@ export async function handlePreviewCreative(args: ToolArgs, ctx: TrainingContext
       return {
         success: true,
         creative_id: item.creative_id || 'unknown',
+        quality_used: effectiveQuality,
         response: { previews: [preview], expires_at: expiresAt },
       };
     });
@@ -9616,6 +9617,7 @@ export async function handlePreviewCreative(args: ToolArgs, ctx: TrainingContext
   return {
     response_type: 'single',
     previews: [preview],
+    quality_used: req.quality ?? 'production',
     expires_at: expiresAt,
   };
 }

--- a/server/tests/unit/creative-agent.test.ts
+++ b/server/tests/unit/creative-agent.test.ts
@@ -378,6 +378,7 @@ describe('handlePreviewCreative', () => {
     }, formats, TEST_BASE_URL);
 
     expect(result.response_type).toBe('single');
+    expect(result.quality_used).toBe('production');
     expect(result.expires_at).toBeTruthy();
     const previews = result.previews as Array<Record<string, unknown>>;
     expect(previews).toHaveLength(1);
@@ -686,9 +687,13 @@ describe('handlePreviewCreative', () => {
 
     const results = result.results as Array<{
       success: boolean;
-      response: { previews: Array<{ input: { name: string }; renders: Array<Record<string, unknown>> }> };
+      quality_used: 'draft' | 'production';
+      response: {
+        previews: Array<{ input: { name: string }; renders: Array<Record<string, unknown>> }>;
+      };
     }>;
     expect(results.map(item => item.success)).toEqual([true, true]);
+    expect(results.map(item => item.quality_used)).toEqual(['draft', 'draft']);
 
     const defaultPreview = results[0].response.previews[0];
     expect(defaultPreview.input.name).toBe('Default preview');

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -7023,6 +7023,8 @@ describe('canonical creative build capabilities', () => {
     });
 
     const results = result.results as Array<Record<string, any>>;
+    expect(results[0].quality_used).toBe('draft');
+    expect(results[1].quality_used).toBe('production');
     const firstRender = results[0].response.previews[0].renders[0];
     expect(firstRender.output_format).toBe('html');
     expect(firstRender.preview_url).toBeUndefined();

--- a/static/compliance/source/protocols/media-buy/scenarios/creative_reception.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/creative_reception.yaml
@@ -208,9 +208,8 @@ phases:
           - check: field_present
             path: "previews[0].renders[0].preview_url"
             description: "Preview includes a renderable URL"
-          - check: field_value
+          - check: field_present
             path: "quality_used"
-            value: "draft"
             description: "Response echoes the quality tier actually rendered"
 
           - check: field_present

--- a/static/compliance/source/protocols/media-buy/scenarios/creative_reception.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/creative_reception.yaml
@@ -171,6 +171,7 @@ phases:
           Return a preview showing the creative in your platform's environment.
           The preview should include your platform's native chrome — not just the
           raw assets, but how they'll actually appear to users.
+          Since the request asks for draft quality, quality_used is draft.
 
         sample_request:
           account:
@@ -207,6 +208,10 @@ phases:
           - check: field_present
             path: "previews[0].renders[0].preview_url"
             description: "Preview includes a renderable URL"
+          - check: field_value
+            path: "quality_used"
+            value: "draft"
+            description: "Response echoes the quality tier actually rendered"
 
           - check: field_present
             path: "context"

--- a/static/schemas/source/creative/preview-creative-response.json
+++ b/static/schemas/source/creative/preview-creative-response.json
@@ -76,6 +76,10 @@
           },
           "minItems": 1
         },
+        "quality_used": {
+          "$ref": "/schemas/enums/creative-quality.json",
+          "description": "Actual render quality applied to every preview in this response. This field MUST be present when the corresponding request supplied `quality`, and SHOULD be present otherwise. It may differ from the requested value when the agent cannot provide that tier, allowing buyers to detect a downgrade before approval."
+        },
         "interactive_url": {
           "type": "string",
           "format": "uri",
@@ -133,6 +137,10 @@
                 "type": "string",
                 "description": "ID of the creative this result corresponds to. Enables correlation when processing batch results.",
                 "x-entity": "creative"
+              },
+              "quality_used": {
+                "$ref": "/schemas/enums/creative-quality.json",
+                "description": "Actual render quality applied to every preview in this successful batch result. This field MUST be present when the effective item request supplied `quality`, whether directly or through the batch-level default, and SHOULD be present otherwise. It may differ from the requested value when the agent cannot provide that tier."
               },
               "response": {
                 "type": "object",

--- a/tests/schema-validation.test.cjs
+++ b/tests/schema-validation.test.cjs
@@ -823,6 +823,7 @@ async function runTests() {
       {
         status: 'completed',
         response_type: 'single',
+        quality_used: 'production',
         previews: [preview]
       },
       {
@@ -832,6 +833,7 @@ async function runTests() {
           {
             success: true,
             creative_id: 'creative_static',
+            quality_used: 'draft',
             response: { previews: [preview] }
           }
         ]
@@ -842,6 +844,9 @@ async function runTests() {
       if (!validate(example)) {
         return validate.errors.map(err => `${err.instancePath} ${err.message}`).join('; ');
       }
+    }
+    if (validate({ ...cases[0], quality_used: 'ultra' })) {
+      return 'preview_creative quality_used must use the creative-quality enum';
     }
     return true;
   });


### PR DESCRIPTION
## Summary

- add `quality_used` to successful `preview_creative` responses so buyers can detect render-quality downgrades before approval
- define the single-preview and batch-result placement, while leaving variant replay responses unchanged
- update the reference and training agents, schema validation, and creative-reception compliance scenario

Closes #6350.

## Validation

- `npm run test:schemas`
- `npx vitest run --config server/vitest.config.ts server/tests/unit/creative-agent.test.ts server/tests/unit/training-agent.test.ts` (672 tests)
- `npm run build:compliance -- --check`
- `npm run test:storyboard-response-schema`
- `npm run test:storyboard-validations-paths`
- `npm run typecheck`
- changeset protocol-scope and status checks
- pre-push current and 3.0 compatibility storyboard matrices
- docs navigation validation

The repository-wide pre-commit unit command exceeded its 180-second wrapper and was terminated with exit 143; it did not report a failing assertion before timeout. The scoped tests and protocol-specific pre-push gates above passed.
