### PR TITLE
fix(site): clean up perspectives docs and Addie

### DIFF
--- a/.changeset/fix-site-docs-addie-bugs.md
+++ b/.changeset/fix-site-docs-addie-bugs.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Route documentation Slack links through the maintained joining guide and restore crawlable public perspective pages.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -125,4 +125,4 @@ This Charter is a discoverability document and is updated when the underlying go
 
 - General: [hello@agenticadvertising.org](mailto:hello@agenticadvertising.org)
 - Governance inquiries: via the [governance page](https://agenticadvertising.org/governance)
-- Protocol questions: [GitHub Discussions](https://github.com/adcontextprotocol/adcp/discussions) or [Slack](https://join.slack.com/t/agenticads/shared_invite/zt-3h15gj6c0-FRTrD_y4HqmeXDKBl2TDEA)
+- Protocol questions: [GitHub Discussions](https://github.com/adcontextprotocol/adcp/discussions) or the [Slack joining guide](https://docs.adcontextprotocol.org/docs/community/joining-slack)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -84,7 +84,7 @@ Anthropic's Claude and Cursor are used throughout AAO's development workflow —
 - Open an [issue](https://github.com/adcontextprotocol/adcp/issues) to propose a change, report a bug, or start a discussion.
 - Submit a [pull request](https://github.com/adcontextprotocol/adcp/pulls) — see [CONTRIBUTING.md](https://github.com/adcontextprotocol/adcp/blob/main/CONTRIBUTING.md) for the PR workflow and changeset requirements.
 - Join a working group — see [docs/community/working-group](https://docs.adcontextprotocol.org/docs/community/working-group).
-- Join the community [Slack](https://join.slack.com/t/agenticads/shared_invite/zt-3h15gj6c0-FRTrD_y4HqmeXDKBl2TDEA).
+- Join the community through the [Slack joining guide](https://docs.adcontextprotocol.org/docs/community/joining-slack).
 
 ## Corrections
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,4 +68,4 @@ For security questions that are not sensitive vulnerability reports:
 - **Documentation**: https://docs.adcontextprotocol.org/docs/building/implementation/security
 - **GitHub Discussions**: Security category
 - **Email**: security@adcontextprotocol.org
-- **Slack**: https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg
+- **Slack**: https://docs.adcontextprotocol.org/docs/community/joining-slack

--- a/docs.json
+++ b/docs.json
@@ -1555,7 +1555,7 @@
     "linkedin": "https://www.linkedin.com/company/ad-context-protocol/",
     "youtube": "https://www.youtube.com/@AgenticAdvertising",
     "github": "https://github.com/adcontextprotocol/adcp",
-    "slack": "https://join.slack.com/t/agenticads/shared_invite/zt-3h15gj6c0-FRTrD_y4HqmeXDKBl2TDEA"
+    "slack": "https://docs.adcontextprotocol.org/docs/community/joining-slack"
   },
   "api": {
     "maintainOrder": true

--- a/docs/ai-disclosure.mdx
+++ b/docs/ai-disclosure.mdx
@@ -58,7 +58,7 @@ To file a grading appeal or protocol-update targeting dispute, email [certificat
 
 Other AI-surface review paths:
 
-- **Content corrections** — factual errors in Addie's teaching, Sage's protocol explanations, or any AI-authored content can be reported via [GitHub issues](https://github.com/adcontextprotocol/adcp/issues) or [Slack](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg). Target turnaround is **five business days**.
+- **Content corrections** — factual errors in Addie's teaching, Sage's protocol explanations, or any AI-authored content can be reported via [GitHub issues](https://github.com/adcontextprotocol/adcp/issues) or the [Slack joining guide](/docs/community/joining-slack). Target turnaround is **five business days**.
 - **Protocol guidance** — Sage is not a substitute for legal or regulatory advice. For compliance-sensitive questions, consult qualified counsel.
 
 ## Content provenance (C2PA)

--- a/docs/building/by-layer/L4/choose-your-sdk.mdx
+++ b/docs/building/by-layer/L4/choose-your-sdk.mdx
@@ -27,7 +27,7 @@ Legend: ✅ shipped · ⚠️ partial / in flight · ❌ not yet covered. **Prod
 
 Pre-3.0 callers should work through the [3.0 migration guide](/docs/reference/migration/index) before upgrading. For the at-a-glance status of every published protocol version, see [Versions & Compatibility](/docs/reference/versions). For procurement-grade context on the support window, see the [v2 sunset timeline](/docs/reference/v2-sunset) and [versioning & governance](/docs/reference/versioning).
 
-**Python and TypeScript carry full L0–L4 coverage as the first-class supported languages.** **Go** is moving in the same direction. **Other languages** are not on the official roadmap; community-maintained ports are welcome — see the [Builders Working Group](/docs/community/working-group) and the [Slack community](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg).
+**Python and TypeScript carry full L0–L4 coverage as the first-class supported languages.** **Go** is moving in the same direction. **Other languages** are not on the official roadmap; community-maintained ports are welcome — see the [Builders Working Group](/docs/community/working-group) and the [Slack community](/docs/community/joining-slack).
 
 ## JavaScript / TypeScript
 

--- a/docs/building/cross-cutting/sdk-stack.mdx
+++ b/docs/building/cross-cutting/sdk-stack.mdx
@@ -196,7 +196,7 @@ Within a given language, the full-stack SDK is the default starting point. The l
 
 ### Current SDK coverage
 
-**Python and TypeScript are the first-class languages.** Both are committed to full L0–L4 coverage — TypeScript is GA across L0–L3 today; Python is finishing its 4.x cycle to the same bar. **Go** is moving in the same direction, with L0 and partial L1 in active development. **Other languages** are not on the official roadmap today, but we're open to community-maintained ports — if you want to help, see the [Builders Working Group](/docs/community/working-group) and the [Slack community](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg).
+**Python and TypeScript are the first-class languages.** Both are committed to full L0–L4 coverage — TypeScript is GA across L0–L3 today; Python is finishing its 4.x cycle to the same bar. **Go** is moving in the same direction, with L0 and partial L1 in active development. **Other languages** are not on the official roadmap today, but we're open to community-maintained ports — if you want to help, see the [Builders Working Group](/docs/community/working-group) and the [Slack community](/docs/community/joining-slack).
 
 Snapshot of what each official SDK ships today. Refresh this table on SDK majors and on AdCP spec revs.
 

--- a/docs/community/joining-slack.mdx
+++ b/docs/community/joining-slack.mdx
@@ -30,7 +30,7 @@ The Slack workspace has a domain allowlist. If your email uses Gmail, a personal
 The current allowlist policy is under review. A decision is pending on whether to drop the allowlist in favor of post-join moderation, or to keep it with a lightweight self-serve invite request form. This page will be updated when the decision is made.
 </Note>
 
-Currently, the allowlist covers company and organizational domains associated with known publishers, agencies, ad tech vendors, and AAO members. Personal email domains (Gmail, Outlook, Yahoo, etc.) require a direct invite.
+Currently, the allowlist covers company and organizational domains associated with known publishers, agencies, ad tech vendors, and AgenticAdvertising.org member organizations. Personal email domains (Gmail, Outlook, Yahoo, etc.) require a direct invite.
 
 If you represent an organization whose domain isn't on the allowlist, the fastest path is to ask Addie or email the team. Allowlist additions are typically processed within one business day.
 

--- a/docs/community/working-group.mdx
+++ b/docs/community/working-group.mdx
@@ -13,9 +13,7 @@ The Ad Context Protocol Working Group is an open community of platform providers
 
 Our primary collaboration happens through Slack:
 
-**[→ Join the AdCP Community on Slack](https://join.slack.com/t/agenticads/shared_invite/zt-3h15gj6c0-FRTrD_y4HqmeXDKBl2TDEA)**
-
-If the link doesn't work (Gmail and some domains are restricted), see [Joining the Community Slack](/docs/community/joining-slack) for how to get a direct invite.
+**[→ Join the AdCP community on Slack](/docs/community/joining-slack)** — the guide includes the public invite and the direct-invite recovery path for restricted domains.
 
 ## What We Discuss
 

--- a/docs/contributing/testable-snippets.md
+++ b/docs/contributing/testable-snippets.md
@@ -404,4 +404,4 @@ When adding new documentation:
 
 - Check existing testable examples in `docs/quickstart.mdx`
 - Review the test suite: `tests/snippet-validation.test.js`
-- Ask in [Slack Community](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg)
+- Ask in the [Slack community](/docs/community/joining-slack)

--- a/docs/curation/coming-soon.mdx
+++ b/docs/curation/coming-soon.mdx
@@ -34,7 +34,7 @@ The Curation Protocol will enable AI assistants to discover and package media in
 
 Want to help shape the Curation Protocol?
 
-- Join our [working group](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg)
+- Join our [working group](/docs/community/joining-slack)
 - Share your use cases
 - Review early drafts
 

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -710,5 +710,5 @@ Foundation governance — structure, voting classes, Board composition, specific
 ## Need help?
 
 - Browse the documentation
-- Ask in [Slack Community](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg)
+- Ask in the [Slack community](/docs/community/joining-slack)
 - Email: support@adcontextprotocol.org

--- a/docs/reference/migration/prerelease-upgrades.mdx
+++ b/docs/reference/migration/prerelease-upgrades.mdx
@@ -223,6 +223,6 @@ All request and response schemas across governance, collection, property, sponso
 
 ## Need help?
 
-- **Community**: [Slack](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg) — best for quick questions from other implementers
+- **Community**: [Slack](/docs/community/joining-slack) — best for quick questions from other implementers
 - **Issues**: [GitHub Issues](https://github.com/adcontextprotocol/adcp/issues) — for bugs, spec questions, or migration edge cases
 - **Full v2 → v3 migration**: [Migration guide](/docs/reference/migration)

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -1600,6 +1600,6 @@ See [Versioning & Governance](/docs/reference/versioning) for the canonical vers
 
 - **Technical Changelog** - [CHANGELOG.md](https://github.com/adcontextprotocol/adcp/blob/main/CHANGELOG.md)
 - **GitHub Releases** - [Release Archive](https://github.com/adcontextprotocol/adcp/releases)
-- **Community** - [Slack](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg)
+- **Community** - [Slack](/docs/community/joining-slack)
 - **Issues** - [GitHub Issues](https://github.com/adcontextprotocol/adcp/issues)
 - **Support** - support@adcontextprotocol.org

--- a/docs/reference/roadmap.mdx
+++ b/docs/reference/roadmap.mdx
@@ -107,6 +107,6 @@ For detailed release notes and version history, see:
 
 AdCP is developed in the open with active working groups on Slack.
 
-- **[Join the AgenticAds Slack](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg)**
+- **[Join the community Slack](/docs/community/joining-slack)**
 - **[GitHub Discussions](https://github.com/adcontextprotocol/adcp/discussions)**
 - **[Working Groups](../community/working-group)**

--- a/docs/reference/whats-new-in-v3.mdx
+++ b/docs/reference/whats-new-in-v3.mdx
@@ -949,6 +949,6 @@ AdCP does not define its own consent framework. Privacy signals (TCF 2.0, GPP, U
 
 ## Getting help
 
-- **Community**: [Slack](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg)
+- **Community**: [Slack](/docs/community/joining-slack)
 - **Issues**: [GitHub Issues](https://github.com/adcontextprotocol/adcp/issues)
 - **Support**: support@adcontextprotocol.org

--- a/docs/slack-invite-recovery.js
+++ b/docs/slack-invite-recovery.js
@@ -1,0 +1,58 @@
+(function routeSlackInvitesThroughRecoveryGuide() {
+  'use strict';
+
+  var guideUrl = 'https://docs.adcontextprotocol.org/docs/community/joining-slack';
+
+  function isJoiningGuide() {
+    return /\/community\/joining-slack\/?$/.test(window.location.pathname);
+  }
+
+  function rewriteDirectInvites(root) {
+    if (isJoiningGuide()) return;
+    if (root.matches && root.matches('a[href^="https://join.slack.com/"]')) {
+      root.href = guideUrl;
+    }
+    root.querySelectorAll('a[href^="https://join.slack.com/"]').forEach(function(anchor) {
+      anchor.href = guideUrl;
+    });
+  }
+
+  function repairJoiningGuideTerminology(root) {
+    if (!isJoiningGuide()) return;
+    var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    var textNode;
+    while ((textNode = walker.nextNode())) {
+      textNode.nodeValue = textNode.nodeValue.replace(
+        /\bAAO members\b/g,
+        'AgenticAdvertising.org member organizations'
+      );
+    }
+  }
+
+  function start() {
+    rewriteDirectInvites(document);
+    repairJoiningGuideTerminology(document);
+    new MutationObserver(function(mutations) {
+      mutations.forEach(function(mutation) {
+        mutation.addedNodes.forEach(function(node) {
+          if (node.nodeType === Node.TEXT_NODE && isJoiningGuide()) {
+            node.nodeValue = node.nodeValue.replace(
+              /\bAAO members\b/g,
+              'AgenticAdvertising.org member organizations'
+            );
+            return;
+          }
+          if (node.nodeType !== Node.ELEMENT_NODE) return;
+          rewriteDirectInvites(node);
+          repairJoiningGuideTerminology(node);
+        });
+      });
+    }).observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/docs/sponsored-intelligence/implementing-si-agents.mdx
+++ b/docs/sponsored-intelligence/implementing-si-agents.mdx
@@ -267,4 +267,4 @@ To make your SI agent available through Addy and other hosts:
 
 - Review the [Task Reference](./tasks/) for detailed schema specifications
 - Explore the [SI Protocol Overview](./overview) for conceptual understanding
-- Join the [Working Group](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg) to discuss implementation questions
+- Join the [working group Slack](/docs/community/joining-slack) to discuss implementation questions

--- a/docs/sponsored-intelligence/implementing-si-hosts.mdx
+++ b/docs/sponsored-intelligence/implementing-si-hosts.mdx
@@ -135,4 +135,4 @@ npx @adcontextprotocol/si-simulator
 - Review the [SI Specification](./specification) for normative requirements
 - See [Implementing SI Agents](./implementing-si-agents) for brand-side implementation
 - Explore the [Task Reference](./tasks/) for detailed schema specifications
-- Join the [Community](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg) for implementation support
+- Join the [community Slack](/docs/community/joining-slack) for implementation support

--- a/docs/sponsored-intelligence/si-chat-protocol.mdx
+++ b/docs/sponsored-intelligence/si-chat-protocol.mdx
@@ -489,7 +489,7 @@ We don't have all the answers. Questions like "how should competing offers be ra
 - **Technical Teams**: Review the protocol components above
 - **Platform Providers**: See implementation considerations for hosts
 - **Brands**: Understand how to build SI-compliant agents
-- **Everyone**: Join the [Community](https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg) to discuss
+- **Everyone**: Join the [community Slack](/docs/community/joining-slack) to discuss
 
 ---
 

--- a/server/public/ai-disclosure.html
+++ b/server/public/ai-disclosure.html
@@ -127,7 +127,7 @@
       <p>To file a grading appeal or protocol-update targeting dispute, email <a href="mailto:certification@agenticadvertising.org">certification@agenticadvertising.org</a> with your learner ID, the module or assessment in question, and the specific finding you are contesting.</p>
       <p>Other AI-surface review paths:</p>
       <ul>
-        <li><strong>Content corrections</strong> &mdash; factual errors in Addie's teaching, Sage's protocol explanations, or any AI-authored content can be reported via <a href="https://github.com/adcontextprotocol/adcp/issues" target="_blank" rel="noopener noreferrer">GitHub issues</a> or <a href="https://join.slack.com/t/agenticads/shared_invite/zt-3c5sxvdjk-x0rVmLB3OFHVUp~WutVWZg" target="_blank" rel="noopener noreferrer">Slack</a>.</li>
+        <li><strong>Content corrections</strong> &mdash; factual errors in Addie's teaching, Sage's protocol explanations, or any AI-authored content can be reported via <a href="https://github.com/adcontextprotocol/adcp/issues" target="_blank" rel="noopener noreferrer">GitHub issues</a> or the <a href="https://docs.adcontextprotocol.org/docs/community/joining-slack" target="_blank" rel="noopener noreferrer">Slack joining guide</a>.</li>
         <li><strong>Protocol guidance</strong> &mdash; Sage is not a substitute for legal or regulatory advice. For compliance-sensitive questions, consult qualified counsel.</li>
       </ul>
 

--- a/server/public/dashboard-membership.html
+++ b/server/public/dashboard-membership.html
@@ -939,7 +939,7 @@
                 <p>Get answers about AdCP, membership, and agentic advertising</p>
               </div>
             </a>
-            <a href="https://join.slack.com/t/agenticadvertising/shared_invite/zt-2vq5tqy3n-c2X3jroBr0Pn_z~9fG8V9Q" target="_blank" class="whats-next-item">
+            <a href="https://docs.adcontextprotocol.org/docs/community/joining-slack" target="_blank" rel="noopener noreferrer" class="whats-next-item">
               <div class="whats-next-icon">&#128172;</div>
               <div class="whats-next-content">
                 <h4>Join the Slack Community</h4>

--- a/server/public/dashboard.html
+++ b/server/public/dashboard.html
@@ -1235,7 +1235,7 @@
               Connect with other members, join working group channels, and participate in community discussions.
             </p>
           </div>
-          <a href="https://join.slack.com/t/agenticads/shared_invite/zt-3h15gj6c0-FRTrD_y4HqmeXDKBl2TDEA"
+          <a href="https://docs.adcontextprotocol.org/docs/community/joining-slack"
              target="_blank" rel="noopener noreferrer"
              style="
                display: inline-flex;

--- a/server/public/perspectives/article.html
+++ b/server/public/perspectives/article.html
@@ -1093,8 +1093,21 @@
 
         // Render markdown content
         if (article.content) {
-          const renderedHtml = marked.parse(article.content);
-          document.getElementById('articleContent').innerHTML = DOMPurify.sanitize(renderedHtml);
+          if (new TextEncoder().encode(article.content).length <= 256000) {
+            const renderedHtml = marked.parse(article.content);
+            document.getElementById('articleContent').innerHTML = DOMPurify.sanitize(renderedHtml, {
+              ALLOWED_TAGS: [
+                'p', 'br', 'strong', 'em', 'a', 'ul', 'ol', 'li',
+                'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre', 'code',
+                'img', 'hr', 'del', 'table', 'thead', 'tbody', 'tr', 'th', 'td'
+              ],
+              ALLOWED_ATTR: ['href', 'src', 'alt', 'title'],
+              ALLOW_DATA_ATTR: false,
+              ALLOWED_URI_REGEXP: /^(?:https:|\/(?!\/)|#)/i
+            });
+          } else if (document.getElementById('mainContent').dataset.serverRendered !== 'true') {
+            document.getElementById('articleContent').textContent = 'Article content is temporarily unavailable.';
+          }
         }
 
         // Show author info if available
@@ -1130,6 +1143,12 @@
 
     function showError() {
       document.getElementById('loadingState').style.display = 'none';
+      const mainContent = document.getElementById('mainContent');
+      if (mainContent.dataset.serverRendered === 'true') {
+        // The initial response already contains the complete published article.
+        // Keep it as the fallback when client enhancement fails transiently.
+        return;
+      }
       document.getElementById('errorState').style.display = 'block';
     }
 

--- a/server/public/stories/index.html
+++ b/server/public/stories/index.html
@@ -485,6 +485,12 @@
         });
       }
 
+      function registerTopicsFromElements(selector) {
+        document.querySelectorAll(selector).forEach(function(element) {
+          registerTopics(element.getAttribute('data-topics'));
+        });
+      }
+
       function matchesTopic(topicStr, topic) {
         if (topic === 'all') return true;
         if (!topicStr) return false;
@@ -492,9 +498,7 @@
       }
 
       // Register topics from static story cards and build pills immediately
-      document.querySelectorAll('#stories-grid .card').forEach(function(card) {
-        registerTopics(card.getAttribute('data-topics'));
-      });
+      registerTopicsFromElements('#stories-grid .card');
       buildPills();
       buildOriginFilter();
 
@@ -730,6 +734,14 @@
 
       // Load perspectives and split into official (research) and member sections
       (async function() {
+        var researchGrid = document.getElementById('research-grid');
+        var perspectivesGrid = document.getElementById('perspectives-grid');
+        if (researchGrid.hasChildNodes() || perspectivesGrid.hasChildNodes()) {
+          registerTopicsFromElements('#research-grid .card, #perspectives-grid .card');
+          buildPills();
+          applyFilter(activeTopic, activeOrigin);
+          return;
+        }
         try {
           var res = await fetch('/api/perspectives?authored=true');
           if (!res.ok) return;
@@ -740,7 +752,6 @@
           var member = items.filter(function(i) { return i.content_origin !== 'official'; });
 
           // Render official content in research grid
-          var researchGrid = document.getElementById('research-grid');
           if (official.length > 0) {
             official.forEach(function(item) {
               researchGrid.appendChild(buildPerspectiveCard(item, 'card'));
@@ -750,7 +761,6 @@
           }
 
           // Render member content in perspectives grid
-          var perspectivesGrid = document.getElementById('perspectives-grid');
           if (member.length > 0) {
             member.forEach(function(item) {
               perspectivesGrid.appendChild(buildPerspectiveCard(item, 'card'));
@@ -769,6 +779,13 @@
 
       // Load industry news
       (async function() {
+        var list = document.getElementById('news-list');
+        if (list.hasChildNodes()) {
+          registerTopicsFromElements('#news-list .news-item');
+          buildPills();
+          applyFilter(activeTopic, activeOrigin);
+          return;
+        }
         try {
           var res = await fetch('/api/latest/featured');
           if (!res.ok) return;
@@ -778,8 +795,6 @@
             document.getElementById('news-section').hidden = true;
             return;
           }
-
-          var list = document.getElementById('news-list');
 
           // Map relevance_tags from RSS feeds to our topic taxonomy
           var NEWS_TAG_MAP = {

--- a/server/src/addie/mcp/docs-indexer.ts
+++ b/server/src/addie/mcp/docs-indexer.ts
@@ -1044,7 +1044,10 @@ async function loadPublishedPerspectives(): Promise<IndexedDoc[]> {
   }>(
     `SELECT slug, title, content, excerpt, author_name, category, content_origin
      FROM perspectives
-     WHERE status = 'published' AND content_type = 'article' AND content IS NOT NULL
+     WHERE status = 'published'
+       AND is_members_only = false
+       AND content_type = 'article'
+       AND content IS NOT NULL
      ORDER BY published_at DESC`
   );
 

--- a/server/src/addie/rules/behaviors.md
+++ b/server/src/addie/rules/behaviors.md
@@ -54,9 +54,9 @@ Do NOT share the invite link silently and walk away. The silent-failure pattern 
 If someone reports that the invite failed for them:
 1. Acknowledge it specifically — it's a domain allowlist issue, not a broken link
 2. Ask for their email address
-3. Escalate using the 'invite' category so the admin team can issue a direct invite
+3. Call `escalate_to_admin` with category `needs_human_action`, including their email address, so the admin team can issue a direct invite
 
-The help page at /docs/community/joining-slack has the full explanation of what happens and what to do.
+The help page at https://docs.adcontextprotocol.org/docs/community/joining-slack has the full explanation of what happens and what to do.
 
 ## Email Verification and Notification Failures
 

--- a/server/src/db/community-db.ts
+++ b/server/src/db/community-db.ts
@@ -421,6 +421,7 @@ export class CommunityDatabase {
        FROM perspectives p
        LEFT JOIN content_authors ca ON ca.perspective_id = p.id
        WHERE p.status = 'published'
+         AND p.is_members_only = false
          AND (p.author_user_id = $1 OR p.proposer_user_id = $1 OR ca.user_id = $1)
        ORDER BY p.published_at DESC
        LIMIT 20`,

--- a/server/src/db/digest-db.ts
+++ b/server/src/db/digest-db.ts
@@ -467,6 +467,7 @@ export async function getRecentMemberPerspectivesForDigest(
      FROM perspectives p
      LEFT JOIN working_groups wg ON wg.id = p.working_group_id
      WHERE p.status = 'published'
+       AND p.is_members_only = false
        AND (p.source_type IS NULL OR p.source_type NOT IN ('rss', 'email'))
        AND (p.content_origin IS NULL OR p.content_origin != 'official')
        AND p.published_at IS NOT NULL
@@ -506,6 +507,7 @@ export async function getRecentOfficialPerspectives(
         p.body
      FROM perspectives p
      WHERE p.status = 'published'
+       AND p.is_members_only = false
        AND p.content_origin = 'official'
        AND p.published_at IS NOT NULL
        AND p.published_at > NOW() - make_interval(days => $1)

--- a/server/src/db/illustration-db.ts
+++ b/server/src/db/illustration-db.ts
@@ -175,6 +175,7 @@ export async function getPerspectiveWithIllustration(slug: string): Promise<{
      FROM perspectives p
      LEFT JOIN working_groups wg ON wg.id = p.working_group_id
      WHERE p.slug = $1 AND p.status = 'published'
+       AND p.is_members_only = false
        AND (p.working_group_id IS NULL OR wg.slug = 'editorial')`,
     [slug]
   );

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -1,5 +1,7 @@
 import express from "express";
 import cookieParser from "cookie-parser";
+import DOMPurify from "isomorphic-dompurify";
+import { Marked } from "marked";
 import { csrfProtection } from "./middleware/csrf.js";
 import { slowResponseTracker } from "./middleware/slow-response.js";
 import { requestMetrics } from "./middleware/request-metrics.js";
@@ -59,10 +61,11 @@ import { isUuid } from "./utils/uuid.js";
 import { resolveUserNameWithFallbacks, sanitizeName } from "./utils/resolve-user-name.js";
 import { scrubCommunityAuthorizedAgents } from "./utils/community-adagents.js";
 import { formatPerspectiveUrlAsMarkdownDestination, normalizePerspectiveExternalUrl } from "./utils/perspective-url.js";
+import { decodeHtmlEntities } from "./utils/html-entities.js";
 import { requireAuth, requireAdmin, requireGlobalAdmin, optionalAuth, invalidateSessionCache, isDevModeEnabled, getDevUser, getAvailableDevUsers, getDevSessionCookieName, encodeDevSessionCookie, DEV_USERS, type DevUserConfig } from "./middleware/auth.js";
 import { invitationRateLimiter, brandCreationRateLimiter, notificationRateLimiter, emailPrefsRateLimiter, adminContentWriteRateLimiter, newsletterSubscribeRateLimiter, newsletterConfirmRateLimiter } from "./middleware/rate-limit.js";
 import { findOrCreateUserByEmail } from "./auth/workos-client.js";
-import { sendNewsletterConfirmation, SLACK_INVITE_URL } from "./notifications/email.js";
+import { sendNewsletterConfirmation } from "./notifications/email.js";
 import { getPerspectiveWithIllustration, getIllustrationData } from "./db/illustration-db.js";
 import { getAssetData as getPerspectiveAssetData } from "./db/perspective-asset-db.js";
 import { generatePerspectiveCard, compositePerspectiveCard } from "./services/perspective-cards.js";
@@ -147,7 +150,7 @@ import { emailPrefsDb } from "./db/email-preferences-db.js";
 import { pendingConfirmationsDb } from "./db/pending-confirmations-db.js";
 import { queuePerspectiveLink } from "./addie/services/content-curator.js";
 import { resolveEscalationsForPerspective } from "./db/escalation-db.js";
-import { serveHtmlWithMetaTags, enrichUserWithMembership, enrichUserWithAdmin } from "./utils/html-config.js";
+import { serveHtmlWithMetaTags, injectMetaTagsIntoHtml, enrichUserWithMembership, enrichUserWithAdmin } from "./utils/html-config.js";
 import { complete, isLLMConfigured } from "./utils/llm.js";
 import { notifyJoinRequest, notifyMemberAdded, notifySubscriptionThankYou } from "./slack/org-group-dm.js";
 import { BansDatabase } from "./db/bans-db.js";
@@ -171,7 +174,12 @@ const __dirname = path.dirname(__filename);
 
 const logger = createLogger('http-server');
 const PUBLIC_SITE_URL = 'https://agenticadvertising.org';
+const SLACK_JOIN_GUIDE_URL = 'https://docs.adcontextprotocol.org/docs/community/joining-slack';
 const PERSPECTIVES_CRAWLER_LIMIT = 200;
+const STORIES_NEWS_LIMIT = 8;
+const ARTICLE_MARKDOWN_CACHE_TTL_MS = 60 * 1000;
+const ARTICLE_MARKDOWN_CACHE_MAX_ENTRIES = 200;
+const MAX_ARTICLE_MARKDOWN_BYTES = 256_000;
 
 interface PublicPerspectiveCrawlerItem {
   slug: string;
@@ -182,6 +190,57 @@ interface PublicPerspectiveCrawlerItem {
   author_name: string | null;
   published_at: Date | string | null;
   updated_at: Date | string | null;
+}
+
+interface StoriesPerspectiveItem {
+  slug: string;
+  title: string;
+  subtitle: string | null;
+  category: string | null;
+  excerpt: string | null;
+  external_url: string | null;
+  author_name: string | null;
+  featured_image_url: string | null;
+  published_at: Date | string | null;
+  tags: string[] | null;
+  content_origin: string;
+}
+
+interface StoriesNewsItem {
+  title: string;
+  source_url: string;
+  summary: string | null;
+  addie_notes: string | null;
+  relevance_tags: string[] | null;
+  feed_name: string | null;
+}
+
+interface PublicPerspectiveArticle {
+  slug: string;
+  title: string;
+  subtitle: string | null;
+  category: string | null;
+  excerpt: string | null;
+  content: string | null;
+  author_name: string | null;
+  author_title: string | null;
+  author_slug: string | null;
+  featured_image_url: string | null;
+  published_at: Date | string | null;
+  updated_at: Date | string | null;
+  tags: string[] | null;
+  like_count: number | null;
+}
+
+interface StoriesSsrFragments {
+  officialCards: string[];
+  memberCards: string[];
+  newsItems: string[];
+}
+
+interface TimedValue<T> {
+  value: T;
+  expiresAt: number;
 }
 
 interface WorkingGroupPostMetaData {
@@ -277,6 +336,7 @@ async function getPublicPerspectiveCrawlerItems(limit = PERSPECTIVES_CRAWLER_LIM
      FROM perspectives p
      LEFT JOIN working_groups wg ON wg.id = p.working_group_id
      WHERE p.status = 'published'
+       AND p.is_members_only = false
        AND (p.working_group_id IS NULL OR wg.slug = 'editorial')
        AND (p.source_type IS NULL OR p.source_type NOT IN ('rss', 'email'))
      ORDER BY p.published_at DESC NULLS LAST, p.created_at DESC
@@ -351,6 +411,289 @@ function buildPerspectivesRss(items: PublicPerspectiveCrawlerItem[]): string {
 ${entries}
   </channel>
 </rss>`;
+}
+
+function replaceOpeningTagById(
+  html: string,
+  id: string,
+  update: (openingTag: string) => string
+): string {
+  const idIndex = html.indexOf(`id="${id}"`);
+  if (idIndex === -1) return html;
+  const tagStart = html.lastIndexOf('<', idIndex);
+  const tagEnd = html.indexOf('>', idIndex);
+  if (tagStart === -1 || tagEnd === -1) return html;
+  const openingTag = html.slice(tagStart, tagEnd + 1);
+  return html.slice(0, tagStart) + update(openingTag) + html.slice(tagEnd + 1);
+}
+
+function replaceElementInnerHtml(html: string, id: string, innerHtml: string): string {
+  const idIndex = html.indexOf(`id="${id}"`);
+  if (idIndex === -1) return html;
+  const tagStart = html.lastIndexOf('<', idIndex);
+  const tagEnd = html.indexOf('>', idIndex);
+  if (tagStart === -1 || tagEnd === -1) return html;
+  const tagMatch = html.slice(tagStart, tagEnd + 1).match(/^<([a-zA-Z0-9-]+)/);
+  if (!tagMatch) return html;
+  const closingTag = `</${tagMatch[1]}>`;
+  const closingIndex = html.indexOf(closingTag, tagEnd + 1);
+  if (closingIndex === -1) return html;
+  return html.slice(0, tagEnd + 1) + innerHtml + html.slice(closingIndex);
+}
+
+function showElementById(html: string, id: string): string {
+  return replaceOpeningTagById(html, id, (openingTag) => openingTag
+    .replace(/\shidden(?=[\s>])/i, '')
+    .replace(/display\s*:\s*none\s*;?/gi, ''));
+}
+
+function hideElementById(html: string, id: string): string {
+  return replaceOpeningTagById(html, id, (openingTag) => (
+    /\shidden(?=[\s>])/i.test(openingTag)
+      ? openingTag
+      : openingTag.replace(/>$/, ' hidden>')
+  ));
+}
+
+function storyTopics(tags: string[] | null | undefined): string[] {
+  return Array.isArray(tags)
+    ? tags.filter((tag): tag is string => typeof tag === 'string' && tag.length > 0)
+    : [];
+}
+
+function buildStoriesPerspectiveCard(item: StoriesPerspectiveItem): string {
+  const externalUrl = normalizePerspectiveExternalUrl(item.external_url);
+  const href = externalUrl ?? `/perspectives/${encodeURIComponent(item.slug)}`;
+  const topics = storyTopics(item.tags).join(',');
+  const image = absolutePublicUrl(item.featured_image_url)
+    ?? `/api/perspectives/${encodeURIComponent(item.slug)}/card.png`;
+  const excerpt = item.excerpt || item.subtitle || '';
+  const externalAttributes = externalUrl ? ' target="_blank" rel="noopener noreferrer"' : '';
+
+  return `<a href="${escapeHtml(href)}" class="card" data-topics="${escapeHtml(topics)}"${externalAttributes}>
+    <img src="${escapeHtml(image)}" alt="" class="card-cover" loading="lazy">
+    <div class="card-body">
+      <span class="card-badge">${escapeHtml(item.category || 'Perspective')}</span>
+      <h3 class="card-title">${escapeHtml(item.title || 'Untitled')}</h3>
+      ${excerpt ? `<p class="card-excerpt">${escapeHtml(excerpt)}</p>` : ''}
+      ${item.author_name ? `<span class="card-meta">${escapeHtml(item.author_name)}</span>` : ''}
+    </div>
+  </a>`;
+}
+
+const STORY_NEWS_TAG_MAP: Record<string, string> = {
+  'media-buying': 'buy-side',
+  'programmatic': 'buy-side',
+  'retail-media': 'retail-media',
+  'ai-agents': 'agentic',
+  'adcp': 'protocol',
+  'signals': 'protocol',
+  'creative': 'content',
+};
+
+function buildStoriesNewsItem(item: StoriesNewsItem): string | null {
+  const href = normalizePerspectiveExternalUrl(item.source_url);
+  if (!href) return null;
+  const topics = storyTopics(item.relevance_tags)
+    .map((tag) => STORY_NEWS_TAG_MAP[tag])
+    .filter((tag, index, all): tag is string => !!tag && all.indexOf(tag) === index)
+    .join(',');
+  const title = decodeHtmlEntities(item.title || '');
+  const summary = decodeHtmlEntities(item.summary || item.addie_notes || '');
+  const source = decodeHtmlEntities(item.feed_name || '');
+
+  return `<a href="${escapeHtml(href)}" class="news-item" target="_blank" rel="noopener noreferrer" data-topics="${escapeHtml(topics)}">
+    <div class="news-item-body">
+      ${source ? `<div class="news-item-source">${escapeHtml(source)}</div>` : ''}
+      <h3 class="news-item-title">${escapeHtml(title)}</h3>
+      ${summary ? `<p class="news-item-summary">${escapeHtml(summary)}</p>` : ''}
+    </div>
+  </a>`;
+}
+
+async function loadStoriesSsrFragments(): Promise<StoriesSsrFragments> {
+  const pool = getPool();
+  const [perspectivesResult, newsResult] = await Promise.all([
+    pool.query<StoriesPerspectiveItem>(
+      `SELECT
+         p.slug, p.title, p.subtitle, p.category, p.excerpt, p.external_url,
+         p.author_name, p.featured_image_url, p.published_at, p.tags, p.content_origin
+       FROM perspectives p
+       LEFT JOIN working_groups wg ON wg.id = p.working_group_id
+       WHERE p.status = 'published'
+         AND p.is_members_only = false
+         AND (p.working_group_id IS NULL OR wg.slug = 'editorial')
+         AND (p.source_type IS NULL OR p.source_type NOT IN ('rss', 'email'))
+       ORDER BY p.published_at DESC NULLS LAST, p.created_at DESC
+       LIMIT 100`
+    ),
+    pool.query<StoriesNewsItem>(
+      `SELECT
+         k.title, k.source_url, k.summary, k.addie_notes, k.relevance_tags,
+         f.name AS feed_name
+       FROM addie_knowledge k
+       LEFT JOIN perspectives p ON k.source_url = p.external_url
+       LEFT JOIN industry_feeds f ON p.feed_id = f.id
+       CROSS JOIN LATERAL (
+         SELECT nc.id
+         FROM notification_channels nc
+         WHERE nc.website_enabled = true
+           AND nc.is_active = true
+           AND nc.slack_channel_id = ANY(COALESCE(k.human_routing_override, k.notification_channel_ids))
+         LIMIT 1
+       ) nc
+       WHERE k.fetch_status = 'success'
+         AND k.publication_status != 'rejected'
+         AND COALESCE(k.human_quality_override, k.quality_score) >= 3
+       ORDER BY
+         CASE WHEN k.publication_status = 'featured' THEN 0 ELSE 1 END,
+         COALESCE(k.published_at, k.created_at) DESC
+       LIMIT $1`,
+      [STORIES_NEWS_LIMIT]
+    ),
+  ]);
+  return {
+    officialCards: perspectivesResult.rows
+      .filter((item) => item.content_origin === 'official')
+      .map(buildStoriesPerspectiveCard),
+    memberCards: perspectivesResult.rows
+      .filter((item) => item.content_origin !== 'official')
+      .map(buildStoriesPerspectiveCard),
+    newsItems: newsResult.rows
+      .map(buildStoriesNewsItem)
+      .filter((item): item is string => item !== null),
+  };
+}
+
+async function injectStoriesSsrContent(html: string): Promise<string> {
+  const { officialCards, memberCards, newsItems } = await loadStoriesSsrFragments();
+
+  html = replaceElementInnerHtml(html, 'research-grid', officialCards.join('\n'));
+  html = replaceElementInnerHtml(html, 'perspectives-grid', memberCards.join('\n'));
+  html = replaceElementInnerHtml(html, 'news-list', newsItems.join('\n'));
+  if (officialCards.length === 0) html = hideElementById(html, 'research-section');
+  if (memberCards.length === 0) html = hideElementById(html, 'perspectives-section');
+  if (newsItems.length === 0) html = hideElementById(html, 'news-section');
+  return html;
+}
+
+const articleMarkdown = new Marked();
+const articleMarkdownCache = new Map<string, TimedValue<string>>();
+
+const ARTICLE_MARKDOWN_SANITIZE_CONFIG = {
+  ALLOWED_TAGS: [
+    'p', 'br', 'strong', 'em', 'a', 'ul', 'ol', 'li',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre', 'code',
+    'img', 'hr', 'del', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
+  ],
+  ALLOWED_ATTR: ['href', 'src', 'alt', 'title'],
+  ALLOW_DATA_ATTR: false,
+  ALLOWED_URI_REGEXP: /^(?:https:|\/(?!\/)|#)/i,
+};
+
+function renderArticleMarkdown(markdown: string | null, cacheKey: string): string {
+  if (!markdown) return '';
+  if (Buffer.byteLength(markdown, 'utf8') > MAX_ARTICLE_MARKDOWN_BYTES) {
+    logger.warn({ cacheKey }, 'Skipping oversized public perspective content');
+    return '<p>Article content is temporarily unavailable.</p>';
+  }
+  const cached = articleMarkdownCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+  articleMarkdownCache.delete(cacheKey);
+
+  const rendered = articleMarkdown.parse(markdown, { async: false }) as string;
+  const sanitized = DOMPurify.sanitize(rendered, ARTICLE_MARKDOWN_SANITIZE_CONFIG);
+  if (articleMarkdownCache.size >= ARTICLE_MARKDOWN_CACHE_MAX_ENTRIES) {
+    const oldestKey = articleMarkdownCache.keys().next().value;
+    if (oldestKey) articleMarkdownCache.delete(oldestKey);
+  }
+  articleMarkdownCache.set(cacheKey, {
+    value: sanitized,
+    expiresAt: Date.now() + ARTICLE_MARKDOWN_CACHE_TTL_MS,
+  });
+  return sanitized;
+}
+
+async function getPublicPerspectiveArticle(slug: string): Promise<PublicPerspectiveArticle | null> {
+  const result = await getPool().query<PublicPerspectiveArticle>(
+    `SELECT
+       p.slug, p.title, p.subtitle, p.category, p.excerpt, p.content,
+       p.author_name, p.author_title, p.featured_image_url,
+       p.published_at, p.updated_at, p.tags, p.like_count,
+       u.slug AS author_slug
+     FROM perspectives p
+     LEFT JOIN users u ON u.workos_user_id = p.author_user_id AND u.is_public = true
+     LEFT JOIN working_groups wg ON wg.id = p.working_group_id
+     WHERE p.slug = $1 AND p.status = 'published'
+       AND p.is_members_only = false
+       AND (p.working_group_id IS NULL OR wg.slug = 'editorial')`,
+    [slug]
+  );
+  return result.rows[0] ?? null;
+}
+
+function formatArticleDisplayDate(value: Date | string | null): string {
+  const date = coerceDate(value);
+  if (!date) return '';
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+function articleAuthorInitials(name: string): string {
+  return name.split(/\s+/).filter(Boolean).slice(0, 2).map((part) => part[0]).join('').toUpperCase();
+}
+
+function injectPerspectiveArticleContent(html: string, article: PublicPerspectiveArticle): string {
+  const date = formatArticleDisplayDate(article.published_at);
+  const authorHref = article.author_slug
+    ? `/community/people/${encodeURIComponent(article.author_slug)}`
+    : '/community/';
+  const headerAuthor = article.author_name
+    ? `<a id="headerAuthorLink" class="article-header-author" href="${escapeHtml(authorHref)}">
+        <span id="headerAuthorAvatar" class="article-header-avatar">${escapeHtml(articleAuthorInitials(article.author_name))}</span>
+        <span id="headerAuthorName">${escapeHtml(article.author_name)}</span>
+      </a>`
+    : '<a id="headerAuthorLink" class="article-header-author" href="#" style="display: none;"></a>';
+  const headerMeta = `${headerAuthor}
+      <span class="article-header-dot" id="headerMetaDot"${article.author_name && date ? '' : ' style="display: none;"'}>&middot;</span>
+      <span id="headerDate">${escapeHtml(date)}</span>`;
+  const tags = storyTopics(article.tags).map((tag) => (
+    `<a class="article-tag" href="/stories?topic=${encodeURIComponent(tag)}">${escapeHtml(tag)}</a>`
+  )).join('');
+
+  html = replaceElementInnerHtml(html, 'heroTitle', escapeHtml(article.title));
+  html = replaceElementInnerHtml(html, 'heroSubtitle', escapeHtml(article.subtitle || ''));
+  html = replaceElementInnerHtml(html, 'heroCategory', escapeHtml(article.category || 'Article'));
+  html = replaceElementInnerHtml(html, 'articleHeaderMeta', headerMeta);
+  html = replaceElementInnerHtml(html, 'articleDate', escapeHtml(date));
+  html = replaceElementInnerHtml(html, 'likeCount', String(article.like_count || 0));
+  html = replaceElementInnerHtml(html, 'articleTags', tags);
+  const articleCacheKey = `${article.slug}:${metaDate(article.updated_at) || ''}`;
+  html = replaceElementInnerHtml(html, 'articleContent', renderArticleMarkdown(article.content, articleCacheKey));
+  if (article.author_name) {
+    const authorTitle = article.author_title ? `, ${article.author_title}` : '';
+    html = replaceElementInnerHtml(
+      html,
+      'authorInfo',
+      `<p><strong id="authorName">${escapeHtml(article.author_name)}</strong><span id="authorTitle">${escapeHtml(authorTitle)}</span></p>`
+    );
+    html = showElementById(html, 'authorInfo');
+  }
+  if (tags) html = showElementById(html, 'articleTags');
+  if (article.author_name || date) html = showElementById(html, 'articleHeaderMeta');
+  html = hideElementById(html, 'loadingState');
+  html = showElementById(html, 'heroSection');
+  html = showElementById(html, 'mainContent');
+  html = replaceOpeningTagById(html, 'mainContent', (openingTag) => (
+    openingTag.includes('data-server-rendered=')
+      ? openingTag
+      : openingTag.replace(/>$/, ' data-server-rendered="true">')
+  ));
+  return html;
 }
 
 function buildRobotsTxt(baseUrl: string, hostLabel: string): string {
@@ -1142,6 +1485,16 @@ export class HTTPServer {
           }
           filePath = path.join(publicPath, ...segments, 'index.html');
           html = await fs.readFile(filePath, 'utf-8');
+        }
+
+        if (urlPath === '/stories' || urlPath === '/stories/' || urlPath === '/stories/index.html') {
+          try {
+            html = await injectStoriesSsrContent(html);
+          } catch (error) {
+            // Keep the client-rendered fallback available if a content query
+            // fails; a transient feed problem should not take down Stories.
+            logger.warn({ error }, 'Failed to server-render Stories content');
+          }
         }
 
         // Cross-domain session bridge: if on AdCP without a session cookie,
@@ -2443,7 +2796,7 @@ export class HTTPServer {
 
       res.json({
         authEnabled: AUTH_ENABLED,
-        slackInviteUrl: SLACK_INVITE_URL,
+        slackInviteUrl: SLACK_JOIN_GUIDE_URL,
         user,
       });
     });
@@ -2942,34 +3295,15 @@ export class HTTPServer {
       }
     });
 
-    // Perspectives detail page - serves article content with SSR meta tags for social sharing
+    // Perspectives detail page - serves article content and metadata in the
+    // initial HTML so search engines and LLM crawlers do not need JavaScript.
     this.app.get("/perspectives/:slug", async (req, res) => {
       const { slug } = req.params;
 
-      // Fetch article data for meta tags (social crawlers don't execute JS)
-      interface ArticleMetaData {
-        title: string;
-        excerpt?: string;
-        subtitle?: string;
-        featured_image_url?: string;
-        author_name?: string;
-        published_at?: string;
-        updated_at?: string;
-      }
-      let article: ArticleMetaData | null = null;
+      let article: PublicPerspectiveArticle | null = null;
       try {
-        const pool = getPool();
-        const result = await pool.query(
-          `SELECT p.title, p.excerpt, p.subtitle, p.featured_image_url, p.author_name, p.published_at, p.updated_at
-           FROM perspectives p
-           LEFT JOIN working_groups wg ON wg.id = p.working_group_id
-           WHERE p.slug = $1 AND p.status = 'published'
-             AND (p.working_group_id IS NULL OR wg.slug = 'editorial')`,
-          [slug]
-        );
-        if (result.rows.length > 0) {
-          article = result.rows[0];
-        } else {
+        article = await getPublicPerspectiveArticle(slug);
+        if (!article) {
           // The article shell renders its own "Article Not Found" state after
           // hydration. Preserve that UI while returning the correct HTTP
           // status to crawlers and other clients.
@@ -2979,17 +3313,40 @@ export class HTTPServer {
         logger.warn({ error, slug }, 'Failed to fetch article for meta tags');
       }
 
-      // Serve HTML with meta tags injected
-      await serveHtmlWithMetaTags(req, res, 'perspectives/article.html', article ? {
+      if (!article) {
+        await serveHtmlWithMetaTags(req, res, 'perspectives/article.html');
+        return;
+      }
+
+      const articlePath = process.env.NODE_ENV === 'production'
+        ? path.join(__dirname, '../server/public/perspectives/article.html')
+        : path.join(__dirname, '../public/perspectives/article.html');
+      let html = await fs.readFile(articlePath, 'utf-8');
+      html = injectMetaTagsIntoHtml(html, {
         title: article.title,
         description: article.excerpt || article.subtitle || article.title,
         image: article.featured_image_url || 'https://agenticadvertising.org/AAo-social.png',
-        url: `https://agenticadvertising.org/perspectives/${slug}`,
+        url: `${PUBLIC_SITE_URL}/perspectives/${encodeURIComponent(slug)}`,
         type: 'article',
-        author: article.author_name,
-        publishedAt: article.published_at,
-        modifiedAt: article.updated_at,
-      } : undefined);
+        author: article.author_name || undefined,
+        publishedAt: metaDate(article.published_at),
+        modifiedAt: metaDate(article.updated_at),
+      });
+      html = injectPerspectiveArticleContent(html, article);
+
+      const user = await getUserFromRequest(req, res);
+      await enrichUserWithMembership(user);
+      await enrichUserWithAdmin(user);
+      const configScript = getAppConfigScript(user);
+      html = html.includes('</head>')
+        ? html.replace('</head>', `${configScript}\n</head>`)
+        : html.replace('<body', `${configScript}\n<body`);
+
+      res.setHeader('Content-Type', 'text/html');
+      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+      res.setHeader('Pragma', 'no-cache');
+      res.setHeader('Expires', '0');
+      res.send(html);
     });
 
     // Legacy redirects
@@ -6188,6 +6545,7 @@ export class HTTPServer {
            FROM perspectives p
            LEFT JOIN working_groups wg ON wg.id = p.working_group_id
            WHERE p.status = 'published'
+             AND p.is_members_only = false
              AND p.content_type = 'article'
              AND (p.working_group_id IS NULL OR wg.slug = 'editorial')
              AND (p.source_type IS NULL OR p.source_type NOT IN ('rss', 'email'))
@@ -6267,6 +6625,7 @@ export class HTTPServer {
           LEFT JOIN users u ON u.workos_user_id = p.author_user_id AND u.is_public = true
           LEFT JOIN working_groups wg ON wg.id = p.working_group_id
           WHERE p.status = 'published'
+            AND p.is_members_only = false
             AND (p.working_group_id IS NULL OR wg.slug = 'editorial')
             ${authored ? "AND (p.source_type IS NULL OR p.source_type NOT IN ('rss', 'email'))" : ''}
           ORDER BY p.published_at DESC NULLS LAST
@@ -6312,7 +6671,8 @@ export class HTTPServer {
           ) pa_report ON true
           WHERE p.slug = $1
             AND (
-              (p.status = 'published' AND (p.working_group_id IS NULL OR wg.slug = 'editorial'))
+              (p.status = 'published' AND p.is_members_only = false
+                AND (p.working_group_id IS NULL OR wg.slug = 'editorial'))
               OR ($2::text IS NOT NULL AND p.status IN ('draft', 'pending_review') AND (
                 p.author_user_id = $2
                 OR EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $2)
@@ -6351,7 +6711,7 @@ export class HTTPServer {
           `SELECT p.id, pa.file_name
            FROM perspectives p
            JOIN perspective_assets pa ON pa.perspective_id = p.id AND pa.asset_type = 'report'
-           WHERE p.slug = $1 AND p.status = 'published'
+           WHERE p.slug = $1 AND p.status = 'published' AND p.is_members_only = false
            LIMIT 1`,
           [slug]
         );
@@ -6384,16 +6744,20 @@ export class HTTPServer {
       try {
         const { slug } = req.params;
         const now = Date.now();
-        const cached = cardImageCache.get(slug);
-        if (cached && cached.expires > now) {
-          res.set('Content-Type', 'image/png');
-          res.set('Cache-Control', 'public, max-age=86400');
-          return res.send(cached.buffer);
-        }
-
+        // Re-check public eligibility before consulting the image cache so a
+        // visibility change cannot leave a cached card anonymously available.
         const perspective = await getPerspectiveWithIllustration(slug);
         if (!perspective) {
           return res.status(404).send('Not found');
+        }
+
+        const cached = cardImageCache.get(slug);
+        if (cached && cached.expires > now) {
+          res.set('Content-Type', 'image/png');
+          // Visibility is checked above on every request. Require shared caches
+          // to revalidate too, so unpublishing a perspective revokes its card.
+          res.set('Cache-Control', 'public, max-age=0, must-revalidate');
+          return res.send(cached.buffer);
         }
 
         const cardOpts = {
@@ -6419,7 +6783,7 @@ export class HTTPServer {
         cardImageCache.set(slug, { buffer: png, expires: now + 86400000 });
 
         res.set('Content-Type', 'image/png');
-        res.set('Cache-Control', 'public, max-age=86400');
+        res.set('Cache-Control', 'public, max-age=0, must-revalidate');
         return res.send(png);
       } catch (error) {
         logger.error({ err: error, slug: req.params.slug }, 'Card image generation error');
@@ -6442,11 +6806,15 @@ export class HTTPServer {
         const userId = req.user?.id ?? null;
 
         const perspResult = await pool.query(
-          `SELECT p.id FROM perspectives p
+          `SELECT p.id,
+                  (p.status = 'published' AND p.is_members_only = false
+                    AND (p.working_group_id IS NULL OR wg.slug = 'editorial')) AS is_public
+           FROM perspectives p
            LEFT JOIN working_groups wg ON wg.id = p.working_group_id
            WHERE p.slug = $1
              AND (
-               (p.status = 'published' AND (p.working_group_id IS NULL OR wg.slug = 'editorial'))
+               (p.status = 'published' AND p.is_members_only = false
+                 AND (p.working_group_id IS NULL OR wg.slug = 'editorial'))
                OR ($2::text IS NOT NULL AND p.status IN ('draft', 'pending_review') AND (
                  p.author_user_id = $2
                  OR EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $2)
@@ -6458,7 +6826,8 @@ export class HTTPServer {
           return res.status(404).send('Not found');
         }
 
-        const asset = await getPerspectiveAssetData(perspResult.rows[0].id, filename);
+        const { id, is_public: isPublic } = perspResult.rows[0];
+        const asset = await getPerspectiveAssetData(id, filename);
         if (!asset) {
           return res.status(404).send('Asset not found');
         }
@@ -6467,7 +6836,10 @@ export class HTTPServer {
         res.setHeader('Content-Type', contentType);
         res.setHeader('X-Content-Type-Options', 'nosniff');
         res.setHeader('Content-Security-Policy', "default-src 'none'");
-        res.setHeader('Cache-Control', 'public, max-age=86400');
+        res.setHeader(
+          'Cache-Control',
+          isPublic ? 'public, max-age=0, must-revalidate' : 'private, no-store'
+        );
         res.setHeader('Content-Disposition', `inline; filename="${encodeURIComponent(asset.file_name)}"`);
         res.setHeader('Content-Length', asset.file_data.length);
         res.send(asset.file_data);

--- a/server/src/newsletters/the-build/builder.ts
+++ b/server/src/newsletters/the-build/builder.ts
@@ -348,6 +348,7 @@ async function buildContributorSpotlight(): Promise<BuildContributor[]> {
        JOIN content_authors ca ON ca.perspective_id = p.id
        JOIN users u ON u.workos_user_id = ca.user_id
        WHERE p.status = 'published'
+         AND p.is_members_only = false
          AND p.published_at > NOW() - INTERVAL '14 days'
          AND p.content_origin = 'member'
        ORDER BY p.published_at DESC

--- a/server/src/routes/latest.ts
+++ b/server/src/routes/latest.ts
@@ -33,6 +33,7 @@ async function getResearchArticleCount(): Promise<number> {
      FROM perspectives p
      JOIN working_groups wg ON p.working_group_id = wg.id
      WHERE p.status = 'published'
+       AND p.is_members_only = false
        AND wg.slug = 'editorial'
        AND (p.source_type IS NULL OR p.source_type NOT IN ('rss', 'email'))`
   );
@@ -257,6 +258,7 @@ export function createLatestRouter(): {
            FROM perspectives p
            JOIN working_groups wg ON p.working_group_id = wg.id
            WHERE p.status = 'published'
+             AND p.is_members_only = false
              AND wg.slug = 'editorial'
              AND (p.source_type IS NULL OR p.source_type NOT IN ('rss', 'email'))
            ORDER BY p.published_at DESC NULLS LAST

--- a/server/tests/integration/perspective-assets.test.ts
+++ b/server/tests/integration/perspective-assets.test.ts
@@ -276,7 +276,7 @@ describe('Perspective Assets Integration Tests', () => {
       expect(response.headers['content-type']).toBe('image/png');
       expect(response.headers['x-content-type-options']).toBe('nosniff');
       expect(response.headers['content-security-policy']).toBe("default-src 'none'");
-      expect(response.headers['cache-control']).toBe('public, max-age=86400');
+      expect(response.headers['cache-control']).toBe('public, max-age=0, must-revalidate');
       expect(response.body).toBeInstanceOf(Buffer);
     });
 

--- a/server/tests/unit/perspective-asset-cache-privacy.test.ts
+++ b/server/tests/unit/perspective-asset-cache-privacy.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  getAssetData: vi.fn(),
+  getPerspectiveWithIllustration: vi.fn(),
+  generatePerspectiveCard: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY ||= 'sk_test_perspective_asset_cache';
+  process.env.WORKOS_CLIENT_ID ||= 'client_test_perspective_asset_cache';
+});
+
+vi.mock('../../src/config.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/config.js')>('../../src/config.js');
+  return {
+    ...actual,
+    getDatabaseConfig: vi.fn().mockReturnValue({
+      connectionString: 'postgresql://localhost/test',
+    }),
+  };
+});
+
+vi.mock('../../src/db/client.js', () => ({
+  initializeDatabase: vi.fn(),
+  getPool: vi.fn().mockReturnValue({ query: mocks.query }),
+  query: (...args: unknown[]) => mocks.query(...args),
+  isDatabaseInitialized: vi.fn().mockReturnValue(true),
+  closeDatabase: vi.fn(),
+  healthCheck: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/db/migrate.js', () => ({
+  runMigrations: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/db/perspective-asset-db.js', () => ({
+  getAssetData: (...args: unknown[]) => mocks.getAssetData(...args),
+}));
+
+vi.mock('../../src/db/illustration-db.js', () => ({
+  getPerspectiveWithIllustration: (...args: unknown[]) => mocks.getPerspectiveWithIllustration(...args),
+  getIllustrationData: vi.fn(),
+}));
+
+vi.mock('../../src/services/perspective-cards.js', () => ({
+  generatePerspectiveCard: (...args: unknown[]) => mocks.generatePerspectiveCard(...args),
+  compositePerspectiveCard: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/auth.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/middleware/auth.js')>(
+    '../../src/middleware/auth.js',
+  );
+  return {
+    ...actual,
+    optionalAuth: (req: Express.Request, _res: Express.Response, next: () => void) => {
+      const userId = req.header('x-test-user');
+      if (userId) {
+        req.user = { id: userId, email: `${userId}@example.test` } as Express.Request['user'];
+      }
+      next();
+    },
+  };
+});
+
+import { HTTPServer } from '../../src/http.js';
+
+describe('perspective asset cache privacy', () => {
+  let server: HTTPServer | undefined;
+
+  beforeEach(() => {
+    mocks.query.mockReset();
+    mocks.getAssetData.mockReset();
+    mocks.getPerspectiveWithIllustration.mockReset();
+    mocks.generatePerspectiveCard.mockReset();
+  });
+
+  afterEach(async () => {
+    await server?.stop();
+    server = undefined;
+  });
+
+  function app() {
+    server = new HTTPServer();
+    return (server as unknown as { app: unknown }).app;
+  }
+
+  it.each([
+    [true, undefined, 'public, max-age=0, must-revalidate'],
+    [false, 'draft-author', 'private, no-store'],
+  ])('sets visibility-aware asset caching when is_public=%s', async (isPublic, userId, expected) => {
+    mocks.query.mockResolvedValueOnce({ rows: [{ id: 'perspective-1', is_public: isPublic }] });
+    mocks.getAssetData.mockResolvedValueOnce({
+      file_data: Buffer.from('asset bytes'),
+      file_mime_type: 'image/png',
+      file_name: 'cover.png',
+    });
+
+    let req = request(app()).get('/api/perspectives/example/assets/cover.png');
+    if (userId) req = req.set('x-test-user', userId);
+    const res = await req;
+
+    expect(res.status).toBe(200);
+    expect(res.headers['cache-control']).toBe(expected);
+    expect(mocks.query).toHaveBeenCalledWith(
+      expect.stringContaining('AS is_public'),
+      ['example', userId ?? null],
+    );
+    expect(mocks.getAssetData).toHaveBeenCalledWith('perspective-1', 'cover.png');
+  });
+
+  it('requires shared caches to revalidate generated and in-process cached cards', async () => {
+    mocks.getPerspectiveWithIllustration.mockResolvedValue({
+      title: 'Public perspective',
+      category: 'Research',
+      author_name: 'Avery Writer',
+      author_title: 'Editor',
+      illustration_id: null,
+    });
+    mocks.generatePerspectiveCard.mockResolvedValue(Buffer.from('png bytes'));
+
+    const httpApp = app();
+    const first = await request(httpApp).get('/api/perspectives/example/card.png');
+    const cached = await request(httpApp).get('/api/perspectives/example/card.png');
+
+    expect(first.status).toBe(200);
+    expect(cached.status).toBe(200);
+    expect(first.headers['cache-control']).toBe('public, max-age=0, must-revalidate');
+    expect(cached.headers['cache-control']).toBe('public, max-age=0, must-revalidate');
+    expect(mocks.getPerspectiveWithIllustration).toHaveBeenCalledTimes(2);
+    expect(mocks.generatePerspectiveCard).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/tests/unit/perspectives-crawlability.test.ts
+++ b/server/tests/unit/perspectives-crawlability.test.ts
@@ -108,6 +108,7 @@ describe('Perspectives crawlability routes', () => {
     expect(res.text).toContain('[Perspectives RSS feed](<https://agenticadvertising.org/perspectives/feed.xml>)');
     expect(res.text).not.toContain('# AdCP - Ad Context Protocol');
     expect(queryMock).toHaveBeenCalledWith(expect.stringContaining("p.status = 'published'"), [200]);
+    expect(queryMock).toHaveBeenCalledWith(expect.stringContaining('p.is_members_only = false'), [200]);
   });
 
   it('normalizes legacy URLs, fails closed on controls, and contains Markdown delimiters', async () => {
@@ -195,6 +196,7 @@ describe('Perspectives crawlability routes', () => {
     expect(res.status).toBe(200);
     expect(res.text).toContain('https://agenticadvertising.org/perspectives/agentic-crawlability');
     expect(queryMock).toHaveBeenCalledWith(expect.stringContaining("p.content_type = 'article'"));
+    expect(queryMock).toHaveBeenCalledWith(expect.stringContaining('p.is_members_only = false'));
     expect(queryMock).toHaveBeenCalledWith(expect.stringContaining("p.source_type IS NULL OR p.source_type NOT IN ('rss', 'email')"));
   });
 
@@ -229,6 +231,140 @@ describe('Perspectives crawlability routes', () => {
     expect(queryMock).toHaveBeenCalledWith(
       expect.stringContaining("p.status = 'published'"),
       ['does-not-exist']
+    );
+  });
+
+  it('server-renders published perspective content and sanitizes stored markdown', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [{
+        slug: 'crawlable-article',
+        title: 'Crawlable <Perspective>',
+        subtitle: 'Readable before JavaScript runs',
+        category: 'Research',
+        excerpt: 'An article that crawlers can read.',
+        content: '## Initial HTML\n\nThe complete article body is here.\n\n| Safe | Table |\n| --- | --- |\n| Cell | Value |\n\n<script>alert("stored-xss")</script>\n\n<img src="x" onerror="alert(1)">\n\n<form action="https://evil.test/steal" style="position:fixed;inset:0"><input type="password"><button>Sign in</button></form>',
+        author_name: 'Avery Writer',
+        author_title: 'Editor',
+        author_slug: 'avery-writer',
+        featured_image_url: null,
+        published_at: new Date('2026-06-01T12:00:00Z'),
+        updated_at: new Date('2026-06-02T12:00:00Z'),
+        tags: ['agentic', 'research'],
+        like_count: 4,
+      }],
+    });
+
+    const httpApp = app();
+    const res = await request(httpApp)
+      .get('/perspectives/crawlable-article')
+      .set('Host', 'agenticadvertising.org');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('<title id="pageTitle">Crawlable &lt;Perspective&gt; | AgenticAdvertising.org</title>');
+    expect(res.text).toContain('<h1 id="heroTitle">Crawlable &lt;Perspective&gt;</h1>');
+    expect(res.text).toContain('<h2>Initial HTML</h2>');
+    expect(res.text).toContain('The complete article body is here.');
+    expect(res.text).toContain('<table>');
+    expect(res.text).toContain('<td>Cell</td>');
+    expect(res.text).toContain('href="/community/people/avery-writer"');
+    expect(res.text).toContain('id="loadingState" class="loading-state" hidden');
+    expect(res.text).toContain('data-server-rendered="true"');
+    expect(res.text).not.toContain('alert("stored-xss")');
+    expect(res.text).not.toContain('onerror="alert(1)"');
+    expect(res.text).not.toContain('<form');
+    expect(res.text).not.toContain('<input');
+    expect(res.text).not.toContain('position:fixed');
+    expect(res.text).not.toContain('evil.test');
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('p.is_members_only = false'),
+      ['crawlable-article']
+    );
+
+  });
+
+  it('server-renders Stories cards and news while retaining safe link boundaries', async () => {
+    queryMock
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            slug: 'official-report',
+            title: 'Official <Report>',
+            subtitle: null,
+            category: 'Research',
+            excerpt: 'The official summary.',
+            external_url: null,
+            author_name: 'Avery Writer',
+            featured_image_url: null,
+            published_at: new Date('2026-06-01T12:00:00Z'),
+            tags: ['strategy'],
+            content_origin: 'official',
+          },
+          ...Array.from({ length: 6 }, (_, index) => ({
+            slug: `official-report-${index + 2}`,
+            title: `Official report ${index + 2}`,
+            subtitle: null,
+            category: 'Research',
+            excerpt: `Official summary ${index + 2}.`,
+            external_url: null,
+            author_name: 'Avery Writer',
+            featured_image_url: null,
+            published_at: new Date('2026-05-31T12:00:00Z'),
+            tags: ['strategy'],
+            content_origin: 'official',
+          })),
+          {
+            slug: 'member-view',
+            title: 'Member View',
+            subtitle: null,
+            category: 'Perspective',
+            excerpt: 'A member contribution.',
+            external_url: 'javascript:alert(1)',
+            author_name: 'Casey Member',
+            featured_image_url: null,
+            published_at: new Date('2026-05-30T12:00:00Z'),
+            tags: ['agentic'],
+            content_origin: 'member',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          title: 'Industry &amp; Agents',
+          source_url: 'https://news.example/agents',
+          summary: 'A useful &amp; safe summary.',
+          addie_notes: null,
+          relevance_tags: ['ai-agents'],
+          feed_name: 'Example News',
+        }],
+      });
+
+    const httpApp = app();
+    const res = await request(httpApp).get('/stories').set('Host', 'agenticadvertising.org');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Official &lt;Report&gt;');
+    expect(res.text).toContain('Official report 7');
+    expect(res.text).toContain('href="/perspectives/member-view"');
+    expect(res.text).not.toContain('javascript:alert(1)');
+    expect(res.text).toContain('href="https://news.example/agents"');
+    expect(res.text).toContain('Industry &amp; Agents');
+    expect(res.text).toContain('A useful &amp; safe summary.');
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    expect(queryMock.mock.calls[0][0]).toContain('p.is_members_only = false');
+
+  });
+
+  it('keeps members-only perspectives out of the anonymous JSON API', async () => {
+    queryMock.mockResolvedValueOnce({ rows: perspectiveRows });
+
+    const res = await request(app())
+      .get('/api/perspectives')
+      .set('Host', 'agenticadvertising.org');
+
+    expect(res.status).toBe(200);
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('p.is_members_only = false'),
+      [100]
     );
   });
 

--- a/server/tests/unit/public-external-url-sinks.test.ts
+++ b/server/tests/unit/public-external-url-sinks.test.ts
@@ -105,7 +105,7 @@ describe('public external URL navigation guard', () => {
     const source = readFileSync(join(publicRoot, 'working-groups/detail.html'), 'utf8');
     const httpSource = readFileSync(join(process.cwd(), 'server/src/http.ts'), 'utf8');
 
-    expect(httpSource).toContain('slackInviteUrl: SLACK_INVITE_URL');
+    expect(httpSource).toContain('slackInviteUrl: SLACK_JOIN_GUIDE_URL');
     expect(httpSource).toContain('isLinkedToSlack,');
     expect(source).toContain('isLinkedToSlack = config.user?.isLinkedToSlack === true');
     expect(source).toContain('const slackCta = resolveSlackCta({');

--- a/server/tests/unit/rules-loader.test.ts
+++ b/server/tests/unit/rules-loader.test.ts
@@ -123,6 +123,16 @@ describe('Addie tool reference', () => {
     expect(rules).toContain("aren't loaded in this conversation");
   });
 
+  it('uses a valid human-action escalation category for failed Slack invites', () => {
+    const rules = loadRules();
+    const slackRules = rules.slice(
+      rules.indexOf('## Slack Invite Domain Restrictions'),
+      rules.indexOf('## Email Verification and Notification Failures')
+    );
+    expect(slackRules).toContain('category `needs_human_action`');
+    expect(slackRules).not.toContain("'invite' category");
+  });
+
   it('every tool in the public docs page is also referenced in the prompt catalog', async () => {
     // The two outputs of build-addie-tool-reference share a registration
     // source but use different render paths (`render` for the docs page,

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -7,6 +7,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const vm = require('vm');
 
 const DOCS_JSON = path.join(__dirname, '../docs.json');
 
@@ -212,6 +213,121 @@ for (const versionEntry of navigation.versions) {
 test('page files belong to only one version', () => {
   if (crossVersionDuplicates.length > 0) {
     throw new Error(`Pages referenced across versions:\n      ${crossVersionDuplicates.join('\n      ')}`);
+  }
+});
+
+test('live docs route Slack invitations through the joining guide', () => {
+  const liveVersion = navigation.versions.find(version => version.default)
+    || navigation.versions[0];
+  const directInvitePages = [];
+
+  for (const page of collectPages(liveVersion.groups).filter(page => page.startsWith('docs/'))) {
+    if (page === 'docs/community/joining-slack') continue;
+    const filePath = fs.existsSync(path.join(rootDir, `${page}.mdx`))
+      ? path.join(rootDir, `${page}.mdx`)
+      : path.join(rootDir, `${page}.md`);
+    const content = fs.readFileSync(filePath, 'utf8');
+    if (content.includes('https://join.slack.com/')) directInvitePages.push(page);
+  }
+
+  if (directInvitePages.length > 0) {
+    throw new Error(
+      `Direct Slack invites bypass the joining guide: ${directInvitePages.join(', ')}`
+    );
+  }
+
+  const currentEntryPoints = [
+    'CHARTER.md',
+    'CONTRIBUTORS.md',
+    'docs.json',
+    'server/public/dashboard.html',
+    'server/public/dashboard-membership.html',
+  ];
+  const directInviteEntryPoints = currentEntryPoints.filter(relativePath => (
+    fs.readFileSync(path.join(rootDir, relativePath), 'utf8').includes('https://join.slack.com/')
+  ));
+  if (directInviteEntryPoints.length > 0) {
+    throw new Error(
+      `Slack entry points bypass the joining guide: ${directInviteEntryPoints.join(', ')}`
+    );
+  }
+
+  // Mintlify temporarily redirects live routes to immutable 3.1.2 snapshots.
+  // Its global custom-script support lets us repair stale invite anchors at
+  // render time without mutating those release artifacts.
+  const recoveryScript = fs.readFileSync(
+    path.join(rootDir, 'docs/slack-invite-recovery.js'),
+    'utf8'
+  );
+  if (!recoveryScript.includes('a[href^="https://join.slack.com/"]')
+      || !recoveryScript.includes('https://docs.adcontextprotocol.org/docs/community/joining-slack')
+      || !recoveryScript.includes('MutationObserver')) {
+    throw new Error('The global Slack recovery script must rewrite direct invite anchors, including dynamically rendered ones');
+  }
+
+  const loadRecoveryHarness = routePath => {
+    const directInvite = 'https://join.slack.com/t/agenticads/shared_invite/example';
+    const makeElement = (href = directInvite, text = '') => ({
+      nodeType: 1,
+      href,
+      textNodes: text ? [{ nodeValue: text }] : [],
+      matches: selector => selector.includes('join.slack.com') && href.startsWith('https://join.slack.com/'),
+      querySelectorAll: () => [],
+    });
+    const initialAnchor = makeElement();
+    const document = {
+      readyState: 'complete',
+      documentElement: {},
+      textNodes: [],
+      querySelectorAll: () => [initialAnchor],
+      createTreeWalker: root => {
+        let index = 0;
+        return { nextNode: () => (root.textNodes || [])[index++] || null };
+      },
+    };
+    let observerCallback;
+    class MutationObserver {
+      constructor(callback) { observerCallback = callback; }
+      observe() {}
+    }
+    const window = { location: { pathname: routePath } };
+    vm.runInNewContext(recoveryScript, {
+      window,
+      document,
+      MutationObserver,
+      Node: { ELEMENT_NODE: 1, TEXT_NODE: 3 },
+      NodeFilter: { SHOW_TEXT: 4 },
+    });
+    return {
+      directInvite,
+      initialAnchor,
+      makeElement,
+      navigate(pathname) { window.location.pathname = pathname; },
+      add(node) { observerCallback([{ addedNodes: [node] }]); },
+    };
+  };
+
+  const guideUrl = 'https://docs.adcontextprotocol.org/docs/community/joining-slack';
+  const harness = loadRecoveryHarness('/dist/docs/3.1.2/intro');
+  if (harness.initialAnchor.href !== guideUrl) {
+    throw new Error('Snapshot pages must rewrite their direct Slack invite to the recovery guide');
+  }
+
+  harness.navigate('/dist/docs/3.1.2/community/joining-slack');
+  const guideContent = harness.makeElement(harness.directInvite, 'For AAO members only');
+  harness.add(guideContent);
+  if (guideContent.href !== harness.directInvite) {
+    throw new Error('SPA navigation to the joining guide must preserve its direct Slack invite');
+  }
+  if (guideContent.textNodes[0].nodeValue.includes('AAO members')) {
+    throw new Error('The joining guide must repair legacy organization terminology');
+  }
+
+  harness.navigate('/dist/docs/3.1.2/intro');
+  const introContent = harness.makeElement();
+  harness.add(introContent);
+  if (introContent.href !== guideUrl) {
+    throw new Error('SPA navigation away from the joining guide must resume invite rewriting');
   }
 });
 

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -62,6 +62,20 @@ function collectGroups(node) {
   return groups;
 }
 
+function isDirectSlackInvite(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' && url.hostname === 'join.slack.com';
+  } catch {
+    return false;
+  }
+}
+
+function containsDirectSlackInvite(content) {
+  const urls = content.match(/https?:\/\/[^\s)\]>'\"]+/g) || [];
+  return urls.some(isDirectSlackInvite);
+}
+
 // --- Run tests ---
 
 log('\n🧪 Docs Navigation Validation Tests');
@@ -227,7 +241,7 @@ test('live docs route Slack invitations through the joining guide', () => {
       ? path.join(rootDir, `${page}.mdx`)
       : path.join(rootDir, `${page}.md`);
     const content = fs.readFileSync(filePath, 'utf8');
-    if (content.includes('https://join.slack.com/')) directInvitePages.push(page);
+    if (containsDirectSlackInvite(content)) directInvitePages.push(page);
   }
 
   if (directInvitePages.length > 0) {
@@ -244,7 +258,7 @@ test('live docs route Slack invitations through the joining guide', () => {
     'server/public/dashboard-membership.html',
   ];
   const directInviteEntryPoints = currentEntryPoints.filter(relativePath => (
-    fs.readFileSync(path.join(rootDir, relativePath), 'utf8').includes('https://join.slack.com/')
+    containsDirectSlackInvite(fs.readFileSync(path.join(rootDir, relativePath), 'utf8'))
   ));
   if (directInviteEntryPoints.length > 0) {
     throw new Error(
@@ -259,19 +273,15 @@ test('live docs route Slack invitations through the joining guide', () => {
     path.join(rootDir, 'docs/slack-invite-recovery.js'),
     'utf8'
   );
-  if (!recoveryScript.includes('a[href^="https://join.slack.com/"]')
-      || !recoveryScript.includes('https://docs.adcontextprotocol.org/docs/community/joining-slack')
-      || !recoveryScript.includes('MutationObserver')) {
-    throw new Error('The global Slack recovery script must rewrite direct invite anchors, including dynamically rendered ones');
-  }
-
   const loadRecoveryHarness = routePath => {
     const directInvite = 'https://join.slack.com/t/agenticads/shared_invite/example';
     const makeElement = (href = directInvite, text = '') => ({
       nodeType: 1,
       href,
       textNodes: text ? [{ nodeValue: text }] : [],
-      matches: selector => selector.includes('join.slack.com') && href.startsWith('https://join.slack.com/'),
+      matches: selector => (
+        selector === 'a[href^="https://join.slack.com/"]' && isDirectSlackInvite(href)
+      ),
       querySelectorAll: () => [],
     });
     const initialAnchor = makeElement();
@@ -311,6 +321,13 @@ test('live docs route Slack invitations through the joining guide', () => {
   const harness = loadRecoveryHarness('/dist/docs/3.1.2/intro');
   if (harness.initialAnchor.href !== guideUrl) {
     throw new Error('Snapshot pages must rewrite their direct Slack invite to the recovery guide');
+  }
+
+  const lookalikeUrl = 'https://attacker.example/?next=https://join.slack.com/t/example';
+  const lookalikeAnchor = harness.makeElement(lookalikeUrl);
+  harness.add(lookalikeAnchor);
+  if (lookalikeAnchor.href !== lookalikeUrl) {
+    throw new Error('Slack invite recovery must not rewrite URLs on unrelated hosts');
   }
 
   harness.navigate('/dist/docs/3.1.2/community/joining-slack');


### PR DESCRIPTION
## What

- Server-render the stories index and perspective articles so crawlers and no-JavaScript clients receive complete public content.
- Keep members-only and non-editorial working-group content out of public pages, feeds, sitemaps, APIs, cards, assets, digests, newsletters, profiles, and Addie's docs index.
- Sanitize and size-bound perspective Markdown on both server and client render paths, and make draft assets private/non-cacheable while public assets and cards revalidate visibility.
- Route website, docs, and Addie Slack guidance through the maintained joining guide, with temporary runtime recovery for stale released-doc snapshots.
- Correct Addie's invalid Slack-invite escalation category and align organization terminology.

## Why

The affected perspective pages were JavaScript-only, public content selectors did not consistently apply the members-only boundary, and released docs snapshots embedded direct Slack invite links that could expire. These separate bugs produced crawlability failures, potential publication leaks, and brittle onboarding guidance.

## Impact

Public perspective content is crawlable before hydration, private/editorial boundaries are consistently enforced, stored Markdown is safely rendered, and Slack onboarding has one maintained recovery path across the site, docs, and Addie.

## Verification

- Full server unit suite: 403 files, 5,717 passed, 30 skipped
- Focused perspective/security/Addie tests: 53 passed
- Docs navigation: 21 passed
- Root unit/pre-commit checks: 1,040 passed plus lint gates
- TypeScript typecheck
- Changeset scope and status checks
- Pre-push schema-link and Mintlify navigation checks
- Runtime, security, and docs/Addie expert reviews

Fixes #4432
Fixes #5357
Fixes #6364
