### PR TITLE
fix(request-signing): align vector CLI guidance

### DIFF
--- a/.changeset/fix-request-signing-vector-counts.md
+++ b/.changeset/fix-request-signing-vector-counts.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": patch
 ---
 
-Remove hard-coded request-signing conformance vector counts from the compliance runner header and request-signing documentation. The guidance now describes the applicable profile and vector directories without totals, so future fixture additions cannot make the prose stale. Comment and documentation text only — no schema, runner logic, or generated artifact is affected.
+Remove hard-coded request-signing conformance vector counts from the compliance runner header and request-signing documentation. The examples now cover both vector directories without totals and explicitly supply matching local vector and key inputs instead of relying on package-internal cache paths. This changes only protocol comments and documentation, not schemas or runner behavior; documentation drift linting and its regression tests are also hardened to preserve the corrected CLI guidance.

--- a/docs/building/by-layer/L1/request-signing.mdx
+++ b/docs/building/by-layer/L1/request-signing.mdx
@@ -717,9 +717,25 @@ The spec ships legacy-profile wire vectors, dedicated 3.2 wire vectors, and the 
 - **Profile-3.2 wire vectors**: body-bound positives and rejections of malformed RFC 8941 `sf-binary`
 
 ```bash
-# Debug a single vector
-adcp signing verify-vector \
-  --vector compliance/cache/3.0.0/test-vectors/request-signing/positive/001-basic-post.json
+# Debug a single vector with the matching public key fixture.
+# Use "latest" for convenience. Pin and record exact released values for both
+# versions when you need to reproduce a verifier debugging run.
+VECTOR_VERSION=latest
+SDK_VERSION=latest
+VECTOR_DIR="$(mktemp -d)"
+trap 'rm -rf "$VECTOR_DIR"' EXIT
+VECTOR_BASE="https://adcontextprotocol.org/compliance/${VECTOR_VERSION}/test-vectors/request-signing"
+
+curl --fail --silent --show-error \
+  --output "${VECTOR_DIR}/vector.json" \
+  "${VECTOR_BASE}/positive/001-basic-post.json"
+curl --fail --silent --show-error \
+  --output "${VECTOR_DIR}/keys.json" \
+  "${VECTOR_BASE}/keys.json"
+
+npx "@adcp/sdk@${SDK_VERSION}" signing verify-vector \
+  --vector "${VECTOR_DIR}/vector.json" \
+  --keys "${VECTOR_DIR}/keys.json"
 ```
 
 ### Grade your verifier

--- a/docs/building/verification/grading.mdx
+++ b/docs/building/verification/grading.mdx
@@ -76,7 +76,7 @@ npx @adcp/sdk@latest signing verify-vector \
 
 Reads the local vector and key-set JSON files and runs the SDK reference verifier. For a self-contained negative vector, compare the reported rejection code with the fixture's `expected_outcome.error_code`; the CLI does not grade that comparison for you and exits with status 1 for an expected rejection. Shell scripts and CI jobs must therefore compare the output rather than treating every nonzero exit as an unexpected tool failure.
 
-Some negative fixtures declare `test_harness_state` and require verifier setup outside the vector itself. For example, `016-replayed-nonce.json` requires a preloaded replay-cache entry and cannot be meaningfully checked by a one-shot CLI invocation. Use the fixture's declared harness state or the full grader for those cases. See the request-signing guide's [downloadable vector example](/docs/building/by-layer/L1/request-signing#conformance-vectors) for a copyable CDN flow.
+Some negative fixtures declare `test_harness_state` and are not self-contained. For example, `016-replayed-nonce.json` requires the verifier harness to preload a replay-cache entry. A local white-box harness can apply the fixture's declared state; live black-box certification uses the full grader's coordinated repeat-request contract. See the request-signing guide's [downloadable vector example](/docs/building/by-layer/L1/request-signing#conformance-vectors) for a copyable CDN flow.
 
 **When to use it:** while implementing or debugging a verifier to isolate canonicalization and validation rules before testing end-to-end.
 

--- a/docs/building/verification/grading.mdx
+++ b/docs/building/verification/grading.mdx
@@ -69,12 +69,16 @@ Outputs:
 Verify a single signing vector without running the full grader. Useful for debugging a specific canonicalization case during implementation.
 
 ```bash
-npx @adcp/sdk@latest signing verify-vector
+npx @adcp/sdk@latest signing verify-vector \
+  --vector /path/to/vector.json \
+  --keys /path/to/keys.json
 ```
 
-Reads a vector from stdin (JSON matching the test-vector schema at [`/compliance/latest/test-vectors/request-signing/`](https://adcontextprotocol.org/compliance/latest/test-vectors/request-signing/)) and reports whether your client's signature base matches the expected output.
+Reads the local vector and key-set JSON files and runs the SDK reference verifier. For a self-contained negative vector, compare the reported rejection code with the fixture's `expected_outcome.error_code`; the CLI does not grade that comparison for you and exits with status 1 for an expected rejection. Shell scripts and CI jobs must therefore compare the output rather than treating every nonzero exit as an unexpected tool failure.
 
-**When to use it:** while implementing a signing client to confirm each component rule in isolation before testing end-to-end.
+Some negative fixtures declare `test_harness_state` and require verifier setup outside the vector itself. For example, `016-replayed-nonce.json` requires a preloaded replay-cache entry and cannot be meaningfully checked by a one-shot CLI invocation. Use the fixture's declared harness state or the full grader for those cases. See the request-signing guide's [downloadable vector example](/docs/building/by-layer/L1/request-signing#conformance-vectors) for a copyable CDN flow.
+
+**When to use it:** while implementing or debugging a verifier to isolate canonicalization and validation rules before testing end-to-end.
 
 ## Related
 

--- a/scripts/lint-doc-compliance-drift.cjs
+++ b/scripts/lint-doc-compliance-drift.cjs
@@ -17,6 +17,7 @@ const path = require('node:path');
 
 const ROOT = path.resolve(__dirname, '..');
 const DEFAULT_DOC_PATH = path.join(ROOT, 'docs', 'building', 'by-layer', 'L1', 'request-signing.mdx');
+const DEFAULT_GRADING_DOC_PATH = path.join(ROOT, 'docs', 'building', 'verification', 'grading.mdx');
 const DEFAULT_CONTRACT_ROOT = path.join(
   ROOT,
   'static',
@@ -110,15 +111,61 @@ function extractDocCodeClaims(markdown) {
   return codes;
 }
 
+function extractFencedBlocks(markdown) {
+  const blocks = [];
+  const pattern = /^\s*(`{3,}|~{3,})[^\r\n]*\r?\n([\s\S]*?)^\s*\1\s*$/gm;
+  for (const match of markdown.matchAll(pattern)) blocks.push(match[2]);
+  return blocks;
+}
+
+function extractVerifyVectorCommands(block) {
+  return block
+    .replace(/\\\r?\n/g, ' ')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line && !line.startsWith('#'))
+    .filter(line => /\bsigning\s+verify-vector\b/.test(line));
+}
+
+function lintVerifyVectorGuidance(markdown, displayPath) {
+  const errors = [];
+  const commands = extractFencedBlocks(markdown).flatMap(extractVerifyVectorCommands);
+  if (commands.length === 0) {
+    errors.push(`${displayPath}: missing signing verify-vector invocation`);
+  }
+
+  for (const command of commands) {
+    if (/\bcompliance\/cache\/[^\s`"']+/.test(command)) {
+      errors.push(`${displayPath}: verify-vector invocations must not use package-internal compliance/cache paths`);
+    }
+    if (!/(?:^|\s)--vector(?:\s|=)/m.test(command)) {
+      errors.push(`${displayPath}: signing verify-vector invocation must pass --vector`);
+    }
+    if (!/(?:^|\s)--keys(?:\s|=)/m.test(command)) {
+      errors.push(`${displayPath}: signing verify-vector invocation must pass --keys`);
+    }
+  }
+
+  if (/\b(?:reads?|reading)\s+(?:a\s+)?vector\s+from\s+stdin\b/i.test(markdown)) {
+    errors.push(`${displayPath}: signing verify-vector reads local files, not stdin`);
+  }
+  return errors;
+}
+
 function lint({
   root = ROOT,
   docPath = DEFAULT_DOC_PATH,
+  gradingDocPath = DEFAULT_GRADING_DOC_PATH,
   contractRoot = DEFAULT_CONTRACT_ROOT,
 } = {}) {
   const contractCodes = collectContractCodes(contractRoot);
   const docCodes = extractDocCodeClaims(fs.readFileSync(docPath, 'utf8'));
   const displayPath = path.relative(root, docPath) || docPath;
+  const gradingDisplayPath = path.relative(root, gradingDocPath) || gradingDocPath;
   const errors = [];
+
+  errors.push(...lintVerifyVectorGuidance(fs.readFileSync(docPath, 'utf8'), displayPath));
+  errors.push(...lintVerifyVectorGuidance(fs.readFileSync(gradingDocPath, 'utf8'), gradingDisplayPath));
 
   if (docCodes === null) {
     errors.push(`${displayPath}: missing expected "### Error codes" section`);
@@ -164,5 +211,8 @@ module.exports = {
   collectContractCodes,
   extractDocCodeClaims,
   extractErrorCodesSection,
+  extractFencedBlocks,
+  extractVerifyVectorCommands,
+  lintVerifyVectorGuidance,
   lint,
 };

--- a/static/compliance/source/test-kits/signed-requests-runner.yaml
+++ b/static/compliance/source/test-kits/signed-requests-runner.yaml
@@ -4,8 +4,9 @@
 # `request_signing.supported: true` in get_adcp_capabilities).
 #
 # The signed-requests storyboard's current black-box contract grades the legacy
-# 3.1 RFC 9421 profile against conformance vectors at
-# /compliance/{version}/test-vectors/request-signing/negative/.
+# 3.1 RFC 9421 profile against all conformance vectors in the `positive/` and
+# `negative/` directories under
+# `/compliance/{version}/test-vectors/request-signing/`.
 # Most vectors are pure black-box: the runner constructs a signed HTTP request,
 # sends it, and checks the response. Three negative vectors assert behavior that
 # depends on verifier state the runner cannot set from the outside:

--- a/tests/lint-doc-compliance-drift.test.cjs
+++ b/tests/lint-doc-compliance-drift.test.cjs
@@ -13,6 +13,16 @@ const {
   lint,
 } = require('../scripts/lint-doc-compliance-drift.cjs');
 
+const VERIFY_VECTOR_BLOCK = `
+\`\`\`bash
+npx @adcp/sdk@latest signing verify-vector --vector /tmp/vector.json --keys /tmp/keys.json
+\`\`\`
+`;
+
+function withVerifyVector(markdown) {
+  return `${markdown}${VERIFY_VECTOR_BLOCK}`;
+}
+
 function makeFixture({ code = 'request_signature_required' } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-doc-compliance-drift-'));
   const contractRoot = path.join(
@@ -25,13 +35,17 @@ function makeFixture({ code = 'request_signature_required' } = {}) {
   );
   const negativeDir = path.join(contractRoot, 'negative');
   const docPath = path.join(root, 'docs', 'building', 'by-layer', 'L1', 'request-signing.mdx');
+  const gradingDocPath = path.join(root, 'docs', 'building', 'verification', 'grading.mdx');
   fs.mkdirSync(negativeDir, { recursive: true });
   fs.mkdirSync(path.dirname(docPath), { recursive: true });
+  fs.mkdirSync(path.dirname(gradingDocPath), { recursive: true });
   fs.writeFileSync(
     path.join(negativeDir, '001-required.json'),
     JSON.stringify({ expected_outcome: { success: false, error_code: code } }),
   );
-  return { root, contractRoot, docPath };
+  fs.writeFileSync(docPath, withVerifyVector('### Error codes\n'));
+  fs.writeFileSync(gradingDocPath, withVerifyVector('# Grading\n'));
+  return { root, contractRoot, docPath, gradingDocPath };
 }
 
 test('repository request-signing guide matches the current source vectors', () => {
@@ -42,7 +56,7 @@ test('repository request-signing guide matches the current source vectors', () =
 
 test('the original seven-code phantom table fails completely', () => {
   const fixture = makeFixture();
-  fs.writeFileSync(fixture.docPath, `# Guide
+  fs.writeFileSync(fixture.docPath, withVerifyVector(`# Guide
 
 ### Error codes
 
@@ -57,7 +71,7 @@ test('the original seven-code phantom table fails completely', () => {
 | \`unsupported_algorithm\` | unsupported |
 
 ## Related
-`);
+`));
 
   const result = lint(fixture);
   assert.equal(result.errors.length, 7);
@@ -78,7 +92,7 @@ test('a table grounded in a vector code passes', () => {
   const fixture = makeFixture();
   fs.writeFileSync(
     fixture.docPath,
-    '### Error codes\n\n| Code | Meaning |\n|---|---|\n| `request_signature_required` | missing |\n',
+    withVerifyVector('### Error codes\n\n| Code | Meaning |\n|---|---|\n| `request_signature_required` | missing |\n'),
   );
 
   const result = lint(fixture);
@@ -88,7 +102,7 @@ test('a table grounded in a vector code passes', () => {
 
 test('taxonomy prose and family references are outside the vector-code claim scope', () => {
   const fixture = makeFixture();
-  fs.writeFileSync(fixture.docPath, `# Guide
+  fs.writeFileSync(fixture.docPath, withVerifyVector(`# Guide
 
 The discovery path may return \`request_signature_brand_json_url_missing\`.
 
@@ -98,7 +112,7 @@ The \`brand_json_url\` field raises \`request_signature_brand_*\` and
 \`request_signature_key_origin_*\` families documented elsewhere.
 
 ## Related
-`);
+`));
 
   const result = lint(fixture);
   assert.deepEqual(result.errors, []);
@@ -117,7 +131,7 @@ Return \`request_signature_required\`. The \`request_signature_brand_*\` family 
 
 test('headings inside fenced examples do not terminate the guarded section', () => {
   const fixture = makeFixture();
-  fs.writeFileSync(fixture.docPath, `### Error codes
+  fs.writeFileSync(fixture.docPath, withVerifyVector(`### Error codes
 
 \`\`\`md
 ## Example response heading
@@ -128,7 +142,7 @@ test('headings inside fenced examples do not terminate the guarded section', () 
 | \`missing_signature\` | invented |
 
 ## Related
-`);
+`));
   const result = lint(fixture);
   assert.equal(result.errors.length, 1);
   assert.match(result.errors[0], /missing_signature/);
@@ -136,8 +150,87 @@ test('headings inside fenced examples do not terminate the guarded section', () 
 
 test('removing the guarded section fails instead of silently disabling the lint', () => {
   const fixture = makeFixture();
-  fs.writeFileSync(fixture.docPath, '# Guide\n\nNo taxonomy here.\n');
+  fs.writeFileSync(fixture.docPath, withVerifyVector('# Guide\n\nNo taxonomy here.\n'));
   const result = lint(fixture);
   assert.equal(result.errors.length, 1);
   assert.match(result.errors[0], /missing expected "### Error codes" section/);
+});
+
+test('package-internal request-signing cache paths fail', () => {
+  const fixture = makeFixture();
+  fs.writeFileSync(fixture.docPath, `### Error codes
+
+\`\`\`bash
+adcp signing verify-vector \\
+  --vector compliance/cache/3.0.0/test-vectors/request-signing/positive/001-basic-post.json \\
+  --keys compliance/cache/3.0.0/test-vectors/request-signing/keys.json
+\`\`\`
+`);
+
+  const result = lint(fixture);
+  assert.ok(result.errors.some(error => error.includes('package-internal compliance/cache')));
+});
+
+test('the old stdin-only verify-vector guidance fails required input checks', () => {
+  const fixture = makeFixture();
+  fs.writeFileSync(fixture.gradingDocPath, `# Grading
+
+\`\`\`bash
+npx @adcp/sdk@latest signing verify-vector
+\`\`\`
+
+Reads a vector from stdin and reports whether it matches the expected output.
+`);
+
+  const result = lint(fixture);
+  assert.ok(result.errors.some(error => error.includes('must pass --vector')));
+  assert.ok(result.errors.some(error => error.includes('must pass --keys')));
+  assert.ok(result.errors.some(error => error.includes('not stdin')));
+});
+
+test('removing verify-vector guidance from either guarded document fails', () => {
+  for (const field of ['docPath', 'gradingDocPath']) {
+    const fixture = makeFixture();
+    fs.writeFileSync(
+      fixture[field],
+      field === 'docPath' ? '### Error codes\n' : '# Grading\n',
+    );
+
+    const result = lint(fixture);
+    assert.ok(
+      result.errors.some(error =>
+        error.includes(path.relative(fixture.root, fixture[field])) &&
+        error.includes('missing signing verify-vector invocation')),
+      field,
+    );
+  }
+});
+
+test('verify-vector flags must belong to the verify command', () => {
+  const fixture = makeFixture();
+  fs.writeFileSync(fixture.gradingDocPath, `# Grading
+
+\`\`\`bash
+npx @adcp/sdk@latest signing verify-vector
+printf '%s\\n' --vector /tmp/vector.json --keys /tmp/keys.json
+\`\`\`
+`);
+
+  const result = lint(fixture);
+  assert.ok(result.errors.some(error => error.includes('must pass --vector')));
+  assert.ok(result.errors.some(error => error.includes('must pass --keys')));
+});
+
+test('verify-vector guidance requires explicit keys even with a local vector', () => {
+  const fixture = makeFixture();
+  fs.writeFileSync(fixture.docPath, `### Error codes
+
+\`\`\`bash
+npx @adcp/sdk@latest signing verify-vector --vector /tmp/vector.json
+\`\`\`
+`);
+
+  const result = lint(fixture);
+  assert.ok(result.errors.some(error => error.includes('must pass --keys')));
+  assert.ok(!result.errors.some(error => error.includes('must pass --vector')));
 });


### PR DESCRIPTION
Fixes #6077
Fixes #6071

## Summary
- replace stale package-internal request-signing vector paths with a copyable public CDN flow
- document the verifier CLI's explicit vector/key inputs, negative exit semantics, and stateful-fixture limits
- remove stale vector counts and harden documentation drift checks against regressions

## Verification
- `npm run test:doc-compliance-drift` (12/12)
- `npm run test:storyboard-test-kits` (12/12)
- `npm run test:compliance-source-authority` (6/6)
- `npm run test:compliance-snippets` (28/28 plus compliance build check)
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- live CDN + `@adcp/sdk@latest` positive-vector smoke test
- protocol expert review: approved
- documentation expert review: approved