### PR TITLE
fix(registry): bound public compliance notices

### DIFF
--- a/server/src/routes/public-compliance-notices.ts
+++ b/server/src/routes/public-compliance-notices.ts
@@ -1,0 +1,134 @@
+import {
+  PUBLIC_COMPLIANCE_NOTICE_LIMITS,
+  type PublicComplianceNotice,
+} from "../schemas/public-compliance-notice.js";
+
+export {
+  PUBLIC_COMPLIANCE_NOTICE_LIMITS,
+  type PublicComplianceNotice,
+} from "../schemas/public-compliance-notice.js";
+
+function boundedIdentifier(
+  value: unknown,
+  maxLength: number
+): string | undefined {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maxLength
+  ) {
+    return undefined;
+  }
+  if (value.trim().length === 0) return undefined;
+  return value;
+}
+
+function boundedDisplayString(
+  value: unknown,
+  maxLength: number
+): string | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  if (value.length <= maxLength) {
+    return value.trim().length > 0 ? value : undefined;
+  }
+
+  let prefix = value.slice(0, maxLength - 1);
+  const lastCodeUnit = prefix.charCodeAt(prefix.length - 1);
+  if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) {
+    prefix = prefix.slice(0, -1);
+  }
+  if (prefix.trim().length === 0) return undefined;
+  return `${prefix}…`;
+}
+
+function normalizedReferenceUrl(value: unknown): string | undefined {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > PUBLIC_COMPLIANCE_NOTICE_LIMITS.referenceUrl ||
+    /[\u0000-\u001F\u007F]/.test(value)
+  ) {
+    return undefined;
+  }
+  if (value.trim().length === 0) return undefined;
+
+  try {
+    const parsed = new URL(value);
+    if (
+      (parsed.protocol !== "https:" && parsed.protocol !== "http:") ||
+      parsed.username.length > 0 ||
+      parsed.password.length > 0
+    ) {
+      return undefined;
+    }
+    const normalized = parsed.toString();
+    return normalized.length <= PUBLIC_COMPLIANCE_NOTICE_LIMITS.referenceUrl
+      ? normalized
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function toPublicComplianceNotice(
+  value: unknown
+): PublicComplianceNotice | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const severity = boundedIdentifier(
+    record.severity,
+    PUBLIC_COMPLIANCE_NOTICE_LIMITS.severity
+  );
+  const code = boundedIdentifier(
+    record.code,
+    PUBLIC_COMPLIANCE_NOTICE_LIMITS.code
+  );
+  const message = boundedDisplayString(
+    record.message,
+    PUBLIC_COMPLIANCE_NOTICE_LIMITS.message
+  );
+  if (!severity || !code || !message) return null;
+
+  const notice: PublicComplianceNotice = { severity, code, message };
+  const effectiveVersion = boundedDisplayString(
+    record.effective_version,
+    PUBLIC_COMPLIANCE_NOTICE_LIMITS.effectiveVersion
+  );
+  const requirement = boundedDisplayString(
+    record.requirement,
+    PUBLIC_COMPLIANCE_NOTICE_LIMITS.requirement
+  );
+  const capabilityPath = boundedDisplayString(
+    record.capability_path,
+    PUBLIC_COMPLIANCE_NOTICE_LIMITS.capabilityPath
+  );
+  const capabilityPointer = boundedDisplayString(
+    record.capability_pointer,
+    PUBLIC_COMPLIANCE_NOTICE_LIMITS.capabilityPointer
+  );
+  const referenceUrl = normalizedReferenceUrl(record.reference_url);
+
+  if (effectiveVersion) notice.effective_version = effectiveVersion;
+  if (requirement) notice.requirement = requirement;
+  if (capabilityPath) notice.capability_path = capabilityPath;
+  if (capabilityPointer) notice.capability_pointer = capabilityPointer;
+  if (referenceUrl) notice.reference_url = referenceUrl;
+  return notice;
+}
+
+export function projectPublicComplianceNotices(
+  value: unknown
+): PublicComplianceNotice[] {
+  if (!Array.isArray(value)) return [];
+
+  const projected: PublicComplianceNotice[] = [];
+  for (const candidate of value.slice(
+    0,
+    PUBLIC_COMPLIANCE_NOTICE_LIMITS.maxScan
+  )) {
+    const notice = toPublicComplianceNotice(candidate);
+    if (notice) projected.push(notice);
+    if (projected.length >= PUBLIC_COMPLIANCE_NOTICE_LIMITS.maxNotices) break;
+  }
+  return projected;
+}

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -59,6 +59,10 @@ import * as policiesDb from "../db/policies-db.js";
 import { createLogger } from "../logger.js";
 import { validateCrawlDomain, validateExternalUrl } from "../utils/url-security.js";
 import {
+  projectPublicComplianceNotices,
+  type PublicComplianceNotice,
+} from "./public-compliance-notices.js";
+import {
   registry,
   ResolvedBrandSchema,
   ResolvedPropertySchema,
@@ -6506,9 +6510,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       // advisories emitted by the runner (e.g., deprecated specialism names,
       // future-required capabilities). Forward-compat: unknown codes/severities
       // are passed through verbatim; callers MUST NOT filter on these values.
-      let notices: Awaited<ReturnType<typeof complianceDb.getLatestNotices>> = [];
+      let notices: PublicComplianceNotice[] = [];
       try {
-        notices = await complianceDb.getLatestNotices(agentUrl);
+        notices = projectPublicComplianceNotices(await complianceDb.getLatestNotices(agentUrl));
       } catch (err) {
         logger.warn({ err, agentUrl }, "Notices query failed (column may not exist yet)");
       }
@@ -6615,8 +6619,8 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         // owner-scoped; non-owner entries carry null scalar diagnostics and
         // empty validation evidence.
         storyboard_statuses: serializedStoryboardStatuses,
-        // Advisory notices from the latest run. Forward-compat: unknown codes
-        // and severities are passed through verbatim (runner-output-contract.yaml).
+        // Advisory notices from the latest run. Unknown code/severity values
+        // remain verbatim, while private and oversized fields are excluded.
         notices,
         observations,
         // Owner-scoped: content is null/false for anonymous and cross-org

--- a/server/src/schemas/public-compliance-notice.ts
+++ b/server/src/schemas/public-compliance-notice.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+
+extendZodWithOpenApi(z);
+
+export const PUBLIC_COMPLIANCE_NOTICE_LIMITS = {
+  maxNotices: 50,
+  maxScan: 100,
+  severity: 64,
+  code: 200,
+  message: 1_000,
+  effectiveVersion: 64,
+  requirement: 500,
+  capabilityPath: 512,
+  capabilityPointer: 1_024,
+  referenceUrl: 2_048,
+} as const;
+
+export const PublicComplianceNoticeSchema = z
+  .object({
+    severity: z.string().min(1).max(PUBLIC_COMPLIANCE_NOTICE_LIMITS.severity),
+    code: z.string().min(1).max(PUBLIC_COMPLIANCE_NOTICE_LIMITS.code),
+    message: z.string().min(1).max(PUBLIC_COMPLIANCE_NOTICE_LIMITS.message),
+    effective_version: z
+      .string()
+      .min(1)
+      .max(PUBLIC_COMPLIANCE_NOTICE_LIMITS.effectiveVersion)
+      .optional(),
+    requirement: z
+      .string()
+      .min(1)
+      .max(PUBLIC_COMPLIANCE_NOTICE_LIMITS.requirement)
+      .optional(),
+    capability_path: z
+      .string()
+      .min(1)
+      .max(PUBLIC_COMPLIANCE_NOTICE_LIMITS.capabilityPath)
+      .optional(),
+    capability_pointer: z
+      .string()
+      .min(1)
+      .max(PUBLIC_COMPLIANCE_NOTICE_LIMITS.capabilityPointer)
+      .optional(),
+    reference_url: z
+      .string()
+      .url()
+      .max(PUBLIC_COMPLIANCE_NOTICE_LIMITS.referenceUrl)
+      .optional(),
+  })
+  .strict();
+
+export type PublicComplianceNotice = z.infer<
+  typeof PublicComplianceNoticeSchema
+>;

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -10,6 +10,10 @@ import { z } from "zod";
 import { ADCP_SPECIALISMS, VERIFICATION_MODES } from "../services/adcp-taxonomy.js";
 import { VALID_BADGE_ROLES } from "../services/badge-svg.js";
 import {
+  PUBLIC_COMPLIANCE_NOTICE_LIMITS,
+  PublicComplianceNoticeSchema,
+} from "./public-compliance-notice.js";
+import {
   extendZodWithOpenApi,
   OpenAPIRegistry,
 } from "@asteasolutions/zod-to-openapi";
@@ -808,7 +812,7 @@ export const AgentComplianceDetailSchema = z
       last_tested_at: z.string().nullable(),
       last_passed_at: z.string().nullable(),
     })).optional().openapi({ description: "Public per-storyboard verdicts and aggregate step counts. First-failure diagnostic fields are populated only for owners; scalar diagnostics are null and validation evidence is empty for other callers." }),
-    notices: z.array(z.any()).optional().openapi({ description: "Run-summary notices from the latest non-dry-run compliance run. Unknown codes/severities are preserved verbatim." }),
+    notices: z.array(PublicComplianceNoticeSchema.openapi("PublicComplianceNotice")).max(PUBLIC_COMPLIANCE_NOTICE_LIMITS.maxNotices).optional().openapi({ description: "Public-safe run-summary notices from the latest non-dry-run compliance run. Unknown code/severity values are preserved verbatim; private fields are omitted." }),
     observations: z.array(z.object({
       category: z.string(),
       severity: z.string(),

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -46,6 +46,7 @@ const ALL_OWNED_URLS = [
   ownedAgentUrl('applicable-oauth'),
   ownedAgentUrl('selected-org-refresh'),
   ownedAgentUrl('selected-org-challenge'),
+  ownedAgentUrl('public-notices'),
 ];
 
 // Toggle which user the auth middleware stamps onto the request. Tests
@@ -359,7 +360,86 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
       .get(`/api/registry/agents/${encodeURIComponent(agentUrl)}/compliance`)
       .send();
     expect(publicCompliance.status).toBe(200);
-    expect(publicCompliance.body.notices).toEqual(latestRun.rows[0].notices_json);
+    expect(publicCompliance.body.notices).toEqual([{
+      severity: 'info',
+      code: 'fixture_notice',
+      message: 'Fixture notice',
+      capability_pointer: '/account/supported_billing/0',
+    }]);
+    expect(publicCompliance.body.notices[0]).not.toHaveProperty('docs_url');
+    expect(publicCompliance.body.notices[0]).not.toHaveProperty('storyboard_ids');
+    expect(publicCompliance.body.notices[0]).not.toHaveProperty('future_runner_field');
+  });
+
+  it('public compliance bounds notice output while retaining the raw private record', async () => {
+    const agentUrl = ownedAgentUrl('public-notices');
+    const refresh = await request(app).post(url(agentUrl)).send();
+    expect(refresh.status).toBe(200);
+
+    const rawNotices = [
+      {
+        severity: 'future_custom_severity',
+        code: 'future_custom_code',
+        message: '😀'.repeat(700),
+        effective_version: 'v'.repeat(100),
+        requirement: 'r'.repeat(700),
+        capability_path: 'p'.repeat(700),
+        capability_pointer: `/${'x'.repeat(1_100)}`,
+        reference_url: 'javascript:alert(1)',
+        experimental_context: { secret: 'private runner state' },
+      },
+      ...Array.from({ length: 54 }, (_, index) => ({
+        severity: 'info',
+        code: `bounded_notice_${index}`,
+        message: `Notice ${index}`,
+        ...(index === 0
+          ? { reference_url: 'https://example.com/docs?version=4#notice' }
+          : {}),
+      })),
+    ];
+    await pool.query(
+      `UPDATE agent_compliance_runs
+       SET notices_json = $2::jsonb
+       WHERE id = (
+         SELECT id FROM agent_compliance_runs
+         WHERE agent_url = $1
+         ORDER BY tested_at DESC
+         LIMIT 1
+       )`,
+      [agentUrl, JSON.stringify(rawNotices)],
+    );
+
+    currentUserId = null;
+    const publicCompliance = await request(app)
+      .get(`/api/registry/agents/${encodeURIComponent(agentUrl)}/compliance`)
+      .send();
+    expect(publicCompliance.status).toBe(200);
+    expect(publicCompliance.body.notices).toHaveLength(50);
+    expect(publicCompliance.body.notices[0]).toMatchObject({
+      severity: 'future_custom_severity',
+      code: 'future_custom_code',
+    });
+    expect(publicCompliance.body.notices[0].message.length).toBeLessThanOrEqual(1_000);
+    expect(publicCompliance.body.notices[0].effective_version.length).toBeLessThanOrEqual(64);
+    expect(publicCompliance.body.notices[0].requirement.length).toBeLessThanOrEqual(500);
+    expect(publicCompliance.body.notices[0].capability_path.length).toBeLessThanOrEqual(512);
+    expect(publicCompliance.body.notices[0].capability_pointer.length).toBeLessThanOrEqual(1_024);
+    expect(publicCompliance.body.notices[0]).not.toHaveProperty('reference_url');
+    expect(publicCompliance.body.notices[0]).not.toHaveProperty('experimental_context');
+    expect(publicCompliance.body.notices[1].reference_url).toBe(
+      'https://example.com/docs?version=4#notice',
+    );
+
+    const stored = await pool.query<{ notices_json: unknown[] }>(
+      `SELECT notices_json
+       FROM agent_compliance_runs
+       WHERE agent_url = $1
+       ORDER BY tested_at DESC
+       LIMIT 1`,
+      [agentUrl],
+    );
+    expect(stored.rows[0].notices_json).toHaveLength(55);
+    expect(stored.rows[0].notices_json[0]).toHaveProperty('experimental_context');
   });
 
   it('admin can refresh an agent they do not own', async () => {

--- a/server/tests/unit/public-compliance-notices.test.ts
+++ b/server/tests/unit/public-compliance-notices.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  PUBLIC_COMPLIANCE_NOTICE_LIMITS,
+  projectPublicComplianceNotices,
+  toPublicComplianceNotice,
+} from "../../src/routes/public-compliance-notices.js";
+
+const validNotice = {
+  severity: "future_custom_severity",
+  code: "future_custom_code",
+  message: "Update this capability before the next release.",
+};
+
+describe("public compliance notice projection", () => {
+  it("preserves unknown code/severity values and allowlisted protocol fields only", () => {
+    const raw = {
+      ...validNotice,
+      effective_version: "4.0",
+      requirement: "request_signing",
+      capability_path: "request_signing.supported",
+      capability_pointer: "/request_signing/supported",
+      reference_url: "https://example.com/docs?version=4#request-signing",
+      docs_url: "https://private.example/docs",
+      storyboard_ids: ["signed_requests"],
+      experimental_context: { internal: true },
+    };
+
+    expect(toPublicComplianceNotice(raw)).toEqual({
+      severity: "future_custom_severity",
+      code: "future_custom_code",
+      message: "Update this capability before the next release.",
+      effective_version: "4.0",
+      requirement: "request_signing",
+      capability_path: "request_signing.supported",
+      capability_pointer: "/request_signing/supported",
+      reference_url: "https://example.com/docs?version=4#request-signing",
+    });
+    expect(raw).toHaveProperty("experimental_context");
+  });
+
+  it("drops malformed notices and oversized machine identifiers without coercion", () => {
+    expect(toPublicComplianceNotice(null)).toBeNull();
+    expect(toPublicComplianceNotice([])).toBeNull();
+    expect(toPublicComplianceNotice({ ...validNotice, code: 123 })).toBeNull();
+    expect(
+      toPublicComplianceNotice({ ...validNotice, severity: "   " })
+    ).toBeNull();
+    expect(
+      toPublicComplianceNotice({ ...validNotice, message: "" })
+    ).toBeNull();
+    expect(
+      toPublicComplianceNotice({
+        ...validNotice,
+        code: "c".repeat(PUBLIC_COMPLIANCE_NOTICE_LIMITS.code + 1),
+      })
+    ).toBeNull();
+    expect(
+      toPublicComplianceNotice({
+        ...validNotice,
+        severity: "s".repeat(PUBLIC_COMPLIANCE_NOTICE_LIMITS.severity + 1),
+      })
+    ).toBeNull();
+  });
+
+  it("bounds display strings without splitting a surrogate pair", () => {
+    const projected = toPublicComplianceNotice({
+      ...validNotice,
+      message: "😀".repeat(PUBLIC_COMPLIANCE_NOTICE_LIMITS.message),
+      requirement: "r".repeat(PUBLIC_COMPLIANCE_NOTICE_LIMITS.requirement + 20),
+      capability_path: "p".repeat(
+        PUBLIC_COMPLIANCE_NOTICE_LIMITS.capabilityPath + 20
+      ),
+      capability_pointer: `/${"x".repeat(
+        PUBLIC_COMPLIANCE_NOTICE_LIMITS.capabilityPointer + 20
+      )}`,
+      effective_version: "v".repeat(
+        PUBLIC_COMPLIANCE_NOTICE_LIMITS.effectiveVersion + 20
+      ),
+    });
+
+    expect(projected).not.toBeNull();
+    expect(projected!.message.length).toBeLessThanOrEqual(
+      PUBLIC_COMPLIANCE_NOTICE_LIMITS.message
+    );
+    expect(projected!.message).toMatch(/…$/);
+    expect(projected!.message).not.toContain("\uFFFD");
+    expect(projected!.requirement).toHaveLength(
+      PUBLIC_COMPLIANCE_NOTICE_LIMITS.requirement
+    );
+    expect(projected!.capability_path).toHaveLength(
+      PUBLIC_COMPLIANCE_NOTICE_LIMITS.capabilityPath
+    );
+    expect(projected!.capability_pointer).toHaveLength(
+      PUBLIC_COMPLIANCE_NOTICE_LIMITS.capabilityPointer
+    );
+    expect(projected!.effective_version).toHaveLength(
+      PUBLIC_COMPLIANCE_NOTICE_LIMITS.effectiveVersion
+    );
+  });
+
+  it("does not scan beyond the bounded display prefix for nonempty content", () => {
+    expect(
+      toPublicComplianceNotice({
+        ...validNotice,
+        message: `${" ".repeat(PUBLIC_COMPLIANCE_NOTICE_LIMITS.message)}hidden`,
+      })
+    ).toBeNull();
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "data:text/html,unsafe",
+    "https://user:password@example.com/docs",
+    "https://example.com/docs\nunsafe",
+    `https://example.com/${"x".repeat(
+      PUBLIC_COMPLIANCE_NOTICE_LIMITS.referenceUrl
+    )}`,
+  ])(
+    "omits unsafe reference URL %s without dropping the notice",
+    (reference_url) => {
+      expect(
+        toPublicComplianceNotice({ ...validNotice, reference_url })
+      ).toEqual(validNotice);
+    }
+  );
+
+  it("caps both raw scanning and projected output while preserving order", () => {
+    const invalid = Array.from({ length: 50 }, () => ({
+      message: "missing identifiers",
+    }));
+    const valid = Array.from({ length: 75 }, (_, index) => ({
+      ...validNotice,
+      code: `notice_${index}`,
+    }));
+
+    const projected = projectPublicComplianceNotices([...invalid, ...valid]);
+    expect(projected).toHaveLength(PUBLIC_COMPLIANCE_NOTICE_LIMITS.maxNotices);
+    expect(projected[0].code).toBe("notice_0");
+    expect(projected.at(-1)?.code).toBe("notice_49");
+
+    const beyondScan = projectPublicComplianceNotices([
+      ...Array.from(
+        { length: PUBLIC_COMPLIANCE_NOTICE_LIMITS.maxScan },
+        () => null
+      ),
+      validNotice,
+    ]);
+    expect(beyondScan).toEqual([]);
+  });
+});

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -3854,8 +3854,10 @@ components:
           description: Public per-storyboard verdicts and aggregate step counts. First-failure diagnostic fields are populated only for owners; scalar diagnostics are null and validation evidence is empty for other callers.
         notices:
           type: array
-          items: {}
-          description: Run-summary notices from the latest non-dry-run compliance run. Unknown codes/severities are preserved verbatim.
+          items:
+            $ref: "#/components/schemas/PublicComplianceNotice"
+          maxItems: 50
+          description: Public-safe run-summary notices from the latest non-dry-run compliance run. Unknown code/severity values are preserved verbatim; private fields are omitted.
         observations:
           type: array
           items:
@@ -3911,6 +3913,46 @@ components:
         - agent_url
         - status
         - lifecycle_stage
+    PublicComplianceNotice:
+      type: object
+      properties:
+        severity:
+          type: string
+          minLength: 1
+          maxLength: 64
+        code:
+          type: string
+          minLength: 1
+          maxLength: 200
+        message:
+          type: string
+          minLength: 1
+          maxLength: 1000
+        effective_version:
+          type: string
+          minLength: 1
+          maxLength: 64
+        requirement:
+          type: string
+          minLength: 1
+          maxLength: 500
+        capability_path:
+          type: string
+          minLength: 1
+          maxLength: 512
+        capability_pointer:
+          type: string
+          minLength: 1
+          maxLength: 1024
+        reference_url:
+          type: string
+          maxLength: 2048
+          format: uri
+      required:
+        - severity
+        - code
+        - message
+      additionalProperties: false
     VerificationBadge:
       type: object
       properties:


### PR DESCRIPTION
Fixes #6396

## Summary
- project a strict eight-field public notice allowlist while retaining raw JSONB privately
- bound scan count, response count, strings, and validated HTTP(S) reference URLs
- replace the permissive OpenAPI notice shape with a shared strict schema
- add unit and anonymous API integration coverage for private-field stripping and bounds

## Verification
- `npx vitest run server/tests/unit/public-compliance-notices.test.ts server/tests/unit/compliance-notices.test.ts` (14/14)
- `npm run typecheck`
- `npm run test:openapi`
- `git diff --check`
- security expert review: approved
- independent code review: approved

The API integration case is included in `registry-api-agent-refresh.test.ts`; the local isolated worktree has no Postgres on port 53198, so the repository CI database job will execute it.