### PR TITLE
fix(dashboard): separate capability probe budget

### DIFF
--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -3600,6 +3600,30 @@
         );
       }
 
+      function parseCapabilityProbeRetrySeconds(bodyRetryAfter, retryAfterHeader) {
+        if (typeof retryAfterHeader === 'string' && /^\d+$/.test(retryAfterHeader.trim())) {
+          const headerSeconds = Number.parseInt(retryAfterHeader, 10);
+          if (headerSeconds > 0) return headerSeconds;
+        }
+        if (typeof bodyRetryAfter === 'number' && Number.isFinite(bodyRetryAfter) && bodyRetryAfter > 0) {
+          return Math.ceil(bodyRetryAfter);
+        }
+        return null;
+      }
+
+      function buildCapabilityProbeRateLimitPanel(errBody, retryAfterHeader, savedStatusSummary) {
+        const retrySeconds = parseCapabilityProbeRetrySeconds(errBody?.retryAfter, retryAfterHeader);
+        const retryMinutes = retrySeconds ? Math.ceil(retrySeconds / 60) : null;
+        const retryText = retryMinutes
+          ? ' Try again in ' + retryMinutes + ' minute' + (retryMinutes === 1 ? '.' : 's.')
+          : ' Try again later.';
+        let html = '<div class="capability-probe-rate-limit" style="padding:var(--space-3);background:var(--color-warning-50);border:1px solid var(--color-warning-200);border-radius:var(--radius-md);color:var(--color-warning-800);font-size:var(--text-sm);margin-bottom:var(--space-2);">';
+        html += '<strong>Capability check paused.</strong> AgenticAdvertising.org has temporarily limited capability checks. Your agent was not contacted.' + retryText;
+        html += '</div>';
+        html += savedStatusSummary || '';
+        return html;
+      }
+
       // Shared: render the storyboard map into a panel
       async function renderStoryboardPicker(panel, agentUrl, cardId, agentTracks) {
         panel.style.display = 'block';
@@ -3728,6 +3752,16 @@
 
           // Non-2xx — surface specific reason before falling back
           const errBody = await res.json().catch(() => ({}));
+
+          if (res.status === 429) {
+            const storyboardStatusMap = await storyboardStatusMapPromise;
+            panel.innerHTML = buildCapabilityProbeRateLimitPanel(
+              errBody,
+              res.headers?.get?.('Retry-After') || null,
+              buildStoryboardStatusSummary(storyboardStatusMap),
+            );
+            return;
+          }
 
           if (errBody.needs_oauth) {
             panel.innerHTML = renderOAuthChallenge(agentUrl, errBody.agent_context_id, errBody.error);

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -278,6 +278,8 @@ export const notificationRateLimiter = rateLimit({
  * Limits: 10 evaluations per hour per user (each eval makes real HTTP calls to external agents).
  * AAO platform admins bypass this limit so they can debug and curate without hitting it.
  */
+export const STORYBOARD_EVAL_RATE_LIMIT_PREFIX = 'storyboard:';
+
 export const storyboardEvalRateLimiter = rateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour
   max: 10,
@@ -285,7 +287,7 @@ export const storyboardEvalRateLimiter = rateLimit({
   skip: skipForAdmins,
   standardHeaders: true,
   legacyHeaders: false,
-  store: new CachedPostgresStore('storyboard:'),
+  store: new CachedPostgresStore(STORYBOARD_EVAL_RATE_LIMIT_PREFIX),
   keyGenerator: generateKey,
   validate: { keyGeneratorIpFallback: false },
   handler: (req: Request, res: Response) => {
@@ -303,6 +305,49 @@ export const storyboardEvalRateLimiter = rateLimit({
     });
   },
 });
+
+/**
+ * Rate limiter for the dashboard's lightweight capability discovery probe.
+ * This endpoint makes one external agent call, so it remains bounded without
+ * consuming the much smaller full storyboard-evaluation budget. The key is
+ * the authenticated user: the requested organization is not trusted until the
+ * route's ownership check runs after this middleware.
+ */
+export const CAPABILITY_PROBE_LIMIT_PER_HOUR = 60;
+export const CAPABILITY_PROBE_RATE_LIMIT_PREFIX = 'capability-probe:';
+
+export function createCapabilityProbeRateLimiter(options: {
+  max?: number;
+  store?: Store;
+} = {}) {
+  const max = options.max ?? CAPABILITY_PROBE_LIMIT_PER_HOUR;
+  return rateLimit({
+    windowMs: 60 * 60 * 1000,
+    max,
+    skip: skipForAdmins,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: options.store ?? new CachedPostgresStore(CAPABILITY_PROBE_RATE_LIMIT_PREFIX),
+    keyGenerator: generateKey,
+    validate: { keyGeneratorIpFallback: false },
+    handler: (req: Request, res: Response) => {
+      logger.warn({
+        userId: (req as any).user?.id,
+        ip: req.ip,
+        path: req.path,
+      }, 'Rate limit exceeded for capability probe');
+
+      const retryAfter = parseRetryAfterSeconds(res.getHeader('Retry-After'));
+      res.status(429).json({
+        error: 'Too many requests',
+        message: `Capability probe limit exceeded (${max} per hour). Please try again later.`,
+        ...(retryAfter !== undefined ? { retryAfter } : {}),
+      });
+    },
+  });
+}
+
+export const capabilityProbeRateLimiter = createCapabilityProbeRateLimiter();
 
 /**
  * Rate limiter for step-by-step storyboard execution.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -25,7 +25,7 @@ import { resolvePrimaryOrganization } from "../db/users-db.js";
 import * as manifestRefsDb from "../db/manifest-refs-db.js";
 import { isUuid } from "../utils/uuid.js";
 import { AsyncSemaphore, SemaphoreOverloadedError } from "../utils/async-semaphore.js";
-import { bulkResolveRateLimiter, brandBulkDomainRateLimiter, brandCreationRateLimiter, storyboardEvalRateLimiter, storyboardStepRateLimiter, agentReadRateLimiter, registryPublisherRateLimiter, registryReadRateLimiter } from "../middleware/rate-limit.js";
+import { bulkResolveRateLimiter, brandBulkDomainRateLimiter, brandCreationRateLimiter, capabilityProbeRateLimiter, storyboardEvalRateLimiter, storyboardStepRateLimiter, agentReadRateLimiter, registryPublisherRateLimiter, registryReadRateLimiter } from "../middleware/rate-limit.js";
 import { compareAdcpVersions, listStoryboards, getStoryboard, getTestKitForStoryboard } from "../services/storyboards.js";
 import {
   hostedComplianceTarget,
@@ -4201,6 +4201,7 @@ registry.registerPath({
     400: { description: "Invalid agent URL", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: ErrorSchema } } },
     403: { description: "Not authorized", content: { "application/json": { schema: ErrorSchema } } },
+    429: { description: "Capability probe rate limit exceeded", content: { "application/json": { schema: RateLimitErrorSchema } } },
     422: {
       description: "Agent requires authentication, or declared capabilities cannot be resolved for the selected compliance target",
       content: {
@@ -8058,7 +8059,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     }
   });
 
-  router.get("/registry/agents/:encodedUrl/applicable-storyboards", storyboardEvalRateLimiter, ...complianceWriteMiddleware, async (req, res) => {
+  router.get("/registry/agents/:encodedUrl/applicable-storyboards", ...complianceWriteMiddleware, capabilityProbeRateLimiter, async (req, res) => {
     const rawAgentUrl = decodeURIComponent(req.params.encodedUrl);
     if (!validateAgentUrlParam(rawAgentUrl)) {
       return res.status(400).json({ error: "Invalid agent URL" });

--- a/server/tests/unit/dashboard-storyboard-rate-limit.test.ts
+++ b/server/tests/unit/dashboard-storyboard-rate-limit.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { describe, expect, it } from 'vitest';
+
+const dashboardSource = readFileSync(
+  new URL('../../public/dashboard-agents.html', import.meta.url),
+  'utf8',
+);
+
+const helperStart = dashboardSource.indexOf('function parseCapabilityProbeRetrySeconds');
+const helperEnd = dashboardSource.indexOf('// Shared: render the storyboard map', helperStart);
+if (helperStart < 0 || helperEnd < 0) {
+  throw new Error('capability probe rate-limit helpers not found');
+}
+const context = vm.createContext({});
+vm.runInContext(dashboardSource.slice(helperStart, helperEnd), context);
+const buildCapabilityProbeRateLimitPanel = context.buildCapabilityProbeRateLimitPanel as (
+  body: { retryAfter?: unknown },
+  retryAfterHeader: string | null,
+  savedStatusSummary: string,
+) => string;
+
+async function renderRateLimitedStoryboardPicker(options: {
+  retryAfter?: unknown;
+  retryAfterHeader?: string | null;
+  statusSummary?: string;
+} = {}) {
+  const renderStart = dashboardSource.indexOf('function parseCapabilityProbeRetrySeconds');
+  const renderEnd = dashboardSource.indexOf('// Storyboard "Test your agent" button', renderStart);
+  if (renderStart < 0 || renderEnd < 0) {
+    throw new Error('storyboard picker implementation not found');
+  }
+
+  const renderContext = vm.createContext({
+    pageState: { orgId: 'org_test' },
+    loadStoryboardStatusMap: async () => new Map([['saved', { status: 'fail' }]]),
+    buildStoryboardStatusSummary: () => options.statusSummary ?? '<div class="saved-summary">Saved status</div>',
+    fetch: async () => ({
+      ok: false,
+      status: 429,
+      json: async () => ({ retryAfter: options.retryAfter }),
+      headers: { get: () => options.retryAfterHeader ?? null },
+    }),
+    console,
+  });
+  vm.runInContext(dashboardSource.slice(renderStart, renderEnd), renderContext);
+  const renderStoryboardPicker = renderContext.renderStoryboardPicker as (
+    panel: { style: Record<string, string>; innerHTML: string; dataset: Record<string, string> },
+    agentUrl: string,
+    cardId: string,
+    agentTracks?: unknown,
+  ) => Promise<void>;
+  const panel = { style: {}, innerHTML: '', dataset: {} };
+
+  await renderStoryboardPicker(panel, 'https://agent.example', 'card-1');
+  return panel.innerHTML;
+}
+
+describe('dashboard capability probe rate-limit guidance', () => {
+  it('routes a real picker 429 through the warning and retains saved status', async () => {
+    const html = await renderRateLimitedStoryboardPicker({
+      retryAfter: 944,
+      retryAfterHeader: '120',
+    });
+
+    expect(html).toContain('Capability check paused.');
+    expect(html).toContain('Try again in 2 minutes.');
+    expect(html).toContain('class="saved-summary"');
+    expect(html).not.toContain('Could not probe agent capabilities');
+  });
+
+  it('shows the rounded retry time without blaming the agent', () => {
+    const html = buildCapabilityProbeRateLimitPanel(
+      { retryAfter: 944 },
+      null,
+      '<div class="saved-summary">Needs attention: 2 storyboards.</div>',
+    );
+
+    expect(html).toContain('Capability check paused.');
+    expect(html).toContain('Your agent was not contacted.');
+    expect(html).toContain('Try again in 16 minutes.');
+    expect(html).toContain('class="saved-summary"');
+    expect(html).not.toContain('Could not probe agent capabilities');
+    expect(html).not.toContain('Agent is reachable');
+    expect(html).not.toContain('storyboard eval budget');
+  });
+
+  it('uses the Retry-After header when present', () => {
+    const html = buildCapabilityProbeRateLimitPanel({}, '120', '');
+    expect(html).toContain('Try again in 2 minutes.');
+  });
+
+  it('treats the Retry-After header as authoritative', () => {
+    const html = buildCapabilityProbeRateLimitPanel({ retryAfter: 944 }, '60', '');
+    expect(html).toContain('Try again in 1 minute.');
+    expect(html).not.toContain('16 minutes');
+  });
+
+  it('uses a safe generic retry when hints are missing or malformed', () => {
+    for (const [body, header] of [
+      [{}, null],
+      [{ retryAfter: Number.NaN }, 'soon'],
+      [{ retryAfter: -1 }, '0'],
+    ] as const) {
+      const html = buildCapabilityProbeRateLimitPanel(body, header, '');
+      expect(html).toContain('Try again later.');
+      expect(html).not.toContain('NaN');
+    }
+  });
+});

--- a/server/tests/unit/rate-limit-retry-after.test.ts
+++ b/server/tests/unit/rate-limit-retry-after.test.ts
@@ -1,9 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import type { IncrementResponse, Options } from 'express-rate-limit';
-import { parseRetryAfterSeconds, createAgentReadRateLimiter, createBrandBulkDomainRateLimiter } from '../../src/middleware/rate-limit.js';
+import { MemoryStore, type IncrementResponse, type Options } from 'express-rate-limit';
+import {
+  CAPABILITY_PROBE_LIMIT_PER_HOUR,
+  CAPABILITY_PROBE_RATE_LIMIT_PREFIX,
+  STORYBOARD_EVAL_RATE_LIMIT_PREFIX,
+  parseRetryAfterSeconds,
+  createAgentReadRateLimiter,
+  createBrandBulkDomainRateLimiter,
+  createCapabilityProbeRateLimiter,
+} from '../../src/middleware/rate-limit.js';
 import type { WeightedIncrementStore } from '../../src/middleware/pg-rate-limit-store.js';
+
+vi.mock('../../src/addie/mcp/admin-tools.js', () => ({
+  isWebUserAAOAdmin: vi.fn().mockResolvedValue(false),
+}));
 
 /**
  * Tests for the retryAfter fallback field we surface on the 429 body
@@ -83,6 +95,71 @@ describe('agentReadRateLimiter 429 body', () => {
     expect(headerSeconds).toBeGreaterThan(0);
     expect(last!.body.retryAfter).toBe(headerSeconds);
   }, 30_000);
+});
+
+describe('capability probe rate limiter', () => {
+  function buildApp(options: {
+    max?: number;
+    responseStatus?: number;
+    isAdmin?: boolean;
+  } = {}) {
+    const app = express();
+    app.use((req, _res, next) => {
+      (req as any).user = {
+        id: 'capability-probe-rate-limit-user',
+        isAdmin: options.isAdmin === true,
+      };
+      next();
+    });
+    app.get(
+      '/probe',
+      createCapabilityProbeRateLimiter({
+        max: options.max ?? 2,
+        store: new MemoryStore(),
+      }),
+      (_req, res) => res.status(options.responseStatus ?? 200).json({ ok: true }),
+    );
+    return app;
+  }
+
+  it('uses a separate 60/hour production budget', () => {
+    expect(CAPABILITY_PROBE_LIMIT_PER_HOUR).toBe(60);
+    expect(CAPABILITY_PROBE_RATE_LIMIT_PREFIX).toBe('capability-probe:');
+    expect(CAPABILITY_PROBE_RATE_LIMIT_PREFIX).not.toBe(
+      STORYBOARD_EVAL_RATE_LIMIT_PREFIX,
+    );
+  });
+
+  it('returns a capability-specific 429 with matching retry hints', async () => {
+    const app = buildApp({ max: 2 });
+    await request(app).get('/probe');
+    await request(app).get('/probe');
+    const limited = await request(app).get('/probe');
+
+    expect(limited.status).toBe(429);
+    expect(limited.body).toMatchObject({
+      error: 'Too many requests',
+      message: 'Capability probe limit exceeded (2 per hour). Please try again later.',
+    });
+    expect(limited.body.retryAfter).toBeGreaterThan(0);
+    expect(limited.body.retryAfter).toBe(
+      Number.parseInt(limited.headers['retry-after'], 10),
+    );
+  });
+
+  it('counts failed probes against the budget', async () => {
+    const app = buildApp({ max: 1, responseStatus: 500 });
+
+    expect((await request(app).get('/probe')).status).toBe(500);
+    expect((await request(app).get('/probe')).status).toBe(429);
+  });
+
+  it('bypasses the capability budget for platform admins', async () => {
+    const app = buildApp({ max: 1, isAdmin: true });
+
+    expect((await request(app).get('/probe')).status).toBe(200);
+    expect((await request(app).get('/probe')).status).toBe(200);
+  });
 });
 
 describe('brand bulk domain rate limiter', () => {

--- a/server/tests/unit/registry-badge-routes.test.ts
+++ b/server/tests/unit/registry-badge-routes.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../src/middleware/rate-limit.js', () => {
     bulkResolveRateLimiter: pass,
     brandBulkDomainRateLimiter: pass,
     brandCreationRateLimiter: pass,
+    capabilityProbeRateLimiter: pass,
     storyboardEvalRateLimiter: pass,
     storyboardStepRateLimiter: pass,
     agentReadRateLimiter: pass,

--- a/server/tests/unit/registry-capability-probe-rate-limit-wiring.test.ts
+++ b/server/tests/unit/registry-capability-probe-rate-limit-wiring.test.ts
@@ -1,0 +1,111 @@
+import type { RequestHandler, Router } from 'express';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY ||= 'sk_test_capability_probe_wiring';
+  process.env.WORKOS_CLIENT_ID ||= 'client_capability_probe_wiring';
+});
+
+const limiterMocks = vi.hoisted(() => {
+  const pass = (_req: unknown, _res: unknown, next: () => void) => next();
+  return {
+    pass,
+    capabilityProbe: vi.fn(pass),
+    storyboardEval: vi.fn(pass),
+    storyboardStep: vi.fn(pass),
+  };
+});
+
+vi.mock('../../src/middleware/rate-limit.js', () => ({
+  bulkResolveRateLimiter: limiterMocks.pass,
+  brandBulkDomainRateLimiter: limiterMocks.pass,
+  brandCreationRateLimiter: limiterMocks.pass,
+  capabilityProbeRateLimiter: limiterMocks.capabilityProbe,
+  storyboardEvalRateLimiter: limiterMocks.storyboardEval,
+  storyboardStepRateLimiter: limiterMocks.storyboardStep,
+  agentReadRateLimiter: limiterMocks.pass,
+  registryPublisherRateLimiter: limiterMocks.pass,
+  registryReadRateLimiter: limiterMocks.pass,
+}));
+
+import {
+  createRegistryApiRouter,
+  type RegistryApiConfig,
+} from '../../src/routes/registry-api.js';
+
+function routeHandlers(
+  router: Router,
+  method: 'get' | 'post',
+  path: string,
+): RequestHandler[] {
+  const layer = (router as unknown as {
+    stack: Array<{
+      route?: {
+        path: string;
+        methods: Record<string, boolean>;
+        stack: Array<{ handle: RequestHandler }>;
+      };
+    }>;
+  }).stack.find(
+    (candidate) =>
+      candidate.route?.path === path && candidate.route.methods[method],
+  );
+  if (!layer?.route) throw new Error(`Route not found: ${method} ${path}`);
+  return layer.route.stack.map((entry) => entry.handle);
+}
+
+function buildRouter(auth: RequestHandler): Router {
+  const config: RegistryApiConfig = {
+    brandManager: {} as RegistryApiConfig['brandManager'],
+    brandDb: {} as RegistryApiConfig['brandDb'],
+    propertyDb: {} as RegistryApiConfig['propertyDb'],
+    adagentsManager: {} as RegistryApiConfig['adagentsManager'],
+    healthChecker: {} as RegistryApiConfig['healthChecker'],
+    crawler: {} as RegistryApiConfig['crawler'],
+    capabilityDiscovery: {} as RegistryApiConfig['capabilityDiscovery'],
+    registryRequestsDb: {
+      trackRequest: async () => {},
+      markResolved: async () => true,
+    },
+    requireAuth: auth,
+    optionalAuth: auth,
+  };
+  return createRegistryApiRouter(config);
+}
+
+describe('registry capability probe limiter wiring', () => {
+  const auth: RequestHandler = (_req, _res, next) => next();
+  const router = buildRouter(auth);
+
+  it('authenticates before applying the dedicated capability probe budget', () => {
+    const handlers = routeHandlers(
+      router,
+      'get',
+      '/registry/agents/:encodedUrl/applicable-storyboards',
+    );
+
+    expect(handlers).toContain(auth);
+    expect(handlers).toContain(limiterMocks.capabilityProbe);
+    expect(handlers).not.toContain(limiterMocks.storyboardEval);
+    expect(handlers.indexOf(auth)).toBeLessThan(
+      handlers.indexOf(limiterMocks.capabilityProbe),
+    );
+  });
+
+  it('leaves full runs, comparisons, and steps on their existing budgets', () => {
+    const runPath = '/registry/agents/:encodedUrl/storyboard/:storyboardId/run';
+    const comparePath = '/registry/agents/:encodedUrl/storyboard/:storyboardId/compare';
+    const stepPath = '/registry/agents/:encodedUrl/storyboard/:storyboardId/step/:stepId';
+
+    const runHandlers = routeHandlers(router, 'post', runPath);
+    const compareHandlers = routeHandlers(router, 'post', comparePath);
+    const stepHandlers = routeHandlers(router, 'post', stepPath);
+
+    expect(runHandlers).toContain(limiterMocks.storyboardEval);
+    expect(compareHandlers).toContain(limiterMocks.storyboardEval);
+    expect(stepHandlers).toContain(limiterMocks.storyboardStep);
+    expect(runHandlers).not.toContain(limiterMocks.capabilityProbe);
+    expect(compareHandlers).not.toContain(limiterMocks.capabilityProbe);
+    expect(stepHandlers).not.toContain(limiterMocks.capabilityProbe);
+  });
+});

--- a/server/tests/unit/registry-feed-stream-route.test.ts
+++ b/server/tests/unit/registry-feed-stream-route.test.ts
@@ -16,6 +16,7 @@ vi.mock('../../src/middleware/rate-limit.js', () => {
     bulkResolveRateLimiter: pass,
     brandBulkDomainRateLimiter: pass,
     brandCreationRateLimiter: pass,
+    capabilityProbeRateLimiter: pass,
     storyboardEvalRateLimiter: pass,
     storyboardStepRateLimiter: pass,
     agentReadRateLimiter: pass,

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -12078,6 +12078,12 @@ paths:
                     description: Specialism ids present in this server's local compliance cache
                 required:
                   - error
+        "429":
+          description: Capability probe rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
         "500":
           description: Server error
           content:


### PR DESCRIPTION
## What changed

- give lightweight capability discovery its own authenticated-user budget of 60 probes per hour
- keep full storyboard runs, comparisons, and steps on their existing budgets
- authenticate before applying the capability limiter so admin bypass and user keys work
- show a truthful dashboard warning with retry timing while retaining saved storyboard status
- document the endpoint's 429 response in generated OpenAPI

## Root cause

`applicable-storyboards` reused the 10/hour full storyboard evaluation limiter, so iterative compliance runs could prevent the dashboard from checking an agent's declared capabilities.

## Validation

- `npm run test:server-unit` — 5,819 passed, 30 skipped
- focused regression suite — 45 passed
- `npm run typecheck`
- `npm run test:openapi`
- product/UX, testing, and code/security expert reviews — clean

Fixes #6392
