### PR TITLE
fix(compliance): bound heartbeat target discovery

### DIFF
--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -11,6 +11,7 @@ import {
   classifyCapabilityResolutionError,
   presentCapabilityResolutionError,
   badgeEligibleVersionsForTargetSelection,
+  HOSTED_TARGET_DISCOVERY_TIMEOUT_MS,
   selectComplianceTargetForAgentSelection,
   type ComplyOptions,
   type ComplianceTargetSelection,
@@ -66,7 +67,11 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
   // so a mid-loop process crash re-queues the agent after this TTL rather than
   // waiting the full check_interval (default 12 h).
   const urls = agentsDue.map(a => a.agent_url);
-  const lockSeconds = urls.length * (HOSTED_FULL_COMPLIANCE_TIMEOUT_MS / 1000) + 300;
+  // Each agent has two bounded capability pre-discoveries: target selection,
+  // then hosted auth defaults inside comply(). Account for both explicitly so
+  // the lock remains valid for the documented worst case.
+  const perAgentBudgetMs = HOSTED_FULL_COMPLIANCE_TIMEOUT_MS + (2 * HOSTED_TARGET_DISCOVERY_TIMEOUT_MS);
+  const lockSeconds = urls.length * (perAgentBudgetMs / 1000) + 300;
   await query(
     `INSERT INTO agent_compliance_status (agent_url, status, last_checked_at)
      SELECT unnest($1::text[]), 'unknown', NOW() + make_interval(secs => $2)

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -47,7 +47,7 @@ import type {
 } from '../../db/compliance-db.js';
 
 const logger = createLogger('addie-compliance-testing');
-const DEFAULT_TARGET_DISCOVERY_TIMEOUT_MS = 10_000;
+export const HOSTED_TARGET_DISCOVERY_TIMEOUT_MS = 30_000;
 
 export interface ComplianceTargetSelection {
   target: HostedComplianceTarget;
@@ -55,28 +55,122 @@ export interface ComplianceTargetSelection {
   supportedVersions?: readonly string[];
 }
 
-function complianceTargetDiscoveryTimeoutMs(options: ComplyOptions): number {
-  const requested = options.timeout_ms;
-  if (typeof requested !== 'number' || !Number.isFinite(requested)) {
-    return DEFAULT_TARGET_DISCOVERY_TIMEOUT_MS;
-  }
-  return Math.max(1_000, Math.min(requested, DEFAULT_TARGET_DISCOVERY_TIMEOUT_MS));
+function abortReason(signal: AbortSignal, fallback: string): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error(fallback);
 }
 
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+function combineAbortSignals(signals: readonly AbortSignal[]): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const handlers = new Map<AbortSignal, () => void>();
+
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      break;
+    }
+    const handler = () => controller.abort(signal.reason);
+    handlers.set(signal, handler);
+    signal.addEventListener('abort', handler, { once: true });
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      for (const [signal, handler] of handlers) {
+        signal.removeEventListener('abort', handler);
+      }
+    },
+  };
+}
+
+function discoveryOptions(
+  options: ComplyOptions,
+  deadlineSignal: AbortSignal,
+): ComplyOptions {
+  const withoutFullRunTimeout = { ...options };
+  delete withoutFullRunTimeout.timeout_ms;
+
+  const safeOptions = withSdkSafeTransport({
+    ...withoutFullRunTimeout,
+    signal: deadlineSignal,
+  });
+  const safeFetch = safeOptions.transport.fetchFn;
+
+  return {
+    ...safeOptions,
+    transport: {
+      ...safeOptions.transport,
+      // The SDK currently omits TestOptions.signal from its second capability
+      // tool call. Compose the deadline at the hosted fetch boundary as well so
+      // every discovery request is cancelled when the outer deadline fires.
+      fetchFn: async (input, init) => {
+        const request = new Request(input, init);
+        const combined = combineAbortSignals([request.signal, deadlineSignal]);
+        try {
+          return await safeFetch(request, { signal: combined.signal });
+        } finally {
+          combined.cleanup();
+        }
+      },
+    },
+  };
+}
+
+async function withDiscoveryDeadline<T>(
+  run: (signal: AbortSignal) => Promise<T>,
+  callerSignal: AbortSignal | undefined,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  const controller = new AbortController();
   let timeout: ReturnType<typeof setTimeout> | undefined;
+  let removeCallerAbort: (() => void) | undefined;
+  let removeDeadlineAbort: (() => void) | undefined;
+
   try {
+    if (callerSignal?.aborted) {
+      controller.abort(callerSignal.reason);
+    } else if (callerSignal) {
+      const onCallerAbort = () => controller.abort(callerSignal.reason);
+      callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+      removeCallerAbort = () => callerSignal.removeEventListener('abort', onCallerAbort);
+    }
+
+    timeout = setTimeout(() => {
+      controller.abort(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const aborted = new Promise<never>((_, reject) => {
+      if (controller.signal.aborted) {
+        reject(abortReason(controller.signal, `${label} aborted`));
+        return;
+      }
+      const onDeadlineAbort = () => reject(abortReason(controller.signal, `${label} aborted`));
+      controller.signal.addEventListener('abort', onDeadlineAbort, { once: true });
+      removeDeadlineAbort = () => controller.signal.removeEventListener('abort', onDeadlineAbort);
+    });
+
     return await Promise.race([
-      promise,
-      new Promise<never>((_, reject) => {
-        timeout = setTimeout(() => {
-          reject(new Error(`${label} timed out after ${timeoutMs}ms`));
-        }, timeoutMs);
-      }),
+      run(controller.signal),
+      aborted,
     ]);
   } finally {
     if (timeout) clearTimeout(timeout);
+    removeCallerAbort?.();
+    removeDeadlineAbort?.();
   }
+}
+
+function discoverCapabilitiesWithDeadline(agentUrl: string, options: ComplyOptions) {
+  return withDiscoveryDeadline(
+    signal => testCapabilityDiscovery(agentUrl, discoveryOptions(options, signal)),
+    options.signal,
+    HOSTED_TARGET_DISCOVERY_TIMEOUT_MS,
+    'Hosted capability pre-discovery',
+  );
 }
 
 // ── Re-exports ────────────────────────────────────────────────────
@@ -104,7 +198,7 @@ async function hostedAuthDefaultsForRun(
   }
 
   try {
-    const discovery = await testCapabilityDiscovery(agentUrl, options);
+    const discovery = await discoverCapabilitiesWithDeadline(agentUrl, options);
     const apiKey = shouldInferStaticFixture
       ? hostedStaticApiKeyForProfile(discovery.profile)
       : undefined;
@@ -153,17 +247,15 @@ export async function selectComplianceTargetForAgentSelection(
   mode: 'preferred' | 'canonical' = 'preferred',
 ): Promise<ComplianceTargetSelection> {
   try {
-    const safeOptions = withSdkSafeTransport(options);
-    const discovery = await withTimeout(
-      testCapabilityDiscovery(agentUrl, safeOptions),
-      complianceTargetDiscoveryTimeoutMs(safeOptions),
-      'Hosted compliance target pre-discovery',
-    );
+    const discovery = await discoverCapabilitiesWithDeadline(agentUrl, options);
     const target = mode === 'canonical'
       ? selectCanonicalHostedComplianceTargetForProfile(discovery.profile, fallback)
       : selectHostedComplianceTargetForProfile(discovery.profile, fallback);
     return { target, confirmed: true, supportedVersions: discovery.profile?.adcp_supported_versions };
   } catch (err) {
+    if (options.signal?.aborted) {
+      throw abortReason(options.signal, 'Hosted compliance target pre-discovery aborted');
+    }
     logger.warn({ err, agentUrl }, 'Could not pre-discover hosted compliance target; using fallback');
     return { target: fallback, confirmed: false };
   }

--- a/server/tests/unit/compliance-heartbeat.test.ts
+++ b/server/tests/unit/compliance-heartbeat.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../src/db/client.js', () => ({
 }));
 
 vi.mock('../../src/addie/services/compliance-testing.js', () => ({
+  HOSTED_TARGET_DISCOVERY_TIMEOUT_MS: 30_000,
   comply: mocks.comply,
   complianceResultToDbInput: mocks.complianceResultToDbInput,
   classifyCapabilityResolutionError: mocks.classifyCapabilityResolutionError,
@@ -122,6 +123,10 @@ describe('runComplianceHeartbeatJob', () => {
       expect.objectContaining({ timeout_ms: 600_000 }),
       target,
       'canonical',
+    );
+    expect(mocks.query).toHaveBeenCalledWith(
+      expect.stringContaining('make_interval'),
+      [['https://agent.example.com/mcp'], 960],
     );
     expect(mocks.comply).toHaveBeenCalledWith(
       'https://agent.example.com/mcp',

--- a/server/tests/unit/compliance-target-discovery.test.ts
+++ b/server/tests/unit/compliance-target-discovery.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  discovery: vi.fn(),
+  safeFetch: vi.fn(),
+  fallbackTarget: {
+    requested: '3.0',
+    version: '3.0.18',
+    complianceDir: '/compliance/3.0.18',
+    schemaRoot: '/schemas/3.0.18',
+  },
+  selectedTarget: {
+    requested: '3.1',
+    version: '3.1.13',
+    complianceDir: '/compliance/3.1.13',
+    schemaRoot: '/schemas/3.1.13',
+  },
+}));
+
+vi.mock('@adcp/sdk/testing', () => ({
+  SAMPLE_BRIEFS: [],
+  getBriefsByVertical: vi.fn(),
+  setAgentTesterLogger: vi.fn(),
+  comply: vi.fn(),
+  loadComplianceIndex: vi.fn(),
+  testCapabilityDiscovery: mocks.discovery,
+  CapabilityResolutionError: class CapabilityResolutionError extends Error {},
+}));
+
+vi.mock('../../src/services/hosted-compliance-version.js', () => ({
+  hostedComplianceTarget: () => mocks.fallbackTarget,
+  hostedAuthProbeTaskForProfile: vi.fn(),
+  hostedStaticApiKeyForProfile: vi.fn(),
+  agentAdvertisesBadgeEligibleHostedComplianceTarget: vi.fn().mockReturnValue(false),
+  badgeEligibleVersionsForHostedComplianceTarget: vi.fn().mockReturnValue([]),
+  selectCanonicalHostedComplianceTargetForProfile: (profile: { adcp_supported_versions?: string[] }) =>
+    profile?.adcp_supported_versions?.includes('3.1')
+      ? mocks.selectedTarget
+      : mocks.fallbackTarget,
+  selectHostedComplianceTargetForProfile: (profile: { adcp_supported_versions?: string[] }) =>
+    profile?.adcp_supported_versions?.includes('3.1')
+      ? mocks.selectedTarget
+      : mocks.fallbackTarget,
+  withHostedComplianceRunOptions: (options: unknown) => options,
+}));
+
+vi.mock('../../src/utils/sdk-safe-fetch.js', () => ({
+  withSdkSafeTransport: (options: Record<string, unknown>) => ({
+    ...options,
+    transport: {
+      ...(options.transport as Record<string, unknown> | undefined),
+      fetchFn: mocks.safeFetch,
+    },
+  }),
+}));
+
+vi.mock('../../src/services/storyboards.js', () => ({
+  getStoryboard: vi.fn(),
+}));
+
+import {
+  HOSTED_TARGET_DISCOVERY_TIMEOUT_MS,
+  selectComplianceTargetForAgentSelection,
+} from '../../src/addie/services/compliance-testing.js';
+
+describe('hosted compliance target discovery deadline', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('allows a slow 3.1 discovery and isolates it from the full-run timeout', async () => {
+    vi.useFakeTimers();
+    let receivedOptions: Record<string, unknown> | undefined;
+    mocks.discovery.mockImplementation((_url, options) => {
+      receivedOptions = options;
+      return new Promise(resolve => setTimeout(() => resolve({
+        profile: { adcp_supported_versions: ['3.1'] },
+        steps: [],
+      }), 15_000));
+    });
+
+    const selectionPromise = selectComplianceTargetForAgentSelection(
+      'https://agent.example/mcp',
+      {
+        timeout_ms: 600_000,
+        test_session_id: 'heartbeat-test',
+        userAgent: 'heartbeat-agent',
+        auth: { type: 'bearer', token: 'secret' },
+      },
+      mocks.fallbackTarget,
+      'canonical',
+    );
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(selectionPromise).resolves.toEqual({
+      target: mocks.selectedTarget,
+      confirmed: true,
+      supportedVersions: ['3.1'],
+    });
+    expect(receivedOptions).toMatchObject({
+      test_session_id: 'heartbeat-test',
+      userAgent: 'heartbeat-agent',
+      auth: { type: 'bearer', token: 'secret' },
+      signal: expect.any(AbortSignal),
+      transport: { fetchFn: expect.any(Function) },
+    });
+    expect(Object.hasOwn(receivedOptions ?? {}, 'timeout_ms')).toBe(false);
+  });
+
+  it('hard-stops at 30 seconds and aborts the hosted fetch boundary', async () => {
+    vi.useFakeTimers();
+    let transportSignal: AbortSignal | undefined;
+    mocks.safeFetch.mockImplementation((_input, init) => new Promise((_resolve, reject) => {
+      transportSignal = init?.signal;
+      transportSignal?.addEventListener('abort', () => reject(transportSignal?.reason), { once: true });
+    }));
+    mocks.discovery.mockImplementation((_url, options) =>
+      options.transport.fetchFn('https://agent.example/mcp'));
+
+    let settled = false;
+    const selectionPromise = selectComplianceTargetForAgentSelection(
+      'https://agent.example/mcp',
+      { timeout_ms: 600_000 },
+      mocks.fallbackTarget,
+      'canonical',
+    ).then(selection => {
+      settled = true;
+      return selection;
+    });
+
+    await vi.advanceTimersByTimeAsync(HOSTED_TARGET_DISCOVERY_TIMEOUT_MS - 1);
+    expect(settled).toBe(false);
+    expect(transportSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(selectionPromise).resolves.toEqual({
+      target: mocks.fallbackTarget,
+      confirmed: false,
+    });
+    expect(transportSignal?.aborted).toBe(true);
+  });
+
+  it('hard-stops even when discovery ignores its signal and never settles', async () => {
+    vi.useFakeTimers();
+    mocks.discovery.mockImplementation(() => new Promise(() => {}));
+
+    let settled = false;
+    const selectionPromise = selectComplianceTargetForAgentSelection(
+      'https://agent.example/mcp',
+      {},
+      mocks.fallbackTarget,
+      'canonical',
+    ).then(selection => {
+      settled = true;
+      return selection;
+    });
+
+    await vi.advanceTimersByTimeAsync(HOSTED_TARGET_DISCOVERY_TIMEOUT_MS - 1);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(selectionPromise).resolves.toEqual({
+      target: mocks.fallbackTarget,
+      confirmed: false,
+    });
+  });
+
+  it('rejects caller cancellation after propagating it through discovery fetches', async () => {
+    const caller = new AbortController();
+    let transportSignal: AbortSignal | undefined;
+    mocks.safeFetch.mockImplementation((_input, init) => new Promise((_resolve, reject) => {
+      transportSignal = init?.signal;
+      transportSignal?.addEventListener('abort', () => reject(transportSignal?.reason), { once: true });
+    }));
+    mocks.discovery.mockImplementation((_url, options) =>
+      options.transport.fetchFn('https://agent.example/mcp'));
+
+    const selectionPromise = selectComplianceTargetForAgentSelection(
+      'https://agent.example/mcp',
+      { signal: caller.signal },
+      mocks.fallbackTarget,
+      'canonical',
+    );
+    caller.abort(new Error('heartbeat stopped'));
+
+    await expect(selectionPromise).rejects.toThrow('heartbeat stopped');
+    expect(transportSignal?.aborted).toBe(true);
+  });
+
+  it('preserves request metadata while composing the discovery deadline signal', async () => {
+    const requestController = new AbortController();
+    let forwardedRequest: Request | undefined;
+    let forwardedSignal: AbortSignal | undefined;
+    mocks.safeFetch.mockImplementation((input, init) => {
+      forwardedRequest = input as Request;
+      forwardedSignal = init?.signal;
+      return new Promise((_resolve, reject) => {
+        forwardedSignal?.addEventListener('abort', () => reject(forwardedSignal?.reason), { once: true });
+      });
+    });
+    mocks.discovery.mockImplementation(async (_url, options) => {
+      await options.transport.fetchFn(new Request('https://agent.example/mcp?probe=1', {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer secret',
+          'content-type': 'application/json',
+          'x-probe': 'capabilities',
+        },
+        body: JSON.stringify({ method: 'get_adcp_capabilities' }),
+        signal: requestController.signal,
+      }));
+      return {
+        profile: { adcp_supported_versions: ['3.1'] },
+        steps: [],
+      };
+    });
+
+    const selectionPromise = selectComplianceTargetForAgentSelection(
+      'https://agent.example/mcp',
+      {},
+      mocks.fallbackTarget,
+      'canonical',
+    );
+    await vi.waitFor(() => expect(forwardedRequest).toBeInstanceOf(Request));
+
+    expect(forwardedRequest?.url).toBe('https://agent.example/mcp?probe=1');
+    expect(forwardedRequest?.method).toBe('POST');
+    expect(forwardedRequest?.headers.get('authorization')).toBe('Bearer secret');
+    expect(forwardedRequest?.headers.get('x-probe')).toBe('capabilities');
+    await expect(forwardedRequest?.clone().json()).resolves.toEqual({
+      method: 'get_adcp_capabilities',
+    });
+    expect(forwardedRequest?.signal).not.toBe(requestController.signal);
+    expect(forwardedSignal).toBeInstanceOf(AbortSignal);
+    expect(forwardedSignal).not.toBe(forwardedRequest?.signal);
+    expect(forwardedSignal?.aborted).toBe(false);
+
+    const requestAbort = new Error('request stopped');
+    requestController.abort(requestAbort);
+    await expect(selectionPromise).resolves.toEqual({
+      target: mocks.fallbackTarget,
+      confirmed: false,
+    });
+    expect(forwardedSignal?.aborted).toBe(true);
+    expect(forwardedSignal?.reason).toBe(requestAbort);
+  });
+
+  it('clears the deadline after a fast successful discovery', async () => {
+    vi.useFakeTimers();
+    let receivedSignal: AbortSignal | undefined;
+    mocks.discovery.mockImplementation((_url, options) => {
+      receivedSignal = options.signal;
+      return Promise.resolve({
+        profile: { adcp_supported_versions: ['3.1'] },
+        steps: [],
+      });
+    });
+
+    const selection = await selectComplianceTargetForAgentSelection(
+      'https://agent.example/mcp',
+      {},
+      mocks.fallbackTarget,
+      'canonical',
+    );
+    expect(selection.target).toBe(mocks.selectedTarget);
+
+    await vi.advanceTimersByTimeAsync(HOSTED_TARGET_DISCOVERY_TIMEOUT_MS);
+    expect(receivedSignal?.aborted).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- give hosted capability pre-discovery an independent 30-second deadline instead of inheriting the full 10-minute compliance timeout
- compose caller, request, and deadline cancellation at the SSRF-safe fetch boundary, including the SDK capability call that currently omits its top-level signal
- bound both target selection and hosted auth-default discovery, and account for both phases in the heartbeat lock TTL

## Validation
- `npx vitest run server/tests/unit/compliance-target-discovery.test.ts server/tests/unit/compliance-heartbeat.test.ts` (8 passed)
- `npm run typecheck`
- `npm run test:server-unit` (415 files; 5,825 passed; 30 skipped)
- live affected-agent smoke selected confirmed AdCP 3.1 / cache 3.1.13 with a 600,000ms full-run timeout
- product, testing, correctness, and security expert reviews clean

Fixes #6384