### PR TITLE
fix(dashboard): describe actual storyboard blockers

### DIFF
--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1644,6 +1644,14 @@
       return 'Not tested';
     }
 
+    function pickStoryboardBlockingReason(statuses) {
+      if (!Array.isArray(statuses) || statuses.length === 0) return null;
+      for (const reason of ['failing', 'partial', 'untested']) {
+        if (statuses.some(row => row?.status === reason)) return reason;
+      }
+      return null;
+    }
+
     function finiteCount(value) {
       const n = Number(value);
       return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
@@ -2242,6 +2250,8 @@
 
       const declaredSpecialisms = Array.isArray(cs?.declared_specialisms) ? cs.declared_specialisms : [];
       const specialismStatus = (cs && typeof cs.specialism_status === 'object' && cs.specialism_status) ? cs.specialism_status : {};
+      const storyboardStatuses = Array.isArray(cs?.storyboard_statuses) ? cs.storyboard_statuses : [];
+      const storyboardBlockingReason = pickStoryboardBlockingReason(storyboardStatuses);
       const checkIntervalHours = Number.isFinite(cs?.check_interval_hours) && cs.check_interval_hours > 0 ? cs.check_interval_hours : 12;
 
       // "On the next heartbeat" is jargon; surface the actual interval so
@@ -2269,6 +2279,21 @@
       const tierNotEligibleSentence = tierLabel && !tierEligible
         ? `Your tier (<strong>${escapeHtml(tierLabel)}</strong>) is not eligible — <a href="/membership" target="_blank" rel="noopener">upgrade to earn badges</a>`
         : null;
+      const storyboardBadgeGuidance = (action) => {
+        const declarationRequirement = declaredSpecialisms.length === 0
+          ? 'Your agent must also declare specialisms in <code>get_adcp_capabilities</code>'
+          : null;
+        if (tierNotEligibleSentence) {
+          return `${action}. ${declarationRequirement ? declarationRequirement + '. ' : ''}${tierNotEligibleSentence}.`;
+        }
+        if (tierEligible) {
+          if (declarationRequirement) {
+            return `${action}. ${declarationRequirement} before it can earn AAO Verified (Spec).`;
+          }
+          return `${action} to earn AAO Verified (Spec).`;
+        }
+        return `${action}. ${declarationRequirement ? declarationRequirement + '. ' : ''}Badge issuance also requires an API-access membership tier.`;
+      };
 
       // No badges yet — show diagnostic hint scoped to the actual situation.
       // The branch order here mirrors pickVerificationHint() in
@@ -2301,9 +2326,14 @@
             hint = `Storyboards are passing — your badge should issue ${nextCheckCopy}. If it doesn't, check that your AAO membership is on an API-access tier.`;
           }
         } else if (status === 'failing' || status === 'degraded') {
-          hint = declaredSpecialisms.length === 0
-            ? 'Storyboards are failing — fix the failing storyboards in this card to earn AAO Verified (Spec). <a href="/docs/building/verification/aao-verified" target="_blank" rel="noopener">Learn more</a>.'
-            : 'Some declared specialisms are failing — fix the failing storyboards in this card to earn AAO Verified (Spec). <a href="/docs/building/verification/aao-verified" target="_blank" rel="noopener">Learn more</a>.';
+          if (storyboardBlockingReason === 'partial') {
+            hint = storyboardBadgeGuidance('Some storyboards have partial results — review the incomplete checks in this card, then re-test');
+          } else if (storyboardBlockingReason === 'untested') {
+            hint = storyboardBadgeGuidance('Some storyboards have not been tested yet — run the applicable untested storyboards in this card');
+          } else {
+            hint = storyboardBadgeGuidance('Some storyboards are failing — fix the failing storyboards in this card, then re-test');
+          }
+          hint += ' <a href="/docs/building/verification/aao-verified" target="_blank" rel="noopener">Learn more</a>.';
         } else {
           hint = `Compliance check will run ${nextCheckCopy}. Earn AAO Verified (Spec) by declaring specialisms in <code>get_adcp_capabilities</code> and passing their storyboards. <a href="/docs/building/verification/aao-verified" target="_blank" rel="noopener">Learn more</a>.`;
         }

--- a/server/src/services/verification-hint.ts
+++ b/server/src/services/verification-hint.ts
@@ -26,13 +26,39 @@ export type VerificationHintKey =
   | 'passing_no_specialisms'
   | 'passing_pending_heartbeat'
   | 'storyboards_failing'
+  | 'storyboards_partial'
+  | 'storyboards_untested'
   | 'unknown_default';
+
+export type StoryboardBlockingReason = 'failing' | 'partial' | 'untested';
+
+export interface StoryboardStatusLike {
+  status?: string | null;
+}
 
 export interface PickHintInput {
   status: ComplianceCardStatus;
   declaredSpecialismCount: number;
   hasAuth: boolean;
   badgeCount: number;
+  storyboardBlockingReason?: StoryboardBlockingReason;
+}
+
+/**
+ * Pick the most actionable blocker from saved storyboard results.
+ * Missing or empty results deliberately return undefined so callers retain
+ * the conservative, backward-compatible fallback for older records.
+ */
+export function pickStoryboardBlockingReason(
+  statuses: readonly (StoryboardStatusLike | null | undefined)[] | null | undefined,
+): StoryboardBlockingReason | undefined {
+  if (!statuses || statuses.length === 0) return undefined;
+
+  for (const reason of ['failing', 'partial', 'untested'] as const) {
+    if (statuses.some((row) => row?.status === reason)) return reason;
+  }
+
+  return undefined;
 }
 
 export function pickVerificationHint(input: PickHintInput): VerificationHintKey | null {
@@ -49,6 +75,8 @@ export function pickVerificationHint(input: PickHintInput): VerificationHintKey 
         : 'passing_pending_heartbeat';
     case 'failing':
     case 'degraded':
+      if (input.storyboardBlockingReason === 'partial') return 'storyboards_partial';
+      if (input.storyboardBlockingReason === 'untested') return 'storyboards_untested';
       return 'storyboards_failing';
     default:
       return 'unknown_default';

--- a/server/tests/unit/dashboard-track-coverage-gap.test.ts
+++ b/server/tests/unit/dashboard-track-coverage-gap.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import vm from 'node:vm';
 import { describe, expect, it } from 'vitest';
+import { pickStoryboardBlockingReason as pickServerStoryboardBlockingReason } from '../../src/services/verification-hint.js';
 
 const dashboardSource = readFileSync(
   new URL('../../public/dashboard-agents.html', import.meta.url),
@@ -16,6 +17,36 @@ const context = vm.createContext({});
 vm.runInContext(dashboardSource.slice(helperStart, helperEnd), context);
 const buildTrackCoverageGapNote = context.buildTrackCoverageGapNote as (
   trackData: { has_coverage_gap_skip?: boolean; status?: string },
+) => string;
+
+const blockerHelperStart = dashboardSource.indexOf('function pickStoryboardBlockingReason');
+const blockerHelperEnd = dashboardSource.indexOf('function finiteCount', blockerHelperStart);
+const verificationPanelStart = dashboardSource.indexOf('function renderVerificationPanel');
+const verificationPanelEnd = dashboardSource.indexOf('function timeAgo', verificationPanelStart);
+if (
+  blockerHelperStart < 0 ||
+  blockerHelperEnd < 0 ||
+  verificationPanelStart < 0 ||
+  verificationPanelEnd < 0
+) {
+  throw new Error('verification panel helpers not found');
+}
+
+const verificationContext = vm.createContext({
+  buildNoticesSectionHtml: () => '',
+  escapeHtml: (value: unknown) => String(value),
+});
+vm.runInContext(dashboardSource.slice(blockerHelperStart, blockerHelperEnd), verificationContext);
+vm.runInContext(dashboardSource.slice(verificationPanelStart, verificationPanelEnd), verificationContext);
+
+type StoryboardStatus = { status?: string | null };
+const pickDashboardStoryboardBlockingReason = verificationContext.pickStoryboardBlockingReason as (
+  statuses?: StoryboardStatus[] | null,
+) => string | null;
+const renderVerificationPanel = verificationContext.renderVerificationPanel as (
+  complianceStatus: Record<string, unknown> | null,
+  agentUrl: string,
+  hasAuth: boolean,
 ) => string;
 
 describe('dashboard track coverage-gap guidance', () => {
@@ -41,5 +72,176 @@ describe('dashboard track coverage-gap guidance', () => {
   it('renders numeric scenario counts without string parsing', () => {
     expect(dashboardSource).toContain('Number(trackData.passed_count)');
     expect(dashboardSource).toContain('Number(trackData.scenario_count)');
+  });
+});
+
+describe('dashboard verification blocker guidance', () => {
+  it.each([
+    {
+      label: 'failing precedence',
+      statuses: [{ status: 'untested' }, { status: 'partial' }, { status: 'failing' }],
+      expected: 'failing',
+    },
+    {
+      label: 'partial precedence',
+      statuses: [{ status: 'passing' }, { status: 'untested' }, { status: 'partial' }],
+      expected: 'partial',
+    },
+    { label: 'untested only', statuses: [{ status: 'passing' }, { status: 'untested' }], expected: 'untested' },
+    { label: 'missing', statuses: undefined, expected: undefined },
+    { label: 'empty', statuses: [], expected: undefined },
+    { label: 'non-blocking', statuses: [{ status: 'passing' }], expected: undefined },
+  ])('matches the server selector for $label results', ({ statuses, expected }) => {
+    const serverReason = pickServerStoryboardBlockingReason(statuses);
+    const dashboardReason = pickDashboardStoryboardBlockingReason(statuses) ?? undefined;
+
+    expect(serverReason).toBe(expected);
+    expect(dashboardReason).toBe(serverReason);
+  });
+
+  it('renders partial guidance for the production reproduction without failing copy', () => {
+    const html = renderVerificationPanel({
+      status: 'degraded',
+      verified_badges: [],
+      declared_specialisms: ['media-buy'],
+      storyboard_statuses: [
+        ...Array.from({ length: 13 }, () => ({ status: 'passing' })),
+        ...Array.from({ length: 4 }, () => ({ status: 'partial' })),
+        ...Array.from({ length: 18 }, () => ({ status: 'untested' })),
+      ],
+    }, 'https://sell.nofluffadvisory.com', true);
+
+    expect(html).toContain('Some storyboards have partial results');
+    expect(html).toContain('review the incomplete checks');
+    expect(html).toContain('then re-test.');
+    expect(html).toContain('Badge issuance also requires an API-access membership tier');
+    expect(html).not.toContain('then re-test to earn');
+    expect(html).not.toContain('Storyboards are failing');
+    expect(html).not.toContain('failing storyboards');
+    expect(html).not.toContain('declared specialisms have partial storyboard results');
+  });
+
+  it.each([
+    { label: 'failing', storyboard_statuses: [{ status: 'failing' }] },
+    { label: 'partial', storyboard_statuses: [{ status: 'partial' }] },
+    { label: 'untested', storyboard_statuses: [{ status: 'untested' }] },
+  ])('requires an upgrade for an ineligible tier with $label results', ({ storyboard_statuses }) => {
+    for (const declared_specialisms of [[], ['media-buy']]) {
+      const html = renderVerificationPanel(
+        {
+          status: 'degraded',
+          verified_badges: [],
+          declared_specialisms,
+          storyboard_statuses,
+          membership_tier_label: 'Explorer',
+          is_api_access_tier: false,
+        },
+        'https://agent.example.com',
+        true,
+      );
+
+      expect(html).toContain('Your tier (<strong>Explorer</strong>) is not eligible');
+      expect(html).toContain('upgrade to earn badges');
+      expect(html).not.toContain('to earn AAO Verified (Spec)');
+      expect(html).not.toContain('before it can earn AAO Verified (Spec)');
+      if (declared_specialisms.length === 0) {
+        expect(html).toContain('must also declare specialisms');
+      }
+    }
+  });
+
+  it.each([
+    { label: 'failing', storyboard_statuses: [{ status: 'failing' }] },
+    { label: 'partial', storyboard_statuses: [{ status: 'partial' }] },
+    { label: 'untested', storyboard_statuses: [{ status: 'untested' }] },
+  ])('requires an API-access tier for unknown-tier viewers with $label results', ({ storyboard_statuses }) => {
+    const unknownTierShapes = [
+      {},
+      { membership_tier_label: 'Galactic', is_api_access_tier: false },
+    ];
+    for (const tierFields of unknownTierShapes) {
+      for (const declared_specialisms of [[], ['media-buy']]) {
+        const html = renderVerificationPanel(
+          {
+            status: 'degraded',
+            verified_badges: [],
+            declared_specialisms,
+            storyboard_statuses,
+            ...tierFields,
+          },
+          'https://agent.example.com',
+          true,
+        );
+
+        expect(html).toContain('Badge issuance also requires an API-access membership tier');
+        expect(html).not.toContain('to earn AAO Verified (Spec)');
+        expect(html).not.toContain('before it can earn AAO Verified (Spec)');
+        expect(html).not.toContain('upgrade to earn badges');
+        if (declared_specialisms.length === 0) {
+          expect(html).toContain('must also declare specialisms');
+        }
+      }
+    }
+  });
+
+  it('keeps action-to-earn guidance for an eligible tier', () => {
+    const html = renderVerificationPanel({
+      status: 'degraded',
+      verified_badges: [],
+      declared_specialisms: ['media-buy'],
+      storyboard_statuses: [{ status: 'partial' }],
+      membership_tier_label: 'Builder',
+      is_api_access_tier: true,
+    }, 'https://agent.example.com', true);
+
+    expect(html).toContain('then re-test to earn AAO Verified (Spec)');
+    expect(html).not.toContain('upgrade to earn badges');
+  });
+
+  it.each([
+    {
+      label: 'failing',
+      storyboard_statuses: [{ status: 'failing' }],
+      expected: 'fix the failing storyboards',
+      shouldRetest: true,
+    },
+    {
+      label: 'partial',
+      storyboard_statuses: [{ status: 'partial' }],
+      expected: 'review the incomplete checks',
+      shouldRetest: true,
+    },
+    {
+      label: 'untested',
+      storyboard_statuses: [{ status: 'untested' }],
+      expected: 'run the applicable untested storyboards',
+      shouldRetest: false,
+    },
+    {
+      label: 'missing results fallback',
+      storyboard_statuses: undefined,
+      expected: 'fix the failing storyboards',
+      shouldRetest: true,
+    },
+  ])('explains both requirements with zero declarations for $label results', (
+    { storyboard_statuses, expected, shouldRetest },
+  ) => {
+    const html = renderVerificationPanel(
+      {
+        status: 'degraded',
+        verified_badges: [],
+        declared_specialisms: [],
+        storyboard_statuses,
+      },
+      'https://agent.example.com',
+      true,
+    );
+
+    expect(html).toContain(expected);
+    if (shouldRetest) expect(html).toContain('then re-test');
+    expect(html).toContain('must also declare specialisms');
+    expect(html).toContain('<code>get_adcp_capabilities</code>');
+    expect(html).toContain('Badge issuance also requires an API-access membership tier');
+    expect(html).not.toContain('before it can earn AAO Verified (Spec)');
   });
 });

--- a/server/tests/unit/verification-hint.test.ts
+++ b/server/tests/unit/verification-hint.test.ts
@@ -1,46 +1,154 @@
 import { describe, it, expect } from 'vitest';
-import { pickVerificationHint } from '../../src/services/verification-hint.js';
+import {
+  pickStoryboardBlockingReason,
+  pickVerificationHint,
+} from '../../src/services/verification-hint.js';
+
+describe('pickStoryboardBlockingReason', () => {
+  it('uses failing before partial and untested regardless of row order', () => {
+    expect(
+      pickStoryboardBlockingReason([
+        { status: 'untested' },
+        { status: 'partial' },
+        { status: 'failing' },
+      ]),
+    ).toBe('failing');
+  });
+
+  it('returns partial for partial-only and passing/partial results', () => {
+    expect(pickStoryboardBlockingReason([{ status: 'partial' }])).toBe('partial');
+    expect(
+      pickStoryboardBlockingReason([{ status: 'passing' }, { status: 'partial' }]),
+    ).toBe('partial');
+  });
+
+  it('returns untested for untested-only and passing/untested results', () => {
+    expect(pickStoryboardBlockingReason([{ status: 'untested' }])).toBe('untested');
+    expect(
+      pickStoryboardBlockingReason([{ status: 'passing' }, { status: 'untested' }]),
+    ).toBe('untested');
+  });
+
+  it('uses partial before untested for mixed non-failing results', () => {
+    expect(
+      pickStoryboardBlockingReason([{ status: 'untested' }, { status: 'partial' }]),
+    ).toBe('partial');
+  });
+
+  it('returns undefined for missing, empty, or non-blocking results', () => {
+    expect(pickStoryboardBlockingReason(undefined)).toBeUndefined();
+    expect(pickStoryboardBlockingReason(null)).toBeUndefined();
+    expect(pickStoryboardBlockingReason([])).toBeUndefined();
+    expect(pickStoryboardBlockingReason([{ status: 'passing' }, {}])).toBeUndefined();
+  });
+});
 
 describe('pickVerificationHint', () => {
   it('returns null when a badge already exists', () => {
     expect(
-      pickVerificationHint({ status: 'passing', declaredSpecialismCount: 1, hasAuth: true, badgeCount: 1 }),
+      pickVerificationHint({
+        status: 'degraded',
+        declaredSpecialismCount: 1,
+        hasAuth: true,
+        badgeCount: 1,
+        storyboardBlockingReason: 'partial',
+      }),
     ).toBeNull();
   });
 
   it('short-circuits to no_auth when auth is missing, even if cached status is passing', () => {
     expect(
-      pickVerificationHint({ status: 'passing', declaredSpecialismCount: 1, hasAuth: false, badgeCount: 0 }),
+      pickVerificationHint({
+        status: 'degraded',
+        declaredSpecialismCount: 1,
+        hasAuth: false,
+        badgeCount: 0,
+        storyboardBlockingReason: 'partial',
+      }),
     ).toBe('no_auth');
   });
 
   it('returns opted_out for opted_out status', () => {
     expect(
-      pickVerificationHint({ status: 'opted_out', declaredSpecialismCount: 0, hasAuth: true, badgeCount: 0 }),
+      pickVerificationHint({
+        status: 'opted_out',
+        declaredSpecialismCount: 0,
+        hasAuth: true,
+        badgeCount: 0,
+        storyboardBlockingReason: 'partial',
+      }),
     ).toBe('opted_out');
   });
 
   it('flags the silent failure: passing run but zero declared specialisms', () => {
     expect(
-      pickVerificationHint({ status: 'passing', declaredSpecialismCount: 0, hasAuth: true, badgeCount: 0 }),
+      pickVerificationHint({
+        status: 'passing',
+        declaredSpecialismCount: 0,
+        hasAuth: true,
+        badgeCount: 0,
+        storyboardBlockingReason: 'partial',
+      }),
     ).toBe('passing_no_specialisms');
   });
 
   it('returns passing_pending_heartbeat when passing with declared specialisms', () => {
     expect(
-      pickVerificationHint({ status: 'passing', declaredSpecialismCount: 2, hasAuth: true, badgeCount: 0 }),
+      pickVerificationHint({
+        status: 'passing',
+        declaredSpecialismCount: 2,
+        hasAuth: true,
+        badgeCount: 0,
+        storyboardBlockingReason: 'untested',
+      }),
     ).toBe('passing_pending_heartbeat');
   });
 
   it('returns storyboards_failing for failing status', () => {
     expect(
-      pickVerificationHint({ status: 'failing', declaredSpecialismCount: 1, hasAuth: true, badgeCount: 0 }),
+      pickVerificationHint({
+        status: 'failing',
+        declaredSpecialismCount: 1,
+        hasAuth: true,
+        badgeCount: 0,
+        storyboardBlockingReason: 'failing',
+      }),
     ).toBe('storyboards_failing');
   });
 
-  it('returns storyboards_failing for degraded status', () => {
+  it('returns the specific storyboard blocker for degraded status', () => {
+    expect(
+      pickVerificationHint({
+        status: 'degraded',
+        declaredSpecialismCount: 1,
+        hasAuth: true,
+        badgeCount: 0,
+        storyboardBlockingReason: 'partial',
+      }),
+    ).toBe('storyboards_partial');
+    expect(
+      pickVerificationHint({
+        status: 'degraded',
+        declaredSpecialismCount: 1,
+        hasAuth: true,
+        badgeCount: 0,
+        storyboardBlockingReason: 'untested',
+      }),
+    ).toBe('storyboards_untested');
+  });
+
+  it('retains the failing fallback when storyboard results are missing or empty', () => {
     expect(
       pickVerificationHint({ status: 'degraded', declaredSpecialismCount: 1, hasAuth: true, badgeCount: 0 }),
+    ).toBe('storyboards_failing');
+    expect(
+      pickVerificationHint({
+        status: 'degraded',
+        declaredSpecialismCount: 1,
+        hasAuth: true,
+        badgeCount: 0,
+        storyboardBlockingReason: pickStoryboardBlockingReason([]),
+      }),
     ).toBe('storyboards_failing');
   });
 


### PR DESCRIPTION
## Summary

- derive dashboard guidance from the highest-priority saved storyboard blocker
- distinguish failing, partial, and untested results without attributing unrelated storyboards to declared specialisms
- preserve declaration and membership-tier requirements so remediation copy never overpromises badge eligibility
- regression-test the real inline dashboard renderer across blocker, declaration, and tier states

Closes #6363

## Validation

- `npx vitest run server/tests/unit/verification-hint.test.ts server/tests/unit/dashboard-track-coverage-gap.test.ts` (39/39)
- dashboard inline-script syntax check
- sparse TypeScript check
- `git diff --check`
- independent expert review and 18-case production-render matrix