### PR TITLE
docs(print): remove invalid artwork examples

### DIFF
--- a/docs/creative/channels/print.mdx
+++ b/docs/creative/channels/print.mdx
@@ -1,46 +1,70 @@
 ---
 title: Print Creative
-description: "Canonical image contracts for print advertising and production-ready artwork."
+description: "Current AdCP limits and seller-defined contracts for production-ready print artwork."
 "og:title": "AdCP — Print Creative"
 ---
 
-Print artwork uses `custom` because production-ready PDF/TIFF, bleed, trim, color-space, and DPI constraints exceed the web-image canonical.
+AdCP does not currently publish a shared print artwork contract. A PDF or other document file must not be labeled `asset_type: "image"`. A TIFF can use `asset_type: "image"` under a seller-defined custom contract, but TIFF is outside the shared web-oriented `image` canonical and the asset type alone does not express trim, bleed, color profile, or effective DPI.
 
-```json
-{
-  "format_option_id": "magazine_full_page",
-  "format_kind": "custom",
-  "format_shape": "print_full_page",
-  "format_schema": {
-    "uri": "https://creative.adcontextprotocol.org/formats/print-full-page.schema.json",
-    "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-  },
-  "canonical_formats_only": true,
-  "params": {
-    "width": 2550,
-    "height": 3300,
-    "file_formats": ["pdf", "tiff"],
-    "slots": [{ "asset_group_id": "image_main", "asset_type": "image", "required": true }]
-  }
-}
-```
+A seller can declare a print contract with `format_kind: "custom"` only after it publishes a real, fetchable JSON Schema and references that schema with its actual HTTPS URI and SHA-256 digest. The custom schema is load-bearing: placeholder URIs and illustrative digests do not produce a usable format declaration.
 
-The product or publisher declaration should document production constraints that cannot be inferred from pixels, including trim size, bleed, safe area, CMYK profile, minimum DPI, and delivery deadline. Price, issue availability, and placement position remain product facts.
+For a full-page format, the seller-hosted schema needs to define at least:
 
-```json
-{
-  "format_kind": "custom",
-  "format_option_ref": { "scope": "product", "format_option_id": "magazine_full_page" },
-  "assets": {
-    "image_main": {
-      "asset_type": "image",
-      "url": "https://cdn.acmeoutdoor.example/magazine-full-page.pdf",
-      "width": 2550,
-      "height": 3300,
-      "alt_text": "Acme Outdoor spring expedition collection"
-    }
-  }
-}
-```
+- the unit used by every dimension;
+- trim width and height;
+- bleed and safe-area insets for each edge;
+- accepted color profiles and minimum effective DPI; and
+- a typed delivery slot supported by the receiving workflow.
+
+The last requirement is currently seller-specific. A seller could define a `zip` slot and document the permitted archive contents, but the core `zip` asset describes a general creative archive and does not standardize PDF/TIFF print delivery. Until AdCP publishes a shared print schema or adds an appropriate typed asset, this page cannot provide a copyable portable or shared print manifest.
 
 See [Canonical formats](/docs/creative/canonical-formats), [Creative manifests](/docs/creative/creative-manifests), and [Media products](/docs/media-buy/product-discovery/media-products).
+
+## Double-page spreads and gatefolds
+
+A double-page spread (DPS) requires more than a wider full-page canvas. Its custom schema must specify whether artwork is supplied as one spread or separate pages, the gutter width, trim and bleed for each page, safe areas around the gutter, and the reading order.
+
+A gatefold needs a separate contract that specifies panel count, panel widths, fold or score lines, panel order, and safe areas around every fold. Those values cannot be inferred from `width` and `height`, and AdCP does not currently host a shared DPS or gatefold schema. A conformant wire example therefore depends on a seller-hosted schema plus a supported typed delivery model; this page intentionally does not invent either one.
+
+## Print and display discovery
+
+A product can advertise that it operates across both channels:
+
+```json
+{
+  "channels": ["print", "display"]
+}
+```
+
+This is a product excerpt, not a complete product. It declares channel scope only. It does not mean that the buyer receives one print placement and one display placement, or that the buyer must submit one creative for each channel. A fixed cross-channel bundle also needs explicit product placements and channel-specific format contracts. Because the current shared schemas do not provide a deployable print artwork contract, this page does not present that fixed bundle as a runnable example.
+
+## Cancellation window
+
+For recurring print inventory, a collection-level `deadline_policy` expresses the cancellation rule once. This fictional weekly publication uses business days for every lead time:
+
+```json
+{
+  "$schema": "https://adcontextprotocol.org/schemas/v3/core/collection.json",
+  "collection_id": "northstar_weekly",
+  "name": "Northstar Weekly",
+  "kind": "publication",
+  "cadence": "weekly",
+  "status": "active",
+  "deadline_policy": {
+    "booking_lead_days": 10,
+    "cancellation_lead_days": 5,
+    "material_stages": [
+      {
+        "stage": "final",
+        "lead_days": 3,
+        "label": "Production-ready PDF"
+      }
+    ],
+    "business_days_only": true
+  }
+}
+```
+
+For an installment scheduled at **09:00 UTC on Monday, October 12, 2026**, the booking deadline is September 28, the penalty-free cancellation deadline is October 5, and final artwork is due October 7, all at 09:00 UTC. An explicit `deadlines` object on that installment overrides this policy, which lets a special issue publish a different cancellation window without changing the collection default.
+
+> Magazine/newspaper/trade-publication comparisons, advertorial/native placements, and position-taxonomy examples remain deferred until [#5686](https://github.com/adcontextprotocol/adcp/issues/5686) defines the relevant placement terminology. Copyable DPS, gatefold, and fixed print-plus-display examples additionally require a fetchable print format schema and a supported typed delivery model; [#5688](https://github.com/adcontextprotocol/adcp/issues/5688) remains open for that follow-up.


### PR DESCRIPTION
## Summary

- remove copy/paste examples that referenced nonexistent custom schemas and modeled PDF documents as image assets
- document the fetchable-schema, digest, production-geometry, and typed-delivery requirements for seller-defined print contracts
- clarify that `channels: ["print", "display"]` is discovery scope, not fixed-bundle composition
- add a schema-valid worked `deadline_policy` cancellation window with verified business-day dates
- keep shared DPS/gatefold/fixed-bundle examples explicitly deferred until the required print schema and asset model exist

Refs #5688

## Validation

- MDX compilation
- JSON parsing and v3 collection schema validation
- channel enum validation
- cancellation date calculation
- `git diff --check`
- independent protocol review

#5688 intentionally remains open for taxonomy- and shared-artifact-dependent examples.