### PR TITLE
feat(content): insert linked images in articles

### DIFF
--- a/server/public/admin-content.html
+++ b/server/public/admin-content.html
@@ -8,6 +8,7 @@
   <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/turndown@7.2.0/dist/turndown.min.js"></script>
+  <script src="/content-image-upload.js"></script>
   <link rel="stylesheet" href="/design-system.css">
   <style>
     body { background: var(--color-bg-page); min-height: 100vh; }
@@ -148,6 +149,16 @@
     .url-input-group input { flex: 1; }
     .markdown-editor-container { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); }
     .markdown-editor-container textarea { min-height: 300px; font-family: var(--font-mono); }
+    .preview-pane img { max-width: 100%; height: auto; }
+    .body-image-toolbar { display: flex; align-items: center; gap: var(--space-3); margin: var(--space-2) 0; flex-wrap: wrap; }
+    .body-image-toolbar small { color: var(--color-text-secondary); font-size: var(--text-xs); }
+    .body-image-panel { border: var(--border-1) solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-4); margin-bottom: var(--space-3); background: var(--color-bg-subtle); }
+    .body-image-fields { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
+    .body-image-fields .file-field { grid-column: 1 / -1; }
+    .body-image-actions { display: flex; gap: var(--space-2); align-items: center; margin-top: var(--space-3); flex-wrap: wrap; }
+    .body-image-status { color: var(--color-success-700); font-size: var(--text-sm); }
+    .body-image-status.error { color: var(--color-error-600); }
+    @media (max-width: 600px) { .body-image-fields { grid-template-columns: 1fr; } }
     .preview-pane { border: var(--border-1) solid var(--color-gray-200); border-radius: var(--radius-md); padding: var(--space-4); background: var(--color-bg-subtle); min-height: 300px; max-height: 400px; overflow-y: auto; }
     .preview-pane.empty { display: flex; align-items: center; justify-content: center; color: var(--color-text-muted); font-style: italic; }
     .char-count { font-size: var(--text-xs); color: var(--color-text-secondary); text-align: right; margin-top: var(--space-1); }
@@ -438,6 +449,32 @@
         <div id="articleFields">
           <div class="form-group">
             <label>Content (Markdown)</label>
+            <div class="body-image-toolbar">
+              <button type="button" class="btn btn-secondary" id="insertBodyImageBtn">Insert image</button>
+              <small id="bodyImageHint">Save as a draft before adding images.</small>
+            </div>
+            <div class="body-image-panel hidden" id="bodyImagePanel">
+              <div class="body-image-fields">
+                <div class="file-field">
+                  <label for="bodyImageFile">Image file</label>
+                  <input type="file" id="bodyImageFile" accept="image/jpeg,image/png,image/webp,image/gif">
+                  <small>JPEG, PNG, WebP, or GIF; maximum 10 MB.</small>
+                </div>
+                <div>
+                  <label for="bodyImageAlt">Alt text</label>
+                  <input type="text" id="bodyImageAlt" required maxlength="300" placeholder="Describe the image">
+                </div>
+                <div>
+                  <label for="bodyImageLink">Link URL (optional)</label>
+                  <input type="url" id="bodyImageLink" placeholder="https://example.com/report">
+                </div>
+              </div>
+              <div class="body-image-actions">
+                <button type="button" class="btn btn-primary" id="uploadBodyImageBtn">Upload and insert</button>
+                <button type="button" class="btn btn-secondary" id="cancelBodyImageBtn">Cancel</button>
+                <span class="body-image-status" id="bodyImageStatus" role="status" aria-live="polite"></span>
+              </div>
+            </div>
             <div class="markdown-editor-container">
               <div><textarea id="articleContent" oninput="updatePreview()" placeholder="Write your perspective in Markdown..."></textarea></div>
               <div><div id="contentPreview" class="preview-pane empty">Start typing to see preview...</div></div>
@@ -661,6 +698,7 @@
     let pendingContent = [];
     let collections = [];
     let editingContent = null;
+    let bodyImageUploader = null;
     let reviewingContent = null;
     let currentDetailItem = null;
     let adminSortField = 'published_at';
@@ -1396,6 +1434,8 @@
       document.getElementById('sectionSelect').value = 'member';
       document.getElementById('autoCoverToggle').checked = true;
       document.getElementById('heroPreview').innerHTML = '<p style="color: var(--color-text-muted); font-size: var(--text-sm);">Cover will be auto-generated after save. Uncheck the toggle above to upload your own.</p>';
+      bodyImageUploader?.close();
+      bodyImageUploader?.refresh();
       document.getElementById('contentModal').style.display = 'flex';
     }
 
@@ -1443,6 +1483,8 @@
       document.getElementById('bylineGroup').classList.remove('hidden');
       document.getElementById('authorNameInput').value = item.author_name || '';
       loadCoauthors(item.id);
+      bodyImageUploader?.close();
+      bodyImageUploader?.refresh();
       document.getElementById('contentModal').style.display = 'flex';
     }
 
@@ -1484,7 +1526,12 @@
       } catch (e) { alert(e.message || 'Failed to delete content. Please try again.'); }
     }
 
-    function closeModal() { document.getElementById('contentModal').style.display = 'none'; editingContent = null; }
+    function closeModal() {
+      document.getElementById('contentModal').style.display = 'none';
+      editingContent = null;
+      bodyImageUploader?.close();
+      bodyImageUploader?.refresh();
+    }
 
     // Quick Share Link modal
     let shareLinkFetchTimer = null;
@@ -1601,7 +1648,22 @@
         el.dispatchEvent(new Event('input', { bubbles: true }));
       });
     }
-    window.addEventListener('DOMContentLoaded', () => wireRichTextPaste('articleContent'));
+    window.addEventListener('DOMContentLoaded', () => {
+      wireRichTextPaste('articleContent');
+      bodyImageUploader = ContentImageUpload.mount({
+        triggerButtonId: 'insertBodyImageBtn',
+        panelId: 'bodyImagePanel',
+        fileInputId: 'bodyImageFile',
+        altInputId: 'bodyImageAlt',
+        linkInputId: 'bodyImageLink',
+        submitButtonId: 'uploadBodyImageBtn',
+        cancelButtonId: 'cancelBodyImageBtn',
+        statusId: 'bodyImageStatus',
+        hintId: 'bodyImageHint',
+        textareaId: 'articleContent',
+        getSlug: () => editingContent?.slug || '',
+      });
+    });
 
     function updateStatusHint() {
       const slug = document.getElementById('collection').value;

--- a/server/public/content-image-upload.js
+++ b/server/public/content-image-upload.js
@@ -1,0 +1,227 @@
+(function (global) {
+  'use strict';
+
+  const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+  const ALLOWED_IMAGE_TYPES = new Set([
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'image/gif',
+  ]);
+
+  function normalizeHttpUrl(value, label) {
+    const trimmed = String(value || '').trim();
+    if (!trimmed) return '';
+    let parsed;
+    try {
+      parsed = new URL(trimmed);
+    } catch {
+      throw new Error(`${label} must be an absolute http:// or https:// URL.`);
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`${label} must be an absolute http:// or https:// URL.`);
+    }
+    if (parsed.username || parsed.password) {
+      throw new Error(`${label} must not include credentials.`);
+    }
+    return parsed.href;
+  }
+
+  function escapeAltText(value) {
+    return String(value || '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .replace(/\\/g, '\\\\')
+      .replace(/([\[\]])/g, '\\$1');
+  }
+
+  function normalizeLinkUrl(value) {
+    const normalized = normalizeHttpUrl(value, 'Link URL');
+    if (normalized && !normalized.startsWith('https:')) {
+      throw new Error('Link URL must use https://.');
+    }
+    return normalized;
+  }
+
+  function buildImageMarkdown(imageUrl, altText, linkUrl) {
+    const normalizedImageUrl = normalizeHttpUrl(imageUrl, 'Image URL');
+    const escapedAlt = escapeAltText(altText);
+    if (!escapedAlt) throw new Error('Alt text is required.');
+
+    const image = `![${escapedAlt}](<${normalizedImageUrl}>)`;
+    const normalizedLinkUrl = normalizeLinkUrl(linkUrl);
+    return normalizedLinkUrl ? `[${image}](<${normalizedLinkUrl}>)` : image;
+  }
+
+  function createUploadFilename(originalName, randomUUID) {
+    const name = String(originalName || 'image').trim();
+    const dot = name.lastIndexOf('.');
+    const rawStem = dot > 0 ? name.slice(0, dot) : name;
+    const rawExtension = dot > 0 ? name.slice(dot).toLowerCase() : '';
+    const stem = rawStem.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '').slice(0, 80) || 'image';
+    const extension = /^\.[a-z0-9]{1,10}$/.test(rawExtension) ? rawExtension : '';
+    const suffix = String(randomUUID()).replace(/[^a-z0-9-]/gi, '').slice(0, 64);
+    return `${stem}-${suffix}${extension}`;
+  }
+
+  function secureRandomId() {
+    if (typeof global.crypto?.randomUUID === 'function') return global.crypto.randomUUID();
+    const bytes = new Uint8Array(16);
+    global.crypto.getRandomValues(bytes);
+    return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+  }
+
+  function insertMarkdown(textarea, markdown, selection) {
+    const start = selection?.start ?? textarea.selectionStart ?? textarea.value.length;
+    const end = selection?.end ?? textarea.selectionEnd ?? start;
+    textarea.value = `${textarea.value.slice(0, start)}${markdown}${textarea.value.slice(end)}`;
+    const caret = start + markdown.length;
+    textarea.setSelectionRange(caret, caret);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.focus();
+    return caret;
+  }
+
+  async function uploadImage({
+    file,
+    slug,
+    altText,
+    linkUrl,
+    fetchImpl = global.fetch,
+    FormDataImpl = global.FormData,
+    randomUUID = secureRandomId,
+    signal,
+  }) {
+    if (!slug) throw new Error('Save this article as a draft before adding images.');
+    if (!file) throw new Error('Choose an image to upload.');
+    if (!ALLOWED_IMAGE_TYPES.has(file.type)) {
+      throw new Error('Choose a JPEG, PNG, WebP, or GIF image.');
+    }
+    if (file.size > MAX_IMAGE_BYTES) throw new Error('Image files must be under 10MB.');
+    if (!escapeAltText(altText)) throw new Error('Alt text is required.');
+    const normalizedLinkUrl = normalizeLinkUrl(linkUrl);
+
+    const formData = new FormDataImpl();
+    formData.append('file', file, createUploadFilename(file.name, randomUUID));
+    formData.append('asset_type', 'attachment');
+    const requestOptions = {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    };
+    if (signal) requestOptions.signal = signal;
+    const response = await fetchImpl(`/api/content/${encodeURIComponent(slug)}/assets`, requestOptions);
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      if (response.status === 401) throw new Error('Your session expired. Sign in and try again.');
+      if (response.status === 403) throw new Error('You do not have permission to add images to this article.');
+      if (response.status === 404) throw new Error('This article no longer exists. Refresh and try again.');
+      throw new Error(body.message || body.error || 'Image upload failed.');
+    }
+    if (!body.asset?.url) throw new Error('The upload succeeded but did not return an image URL.');
+    return {
+      markdown: buildImageMarkdown(body.asset.url, altText, normalizedLinkUrl),
+      asset: body.asset,
+    };
+  }
+
+  function mount(options) {
+    const trigger = document.getElementById(options.triggerButtonId);
+    const panel = document.getElementById(options.panelId);
+    const fileInput = document.getElementById(options.fileInputId);
+    const altInput = document.getElementById(options.altInputId);
+    const linkInput = document.getElementById(options.linkInputId);
+    const submit = document.getElementById(options.submitButtonId);
+    const cancel = document.getElementById(options.cancelButtonId);
+    const status = document.getElementById(options.statusId);
+    const hint = document.getElementById(options.hintId);
+    const textarea = document.getElementById(options.textareaId);
+    let insertionPoint = null;
+    let uploadGeneration = 0;
+    let activeController = null;
+
+    function refresh() {
+      const enabled = Boolean(options.getSlug());
+      trigger.disabled = !enabled;
+      trigger.title = enabled ? 'Upload an image and insert it at the cursor' : 'Save as a draft before adding images';
+      hint.textContent = enabled
+        ? 'Images are inserted at the current cursor position.'
+        : 'Save as a draft before adding images.';
+    }
+
+    function close() {
+      uploadGeneration += 1;
+      activeController?.abort();
+      activeController = null;
+      insertionPoint = null;
+      fileInput.value = '';
+      altInput.value = '';
+      linkInput.value = '';
+      submit.disabled = false;
+      submit.textContent = 'Upload and insert';
+      panel.classList.add('hidden');
+      status.textContent = '';
+      status.classList.remove('error');
+    }
+
+    trigger.addEventListener('click', () => {
+      refresh();
+      if (trigger.disabled) return;
+      insertionPoint = { start: textarea.selectionStart, end: textarea.selectionEnd };
+      status.textContent = '';
+      panel.classList.remove('hidden');
+      fileInput.focus();
+    });
+    cancel.addEventListener('click', close);
+    submit.addEventListener('click', async () => {
+      const generation = ++uploadGeneration;
+      const slug = options.getSlug();
+      const controller = new global.AbortController();
+      activeController?.abort();
+      activeController = controller;
+      submit.disabled = true;
+      submit.textContent = 'Uploading…';
+      status.textContent = '';
+      try {
+        const result = await uploadImage({
+          file: fileInput.files?.[0],
+          slug,
+          altText: altInput.value,
+          linkUrl: linkInput.value,
+          signal: controller.signal,
+        });
+        if (generation !== uploadGeneration || slug !== options.getSlug()) return;
+        insertMarkdown(textarea, result.markdown, insertionPoint);
+        insertionPoint = { start: textarea.selectionStart, end: textarea.selectionEnd };
+        fileInput.value = '';
+        altInput.value = '';
+        linkInput.value = '';
+        status.textContent = 'Image inserted. Save changes to keep it in the article.';
+        status.classList.remove('error');
+      } catch (error) {
+        if (generation !== uploadGeneration || error?.name === 'AbortError') return;
+        status.textContent = error instanceof Error ? error.message : 'Image upload failed.';
+        status.classList.add('error');
+      } finally {
+        if (generation === uploadGeneration) {
+          activeController = null;
+          submit.disabled = false;
+          submit.textContent = 'Upload and insert';
+        }
+      }
+    });
+
+    refresh();
+    return { refresh, close };
+  }
+
+  global.ContentImageUpload = {
+    MAX_IMAGE_BYTES,
+    buildImageMarkdown,
+    createUploadFilename,
+    insertMarkdown,
+    mount,
+    normalizeHttpUrl,
+    uploadImage,
+  };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/server/public/my-content.html
+++ b/server/public/my-content.html
@@ -9,6 +9,7 @@
   <script src="/nav.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/turndown@7.2.0/dist/turndown.min.js"></script>
+  <script src="/content-image-upload.js"></script>
   <link rel="stylesheet" href="/design-system.css">
   <style>
     body {
@@ -420,6 +421,16 @@
       min-height: 300px;
       font-family: var(--font-mono);
     }
+    .preview-pane img { max-width: 100%; height: auto; }
+    .body-image-toolbar { display: flex; align-items: center; gap: var(--space-3); margin: var(--space-2) 0; flex-wrap: wrap; }
+    .body-image-toolbar small { color: var(--color-text-secondary); font-size: var(--text-xs); }
+    .body-image-panel { border: var(--border-1) solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-4); margin-bottom: var(--space-3); background: var(--color-bg-subtle); }
+    .body-image-fields { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
+    .body-image-fields .file-field { grid-column: 1 / -1; }
+    .body-image-actions { display: flex; gap: var(--space-2); align-items: center; margin-top: var(--space-3); flex-wrap: wrap; }
+    .body-image-status { color: var(--color-success-700); font-size: var(--text-sm); }
+    .body-image-status.error { color: var(--color-error-600); }
+    @media (max-width: 600px) { .body-image-fields { grid-template-columns: 1fr; } }
     .article-content h2 { font-size: 1.5rem; font-weight: 700; color: var(--color-text-heading); margin-top: 2rem; margin-bottom: 1rem; }
     .article-content h3 { font-size: 1.25rem; font-weight: 600; color: var(--color-text-heading); margin-top: 1.5rem; margin-bottom: 0.75rem; }
     .article-content p { font-size: 1.1rem; line-height: 1.8; color: var(--color-text-heading); margin-bottom: 1rem; }
@@ -702,6 +713,32 @@
         <div id="articleFields">
           <div class="form-group">
             <label>Content (Markdown)</label>
+            <div class="body-image-toolbar">
+              <button type="button" class="btn btn-secondary" id="insertBodyImageBtn">Insert image</button>
+              <small id="bodyImageHint">Save as a draft before adding images.</small>
+            </div>
+            <div class="body-image-panel hidden" id="bodyImagePanel">
+              <div class="body-image-fields">
+                <div class="file-field">
+                  <label for="bodyImageFile">Image file</label>
+                  <input type="file" id="bodyImageFile" accept="image/jpeg,image/png,image/webp,image/gif">
+                  <small>JPEG, PNG, WebP, or GIF; maximum 10 MB.</small>
+                </div>
+                <div>
+                  <label for="bodyImageAlt">Alt text</label>
+                  <input type="text" id="bodyImageAlt" required maxlength="300" placeholder="Describe the image">
+                </div>
+                <div>
+                  <label for="bodyImageLink">Link URL (optional)</label>
+                  <input type="url" id="bodyImageLink" placeholder="https://example.com/report">
+                </div>
+              </div>
+              <div class="body-image-actions">
+                <button type="button" class="btn btn-primary" id="uploadBodyImageBtn">Upload and insert</button>
+                <button type="button" class="btn btn-secondary" id="cancelBodyImageBtn">Cancel</button>
+                <span class="body-image-status" id="bodyImageStatus" role="status" aria-live="polite"></span>
+              </div>
+            </div>
             <div class="markdown-editor-container">
               <div>
                 <textarea id="articleContent" oninput="updatePreview()" placeholder="Write your content in Markdown..."></textarea>
@@ -777,6 +814,7 @@
     let committees = [];
     let currentUser = null;
     let editingContent = null;
+    let bodyImageUploader = null;
     let reviewingContent = null;
     let canReview = false;
     let isAdmin = false;
@@ -1117,6 +1155,8 @@
       setContentType('article');
       updateExcerptCount();
       updateStatusHint();
+      bodyImageUploader?.close();
+      bodyImageUploader?.refresh();
       document.getElementById('contentModal').style.display = 'flex';
     }
 
@@ -1145,6 +1185,8 @@
       updatePreview();
       updateExcerptCount();
       updateStatusHint();
+      bodyImageUploader?.close();
+      bodyImageUploader?.refresh();
       document.getElementById('contentModal').style.display = 'flex';
     }
 
@@ -1162,6 +1204,8 @@
     function closeModal() {
       document.getElementById('contentModal').style.display = 'none';
       editingContent = null;
+      bodyImageUploader?.close();
+      bodyImageUploader?.refresh();
     }
 
     // Set content type
@@ -1231,7 +1275,22 @@
         el.dispatchEvent(new Event('input', { bubbles: true }));
       });
     }
-    window.addEventListener('DOMContentLoaded', () => wireRichTextPaste('articleContent'));
+    window.addEventListener('DOMContentLoaded', () => {
+      wireRichTextPaste('articleContent');
+      bodyImageUploader = ContentImageUpload.mount({
+        triggerButtonId: 'insertBodyImageBtn',
+        panelId: 'bodyImagePanel',
+        fileInputId: 'bodyImageFile',
+        altInputId: 'bodyImageAlt',
+        linkInputId: 'bodyImageLink',
+        submitButtonId: 'uploadBodyImageBtn',
+        cancelButtonId: 'cancelBodyImageBtn',
+        statusId: 'bodyImageStatus',
+        hintId: 'bodyImageHint',
+        textareaId: 'articleContent',
+        getSlug: () => editingContent?.slug || '',
+      });
+    });
 
     // Update status hint based on collection
     function updateStatusHint() {

--- a/server/public/perspectives/article.html
+++ b/server/public/perspectives/article.html
@@ -258,6 +258,13 @@
     .article-content a:hover {
       text-decoration: underline;
     }
+    .article-content img {
+      display: block;
+      max-width: 100%;
+      height: auto;
+      margin: var(--space-5) auto;
+      border-radius: var(--radius-md);
+    }
     .article-content blockquote {
       border-left: 4px solid var(--color-brand);
       margin: 1.5rem 0;

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -6821,6 +6821,7 @@ export class HTTPServer {
         const { slug, filename } = req.params;
         const pool = getPool();
         const userId = req.user?.id ?? null;
+        const userIsAdmin = userId ? await isWebUserAAOAdmin(userId) : false;
 
         const perspResult = await pool.query(
           `SELECT p.id,
@@ -6832,12 +6833,14 @@ export class HTTPServer {
              AND (
                (p.status = 'published' AND p.is_members_only = false
                  AND (p.working_group_id IS NULL OR wg.slug = 'editorial'))
-               OR ($2::text IS NOT NULL AND p.status IN ('draft', 'pending_review') AND (
+               OR ($2::text IS NOT NULL AND (
                  p.author_user_id = $2
+                 OR p.proposer_user_id = $2
                  OR EXISTS (SELECT 1 FROM content_authors ca WHERE ca.perspective_id = p.id AND ca.user_id = $2)
+                 OR $3::boolean
                ))
              )`,
-          [slug, userId]
+          [slug, userId, userIsAdmin]
         );
         if (perspResult.rows.length === 0) {
           return res.status(404).send('Not found');

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -735,6 +735,36 @@ export const contentFetchUrlRateLimiter = rateLimit({
 });
 
 /**
+ * Rate limiter for perspective asset uploads.
+ * Limits: 30 uploads per hour per authenticated user.
+ *
+ * Asset uploads buffer data in memory and persist it in Postgres, so this
+ * endpoint needs a tighter write ceiling than ordinary content edits.
+ */
+export const contentAssetUploadRateLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  store: new CachedPostgresStore('content-asset-upload:'),
+  keyGenerator: generateKey,
+  validate: { keyGeneratorIpFallback: false },
+  handler: (req: Request, res: Response) => {
+    logger.warn({
+      userId: (req as any).user?.id,
+      ip: req.ip,
+      path: req.path,
+    }, 'Rate limit exceeded for content asset uploads');
+
+    res.status(429).json({
+      error: 'Too many requests',
+      message: 'Image upload rate limit exceeded (30 per hour). Please try again later.',
+      retryAfter: Math.ceil(60 * 60),
+    });
+  },
+});
+
+/**
  * Rate limiter for the unauthenticated /api/registry/publisher endpoint.
  * Tighter than the generic registry read limit because each request fans out
  * to up to 50 DB queries (per-agent rollup cap from PR #4106). At 20 req/min

--- a/server/src/routes/content.ts
+++ b/server/src/routes/content.ts
@@ -10,9 +10,11 @@
 
 import { Router } from 'express';
 import multer from 'multer';
+import { fileTypeFromBuffer } from 'file-type';
+import sharp from 'sharp';
 import { createLogger } from '../logger.js';
 import { requireAuth } from '../middleware/auth.js';
-import { contentProposeRateLimiter, contentFetchUrlRateLimiter } from '../middleware/rate-limit.js';
+import { contentProposeRateLimiter, contentFetchUrlRateLimiter, contentAssetUploadRateLimiter } from '../middleware/rate-limit.js';
 import { getPool } from '../db/client.js';
 import { isWebUserAAOAdmin } from '../addie/mcp/admin-tools.js';
 import { sendChannelMessage } from '../slack/client.js';
@@ -33,6 +35,8 @@ import { checkContentSubmissionTier } from '../services/membership-tiers.js';
 import { normalizePerspectiveExternalUrl } from '../utils/perspective-url.js';
 
 const logger = createLogger('content-routes');
+const MAX_ASSETS_PER_PERSPECTIVE = 100;
+const MAX_ASSET_BYTES_PER_PERSPECTIVE = 100 * 1024 * 1024;
 
 /**
  * In-process per-user submission rate tracker.
@@ -1511,7 +1515,7 @@ export function createContentRouter(): Router {
   });
 
   // POST /api/content/:slug/assets - Upload asset for a perspective
-  router.post('/:slug/assets', requireAuth, (req: any, res: any, next: any) => {
+  router.post('/:slug/assets', requireAuth, contentAssetUploadRateLimiter, (req: any, res: any, next: any) => {
     assetUpload.single('file')(req, res, (err: any) => {
       if (err instanceof multer.MulterError) {
         if (err.code === 'LIMIT_FILE_SIZE') {
@@ -1543,6 +1547,18 @@ export function createContentRouter(): Router {
         return res.status(400).json({ error: 'Image files must be under 10MB' });
       }
 
+      const detectedType = await fileTypeFromBuffer(file.buffer);
+      if (detectedType?.mime !== file.mimetype) {
+        return res.status(400).json({ error: 'File contents do not match the declared file type' });
+      }
+      if (file.mimetype.startsWith('image/')) {
+        try {
+          await sharp(file.buffer, { limitInputPixels: 24_000_000, failOn: 'error' }).metadata();
+        } catch {
+          return res.status(400).json({ error: 'Image data is invalid or exceeds the 24 megapixel limit' });
+        }
+      }
+
       const pool = getPool();
       const perspResult = await pool.query(
         `SELECT id FROM perspectives WHERE slug = $1`,
@@ -1568,6 +1584,30 @@ export function createContentRouter(): Router {
       }
 
       const sanitizedFilename = file.originalname.replace(/[^\w.\-() ]/g, '_').slice(0, 200);
+      const usageResult = await pool.query(
+        `SELECT COUNT(*)::int AS asset_count,
+                COALESCE(SUM(file_size_bytes), 0)::bigint AS total_bytes,
+                COUNT(*) FILTER (
+                  WHERE ($2 = 'cover_image' AND asset_type = 'cover_image')
+                     OR ($2 <> 'cover_image' AND file_name = $3)
+                )::int AS replacement_count,
+                COALESCE(SUM(file_size_bytes) FILTER (
+                  WHERE ($2 = 'cover_image' AND asset_type = 'cover_image')
+                     OR ($2 <> 'cover_image' AND file_name = $3)
+                ), 0)::bigint AS replacement_bytes
+         FROM perspective_assets
+         WHERE perspective_id = $1`,
+        [perspectiveId, assetType, sanitizedFilename]
+      );
+      const usage = usageResult.rows[0];
+      const projectedCount = Number(usage.asset_count) + (Number(usage.replacement_count) > 0 ? 0 : 1);
+      const projectedBytes = Number(usage.total_bytes) - Number(usage.replacement_bytes) + file.size;
+      if (projectedCount > MAX_ASSETS_PER_PERSPECTIVE || projectedBytes > MAX_ASSET_BYTES_PER_PERSPECTIVE) {
+        return res.status(413).json({
+          error: 'Perspective asset storage limit exceeded',
+          message: 'Each article can store up to 100 files and 100MB of assets.',
+        });
+      }
 
       const asset = await createAsset({
         perspective_id: perspectiveId,

--- a/server/tests/integration/perspective-assets.test.ts
+++ b/server/tests/integration/perspective-assets.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 
+const adminAccess = vi.hoisted(() => ({ enabled: true }));
+
 // Mock WorkOS client before any imports that depend on it
 vi.mock('../../src/auth/workos-client.js', () => ({
   workos: {
@@ -70,7 +72,7 @@ vi.mock('../../src/addie/mcp/admin-tools.js', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>;
   return {
     ...actual,
-    isWebUserAAOAdmin: vi.fn().mockResolvedValue(true),
+    isWebUserAAOAdmin: vi.fn().mockImplementation(async () => adminAccess.enabled),
   };
 });
 
@@ -249,6 +251,50 @@ describe('Perspective Assets Integration Tests', () => {
         .expect(400);
     });
 
+    it('should reject content whose bytes do not match the declared image type', async () => {
+      const response = await request(app)
+        .post(`/api/content/${TEST_SLUG}/assets`)
+        .attach('file', Buffer.from('<html><body>not an image</body></html>'), {
+          filename: 'spoofed.png',
+          contentType: 'image/png',
+        })
+        .field('asset_type', 'attachment')
+        .expect(400);
+
+      expect(response.body.error).toContain('do not match');
+    });
+
+    it('should enforce the per-perspective asset count quota', async () => {
+      const slug = 'test-asset-quota';
+      const result = await pool.query(
+        `INSERT INTO perspectives (slug, content_type, title, content, status, working_group_id, content_origin, author_user_id)
+         VALUES ($1, 'article', 'Quota test', 'Body', 'draft', $2, 'member', 'user_test_assets')
+         ON CONFLICT (slug) DO UPDATE SET author_user_id = 'user_test_assets'
+         RETURNING id`,
+        [slug, testWgId]
+      );
+      const perspectiveId = result.rows[0].id;
+      await pool.query(
+        `INSERT INTO perspective_assets
+           (perspective_id, asset_type, file_name, file_mime_type, file_data, file_size_bytes, uploaded_by_user_id)
+         SELECT $1, 'attachment', 'quota-' || n || '.png', 'image/png', decode('00', 'hex'), 1, 'user_test_assets'
+         FROM generate_series(1, 100) AS n
+         ON CONFLICT (perspective_id, file_name) DO NOTHING`,
+        [perspectiveId]
+      );
+
+      try {
+        const response = await request(app)
+          .post(`/api/content/${slug}/assets`)
+          .attach('file', createTestPng(), { filename: 'over-quota.png', contentType: 'image/png' })
+          .field('asset_type', 'attachment')
+          .expect(413);
+        expect(response.body.message).toContain('100 files');
+      } finally {
+        await pool.query(`DELETE FROM perspectives WHERE id = $1`, [perspectiveId]);
+      }
+    });
+
     it('should sanitize filenames', async () => {
       const png = createTestPng();
       const response = await request(app)
@@ -316,6 +362,53 @@ describe('Perspective Assets Integration Tests', () => {
         .expect(404);
 
       await pool.query(`DELETE FROM perspectives WHERE slug = 'test-draft-perspective'`);
+    });
+
+    it('allows an author to preview an asset while revisions are needed', async () => {
+      adminAccess.enabled = false;
+      await pool.query(`UPDATE perspectives SET status = 'needs_revisions' WHERE id = $1`, [testPerspectiveId]);
+
+      try {
+        const response = await request(app)
+          .get(`/api/perspectives/${TEST_SLUG}/assets/new-cover.png`)
+          .expect(200);
+
+        expect(response.headers['cache-control']).toBe('private, no-store');
+      } finally {
+        adminAccess.enabled = true;
+        await pool.query(`UPDATE perspectives SET status = 'published' WHERE id = $1`, [testPerspectiveId]);
+      }
+    });
+
+    it('lets admins preview private assets without exposing them to other users', async () => {
+      const slug = 'test-admin-private-asset';
+      await pool.query(
+        `INSERT INTO perspectives (slug, content_type, title, content, status, working_group_id, content_origin, author_user_id)
+         VALUES ($1, 'article', 'Private draft', 'Draft body', 'draft', $2, 'member', 'another_user')
+         ON CONFLICT (slug) DO UPDATE SET status = 'draft', author_user_id = 'another_user'`,
+        [slug, testWgId]
+      );
+
+      try {
+        await request(app)
+          .post(`/api/content/${slug}/assets`)
+          .attach('file', createTestPng(), { filename: 'private.png', contentType: 'image/png' })
+          .field('asset_type', 'attachment')
+          .expect(201);
+
+        const adminResponse = await request(app)
+          .get(`/api/perspectives/${slug}/assets/private.png`)
+          .expect(200);
+        expect(adminResponse.headers['cache-control']).toBe('private, no-store');
+
+        adminAccess.enabled = false;
+        await request(app)
+          .get(`/api/perspectives/${slug}/assets/private.png`)
+          .expect(404);
+      } finally {
+        adminAccess.enabled = true;
+        await pool.query(`DELETE FROM perspectives WHERE slug = $1`, [slug]);
+      }
     });
   });
 

--- a/server/tests/unit/content-body-image-editor.test.ts
+++ b/server/tests/unit/content-body-image-editor.test.ts
@@ -1,0 +1,288 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import vm from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+
+const publicRoot = join(process.cwd(), 'server/public');
+const helperSource = readFileSync(join(publicRoot, 'content-image-upload.js'), 'utf8');
+
+class BrowserEvent {
+  type: string;
+  bubbles: boolean;
+
+  constructor(type: string, options: { bubbles?: boolean } = {}) {
+    this.type = type;
+    this.bubbles = Boolean(options.bubbles);
+  }
+}
+
+function loadHelper(extra: Record<string, unknown> = {}) {
+  const providedWindow = (extra.window || {}) as Record<string, unknown>;
+  const context = vm.createContext({
+    URL,
+    Event: BrowserEvent,
+    ...extra,
+    window: { AbortController, ...providedWindow },
+  });
+  vm.runInContext(helperSource, context);
+  return (context.window as { ContentImageUpload: any }).ContentImageUpload;
+}
+
+function mountedHarness(fetchImpl: Function) {
+  let slug = 'article-a';
+  const listeners = new Map<string, Function>();
+  const elements: Record<string, any> = {};
+  for (const id of ['trigger', 'panel', 'file', 'alt', 'link', 'submit', 'cancel', 'status', 'hint', 'textarea']) {
+    elements[id] = {
+      id,
+      classList: { add: vi.fn(), remove: vi.fn() },
+      value: '',
+      textContent: '',
+      disabled: false,
+      files: [],
+      selectionStart: 0,
+      selectionEnd: 0,
+      addEventListener: (event: string, callback: Function) => listeners.set(`${id}:${event}`, callback),
+      focus: vi.fn(),
+      setSelectionRange(start: number, end: number) {
+        this.selectionStart = start;
+        this.selectionEnd = end;
+      },
+      dispatchEvent: vi.fn(),
+    };
+  }
+  class TestFormData { append() {} }
+  const helper = loadHelper({
+    document: { getElementById: (id: string) => elements[id] },
+    window: {
+      AbortController,
+      fetch: fetchImpl,
+      FormData: TestFormData,
+      crypto: { randomUUID: () => 'upload-id' },
+    },
+  });
+  const uploader = helper.mount({
+    triggerButtonId: 'trigger', panelId: 'panel', fileInputId: 'file', altInputId: 'alt',
+    linkInputId: 'link', submitButtonId: 'submit', cancelButtonId: 'cancel', statusId: 'status',
+    hintId: 'hint', textareaId: 'textarea', getSlug: () => slug,
+  });
+  return {
+    elements,
+    listeners,
+    uploader,
+    setSlug(value: string) { slug = value; },
+  };
+}
+
+describe('content body image editor', () => {
+  it.each(['my-content.html', 'admin-content.html'])('wires image insertion into %s', (file) => {
+    const html = readFileSync(join(publicRoot, file), 'utf8');
+
+    expect(html).toContain('<script src="/content-image-upload.js"></script>');
+    expect(html).toContain('id="insertBodyImageBtn"');
+    expect(html).toContain('id="bodyImageAlt" required');
+    expect(html).toContain('id="bodyImageLink"');
+    expect(html).toContain("getSlug: () => editingContent?.slug || ''");
+    expect(html).toContain('.preview-pane img { max-width: 100%; height: auto; }');
+  });
+
+  it('keeps published body images within the article width', () => {
+    const html = readFileSync(join(publicRoot, 'perspectives/article.html'), 'utf8');
+    expect(html).toContain('.article-content img {');
+    expect(html).toContain('max-width: 100%');
+    expect(html).toContain('height: auto');
+  });
+
+  it('builds accessible image and linked-image Markdown with escaped alt text', () => {
+    const helper = loadHelper();
+
+    expect(helper.buildImageMarkdown(
+      'https://agenticadvertising.org/api/perspectives/post/assets/panel.png',
+      'Panel [at Cannes]',
+      ''
+    )).toBe('![Panel \\[at Cannes\\]](<https://agenticadvertising.org/api/perspectives/post/assets/panel.png>)');
+    expect(helper.buildImageMarkdown(
+      'https://agenticadvertising.org/image.png',
+      'Whitepaper cover',
+      'https://example.com/whitepaper'
+    )).toBe('[![Whitepaper cover](<https://agenticadvertising.org/image.png>)](<https://example.com/whitepaper>)');
+    expect(() => helper.buildImageMarkdown('https://example.com/image.png', 'Alt', 'javascript:alert(1)'))
+      .toThrow(/absolute http:\/\/ or https:\/\//);
+    expect(() => helper.buildImageMarkdown('https://example.com/image.png', 'Alt', 'https://user:secret@example.com/'))
+      .toThrow('Link URL must not include credentials.');
+    expect(() => helper.buildImageMarkdown('https://example.com/image.png', 'Alt', 'http://example.com/report'))
+      .toThrow('Link URL must use https://.');
+    expect(() => helper.buildImageMarkdown('https://example.com/image.png', ' ', ''))
+      .toThrow('Alt text is required.');
+  });
+
+  it('uploads a uniquely named attachment and returns Markdown', async () => {
+    const helper = loadHelper();
+    const parts: Array<[string, unknown, string?]> = [];
+    class TestFormData {
+      append(name: string, value: unknown, filename?: string) {
+        parts.push([name, value, filename]);
+      }
+    }
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ asset: { url: 'https://agenticadvertising.org/api/perspectives/story/assets/panel-unique.png' } }),
+    });
+    const file = { name: 'panel photo.png', type: 'image/png', size: 1024 };
+
+    const result = await helper.uploadImage({
+      file,
+      slug: 'story slug',
+      altText: 'Cannes panel',
+      linkUrl: 'https://example.com/report',
+      fetchImpl,
+      FormDataImpl: TestFormData,
+      randomUUID: () => 'unique-id',
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith('/api/content/story%20slug/assets', {
+      method: 'POST',
+      credentials: 'include',
+      body: expect.any(TestFormData),
+    });
+    expect(parts).toEqual([
+      ['file', file, 'panel-photo-unique-id.png'],
+      ['asset_type', 'attachment', undefined],
+    ]);
+    expect(result.markdown).toContain('[![Cannes panel]');
+    expect(helper.createUploadFilename('panel photo.png', () => 'second-id'))
+      .toBe('panel-photo-second-id.png');
+    expect(helper.createUploadFilename('panel photo.png', () => 'second-id'))
+      .not.toBe(parts[0][2]);
+  });
+
+  it('validates images before upload and surfaces useful server failures', async () => {
+    const helper = loadHelper();
+    const fetchImpl = vi.fn();
+    const base = {
+      slug: 'story', altText: 'Alt', linkUrl: '', fetchImpl,
+      FormDataImpl: class { append() {} }, randomUUID: () => 'id',
+    };
+
+    await expect(helper.uploadImage({ ...base, file: { name: 'x.svg', type: 'image/svg+xml', size: 10 } }))
+      .rejects.toThrow('Choose a JPEG, PNG, WebP, or GIF image.');
+    await expect(helper.uploadImage({ ...base, file: { name: 'x.png', type: 'image/png', size: helper.MAX_IMAGE_BYTES + 1 } }))
+      .rejects.toThrow('Image files must be under 10MB.');
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    fetchImpl.mockResolvedValue({ ok: false, status: 403, json: async () => ({}) });
+    await expect(helper.uploadImage({ ...base, file: { name: 'x.png', type: 'image/png', size: 10 } }))
+      .rejects.toThrow('You do not have permission');
+  });
+
+  it('replaces the captured selection, restores the caret, and dispatches input', () => {
+    const helper = loadHelper();
+    const events: BrowserEvent[] = [];
+    const textarea = {
+      value: 'Before selected after',
+      selectionStart: 7,
+      selectionEnd: 15,
+      setSelectionRange(start: number, end: number) {
+        this.selectionStart = start;
+        this.selectionEnd = end;
+      },
+      dispatchEvent(event: BrowserEvent) { events.push(event); },
+      focus: vi.fn(),
+    };
+
+    const caret = helper.insertMarkdown(textarea, '![Alt](<https://example.com/image.png>)', { start: 7, end: 15 });
+
+    expect(textarea.value).toBe('Before ![Alt](<https://example.com/image.png>) after');
+    expect(textarea.selectionStart).toBe(caret);
+    expect(textarea.selectionEnd).toBe(caret);
+    expect(events).toEqual([expect.objectContaining({ type: 'input', bubbles: true })]);
+    expect(textarea.focus).toHaveBeenCalled();
+  });
+
+  it('disables insertion until the article has a slug', () => {
+    let slug = '';
+    const listeners = new Map<string, Function>();
+    const classList = { add: vi.fn(), remove: vi.fn() };
+    const elements: Record<string, any> = {};
+    for (const id of ['trigger', 'panel', 'file', 'alt', 'link', 'submit', 'cancel', 'status', 'hint', 'textarea']) {
+      elements[id] = {
+        id, classList, value: '', textContent: '', disabled: false, selectionStart: 0, selectionEnd: 0,
+        addEventListener: (event: string, callback: Function) => listeners.set(`${id}:${event}`, callback),
+        focus: vi.fn(), setSelectionRange: vi.fn(), dispatchEvent: vi.fn(),
+      };
+    }
+    const helper = loadHelper({ document: { getElementById: (id: string) => elements[id] } });
+    const uploader = helper.mount({
+      triggerButtonId: 'trigger', panelId: 'panel', fileInputId: 'file', altInputId: 'alt',
+      linkInputId: 'link', submitButtonId: 'submit', cancelButtonId: 'cancel', statusId: 'status',
+      hintId: 'hint', textareaId: 'textarea', getSlug: () => slug,
+    });
+
+    expect(elements.trigger.disabled).toBe(true);
+    expect(elements.hint.textContent).toBe('Save as a draft before adding images.');
+    slug = 'saved-story';
+    uploader.refresh();
+    expect(elements.trigger.disabled).toBe(false);
+  });
+
+  it('aborts and invalidates a pending upload when the editor closes or switches articles', async () => {
+    let resolveFetch!: (value: unknown) => void;
+    let requestSignal: AbortSignal | undefined;
+    const fetchImpl = vi.fn((_url, options) => {
+      requestSignal = options.signal;
+      return new Promise(resolve => { resolveFetch = resolve; });
+    });
+    const { elements, listeners, uploader, setSlug } = mountedHarness(fetchImpl);
+    elements.textarea.value = 'Article A';
+    elements.textarea.selectionStart = elements.textarea.value.length;
+    elements.textarea.selectionEnd = elements.textarea.value.length;
+    listeners.get('trigger:click')?.();
+    elements.file.files = [{ name: 'panel.png', type: 'image/png', size: 100 }];
+    elements.file.value = 'panel.png';
+    elements.alt.value = 'Panel';
+
+    const pending = listeners.get('submit:click')?.();
+    expect(requestSignal?.aborted).toBe(false);
+    setSlug('article-b');
+    uploader.close();
+    expect(requestSignal?.aborted).toBe(true);
+
+    resolveFetch({
+      ok: true,
+      status: 201,
+      json: async () => ({ asset: { url: 'https://agenticadvertising.org/image.png' } }),
+    });
+    await pending;
+
+    expect(elements.textarea.value).toBe('Article A');
+    expect(elements.file.value).toBe('');
+    expect(elements.alt.value).toBe('');
+    expect(elements.link.value).toBe('');
+  });
+
+  it('preserves edits and upload fields when a pending upload fails', async () => {
+    let resolveFetch!: (value: unknown) => void;
+    const fetchImpl = vi.fn(() => new Promise(resolve => { resolveFetch = resolve; }));
+    const { elements, listeners } = mountedHarness(fetchImpl);
+    elements.textarea.value = 'Original body';
+    elements.textarea.selectionStart = elements.textarea.value.length;
+    elements.textarea.selectionEnd = elements.textarea.value.length;
+    listeners.get('trigger:click')?.();
+    elements.file.files = [{ name: 'panel.png', type: 'image/png', size: 100 }];
+    elements.file.value = 'panel.png';
+    elements.alt.value = 'Panel';
+    elements.link.value = 'https://example.com/report';
+
+    const pending = listeners.get('submit:click')?.();
+    elements.textarea.value = 'Original body plus edits made during upload';
+    resolveFetch({ ok: false, status: 500, json: async () => ({ message: 'Storage unavailable' }) });
+    await pending;
+
+    expect(elements.textarea.value).toBe('Original body plus edits made during upload');
+    expect(elements.file.value).toBe('panel.png');
+    expect(elements.alt.value).toBe('Panel');
+    expect(elements.link.value).toBe('https://example.com/report');
+    expect(elements.status.textContent).toBe('Storage unavailable');
+  });
+});

--- a/server/tests/unit/perspective-asset-cache-privacy.test.ts
+++ b/server/tests/unit/perspective-asset-cache-privacy.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   getAssetData: vi.fn(),
   getPerspectiveWithIllustration: vi.fn(),
   generatePerspectiveCard: vi.fn(),
+  isWebUserAAOAdmin: vi.fn(),
 }));
 
 vi.hoisted(() => {
@@ -50,6 +51,14 @@ vi.mock('../../src/services/perspective-cards.js', () => ({
   compositePerspectiveCard: vi.fn(),
 }));
 
+vi.mock('../../src/addie/mcp/admin-tools.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    isWebUserAAOAdmin: (...args: unknown[]) => mocks.isWebUserAAOAdmin(...args),
+  };
+});
+
 vi.mock('../../src/middleware/auth.js', async () => {
   const actual = await vi.importActual<typeof import('../../src/middleware/auth.js')>(
     '../../src/middleware/auth.js',
@@ -76,6 +85,7 @@ describe('perspective asset cache privacy', () => {
     mocks.getAssetData.mockReset();
     mocks.getPerspectiveWithIllustration.mockReset();
     mocks.generatePerspectiveCard.mockReset();
+    mocks.isWebUserAAOAdmin.mockReset().mockResolvedValue(false);
   });
 
   afterEach(async () => {
@@ -107,7 +117,7 @@ describe('perspective asset cache privacy', () => {
     expect(res.headers['cache-control']).toBe(expected);
     expect(mocks.query).toHaveBeenCalledWith(
       expect.stringContaining('AS is_public'),
-      ['example', userId ?? null],
+      ['example', userId ?? null, false],
     );
     expect(mocks.getAssetData).toHaveBeenCalledWith('perspective-1', 'cover.png');
   });


### PR DESCRIPTION
## Summary
- add accessible inline image upload controls to member and admin article editors
- insert image or linked-image Markdown at the captured cursor with responsive previews and published rendering
- harden uploads with unique filenames, magic-byte and pixel validation, rate limits, storage quotas, and private asset authorization
- cover upload lifecycle, validation, Markdown construction, authorization, spoofed MIME, and quota behavior

## Validation
- node --check server/public/content-image-upload.js
- npx vitest run --config server/vitest.config.ts server/tests/unit/content-body-image-editor.test.ts server/tests/unit/admin-content-delete-ux.test.ts
- npm run typecheck
- git diff --check origin/main...HEAD

The database-backed perspective asset integration suite loads locally but requires the repository PostgreSQL service; CI will execute it.

Closes #5803