### PR TITLE
docs: distinguish refinement from price negotiation

### DIFF
--- a/docs/media-buy/product-discovery/refinement.mdx
+++ b/docs/media-buy/product-discovery/refinement.mdx
@@ -150,6 +150,29 @@ Orchestrators SHOULD cross-check entries by the echoed id rather than trusting p
 
 ## Common refinement patterns
 
+### Price and budget asks
+
+Use the free-text `ask` field for commercial requests such as a lower price or a different budget allocation. For example, a buyer can ask for a proposal-scoped CPM reduction:
+
+```json
+{
+  "buying_mode": "refine",
+  "refine": [
+    {
+      "scope": "proposal",
+      "proposal_id": "prop_awareness_q2",
+      "ask": "reduce the CPM by 10% while keeping the same inventory and dates"
+    }
+  ]
+}
+```
+
+Buyers discover refinement support when `get_adcp_capabilities.media_buy.buying_modes` includes `"refine"`. That declaration means the seller can receive this free-text ask; it does not guarantee that the seller understands every negotiation strategy or has commercial flexibility on price. There is no finer-grained price-negotiation capability flag.
+
+When the seller returns `refinement_applied`, read the matching entry's `status` (`applied`, `partial`, or `unable`) and optional `notes` to learn how it handled this specific request. These fields acknowledge handling; they are not the executable commercial terms. Inspect the returned proposal's pricing and allocations before finalizing or buying.
+
+Because the entire `refinement_applied` field is optional, omission communicates no per-ask outcome: do not infer `applied`, `partial`, or `unable`. A seller may omit it even when the response applies the requested change. Treat the returned proposal and any reported outcome as runtime evidence for this request, not as a general promise that the seller can negotiate price.
+
 ### Find similar products
 
 Use `more_like_this` to discover products similar to ones you like. The seller returns the original product plus additional options matching its characteristics:

--- a/server/tests/unit/docs-indexer.test.ts
+++ b/server/tests/unit/docs-indexer.test.ts
@@ -125,6 +125,16 @@ describe('docs-indexer', () => {
       const results = searchDocs('xyzzy_nonexistent_term_12345');
       expect(results.length).toBe(0);
     });
+
+    it('finds the distinction between refinement and price-negotiation capability', () => {
+      const results = searchDocs('price negotiation refinement capability', { limit: 5 });
+      expect(results.map((doc) => doc.id)).toContain('doc:media-buy/product-discovery/refinement');
+
+      const refinement = getDocById('media-buy/product-discovery/refinement');
+      expect(refinement?.content).toContain('There is no finer-grained price-negotiation capability flag.');
+      expect(refinement?.content).toContain('omission communicates no per-ask outcome');
+      expect(refinement?.content).toContain("Inspect the returned proposal's pricing and allocations");
+    });
   });
 
   describe('schema and MDX retrieval (#5861)', () => {


### PR DESCRIPTION
## Summary
- show a proposal-scoped price and budget refinement ask
- distinguish declared refine support from price-negotiation competence or commercial flexibility
- explain optional refinement_applied acknowledgments and require buyers to inspect executable proposal terms
- keep the distinction searchable through Addie docs indexing

## Validation
- npx vitest run --config server/vitest.config.ts server/tests/unit/docs-indexer.test.ts -t price-negotiation
- node tests/snippet-validation.test.cjs --file docs/media-buy/product-discovery/refinement.mdx
- git diff --check

No changeset: documentation-only clarification with no protocol surface change.

Closes #6101