### PR TITLE
feat(website): publish membership agreement page

### DIFF
--- a/server/public/agreement.html
+++ b/server/public/agreement.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Agreement - AgenticAdvertising.org</title>
+  <meta name="description" content="Read the current AgenticAdvertising.org membership agreement.">
   <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
@@ -58,8 +59,13 @@
   <script>
     (async function() {
       const params = new URLSearchParams(window.location.search);
-      const type = params.get('type');
-      const version = params.get('version');
+      const canonicalMembershipPath = '/legal/membership-agreement';
+      const normalizedPath = window.location.pathname.replace(/\/$/, '');
+      const isCanonicalMembership = normalizedPath === canonicalMembershipPath;
+      const type = isCanonicalMembership ? 'membership' : params.get('type');
+      // The canonical legal URL is intentionally always current. Versioned
+      // historical documents remain available through /api/agreement.
+      const version = isCanonicalMembership ? null : params.get('version');
 
       if (!type) {
         document.getElementById('loading').style.display = 'none';
@@ -75,10 +81,18 @@
         ip_policy: 'IP Policy'
       };
 
-      const qs = version ? `type=${type}&version=${version}&format=json` : `type=${type}&format=json`;
+      const query = new URLSearchParams({ type, format: 'json' });
+      if (version) query.set('version', version);
+
+      if (isCanonicalMembership) {
+        const canonical = document.createElement('link');
+        canonical.rel = 'canonical';
+        canonical.href = 'https://agenticadvertising.org/legal/membership-agreement';
+        document.head.appendChild(canonical);
+      }
 
       try {
-        const res = await fetch(`/api/agreement?${qs}`);
+        const res = await fetch(`/api/agreement?${query.toString()}`);
         if (!res.ok) throw new Error('Not found');
         const data = await res.json();
 

--- a/server/public/dashboard-membership.html
+++ b/server/public/dashboard-membership.html
@@ -1088,7 +1088,7 @@
           <div id="invoice-agreement-section" style="background: var(--color-bg-subtle); border: 1px solid var(--color-border); border-radius: 8px; padding: 16px; margin-bottom: 16px;">
             <label style="display: flex; align-items: flex-start; gap: 10px; cursor: pointer;">
               <input type="checkbox" id="invoice-agreement-checkbox" style="margin-top: 3px; cursor: pointer;">
-              <span style="font-size: 14px;">I have read and agree to the <a href="/membership-agreement" target="_blank" rel="noopener" style="color: var(--color-brand);">AgenticAdvertising.org membership agreement</a>.</span>
+              <span style="font-size: 14px;">I have read and agree to the <a href="/legal/membership-agreement" target="_blank" rel="noopener" style="color: var(--color-brand);">AgenticAdvertising.org membership agreement</a>.</span>
             </label>
           </div>
 
@@ -2313,7 +2313,10 @@
 
     // View an agreement
     function viewAgreement(type) {
-      window.open(`/api/agreement?type=${encodeURIComponent(type)}`, '_blank');
+      const url = type === 'membership'
+        ? '/legal/membership-agreement'
+        : `/api/agreement?type=${encodeURIComponent(type)}`;
+      window.open(url, '_blank', 'noopener');
     }
 
     // Standalone "Review & Sign" flow for the membership agreement. Opens a

--- a/server/public/dashboard.html
+++ b/server/public/dashboard.html
@@ -4621,7 +4621,9 @@
       const baseUrl = window.location.hostname === 'localhost'
         ? window.location.origin
         : 'https://agenticadvertising.org';
-      const url = `${baseUrl}/api/agreement?type=${type}`;
+      const url = type === 'membership'
+        ? `${baseUrl}/legal/membership-agreement`
+        : `${baseUrl}/api/agreement?type=${encodeURIComponent(type)}`;
 
       try {
         await navigator.clipboard.writeText(url);

--- a/server/public/governance.html
+++ b/server/public/governance.html
@@ -554,7 +554,7 @@
             The complete bylaws of the Agentic Advertising Network, defining our governance structure, voting procedures, and member rights.
           </div>
         </a>
-        <a href="/api/agreement?type=membership" class="doc-card">
+        <a href="/legal/membership-agreement" class="doc-card">
           <div class="doc-card-icon">&#x1F4DD;</div>
           <div class="doc-card-title">Membership Agreement</div>
           <div class="doc-card-desc">

--- a/server/public/invite.html
+++ b/server/public/invite.html
@@ -162,7 +162,7 @@
             <div class="agreement-block">
               <label style="display: flex; align-items: flex-start; gap: 10px; cursor: pointer; font-weight: normal;">
                 <input type="checkbox" id="agreementCheckbox" style="margin-top: 3px; cursor: pointer;">
-                <span>I have read and agree to the <a href="/membership-agreement" target="_blank" rel="noopener">AgenticAdvertising.org Membership Agreement</a>.</span>
+                <span>I have read and agree to the <a href="/legal/membership-agreement" target="_blank" rel="noopener">AgenticAdvertising.org Membership Agreement</a>.</span>
               </label>
             </div>
 

--- a/server/public/nav.js
+++ b/server/public/nav.js
@@ -936,8 +936,9 @@
           </div>
           <div class="aao-footer__bottom">
             <div class="aao-footer__legal">
-              <a href="/api/agreement?type=privacy_policy">Privacy</a>
-              <a href="/api/agreement?type=terms_of_service">Terms</a>
+              <a href="/legal/privacy">Privacy</a>
+              <a href="/legal/terms">Terms</a>
+              <a href="/legal/membership-agreement">Membership agreement</a>
               <a href="/api/agreement?type=bylaws">Bylaws</a>
               <a href="/ai-disclosure">AI Disclosure</a>
             </div>

--- a/server/src/addie/rules/urls.md
+++ b/server/src/addie/rules/urls.md
@@ -24,6 +24,7 @@ versioned documentation snapshot.
 - https://agenticadvertising.org/community — Community hub
 - https://agenticadvertising.org/legal/terms — Terms of Service (canonical path; /terms redirects here)
 - https://agenticadvertising.org/legal/privacy — Privacy Policy (canonical path; /privacy redirects here)
+- https://agenticadvertising.org/legal/membership-agreement — Current AgenticAdvertising.org membership agreement (canonical path; /membership-agreement redirects here)
 - https://agenticadvertising.org/.well-known/oauth-authorization-server — OAuth authorization server metadata (RFC 8414)
 - https://agenticadvertising.org/.well-known/oauth-protected-resource/api — Protected resource metadata for /api (RFC 9728)
 - https://agenticadvertising.org/.well-known/oauth-protected-resource/mcp — Protected resource metadata for /mcp (RFC 9728)
@@ -67,9 +68,10 @@ substitute listed or call `search_docs`. Do not emit the hallucinated path.
 | `agenticadvertising.org/faq` | Doesn't exist — use `search_docs` |
 | `agenticadvertising.org/contact` | Doesn't exist — direct users to the community hub (`/community`) or working groups (`/committees?type=working_group`) |
 | `agenticadvertising.org/help` | Doesn't exist — use `search_docs` or `/docs/quickstart` |
-| `agenticadvertising.org/legal/about` | Doesn't exist — `/legal/` only has `terms` and `privacy` |
+| `agenticadvertising.org/legal/about` | Doesn't exist — use `search_docs` or one of the listed canonical legal pages |
 | `agenticadvertising.org/terms` | Redirect only — always cite the canonical `/legal/terms` |
 | `agenticadvertising.org/privacy` | Redirect only — always cite the canonical `/legal/privacy` |
+| `agenticadvertising.org/membership-agreement` | Redirect only — always cite the canonical `/legal/membership-agreement` |
 
 ## Deprecated — do not cite
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -25,6 +25,7 @@ import { PublisherTracker } from "./publishers.js";
 import { PropertiesService } from "./properties.js";
 import { AdAgentsManager } from "./adagents-manager.js";
 import { mountSchemasRoutes, mountComplianceRoutes, mountProtocolRoutes } from "./schemas-middleware.js";
+import { renderLegalMarkdown } from "./legal-markdown.js";
 import { closeDatabase, getPool, healthCheck } from "./db/client.js";
 import { AuthenticationRequiredError, CreativeAgentClient, SingleAgentClient } from "@adcp/sdk";
 import { sdkSafeFetch, withSdkSafeTransport } from "./utils/sdk-safe-fetch.js";
@@ -2774,9 +2775,16 @@ export class HTTPServer {
     this.app.get('/dashboard/api-keys', (req, res) => serveDashboardPage(req, res, 'dashboard-api-keys.html'));
     this.app.get('/dashboard/addie', (_req, res) => res.redirect('/chat'));
 
-    // Legal page redirects — canonical paths are /legal/terms and /legal/privacy
+    // Public membership agreement. The page shell fetches the current database-backed
+    // agreement, so this canonical URL always matches the agreement used at checkout.
+    this.app.get('/legal/membership-agreement', async (req, res) => {
+      await this.serveHtmlWithConfig(req, res, 'agreement.html');
+    });
+
+    // Legal page redirects — canonical paths live under /legal/.
     this.app.get('/terms', (_req, res) => res.redirect(301, '/legal/terms'));
     this.app.get('/privacy', (_req, res) => res.redirect(301, '/legal/privacy'));
+    this.app.get('/membership-agreement', (_req, res) => res.redirect(301, '/legal/membership-agreement'));
 
     // My Content redirect is handled in pre-static middleware block above
 
@@ -9209,6 +9217,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
 
     // GET /api/agreement/current - Get current agreement by type
     this.app.get('/api/agreement/current', async (req, res) => {
+      res.setHeader('Cache-Control', 'no-store');
       try {
         const type = (req.query.type as string) || 'membership';
 
@@ -9244,6 +9253,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
 
     // GET /api/agreement - Get specific agreement by type and version (or current if no version)
     this.app.get('/api/agreement', async (req, res) => {
+      res.setHeader('Cache-Control', 'no-store');
       try {
         const type = req.query.type as string;
         const version = req.query.version as string;
@@ -9282,8 +9292,7 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
           });
         }
 
-        const { marked } = await import('marked');
-        const htmlContent = await marked(agreement.text);
+        const htmlContent = renderLegalMarkdown(agreement.text);
 
         return res.json({
           version: agreement.version,

--- a/server/src/legal-markdown.ts
+++ b/server/src/legal-markdown.ts
@@ -1,0 +1,21 @@
+import DOMPurify from 'isomorphic-dompurify';
+import { Marked } from 'marked';
+
+const legalMarkdown = new Marked();
+
+const LEGAL_MARKDOWN_SANITIZE_CONFIG = {
+  ALLOWED_TAGS: [
+    'p', 'br', 'strong', 'em', 'a', 'ul', 'ol', 'li',
+    'h1', 'h2', 'h3', 'h4', 'blockquote', 'pre', 'code',
+    'hr', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
+  ],
+  ALLOWED_ATTR: ['href', 'title'],
+  ALLOW_DATA_ATTR: false,
+  ALLOWED_URI_REGEXP: /^(?:https:|\/(?!\/)|#)/i,
+};
+
+/** Render administrator-authored legal Markdown for insertion into a public page. */
+export function renderLegalMarkdown(markdown: string): string {
+  const rendered = legalMarkdown.parse(markdown, { async: false }) as string;
+  return DOMPurify.sanitize(rendered, LEGAL_MARKDOWN_SANITIZE_CONFIG);
+}

--- a/server/src/legal-markdown.ts
+++ b/server/src/legal-markdown.ts
@@ -11,7 +11,9 @@ const LEGAL_MARKDOWN_SANITIZE_CONFIG = {
   ],
   ALLOWED_ATTR: ['href', 'title'],
   ALLOW_DATA_ATTR: false,
-  ALLOWED_URI_REGEXP: /^(?:https:|\/(?!\/)|#)/i,
+  // Legal notices commonly use email contacts. Keep those and secure/internal
+  // links, while rejecting plain HTTP, protocol-relative, and active schemes.
+  ALLOWED_URI_REGEXP: /^(?:https:|mailto:|\/(?!\/)|#)/i,
 };
 
 /** Render administrator-authored legal Markdown for insertion into a public page. */

--- a/server/tests/unit/membership-agreement-page.test.ts
+++ b/server/tests/unit/membership-agreement-page.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import { renderLegalMarkdown } from '../../src/legal-markdown.js';
+
+const root = process.cwd();
+const httpSource = readFileSync(join(root, 'server/src/http.ts'), 'utf8');
+const pageSource = readFileSync(join(root, 'server/public/agreement.html'), 'utf8');
+const dashboardLegacySource = readFileSync(join(root, 'server/public/dashboard.html'), 'utf8');
+const dashboardSource = readFileSync(join(root, 'server/public/dashboard-membership.html'), 'utf8');
+const inviteSource = readFileSync(join(root, 'server/public/invite.html'), 'utf8');
+const governanceSource = readFileSync(join(root, 'server/public/governance.html'), 'utf8');
+const navSource = readFileSync(join(root, 'server/public/nav.js'), 'utf8');
+const addieUrls = readFileSync(join(root, 'server/src/addie/rules/urls.md'), 'utf8');
+
+describe('public membership agreement page', () => {
+  it('serves the shared agreement shell at the canonical path and redirects the legacy path', () => {
+    expect(httpSource).toContain("this.app.get('/legal/membership-agreement'");
+    expect(httpSource).toContain("this.serveHtmlWithConfig(req, res, 'agreement.html')");
+    expect(httpSource).toContain(
+      "this.app.get('/membership-agreement', (_req, res) => res.redirect(301, '/legal/membership-agreement'))",
+    );
+  });
+
+  it('loads the current membership agreement when opened at the canonical path', () => {
+    expect(pageSource).toContain("isCanonicalMembership ? 'membership' : params.get('type')");
+    expect(pageSource).toContain("isCanonicalMembership ? null : params.get('version')");
+    expect(pageSource).toContain("new URLSearchParams({ type, format: 'json' })");
+    expect(pageSource).toContain("fetch(`/api/agreement?${query.toString()}`)");
+  });
+
+  it('uses the canonical path from membership UI and the global footer', () => {
+    expect(dashboardSource).toContain('href="/legal/membership-agreement"');
+    expect(dashboardSource).toContain("type === 'membership'");
+    expect(navSource).toContain('<a href="/legal/membership-agreement">Membership agreement</a>');
+    expect(inviteSource).toContain('href="/legal/membership-agreement"');
+    expect(governanceSource).toContain('href="/legal/membership-agreement" class="doc-card"');
+    expect(dashboardLegacySource).toContain("`${baseUrl}/legal/membership-agreement`");
+  });
+
+  it('prevents caches from serving stale legal text', () => {
+    const agreementApiStart = httpSource.indexOf("this.app.get('/api/agreement/current'");
+    const agreementApiEnd = httpSource.indexOf('// NOTE: Organization routes', agreementApiStart);
+    const agreementApiSource = httpSource.slice(agreementApiStart, agreementApiEnd);
+    expect(agreementApiSource.match(/res\.setHeader\('Cache-Control', 'no-store'\)/g)).toHaveLength(2);
+  });
+
+  it('sanitizes rendered agreement Markdown before returning public HTML', () => {
+    const agreementApiStart = httpSource.indexOf("this.app.get('/api/agreement/current'");
+    const agreementApiEnd = httpSource.indexOf('// NOTE: Organization routes', agreementApiStart);
+    const agreementApiSource = httpSource.slice(agreementApiStart, agreementApiEnd);
+    expect(agreementApiSource).toContain('renderLegalMarkdown(agreement.text)');
+
+    const rendered = renderLegalMarkdown(`
+# Membership Agreement
+
+<script>alert('script')</script>
+
+<img src="https://tracker.example/pixel" onerror="alert('event')">
+
+[Unsafe](javascript:alert('link'))
+
+[Safe](https://agenticadvertising.org/legal/terms "Terms")
+`);
+
+    expect(rendered).toContain('<h1>Membership Agreement</h1>');
+    expect(rendered).toContain('href="https://agenticadvertising.org/legal/terms"');
+    expect(rendered).not.toMatch(/<script|<img|onerror|javascript:/i);
+  });
+
+  it('registers the canonical path for Addie and marks the legacy path redirect-only', () => {
+    expect(addieUrls).toContain(
+      'https://agenticadvertising.org/legal/membership-agreement — Current AgenticAdvertising.org membership agreement',
+    );
+    expect(addieUrls).toContain(
+      '`agenticadvertising.org/membership-agreement` | Redirect only — always cite the canonical `/legal/membership-agreement`',
+    );
+  });
+});

--- a/server/tests/unit/membership-agreement-page.test.ts
+++ b/server/tests/unit/membership-agreement-page.test.ts
@@ -61,10 +61,16 @@ describe('public membership agreement page', () => {
 [Unsafe](javascript:alert('link'))
 
 [Safe](https://agenticadvertising.org/legal/terms "Terms")
+
+[Email](mailto:legal@agenticadvertising.org)
+
+[Insecure](http://agenticadvertising.org/legal/terms)
 `);
 
     expect(rendered).toContain('<h1>Membership Agreement</h1>');
     expect(rendered).toContain('href="https://agenticadvertising.org/legal/terms"');
+    expect(rendered).toContain('href="mailto:legal@agenticadvertising.org"');
+    expect(rendered).not.toContain('href="http://agenticadvertising.org/legal/terms"');
     expect(rendered).not.toMatch(/<script|<img|onerror|javascript:/i);
   });
 


### PR DESCRIPTION
## Summary
- publish the current database-backed membership agreement at `/legal/membership-agreement` and redirect the legacy path
- canonicalize membership-agreement links across checkout, invite, governance, dashboard, footer, and Addie guidance
- sanitize public legal Markdown and disable caching so newly published terms are safe and immediately current

## Source of truth and sync
The membership checkout and this public page both read the current `membership` agreement from the same database API. Publishing a new current agreement therefore updates both surfaces without a manual copy or sync job. The canonical page ignores `type` and `version` query overrides so it always displays the current membership agreement.

## Verification
- `npx vitest run --config server/vitest.config.ts server/tests/unit/membership-agreement-page.test.ts server/tests/unit/route-safety.test.ts`
- `npm run typecheck`
- `node --test --test-force-exit --test-timeout=30000 tests/check-owned-links.test.cjs`
- browser inline-script syntax parse and `node --check server/public/nav.js`
- product/UX expert: approved
- security expert: approved
- code-review expert: approved

Closes #4550