### PR TITLE
docs(prebid): route Sales Agent support questions

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -208,7 +208,11 @@ AdCP is governed by AgenticAdvertising.Org (AAO), a pending 501(c)(6) trade asso
 
 The interim board (as of 2026-04-18) has four directors: Michael Blum (Scope3), Brian O'Kelley (Scope3), Pia Malovrh (Celtra), and Benjamin Masse (Triton Digital). The elected board — first Annual General Meeting on **May 6, 2026** — has equal representation across four voting classes (Brands, Agencies, Publishers, Technology Providers), with a target of ten seats per class. Day-to-day protocol work happens in [working groups](/docs/community/working-group); change proposals flow through this repository.
 
-**Reference sell-side implementation lives at Prebid.** Development of the sell-side AI agent reference code was handed to the [Prebid community](https://www.prebid.org/) in February 2026, [reported by AdExchanger](https://www.adexchanger.com/ad-exchange-news/the-agentic-advertising-organization-hands-development-of-its-sell-side-agent-to-prebid/). AAO owns the specification; Prebid owns the reference software. Spec governance and reference-implementation development are intentionally separate organizations.
+**A sell-side implementation lives at Prebid.** Development of the Prebid Sales Agent was handed to the [Prebid community](https://prebid.org/) in February 2026, [reported by AdExchanger](https://www.adexchanger.com/ad-exchange-news/the-agentic-advertising-organization-hands-development-of-its-sell-side-agent-to-prebid/). AgenticAdvertising.org maintains the specification; Prebid maintains the Prebid Sales Agent implementation. Spec governance and implementation development remain separate.
+</Accordion>
+
+<Accordion title="Who supports Prebid Sales Agent setup and upgrades?">
+Prebid.org maintains the Prebid Sales Agent and its build and release pipeline. For setup, dependency, version, build, or upgrade help, start with the project's [documentation](https://github.com/prebid/salesagent/tree/main/docs). If the documentation does not answer your question, use Prebid's [official Sales Agent support page](https://prebid.org/product-suite/sales-agent/) or email [support@prebid.org](mailto:support@prebid.org). AgenticAdvertising.org does not maintain or support this build pipeline.
 </Accordion>
 
 <Accordion title="Do AdCP examples use real brand names?">

--- a/server/src/addie/rules/knowledge.md
+++ b/server/src/addie/rules/knowledge.md
@@ -310,6 +310,10 @@ Be thoughtful about decommoditization of inventory - support all forms of advert
 ## Prebid Expertise
 You have comprehensive Prebid documentation indexed. Use search_repos with repo_id "prebid-docs" for the full docs site, "prebid-js" for source code and module docs, and "prebid-server" for server source.
 
+### Prebid Sales Agent support boundary
+
+Prebid.org maintains the Prebid Sales Agent and its build and release pipeline. For Sales Agent setup, dependency, version, build, or upgrade questions, inspect the indexed repository first with search_repos and repo_id "salesagent". If the repository does not establish the answer, say so and direct the user to Prebid's official Sales Agent support page at https://prebid.org/product-suite/sales-agent/ or support@prebid.org. Do not invent package files, repository names, versions, or upgrade steps, and do not route these questions to AgenticAdvertising.org Slack.
+
 ## Prebid.js
 
 Client-side header bidding library that runs in the browser:

--- a/server/tests/unit/rules-loader.test.ts
+++ b/server/tests/unit/rules-loader.test.ts
@@ -73,6 +73,17 @@ describe('Rules Loader', () => {
     expect(rules).not.toContain('tmpm');
   });
 
+  it('routes Prebid Sales Agent build questions to the owning project without guessing', () => {
+    const rules = loadRules();
+
+    expect(rules).toContain('Prebid.org maintains the Prebid Sales Agent');
+    expect(rules).toContain('repo_id "salesagent"');
+    expect(rules).toContain('https://prebid.org/product-suite/sales-agent/');
+    expect(rules).toContain('support@prebid.org');
+    expect(rules).toContain('Do not invent package files, repository names, versions, or upgrade steps');
+    expect(rules).toContain('do not route these questions to AgenticAdvertising.org Slack');
+  });
+
   it('should cache results across calls', () => {
     const first = loadRules();
     const second = loadRules();


### PR DESCRIPTION
## Summary
- add a searchable FAQ answer for Prebid Sales Agent setup, build, version, and upgrade support
- teach Addie to inspect the indexed `salesagent` repository first, admit when it cannot establish an answer, and avoid fabricated upgrade mechanics
- route unresolved questions to Prebid’s official Sales Agent support page / `support@prebid.org`, not AgenticAdvertising.org Slack or restricted GitHub issue creation

## Verification
- `npx vitest run --config server/vitest.config.ts server/tests/unit/rules-loader.test.ts` (13/13)
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- official Prebid Sales Agent product page and support destination verified current
- docs expert: approved after support/placement corrections
- prompt expert: approved
- code-review expert: approved

Closes #3790