### PR TITLE
fix(compliance): preserve target on discovery failure

### DIFF
--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -93,12 +93,14 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
         auth: sdkAuth,
         userAgent: AAO_UA_COMPLIANCE,
       };
+      const seededSupportedVersions = await complianceDb.getRecentSupportedVersions(agent.agent_url);
 
       runTargetSelection = await selectComplianceTargetForAgentSelection(
         agent.agent_url,
         complyOptions,
         fallbackComplianceTarget,
         'canonical',
+        seededSupportedVersions,
       );
       runTarget = runTargetSelection.target;
       const complianceResult = await comply(agent.agent_url, complyOptions, runTarget);

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -4539,11 +4539,13 @@ export function createMemberToolHandlers(
     const authOption = buildAuthOption(resolved);
 
     if (!hasExplicitComplianceTarget(input)) {
+      const seededSupportedVersions = await complianceDb.getRecentSupportedVersions(resolved.resolvedUrl);
       runTargetSelection = await selectComplianceTargetForAgentSelection(
         resolved.resolvedUrl,
         { auth: authOption },
         complianceTarget,
         'canonical',
+        seededSupportedVersions,
       );
       runTarget = runTargetSelection.target;
     } else {

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -245,6 +245,7 @@ export async function selectComplianceTargetForAgentSelection(
   options: ComplyOptions,
   fallback: HostedComplianceTarget = defaultComplianceTarget(),
   mode: 'preferred' | 'canonical' = 'preferred',
+  seededSupportedVersions?: readonly string[],
 ): Promise<ComplianceTargetSelection> {
   try {
     const discovery = await discoverCapabilitiesWithDeadline(agentUrl, options);
@@ -256,7 +257,26 @@ export async function selectComplianceTargetForAgentSelection(
     if (options.signal?.aborted) {
       throw abortReason(options.signal, 'Hosted compliance target pre-discovery aborted');
     }
-    logger.warn({ err, agentUrl }, 'Could not pre-discover hosted compliance target; using fallback');
+
+    const supportedVersions = [...new Set(
+      (seededSupportedVersions ?? []).filter(version => version.trim().length > 0),
+    )];
+    if (supportedVersions.length > 0) {
+      const profile = { adcp_supported_versions: supportedVersions };
+      const target = mode === 'canonical'
+        ? selectCanonicalHostedComplianceTargetForProfile(profile, fallback)
+        : selectHostedComplianceTargetForProfile(profile, fallback);
+      logger.warn(
+        { err, agentUrl, supportedVersions, selectedTarget: target.requested },
+        'Could not pre-discover hosted compliance target; using recent stored profile',
+      );
+      // The stored profile is safe for choosing which grader to attempt, but
+      // must not flow into badge eligibility. Only a profile observed during
+      // the current run may support issuing or retaining public badges.
+      return { target, confirmed: false };
+    }
+
+    logger.warn({ err, agentUrl }, 'Could not pre-discover hosted compliance target; using default fallback');
     return { target: fallback, confirmed: false };
   }
 }
@@ -266,8 +286,15 @@ export async function selectComplianceTargetForAgent(
   options: ComplyOptions,
   fallback: HostedComplianceTarget = defaultComplianceTarget(),
   mode: 'preferred' | 'canonical' = 'preferred',
+  seededSupportedVersions?: readonly string[],
 ): Promise<HostedComplianceTarget> {
-  const selection = await selectComplianceTargetForAgentSelection(agentUrl, options, fallback, mode);
+  const selection = await selectComplianceTargetForAgentSelection(
+    agentUrl,
+    options,
+    fallback,
+    mode,
+    seededSupportedVersions,
+  );
   return selection.target;
 }
 

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -886,6 +886,33 @@ export class ComplianceDatabase {
   }
 
   /**
+   * Return the most recently observed supported AdCP versions within a bounded
+   * window. This is a warm fallback for transient capability-discovery
+   * failures; live discovery remains authoritative whenever it succeeds.
+   */
+  async getRecentSupportedVersions(agentUrl: string, maxAgeHours = 7 * 24): Promise<string[]> {
+    if (!Number.isInteger(maxAgeHours) || maxAgeHours <= 0) {
+      throw new Error('maxAgeHours must be a positive integer');
+    }
+
+    const result = await query(
+      `SELECT agent_profile_json->'adcp_supported_versions' AS supported_versions
+       FROM agent_compliance_runs
+       WHERE agent_url = $1
+         AND tested_at >= NOW() - make_interval(hours => $2)
+         AND jsonb_typeof(agent_profile_json->'adcp_supported_versions') = 'array'
+       ORDER BY tested_at DESC
+       LIMIT 1`,
+      [agentUrl, maxAgeHours],
+    );
+    const versions = result.rows[0]?.supported_versions;
+    if (!Array.isArray(versions)) return [];
+    return versions.filter(
+      (version: unknown): version is string => typeof version === 'string' && version.trim().length > 0,
+    );
+  }
+
+  /**
    * Return the notices_json array from the most recent non-dry-run compliance
    * run for the agent. Returns an empty array when no run exists or when the
    * latest run stored no notices.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -7520,11 +7520,13 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             userAgent: AAO_UA_COMPLIANCE,
             ...(resolvedAuth && { auth: resolvedAuth }),
           };
+          const seededSupportedVersions = await complianceDb.getRecentSupportedVersions(agentUrl);
           const runTargetSelection = await selectComplianceTargetForAgentSelection(
             agentUrl,
             complyOptions,
             complianceTarget,
             'canonical',
+            seededSupportedVersions,
           );
           const runTarget = runTargetSelection.target;
           const complyResult = await comply(agentUrl, complyOptions, runTarget);
@@ -8386,11 +8388,13 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           storyboards: [req.params.storyboardId],
           ...(sdkAuth && { auth: sdkAuth }),
         };
+        const seededSupportedVersions = await complianceDb.getRecentSupportedVersions(agentUrl);
         const runTargetSelection = await selectComplianceTargetForAgentSelection(
           agentUrl,
           complyOptions,
           complianceTarget,
           'canonical',
+          seededSupportedVersions,
         );
         const runTarget = runTargetSelection.target;
         const storyboard = getComplianceStoryboardById(req.params.storyboardId, hostedComplianceOptions(runTarget));

--- a/server/tests/unit/compliance-db-supported-versions.test.ts
+++ b/server/tests/unit/compliance-db-supported-versions.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+  getClient: vi.fn(),
+}));
+
+vi.mock('../../src/db/encryption.js', () => ({
+  decrypt: vi.fn(),
+  encrypt: vi.fn(),
+  deriveKey: vi.fn(),
+}));
+
+import { ComplianceDatabase } from '../../src/db/compliance-db.js';
+import { query } from '../../src/db/client.js';
+
+const mockedQuery = vi.mocked(query);
+
+describe('ComplianceDatabase.getRecentSupportedVersions', () => {
+  const db = new ComplianceDatabase();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns string versions from the most recent profile inside the default seven-day window', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ supported_versions: ['3.1', null, '', '3.0'] }],
+      rowCount: 1,
+    } as never);
+
+    await expect(db.getRecentSupportedVersions('https://agent.example/mcp'))
+      .resolves.toEqual(['3.1', '3.0']);
+    expect(mockedQuery).toHaveBeenCalledWith(
+      expect.stringContaining("jsonb_typeof(agent_profile_json->'adcp_supported_versions') = 'array'"),
+      ['https://agent.example/mcp', 168],
+    );
+  });
+
+  it('returns an empty list when no recent stored profile exists', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never);
+
+    await expect(db.getRecentSupportedVersions('https://agent.example/mcp')).resolves.toEqual([]);
+  });
+
+  it('rejects an invalid recency window before querying', async () => {
+    await expect(db.getRecentSupportedVersions('https://agent.example/mcp', 0))
+      .rejects.toThrow('maxAgeHours must be a positive integer');
+    expect(mockedQuery).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/compliance-heartbeat.test.ts
+++ b/server/tests/unit/compliance-heartbeat.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   getAgentsDueForCheck: vi.fn(),
+  getRecentSupportedVersions: vi.fn(),
   resolveOwnerAuth: vi.fn(),
   recordComplianceRun: vi.fn(),
   query: vi.fn(),
@@ -21,6 +22,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../../src/db/compliance-db.js', () => ({
   ComplianceDatabase: class {
     getAgentsDueForCheck = mocks.getAgentsDueForCheck;
+    getRecentSupportedVersions = mocks.getRecentSupportedVersions;
     resolveOwnerAuth = mocks.resolveOwnerAuth;
     recordComplianceRun = mocks.recordComplianceRun;
     getBadgesForAgent = vi.fn().mockResolvedValue([]);
@@ -80,6 +82,7 @@ describe('runComplianceHeartbeatJob', () => {
     ]);
     mocks.query.mockResolvedValue({ rows: [], rowCount: 0 });
     mocks.resolveOwnerAuth.mockResolvedValue(undefined);
+    mocks.getRecentSupportedVersions.mockResolvedValue(['3.1']);
     mocks.adaptAuthForSdk.mockResolvedValue(undefined);
     mocks.selectComplianceTargetForAgentSelection.mockResolvedValue({ target, confirmed: false });
     mocks.classifyCapabilityResolutionError.mockReturnValue(null);
@@ -123,6 +126,7 @@ describe('runComplianceHeartbeatJob', () => {
       expect.objectContaining({ timeout_ms: 600_000 }),
       target,
       'canonical',
+      ['3.1'],
     );
     expect(mocks.query).toHaveBeenCalledWith(
       expect.stringContaining('make_interval'),

--- a/server/tests/unit/compliance-target-discovery.test.ts
+++ b/server/tests/unit/compliance-target-discovery.test.ts
@@ -166,6 +166,40 @@ describe('hosted compliance target discovery deadline', () => {
     });
   });
 
+  it('uses recent stored supported versions when live discovery fails', async () => {
+    mocks.discovery.mockRejectedValue(new Error('temporary probe failure'));
+
+    await expect(selectComplianceTargetForAgentSelection(
+      'https://agent.example/mcp',
+      {},
+      mocks.fallbackTarget,
+      'canonical',
+      ['3.1', '3.1', ''],
+    )).resolves.toEqual({
+      target: mocks.selectedTarget,
+      confirmed: false,
+    });
+  });
+
+  it('prefers successful live discovery over recent stored versions', async () => {
+    mocks.discovery.mockResolvedValue({
+      profile: { adcp_supported_versions: ['3.0'] },
+      steps: [],
+    });
+
+    await expect(selectComplianceTargetForAgentSelection(
+      'https://agent.example/mcp',
+      {},
+      mocks.fallbackTarget,
+      'canonical',
+      ['3.1'],
+    )).resolves.toEqual({
+      target: mocks.fallbackTarget,
+      confirmed: true,
+      supportedVersions: ['3.0'],
+    });
+  });
+
   it('rejects caller cancellation after propagating it through discovery fetches', async () => {
     const caller = new AbortController();
     let transportSignal: AbortSignal | undefined;


### PR DESCRIPTION
## Summary

- reuse the most recent stored `adcp_supported_versions` profile when live capability discovery fails
- bound the warm fallback to profiles observed within seven days and keep the selection `confirmed: false`
- apply the fallback consistently to heartbeat, owner refresh, storyboard, and Addie quality runs

Live capability discovery remains authoritative whenever it succeeds. The persistent owner-controlled target selector remains tracked separately in #6383.

No changeset: server-only compliance behavior with no protocol or public SDK surface change.

## Validation

- `npx vitest run server/tests/unit/compliance-target-discovery.test.ts server/tests/unit/compliance-heartbeat.test.ts server/tests/unit/compliance-db-supported-versions.test.ts`
- `npm run typecheck`
- `npm run test:server-unit -- --reporter=dot` (419 files, 5,873 passed, 30 skipped)
- full pre-commit suites before server-unit passed; the hook timeout was 240s while the successful server-unit run took 247.72s locally

Fixes #6375