### PR TITLE
fix(compliance): harden MCP discovery Accept header

### DIFF
--- a/server/src/adagents-manager.ts
+++ b/server/src/adagents-manager.ts
@@ -1,10 +1,9 @@
 import { PropertyDefinition, PlacementDefinition } from './types.js';
 import { AAO_UA_VALIDATOR } from './config/user-agents.js';
 import { safeFetchAxiosLike, classifySafeFetchError } from './utils/url-security.js';
-import { withSdkSafeTransport } from './utils/sdk-safe-fetch.js';
+import { MCP_ACCEPT_HEADER, withSdkSafeTransport } from './utils/sdk-safe-fetch.js';
 import { canonicalizePublisherDomain } from './services/publisher-domain.js';
 
-const MCP_ACCEPT_HEADER = 'application/json, text/event-stream';
 const ADS_TXT_MAX_REDIRECTS = 5;
 // The initial /.well-known/adagents.json fetch follows same-registrable-domain
 // redirects only (apex↔www, HTTPS-preserving), capped at 3 hops, so standard

--- a/server/src/utils/sdk-safe-fetch.ts
+++ b/server/src/utils/sdk-safe-fetch.ts
@@ -1,6 +1,7 @@
 import { safeFetch } from './url-security.js';
 
 const SDK_MAX_REQUEST_BYTES = 10 * 1024 * 1024;
+export const MCP_ACCEPT_HEADER = 'application/json, text/event-stream';
 const SENSITIVE_REDIRECT_HEADERS = [
   'authorization',
   'proxy-authorization',
@@ -41,6 +42,9 @@ export function createSdkSafeFetch(safeFetchImpl: SafeFetchImpl = safeFetch): ty
 
     let body: Uint8Array | undefined;
     if (method === 'POST') {
+      if (!request.headers.has('accept')) {
+        request.headers.set('accept', MCP_ACCEPT_HEADER);
+      }
       if (!request.body) {
         throw new Error('SDK safe fetch POST requests require a body');
       }

--- a/tests/sdk-safe-fetch.test.ts
+++ b/tests/sdk-safe-fetch.test.ts
@@ -6,6 +6,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   createSdkSafeFetch,
+  MCP_ACCEPT_HEADER,
   sdkSafeFetch,
   withSdkSafeTransport,
 } from '../server/src/utils/sdk-safe-fetch.js';
@@ -35,7 +36,30 @@ describe('SDK safe fetch adapter', () => {
     expect(url).toBe('https://agent.example/mcp');
     expect(options).toMatchObject({ method: 'POST', maxRedirects: 0 });
     expect(options?.headers?.authorization).toBe('Bearer secret');
+    expect(options?.headers?.accept).toBe(MCP_ACCEPT_HEADER);
     expect(new TextDecoder().decode(options?.body as Uint8Array)).toContain('tools/list');
+  });
+
+  it('preserves an explicit Accept header on SDK POST requests', async () => {
+    const safeFetchImpl = vi.fn(async () => new Response('{}', { status: 200 }));
+    const fetchFn = createSdkSafeFetch(safeFetchImpl);
+
+    await fetchFn('https://agent.example/mcp', {
+      method: 'POST',
+      headers: { Accept: 'application/problem+json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list' }),
+    });
+
+    expect(safeFetchImpl.mock.calls[0][1]?.headers?.accept).toBe('application/problem+json');
+  });
+
+  it('does not add the MCP Accept header to non-POST requests', async () => {
+    const safeFetchImpl = vi.fn(async () => new Response('{}', { status: 200 }));
+    const fetchFn = createSdkSafeFetch(safeFetchImpl);
+
+    await fetchFn('https://agent.example/.well-known/adagents.json');
+
+    expect(safeFetchImpl.mock.calls[0][1]?.headers?.accept).toBeUndefined();
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- inject the MCP Streamable HTTP `Accept: application/json, text/event-stream` value for SDK POST requests that do not already specify one
- preserve explicit caller headers and leave non-POST requests unchanged
- share the existing header constant with the direct MCP preflight path

This is defense-in-depth for unauthenticated SDK discovery calls. The original #6382 incident was closed after an authenticated live trace showed the correct header and identified #6384 as its observed cause; the remaining no-auth SDK source bug is tracked in adcontextprotocol/adcp-client#2515.

No changeset: server transport hardening only; no AdCP wire/schema surface change.

## Validation

- `npx vitest run tests/sdk-safe-fetch.test.ts` (11 passed)
- `npm run typecheck`
- repository pre-commit suite
- current and 3.0-compat storyboard pre-push matrices

Related: #6382
Related: adcontextprotocol/adcp-client#2515