### PR TITLE
Fix dashboard compliance retest feedback

### DIFF
--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -2014,7 +2014,7 @@
             <div class="agent-meta-row">
               <span></span>
               <div class="agent-meta-row-actions">
-                <button class="agent-refresh-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" title="Re-probe this agent so the public registry shows fresh online / tools / type">Recheck status</button>
+                <button class="agent-refresh-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" title="Re-detect supported AdCP versions, refresh registry status, and run compliance now">Recheck &amp; retest</button>
                 <button class="agent-storyboard-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">Test your agent</button>
                 <button class="agent-action-link agent-action-link--danger" onclick="deleteAgent(${index})">Delete</button>
               </div>
@@ -2143,7 +2143,7 @@
                 <button class="agent-connect-toggle agent-action-link" data-card-id="${cardId}" data-agent-url="${escapeHtml(agent.url)}">${hasAuth ? 'Update auth' : 'Connect agent'}</button>
                 <button class="agent-history-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">History</button>
                 <button class="agent-requests-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}">Requests</button>
-                <button class="agent-refresh-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" title="Re-probe this agent so the public registry shows fresh online / tools / type. Distinct from Test (which runs storyboard compliance).">Recheck status</button>
+                <button class="agent-refresh-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" title="Re-detect supported AdCP versions, refresh registry status, and rerun the full compliance suite">Recheck &amp; retest</button>
                 <button class="agent-requeue-btn agent-action-link" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" title="Queue this agent for the next scheduled compliance heartbeat (runs within ~1 hour).">Requeue comply</button>
                 <button class="agent-storyboard-btn" data-agent-url="${escapeHtml(agent.url)}" data-card-id="${cardId}" data-agent-tracks="${escapeHtml(JSON.stringify(tracks))}" title="Run the full storyboard compliance suite against this agent.">Test</button>
                 <button class="agent-action-link agent-action-link--danger" onclick="deleteAgent(${index})">Delete</button>
@@ -3250,18 +3250,54 @@
       }
     });
 
-    // Recheck registry snapshot for one agent. Re-probes capabilities + health
-    // and updates the public registry's online / tools / type display without
-    // waiting for the periodic crawl. Successes flash and auto-dismiss; errors
-    // and rate-limit messages persist on the card so an operator who alt-tabs
-    // doesn't lose the diagnostic.
+    function buildAgentRefreshSummary(data) {
+      const parts = [
+        data.online ? '✓ Online' : '✗ Offline',
+        (data.tools_count ?? 0) + ' tools',
+        data.inferred_type && data.inferred_type !== 'unknown' ? data.inferred_type : 'type unknown',
+      ];
+      if (data.type_promoted) parts.push('type promoted');
+      if (data.oauth_required) parts.push('OAuth required');
+      if (data.compliance?.ran) {
+        const requestedTarget = data.compliance.requested_compliance_target;
+        const cacheVersion = data.compliance.adcp_version;
+        if (requestedTarget && cacheVersion) {
+          parts.push(`Retested against AdCP ${requestedTarget} (cache ${cacheVersion})`);
+        } else if (requestedTarget) {
+          parts.push(`Retested against AdCP ${requestedTarget}`);
+        }
+        const passing = data.compliance.storyboards_passing ?? 0;
+        const total = data.compliance.storyboards_total ?? 0;
+        parts.push(`compliance: ${passing}/${total}`);
+      } else if (data.compliance?.error) {
+        parts.push(`compliance not run (${data.compliance.error})`);
+      }
+      return parts.join(' · ');
+    }
+
+    function isSuccessfulAgentRetest(data) {
+      return data.online === true && data.compliance?.ran === true;
+    }
+
+    async function reloadAgentCardAfterRefresh(agentUrl) {
+      const state = await fetchAgentState({ url: agentUrl }, pageState.orgId);
+      pageState.complianceMap.set(agentUrl, state);
+      swapAgentCard(agentUrl);
+    }
+
+    // Recheck registry snapshot for one agent. Re-probes capabilities + health,
+    // negotiates against the agent's current supported_versions, and reruns
+    // compliance without waiting for the periodic crawl. Successes flash and
+    // auto-dismiss; errors and rate-limit messages persist on the card so an
+    // operator who alt-tabs doesn't lose the diagnostic.
     document.addEventListener('click', async function(e) {
       const btn = e.target.closest('.agent-refresh-btn');
       if (!btn) return;
 
       const agentUrl = btn.dataset.agentUrl;
+      const cardId = btn.dataset.cardId;
       const originalLabel = btn.textContent;
-      const actionsRow = btn.closest('.agent-meta-row-actions');
+      let actionsRow = btn.closest('.agent-meta-row-actions');
 
       // Kill any prior result message on this card so a re-click doesn't
       // stack flashes — only the latest matters.
@@ -3300,27 +3336,19 @@
         const data = await res.json().catch(() => ({}));
 
         if (res.status === 200) {
-          const parts = [
-            data.online ? '✓ Online' : '✗ Offline',
-            (data.tools_count ?? 0) + ' tools',
-            data.inferred_type && data.inferred_type !== 'unknown' ? data.inferred_type : 'type unknown',
-          ];
-          if (data.type_promoted) parts.push('type promoted');
-          if (data.oauth_required) parts.push('OAuth required');
-          if (data.compliance?.ran) {
-            const passing = data.compliance.storyboards_passing ?? 0;
-            const total = data.compliance.storyboards_total ?? 0;
-            parts.push(`compliance: ${passing}/${total}`);
-          } else if (data.compliance?.error) {
-            parts.push(`compliance not run (${data.compliance.error})`);
-          }
+          // The refresh response is written before it returns. Re-fetch and
+          // replace this card so a previous-version verdict does not linger
+          // until the operator reloads the entire dashboard.
+          await reloadAgentCardAfterRefresh(agentUrl);
+          actionsRow = document.getElementById(cardId)?.querySelector('.agent-meta-row-actions') || null;
           // Online flashes auto-dismiss; offline-but-reachable persists so
           // the operator can read the diagnostic at their pace.
+          const retestSucceeded = isSuccessfulAgentRetest(data);
           const flash = renderFlash({
-            severity: data.online ? 'success' : 'warning',
-            text: parts.join(' · '),
+            severity: retestSucceeded ? 'success' : 'warning',
+            text: buildAgentRefreshSummary(data),
           });
-          if (data.online && flash) setTimeout(() => flash.remove(), 8000);
+          if (retestSucceeded && flash) setTimeout(() => flash.remove(), 8000);
         } else if (res.status === 429) {
           renderFlash({
             severity: 'warning',
@@ -3826,7 +3854,7 @@
             let html = '<div style="padding:var(--space-3);background:var(--color-error-50);border:1px solid var(--color-error-200);border-radius:var(--radius-md);color:var(--color-error-700);font-size:var(--text-sm);">';
             html += '<strong>Unsupported compliance target.</strong> This check selected <code>' + escapeHtml(String(complianceVersion)) + '</code>, but the agent advertises <code>adcp.supported_versions</code>:';
             html += '<div style="margin-top:var(--space-2);font-family:var(--font-mono);font-size:var(--text-xs);">' + escapeHtml(String(supportedVersions)) + '</div>';
-            html += '<div style="margin-top:var(--space-2);font-size:var(--text-xs);color:var(--color-error-600);">Select a compliance target the agent supports, or update the agent\'s capabilities if it is ready for this target.</div>';
+            html += '<div style="margin-top:var(--space-2);font-size:var(--text-xs);color:var(--color-error-600);">Targets are selected automatically. Use Recheck &amp; retest to re-detect the advertised versions and run the matching suite. If the versions shown above are not what the agent intends to support, update <code>get_adcp_capabilities</code> first.</div>';
             html += '</div>';
             panel.innerHTML = html;
             return;

--- a/server/tests/unit/dashboard-agent-refresh.test.ts
+++ b/server/tests/unit/dashboard-agent-refresh.test.ts
@@ -1,0 +1,232 @@
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+const dashboardSource = readFileSync(
+  new URL("../../public/dashboard-agents.html", import.meta.url),
+  "utf8"
+);
+
+const helperStart = dashboardSource.indexOf(
+  "function buildAgentRefreshSummary"
+);
+const helperEnd = dashboardSource.indexOf(
+  "// Recheck registry snapshot for one agent",
+  helperStart
+);
+if (helperStart < 0 || helperEnd < 0) {
+  throw new Error("agent refresh helpers not found");
+}
+
+function loadRefreshHelpers(overrides: Record<string, unknown> = {}) {
+  const context = vm.createContext({
+    fetchAgentState: vi.fn(),
+    pageState: { orgId: "org_test", complianceMap: new Map() },
+    swapAgentCard: vi.fn(),
+    ...overrides,
+  });
+  vm.runInContext(dashboardSource.slice(helperStart, helperEnd), context);
+  return context;
+}
+
+function loadRefreshClickHandler(options: {
+  responseData: Record<string, unknown>;
+  reloadAgentCardAfterRefresh?: ReturnType<typeof vi.fn>;
+  setTimeout?: ReturnType<typeof vi.fn>;
+}) {
+  const handlerStart = dashboardSource.indexOf(
+    "document.addEventListener('click', async function(e)",
+    helperEnd
+  );
+  const handlerEnd = dashboardSource.indexOf(
+    "// Requeue agent for next compliance heartbeat",
+    handlerStart
+  );
+  if (handlerStart < 0 || handlerEnd < 0) {
+    throw new Error("agent refresh click handler not found");
+  }
+
+  let clickHandler: ((event: unknown) => Promise<void>) | undefined;
+  const oldParent = { querySelector: vi.fn(() => null), appendChild: vi.fn() };
+  const newParent = { querySelector: vi.fn(() => null), appendChild: vi.fn() };
+  const oldActionsRow = { parentElement: oldParent };
+  const newActionsRow = { parentElement: newParent };
+  const button = {
+    dataset: { agentUrl: "https://seller.example/mcp", cardId: "agent-card" },
+    textContent: "Recheck & retest",
+    disabled: false,
+    closest: vi.fn(() => oldActionsRow),
+  };
+  const reloadAgentCardAfterRefresh =
+    options.reloadAgentCardAfterRefresh ?? vi.fn().mockResolvedValue(undefined);
+  const setTimeout = options.setTimeout ?? vi.fn();
+  const fetch = vi.fn().mockResolvedValue({
+    status: 200,
+    json: vi.fn().mockResolvedValue(options.responseData),
+  });
+  const document = {
+    addEventListener: vi.fn(
+      (_event: string, handler: (event: unknown) => Promise<void>) => {
+        clickHandler = handler;
+      }
+    ),
+    createElement: vi.fn(() => ({
+      className: "",
+      style: { cssText: "", background: "", color: "" },
+      textContent: "",
+      remove: vi.fn(),
+    })),
+    getElementById: vi.fn(() => ({
+      querySelector: vi.fn(() => newActionsRow),
+    })),
+  };
+  const context = vm.createContext({
+    document,
+    fetch,
+    pageState: { orgId: "org_test" },
+    reloadAgentCardAfterRefresh,
+    buildAgentRefreshSummary: vi.fn(() => "refresh summary"),
+    isSuccessfulAgentRetest: (data: {
+      online?: boolean;
+      compliance?: { ran?: boolean };
+    }) => data.online === true && data.compliance?.ran === true,
+    setTimeout,
+  });
+  vm.runInContext(dashboardSource.slice(handlerStart, handlerEnd), context);
+  if (!clickHandler)
+    throw new Error("agent refresh click handler was not registered");
+
+  return {
+    click: () => clickHandler!({ target: { closest: () => button } }),
+    reloadAgentCardAfterRefresh,
+    setTimeout,
+    newParent,
+  };
+}
+
+describe("dashboard agent refresh", () => {
+  it("reports the newly negotiated target and concrete cache after a 3.0 to 3.1 migration", () => {
+    const context = loadRefreshHelpers();
+    const buildAgentRefreshSummary = context.buildAgentRefreshSummary as (
+      data: Record<string, unknown>
+    ) => string;
+
+    const summary = buildAgentRefreshSummary({
+      online: true,
+      tools_count: 7,
+      inferred_type: "sales",
+      compliance: {
+        ran: true,
+        requested_compliance_target: "3.1",
+        adcp_version: "3.1.4",
+        storyboards_passing: 12,
+        storyboards_total: 14,
+      },
+    });
+
+    expect(summary).toContain("Retested against AdCP 3.1 (cache 3.1.4)");
+    expect(summary).toContain("compliance: 12/14");
+    expect(summary).not.toContain("3.0");
+  });
+
+  it("stores freshly fetched compliance state and swaps the stale card", async () => {
+    const freshState = {
+      url: "https://seller.example/mcp",
+      compliance: { adcp_version: "3.1.4" },
+    };
+    const fetchAgentState = vi.fn().mockResolvedValue(freshState);
+    const complianceMap = new Map();
+    const swapAgentCard = vi.fn();
+    const context = loadRefreshHelpers({
+      fetchAgentState,
+      pageState: { orgId: "org_test", complianceMap },
+      swapAgentCard,
+    });
+    const reloadAgentCardAfterRefresh = context.reloadAgentCardAfterRefresh as (
+      agentUrl: string
+    ) => Promise<void>;
+
+    await reloadAgentCardAfterRefresh("https://seller.example/mcp");
+
+    expect(fetchAgentState).toHaveBeenCalledWith(
+      { url: "https://seller.example/mcp" },
+      "org_test"
+    );
+    expect(complianceMap.get("https://seller.example/mcp")).toBe(freshState);
+    expect(swapAgentCard).toHaveBeenCalledWith("https://seller.example/mcp");
+  });
+
+  it("keeps online probes with a failed compliance rerun out of the success state", () => {
+    const context = loadRefreshHelpers();
+    const isSuccessfulAgentRetest = context.isSuccessfulAgentRetest as (
+      data: Record<string, unknown>
+    ) => boolean;
+
+    expect(
+      isSuccessfulAgentRetest({
+        online: true,
+        compliance: { ran: false, error: "Agent requires OAuth authorization" },
+      })
+    ).toBe(false);
+    expect(
+      isSuccessfulAgentRetest({
+        online: true,
+        compliance: { ran: true },
+      })
+    ).toBe(true);
+    expect(
+      isSuccessfulAgentRetest({
+        online: false,
+        compliance: { ran: true },
+      })
+    ).toBe(false);
+  });
+
+  it("wires a successful refresh response through card replacement before rendering its result", async () => {
+    const harness = loadRefreshClickHandler({
+      responseData: {
+        online: true,
+        compliance: {
+          ran: true,
+          requested_compliance_target: "3.1",
+          adcp_version: "3.1.4",
+        },
+      },
+    });
+
+    await harness.click();
+
+    expect(harness.reloadAgentCardAfterRefresh).toHaveBeenCalledWith(
+      "https://seller.example/mcp"
+    );
+    expect(harness.newParent.appendChild).toHaveBeenCalledOnce();
+    expect(
+      harness.reloadAgentCardAfterRefresh.mock.invocationCallOrder[0]
+    ).toBeLessThan(harness.newParent.appendChild.mock.invocationCallOrder[0]);
+    expect(harness.setTimeout).toHaveBeenCalledOnce();
+  });
+
+  it("keeps an online probe with a failed retest as a persistent warning", async () => {
+    const harness = loadRefreshClickHandler({
+      responseData: {
+        online: true,
+        compliance: { ran: false, error: "Agent requires OAuth authorization" },
+      },
+    });
+
+    await harness.click();
+
+    expect(harness.newParent.appendChild).toHaveBeenCalledOnce();
+    const flash = harness.newParent.appendChild.mock.calls[0][0];
+    expect(flash.style.background).toBe("var(--color-warning-bg)");
+    expect(harness.setTimeout).not.toHaveBeenCalled();
+  });
+
+  it("does not instruct owners to select a target that has no dashboard control", () => {
+    expect(dashboardSource).toContain("Recheck &amp; retest");
+    expect(dashboardSource).toContain("adcp.supported_versions");
+    expect(dashboardSource).not.toContain(
+      "Select a compliance target the agent supports"
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- Rename the dashboard action to **Recheck & retest** and explain that it re-detects supported AdCP versions.
- Refresh and replace the agent card after a successful owner-triggered run, so an old 3.0 verdict does not linger after a 3.1 migration.
- Report both the negotiated target alias and concrete compliance cache version.
- Keep incomplete retests as persistent warnings and replace the nonexistent target-selector guidance with the automatic recovery path.

## Why

The underlying target-selection bug was fixed by live capability negotiation and the recent warm fallback. The dashboard still looked stuck because it did not reload the card after `/refresh`, and its error copy told owners to select a target even though no such control exists.

Closes #6383.

## Validation

- `npm exec vitest run -- --config server/vitest.config.ts server/tests/unit/dashboard-agent-refresh.test.ts server/tests/unit/dashboard-storyboard-rate-limit.test.ts server/tests/unit/dashboard-track-coverage-gap.test.ts` (34 tests)
- `npm run typecheck`
- `git diff --check`
- Product/UX expert review: approved
- AdCP protocol expert review: approved
