### PR TITLE
fix: audit brand hierarchy changes

### DIFF
--- a/server/src/addie/mcp/registry-review.ts
+++ b/server/src/addie/mcp/registry-review.ts
@@ -200,7 +200,10 @@ Does this look like a legitimate ${record.entity_type} record? Check for spam, n
       });
       // Delete the malicious record
       if (record.entity_type === 'brand') {
-        await brandDb.deleteDiscoveredBrand(record.domain);
+        await brandDb.deleteDiscoveredBrand(record.domain, {
+          actor_user_id: 'system:addie',
+          source: 'addie_malicious_record_cleanup',
+        });
       } else {
         await propertyDb.deleteHostedPropertyByDomain(record.domain);
       }

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -1,5 +1,6 @@
 import { query, getClient } from './client.js';
 import { canonicalizeBrandDomain, assertValidBrandDomain } from '../services/identifier-normalization.js';
+import type { PoolClient } from 'pg';
 import type {
   HostedBrand,
   DiscoveredBrand,
@@ -97,14 +98,16 @@ export function sanitizeBrandSnapshot<T extends Record<string, unknown>>(snapsho
  *    `organization_domains.domain` but pollutes the registry)
  *  - self-reference (a brand cannot be its own house)
  *
- * Empty / null / undefined are passed through — callers use those to clear
- * the field.
+ * `undefined` means "not provided" while null / empty string mean "clear".
+ * Keeping that distinction prevents unrelated cache upserts from silently
+ * removing an existing hierarchy edge.
  */
 function validateHouseDomainArg(
   houseDomain: string | undefined | null,
   brandDomain: string,
-): string | undefined {
-  if (houseDomain == null || houseDomain === '') return undefined;
+): string | null | undefined {
+  if (houseDomain === undefined) return undefined;
+  if (houseDomain === null || houseDomain === '') return null;
   if (typeof houseDomain !== 'string') {
     throw new Error('house_domain must be a string');
   }
@@ -117,6 +120,96 @@ function validateHouseDomainArg(
     throw new Error('house_domain cannot equal the brand domain (self-reference)');
   }
   return canonical;
+}
+
+export interface BrandHouseDomainAuditContext {
+  actor_user_id: string;
+  source: string;
+  revision_number?: number;
+  rolled_back_to_revision?: number;
+}
+
+/** Serialize every hierarchy-edge writer, including writers for absent rows. */
+export async function lockBrandHouseDomainWriter(
+  client: Pick<PoolClient, 'query'>,
+  domain: string,
+): Promise<void> {
+  await client.query(
+    'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+    [domain],
+  );
+}
+
+/**
+ * Record one canonical hierarchy-edge mutation on the caller's transaction.
+ * The brand write and audit insert must succeed or roll back together.
+ */
+export async function recordBrandHouseDomainChange(
+  client: Pick<PoolClient, 'query'>,
+  input: {
+    domain: string;
+    prior_house_domain: string | null;
+    new_house_domain: string | null;
+    audit: BrandHouseDomainAuditContext;
+  },
+): Promise<void> {
+  if (input.prior_house_domain === input.new_house_domain) return;
+
+  const parentDomains = [...new Set([
+    input.new_house_domain,
+    input.prior_house_domain,
+  ]
+    .filter((domain): domain is string => Boolean(domain))
+    .map(domain => domain.toLowerCase()))];
+  const parentOrgByDomain = new Map<string, string>();
+  if (parentDomains.length > 0) {
+    const orgResult = await client.query<{ domain: string; workos_organization_id: string }>(
+      `SELECT LOWER(domain) AS domain, MIN(workos_organization_id) AS workos_organization_id
+       FROM organization_domains
+       WHERE verified = true AND LOWER(domain) = ANY($1::text[])
+       GROUP BY LOWER(domain)`,
+      [parentDomains],
+    );
+    for (const row of orgResult.rows) {
+      parentOrgByDomain.set(row.domain, row.workos_organization_id);
+    }
+  }
+
+  const priorParentOrgId = input.prior_house_domain
+    ? parentOrgByDomain.get(input.prior_house_domain.toLowerCase()) ?? null
+    : null;
+  const newParentOrgId = input.new_house_domain
+    ? parentOrgByDomain.get(input.new_house_domain.toLowerCase()) ?? null
+    : null;
+  const auditOrgId = newParentOrgId
+    ?? priorParentOrgId
+    ?? 'system_brand_registry';
+
+  await client.query(
+    `INSERT INTO registry_audit_log
+     (workos_organization_id, workos_user_id, action, resource_type, resource_id, details)
+     VALUES ($1, $2, 'brand_house_domain_changed', 'brand', $3, $4)`,
+    [
+      auditOrgId,
+      input.audit.actor_user_id,
+      input.domain,
+      JSON.stringify({
+        schema_version: 1,
+        domain: input.domain,
+        prior_house_domain: input.prior_house_domain,
+        new_house_domain: input.new_house_domain,
+        prior_parent_org_id: priorParentOrgId,
+        new_parent_org_id: newParentOrgId,
+        mutation_source: input.audit.source,
+        ...(input.audit.revision_number !== undefined
+          ? { revision_number: input.audit.revision_number }
+          : {}),
+        ...(input.audit.rolled_back_to_revision !== undefined
+          ? { rolled_back_to_revision: input.audit.rolled_back_to_revision }
+          : {}),
+      }),
+    ],
+  );
 }
 
 /**
@@ -263,7 +356,7 @@ export interface UpsertDiscoveredBrandInput {
   domain: string;
   brand_id?: string;
   canonical_domain?: string;
-  house_domain?: string;
+  house_domain?: string | null;
   brand_name?: string;
   brand_names?: LocalizedName[];
   keller_type?: KellerType;
@@ -280,6 +373,7 @@ export interface UpsertDiscoveredBrandInput {
   classification?: TrustedBrandClassification;
   source_type: 'brand_json' | 'community' | 'enriched' | 'stub';
   expires_at?: Date;
+  house_domain_audit?: BrandHouseDomainAuditContext;
 }
 
 /**
@@ -711,46 +805,79 @@ export class BrandDatabase {
       ? { ...(sanitized ?? {}), classification: { ...input.classification } }
       : sanitized;
 
-    const result = await query<DiscoveredBrand>(
-      `INSERT INTO brands (
-        domain, brand_id, canonical_domain, house_domain, brand_name, brand_names,
-        keller_type, parent_brand, brand_agent_url, brand_agent_capabilities,
-        has_brand_manifest, brand_manifest, source_type, last_validated, expires_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), $14)
-      ON CONFLICT (domain) DO UPDATE SET
-        brand_id = COALESCE(EXCLUDED.brand_id, brands.brand_id),
-        canonical_domain = EXCLUDED.canonical_domain,
-        house_domain = EXCLUDED.house_domain,
-        brand_name = EXCLUDED.brand_name,
-        brand_names = EXCLUDED.brand_names,
-        keller_type = EXCLUDED.keller_type,
-        parent_brand = EXCLUDED.parent_brand,
-        brand_agent_url = EXCLUDED.brand_agent_url,
-        brand_agent_capabilities = EXCLUDED.brand_agent_capabilities,
-        has_brand_manifest = COALESCE(EXCLUDED.has_brand_manifest, brands.has_brand_manifest),
-        brand_manifest = COALESCE(EXCLUDED.brand_manifest, brands.brand_manifest),
-        source_type = EXCLUDED.source_type,
-        last_validated = NOW(),
-        expires_at = EXCLUDED.expires_at
-      RETURNING *`,
-      [
-        canonicalDomain,
-        input.brand_id || null,
-        input.canonical_domain || null,
-        canonicalHouseDomain ?? null,
-        input.brand_name || null,
-        input.brand_names ? JSON.stringify(input.brand_names) : '[]',
-        input.keller_type || null,
-        input.parent_brand || null,
-        input.brand_agent_url || null,
-        input.brand_agent_capabilities || null,
-        input.has_brand_manifest != null ? input.has_brand_manifest : null,
-        persistedManifest ? JSON.stringify(persistedManifest) : null,
-        input.source_type,
-        input.expires_at || null,
-      ]
-    );
-    return this.deserializeDiscoveredBrand(result.rows[0]);
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+      // Serialize writers for one domain even when the row does not exist yet,
+      // so the audit event always describes the immediately preceding value.
+      await lockBrandHouseDomainWriter(client, canonicalDomain);
+      const priorResult = await client.query<{ house_domain: string | null }>(
+        'SELECT house_domain FROM brands WHERE domain = $1',
+        [canonicalDomain],
+      );
+      const priorHouseDomain = priorResult.rows[0]?.house_domain ?? null;
+
+      const result = await client.query<DiscoveredBrand>(
+        `INSERT INTO brands (
+          domain, brand_id, canonical_domain, house_domain, brand_name, brand_names,
+          keller_type, parent_brand, brand_agent_url, brand_agent_capabilities,
+          has_brand_manifest, brand_manifest, source_type, last_validated, expires_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), $14)
+        ON CONFLICT (domain) DO UPDATE SET
+          brand_id = COALESCE(EXCLUDED.brand_id, brands.brand_id),
+          canonical_domain = EXCLUDED.canonical_domain,
+          house_domain = CASE WHEN $15::boolean THEN EXCLUDED.house_domain ELSE brands.house_domain END,
+          brand_name = EXCLUDED.brand_name,
+          brand_names = EXCLUDED.brand_names,
+          keller_type = EXCLUDED.keller_type,
+          parent_brand = EXCLUDED.parent_brand,
+          brand_agent_url = EXCLUDED.brand_agent_url,
+          brand_agent_capabilities = EXCLUDED.brand_agent_capabilities,
+          has_brand_manifest = COALESCE(EXCLUDED.has_brand_manifest, brands.has_brand_manifest),
+          brand_manifest = COALESCE(EXCLUDED.brand_manifest, brands.brand_manifest),
+          source_type = EXCLUDED.source_type,
+          last_validated = NOW(),
+          expires_at = EXCLUDED.expires_at
+        RETURNING *`,
+        [
+          canonicalDomain,
+          input.brand_id || null,
+          input.canonical_domain || null,
+          canonicalHouseDomain ?? null,
+          input.brand_name || null,
+          input.brand_names ? JSON.stringify(input.brand_names) : '[]',
+          input.keller_type || null,
+          input.parent_brand || null,
+          input.brand_agent_url || null,
+          input.brand_agent_capabilities || null,
+          input.has_brand_manifest != null ? input.has_brand_manifest : null,
+          persistedManifest ? JSON.stringify(persistedManifest) : null,
+          input.source_type,
+          input.expires_at || null,
+          input.house_domain !== undefined,
+        ],
+      );
+
+      if (input.house_domain !== undefined) {
+        await recordBrandHouseDomainChange(client, {
+          domain: canonicalDomain,
+          prior_house_domain: priorHouseDomain,
+          new_house_domain: result.rows[0].house_domain ?? null,
+          audit: input.house_domain_audit ?? {
+            actor_user_id: 'system:brand-database',
+            source: 'upsert_discovered_brand',
+          },
+        });
+      }
+
+      await client.query('COMMIT');
+      return this.deserializeDiscoveredBrand(result.rows[0]);
+    } catch (error) {
+      try { await client.query('ROLLBACK'); } catch { /* preserve original error */ }
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   /**
@@ -862,15 +989,49 @@ export class BrandDatabase {
   }
 
   /**
-   * Delete a discovered brand
+   * Delete a discovered brand and record removal of any hierarchy edge.
    */
-  async deleteDiscoveredBrand(domain: string): Promise<boolean> {
-    const result = await query('DELETE FROM brands WHERE domain = $1', [domain.toLowerCase()]);
-    return result.rowCount !== null && result.rowCount > 0;
+  async deleteDiscoveredBrand(
+    domain: string,
+    audit: BrandHouseDomainAuditContext = {
+      actor_user_id: 'system:brand-database',
+      source: 'delete_discovered_brand',
+    },
+  ): Promise<boolean> {
+    const canonicalDomain = domain.toLowerCase();
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+      await lockBrandHouseDomainWriter(client, canonicalDomain);
+      const result = await client.query<{ domain: string; house_domain: string | null }>(
+        'DELETE FROM brands WHERE domain = $1 RETURNING domain, house_domain',
+        [canonicalDomain],
+      );
+      const deleted = result.rows[0];
+      if (deleted) {
+        await recordBrandHouseDomainChange(client, {
+          domain: deleted.domain,
+          prior_house_domain: deleted.house_domain,
+          new_house_domain: null,
+          audit,
+        });
+      }
+      await client.query('COMMIT');
+      return Boolean(deleted);
+    } catch (error) {
+      try { await client.query('ROLLBACK'); } catch { /* preserve original error */ }
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   /**
-   * Delete expired discovered brands
+   * Delete expired discovered brands.
+   *
+   * This maintenance primitive currently has no runtime caller. It must be
+   * routed through deleteDiscoveredBrand (with a stable maintenance actor)
+   * before activation so hierarchy-edge removals remain auditable.
    */
   async deleteExpiredBrands(): Promise<number> {
     const result = await query('DELETE FROM brands WHERE expires_at < NOW()');
@@ -1150,6 +1311,7 @@ export class BrandDatabase {
     const client = await getClient();
     try {
       await client.query('BEGIN');
+      await lockBrandHouseDomainWriter(client, canonicalDomain);
 
       const insertResult = await client.query<DiscoveredBrand>(
         `INSERT INTO brands (
@@ -1191,6 +1353,17 @@ export class BrandDatabase {
           editor.name || null,
         ]
       );
+
+      await recordBrandHouseDomainChange(client, {
+        domain: brand.domain,
+        prior_house_domain: null,
+        new_house_domain: brand.house_domain ?? null,
+        audit: {
+          actor_user_id: editor.user_id,
+          source: 'community_create',
+          revision_number: 1,
+        },
+      });
 
       await client.query('COMMIT');
       return this.deserializeDiscoveredBrand(brand);
@@ -1300,7 +1473,7 @@ export class BrandDatabase {
       brand_names?: LocalizedName[];
       keller_type?: KellerType;
       parent_brand?: string;
-      house_domain?: string;
+      house_domain?: string | null;
       canonical_domain?: string;
       brand_agent_url?: string;
       brand_agent_capabilities?: string[];
@@ -1320,6 +1493,7 @@ export class BrandDatabase {
     const client = await getClient();
     try {
       await client.query('BEGIN');
+      await lockBrandHouseDomainWriter(client, canonicalDomain);
 
       // Lock the row
       const lockResult = await client.query<DiscoveredBrand>(
@@ -1469,6 +1643,19 @@ export class BrandDatabase {
         values
       );
 
+      if (input.house_domain !== undefined) {
+        await recordBrandHouseDomainChange(client, {
+          domain: canonicalDomain,
+          prior_house_domain: current.house_domain ?? null,
+          new_house_domain: updateResult.rows[0].house_domain ?? null,
+          audit: {
+            actor_user_id: input.editor_user_id,
+            source: 'community_edit',
+            revision_number: revisionNumber,
+          },
+        });
+      }
+
       await client.query('COMMIT');
       return {
         brand: this.deserializeDiscoveredBrand(updateResult.rows[0]),
@@ -1490,14 +1677,16 @@ export class BrandDatabase {
     toRevisionNumber: number,
     editor: { user_id: string; email?: string; name?: string }
   ): Promise<{ brand: DiscoveredBrand; revision_number: number }> {
+    const canonicalDomain = domain.toLowerCase();
     const client = await getClient();
     try {
       await client.query('BEGIN');
+      await lockBrandHouseDomainWriter(client, canonicalDomain);
 
       // Get target revision
       const targetResult = await client.query<{ snapshot: string }>(
         'SELECT snapshot FROM brand_revisions WHERE brand_domain = $1 AND revision_number = $2',
-        [domain.toLowerCase(), toRevisionNumber]
+        [canonicalDomain, toRevisionNumber]
       );
       if (targetResult.rows.length === 0) {
         throw new Error(`Revision ${toRevisionNumber} not found for ${domain}`);
@@ -1510,7 +1699,7 @@ export class BrandDatabase {
       // Lock current row and get current state for the new revision snapshot
       const currentResult = await client.query<DiscoveredBrand>(
         'SELECT * FROM brands WHERE domain = $1 FOR UPDATE',
-        [domain.toLowerCase()]
+        [canonicalDomain]
       );
       if (currentResult.rows.length === 0) {
         throw new Error(`Brand not found: ${domain}`);
@@ -1526,7 +1715,7 @@ export class BrandDatabase {
       // Get next revision number
       const revResult = await client.query<{ next_rev: number }>(
         'SELECT COALESCE(MAX(revision_number), 0) + 1 as next_rev FROM brand_revisions WHERE brand_domain = $1',
-        [domain.toLowerCase()]
+        [canonicalDomain]
       );
       const revisionNumber = revResult.rows[0].next_rev;
 
@@ -1538,7 +1727,7 @@ export class BrandDatabase {
           edit_summary, is_rollback, rolled_back_to
         ) VALUES ($1, $2, $3, $4, $5, $6, $7, true, $8)`,
         [
-          domain.toLowerCase(),
+          canonicalDomain,
           revisionNumber,
           JSON.stringify(sanitizeBrandSnapshot(current as unknown as Record<string, unknown>)),
           editor.user_id,
@@ -1565,7 +1754,7 @@ export class BrandDatabase {
         WHERE domain = $1
         RETURNING *`,
         [
-          domain.toLowerCase(),
+          canonicalDomain,
           snapshot.canonical_domain || null,
           snapshot.house_domain || null,
           snapshot.brand_name || null,
@@ -1578,6 +1767,18 @@ export class BrandDatabase {
           snapshot.brand_manifest ? JSON.stringify(snapshot.brand_manifest) : null,
         ]
       );
+
+      await recordBrandHouseDomainChange(client, {
+        domain: canonicalDomain,
+        prior_house_domain: current.house_domain ?? null,
+        new_house_domain: updateResult.rows[0].house_domain ?? null,
+        audit: {
+          actor_user_id: editor.user_id,
+          source: 'rollback',
+          revision_number: revisionNumber,
+          rolled_back_to_revision: toRevisionNumber,
+        },
+      });
 
       await client.query('COMMIT');
       return {

--- a/server/src/routes/admin/brand-enrichment.ts
+++ b/server/src/routes/admin/brand-enrichment.ts
@@ -11,6 +11,10 @@ import { requireAuth, requireAdmin } from '../../middleware/auth.js';
 import { isBrandfetchConfigured } from '../../services/brandfetch.js';
 import { query, getClient } from '../../db/client.js';
 import {
+  lockBrandHouseDomainWriter,
+  recordBrandHouseDomainChange,
+} from '../../db/brand-db.js';
+import {
   enrichBrand,
   enrichBrands,
   expandHouse,
@@ -432,6 +436,7 @@ export function setupBrandEnrichmentRoutes(apiRouter: Router): void {
         let priorRow: { domain: string; house_domain: string | null; keller_type: string | null };
         try {
           await client.query('BEGIN');
+          await lockBrandHouseDomainWriter(client, domain);
 
           const existing = await client.query<{ domain: string; house_domain: string | null; keller_type: string | null }>(
             `SELECT domain, house_domain, keller_type FROM brands WHERE domain = $1 FOR UPDATE`,
@@ -479,40 +484,16 @@ export function setupBrandEnrichmentRoutes(apiRouter: Router): void {
             }
           }
 
-          // Audit log: house_domain feeds the brand-hierarchy auto-link path
-          // (autoLinkByVerifiedDomain via findPayingOrgForDomain), so changes
-          // to it can grant new sets of users access to a paying org. Track
-          // each change so a misbehaving / compromised admin is detectable.
-          if (house_domain !== undefined && (house_domain || null) !== priorRow.house_domain) {
-            // Look up the paying org whose hierarchy is impacted, falling
-            // back to a sentinel. registry_audit_log has no FK on the
-            // workos_organization_id column, so the sentinel is safe.
-            const candidateOrgs = await client.query<{ workos_organization_id: string }>(
-              `SELECT od.workos_organization_id FROM organization_domains od
-               WHERE od.verified = true AND LOWER(od.domain) = ANY($1::text[])
-               LIMIT 1`,
-              [[house_domain, priorRow.house_domain].filter(Boolean).map((d) => (d as string).toLowerCase())]
-            );
-            const auditOrgId = candidateOrgs.rows[0]?.workos_organization_id ?? 'system_brand_registry';
-
-            await client.query(
-              `INSERT INTO registry_audit_log
-               (workos_organization_id, workos_user_id, action, resource_type, resource_id, details)
-               VALUES ($1, $2, $3, $4, $5, $6)`,
-              [
-                auditOrgId,
-                req.user!.id,
-                'brand_house_domain_changed',
-                'brand',
-                domain,
-                JSON.stringify({
-                  domain,
-                  prior_house_domain: priorRow.house_domain,
-                  new_house_domain: house_domain || null,
-                  admin_email: req.user!.email,
-                }),
-              ]
-            );
+          if (house_domain !== undefined) {
+            await recordBrandHouseDomainChange(client, {
+              domain,
+              prior_house_domain: priorRow.house_domain,
+              new_house_domain: brandRow.house_domain ?? null,
+              audit: {
+                actor_user_id: req.user!.id,
+                source: 'admin_brand_enrichment',
+              },
+            });
           }
 
           await client.query('COMMIT');

--- a/server/src/services/brand-enrichment.ts
+++ b/server/src/services/brand-enrichment.ts
@@ -158,7 +158,10 @@ export async function enrichBrand(domain: string): Promise<BrandEnrichmentResult
 
     // Remove the variant from brands (it's just a regional redirect)
     try {
-      await brandDb.deleteDiscoveredBrand(domain);
+      await brandDb.deleteDiscoveredBrand(domain, {
+        actor_user_id: 'system:brand-classifier',
+        source: 'classifier_variant_cleanup',
+      });
     } catch {
       // May not exist, that's fine
     }
@@ -235,9 +238,15 @@ export async function enrichBrand(domain: string): Promise<BrandEnrichmentResult
     // Apply classification fields if available
     ...(classification ? {
       keller_type: classification.keller_type,
-      house_domain: classification.house_domain || undefined,
+      // The classifier owns this field: null is an explicit decision to
+      // clear a stale hierarchy edge, while omission preserves it.
+      house_domain: classification.house_domain,
       parent_brand: classification.parent_brand || undefined,
       canonical_domain: classification.canonical_domain,
+      house_domain_audit: {
+        actor_user_id: 'system:brand-classifier',
+        source: 'classifier',
+      },
       classification: {
         confidence: classification.confidence,
         reasoning: classification.reasoning,
@@ -616,6 +625,10 @@ export async function expandHouse(houseDomain: string, options: {
         keller_type: brand.keller_type || 'sub_brand',
         house_domain: houseDomain,
         parent_brand: houseName,
+        house_domain_audit: {
+          actor_user_id: 'system:house-expansion',
+          source: 'house_expansion',
+        },
       });
       seeded++;
       existingBrands.add(domain);

--- a/server/tests/integration/admin-brand-enrichment-audit.test.ts
+++ b/server/tests/integration/admin-brand-enrichment-audit.test.ts
@@ -3,8 +3,9 @@
  *
  * `house_domain` feeds the brand-hierarchy auto-link path, so changes to it
  * can graft new sets of users onto a paying org's auto-link reach. The PATCH
- * handler must write a registry_audit_log row with prior + new values + admin
- * email so a misbehaving / compromised admin is detectable.
+ * handler must write a registry_audit_log row with prior + new values and a
+ * stable actor ID so a misbehaving / compromised admin is detectable without
+ * duplicating user PII into event details.
  *
  * Per security review on PR #3378.
  */
@@ -14,6 +15,7 @@ import { HTTPServer } from '../../src/http.js';
 import request from 'supertest';
 import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
+import { BrandDatabase } from '../../src/db/brand-db.js';
 import type { Pool } from 'pg';
 
 vi.mock('../../src/middleware/auth.js', async (importOriginal) => ({
@@ -59,16 +61,16 @@ describe('admin brand PATCH audit log', () => {
   }, 60000);
 
   afterAll(async () => {
-    await pool.query('DELETE FROM registry_audit_log WHERE workos_user_id = $1', ['user_test_admin_audit']);
+    await pool.query('DELETE FROM registry_audit_log WHERE resource_id = $1', [TEST_BRAND_DOMAIN]);
     await pool.query('DELETE FROM brands WHERE domain = $1', [TEST_BRAND_DOMAIN]);
     await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = $1', [TEST_PARENT_ORG_ID]);
     await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_PARENT_ORG_ID]);
-    await server.stop();
+    if (server) await server.stop();
     await closeDatabase();
   });
 
   beforeEach(async () => {
-    await pool.query('DELETE FROM registry_audit_log WHERE workos_user_id = $1', ['user_test_admin_audit']);
+    await pool.query('DELETE FROM registry_audit_log WHERE resource_id = $1', [TEST_BRAND_DOMAIN]);
     await pool.query('DELETE FROM brands WHERE domain = $1', [TEST_BRAND_DOMAIN]);
     await pool.query('DELETE FROM organization_domains WHERE workos_organization_id = $1', [TEST_PARENT_ORG_ID]);
     await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_PARENT_ORG_ID]);
@@ -113,11 +115,14 @@ describe('admin brand PATCH audit log', () => {
     expect(audit.rows[0].action).toBe('brand_house_domain_changed');
     expect(audit.rows[0].workos_organization_id).toBe(TEST_PARENT_ORG_ID); // resolved, not sentinel
     expect(audit.rows[0].details).toMatchObject({
+      schema_version: 1,
       domain: TEST_BRAND_DOMAIN,
       prior_house_domain: null,
       new_house_domain: TEST_PARENT_DOMAIN,
-      admin_email: 'admin-audit@test.com',
+      new_parent_org_id: TEST_PARENT_ORG_ID,
+      mutation_source: 'admin_brand_enrichment',
     });
+    expect(audit.rows[0].details).not.toHaveProperty('admin_email');
   });
 
   it('writes an audit row when house_domain changes from one value to another', async () => {
@@ -209,4 +214,97 @@ describe('admin brand PATCH audit log', () => {
       new_house_domain: null,
     });
   });
+
+  it('preserves omission, clears explicit null, and audits only the clear in PostgreSQL', async () => {
+    const db = new BrandDatabase();
+    await pool.query(
+      'UPDATE brands SET house_domain = $1 WHERE domain = $2',
+      [TEST_PARENT_DOMAIN, TEST_BRAND_DOMAIN],
+    );
+
+    await db.upsertDiscoveredBrand({
+      domain: TEST_BRAND_DOMAIN,
+      brand_name: 'Cache refresh',
+      source_type: 'enriched',
+    });
+    const preserved = await pool.query<{ house_domain: string | null }>(
+      'SELECT house_domain FROM brands WHERE domain = $1',
+      [TEST_BRAND_DOMAIN],
+    );
+    expect(preserved.rows[0].house_domain).toBe(TEST_PARENT_DOMAIN);
+
+    await db.upsertDiscoveredBrand({
+      domain: TEST_BRAND_DOMAIN,
+      house_domain: null,
+      source_type: 'enriched',
+      house_domain_audit: {
+        actor_user_id: 'system:integration-classifier',
+        source: 'classifier',
+      },
+    });
+    const cleared = await pool.query<{ house_domain: string | null }>(
+      'SELECT house_domain FROM brands WHERE domain = $1',
+      [TEST_BRAND_DOMAIN],
+    );
+    expect(cleared.rows[0].house_domain).toBeNull();
+
+    const audit = await pool.query<{ details: Record<string, unknown> }>(
+      `SELECT details FROM registry_audit_log
+       WHERE resource_id = $1 AND action = 'brand_house_domain_changed'`,
+      [TEST_BRAND_DOMAIN],
+    );
+    expect(audit.rows).toHaveLength(1);
+    expect(audit.rows[0].details).toMatchObject({
+      prior_house_domain: TEST_PARENT_DOMAIN,
+      new_house_domain: null,
+      mutation_source: 'classifier',
+    });
+  });
+
+  it('serializes mixed writers into an unbroken prior-to-new audit chain', async () => {
+    const db = new BrandDatabase();
+    const fence = await pool.connect();
+    await fence.query('BEGIN');
+    await fence.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [TEST_BRAND_DOMAIN]);
+
+    const upsert = db.upsertDiscoveredBrand({
+      domain: TEST_BRAND_DOMAIN,
+      house_domain: TEST_PARENT_DOMAIN,
+      source_type: 'enriched',
+      house_domain_audit: {
+        actor_user_id: 'system:concurrency-test',
+        source: 'classifier',
+      },
+    });
+    const adminPatch = request(app)
+      .patch(`/api/admin/brand-enrichment/brand/${TEST_BRAND_DOMAIN}`)
+      .send({ house_domain: TEST_NEW_PARENT_DOMAIN })
+      .then(response => response);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    await fence.query('COMMIT');
+    fence.release();
+
+    const [, adminResponse] = await Promise.all([upsert, adminPatch]);
+    expect(adminResponse.status).toBe(200);
+
+    const events = await pool.query<{ details: Record<string, unknown> }>(
+      `SELECT details FROM registry_audit_log
+       WHERE resource_id = $1 AND action = 'brand_house_domain_changed'
+       ORDER BY created_at, id`,
+      [TEST_BRAND_DOMAIN],
+    );
+    expect(events.rows).toHaveLength(2);
+    const details = events.rows.map(row => row.details);
+    const first = details.find(event => event.prior_house_domain === null);
+    expect(first).toBeDefined();
+    const second = details.find(event => event !== first);
+    expect(second?.prior_house_domain).toBe(first?.new_house_domain);
+
+    const current = await pool.query<{ house_domain: string | null }>(
+      'SELECT house_domain FROM brands WHERE domain = $1',
+      [TEST_BRAND_DOMAIN],
+    );
+    expect(current.rows[0].house_domain).toBe(second?.new_house_domain);
+  }, 10000);
 });

--- a/server/tests/unit/brand-db-edit-promote-source-type.test.ts
+++ b/server/tests/unit/brand-db-edit-promote-source-type.test.ts
@@ -39,6 +39,8 @@ function makeClient(current: Record<string, unknown>) {
   queryFn
     // BEGIN
     .mockResolvedValueOnce(undefined)
+    // shared per-domain advisory lock
+    .mockResolvedValueOnce(undefined)
     // SELECT ... FOR UPDATE (current row)
     .mockResolvedValueOnce({ rows: [current] })
     // SELECT next_rev

--- a/server/tests/unit/brand-db-house-domain-validation.test.ts
+++ b/server/tests/unit/brand-db-house-domain-validation.test.ts
@@ -51,6 +51,25 @@ function makeClient() {
   };
 }
 
+function mockUpsertClient(
+  returned: Record<string, unknown>,
+  priorHouseDomain: string | null | undefined = undefined,
+) {
+  const client = makeClient();
+  client.query.mockImplementation(async (sql: string) => {
+    if (sql.includes('SELECT house_domain FROM brands')) {
+      return priorHouseDomain === undefined
+        ? { rows: [] }
+        : { rows: [{ house_domain: priorHouseDomain }] };
+    }
+    if (sql.includes('INSERT INTO brands')) return { rows: [returned] };
+    if (sql.includes('FROM organization_domains')) return { rows: [] };
+    return { rows: [] };
+  });
+  mocks.getClient.mockResolvedValueOnce(client);
+  return client;
+}
+
 describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
   let db: BrandDatabase;
 
@@ -73,9 +92,9 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
     });
 
     it('strips caller-supplied classification.confidence and brand_context from brand_manifest', async () => {
-      mocks.query.mockResolvedValueOnce({
-        rows: [{ domain: 'attacker.example', brand_names: '[]', brand_manifest: null, discovered_at: new Date(), last_validated: new Date() }],
-      });
+      const client = mockUpsertClient(
+        { domain: 'attacker.example', brand_names: '[]', brand_manifest: null, discovered_at: new Date(), last_validated: new Date() },
+      );
 
       await db.upsertDiscoveredBrand({
         domain: 'attacker.example',
@@ -89,8 +108,10 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
         source_type: 'community',
       });
 
-      expect(mocks.query).toHaveBeenCalledTimes(1);
-      const params = mocks.query.mock.calls[0][1] as unknown[];
+      const insertCall = client.query.mock.calls.find(call =>
+        typeof call[0] === 'string' && call[0].includes('INSERT INTO brands'),
+      );
+      const params = insertCall![1] as unknown[];
       // brand_manifest is the 12th positional param ($12) in the INSERT.
       const persistedManifest = JSON.parse(params[11] as string);
       expect(persistedManifest).not.toHaveProperty('classification');
@@ -99,9 +120,9 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
     });
 
     it('writes a trusted classification via input.classification (round-trip)', async () => {
-      mocks.query.mockResolvedValueOnce({
-        rows: [{ domain: 'attacker.example', brand_names: '[]', brand_manifest: null, discovered_at: new Date(), last_validated: new Date() }],
-      });
+      const client = mockUpsertClient(
+        { domain: 'attacker.example', brand_names: '[]', brand_manifest: null, discovered_at: new Date(), last_validated: new Date() },
+      );
 
       await db.upsertDiscoveredBrand({
         domain: 'attacker.example',
@@ -111,7 +132,10 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
         source_type: 'enriched',
       });
 
-      const params = mocks.query.mock.calls[0][1] as unknown[];
+      const insertCall = client.query.mock.calls.find(call =>
+        typeof call[0] === 'string' && call[0].includes('INSERT INTO brands'),
+      );
+      const params = insertCall![1] as unknown[];
       const persistedManifest = JSON.parse(params[11] as string);
       expect(persistedManifest.classification).toEqual({
         confidence: 'high',
@@ -156,8 +180,13 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
     });
 
     it('canonicalizes a valid house_domain (lowercases, strips www)', async () => {
-      mocks.query.mockResolvedValueOnce({
-        rows: [{ domain: 'sub.example', brand_names: '[]', brand_manifest: null, discovered_at: new Date(), last_validated: new Date() }],
+      const client = mockUpsertClient({
+        domain: 'sub.example',
+        house_domain: 'house.example',
+        brand_names: '[]',
+        brand_manifest: null,
+        discovered_at: new Date(),
+        last_validated: new Date(),
       });
 
       await db.upsertDiscoveredBrand({
@@ -167,7 +196,10 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
         source_type: 'community',
       });
 
-      const params = mocks.query.mock.calls[0][1] as unknown[];
+      const insertCall = client.query.mock.calls.find(call =>
+        typeof call[0] === 'string' && call[0].includes('INSERT INTO brands'),
+      );
+      const params = insertCall![1] as unknown[];
       // house_domain is the 4th positional param ($4) in the INSERT.
       expect(params[3]).toBe('house.example');
     });
@@ -179,6 +211,8 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
       mocks.getClient.mockResolvedValueOnce(client);
       client.query
         // BEGIN
+        .mockResolvedValueOnce(undefined)
+        // advisory lock
         .mockResolvedValueOnce(undefined)
         // INSERT into brands
         .mockResolvedValueOnce({
@@ -241,6 +275,8 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
       const client = makeClient();
       mocks.getClient.mockResolvedValueOnce(client);
       // BEGIN
+      client.query.mockResolvedValueOnce(undefined);
+      // advisory lock
       client.query.mockResolvedValueOnce(undefined);
       // SELECT ... FOR UPDATE returns prior state with a trusted classification block
       client.query.mockResolvedValueOnce({
@@ -314,6 +350,8 @@ describe('BrandDatabase: house_domain write-path validation (#3467)', () => {
       mocks.getClient.mockResolvedValueOnce(client);
       client.query
         // BEGIN
+        .mockResolvedValueOnce(undefined)
+        // advisory lock
         .mockResolvedValueOnce(undefined)
         // SELECT target revision
         .mockResolvedValueOnce({

--- a/server/tests/unit/brand-enrichment-expand-house-tool-use.test.ts
+++ b/server/tests/unit/brand-enrichment-expand-house-tool-use.test.ts
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   upsertDiscoveredBrand: vi.fn(),
   query: vi.fn(),
   registryRequestsMarkResolved: vi.fn(),
+  fetchBrandData: vi.fn(),
+  classifyBrand: vi.fn(),
 }));
 
 vi.mock('@anthropic-ai/sdk', () => {
@@ -45,8 +47,8 @@ vi.mock('../../src/db/client.js', () => ({
 }));
 
 vi.mock('../../src/services/brandfetch.js', () => ({
-  fetchBrandData: vi.fn(),
-  isBrandfetchConfigured: () => false,
+  fetchBrandData: mocks.fetchBrandData,
+  isBrandfetchConfigured: () => true,
   ENRICHMENT_CACHE_MAX_AGE_MS: 86_400_000,
 }));
 
@@ -55,7 +57,7 @@ vi.mock('../../src/services/logo-cdn.js', () => ({
 }));
 
 vi.mock('../../src/services/brand-classifier.js', () => ({
-  classifyBrand: vi.fn().mockResolvedValue(null),
+  classifyBrand: mocks.classifyBrand,
 }));
 
 vi.mock('../../src/services/enrichment.js', () => ({
@@ -84,6 +86,8 @@ describe('expandHouse: tool_use contract', () => {
     mocks.upsertDiscoveredBrand.mockReset();
     mocks.query.mockReset();
     mocks.registryRequestsMarkResolved.mockReset();
+    mocks.fetchBrandData.mockReset();
+    mocks.classifyBrand.mockReset();
 
     // Default house: a master brand
     mocks.getDiscoveredBrandByDomain.mockResolvedValue({
@@ -94,6 +98,8 @@ describe('expandHouse: tool_use contract', () => {
     });
     mocks.query.mockResolvedValue({ rows: [] }); // no existing sub-brands
     mocks.upsertDiscoveredBrand.mockResolvedValue({});
+    mocks.classifyBrand.mockResolvedValue(null);
+    mocks.registryRequestsMarkResolved.mockResolvedValue(undefined);
 
     vi.resetModules();
     ({ expandHouse } = await import('../../src/services/brand-enrichment.js'));
@@ -134,6 +140,13 @@ describe('expandHouse: tool_use contract', () => {
     expect(result.discovered).toBe(2);
     expect(result.seeded).toBe(2);
     expect(mocks.upsertDiscoveredBrand).toHaveBeenCalledTimes(2);
+    expect(mocks.upsertDiscoveredBrand).toHaveBeenCalledWith(expect.objectContaining({
+      house_domain: 'pg.com',
+      house_domain_audit: {
+        actor_user_id: 'system:house-expansion',
+        source: 'house_expansion',
+      },
+    }));
   });
 
   it('throws when the model does not emit a tool_use block (defensive)', async () => {
@@ -144,5 +157,36 @@ describe('expandHouse: tool_use contract', () => {
     await expect(expandHouse('pg.com', { enrichAfterSeed: false })).rejects.toThrow(
       /Failed to parse brand discovery response/,
     );
+  });
+
+  it('passes an explicit classifier null through as an audited clear', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue(null);
+    mocks.fetchBrandData.mockResolvedValue({
+      success: true,
+      domain: 'standalone.test',
+      manifest: { name: 'Standalone', url: 'https://standalone.test' },
+      highQuality: true,
+    });
+    mocks.classifyBrand.mockResolvedValue({
+      keller_type: 'master',
+      house_domain: null,
+      parent_brand: null,
+      canonical_domain: 'standalone.test',
+      related_domains: [],
+      confidence: 'high',
+      reasoning: 'Top-level brand',
+    });
+
+    const { enrichBrand } = await import('../../src/services/brand-enrichment.js');
+    const result = await enrichBrand('standalone.test');
+
+    expect(result.status).toBe('enriched');
+    expect(mocks.upsertDiscoveredBrand).toHaveBeenCalledWith(expect.objectContaining({
+      house_domain: null,
+      house_domain_audit: {
+        actor_user_id: 'system:brand-classifier',
+        source: 'classifier',
+      },
+    }));
   });
 });

--- a/server/tests/unit/brand-house-domain-audit.test.ts
+++ b/server/tests/unit/brand-house-domain-audit.test.ts
@@ -1,0 +1,342 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  getClient: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  query: mocks.query,
+  getClient: mocks.getClient,
+}));
+
+import {
+  BrandDatabase,
+  recordBrandHouseDomainChange,
+} from '../../src/db/brand-db.js';
+
+function makeClient() {
+  return {
+    query: vi.fn(),
+    release: vi.fn(),
+  };
+}
+
+function brandRow(domain: string, houseDomain: string | null) {
+  return {
+    domain,
+    house_domain: houseDomain,
+    brand_names: '[]',
+    brand_manifest: null,
+    source_type: 'enriched',
+    discovered_at: new Date(),
+    last_validated: new Date(),
+  };
+}
+
+describe('brand house-domain audit trail (#3419)', () => {
+  beforeEach(() => {
+    mocks.query.mockReset();
+    mocks.getClient.mockReset();
+  });
+
+  it('records deterministic prior/new organization attribution without PII', async () => {
+    const client = makeClient();
+    client.query
+      .mockResolvedValueOnce({
+        rows: [
+          { domain: 'old-house.example', workos_organization_id: 'org-old' },
+          { domain: 'new-house.example', workos_organization_id: 'org-new' },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await recordBrandHouseDomainChange(client as never, {
+      domain: 'brand.example',
+      prior_house_domain: 'old-house.example',
+      new_house_domain: 'new-house.example',
+      audit: { actor_user_id: 'user-1', source: 'community_edit', revision_number: 7 },
+    });
+
+    const auditParams = client.query.mock.calls[1][1] as unknown[];
+    expect(auditParams.slice(0, 3)).toEqual(['org-new', 'user-1', 'brand.example']);
+    const details = JSON.parse(auditParams[3] as string);
+    expect(details).toEqual({
+      schema_version: 1,
+      domain: 'brand.example',
+      prior_house_domain: 'old-house.example',
+      new_house_domain: 'new-house.example',
+      prior_parent_org_id: 'org-old',
+      new_parent_org_id: 'org-new',
+      mutation_source: 'community_edit',
+      revision_number: 7,
+    });
+    expect(JSON.stringify(details)).not.toContain('email');
+  });
+
+  it('does not write an audit event for an unchanged edge', async () => {
+    const client = makeClient();
+    await recordBrandHouseDomainChange(client as never, {
+      domain: 'brand.example',
+      prior_house_domain: 'house.example',
+      new_house_domain: 'house.example',
+      audit: { actor_user_id: 'user-1', source: 'community_edit' },
+    });
+    expect(client.query).not.toHaveBeenCalled();
+  });
+
+  it('preserves an existing edge when an unrelated upsert omits house_domain', async () => {
+    const db = new BrandDatabase();
+    const client = makeClient();
+    client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT house_domain FROM brands')) {
+        return { rows: [{ house_domain: 'house.example' }] };
+      }
+      if (sql.includes('INSERT INTO brands')) {
+        return { rows: [brandRow('brand.example', 'house.example')] };
+      }
+      return { rows: [] };
+    });
+    mocks.getClient.mockResolvedValueOnce(client);
+
+    await db.upsertDiscoveredBrand({
+      domain: 'brand.example',
+      brand_name: 'Refreshed name',
+      source_type: 'enriched',
+    });
+
+    const insert = client.query.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('INSERT INTO brands'),
+    )!;
+    expect((insert[1] as unknown[])[14]).toBe(false);
+    expect(client.query.mock.calls.some(call =>
+      typeof call[0] === 'string' && call[0].includes('registry_audit_log'),
+    )).toBe(false);
+  });
+
+  it('audits an explicit clear and attributes it to the prior parent organization', async () => {
+    const db = new BrandDatabase();
+    const client = makeClient();
+    client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT house_domain FROM brands')) {
+        return { rows: [{ house_domain: 'house.example' }] };
+      }
+      if (sql.includes('INSERT INTO brands')) {
+        return { rows: [brandRow('brand.example', null)] };
+      }
+      if (sql.includes('FROM organization_domains')) {
+        return { rows: [{ domain: 'house.example', workos_organization_id: 'org-house' }] };
+      }
+      return { rows: [] };
+    });
+    mocks.getClient.mockResolvedValueOnce(client);
+
+    await db.upsertDiscoveredBrand({
+      domain: 'brand.example',
+      house_domain: null,
+      house_domain_audit: { actor_user_id: 'system:brand-classifier', source: 'classifier' },
+      source_type: 'enriched',
+    });
+
+    const insert = client.query.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('INSERT INTO brands'),
+    )!;
+    expect((insert[1] as unknown[])[14]).toBe(true);
+    const audit = client.query.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('registry_audit_log'),
+    )!;
+    expect((audit[1] as unknown[]).slice(0, 3)).toEqual([
+      'org-house',
+      'system:brand-classifier',
+      'brand.example',
+    ]);
+  });
+
+  it('audits a non-null edge on first insert', async () => {
+    const db = new BrandDatabase();
+    const client = makeClient();
+    client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT house_domain FROM brands')) return { rows: [] };
+      if (sql.includes('INSERT INTO brands')) {
+        return { rows: [brandRow('brand.example', 'house.example')] };
+      }
+      if (sql.includes('FROM organization_domains')) return { rows: [] };
+      return { rows: [] };
+    });
+    mocks.getClient.mockResolvedValueOnce(client);
+
+    await db.upsertDiscoveredBrand({
+      domain: 'brand.example',
+      house_domain: 'house.example',
+      source_type: 'community',
+    });
+
+    const audit = client.query.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('registry_audit_log'),
+    );
+    expect(audit).toBeDefined();
+  });
+
+  it('rolls back the brand write when the audit insert fails', async () => {
+    const db = new BrandDatabase();
+    const client = makeClient();
+    client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT house_domain FROM brands')) {
+        return { rows: [{ house_domain: 'old-house.example' }] };
+      }
+      if (sql.includes('INSERT INTO brands')) {
+        return { rows: [brandRow('brand.example', 'new-house.example')] };
+      }
+      if (sql.includes('FROM organization_domains')) return { rows: [] };
+      if (sql.includes('registry_audit_log')) throw new Error('audit unavailable');
+      return { rows: [] };
+    });
+    mocks.getClient.mockResolvedValueOnce(client);
+
+    await expect(db.upsertDiscoveredBrand({
+      domain: 'brand.example',
+      house_domain: 'new-house.example',
+      source_type: 'enriched',
+    })).rejects.toThrow('audit unavailable');
+
+    expect(client.query).toHaveBeenCalledWith('ROLLBACK');
+    expect(client.query).not.toHaveBeenCalledWith('COMMIT');
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('attributes a community create to its editor and revision', async () => {
+    const db = new BrandDatabase();
+    const client = makeClient();
+    client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('INSERT INTO brands')) {
+        return { rows: [brandRow('brand.example', 'house.example')] };
+      }
+      if (sql.includes('FROM organization_domains')) return { rows: [] };
+      return { rows: [] };
+    });
+    mocks.getClient.mockResolvedValueOnce(client);
+
+    await db.createDiscoveredBrand({
+      domain: 'brand.example',
+      house_domain: 'house.example',
+      source_type: 'community',
+    }, { user_id: 'community-editor' });
+
+    const audit = client.query.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('registry_audit_log'),
+    )!;
+    expect((audit[1] as unknown[])[1]).toBe('community-editor');
+    expect(JSON.parse((audit[1] as unknown[])[3] as string)).toMatchObject({
+      mutation_source: 'community_create',
+      revision_number: 1,
+    });
+  });
+
+  it('attributes a community edit and records its revision', async () => {
+    const db = new BrandDatabase();
+    const client = makeClient();
+    const current = {
+      ...brandRow('brand.example', 'old-house.example'),
+      source_type: 'community',
+      review_status: 'approved',
+    };
+    client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT * FROM brands')) return { rows: [current] };
+      if (sql.includes('SELECT COALESCE(MAX(revision_number)')) return { rows: [{ next_rev: 3 }] };
+      if (sql.startsWith('UPDATE brands SET')) {
+        return { rows: [brandRow('brand.example', 'new-house.example')] };
+      }
+      if (sql.includes('FROM organization_domains')) return { rows: [] };
+      return { rows: [] };
+    });
+    mocks.getClient.mockResolvedValueOnce(client);
+
+    await db.editDiscoveredBrand('brand.example', {
+      house_domain: 'new-house.example',
+      edit_summary: 'Correct parent',
+      editor_user_id: 'community-editor',
+    });
+
+    const audit = client.query.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('registry_audit_log'),
+    )!;
+    expect((audit[1] as unknown[])[1]).toBe('community-editor');
+    expect(JSON.parse((audit[1] as unknown[])[3] as string)).toMatchObject({
+      mutation_source: 'community_edit',
+      revision_number: 3,
+    });
+  });
+
+  it('records rollback provenance only when the restored edge changes', async () => {
+    const db = new BrandDatabase();
+    const client = makeClient();
+    const current = {
+      ...brandRow('brand.example', 'new-house.example'),
+      source_type: 'community',
+      review_status: 'approved',
+    };
+    client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT snapshot FROM brand_revisions')) {
+        return { rows: [{ snapshot: { house_domain: 'old-house.example' } }] };
+      }
+      if (sql.includes('SELECT * FROM brands')) return { rows: [current] };
+      if (sql.includes('SELECT COALESCE(MAX(revision_number)')) return { rows: [{ next_rev: 8 }] };
+      if (sql.includes('UPDATE brands SET')) {
+        return { rows: [brandRow('brand.example', 'old-house.example')] };
+      }
+      if (sql.includes('FROM organization_domains')) return { rows: [] };
+      return { rows: [] };
+    });
+    mocks.getClient.mockResolvedValueOnce(client);
+
+    await db.rollbackBrand('brand.example', 4, { user_id: 'rollback-admin' });
+
+    const audit = client.query.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('registry_audit_log'),
+    )!;
+    expect((audit[1] as unknown[])[1]).toBe('rollback-admin');
+    expect(JSON.parse((audit[1] as unknown[])[3] as string)).toMatchObject({
+      mutation_source: 'rollback',
+      revision_number: 8,
+      rolled_back_to_revision: 4,
+      prior_house_domain: 'new-house.example',
+      new_house_domain: 'old-house.example',
+    });
+  });
+
+  it('audits edge removal in the same transaction as a discovered-brand delete', async () => {
+    const db = new BrandDatabase();
+    const client = makeClient();
+    client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('DELETE FROM brands')) {
+        return { rows: [{ domain: 'brand.example', house_domain: 'house.example' }] };
+      }
+      if (sql.includes('FROM organization_domains')) return { rows: [] };
+      return { rows: [] };
+    });
+    mocks.getClient.mockResolvedValueOnce(client);
+
+    const deleted = await db.deleteDiscoveredBrand('brand.example', {
+      actor_user_id: 'system:addie',
+      source: 'addie_malicious_record_cleanup',
+    });
+
+    expect(deleted).toBe(true);
+    const deleteIndex = client.query.mock.calls.findIndex(call =>
+      typeof call[0] === 'string' && call[0].includes('DELETE FROM brands'),
+    );
+    const auditIndex = client.query.mock.calls.findIndex(call =>
+      typeof call[0] === 'string' && call[0].includes('registry_audit_log'),
+    );
+    const commitIndex = client.query.mock.calls.findIndex(call => call[0] === 'COMMIT');
+    expect(deleteIndex).toBeGreaterThan(-1);
+    expect(auditIndex).toBeGreaterThan(deleteIndex);
+    expect(commitIndex).toBeGreaterThan(auditIndex);
+    const details = JSON.parse((client.query.mock.calls[auditIndex][1] as unknown[])[3] as string);
+    expect(details).toMatchObject({
+      prior_house_domain: 'house.example',
+      new_house_domain: null,
+      mutation_source: 'addie_malicious_record_cleanup',
+    });
+  });
+});


### PR DESCRIPTION
Closes #3419

## Summary
- centralize brand house-domain audit events across upsert, create, edit, rollback, admin patch, and deletion paths
- serialize every relationship writer with the same per-domain transaction lock and roll back mutations when auditing fails
- preserve existing hierarchy on omitted fields while treating explicit null as a clear
- attach stable human/system attribution without duplicating email or classifier reasoning

## Validation
- 34 focused unit tests pass
- TypeScript typecheck passes
- expert product and security re-review: no blockers
- PostgreSQL integration test updated with omission/null and mixed-writer coverage; local execution is blocked by the existing migration 533 filename collision on the shared test database