### PR TITLE
fix(compliance): avoid untrusted fallback verdicts

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.8';
+export const CODE_VERSION = '2026.08.9';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -11,8 +11,10 @@ import {
   classifyCapabilityResolutionError,
   presentCapabilityResolutionError,
   badgeEligibleVersionsForTargetSelection,
+  hasTrustworthyComplianceTarget,
   HOSTED_TARGET_DISCOVERY_TIMEOUT_MS,
   selectComplianceTargetForAgentSelection,
+  storedComplianceTargetMatchesObservedProfile,
   type ComplyOptions,
   type ComplianceTargetSelection,
 } from '../services/compliance-testing.js';
@@ -82,7 +84,11 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
   for (const agent of agentsDue) {
     const startTime = Date.now();
     let runTarget = fallbackComplianceTarget;
-    let runTargetSelection: ComplianceTargetSelection = { target: fallbackComplianceTarget, confirmed: false };
+    let runTargetSelection: ComplianceTargetSelection = {
+      target: fallbackComplianceTarget,
+      confirmed: false,
+      source: 'default',
+    };
     try {
       const auth = await complianceDb.resolveOwnerAuth(agent.agent_url);
       const sdkAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `heartbeat:${agent.agent_url}` });
@@ -102,8 +108,30 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
         'canonical',
         seededSupportedVersions,
       );
+      if (!hasTrustworthyComplianceTarget(runTargetSelection)) {
+        logger.warn(
+          { agentUrl: agent.agent_url, seededSupportedVersions },
+          'Compliance heartbeat skipped because no trustworthy target could be selected',
+        );
+        await complianceDb.deferComplianceCheckAfterInconclusiveTarget(agent.agent_url);
+        result.skipped++;
+        continue;
+      }
       runTarget = runTargetSelection.target;
       const complianceResult = await comply(agent.agent_url, complyOptions, runTarget);
+      if (!storedComplianceTargetMatchesObservedProfile(runTargetSelection, complianceResult.agent_profile)) {
+        logger.warn(
+          {
+            agentUrl: agent.agent_url,
+            selectedTarget: runTarget.requested,
+            observedSupportedVersions: complianceResult.agent_profile?.adcp_supported_versions,
+          },
+          'Compliance heartbeat skipped because the live run superseded its stored target',
+        );
+        await complianceDb.deferComplianceCheckAfterInconclusiveTarget(agent.agent_url);
+        result.skipped++;
+        continue;
+      }
 
       logOutboundRequest({
         agent_url: agent.agent_url,
@@ -207,6 +235,29 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+      // Errors before a compatible target is selected are infrastructure or
+      // discovery failures, not evidence that the agent failed compliance.
+      // Never let the catch path turn the platform default into a canonical
+      // public verdict. Best-effort lock release preserves a concurrent owner
+      // refresh via the compare-and-set predicate in the database method.
+      if (!hasTrustworthyComplianceTarget(runTargetSelection)) {
+        logger.warn(
+          { agentUrl: agent.agent_url, err: error },
+          'Compliance heartbeat skipped after target selection remained inconclusive',
+        );
+        try {
+          await complianceDb.deferComplianceCheckAfterInconclusiveTarget(agent.agent_url);
+        } catch (deferError) {
+          logger.error(
+            { agentUrl: agent.agent_url, deferError },
+            'Failed to defer compliance heartbeat after inconclusive target selection',
+          );
+        }
+        result.skipped++;
+        continue;
+      }
+
       const isAgentTimeout = /timed?\s*out/i.test(errorMessage);
       const isSavedAuthConfigError = /step\.auth\.basic\.username must be a non-empty string/i.test(errorMessage);
       const capsError = classifyCapabilityResolutionError(error);

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -47,8 +47,11 @@ import {
   complianceResultToDbInput,
   loadComplianceIndex,
   badgeEligibleVersionsForTargetSelection,
+  hasTrustworthyComplianceTarget,
   selectComplianceTargetForAgent,
   selectComplianceTargetForAgentSelection,
+  storedComplianceTargetMatchesObservedProfile,
+  UNRESOLVED_COMPLIANCE_TARGET_MESSAGE,
   type ComplyOptions,
   type CapabilityResolutionErrorInfo,
   type ComplianceTargetSelection,
@@ -4516,6 +4519,7 @@ export function createMemberToolHandlers(
     let runTargetSelection: ComplianceTargetSelection = {
       target: runTarget,
       confirmed: false,
+      source: 'explicit',
     };
     let skippedCanonicalWriteReason: 'target' | 'tracks' | null = null;
 
@@ -4547,6 +4551,12 @@ export function createMemberToolHandlers(
         'canonical',
         seededSupportedVersions,
       );
+      if (!hasTrustworthyComplianceTarget(runTargetSelection)) {
+        return (
+          `**Compliance target unavailable**\n\n${UNRESOLVED_COMPLIANCE_TARGET_MESSAGE} ` +
+          `Retry after \`get_adcp_capabilities\` is responding reliably, or choose an explicit supported target for a diagnostic run.`
+        );
+      }
       runTarget = runTargetSelection.target;
     } else {
       const targetError = await explicitTargetSupportErrorFromAgent(
@@ -4568,6 +4578,12 @@ export function createMemberToolHandlers(
 
     try {
       const result = await comply(resolved.resolvedUrl, complyOptions, runTarget);
+      if (!storedComplianceTargetMatchesObservedProfile(runTargetSelection, result.agent_profile)) {
+        return (
+          `**Compliance target unavailable**\n\n${UNRESOLVED_COMPLIANCE_TARGET_MESSAGE} ` +
+          `The agent's live profile changed after the diagnostic target was selected; retry the evaluation.`
+        );
+      }
       const badgeEligibleAdcpVersions = [
         ...badgeEligibleVersionsForTargetSelection(runTargetSelection, result.agent_profile),
       ];

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -24,6 +24,7 @@ import {
   hostedComplianceTarget,
   hostedAuthProbeTaskForProfile,
   hostedStaticApiKeyForProfile,
+  agentAdvertisesHostedComplianceTarget,
   agentAdvertisesBadgeEligibleHostedComplianceTarget,
   badgeEligibleVersionsForHostedComplianceTarget,
   selectCanonicalHostedComplianceTargetForProfile,
@@ -52,7 +53,31 @@ export const HOSTED_TARGET_DISCOVERY_TIMEOUT_MS = 30_000;
 export interface ComplianceTargetSelection {
   target: HostedComplianceTarget;
   confirmed: boolean;
+  source: 'live' | 'stored' | 'explicit' | 'default';
   supportedVersions?: readonly string[];
+}
+
+export const UNRESOLVED_COMPLIANCE_TARGET_MESSAGE =
+  'Could not determine a compatible compliance target from live capabilities or recent compliance history.';
+
+export function hasTrustworthyComplianceTarget(selection: ComplianceTargetSelection): boolean {
+  return selection.source !== 'default';
+}
+
+/**
+ * A stored profile may choose a safe target for a diagnostic attempt, but the
+ * profile observed by that attempt is newer evidence. Refuse to publish the
+ * result if the agent no longer advertises the stored target.
+ */
+export function storedComplianceTargetMatchesObservedProfile(
+  selection: ComplianceTargetSelection,
+  profile?: { adcp_supported_versions?: readonly string[] },
+): boolean {
+  if (selection.source !== 'stored') return true;
+  return agentAdvertisesHostedComplianceTarget(
+    profile?.adcp_supported_versions,
+    selection.target,
+  );
 }
 
 function abortReason(signal: AbortSignal, fallback: string): Error {
@@ -252,7 +277,15 @@ export async function selectComplianceTargetForAgentSelection(
     const target = mode === 'canonical'
       ? selectCanonicalHostedComplianceTargetForProfile(discovery.profile, fallback)
       : selectHostedComplianceTargetForProfile(discovery.profile, fallback);
-    return { target, confirmed: true, supportedVersions: discovery.profile?.adcp_supported_versions };
+    const supportedVersions = discovery.profile?.adcp_supported_versions;
+    if (!agentAdvertisesHostedComplianceTarget(supportedVersions, target)) {
+      logger.warn(
+        { agentUrl, supportedVersions },
+        'Could not match live profile to a hosted compliance target; using default fallback',
+      );
+      return { target: fallback, confirmed: false, source: 'default', supportedVersions };
+    }
+    return { target, confirmed: true, source: 'live', supportedVersions };
   } catch (err) {
     if (options.signal?.aborted) {
       throw abortReason(options.signal, 'Hosted compliance target pre-discovery aborted');
@@ -266,6 +299,13 @@ export async function selectComplianceTargetForAgentSelection(
       const target = mode === 'canonical'
         ? selectCanonicalHostedComplianceTargetForProfile(profile, fallback)
         : selectHostedComplianceTargetForProfile(profile, fallback);
+      if (!agentAdvertisesHostedComplianceTarget(supportedVersions, target)) {
+        logger.warn(
+          { err, agentUrl, supportedVersions },
+          'Could not match recent stored profile to a hosted compliance target; using default fallback',
+        );
+        return { target: fallback, confirmed: false, source: 'default' };
+      }
       logger.warn(
         { err, agentUrl, supportedVersions, selectedTarget: target.requested },
         'Could not pre-discover hosted compliance target; using recent stored profile',
@@ -273,11 +313,11 @@ export async function selectComplianceTargetForAgentSelection(
       // The stored profile is safe for choosing which grader to attempt, but
       // must not flow into badge eligibility. Only a profile observed during
       // the current run may support issuing or retaining public badges.
-      return { target, confirmed: false };
+      return { target, confirmed: false, source: 'stored' };
     }
 
     logger.warn({ err, agentUrl }, 'Could not pre-discover hosted compliance target; using default fallback');
-    return { target: fallback, confirmed: false };
+    return { target: fallback, confirmed: false, source: 'default' };
   }
 }
 
@@ -302,6 +342,7 @@ export function badgeEligibleVersionsForTargetSelection(
   selection: ComplianceTargetSelection,
   profile?: { adcp_supported_versions?: readonly string[] },
 ): readonly string[] {
+  if (!hasTrustworthyComplianceTarget(selection)) return [];
   const versions = badgeEligibleVersionsForHostedComplianceTarget(selection.target);
   if (versions.length === 0) return [];
   if (selection.confirmed) return versions;

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -913,6 +913,25 @@ export class ComplianceDatabase {
   }
 
   /**
+   * Release an in-progress heartbeat lock without publishing a verdict.
+   *
+   * Setting the timestamp to NOW() puts the agent back on its normal monitoring
+   * cadence instead of leaving it oldest-due and starving the queue. The
+   * future-timestamp predicate is a compare-and-set guard: an owner refresh or
+   * another successful run that already replaced the lock must win.
+   */
+  async deferComplianceCheckAfterInconclusiveTarget(agentUrl: string): Promise<boolean> {
+    const result = await query(
+      `UPDATE agent_compliance_status
+       SET last_checked_at = NOW(), updated_at = NOW()
+       WHERE agent_url = $1
+         AND last_checked_at > NOW()`,
+      [agentUrl],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
    * Return the notices_json array from the most recent non-dry-run compliance
    * run for the agent. Returns an empty array when no run exists or when the
    * latest run stored no notices.

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -44,8 +44,11 @@ import {
   presentCapabilityResolutionError,
   computeSpecialismStatus,
   badgeEligibleVersionsForTargetSelection,
+  hasTrustworthyComplianceTarget,
   selectComplianceTargetForAgent,
   selectComplianceTargetForAgentSelection,
+  storedComplianceTargetMatchesObservedProfile,
+  UNRESOLVED_COMPLIANCE_TARGET_MESSAGE,
 } from "../addie/services/compliance-testing.js";
 import { getPublicJwks } from "../services/verification-token.js";
 import { renderBadgeSvg, VALID_BADGE_ROLES } from "../services/badge-svg.js";
@@ -7528,8 +7531,14 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             'canonical',
             seededSupportedVersions,
           );
+          if (!hasTrustworthyComplianceTarget(runTargetSelection)) {
+            throw new Error(UNRESOLVED_COMPLIANCE_TARGET_MESSAGE);
+          }
           const runTarget = runTargetSelection.target;
           const complyResult = await comply(agentUrl, complyOptions, runTarget);
+          if (!storedComplianceTargetMatchesObservedProfile(runTargetSelection, complyResult.agent_profile)) {
+            throw new Error(UNRESOLVED_COMPLIANCE_TARGET_MESSAGE);
+          }
           const runBadgeEligibleVersions = [
             ...badgeEligibleVersionsForTargetSelection(runTargetSelection, complyResult.agent_profile),
           ];
@@ -8396,6 +8405,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           'canonical',
           seededSupportedVersions,
         );
+        if (!hasTrustworthyComplianceTarget(runTargetSelection)) {
+          return res.status(422).json({
+            error: UNRESOLVED_COMPLIANCE_TARGET_MESSAGE,
+            error_kind: 'unresolved_compliance_target',
+          });
+        }
         const runTarget = runTargetSelection.target;
         const storyboard = getComplianceStoryboardById(req.params.storyboardId, hostedComplianceOptions(runTarget));
         if (!storyboard) {
@@ -8403,9 +8418,6 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         }
 
         const complyResult = await comply(agentUrl, complyOptions, runTarget);
-        const runBadgeEligibleVersions = [
-          ...badgeEligibleVersionsForTargetSelection(runTargetSelection, complyResult.agent_profile),
-        ];
 
         if (complyResult.overall_status === 'auth_required') {
           const agentContextId = await ensureAgentContextId(orgId, agentUrl, req.user.id);
@@ -8415,6 +8427,15 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             ...(agentContextId && { agent_context_id: agentContextId }),
           });
         }
+        if (!storedComplianceTargetMatchesObservedProfile(runTargetSelection, complyResult.agent_profile)) {
+          return res.status(422).json({
+            error: UNRESOLVED_COMPLIANCE_TARGET_MESSAGE,
+            error_kind: 'unresolved_compliance_target',
+          });
+        }
+        const runBadgeEligibleVersions = [
+          ...badgeEligibleVersionsForTargetSelection(runTargetSelection, complyResult.agent_profile),
+        ];
 
         // Record the run (pass storyboard ID for per-storyboard status materialization).
         // Owner-only path (gated above by resolveAgentOwnerOrg), so triggered_by

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -180,7 +180,7 @@ function makeComplianceResult(options: { specialisms?: string[]; storyboardId?: 
         message: 'Fixture observation',
       },
     ],
-    agent_profile: { specialisms },
+    agent_profile: { specialisms, adcp_supported_versions: ['3.0'] },
   };
 }
 
@@ -297,6 +297,7 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
         tools: [],
         supported_protocols: ['media_buy'],
         specialisms: [],
+        adcp_supported_versions: ['3.0'],
       },
       steps: [{ step: 'Discover agent profile', passed: true, duration_ms: 1 }],
     });

--- a/server/tests/unit/compliance-db-supported-versions.test.ts
+++ b/server/tests/unit/compliance-db-supported-versions.test.ts
@@ -48,4 +48,23 @@ describe('ComplianceDatabase.getRecentSupportedVersions', () => {
       .rejects.toThrow('maxAgeHours must be a positive integer');
     expect(mockedQuery).not.toHaveBeenCalled();
   });
+
+  it('defers an inconclusive check only while its future heartbeat lock is still held', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 } as never);
+
+    await expect(db.deferComplianceCheckAfterInconclusiveTarget('https://agent.example/mcp'))
+      .resolves.toBe(true);
+
+    expect(mockedQuery).toHaveBeenCalledWith(
+      expect.stringMatching(/SET last_checked_at = NOW\(\)[\s\S]*last_checked_at > NOW\(\)/),
+      ['https://agent.example/mcp'],
+    );
+  });
+
+  it('preserves a concurrent completed run when the heartbeat lock is no longer current', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never);
+
+    await expect(db.deferComplianceCheckAfterInconclusiveTarget('https://agent.example/mcp'))
+      .resolves.toBe(false);
+  });
 });

--- a/server/tests/unit/compliance-heartbeat.test.ts
+++ b/server/tests/unit/compliance-heartbeat.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   getAgentsDueForCheck: vi.fn(),
   getRecentSupportedVersions: vi.fn(),
+  deferComplianceCheckAfterInconclusiveTarget: vi.fn(),
   resolveOwnerAuth: vi.fn(),
   recordComplianceRun: vi.fn(),
   query: vi.fn(),
@@ -23,6 +24,7 @@ vi.mock('../../src/db/compliance-db.js', () => ({
   ComplianceDatabase: class {
     getAgentsDueForCheck = mocks.getAgentsDueForCheck;
     getRecentSupportedVersions = mocks.getRecentSupportedVersions;
+    deferComplianceCheckAfterInconclusiveTarget = mocks.deferComplianceCheckAfterInconclusiveTarget;
     resolveOwnerAuth = mocks.resolveOwnerAuth;
     recordComplianceRun = mocks.recordComplianceRun;
     getBadgesForAgent = vi.fn().mockResolvedValue([]);
@@ -41,6 +43,12 @@ vi.mock('../../src/addie/services/compliance-testing.js', () => ({
   classifyCapabilityResolutionError: mocks.classifyCapabilityResolutionError,
   presentCapabilityResolutionError: mocks.presentCapabilityResolutionError,
   badgeEligibleVersionsForTargetSelection: mocks.badgeEligibleVersionsForTargetSelection,
+  hasTrustworthyComplianceTarget: (selection: { source?: string }) => selection.source !== 'default',
+  storedComplianceTargetMatchesObservedProfile: (
+    selection: { source?: string; target?: { requested?: string } },
+    profile?: { adcp_supported_versions?: string[] },
+  ) => selection.source !== 'stored'
+    || Boolean(profile?.adcp_supported_versions?.includes(selection.target?.requested ?? '')),
   selectComplianceTargetForAgentSelection: mocks.selectComplianceTargetForAgentSelection,
 }));
 
@@ -78,13 +86,13 @@ describe('runComplianceHeartbeatJob', () => {
     vi.clearAllMocks();
     mocks.hostedComplianceTarget.mockReturnValue(target);
     mocks.getAgentsDueForCheck.mockResolvedValue([
-      { agent_url: 'https://agent.example.com/mcp', lifecycle_stage: 'testing' },
+      { agent_url: 'https://agent.example.com/mcp', lifecycle_stage: 'testing', last_checked_at: null },
     ]);
     mocks.query.mockResolvedValue({ rows: [], rowCount: 0 });
     mocks.resolveOwnerAuth.mockResolvedValue(undefined);
     mocks.getRecentSupportedVersions.mockResolvedValue(['3.1']);
     mocks.adaptAuthForSdk.mockResolvedValue(undefined);
-    mocks.selectComplianceTargetForAgentSelection.mockResolvedValue({ target, confirmed: false });
+    mocks.selectComplianceTargetForAgentSelection.mockResolvedValue({ target, confirmed: false, source: 'stored' });
     mocks.classifyCapabilityResolutionError.mockReturnValue(null);
     mocks.badgeEligibleVersionsForTargetSelection.mockReturnValue([]);
     mocks.complianceResultToDbInput.mockReturnValue({
@@ -172,5 +180,56 @@ describe('runComplianceHeartbeatJob', () => {
         }],
       }),
     );
+  });
+
+  it('defers on the normal cadence and skips when no trustworthy target exists', async () => {
+    mocks.getAgentsDueForCheck.mockResolvedValueOnce([
+      { agent_url: 'https://agent.example.com/mcp', lifecycle_stage: 'testing', last_checked_at: null },
+    ]);
+    mocks.getRecentSupportedVersions.mockResolvedValueOnce([]);
+    mocks.selectComplianceTargetForAgentSelection.mockResolvedValueOnce({
+      target,
+      confirmed: false,
+      source: 'default',
+    });
+
+    const { runComplianceHeartbeatJob } = await import('../../src/addie/jobs/compliance-heartbeat.js');
+    const result = await runComplianceHeartbeatJob({ limit: 1 });
+
+    expect(result).toEqual({ checked: 0, passed: 0, failed: 0, skipped: 1 });
+    expect(mocks.deferComplianceCheckAfterInconclusiveTarget)
+      .toHaveBeenCalledWith('https://agent.example.com/mcp');
+    expect(mocks.comply).not.toHaveBeenCalled();
+    expect(mocks.recordComplianceRun).not.toHaveBeenCalled();
+  });
+
+  it('does not record a fallback failure when an error occurs before target selection', async () => {
+    mocks.resolveOwnerAuth.mockRejectedValueOnce(new Error('credential store unavailable'));
+
+    const { runComplianceHeartbeatJob } = await import('../../src/addie/jobs/compliance-heartbeat.js');
+    const result = await runComplianceHeartbeatJob({ limit: 1 });
+
+    expect(result).toEqual({ checked: 0, passed: 0, failed: 0, skipped: 1 });
+    expect(mocks.deferComplianceCheckAfterInconclusiveTarget)
+      .toHaveBeenCalledWith('https://agent.example.com/mcp');
+    expect(mocks.comply).not.toHaveBeenCalled();
+    expect(mocks.recordComplianceRun).not.toHaveBeenCalled();
+  });
+
+  it('does not publish a stored-target result superseded by the live run profile', async () => {
+    mocks.comply.mockResolvedValueOnce({
+      overall_status: 'failing',
+      summary: { headline: 'Version mismatch' },
+      agent_profile: { adcp_supported_versions: ['3.0'] },
+      observations: [],
+    });
+
+    const { runComplianceHeartbeatJob } = await import('../../src/addie/jobs/compliance-heartbeat.js');
+    const result = await runComplianceHeartbeatJob({ limit: 1 });
+
+    expect(result).toEqual({ checked: 0, passed: 0, failed: 0, skipped: 1 });
+    expect(mocks.deferComplianceCheckAfterInconclusiveTarget)
+      .toHaveBeenCalledWith('https://agent.example.com/mcp');
+    expect(mocks.recordComplianceRun).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/unit/compliance-target-discovery.test.ts
+++ b/server/tests/unit/compliance-target-discovery.test.ts
@@ -41,6 +41,8 @@ vi.mock('../../src/services/hosted-compliance-version.js', () => ({
     profile?.adcp_supported_versions?.includes('3.1')
       ? mocks.selectedTarget
       : mocks.fallbackTarget,
+  agentAdvertisesHostedComplianceTarget: (versions: string[] | undefined, target: { requested: string }) =>
+    Boolean(versions?.includes(target.requested)),
   withHostedComplianceRunOptions: (options: unknown) => options,
 }));
 
@@ -96,6 +98,7 @@ describe('hosted compliance target discovery deadline', () => {
     await expect(selectionPromise).resolves.toEqual({
       target: mocks.selectedTarget,
       confirmed: true,
+      source: 'live',
       supportedVersions: ['3.1'],
     });
     expect(receivedOptions).toMatchObject({
@@ -137,6 +140,7 @@ describe('hosted compliance target discovery deadline', () => {
     await expect(selectionPromise).resolves.toEqual({
       target: mocks.fallbackTarget,
       confirmed: false,
+      source: 'default',
     });
     expect(transportSignal?.aborted).toBe(true);
   });
@@ -163,6 +167,7 @@ describe('hosted compliance target discovery deadline', () => {
     await expect(selectionPromise).resolves.toEqual({
       target: mocks.fallbackTarget,
       confirmed: false,
+      source: 'default',
     });
   });
 
@@ -178,6 +183,23 @@ describe('hosted compliance target discovery deadline', () => {
     )).resolves.toEqual({
       target: mocks.selectedTarget,
       confirmed: false,
+      source: 'stored',
+    });
+  });
+
+  it('rejects recent stored versions that do not match a hosted target', async () => {
+    mocks.discovery.mockRejectedValue(new Error('temporary probe failure'));
+
+    await expect(selectComplianceTargetForAgentSelection(
+      'https://agent.example/mcp',
+      {},
+      mocks.fallbackTarget,
+      'canonical',
+      ['4.0'],
+    )).resolves.toEqual({
+      target: mocks.fallbackTarget,
+      confirmed: false,
+      source: 'default',
     });
   });
 
@@ -196,7 +218,27 @@ describe('hosted compliance target discovery deadline', () => {
     )).resolves.toEqual({
       target: mocks.fallbackTarget,
       confirmed: true,
+      source: 'live',
       supportedVersions: ['3.0'],
+    });
+  });
+
+  it('does not trust successful live discovery when no hosted target matches', async () => {
+    mocks.discovery.mockResolvedValue({
+      profile: { adcp_supported_versions: ['4.0'] },
+      steps: [],
+    });
+
+    await expect(selectComplianceTargetForAgentSelection(
+      'https://agent.example/mcp',
+      {},
+      mocks.fallbackTarget,
+      'canonical',
+    )).resolves.toEqual({
+      target: mocks.fallbackTarget,
+      confirmed: false,
+      source: 'default',
+      supportedVersions: ['4.0'],
     });
   });
 
@@ -275,6 +317,7 @@ describe('hosted compliance target discovery deadline', () => {
     await expect(selectionPromise).resolves.toEqual({
       target: mocks.fallbackTarget,
       confirmed: false,
+      source: 'default',
     });
     expect(forwardedSignal?.aborted).toBe(true);
     expect(forwardedSignal?.reason).toBe(requestAbort);

--- a/server/tests/unit/storyboards.test.ts
+++ b/server/tests/unit/storyboards.test.ts
@@ -36,6 +36,7 @@ import {
 } from '@adcp/sdk/testing';
 import {
   badgeEligibleVersionsForTargetSelection,
+  storedComplianceTargetMatchesObservedProfile,
 } from '../../src/addie/services/compliance-testing.js';
 
 /**
@@ -274,12 +275,30 @@ describe('wrapper contract', () => {
   it('does not treat an unconfirmed fallback target as badge eligible', () => {
     const stable = hostedComplianceTarget('3.0');
 
-    expect(badgeEligibleVersionsForTargetSelection({ target: stable, confirmed: false })).toEqual([]);
+    expect(badgeEligibleVersionsForTargetSelection({ target: stable, confirmed: false, source: 'default' })).toEqual([]);
     expect(badgeEligibleVersionsForTargetSelection(
-      { target: stable, confirmed: false },
+      { target: stable, confirmed: false, source: 'stored' },
       { adcp_supported_versions: ['3.0'] },
     )).toEqual(['3.0']);
-    expect(badgeEligibleVersionsForTargetSelection({ target: stable, confirmed: true })).toEqual(['3.0']);
+    expect(badgeEligibleVersionsForTargetSelection(
+      { target: stable, confirmed: false, source: 'explicit' },
+      { adcp_supported_versions: ['3.0'] },
+    )).toEqual(['3.0']);
+    expect(badgeEligibleVersionsForTargetSelection({ target: stable, confirmed: true, source: 'live' })).toEqual(['3.0']);
+  });
+
+  it('lets the live run profile supersede a stored compliance target before publication', () => {
+    const stable = hostedComplianceTarget('3.0');
+    const storedSelection = { target: stable, confirmed: false, source: 'stored' as const };
+
+    expect(storedComplianceTargetMatchesObservedProfile(
+      storedSelection,
+      { adcp_supported_versions: ['3.0'] },
+    )).toBe(true);
+    expect(storedComplianceTargetMatchesObservedProfile(
+      storedSelection,
+      { adcp_supported_versions: ['3.1'] },
+    )).toBe(false);
   });
 
   it('rejects unsupported compliance targets before path resolution', () => {


### PR DESCRIPTION
## Summary

- track whether a hosted compliance target came from live capabilities, recent stored history, an explicit request, or the platform default
- refuse canonical heartbeat, dashboard, storyboard, and Addie verdict writes when no compatible target can be trusted
- revalidate a stored target against the profile observed by the live compliance run before publishing
- defer inconclusive heartbeat checks on the normal cadence with a compare-and-set guard so they neither starve the queue nor overwrite a concurrent owner refresh

## Why

This is a follow-up safety layer for #6383, #6419, and #6422. A capability discovery failure could still fall through to the hosted default and publish a misleading result against AdCP 3.0 after an agent had migrated to 3.1. A recently stored target could also become stale between pre-discovery and the live run.

The canonical product behavior remains automatic selection of the highest compatible advertised hosted line. This PR does not add a multi-version compatibility matrix.

## Validation

- `npm run typecheck`
- 118 focused and affected integration tests
- full server unit suite completed green before the final expert-review adjustments (5,896 passed, 30 skipped)
- repository pre-commit unit stages passed; the full server stage exceeded the local 240-second hook wrapper rather than reporting a test failure

No changeset: server/Addie-only behavior.
