### PR TITLE
fix(compliance): revoke badges on monitoring opt-out

### DIFF
--- a/docs/building/verification/aao-verified.mdx
+++ b/docs/building/verification/aao-verified.mdx
@@ -6,7 +6,7 @@ description: "The public trust mark for AdCP agents. Two qualifiers — Verified
 ---
 
 **Status**: Request for Comments
-**Last Updated**: May 11, 2026
+**Last Updated**: August 12, 2026
 
 **AAO Verified** is the public trust mark for AdCP agents. It carries one of two qualifiers in parens — **(Spec)** or **(Sandbox)** — and may carry both. The qualifier names *which axis* of verification an agent has earned.
 
@@ -186,6 +186,32 @@ Verification is continuously re-evaluated, not a one-time certificate.
 
 Membership lapse revokes the entire badge regardless of test results — public trust marks require active membership.
 
+### Registry visibility and compliance opt-out
+
+Registry visibility and badge verification are separate controls. `public`,
+`members_only`, and `private` determine who can discover an agent in registry
+listings. They do not change whether an already-known agent URL can be checked
+for an earned badge. This keeps a trust mark verifiable by a buyer who already
+has the URL without making a private agent discoverable.
+
+Compliance opt-out is different: it deliberately stops new evidence from
+qualifying the public trust mark. Owners may still run and retain private
+diagnostic tests while opted out, but those results cannot issue a badge.
+Opting out immediately revokes every active and degraded badge across all
+roles and AdCP versions. Public verification,
+versioned and unversioned SVGs, embeds, registry summaries, and brand
+enrichment then return the same unverified result as an unknown or
+never-verified agent. There is no 48-hour grace period for an intentional
+opt-out. Re-enabling monitoring does not restore an old badge; a new passing
+full-suite run must earn it again. Partial storyboard reruns remain
+non-qualifying until that fresh full-suite run completes.
+
+Badge SVGs use ETags but require revalidation before reuse, so embeds observe
+the revocation on their next request. Signed JWTs are offline, expiring proofs
+and cannot learn about a later revocation by themselves. A verifier that needs
+current status must check the registry API; its JSON badge-state responses are
+not cacheable and are the authoritative real-time source.
+
 ## Mark semantics
 
 A seller MAY hold:
@@ -224,7 +250,7 @@ https://agenticadvertising.org/api/registry/agents/{url-encoded-agent-url}/badge
 
 Buyers who want auto-upgrade behavior (the embedded image flips from `Media Buy Agent 3.0 (Spec)` to `Media Buy Agent 3.1 (Spec + Sandbox)` automatically when the agent earns 3.1) embed the legacy URL. Buyers who want to call out "verified for AdCP 3.0" specifically embed the version-pinned URL.
 
-Both return a shields.io-style SVG with `Content-Security-Policy: script-src 'none'` and 5-minute caching. Renders teal when verified, grey when not. Unknown agents and revoked or never-earned badges return a successful `200` grey "Not Verified" SVG, including version-pinned URLs at versions the agent never earned. An unknown role instead returns `400` with the valid role slugs; a temporary status-store failure returns an uncached `503`.
+Both return a shields.io-style SVG with `Content-Security-Policy: script-src 'none'` and ETag revalidation on every use. Renders teal when verified, grey when not. Unknown agents, opted-out agents, and revoked or never-earned badges return a successful `200` grey "Not Verified" SVG, including version-pinned URLs at versions the agent never earned. An unknown role instead returns `400` with the valid role slugs; a temporary status-store failure returns an uncached `503`.
 
 Valid badge role slugs are `media-buy`, `creative`, `signals`, `governance`, `brand`, and `sponsored-intelligence`. These URL slugs are kebab-case. Do not substitute compliance track identifiers such as `media_buy`, which are snake_case and describe test organization rather than badge identity.
 

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -330,16 +330,20 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
 
         if (badgeEligibleAdcpVersions.length > 0) {
           const eligibleBadgeVersions = new Set(badgeEligibleAdcpVersions);
+          const badgeMetadata = await complianceDb.getRegistryMetadata(agent.agent_url);
+          const expectedBadgeGeneration = badgeMetadata?.badge_requalification_generation ?? '0';
           const existingBadges = await complianceDb.getBadgesForAgent(agent.agent_url);
           const revoked = [];
           for (const badge of existingBadges) {
             if (!eligibleBadgeVersions.has(badge.adcp_version)) continue;
-            await complianceDb.revokeBadge(
+            const didRevoke = await complianceDb.revokeBadge(
               agent.agent_url,
               badge.role,
               badge.adcp_version,
               'Authoritative compliance run failed before storyboard verification',
+              expectedBadgeGeneration,
             );
+            if (!didRevoke) continue;
             revoked.push({
               role: badge.role,
               reason: 'Authoritative compliance run failed',

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -4377,6 +4377,7 @@ export function createMemberToolHandlers(
     }
 
     const optedOut = registryMetadata?.compliance_opt_out === true;
+    const requalificationRequired = registryMetadata?.badge_requalification_required === true;
 
     let response = `## Agent Status: ${registryUrl}\n\n`;
     if (registryMetadata?.lifecycle_stage) {
@@ -4422,6 +4423,8 @@ export function createMemberToolHandlers(
     response += `\n### Compliance (latest comply run)\n`;
     if (optedOut) {
       response += `_This agent has opted out of compliance monitoring._\n`;
+    } else if (requalificationRequired) {
+      response += `_Monitoring is enabled, but badges remain suppressed until a fresh passing full-suite compliance run completes. Partial storyboard reruns cannot restore verification first._\n`;
     } else if (complianceStatus) {
       response += `**Status:** ${complianceStatus.status}\n`;
       if (complianceStatus.headline) {

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -1,8 +1,10 @@
 import { query, getClient } from './client.js';
 import { decrypt as decryptToken } from './encryption.js';
 import { logger as baseLogger } from '../logger.js';
+import { CatalogEventsDatabase } from './catalog-events-db.js';
 
 const logger = baseLogger.child({ module: 'compliance-db' });
+const catalogEventsDb = new CatalogEventsDatabase();
 
 // =====================================================
 // TYPES
@@ -74,6 +76,8 @@ export interface AgentRegistryMetadata {
   agent_url: string;
   lifecycle_stage: LifecycleStage;
   compliance_opt_out: boolean;
+  badge_requalification_required: boolean;
+  badge_requalification_generation: string;
   monitoring_paused: boolean;
   check_interval_hours: number;
   monitoring_paused_at: Date | null;
@@ -313,20 +317,18 @@ export class ComplianceDatabase {
 
   async upsertRegistryMetadata(
     agentUrl: string,
-    updates: { lifecycle_stage?: LifecycleStage; compliance_opt_out?: boolean },
+    updates: { lifecycle_stage?: LifecycleStage },
   ): Promise<AgentRegistryMetadata> {
     const result = await query(
-      `INSERT INTO agent_registry_metadata (agent_url, lifecycle_stage, compliance_opt_out)
-       VALUES ($1, COALESCE($2, 'production'), COALESCE($3, FALSE))
+      `INSERT INTO agent_registry_metadata (agent_url, lifecycle_stage)
+       VALUES ($1, COALESCE($2, 'production'))
        ON CONFLICT (agent_url) DO UPDATE SET
          lifecycle_stage = COALESCE($2, agent_registry_metadata.lifecycle_stage),
-         compliance_opt_out = COALESCE($3, agent_registry_metadata.compliance_opt_out),
          updated_at = NOW()
        RETURNING *`,
       [
         agentUrl,
         updates.lifecycle_stage ?? null,
-        updates.compliance_opt_out ?? null,
       ],
     );
     return result.rows[0];
@@ -338,6 +340,211 @@ export class ComplianceDatabase {
       [agentUrl],
     );
     return result.rows[0] || null;
+  }
+
+  /**
+   * Change compliance monitoring state and revoke any public badge state in
+   * the same serialized transaction. Re-enabling keeps the requalification
+   * gate closed; only a later full-suite badge fan-out may open it.
+   */
+  async setComplianceOptOut(
+    agentUrl: string,
+    optOut: boolean,
+    actor = 'api:compliance-opt-out',
+    emitPublicEvent = false,
+  ): Promise<{
+    metadata: AgentRegistryMetadata;
+    revoked: Array<Pick<AgentVerificationBadge, 'role' | 'adcp_version'>>;
+  }> {
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+        [`verification-badge:${agentUrl}`],
+      );
+
+      const existingResult = await client.query(
+        `SELECT compliance_opt_out, badge_requalification_required, badge_requalification_generation
+         FROM agent_registry_metadata
+         WHERE agent_url = $1
+         FOR UPDATE`,
+        [agentUrl],
+      );
+      const existing = existingResult.rows[0] as
+        | {
+            compliance_opt_out: boolean;
+            badge_requalification_required: boolean;
+            badge_requalification_generation: string;
+          }
+        | undefined;
+      const requiresRequalification = optOut
+        || existing?.compliance_opt_out === true
+        || existing?.badge_requalification_required === true;
+
+      const metadataResult = await client.query(
+        `INSERT INTO agent_registry_metadata (
+           agent_url, compliance_opt_out, badge_requalification_required,
+           badge_requalification_generation
+         ) VALUES ($1, $2, $3, 1)
+         ON CONFLICT (agent_url) DO UPDATE SET
+           compliance_opt_out = EXCLUDED.compliance_opt_out,
+           badge_requalification_required = EXCLUDED.badge_requalification_required,
+           badge_requalification_generation = agent_registry_metadata.badge_requalification_generation + 1,
+           updated_at = NOW()
+         RETURNING *`,
+        [agentUrl, optOut, requiresRequalification],
+      );
+
+      let revoked: Array<Pick<AgentVerificationBadge, 'role' | 'adcp_version'>> = [];
+      const revocationReason = optOut
+        ? 'Compliance monitoring opted out'
+        : 'Compliance monitoring re-enabled; fresh qualifying run required';
+      if (optOut || existing?.compliance_opt_out || existing?.badge_requalification_required) {
+        const revokedResult = await client.query(
+          `UPDATE agent_verification_badges
+           SET status = 'revoked', revoked_at = NOW(), revocation_reason = $2, updated_at = NOW()
+           WHERE agent_url = $1 AND status IN ('active', 'degraded')
+           RETURNING role, adcp_version`,
+          [agentUrl, revocationReason],
+        );
+        revoked = revokedResult.rows as Array<Pick<AgentVerificationBadge, 'role' | 'adcp_version'>>;
+      }
+
+      let isCurrentlyPublic = false;
+      if (emitPublicEvent && revoked.length > 0) {
+        const visibilityResult = await client.query(
+          `SELECT 1 FROM member_profiles mp
+           CROSS JOIN LATERAL jsonb_array_elements(mp.agents) agent
+           WHERE agent->>'url' = $1 AND agent->>'visibility' = 'public'
+           LIMIT 1`,
+          [agentUrl],
+        );
+        isCurrentlyPublic = visibilityResult.rowCount === 1;
+      }
+      if (isCurrentlyPublic) {
+        const generation = String(metadataResult.rows[0].badge_requalification_generation);
+        await catalogEventsDb.writeEvents(
+          revoked.map((badge) => ({
+            event_type: 'agent.verification_lost',
+            entity_type: 'agent',
+            entity_id: agentUrl,
+            payload: {
+              agent_url: agentUrl,
+              role: badge.role,
+              adcp_version: badge.adcp_version,
+              reason: revocationReason,
+              badge_requalification_generation: generation,
+            },
+            actor,
+          })),
+          client,
+        );
+      }
+
+      await client.query('COMMIT');
+      return {
+        metadata: metadataResult.rows[0] as AgentRegistryMetadata,
+        revoked,
+      };
+    } catch (error) {
+      await client.query('ROLLBACK').catch((rollbackError) => {
+        logger.warn({ err: rollbackError, agentUrl }, 'Badge opt-out rollback failed');
+      });
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Start an epoch-bound full-suite requalification attempt. Clearing prior
+   * provisional writes prevents a failed earlier attempt from leaking when a
+   * later attempt opens the gate.
+   */
+  async prepareBadgeRequalification(agentUrl: string, expectedGeneration: string): Promise<string | null> {
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+        [`verification-badge:${agentUrl}`],
+      );
+      const metadataResult = await client.query(
+        `SELECT 1 FROM agent_registry_metadata
+         WHERE agent_url = $1
+           AND compliance_opt_out = FALSE
+           AND badge_requalification_required = TRUE
+           AND badge_requalification_generation = $2::bigint`,
+        [agentUrl, expectedGeneration],
+      );
+      if (metadataResult.rowCount !== 1) {
+        await client.query('COMMIT');
+        return null;
+      }
+      const attemptResult = await client.query(
+        `UPDATE agent_registry_metadata
+         SET badge_requalification_generation = badge_requalification_generation + 1,
+             updated_at = NOW()
+         WHERE agent_url = $1
+           AND badge_requalification_generation = $2::bigint
+         RETURNING badge_requalification_generation::text AS generation`,
+        [agentUrl, expectedGeneration],
+      );
+      const attemptGeneration = attemptResult.rows[0]?.generation as string | undefined;
+      if (!attemptGeneration) {
+        await client.query('COMMIT');
+        return null;
+      }
+      await client.query(
+        `UPDATE agent_verification_badges
+         SET status = 'revoked', revoked_at = NOW(),
+             revocation_reason = 'Superseded by fresh full-suite requalification',
+             updated_at = NOW()
+         WHERE agent_url = $1 AND status IN ('active', 'degraded')`,
+        [agentUrl],
+      );
+      await client.query('COMMIT');
+      return attemptGeneration;
+    } catch (error) {
+      await client.query('ROLLBACK').catch((rollbackError) => {
+        logger.warn({ err: rollbackError, agentUrl }, 'Badge requalification preparation rollback failed');
+      });
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  /** Open only the exact post-opt-out generation qualified by this run. */
+  async completeBadgeRequalification(agentUrl: string, expectedGeneration: string): Promise<boolean> {
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+        [`verification-badge:${agentUrl}`],
+      );
+      const result = await client.query(
+        `UPDATE agent_registry_metadata
+         SET badge_requalification_required = FALSE, updated_at = NOW()
+         WHERE agent_url = $1
+           AND compliance_opt_out = FALSE
+           AND badge_requalification_required = TRUE
+           AND badge_requalification_generation = $2::bigint
+         RETURNING agent_url`,
+        [agentUrl, expectedGeneration],
+      );
+      await client.query('COMMIT');
+      return result.rowCount === 1;
+    } catch (error) {
+      await client.query('ROLLBACK').catch((rollbackError) => {
+        logger.warn({ err: rollbackError, agentUrl }, 'Badge requalification rollback failed');
+      });
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   /**
@@ -1458,14 +1665,51 @@ export class ComplianceDatabase {
     verification_token?: string;
     token_expires_at?: Date;
     membership_org_id?: string;
-  }): Promise<AgentVerificationBadge> {
+    /** Badge-policy generation observed when this fan-out began. */
+    expected_badge_generation?: string;
+    /** True only for a full-suite attempt rebuilding a closed gate. */
+    requalification_attempt?: boolean;
+  }): Promise<AgentVerificationBadge | null> {
     const modes = badge.verification_modes ?? ['spec'];
-    const result = await query(
-      `INSERT INTO agent_verification_badges (
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+        [`verification-badge:${badge.agent_url}`],
+      );
+      const result = await client.query(
+        `INSERT INTO agent_verification_badges (
         agent_url, role, adcp_version, verified_specialisms, verification_modes, verified_protocol_version,
         verification_token, token_expires_at, membership_org_id,
         status, verified_at, updated_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', NOW(), NOW())
+      )
+      SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', NOW(), NOW()
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM agent_registry_metadata
+        WHERE agent_url = $1 AND compliance_opt_out = TRUE
+      )
+        AND (
+          $10::bigint IS NULL
+          OR (
+            COALESCE((
+              SELECT badge_requalification_generation
+              FROM agent_registry_metadata
+              WHERE agent_url = $1
+            ), 0) = $10::bigint
+            AND (
+              $11::boolean = FALSE
+              OR EXISTS (
+                SELECT 1 FROM agent_registry_metadata
+                WHERE agent_url = $1
+                  AND compliance_opt_out = FALSE
+                  AND badge_requalification_required = TRUE
+                  AND badge_requalification_generation = $10::bigint
+              )
+            )
+          )
+        )
       ON CONFLICT (agent_url, role, adcp_version) DO UPDATE SET
         verified_specialisms = $4,
         verification_modes = $5,
@@ -1478,20 +1722,34 @@ export class ComplianceDatabase {
         revoked_at = NULL,
         revocation_reason = NULL,
         updated_at = NOW()
-      RETURNING *`,
-      [
-        badge.agent_url,
-        badge.role,
-        badge.adcp_version,
-        badge.verified_specialisms,
-        modes,
-        badge.verified_protocol_version ?? null,
-        badge.verification_token ?? null,
-        badge.token_expires_at ?? null,
-        badge.membership_org_id ?? null,
-      ],
-    );
-    return result.rows[0] as AgentVerificationBadge;
+        RETURNING *`,
+        [
+          badge.agent_url,
+          badge.role,
+          badge.adcp_version,
+          badge.verified_specialisms,
+          modes,
+          badge.verified_protocol_version ?? null,
+          badge.verification_token ?? null,
+          badge.token_expires_at ?? null,
+          badge.membership_org_id ?? null,
+          badge.expected_badge_generation ?? null,
+          badge.requalification_attempt ?? false,
+        ],
+      );
+      // The per-agent lock is shared with setComplianceOptOut. The metadata
+      // predicate therefore observes the latest transition after the lock is
+      // acquired and cannot commit a badge behind a concurrent revocation.
+      await client.query('COMMIT');
+      return (result.rows[0] as AgentVerificationBadge | undefined) ?? null;
+    } catch (error) {
+      await client.query('ROLLBACK').catch((rollbackError) => {
+        logger.warn({ err: rollbackError, agentUrl: badge.agent_url }, 'Badge upsert rollback failed');
+      });
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   async getBadgesForAgent(agentUrl: string): Promise<AgentVerificationBadge[]> {
@@ -1501,8 +1759,12 @@ export class ComplianceDatabase {
     // major or minor numbers. CHECK constraint guarantees both
     // segments are valid integers.
     const result = await query(
-      `SELECT * FROM agent_verification_badges
-       WHERE agent_url = $1 AND status IN ('active', 'degraded')
+      `SELECT b.* FROM agent_verification_badges b
+       LEFT JOIN agent_registry_metadata m ON m.agent_url = b.agent_url
+       WHERE b.agent_url = $1
+         AND b.status IN ('active', 'degraded')
+         AND COALESCE(m.compliance_opt_out, FALSE) = FALSE
+         AND COALESCE(m.badge_requalification_required, FALSE) = FALSE
        ORDER BY split_part(adcp_version, '.', 1)::int DESC,
                 split_part(adcp_version, '.', 2)::int DESC,
                 role`,
@@ -1522,9 +1784,12 @@ export class ComplianceDatabase {
     adcpVersion: string,
   ): Promise<AgentVerificationBadge | null> {
     const result = await query(
-      `SELECT * FROM agent_verification_badges
-       WHERE agent_url = $1 AND role = $2 AND adcp_version = $3
-         AND status IN ('active', 'degraded')`,
+      `SELECT b.* FROM agent_verification_badges b
+       LEFT JOIN agent_registry_metadata m ON m.agent_url = b.agent_url
+       WHERE b.agent_url = $1 AND b.role = $2 AND b.adcp_version = $3
+         AND b.status IN ('active', 'degraded')
+         AND COALESCE(m.compliance_opt_out, FALSE) = FALSE
+         AND COALESCE(m.badge_requalification_required, FALSE) = FALSE`,
       [agentUrl, role, adcpVersion],
     );
     return (result.rows[0] as AgentVerificationBadge) ?? null;
@@ -1544,8 +1809,12 @@ export class ComplianceDatabase {
   ): Promise<AgentVerificationBadge | null> {
     // Numeric sort — see getBadgesForAgent comment.
     const result = await query(
-      `SELECT * FROM agent_verification_badges
-       WHERE agent_url = $1 AND role = $2 AND status IN ('active', 'degraded')
+      `SELECT b.* FROM agent_verification_badges b
+       LEFT JOIN agent_registry_metadata m ON m.agent_url = b.agent_url
+       WHERE b.agent_url = $1 AND b.role = $2
+         AND b.status IN ('active', 'degraded')
+         AND COALESCE(m.compliance_opt_out, FALSE) = FALSE
+         AND COALESCE(m.badge_requalification_required, FALSE) = FALSE
        ORDER BY split_part(adcp_version, '.', 1)::int DESC,
                 split_part(adcp_version, '.', 2)::int DESC
        LIMIT 1`,
@@ -1559,35 +1828,264 @@ export class ComplianceDatabase {
     role: BadgeRole,
     adcpVersion: string,
     reason: string,
-  ): Promise<void> {
-    await query(
+    expectedGeneration?: string,
+  ): Promise<boolean> {
+    if (expectedGeneration !== undefined) {
+      const client = await getClient();
+      try {
+        await client.query('BEGIN');
+        await client.query(
+          'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+          [`verification-badge:${agentUrl}`],
+        );
+        const result = await client.query(
+          `UPDATE agent_verification_badges
+           SET status = 'revoked', revoked_at = NOW(), revocation_reason = $4, updated_at = NOW()
+           WHERE agent_url = $1 AND role = $2 AND adcp_version = $3
+             AND status IN ('active', 'degraded')
+             AND COALESCE((
+               SELECT badge_requalification_generation
+               FROM agent_registry_metadata WHERE agent_url = $1
+             ), 0) = $5::bigint`,
+          [agentUrl, role, adcpVersion, reason, expectedGeneration],
+        );
+        await client.query('COMMIT');
+        return (result.rowCount ?? 0) > 0;
+      } catch (error) {
+        await client.query('ROLLBACK').catch(() => undefined);
+        throw error;
+      } finally {
+        client.release();
+      }
+    }
+    const result = await query(
       `UPDATE agent_verification_badges
        SET status = 'revoked', revoked_at = NOW(), revocation_reason = $4, updated_at = NOW()
        WHERE agent_url = $1 AND role = $2 AND adcp_version = $3 AND status IN ('active', 'degraded')`,
       [agentUrl, role, adcpVersion, reason],
     );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async revokeAllBadges(
+    agentUrl: string,
+    reason: string,
+  ): Promise<Array<Pick<AgentVerificationBadge, 'role' | 'adcp_version'>>> {
+    const result = await query(
+      `UPDATE agent_verification_badges
+       SET status = 'revoked', revoked_at = NOW(), revocation_reason = $2, updated_at = NOW()
+       WHERE agent_url = $1 AND status IN ('active', 'degraded')
+       RETURNING role, adcp_version`,
+      [agentUrl, reason],
+    );
+    return result.rows as Array<Pick<AgentVerificationBadge, 'role' | 'adcp_version'>>;
+  }
+
+  /**
+   * Best-effort fan-out cleanup that cannot revoke badges after monitoring was
+   * re-enabled. The opt-out state is re-read under the shared badge lock.
+   */
+  async revokeAllBadgesIfOptedOut(
+    agentUrl: string,
+    reason: string,
+  ): Promise<Array<Pick<AgentVerificationBadge, 'role' | 'adcp_version'>>> {
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+        [`verification-badge:${agentUrl}`],
+      );
+      const metadataResult = await client.query(
+        `SELECT 1 FROM agent_registry_metadata
+         WHERE agent_url = $1 AND compliance_opt_out = TRUE`,
+        [agentUrl],
+      );
+      if (metadataResult.rowCount !== 1) {
+        await client.query('COMMIT');
+        return [];
+      }
+      const result = await client.query(
+        `UPDATE agent_verification_badges
+         SET status = 'revoked', revoked_at = NOW(), revocation_reason = $2, updated_at = NOW()
+         WHERE agent_url = $1 AND status IN ('active', 'degraded')
+         RETURNING role, adcp_version`,
+        [agentUrl, reason],
+      );
+      await client.query('COMMIT');
+      return result.rows as Array<Pick<AgentVerificationBadge, 'role' | 'adcp_version'>>;
+    } catch (error) {
+      await client.query('ROLLBACK').catch((rollbackError) => {
+        logger.warn({ err: rollbackError, agentUrl }, 'Opted-out badge cleanup rollback failed');
+      });
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Publish badge feed events only if each result still matches current badge
+   * state. The shared per-agent lock orders these events against opt-out and
+   * requalification transitions, preventing delayed notifications from
+   * appending stale trust state after a newer transition.
+   */
+  async publishVerificationChangeEventsIfCurrent(
+    agentUrl: string,
+    issued: Array<{ role: string; adcp_version?: string }>,
+    revoked: Array<{ role: string; reason: string; adcp_version?: string }>,
+    actor: string,
+  ): Promise<void> {
+    if (issued.length === 0 && revoked.length === 0) return;
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+        [`verification-badge:${agentUrl}`],
+      );
+      const visibilityResult = await client.query(
+        `SELECT 1
+         FROM member_profiles mp
+         CROSS JOIN LATERAL jsonb_array_elements(mp.agents) agent
+         WHERE agent->>'url' = $1 AND agent->>'visibility' = 'public'
+         LIMIT 1`,
+        [agentUrl],
+      );
+      if (visibilityResult.rowCount !== 1) {
+        await client.query('COMMIT');
+        return;
+      }
+
+      for (const badge of issued) {
+        const current = await client.query(
+          `SELECT b.role, b.adcp_version, b.verified_specialisms,
+                  COALESCE(m.badge_requalification_generation, 0)::text AS generation
+           FROM agent_verification_badges b
+           LEFT JOIN agent_registry_metadata m ON m.agent_url = b.agent_url
+           WHERE b.agent_url = $1 AND b.role = $2
+             AND ($3::text IS NULL OR b.adcp_version = $3)
+             AND b.status IN ('active', 'degraded')
+             AND COALESCE(m.compliance_opt_out, FALSE) = FALSE
+             AND COALESCE(m.badge_requalification_required, FALSE) = FALSE
+           ORDER BY split_part(b.adcp_version, '.', 1)::int DESC,
+                    split_part(b.adcp_version, '.', 2)::int DESC
+           LIMIT 1`,
+          [agentUrl, badge.role, badge.adcp_version ?? null],
+        );
+        const row = current.rows[0];
+        if (!row) continue;
+        await catalogEventsDb.writeEvent({
+          event_type: 'agent.verification_earned',
+          entity_type: 'agent',
+          entity_id: agentUrl,
+          payload: {
+            agent_url: agentUrl,
+            role: row.role,
+            adcp_version: row.adcp_version,
+            verified_specialisms: row.verified_specialisms,
+            badge_requalification_generation: row.generation,
+          },
+          actor,
+        }, client);
+      }
+
+      for (const badge of revoked) {
+        const current = await client.query(
+          `SELECT b.role, b.adcp_version,
+                  COALESCE(m.badge_requalification_generation, 0)::text AS generation
+           FROM agent_verification_badges b
+           LEFT JOIN agent_registry_metadata m ON m.agent_url = b.agent_url
+           WHERE b.agent_url = $1 AND b.role = $2
+             AND ($3::text IS NULL OR b.adcp_version = $3)
+             AND b.status = 'revoked'
+           ORDER BY split_part(b.adcp_version, '.', 1)::int DESC,
+                    split_part(b.adcp_version, '.', 2)::int DESC
+           LIMIT 1`,
+          [agentUrl, badge.role, badge.adcp_version ?? null],
+        );
+        const row = current.rows[0];
+        if (!row) continue;
+        await catalogEventsDb.writeEvent({
+          event_type: 'agent.verification_lost',
+          entity_type: 'agent',
+          entity_id: agentUrl,
+          payload: {
+            agent_url: agentUrl,
+            role: row.role,
+            adcp_version: row.adcp_version,
+            reason: badge.reason,
+            badge_requalification_generation: row.generation,
+          },
+          actor,
+        }, client);
+      }
+
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK').catch((rollbackError) => {
+        logger.warn({ err: rollbackError, agentUrl }, 'Verification event rollback failed');
+      });
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   async degradeBadge(
     agentUrl: string,
     role: BadgeRole,
     adcpVersion: string,
-  ): Promise<void> {
-    await query(
+    expectedGeneration?: string,
+  ): Promise<boolean> {
+    if (expectedGeneration !== undefined) {
+      const client = await getClient();
+      try {
+        await client.query('BEGIN');
+        await client.query(
+          'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+          [`verification-badge:${agentUrl}`],
+        );
+        const result = await client.query(
+          `UPDATE agent_verification_badges
+           SET status = 'degraded', updated_at = NOW()
+           WHERE agent_url = $1 AND role = $2 AND adcp_version = $3
+             AND status = 'active'
+             AND COALESCE((
+               SELECT badge_requalification_generation
+               FROM agent_registry_metadata WHERE agent_url = $1
+             ), 0) = $4::bigint`,
+          [agentUrl, role, adcpVersion, expectedGeneration],
+        );
+        await client.query('COMMIT');
+        return (result.rowCount ?? 0) > 0;
+      } catch (error) {
+        await client.query('ROLLBACK').catch(() => undefined);
+        throw error;
+      } finally {
+        client.release();
+      }
+    }
+    const result = await query(
       `UPDATE agent_verification_badges
        SET status = 'degraded', updated_at = NOW()
        WHERE agent_url = $1 AND role = $2 AND adcp_version = $3 AND status = 'active'`,
       [agentUrl, role, adcpVersion],
     );
+    return (result.rowCount ?? 0) > 0;
   }
 
   async bulkGetActiveBadges(agentUrls: string[]): Promise<Map<string, AgentVerificationBadge[]>> {
     if (agentUrls.length === 0) return new Map();
     // Numeric sort — see getBadgesForAgent comment.
     const result = await query(
-      `SELECT * FROM agent_verification_badges
-       WHERE agent_url = ANY($1) AND status IN ('active', 'degraded')
-       ORDER BY agent_url,
+      `SELECT b.* FROM agent_verification_badges b
+       LEFT JOIN agent_registry_metadata m ON m.agent_url = b.agent_url
+       WHERE b.agent_url = ANY($1)
+         AND b.status IN ('active', 'degraded')
+         AND COALESCE(m.compliance_opt_out, FALSE) = FALSE
+         AND COALESCE(m.badge_requalification_required, FALSE) = FALSE
+       ORDER BY b.agent_url,
                 split_part(adcp_version, '.', 1)::int DESC,
                 split_part(adcp_version, '.', 2)::int DESC,
                 role`,
@@ -1605,8 +2103,12 @@ export class ComplianceDatabase {
   async getVerifiedAgentsByRole(role: BadgeRole): Promise<AgentVerificationBadge[]> {
     // Numeric sort — see getBadgesForAgent comment.
     const result = await query(
-      `SELECT * FROM agent_verification_badges
-       WHERE role = $1 AND status IN ('active', 'degraded')
+      `SELECT b.* FROM agent_verification_badges b
+       LEFT JOIN agent_registry_metadata m ON m.agent_url = b.agent_url
+       WHERE b.role = $1
+         AND b.status IN ('active', 'degraded')
+         AND COALESCE(m.compliance_opt_out, FALSE) = FALSE
+         AND COALESCE(m.badge_requalification_required, FALSE) = FALSE
        ORDER BY split_part(adcp_version, '.', 1)::int DESC,
                 split_part(adcp_version, '.', 2)::int DESC,
                 verified_at DESC`,

--- a/server/src/db/migrations/543_badge_requalification_gate.sql
+++ b/server/src/db/migrations/543_badge_requalification_gate.sql
@@ -1,0 +1,52 @@
+-- Keep badge state hidden after compliance monitoring is re-enabled until a
+-- fresh full-suite run has rebuilt every qualifying verdict.
+ALTER TABLE agent_registry_metadata
+  ADD COLUMN IF NOT EXISTS badge_requalification_required BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE agent_registry_metadata
+  ADD COLUMN IF NOT EXISTS badge_requalification_generation BIGINT NOT NULL DEFAULT 0;
+
+-- Existing opt-outs predate the gate. Preserve their closed state and make
+-- any previously suppressed badge revocation durable during rollout.
+UPDATE agent_registry_metadata
+SET badge_requalification_required = TRUE,
+    badge_requalification_generation = GREATEST(badge_requalification_generation, 1)
+WHERE compliance_opt_out = TRUE;
+
+WITH revoked AS (
+  UPDATE agent_verification_badges b
+  SET status = 'revoked',
+      revoked_at = NOW(),
+      revocation_reason = 'Compliance monitoring opted out',
+      updated_at = NOW()
+  FROM agent_registry_metadata m
+  WHERE b.agent_url = m.agent_url
+    AND m.compliance_opt_out = TRUE
+    AND b.status IN ('active', 'degraded')
+  RETURNING b.agent_url, b.role, b.adcp_version,
+            m.badge_requalification_generation
+)
+INSERT INTO catalog_events (
+  event_id, event_type, entity_type, entity_id, payload, actor
+)
+SELECT
+  uuidv7(),
+  'agent.verification_lost',
+  'agent',
+  agent_url,
+  jsonb_build_object(
+    'agent_url', agent_url,
+    'role', role,
+    'adcp_version', adcp_version,
+    'reason', 'Compliance monitoring opted out',
+    'badge_requalification_generation', badge_requalification_generation::text
+  ),
+  'migration:543_badge_requalification_gate'
+FROM revoked r
+WHERE EXISTS (
+  SELECT 1
+  FROM member_profiles mp
+  CROSS JOIN LATERAL jsonb_array_elements(mp.agents) agent
+  WHERE agent->>'url' = r.agent_url
+    AND agent->>'visibility' = 'public'
+);

--- a/server/src/notifications/compliance.ts
+++ b/server/src/notifications/compliance.ts
@@ -11,7 +11,7 @@ import { notifyUser } from './notification-service.js';
 import { NotificationDatabase } from '../db/notification-db.js';
 import { CatalogEventsDatabase } from '../db/catalog-events-db.js';
 import { query } from '../db/client.js';
-import type { ComplianceStatus, TrackSummaryEntry, StoryboardStatusEntry } from '../db/compliance-db.js';
+import { ComplianceDatabase, type ComplianceStatus, type TrackSummaryEntry, type StoryboardStatusEntry } from '../db/compliance-db.js';
 import type { SlackBlockMessage } from '../slack/types.js';
 
 const logger = baseLogger.child({ module: 'compliance-notifications' });
@@ -19,6 +19,7 @@ const logger = baseLogger.child({ module: 'compliance-notifications' });
 const CHANNEL_ID = process.env.REGISTRY_EDITS_CHANNEL_ID;
 const notificationDb = new NotificationDatabase();
 const eventsDb = new CatalogEventsDatabase();
+const complianceDb = new ComplianceDatabase();
 
 interface ComplianceChangeInput {
   agentUrl: string;
@@ -49,6 +50,21 @@ async function resolveAgentOwnerUserIds(agentUrl: string): Promise<string[]> {
   } catch (error) {
     logger.debug({ error, agentUrl }, 'Could not resolve agent owner');
     return [];
+  }
+}
+
+async function isAgentPublic(agentUrl: string): Promise<boolean> {
+  try {
+    const result = await query(
+      `SELECT 1 FROM member_profiles mp
+       CROSS JOIN LATERAL jsonb_array_elements(mp.agents) agent
+       WHERE agent->>'url' = $1 AND agent->>'visibility' = 'public'
+       LIMIT 1`,
+      [agentUrl],
+    );
+    return result.rowCount === 1;
+  } catch {
+    return false;
   }
 }
 
@@ -206,6 +222,11 @@ interface VerificationChangeInput {
   // messages.
   issued: Array<{ role: string; specialisms: string[]; adcp_version?: string }>;
   revoked: Array<{ role: string; reason: string; adcp_version?: string }>;
+  actor?: string;
+  /** False when the caller persisted feed events transactionally. */
+  emitFeedEvents?: boolean;
+  /** False for non-public agents so shared channels cannot enumerate them. */
+  notifyChannel?: boolean;
 }
 
 function badgeQualifier(adcpVersion: string | undefined): string {
@@ -219,9 +240,10 @@ function badgeQualifier(adcpVersion: string | undefined): string {
 export async function notifyVerificationChange(input: VerificationChangeInput): Promise<void> {
   const { agentUrl, issued, revoked } = input;
   const name = agentDisplayName(agentUrl);
+  const notifySharedChannel = input.notifyChannel ?? await isAgentPublic(agentUrl);
 
   // Post to Slack channel
-  if (CHANNEL_ID && isSlackConfigured()) {
+  if (notifySharedChannel && CHANNEL_ID && isSlackConfigured()) {
     try {
       for (const badge of issued) {
         const versionTag = badgeQualifier(badge.adcp_version);
@@ -294,35 +316,13 @@ export async function notifyVerificationChange(input: VerificationChangeInput): 
   }
 
   // Emit change feed events
-  try {
-    for (const badge of issued) {
-      await eventsDb.writeEvent({
-        event_type: 'agent.verification_earned',
-        entity_type: 'agent',
-        entity_id: agentUrl,
-        payload: {
-          agent_url: agentUrl,
-          role: badge.role,
-          verified_specialisms: badge.specialisms,
-          ...(badge.adcp_version && { adcp_version: badge.adcp_version }),
-        },
-        actor: 'pipeline:compliance-heartbeat',
-      });
-    }
-    for (const badge of revoked) {
-      await eventsDb.writeEvent({
-        event_type: 'agent.verification_lost',
-        entity_type: 'agent',
-        entity_id: agentUrl,
-        payload: {
-          agent_url: agentUrl,
-          role: badge.role,
-          reason: badge.reason,
-          ...(badge.adcp_version && { adcp_version: badge.adcp_version }),
-        },
-        actor: 'pipeline:compliance-heartbeat',
-      });
-    }
+  if (input.emitFeedEvents !== false) try {
+    await complianceDb.publishVerificationChangeEventsIfCurrent(
+      agentUrl,
+      issued,
+      revoked,
+      input.actor ?? 'pipeline:compliance-heartbeat',
+    );
   } catch (error) {
     logger.error({ error, agentUrl }, 'Failed to emit verification change feed event');
   }

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -11,6 +11,7 @@ import type { Request, RequestHandler } from "express";
 import { z } from "zod";
 import escapeHtml from "escape-html";
 import {
+  findOwnedAgentVisibility,
   findOwnerOrgForUser,
   isOrgOwnerOfAgent,
   resolveOwnerOrgForUser,
@@ -53,6 +54,7 @@ import {
 import { getPublicJwks } from "../services/verification-token.js";
 import { renderBadgeSvg, VALID_BADGE_ROLES } from "../services/badge-svg.js";
 import { revokeUnsupportedPublicBadges, runBadgeFanOut } from "../services/badge-issuance.js";
+import { notifyVerificationChange } from "../notifications/compliance.js";
 import { resolveOwnerMembership, tierLabel } from "../services/membership-tiers.js";
 import { inferDiagnosticAgentType } from "../lib/diagnostic-agent-type-inference.js";
 import { isValidAdcpVersionShape } from "../services/adcp-taxonomy.js";
@@ -3397,9 +3399,9 @@ registry.registerPath({
   method: "get",
   path: "/api/registry/agents/{encodedUrl}/verification",
   operationId: "getAgentVerification",
-  summary: "Get agent AAO Verified status",
+  summary: "Get agent AgenticAdvertising.org Verified status",
   description:
-    "Returns AAO Verified badge status for a single agent. Public and cacheable. Includes role badges, verified storyboards, and a link to the agent's registry listing.",
+    "Returns AgenticAdvertising.org Verified badge status for a single agent. Registry visibility controls discovery, not verification, so earned badges remain publicly verifiable for private agents. Compliance opt-out immediately suppresses all badges and returns the same unverified shape as an unknown or never-verified agent.",
   tags: ["Agent Compliance"],
   request: {
     params: z.object({
@@ -3419,7 +3421,7 @@ registry.registerPath({
   path: "/api/registry/agents/{encodedUrl}/badge/{role}.svg",
   operationId: "getAgentBadgeSvg",
   summary: "Get agent verification badge SVG",
-  description: "Returns an SVG badge image for the specified agent and role. Shows the role-specific AgenticAdvertising.org Verified mark (teal) when verified, or 'Not Verified' (grey) when not. Cacheable and suitable for embedding in websites.",
+  description: "Returns an SVG badge image for the specified agent and role. Shows the role-specific AgenticAdvertising.org Verified mark (teal) when verified, or 'Not Verified' (grey) when not. Responses use ETags but must be revalidated before reuse so opt-out revocation is reflected immediately. Registry visibility does not affect verification.",
   tags: ["Agent Compliance"],
   request: {
     params: z.object({
@@ -3440,7 +3442,7 @@ registry.registerPath({
   path: "/api/registry/agents/{encodedUrl}/badge/{role}/embed",
   operationId: "getAgentBadgeEmbed",
   summary: "Get embeddable badge code",
-  description: "Returns HTML and Markdown embed snippets for displaying an AAO Verified badge on websites, social profiles, and documentation. The badge links to the agent's AAO registry listing.",
+  description: "Returns HTML and Markdown embed snippets for displaying an AgenticAdvertising.org Verified badge on websites, social profiles, and documentation. Private registry visibility does not suppress verification. Compliance opt-out returns `verified: false` without revealing why the badge is ineligible.",
   tags: ["Agent Compliance"],
   request: {
     params: z.object({
@@ -3477,7 +3479,7 @@ registry.registerPath({
   path: "/api/registry/agents/{encodedUrl}/badge/{role}/{version}.svg",
   operationId: "getAgentBadgeVersionedSvg",
   summary: "Get version-pinned agent verification badge SVG",
-  description: "Returns an SVG badge image scoped to a specific AdCP release (MAJOR.MINOR, e.g. '3.0'). Buyers who want to call out 'verified for 3.0' embed this instead of the legacy `/badge/{role}.svg` (which auto-upgrades to the highest active version). Renders 'Not Verified' when the agent never earned a badge at this version.",
+  description: "Returns an SVG badge image scoped to a specific AdCP release (MAJOR.MINOR, e.g. '3.0'). Buyers who want to call out 'verified for 3.0' embed this instead of the legacy `/badge/{role}.svg` (which auto-upgrades to the highest active version). Renders 'Not Verified' when the agent never earned a badge at this version or opted out of compliance monitoring. Registry visibility does not affect verification.",
   tags: ["Agent Compliance"],
   request: {
     params: z.object({
@@ -3499,7 +3501,7 @@ registry.registerPath({
   path: "/api/registry/agents/{encodedUrl}/badge/{role}/{version}/embed",
   operationId: "getAgentBadgeVersionedEmbed",
   summary: "Get version-pinned embeddable badge code",
-  description: "Returns HTML and Markdown embed snippets that point at the version-pinned SVG. Alt text includes the version (e.g. 'AAO Verified Media Buy Agent 3.0'). Buyers who want to freeze on a specific AdCP release embed these instead of the legacy `/badge/{role}/embed`.",
+  description: "Returns HTML and Markdown embed snippets that point at the version-pinned SVG. Alt text includes the version (e.g. 'AgenticAdvertising.org Verified Media Buy Agent 3.0'). Buyers who want to freeze on a specific AdCP release embed these instead of the legacy `/badge/{role}/embed`. Compliance opt-out returns `verified: false`; registry visibility does not affect verification.",
   tags: ["Agent Compliance"],
   request: {
     params: z.object({
@@ -3681,7 +3683,7 @@ registry.registerPath({
   operationId: "updateAgentComplianceOptOut",
   summary: "Update compliance opt-out",
   description:
-    "Opt an agent in or out of public compliance reporting. Requires authentication and ownership of the agent.",
+    "Opt an agent in or out of public compliance reporting. Opting out immediately revokes every active badge version. Re-enabling monitoring keeps badges suppressed until a fresh passing full-suite run earns them again; partial storyboard reruns cannot restore verification first. Requires authentication and ownership of the agent.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -5029,6 +5031,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
   router.get("/brands/brand-json", registryReadRateLimiter, async (req, res) => {
     try {
+      // Responses may carry live badge state; never let an enriched manifest
+      // retain verified=true after an opt-out transition.
+      res.setHeader("Cache-Control", "no-store");
       const domain = ((req.query.domain as string) || "").toLowerCase();
       const fresh = req.query.fresh === "true";
       if (!isValidDomain(domain)) {
@@ -6202,6 +6207,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         ? (Array.isArray(rawVerificationMode) ? (rawVerificationMode as string[]) : [rawVerificationMode as string])
         : undefined;
       const withVerified = req.query.verified === "true";
+      if (withCompliance || withVerified || verificationModes?.length) {
+        res.setHeader("Cache-Control", "no-store");
+      }
 
       if (verificationModes?.length) {
         const invalid = verificationModes.filter((m) => !isVerificationMode(m));
@@ -6445,6 +6453,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
   router.get("/registry/agents/:encodedUrl/compliance", agentReadRateLimiter, optAuth, async (req, res) => {
     try {
+      res.setHeader("Cache-Control", "no-store");
       const agentUrl = decodeURIComponent(req.params.encodedUrl);
       if (!validateAgentUrlParam(agentUrl)) {
         return res.status(400).json({ error: "Invalid agent URL" });
@@ -6471,6 +6480,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           status: "opted_out",
           lifecycle_stage: metadata.lifecycle_stage || "production",
           compliance_opt_out: true,
+          badge_requalification_required: true,
         });
       }
 
@@ -6480,6 +6490,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
           status: "unknown",
           lifecycle_stage: metadata?.lifecycle_stage || "production",
           compliance_opt_out: false,
+          badge_requalification_required: metadata?.badge_requalification_required ?? false,
           tracks: {},
           streak_days: 0,
           last_checked_at: null,
@@ -6605,6 +6616,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         status: status.status,
         lifecycle_stage: metadata?.lifecycle_stage || "production",
         compliance_opt_out: metadata?.compliance_opt_out ?? false,
+        badge_requalification_required: metadata?.badge_requalification_required ?? false,
         tracks: status.tracks_summary_json || {},
         track_details: status.track_details_json || [],
         streak_days: status.streak_days,
@@ -6752,6 +6764,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
       const encodedUrl = encodeURIComponent(agentUrl);
 
+      res.setHeader("Cache-Control", "no-store");
       res.json({
         agent_url: agentUrl,
         verified: badges.length > 0,
@@ -6785,7 +6798,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
     res.setHeader("Content-Type", "image/svg+xml");
     res.setHeader("Content-Security-Policy", "script-src 'none'");
     res.setHeader("X-Content-Type-Options", "nosniff");
-    res.setHeader("Cache-Control", "public, max-age=300, s-maxage=300, must-revalidate");
+    // Trust state can be revoked deliberately through compliance opt-out.
+    // Allow caches to retain the response body and ETag, but require them to
+    // revalidate before every use so a stale teal badge cannot survive the
+    // revocation cycle.
+    res.setHeader("Cache-Control", "public, max-age=0, s-maxage=0, must-revalidate");
     // ETag covers role, version, and the mode set so a transition (e.g.
     // add 'live', upgrade to 3.1) invalidates caches for the badge URL.
     res.setHeader("ETag", etag);
@@ -6938,8 +6955,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       // legacy URL auto-upgrades, so a buyer who copies this snippet
       // gets the newest version's image without changing the alt text
       // they pasted into their site.
-      const altText = `AAO Verified ${roleLabelForEmbed(role)} Agent`;
+      const altText = `AgenticAdvertising.org Verified ${roleLabelForEmbed(role)} Agent`;
 
+      res.setHeader("Cache-Control", "no-store");
       res.json(buildEmbedResponse({ agentUrl, role, badgeSvgUrl, altText, verified, adcpVersion }));
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Failed to generate embed code");
@@ -6977,8 +6995,9 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       const baseUrl = process.env.PUBLIC_BASE_URL || 'https://agenticadvertising.org';
       const encodedUrl = encodeURIComponent(agentUrl);
       const badgeSvgUrl = `${baseUrl}/api/registry/agents/${encodedUrl}/badge/${role}/${version}.svg`;
-      const altText = `AAO Verified ${roleLabelForEmbed(role)} Agent ${version}`;
+      const altText = `AgenticAdvertising.org Verified ${roleLabelForEmbed(role)} Agent ${version}`;
 
+      res.setHeader("Cache-Control", "no-store");
       res.json(buildEmbedResponse({ agentUrl, role, badgeSvgUrl, altText, verified, adcpVersion: version }));
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Failed to generate version-pinned embed code");
@@ -7218,10 +7237,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
 
   router.put("/registry/agents/:encodedUrl/compliance/opt-out", ...complianceWriteMiddleware, async (req, res) => {
     try {
-      const agentUrl = decodeURIComponent(req.params.encodedUrl);
-      if (!validateAgentUrlParam(agentUrl)) {
+      const rawAgentUrl = decodeURIComponent(req.params.encodedUrl);
+      if (!validateAgentUrlParam(rawAgentUrl)) {
         return res.status(400).json({ error: "Invalid agent URL" });
       }
+      const agentUrl = canonicalizeAgentUrl(rawAgentUrl);
+      if (!agentUrl) return res.status(400).json({ error: "Invalid agent URL" });
 
       if (!req.user) {
         return res.status(401).json({ error: "Authentication required" });
@@ -7238,11 +7259,40 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         return res.status(400).json({ error: "opt_out must be a boolean" });
       }
 
-      const metadata = await complianceDb.upsertRegistryMetadata(agentUrl, {
-        compliance_opt_out: opt_out,
-      });
+      const eventActor = `user:${req.user.id}`;
+      const agentVisibility = await findOwnedAgentVisibility(req.user.id, agentUrl);
+      if (!agentVisibility) {
+        return res.status(403).json({ error: "You do not have permission to modify this agent" });
+      }
+      const isPublicAgent = agentVisibility === 'public';
+      const transition = await complianceDb.setComplianceOptOut(
+        agentUrl,
+        opt_out,
+        eventActor,
+        isPublicAgent,
+      );
+      if (transition.revoked.length > 0) {
+        const reason = opt_out
+          ? 'Compliance monitoring opted out'
+          : 'Compliance monitoring re-enabled; fresh qualifying run required';
+        try {
+          await notifyVerificationChange({
+            agentUrl,
+            issued: [],
+            revoked: transition.revoked.map((badge) => ({ ...badge, reason })),
+            actor: eventActor,
+            emitFeedEvents: false,
+            ...(!isPublicAgent && { notifyChannel: false }),
+          });
+        } catch (notificationError) {
+          logger.error(
+            { err: notificationError, agentUrl },
+            'Failed to publish badge revocation notifications after compliance opt-out transition',
+          );
+        }
+      }
 
-      res.json(metadata);
+      res.json(transition.metadata);
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Failed to update compliance opt-out");
       res.status(500).json({ error: "Failed to update compliance opt-out" });

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -772,6 +772,9 @@ export const AgentComplianceDetailSchema = z
     status: z.enum(["passing", "degraded", "failing", "unknown", "opted_out"]),
     lifecycle_stage: z.enum(["development", "testing", "production", "deprecated"]),
     compliance_opt_out: z.boolean().optional(),
+    badge_requalification_required: z.boolean().optional().openapi({
+      description: "True when monitoring is enabled but badges remain suppressed until a fresh passing full-suite run completes.",
+    }),
     tracks: z.record(z.string(), z.string()).optional(),
     track_details: z.array(z.object({
       track: z.string(),
@@ -1235,6 +1238,9 @@ export const RegistryMetadataSchema = z
     agent_url: z.string(),
     lifecycle_stage: z.enum(["development", "testing", "production", "deprecated"]),
     compliance_opt_out: z.boolean(),
+    badge_requalification_required: z.boolean().openapi({
+      description: "True after opt-out until a fresh full-suite compliance run completes badge requalification.",
+    }),
     monitoring_paused: z.boolean(),
     check_interval_hours: z.number().int(),
     monitoring_paused_at: z.string().nullable(),

--- a/server/src/scripts/reconcile-agent-url-canonicalization.ts
+++ b/server/src/scripts/reconcile-agent-url-canonicalization.ts
@@ -55,6 +55,8 @@ interface MetadataRow {
   agent_url: string;
   lifecycle_stage: string;
   compliance_opt_out: boolean;
+  badge_requalification_required: boolean;
+  badge_requalification_generation: string;
   monitoring_paused: boolean;
   check_interval_hours: number;
   monitoring_paused_at: Date | null;
@@ -236,6 +238,17 @@ async function main(): Promise<void> {
         agent_url: canonical,
         lifecycle_stage: mostRecent.lifecycle_stage,
         compliance_opt_out: rows.some(r => r.compliance_opt_out),
+        badge_requalification_required: rows.some(r => r.badge_requalification_required),
+        // Bump beyond every source row so an in-flight pre-merge full-suite
+        // run cannot clear the merged row's requalification gate.
+        badge_requalification_generation: (
+          rows.reduce(
+            (max, row) => BigInt(row.badge_requalification_generation) > max
+              ? BigInt(row.badge_requalification_generation)
+              : max,
+            0n,
+          ) + 1n
+        ).toString(),
         monitoring_paused: rows.some(r => r.monitoring_paused),
         check_interval_hours: Math.min(...rows.map(r => r.check_interval_hours)),
         monitoring_paused_at: maxNullableDate(rows.map(r => r.monitoring_paused_at)),
@@ -265,13 +278,17 @@ async function main(): Promise<void> {
         );
         await client.query(
           `INSERT INTO agent_registry_metadata
-            (agent_url, lifecycle_stage, compliance_opt_out, monitoring_paused,
-             check_interval_hours, monitoring_paused_at, created_at, updated_at)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+            (agent_url, lifecycle_stage, compliance_opt_out,
+             badge_requalification_required, badge_requalification_generation,
+             monitoring_paused, check_interval_hours, monitoring_paused_at,
+             created_at, updated_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
           [
             merged.agent_url,
             merged.lifecycle_stage,
             merged.compliance_opt_out,
+            merged.badge_requalification_required,
+            merged.badge_requalification_generation,
             merged.monitoring_paused,
             merged.check_interval_hours,
             merged.monitoring_paused_at,

--- a/server/src/services/agent-ownership.ts
+++ b/server/src/services/agent-ownership.ts
@@ -32,6 +32,35 @@
 
 import { query } from '../db/client.js';
 import { canonicalizeAgentUrl } from '../db/publisher-db.js';
+import type { AgentVisibility } from '../types.js';
+
+/** Resolve the owned agent's directory visibility without exposing it publicly. */
+export async function findOwnedAgentVisibility(
+  userId: string,
+  agentUrl: string,
+): Promise<AgentVisibility | null> {
+  try {
+    const lookupAgentUrl = canonicalizeAgentUrl(agentUrl) ?? agentUrl;
+    const result = await query<{ visibility: string | null }>(
+      `SELECT agent->>'visibility' AS visibility
+       FROM member_profiles mp
+       JOIN organization_memberships om
+         ON om.workos_organization_id = mp.workos_organization_id
+       CROSS JOIN LATERAL jsonb_array_elements(mp.agents) agent
+       WHERE agent->>'url' = $1
+         AND om.workos_user_id = $2
+       LIMIT 1`,
+      [lookupAgentUrl, userId],
+    );
+    if (!result.rows[0]) return null;
+    const visibility = result.rows[0].visibility;
+    return visibility === 'public' || visibility === 'members_only' || visibility === 'private'
+      ? visibility
+      : 'private';
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Find the org id of any org the user is a member of that owns the agent.

--- a/server/src/services/badge-issuance.ts
+++ b/server/src/services/badge-issuance.ts
@@ -46,6 +46,8 @@ export async function revokeUnsupportedPublicBadges(params: {
   const result: BadgeIssuanceResult = { issued: [], revoked: [], degraded: [], unchanged: [] };
   if (!supportedVersions?.length) return result;
 
+  const metadata = await complianceDb.getRegistryMetadata(agentUrl);
+  const expectedBadgeGeneration = metadata?.badge_requalification_generation ?? '0';
   const publicBadgeVersions = new Set<string>(SUPPORTED_BADGE_VERSIONS);
   const existingBadges = await complianceDb.getBadgesForAgent(agentUrl);
 
@@ -54,7 +56,14 @@ export async function revokeUnsupportedPublicBadges(params: {
     if (advertisesPublicBadgeVersion(supportedVersions, badge.adcp_version)) continue;
 
     const reason = `Agent no longer advertises AdCP ${badge.adcp_version} support`;
-    await complianceDb.revokeBadge(agentUrl, badge.role, badge.adcp_version, reason);
+    const revoked = await complianceDb.revokeBadge(
+      agentUrl,
+      badge.role,
+      badge.adcp_version,
+      reason,
+      expectedBadgeGeneration,
+    );
+    if (!revoked) continue;
     result.revoked.push({ role: badge.role, reason, adcp_version: badge.adcp_version });
     logger.info(
       { agentUrl, role: badge.role, adcpVersion: badge.adcp_version },
@@ -84,6 +93,8 @@ export async function processAgentBadges(
   overallPassing: boolean,
   membershipOrgId?: string,
   adcpVersion: string = DEFAULT_BADGE_ADCP_VERSION,
+  expectedBadgeGeneration?: string,
+  requalificationAttempt = false,
 ): Promise<BadgeIssuanceResult> {
   const result: BadgeIssuanceResult = { issued: [], revoked: [], degraded: [], unchanged: [] };
 
@@ -102,7 +113,14 @@ export async function processAgentBadges(
   // trust mark.
   if (!membershipOrgId) {
     for (const existing of existingAllVersions) {
-      await complianceDb.revokeBadge(agentUrl, existing.role, existing.adcp_version, 'Membership lapsed');
+      const revoked = await complianceDb.revokeBadge(
+        agentUrl,
+        existing.role,
+        existing.adcp_version,
+        'Membership lapsed',
+        expectedBadgeGeneration,
+      );
+      if (!revoked) continue;
       result.revoked.push({ role: existing.role, reason: 'Membership lapsed', adcp_version: existing.adcp_version });
       logger.info({ agentUrl, role: existing.role, adcpVersion: existing.adcp_version }, 'Badge revoked — membership lapsed');
     }
@@ -145,7 +163,7 @@ export async function processAgentBadges(
         }
       }
 
-      await complianceDb.upsertBadge({
+      const persistedBadge = await complianceDb.upsertBadge({
         agent_url: agentUrl,
         role: roleResult.role,
         adcp_version: adcpVersion,
@@ -154,7 +172,17 @@ export async function processAgentBadges(
         verification_token: token,
         token_expires_at: tokenExpiresAt,
         membership_org_id: membershipOrgId,
+        expected_badge_generation: expectedBadgeGeneration,
+        requalification_attempt: requalificationAttempt,
       });
+
+      if (!persistedBadge) {
+        logger.info(
+          { agentUrl, role: roleResult.role, adcpVersion },
+          'Badge issuance suppressed because compliance monitoring is opted out',
+        );
+        continue;
+      }
 
       if (!existing) {
         result.issued.push({ role: roleResult.role, specialisms: roleResult.specialisms, adcp_version: adcpVersion });
@@ -164,7 +192,13 @@ export async function processAgentBadges(
       }
     } else if (existing) {
       if (existing.status === 'active') {
-        await complianceDb.degradeBadge(agentUrl, roleResult.role, adcpVersion);
+        const degraded = await complianceDb.degradeBadge(
+          agentUrl,
+          roleResult.role,
+          adcpVersion,
+          expectedBadgeGeneration,
+        );
+        if (!degraded) continue;
         result.degraded.push({ role: roleResult.role, adcp_version: adcpVersion });
         logger.info({ agentUrl, role: roleResult.role, adcpVersion, failing: roleResult.failing, untested: roleResult.untested }, 'Badge degraded');
       } else if (existing.status === 'degraded') {
@@ -176,7 +210,14 @@ export async function processAgentBadges(
             roleResult.failing.length > 0 ? `Failing specialisms: ${roleResult.failing.join(', ')}` : undefined,
             roleResult.untested.length > 0 ? `Untested specialisms: ${roleResult.untested.join(', ')}` : undefined,
           ].filter(Boolean).join('; ');
-          await complianceDb.revokeBadge(agentUrl, roleResult.role, adcpVersion, `${reason} for 48+ hours`);
+          const revoked = await complianceDb.revokeBadge(
+            agentUrl,
+            roleResult.role,
+            adcpVersion,
+            `${reason} for 48+ hours`,
+            expectedBadgeGeneration,
+          );
+          if (!revoked) continue;
           result.revoked.push({ role: roleResult.role, reason, adcp_version: adcpVersion });
           logger.info({ agentUrl, role: roleResult.role, adcpVersion, failing: roleResult.failing, untested: roleResult.untested }, 'Badge revoked after 48h grace');
         } else {
@@ -190,7 +231,14 @@ export async function processAgentBadges(
   const activeRoles = new Set(verification.roles.map(r => r.role));
   for (const existing of existingBadges) {
     if (!activeRoles.has(existing.role)) {
-      await complianceDb.revokeBadge(agentUrl, existing.role, adcpVersion, 'Role no longer in declared specialisms');
+      const revoked = await complianceDb.revokeBadge(
+        agentUrl,
+        existing.role,
+        adcpVersion,
+        'Role no longer in declared specialisms',
+        expectedBadgeGeneration,
+      );
+      if (!revoked) continue;
       result.revoked.push({ role: existing.role, reason: 'Role no longer declared', adcp_version: adcpVersion });
     }
   }
@@ -225,6 +273,49 @@ export async function runBadgeFanOut(params: {
   const adcpVersions = (params.adcpVersions === undefined ? [DEFAULT_BADGE_ADCP_VERSION] : params.adcpVersions)
     .filter((version): version is string => typeof version === 'string' && version.length > 0);
   const aggregate: BadgeIssuanceResult = { issued: [], revoked: [], degraded: [], unchanged: [] };
+
+  const metadata = await complianceDb.getRegistryMetadata(agentUrl);
+  if (metadata?.compliance_opt_out) {
+    const revoked = await complianceDb.revokeAllBadgesIfOptedOut(
+      agentUrl,
+      'Compliance monitoring opted out',
+    );
+    aggregate.revoked.push(...revoked.map((badge) => ({
+      role: badge.role,
+      adcp_version: badge.adcp_version,
+      reason: 'Compliance monitoring opted out',
+    })));
+    logger.info(
+      { agentUrl, revoked: revoked.length },
+      'Badge fan-out suppressed because compliance monitoring is opted out',
+    );
+    return aggregate;
+  }
+
+  // Re-enabling monitoring never restores old trust state. Partial owner
+  // retests continue to be recorded, but only a fresh authoritative full-suite
+  // run (identified by runId) may rebuild badges and open the public-read gate.
+  if (metadata?.badge_requalification_required && !runId) {
+    logger.info(
+      { agentUrl },
+      'Badge fan-out suppressed until a fresh full-suite compliance run completes',
+    );
+    return aggregate;
+  }
+
+  let expectedBadgeGeneration = metadata?.badge_requalification_generation ?? '0';
+  let requalificationGeneration: string | undefined;
+  if (metadata?.badge_requalification_required && runId) {
+    const attemptGeneration = await complianceDb.prepareBadgeRequalification(
+      agentUrl,
+      expectedBadgeGeneration,
+    );
+    // A newer opt-out/re-enable transition superseded this run before badge
+    // processing began. Do not let old evidence write into the new epoch.
+    if (!attemptGeneration) return aggregate;
+    expectedBadgeGeneration = attemptGeneration;
+    requalificationGeneration = attemptGeneration;
+  }
 
   if (declaredSpecialisms.length === 0 || adcpVersions.length === 0) {
     return aggregate;
@@ -272,7 +363,7 @@ export async function runBadgeFanOut(params: {
     storyboardStatuses.every(s => s.status === 'passing');
 
   if (!membershipOrgId) {
-    return processAgentBadges(
+    const result = await processAgentBadges(
       complianceDb,
       agentUrl,
       declaredSpecialisms,
@@ -280,7 +371,10 @@ export async function runBadgeFanOut(params: {
       overallPassing,
       undefined,
       adcpVersions[0] ?? DEFAULT_BADGE_ADCP_VERSION,
+      expectedBadgeGeneration,
+      requalificationGeneration !== undefined,
     );
+    return result;
   }
 
   const supportedBadgeVersions = new Set<string>(SUPPORTED_BADGE_VERSIONS);
@@ -297,7 +391,14 @@ export async function runBadgeFanOut(params: {
     }
     if (!reason) continue;
 
-    await complianceDb.revokeBadge(agentUrl, badge.role, badge.adcp_version, reason);
+    const revoked = await complianceDb.revokeBadge(
+      agentUrl,
+      badge.role,
+      badge.adcp_version,
+      reason,
+      expectedBadgeGeneration,
+    );
+    if (!revoked) continue;
     aggregate.revoked.push({ role: badge.role, reason, adcp_version: badge.adcp_version });
     logger.info(
       { agentUrl, role: badge.role, adcpVersion: badge.adcp_version },
@@ -305,6 +406,7 @@ export async function runBadgeFanOut(params: {
     );
   }
 
+  let processingFailed = false;
   for (const adcpVersion of adcpVersions) {
     // Per-version try/catch matches the heartbeat behavior: a failure
     // at one version must not poison another version's issuance, and a
@@ -322,6 +424,8 @@ export async function runBadgeFanOut(params: {
         overallPassing,
         membershipOrgId,
         adcpVersion,
+        expectedBadgeGeneration,
+        requalificationGeneration !== undefined,
       );
 
       for (const issued of versionResult.issued) aggregate.issued.push(issued);
@@ -329,6 +433,7 @@ export async function runBadgeFanOut(params: {
       for (const degraded of versionResult.degraded) aggregate.degraded.push(degraded);
       for (const unchanged of versionResult.unchanged) aggregate.unchanged.push(unchanged);
     } catch (versionError) {
+      processingFailed = true;
       const errorMessage = versionError instanceof Error ? versionError.message : String(versionError);
       logger.error(
         { versionError, agentUrl, adcpVersion },
@@ -339,6 +444,10 @@ export async function runBadgeFanOut(params: {
         errorMessage: `Per-version badge processing failed for ${agentUrl} at AdCP ${adcpVersion}: ${errorMessage}`,
       });
     }
+  }
+
+  if (requalificationGeneration && runId && !processingFailed && aggregate.issued.length > 0) {
+    await complianceDb.completeBadgeRequalification(agentUrl, requalificationGeneration);
   }
 
   return aggregate;

--- a/server/tests/integration/compliance-badge-opt-out-race.test.ts
+++ b/server/tests/integration/compliance-badge-opt-out-race.test.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Pool } from 'pg';
+import { closeDatabase, initializeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { ComplianceDatabase } from '../../src/db/compliance-db.js';
+
+describe.skipIf(!process.env.DATABASE_URL)('compliance badge opt-out serialization', () => {
+  let pool: Pool;
+  const db = new ComplianceDatabase();
+  const agentUrls: string[] = [];
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  });
+
+  afterAll(async () => {
+    if (agentUrls.length > 0) {
+      await pool.query('DELETE FROM agent_verification_badges WHERE agent_url = ANY($1::text[])', [agentUrls]);
+      await pool.query('DELETE FROM agent_registry_metadata WHERE agent_url = ANY($1::text[])', [agentUrls]);
+    }
+    await closeDatabase();
+  });
+
+  it('cannot commit an active badge behind opt-out or expose it on re-enable', async () => {
+    const agentUrl = `https://${randomUUID()}.badge-race.example/mcp`;
+    agentUrls.push(agentUrl);
+    await pool.query(
+      `INSERT INTO agent_registry_metadata (
+         agent_url, compliance_opt_out, badge_requalification_required
+       ) VALUES ($1, FALSE, FALSE)`,
+      [agentUrl],
+    );
+
+    // Hold the same lock used by both operations so they are definitely
+    // concurrent before PostgreSQL chooses a serialized order.
+    const fence = await pool.connect();
+    await fence.query('BEGIN');
+    await fence.query(
+      'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+      [`verification-badge:${agentUrl}`],
+    );
+
+    const issuance = db.upsertBadge({
+      agent_url: agentUrl,
+      role: 'media-buy',
+      adcp_version: '3.1',
+      verified_specialisms: ['sales-broadcast-tv'],
+    });
+    const optOut = db.setComplianceOptOut(agentUrl, true);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await fence.query('COMMIT');
+    fence.release();
+
+    await Promise.all([issuance, optOut]);
+
+    const optedOut = await pool.query(
+      `SELECT compliance_opt_out, badge_requalification_required
+       FROM agent_registry_metadata WHERE agent_url = $1`,
+      [agentUrl],
+    );
+    expect(optedOut.rows[0]).toMatchObject({
+      compliance_opt_out: true,
+      badge_requalification_required: true,
+    });
+    const activeAfterOptOut = await pool.query(
+      `SELECT 1 FROM agent_verification_badges
+       WHERE agent_url = $1 AND status IN ('active', 'degraded')`,
+      [agentUrl],
+    );
+    expect(activeAfterOptOut.rowCount).toBe(0);
+
+    const reenabled = await db.setComplianceOptOut(agentUrl, false);
+    expect(reenabled.metadata).toMatchObject({
+      compliance_opt_out: false,
+      badge_requalification_required: true,
+    });
+    expect(await db.getBadgesForAgent(agentUrl)).toEqual([]);
+
+    const transitionGeneration = reenabled.metadata.badge_requalification_generation;
+    const attemptFence = await pool.connect();
+    await attemptFence.query('BEGIN');
+    await attemptFence.query(
+      'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+      [`verification-badge:${agentUrl}`],
+    );
+    const firstAttempt = db.prepareBadgeRequalification(agentUrl, transitionGeneration);
+    const secondAttempt = db.prepareBadgeRequalification(agentUrl, transitionGeneration);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await attemptFence.query('COMMIT');
+    attemptFence.release();
+
+    const attemptTokens = await Promise.all([firstAttempt, secondAttempt]);
+    expect(attemptTokens.filter((token) => token !== null)).toHaveLength(1);
+    expect(attemptTokens.filter((token) => token === null)).toHaveLength(1);
+  });
+});

--- a/server/tests/unit/badge-fan-out.test.ts
+++ b/server/tests/unit/badge-fan-out.test.ts
@@ -45,16 +45,35 @@ function status(id: string, s: StoryboardStatus) {
 function makeDb(opts: {
   existingBadges?: AgentVerificationBadge[];
   latestStatuses?: ReturnType<typeof status>[];
+  optedOut?: boolean;
+  requalificationRequired?: boolean;
 }): ComplianceDatabase {
   const upserts: any[] = [];
   const degrades: any[] = [];
   const revokes: any[] = [];
   return {
+    getRegistryMetadata: vi.fn().mockResolvedValue(
+      opts.optedOut || opts.requalificationRequired
+        ? {
+            compliance_opt_out: opts.optedOut ?? false,
+            badge_requalification_required: opts.requalificationRequired ?? false,
+            badge_requalification_generation: '7',
+          }
+        : null,
+    ),
     getBadgesForAgent: vi.fn().mockResolvedValue(opts.existingBadges ?? []),
     getStoryboardStatuses: vi.fn().mockResolvedValue(opts.latestStatuses ?? []),
     upsertBadge: vi.fn().mockImplementation((b: any) => { upserts.push(b); return Promise.resolve({ ...badge(b.role), ...b }); }),
-    degradeBadge: vi.fn().mockImplementation((...args: any[]) => { degrades.push(args); return Promise.resolve(undefined); }),
-    revokeBadge: vi.fn().mockImplementation((...args: any[]) => { revokes.push(args); return Promise.resolve(undefined); }),
+    degradeBadge: vi.fn().mockImplementation((...args: any[]) => { degrades.push(args); return Promise.resolve(true); }),
+    revokeBadge: vi.fn().mockImplementation((...args: any[]) => { revokes.push(args); return Promise.resolve(true); }),
+    revokeAllBadges: vi.fn().mockResolvedValue(
+      (opts.existingBadges ?? []).map(({ role, adcp_version }) => ({ role, adcp_version })),
+    ),
+    revokeAllBadgesIfOptedOut: vi.fn().mockResolvedValue(
+      (opts.existingBadges ?? []).map(({ role, adcp_version }) => ({ role, adcp_version })),
+    ),
+    prepareBadgeRequalification: vi.fn().mockResolvedValue('8'),
+    completeBadgeRequalification: vi.fn().mockResolvedValue(true),
     _upserts: upserts,
     _degrades: degrades,
     _revokes: revokes,
@@ -74,6 +93,128 @@ describe('runBadgeFanOut', () => {
     expect(result.issued).toHaveLength(0);
     expect(result.revoked).toHaveLength(0);
     expect(db.getStoryboardStatuses).not.toHaveBeenCalled();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('revokes every active badge and blocks issuance while compliance is opted out', async () => {
+    const db = makeDb({
+      optedOut: true,
+      existingBadges: [
+        badge('media-buy', 'active', '3.0'),
+        badge('creative', 'degraded', '3.1'),
+      ],
+      latestStatuses: [status('sales_broadcast_tv', 'passing')],
+    });
+
+    const result = await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv'],
+      adcpVersions: ['3.0', '3.1'],
+    });
+
+    expect(db.revokeAllBadgesIfOptedOut).toHaveBeenCalledWith(
+      'https://example.com/mcp',
+      'Compliance monitoring opted out',
+    );
+    expect(result.revoked).toEqual([
+      { role: 'media-buy', adcp_version: '3.0', reason: 'Compliance monitoring opted out' },
+      { role: 'creative', adcp_version: '3.1', reason: 'Compliance monitoring opted out' },
+    ]);
+    expect(db.upsertBadge).not.toHaveBeenCalled();
+    expect(db.getStoryboardStatuses).not.toHaveBeenCalled();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks partial storyboard fan-out after re-enable until a full-suite run completes', async () => {
+    const db = makeDb({
+      requalificationRequired: true,
+      latestStatuses: [status('sales_broadcast_tv', 'passing')],
+    });
+
+    const result = await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv'],
+    });
+
+    expect(result).toEqual({ issued: [], revoked: [], degraded: [], unchanged: [] });
+    expect(db.getStoryboardStatuses).not.toHaveBeenCalled();
+    expect(db.upsertBadge).not.toHaveBeenCalled();
+    expect(db.completeBadgeRequalification).not.toHaveBeenCalled();
+  });
+
+  it('opens the requalification gate only after fresh full-suite badge processing succeeds', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ workos_organization_id: 'org_member' }], rowCount: 1, command: 'SELECT', oid: 0, fields: [] } as never);
+    const db = makeDb({
+      requalificationRequired: true,
+      latestStatuses: [status('sales_broadcast_tv', 'passing')],
+    });
+
+    await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv'],
+      runId: 'fresh-full-suite',
+    });
+
+    expect(db.getStoryboardStatuses).toHaveBeenCalledWith(
+      'https://example.com/mcp',
+      { runId: 'fresh-full-suite' },
+    );
+    expect(db.upsertBadge).toHaveBeenCalled();
+    expect(db.prepareBadgeRequalification).toHaveBeenCalledWith('https://example.com/mcp', '7');
+    expect(db.completeBadgeRequalification).toHaveBeenCalledWith('https://example.com/mcp', '8');
+  });
+
+  it('keeps the gate closed when a fresh full-suite run earns no badge', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ workos_organization_id: 'org_member' }], rowCount: 1, command: 'SELECT', oid: 0, fields: [] } as never);
+    const db = makeDb({
+      requalificationRequired: true,
+      latestStatuses: [status('sales_broadcast_tv', 'failing')],
+    });
+
+    await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv'],
+      runId: 'fresh-failing-full-suite',
+    });
+
+    expect(db.upsertBadge).not.toHaveBeenCalled();
+    expect(db.completeBadgeRequalification).not.toHaveBeenCalled();
+  });
+
+  it('keeps the gate closed when the full-suite run has no eligible membership', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0, command: 'SELECT', oid: 0, fields: [] } as never);
+    const db = makeDb({
+      requalificationRequired: true,
+      latestStatuses: [status('sales_broadcast_tv', 'passing')],
+    });
+
+    await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv'],
+      runId: 'fresh-full-suite-without-membership',
+    });
+
+    expect(db.completeBadgeRequalification).not.toHaveBeenCalled();
+  });
+
+  it('abandons a stale full-suite run when a newer transition supersedes its generation', async () => {
+    const db = makeDb({ requalificationRequired: true });
+    vi.mocked(db.prepareBadgeRequalification).mockResolvedValue(null);
+
+    await runBadgeFanOut({
+      complianceDb: db,
+      agentUrl: 'https://example.com/mcp',
+      declaredSpecialisms: ['sales-broadcast-tv'],
+      runId: 'stale-full-suite',
+    });
+
+    expect(db.upsertBadge).not.toHaveBeenCalled();
+    expect(db.completeBadgeRequalification).not.toHaveBeenCalled();
     expect(queryMock).not.toHaveBeenCalled();
   });
 
@@ -199,6 +340,7 @@ describe('runBadgeFanOut', () => {
       'media-buy',
       '4.0',
       'AdCP 4.0 public badge issuance is not currently enabled',
+      '0',
     );
   });
 
@@ -230,6 +372,7 @@ describe('runBadgeFanOut', () => {
       'media-buy',
       '3.1',
       'Agent no longer advertises AdCP 3.1 support',
+      '0',
     );
   });
 

--- a/server/tests/unit/badge-issuance.test.ts
+++ b/server/tests/unit/badge-issuance.test.ts
@@ -41,8 +41,8 @@ function makeMockDb(existingBadges: AgentVerificationBadge[]): ComplianceDatabas
   return {
     getBadgesForAgent: vi.fn().mockResolvedValue(existingBadges),
     upsertBadge: vi.fn().mockImplementation((b) => Promise.resolve({ ...makeBadge(b.role), ...b })),
-    degradeBadge: vi.fn().mockResolvedValue(undefined),
-    revokeBadge: vi.fn().mockResolvedValue(undefined),
+    degradeBadge: vi.fn().mockResolvedValue(true),
+    revokeBadge: vi.fn().mockResolvedValue(true),
   } as unknown as ComplianceDatabase;
 }
 
@@ -108,6 +108,24 @@ describe('processAgentBadges — membership gating', () => {
     expect(upsertCall.verification_modes).toEqual(['spec']);
   });
 
+  it('does not report issuance when the database suppresses a concurrent opt-out write', async () => {
+    const db = makeMockDb([]);
+    vi.mocked(db.upsertBadge).mockResolvedValueOnce(null);
+
+    const result = await processAgentBadges(
+      db,
+      'https://example.com/mcp',
+      ['sales-broadcast-tv'],
+      [makeStatus('sales_broadcast_tv', 'passing')],
+      true,
+      'org_test',
+    );
+
+    expect(db.upsertBadge).toHaveBeenCalledTimes(1);
+    expect(result.issued).toEqual([]);
+    expect(result.unchanged).toEqual([]);
+  });
+
   it('preserves an existing live mode when re-asserting spec', async () => {
     // Simulate an agent that earned (Spec + Live) earlier; storyboards still
     // pass — the upsert must not strip 'live' off the badge.
@@ -145,6 +163,25 @@ describe('processAgentBadges — membership gating', () => {
     expect(db.degradeBadge).toHaveBeenCalledTimes(1);
   });
 
+  it('does not report a degradation suppressed by a newer badge generation', async () => {
+    const db = makeMockDb([makeBadge('media-buy', 'active')]);
+    vi.mocked(db.degradeBadge).mockResolvedValueOnce(false);
+
+    const result = await processAgentBadges(
+      db,
+      'https://example.com/mcp',
+      ['sales-broadcast-tv'],
+      [makeStatus('sales_broadcast_tv', 'failing')],
+      false,
+      'org_test',
+      '3.0',
+      '7',
+    );
+
+    expect(result.degraded).toEqual([]);
+    expect(result.revoked).toEqual([]);
+  });
+
   it('revokes a degraded badge after 48-hour grace period', async () => {
     const existing = [makeBadge('media-buy', 'degraded', 49 * 60 * 60 * 1000)];
     const db = makeMockDb(existing);
@@ -161,6 +198,24 @@ describe('processAgentBadges — membership gating', () => {
     expect(result.revoked).toHaveLength(1);
     expect(result.revoked[0].role).toBe('media-buy');
     expect(result.revoked[0].reason).toMatch(/Failing specialisms/);
+  });
+
+  it('does not report a revocation suppressed by a newer badge generation', async () => {
+    const db = makeMockDb([makeBadge('media-buy', 'degraded', 49 * 60 * 60 * 1000)]);
+    vi.mocked(db.revokeBadge).mockResolvedValueOnce(false);
+
+    const result = await processAgentBadges(
+      db,
+      'https://example.com/mcp',
+      ['sales-broadcast-tv'],
+      [makeStatus('sales_broadcast_tv', 'failing')],
+      false,
+      'org_test',
+      '3.0',
+      '7',
+    );
+
+    expect(result.revoked).toEqual([]);
   });
 
   it('reports a zero-step specialism as untested when revoking after the grace period', async () => {
@@ -189,6 +244,7 @@ describe('processAgentBadges — membership gating', () => {
       'media-buy',
       '3.0',
       'Untested specialisms: sales-broadcast-tv for 48+ hours',
+      undefined,
     );
   });
 

--- a/server/tests/unit/compliance-db-badge-policy.test.ts
+++ b/server/tests/unit/compliance-db-badge-policy.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+  getClient: vi.fn(),
+}));
+
+vi.mock('../../src/db/encryption.js', () => ({
+  decrypt: vi.fn(),
+  encrypt: vi.fn(),
+  deriveKey: vi.fn(),
+}));
+
+import { ComplianceDatabase } from '../../src/db/compliance-db.js';
+import { getClient, query } from '../../src/db/client.js';
+
+const mockedQuery = vi.mocked(query);
+const mockedGetClient = vi.mocked(getClient);
+
+function mockClient(results: Array<{ rows?: unknown[]; rowCount?: number }> = []) {
+  const client = {
+    query: vi.fn(),
+    release: vi.fn(),
+  };
+  for (const result of results) {
+    client.query.mockResolvedValueOnce({ rows: [], rowCount: 0, ...result });
+  }
+  mockedGetClient.mockResolvedValue(client as never);
+  return client;
+}
+
+describe('ComplianceDatabase badge opt-out policy', () => {
+  const db = new ComplianceDatabase();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedQuery.mockResolvedValue({ rows: [], rowCount: 0 } as never);
+  });
+
+  it('suppresses opted-out agents from every active badge read helper', async () => {
+    await db.getBadgesForAgent('https://agent.example/mcp');
+    await db.getActiveBadge('https://agent.example/mcp', 'media-buy', '3.1');
+    await db.getHighestVersionActiveBadge('https://agent.example/mcp', 'media-buy');
+    await db.bulkGetActiveBadges(['https://agent.example/mcp']);
+    await db.getVerifiedAgentsByRole('media-buy');
+
+    expect(mockedQuery).toHaveBeenCalledTimes(5);
+    for (const [sql] of mockedQuery.mock.calls) {
+      expect(sql).toContain('LEFT JOIN agent_registry_metadata');
+      expect(sql).toContain('COALESCE(m.compliance_opt_out, FALSE) = FALSE');
+      expect(sql).toContain('COALESCE(m.badge_requalification_required, FALSE) = FALSE');
+    }
+  });
+
+  it('serializes the final badge write and fails closed against the latest opt-out state', async () => {
+    const client = mockClient([
+      {}, // BEGIN
+      {}, // advisory lock
+      { rows: [] }, // guarded upsert sees opted-out metadata
+      {}, // COMMIT
+    ]);
+
+    await expect(db.upsertBadge({
+      agent_url: 'https://agent.example/mcp',
+      role: 'media-buy',
+      adcp_version: '3.1',
+      verified_specialisms: ['sales-broadcast-tv'],
+    })).resolves.toBeNull();
+
+    expect(client.query.mock.calls.map(([sql]) => sql)).toEqual([
+      'BEGIN',
+      'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+      expect.stringMatching(/WHERE NOT EXISTS \([\s\S]*compliance_opt_out = TRUE/),
+      'COMMIT',
+    ]);
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringMatching(/WHERE NOT EXISTS \([\s\S]*compliance_opt_out = TRUE/),
+      [
+        'https://agent.example/mcp',
+        'media-buy',
+        '3.1',
+        ['sales-broadcast-tv'],
+        ['spec'],
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+      ],
+    );
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('atomically opts out, revokes every badge, and leaves requalification required', async () => {
+    const client = mockClient([
+      {}, // BEGIN
+      {}, // advisory lock
+      { rows: [{ compliance_opt_out: false, badge_requalification_required: false }] },
+      { rows: [{ agent_url: 'https://agent.example/mcp', compliance_opt_out: true, badge_requalification_required: true }] },
+      { rows: [{ role: 'media-buy', adcp_version: '3.1' }], rowCount: 1 },
+      {}, // COMMIT
+    ]);
+
+    await expect(db.setComplianceOptOut('https://agent.example/mcp', true)).resolves.toMatchObject({
+      metadata: { compliance_opt_out: true, badge_requalification_required: true },
+      revoked: [{ role: 'media-buy', adcp_version: '3.1' }],
+    });
+
+    expect(client.query.mock.calls.map(([sql]) => sql)).toEqual([
+      'BEGIN',
+      'SELECT pg_advisory_xact_lock(hashtextextended($1, 0))',
+      expect.stringContaining('FOR UPDATE'),
+      expect.stringContaining('badge_requalification_required'),
+      expect.stringMatching(/UPDATE agent_verification_badges[\s\S]*status IN \('active', 'degraded'\)/),
+      'COMMIT',
+    ]);
+  });
+
+  it('revokes defensively before re-enable commits and keeps the public gate closed', async () => {
+    const client = mockClient([
+      {},
+      {},
+      { rows: [{ compliance_opt_out: true, badge_requalification_required: true }] },
+      { rows: [{ agent_url: 'https://agent.example/mcp', compliance_opt_out: false, badge_requalification_required: true }] },
+      { rows: [], rowCount: 0 },
+      {},
+    ]);
+
+    await expect(db.setComplianceOptOut('https://agent.example/mcp', false)).resolves.toMatchObject({
+      metadata: { compliance_opt_out: false, badge_requalification_required: true },
+    });
+
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE agent_verification_badges'),
+      ['https://agent.example/mcp', 'Compliance monitoring re-enabled; fresh qualifying run required'],
+    );
+  });
+
+  it('rolls back both metadata and badge revocation when the transition fails', async () => {
+    const client = mockClient([
+      {},
+      {},
+      { rows: [{ compliance_opt_out: false, badge_requalification_required: false }] },
+      { rows: [{ compliance_opt_out: true, badge_requalification_required: true }] },
+    ]);
+    client.query
+      .mockRejectedValueOnce(new Error('revocation failed'))
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    await expect(db.setComplianceOptOut('https://agent.example/mcp', true))
+      .rejects.toThrow('revocation failed');
+
+    expect(client.query).toHaveBeenLastCalledWith('ROLLBACK');
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('revokes all active and degraded versions in one transition', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [
+        { role: 'media-buy', adcp_version: '3.0' },
+        { role: 'media-buy', adcp_version: '3.1' },
+      ],
+      rowCount: 2,
+    } as never);
+
+    await expect(db.revokeAllBadges(
+      'https://agent.example/mcp',
+      'Compliance monitoring opted out',
+    )).resolves.toEqual([
+      { role: 'media-buy', adcp_version: '3.0' },
+      { role: 'media-buy', adcp_version: '3.1' },
+    ]);
+
+    expect(mockedQuery).toHaveBeenCalledWith(
+      expect.stringMatching(/status IN \('active', 'degraded'\)[\s\S]*RETURNING role, adcp_version/),
+      ['https://agent.example/mcp', 'Compliance monitoring opted out'],
+    );
+  });
+
+  it('reports a generation-guarded revocation no-op so callers cannot notify stale changes', async () => {
+    const client = mockClient([
+      {},
+      {},
+      { rowCount: 0 },
+      {},
+    ]);
+
+    await expect(db.revokeBadge(
+      'https://agent.example/mcp',
+      'media-buy',
+      '3.1',
+      'Compliance failed',
+      '7',
+    )).resolves.toBe(false);
+
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining('badge_requalification_generation'),
+      ['https://agent.example/mcp', 'media-buy', '3.1', 'Compliance failed', '7'],
+    );
+  });
+
+  it('reports a generation-guarded degradation only when the row changed', async () => {
+    mockClient([
+      {},
+      {},
+      { rowCount: 1 },
+      {},
+    ]);
+
+    await expect(db.degradeBadge(
+      'https://agent.example/mcp',
+      'media-buy',
+      '3.1',
+      '7',
+    )).resolves.toBe(true);
+  });
+});

--- a/server/tests/unit/registry-badge-routes.test.ts
+++ b/server/tests/unit/registry-badge-routes.test.ts
@@ -16,7 +16,25 @@ const complianceMocks = vi.hoisted(() => ({
   getHighestVersionActiveBadge: vi.fn(),
   getActiveBadge: vi.fn(),
   getBadgesForAgent: vi.fn(),
+  getRegistryMetadata: vi.fn(),
+  upsertRegistryMetadata: vi.fn(),
+  setComplianceOptOut: vi.fn(),
+  revokeAllBadges: vi.fn(),
 }));
+
+const notificationMocks = vi.hoisted(() => ({
+  notifyVerificationChange: vi.fn(),
+}));
+
+const ownershipMocks = vi.hoisted(() => ({
+  findOwnedAgentVisibility: vi.fn(),
+  findOwnerOrgForUser: vi.fn(),
+  isOrgOwnerOfAgent: vi.fn(),
+  resolveOwnerOrgForUser: vi.fn(),
+}));
+
+vi.mock('../../src/services/agent-ownership.js', () => ownershipMocks);
+vi.mock('../../src/notifications/compliance.js', () => notificationMocks);
 
 vi.mock('../../src/middleware/rate-limit.js', () => {
   const pass: import('express').RequestHandler = (_req, _res, next) => next();
@@ -41,6 +59,10 @@ vi.mock('../../src/db/compliance-db.js', () => ({
     getHighestVersionActiveBadge = complianceMocks.getHighestVersionActiveBadge;
     getActiveBadge = complianceMocks.getActiveBadge;
     getBadgesForAgent = complianceMocks.getBadgesForAgent;
+    getRegistryMetadata = complianceMocks.getRegistryMetadata;
+    upsertRegistryMetadata = complianceMocks.upsertRegistryMetadata;
+    setComplianceOptOut = complianceMocks.setComplianceOptOut;
+    revokeAllBadges = complianceMocks.revokeAllBadges;
   },
 }));
 
@@ -55,9 +77,16 @@ const VALID_ROLES = [
   'sponsored-intelligence',
 ];
 
-function buildApp(): express.Express {
+function buildApp(
+  visibility: 'public' | 'members_only' | 'private' = 'public',
+  authenticated = false,
+): express.Express {
   const app = express();
-  const passAuth: import('express').RequestHandler = (_req, _res, next) => next();
+  app.use(express.json());
+  const passAuth: import('express').RequestHandler = (req, _res, next) => {
+    if (authenticated) req.user = { id: 'user_badge_owner' } as typeof req.user;
+    next();
+  };
   const config: RegistryApiConfig = {
     brandManager: {} as RegistryApiConfig['brandManager'],
     brandDb: {} as RegistryApiConfig['brandDb'],
@@ -71,6 +100,7 @@ function buildApp(): express.Express {
           url: AGENT_URL,
           type: 'sales',
           protocol: 'mcp',
+          visibility,
         }]),
       }),
     } as unknown as RegistryApiConfig['crawler'],
@@ -92,6 +122,17 @@ describe('registry badge routes', () => {
     complianceMocks.getHighestVersionActiveBadge.mockResolvedValue(null);
     complianceMocks.getActiveBadge.mockResolvedValue(null);
     complianceMocks.getBadgesForAgent.mockResolvedValue([]);
+    complianceMocks.getRegistryMetadata.mockResolvedValue(null);
+    complianceMocks.upsertRegistryMetadata.mockResolvedValue({ compliance_opt_out: false });
+    complianceMocks.setComplianceOptOut.mockResolvedValue({
+      metadata: { compliance_opt_out: false },
+      revoked: [],
+    });
+    complianceMocks.revokeAllBadges.mockResolvedValue([]);
+    notificationMocks.notifyVerificationChange.mockReset();
+    notificationMocks.notifyVerificationChange.mockResolvedValue(undefined);
+    ownershipMocks.findOwnerOrgForUser.mockResolvedValue('org_badge_owner');
+    ownershipMocks.findOwnedAgentVisibility.mockResolvedValue('public');
   });
 
   it('reports every active version per verified role in newest-first order', async () => {
@@ -159,7 +200,7 @@ describe('registry badge routes', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers['content-type']).toMatch(/^image\/svg\+xml/);
-    expect(response.headers['cache-control']).toBe('public, max-age=300, s-maxage=300, must-revalidate');
+    expect(response.headers['cache-control']).toBe('public, max-age=0, s-maxage=0, must-revalidate');
     expect(response.body.toString()).toContain('Not Verified');
   });
 
@@ -177,6 +218,7 @@ describe('registry badge routes', () => {
       verified: false,
       adcp_version: '3.1',
     });
+    expect(response.headers['cache-control']).toBe('no-store');
   });
 
   it('reports an exact active role-version badge as verified', async () => {
@@ -196,6 +238,7 @@ describe('registry badge routes', () => {
       verified: true,
       adcp_version: '3.1',
     });
+    expect(response.headers['cache-control']).toBe('no-store');
   });
 
   it('reports the highest active version from the unversioned embed', async () => {
@@ -215,6 +258,130 @@ describe('registry badge routes', () => {
       verified: true,
       adcp_version: '3.10',
     });
+    expect(response.headers['cache-control']).toBe('no-store');
+  });
+
+  it('keeps badge verification independent from private registry discoverability', async () => {
+    complianceMocks.getHighestVersionActiveBadge.mockResolvedValue({
+      role: 'media-buy',
+      adcp_version: '3.1',
+      verification_modes: ['spec'],
+    });
+    const encodedUrl = encodeURIComponent(AGENT_URL);
+
+    const response = await request(buildApp('private'))
+      .get(`/api/registry/agents/${encodedUrl}/badge/media-buy/embed`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      agent_url: AGENT_URL,
+      role: 'media-buy',
+      verified: true,
+      adcp_version: '3.1',
+    });
+  });
+
+  it.each([
+    ['verification', 'json'],
+    ['badge/media-buy.svg', 'svg'],
+    ['badge/media-buy/embed', 'embed'],
+    ['badge/media-buy/3.1.svg', 'svg'],
+    ['badge/media-buy/3.1/embed', 'embed'],
+  ] as const)('renders database-suppressed badge state on %s', async (suffix, responseKind) => {
+    const encodedUrl = encodeURIComponent(AGENT_URL);
+
+    const response = await request(buildApp())
+      .get(`/api/registry/agents/${encodedUrl}/${suffix}`);
+
+    expect(response.status).toBe(200);
+    if (responseKind === 'svg') {
+      expect(response.body.toString()).toContain('Not Verified');
+      expect(response.headers['cache-control']).toBe('public, max-age=0, s-maxage=0, must-revalidate');
+    } else if (responseKind === 'embed') {
+      expect(response.body.verified).toBe(false);
+      expect(response.headers['cache-control']).toBe('no-store');
+    } else {
+      expect(response.body).toMatchObject({ verified: false, badges: [] });
+      expect(response.headers['cache-control']).toBe('no-store');
+    }
+    expect(complianceMocks.getRegistryMetadata).not.toHaveBeenCalled();
+  });
+
+  it('revokes every badge immediately when an owner opts out', async () => {
+    complianceMocks.setComplianceOptOut.mockResolvedValue({
+      metadata: { agent_url: AGENT_URL, compliance_opt_out: true },
+      revoked: [
+        { role: 'media-buy', adcp_version: '3.0' },
+        { role: 'creative', adcp_version: '3.1' },
+      ],
+    });
+    const encodedUrl = encodeURIComponent(AGENT_URL);
+
+    const response = await request(buildApp('private', true))
+      .put(`/api/registry/agents/${encodedUrl}/compliance/opt-out`)
+      .send({ opt_out: true });
+
+    expect(response.status).toBe(200);
+    expect(complianceMocks.setComplianceOptOut).toHaveBeenCalledWith(
+      AGENT_URL,
+      true,
+      'user:user_badge_owner',
+      true,
+    );
+    expect(notificationMocks.notifyVerificationChange).toHaveBeenCalledWith({
+      agentUrl: AGENT_URL,
+      issued: [],
+      revoked: [
+        { role: 'media-buy', adcp_version: '3.0', reason: 'Compliance monitoring opted out' },
+        { role: 'creative', adcp_version: '3.1', reason: 'Compliance monitoring opted out' },
+      ],
+      actor: 'user:user_badge_owner',
+      emitFeedEvents: false,
+    });
+  });
+
+  it('canonicalizes the agent URL before ownership and opt-out writes', async () => {
+    const rawAgentUrl = 'HTTPS://BADGE.EXAMPLE.COM/MCP/';
+    const canonicalAgentUrl = 'https://badge.example.com/mcp';
+
+    const response = await request(buildApp('private', true))
+      .put(`/api/registry/agents/${encodeURIComponent(rawAgentUrl)}/compliance/opt-out`)
+      .send({ opt_out: true });
+
+    expect(response.status).toBe(200);
+    expect(ownershipMocks.findOwnerOrgForUser).toHaveBeenCalledWith(
+      'user_badge_owner',
+      canonicalAgentUrl,
+    );
+    expect(complianceMocks.setComplianceOptOut).toHaveBeenCalledWith(
+      canonicalAgentUrl,
+      true,
+      'user:user_badge_owner',
+      true,
+    );
+  });
+
+  it('keeps private-agent revocation notifications out of shared channels and feeds', async () => {
+    ownershipMocks.findOwnedAgentVisibility.mockResolvedValue('private');
+    complianceMocks.setComplianceOptOut.mockResolvedValue({
+      metadata: { agent_url: AGENT_URL, compliance_opt_out: true },
+      revoked: [{ role: 'media-buy', adcp_version: '3.1' }],
+    });
+
+    const response = await request(buildApp('private', true))
+      .put(`/api/registry/agents/${encodeURIComponent(AGENT_URL)}/compliance/opt-out`)
+      .send({ opt_out: true });
+
+    expect(response.status).toBe(200);
+    expect(complianceMocks.setComplianceOptOut).toHaveBeenCalledWith(
+      AGENT_URL,
+      true,
+      'user:user_badge_owner',
+      false,
+    );
+    expect(notificationMocks.notifyVerificationChange).toHaveBeenCalledWith(
+      expect.objectContaining({ emitFeedEvents: false, notifyChannel: false }),
+    );
   });
 
   it.each([

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -3694,6 +3694,9 @@ components:
             - deprecated
         compliance_opt_out:
           type: boolean
+        badge_requalification_required:
+          type: boolean
+          description: True when monitoring is enabled but badges remain suppressed until a fresh passing full-suite run completes.
         tracks:
           type: object
           additionalProperties:
@@ -4180,6 +4183,9 @@ components:
             - deprecated
         compliance_opt_out:
           type: boolean
+        badge_requalification_required:
+          type: boolean
+          description: True after opt-out until a fresh full-suite compliance run completes badge requalification.
         monitoring_paused:
           type: boolean
         check_interval_hours:
@@ -4196,6 +4202,7 @@ components:
         - agent_url
         - lifecycle_stage
         - compliance_opt_out
+        - badge_requalification_required
         - monitoring_paused
         - check_interval_hours
         - monitoring_paused_at
@@ -10286,8 +10293,8 @@ paths:
   /api/registry/agents/{encodedUrl}/verification:
     get:
       operationId: getAgentVerification
-      summary: Get agent AAO Verified status
-      description: Returns AAO Verified badge status for a single agent. Public and cacheable. Includes role badges, verified storyboards, and a link to the agent's registry listing.
+      summary: Get agent AgenticAdvertising.org Verified status
+      description: Returns AgenticAdvertising.org Verified badge status for a single agent. Registry visibility controls discovery, not verification, so earned badges remain publicly verifiable for private agents. Compliance opt-out immediately suppresses all badges and returns the same unverified shape as an unknown or never-verified agent.
       tags:
         - Agent Compliance
       parameters:
@@ -10328,7 +10335,7 @@ paths:
     get:
       operationId: getAgentBadgeSvg
       summary: Get agent verification badge SVG
-      description: Returns an SVG badge image for the specified agent and role. Shows the role-specific AgenticAdvertising.org Verified mark (teal) when verified, or 'Not Verified' (grey) when not. Cacheable and suitable for embedding in websites.
+      description: Returns an SVG badge image for the specified agent and role. Shows the role-specific AgenticAdvertising.org Verified mark (teal) when verified, or 'Not Verified' (grey) when not. Responses use ETags but must be revalidated before reuse so opt-out revocation is reflected immediately. Registry visibility does not affect verification.
       tags:
         - Agent Compliance
       parameters:
@@ -10392,7 +10399,7 @@ paths:
     get:
       operationId: getAgentBadgeEmbed
       summary: Get embeddable badge code
-      description: Returns HTML and Markdown embed snippets for displaying an AAO Verified badge on websites, social profiles, and documentation. The badge links to the agent's AAO registry listing.
+      description: "Returns HTML and Markdown embed snippets for displaying an AgenticAdvertising.org Verified badge on websites, social profiles, and documentation. Private registry visibility does not suppress verification. Compliance opt-out returns `verified: false` without revealing why the badge is ineligible."
       tags:
         - Agent Compliance
       parameters:
@@ -10485,7 +10492,7 @@ paths:
     get:
       operationId: getAgentBadgeVersionedSvg
       summary: Get version-pinned agent verification badge SVG
-      description: Returns an SVG badge image scoped to a specific AdCP release (MAJOR.MINOR, e.g. '3.0'). Buyers who want to call out 'verified for 3.0' embed this instead of the legacy `/badge/{role}.svg` (which auto-upgrades to the highest active version). Renders 'Not Verified' when the agent never earned a badge at this version.
+      description: Returns an SVG badge image scoped to a specific AdCP release (MAJOR.MINOR, e.g. '3.0'). Buyers who want to call out 'verified for 3.0' embed this instead of the legacy `/badge/{role}.svg` (which auto-upgrades to the highest active version). Renders 'Not Verified' when the agent never earned a badge at this version or opted out of compliance monitoring. Registry visibility does not affect verification.
       tags:
         - Agent Compliance
       parameters:
@@ -10556,7 +10563,7 @@ paths:
     get:
       operationId: getAgentBadgeVersionedEmbed
       summary: Get version-pinned embeddable badge code
-      description: Returns HTML and Markdown embed snippets that point at the version-pinned SVG. Alt text includes the version (e.g. 'AAO Verified Media Buy Agent 3.0'). Buyers who want to freeze on a specific AdCP release embed these instead of the legacy `/badge/{role}/embed`.
+      description: "Returns HTML and Markdown embed snippets that point at the version-pinned SVG. Alt text includes the version (e.g. 'AgenticAdvertising.org Verified Media Buy Agent 3.0'). Buyers who want to freeze on a specific AdCP release embed these instead of the legacy `/badge/{role}/embed`. Compliance opt-out returns `verified: false`; registry visibility does not affect verification."
       tags:
         - Agent Compliance
       parameters:
@@ -10942,7 +10949,7 @@ paths:
     put:
       operationId: updateAgentComplianceOptOut
       summary: Update compliance opt-out
-      description: Opt an agent in or out of public compliance reporting. Requires authentication and ownership of the agent.
+      description: Opt an agent in or out of public compliance reporting. Opting out immediately revokes every active badge version. Re-enabling monitoring keeps badges suppressed until a fresh passing full-suite run earns them again; partial storyboard reruns cannot restore verification first. Requires authentication and ownership of the agent.
       tags:
         - Agent Compliance
       security:


### PR DESCRIPTION
Closes #6386.

## Policy

- Registry visibility controls discovery only. A known agent URL can still be checked for an earned badge.
- Compliance opt-out immediately revokes and suppresses all badge roles and versions, with no grace period.
- Re-enabling monitoring does not restore prior trust state; a fresh passing full-suite run must requalify the agent.
- Unknown, opted-out, and otherwise ineligible agents return the same public unverified shape.

## Implementation

- Makes opt-out and badge revocation one serialized database transaction.
- Adds a monotonic requalification generation and per-attempt CAS token so stale or concurrent runs cannot restore badges.
- Applies the opt-out/requalification gate to every public badge read and badge-bearing response, with no-store JSON and revalidated SVG caching.
- Keeps shared Slack and feed events public-only while preserving owner notifications.
- Backfills existing opted-out agents and updates operator status, OpenAPI, and policy documentation.

## Validation

- Product, code, and security expert reviews: approved with no blockers.
- Focused badge/route/database tests: 63 passed.
- Full server unit suite: 426 files, 5,958 passed, 30 skipped.
- Typecheck, OpenAPI generation, migration validation, docs navigation, docs drift, changeset scope, and diff checks passed.
- Database-backed race test runs when `DATABASE_URL` is available in CI; it is skipped locally without a test database.

No changeset: this changes the website compliance service and its OpenAPI surface, not a protocol package release surface.
