### PR TITLE
fix(admin): restore static admin brand logo workflows

### DIFF
--- a/server/src/routes/brand-logos.ts
+++ b/server/src/routes/brand-logos.ts
@@ -76,13 +76,16 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
         const domain = req.params.domain.toLowerCase();
         const user = (req as any).user;
         const apiKey = (req as Request & { apiKey?: ValidatedApiKey }).apiKey;
+        const isStaticAdmin = Boolean(
+          (req as Request & { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey,
+        );
 
         if (!logoDomainPattern.test(domain)) {
           return res.status(400).json({ error: 'Invalid domain' });
         }
 
         // Membership check
-        if (!user.isMember) {
+        if (!isStaticAdmin && !user.isMember) {
           const enriched = await enrichUserWithMembership(user);
           if (!enriched?.isMember) {
             return res.status(403).json({ error: 'Membership required to upload logos' });
@@ -107,8 +110,13 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
           hostedForOwnership?.domain_verified &&
           hostedForOwnership.workos_organization_id === apiKey.organizationId
         );
-        const isOwner = isApiKeyOwner || (await isVerifiedBrandOwner(user.id, domain, brandDb));
-        if (!isOwner) {
+        const isOwner = !isStaticAdmin
+          && (isApiKeyOwner || (await isVerifiedBrandOwner(user.id, domain, brandDb)));
+        // Static-admin uploads are support actions, not owner attestations.
+        // They bypass the community queue, but attribution below remains tied
+        // to a hosted member org when one exists.
+        const isTrustedUploader = isOwner || isStaticAdmin;
+        if (!isTrustedUploader) {
           if (hostedForOwnership?.domain_verified && hostedForOwnership.workos_organization_id) {
             return res.status(403).json({
               error: `This brand is verified-owned. Only members of the owning organization can change its logo. If you believe you own ${domain}, start a brand-claim challenge to prove DNS control.`,
@@ -135,7 +143,7 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
         // both insert (cap = N×concurrency). The HTTP route's rate
         // limiter bounds this. Hard upper limit is moderator workload,
         // not a security boundary.
-        if (!isOwner) {
+        if (!isTrustedUploader) {
           const pendingDomainCount = await brandLogoDb.countPendingDomainsForUser(
             user.id,
             PENDING_THRESHOLD_WINDOW_MS,
@@ -161,8 +169,9 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
         // rejected/deleted don't permanently consume slots) are reserved
         // to MAX_COMMUNITY_LOGOS_PER_BRAND so a verified owner uploading
         // after the community-pending pool filled isn't locked out of
-        // their own brand. Owner uploads still respect the overall cap.
-        if (isOwner) {
+        // their own brand. Owner and static-admin uploads still respect the
+        // overall cap.
+        if (isTrustedUploader) {
           const count = await brandLogoDb.countBrandLogos(domain);
           if (count >= MAX_LOGOS_PER_BRAND) {
             return res.status(400).json({ error: `Maximum ${MAX_LOGOS_PER_BRAND} logos per brand` });
@@ -212,20 +221,24 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
 
         // Original filename
         const originalFilename = req.file.originalname?.slice(0, 255);
-        const uploaderOrgId = isOwner
-          ? hostedForOwnership?.workos_organization_id ?? apiKey?.organizationId ?? null
+        const uploaderOrgId = isTrustedUploader
+          ? hostedForOwnership?.workos_organization_id
+            ?? (isOwner ? apiKey?.organizationId ?? null : null)
           : apiKey?.organizationId ?? (await resolvePrimaryOrganization(user.id).catch((err) => {
               logger.warn({ err, userId: user.id }, 'Failed to resolve uploader org for brand-logo provenance');
               return null;
             }));
 
-        // Verified owners are auto-approved — domain control is the attestation.
+        // Verified owners and authenticated support actions are auto-approved.
+        // Only the former are owner-attested; `source` preserves that distinction.
         // Community uploads (only allowed when no owner has verified yet) queue
         // for moderator review so a bad actor can't instantly swap a brand's
         // storefront logo. Walks back the community half of #3393 per Brian's
         // direction; ops tunes the moderation cadence.
-        const source = isOwner ? 'brand_owner' : 'community';
-        const reviewStatus = isOwner ? 'approved' : 'pending';
+        const isAttributedToMemberOrg = isOwner
+          || Boolean(isStaticAdmin && hostedForOwnership?.workos_organization_id);
+        const source = isAttributedToMemberOrg ? 'brand_owner' : 'community';
+        const reviewStatus = isTrustedUploader ? 'approved' : 'pending';
 
         // Insert
         const logo = await brandLogoDb.insertBrandLogo({
@@ -243,12 +256,24 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
           uploaded_by_email: user.email,
           upload_note: note,
           original_filename: originalFilename,
-          source_flow: isOwner ? 'brand_builder_owner_upload' : 'community_logo_upload',
+          source_flow: isStaticAdmin
+            ? 'static_admin_logo_upload'
+            : isOwner
+              ? 'brand_builder_owner_upload'
+              : 'community_logo_upload',
           provenance: {
-            approval_path: isOwner ? 'owner_auto_approved' : 'moderator_review_required',
-            source_flow: isOwner ? 'brand_builder_owner_upload' : 'community_logo_upload',
+            approval_path: isStaticAdmin
+              ? 'static_admin_support_action'
+              : isOwner
+                ? 'owner_auto_approved'
+                : 'moderator_review_required',
+            source_flow: isStaticAdmin
+              ? 'static_admin_logo_upload'
+              : isOwner
+                ? 'brand_builder_owner_upload'
+                : 'community_logo_upload',
             intended_use: 'brand_json',
-            uploader_path: isOwner ? 'owner' : 'community',
+            uploader_path: isStaticAdmin ? 'admin' : isOwner ? 'owner' : 'community',
           },
         });
 
@@ -285,7 +310,11 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
 
         // Create a brand revision noting the upload
         try {
-          const reviewNote = isOwner ? 'verified owner — auto-approved' : 'community — pending review';
+          const reviewNote = isStaticAdmin
+            ? 'static admin support action — approved'
+            : isOwner
+              ? 'verified owner — auto-approved'
+              : 'community — pending review';
           await brandDb.editDiscoveredBrand(domain, {
             edit_summary: `Logo uploaded by ${user.email} (${reviewNote})`,
             editor_user_id: user.id,
@@ -513,7 +542,9 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
     async (req: Request, res: Response) => {
       try {
         const user = (req as any).user;
-        const moderator = await isRegistryModerator(user.id);
+        const isStaticAdmin = (req as Request & { isStaticAdminApiKey?: boolean })
+          .isStaticAdminApiKey === true;
+        const moderator = isStaticAdmin || await isRegistryModerator(user.id);
         if (!moderator) {
           return res.status(403).json({ error: 'Brand-registry moderators only' });
         }
@@ -573,7 +604,9 @@ export function createBrandLogoRouter(config: BrandLogoRoutesConfig): Router {
         }
 
         const row = await brandLogoDb.getBrandLogoById(logoId);
-        const moderator = await isRegistryModerator(user.id);
+        const isStaticAdmin = (req as Request & { isStaticAdminApiKey?: boolean })
+          .isStaticAdminApiKey === true;
+        const moderator = isStaticAdmin || await isRegistryModerator(user.id);
         const owner = row ? await isVerifiedBrandOwner(user.id, row.domain, brandDb) : false;
 
         // Conflate not-found and not-authorized for unauthorized callers

--- a/server/tests/unit/brand-logos-moderator-queue.test.ts
+++ b/server/tests/unit/brand-logos-moderator-queue.test.ts
@@ -46,6 +46,7 @@ vi.mock('../../src/middleware/rate-limit.js', () => ({
 vi.mock('../../src/middleware/auth.js', () => ({
   requireAuth: (req: any, _res: unknown, next: () => void) => {
     req.user = { id: currentUserId, email: `${currentUserId}@test.example`, isMember: true };
+    if (currentIsStaticAdmin) req.isStaticAdminApiKey = true;
     next();
   },
   optionalAuth: (req: any, _res: unknown, next: () => void) => {
@@ -83,6 +84,7 @@ import type { BrandDatabase } from '../../src/db/brand-db.js';
 import type { BansDatabase } from '../../src/db/bans-db.js';
 
 let currentUserId = 'user_test';
+let currentIsStaticAdmin = false;
 
 function makeApp() {
   const brandDb = {
@@ -103,6 +105,7 @@ describe('GET /api/brand-logos/pending', () => {
     mocks.isModerator.mockReset();
     mocks.getPending.mockReset();
     currentUserId = 'user_test';
+    currentIsStaticAdmin = false;
   });
 
   it('403s non-moderators', async () => {
@@ -145,6 +148,24 @@ describe('GET /api/brand-logos/pending', () => {
     });
   });
 
+  it('allows the static admin principal to list the queue', async () => {
+    currentUserId = 'admin_api_key';
+    currentIsStaticAdmin = true;
+    mocks.isModerator.mockResolvedValue(false);
+    mocks.getPending.mockResolvedValue([]);
+    const res = await request(makeApp()).get('/api/brand-logos/pending');
+    expect(res.status).toBe(200);
+    expect(mocks.isModerator).not.toHaveBeenCalled();
+  });
+
+  it('does not trust the static admin user id without validated credential state', async () => {
+    currentUserId = 'admin_api_key';
+    mocks.isModerator.mockResolvedValue(false);
+    const res = await request(makeApp()).get('/api/brand-logos/pending');
+    expect(res.status).toBe(403);
+    expect(mocks.getPending).not.toHaveBeenCalled();
+  });
+
   it('clamps limit to a sane upper bound and rejects negative offset', async () => {
     mocks.isModerator.mockResolvedValue(true);
     mocks.getPending.mockResolvedValue([]);
@@ -158,6 +179,8 @@ describe('GET /api/brand-logos/:id/preview', () => {
     mocks.isModerator.mockReset();
     mocks.isOwner.mockReset();
     mocks.getLogoById.mockReset();
+    currentUserId = 'user_test';
+    currentIsStaticAdmin = false;
   });
 
   it('400s on a non-uuid id', async () => {
@@ -181,6 +204,37 @@ describe('GET /api/brand-logos/:id/preview', () => {
     // approval/rejection/deletion mid-cache.
     expect(res.headers['cache-control']).toBe('private, no-store');
     expect(res.body).toBeInstanceOf(Buffer);
+  });
+
+  it('serves pending bytes to the static admin principal', async () => {
+    currentUserId = 'admin_api_key';
+    currentIsStaticAdmin = true;
+    mocks.isModerator.mockResolvedValue(false);
+    mocks.getLogoById.mockResolvedValue({
+      id: '66666666-6666-6666-6666-666666666666',
+      domain: 'acme.example',
+      content_type: 'image/png',
+      data: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+      review_status: 'pending',
+    });
+    const res = await request(makeApp()).get('/api/brand-logos/66666666-6666-6666-6666-666666666666/preview');
+    expect(res.status).toBe(200);
+    expect(mocks.isModerator).not.toHaveBeenCalled();
+  });
+
+  it('does not serve pending bytes to the static admin id without validated credential state', async () => {
+    currentUserId = 'admin_api_key';
+    mocks.isModerator.mockResolvedValue(false);
+    mocks.isOwner.mockResolvedValue(false);
+    mocks.getLogoById.mockResolvedValue({
+      id: '77777777-7777-7777-7777-777777777777',
+      domain: 'acme.example',
+      content_type: 'image/png',
+      data: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+      review_status: 'pending',
+    });
+    const res = await request(makeApp()).get('/api/brand-logos/77777777-7777-7777-7777-777777777777/preview');
+    expect(res.status).toBe(403);
   });
 
   it('falls back to owner check when caller is not a moderator', async () => {

--- a/server/tests/unit/brand-logos-upload-auth.test.ts
+++ b/server/tests/unit/brand-logos-upload-auth.test.ts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   rebuildManifestLogos: vi.fn().mockResolvedValue(undefined),
   notifyPendingBrandLogo: vi.fn().mockResolvedValue(null),
   resolvePrimaryOrganization: vi.fn().mockResolvedValue('org_test'),
+  enrichUserWithMembership: vi.fn().mockResolvedValue({ isMember: true }),
 }));
 
 vi.mock('../../src/notifications/registry.js', () => ({
@@ -41,7 +42,7 @@ vi.mock('../../src/services/brand-logo-auth.js', () => ({
 }));
 
 vi.mock('../../src/utils/html-config.js', () => ({
-  enrichUserWithMembership: vi.fn().mockResolvedValue({ isMember: true }),
+  enrichUserWithMembership: (...args: unknown[]) => mocks.enrichUserWithMembership(...args),
 }));
 
 vi.mock('../../src/middleware/rate-limit.js', () => ({
@@ -51,7 +52,16 @@ vi.mock('../../src/middleware/rate-limit.js', () => ({
 vi.mock('../../src/middleware/auth.js', () => ({
   requireAuth: (req: any, _res: unknown, next: () => void) => {
     const apiKeyOrgId = req.headers['x-test-api-key-org-id'];
-    if (typeof apiKeyOrgId === 'string') {
+    if (req.headers['x-test-static-admin'] === 'true') {
+      req.isStaticAdminApiKey = true;
+      req.user = {
+        id: 'admin_api_key',
+        email: 'admin-api-key@internal',
+        firstName: 'Admin',
+        lastName: 'API Key',
+        isMember: false,
+      };
+    } else if (typeof apiKeyOrgId === 'string') {
       req.apiKey = {
         id: 'key_test',
         organizationId: apiKeyOrgId,
@@ -150,6 +160,8 @@ describe('POST /api/brands/:domain/logos write authority', () => {
     mocks.setSlackThreadTs.mockResolvedValue(undefined);
     mocks.resolvePrimaryOrganization.mockReset();
     mocks.resolvePrimaryOrganization.mockResolvedValue('org_test');
+    mocks.enrichUserWithMembership.mockReset();
+    mocks.enrichUserWithMembership.mockResolvedValue({ isMember: true });
     mocks.insertLogo.mockImplementation(async (input) => ({
       id: 'logo_test_id',
       ...input,
@@ -234,6 +246,89 @@ describe('POST /api/brands/:domain/logos write authority', () => {
     );
     expect(mocks.resolvePrimaryOrganization).not.toHaveBeenCalled();
     expect(mocks.notifyPendingBrandLogo).not.toHaveBeenCalled();
+  });
+
+  it('allows the static admin key to repair a verified owner logo', async () => {
+    const { app, brandDb } = makeApp({
+      hostedBrand: { workos_organization_id: 'org_owner', domain_verified: true },
+      isOwner: false,
+    });
+    const res = await request(app)
+      .post('/api/brands/example.com/logos')
+      .set('x-test-static-admin', 'true')
+      .field('tags', 'primary')
+      .attach('file', MINIMAL_PNG, { filename: 'logo.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.review_status).toBe('approved');
+    expect(mocks.insertLogo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'brand_owner',
+        review_status: 'approved',
+        uploaded_by_user_id: 'admin_api_key',
+        uploaded_by_org_id: 'org_owner',
+        source_flow: 'static_admin_logo_upload',
+        provenance: expect.objectContaining({
+          approval_path: 'static_admin_support_action',
+          source_flow: 'static_admin_logo_upload',
+          uploader_path: 'admin',
+        }),
+      }),
+    );
+    expect(mocks.enrichUserWithMembership).not.toHaveBeenCalled();
+    expect(mocks.isVerifiedOwner).not.toHaveBeenCalled();
+    expect(brandDb.editDiscoveredBrand).toHaveBeenCalledWith(
+      'example.com',
+      expect.objectContaining({ edit_summary: expect.stringContaining('static admin support action — approved') }),
+    );
+  });
+
+  it('allows the static admin key to repair an unverified member brand', async () => {
+    const { app } = makeApp({
+      hostedBrand: { workos_organization_id: 'org_owner', domain_verified: false },
+      isOwner: false,
+    });
+    const res = await request(app)
+      .post('/api/brands/example.com/logos')
+      .set('x-test-static-admin', 'true')
+      .field('tags', 'primary')
+      .attach('file', MINIMAL_PNG, { filename: 'logo.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.review_status).toBe('approved');
+    expect(mocks.insertLogo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'brand_owner',
+        uploaded_by_org_id: 'org_owner',
+        source_flow: 'static_admin_logo_upload',
+      }),
+    );
+    expect(mocks.enrichUserWithMembership).not.toHaveBeenCalled();
+    expect(mocks.isVerifiedOwner).not.toHaveBeenCalled();
+  });
+
+  it('keeps an admin-approved unowned upload out of owner-attested provenance', async () => {
+    const { app } = makeApp({ hostedBrand: null, isOwner: false });
+    const res = await request(app)
+      .post('/api/brands/example.com/logos')
+      .set('x-test-static-admin', 'true')
+      .field('tags', 'primary')
+      .attach('file', MINIMAL_PNG, { filename: 'logo.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.review_status).toBe('approved');
+    expect(mocks.insertLogo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'community',
+        review_status: 'approved',
+        uploaded_by_org_id: undefined,
+        source_flow: 'static_admin_logo_upload',
+        provenance: expect.objectContaining({
+          approval_path: 'static_admin_support_action',
+          uploader_path: 'admin',
+        }),
+      }),
+    );
   });
 
   it('queues community uploads as pending when no verified owner exists', async () => {


### PR DESCRIPTION
## Summary

- restore brand-logo uploads made with the validated static admin API key
- preserve truthful owner and static-admin provenance while auto-approving support uploads
- allow validated static admins to access the logo moderation queue and previews
- cover hosted, unverified, unowned, and authorization edge cases

## Validation

- code-review expert: approved
- Node.js testing expert: approved
- `npm run typecheck`
- full pre-commit suite: 426 files, 5,965 tests passed (30 skipped)
- focused brand-logo suite: 49 tests passed
