### PR TITLE
fix(crawler): allow profiles for member-registered agents

### DIFF
--- a/server/src/db/migrations/544_drop_agent_inventory_profiles_discovered_agent_fk.sql
+++ b/server/src/db/migrations/544_drop_agent_inventory_profiles_discovered_agent_fk.sql
@@ -1,0 +1,11 @@
+-- Inventory profiles are built for public agents registered in member_profiles.
+-- A registered agent may also appear in discovered_agents when a publisher's
+-- adagents.json names it, but that discovery row is neither required nor the
+-- source of truth for registry enrollment. Requiring it as a parent therefore
+-- makes valid member-only agents fail the crawler's profile materialization.
+--
+-- Keep agent_url as the profile's primary key, but do not attach it to one of
+-- the several registries from which an agent can originate.
+
+ALTER TABLE agent_inventory_profiles
+  DROP CONSTRAINT IF EXISTS agent_inventory_profiles_agent_url_fkey;

--- a/server/tests/integration/registry-search.test.ts
+++ b/server/tests/integration/registry-search.test.ts
@@ -72,6 +72,8 @@ const TEST_PROFILES: ProfileUpsertInput[] = [
   },
 ];
 
+const MEMBER_ONLY_AGENT = 'https://member-only-agent.example.com';
+
 describe('Registry Search Integration Tests', () => {
   let pool: Pool;
   let profilesDb: AgentInventoryProfilesDatabase;
@@ -95,7 +97,8 @@ describe('Registry Search Integration Tests', () => {
   });
 
   afterAll(async () => {
-    // Clean up in reverse FK order
+    // Clean up test fixtures.
+    await pool.query('DELETE FROM agent_inventory_profiles WHERE agent_url = $1', [MEMBER_ONLY_AGENT]);
     for (const p of TEST_PROFILES) {
       await pool.query('DELETE FROM agent_inventory_profiles WHERE agent_url = $1', [p.agent_url]);
       await pool.query('DELETE FROM discovered_agents WHERE agent_url = $1', [p.agent_url]);
@@ -257,6 +260,23 @@ describe('Registry Search Integration Tests', () => {
       const result = await profilesDb.search({ channels: ['ctv'] });
       const countA = result.results.filter(r => r.agent_url === 'https://agent-a.example.com').length;
       expect(countA).toBe(1);
+    });
+  });
+
+  describe('member-profile agents', () => {
+    it('batch-upserts a profile without a discovered_agents row', async () => {
+      await pool.query('DELETE FROM agent_inventory_profiles WHERE agent_url = $1', [MEMBER_ONLY_AGENT]);
+      await pool.query('DELETE FROM discovered_agents WHERE agent_url = $1', [MEMBER_ONLY_AGENT]);
+
+      const persisted = await profilesDb.upsertProfiles([{
+        agent_url: MEMBER_ONLY_AGENT,
+        channels: ['display'],
+        property_count: 1,
+        publisher_count: 1,
+      }]);
+
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0].agent_url).toBe(MEMBER_ONLY_AGENT);
     });
   });
 


### PR DESCRIPTION
## Summary

- remove the invalid foreign key from `agent_inventory_profiles.agent_url` to `discovered_agents.agent_url`
- retain `agent_url` as the inventory profile primary key
- cover batch profile materialization for a member-registered agent with no discovery row

## Root cause

The crawler builds inventory profiles for public agents registered in `member_profiles`, while the profile table required every agent URL to exist in `discovered_agents`. A valid registered agent does not necessarily have a discovery row, so batch profile upserts failed with `agent_inventory_profiles_agent_url_fkey`.

## Impact

Member-registered agents can now have inventory profiles materialized without first appearing in publisher discovery data, preventing the crawler worker from aborting on valid registry state.

## Validation

- `npm run test:migrations`
- focused crawler and inventory-profile unit tests: 23 passed
- registry-search integration suite against fresh PostgreSQL: 15 passed
- repository precommit suite: 1,042 general tests and 5,965 server tests passed
- `npm run typecheck`
