### PR TITLE
fix(councils): allow staff joins and link membership

### DIFF
--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -130,6 +130,22 @@
       margin-bottom: var(--space-6);
     }
 
+    .join-notice {
+      flex-basis: 100%;
+      padding: var(--space-3) var(--space-4);
+      border: var(--border-1) solid var(--color-warning-300);
+      border-radius: var(--radius-md);
+      background: var(--color-warning-bg);
+      color: var(--color-warning-fg);
+      font-size: var(--text-sm);
+    }
+
+    .join-notice a {
+      color: inherit;
+      font-weight: var(--font-semibold);
+      text-decoration: underline;
+    }
+
     .btn {
       display: inline-flex;
       align-items: center;
@@ -1196,6 +1212,11 @@
           <div id="loginPromptInline" style="display: none;">
             <a href="/auth/login" class="btn btn-secondary">Log in to join</a>
           </div>
+          <div id="joinNotice" class="join-notice" role="alert" aria-atomic="true" hidden>
+            <span id="joinNoticeMessage"></span>
+            <a id="joinNoticeLink" href="" hidden></a>
+            <span id="joinNoticeSuffix"></span>
+          </div>
         </div>
 
         <!-- Leadership -->
@@ -2191,6 +2212,33 @@
         currentGroup.committee_type === 'council' ? 'Join Council' : 'Join Working Group';
     }
 
+    function hideJoinNotice() {
+      document.getElementById('joinNotice').hidden = true;
+    }
+
+    function showJoinNotice(data) {
+      const notice = document.getElementById('joinNotice');
+      const message = document.getElementById('joinNoticeMessage');
+      const link = document.getElementById('joinNoticeLink');
+      const suffix = document.getElementById('joinNoticeSuffix');
+      const ctaUrl = safeExternalHttpUrl(data?.cta_url);
+
+      message.textContent = data?.message || data?.error || 'Failed to join group';
+      link.hidden = !ctaUrl;
+      link.removeAttribute('href');
+      link.textContent = '';
+      suffix.textContent = '';
+
+      if (ctaUrl) {
+        message.textContent += ' ';
+        link.href = ctaUrl;
+        link.textContent = data.cta_label || 'Learn more';
+        suffix.textContent = data.cta_suffix ? ` ${data.cta_suffix}` : '';
+      }
+
+      notice.hidden = false;
+    }
+
     async function joinGroup() {
       if (!currentUser) {
         window.location.href = `/auth/login?return_to=${encodeURIComponent(window.location.pathname)}`;
@@ -2198,6 +2246,7 @@
       }
 
       const joinBtn = document.getElementById('joinBtn');
+      hideJoinNotice();
       joinBtn.disabled = true;
       document.getElementById('joinBtnLabel').textContent = 'Joining...';
 
@@ -2219,12 +2268,12 @@
           await loadWorkingGroup();
         } else {
           const data = await response.json();
-          alert(data.message || data.error || 'Failed to join group');
+          showJoinNotice(data);
           resetJoinButton();
         }
       } catch (error) {
         console.error('Error joining group:', error);
-        alert('Failed to join group');
+        showJoinNotice({ error: 'Failed to join group' });
         resetJoinButton();
       }
     }

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.9';
+export const CODE_VERSION = '2026.08.10';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -111,7 +111,8 @@ import {
   withdrawCommitteeInterest as withdrawCommitteeInterestService,
   listMyWorkingGroups as listMyWorkingGroupsService,
   listMyCommitteeInterests as listMyCommitteeInterestsService,
-  MASTERMIND_COUNCIL_MEMBERSHIP_NOTICE,
+  MASTERMIND_COUNCIL_MEMBERSHIP_DENIAL,
+  MASTERMIND_COUNCIL_MEMBERSHIP_URL,
   WorkingGroupMembershipError,
 } from '../../services/working-group-membership-service.js';
 import { listMyContent as listMyContentService } from '../../services/my-content-service.js';
@@ -2604,7 +2605,7 @@ export function createMemberToolHandlers(
           return `"${error.meta.groupName}" is a private working group that requires an invitation. Use request_working_group_invitation to request access.`;
         }
         if (error.is('council_membership_required')) {
-          return MASTERMIND_COUNCIL_MEMBERSHIP_NOTICE;
+          return `${MASTERMIND_COUNCIL_MEMBERSHIP_DENIAL} [Sign up for membership here](${MASTERMIND_COUNCIL_MEMBERSHIP_URL}) starting at $50 annually.`;
         }
         if (error.is('community_only_seat_blocked')) {
           return `Joining "${error.meta.groupName}" requires a contributor seat. Ask your org admin to upgrade your access.`;

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -40,7 +40,8 @@ import {
   withdrawCommitteeInterest as withdrawCommitteeInterestService,
   listMyWorkingGroups as listMyWorkingGroupsService,
   listMyCommitteeInterests as listMyCommitteeInterestsService,
-  MASTERMIND_COUNCIL_MEMBERSHIP_NOTICE,
+  MASTERMIND_COUNCIL_MEMBERSHIP_DENIAL,
+  MASTERMIND_COUNCIL_MEMBERSHIP_URL,
   WorkingGroupMembershipError,
 } from "../services/working-group-membership-service.js";
 import {
@@ -1205,7 +1206,10 @@ export function createCommitteeRouters(): {
         if (error.is('council_membership_required')) {
           return res.status(403).json({
             error: 'Paid membership required',
-            message: MASTERMIND_COUNCIL_MEMBERSHIP_NOTICE,
+            message: MASTERMIND_COUNCIL_MEMBERSHIP_DENIAL,
+            cta_url: MASTERMIND_COUNCIL_MEMBERSHIP_URL,
+            cta_label: 'Sign up for membership here',
+            cta_suffix: 'starting at $50 annually.',
           });
         }
         if (error.is('community_only_seat_blocked')) {

--- a/server/src/services/working-group-membership-service.ts
+++ b/server/src/services/working-group-membership-service.ts
@@ -43,6 +43,10 @@ const workingGroupDb = new WorkingGroupDatabase();
 
 export const MASTERMIND_COUNCIL_MEMBERSHIP_NOTICE =
   'Our Mastermind Councils are for paying member tiers only. AgenticAdvertising.org membership starts at $50 annually.';
+export const MASTERMIND_COUNCIL_MEMBERSHIP_DENIAL =
+  'Our Mastermind Councils are for paying member tiers only.';
+export const MASTERMIND_COUNCIL_MEMBERSHIP_URL =
+  'https://agenticadvertising.org/membership#:~:text=Membership%20pricing,-Explorer';
 
 /**
  * Caller identity. Both route (`req.user`) and Addie tool
@@ -139,6 +143,10 @@ function userDisplayName(user: WorkingGroupServiceUser): string {
   return user.email;
 }
 
+function isAgenticAdvertisingStaff(user: WorkingGroupServiceUser): boolean {
+  return user.email.trim().toLowerCase().endsWith('@agenticadvertising.org');
+}
+
 export interface JoinWorkingGroupInput {
   user: WorkingGroupServiceUser;
   slug: string;
@@ -173,7 +181,11 @@ export async function joinWorkingGroup({ user, slug }: JoinWorkingGroupInput): P
     // Mastermind Councils are open to every active paid tier, including the
     // $50 Explorer tier. This is deliberately separate from contributor-seat
     // and API-access eligibility, both of which exclude Explorer.
-    const hasActiveMembership = await hasActiveMembershipForUser(user.id);
+    // The platform organization is the operator, not a Stripe subscriber, so
+    // staff do not have a paid subscription row even though they are eligible
+    // to participate. Keep the exception narrow to authenticated staff email.
+    const hasActiveMembership =
+      isAgenticAdvertisingStaff(user) || (await hasActiveMembershipForUser(user.id));
     if (!hasActiveMembership) {
       throw new WorkingGroupMembershipError(
         'council_membership_required',

--- a/server/tests/unit/mastermind-council-join-route.test.ts
+++ b/server/tests/unit/mastermind-council-join-route.test.ts
@@ -1,0 +1,125 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  joinWorkingGroup: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/auth.js', () => {
+  const requireAuth = (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = {
+      id: 'user_outsider',
+      email: 'mary@endorsable.ai',
+      firstName: 'Mary',
+      lastName: 'Tester',
+    } as Express.Request['user'];
+    next();
+  };
+  const passthrough = (_req: express.Request, _res: express.Response, next: express.NextFunction) => next();
+  return {
+    requireAuth,
+    requireGlobalAdmin: [requireAuth, passthrough, passthrough],
+    optionalAuth: passthrough,
+    createRequireWorkingGroupLeader: () => passthrough,
+    createRequireWorkingGroupMember: () => passthrough,
+  };
+});
+
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class {},
+}));
+vi.mock('../../src/addie/mcp/admin-tools.js', () => ({
+  invalidateWebAdminStatusCache: vi.fn(),
+  isWebUserAAOAdmin: vi.fn().mockResolvedValue(false),
+}));
+vi.mock('../../src/addie/index.js', () => ({ invalidateMemberContextCache: vi.fn() }));
+vi.mock('../../src/addie/jobs/committee-document-indexer.js', () => ({ reindexDocument: vi.fn() }));
+vi.mock('../../src/addie/mcp/docs-indexer.js', () => ({ refreshWorkingGroupDocs: vi.fn() }));
+vi.mock('../../src/slack/sync.js', () => ({
+  syncWorkingGroupMembersFromSlack: vi.fn(),
+  syncAllWorkingGroupMembersFromSlack: vi.fn(),
+}));
+vi.mock('../../src/notifications/slack.js', () => ({ notifyPublishedPost: vi.fn() }));
+vi.mock('../../src/notifications/notification-service.js', () => ({ notifyUser: vi.fn() }));
+vi.mock('../../src/slack/client.js', () => ({
+  createChannel: vi.fn(),
+  setChannelPurpose: vi.fn(),
+  sendChannelMessage: vi.fn(),
+  inviteToChannel: vi.fn(),
+  isSlackConfigured: vi.fn(() => false),
+}));
+vi.mock('../../src/addie/services/wg-welcome.js', () => ({ sendWgWelcomeMessage: vi.fn() }));
+vi.mock('../../src/services/working-group-membership-service.js', () => {
+  class WorkingGroupMembershipError extends Error {
+    constructor(
+      readonly code: string,
+      message: string,
+      readonly meta: Record<string, unknown>,
+    ) {
+      super(message);
+    }
+
+    is(code: string): boolean {
+      return this.code === code;
+    }
+  }
+
+  return {
+    joinWorkingGroup: mocks.joinWorkingGroup,
+    expressCommitteeInterest: vi.fn(),
+    withdrawCommitteeInterest: vi.fn(),
+    listMyWorkingGroups: vi.fn(),
+    listMyCommitteeInterests: vi.fn(),
+    MASTERMIND_COUNCIL_MEMBERSHIP_DENIAL: 'Our Mastermind Councils are for paying member tiers only.',
+    MASTERMIND_COUNCIL_MEMBERSHIP_URL:
+      'https://agenticadvertising.org/membership#:~:text=Membership%20pricing,-Explorer',
+    WorkingGroupMembershipError,
+  };
+});
+
+const { createCommitteeRouters } = await import('../../src/routes/committees.js');
+const { WorkingGroupMembershipError } = await import('../../src/services/working-group-membership-service.js');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/working-groups', createCommitteeRouters().publicApiRouter);
+  return app;
+}
+
+describe('Mastermind Council join route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.joinWorkingGroup.mockRejectedValue(
+      new WorkingGroupMembershipError(
+        'council_membership_required',
+        'Paid membership required',
+        { slug: 'growth-council', groupName: 'Growth Council' },
+      ),
+    );
+  });
+
+  it('returns the complete linked membership CTA contract for an unpaid caller', async () => {
+    const response = await request(createApp())
+      .post('/api/working-groups/growth-council/join')
+      .expect(403);
+
+    expect(response.body).toEqual({
+      error: 'Paid membership required',
+      message: 'Our Mastermind Councils are for paying member tiers only.',
+      cta_url: 'https://agenticadvertising.org/membership#:~:text=Membership%20pricing,-Explorer',
+      cta_label: 'Sign up for membership here',
+      cta_suffix: 'starting at $50 annually.',
+    });
+    expect(mocks.joinWorkingGroup).toHaveBeenCalledWith({
+      user: {
+        id: 'user_outsider',
+        email: 'mary@endorsable.ai',
+        firstName: 'Mary',
+        lastName: 'Tester',
+      },
+      slug: 'growth-council',
+    });
+  });
+});

--- a/server/tests/unit/mastermind-council-membership-service.test.ts
+++ b/server/tests/unit/mastermind-council-membership-service.test.ts
@@ -120,6 +120,33 @@ describe('Mastermind Council join membership boundary', () => {
     expect(mocks.sendWelcome).toHaveBeenCalledOnce();
   });
 
+  it('allows authenticated AgenticAdvertising.org staff without a paid subscription row', async () => {
+    const staffUser = { ...user, email: 'Mary@AgenticAdvertising.org' };
+
+    await expect(joinWorkingGroup({ user: staffUser, slug: council.slug })).resolves.toMatchObject({
+      groupId: council.id,
+      groupSlug: council.slug,
+    });
+
+    expect(mocks.hasActiveMembership).not.toHaveBeenCalled();
+    expect(mocks.addMembership).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    'mary@notagenticadvertising.org',
+    'mary@agenticadvertising.org.evil.test',
+    'mary@updates.agenticadvertising.org',
+  ])('does not treat the non-staff domain in %s as staff', async (email) => {
+    const lookalikeUser = { ...user, email };
+
+    await expect(joinWorkingGroup({ user: lookalikeUser, slug: council.slug })).rejects.toMatchObject({
+      code: 'council_membership_required',
+    });
+
+    expect(mocks.hasActiveMembership).toHaveBeenCalledWith(lookalikeUser.id);
+    expect(mocks.addMembership).not.toHaveBeenCalled();
+  });
+
   it('leaves non-council contributor-seat behavior unchanged', async () => {
     mocks.getGroup.mockResolvedValue(workingGroup);
 

--- a/server/tests/unit/mastermind-council-surfaces.test.ts
+++ b/server/tests/unit/mastermind-council-surfaces.test.ts
@@ -1,16 +1,27 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { JSDOM } from 'jsdom';
 import { describe, expect, it } from 'vitest';
 
 const root = process.cwd();
 const committees = readFileSync(join(root, 'server/public/committees.html'), 'utf8');
 const detail = readFileSync(join(root, 'server/public/working-groups/detail.html'), 'utf8');
 const markdownHelper = readFileSync(join(root, 'server/public/js/markdown-to-plain-text.js'), 'utf8');
+const externalUrlHelper = readFileSync(join(root, 'server/public/external-url.js'), 'utf8');
 const service = readFileSync(join(root, 'server/src/services/working-group-membership-service.ts'), 'utf8');
 const route = readFileSync(join(root, 'server/src/routes/committees.ts'), 'utf8');
 const addie = readFileSync(join(root, 'server/src/addie/mcp/member-tools.ts'), 'utf8');
 
 const notice = 'Our Mastermind Councils are for paying member tiers only. AgenticAdvertising.org membership starts at $50 annually.';
+
+function sourceSection(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  if (startIndex < 0 || endIndex < 0) {
+    throw new Error(`Could not extract source section from ${start} to ${end}`);
+  }
+  return source.slice(startIndex, endIndex);
+}
 
 describe('Mastermind Council public and adapter surfaces', () => {
   it('uses the requested Council landing-page copy while preserving other type copy', () => {
@@ -49,10 +60,64 @@ describe('Mastermind Council public and adapter surfaces', () => {
     expect(detail.match(/resetJoinButton\(\);/g)).toHaveLength(4);
   });
 
-  it('shares the exact denial notice across HTTP, browser, and Addie adapters', () => {
+  it('shares the denial and linked membership CTA across HTTP, browser, and Addie adapters', () => {
     expect(service).toContain(`'${notice}'`);
-    expect(route).toMatch(/error\.is\('council_membership_required'\)[\s\S]*?res\.status\(403\)[\s\S]*?message: MASTERMIND_COUNCIL_MEMBERSHIP_NOTICE/);
-    expect(detail).toContain("alert(data.message || data.error || 'Failed to join group')");
-    expect(addie).toMatch(/error\.is\('council_membership_required'\)[\s\S]*?return MASTERMIND_COUNCIL_MEMBERSHIP_NOTICE/);
+    expect(route).toMatch(/error\.is\('council_membership_required'\)[\s\S]*?res\.status\(403\)[\s\S]*?cta_url: MASTERMIND_COUNCIL_MEMBERSHIP_URL/);
+    expect(detail).toContain('id="joinNotice" class="join-notice" role="alert" aria-atomic="true" hidden');
+    expect(detail).toContain('const ctaUrl = safeExternalHttpUrl(data?.cta_url);');
+    expect(detail).toContain("message.textContent = data?.message || data?.error || 'Failed to join group';");
+    expect(detail).toContain("link.textContent = data.cta_label || 'Learn more';");
+    expect(detail).toContain("suffix.textContent = data.cta_suffix ? ` ${data.cta_suffix}` : '';");
+    expect(detail).toContain('showJoinNotice(data);');
+    expect(detail).not.toContain("alert(data.message || data.error || 'Failed to join group')");
+    expect(addie).toMatch(/error\.is\('council_membership_required'\)[\s\S]*?\[Sign up for membership here\]\(\$\{MASTERMIND_COUNCIL_MEMBERSHIP_URL\}\)/);
+  });
+
+  it('renders the council denial as safe inline text and an allowlisted membership link', () => {
+    const dom = new JSDOM(`
+      <div id="joinNotice" hidden>
+        <span id="joinNoticeMessage"></span>
+        <a id="joinNoticeLink" href="" hidden></a>
+        <span id="joinNoticeSuffix"></span>
+      </div>
+    `, { url: 'https://agenticadvertising.org/working-groups/growth-council' });
+    const browserGlobal: Record<string, unknown> = {};
+    new Function('window', externalUrlHelper)(browserGlobal);
+    const safeExternalHttpUrl = browserGlobal.safeExternalHttpUrl as (value: unknown) => string | null;
+    const noticeFunctions = sourceSection(detail, 'function hideJoinNotice()', 'async function joinGroup()');
+    const { showJoinNotice } = new Function(
+      'document',
+      'safeExternalHttpUrl',
+      `${noticeFunctions}\nreturn { showJoinNotice, hideJoinNotice };`,
+    )(dom.window.document, safeExternalHttpUrl) as {
+      showJoinNotice: (data: Record<string, string>) => void;
+    };
+
+    showJoinNotice({
+      message: '<img src=x onerror="globalThis.__councilXss = true">',
+      cta_url: 'javascript:globalThis.__councilXss = true',
+      cta_label: 'Unsafe link',
+      cta_suffix: 'unsafe suffix',
+    });
+
+    const noticeElement = dom.window.document.getElementById('joinNotice')!;
+    const link = dom.window.document.getElementById('joinNoticeLink') as HTMLAnchorElement;
+    expect(noticeElement.hidden).toBe(false);
+    expect(noticeElement.textContent).toContain('<img src=x onerror="globalThis.__councilXss = true">');
+    expect(noticeElement.querySelector('img')).toBeNull();
+    expect(link.hidden).toBe(true);
+    expect(link.hasAttribute('href')).toBe(false);
+
+    showJoinNotice({
+      message: 'Our Mastermind Councils are for paying member tiers only.',
+      cta_url: 'https://agenticadvertising.org/membership#:~:text=Membership%20pricing,-Explorer',
+      cta_label: 'Sign up for membership here',
+      cta_suffix: 'starting at $50 annually.',
+    });
+
+    expect(link.hidden).toBe(false);
+    expect(link.href).toBe('https://agenticadvertising.org/membership#:~:text=Membership%20pricing,-Explorer');
+    expect(link.textContent).toBe('Sign up for membership here');
+    expect(noticeElement.textContent).toContain('starting at $50 annually.');
   });
 });

--- a/server/tests/unit/public-external-url-sinks.test.ts
+++ b/server/tests/unit/public-external-url-sinks.test.ts
@@ -118,6 +118,7 @@ describe('public external URL navigation guard', () => {
     ['working-groups/detail.html', 'safeExternalHttpUrl(currentGroup.slack_channel_url)'],
     ['working-groups/detail.html', 'safeExternalHttpUrl(meeting.zoom_join_url)'],
     ['working-groups/detail.html', 'safeExternalHttpUrl(doc.document_url)'],
+    ['working-groups/detail.html', 'safeExternalHttpUrl(data?.cta_url)'],
     ['admin-account-detail.html', 'safeExternalHttpUrl(pendingInvoice.hosted_invoice_url)'],
     ['chat.html', 'safeExternalHttpUrl(data.url)'],
     ['chat.html', 'safeExternalHttpUrl(item.url)'],

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -1245,6 +1245,23 @@ describe('createMemberToolHandlers', () => {
       expect(result).toContain('Media Buying Protocol');
     });
 
+    it('join_working_group renders a linked membership CTA for council denials', async () => {
+      vi.spyOn(wgService, 'joinWorkingGroup').mockRejectedValue(
+        new wgService.WorkingGroupMembershipError('council_membership_required', 'Paid membership required', {
+          slug: 'growth-council',
+          groupName: 'Growth Council',
+        }),
+      );
+      const handlers = createMemberToolHandlers(memberCtx);
+      const result = await handlers.get('join_working_group')!({ slug: 'growth-council' });
+
+      expect(result).toBe(
+        'Our Mastermind Councils are for paying member tiers only. ' +
+          '[Sign up for membership here](https://agenticadvertising.org/membership#:~:text=Membership%20pricing,-Explorer) ' +
+          'starting at $50 annually.',
+      );
+    });
+
     it('join_working_group disambiguates private vs not-found vs already-member by code, not status', async () => {
       // Private group
       vi.spyOn(wgService, 'joinWorkingGroup').mockRejectedValueOnce(


### PR DESCRIPTION
## Summary

- allow authenticated `@agenticadvertising.org` staff to join Mastermind Councils without a Stripe subscription row
- return a structured membership CTA for unpaid callers and render it as an accessible inline notice
- keep the browser CTA safe with text-only rendering and the shared external URL allowlist
- add service, Express route, JSDOM, URL-sink, and Addie regression coverage

## Root cause

The platform organization intentionally has no paid subscription row, so its staff were rejected by the same membership lookup used for outside participants. The unpaid response also exposed the signup destination only as unlinked copy.

## Impact

AgenticAdvertising.org staff can join active public councils, while other unpaid users still receive a denial with a clickable membership signup link. Private-group and non-council membership rules are unchanged.

## Validation

- full pre-commit suite: 5,972 passed, 30 skipped
- focused council server suite: 42 passed
- Addie member-tools suite: 62 passed
- TypeScript typecheck
- `git diff --check`
- code, UI, and security expert review

Closes #6366
