### PR TITLE
fix(compliance): preserve scoped capabilities during adaptation

### DIFF
--- a/.agents/sdk-shim-ledger.json
+++ b/.agents/sdk-shim-ledger.json
@@ -45,17 +45,19 @@
     "kind": "installed_sdk_runtime_patch",
     "status": "temporary",
     "owner": "training-agent",
-    "upstream": "adcontextprotocol/adcp-client#2495",
-    "problem": "The rc.15 storyboard task map forces get_products onto a legacy-only wire even though the AdCP 3.1 migration scenario grades the transitional dual response. The installed runtime must leave this wire selection unspecified while retaining explicit legacy routing for other creative tasks.",
-    "localBehavior": "Patch both compiled SDK module formats after installation so the storyboard runner leaves get_products wire selection unspecified while retaining explicit legacy routing for other creative tasks.",
-    "removalCondition": "Remove the patch script, Docker invocations, and ledger entry after an SDK release stops injecting the legacy-only wire hint for storyboard get_products and both current and released-3.0 storyboard matrices pass without the patch.",
+    "upstream": "adcontextprotocol/adcp-client#2495, adcontextprotocol/adcp-client#2527",
+    "problem": "The rc.17 storyboard task map forces get_products onto a legacy-only wire, and scoped transports discover capabilities without carrying them into request adaptation. The latter makes 3.1 sellers look pre-3.1 and strips filters.pricing_currencies.",
+    "localBehavior": "Patch both compiled SDK module formats after installation so the storyboard runner leaves get_products wire selection unspecified and request-local capabilities drive version adaptation without cross-tenant caching.",
+    "removalCondition": "Remove the patch script, Docker invocations, and ledger entry after an SDK release fixes storyboard get_products routing and carries scoped capabilities into request adaptation, and both current and released-3.0 storyboard matrices pass without the patch.",
     "paths": [
       "scripts/patch-sdk-rc15.mjs",
       "tests/patch-sdk-rc15.test.cjs"
     ],
     "terms": [
       "node_modules/@adcp/sdk/dist/lib/testing/storyboard/task-map.js",
-      "node_modules/@adcp/sdk/dist/lib/testing/storyboard/task-map.mjs"
+      "node_modules/@adcp/sdk/dist/lib/testing/storyboard/task-map.mjs",
+      "node_modules/@adcp/sdk/dist/lib/core/SingleAgentClient.js",
+      "node_modules/@adcp/sdk/dist/lib/core/SingleAgentClient.mjs"
     ]
   }
 ]

--- a/scripts/patch-sdk-rc15.mjs
+++ b/scripts/patch-sdk-rc15.mjs
@@ -5,20 +5,37 @@ import path from 'node:path';
 
 // This temporary patch remains version-locked even though its filename dates
 // from the release where it was introduced. Remove it when the upstream
-// get_products routing fix ships.
+// get_products routing and scoped capability propagation fixes ship.
 const EXPECTED_VERSION = '13.0.0-rc.17';
 const packageJson = JSON.parse(fs.readFileSync(path.resolve('node_modules/@adcp/sdk/package.json'), 'utf8'));
 
 if (packageJson.version !== EXPECTED_VERSION) {
   throw new Error(
     `Refusing to patch @adcp/sdk ${packageJson.version}; expected ${EXPECTED_VERSION}. ` +
-    'Remove this patcher when the upstream storyboard get_products routing fix ships.',
+    'Remove this patcher when the upstream storyboard routing and scoped capability fixes ship.',
   );
 }
 
 const storyboardTaskMapFiles = [
   'node_modules/@adcp/sdk/dist/lib/testing/storyboard/task-map.js',
   'node_modules/@adcp/sdk/dist/lib/testing/storyboard/task-map.mjs',
+];
+
+const singleAgentClientFiles = [
+  {
+    relative: 'node_modules/@adcp/sdk/dist/lib/core/SingleAgentClient.js',
+    resolveAdapterOriginal:
+      '    const adapterKey = (0, import_version2.resolveAdapterKey)(this.resolvedAdcpVersion, this.cachedCapabilities);',
+    resolveAdapterPatched:
+      '    const adapterKey = (0, import_version2.resolveAdapterKey)(this.resolvedAdcpVersion, perCallCapabilities ?? this.cachedCapabilities);',
+  },
+  {
+    relative: 'node_modules/@adcp/sdk/dist/lib/core/SingleAgentClient.mjs',
+    resolveAdapterOriginal:
+      '    const adapterKey = resolveAdapterKey(this.resolvedAdcpVersion, this.cachedCapabilities);',
+    resolveAdapterPatched:
+      '    const adapterKey = resolveAdapterKey(this.resolvedAdcpVersion, perCallCapabilities ?? this.cachedCapabilities);',
+  },
 ];
 
 const originalCallParams = '  const callParams = legacyMethodName ? withLegacyCreativeWireHint(params) : params;';
@@ -28,37 +45,82 @@ function countOccurrences(source, token) {
   return source.split(token).length - 1;
 }
 
-const storyboardTaskMaps = storyboardTaskMapFiles.map(relative => {
+function preparePatch(relative, replacements) {
   const file = path.resolve(relative);
   const source = fs.readFileSync(file, 'utf8');
-  const originalCount = countOccurrences(source, originalCallParams);
-  const patchedCount = countOccurrences(source, patchedCallParams);
-  const needsPatch = originalCount === 1 && patchedCount === 0;
-  const alreadyPatched = originalCount === 0 && patchedCount === 1;
-  if (!needsPatch && !alreadyPatched) {
-    throw new Error(`Unexpected ${EXPECTED_VERSION} storyboard task-map shape in ${relative}`);
+  const states = replacements.map(({ original, patched, expectedCount = 1 }) => {
+    const originalCount = countOccurrences(source, original);
+    const patchedCount = countOccurrences(source, patched);
+    const needsPatch = originalCount === expectedCount && patchedCount === 0;
+    const alreadyPatched = originalCount === 0 && patchedCount === expectedCount;
+    if (!needsPatch && !alreadyPatched) {
+      throw new Error(`Unexpected ${EXPECTED_VERSION} SDK shape in ${relative}`);
+    }
+    return needsPatch ? 'original' : 'patched';
+  });
+  if (new Set(states).size !== 1) {
+    throw new Error(`Mixed ${EXPECTED_VERSION} SDK patch state in ${relative}`);
   }
-  return {
-    file,
-    source,
-    output: needsPatch ? source.replace(originalCallParams, patchedCallParams) : source,
-  };
-});
+  const output = states[0] === 'original'
+    ? replacements.reduce((current, { original, patched }) => current.replaceAll(original, patched), source)
+    : source;
+  return { file, source, output, replacements };
+}
+
+const storyboardTaskMaps = storyboardTaskMapFiles.map(relative => preparePatch(relative, [{
+  original: originalCallParams,
+  patched: patchedCallParams,
+}]));
+
+const adaptRequestSignature =
+  '  adaptRequest(taskType, params, serverVersion, debugLogs, perCallToolSchemas) {';
+const patchedAdaptRequestSignature =
+  '  adaptRequest(taskType, params, serverVersion, debugLogs, perCallToolSchemas, perCallCapabilities) {';
+const perCallToolSchemasArgument = 'capabilityDiscoveryContext.toolSchemas\n';
+const patchedPerCallToolSchemasArgument =
+  'capabilityDiscoveryContext.toolSchemas, capabilityDiscoveryContext.capabilities\n';
+const detectServerVersion = `  async detectServerVersion(options) {
+    const capabilities = await this.getCapabilities(options);
+    return capabilities.version;
+  }`;
+const patchedDetectServerVersion = `  async detectServerVersion(options) {
+    const capabilities = await this.getCapabilities(options);
+    const discoveryContext = options?.[CAPABILITY_DISCOVERY_CONTEXT];
+    if (discoveryContext) discoveryContext.capabilities = capabilities;
+    return capabilities.version;
+  }`;
+
+const singleAgentClients = singleAgentClientFiles.map(({
+  relative,
+  resolveAdapterOriginal,
+  resolveAdapterPatched,
+}) => preparePatch(relative, [
+  {
+    original: perCallToolSchemasArgument,
+    patched: patchedPerCallToolSchemasArgument,
+    expectedCount: 2,
+  },
+  { original: adaptRequestSignature, patched: patchedAdaptRequestSignature },
+  { original: resolveAdapterOriginal, patched: resolveAdapterPatched },
+  { original: detectServerVersion, patched: patchedDetectServerVersion },
+]));
 
 // Validate both module formats before writing either one so a corrupt or
 // unexpected SDK artifact cannot leave the install only partially patched.
-for (const { file, source, output } of storyboardTaskMaps) {
+for (const { file, source, output } of [...storyboardTaskMaps, ...singleAgentClients]) {
   if (output !== source) {
     fs.writeFileSync(file, output);
   }
 }
 
-for (const relative of storyboardTaskMapFiles) {
-  const source = fs.readFileSync(path.resolve(relative), 'utf8');
-  if (
-    countOccurrences(source, originalCallParams) !== 0 ||
-    countOccurrences(source, patchedCallParams) !== 1
-  ) {
-    throw new Error(`@adcp/sdk ${EXPECTED_VERSION} storyboard task-map patch verification failed for ${relative}`);
+for (const { file, replacements } of [...storyboardTaskMaps, ...singleAgentClients]) {
+  const source = fs.readFileSync(file, 'utf8');
+  for (const { original, patched, expectedCount = 1 } of replacements) {
+    if (
+      countOccurrences(source, original) !== 0 ||
+      countOccurrences(source, patched) !== expectedCount
+    ) {
+      throw new Error(`@adcp/sdk ${EXPECTED_VERSION} patch verification failed for ${file}`);
+    }
   }
 }

--- a/tests/patch-sdk-rc15.test.cjs
+++ b/tests/patch-sdk-rc15.test.cjs
@@ -11,6 +11,10 @@ const TASK_MAP_FILES = [
   'node_modules/@adcp/sdk/dist/lib/testing/storyboard/task-map.js',
   'node_modules/@adcp/sdk/dist/lib/testing/storyboard/task-map.mjs',
 ];
+const SINGLE_AGENT_CLIENT_FILES = [
+  'node_modules/@adcp/sdk/dist/lib/core/SingleAgentClient.js',
+  'node_modules/@adcp/sdk/dist/lib/core/SingleAgentClient.mjs',
+];
 
 const TASK_MAP_SOURCE = `function withLegacyCreativeWireHint(params) {
   return { ...params, ext: { adcp: { creative_wire: "legacy" } } };
@@ -21,6 +25,31 @@ async function executeStoryboardTask(client, taskName, params) {
   return await client[legacyMethodName](callParams);
 }
 module.exports = { executeStoryboardTask };
+`;
+
+const SINGLE_AGENT_CLIENT_SOURCE = `const CAPABILITY_DISCOVERY_CONTEXT = Symbol("capabilityDiscoveryContext");
+function resolveAdapterKey() {}
+const import_version2 = { resolveAdapterKey };
+class SingleAgentClient {
+  executeCanonical(capabilityDiscoveryContext) {
+    return this.adaptRequest("get_products", {}, "v3", [], capabilityDiscoveryContext.toolSchemas
+    );
+  }
+  executeUnprojected(capabilityDiscoveryContext) {
+    return this.adaptRequest("get_products", {}, "v3", [], capabilityDiscoveryContext.toolSchemas
+    );
+  }
+  adaptRequest(taskType, params, serverVersion, debugLogs, perCallToolSchemas) {
+    const adapterKey = resolveAdapterKey(this.resolvedAdcpVersion, this.cachedCapabilities);
+    return adapterKey;
+  }
+  async getCapabilities() { return { version: "v3" }; }
+  async detectServerVersion(options) {
+    const capabilities = await this.getCapabilities(options);
+    return capabilities.version;
+  }
+}
+module.exports = { SingleAgentClient };
 `;
 
 function writeFixture(version = '13.0.0-rc.17') {
@@ -34,6 +63,17 @@ function writeFixture(version = '13.0.0-rc.17') {
     fs.writeFileSync(file, relative.endsWith('.mjs')
       ? TASK_MAP_SOURCE.replace('module.exports = { executeStoryboardTask };', 'export { executeStoryboardTask };')
       : TASK_MAP_SOURCE);
+  }
+  for (const relative of SINGLE_AGENT_CLIENT_FILES) {
+    const file = path.join(root, relative);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const source = relative.endsWith('.mjs')
+      ? SINGLE_AGENT_CLIENT_SOURCE.replace('module.exports = { SingleAgentClient };', 'export { SingleAgentClient };')
+      : SINGLE_AGENT_CLIENT_SOURCE.replace(
+        '    const adapterKey = resolveAdapterKey(this.resolvedAdcpVersion, this.cachedCapabilities);',
+        '    const adapterKey = (0, import_version2.resolveAdapterKey)(this.resolvedAdcpVersion, this.cachedCapabilities);',
+      );
+    fs.writeFileSync(file, source);
   }
   return root;
 }
@@ -49,9 +89,16 @@ test('hosted SDK patch fixes get_products routing in CJS and ESM idempotently', 
   const first = runPatcher(root);
   assert.equal(first.status, 0, first.stderr);
   const files = TASK_MAP_FILES.map(relative => path.join(root, relative));
+  const clientFiles = SINGLE_AGENT_CLIENT_FILES.map(relative => path.join(root, relative));
   const once = files.map(file => fs.readFileSync(file, 'utf8'));
+  const clientsOnce = clientFiles.map(file => fs.readFileSync(file, 'utf8'));
   for (const source of once) assert.ok(source.includes('taskName !== "get_products"'));
-  for (const file of files) {
+  for (const source of clientsOnce) {
+    assert.ok(source.includes('perCallCapabilities ?? this.cachedCapabilities'));
+    assert.equal((source.match(/capabilityDiscoveryContext\.capabilities/g) ?? []).length, 2);
+    assert.ok(source.includes('discoveryContext.capabilities = capabilities'));
+  }
+  for (const file of [...files, ...clientFiles]) {
     const checked = spawnSync(process.execPath, ['--check', file], { encoding: 'utf8' });
     assert.equal(checked.status, 0, checked.stderr);
   }
@@ -63,9 +110,16 @@ test('hosted SDK patch fixes get_products routing in CJS and ESM idempotently', 
     syncCreativesLegacy: async params => params,
   };
   for (const taskMap of [cjsTaskMap, esmTaskMap]) {
+    const request = {
+      buying_mode: 'wholesale',
+      filters: { pricing_currencies: ['USD'] },
+      fields: ['product_id', 'pricing_options'],
+      account: { account_id: 'account-1' },
+      context: { correlation_id: 'pricing-filter-test' },
+    };
     assert.deepEqual(
-      await taskMap.executeStoryboardTask(client, 'get_products', { buying_mode: 'wholesale' }),
-      { buying_mode: 'wholesale' },
+      await taskMap.executeStoryboardTask(client, 'get_products', request),
+      request,
     );
     assert.deepEqual(
       await taskMap.executeStoryboardTask(client, 'sync_creatives', { creatives: [] }),
@@ -76,6 +130,7 @@ test('hosted SDK patch fixes get_products routing in CJS and ESM idempotently', 
   const second = runPatcher(root);
   assert.equal(second.status, 0, second.stderr);
   assert.deepEqual(files.map(file => fs.readFileSync(file, 'utf8')), once);
+  assert.deepEqual(clientFiles.map(file => fs.readFileSync(file, 'utf8')), clientsOnce);
 });
 
 test('hosted SDK patch refuses an unreviewed SDK version before modifying artifacts', (t) => {
@@ -100,7 +155,7 @@ test('hosted SDK patch rejects an unexpected task-map source shape', (t) => {
 
   const result = runPatcher(root);
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /Unexpected 13\.0\.0-rc\.17 storyboard task-map shape/);
+  assert.match(result.stderr, /Unexpected 13\.0\.0-rc\.17 SDK shape/);
 });
 
 test('hosted SDK patch rejects mixed original and patched call sites before writing either format', (t) => {
@@ -115,7 +170,7 @@ test('hosted SDK patch rejects mixed original and patched call sites before writ
 
   const result = runPatcher(root);
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /Unexpected 13\.0\.0-rc\.17 storyboard task-map shape/);
+  assert.match(result.stderr, /Unexpected 13\.0\.0-rc\.17 SDK shape/);
   assert.equal(fs.readFileSync(cjsFile, 'utf8'), cjsBefore);
 });
 
@@ -130,7 +185,7 @@ test('hosted SDK patch rejects duplicate original call sites before writing eith
 
   const result = runPatcher(root);
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /Unexpected 13\.0\.0-rc\.17 storyboard task-map shape/);
+  assert.match(result.stderr, /Unexpected 13\.0\.0-rc\.17 SDK shape/);
   assert.equal(fs.readFileSync(cjsFile, 'utf8'), cjsBefore);
 });
 
@@ -150,6 +205,117 @@ test('hosted SDK patch preflights both module formats before writing either one'
 
   const result = runPatcher(root);
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /Unexpected 13\.0\.0-rc\.17 storyboard task-map shape/);
+  assert.match(result.stderr, /Unexpected 13\.0\.0-rc\.17 SDK shape/);
   assert.equal(fs.readFileSync(cjsFile, 'utf8'), cjsBefore);
+});
+
+test('hosted SDK patch preflights core clients before writing any artifact', (t) => {
+  const root = writeFixture();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const taskMapFile = path.join(root, TASK_MAP_FILES[0]);
+  const clientFile = path.join(root, SINGLE_AGENT_CLIENT_FILES[1]);
+  const taskMapBefore = fs.readFileSync(taskMapFile, 'utf8');
+  fs.writeFileSync(
+    clientFile,
+    fs.readFileSync(clientFile, 'utf8').replace(
+      '  adaptRequest(taskType, params, serverVersion, debugLogs, perCallToolSchemas) {',
+      '  adaptRequest(taskType, params, serverVersion, debugLogs) {',
+    ),
+  );
+
+  const result = runPatcher(root);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unexpected 13\.0\.0-rc\.17 SDK shape/);
+  assert.equal(fs.readFileSync(taskMapFile, 'utf8'), taskMapBefore);
+});
+
+async function loadInstalledSingleAgentClients() {
+  const cjsPath = path.resolve(__dirname, '..', SINGLE_AGENT_CLIENT_FILES[0]);
+  const esmPath = path.resolve(__dirname, '..', SINGLE_AGENT_CLIENT_FILES[1]);
+  return [
+    require(cjsPath).SingleAgentClient,
+    (await import(pathToFileURL(esmPath).href)).SingleAgentClient,
+  ];
+}
+
+async function runScopedCapabilityCase(SingleAgentClient, supportedVersion, methodName) {
+  const client = new SingleAgentClient({
+    id: `scoped-${supportedVersion}`,
+    name: `Scoped ${supportedVersion}`,
+    agent_uri: 'https://agent.example/mcp',
+    protocol: 'mcp',
+  }, {
+    transport: { fetchFn: async () => { throw new Error('unexpected network call'); } },
+    validation: { requests: 'off', responses: 'off' },
+    validateFeatures: false,
+  });
+  client.ensureEndpointDiscovered = async () => client.normalizedAgent;
+  client.getAgentInfo = async () => ({
+    tools: [
+      { name: 'get_adcp_capabilities', inputSchema: { type: 'object', properties: {} } },
+      {
+        name: 'get_products',
+        inputSchema: {
+          type: 'object',
+          properties: { buying_mode: { type: 'string' }, filters: { type: 'object' } },
+        },
+      },
+    ],
+  });
+  let outbound;
+  client.executor.executeTask = async (_agent, taskName, params) => {
+    if (taskName === 'get_adcp_capabilities') {
+      return {
+        success: true,
+        status: 'completed',
+        data: {
+          adcp: {
+            major_versions: [3],
+            supported_versions: [supportedVersion],
+            build_version: supportedVersion === '3.1' ? '3.1.13' : '3.0.14',
+          },
+          supported_protocols: ['media_buy'],
+        },
+        metadata: { status: 'completed', taskName },
+        debug_logs: [],
+      };
+    }
+    outbound = params;
+    return {
+      success: true,
+      status: 'completed',
+      data: { products: [] },
+      metadata: { status: 'completed', taskName },
+      debug_logs: [],
+    };
+  };
+  const result = await client[methodName]({
+    buying_mode: 'wholesale',
+    filters: { pricing_currencies: ['USD'] },
+  });
+  return { client, outbound, result };
+}
+
+test('installed SDK uses request-local scoped capabilities for get_products adaptation', async () => {
+  for (const SingleAgentClient of await loadInstalledSingleAgentClients()) {
+    for (const methodName of ['getProducts', 'getProductsLegacy']) {
+      const v31 = await runScopedCapabilityCase(SingleAgentClient, '3.1', methodName);
+      assert.deepEqual(v31.outbound.filters, { pricing_currencies: ['USD'] });
+      assert.equal(
+        v31.result.debug_logs?.some(log => log.type === 'pre31_pricing_currencies_stripped'),
+        false,
+      );
+      assert.equal(v31.client.cachedCapabilities, undefined, 'scoped capabilities must remain request-local');
+      assert.equal(v31.client.cachedToolSchemas, undefined, 'scoped tool schemas must remain request-local');
+
+      const v30 = await runScopedCapabilityCase(SingleAgentClient, '3.0', methodName);
+      assert.deepEqual(v30.outbound.filters, {});
+      assert.equal(
+        v30.result.debug_logs?.some(log => log.type === 'pre31_pricing_currencies_stripped'),
+        true,
+      );
+      assert.equal(v30.client.cachedCapabilities, undefined, 'scoped capabilities must remain request-local');
+      assert.equal(v30.client.cachedToolSchemas, undefined, 'scoped tool schemas must remain request-local');
+    }
+  }
 });


### PR DESCRIPTION
## Summary

- carry scoped capability discovery into the same call's SDK request adaptation without populating shared caches
- extend the exact-version, fail-closed rc.17 patch across CJS and ESM `SingleAgentClient` artifacts
- cover canonical and legacy `get_products` paths, 3.1 preservation, genuine 3.0 down-adaptation, cache isolation, idempotence, and all-artifact preflight

## Root cause

Hosted compliance supplies `transport.fetchFn`, so the SDK intentionally avoids caching capabilities across calls. rc.17 carried request-local tool schemas into `adaptRequest()` but discarded the request-local capabilities. Adaptation then saw no cached 3.1 evidence, selected the 3.0 adapter, and stripped `filters.pricing_currencies`.

The fix keeps the discovered capabilities on the existing per-call context. It does not cache them globally, preserving auth/tenant isolation.

Closes #6439.
Upstream SDK fix: adcontextprotocol/adcp-client#2527.
Existing task-map upstream: adcontextprotocol/adcp-client#2495.

## Validation

- `npm run test:sdk-shims` — 12/12
- `npm run precommit` components:
  - repo unit tests — 1,043/1,043
  - server unit tests — 5,972 passed, 30 skipped across 427 files
  - dynamic-import, format-identity, and state-change boundary lints
  - TypeScript typecheck
- pre-push current compliance storyboard matrix — all seven tenants above floors
- pre-push released 3.0.22 compatibility matrix — all seven tenants above floors
- `node scripts/check-changeset-protocol-scope.cjs origin/main` — no protocol changeset required
- code review — no findings
- security review — no vulnerabilities; request-local tenant isolation stress-tested
- protocol review — no functional/version findings; upstream-removal-path note resolved
