### PR TITLE
refactor(addie): extract DM stream reducer

### DIFF
--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -19,7 +19,6 @@ const { App, Assistant, LogLevel } = bolt;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ExpressReceiver = (bolt as any).default?.ExpressReceiver ?? (bolt as any).ExpressReceiver;
 import type { SlackEventMiddlewareArgs } from '@slack/bolt';
-import type { ChatAppendStreamArguments } from '@slack/web-api';
 // Import internal Assistant types for handler signatures
 import type {
   AssistantThreadStartedMiddlewareArgs,
@@ -112,15 +111,19 @@ import {
 import {
   splitMrkdwnIntoSections,
   truncateNotificationText,
-  decideStreamAppend,
   planStreamStopFailureFallback,
   resolveStreamTurnCompletion,
-  summarizeSlackStreamError,
   STREAM_DELIVERY_UNCERTAIN_NOTICE,
   DEFAULT_STREAM_SOFT_CAP,
 } from './slack-blocks.js';
-
-type StreamChunk = NonNullable<ChatAppendStreamArguments['chunks']>[number];
+import {
+  createSlackDmStreamState,
+  interpretSlackDmStreamEvent,
+  planSlackDmTerminalDelivery,
+  resolveSlackDmStreamSoftCap,
+  shouldStopSlackDmStream,
+  type SlackDmStreamInterpreter,
+} from './slack-dm-stream.js';
 
 /**
  * Slack rejects `chat.stopStream` with `msg_too_long` once the cumulative
@@ -133,16 +136,14 @@ type StreamChunk = NonNullable<ChatAppendStreamArguments['chunks']>[number];
  */
 const STREAM_SOFT_CAP = (() => {
   const raw = process.env.ADDIE_STREAM_SOFT_CAP;
-  if (!raw) return DEFAULT_STREAM_SOFT_CAP;
-  const parsed = parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 1000 || parsed > 11000) {
+  const resolution = resolveSlackDmStreamSoftCap(raw, DEFAULT_STREAM_SOFT_CAP);
+  if (resolution.invalid) {
     logger.warn(
       { raw, default: DEFAULT_STREAM_SOFT_CAP },
       'Addie Bolt: ADDIE_STREAM_SOFT_CAP invalid — using default. Must parse as int in [1000, 11000].',
     );
-    return DEFAULT_STREAM_SOFT_CAP;
   }
-  return parsed;
+  return resolution.value;
 })();
 
 const STREAM_CONTINUATION_TAIL = '\n\n_(continued in next message ↓)_';
@@ -898,33 +899,6 @@ async function setAgentViewSuggestedPrompts(client: any, userId: string, channel
     // In Slack's Agent messaging experience, prompts are pinned to the app
     // Messages tab and do not belong to a specific assistant thread.
   });
-}
-
-function formatToolTaskTitle(toolName: string): string {
-  return toolName.trim() ? `Call ${toolName}` : 'Call Addie tool';
-}
-
-function buildPlanTitleChunk(): StreamChunk {
-  return {
-    type: 'plan_update',
-    title: 'Addie is working',
-  };
-}
-
-function buildToolTaskChunk(
-  taskId: string,
-  toolName: string,
-  status: 'in_progress' | 'complete' | 'error',
-): StreamChunk {
-  return {
-    type: 'task_update',
-    id: taskId,
-    title: formatToolTaskTitle(toolName),
-    status,
-    ...(status === 'in_progress'
-      ? { details: `Using Addie tool: ${toolName}` }
-      : { output: status === 'error' ? `Tool failed: ${toolName}` : `Tool completed: ${toolName}` }),
-  };
 }
 
 /**
@@ -1778,23 +1752,16 @@ async function handleUserMessage({
   // Process with Claude using streaming
   let response: AddieResponse | undefined;
   let fullText = '';
-  const toolsUsed: string[] = [];
-  const toolExecutions: { tool_name: string; parameters: Record<string, unknown>; result: string }[] = [];
+  let toolsUsed: string[] = [];
+  let toolExecutions: { tool_name: string; parameters: Record<string, unknown>; result: string }[] = [];
   // Mid-stream upstream failure tracking (#4797). When set, we render a recovery
   // banner in Slack and skip persisting the partial turn so prompt assembly for
   // the next turn doesn't feed the model a truncated assistant message.
   let streamWasInterrupted = false;
   let streamInterruptCategory = '';
-  // Length-cap continuation state. When the streamed message approaches
-  // Slack's `msg_too_long` cap, we finalize the in-flight stream and route
-  // subsequent deltas into a continuation buffer that ships as a follow-up
-  // message after the model finishes. `streamWriteable` flips false the
-  // moment we attempt to stop — subsequent text deltas skip the stream API
-  // either way (continuation goes into the buffer; failed-stop falls
-  // through to the post-loop chunked-say() fallback via fullText).
+  // Length-cap continuation state. The reducer tracks whether Slack remains
+  // writeable and routes subsequent deltas into this post-loop buffer.
   let streamedLen = 0;
-  let streamWriteable = true;
-  let streamFinalizedEarly = false;
   let continuationBuffer = '';
 
   try {
@@ -1817,149 +1784,37 @@ async function handleUserMessage({
         task_display_mode: 'plan',
       });
 
-      // Process Claude response stream (pass conversation history for context)
-      // Track tool invocations for unique task_update IDs (same tool can run multiple times)
-      let toolInvocationCount = 0;
-      const activeToolTaskIds: string[] = [];
-      let planTitleSent = false;
+      // Process Claude response stream (pass conversation history for context).
+      // The reducer owns the event state; this interpreter executes each Slack
+      // effect sequentially and feeds its outcome back before advancing.
+      let streamState = createSlackDmStreamState();
+      const streamInterpreter: SlackDmStreamInterpreter = {
+        append: payload => streamer.append(payload),
+        stop: () => streamer.stop({ blocks: [buildFeedbackBlock()] }),
+        say: message => say(message),
+        setStatus: status => setStatus(status),
+        log: (level, fields, message) => logger[level](fields, message),
+      };
 
       for await (const event of claudeClient.processMessageStream(inputValidation.sanitized, conversationHistory, routedTools.tools, processOptions)) {
-        if (event.type === 'text') {
-          fullText += event.text;
-          // Once we've attempted to stop the stream (whether stop succeeded
-          // and we're in continuation mode, or stop failed and we're heading
-          // for the post-loop fallback), don't touch the stream API. In the
-          // continuation case, accumulate into the buffer for the follow-up
-          // post; in the failed-stop case, fullText carries the full reply
-          // and the post-loop fallback will chunk it via say().
-          if (!streamWriteable) {
-            if (streamFinalizedEarly) continuationBuffer += event.text;
-            continue;
-          }
-          // Note: don't apply wrapUrlsForSlack() per-chunk — URLs can span chunk
-          // boundaries. Slack auto-links bare https:// URLs in streamed messages.
-          const decision = decideStreamAppend(streamedLen, event.text, STREAM_SOFT_CAP);
-          if (decision.appendPart) {
-            try {
-              await streamer.append({ markdown_text: decision.appendPart });
-              streamedLen += decision.appendPart.length;
-            } catch (streamError) {
-              logger.warn({ streamError }, 'Addie Bolt: Stream append failed for chunk, continuing');
-            }
-          }
-          if (decision.shouldFinalize) {
-            logger.info(
-              { streamedLen, softCap: STREAM_SOFT_CAP, carryLen: decision.carryPart.length, fullTextLen: fullText.length },
-              'Addie Bolt: Stream length cap reached — finalizing and switching to continuation',
-            );
-            try {
-              await streamer.append({ markdown_text: STREAM_CONTINUATION_TAIL });
-            } catch (appendError) {
-              logger.warn({ appendError }, 'Addie Bolt: Continuation tail marker append failed');
-            }
-            streamWriteable = false;
-            try {
-              await streamer.stop({ blocks: [buildFeedbackBlock()] });
-              streamFinalizedEarly = true;
-              continuationBuffer = decision.carryPart;
-            } catch (stopError) {
-              // Stop failed — the first chunk's wire delivery is uncertain.
-              // Don't flip `streamFinalizedEarly`; let the existing post-loop
-              // fallback recover via `fullText` (it can post the entire reply
-              // as a chunked say()).
-              logger.warn({ stopError }, 'Addie Bolt: Stream stop at length cap failed — falling through to post-loop fallback');
-            }
-          }
-        } else if (event.type === 'tool_start') {
-          toolsUsed.push(event.tool_name);
-          toolInvocationCount++;
-          const taskId = `${event.tool_name}_${toolInvocationCount}`;
-          activeToolTaskIds.push(taskId);
-          // Skip the task widget once we've closed the stream — any
-          // append would throw on a completed stream. Tool widgets simply
-          // won't render for tools that fire after the cap.
-          if (streamWriteable) {
-            try {
-              const chunks: StreamChunk[] = [];
-              if (!planTitleSent) {
-                chunks.push(buildPlanTitleChunk());
-                planTitleSent = true;
-              }
-              chunks.push(buildToolTaskChunk(taskId, event.tool_name, 'in_progress'));
-              await streamer.append({
-                chunks,
-              });
-            } catch {
-              // Ignore stream errors for status updates
-            }
-          }
-        } else if (event.type === 'tool_end') {
-          toolExecutions.push({
-            tool_name: event.tool_name,
-            parameters: {},
-            result: event.result,
-          });
-          const taskId = activeToolTaskIds.pop() || event.tool_name;
-          if (streamWriteable) {
-            try {
-              await streamer.append({
-                chunks: [buildToolTaskChunk(taskId, event.tool_name, event.is_error ? 'error' : 'complete')],
-              });
-            } catch {
-              // Ignore stream errors for status updates
-            }
-          }
-        } else if (event.type === 'retry') {
-          // Show retry status to user
-          try {
-            await setStatus(`${event.reason}, retrying (${event.attempt}/${event.maxRetries})...`);
-          } catch {
-            // Ignore status update errors
-          }
-        } else if (event.type === 'stream_error') {
-          // Mid-stream upstream failure after partial delivery (#4797). Render
-          // the recovery banner in place, finalize the Slack message with
-          // feedback buttons, and mark the terminal turn for discard. The
-          // Claude client may complete the generator normally after yielding
-          // this event, so persistence cannot depend on an outer exception.
-          streamWasInterrupted = true;
-          const errorSummary = summarizeSlackStreamError(event.reason);
-          streamInterruptCategory = errorSummary.category;
-          logger.warn(
-            { category: errorSummary.category, deltasBeforeError: event.deltasBeforeError, fullTextLength: fullText.length, streamFinalizedEarly },
-            'Addie Bolt: Stream interrupted mid-reply — discarding partial turn'
-          );
-          if (!streamWriteable) {
-            // First chunk already shipped + sealed (or stop attempt already
-            // happened); post the recovery banner as a follow-up in the
-            // same thread so the user knows the rest isn't coming.
-            try {
-              await say(errorSummary.followupRecoveryText);
-            } catch (sayError) {
-              logger.warn({ sayError }, 'Addie Bolt: Recovery banner say() failed after stream close');
-            }
-          } else {
-            try {
-              await streamer.append({
-                markdown_text: errorSummary.inlineRecoveryText,
-              });
-            } catch (appendError) {
-              logger.warn({ appendError }, 'Addie Bolt: Recovery banner append failed');
-            }
-            streamWriteable = false;
-            try {
-              await streamer.stop({ blocks: [buildFeedbackBlock()] });
-            } catch (stopError) {
-              logger.warn({ stopError }, 'Addie Bolt: Streamer stop after interruption failed');
-            }
-          }
-          break;
-        } else if (event.type === 'done') {
-          response = event.response;
-        } else if (event.type === 'error') {
-          throw new Error(event.error);
-        }
+        streamState = await interpretSlackDmStreamEvent(
+          streamState,
+          event,
+          { softCap: STREAM_SOFT_CAP, continuationTail: STREAM_CONTINUATION_TAIL },
+          streamInterpreter,
+        );
+        fullText = streamState.fullText;
+        toolsUsed = [...streamState.toolsUsed];
+        toolExecutions = [...streamState.toolExecutions];
+        response = streamState.response;
+        streamedLen = streamState.delivery.streamedLen;
+        continuationBuffer = streamState.continuationBuffer;
+        streamWasInterrupted = streamState.streamWasInterrupted;
+        streamInterruptCategory = streamState.streamInterruptCategory;
+        if (shouldStopSlackDmStream(streamState)) break;
       }
+
+      const terminalDeliveryPlan = planSlackDmTerminalDelivery(streamState);
 
       // If the stream was finalized early due to length cap, post the
       // continuation buffer as a follow-up message in the same thread.
@@ -1970,7 +1825,7 @@ async function handleUserMessage({
       // we've already shipped the first chunk, the downstream persistence
       // logic still discards the turn. The user sees both messages but
       // the next turn starts fresh — matching #4797's contract.
-      if (streamFinalizedEarly) {
+      if (terminalDeliveryPlan === 'continuation') {
         try {
           const guarded = guardBareJsonEnvelope(continuationBuffer, { pathTag: 'dm-streaming-continuation' });
           const continuationValidation = validateOutput(guarded.text);
@@ -1994,46 +1849,38 @@ async function handleUserMessage({
         } catch (continuationError) {
           logger.warn({ continuationError, continuationLen: continuationBuffer.length }, 'Addie Bolt: Continuation post failed');
         }
-      } else if (!streamWriteable) {
-        // Stream was closed mid-flow (length-cap stop failed, or upstream
-        // interruption with a successful recovery banner). Skip the second
-        // stop attempt — it would throw and we'd just land in the same
-        // fallback branch. If answer text already reached Slack, post only a
-        // delivery notice so we do not duplicate the streamed response.
-        if (!streamWasInterrupted) {
-          const fallbackPlan = planStreamStopFailureFallback(streamedLen);
-          if (fallbackPlan === 'delivery-notice') {
-            try {
-              await say(STREAM_DELIVERY_UNCERTAIN_NOTICE);
-            } catch (noticeError) {
-              logger.warn({ noticeError, streamedLen, fullTextLen: fullText.length }, 'Addie Bolt: Stream delivery notice say() failed');
-            }
-          } else {
-            try {
-              const guarded = guardBareJsonEnvelope(fullText, { pathTag: 'dm-streaming-stop-failed' });
-              const fallbackValidation = validateOutput(guarded.text);
-              const { text: fallbackText, images: fallbackImages } = extractMarkdownImages(fallbackValidation.sanitized);
-              const slackText = wrapUrlsForSlack(fallbackText);
-              if (slackText.trim()) {
-                await say({
-                  text: truncateNotificationText(slackText),
-                  blocks: [
-                    ...splitMrkdwnIntoSections(slackText),
-                    ...fallbackImages.slice(0, 3).map(img => ({
-                      type: 'image' as const,
-                      image_url: img.url,
-                      alt_text: img.alt,
-                    })),
-                    buildFeedbackBlock(),
-                  ],
-                });
-              }
-            } catch (fallbackError) {
-              logger.error({ fallbackError, fullTextLen: fullText.length }, 'Addie Bolt: Stop-failed fallback say() also failed');
-            }
-          }
+      } else if (terminalDeliveryPlan === 'delivery-notice') {
+        // The length-cap stop failed after answer text already reached Slack.
+        // Post only a delivery notice so we do not duplicate the response.
+        try {
+          await say(STREAM_DELIVERY_UNCERTAIN_NOTICE);
+        } catch (noticeError) {
+          logger.warn({ noticeError, streamedLen, fullTextLen: fullText.length }, 'Addie Bolt: Stream delivery notice say() failed');
         }
-      } else {
+      } else if (terminalDeliveryPlan === 'full-response') {
+        try {
+          const guarded = guardBareJsonEnvelope(fullText, { pathTag: 'dm-streaming-stop-failed' });
+          const fallbackValidation = validateOutput(guarded.text);
+          const { text: fallbackText, images: fallbackImages } = extractMarkdownImages(fallbackValidation.sanitized);
+          const slackText = wrapUrlsForSlack(fallbackText);
+          if (slackText.trim()) {
+            await say({
+              text: truncateNotificationText(slackText),
+              blocks: [
+                ...splitMrkdwnIntoSections(slackText),
+                ...fallbackImages.slice(0, 3).map(img => ({
+                  type: 'image' as const,
+                  image_url: img.url,
+                  alt_text: img.alt,
+                })),
+                buildFeedbackBlock(),
+              ],
+            });
+          }
+        } catch (fallbackError) {
+          logger.error({ fallbackError, fullTextLen: fullText.length }, 'Addie Bolt: Stop-failed fallback say() also failed');
+        }
+      } else if (terminalDeliveryPlan === 'normal-stop') {
         // Stop the stream with feedback buttons and any inline images.
         try {
           // Cap-exceeded responses have no streamed text — deliver the cap

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.10';
+export const CODE_VERSION = '2026.08.11';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/slack-dm-stream.ts
+++ b/server/src/addie/slack-dm-stream.ts
@@ -1,0 +1,586 @@
+import type { AddieResponse, StreamEvent } from './claude-client.js';
+import {
+  DEFAULT_STREAM_SOFT_CAP,
+  decideStreamAppend,
+  planStreamStopFailureFallback,
+  summarizeSlackStreamError,
+  type StreamAppendDecision,
+} from './slack-blocks.js';
+
+export type SlackDmToolExecution = {
+  tool_name: string;
+  parameters: Record<string, unknown>;
+  result: string;
+};
+
+export type SlackDmStreamChunk =
+  | { type: 'plan_update'; title: string }
+  | {
+      type: 'task_update';
+      id: string;
+      title: string;
+      status: 'in_progress' | 'complete' | 'error';
+      details?: string;
+      output?: string;
+    };
+
+export type SlackDmStreamDelivery =
+  | { tag: 'open'; streamedLen: number }
+  | { tag: 'cap_finalized'; streamedLen: number }
+  | { tag: 'closed_uncertain'; streamedLen: number; reason: 'length_cap' | 'interrupted' };
+
+type PendingTransition =
+  | { kind: 'text_append'; decision: StreamAppendDecision }
+  | { kind: 'cap_tail'; carryPart: string }
+  | { kind: 'cap_stop'; carryPart: string }
+  | { kind: 'tool_update' }
+  | { kind: 'retry_status' }
+  | { kind: 'recovery_append' }
+  | { kind: 'recovery_stop' }
+  | { kind: 'recovery_say' };
+
+export type SlackDmStreamPhase =
+  | { tag: 'ready' }
+  | { tag: 'awaiting_effect'; effectId: string; transition: PendingTransition }
+  | { tag: 'terminal' };
+
+export interface SlackDmStreamState {
+  phase: SlackDmStreamPhase;
+  delivery: SlackDmStreamDelivery;
+  fullText: string;
+  toolsUsed: readonly string[];
+  toolExecutions: readonly SlackDmToolExecution[];
+  toolInvocationCount: number;
+  activeToolTaskIds: readonly string[];
+  planTitleSent: boolean;
+  response?: AddieResponse;
+  streamWasInterrupted: boolean;
+  streamInterruptCategory: string;
+  continuationBuffer: string;
+  nextEffectOrdinal: number;
+}
+
+export interface SlackDmStreamConfig {
+  softCap: number;
+  continuationTail: string;
+}
+
+export type SlackDmStreamEffect =
+  | {
+      kind: 'stream_append';
+      effectId: string;
+      payload: { markdown_text: string } | { chunks: SlackDmStreamChunk[] };
+    }
+  | { kind: 'stream_stop'; effectId: string }
+  | { kind: 'say'; effectId: string; message: string }
+  | { kind: 'set_status'; effectId: string; status: string }
+  | {
+      kind: 'log';
+      level: 'info' | 'warn' | 'error';
+      fields: Record<string, unknown>;
+      message: string;
+    }
+  | { kind: 'throw_error'; error: string };
+
+export type SlackDmStreamFeedbackEvent = {
+  type: 'effect_outcome';
+  effectId: string;
+  outcome: 'success' | 'failure';
+  error?: unknown;
+};
+
+export type SlackDmStreamReducerEvent = StreamEvent | SlackDmStreamFeedbackEvent;
+
+export interface SlackDmStreamReduction {
+  state: SlackDmStreamState;
+  effects: SlackDmStreamEffect[];
+}
+
+export type SlackDmTerminalDeliveryPlan =
+  | 'continuation'
+  | 'none'
+  | 'delivery-notice'
+  | 'full-response'
+  | 'normal-stop';
+
+export interface SlackDmStreamInterpreter {
+  append(payload: Extract<SlackDmStreamEffect, { kind: 'stream_append' }>['payload']): Promise<unknown>;
+  stop(): Promise<unknown>;
+  say(message: string): Promise<unknown>;
+  setStatus(status: string): Promise<unknown>;
+  log(level: 'info' | 'warn' | 'error', fields: Record<string, unknown>, message: string): void;
+}
+
+export interface SlackDmStreamSoftCapResolution {
+  value: number;
+  invalid: boolean;
+}
+
+/** Parse the stream soft-cap override without reading process-global state. */
+export function resolveSlackDmStreamSoftCap(
+  raw: string | undefined,
+  defaultValue = DEFAULT_STREAM_SOFT_CAP,
+): SlackDmStreamSoftCapResolution {
+  if (!raw) return { value: defaultValue, invalid: false };
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1000 || parsed > 11000) {
+    return { value: defaultValue, invalid: true };
+  }
+  return { value: parsed, invalid: false };
+}
+
+export function createSlackDmStreamState(): SlackDmStreamState {
+  return {
+    phase: { tag: 'ready' },
+    delivery: { tag: 'open', streamedLen: 0 },
+    fullText: '',
+    toolsUsed: [],
+    toolExecutions: [],
+    toolInvocationCount: 0,
+    activeToolTaskIds: [],
+    planTitleSent: false,
+    streamWasInterrupted: false,
+    streamInterruptCategory: '',
+    continuationBuffer: '',
+    nextEffectOrdinal: 1,
+  };
+}
+
+/** Select the existing post-loop delivery branch without performing any I/O. */
+export function planSlackDmTerminalDelivery(
+  state: SlackDmStreamState,
+): SlackDmTerminalDeliveryPlan {
+  if (state.delivery.tag === 'cap_finalized') return 'continuation';
+  if (state.delivery.tag === 'closed_uncertain') {
+    if (state.streamWasInterrupted) return 'none';
+    return planStreamStopFailureFallback(state.delivery.streamedLen);
+  }
+  return 'normal-stop';
+}
+
+/** The Bolt provider loop uses this terminal tag as its break condition. */
+export function shouldStopSlackDmStream(state: SlackDmStreamState): boolean {
+  return state.phase.tag === 'terminal';
+}
+
+function formatToolTaskTitle(toolName: string): string {
+  return toolName.trim() ? `Call ${toolName}` : 'Call Addie tool';
+}
+
+function buildPlanTitleChunk(): SlackDmStreamChunk {
+  return { type: 'plan_update', title: 'Addie is working' };
+}
+
+function buildToolTaskChunk(
+  taskId: string,
+  toolName: string,
+  status: 'in_progress' | 'complete' | 'error',
+): SlackDmStreamChunk {
+  return {
+    type: 'task_update',
+    id: taskId,
+    title: formatToolTaskTitle(toolName),
+    status,
+    ...(status === 'in_progress'
+      ? { details: `Using Addie tool: ${toolName}` }
+      : { output: status === 'error' ? `Tool failed: ${toolName}` : `Tool completed: ${toolName}` }),
+  };
+}
+
+function scheduleAsyncEffect(
+  state: SlackDmStreamState,
+  transition: PendingTransition,
+  makeEffect: (effectId: string) => SlackDmStreamEffect,
+  precedingEffects: SlackDmStreamEffect[] = [],
+): SlackDmStreamReduction {
+  const effectId = `stream_effect_${state.nextEffectOrdinal}`;
+  return {
+    state: {
+      ...state,
+      phase: { tag: 'awaiting_effect', effectId, transition },
+      nextEffectOrdinal: state.nextEffectOrdinal + 1,
+    },
+    effects: [...precedingEffects, makeEffect(effectId)],
+  };
+}
+
+function beginCapFinalization(
+  state: SlackDmStreamState,
+  carryPart: string,
+  config: SlackDmStreamConfig,
+  precedingEffects: SlackDmStreamEffect[] = [],
+): SlackDmStreamReduction {
+  const streamedLen = state.delivery.streamedLen;
+  const capLog: SlackDmStreamEffect = {
+    kind: 'log',
+    level: 'info',
+    fields: {
+      streamedLen,
+      softCap: config.softCap,
+      carryLen: carryPart.length,
+      fullTextLen: state.fullText.length,
+    },
+    message: 'Addie Bolt: Stream length cap reached — finalizing and switching to continuation',
+  };
+  return scheduleAsyncEffect(
+    state,
+    { kind: 'cap_tail', carryPart },
+    effectId => ({
+      kind: 'stream_append',
+      effectId,
+      payload: { markdown_text: config.continuationTail },
+    }),
+    [...precedingEffects, capLog],
+  );
+}
+
+function scheduleCapStop(
+  state: SlackDmStreamState,
+  carryPart: string,
+  precedingEffects: SlackDmStreamEffect[] = [],
+): SlackDmStreamReduction {
+  const closedState: SlackDmStreamState = {
+    ...state,
+    delivery: {
+      tag: 'closed_uncertain',
+      streamedLen: state.delivery.streamedLen,
+      reason: 'length_cap',
+    },
+  };
+  return scheduleAsyncEffect(
+    closedState,
+    { kind: 'cap_stop', carryPart },
+    effectId => ({ kind: 'stream_stop', effectId }),
+    precedingEffects,
+  );
+}
+
+function scheduleRecoveryStop(
+  state: SlackDmStreamState,
+  precedingEffects: SlackDmStreamEffect[] = [],
+): SlackDmStreamReduction {
+  const closedState: SlackDmStreamState = {
+    ...state,
+    delivery: {
+      tag: 'closed_uncertain',
+      streamedLen: state.delivery.streamedLen,
+      reason: 'interrupted',
+    },
+  };
+  return scheduleAsyncEffect(
+    closedState,
+    { kind: 'recovery_stop' },
+    effectId => ({ kind: 'stream_stop', effectId }),
+    precedingEffects,
+  );
+}
+
+function reduceEffectOutcome(
+  state: SlackDmStreamState,
+  event: SlackDmStreamFeedbackEvent,
+  config: SlackDmStreamConfig,
+): SlackDmStreamReduction {
+  if (state.phase.tag !== 'awaiting_effect' || state.phase.effectId !== event.effectId) {
+    return {
+      state,
+      effects: [{
+        kind: 'log',
+        level: 'warn',
+        fields: { effectId: event.effectId, phase: state.phase.tag },
+        message: 'Addie Bolt: Ignoring stale stream effect outcome',
+      }],
+    };
+  }
+
+  const transition = state.phase.transition;
+  const readyState: SlackDmStreamState = { ...state, phase: { tag: 'ready' } };
+
+  if (transition.kind === 'text_append') {
+    const appendSucceeded = event.outcome === 'success';
+    const nextState: SlackDmStreamState = appendSucceeded
+      ? {
+          ...readyState,
+          delivery: {
+            tag: 'open',
+            streamedLen: readyState.delivery.streamedLen + transition.decision.appendPart.length,
+          },
+        }
+      : readyState;
+    const failureLog: SlackDmStreamEffect[] = appendSucceeded ? [] : [{
+      kind: 'log',
+      level: 'warn',
+      fields: { streamError: event.error },
+      message: 'Addie Bolt: Stream append failed for chunk, continuing',
+    }];
+    return transition.decision.shouldFinalize
+      ? beginCapFinalization(nextState, transition.decision.carryPart, config, failureLog)
+      : { state: nextState, effects: failureLog };
+  }
+
+  if (transition.kind === 'cap_tail') {
+    const failureLog: SlackDmStreamEffect[] = event.outcome === 'failure' ? [{
+      kind: 'log',
+      level: 'warn',
+      fields: { appendError: event.error },
+      message: 'Addie Bolt: Continuation tail marker append failed',
+    }] : [];
+    return scheduleCapStop(readyState, transition.carryPart, failureLog);
+  }
+
+  if (transition.kind === 'cap_stop') {
+    if (event.outcome === 'success') {
+      return {
+        state: {
+          ...readyState,
+          delivery: { tag: 'cap_finalized', streamedLen: readyState.delivery.streamedLen },
+          continuationBuffer: transition.carryPart,
+        },
+        effects: [],
+      };
+    }
+    return {
+      state: readyState,
+      effects: [{
+        kind: 'log',
+        level: 'warn',
+        fields: { stopError: event.error },
+        message: 'Addie Bolt: Stream stop at length cap failed — falling through to post-loop fallback',
+      }],
+    };
+  }
+
+  if (transition.kind === 'recovery_append') {
+    const failureLog: SlackDmStreamEffect[] = event.outcome === 'failure' ? [{
+      kind: 'log',
+      level: 'warn',
+      fields: { appendError: event.error },
+      message: 'Addie Bolt: Recovery banner append failed',
+    }] : [];
+    return scheduleRecoveryStop(readyState, failureLog);
+  }
+
+  if (transition.kind === 'recovery_stop') {
+    return {
+      state: { ...readyState, phase: { tag: 'terminal' } },
+      effects: event.outcome === 'failure' ? [{
+        kind: 'log',
+        level: 'warn',
+        fields: { stopError: event.error },
+        message: 'Addie Bolt: Streamer stop after interruption failed',
+      }] : [],
+    };
+  }
+
+  if (transition.kind === 'recovery_say') {
+    return {
+      state: { ...readyState, phase: { tag: 'terminal' } },
+      effects: event.outcome === 'failure' ? [{
+        kind: 'log',
+        level: 'warn',
+        fields: { sayError: event.error },
+        message: 'Addie Bolt: Recovery banner say() failed after stream close',
+      }] : [],
+    };
+  }
+
+  return { state: readyState, effects: [] };
+}
+
+export function reduceSlackDmStreamEvent(
+  state: SlackDmStreamState,
+  event: SlackDmStreamReducerEvent,
+  config: SlackDmStreamConfig,
+): SlackDmStreamReduction {
+  if (event.type === 'effect_outcome') {
+    return reduceEffectOutcome(state, event, config);
+  }
+  if (state.phase.tag !== 'ready') {
+    return {
+      state,
+      effects: [{
+        kind: 'log',
+        level: 'warn',
+        fields: { eventType: event.type, phase: state.phase.tag },
+        message: 'Addie Bolt: Ignoring stream event while an effect is pending',
+      }],
+    };
+  }
+
+  if (event.type === 'text') {
+    const textState: SlackDmStreamState = { ...state, fullText: state.fullText + event.text };
+    if (textState.delivery.tag === 'cap_finalized') {
+      return {
+        state: { ...textState, continuationBuffer: textState.continuationBuffer + event.text },
+        effects: [],
+      };
+    }
+    if (textState.delivery.tag === 'closed_uncertain') {
+      return { state: textState, effects: [] };
+    }
+
+    const decision = decideStreamAppend(textState.delivery.streamedLen, event.text, config.softCap);
+    if (!decision.appendPart) {
+      return decision.shouldFinalize
+        ? beginCapFinalization(textState, decision.carryPart, config)
+        : { state: textState, effects: [] };
+    }
+    return scheduleAsyncEffect(
+      textState,
+      { kind: 'text_append', decision },
+      effectId => ({
+        kind: 'stream_append',
+        effectId,
+        payload: { markdown_text: decision.appendPart },
+      }),
+    );
+  }
+
+  if (event.type === 'tool_start') {
+    const toolInvocationCount = state.toolInvocationCount + 1;
+    const taskId = `${event.tool_name}_${toolInvocationCount}`;
+    const toolState: SlackDmStreamState = {
+      ...state,
+      toolsUsed: [...state.toolsUsed, event.tool_name],
+      toolInvocationCount,
+      activeToolTaskIds: [...state.activeToolTaskIds, taskId],
+    };
+    if (toolState.delivery.tag !== 'open') return { state: toolState, effects: [] };
+
+    const chunks: SlackDmStreamChunk[] = [];
+    if (!toolState.planTitleSent) chunks.push(buildPlanTitleChunk());
+    chunks.push(buildToolTaskChunk(taskId, event.tool_name, 'in_progress'));
+    return scheduleAsyncEffect(
+      { ...toolState, planTitleSent: true },
+      { kind: 'tool_update' },
+      effectId => ({ kind: 'stream_append', effectId, payload: { chunks } }),
+    );
+  }
+
+  if (event.type === 'tool_end') {
+    const activeToolTaskIds = [...state.activeToolTaskIds];
+    const taskId = activeToolTaskIds.pop() || event.tool_name;
+    const toolState: SlackDmStreamState = {
+      ...state,
+      activeToolTaskIds,
+      toolExecutions: [...state.toolExecutions, {
+        tool_name: event.tool_name,
+        parameters: {},
+        result: event.result,
+      }],
+    };
+    if (toolState.delivery.tag !== 'open') return { state: toolState, effects: [] };
+    return scheduleAsyncEffect(
+      toolState,
+      { kind: 'tool_update' },
+      effectId => ({
+        kind: 'stream_append',
+        effectId,
+        payload: {
+          chunks: [buildToolTaskChunk(taskId, event.tool_name, event.is_error ? 'error' : 'complete')],
+        },
+      }),
+    );
+  }
+
+  if (event.type === 'retry') {
+    return scheduleAsyncEffect(
+      state,
+      { kind: 'retry_status' },
+      effectId => ({
+        kind: 'set_status',
+        effectId,
+        status: `${event.reason}, retrying (${event.attempt}/${event.maxRetries})...`,
+      }),
+    );
+  }
+
+  if (event.type === 'stream_error') {
+    const errorSummary = summarizeSlackStreamError(event.reason);
+    const interruptedState: SlackDmStreamState = {
+      ...state,
+      streamWasInterrupted: true,
+      streamInterruptCategory: errorSummary.category,
+    };
+    const interruptLog: SlackDmStreamEffect = {
+      kind: 'log',
+      level: 'warn',
+      fields: {
+        category: errorSummary.category,
+        deltasBeforeError: event.deltasBeforeError,
+        fullTextLength: state.fullText.length,
+        streamFinalizedEarly: state.delivery.tag === 'cap_finalized',
+      },
+      message: 'Addie Bolt: Stream interrupted mid-reply — discarding partial turn',
+    };
+    if (state.delivery.tag !== 'open') {
+      return scheduleAsyncEffect(
+        interruptedState,
+        { kind: 'recovery_say' },
+        effectId => ({ kind: 'say', effectId, message: errorSummary.followupRecoveryText }),
+        [interruptLog],
+      );
+    }
+    return scheduleAsyncEffect(
+      interruptedState,
+      { kind: 'recovery_append' },
+      effectId => ({
+        kind: 'stream_append',
+        effectId,
+        payload: { markdown_text: errorSummary.inlineRecoveryText },
+      }),
+      [interruptLog],
+    );
+  }
+
+  if (event.type === 'done') {
+    return { state: { ...state, response: event.response }, effects: [] };
+  }
+
+  return { state, effects: [{ kind: 'throw_error', error: event.error }] };
+}
+
+async function executeEffect(
+  effect: SlackDmStreamEffect,
+  interpreter: SlackDmStreamInterpreter,
+): Promise<SlackDmStreamFeedbackEvent | undefined> {
+  if (effect.kind === 'log') {
+    interpreter.log(effect.level, effect.fields, effect.message);
+    return undefined;
+  }
+  if (effect.kind === 'throw_error') throw new Error(effect.error);
+
+  try {
+    if (effect.kind === 'stream_append') await interpreter.append(effect.payload);
+    else if (effect.kind === 'stream_stop') await interpreter.stop();
+    else if (effect.kind === 'say') await interpreter.say(effect.message);
+    else await interpreter.setStatus(effect.status);
+    return { type: 'effect_outcome', effectId: effect.effectId, outcome: 'success' };
+  } catch (error) {
+    return { type: 'effect_outcome', effectId: effect.effectId, outcome: 'failure', error };
+  }
+}
+
+/**
+ * Execute one provider event and all of the ordered Slack effects it causes.
+ * Async outcomes are fed back through the reducer before the next effect runs.
+ */
+export async function interpretSlackDmStreamEvent(
+  state: SlackDmStreamState,
+  event: StreamEvent,
+  config: SlackDmStreamConfig,
+  interpreter: SlackDmStreamInterpreter,
+): Promise<SlackDmStreamState> {
+  let reduction = reduceSlackDmStreamEvent(state, event, config);
+  while (true) {
+    let feedback: SlackDmStreamFeedbackEvent | undefined;
+    for (const effect of reduction.effects) {
+      const result = await executeEffect(effect, interpreter);
+      if (result) {
+        feedback = result;
+        break;
+      }
+    }
+    if (!feedback) return reduction.state;
+    reduction = reduceSlackDmStreamEvent(reduction.state, feedback, config);
+  }
+}

--- a/server/tests/unit/addie/slack-dm-stream.test.ts
+++ b/server/tests/unit/addie/slack-dm-stream.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createSlackDmStreamState,
+  interpretSlackDmStreamEvent,
+  planSlackDmTerminalDelivery,
+  reduceSlackDmStreamEvent,
+  resolveSlackDmStreamSoftCap,
+  shouldStopSlackDmStream,
+  type SlackDmStreamConfig,
+  type SlackDmStreamInterpreter,
+  type SlackDmStreamState,
+} from '../../../src/addie/slack-dm-stream.js';
+import type { StreamEvent } from '../../../src/addie/claude-client.js';
+
+const CONFIG: SlackDmStreamConfig = {
+  softCap: 10,
+  continuationTail: '<continued>',
+};
+
+describe('resolveSlackDmStreamSoftCap', () => {
+  it.each([
+    { raw: undefined, value: 9000, invalid: false },
+    { raw: '', value: 9000, invalid: false },
+    { raw: '1000', value: 1000, invalid: false },
+    { raw: '11000', value: 11000, invalid: false },
+    { raw: '999', value: 9000, invalid: true },
+    { raw: '11001', value: 9000, invalid: true },
+    { raw: 'nope', value: 9000, invalid: true },
+    { raw: '9000abc', value: 9000, invalid: false },
+  ])('resolves $raw to $value (invalid=$invalid)', ({ raw, value, invalid }) => {
+    expect(resolveSlackDmStreamSoftCap(raw)).toEqual({ value, invalid });
+  });
+});
+
+function makeIo(options: { failStop?: boolean; failAppendAt?: number; failSay?: boolean } = {}) {
+  const calls: Array<{ kind: string; value?: unknown }> = [];
+  let appendCount = 0;
+  const io: SlackDmStreamInterpreter = {
+    append: vi.fn(async payload => {
+      appendCount++;
+      calls.push({ kind: 'append', value: payload });
+      if (options.failAppendAt === appendCount) throw new Error(`append ${appendCount} failed`);
+    }),
+    stop: vi.fn(async () => {
+      calls.push({ kind: 'stop' });
+      if (options.failStop) throw new Error('stop failed');
+    }),
+    say: vi.fn(async message => {
+      calls.push({ kind: 'say', value: message });
+      if (options.failSay) throw new Error('say failed');
+    }),
+    setStatus: vi.fn(async status => {
+      calls.push({ kind: 'status', value: status });
+    }),
+    log: vi.fn((level, fields, message) => {
+      calls.push({ kind: `log:${level}`, value: { fields, message } });
+    }),
+  };
+  return { io, calls };
+}
+
+function streamError(reason = 'overloaded_error'): StreamEvent {
+  return {
+    type: 'stream_error',
+    reason,
+    deltasBeforeError: 2,
+    tool_executions: [],
+    certification_reserve_used: false,
+  };
+}
+
+async function hitCap(io: SlackDmStreamInterpreter): Promise<SlackDmStreamState> {
+  return interpretSlackDmStreamEvent(
+    createSlackDmStreamState(),
+    { type: 'text', text: 'abcdefghijklmno' },
+    CONFIG,
+    io,
+  );
+}
+
+describe('Slack DM stream degenerate paths', () => {
+  it('finalizes at the length cap and carries the remainder after stop succeeds', async () => {
+    const { io, calls } = makeIo();
+    const state = await hitCap(io);
+
+    expect(state.delivery).toEqual({ tag: 'cap_finalized', streamedLen: 10 });
+    expect(state.continuationBuffer).toBe('klmno');
+    expect(state.fullText).toBe('abcdefghijklmno');
+    expect(planSlackDmTerminalDelivery(state)).toBe('continuation');
+    expect(calls.map(call => call.kind)).toEqual(['append', 'log:info', 'append', 'stop']);
+    expect(calls[0].value).toEqual({ markdown_text: 'abcdefghij' });
+    expect(calls[2].value).toEqual({ markdown_text: '<continued>' });
+  });
+
+  it('marks delivery uncertain when the cap stop fails', async () => {
+    const { io, calls } = makeIo({ failStop: true });
+    const state = await hitCap(io);
+
+    expect(state.delivery).toEqual({ tag: 'closed_uncertain', streamedLen: 10, reason: 'length_cap' });
+    expect(state.continuationBuffer).toBe('');
+    expect(planSlackDmTerminalDelivery(state)).toBe('delivery-notice');
+    expect(calls.map(call => call.kind)).toEqual(['append', 'log:info', 'append', 'stop', 'log:warn']);
+    expect(calls.at(-1)?.value).toMatchObject({
+      message: 'Addie Bolt: Stream stop at length cap failed — falling through to post-loop fallback',
+    });
+  });
+
+  it('renders inline recovery and stops when stream_error arrives before the cap', async () => {
+    const { io, calls } = makeIo();
+    let state = await interpretSlackDmStreamEvent(
+      createSlackDmStreamState(),
+      { type: 'text', text: 'abc' },
+      CONFIG,
+      io,
+    );
+    state = await interpretSlackDmStreamEvent(state, streamError(), CONFIG, io);
+
+    expect(state.phase).toEqual({ tag: 'terminal' });
+    expect(state.delivery).toEqual({ tag: 'closed_uncertain', streamedLen: 3, reason: 'interrupted' });
+    expect(state.streamWasInterrupted).toBe(true);
+    expect(state.streamInterruptCategory).toBe('overloaded');
+    expect(planSlackDmTerminalDelivery(state)).toBe('none');
+    expect(calls.map(call => call.kind)).toEqual(['append', 'log:warn', 'append', 'stop']);
+  });
+
+  it('keeps the finalized continuation and posts recovery before post-loop continuation on late stream_error', async () => {
+    const { io, calls } = makeIo();
+    let state = await hitCap(io);
+    state = await interpretSlackDmStreamEvent(state, { type: 'text', text: 'pqr' }, CONFIG, io);
+    state = await interpretSlackDmStreamEvent(state, streamError('api_error'), CONFIG, io);
+
+    expect(state.phase).toEqual({ tag: 'terminal' });
+    expect(state.delivery).toEqual({ tag: 'cap_finalized', streamedLen: 10 });
+    expect(state.continuationBuffer).toBe('klmnopqr');
+    expect(state.streamWasInterrupted).toBe(true);
+    expect(planSlackDmTerminalDelivery(state)).toBe('continuation');
+    // The first message is already sealed by stop; the recovery follow-up is
+    // sent here, and bolt-app's unchanged post-loop path posts continuation third.
+    expect(calls.map(call => call.kind)).toEqual([
+      'append', 'log:info', 'append', 'stop', 'log:warn', 'say',
+    ]);
+  });
+
+  it('posts follow-up recovery after a cap stop failure without retrying the stream', async () => {
+    const { io, calls } = makeIo({ failStop: true });
+    let state = await hitCap(io);
+    state = await interpretSlackDmStreamEvent(state, streamError(), CONFIG, io);
+
+    expect(state.phase).toEqual({ tag: 'terminal' });
+    expect(state.delivery).toEqual({ tag: 'closed_uncertain', streamedLen: 10, reason: 'length_cap' });
+    expect(planSlackDmTerminalDelivery(state)).toBe('none');
+    expect(calls.map(call => call.kind)).toEqual([
+      'append', 'log:info', 'append', 'stop', 'log:warn', 'log:warn', 'say',
+    ]);
+  });
+
+  it('keeps streamedLen at zero when the cap-prefix append and stop both fail', async () => {
+    const { io, calls } = makeIo({ failAppendAt: 1, failStop: true });
+    const state = await hitCap(io);
+
+    expect(state.delivery).toEqual({ tag: 'closed_uncertain', streamedLen: 0, reason: 'length_cap' });
+    expect(planSlackDmTerminalDelivery(state)).toBe('full-response');
+    expect(calls.map(call => call.kind)).toEqual([
+      'append', 'log:warn', 'log:info', 'append', 'stop', 'log:warn',
+    ]);
+    expect(calls[1].value).toMatchObject({
+      message: 'Addie Bolt: Stream append failed for chunk, continuing',
+    });
+  });
+
+  it('logs a tail append failure before stopping with the successful prefix length', async () => {
+    const { io, calls } = makeIo({ failAppendAt: 2 });
+    const state = await hitCap(io);
+
+    expect(state.delivery).toEqual({ tag: 'cap_finalized', streamedLen: 10 });
+    expect(planSlackDmTerminalDelivery(state)).toBe('continuation');
+    expect(calls.map(call => call.kind)).toEqual([
+      'append', 'log:info', 'append', 'log:warn', 'stop',
+    ]);
+    expect(calls[3].value).toMatchObject({
+      message: 'Addie Bolt: Continuation tail marker append failed',
+    });
+  });
+
+  it('logs recovery append failure before stop and remains terminal', async () => {
+    const { io, calls } = makeIo({ failAppendAt: 2 });
+    let state = await interpretSlackDmStreamEvent(
+      createSlackDmStreamState(),
+      { type: 'text', text: 'abc' },
+      CONFIG,
+      io,
+    );
+    state = await interpretSlackDmStreamEvent(state, streamError(), CONFIG, io);
+
+    expect(state.phase).toEqual({ tag: 'terminal' });
+    expect(calls.map(call => call.kind)).toEqual([
+      'append', 'log:warn', 'append', 'log:warn', 'stop',
+    ]);
+    expect(calls[3].value).toMatchObject({ message: 'Addie Bolt: Recovery banner append failed' });
+  });
+
+  it('logs recovery stop failure after the inline banner and remains terminal', async () => {
+    const { io, calls } = makeIo({ failStop: true });
+    let state = await interpretSlackDmStreamEvent(
+      createSlackDmStreamState(),
+      { type: 'text', text: 'abc' },
+      CONFIG,
+      io,
+    );
+    state = await interpretSlackDmStreamEvent(state, streamError(), CONFIG, io);
+
+    expect(state.phase).toEqual({ tag: 'terminal' });
+    expect(calls.map(call => call.kind)).toEqual([
+      'append', 'log:warn', 'append', 'stop', 'log:warn',
+    ]);
+    expect(calls[4].value).toMatchObject({ message: 'Addie Bolt: Streamer stop after interruption failed' });
+  });
+
+  it('logs a post-close recovery say failure after the recovery attempt', async () => {
+    const { io, calls } = makeIo({ failSay: true });
+    let state = await hitCap(io);
+    state = await interpretSlackDmStreamEvent(state, streamError(), CONFIG, io);
+
+    expect(state.phase).toEqual({ tag: 'terminal' });
+    expect(calls.map(call => call.kind)).toEqual([
+      'append', 'log:info', 'append', 'stop', 'log:warn', 'say', 'log:warn',
+    ]);
+    expect(calls[6].value).toMatchObject({
+      message: 'Addie Bolt: Recovery banner say() failed after stream close',
+    });
+  });
+});
+
+describe('reduceSlackDmStreamEvent reachable state table', () => {
+  const response = {
+    text: 'done', tools_used: [], tool_executions: [], flagged: false,
+  };
+
+  it('routes text exactly from open, finalized, and uncertain traced states', async () => {
+    const openIo = makeIo();
+    const open = await interpretSlackDmStreamEvent(
+      createSlackDmStreamState(),
+      { type: 'text', text: 'ab' },
+      CONFIG,
+      openIo.io,
+    );
+    const finalized = await hitCap(makeIo().io);
+    const uncertain = await hitCap(makeIo({ failStop: true }).io);
+
+    const openText = reduceSlackDmStreamEvent(open, { type: 'text', text: 'xy' }, CONFIG);
+    expect(openText.state).toMatchObject({
+      phase: { tag: 'awaiting_effect' },
+      delivery: { tag: 'open', streamedLen: 2 },
+      fullText: 'abxy',
+    });
+    expect(openText.effects).toMatchObject([
+      { kind: 'stream_append', effectId: 'stream_effect_2', payload: { markdown_text: 'xy' } },
+    ]);
+
+    const finalizedText = reduceSlackDmStreamEvent(finalized, { type: 'text', text: 'xy' }, CONFIG);
+    expect(finalizedText.effects).toEqual([]);
+    expect(finalizedText.state).toMatchObject({
+      delivery: { tag: 'cap_finalized', streamedLen: 10 },
+      fullText: 'abcdefghijklmnoxy',
+      continuationBuffer: 'klmnoxy',
+    });
+
+    const uncertainText = reduceSlackDmStreamEvent(uncertain, { type: 'text', text: 'xy' }, CONFIG);
+    expect(uncertainText.effects).toEqual([]);
+    expect(uncertainText.state).toMatchObject({
+      delivery: { tag: 'closed_uncertain', streamedLen: 10, reason: 'length_cap' },
+      fullText: 'abcdefghijklmnoxy',
+      continuationBuffer: '',
+    });
+  });
+
+  it('orders key effects from coherent open and closed traces', async () => {
+    const open = await interpretSlackDmStreamEvent(
+      createSlackDmStreamState(),
+      { type: 'text', text: 'ab' },
+      CONFIG,
+      makeIo().io,
+    );
+    const finalized = await hitCap(makeIo().io);
+
+    const startOpen = reduceSlackDmStreamEvent(open, {
+      type: 'tool_start', tool_name: 'lookup', parameters: {},
+    }, CONFIG);
+    expect(startOpen.effects).toMatchObject([{
+      kind: 'stream_append',
+      payload: { chunks: [
+        { type: 'plan_update' },
+        { type: 'task_update', id: 'lookup_1', status: 'in_progress' },
+      ] },
+    }]);
+
+    const startClosed = reduceSlackDmStreamEvent(finalized, {
+      type: 'tool_start', tool_name: 'lookup', parameters: {},
+    }, CONFIG);
+    expect(startClosed.effects).toEqual([]);
+    expect(startClosed.state.toolsUsed).toEqual(['lookup']);
+
+    const retry = reduceSlackDmStreamEvent(open, {
+      type: 'retry', attempt: 2, maxRetries: 3, delayMs: 5, reason: 'Busy',
+    }, CONFIG);
+    expect(retry.effects).toMatchObject([
+      { kind: 'set_status', effectId: 'stream_effect_2', status: 'Busy, retrying (2/3)...' },
+    ]);
+
+    const openError = reduceSlackDmStreamEvent(open, streamError(), CONFIG);
+    expect(openError.effects.map(effect => effect.kind)).toEqual(['log', 'stream_append']);
+    const closedError = reduceSlackDmStreamEvent(finalized, streamError(), CONFIG);
+    expect(closedError.effects.map(effect => effect.kind)).toEqual(['log', 'say']);
+
+    const done = reduceSlackDmStreamEvent(open, { type: 'done', response }, CONFIG);
+    expect(done.state.response).toBe(response);
+    expect(done.effects).toEqual([]);
+
+    const error = reduceSlackDmStreamEvent(open, { type: 'error', error: 'boom' }, CONFIG);
+    expect(error.effects).toEqual([{ kind: 'throw_error', error: 'boom' }]);
+  });
+
+  it('marks interruption terminal so Bolt breaks before accepting another provider event', async () => {
+    const { io } = makeIo();
+    let state = await interpretSlackDmStreamEvent(
+      createSlackDmStreamState(),
+      { type: 'text', text: 'abc' },
+      CONFIG,
+      io,
+    );
+    state = await interpretSlackDmStreamEvent(state, streamError(), CONFIG, io);
+
+    expect(shouldStopSlackDmStream(state)).toBe(true);
+    const later = reduceSlackDmStreamEvent(state, { type: 'text', text: 'must-not-append' }, CONFIG);
+    expect(later.state).toBe(state);
+    expect(later.effects).toEqual([{
+      kind: 'log',
+      level: 'warn',
+      fields: { eventType: 'text', phase: 'terminal' },
+      message: 'Addie Bolt: Ignoring stream event while an effect is pending',
+    }]);
+  });
+});
+
+describe('Slack DM stream tool metadata', () => {
+  it('uses unique task ids, sends the plan title once, and records tool completion', async () => {
+    const { io, calls } = makeIo({ failAppendAt: 1 });
+    let state = createSlackDmStreamState();
+    state = await interpretSlackDmStreamEvent(state, {
+      type: 'tool_start', tool_name: 'lookup', parameters: { query: 'first' },
+    }, CONFIG, io);
+    state = await interpretSlackDmStreamEvent(state, {
+      type: 'tool_start', tool_name: 'lookup', parameters: { query: 'second' },
+    }, CONFIG, io);
+    state = await interpretSlackDmStreamEvent(state, {
+      type: 'tool_end', tool_name: 'lookup', result: 'ok', is_error: false,
+    }, CONFIG, io);
+
+    expect(state.toolsUsed).toEqual(['lookup', 'lookup']);
+    expect(state.activeToolTaskIds).toEqual(['lookup_1']);
+    expect(state.toolExecutions).toEqual([{ tool_name: 'lookup', parameters: {}, result: 'ok' }]);
+    const appendPayloads = calls.filter(call => call.kind === 'append').map(call => call.value);
+    expect(appendPayloads[0]).toMatchObject({ chunks: [
+      { type: 'plan_update', title: 'Addie is working' },
+      { type: 'task_update', id: 'lookup_1', status: 'in_progress' },
+    ] });
+    expect(appendPayloads[1]).toMatchObject({ chunks: [
+      { type: 'task_update', id: 'lookup_2', status: 'in_progress' },
+    ] });
+    expect(appendPayloads[2]).toMatchObject({ chunks: [
+      { type: 'task_update', id: 'lookup_2', status: 'complete', output: 'Tool completed: lookup' },
+    ] });
+  });
+
+  it('keeps tool metadata but suppresses widgets after a traced stream close', async () => {
+    const initial = await hitCap(makeIo().io);
+    const start = reduceSlackDmStreamEvent(initial, {
+      type: 'tool_start', tool_name: 'late_tool', parameters: {},
+    }, CONFIG);
+    const end = reduceSlackDmStreamEvent(start.state, {
+      type: 'tool_end', tool_name: 'late_tool', result: 'late result', is_error: true,
+    }, CONFIG);
+
+    expect(start.effects).toEqual([]);
+    expect(end.effects).toEqual([]);
+    expect(end.state.toolsUsed).toEqual(['late_tool']);
+    expect(end.state.toolExecutions).toEqual([
+      { tool_name: 'late_tool', parameters: {}, result: 'late result' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- extract Addie DM stream event handling into a pure tagged-state reducer
- feed asynchronous Slack effect outcomes back through a sequential interpreter
- preserve current continuation, recovery, tool-widget, and fallback behavior
- use a pure terminal delivery planner and soft-cap parser to make edge cases directly testable
- bump Addie CODE_VERSION to 2026.08.11

## Verification

- 59 focused Slack stream/block tests pass
- npm run typecheck
- git diff --check
- independent code and testing expert reviews: no remaining findings

No changeset: this is Addie-only server behavior, explicitly excluded by repository policy.

Closes #4826