### PR TITLE
[codex] Test governance auth probe selection

### DIFF
--- a/server/tests/unit/storyboard-runner-options.test.ts
+++ b/server/tests/unit/storyboard-runner-options.test.ts
@@ -134,6 +134,22 @@ describe('storyboard runner option helpers', () => {
     });
   });
 
+  it('uses an SDK-allowlisted governance probe without required inputs', () => {
+    const kit: LoadedTestKit = {
+      auth: {
+        api_key: 'kit-api-key',
+        probe_task: 'list_creatives',
+      },
+    };
+
+    expect(testKitOptionsFromKit(kit, 'governance')).toEqual({
+      auth: {
+        api_key: 'kit-api-key',
+        probe_task: 'list_content_standards',
+      },
+    });
+  });
+
   it('requires probe_task when a test kit declares auth credentials', () => {
     const kit: LoadedTestKit = { auth: { api_key: 'kit-api-key' } };
 


### PR DESCRIPTION
## What changed

- add focused regression coverage for the governance tenant's `security_baseline` probe selection
- assert that a generic test-kit probe is replaced by the SDK-allowlisted, input-free `list_content_standards` task

## Why

The functional governance override was already merged in #5446, but #4097 remained open and the mapping had no dedicated unit assertion. This test makes the resolved behavior explicit and protects it from regression.

## Impact

Test-only change. Runtime behavior and protocol surfaces are unchanged.

## Verification

- `npx vitest run --root server tests/unit/storyboard-runner-options.test.ts --reporter=verbose` — 11/11 passed
- `TENANT_PATH=governance npx tsx server/tests/manual/run-storyboards.ts --filter security_baseline` — 4 passed, 0 failed, 3 expected OAuth-not-advertised skips
- repository precommit hook, including server tests and TypeScript typecheck — passed

Follow-up to #4097.
