### PR TITLE
docs(taxonomy): promote media channels to stable

### DIFF
--- a/.changeset/promote-media-channel-taxonomy.md
+++ b/.changeset/promote-media-channel-taxonomy.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Promote the released 20-value media channel taxonomy from draft documentation status to a stable normative surface by lazy consensus.

--- a/docs/reference/media-channel-taxonomy.mdx
+++ b/docs/reference/media-channel-taxonomy.mdx
@@ -1,15 +1,17 @@
 ---
 title: Media Channel Taxonomy
-description: "AdCP media channel taxonomy: the 19 standardized channel types (CTV, OLV, DOOH, podcasts, retail media, etc.) used for media planning and budget allocation."
+description: "AdCP media channel taxonomy: the 20 standardized channel types (CTV, OLV, DOOH, podcasts, retail media, etc.) used for media planning and budget allocation."
 "og:title": "AdCP — Media Channel Taxonomy"
 ---
 
 # Media Channel Taxonomy
 
 <Info>
-**Status**: Draft Specification
-**Version**: 1.0.0-draft
-**Last Updated**: 2026-01-23
+**Status**: Stable Specification
+**Version**: 1.0.0
+**Last Updated**: 2026-08-14
+
+Existing channel values are a GA-lined normative surface and follow the protocol's compatibility rules for removal or renaming.
 </Info>
 
 This specification defines a standardized taxonomy for advertising media channels. It is designed for interoperability across media planning tools, ad tech platforms, and AI-powered advertising agents.

--- a/docs/reference/media-channel-taxonomy.mdx
+++ b/docs/reference/media-channel-taxonomy.mdx
@@ -8,7 +8,7 @@ description: "AdCP media channel taxonomy: the 20 standardized channel types (CT
 
 <Info>
 **Status**: Stable Specification
-**Version**: 1.0.0
+**Version**: 1.1.0
 **Last Updated**: 2026-08-14
 
 Existing channel values are a GA-lined normative surface and follow the protocol's compatibility rules for removal or renaming.
@@ -781,10 +781,11 @@ The following channels may be added in future versions based on market evolution
 
 ## Changelog
 
-### 1.1.0-draft (2026-03-13)
+### 1.1.0 (2026-08-14)
 
 - Rename `ai_media` to `sponsored_intelligence` — Sponsored Intelligence is the umbrella for AI platform advertising (AI assistants, AI search, generative AI experiences)
 - 20 channels defined
+- Promote the released taxonomy to a stable normative surface by lazy consensus (#6261)
 
 ### 1.0.0-draft (2026-01-23)
 


### PR DESCRIPTION
## Summary

- promote the media channel taxonomy from draft to stable 1.1.0
- record that existing values follow ordinary protocol compatibility rules
- correct the page description from 19 to the current 20 channel values

## Decision

Option A: lazy consensus. The taxonomy is already released and used as a normative dependency; no separate WG ballot is required.

## Validation

- `npm run test:docs-nav`

Closes #6261
