### PR TITLE
Upgrade AI model defaults and compatibility

### DIFF
--- a/.agents/playbook.md
+++ b/.agents/playbook.md
@@ -728,7 +728,7 @@ Module and exam completion is only available through Addie's tool calls — neve
 
 ### Gemini image generation
 
-**Model**: `gemini-3.1-flash-image-preview` (via `responseModalities: ["TEXT", "IMAGE"]`)
+**Model**: `gemini-3.1-flash-image` (via `responseModalities: ["TEXT", "IMAGE"]`)
 
 **Base style prompt** (include in every image request):
 ```

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -96,4 +96,4 @@ jobs:
           app-id: ${{ secrets.SECRETARIAT_APP_ID }}
           app-private-key: ${{ secrets.SECRETARIAT_APP_PRIVATE_KEY }}
           # Optional; defaults to the review action's pinned model.
-          model: claude-opus-4-8
+          model: claude-opus-5

--- a/.github/workflows/check-image-alt-text.yml
+++ b/.github/workflows/check-image-alt-text.yml
@@ -114,7 +114,7 @@ jobs:
             rm -f "$IMG_B64_FILE"
 
             # Call Gemini API using file input to avoid shell arg limits
-            RESPONSE=$(curl -s --max-time 60 "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent" \
+            RESPONSE=$(curl -s --max-time 60 "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent" \
               -H 'Content-Type: application/json' \
               -H "x-goog-api-key: ${GEMINI_API_KEY}" \
               -d @"$PAYLOAD_FILE" 2>/dev/null)

--- a/scripts/check-image-quality.sh
+++ b/scripts/check-image-quality.sh
@@ -104,7 +104,7 @@ if [ -n "$STAGED_IMAGES" ] && [ -n "${GEMINI_API_KEY:-}" ]; then
       rm -f "$IMG_B64_FILE"
 
       RESPONSE=$(curl -s --max-time 30 \
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent" \
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent" \
         -H 'Content-Type: application/json' \
         -H "x-goog-api-key: ${GEMINI_API_KEY}" \
         -d @"$PAYLOAD_FILE" 2>/dev/null)

--- a/scripts/generate-images.ts
+++ b/scripts/generate-images.ts
@@ -22,6 +22,7 @@ import * as path from "path";
 import { createHash } from "crypto";
 import sharp from "sharp";
 import { signC2PA, isC2PASigningEnabled } from "../server/src/services/c2pa.js";
+import { GeminiModelConfig } from "../server/src/config/models.js";
 
 const STYLES: Record<string, string> = {
   addie: `Flat illustration, blue-led color palette (#1a36b4 primary, #2d4fd6 secondary, #6b8cef light accents) with teal used only as a minor supporting accent. Graphic novel style with clean panel borders. Clean, minimal linework with subtle gradients. Tech-forward but warm. No real brand names or logos. Wide aspect ratio suitable for documentation headers (roughly 16:9). Characters should have simple but expressive faces. Use white/light backgrounds for readability.`,
@@ -48,7 +49,7 @@ async function validateImage(
   imageBuffer: Buffer,
   altText?: string,
 ): Promise<ValidationResult | null> {
-  const model = genAI.getGenerativeModel({ model: "gemini-2.0-flash" });
+  const model = genAI.getGenerativeModel({ model: GeminiModelConfig.fast });
 
   let validationPrompt =
     `Analyze this image for quality. List ALL text visible in the image verbatim — every word, label, and caption exactly as rendered. ` +
@@ -107,7 +108,7 @@ async function generateAndSaveImage(
   style: string,
 ): Promise<Buffer | null> {
   const model = genAI.getGenerativeModel({
-    model: "gemini-3.1-flash-image-preview",
+    model: GeminiModelConfig.image,
     generationConfig: {
       // @ts-expect-error - responseModalities not in SDK types yet
       responseModalities: ["TEXT", "IMAGE"],
@@ -162,7 +163,7 @@ async function signStoryboardIfEnabled(
     const signed = signC2PA(pngBuffer, {
       claimGenerator: "AAO Docs Storyboard Generator",
       title: path.basename(outputPath),
-      softwareAgent: { name: "gemini-3.1-flash-image-preview", version: "preview" },
+      softwareAgent: { name: GeminiModelConfig.image, version: GeminiModelConfig.imageVersion },
       attributes: {
         style,
         relative_path: path.relative(process.cwd(), outputPath),

--- a/scripts/review-engagement-quality.ts
+++ b/scripts/review-engagement-quality.ts
@@ -183,9 +183,9 @@ async function reviewSnapshot(
   verbose: boolean,
 ): Promise<ReviewResult> {
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-5',
     max_tokens: 512,
-    temperature: 0,
+    thinking: { type: 'disabled' },
     system: REVIEW_RUBRIC,
     messages: [{
       role: 'user',

--- a/server/scripts/repro-addie-thread-speaker.ts
+++ b/server/scripts/repro-addie-thread-speaker.ts
@@ -116,8 +116,8 @@ const TOOLS = [
 async function callClaude(label: string, turns: { role: 'user' | 'assistant'; content: string }[]) {
   console.log(`\n--- LIVE: ${label} ---`);
   const resp = await client.messages.create({
-    model: 'claude-sonnet-4-6',
-    max_tokens: 1024,
+    model: 'claude-sonnet-5',
+    max_tokens: 4096,
     system: SYSTEM,
     tools: TOOLS,
     messages: turns,

--- a/server/scripts/test-tool-sets-local.ts
+++ b/server/scripts/test-tool-sets-local.ts
@@ -207,7 +207,7 @@ Respond with ONLY the JSON object, no other text.`;
 async function runRouter(message: string): Promise<{ tool_sets: string[]; reason: string; latency_ms: number }> {
   const start = Date.now();
   const response = await anthropic.messages.create({
-    model: 'claude-haiku-4-5-20250514',
+    model: 'claude-haiku-4-5',
     max_tokens: 200,
     messages: [{ role: 'user', content: buildRouterPrompt(message) }],
   });

--- a/server/scripts/test-tool-sets.ts
+++ b/server/scripts/test-tool-sets.ts
@@ -113,7 +113,7 @@ Respond with ONLY the JSON object, no other text.`;
  */
 async function runNewRouter(message: string): Promise<{ tool_sets: string[]; reason: string }> {
   const response = await anthropic.messages.create({
-    model: 'claude-haiku-4-5-20250514',
+    model: 'claude-haiku-4-5',
     max_tokens: 200,
     messages: [{ role: 'user', content: buildToolSetRouterPrompt(message) }],
   });

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -955,7 +955,9 @@ export class AddieClaudeClient {
         response = await withRetry(
           () => this.client.beta.messages.create({
             model: effectiveModel,
-            max_tokens: 4096,
+            // Sonnet 5 uses adaptive thinking by default; leave room for its
+            // thinking summary plus the user-visible answer/tool calls.
+            max_tokens: 8192,
             system: systemBlocks,
             tools: retriedEmptyPostToolResponse ? [] : [
               ...customTools,
@@ -1705,7 +1707,9 @@ export class AddieClaudeClient {
           try {
             const stream = this.client.beta.messages.stream({
               model: effectiveModel,
-              max_tokens: 4096,
+              // Sonnet 5 uses adaptive thinking by default; leave room for its
+              // thinking summary plus the user-visible answer/tool calls.
+              max_tokens: 8192,
               system: systemBlocks,
               tools: retriedEmptyPostToolResponse ? [] : customTools,
               messages,

--- a/server/src/addie/claude-pricing.ts
+++ b/server/src/addie/claude-pricing.ts
@@ -11,7 +11,7 @@
  *     cap by rewriting pricing).
  *
  * Update these alongside Anthropic's pricing page when model rates
- * change. Last refresh: April 2026.
+ * change. Last refresh: August 2026.
  */
 
 /** Per-million-token prices. Converted to per-token via × 1/1_000_000 downstream. */
@@ -25,22 +25,28 @@ interface ModelRates {
 }
 
 const PRICING_PER_MILLION_TOKENS: Record<string, ModelRates> = {
-  // Claude Opus 4.x — premium tier
-  'claude-opus-4-6': { inputUsd: 15, outputUsd: 75, cacheCreationUsd: 18.75, cacheReadUsd: 1.5 },
-  'claude-opus-4-7': { inputUsd: 15, outputUsd: 75, cacheCreationUsd: 18.75, cacheReadUsd: 1.5 },
-  // Claude Sonnet 4.x — balanced tier (most Addie calls)
+  // Claude Fable — highest-cost generally available tier
+  'claude-fable-5': { inputUsd: 10, outputUsd: 50, cacheCreationUsd: 12.5, cacheReadUsd: 1 },
+  // Claude Opus — premium tier
+  'claude-opus-4-6': { inputUsd: 5, outputUsd: 25, cacheCreationUsd: 6.25, cacheReadUsd: 0.5 },
+  'claude-opus-4-7': { inputUsd: 5, outputUsd: 25, cacheCreationUsd: 6.25, cacheReadUsd: 0.5 },
+  'claude-opus-4-8': { inputUsd: 5, outputUsd: 25, cacheCreationUsd: 6.25, cacheReadUsd: 0.5 },
+  'claude-opus-5': { inputUsd: 5, outputUsd: 25, cacheCreationUsd: 6.25, cacheReadUsd: 0.5 },
+  // Claude Sonnet — balanced tier (most Addie calls). Sonnet 5 is kept at
+  // its standard post-promotion rate so the daily cap remains conservative.
   'claude-sonnet-4-5': { inputUsd: 3, outputUsd: 15, cacheCreationUsd: 3.75, cacheReadUsd: 0.3 },
   'claude-sonnet-4-6': { inputUsd: 3, outputUsd: 15, cacheCreationUsd: 3.75, cacheReadUsd: 0.3 },
+  'claude-sonnet-5': { inputUsd: 3, outputUsd: 15, cacheCreationUsd: 3.75, cacheReadUsd: 0.3 },
   // Claude Haiku 4.x — fast / cheap tier (routing, classification)
   'claude-haiku-4-5': { inputUsd: 1, outputUsd: 5, cacheCreationUsd: 1.25, cacheReadUsd: 0.1 },
 };
 
 /**
  * Fallback rates applied to unknown model IDs (new model ships before
- * this table is updated). Conservatively priced as Opus so the cost
+ * this table is updated). Conservatively priced as Fable so the cost
  * cap won't accidentally give away premium usage while we catch up.
  */
-const UNKNOWN_MODEL_FALLBACK: ModelRates = PRICING_PER_MILLION_TOKENS['claude-opus-4-7'];
+const UNKNOWN_MODEL_FALLBACK: ModelRates = PRICING_PER_MILLION_TOKENS['claude-fable-5'];
 
 export interface ClaudeUsage {
   input_tokens: number;
@@ -54,7 +60,7 @@ export interface ClaudeUsage {
  * (1/1,000,000 of a dollar). Integer math throughout so a day's worth
  * of tiny calls can be summed without floating-point drift.
  *
- * Unknown model IDs fall through to the Opus rate — overestimating
+ * Unknown model IDs fall through to the Fable rate — overestimating
  * cost is safer than underestimating for a security gate.
  */
 export function costUsdMicros(model: string, usage: ClaudeUsage): number {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.11';
+export const CODE_VERSION = '2026.08.12';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/jobs/geo-monitor.ts
+++ b/server/src/addie/jobs/geo-monitor.ts
@@ -9,7 +9,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { logger as baseLogger } from '../../logger.js';
 import { query } from '../../db/client.js';
-import { ModelConfig } from '../../config/models.js';
+import { disableAdaptiveThinking, ModelConfig } from '../../config/models.js';
 import { syncGeoPromptsFromLLMPulse } from '../../services/geo-prompt-sync.js';
 import { submitBatch, extractText } from '../../utils/batch.js';
 import type { BatchRequest } from '../../utils/batch.js';
@@ -170,6 +170,7 @@ export async function runGeoMonitorJob(options: { limit?: number } = {}): Promis
     params: {
       model,
       max_tokens: 1024,
+      ...disableAdaptiveThinking(model),
       system: SYSTEM_PROMPT,
       messages: [{ role: 'user', content: prompt.prompt_text }],
     },

--- a/server/src/addie/jobs/shadow-evaluator.ts
+++ b/server/src/addie/jobs/shadow-evaluator.ts
@@ -20,7 +20,7 @@ import { createLogger } from '../../logger.js';
 import { query } from '../../db/client.js';
 import { getThreadReplies } from '../../slack/client.js';
 import { getThreadService } from '../thread-service.js';
-import { ModelConfig, AddieModelConfig } from '../../config/models.js';
+import { disableAdaptiveThinking, ModelConfig, AddieModelConfig } from '../../config/models.js';
 import { loadRules, loadResponseStyle } from '../rules/index.js';
 import { ADDIE_TOOL_REFERENCE } from '../prompts.js';
 import { gradeShape, type ShapeReport } from '../testing/shape-grader.js';
@@ -164,6 +164,7 @@ export async function compareResponses(
   const response = await client.messages.create({
     model: judgeModel,
     max_tokens: 300,
+    ...disableAdaptiveThinking(judgeModel),
     // System prompt gives the judge a stable refusal anchor independent
     // of the user-message content. The fence already strips closing tags,
     // but the system prompt is defense in depth — even if a future change
@@ -205,7 +206,8 @@ Respond with ONLY a JSON object:
     }],
   });
 
-  const text = response.content[0].type === 'text' ? response.content[0].text : '';
+  const textBlock = response.content.find((block) => block.type === 'text');
+  const text = textBlock?.type === 'text' ? textBlock.text : '';
   try {
     let jsonStr = text.trim();
     if (jsonStr.startsWith('```')) {
@@ -341,11 +343,12 @@ export async function runShadowEvaluatorJob(
       const shadowModel = resolveShadowModel();
       const shadowResult = await client.messages.create({
         model: shadowModel,
-        max_tokens: 1000,
+        max_tokens: 4096,
         system: systemPrompt,
         messages: [{ role: 'user', content: ctx.shadow_eval_question }],
       });
-      const shadowResponse = shadowResult.content[0].type === 'text' ? shadowResult.content[0].text : '';
+      const shadowTextBlock = shadowResult.content.find((block) => block.type === 'text');
+      const shadowResponse = shadowTextBlock?.type === 'text' ? shadowTextBlock.text : '';
 
       if (!shadowResponse) {
         await threadService.patchThreadContext(thread.thread_id, { shadow_eval_status: 'error' });

--- a/server/src/addie/jobs/wg-slack-context.ts
+++ b/server/src/addie/jobs/wg-slack-context.ts
@@ -12,7 +12,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { createLogger } from '../../logger.js';
-import { ModelConfig } from '../../config/models.js';
+import { disableAdaptiveThinking, ModelConfig } from '../../config/models.js';
 import { WorkingGroupDatabase } from '../../db/working-group-db.js';
 import { getChannelHistory, getChannelInfo } from '../../slack/client.js';
 import type { SlackHistoryMessage } from '../../slack/client.js';
@@ -241,9 +241,11 @@ export async function runWgSlackContextJob(
   const response = await client.messages.create({
     model: ModelConfig.primary,
     max_tokens: 3000,
+    ...disableAdaptiveThinking(ModelConfig.primary),
     messages: [{ role: 'user', content: buildDistillerPrompt(threads) }],
   });
-  const raw = response.content[0]?.type === 'text' ? response.content[0].text.trim() : '';
+  const textBlock = response.content.find((block) => block.type === 'text');
+  const raw = textBlock?.type === 'text' ? textBlock.text.trim() : '';
 
   if (!raw || raw.includes(NO_CONTENT_SENTINEL)) {
     result.skipped = 'no-spec-content';

--- a/server/src/addie/services/engagement-planner.ts
+++ b/server/src/addie/services/engagement-planner.ts
@@ -8,7 +8,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { createLogger } from '../../logger.js';
-import { ModelConfig } from '../../config/models.js';
+import { disableAdaptiveThinking, ModelConfig } from '../../config/models.js';
 import { STAGE_ORDER } from '../../db/relationship-db.js';
 import type { PersonRelationship, RelationshipStage } from '../../db/relationship-db.js';
 import type { MemberCapabilities } from '../types.js';
@@ -396,15 +396,15 @@ export async function composeMessage(
     {
       model: ModelConfig.primary,
       max_tokens: 1024,
-      temperature: 0.7,
+      ...disableAdaptiveThinking(ModelConfig.primary),
       system: COMPOSE_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: userPrompt }],
     },
     { signal: AbortSignal.timeout(30000) }
   );
 
-  const content = response.content[0];
-  if (content.type !== 'text') {
+  const content = response.content.find((block) => block.type === 'text');
+  if (!content || content.type !== 'text') {
     logger.warn('Unexpected response type from model');
     return null;
   }

--- a/server/src/addie/services/si-agent-service.ts
+++ b/server/src/addie/services/si-agent-service.ts
@@ -827,7 +827,7 @@ export class SiAgentService {
     try {
       const response = await this.anthropic.messages.create({
         model: ModelConfig.primary,
-        max_tokens: 1024,
+        max_tokens: 4096,
         system: systemPrompt,
         messages,
       });
@@ -906,7 +906,7 @@ export class SiAgentService {
       // Use streaming API
       const stream = this.anthropic.messages.stream({
         model: ModelConfig.primary,
-        max_tokens: 1024,
+        max_tokens: 4096,
         system: systemPrompt,
         messages,
       });

--- a/server/src/config/models.ts
+++ b/server/src/config/models.ts
@@ -11,10 +11,10 @@
 export const ModelConfig = {
   /**
    * Primary model for complex tasks (Addie chat, rule analysis)
-   * Default: claude-sonnet-4-6
+   * Default: claude-sonnet-5
    * Override: CLAUDE_MODEL_PRIMARY
    */
-  primary: process.env.CLAUDE_MODEL_PRIMARY || 'claude-sonnet-4-6',
+  primary: process.env.CLAUDE_MODEL_PRIMARY || 'claude-sonnet-5',
 
   /**
    * Fast model for simple tasks (insight extraction, classification)
@@ -25,19 +25,19 @@ export const ModelConfig = {
 
   /**
    * Precision model for high-stakes tasks (billing, financial, legal)
-   * Default: claude-opus-4-6 (most capable, but more expensive)
+   * Default: claude-opus-5 (frontier reasoning at the Opus price tier)
    * Override: CLAUDE_MODEL_PRECISION
    *
    * Use this when accuracy is critical and hallucinations are costly.
    * Examples: sending invoices, quoting prices, handling payments.
    */
-  precision: process.env.CLAUDE_MODEL_PRECISION || 'claude-opus-4-6',
+  precision: process.env.CLAUDE_MODEL_PRECISION || 'claude-opus-5',
 
   /**
    * Depth model for multi-step reasoning, expert consultation, and long-
    * context synthesis. Same model powers the AdCP triage routines so
    * Addie's deep-question answers stay consistent with GitHub triage.
-   * Default: claude-opus-4-7
+   * Default: claude-opus-5
    * Override: CLAUDE_MODEL_DEPTH
    *
    * Use this when the turn requires reasoning across many docs, multi-
@@ -45,8 +45,41 @@ export const ModelConfig = {
    * (billing accuracy) — depth is about thinking, precision is about
    * "don't hallucinate this number."
    */
-  depth: process.env.CLAUDE_MODEL_DEPTH || 'claude-opus-4-7',
+  depth: process.env.CLAUDE_MODEL_DEPTH || 'claude-opus-5',
 } as const;
+
+/**
+ * Gemini models used by the image pipeline.
+ *
+ * Gemini 3.7 Flash is the general multimodal workhorse, but it does not emit
+ * images. Native image generation therefore uses the current stable Flash
+ * Image model instead of the retired preview endpoint.
+ */
+const geminiImageModel = process.env.GEMINI_MODEL_IMAGE || 'gemini-3.1-flash-image';
+
+export const GeminiModelConfig = {
+  /** Image inspection, validation, and other text-output multimodal tasks. */
+  fast: process.env.GEMINI_MODEL_FAST || 'gemini-3.7-flash',
+
+  /** Native image generation and editing. */
+  image: geminiImageModel,
+
+  /** C2PA version paired with the selected image model. */
+  imageVersion: process.env.GEMINI_MODEL_IMAGE_VERSION || geminiImageModel.replace(/^gemini-/, ''),
+} as const;
+
+/**
+ * Request fragment for bounded jobs that should not spend their response
+ * budget on adaptive thinking. Older/overridden models receive no unknown
+ * request field, preserving the model override contract.
+ */
+export function disableAdaptiveThinking(model: string):
+  | { thinking: { type: 'disabled' } }
+  | Record<string, never> {
+  // Fable 5 and Mythos 5/Preview always think and reject `disabled`.
+  const supportsDisablingThinking = /^claude-(?:sonnet-5|opus-(?:4-[78]|5))$/.test(model);
+  return supportsDisablingThinking ? { thinking: { type: 'disabled' } } : {};
+}
 
 /**
  * Addie-specific model configuration
@@ -75,7 +108,7 @@ export const AddieModelConfig = {
    * failure modes — ritual phrases, length blow-out on short questions,
    * fabrication of integration details — which trace to Haiku's poor
    * adherence to negative instructions and conservative tool-call gating.
-   * Sonnet handles those substantially better at ~10x per-turn cost.
+   * Sonnet handles those substantially better at a higher per-turn cost.
    * Total spend is bounded by `anonymousDailyLimiter` (50 messages/IP/day)
    * + the per-IP $5 daily Claude API cap, both unchanged by this default.
    *

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -18,7 +18,7 @@ import {
   type ThreadChannel,
 } from "../addie/thread-service.js";
 import Anthropic from "@anthropic-ai/sdk";
-import { ModelConfig } from "../config/models.js";
+import { disableAdaptiveThinking, ModelConfig } from "../config/models.js";
 import { AddieRouter, type RoutingContext } from "../addie/router.js";
 import { sanitizeInput } from "../addie/security.js";
 import { runSlackHistoryBackfill } from "../addie/jobs/slack-history-backfill.js";
@@ -897,10 +897,12 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
       const response = await client.messages.create({
         model: ModelConfig.primary,
         max_tokens: 1500,
+        ...disableAdaptiveThinking(ModelConfig.primary),
         messages: [{ role: 'user', content: diagnosisPrompt }],
       });
 
-      const analysis = response.content[0].type === 'text' ? response.content[0].text : '';
+      const textBlock = response.content.find((block) => block.type === 'text');
+      const analysis = textBlock?.type === 'text' ? textBlock.text : '';
 
       logger.info({ threadId: id }, "Generated Claude diagnosis for thread");
       res.json({

--- a/server/src/services/brand-classifier.ts
+++ b/server/src/services/brand-classifier.ts
@@ -19,7 +19,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { createLogger } from '../logger.js';
-import { ModelConfig } from '../config/models.js';
+import { disableAdaptiveThinking, ModelConfig } from '../config/models.js';
 import type { KellerType } from '../types.js';
 import type { BrandfetchEnrichmentResult } from './brandfetch.js';
 import { canonicalizeBrandDomain } from './identifier-normalization.js';
@@ -95,6 +95,7 @@ export async function classifyBrand(
     const response = await getClient().messages.create({
       model: ModelConfig.primary,
       max_tokens: 300,
+      ...disableAdaptiveThinking(ModelConfig.primary),
       tools: [
         {
           name: 'classify_brand',

--- a/server/src/services/brand-enrichment.ts
+++ b/server/src/services/brand-enrichment.ts
@@ -17,7 +17,7 @@ import { brandDb } from '../db/brand-db.js';
 import { registryRequestsDb } from '../db/registry-requests-db.js';
 import { query } from '../db/client.js';
 import { getPool } from '../db/client.js';
-import { ModelConfig } from '../config/models.js';
+import { disableAdaptiveThinking, ModelConfig } from '../config/models.js';
 import { enrichOrganization } from './enrichment.js';
 import { isLushaConfigured } from './lusha.js';
 import type { UpsertDiscoveredBrandInput } from '../db/brand-db.js';
@@ -543,6 +543,7 @@ export async function expandHouse(houseDomain: string, options: {
   const response = await anthropic.messages.create({
     model: ModelConfig.primary,
     max_tokens: 4096,
+    ...disableAdaptiveThinking(ModelConfig.primary),
     tools: [
       {
         name: 'discover_sub_brands',

--- a/server/src/services/illustration-generator.ts
+++ b/server/src/services/illustration-generator.ts
@@ -15,10 +15,10 @@ import { getAllNewsletters } from '../newsletters/registry.js';
 import type { NewsletterConfig } from '../newsletters/config.js';
 import { signC2PA, isC2PASigningEnabled } from './c2pa.js';
 import { notifySystemError } from '../addie/error-notifier.js';
+import { GeminiModelConfig } from '../config/models.js';
 
-const GEMINI_IMAGE_MODEL = 'gemini-3.1-flash-image-preview';
-// Matches the -preview suffix above; bump together when promoting to a stable Gemini release.
-const GEMINI_IMAGE_VERSION = 'preview';
+const GEMINI_IMAGE_MODEL = GeminiModelConfig.image;
+const GEMINI_IMAGE_VERSION = GeminiModelConfig.imageVersion;
 
 function findNewsletterByCategory(category: string): NewsletterConfig | null {
   return getAllNewsletters().find((n) => n.perspectiveCategory === category) || null;

--- a/server/src/services/portrait-generator.ts
+++ b/server/src/services/portrait-generator.ts
@@ -13,11 +13,12 @@ import { createLogger } from '../logger.js';
 import { withGeminiRetry } from '../utils/gemini-retry.js';
 import { signC2PA, isC2PASigningEnabled } from './c2pa.js';
 import { notifySystemError } from '../addie/error-notifier.js';
+import { GeminiModelConfig } from '../config/models.js';
 
 const logger = createLogger('portrait-generator');
 
-const GEMINI_IMAGE_MODEL = 'gemini-3.1-flash-image-preview';
-const GEMINI_IMAGE_VERSION = 'preview';
+const GEMINI_IMAGE_MODEL = GeminiModelConfig.image;
+const GEMINI_IMAGE_VERSION = GeminiModelConfig.imageVersion;
 
 const PALETTES: Record<string, string> = {
   amber: `Flat illustration, amber/gold-led color palette (#D4A017 primary, #F4C430 secondary, #FFE066 light accents). Graphic novel style with clean linework and subtle gradients. Circular composition centered on the subject, suitable for avatar/profile use. Warm, approachable tone.`,
@@ -96,7 +97,7 @@ export async function generatePortrait(options: GeneratePortraitOptions): Promis
   const ai = getGenAI();
   const model = ai.getGenerativeModel(
     {
-      model: 'gemini-3.1-flash-image-preview',
+      model: GEMINI_IMAGE_MODEL,
       generationConfig: {
         // @ts-expect-error - responseModalities not in SDK types yet
         responseModalities: ['TEXT', 'IMAGE'],
@@ -244,7 +245,7 @@ export async function validatePortrait(imageBuffer: Buffer): Promise<{
   issues: string[];
 }> {
   const ai = getGenAI();
-  const model = ai.getGenerativeModel({ model: 'gemini-2.0-flash' }, { timeout: 30_000 });
+  const model = ai.getGenerativeModel({ model: GeminiModelConfig.fast }, { timeout: 30_000 });
 
   const validationPrompt =
     `Analyze this portrait illustration for quality. Check: ` +

--- a/server/src/services/prospect-cleanup.ts
+++ b/server/src/services/prospect-cleanup.ts
@@ -8,7 +8,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { getPool } from "../db/client.js";
 import { createLogger } from "../logger.js";
-import { ModelConfig } from "../config/models.js";
+import { disableAdaptiveThinking, ModelConfig } from "../config/models.js";
 import {
   getLushaClient,
   isLushaConfigured,
@@ -751,6 +751,7 @@ export class ProspectCleanupService {
           const response = await this.client.messages.create({
             model: this.model,
             max_tokens: 2048,
+            ...disableAdaptiveThinking(this.model),
             tools: [
               {
                 type: "web_search_20250305",
@@ -815,7 +816,9 @@ Be thorough but concise. Focus on actionable improvements.`,
 
       const response = await this.client.messages.create({
         model: this.model,
-        max_tokens: 4096,
+        // Preserve adaptive thinking for this agentic tool loop, with enough
+        // room for thinking plus tool calls and the final analysis.
+        max_tokens: 8192,
         system: CLEANUP_SYSTEM_PROMPT,
         tools: CLEANUP_TOOLS,
         messages,
@@ -895,7 +898,34 @@ Be thorough but concise. Focus on actionable improvements.`,
           content: response.content as Anthropic.ContentBlock[],
         });
         messages.push({ role: "user", content: toolResults });
+        continue;
       }
+
+      // The stable SDK union does not yet expose `compaction`, though the API
+      // can return it as a resumable stop reason.
+      const resumableStopReason = response.stop_reason as string | null;
+      if (resumableStopReason === "pause_turn" || resumableStopReason === "compaction") {
+        messages.push({
+          role: "assistant",
+          content: response.content as Anthropic.ContentBlock[],
+        });
+        continue;
+      }
+
+      // Do not resubmit an unchanged prompt after truncation, refusal, or
+      // another terminal stop reason; doing so can repeat the same costly
+      // response until the iteration limit.
+      const textBlock = response.content.find((c) => c.type === "text");
+      const partialAnalysis = textBlock?.type === "text" ? textBlock.text : "";
+      logger.warn(
+        { orgId, stopReason: response.stop_reason },
+        "Prospect cleanup stopped before completing its tool loop",
+      );
+      return {
+        analysis: partialAnalysis || `Analysis stopped: ${response.stop_reason ?? "unknown reason"}`,
+        suggested_actions: suggestedActions,
+        tool_calls: toolCalls,
+      };
     }
 
     return {

--- a/server/src/utils/llm.ts
+++ b/server/src/utils/llm.ts
@@ -6,7 +6,7 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
-import { ModelConfig } from '../config/models.js';
+import { disableAdaptiveThinking, ModelConfig } from '../config/models.js';
 import { withRetry } from './anthropic-retry.js';
 import { logger } from '../logger.js';
 
@@ -106,6 +106,9 @@ export async function complete(options: CompleteOptions): Promise<LLMResult> {
       return getClient().messages.create({
         model: modelId,
         max_tokens: maxTokens,
+        // This helper serves bounded one-shot completions. Avoid spending a
+        // small response budget on adaptive thinking for Sonnet/Opus tiers.
+        ...(model !== 'fast' && disableAdaptiveThinking(modelId)),
         ...(system && { system }),
         messages: [{ role: 'user', content: prompt }],
       });
@@ -119,9 +122,9 @@ export async function complete(options: CompleteOptions): Promise<LLMResult> {
   if (!response.content || response.content.length === 0) {
     throw new Error('Empty response from LLM');
   }
-  const content = response.content[0];
+  const content = response.content.find((block) => block.type === 'text');
 
-  if (content.type !== 'text') {
+  if (!content || content.type !== 'text') {
     throw new Error('Unexpected response type from LLM');
   }
 

--- a/server/src/utils/token-limiter.ts
+++ b/server/src/utils/token-limiter.ts
@@ -16,8 +16,13 @@ import { logger } from '../logger.js';
  * Reserve buffer space for system prompt, tools, and response generation.
  */
 export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
+  'claude-fable-5': 1000000,
   'claude-opus-4-6': 1000000,
+  'claude-opus-4-7': 1000000,
+  'claude-opus-4-8': 1000000,
+  'claude-opus-5': 1000000,
   'claude-sonnet-4-6': 1000000,
+  'claude-sonnet-5': 1000000,
   'claude-haiku-4-5': 200000,
   // Default for unknown models
   default: 200000,
@@ -54,7 +59,7 @@ export const TOKEN_BUFFERS = {
    */
   prependedContext: 10000,
   /** Reserve space for response generation */
-  responseBuffer: 5000,
+  responseBuffer: 10000,
   /** Safety margin for any miscalculation */
   safetyMargin: 10000,
 };
@@ -112,18 +117,18 @@ export function getConversationTokenLimit(model?: string, toolCount?: number): n
  * Estimate token count from text using a character-based heuristic.
  *
  * Claude uses a BPE tokenizer where:
- * - English text averages ~4 characters per token
- * - Code and structured data can be 3-5 chars per token
- * - We use 3.5 to be conservative (overestimate slightly)
+ * - English text historically averaged ~4 characters per token
+ * - Sonnet 5's tokenizer produces roughly 30% more tokens than Sonnet 4.6
+ * - We use 2.7 to stay conservative across current Claude models
  *
  * This is NOT exact but is fast for local estimation.
  * Use Anthropic's API for precise counts when needed.
  */
 export function estimateTokens(text: string): number {
   if (!text) return 0;
-  // Conservative estimate: ~3.5 characters per token
+  // Conservative estimate: ~2.7 characters per token
   // This slightly overestimates which is safer than underestimating
-  return Math.ceil(text.length / 3.5);
+  return Math.ceil(text.length / 2.7);
 }
 
 /**

--- a/server/tests/qualitative/replay-prod-scenarios.ts
+++ b/server/tests/qualitative/replay-prod-scenarios.ts
@@ -310,8 +310,8 @@ async function generateResponse(message: string, confidence: ConfidenceTier): Pr
   const systemPrompt = [basePrompt, calibration].filter(Boolean).join('\n\n');
 
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-6', // Use the same model Addie uses in prod for chat
-    max_tokens: 500,
+    model: 'claude-sonnet-5', // Use the same model Addie uses in prod for chat
+    max_tokens: 4096,
     system: systemPrompt,
     messages: [{ role: 'user', content: message }],
   });
@@ -357,8 +357,8 @@ function getRfcVariantSuffix(): { name: string; suffix: string } {
  * tool call so the grader can score whether search_docs / get_schema were
  * invoked before any draft was emitted.
  *
- * Temperature pinned to 0 to reduce run-to-run variance — variants need a
- * clean signal, and this isn't a creativity benchmark.
+ * Sonnet 5 no longer accepts sampling parameters, so variants rely on the
+ * same default sampling behavior used by production Addie.
  */
 async function generateRfcResponse(
   message: string,
@@ -380,9 +380,8 @@ async function generateRfcResponse(
   const MAX_TURNS = 6;
   for (let turn = 0; turn < MAX_TURNS; turn++) {
     const response = await client.messages.create({
-      model: 'claude-sonnet-4-6',
-      max_tokens: 1500,
-      temperature: 0,
+      model: 'claude-sonnet-5',
+      max_tokens: 4096,
       system: systemPrompt,
       tools: RFC_STUB_TOOLS as unknown as Anthropic.Tool[],
       messages,

--- a/server/tests/unit/addie-response-truncation.test.ts
+++ b/server/tests/unit/addie-response-truncation.test.ts
@@ -426,7 +426,7 @@ describe('Addie response truncation (#4431)', () => {
     expect(mocks.recordCost).toHaveBeenCalledOnce();
     expect(mocks.recordCost).toHaveBeenCalledWith(
       'user-4431',
-      'claude-sonnet-4-6',
+      'claude-sonnet-5',
       expect.objectContaining({ input_tokens: 8, output_tokens: 10 }),
     );
   });

--- a/server/tests/unit/claude-client-cost-gate.test.ts
+++ b/server/tests/unit/claude-client-cost-gate.test.ts
@@ -44,10 +44,10 @@ beforeEach(() => {
 
 describe('claude-client entry-gate behavior (#2790)', () => {
   it('processMessage short-circuits with cost_cap_exceeded when the user is over budget', async () => {
-    // Burn the anonymous cap for `user-x`. Opus is $15/M-token input,
-    // so we need >cap × 1M / 15 tokens to exceed the cap with one charge.
-    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 15) + 1;
-    await recordCost('user-x', 'claude-opus-4-7', { input_tokens: tokensToExceedCap, output_tokens: 0 });
+    // Burn the anonymous cap for `user-x`. Opus is $5/M-token input,
+    // so we need >cap × 1M / 5 tokens to exceed the cap with one charge.
+    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 5) + 1;
+    await recordCost('user-x', 'claude-opus-5', { input_tokens: tokensToExceedCap, output_tokens: 0 });
 
     const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
     const response = await client.processMessage(
@@ -67,8 +67,8 @@ describe('claude-client entry-gate behavior (#2790)', () => {
   });
 
   it('processMessageStream yields a single cost_cap_exceeded done event when over budget', async () => {
-    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 15) + 1;
-    await recordCost('user-y', 'claude-opus-4-7', { input_tokens: tokensToExceedCap, output_tokens: 0 });
+    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 5) + 1;
+    await recordCost('user-y', 'claude-opus-5', { input_tokens: tokensToExceedCap, output_tokens: 0 });
 
     const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
     const events: Array<{ type: string; response?: { flagged: boolean; flag_reason?: string } }> = [];

--- a/server/tests/unit/claude-cost-tracker.test.ts
+++ b/server/tests/unit/claude-cost-tracker.test.ts
@@ -80,11 +80,10 @@ describe('checkCostCap', () => {
 
   it('blocks the call that crosses the daily budget', async () => {
     // Burn just over the anonymous budget ($3 in current config) with one
-    // big Opus charge. Opus input is $15/M-token, so to push past $3 we
-    // need >200,000 input tokens (200_000 × 15 = 3,000,000 micros = $3.00).
-    // Use 200,001 to land just above the cap.
-    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 15) + 1;
-    await recordCost('u-cap', 'claude-opus-4-7', { input_tokens: tokensToExceedCap, output_tokens: 0 });
+    // big Opus charge. Opus input is $5/M-token, so compute the exact
+    // number of input tokens needed to land just above the cap.
+    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 5) + 1;
+    await recordCost('u-cap', 'claude-opus-5', { input_tokens: tokensToExceedCap, output_tokens: 0 });
     const result = await checkCostCap('u-cap', 'anonymous');
     expect(result.ok).toBe(false);
     expect(result.remainingUsd).toBe(0);
@@ -94,8 +93,8 @@ describe('checkCostCap', () => {
   });
 
   it('tracks users independently', async () => {
-    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 15) + 1;
-    await recordCost('u-heavy', 'claude-opus-4-7', { input_tokens: tokensToExceedCap, output_tokens: 0 });
+    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 5) + 1;
+    await recordCost('u-heavy', 'claude-opus-5', { input_tokens: tokensToExceedCap, output_tokens: 0 });
     expect((await checkCostCap('u-heavy', 'anonymous')).ok).toBe(false);
     expect((await checkCostCap('u-light', 'anonymous')).ok).toBe(true);
   });
@@ -112,7 +111,7 @@ describe('checkCostCap', () => {
   });
 
   it('does not cap AAO team usage', async () => {
-    await recordCost('u-aao-team', 'claude-opus-4-7', { input_tokens: 10_000_000, output_tokens: 10_000_000 });
+    await recordCost('u-aao-team', 'claude-opus-5', { input_tokens: 10_000_000, output_tokens: 10_000_000 });
     const result = await checkCostCap('u-aao-team', 'aao_team');
     expect(result.ok).toBe(true);
     expect(result.tier).toBe('aao_team');
@@ -136,7 +135,7 @@ describe('recordCost', () => {
   });
 
   it('is a no-op for system users (they shouldn\'t count toward any per-user cap)', async () => {
-    await recordCost('system:addie', 'claude-opus-4-7', { input_tokens: 100_000, output_tokens: 50_000 });
+    await recordCost('system:addie', 'claude-opus-5', { input_tokens: 100_000, output_tokens: 50_000 });
     // Any non-system user starts fresh.
     expect((await checkCostCap('u-fresh', 'anonymous')).spentCents).toBe(0);
   });
@@ -154,7 +153,7 @@ describe('recordCost', () => {
 
 describe('buildSlackCostOptions', () => {
   it('charges a public home-workspace discussion to a bounded community scope, not the speaker', async () => {
-    await recordCost('slack:U-PUBLIC', 'claude-opus-4-7', {
+    await recordCost('slack:U-PUBLIC', 'claude-opus-5', {
       input_tokens: 10_000_000,
       output_tokens: 10_000_000,
     });
@@ -184,7 +183,7 @@ describe('buildSlackCostOptions', () => {
       options.costScope.tier,
     )).ok).toBe(true);
 
-    await recordCost(options.costScope.userId, 'claude-opus-4-7', {
+    await recordCost(options.costScope.userId, 'claude-opus-5', {
       input_tokens: 10_000_000,
       output_tokens: 10_000_000,
     });
@@ -289,8 +288,8 @@ describe('calendar-day (UTC midnight) reset semantics', () => {
   });
 
   it('stays blocked until UTC midnight even if 24h has not elapsed since the charge', async () => {
-    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 15) + 1;
-    await recordCost('u-cal', 'claude-opus-4-7', { input_tokens: tokensToExceedCap, output_tokens: 0 });
+    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 5) + 1;
+    await recordCost('u-cal', 'claude-opus-5', { input_tokens: tokensToExceedCap, output_tokens: 0 });
     expect((await checkCostCap('u-cal', 'anonymous')).ok).toBe(false);
 
     // 14h later (08:00 UTC the next day) is well short of 24h since
@@ -302,8 +301,8 @@ describe('calendar-day (UTC midnight) reset semantics', () => {
   });
 
   it('stays capped right up to 23:59:59.999 UTC on the day of the charge', async () => {
-    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 15) + 1;
-    await recordCost('u-cal2', 'claude-opus-4-7', { input_tokens: tokensToExceedCap, output_tokens: 0 });
+    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 5) + 1;
+    await recordCost('u-cal2', 'claude-opus-5', { input_tokens: tokensToExceedCap, output_tokens: 0 });
 
     vi.setSystemTime(new Date('2026-04-22T23:59:59.999Z'));
     expect((await checkCostCap('u-cal2', 'anonymous')).ok).toBe(false);
@@ -315,12 +314,12 @@ describe('calendar-day (UTC midnight) reset semantics', () => {
   it('retryAfterMs reflects time until the next UTC midnight, not a per-charge anniversary', async () => {
     // At 18:00 UTC, next midnight is 6h away regardless of when
     // within today's window the charges landed.
-    const perChargeTokens = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 15 / 3) + 1;
-    await recordCost('u-slide', 'claude-opus-4-7', { input_tokens: perChargeTokens, output_tokens: 0 });
+    const perChargeTokens = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 5 / 3) + 1;
+    await recordCost('u-slide', 'claude-opus-5', { input_tokens: perChargeTokens, output_tokens: 0 });
     vi.advanceTimersByTime(30 * 60 * 1000);
-    await recordCost('u-slide', 'claude-opus-4-7', { input_tokens: perChargeTokens, output_tokens: 0 });
+    await recordCost('u-slide', 'claude-opus-5', { input_tokens: perChargeTokens, output_tokens: 0 });
     vi.advanceTimersByTime(30 * 60 * 1000);
-    await recordCost('u-slide', 'claude-opus-4-7', { input_tokens: perChargeTokens, output_tokens: 0 });
+    await recordCost('u-slide', 'claude-opus-5', { input_tokens: perChargeTokens, output_tokens: 0 });
 
     const result = await checkCostCap('u-slide', 'anonymous');
     expect(result.ok).toBe(false);
@@ -331,7 +330,7 @@ describe('calendar-day (UTC midnight) reset semantics', () => {
   });
 
   it('does not count a charge from a previous UTC day toward today\'s budget', async () => {
-    await recordCost('u-yesterday', 'claude-opus-4-7', { input_tokens: 10_000_000, output_tokens: 0 });
+    await recordCost('u-yesterday', 'claude-opus-5', { input_tokens: 10_000_000, output_tokens: 0 });
     expect((await checkCostCap('u-yesterday', 'anonymous')).ok).toBe(false);
 
     vi.setSystemTime(new Date('2026-04-23T00:00:01.000Z'));
@@ -348,10 +347,10 @@ describe('scope-key shape independence', () => {
   beforeEach(() => __setCostTrackerStore(__createInMemoryCostStore()));
 
   it('keys Slack, WorkOS, and anonymous scopes as distinct users', async () => {
-    // Burn a WorkOS-style user's budget. Need >cap × $1M-tokens / $15-per-M
+    // Burn a WorkOS-style user's budget. Need >cap × $1M-tokens / $5-per-M
     // to exceed the anonymous cap with one Opus charge.
-    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 15) + 1;
-    await recordCost('user_01H9ABCDEFG', 'claude-opus-4-7', { input_tokens: tokensToExceedCap, output_tokens: 0 });
+    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 5) + 1;
+    await recordCost('user_01H9ABCDEFG', 'claude-opus-5', { input_tokens: tokensToExceedCap, output_tokens: 0 });
     expect((await checkCostCap('user_01H9ABCDEFG', 'anonymous')).ok).toBe(false);
 
     // A Slack-namespaced caller on the same underlying Slack user
@@ -366,8 +365,8 @@ describe('scope-key shape independence', () => {
     // A would-be spoofer that happens to have a `system:` prefix
     // but isn't on the literal allowlist gets limited like anyone
     // else (matches the tool-rate-limiter's literal-allowlist rule).
-    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 15) + 1;
-    await recordCost('system:fake', 'claude-opus-4-7', { input_tokens: tokensToExceedCap, output_tokens: 0 });
+    const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 5) + 1;
+    await recordCost('system:fake', 'claude-opus-5', { input_tokens: tokensToExceedCap, output_tokens: 0 });
     expect((await checkCostCap('system:fake', 'anonymous')).ok).toBe(false);
 
     // The real system user is still exempt and runs uncapped.

--- a/server/tests/unit/claude-pricing.test.ts
+++ b/server/tests/unit/claude-pricing.test.ts
@@ -15,12 +15,12 @@ describe('costUsdMicros', () => {
 
   it('prices Sonnet at $3/M input, $15/M output', () => {
     // 10k input, 5k output: 10_000*3 + 5_000*15 = 30_000 + 75_000 = 105_000 micros ($0.105)
-    expect(costUsdMicros('claude-sonnet-4-6', { input_tokens: 10_000, output_tokens: 5_000 })).toBe(105_000);
+    expect(costUsdMicros('claude-sonnet-5', { input_tokens: 10_000, output_tokens: 5_000 })).toBe(105_000);
   });
 
-  it('prices Opus at $15/M input, $75/M output', () => {
-    // 1000 input, 500 output: 1000*15 + 500*75 = 15_000 + 37_500 = 52_500 micros
-    expect(costUsdMicros('claude-opus-4-7', { input_tokens: 1000, output_tokens: 500 })).toBe(52_500);
+  it('prices Opus at $5/M input, $25/M output', () => {
+    // 1000 input, 500 output: 1000*5 + 500*25 = 5_000 + 12_500 = 17_500 micros
+    expect(costUsdMicros('claude-opus-5', { input_tokens: 1000, output_tokens: 500 })).toBe(17_500);
   });
 
   it('applies cache-creation and cache-read rates (Sonnet)', () => {
@@ -40,13 +40,13 @@ describe('costUsdMicros', () => {
     );
   });
 
-  it('falls back to Opus pricing for unknown models (overestimate rather than underestimate)', () => {
+  it('falls back to Fable pricing for unknown models (overestimate rather than underestimate)', () => {
     // If Anthropic ships a new model before this table is updated,
-    // the gate still charges conservatively. 1000 input at Opus rate
-    // = 1000 * 15 = 15_000 micros. Matches explicit Opus call.
+    // the gate still charges conservatively. 1000 input at Fable rate
+    // = 1000 * 10 = 10_000 micros. Matches explicit Fable call.
     const unknownCost = costUsdMicros('claude-made-up-9-0', { input_tokens: 1000, output_tokens: 0 });
-    const opusCost = costUsdMicros('claude-opus-4-7', { input_tokens: 1000, output_tokens: 0 });
-    expect(unknownCost).toBe(opusCost);
+    const fableCost = costUsdMicros('claude-fable-5', { input_tokens: 1000, output_tokens: 0 });
+    expect(unknownCost).toBe(fableCost);
   });
 
   it('ceilings fractional results so a sub-micro charge still increments the counter', () => {
@@ -66,9 +66,10 @@ describe('costUsdMicros', () => {
 
 describe('__hasKnownPricing', () => {
   it('returns true for supported models', () => {
-    expect(__hasKnownPricing('claude-sonnet-4-6')).toBe(true);
+    expect(__hasKnownPricing('claude-sonnet-5')).toBe(true);
     expect(__hasKnownPricing('claude-haiku-4-5')).toBe(true);
-    expect(__hasKnownPricing('claude-opus-4-7')).toBe(true);
+    expect(__hasKnownPricing('claude-opus-5')).toBe(true);
+    expect(__hasKnownPricing('claude-fable-5')).toBe(true);
   });
 
   it('returns false for unknown models', () => {

--- a/server/tests/unit/model-config.test.ts
+++ b/server/tests/unit/model-config.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { disableAdaptiveThinking, GeminiModelConfig } from '../../src/config/models.js';
+
+describe('disableAdaptiveThinking', () => {
+  it.each([
+    'claude-sonnet-5',
+    'claude-opus-4-7',
+    'claude-opus-4-8',
+    'claude-opus-5',
+  ])('disables thinking only on supported model %s', (model) => {
+    expect(disableAdaptiveThinking(model)).toEqual({ thinking: { type: 'disabled' } });
+  });
+
+  it.each([
+    'claude-fable-5',
+    'claude-mythos-5',
+    'claude-mythos-preview',
+    'claude-opus-4-6',
+    'claude-sonnet-4-6',
+    'claude-haiku-4-5',
+    'custom-model',
+  ])('omits unsupported thinking configuration for %s', (model) => {
+    expect(disableAdaptiveThinking(model)).toEqual({});
+  });
+});
+
+describe('GeminiModelConfig', () => {
+  it('keeps C2PA version provenance aligned with the selected image model', () => {
+    const expectedVersion = process.env.GEMINI_MODEL_IMAGE_VERSION
+      || GeminiModelConfig.image.replace(/^gemini-/, '');
+    expect(GeminiModelConfig.imageVersion).toBe(expectedVersion);
+  });
+});

--- a/server/tests/unit/prospect-cleanup-resume.test.ts
+++ b/server/tests/unit/prospect-cleanup-resume.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ProspectCleanupService } from '../../src/services/prospect-cleanup.js';
+
+describe('ProspectCleanupService resumable turns', () => {
+  it.each(['pause_turn', 'compaction'] as const)(
+    'continues after %s without replaying the original prompt unchanged',
+    async (stopReason) => {
+      const responses = [
+        {
+          stop_reason: stopReason,
+          content: [{ type: 'text', text: 'Intermediate state' }],
+        },
+        {
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: 'Final analysis' }],
+        },
+      ];
+      const messageSnapshots: unknown[][] = [];
+      const create = vi.fn(async (params: { messages: unknown[] }) => {
+        messageSnapshots.push(structuredClone(params.messages));
+        return responses[messageSnapshots.length - 1];
+      });
+      const service = new ProspectCleanupService('test-key', 'claude-sonnet-5');
+      Object.defineProperty(service, 'client', {
+        value: { messages: { create } },
+      });
+
+      const result = await service.analyzeWithClaude('org-test');
+
+      expect(result.analysis).toBe('Final analysis');
+      expect(create).toHaveBeenCalledTimes(2);
+      expect(messageSnapshots[0]).toHaveLength(1);
+      expect(messageSnapshots[1]).toEqual([
+        expect.objectContaining({ role: 'user' }),
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Intermediate state' }],
+        },
+      ]);
+    },
+  );
+});

--- a/server/tests/unit/wg-slack-context-job.test.ts
+++ b/server/tests/unit/wg-slack-context-job.test.ts
@@ -31,6 +31,7 @@ vi.mock('@anthropic-ai/sdk', () => ({
 
 vi.mock('../../src/config/models.js', () => ({
   ModelConfig: { primary: 'test-model', fast: 'test-model' },
+  disableAdaptiveThinking: () => ({}),
 }));
 
 function wg(name: string, channelId: string) {

--- a/specs/member-portraits.md
+++ b/specs/member-portraits.md
@@ -113,7 +113,7 @@ Flow:
 1. Validate membership (paid tier required)
 2. Accept uploaded photo into memory (not disk)
 3. Assemble prompt with amber palette + vibe + photo reference
-4. Call Gemini `gemini-3.1-flash-image-preview` with photo as reference image
+4. Call Gemini `gemini-3.1-flash-image` with photo as reference image
 5. Store generated PNG in `member_portraits` (BYTEA)
 6. Delete uploaded photo from memory
 7. Set status = `generated`, return preview URL

--- a/tests/utils/token-limiter.test.ts
+++ b/tests/utils/token-limiter.test.ts
@@ -30,20 +30,20 @@ describe('estimateTokens', () => {
   });
 
   it('should estimate tokens for short text', () => {
-    // "Hello world" = 11 chars, ~3 tokens at 3.5 chars/token
+    // Sonnet 5's tokenizer needs a conservative ~2.7 chars/token estimate.
     const result = estimateTokens('Hello world');
-    expect(result).toBe(Math.ceil(11 / 3.5)); // 4
+    expect(result).toBe(Math.ceil(11 / 2.7)); // 5
   });
 
   it('should estimate tokens for longer text', () => {
     const text = 'This is a longer piece of text that should have more tokens.';
     const result = estimateTokens(text);
-    expect(result).toBe(Math.ceil(text.length / 3.5));
+    expect(result).toBe(Math.ceil(text.length / 2.7));
   });
 
   it('should round up token estimates', () => {
-    // 10 chars / 3.5 = 2.857... should round up to 3
-    expect(estimateTokens('1234567890')).toBe(3);
+    // 10 chars / 2.7 = 3.703... should round up to 4
+    expect(estimateTokens('1234567890')).toBe(4);
   });
 });
 
@@ -182,8 +182,8 @@ describe('getConversationTokenLimit', () => {
   });
 
   it('should return model-specific limit minus reserved tokens', () => {
-    const limit = getConversationTokenLimit('claude-sonnet-4-6');
-    expect(limit).toBe(MODEL_CONTEXT_LIMITS['claude-sonnet-4-6'] - RESERVED_TOKENS);
+    const limit = getConversationTokenLimit('claude-sonnet-5');
+    expect(limit).toBe(MODEL_CONTEXT_LIMITS['claude-sonnet-5'] - RESERVED_TOKENS);
   });
 
   it('should use default for unknown models', () => {
@@ -193,28 +193,28 @@ describe('getConversationTokenLimit', () => {
 
   it('should use dynamic calculation when toolCount is provided', () => {
     const toolCount = 50;
-    const limit = getConversationTokenLimit('claude-sonnet-4-6', toolCount);
+    const limit = getConversationTokenLimit('claude-sonnet-5', toolCount);
 
     // Expected: model limit - (system prompt + tool tokens + prepended context + response buffer + safety margin)
     const expectedToolTokens = estimateToolTokens(toolCount);
     const expectedReserved = TOKEN_BUFFERS.systemPrompt + expectedToolTokens +
       TOKEN_BUFFERS.prependedContext + TOKEN_BUFFERS.responseBuffer + TOKEN_BUFFERS.safetyMargin;
-    const expectedLimit = MODEL_CONTEXT_LIMITS['claude-sonnet-4-6'] - expectedReserved;
+    const expectedLimit = MODEL_CONTEXT_LIMITS['claude-sonnet-5'] - expectedReserved;
 
     expect(limit).toBe(expectedLimit);
   });
 
   it('should give more conversation budget with fewer tools', () => {
-    const limitWithFewTools = getConversationTokenLimit('claude-sonnet-4-6', 10);
-    const limitWithManyTools = getConversationTokenLimit('claude-sonnet-4-6', 100);
+    const limitWithFewTools = getConversationTokenLimit('claude-sonnet-5', 10);
+    const limitWithManyTools = getConversationTokenLimit('claude-sonnet-5', 100);
 
     // Fewer tools = more room for conversation
     expect(limitWithFewTools).toBeGreaterThan(limitWithManyTools);
   });
 
   it('should differ from static buffer when toolCount provided', () => {
-    const staticLimit = getConversationTokenLimit('claude-sonnet-4-6');
-    const dynamicLimit = getConversationTokenLimit('claude-sonnet-4-6', 50);
+    const staticLimit = getConversationTokenLimit('claude-sonnet-5');
+    const dynamicLimit = getConversationTokenLimit('claude-sonnet-5', 50);
 
     // Dynamic calculation should differ from static RESERVED_TOKENS buffer
     expect(dynamicLimit).not.toBe(staticLimit);


### PR DESCRIPTION
## Summary

- upgrade Gemini text and vision validation to Gemini 3.7 Flash
- promote image generation from the preview endpoint to stable Gemini 3.1 Flash Image
- upgrade primary Claude workloads to Sonnet 5 and precision/depth workloads to Opus 5
- adapt bounded and conversational calls to current thinking behavior, tokenizer density, context limits, and stop reasons
- refresh Claude pricing and cost-cap accounting tables
- keep Gemini C2PA provenance aligned with model overrides

## Why

The repository still selected several superseded or preview model IDs. New Claude defaults also require explicit handling for adaptive thinking, sampling restrictions, denser tokenization, and resumable responses.

## Impact

Addie and model-backed jobs use current model generations by default while preserving environment overrides. Bounded jobs avoid unnecessary thinking spend; conversational and tool-loop paths retain enough output headroom and correctly resume provider-managed turns.

## Validation

- specialist code, security, and Node test reviews: approved with no remaining findings
- repository pre-commit gate: passed
- server unit suite: 6,114 passed, 30 skipped
- focused model/config/resume/token tests: passed
- OpenAPI generation check: passed
- TypeScript typecheck: passed
- live model discovery and minimal inference smoke tests passed for Gemini 3.7 Flash, Gemini 3.1 Flash Image, Claude Sonnet 5, and Claude Opus 5
- `git diff --check`: passed

No changeset is required because this does not change a protocol release surface.
