### PR TITLE
fix(ci): roll Ladon reviewer back to Opus 4.8

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -96,4 +96,4 @@ jobs:
           app-id: ${{ secrets.SECRETARIAT_APP_ID }}
           app-private-key: ${{ secrets.SECRETARIAT_APP_PRIVATE_KEY }}
           # Optional; defaults to the review action's pinned model.
-          model: claude-opus-5
+          model: claude-opus-4-8


### PR DESCRIPTION
## What changed

- Roll the Ladon AI reviewer model back from `claude-opus-5` to `claude-opus-4-8`.

## Why

The last successful review of PR #6203 used Opus 4.8 and completed in 30 of 60 allowed turns. After the model upgrade, three Opus 5 attempts exhausted the 60-turn limit without emitting findings.

The rebased PR also produced an unusually large review delta, so this is an operational rollback rather than a claim that the model alone caused the failures. It restores the last known-good reviewer configuration while rebase-delta handling and final-output turn reservation are hardened separately.

## Impact

New Ladon review runs use the model configuration that was working before the upgrade.

## Validation

- `git diff --check`
- `node scripts/check-pr-title.cjs "fix(ci): roll Ladon reviewer back to Opus 4.8"`
