### PR TITLE
feat(media-buy): add browser family targeting

### DIFF
--- a/.changeset/add-browser-family-targeting.md
+++ b/.changeset/add-browser-family-targeting.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add portable browser-family inclusion and exclusion to targeting-aware product discovery and package execution. Products declare `browser` and `browser_exclude` support independently, either without restriction or with explicit supported-family subsets. The canonical taxonomy distinguishes recognized-but-unlisted `other` browsers from unclassifiable `unknown` browsers and intentionally excludes browser versions and seller-native targeting IDs.

--- a/docs/media-buy/advanced-topics/targeting.mdx
+++ b/docs/media-buy/advanced-topics/targeting.mdx
@@ -43,6 +43,29 @@ When the buyer wants package-level control over specific selectable signals that
 
 Products can also expose `included_signals` for signals already bundled into or planned into the product. Those signals are descriptive product metadata, not package-level targeting controls, and buyers do not echo them in `signal_targeting_groups`.
 
+## Browser-family targeting
+
+Use `targeting_overlay.browser` and `targeting_overlay.browser_exclude` for portable browser-family constraints. The fields intentionally stop at families: browser versions, user-agent strings, backend segment IDs, and arbitrary ad-server key/value expressions are not part of the contract.
+
+```json
+{
+  "targeting_overlay": {
+    "browser": ["chrome", "safari", "samsung_internet"],
+    "browser_exclude": ["safari"]
+  }
+}
+```
+
+Values within `browser` use OR semantics, and `browser_exclude` wins on overlap, so this example delivers on Chrome or Samsung Internet but not Safari. When `browser` is present, omitted families are not eligible. The canonical families are `chrome`, `safari`, `firefox`, `edge`, `opera`, `samsung_internet`, `android_webview`, `other`, and `unknown`.
+
+`other` means the seller recognizes the browser family but it is not one of the explicitly named families. For example, a FreeWheel connector can map recognized values such as Amazon Silk, Android Browser, or Internet Explorer to `other`. `unknown` means the seller cannot classify the browser into a recognized family. Include either value explicitly when that traffic should be eligible; omitting it from an inclusion list excludes it. Samsung Internet remains distinct from Chrome even though both are Chromium-based. `android_webview` means the impression itself is reliably classified as rendering in Android WebView; a native-app placement or an in-app browser opened after a click is not automatically Android WebView.
+
+Browser family describes the impression delivery and rendering environment, not the post-click landing-page browser. Sellers must not infer it solely from operating system, device, “Web” or “Mobile Web” inventory, or placement. Sellers advertising browser support map these portable values to their platform controls internally. A social or app-only product with only device, OS, or placement controls omits `overlay_support.browser` and `overlay_support.browser_exclude` rather than approximating browser support.
+
+Browser and device constraints intersect. For example, `browser: ["safari"]` with `device_platform: ["android"]` may have no executable inventory. During discovery, the seller excludes an incompatible product or returns a configured product with a sparse, buyer-visible `targeting_resolution.modifications` alternative. At create or update, it rejects an exact combination it cannot enforce rather than silently broadening delivery.
+
+Inclusion and exclusion are independent product capabilities. Use concrete values in `targeting_overlay` when pricing and forecasts must reflect them now, and use `required_overlay_support.browser` or `required_overlay_support.browser_exclude` when package values will be supplied later. Requirement `true` asks for any positive support; `{ "families": ["chrome", "firefox"] }` requires both named families. A product advertises unrestricted support as `true`, or partial support as `{ "families": [...] }`. Products such as CTV, audio, DOOH, or app inventory can omit browser support entirely.
+
 ## Portable demographic targeting
 
 Use `targeting_overlay.demographics` when the buyer needs a demographic predicate to survive product discovery, purchase, seller compilation, and readback without being reinterpreted from prose. AdCP 3.2 standardizes age first:
@@ -891,6 +914,23 @@ For products where inventory and audience planning are inseparable, such as line
 - **Examples**: `["dooh"]`, `["ctv", "dooh"]`
 - **Use cases**: Exclude CTV for app-install campaigns, exclude DOOH for direct-response campaigns
 - **Note**: Supported when seller declares `device_type: true` in `get_adcp_capabilities`
+
+### browser
+
+- **Description**: Restrict impression delivery to canonical browser families
+- **Format**: Non-empty array of `chrome`, `safari`, `firefox`, `edge`, `opera`, `samsung_internet`, `android_webview`, `other`, or `unknown`
+- **Examples**: `["chrome"]`, `["chrome", "firefox"]`, `["safari", "unknown"]`
+- **Semantics**: Values use OR; when present, omitted families are ineligible. The field describes the impression rendering environment, not a post-click browser.
+- **Discovery**: Require any later-selectable family with `required_overlay_support.browser: true`, or require a subset with `required_overlay_support.browser.families`. Products disclose unrestricted support as `true` or partial support with `overlay_support.browser.families`.
+
+### browser_exclude
+
+- **Description**: Exclude canonical browser families from impression delivery
+- **Format**: Non-empty array using the same values as `browser`
+- **Examples**: `["unknown"]`, `["safari", "android_webview"]`
+- **Conflict rule**: Exclusion wins when the same family appears in both browser fields
+- **Discovery**: Inclusion and exclusion support are independent; `required_overlay_support.browser_exclude` and `overlay_support.browser_exclude` use the same `true` or `{ "families": [...] }` capability form.
+- **Failure rule**: A seller that cannot enforce the exclusion rejects the request instead of dropping it
 
 ### language
 - **Description**: Restrict to users with specific language preferences

--- a/static/compliance/source/protocols/media-buy/scenarios/targeting_aware_discovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/targeting_aware_discovery.yaml
@@ -53,9 +53,13 @@ prerequisites:
   description: |
     The controller seeds a non-guaranteed video product with US inventory,
     Nielsen DMA support, two targetable publisher-scoped placements, list
-    targeting support, and enumerated age intervals. The seller can return
-    request-scoped configured products derived from this catalog product. The
-    expired configured fixture is a retained tombstone issued to this scenario's
+    targeting support, enumerated age intervals, and deterministic browser
+    inventory. Chrome, Firefox, and unclassifiable browser traffic are
+    forecastable; Safari is recognized and targetable but has no inventory in
+    the seeded forecast window. Safari is compatible only with iOS and macOS,
+    so Safari plus Android is unenforceable. The seller can return request-scoped
+    configured products derived from this catalog product. The expired
+    configured fixture is a retained tombstone issued to this scenario's
     authenticated account and discovery lineage; inaccessible lineages are not
     exposed.
   test_kit: "test-kits/acme-outdoor.yaml"
@@ -89,7 +93,12 @@ fixtures:
           max_values_per_package: 2
         property_list: true
         collection_list: true
+        device_platform: true
         device_platform_exclude: true
+        browser:
+          families: ["chrome", "safari", "firefox", "unknown"]
+        browser_exclude:
+          families: ["chrome", "safari", "firefox", "unknown"]
         keyword_targets: true
         demographics:
           age: true
@@ -104,6 +113,11 @@ fixtures:
               age: { min: 25, max: 34, include_unknown: false }
             - interval_id: "age_35_44"
               age: { min: 35, max: 44, include_unknown: false }
+      browser_inventory:
+        forecastable_families: ["chrome", "firefox", "unknown"]
+        unavailable_families: ["safari"]
+        platform_compatibility:
+          safari: ["ios", "macos"]
     - product_id: "targeting_aware_fixed_placement"
       delivery_type: "non_guaranteed"
       channels: ["ctv"]
@@ -361,6 +375,8 @@ phases:
           targeting_overlay:
             geo_countries: ["US"]
             device_platform_exclude: ["fire_os"]
+            browser: ["chrome", "safari", "unknown"]
+            browser_exclude: ["safari"]
             property_list:
               agent_url: "https://governance.pinnacle-agency.example"
               list_id: "acme_outdoor_allowlist_v1"
@@ -379,6 +395,10 @@ phases:
             property_list: true
             collection_list: true
             device_platform_exclude: true
+            browser:
+              families: ["chrome", "firefox"]
+            browser_exclude:
+              families: ["unknown"]
             keyword_targets:
               supported_match_types: ["exact"]
           context:
@@ -386,10 +406,12 @@ phases:
         expected: |
           Return one configured product whose price and availability forecast
           are scoped to US feed inventory, the selected property and collection
-          lists, and the Fire OS exclusion. Exact acceptance omits
+          lists, the Fire OS exclusion, and Chrome or unclassified browser
+          traffic with Safari excluded. Exact acceptance omits
           targeting_resolution. overlay_support confirms later DMA, placement,
-          property-list, collection-list, and device-platform exclusion without
-          returning one product per possible value.
+          property-list, collection-list, platform, and independent browser
+          inclusion/exclusion control without returning one product per possible
+          value.
         context_outputs:
           - key: "exact_product_id"
             path: "products[0].product_id"
@@ -430,6 +452,16 @@ phases:
             path: "products[0].overlay_support.device_platform_exclude"
             value: true
             description: "Platform exclusion support is declared independently"
+          - check: field_value
+            path: "products[0].overlay_support.browser"
+            value:
+              families: ["chrome", "safari", "firefox", "unknown"]
+            description: "Required later browser inclusion support is declared by family"
+          - check: field_value
+            path: "products[0].overlay_support.browser_exclude"
+            value:
+              families: ["chrome", "safari", "firefox", "unknown"]
+            description: "Required later browser exclusion support is declared independently"
 
       - id: get_unsupported_future_targeting
         title: "Exclude products that lack a required future dimension"
@@ -821,7 +853,7 @@ phases:
             description: "A recognized expired configured product uses PRODUCT_EXPIRED"
 
   - id: modified_targeting_discovery
-    title: "Accept a seller-supported demographic alternative through product selection"
+    title: "Accept sparse demographic and browser alternatives through product selection"
     steps:
       - id: get_modified_age_product
         title: "Request an age range the product cannot execute exactly"
@@ -841,13 +873,15 @@ phases:
           targeting_overlay:
             demographics:
               age: { min: 21, max: 35, include_unknown: false }
+            browser: ["chrome", "safari"]
           context:
             correlation_id: "targeting_aware_discovery--modified_age"
         expected: |
-          Return a distinct configured product proposing ages 25–34. The sparse
-          resolution contains only /demographics/age, expires_at bounds the
-          offer, and the forecast reflects ages 25–34 rather than the catalog
-          product or original inexact request.
+          Return a distinct configured product proposing ages 25–34 and
+          removing Safari because only Chrome has forecastable inventory for
+          the requested discovery scope. The ordered sparse resolution changes only
+          /demographics/age and /browser, expires_at bounds the offer, and the
+          forecast reflects the resulting effective targeting.
         context_outputs:
           - key: "modified_product_id"
             path: "products[0].product_id"
@@ -868,6 +902,18 @@ phases:
             path: "products[0].targeting_resolution.modifications[0].applied"
             value: { min: 25, max: 34, include_unknown: false }
             description: "Configured age predicate is 25–34 with unknown ages excluded"
+          - check: field_value
+            path: "products[0].targeting_resolution.modifications[1].operation"
+            value: "remove_values"
+            description: "Browser set changes use the sparse set operation"
+          - check: field_value
+            path: "products[0].targeting_resolution.modifications[1].path"
+            value: "/browser"
+            description: "Browser modification targets the complete browser-family set"
+          - check: field_contains
+            path: "products[0].targeting_resolution.modifications[1].values[*]"
+            value: "safari"
+            description: "The configured offer visibly removes Safari"
           - check: field_present
             path: "products[0].expires_at"
             description: "Modified configured product is time-bound"
@@ -895,9 +941,9 @@ phases:
               bid_price: 14.0
               budget: 5000
         expected: |
-          Selecting the configured product accepts ages 25–34. The response
-          package echoes complete effective targeting and never stores
-          equivalent false.
+          Selecting the configured product accepts ages 25–34 and Chrome-only
+          browser targeting. The response package echoes complete effective
+          targeting and never stores equivalent false.
         context_outputs:
           - key: "modified_media_buy_id"
             path: "media_buy_id"
@@ -912,6 +958,13 @@ phases:
             path: "packages[0].targeting_overlay.demographics.age.max"
             value: 34
             description: "Accepted effective upper bound is echoed"
+          - check: field_value
+            path: "packages[0].targeting_overlay.browser[0]"
+            value: "chrome"
+            description: "Accepted effective browser family is echoed"
+          - check: field_absent
+            path: "packages[0].targeting_overlay.browser[1]"
+            description: "Removed Safari is not booked"
           - check: field_value
             path: "packages[0].targeting_resolution.demographics.equivalent"
             value: true
@@ -944,9 +997,9 @@ phases:
               bid_price: 14.0
               budget: 5000
         expected: |
-          The configured product retains the US, Fire OS exclusion, property,
-          collection, and feed targeting accepted at discovery even though the
-          buyer does not repeat it.
+          The configured product retains the US, Fire OS exclusion, browser
+          inclusion/exclusion, property, collection, and feed targeting
+          accepted at discovery even though the buyer does not repeat it.
         context_outputs:
           - key: "placement_media_buy_id"
             path: "media_buy_id"
@@ -967,6 +1020,28 @@ phases:
             path: "packages[0].targeting_overlay.device_platform_exclude[0]"
             value: "fire_os"
             description: "Configured-product platform exclusion is booked without repetition"
+          - check: field_contains
+            path: "packages[0].targeting_overlay.browser[*]"
+            value: "chrome"
+            description: "Named Chrome traffic remains in the booked inclusion set"
+          - check: field_contains
+            path: "packages[0].targeting_overlay.browser[*]"
+            value: "safari"
+            description: "Overlapping Safari remains explicit in the booked inclusion set"
+          - check: field_contains
+            path: "packages[0].targeting_overlay.browser[*]"
+            value: "unknown"
+            description: "Explicitly eligible unclassifiable browsers remain in the booked inclusion set"
+          - check: field_absent
+            path: "packages[0].targeting_overlay.browser[3]"
+            description: "Booked browser inclusion has exactly the three requested families"
+          - check: field_contains
+            path: "packages[0].targeting_overlay.browser_exclude[*]"
+            value: "safari"
+            description: "Overlapping Safari exclusion is booked and wins during delivery"
+          - check: field_absent
+            path: "packages[0].targeting_overlay.browser_exclude[1]"
+            description: "Booked browser exclusion has exactly the one requested family"
           - check: field_value
             path: "packages[0].targeting_overlay.property_list.list_id"
             value: "acme_outdoor_allowlist_v1"
@@ -1002,6 +1077,8 @@ phases:
               targeting_overlay:
                 geo_countries: ["US"]
                 device_platform_exclude: ["fire_os"]
+                browser: ["chrome", "firefox"]
+                browser_exclude: ["unknown"]
                 property_list:
                   agent_url: "https://governance.pinnacle-agency.example"
                   list_id: "acme_outdoor_allowlist_v1"
@@ -1015,8 +1092,10 @@ phases:
                       placement_id: "short_video"
         expected: |
           Apply the full overlay replacement atomically under update_targeting.
-          The response echoes short_video as the committed purchased set. The
-          seller rejects rather than partially applying an invalid selection.
+          The response echoes short_video plus the later-selected Chrome or
+          Firefox inclusion and unknown-browser exclusion. This exercises the
+          independently advertised future browser capabilities. The seller
+          rejects rather than partially applying an invalid selection.
         validations:
           - check: response_schema
             description: "Response matches update-media-buy-response.json"
@@ -1039,6 +1118,69 @@ phases:
                     - publisher_domain: "pinnacle-media.example"
                       placement_id: "short_video"
             description: "Update response returns complete post-update placement targeting state"
+          - check: field_contains
+            path: "affected_packages[*].targeting_overlay.browser[*]"
+            value: "chrome"
+            description: "Update applies later-selected Chrome inclusion"
+          - check: field_contains
+            path: "affected_packages[*].targeting_overlay.browser[*]"
+            value: "firefox"
+            description: "Update applies later-selected Firefox inclusion"
+          - check: field_absent
+            path: "affected_packages[0].targeting_overlay.browser[2]"
+            description: "Update returns exactly two selected browser families"
+          - check: field_contains
+            path: "affected_packages[*].targeting_overlay.browser_exclude[*]"
+            value: "unknown"
+            description: "Update applies the later-selected unknown-browser exclusion"
+          - check: field_absent
+            path: "affected_packages[0].targeting_overlay.browser_exclude[1]"
+            description: "Update returns exactly one browser exclusion"
+
+      - id: reject_incompatible_browser_platform
+        title: "Reject an incompatible browser and device combination"
+        task: update_media_buy
+        schema_ref: "media-buy/update-media-buy-request.json"
+        response_schema_ref: "media-buy/update-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/update_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          media_buy_id: "$context.placement_media_buy_id"
+          idempotency_key: "$generate:uuid_v4#targeting_aware_discovery_incompatible_browser_platform"
+          packages:
+            - package_id: "$context.placement_package_id"
+              targeting_overlay:
+                geo_countries: ["US"]
+                device_platform: ["android"]
+                device_platform_exclude: ["fire_os"]
+                browser: ["safari"]
+                browser_exclude: ["unknown"]
+                property_list:
+                  agent_url: "https://governance.pinnacle-agency.example"
+                  list_id: "acme_outdoor_allowlist_v1"
+                collection_list:
+                  agent_url: "https://governance.pinnacle-agency.example"
+                  list_id: "acme_outdoor_collections_v1"
+                placement_selection:
+                  mode: "selected"
+                  placement_refs:
+                    - publisher_domain: "pinnacle-media.example"
+                      placement_id: "short_video"
+        expected: |
+          Reject atomically with UNSUPPORTED_FEATURE because the seeded product
+          can classify both dimensions but cannot execute Safari on Android.
+          The prior Chrome-or-Firefox targeting remains committed.
+        validations:
+          - check: error_code
+            value: "UNSUPPORTED_FEATURE"
+            description: "An unenforceable browser and platform intersection is rejected"
 
       - id: reject_cross_publisher_placement
         title: "Reject a placement outside the product publisher scope"
@@ -1132,7 +1274,7 @@ phases:
         expected: |
           Return complete effective targeting with short_video selected. The
           stored package does not expose a separate effective-placement source
-          of truth. Both rejected updates were atomic and left this state
+          of truth. All three rejected updates were atomic and left this state
           unchanged.
         validations:
           - check: response_schema
@@ -1157,6 +1299,24 @@ phases:
             path: "media_buys[0].packages[0].targeting_overlay.device_platform_exclude[0]"
             value: "fire_os"
             description: "Readback preserves the purchased platform exclusion"
+          - check: field_contains
+            path: "media_buys[0].packages[0].targeting_overlay.browser[*]"
+            value: "chrome"
+            description: "Readback preserves later-selected Chrome inclusion"
+          - check: field_contains
+            path: "media_buys[0].packages[0].targeting_overlay.browser[*]"
+            value: "firefox"
+            description: "Readback preserves later-selected browser inclusion"
+          - check: field_absent
+            path: "media_buys[0].packages[0].targeting_overlay.browser[2]"
+            description: "Readback browser inclusion has exactly two families"
+          - check: field_contains
+            path: "media_buys[0].packages[0].targeting_overlay.browser_exclude[*]"
+            value: "unknown"
+            description: "Readback preserves later-selected browser exclusion"
+          - check: field_absent
+            path: "media_buys[0].packages[0].targeting_overlay.browser_exclude[1]"
+            description: "Readback browser exclusion has exactly one family"
           - check: field_value
             path: "media_buys[0].packages[0].targeting_overlay.property_list.list_id"
             value: "acme_outdoor_allowlist_v1"

--- a/static/schemas/source/core/targeting-modification.json
+++ b/static/schemas/source/core/targeting-modification.json
@@ -45,6 +45,8 @@
             "/device_platform_exclude",
             "/device_type",
             "/device_type_exclude",
+            "/browser",
+            "/browser_exclude",
             "/language"
           ],
           "description": "Supported targeting field with string-set semantics. Postal-area paths identify their group with selector; direct top-level sets omit selector."

--- a/static/schemas/source/core/targeting-overlay-requirements.json
+++ b/static/schemas/source/core/targeting-overlay-requirements.json
@@ -41,6 +41,25 @@
           "additionalProperties": false
         }
       ]
+    },
+    "browserRequirement": {
+      "anyOf": [
+        { "$ref": "#/definitions/required" },
+        {
+          "type": "object",
+          "description": "Require later package-level selection for the listed canonical browser families. The requirement matches unrestricted true support or structured support containing every requested family.",
+          "properties": {
+            "families": {
+              "type": "array",
+              "items": { "$ref": "/schemas/enums/browser-family.json" },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          },
+          "required": ["families"],
+          "additionalProperties": false
+        }
+      ]
     }
   },
   "properties": {
@@ -114,6 +133,8 @@
     "device_platform_exclude": { "$ref": "#/definitions/required" },
     "device_type": { "$ref": "#/definitions/required" },
     "device_type_exclude": { "$ref": "#/definitions/required" },
+    "browser": { "$ref": "#/definitions/browserRequirement" },
+    "browser_exclude": { "$ref": "#/definitions/browserRequirement" },
     "store_catchments": { "$ref": "#/definitions/required" },
     "language": { "$ref": "#/definitions/required" },
     "keyword_targets": { "$ref": "#/definitions/keywordRequirement" },

--- a/static/schemas/source/core/targeting-overlay-support.json
+++ b/static/schemas/source/core/targeting-overlay-support.json
@@ -67,6 +67,26 @@
           "additionalProperties": false
         }
       ]
+    },
+    "browserSupport": {
+      "anyOf": [
+        { "$ref": "#/definitions/supported" },
+        {
+          "type": "object",
+          "description": "Canonical browser families that may be selected on packages later. This is executable targeting capability, not a guarantee of inventory for every family.",
+          "properties": {
+            "families": {
+              "type": "array",
+              "items": { "$ref": "/schemas/enums/browser-family.json" },
+              "minItems": 1,
+              "uniqueItems": true
+            },
+            "ext": { "$ref": "/schemas/core/ext.json" }
+          },
+          "required": ["families"],
+          "additionalProperties": false
+        }
+      ]
     }
   },
   "properties": {
@@ -158,6 +178,8 @@
     "device_platform_exclude": { "$ref": "#/definitions/supported" },
     "device_type": { "$ref": "#/definitions/supported" },
     "device_type_exclude": { "$ref": "#/definitions/supported" },
+    "browser": { "$ref": "#/definitions/browserSupport" },
+    "browser_exclude": { "$ref": "#/definitions/browserSupport" },
     "store_catchments": { "$ref": "#/definitions/supported" },
     "language": { "$ref": "#/definitions/supported" },
     "keyword_targets": { "$ref": "#/definitions/keywordSupport" },

--- a/static/schemas/source/core/targeting.json
+++ b/static/schemas/source/core/targeting.json
@@ -238,6 +238,24 @@
       },
       "minItems": 1
     },
+    "browser": {
+      "type": "array",
+      "description": "Restrict delivery to specific canonical browser families in the impression delivery and rendering environment, not the post-click landing-page browser. Values MUST NOT be inferred solely from operating system, device, web/mobile-web inventory, or placement. Values in this array use OR semantics. When browser is supplied, families not listed are ineligible: other includes a seller-recognized family that is not explicitly enumerated, while unknown includes a browser the seller cannot classify into a recognized family. When the same family appears in browser and browser_exclude, exclusion wins. Browser and device constraints intersect; a seller that cannot enforce the exact combination MUST exclude or explicitly reconfigure the product during discovery and MUST reject it at create or update rather than silently widening delivery. Browser versions and seller-native IDs are intentionally unsupported.",
+      "items": {
+        "$ref": "/schemas/enums/browser-family.json"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "browser_exclude": {
+      "type": "array",
+      "description": "Exclude specific canonical browser families from delivery. other excludes seller-recognized families that are not explicitly enumerated; unknown excludes browsers the seller cannot classify into a recognized family. When the same family appears in browser and browser_exclude, exclusion wins. Sellers MUST reject a request they cannot enforce rather than silently dropping the exclusion.",
+      "items": {
+        "$ref": "/schemas/enums/browser-family.json"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
     "store_catchments": {
       "type": "array",
       "description": "Target users within store catchment areas from a synced store catalog. Each entry references a store-type catalog and optionally narrows to specific stores or catchment zones.",

--- a/static/schemas/source/enums/browser-family.json
+++ b/static/schemas/source/enums/browser-family.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/browser-family.json",
+  "title": "Browser Family",
+  "description": "Portable browser families for targeting the impression delivery and rendering environment, not a post-click landing-page browser. Values identify browser families, not versions or seller-native browser IDs, and MUST NOT be inferred solely from operating system, device, web/mobile-web inventory, or placement. android_webview means an impression reliably classified as rendering in Android WebView. other means a seller-recognized browser family that is not explicitly enumerated; unknown means the seller cannot classify the browser into a recognized family.",
+  "type": "string",
+  "enum": [
+    "chrome",
+    "safari",
+    "firefox",
+    "edge",
+    "opera",
+    "samsung_internet",
+    "android_webview",
+    "other",
+    "unknown"
+  ]
+}

--- a/tests/targeting-aware-discovery.test.cjs
+++ b/tests/targeting-aware-discovery.test.cjs
@@ -207,6 +207,129 @@ test("device-platform exclusion is typed and independently discoverable", async 
   assert.match(targetingSchema, /MUST reject/);
 });
 
+test("browser-family inclusion and exclusion are typed and independently discoverable", async () => {
+  const [validateTargeting, validateRequirements, validateSupport] =
+    await Promise.all([
+      compile("/schemas/core/targeting.json"),
+      compile("/schemas/core/targeting-overlay-requirements.json"),
+      compile("/schemas/core/targeting-overlay-support.json"),
+    ]);
+  const canonicalFamilies = [
+    "chrome",
+    "safari",
+    "firefox",
+    "edge",
+    "opera",
+    "samsung_internet",
+    "android_webview",
+    "other",
+    "unknown",
+  ];
+
+  assert.equal(
+    validateTargeting({
+      browser: canonicalFamilies,
+      browser_exclude: ["safari", "unknown"],
+    }),
+    true,
+    errors(validateTargeting)
+  );
+  for (const invalid of [
+    { browser: [] },
+    { browser: ["internet_explorer"] },
+    { browser: ["chrome", "chrome"] },
+    { browser_exclude: [] },
+    { browser_exclude: ["chromium"] },
+  ]) {
+    assert.equal(
+      validateTargeting(invalid),
+      false,
+      `invalid browser targeting must fail: ${JSON.stringify(invalid)}`
+    );
+  }
+  assert.equal(
+    validateRequirements({ browser: true, browser_exclude: true }),
+    true,
+    errors(validateRequirements)
+  );
+  assert.equal(
+    validateRequirements({
+      browser: { families: ["chrome", "firefox"] },
+      browser_exclude: { families: ["unknown"] },
+    }),
+    true,
+    errors(validateRequirements)
+  );
+  assert.equal(
+    validateSupport({ browser: true, browser_exclude: true }),
+    true,
+    errors(validateSupport)
+  );
+  assert.equal(
+    validateSupport({
+      browser: { families: ["chrome", "firefox"] },
+      browser_exclude: { families: ["unknown"] },
+    }),
+    true,
+    errors(validateSupport)
+  );
+  for (const invalid of [
+    { browser: {} },
+    { browser: { families: [] } },
+    { browser: { families: ["internet_explorer"] } },
+    { browser_exclude: { families: ["unknown", "unknown"] } },
+  ]) {
+    assert.equal(
+      validateRequirements(invalid),
+      false,
+      `invalid browser requirement must fail: ${JSON.stringify(invalid)}`
+    );
+    assert.equal(
+      validateSupport(invalid),
+      false,
+      `invalid browser support must fail: ${JSON.stringify(invalid)}`
+    );
+  }
+  assert.equal(
+    validateRequirements({ browser: false }),
+    false,
+    "browser support requirements are positive capabilities"
+  );
+  assert.equal(
+    validateSupport({ browser: true }),
+    true,
+    errors(validateSupport)
+  );
+  assert.equal(
+    validateSupport({ browser_exclude: true }),
+    true,
+    errors(validateSupport)
+  );
+
+  const browserEnum = JSON.parse(
+    fs.readFileSync(
+      path.join(SCHEMA_ROOT, "enums", "browser-family.json"),
+      "utf8"
+    )
+  );
+  assert.deepEqual(browserEnum.enum, canonicalFamilies);
+  assert.match(browserEnum.description, /other means a seller-recognized/i);
+  assert.match(browserEnum.description, /unknown means the seller cannot classify/i);
+  assert.match(browserEnum.description, /impression delivery and rendering environment/i);
+  assert.match(browserEnum.description, /MUST NOT be inferred solely/i);
+  assert.match(browserEnum.description, /android_webview means an impression reliably classified/i);
+
+  const targeting = JSON.parse(
+    fs.readFileSync(path.join(SCHEMA_ROOT, "core", "targeting.json"), "utf8")
+  );
+  assert.match(targeting.properties.browser.description, /families not listed are ineligible/i);
+  assert.match(targeting.properties.browser.description, /exclusion wins/i);
+  assert.match(targeting.properties.browser.description, /Browser and device constraints intersect/i);
+  assert.match(targeting.properties.browser.description, /not the post-click landing-page browser/i);
+  assert.match(targeting.properties.browser.description, /MUST reject/i);
+  assert.match(targeting.properties.browser_exclude.description, /exclusion wins/i);
+});
+
 test("seller targeting rollups are explicit true-valued routing hints", async () => {
   const validate = await compile(
     "/schemas/protocol/get-adcp-capabilities-response.json"
@@ -482,6 +605,29 @@ test("targeting-aware storyboard grades filters and configured targeting end to 
     ["fire_os"]
   );
   assert.deepEqual(
+    step("get_exact_targeted_product").sample_request.targeting_overlay.browser,
+    ["chrome", "safari", "unknown"],
+    "exact discovery must exercise named, overlapping, and unclassifiable browser families"
+  );
+  assert.deepEqual(
+    step("get_exact_targeted_product").sample_request.targeting_overlay
+      .browser_exclude,
+    ["safari"],
+    "exact discovery must exercise exclusion-wins semantics"
+  );
+  assert.deepEqual(
+    step("get_exact_targeted_product").sample_request.required_overlay_support
+      .browser,
+    { families: ["chrome", "firefox"] },
+    "discovery must require later browser inclusion for the selected families"
+  );
+  assert.deepEqual(
+    step("get_exact_targeted_product").sample_request.required_overlay_support
+      .browser_exclude,
+    { families: ["unknown"] },
+    "discovery must require later browser exclusion independently"
+  );
+  assert.deepEqual(
     step("get_exact_targeted_product").sample_request.required_overlay_support
       .keyword_targets,
     { supported_match_types: ["exact"] },
@@ -506,6 +652,64 @@ test("targeting-aware storyboard grades filters and configured targeting end to 
     ),
     true,
     "support true must satisfy an object requirement"
+  );
+  for (const field of [
+    "browser",
+    "browser_exclude",
+  ]) {
+    const validation = step("get_exact_targeted_product").validations.find(
+      (candidate) =>
+        candidate.check === "field_value" &&
+        candidate.path === `products[0].overlay_support.${field}`
+    );
+    assert.deepEqual(
+      validation?.value,
+      { families: ["chrome", "safari", "firefox", "unknown"] },
+      `${field} support must be graded independently by family`
+    );
+  }
+  assert.deepEqual(
+    storyboard.fixtures.products[0].browser_inventory,
+    {
+      forecastable_families: ["chrome", "firefox", "unknown"],
+      unavailable_families: ["safari"],
+      platform_compatibility: { safari: ["ios", "macos"] },
+    },
+    "browser discovery outcomes must be grounded in deterministic seeded inventory"
+  );
+
+  assert.deepEqual(
+    step("get_modified_age_product").sample_request.targeting_overlay.browser,
+    ["chrome", "safari"]
+  );
+  assert.equal(
+    hasCheck(
+      "get_modified_age_product",
+      "field_value",
+      "products[0].targeting_resolution.modifications[1].operation",
+      "remove_values"
+    ),
+    true,
+    "browser alternatives must use sparse set removal"
+  );
+  assert.equal(
+    hasCheck(
+      "get_modified_age_product",
+      "field_value",
+      "products[0].targeting_resolution.modifications[1].path",
+      "/browser"
+    ),
+    true,
+    "the browser modification path must be graded"
+  );
+  assert.equal(
+    hasCheck(
+      "create_from_modified_product",
+      "field_absent",
+      "packages[0].targeting_overlay.browser[1]"
+    ),
+    true,
+    "booked readback must prove the removed browser was not restored"
   );
 
   const briefConfirmation = step("get_brief_targeted_product").validations.find(
@@ -619,6 +823,85 @@ test("targeting-aware storyboard grades filters and configured targeting end to 
       `${id} must grade persistence of the concrete platform exclusion`
     );
   }
+  for (const [id, path, value] of [
+    ["create_feed_package", "packages[0].targeting_overlay.browser[*]", "chrome"],
+    ["create_feed_package", "packages[0].targeting_overlay.browser[*]", "safari"],
+    ["create_feed_package", "packages[0].targeting_overlay.browser[*]", "unknown"],
+    ["create_feed_package", "packages[0].targeting_overlay.browser_exclude[*]", "safari"],
+    ["read_updated_placement", "media_buys[0].packages[0].targeting_overlay.browser[*]", "chrome"],
+    ["read_updated_placement", "media_buys[0].packages[0].targeting_overlay.browser[*]", "firefox"],
+    ["read_updated_placement", "media_buys[0].packages[0].targeting_overlay.browser_exclude[*]", "unknown"],
+  ]) {
+    assert.equal(
+      hasCheck(id, "field_contains", path, value),
+      true,
+      `${id} must grade browser value ${value}`
+    );
+  }
+  for (const [id, path] of [
+    ["create_feed_package", "packages[0].targeting_overlay.browser[3]"],
+    ["create_feed_package", "packages[0].targeting_overlay.browser_exclude[1]"],
+    ["update_to_short_video", "affected_packages[0].targeting_overlay.browser[2]"],
+    ["update_to_short_video", "affected_packages[0].targeting_overlay.browser_exclude[1]"],
+    ["read_updated_placement", "media_buys[0].packages[0].targeting_overlay.browser[2]"],
+    ["read_updated_placement", "media_buys[0].packages[0].targeting_overlay.browser_exclude[1]"],
+  ]) {
+    assert.equal(
+      hasCheck(id, "field_absent", path),
+      true,
+      `${id} must grade browser set cardinality at ${path}`
+    );
+  }
+  assert.deepEqual(
+    step("update_to_short_video").sample_request.packages[0].targeting_overlay.browser,
+    ["chrome", "firefox"],
+    "update must exercise later package-level browser selection"
+  );
+  assert.deepEqual(
+    step("update_to_short_video").sample_request.packages[0].targeting_overlay
+      .browser_exclude,
+    ["unknown"],
+    "update must exercise later package-level browser exclusion"
+  );
+  assert.equal(
+    hasCheck(
+      "reject_incompatible_browser_platform",
+      "error_code",
+      undefined,
+      "UNSUPPORTED_FEATURE"
+    ),
+    true,
+    "an unenforceable browser and device intersection must be rejected"
+  );
+  assert.deepEqual(
+    step("reject_incompatible_browser_platform").sample_request.packages[0]
+      .targeting_overlay,
+    {
+      geo_countries: ["US"],
+      device_platform: ["android"],
+      device_platform_exclude: ["fire_os"],
+      browser: ["safari"],
+      browser_exclude: ["unknown"],
+      property_list: {
+        agent_url: "https://governance.pinnacle-agency.example",
+        list_id: "acme_outdoor_allowlist_v1",
+      },
+      collection_list: {
+        agent_url: "https://governance.pinnacle-agency.example",
+        list_id: "acme_outdoor_collections_v1",
+      },
+      placement_selection: {
+        mode: "selected",
+        placement_refs: [
+          {
+            publisher_domain: "pinnacle-media.example",
+            placement_id: "short_video",
+          },
+        ],
+      },
+    },
+    "the negative vector must be otherwise-complete replacement targeting"
+  );
 
   for (const [path, contextKey] of [
     ["media_buys[0].media_buy_id", "placement_media_buy_id"],
@@ -811,6 +1094,18 @@ test("targeting modifications are sparse and use semantic set operations", async
           operation: "remove_values",
           path: "/device_platform_exclude",
           values: ["fire_os"],
+          reason: "The configured offer cannot preserve this exclusion.",
+        },
+        {
+          operation: "remove_values",
+          path: "/browser",
+          values: ["safari"],
+          reason: "No forecastable Safari inventory is available for the discovery scope.",
+        },
+        {
+          operation: "remove_values",
+          path: "/browser_exclude",
+          values: ["unknown"],
           reason: "The configured offer cannot preserve this exclusion.",
         },
       ],


### PR DESCRIPTION
## Summary

- add typed browser-family inclusion and exclusion to targeting overlays
- support unrestricted or per-family product capability discovery
- document portable mapping, impression-rendering semantics, and seller trust boundaries
- add deterministic discovery, create, update, rejection, and readback compliance coverage

## Why

Buyers need portable browser-family constraints without exposing browser versions, user-agent strings, or seller-native ad-server identifiers. Product-scoped capability discovery allows sellers to expose only the families they can execute and lets social or app-only inventory omit browser targeting entirely.

## Impact

This is an additive 3.2 contract change. Sellers can map native browser catalogs internally, while buyers receive stable `browser` and `browser_exclude` fields with explicit overlap, unknown, and failure semantics.

## Validation

- `npm run test:targeting-aware-discovery`
- `npm run test:schemas`
- `npm run test:targeting-overlay-vectors`
- `npm run test:build-schemas-hoist-enums`
- `npm run docs:json-field-audit`
- `npm run lint:schema-links`
- `npm run test:schema-utf8`
- `npm run typecheck`
- `npm run build:compliance -- --check`
- targeted storyboard schema and lint suites

Closes #6223