### PR TITLE
fix(schema): replace drifted inline enums with $ref and add drift lint

### DIFF
--- a/.changeset/fix-inline-enum-drift.md
+++ b/.changeset/fix-inline-enum-drift.md
@@ -1,0 +1,10 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix three inline enum drift bugs where canonical enum files gained values that were missed in inline copies, and add a CI lint to prevent the class of bug.
+
+- Replace inline property-type enum in get-adcp-capabilities-response.json trusted_match.surfaces with $ref (missing linear_tv)
+- Replace inline adcp-protocol enum in registry-event.json badgeRole with $ref (missing measurement)
+- Replace inline catalog-type enum in sponsored_placement.json supported_catalog_types with $ref (missing promotion)
+- Add scripts/lint-schema-enum-drift.cjs: detects inline enums that are strict subsets of canonical enums, preventing future drift

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deploy:cdn-artifacts-cutover:dry-run": "wrangler deploy --config workers/artifact-cdn/wrangler.cutover.toml --dry-run",
     "verify:cdn-artifacts-cutover": "node scripts/verify-cdn-artifacts-cutover.mjs",
     "typecheck": "tsc --project server/tsconfig.json --noEmit",
-    "test:schemas": "node tests/schema-validation.test.cjs && node --test tests/schema-deprecation-metadata.test.cjs tests/creative-rotation.test.cjs && npm run test:geo-region-targeting",
+    "test:schemas": "node tests/schema-validation.test.cjs && node --test tests/schema-deprecation-metadata.test.cjs tests/creative-rotation.test.cjs tests/lint-schema-enum-drift.test.cjs && npm run test:geo-region-targeting",
     "test:performance-feedback": "node --test --test-force-exit --test-timeout=30000 tests/performance-feedback-contract.test.cjs",
     "test:dist-schema-version-ids": "node --test --test-force-exit --test-timeout=30000 tests/dist-schema-version-ids.test.cjs",
     "test:examples": "node tests/example-validation-simple.test.cjs && npm run test:tmp-context-merge",

--- a/scripts/lint-schema-enum-drift.cjs
+++ b/scripts/lint-schema-enum-drift.cjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * Detect inline enum definitions in schema files that have drifted from
+ * canonical enum files in enums/.
+ *
+ * Why this lint exists
+ * --------------------
+ * When a schema defines an inline `"enum": [...]` whose values overlap with a
+ * canonical enum file, the inline copy can silently drift as the canonical
+ * evolves (values added or removed). The brand.json property-type drift
+ * (#6330 / PR #6334) is the motivating example: `linear_tv` and
+ * `ai_assistant` were added to `enums/property-type.json` but the inline copy
+ * in `brand.json` was missed, causing validation to reject valid documents.
+ *
+ * Rules
+ * -----
+ *   subset_drift  — inline values are a strict subset of a canonical enum,
+ *                    missing values that were likely added later.
+ *                    EXIT CODE 1 — this is a real drift bug.
+ *
+ * Informational (does not fail the lint):
+ *   exact_match   — inline values are identical to a canonical enum.
+ *                    Printed with --verbose. Candidate for $ref migration.
+ *
+ * Allowlist
+ * ---------
+ * Some inline enums are intentionally narrower than their canonical source
+ * (state-machine constraints, conditional restrictions, different concepts
+ * with overlapping values). These are listed in ALLOWED below.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const SCHEMA_DIR = path.join(ROOT, 'static', 'schemas', 'source');
+const ENUM_DIR = path.join(SCHEMA_DIR, 'enums');
+
+// Inline enums that are intentionally narrower or use overlapping values
+// from a different concept. Key: "relFile|jsonPathPrefix". Use * for any path.
+const ALLOWED = new Set([
+  // Capabilities response: snake_case wire format vs kebab-case canonical
+  'protocol/get-adcp-capabilities-response.json|/properties/supported_protocols',
+  // Capabilities: co-branding excludes "none" intentionally
+  'protocol/get-adcp-capabilities-response.json|/properties/creative',
+  'protocol/get-adcp-capabilities-response.json|/properties/media_buy/properties/execution/properties/co_branding',
+  // Capabilities: quantitative vs numeric — established SI term
+  'protocol/get-adcp-capabilities-response.json|/properties/sponsored_intelligence',
+  // State-machine transition constraints
+  'creative/creative-status-changed-webhook.json|*',
+  // Governance conditional restrictions
+  'governance/check-governance-request.json|*',
+  'governance/check-governance-response.json|*',
+  // Notification config: account-anchored event types only
+  'core/notification-config.json|*',
+  // Creative approval scope: allOf+$ref intentional narrowing
+  'core/creative-approval-scope.json|*',
+  // Diagnostic severity (error/warning/info) is distinct from escalation severity
+  'core/diagnostic-issue.json|*',
+  // Signal definition methodology intentionally excludes "projected"
+  'core/signal-definition.json|*',
+  'core/signal-definition-enrichment.json|*',
+  // Manifest protocol includes internal sub-protocols; idempotency_requirement distinct concept
+  'manifest.schema.json|*',
+  // Overlay uses fraction for relative positioning — distinct from dimension-unit dp
+  'core/overlay.json|*',
+  // Property feature type: quantitative is the established term (not numeric)
+  'property/property-feature-definition.json|*',
+  // Package-level indicators intentionally exclude assignment-only types
+  'media-buy/get-media-buys-response.json|*',
+  // Sync response managed_by: buyer/seller overlaps canceled-by but distinct concept
+  'media-buy/sync-event-sources-response.json|/oneOf/0/properties/event_sources/items/properties/managed_by',
+  // Sync response action: accounts only use created/failed/unchanged/updated (no deleted)
+  'account/sync-accounts-response.json|/oneOf/0/properties/accounts/items/properties/action',
+  // canonical-media-buy-action oneOf branch intentionally lists a subset of actions
+  'core/canonical-media-buy-action.json|*',
+  // Event surface category has owned_property not in action-source (broader concept)
+  'core/event-surface.json|*',
+  // Creative format base has broader asset types and different watermark types
+  'formats/canonical/_base.json|*',
+  // Sponsored placement supported_id_types includes asin (broader than content-id-type)
+  'formats/canonical/sponsored_placement.json|/properties/supported_id_types',
+  // Delivery status is a superset of media-buy-status (includes failed, pending, etc.)
+  'media-buy/get-media-buy-delivery-response.json|*',
+  'media-buy/media-buy-delivery-webhook-result.json|*',
+  // GOP type open/closed overlaps but is distinct concept
+  'core/opportunity-context.json|*',
+]);
+
+function loadCanonicalEnums() {
+  const enums = new Map();
+  if (!fs.existsSync(ENUM_DIR)) return enums;
+  for (const file of fs.readdirSync(ENUM_DIR)) {
+    if (!file.endsWith('.json')) continue;
+    try {
+      const doc = JSON.parse(fs.readFileSync(path.join(ENUM_DIR, file), 'utf8'));
+      if (Array.isArray(doc.enum)) {
+        enums.set(file, { values: new Set(doc.enum), sorted: [...doc.enum].sort() });
+      }
+    } catch { /* skip malformed */ }
+  }
+  return enums;
+}
+
+function walkSchemaEnums(obj, currentPath, results) {
+  if (!obj || typeof obj !== 'object') return;
+  if (Array.isArray(obj)) {
+    obj.forEach((item, i) => walkSchemaEnums(item, `${currentPath}/${i}`, results));
+    return;
+  }
+  if (Array.isArray(obj.enum) && obj.enum.length >= 2 && obj.enum.every(v => typeof v === 'string')) {
+    results.push({ path: currentPath, values: new Set(obj.enum), sorted: [...obj.enum].sort() });
+  }
+  for (const [key, val] of Object.entries(obj)) {
+    if (key === '$ref') continue;
+    walkSchemaEnums(val, `${currentPath}/${key}`, results);
+  }
+}
+
+function isAllowed(relFile, jsonPath) {
+  for (const entry of ALLOWED) {
+    const [file, prefix] = entry.split('|');
+    if (file !== relFile) continue;
+    if (prefix === '*' || jsonPath.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+function findBestMatch(inline, canonicals) {
+  let best = null;
+  let bestScore = 0;
+  for (const [enumFile, canonical] of canonicals) {
+    const overlap = [...inline.values].filter(v => canonical.values.has(v));
+    const score = overlap.length / Math.max(inline.values.size, canonical.values.size);
+    if (score >= 0.7 && score > bestScore) {
+      bestScore = score;
+      best = { enumFile, canonical, score };
+    }
+  }
+  return best;
+}
+
+function lint(schemaDir = SCHEMA_DIR) {
+  const canonicals = loadCanonicalEnums();
+  const driftViolations = [];
+  const exactMatches = [];
+
+  function processFile(absPath) {
+    const relFile = path.relative(schemaDir, absPath);
+    if (relFile.startsWith('enums/') || relFile.startsWith('enums\\')) return;
+
+    let doc;
+    try { doc = JSON.parse(fs.readFileSync(absPath, 'utf8')); } catch { return; }
+
+    const inlineEnums = [];
+    walkSchemaEnums(doc, '', inlineEnums);
+
+    for (const inline of inlineEnums) {
+      const match = findBestMatch(inline, canonicals);
+      if (!match) continue;
+      if (isAllowed(relFile, inline.path)) continue;
+
+      const missing = [...match.canonical.values].filter(v => !inline.values.has(v));
+      const extra = [...inline.values].filter(v => !match.canonical.values.has(v));
+
+      if (missing.length === 0 && extra.length === 0) {
+        exactMatches.push({
+          file: relFile,
+          path: inline.path,
+          canonicalEnum: match.enumFile,
+        });
+      } else if (extra.length === 0 && missing.length > 0) {
+        driftViolations.push({
+          file: relFile,
+          path: inline.path,
+          canonicalEnum: match.enumFile,
+          missing: missing.sort(),
+        });
+      }
+    }
+  }
+
+  function walkDir(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walkDir(full);
+      else if (entry.name.endsWith('.json') && entry.name !== 'index.json') processFile(full);
+    }
+  }
+
+  walkDir(schemaDir);
+  return { driftViolations, exactMatches };
+}
+
+if (require.main === module) {
+  const verbose = process.argv.includes('--verbose');
+  const { driftViolations, exactMatches } = lint();
+
+  if (verbose && exactMatches.length > 0) {
+    console.log(`ℹ ${exactMatches.length} inline enum(s) are exact matches — candidates for $ref migration:\n`);
+    for (const m of exactMatches) {
+      console.log(`  ${m.file}${m.path} → enums/${m.canonicalEnum}`);
+    }
+    console.log();
+  }
+
+  if (driftViolations.length === 0) {
+    console.log(`✓ schema inline-enum drift lint: no drift violations${exactMatches.length ? ` (${exactMatches.length} exact-match $ref candidates)` : ''}`);
+    process.exit(0);
+  }
+
+  console.error(`✗ schema inline-enum drift lint: ${driftViolations.length} drift violation(s)\n`);
+  for (const v of driftViolations) {
+    console.error(`  ${v.file}${v.path}`);
+    console.error(`    canonical: enums/${v.canonicalEnum}`);
+    console.error(`    missing from inline: ${v.missing.join(', ')}`);
+    console.error();
+  }
+  process.exit(1);
+}
+
+module.exports = { lint, loadCanonicalEnums, ALLOWED };

--- a/static/schemas/source/core/registry-event.json
+++ b/static/schemas/source/core/registry-event.json
@@ -486,8 +486,7 @@
           "additionalProperties": true
     },
     "badgeRole": {
-      "type": "string",
-      "enum": ["media-buy", "creative", "signals", "governance", "brand", "sponsored-intelligence"]
+      "$ref": "/schemas/enums/adcp-protocol.json"
     },
     "stringArray": {
       "type": "array",

--- a/static/schemas/source/formats/canonical/sponsored_placement.json
+++ b/static/schemas/source/formats/canonical/sponsored_placement.json
@@ -23,8 +23,7 @@
     "supported_catalog_types": {
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": ["product", "store", "offering", "hotel", "flight", "vehicle", "real_estate", "education", "destination", "app", "job", "inventory"]
+        "$ref": "/schemas/enums/catalog-type.json"
       },
       "description": "Catalog types this product accepts."
     },

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -997,18 +997,7 @@
                   "type": "array",
                   "description": "Surface types this seller supports via TMP.",
                   "items": {
-                    "type": "string",
-                    "enum": [
-                      "website",
-                      "mobile_app",
-                      "ctv_app",
-                      "desktop_app",
-                      "dooh",
-                      "podcast",
-                      "radio",
-                      "streaming_audio",
-                      "ai_assistant"
-                    ]
+                    "$ref": "/schemas/enums/property-type.json"
                   }
                 }
               }

--- a/tests/lint-schema-enum-drift.test.cjs
+++ b/tests/lint-schema-enum-drift.test.cjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { lint, loadCanonicalEnums, ALLOWED } = require('../scripts/lint-schema-enum-drift.cjs');
+
+test('source tree has no inline-enum drift violations', () => {
+  const { driftViolations } = lint();
+  assert.deepEqual(
+    driftViolations,
+    [],
+    'inline enums have drifted from their canonical enum files:\n' +
+      driftViolations
+        .map(
+          (v) =>
+            `  ${v.file}${v.path} — missing: ${v.missing.join(', ')} (canonical: enums/${v.canonicalEnum})`,
+        )
+        .join('\n'),
+  );
+});
+
+test('canonical enums load from enums/ directory', () => {
+  const enums = loadCanonicalEnums();
+  assert.ok(enums.size > 0, 'expected at least one canonical enum file');
+  assert.ok(enums.has('property-type.json'), 'expected property-type.json in canonical enums');
+  assert.ok(enums.has('account-status.json'), 'expected account-status.json in canonical enums');
+});
+
+test('capabilities trusted_match.surfaces uses $ref to property-type.json', () => {
+  const capFile = path.resolve(
+    __dirname,
+    '..',
+    'static',
+    'schemas',
+    'source',
+    'protocol',
+    'get-adcp-capabilities-response.json',
+  );
+  const doc = JSON.parse(fs.readFileSync(capFile, 'utf8'));
+  const surfaces =
+    doc.properties.media_buy.properties.execution.properties.trusted_match.properties.surfaces
+      .items;
+  assert.ok(surfaces.$ref, 'trusted_match.surfaces.items should use $ref, not inline enum');
+  assert.ok(
+    surfaces.$ref.includes('property-type'),
+    'trusted_match.surfaces should reference property-type.json',
+  );
+});
+
+test('registry-event badgeRole uses $ref to adcp-protocol.json', () => {
+  const regFile = path.resolve(
+    __dirname,
+    '..',
+    'static',
+    'schemas',
+    'source',
+    'core',
+    'registry-event.json',
+  );
+  const doc = JSON.parse(fs.readFileSync(regFile, 'utf8'));
+  const badgeRole = doc.$defs.badgeRole;
+  assert.ok(badgeRole.$ref, 'badgeRole should use $ref, not inline enum');
+  assert.ok(
+    badgeRole.$ref.includes('adcp-protocol'),
+    'badgeRole should reference adcp-protocol.json',
+  );
+});
+
+test('sponsored_placement supported_catalog_types uses $ref to catalog-type.json', () => {
+  const spFile = path.resolve(
+    __dirname,
+    '..',
+    'static',
+    'schemas',
+    'source',
+    'formats',
+    'canonical',
+    'sponsored_placement.json',
+  );
+  const doc = JSON.parse(fs.readFileSync(spFile, 'utf8'));
+  const items = doc.properties.supported_catalog_types.items;
+  assert.ok(items.$ref, 'supported_catalog_types.items should use $ref, not inline enum');
+  assert.ok(
+    items.$ref.includes('catalog-type'),
+    'supported_catalog_types should reference catalog-type.json',
+  );
+});
+
+test('allowlist entries reference files that exist', () => {
+  const schemaDir = path.resolve(__dirname, '..', 'static', 'schemas', 'source');
+  for (const entry of ALLOWED) {
+    const file = entry.split('|')[0];
+    const absPath = path.join(schemaDir, file);
+    assert.ok(fs.existsSync(absPath), `allowlist entry references non-existent file: ${file}`);
+  }
+});

--- a/tests/lint-schema-enum-drift.test.cjs
+++ b/tests/lint-schema-enum-drift.test.cjs
@@ -3,6 +3,7 @@
 'use strict';
 
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const assert = require('node:assert/strict');
@@ -29,6 +30,43 @@ test('canonical enums load from enums/ directory', () => {
   assert.ok(enums.size > 0, 'expected at least one canonical enum file');
   assert.ok(enums.has('property-type.json'), 'expected property-type.json in canonical enums');
   assert.ok(enums.has('account-status.json'), 'expected account-status.json in canonical enums');
+});
+
+test('lint reports an inline enum that is a strict subset of a canonical enum', (t) => {
+  const schemaDir = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-enum-drift-'));
+  t.after(() => fs.rmSync(schemaDir, { recursive: true, force: true }));
+
+  fs.writeFileSync(
+    path.join(schemaDir, 'drifted.json'),
+    JSON.stringify({
+      type: 'object',
+      properties: {
+        surface: {
+          type: 'string',
+          enum: [
+            'website',
+            'mobile_app',
+            'ctv_app',
+            'desktop_app',
+            'dooh',
+            'podcast',
+            'radio',
+            'streaming_audio',
+            'ai_assistant',
+          ],
+        },
+      },
+    }),
+  );
+
+  assert.deepEqual(lint(schemaDir).driftViolations, [
+    {
+      file: 'drifted.json',
+      path: '/properties/surface',
+      canonicalEnum: 'property-type.json',
+      missing: ['linear_tv'],
+    },
+  ]);
 });
 
 test('capabilities trusted_match.surfaces uses $ref to property-type.json', () => {


### PR DESCRIPTION
## Summary

Three inline enum definitions had silently drifted from their canonical enum files — same class of bug as the brand.json property-type drift fixed in #6334.

**Drift fixes:**
- `get-adcp-capabilities-response.json`: `trusted_match.surfaces` was missing `linear_tv` (9/10 values from `enums/property-type.json`)
- `registry-event.json`: `badgeRole` was missing `measurement` (6/7 values from `enums/adcp-protocol.json`)
- `sponsored_placement.json`: `supported_catalog_types` was missing `promotion` (12/13 values from `enums/catalog-type.json`)

All three converted from inline enum to `$ref` so they track the canonical source going forward.

**Prevention:**
- `scripts/lint-schema-enum-drift.cjs` scans all schema files for inline enums that are strict subsets of a canonical `enums/` file. Fails on subset drift; reports exact matches as advisory `$ref` migration candidates (`--verbose`). Comprehensive allowlist for intentional restrictions (state-machine constraints, conditional narrowing, distinct-concept overlaps).

## Validation

- `node --test tests/lint-schema-enum-drift.test.cjs` — 6/6 pass
- `npm run typecheck` — clean
- Full pre-commit suite (6100+ tests) — clean
- Pre-push hooks (changeset policy, version sync) — all pass
- The lint itself passes clean: 0 drift violations, 15 exact-match $ref migration candidates noted