### PR TITLE
test(compliance): cover async media buy task lifecycle

### DIFF
--- a/.changeset/complete-async-media-buy-tasks.md
+++ b/.changeset/complete-async-media-buy-tasks.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Add deterministic compliance coverage for reconciling submitted `create_media_buy` tasks through `get_task_status` and `list_tasks`, including controller-driven terminal completion.

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -2200,22 +2200,70 @@ function handleForceGetProductsRejection(
  * result are idempotent no-ops; tasks at any other terminal state return
  * INVALID_TRANSITION.
  *
- * Buyer-side observability via tasks/get is intentionally **deferred** to a
- * follow-up. The MCP SDK's TaskStore generates task_ids server-side and exposes
- * no API for caller-supplied IDs, and the SDK's auto-registered tasks/get
- * returns the MCP Task shape rather than the AdCP `tasks-get-response.json`
- * shape — both gaps need fixing before a storyboard polling phase against the
- * training-agent can pass. This commit ships the controller-side primitive
- * (the directive write) so other reference sellers and the upstream SDK have a
- * concrete behavior to mirror; the storyboard extension lands once the
- * polling integration exists. See PR description for the deferred tracking.
+ * The v6 sales facade registers forced submitted tasks through handoffToTask
+ * and waits on waitForForcedTaskCompletion below. Resolving that waiter lets
+ * the SDK project the same task through get_task_status and list_tasks; the
+ * tenant controller adapter also completes the shared registry before it
+ * returns so the next polling step cannot race the background handoff.
  */
 const FORCED_TASK_COMPLETIONS = new Map<string, { result: Record<string, unknown>; ownerKey: string; completedAt: string }>();
 const MAX_FORCED_TASK_COMPLETIONS = 1000;
+const FORCED_TASK_COMPLETION_TIMEOUT_MS = 15 * 60 * 1000;
+interface PendingForcedTaskCompletion {
+  ownerKey: string;
+  resolve: (result: Record<string, unknown>) => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+const PENDING_FORCED_TASK_COMPLETIONS = new Map<string, PendingForcedTaskCompletion>();
+
+/**
+ * Register the background half of a forceable async task. The v6 task
+ * framework owns the buyer-visible task registry; resolving this promise lets
+ * that framework write the terminal result to get_task_status/list_tasks.
+ */
+export function waitForForcedTaskCompletion(
+  taskId: string,
+  ownerKey: string,
+): Promise<Record<string, unknown>> {
+  const completed = FORCED_TASK_COMPLETIONS.get(taskId);
+  if (completed) {
+    if (completed.ownerKey !== ownerKey) {
+      return Promise.reject(new Error(`Task "${taskId}" belongs to another sandbox account`));
+    }
+    return Promise.resolve(completed.result);
+  }
+
+  const pending = PENDING_FORCED_TASK_COMPLETIONS.get(taskId);
+  if (pending) {
+    if (pending.ownerKey !== ownerKey) {
+      return Promise.reject(new Error(`Task "${taskId}" is already registered for another sandbox account`));
+    }
+    return Promise.reject(new Error(`Task "${taskId}" already has a pending completion waiter`));
+  }
+
+  if (PENDING_FORCED_TASK_COMPLETIONS.size >= MAX_FORCED_TASK_COMPLETIONS) {
+    return Promise.reject(new Error(`Pending forced-completion cap reached (${MAX_FORCED_TASK_COMPLETIONS})`));
+  }
+
+  return new Promise<Record<string, unknown>>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      PENDING_FORCED_TASK_COMPLETIONS.delete(taskId);
+      reject(new Error(`Task "${taskId}" was not completed within the 15-minute compliance window`));
+    }, FORCED_TASK_COMPLETION_TIMEOUT_MS);
+    timeout.unref();
+    PENDING_FORCED_TASK_COMPLETIONS.set(taskId, { ownerKey, resolve, reject, timeout });
+  });
+}
 
 /** Test-only: clear the forced-completion pool. */
 export function clearForcedTaskCompletions(): void {
   FORCED_TASK_COMPLETIONS.clear();
+  for (const pending of PENDING_FORCED_TASK_COMPLETIONS.values()) {
+    clearTimeout(pending.timeout);
+    pending.reject(new Error('Forced task completion state was reset'));
+  }
+  PENDING_FORCED_TASK_COMPLETIONS.clear();
 }
 
 /** Test-only: read the forced-completion pool. */
@@ -2298,6 +2346,15 @@ function handleForceTaskCompletion(sessionKey: string, rawArgs: Record<string, u
     };
   }
 
+  const pending = PENDING_FORCED_TASK_COMPLETIONS.get(taskId);
+  if (pending && pending.ownerKey !== sessionKey) {
+    return {
+      success: false,
+      error: 'NOT_FOUND',
+      error_detail: `Task "${taskId}" was not registered for this sandbox account`,
+    };
+  }
+
   if (FORCED_TASK_COMPLETIONS.size >= MAX_FORCED_TASK_COMPLETIONS) {
     return {
       success: false,
@@ -2311,6 +2368,11 @@ function handleForceTaskCompletion(sessionKey: string, rawArgs: Record<string, u
     ownerKey: sessionKey,
     completedAt: new Date().toISOString(),
   });
+  if (pending) {
+    clearTimeout(pending.timeout);
+    PENDING_FORCED_TASK_COMPLETIONS.delete(taskId);
+    pending.resolve(result as Record<string, unknown>);
+  }
 
   return {
     success: true,

--- a/server/src/training-agent/tenants/comply.ts
+++ b/server/src/training-agent/tenants/comply.ts
@@ -21,7 +21,7 @@ import {
   type ComplyControllerConfig,
   type ComplyControllerContext,
 } from '@adcp/sdk/testing';
-import { TOOL_INPUT_SHAPE } from '@adcp/sdk/server';
+import { TOOL_INPUT_SHAPE, type TaskRegistry } from '@adcp/sdk/server';
 import { handleComplyTestController } from '../comply-test-controller.js';
 import type { ToolArgs, TrainingContext } from '../types.js';
 
@@ -123,10 +123,15 @@ function seedAdapter(scenario: string, storyboardCompat?: TrainingContext['story
   };
 }
 
-function forceAdapter(scenario: string, storyboardCompat?: TrainingContext['storyboardCompat']): AdapterShim {
+function forceAdapter(
+  scenario: string,
+  storyboardCompat?: TrainingContext['storyboardCompat'],
+  afterSuccess?: (params: Record<string, unknown>) => Promise<void>,
+): AdapterShim {
   return async (params, ctx) => {
     const result = await dispatchV5(scenario, params as Record<string, unknown>, ctx.input, storyboardCompat);
     throwOnFailure(result);
+    await afterSuccess?.(params as Record<string, unknown>);
     return result;
   };
 }
@@ -228,6 +233,7 @@ export function buildCreativeComplyConfig(
 
 export function buildSalesComplyConfig(
   storyboardCompat?: TrainingContext['storyboardCompat'],
+  taskRegistry?: TaskRegistry,
 ): ComplyControllerConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const cast = (a: AdapterShim) => a as any;
@@ -250,7 +256,22 @@ export function buildSalesComplyConfig(
       media_buy_status: cast(forceAdapter('force_media_buy_status', storyboardCompat)),
       create_media_buy_arm: cast(forceAdapter('force_create_media_buy_arm', storyboardCompat)),
       get_products_arm: cast(forceAdapter('force_get_products_arm', storyboardCompat)),
-      task_completion: cast(forceAdapter('force_task_completion', storyboardCompat)),
+      task_completion: cast(forceAdapter(
+        'force_task_completion',
+        storyboardCompat,
+        async params => {
+          if (!taskRegistry) return;
+          const taskId = params.task_id;
+          const result = params.result;
+          if (typeof taskId === 'string' && result && typeof result === 'object' && !Array.isArray(result)) {
+            // The controller response is not returned until the buyer-visible
+            // registry reflects completion, avoiding a race with the next
+            // get_task_status storyboard step. The handoff worker performs
+            // the same idempotent completion after its waiter resolves.
+            await taskRegistry.complete(taskId, result);
+          }
+        },
+      )),
       // force_creative_status drives dependency_impairment storyboards —
       // toggles creative.status and propagates to dependent media buys'
       // impairments[] via the v5 store's propagateCreativeImpairment.

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -181,7 +181,10 @@ function pickStateStore(): AdcpStateStore {
   return new PostgresStateStore(lazyPool);
 }
 
-function buildDefaultServerOptions(storyboardCompat?: TrainingContext['storyboardCompat']): CreateAdcpServerFromPlatformOptions {
+function buildDefaultServerOptions(
+  storyboardCompat?: TrainingContext['storyboardCompat'],
+  taskRegistry: TaskRegistry = pickTaskRegistry(),
+): CreateAdcpServerFromPlatformOptions {
   const projectionAdapters = creativeProjectionAdapters();
   return {
     name: 'adcp-training-agent',
@@ -196,7 +199,7 @@ function buildDefaultServerOptions(storyboardCompat?: TrainingContext['storyboar
     // default. Preserve the training agent's existing integration contract
     // while its consumers migrate to inline-terminal handling.
     autoEmitCompletionWebhooks: true,
-    taskRegistry: pickTaskRegistry(),
+    taskRegistry,
     taskStore: sharedTrainingTaskStore,
     stateStore: pickStateStore(),
     mergeSeam: 'log-once',
@@ -268,15 +271,16 @@ export function createRegistryHolder(options: { storyboardCompat?: TrainingConte
         const t0 = Date.now();
         logger.info('Tenant registry init starting');
         const hostBase = buildHostBaseUrl();
+        const taskRegistry = pickTaskRegistry();
         const reg = createTenantRegistry({
-          defaultServerOptions: buildDefaultServerOptions(options.storyboardCompat),
+          defaultServerOptions: buildDefaultServerOptions(options.storyboardCompat, taskRegistry),
           jwksValidator: noopJwksValidator,
           autoValidate: true,
         });
         const tCreate = Date.now();
         const configs = [
           { id: 'signals', cfg: buildSignalsTenantConfig(hostBase, options) },
-          { id: 'sales', cfg: buildSalesTenantConfig(hostBase, options) },
+          { id: 'sales', cfg: buildSalesTenantConfig(hostBase, options, taskRegistry) },
           { id: 'governance', cfg: buildGovernanceTenantConfig(hostBase, options) },
           { id: 'creative', cfg: buildCreativeTenantConfig(hostBase, options) },
           { id: 'creative-builder', cfg: buildCreativeBuilderTenantConfig(hostBase, options) },

--- a/server/src/training-agent/tenants/sales.ts
+++ b/server/src/training-agent/tenants/sales.ts
@@ -6,7 +6,7 @@
  */
 
 import { z } from 'zod';
-import type { TenantConfig } from '@adcp/sdk/server';
+import type { TaskRegistry, TenantConfig } from '@adcp/sdk/server';
 import {
   TrainingSalesPlatform,
   legacyGetProductsHandler,
@@ -72,7 +72,11 @@ const SYNC_GOVERNANCE_SCHEMA = {
   context: z.any().optional(),
 };
 
-export function buildSalesTenantConfig(host: string, options: { storyboardCompat?: TrainingContext['storyboardCompat'] } = {}): {
+export function buildSalesTenantConfig(
+  host: string,
+  options: { storyboardCompat?: TrainingContext['storyboardCompat'] } = {},
+  taskRegistry?: TaskRegistry,
+): {
   tenantId: string;
   config: TenantConfig;
 } {
@@ -136,7 +140,7 @@ export function buildSalesTenantConfig(host: string, options: { storyboardCompat
             }),
           }),
         },
-        complyTest: buildSalesComplyConfig(options.storyboardCompat),
+        complyTest: buildSalesComplyConfig(options.storyboardCompat, taskRegistry),
       },
     },
   };

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -20,6 +20,7 @@ import {
   stopSessionCleanup,
 } from '../state.js';
 import { clearSiSessions } from '../si-handlers.js';
+import { clearForcedTaskCompletions } from '../comply-test-controller.js';
 import { getAgentUrl } from '../config.js';
 import { projectV1ProductToV2 } from '@adcp/sdk/v2/projection';
 
@@ -139,12 +140,14 @@ describe('tenant routing smoke', () => {
     clearSessions();
     clearAccountStore();
     clearSiSessions();
+    clearForcedTaskCompletions();
   });
 
   afterEach(() => {
     clearSessions();
     clearAccountStore();
     clearSiSessions();
+    clearForcedTaskCompletions();
     stopSessionCleanup();
   });
 
@@ -338,6 +341,108 @@ describe('tenant routing smoke', () => {
       expect(body.result?.structuredContent?.compliance_testing?.scenarios).toEqual(
         expect.arrayContaining(SALES_CURRENT_SCENARIOS),
       );
+    } finally {
+      await close();
+    }
+  }, 15000);
+
+  it('reconciles a forced create_media_buy task through submitted and completed states', async () => {
+    const { baseUrl, close } = await bootServer();
+    try {
+      const url = `${baseUrl}/sales/mcp`;
+      await initializeTenant(url);
+      const account = {
+        brand: { domain: 'async-lifecycle.example' },
+        operator: 'pinnacle-agency.example',
+        sandbox: true,
+      };
+      const taskId = 'task_training_async_lifecycle';
+      const completion = {
+        media_buy_id: 'mb_training_async_lifecycle',
+        media_buy_status: 'pending_creatives',
+        confirmed_at: '2026-08-15T12:00:00Z',
+        revision: 1,
+        currency: 'USD',
+        packages: [{
+          package_id: 'pkg_training_async_lifecycle',
+          product_id: 'async_lifecycle_video_q3',
+          pricing_option_id: 'async_lifecycle_cpm',
+          budget: 30_000,
+          paused: false,
+        }],
+      };
+      const payload = (response: Record<string, unknown>) => (
+        response as { result?: { structuredContent?: Record<string, unknown> } }
+      ).result?.structuredContent;
+
+      const forced = payload(await callTenantTool(url, 2, 'comply_test_controller', {
+        account,
+        scenario: 'force_create_media_buy_arm',
+        params: { arm: 'submitted', task_id: taskId },
+      }));
+      expect(forced?.success).toBe(true);
+
+      const submitted = payload(await callTenantTool(url, 3, 'create_media_buy', {
+        account,
+        brand: account.brand,
+        start_time: 'asap',
+        end_time: '2099-09-30T23:59:59Z',
+        packages: [{
+          product_id: 'async_lifecycle_video_q3',
+          pricing_option_id: 'async_lifecycle_cpm',
+          budget: 30_000,
+        }],
+        idempotency_key: 'training-async-lifecycle-create-0001',
+      }));
+      expect(submitted).toMatchObject({ status: 'submitted', task_id: taskId });
+
+      const pendingRead = payload(await callTenantTool(url, 4, 'get_task_status', {
+        account,
+        task_id: taskId,
+      }));
+      expect(pendingRead).toMatchObject({
+        task_id: taskId,
+        task_type: 'create_media_buy',
+        protocol: 'media-buy',
+        status: 'submitted',
+      });
+
+      const pendingList = payload(await callTenantTool(url, 5, 'list_tasks', {
+        account,
+        filters: { task_ids: [taskId], task_type: 'create_media_buy' },
+        pagination: { max_results: 1 },
+      }));
+      expect(pendingList?.tasks).toEqual([
+        expect.objectContaining({ task_id: taskId, task_type: 'create_media_buy', status: 'submitted' }),
+      ]);
+
+      const completed = payload(await callTenantTool(url, 6, 'comply_test_controller', {
+        account,
+        scenario: 'force_task_completion',
+        params: { task_id: taskId, result: completion },
+      }));
+      expect(completed).toMatchObject({ success: true, current_state: 'completed' });
+
+      const terminalRead = payload(await callTenantTool(url, 7, 'get_task_status', {
+        account,
+        task_id: taskId,
+        include_result: true,
+      }));
+      expect(terminalRead).toMatchObject({
+        task_id: taskId,
+        task_type: 'create_media_buy',
+        status: 'completed',
+        result: completion,
+      });
+
+      const terminalList = payload(await callTenantTool(url, 8, 'list_tasks', {
+        account,
+        filters: { task_ids: [taskId], task_type: 'create_media_buy', status: 'completed' },
+        pagination: { max_results: 1 },
+      }));
+      expect(terminalList?.tasks).toEqual([
+        expect.objectContaining({ task_id: taskId, task_type: 'create_media_buy', status: 'completed' }),
+      ]);
     } finally {
       await close();
     }

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -47,6 +47,8 @@ import {
 import { handleSyncAudiences } from './audience-handlers.js';
 import { syncAccountsUpsert } from './v6-account-helpers.js';
 import { trainingBuyerAgentRegistry } from './buyer-agent-registry.js';
+import { waitForForcedTaskCompletion } from './comply-test-controller.js';
+import { sessionKeyFromArgs } from './state.js';
 import type { ToolArgs, TrainingContext } from './types.js';
 
 interface TrainingSalesMeta {
@@ -551,10 +553,10 @@ export class TrainingSalesPlatform
       // the submitted arm is `ctx.handoffToTask`. Pass the directive's
       // task_id through `TaskHandoffOptions.task_id` so the response
       // echoes the caller-supplied id (adcp-client#1554, SDK 6.11+).
-      // The handoff fn throws because the test directive only asserts
-      // on the immediate submitted envelope; no buyer polls completion
-      // in this scenario, so the throw surfaces a clean error if anyone
-      // ever does.
+      // Keep the handoff pending until force_task_completion resolves the
+      // controller-side waiter. The framework then writes the same result to
+      // its task registry, which makes get_task_status and list_tasks converge
+      // on the controller-driven terminal state.
       if (
         v5Result &&
         typeof v5Result === 'object' &&
@@ -562,16 +564,10 @@ export class TrainingSalesPlatform
         typeof (v5Result as { task_id?: unknown }).task_id === 'string'
       ) {
         const submitted = v5Result as { task_id: string; message?: string };
+        const completionOwnerKey = sessionKeyFromArgs(args, 'open');
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return ctx.handoffToTask(
-          async () => {
-            throw new AdcpError('NOT_IMPLEMENTED', {
-              recovery: 'terminal',
-              message:
-                'force_create_media_buy_arm directive issued the submitted envelope; ' +
-                'the test directive does not register a completion handler.',
-            });
-          },
+          async () => await waitForForcedTaskCompletion(submitted.task_id, completionOwnerKey),
           { task_id: submitted.task_id },
         ) as any;
       }

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -24,6 +24,7 @@ requires_scenarios:
   - media_buy_seller/creative_fate_after_cancellation
   - media_buy_seller/inline_creatives_without_sync
   - media_buy_seller/create_media_buy_async
+  - media_buy_seller/create_media_buy_async_lifecycle
   - media_buy_seller/dependency_impairment
   - media_buy_seller/dependency_impairment_audience
   - media_buy_seller/dependency_impairment_cardinality

--- a/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async_lifecycle.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async_lifecycle.yaml
@@ -1,0 +1,405 @@
+id: media_buy_seller/create_media_buy_async_lifecycle
+version: "1.0.0"
+introduced_in: "3.2"
+title: "Seller exposes create_media_buy tasks through read and list lifecycle tools"
+category: media_buy_seller
+summary: "Forces create_media_buy into the submitted arm, reconciles the task through get_task_status and list_tasks, completes it deterministically, and verifies the terminal media-buy result."
+track: media_buy
+
+# The async arm is optional. Sellers that cannot deterministically exercise it
+# skip this scenario before any state is created.
+requires_capability:
+  path: compliance_testing.scenarios
+  contains: force_create_media_buy_arm
+
+required_tools:
+  - create_media_buy
+  - get_task_status
+  - list_tasks
+  - comply_test_controller
+
+narrative: |
+  A submitted create_media_buy response is useful only when the buyer can
+  reconcile the task later. This scenario closes that loop across the three
+  surfaces that share the task identity: create_media_buy issues task_id,
+  get_task_status reads the task, and list_tasks discovers it for recovery.
+
+  The compliance controller makes both ends deterministic. It forces the next
+  create_media_buy call into the submitted arm, then force_task_completion
+  resolves that exact task with a schema-valid CreateMediaBuyResponse. The
+  storyboard observes the task before and after completion so a seller cannot
+  return an untracked task_id or let its read and list views drift.
+
+  get_task_status and list_tasks are optional AdCP task-reconciliation tools.
+  Their steps use requires_tool so a baseline media-buy seller that does not
+  advertise either surface is not failed for omitting it. When advertised,
+  each surface is graded.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - supports_test_controller
+  examples:
+    - "Sellers that defer media-buy creation for IO signing or human approval"
+    - "Platforms that queue media-buy activation for asynchronous processing"
+
+caller:
+  role: compliance_runner
+  example: "AdCP Verified runner reconciling an asynchronous media buy"
+
+prerequisites:
+  description: |
+    Seller exposes comply_test_controller in sandbox mode and advertises
+    force_create_media_buy_arm. The terminal phase also requires the seller to
+    advertise force_task_completion. Task read/list steps run only when the
+    corresponding optional tools are advertised.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "async_lifecycle_video_q3"
+      delivery_type: "guaranteed"
+      channels: ["video"]
+      format_options:
+        - format_option_id: "video_30s"
+          format_kind: "video_hosted"
+          params:
+            duration_ms_exact: 30000
+  pricing_options:
+    - product_id: "async_lifecycle_video_q3"
+      pricing_option_id: "async_lifecycle_cpm"
+      pricing_model: "cpm"
+      currency: "USD"
+      fixed_price: 18.0
+
+phases:
+  - id: submit_async_media_buy
+    title: "Create a deterministic submitted task"
+    narrative: |
+      Register a one-shot controller directive, then create the media buy. The
+      response task_id must be the exact identity registered by the controller.
+
+    steps:
+      - id: force_create_media_buy_submitted
+        title: "Force the next create_media_buy into the submitted arm"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        schema_ref: "compliance/comply-test-controller-request.json"
+        response_schema_ref: "compliance/comply-test-controller-response.json"
+        doc_ref: "/building/by-layer/L3/comply-test-controller"
+        comply_scenario: create_media_buy_async_lifecycle
+        stateful: true
+        context_outputs:
+          - name: forced_async_media_buy_task_id
+            path: "forced.task_id"
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          scenario: "force_create_media_buy_arm"
+          params:
+            arm: "submitted"
+            task_id: "task_async_media_buy_lifecycle_q3"
+            message: "Awaiting insertion-order approval"
+          context:
+            correlation_id: "create_media_buy_async_lifecycle--force_submitted"
+        validations:
+          - check: response_schema
+            description: "Response matches comply-test-controller-response.json"
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Controller accepts the submitted-arm directive"
+          - check: field_value
+            path: "forced.arm"
+            value: "submitted"
+            description: "Controller echoes the forced response arm"
+          - check: field_value
+            path: "forced.task_id"
+            value: "task_async_media_buy_lifecycle_q3"
+            description: "Controller echoes the deterministic task identity"
+
+      - id: create_submitted_media_buy
+        title: "Create the media buy and capture its task"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy_async_lifecycle
+        stateful: true
+        context_outputs:
+          - name: async_media_buy_task_id
+            path: "task_id"
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          brand:
+            domain: "acmeoutdoor.example"
+          start_time: "asap"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "async_lifecycle_video_q3"
+              budget: 30000
+              pricing_option_id: "async_lifecycle_cpm"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_create_media_buy_async_lifecycle_submit"
+          context:
+            correlation_id: "create_media_buy_async_lifecycle--create_submitted"
+        validations:
+          - check: response_schema
+            description: "Response matches the submitted arm of create-media-buy-response.json"
+          - check: field_value
+            path: "status"
+            value: "submitted"
+            description: "The media-buy operation is queued as an async task"
+          - check: field_value
+            path: "task_id"
+            value: "$context.forced_async_media_buy_task_id"
+            description: "create_media_buy returns the controller-issued task identity"
+          - check: field_absent
+            path: "media_buy_id"
+            description: "The media buy is issued only on terminal completion"
+          - check: field_absent
+            path: "packages"
+            description: "Packages are issued only on terminal completion"
+
+  - id: reconcile_submitted_task
+    title: "Read the submitted task consistently"
+    narrative: |
+      Optional task-reconciliation surfaces must resolve the task identity from
+      create_media_buy and agree that it is still submitted.
+
+    steps:
+      - id: get_submitted_media_buy_task
+        title: "Poll the submitted task"
+        task: get_task_status
+        requires_tool: get_task_status
+        schema_ref: "protocol/get-task-status-request.json"
+        response_schema_ref: "protocol/get-task-status-response.json"
+        doc_ref: "/protocol/get_task_status"
+        comply_scenario: create_media_buy_async_lifecycle
+        stateful: true
+        sample_request:
+          task_id: "$context.async_media_buy_task_id"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          context:
+            correlation_id: "create_media_buy_async_lifecycle--get_submitted"
+        validations:
+          - check: response_schema
+            description: "Response matches get-task-status-response.json"
+          - check: field_value
+            path: "task_id"
+            value: "$context.async_media_buy_task_id"
+            description: "Polling resolves the task returned by create_media_buy"
+          - check: field_value
+            path: "task_type"
+            value: "create_media_buy"
+            description: "Task type identifies the originating operation"
+          - check: field_value
+            path: "protocol"
+            value: "media-buy"
+            description: "Task remains in the media-buy protocol"
+          - check: field_value
+            path: "status"
+            value: "submitted"
+            description: "Task remains submitted before controller completion"
+
+      - id: list_submitted_media_buy_task
+        title: "Discover the submitted task through list_tasks"
+        task: list_tasks
+        requires_tool: list_tasks
+        schema_ref: "protocol/list-tasks-request.json"
+        response_schema_ref: "protocol/list-tasks-response.json"
+        doc_ref: "/protocol/list_tasks"
+        comply_scenario: create_media_buy_async_lifecycle
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          filters:
+            task_ids:
+              - "$context.async_media_buy_task_id"
+            task_type: "create_media_buy"
+          pagination:
+            max_results: 1
+          context:
+            correlation_id: "create_media_buy_async_lifecycle--list_submitted"
+        validations:
+          - check: response_schema
+            description: "Response matches list-tasks-response.json"
+          - check: field_value
+            path: "query_summary.total_matching"
+            value: 1
+            description: "The exact task filter matches one task"
+          - check: field_value
+            path: "tasks[0].task_id"
+            value: "$context.async_media_buy_task_id"
+            description: "list_tasks discovers the task returned by create_media_buy"
+          - check: field_value
+            path: "tasks[0].task_type"
+            value: "create_media_buy"
+            description: "Listed task identifies the originating operation"
+          - check: field_value
+            path: "tasks[0].domain"
+            value: "media-buy"
+            description: "Listed task remains in the media-buy domain"
+          - check: field_value
+            path: "tasks[0].status"
+            value: "submitted"
+            description: "List and read surfaces agree on submitted status"
+
+  - id: complete_and_reconcile_task
+    title: "Complete the task and observe its terminal result"
+    requires_capability:
+      path: compliance_testing.scenarios
+      contains: force_task_completion
+    narrative: |
+      Resolve the submitted task with a valid media-buy response, then verify
+      get_task_status and list_tasks converge on the same completed identity.
+
+    steps:
+      - id: complete_async_media_buy_task
+        title: "Force the media-buy task to completion"
+        task: comply_test_controller
+        requires_tool: comply_test_controller
+        schema_ref: "compliance/comply-test-controller-request.json"
+        response_schema_ref: "compliance/comply-test-controller-response.json"
+        doc_ref: "/building/by-layer/L3/comply-test-controller"
+        comply_scenario: create_media_buy_async_lifecycle
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          scenario: "force_task_completion"
+          params:
+            task_id: "$context.async_media_buy_task_id"
+            result:
+              media_buy_id: "mb_async_media_buy_lifecycle_q3"
+              media_buy_status: "pending_creatives"
+              confirmed_at: "2026-08-15T12:00:00Z"
+              revision: 1
+              currency: "USD"
+              packages:
+                - package_id: "pkg_async_media_buy_lifecycle_q3"
+                  product_id: "async_lifecycle_video_q3"
+                  budget: 30000
+                  pricing_option_id: "async_lifecycle_cpm"
+                  paused: false
+              context:
+                correlation_id: "create_media_buy_async_lifecycle--terminal_result"
+          context:
+            correlation_id: "create_media_buy_async_lifecycle--complete"
+        validations:
+          - check: response_schema
+            description: "Response matches comply-test-controller-response.json"
+          - check: field_value
+            path: "success"
+            allowed_values: [true]
+            description: "Controller completes the submitted task"
+          - check: field_value
+            path: "current_state"
+            value: "completed"
+            description: "Controller reports the terminal task state"
+
+      - id: get_completed_media_buy_task
+        title: "Poll the completed task with its result"
+        task: get_task_status
+        requires_tool: get_task_status
+        schema_ref: "protocol/get-task-status-request.json"
+        response_schema_ref: "protocol/get-task-status-response.json"
+        doc_ref: "/protocol/get_task_status"
+        comply_scenario: create_media_buy_async_lifecycle
+        stateful: true
+        sample_request:
+          task_id: "$context.async_media_buy_task_id"
+          include_result: true
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          context:
+            correlation_id: "create_media_buy_async_lifecycle--get_completed"
+        validations:
+          - check: response_schema
+            description: "Response matches get-task-status-response.json"
+          - check: field_value
+            path: "task_id"
+            value: "$context.async_media_buy_task_id"
+            description: "Terminal polling preserves the submitted task identity"
+          - check: field_value
+            path: "task_type"
+            value: "create_media_buy"
+            description: "Terminal task preserves its originating operation"
+          - check: field_value
+            path: "status"
+            value: "completed"
+            description: "Polling observes the deterministic terminal state"
+          - check: field_value
+            path: "result.media_buy_id"
+            value: "mb_async_media_buy_lifecycle_q3"
+            description: "Terminal result issues the media-buy identity"
+          - check: field_value
+            path: "result.packages[0].package_id"
+            value: "pkg_async_media_buy_lifecycle_q3"
+            description: "Terminal result carries the created package"
+          - check: field_value
+            path: "result.context.correlation_id"
+            value: "create_media_buy_async_lifecycle--terminal_result"
+            description: "Controller-supplied terminal context round-trips unchanged"
+
+      - id: list_completed_media_buy_task
+        title: "Discover the completed task through list_tasks"
+        task: list_tasks
+        requires_tool: list_tasks
+        schema_ref: "protocol/list-tasks-request.json"
+        response_schema_ref: "protocol/list-tasks-response.json"
+        doc_ref: "/protocol/list_tasks"
+        comply_scenario: create_media_buy_async_lifecycle
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          filters:
+            task_ids:
+              - "$context.async_media_buy_task_id"
+            task_type: "create_media_buy"
+            status: "completed"
+          pagination:
+            max_results: 1
+          context:
+            correlation_id: "create_media_buy_async_lifecycle--list_completed"
+        validations:
+          - check: response_schema
+            description: "Response matches list-tasks-response.json"
+          - check: field_value
+            path: "query_summary.total_matching"
+            value: 1
+            description: "The completed-task filter matches one task"
+          - check: field_value
+            path: "tasks[0].task_id"
+            value: "$context.async_media_buy_task_id"
+            description: "Terminal list view preserves the submitted task identity"
+          - check: field_value
+            path: "tasks[0].status"
+            value: "completed"
+            description: "List and read surfaces agree on terminal status"


### PR DESCRIPTION
## Summary

- add a 3.2 compliance storyboard for the full `create_media_buy` submitted/read/list/complete lifecycle
- keep `get_task_status` and `list_tasks` optional for baseline implementations
- connect the training agent's forced completion control to its shared task registry so the lifecycle completes without a polling race

Closes #6174

## Validation

- `npm run build`
- `npm run test:storyboards` (current 3.2 and released 3.0 compatibility matrices)
- `npm run typecheck`
- focused training-agent lifecycle, controller, storyboard schema, and path validation tests
- server unit suite: 6,126 passed; one unrelated shared-state miss passed immediately in isolation

No SDK release is required; the repository's pinned SDK already includes the task status/list primitives used here.
