### PR TITLE
test(compliance): ground read and list storyboards in prior state

### DIFF
--- a/.changeset/ground-storyboard-readbacks.md
+++ b/.changeset/ground-storyboard-readbacks.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Ground media-buy, creative, and governance read/list storyboard assertions in state created by prior steps.

--- a/static/compliance/source/protocols/creative/index.yaml
+++ b/static/compliance/source/protocols/creative/index.yaml
@@ -256,8 +256,8 @@ phases:
         comply_scenario: creative_flow
         stateful: true
         expected: |
-          Return delivery for the requested creative, including aggregate metrics and
-          its variant collection.
+          Return delivery for the requested creative and its variant collection,
+          including aggregate metrics when available.
         sample_request:
           account:
             brand:
@@ -275,9 +275,6 @@ phases:
             path: "creatives[0].creative_id"
             context_key: "synced_creative_id"
             description: "DR-0001 / get_creative_delivery filter contract: delivery belongs to the requested synced creative"
-          - check: field_present
-            path: "creatives[0].totals.impressions"
-            description: "DR-0001 / creative delivery response contract: aggregate impressions are present"
           - check: field_present
             path: "creatives[0].variants"
             description: "DR-0001 / creative delivery response contract: the required variants collection is present"

--- a/static/compliance/source/protocols/creative/index.yaml
+++ b/static/compliance/source/protocols/creative/index.yaml
@@ -190,10 +190,10 @@ phases:
             path: "context.correlation_id"
             value: "creative_lifecycle--list_all"
             description: "Context correlation_id returned unchanged"
-          - check: field_equals_context
-            path: "creatives[0].creative_id"
-            context_key: "synced_creative_id"
-            description: "list_creatives returns the creative synced earlier"
+          - check: field_contains
+            path: "creatives[*].creative_id"
+            value: "$context.synced_creative_id"
+            description: "DR-0001 / list_creatives account contract: the creative synced earlier remains discoverable"
       - id: list_filtered
         title: "List creatives filtered by format"
         narrative: |
@@ -235,10 +235,56 @@ phases:
             path: "context.correlation_id"
             value: "creative_lifecycle--list_filtered"
             description: "Context correlation_id returned unchanged"
+          - check: field_contains
+            path: "creatives[*].creative_id"
+            value: "$context.synced_creative_id"
+            description: "DR-0001 / list_creatives format filter contract: the synced image creative remains in the filtered result"
+  - id: delivery_readback
+    title: "Read delivery for the synced creative"
+    narrative: |
+      The buyer requests delivery for the creative synced earlier. The response must
+      identify that creative rather than returning unrelated but schema-valid data.
+
+    steps:
+      - id: get_synced_creative_delivery
+        title: "Get delivery for the synced creative"
+        task: get_creative_delivery
+        requires_tool: get_creative_delivery
+        schema_ref: "creative/get-creative-delivery-request.json"
+        response_schema_ref: "creative/get-creative-delivery-response.json"
+        doc_ref: "/creative/task-reference/get_creative_delivery"
+        comply_scenario: creative_flow
+        stateful: true
+        expected: |
+          Return delivery for the requested creative, including aggregate metrics and
+          its variant collection.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          creative_ids:
+            - "$context.synced_creative_id"
+          context:
+            correlation_id: "creative_lifecycle--get_synced_creative_delivery"
+        validations:
+          - check: response_schema
+            description: "Response matches get-creative-delivery-response.json schema"
           - check: field_equals_context
             path: "creatives[0].creative_id"
             context_key: "synced_creative_id"
-            description: "Filtered list_creatives returns the display creative synced earlier"
+            description: "DR-0001 / get_creative_delivery filter contract: delivery belongs to the requested synced creative"
+          - check: field_present
+            path: "creatives[0].totals.impressions"
+            description: "DR-0001 / creative delivery response contract: aggregate impressions are present"
+          - check: field_present
+            path: "creatives[0].variants"
+            description: "DR-0001 / creative delivery response contract: the required variants collection is present"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_lifecycle--get_synced_creative_delivery"
+            description: "Context correlation_id returned unchanged"
   - id: build_and_preview
     title: "Preview display creative"
     narrative: |

--- a/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
@@ -178,6 +178,13 @@ phases:
               budget: 10000
               pricing_option_id: "$context.pricing_option_2_id"
           idempotency_key: "$generate:uuid_v4#media_buy_seller_delivery_reporting_setup_create_media_buy"
+        context_outputs:
+          - name: delivery_media_buy_id
+            path: "media_buy_id"
+          - name: delivery_package_1_id
+            path: "packages[0].package_id"
+          - name: delivery_package_2_id
+            path: "packages[1].package_id"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
@@ -241,6 +248,24 @@ phases:
           - check: field_present
             path: "media_buy_deliveries"
             description: "Response contains delivery data"
+          - check: field_equals_context
+            path: "media_buy_deliveries[0].media_buy_id"
+            context_key: "delivery_media_buy_id"
+            description: "DR-0001 / get_media_buy_delivery filter contract: the requested media buy is the one returned"
+          - check: field_contains
+            path: "media_buy_deliveries[0].by_package[*].package_id"
+            value: "$context.delivery_package_1_id"
+            description: "DR-0001 / delivery response contract: reporting includes the first package created for the buy"
+          - check: field_contains
+            path: "media_buy_deliveries[0].by_package[*].package_id"
+            value: "$context.delivery_package_2_id"
+            description: "DR-0001 / delivery response contract: reporting includes the second package created for the buy"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.impressions"
+            description: "DR-0001 / delivery response contract: simulated impressions are reported substantively"
+          - check: field_present
+            path: "media_buy_deliveries[0].totals.spend"
+            description: "DR-0001 / delivery response contract: simulated spend is reported substantively"
 
   - id: viewability_delivery
     title: "Delivery reporting surfaces viewability.viewed_seconds for viewability-capable products"

--- a/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
@@ -261,9 +261,6 @@ phases:
             value: "$context.delivery_package_2_id"
             description: "DR-0001 / delivery response contract: reporting includes the second package created for the buy"
           - check: field_present
-            path: "media_buy_deliveries[0].totals.impressions"
-            description: "DR-0001 / delivery response contract: simulated impressions are reported substantively"
-          - check: field_present
             path: "media_buy_deliveries[0].totals.spend"
             description: "DR-0001 / delivery response contract: simulated spend is reported substantively"
 

--- a/static/compliance/source/specialisms/collection-lists/index.yaml
+++ b/static/compliance/source/specialisms/collection-lists/index.yaml
@@ -214,6 +214,10 @@ phases:
             path: "context.correlation_id"
             value: "collection_lists--list_collection_lists"
             description: "Context correlation_id returned unchanged"
+          - check: field_contains
+            path: "lists[*].list_id"
+            value: "$context.collection_list_id"
+            description: "DR-0001 / list_collection_lists name filter contract: the just-created collection list is returned"
 
       - id: get_collection_list
         title: "Get a specific collection list with resolved collections"
@@ -258,6 +262,10 @@ phases:
             path: "context.correlation_id"
             value: "collection_lists--get_collection_list"
             description: "Context correlation_id returned unchanged"
+          - check: field_equals_context
+            path: "list.list_id"
+            context_key: "collection_list_id"
+            description: "DR-0001 / get_collection_list identity contract: readback returns the requested created list"
 
   - id: update_list
     title: "Update collection lists"

--- a/static/compliance/source/specialisms/content-standards/index.yaml
+++ b/static/compliance/source/specialisms/content-standards/index.yaml
@@ -152,6 +152,9 @@ phases:
           idempotency_key: "$generate:uuid_v4#content_standards_create_standards_create_content_standards"
           context:
             correlation_id: "content_standards--create_content_standards"
+        context_outputs:
+          - name: content_standards_id
+            path: "standards_id"
         validations:
           - check: response_schema
             description: "Response matches create-content-standards-response.json schema"
@@ -205,6 +208,10 @@ phases:
             path: "context.correlation_id"
             value: "content_standards--list_content_standards"
             description: "Context correlation_id returned unchanged"
+          - check: field_contains
+            path: "standards[*].standards_id"
+            value: "$context.content_standards_id"
+            description: "DR-0001 / list_content_standards account contract: the just-created standards set is returned"
       - id: get_content_standards
         title: "Get a specific content standard"
         narrative: |
@@ -241,6 +248,10 @@ phases:
             path: "context.correlation_id"
             value: "content_standards--get_content_standards"
             description: "Context correlation_id returned unchanged"
+          - check: field_equals_context
+            path: "standards_id"
+            context_key: "content_standards_id"
+            description: "DR-0001 / get_content_standards identity contract: readback returns the requested created standards set"
   - id: update_standards
     title: "Update content standards"
     narrative: |

--- a/static/compliance/source/specialisms/property-lists/index.yaml
+++ b/static/compliance/source/specialisms/property-lists/index.yaml
@@ -206,6 +206,10 @@ phases:
             path: "context.correlation_id"
             value: "property_lists--list_property_lists"
             description: "Context correlation_id returned unchanged"
+          - check: field_contains
+            path: "lists[*].list_id"
+            value: "$context.property_list_id"
+            description: "DR-0001 / list_property_lists name filter contract: the just-created property list is returned"
       - id: get_property_list
         title: "Get a specific property list"
         narrative: |
@@ -242,6 +246,10 @@ phases:
             path: "context.correlation_id"
             value: "property_lists--get_property_list"
             description: "Context correlation_id returned unchanged"
+          - check: field_equals_context
+            path: "list.list_id"
+            context_key: "property_list_id"
+            description: "DR-0001 / get_property_list identity contract: readback returns the requested created list"
   - id: update_list
     title: "Update property lists"
     narrative: |


### PR DESCRIPTION
## Summary

- capture media-buy and package identities at creation, then require delivery reporting to return those identities with substantive totals
- make creative list checks order-independent and add a delivery readback for the creative synced earlier in the lifecycle
- require property-list, collection-list, and content-standards list/get flows to return the entities created by prior steps
- add a patch changeset for the additive compliance coverage

These assertions are grounded in the existing DR-0001 response and filter contracts. They use equality or membership against captured state, so they do not assume different requests must produce byte-different responses.

## Validation

- `npm run build:compliance`
- focused storyboard schema, path, context-entity, scoping, and check-enum suites
- `npm run test:storyboards`
- `npm run test:storyboards:3.0-compat` (released bundle 3.0.22)
- pre-commit repository suite: 434 test files / 6,127 tests passed, plus TypeScript typecheck
- changeset protocol-scope, version-sync, PR-title, and diff-hygiene checks

Closes #6173
