### PR TITLE
docs(protocol): require deterministic read filters

### DIFF
--- a/.changeset/enforce-deterministic-read-filters.md
+++ b/.changeset/enforce-deterministic-read-filters.md
@@ -1,5 +1,0 @@
----
-"adcontextprotocol": minor
----
-
-Require delivery, media-buy, and creative-list responses to honor deterministic date, identity, and status filters through observable membership and boundary semantics.

--- a/.changeset/enforce-deterministic-read-filters.md
+++ b/.changeset/enforce-deterministic-read-filters.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Require delivery, media-buy, and creative-list responses to honor deterministic date, identity, and status filters through observable membership and boundary semantics.

--- a/docs/creative/task-reference/list_creatives.mdx
+++ b/docs/creative/task-reference/list_creatives.mdx
@@ -96,6 +96,19 @@ All active filter fields compose with **AND logic**. For example, the following 
 }
 ```
 
+For deterministic status and assignment filters, every returned creative MUST
+satisfy the supplied predicates: `status` MUST be a member of `statuses`, and a
+sales agent applying `media_buy_ids` MUST return only creatives with an
+assignment to at least one requested media buy. These predicates remain in force
+across every page and compose with each other and with all other active filters.
+A seller MUST NOT accept them and return the unfiltered library.
+
+A filtered request can validly return the same rows as an unfiltered request
+when every visible creative already matches. Conformance is established from
+status and assignment membership—not by requiring the two response payloads to
+differ. Standalone creative agents retain the documented exception for
+sales-agent-specific assignment filters.
+
 Use `asset_types: ["published_post"]` to find existing-published-post reference creatives across sellers without enumerating publisher-specific format options, or `asset_types: ["zip"]` to find HTML5 bundle archives. Values such as `url`, `text`, and `image` are common companion assets, so they often produce broad result sets when used alone.
 
 Agents that do not implement `asset_types` MUST ignore that field and apply all other active filters. They must not reject the request solely because the filter is unsupported. Because unsupported agents deliberately over-return, buyers that require an exact filtered result MUST retain a local fallback: request `assets` (or omit `fields`), traverse every page until `pagination.has_more` is false, and locally inspect the returned top-level asset objects. When a seller returns `query_summary.filters_applied`, buyers can verify that it includes `asset_types`; absence means the local fallback is required.

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -34,11 +34,10 @@ Retrieve comprehensive delivery metrics and performance data for media buy repor
 
 ### Deterministic filter contract
 
-When a seller accepts deterministic filters, it MUST scope the response to every
-supplied filter. Every `media_buy_deliveries[]` row MUST have a `media_buy_id` in
-`media_buy_ids` when that filter is present and a lifecycle `status` in
-`status_filter` when that filter is present. Multiple filters apply
-conjunctively; a seller MUST NOT accept them and return an unfiltered result.
+`media_buy_ids` and accepted date bounds MUST observably scope the response.
+Every `media_buy_deliveries[]` row MUST have a `media_buy_id` in
+`media_buy_ids` when that filter is present. A seller MUST NOT accept the filter
+and return delivery rows for other buys.
 
 For an accepted `start_date` and `end_date`, `reporting_period.start` and
 `reporting_period.end` MUST represent those exact UTC day boundaries, and all

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -32,6 +32,25 @@ Retrieve comprehensive delivery metrics and performance data for media buy repor
 
 > **Date Range Behavior**: The date range is **start-inclusive, end-exclusive**. For example, `start_date: "2026-01-01"` and `end_date: "2026-01-02"` returns delivery data for January 1st only (from `2026-01-01 00:00:00` up to, but not including, `2026-01-02 00:00:00`). To get a full week of data (Jan 1-7), use `end_date: "2026-01-08"`.
 
+### Deterministic filter contract
+
+When a seller accepts deterministic filters, it MUST scope the response to every
+supplied filter. Every `media_buy_deliveries[]` row MUST have a `media_buy_id` in
+`media_buy_ids` when that filter is present and a lifecycle `status` in
+`status_filter` when that filter is present. Multiple filters apply
+conjunctively; a seller MUST NOT accept them and return an unfiltered result.
+
+For an accepted `start_date` and `end_date`, `reporting_period.start` and
+`reporting_period.end` MUST represent those exact UTC day boundaries, and all
+aggregates, per-buy totals, daily rows, and requested window slices MUST be
+computed only from delivery in the start-inclusive, end-exclusive interval.
+Delivery outside that interval MUST NOT contribute to the response.
+
+A filtered request can legitimately return the same rows and values as a less
+restrictive request when all underlying delivery already matches. Conformance is
+therefore established from returned membership, status, and date boundaries—not
+by requiring two response payloads to differ.
+
 **Date Range Examples**:
 
 | start_date | end_date | Data Returned |

--- a/docs/media-buy/task-reference/get_media_buys.mdx
+++ b/docs/media-buy/task-reference/get_media_buys.mdx
@@ -39,6 +39,19 @@ Sellers that need to partition inventory away from a caller MUST do so at the **
 
 When `media_buy_ids` are provided, no implicit status filtering is applied. Pass `status_filter` explicitly if you want to filter identified buys by status.
 
+### Deterministic filter contract
+
+Every returned `media_buys[]` row MUST have a `media_buy_id` in
+`media_buy_ids` when that filter is present and a `status` in `status_filter`
+when that filter is present. When both are supplied, both predicates apply to
+every row, across every page. A seller MUST NOT accept a schema-valid filter and
+return unfiltered account results.
+
+A filter can validly leave the result unchanged when every accessible buy
+already matches. Conformance is established from the returned rows' ID and
+status membership—not by requiring filtered and unfiltered response payloads to
+differ.
+
 ## Response
 
 Returns an array of media buys with current status, creative approval state, and optionally delivery snapshots:

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -55,7 +55,7 @@
         "end": {
           "type": "string",
           "format": "date-time",
-          "description": "ISO 8601 end timestamp in UTC (e.g., 2024-02-05T23:59:59Z)"
+          "description": "ISO 8601 exclusive end timestamp in UTC (e.g., 2024-02-06T00:00:00Z for a report covering 2024-02-05)"
         }
       },
       "required": [


### PR DESCRIPTION
## Summary

Establish the normative prerequisite for the remaining #2902 behavioral conformance work:

- `get_media_buy_delivery` MUST honor media-buy, lifecycle-status, and accepted half-open date filters; `reporting_period` reflects the exact requested UTC boundaries and out-of-range delivery cannot contribute.
- `get_media_buys` MUST return only rows whose IDs and statuses satisfy every supplied deterministic filter, across pagination.
- sales-agent `list_creatives` results MUST satisfy supplied creative-status and media-buy-assignment filters, across pagination.
- conformance is defined by membership and boundary properties, not by requiring filtered and unfiltered payloads to differ.

This is intentionally the normative first half of #2902 under DR-0001. The graded seeded storyboards will follow after this contract lands.

Refs #2902

## Validation

- repository pre-commit root suite: 67 files / 1,043 tests passed; the later server-unit phase exceeded the hook's fixed wall-clock cap rather than failing
- `npm run check:seo`
- `npm run lint:schema-links`
- `npm run test:examples`
- `npm run test:doc-compliance-drift`
- `npm run test:docs-nav`
- `npm run test:compliance-snippets`
- `npm run build:compliance -- --check` (serial rerun clean)
- `git diff --check`
