### PR TITLE
feat(media-buy): add shared media buy name

### DIFF
--- a/.changeset/add-name-field-to-media-buy.md
+++ b/.changeset/add-name-field-to-media-buy.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add an optional, persisted `name` to media-buy create, update, success, and read surfaces so buyers and sellers can share a human-readable trafficking label without overloading financial references or opaque context.

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -158,6 +158,7 @@ npx @adcp/sdk@latest \
 | `paused` | boolean | No | Create the media buy with delivery held. When true and the buy would otherwise be active, `media_buy_status` is `paused`. Setup blockers still take precedence: missing creatives yield `pending_creatives`, and future flights yield `pending_start`; the hold becomes visible as `paused` after those blockers clear. |
 | `invoice_recipient` | [BusinessEntity](/docs/building/by-layer/L2/accounts-and-agents#billing-entity-and-invoice-recipient) | No | Override the account's default billing entity for this buy. The seller MUST validate the recipient is authorized and include it in [`check_governance`](/docs/governance/campaign/tasks/check_governance) when governance agents are configured. |
 | `po_number` | string | No | Purchase order number |
+| `name` | string | No | Human-readable shared label for trafficking UI display and buyer-seller communication (maximum 255 characters). Sellers persist and echo it unchanged; it is not a purchase-order, reconciliation, or identity key. |
 | `idempotency_key` | string | No | Unique key for safe retries. If a request with the same key and account has already been processed, the seller returns the existing media buy. MUST be unique per (seller, request) pair. Min 16 chars. |
 | `context` | object | No | Opaque correlation data echoed unchanged in the response. Use for internal tracking, trace IDs, or other caller-specific identifiers. |
 | `reporting_webhook` | ReportingWebhook | No | Automated reporting delivery configuration |
@@ -281,6 +282,7 @@ A provider portfolio bidding strategy illustrates the current abstraction bounda
 | Field | Description |
 |-------|-------------|
 | `media_buy_id` | Seller's unique identifier |
+| `name` | Persisted human-readable media-buy label. When supplied in the request, the seller MUST echo it unchanged. |
 | `account` | Resolved account billed for this media buy, echoed as a full [Account](/docs/building/by-layer/L2/accounts-and-agents#account-references) object (includes `account_id`, `name`, `status`, and the resolved `brand`/`operator`). When the request used implicit resolution (`brand` + `operator`), this confirms the account the seller resolved. Optional. |
 | `confirmed_at` | ISO 8601 timestamp when the seller committed to the media buy. Stable after it is set. May be `null` in deferred/manual approval flows until seller commitment occurs. |
 | `creative_deadline` | ISO 8601 timestamp for creative upload deadline |

--- a/docs/media-buy/task-reference/get_media_buys.mdx
+++ b/docs/media-buy/task-reference/get_media_buys.mdx
@@ -58,6 +58,7 @@ Returns an array of media buys with current status, creative approval state, and
 | Field | Description |
 |-------|-------------|
 | `media_buy_id` | Seller's media buy identifier |
+| `name` | Persisted human-readable label for trafficking UI display and buyer-seller communication. Sellers MUST return it for AdCP-created buys that supplied `name`; it may be absent for external buys or buys created without one. It is not an identifier or financial reference. |
 | `accepted_proposal_id` | Current immutable commercial snapshot used to begin [`refine_proposals`](/docs/media-buy/task-reference/refine_proposals); present for compact-lifecycle buys. |
 | `accepted_proposal_terms_digest` | Digest binding the current accepted proposal terms for recovery and governance verification. |
 | `accepted_proposal` | Complete accepted canonical proposal for compact-lifecycle buys. Together with the ID and digest, this lets a restarted client refine the current commercial envelope without reconstructing historical offers. |

--- a/docs/media-buy/task-reference/update_media_buy.mdx
+++ b/docs/media-buy/task-reference/update_media_buy.mdx
@@ -191,6 +191,7 @@ asyncio.run(create_and_pause_campaign())
 |-----------|------|----------|-------------|
 | `account` | [account-ref](/docs/building/by-layer/L2/accounts-and-agents#account-references) | Yes | Account that owns this media buy. Pass `{ "account_id": "..." }` or `{ "brand": {...}, "operator": "..." }`. Required for governance checks and account resolution. |
 | `media_buy_id` | string | Yes | Seller's media buy identifier to update |
+| `name` | string | No | Replacement human-readable label for trafficking UI display and buyer-seller communication (maximum 255 characters). A seller that cannot update it mid-flight SHOULD return the prior unchanged value rather than silently dropping the field. |
 | `revision` | integer | No | Expected current revision for optimistic concurrency. Seller rejects with [`CONFLICT`](/docs/building/verification/compliance-catalog#error-code-conflict) on mismatch. Obtain from [`get_media_buys`](/docs/media-buy/task-reference/get_media_buys) or the most recent response. |
 | `start_time` | string | No | Updated campaign start time |
 | `end_time` | string | No | Updated campaign end time |
@@ -271,6 +272,7 @@ For budget/pacing interaction and bidding inheritance, see [Budget & Pacing Cont
 | Field | Description |
 |-------|-------------|
 | `media_buy_id` | Media buy identifier |
+| `name` | Persisted human-readable label after the update. When the request supplied `name`, the seller MUST return the stored value (updated or prior unchanged value). |
 | `media_buy_status` | Media buy lifecycle status after the update (present when status changes, e.g., cancellation). Canonical 3.1 field. See [Migration › `media_buy_status`](/docs/reference/migration/media-buy-status). |
 | `status` | **Deprecated in 3.1, removed in 3.2** ([#4906](https://github.com/adcontextprotocol/adcp/issues/4906)). Use `media_buy_status` instead. Top-level `status` collides with the envelope task-status on flat-serialized MCP wire. |
 | `revision` | Revision number after this update. Use in subsequent requests intended to change state for optimistic concurrency. Exact idempotency replays return the prior revision. |

--- a/static/schemas/source/core/media-buy.json
+++ b/static/schemas/source/core/media-buy.json
@@ -10,6 +10,11 @@
       "description": "Seller's unique identifier for the media buy",
       "x-entity": "media_buy"
     },
+    "name": {
+      "type": "string",
+      "maxLength": 255,
+      "description": "Human-readable name for this media buy, shared by buyer and seller for trafficking UI display and operational communication. Sellers MUST include the persisted name on read surfaces such as get_media_buys when the media buy was created through AdCP with name. Sellers MAY omit name for media buys created outside AdCP or created without name. This display label is not an identifier or financial reference."
+    },
     "accepted_proposal_id": {
       "type": "string",
       "minLength": 1,

--- a/static/schemas/source/core/media-buy.json
+++ b/static/schemas/source/core/media-buy.json
@@ -12,7 +12,9 @@
     },
     "name": {
       "type": "string",
+      "minLength": 1,
       "maxLength": 255,
+      "pattern": "\\S",
       "description": "Human-readable name for this media buy, shared by buyer and seller for trafficking UI display and operational communication. Sellers MUST include the persisted name on read surfaces such as get_media_buys when the media buy was created through AdCP with name. Sellers MAY omit name for media buys created outside AdCP or created without name. This display label is not an identifier or financial reference."
     },
     "accepted_proposal_id": {

--- a/static/schemas/source/media-buy/create-media-buy-request.json
+++ b/static/schemas/source/media-buy/create-media-buy-request.json
@@ -182,6 +182,11 @@
       "type": "string",
       "description": "Purchase order number for tracking"
     },
+    "name": {
+      "type": "string",
+      "maxLength": 255,
+      "description": "Human-readable name for this media buy, shared by buyer and seller for trafficking UI display and operational communication. When supplied, the seller MUST persist it and echo it unchanged on the create success response and subsequent get_media_buys reads. This display label is not an identifier or financial reference."
+    },
     "agency_estimate_number": {
       "type": "string",
       "maxLength": 100,

--- a/static/schemas/source/media-buy/create-media-buy-request.json
+++ b/static/schemas/source/media-buy/create-media-buy-request.json
@@ -184,7 +184,9 @@
     },
     "name": {
       "type": "string",
+      "minLength": 1,
       "maxLength": 255,
+      "pattern": "\\S",
       "description": "Human-readable name for this media buy, shared by buyer and seller for trafficking UI display and operational communication. When supplied, the seller MUST persist it and echo it unchanged on the create success response and subsequent get_media_buys reads. This display label is not an identifier or financial reference."
     },
     "agency_estimate_number": {

--- a/static/schemas/source/media-buy/create-media-buy-response.json
+++ b/static/schemas/source/media-buy/create-media-buy-response.json
@@ -31,7 +31,9 @@
         },
         "name": {
           "type": "string",
+          "minLength": 1,
           "maxLength": 255,
+          "pattern": "\\S",
           "description": "Persisted human-readable name for this media buy. When create_media_buy supplied name, the seller MUST echo it unchanged here. This display label is shared for trafficking UI display and operational communication; it is not an identifier or financial reference."
         },
         "account": {

--- a/static/schemas/source/media-buy/create-media-buy-response.json
+++ b/static/schemas/source/media-buy/create-media-buy-response.json
@@ -29,6 +29,11 @@
           "description": "Seller's unique identifier for the created media buy",
           "x-entity": "media_buy"
         },
+        "name": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Persisted human-readable name for this media buy. When create_media_buy supplied name, the seller MUST echo it unchanged here. This display label is shared for trafficking UI display and operational communication; it is not an identifier or financial reference."
+        },
         "account": {
           "$ref": "/schemas/core/account.json",
           "description": "Account billed for this media buy. Includes advertiser, billing proxy (if any), and rate card applied."

--- a/static/schemas/source/media-buy/get-media-buys-response.json
+++ b/static/schemas/source/media-buy/get-media-buys-response.json
@@ -26,7 +26,9 @@
           },
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 255,
+            "pattern": "\\S",
             "description": "Persisted human-readable name for this media buy, shared by buyer and seller for trafficking UI display and operational communication. Sellers MUST include name when the media buy was created through AdCP with name. Sellers MAY omit it for media buys created outside AdCP or created without name. This display label is not an identifier or financial reference."
           },
           "accepted_proposal_id": {

--- a/static/schemas/source/media-buy/get-media-buys-response.json
+++ b/static/schemas/source/media-buy/get-media-buys-response.json
@@ -24,6 +24,11 @@
             "description": "Seller's unique identifier for the media buy",
             "x-entity": "media_buy"
           },
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Persisted human-readable name for this media buy, shared by buyer and seller for trafficking UI display and operational communication. Sellers MUST include name when the media buy was created through AdCP with name. Sellers MAY omit it for media buys created outside AdCP or created without name. This display label is not an identifier or financial reference."
+          },
           "accepted_proposal_id": {
             "type": "string",
             "minLength": 1,

--- a/static/schemas/source/media-buy/update-media-buy-request.json
+++ b/static/schemas/source/media-buy/update-media-buy-request.json
@@ -128,7 +128,9 @@
     },
     "name": {
       "type": "string",
+      "minLength": 1,
       "maxLength": 255,
+      "pattern": "\\S",
       "description": "Replacement human-readable name for this media buy, used for trafficking UI display and operational communication. Sellers that cannot update name mid-flight SHOULD echo the prior unchanged value in the success response rather than silently dropping the field. This display label is not an identifier or financial reference."
     },
     "revision": {

--- a/static/schemas/source/media-buy/update-media-buy-request.json
+++ b/static/schemas/source/media-buy/update-media-buy-request.json
@@ -126,6 +126,11 @@
       "description": "Seller's ID of the media buy to update",
       "x-entity": "media_buy"
     },
+    "name": {
+      "type": "string",
+      "maxLength": 255,
+      "description": "Replacement human-readable name for this media buy, used for trafficking UI display and operational communication. Sellers that cannot update name mid-flight SHOULD echo the prior unchanged value in the success response rather than silently dropping the field. This display label is not an identifier or financial reference."
+    },
     "revision": {
       "type": "integer",
       "description": "Expected current revision for optimistic concurrency. Optional for backward compatibility. When provided, sellers MUST reject the update with CONFLICT if the media buy's current revision does not match, and MUST enforce that comparison atomically with the write. Obtain from get_media_buys or the most recent create/update response.",

--- a/static/schemas/source/media-buy/update-media-buy-response.json
+++ b/static/schemas/source/media-buy/update-media-buy-response.json
@@ -25,7 +25,9 @@
         },
         "name": {
           "type": "string",
+          "minLength": 1,
           "maxLength": 255,
+          "pattern": "\\S",
           "description": "Persisted human-readable name after the update. When update_media_buy supplied name, the seller MUST return the stored value here; a seller that could not apply the replacement SHOULD return the prior unchanged value rather than silently dropping the field. This display label is not an identifier or financial reference."
         },
         "media_buy_status": {

--- a/static/schemas/source/media-buy/update-media-buy-response.json
+++ b/static/schemas/source/media-buy/update-media-buy-response.json
@@ -23,6 +23,11 @@
           "description": "Seller's identifier for the media buy",
           "x-entity": "media_buy"
         },
+        "name": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Persisted human-readable name after the update. When update_media_buy supplied name, the seller MUST return the stored value here; a seller that could not apply the replacement SHOULD return the prior unchanged value rather than silently dropping the field. This display label is not an identifier or financial reference."
+        },
         "media_buy_status": {
           "$ref": "/schemas/enums/media-buy-status.json",
           "description": "Media buy status after the update. Present when the update changes the media buy's status (e.g., cancellation transitions to 'canceled', pause transitions to 'paused'). Added in 3.1: at the top level of flat-on-the-wire MCP responses, the `status` key is reserved for the envelope TaskStatus. Sellers SHOULD emit `media_buy_status` from 3.1 onward; the legacy top-level `status: MediaBuyStatus` form is deprecated and removed in 3.2 (#4906). When the deprecated `status` is also present during the 3.1 deprecation window, both MUST carry identical values — divergent emission is a conformance violation flagged by 3.1 compliance storyboards."

--- a/tests/media-buy-name-contract.test.cjs
+++ b/tests/media-buy-name-contract.test.cjs
@@ -85,6 +85,12 @@ describe("media-buy name contract", () => {
         false,
         `${label} must reject a 256-character name`
       );
+      assert.equal(validate(""), false, `${label} must reject an empty name`);
+      assert.equal(
+        validate(" \t\n "),
+        false,
+        `${label} must reject a whitespace-only name`
+      );
     }
   });
 

--- a/tests/media-buy-name-contract.test.cjs
+++ b/tests/media-buy-name-contract.test.cjs
@@ -1,0 +1,105 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const Ajv = require("ajv");
+
+const SCHEMA_BASE_DIR = path.join(
+  __dirname,
+  "..",
+  "static",
+  "schemas",
+  "source"
+);
+
+function load(relativePath) {
+  return JSON.parse(
+    fs.readFileSync(path.join(SCHEMA_BASE_DIR, relativePath), "utf8")
+  );
+}
+
+function successProperties(relativePath, title) {
+  const schema = load(relativePath);
+  return schema.oneOf.find((branch) => branch.title === title).properties;
+}
+
+const surfaces = [
+  {
+    label: "core MediaBuy",
+    field: load("core/media-buy.json").properties.name,
+    obligation: /MUST include the persisted name/,
+  },
+  {
+    label: "create request",
+    field: load("media-buy/create-media-buy-request.json").properties.name,
+    obligation: /MUST persist it and echo it unchanged/,
+  },
+  {
+    label: "update request",
+    field: load("media-buy/update-media-buy-request.json").properties.name,
+    obligation: /SHOULD echo the prior unchanged value/,
+  },
+  {
+    label: "create success",
+    field: successProperties(
+      "media-buy/create-media-buy-response.json",
+      "CreateMediaBuySuccess"
+    ).name,
+    obligation: /MUST echo it unchanged/,
+  },
+  {
+    label: "update success",
+    field: successProperties(
+      "media-buy/update-media-buy-response.json",
+      "UpdateMediaBuySuccess"
+    ).name,
+    obligation: /MUST return the stored value/,
+  },
+  {
+    label: "get_media_buys item",
+    field: load("media-buy/get-media-buys-response.json").properties.media_buys
+      .items.properties.name,
+    obligation: /MUST include name/,
+  },
+];
+
+describe("media-buy name contract", () => {
+  it("declares the same bounded display label on every write and read surface", () => {
+    const ajv = new Ajv({ strict: false });
+    for (const { label, field } of surfaces) {
+      assert.equal(field.type, "string", `${label} name must be a string`);
+      assert.equal(
+        field.maxLength,
+        255,
+        `${label} name must use the shared 255-character limit`
+      );
+
+      const validate = ajv.compile(field);
+      assert.equal(
+        validate("A".repeat(255)),
+        true,
+        `${label} must accept a 255-character name`
+      );
+      assert.equal(
+        validate("A".repeat(256)),
+        false,
+        `${label} must reject a 256-character name`
+      );
+    }
+  });
+
+  it("keeps persistence and readback obligations normative", () => {
+    for (const { label, field, obligation } of surfaces) {
+      assert.match(
+        field.description,
+        obligation,
+        `${label} lost its name persistence obligation`
+      );
+      assert.match(
+        field.description,
+        /not an identifier or financial reference/i,
+        `${label} must distinguish the display label from identity and finance fields`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add optional `name` to media-buy create and update requests
- persist and return the shared label on create/update success, canonical `MediaBuy`, and `get_media_buys`
- define the value as a bounded trafficking UI and buyer-seller communication label, not an identifier or financial reference
- document create, update, and readback behavior and guard all six schema surfaces with a drift test

## Validation

- focused media-buy name contract tests
- schema validation, composed schema validation, and documentation JSON validation
- MCP schema projection and analysis (24 passed)
- schema link lint/tests and docs navigation (21 passed)
- TypeScript typecheck
- authoritative pre-commit suites (6,127 passed; 30 skipped)
- changeset protocol-scope validation

Closes #5802
