### PR TITLE
feat(media-buy): add package creative rotation

### DIFF
--- a/.changeset/rotate-package-creatives.md
+++ b/.changeset/rotate-package-creatives.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add package-scoped weighted, even, sequential, and random creative rotation with package-local groups and validated sequence positions.

--- a/docs/reference/migration/creatives.mdx
+++ b/docs/reference/migration/creatives.mdx
@@ -110,6 +110,53 @@ Control what percentage of impressions each creative receives:
 
 Weights are relative — they don't need to sum to 100, but doing so makes intent clear.
 
+### Rotation modes and groups
+
+`rotation_mode` is a package policy carried on each assignment row. All assignments in one package MUST resolve to the same mode; omission resolves to `weighted`, preserving the pre-3.2 behavior above. A seller MUST reject conflicting modes with `VALIDATION_ERROR` before creating or updating the package rather than picking the first row.
+
+| Mode | Selection behavior |
+|---|---|
+| `weighted` | Select proportionally by `weight`. Omitted weights are equal; `weight: 0` pauses an assignment. This is the default. |
+| `even` | Balance delivery across eligible assignments without buyer-supplied weights. |
+| `sequential` | Cycle through `sequence_position` in ascending order within each group. Every assignment requires a position. |
+| `random` | Make an independent uniform selection from the eligible assignments. |
+
+`group_id` identifies a pool only within its containing package; the same value in another package is unrelated. Assignments without `group_id` belong to the package's default group. In sequential mode, positions start at 1 and MUST be unique within each effective group, so separate groups may reuse the same positions.
+
+Conventional weighted pool (the legacy shape remains valid):
+
+```json
+{
+  "creative_assignments": [
+    { "creative_id": "host_read_30", "weight": 70 },
+    { "creative_id": "produced_spot_30", "weight": 30 }
+  ]
+}
+```
+
+Sequential podcast storytelling:
+
+```json
+{
+  "creative_assignments": [
+    {
+      "creative_id": "story_chapter_1",
+      "rotation_mode": "sequential",
+      "group_id": "listener_story",
+      "sequence_position": 1
+    },
+    {
+      "creative_id": "story_chapter_2",
+      "rotation_mode": "sequential",
+      "group_id": "listener_story",
+      "sequence_position": 2
+    }
+  ]
+}
+```
+
+`weight` is valid only for the effective `weighted` mode. `sequence_position` is valid only for explicit `sequential` assignments. Package validators additionally enforce effective-mode consistency and position uniqueness because JSON Schema draft-07 cannot compare values across assignment rows.
+
 ### Placement targeting
 
 Assign specific creatives to specific placements within a product:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deploy:cdn-artifacts-cutover:dry-run": "wrangler deploy --config workers/artifact-cdn/wrangler.cutover.toml --dry-run",
     "verify:cdn-artifacts-cutover": "node scripts/verify-cdn-artifacts-cutover.mjs",
     "typecheck": "tsc --project server/tsconfig.json --noEmit",
-    "test:schemas": "node tests/schema-validation.test.cjs && node --test tests/schema-deprecation-metadata.test.cjs && npm run test:geo-region-targeting",
+    "test:schemas": "node tests/schema-validation.test.cjs && node --test tests/schema-deprecation-metadata.test.cjs tests/creative-rotation.test.cjs && npm run test:geo-region-targeting",
     "test:performance-feedback": "node --test --test-force-exit --test-timeout=30000 tests/performance-feedback-contract.test.cjs",
     "test:dist-schema-version-ids": "node --test --test-force-exit --test-timeout=30000 tests/dist-schema-version-ids.test.cjs",
     "test:examples": "node tests/example-validation-simple.test.cjs && npm run test:tmp-context-merge",

--- a/static/schemas/source/core/creative-assignment.json
+++ b/static/schemas/source/core/creative-assignment.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/core/creative-assignment.json",
   "title": "Creative Assignment",
-  "description": "Assignment of a creative asset to a package with optional creative routing by placement. Used in create_media_buy and update_media_buy requests. Buyers identify the stored creative with `creative_id` only. A generic `id` alias, if present due to adapter-internal payload reuse, is not an AdCP identifier and sellers MUST ignore it on input. Note: sync_creatives does not support placement_refs or placement_ids - use create/update_media_buy for placement-level creative routing.",
+  "description": "Assignment of a creative asset to a package with optional rotation and placement routing. Used in create_media_buy and update_media_buy requests. Buyers identify the stored creative with `creative_id` only. A generic `id` alias, if present due to adapter-internal payload reuse, is not an AdCP identifier and sellers MUST ignore it on input. Note: sync_creatives does not support package rotation, placement_refs, or placement_ids - use create/update_media_buy for package-level trafficking controls.",
   "type": "object",
   "properties": {
     "creative_id": {
@@ -12,9 +12,24 @@
     },
     "weight": {
       "type": "number",
-      "description": "Relative delivery weight for this creative (0–100). When multiple creatives are assigned to the same package, weights determine impression distribution proportionally — a creative with weight 2 gets twice the delivery of weight 1. When omitted, the creative receives equal rotation with other unweighted creatives. A weight of 0 means the creative is assigned but paused (receives no delivery).",
+      "description": "Relative delivery weight for this creative (0–100). Valid when the package's effective rotation_mode is weighted, including the backward-compatible default when rotation_mode is omitted. Weights determine impression distribution proportionally — a creative with weight 2 gets twice the delivery of weight 1. When omitted, the creative receives equal weight with other unweighted creatives. A weight of 0 means the creative is assigned but paused (receives no delivery).",
       "minimum": 0,
       "maximum": 100
+    },
+    "rotation_mode": {
+      "type": "string",
+      "enum": ["weighted", "even", "sequential", "random"],
+      "description": "Package-scoped rotation policy repeated on assignment rows for wire compatibility. Omission means weighted, preserving existing weight behavior. Every assignment in a package MUST resolve to the same effective mode: weighted uses relative weights; even balances delivery across eligible assignments; sequential cycles through sequence_position in ascending order within each group; random makes an independent uniform selection from eligible assignments. Sellers MUST reject conflicting effective modes rather than choose one by array order."
+    },
+    "group_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Package-local creative pool identifier. The identifier has no meaning outside this package. Assignments that omit group_id belong to the package's default group; one eligible creative is selected from each applicable group per serving opportunity."
+    },
+    "sequence_position": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "One-based order within the assignment's package-local group. Required only for sequential rotation and unique within that group."
     },
     "placement_refs": {
       "type": "array",
@@ -35,5 +50,28 @@
     }
   },
   "required": ["creative_id"],
+  "allOf": [
+    {
+      "if": {
+        "properties": { "rotation_mode": { "const": "sequential" } },
+        "required": ["rotation_mode"]
+      },
+      "then": { "required": ["sequence_position"] }
+    },
+    {
+      "if": { "required": ["sequence_position"] },
+      "then": {
+        "properties": { "rotation_mode": { "const": "sequential" } },
+        "required": ["rotation_mode"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "rotation_mode": { "enum": ["even", "sequential", "random"] } },
+        "required": ["rotation_mode"]
+      },
+      "then": { "not": { "required": ["weight"] } }
+    }
+  ],
   "additionalProperties": true
 }

--- a/static/schemas/source/core/package.json
+++ b/static/schemas/source/core/package.json
@@ -159,7 +159,20 @@
     },
     "creative_assignments": {
       "type": "array",
-      "description": "Creative assets assigned to this package",
+      "description": "Creative assets assigned to this package, including the committed package-scoped rotation policy. Omitted rotation_mode reads as weighted for backward compatibility; all assignments resolve to one effective mode, and sequential positions are unique within each package-local group.",
+      "x-adcp-validation": {
+        "verifier_constraints": {
+          "package_rotation_policy": {
+            "effective_mode": "assignment.rotation_mode_or_weighted_default",
+            "mode_consistency": "all_assignments_equal",
+            "sequence_positions": "required_and_unique_per_effective_group_when_sequential",
+            "effective_group": "assignment.group_id_or_package_default",
+            "group_namespace": "package_id",
+            "on_violation": "reject_invalid_readback"
+          }
+        },
+        "spec": "docs/reference/migration/creatives.mdx#rotation-modes-and-groups"
+      },
       "items": {
         "$ref": "/schemas/core/creative-assignment.json"
       }

--- a/static/schemas/source/media-buy/package-request.json
+++ b/static/schemas/source/media-buy/package-request.json
@@ -234,7 +234,20 @@
     },
     "creative_assignments": {
       "type": "array",
-      "description": "Assign existing library creatives to this package with optional weights and placement targeting",
+      "description": "Assign existing library creatives to this package with optional rotation, grouping, weights, and placement targeting. rotation_mode is package-scoped: omission resolves to weighted, and every assignment MUST resolve to the same effective mode. In sequential mode, sequence_position MUST be unique within each package-local group. Sellers reject conflicts with VALIDATION_ERROR before creating the package.",
+      "x-adcp-validation": {
+        "verifier_constraints": {
+          "package_rotation_policy": {
+            "effective_mode": "assignment.rotation_mode_or_weighted_default",
+            "mode_consistency": "all_assignments_equal",
+            "sequence_positions": "required_and_unique_per_effective_group_when_sequential",
+            "effective_group": "assignment.group_id_or_package_default",
+            "group_namespace": "package_id",
+            "on_violation": "reject_before_mutation_with_VALIDATION_ERROR"
+          }
+        },
+        "spec": "docs/reference/migration/creatives.mdx#rotation-modes-and-groups"
+      },
       "items": {
         "$ref": "/schemas/core/creative-assignment.json"
       },

--- a/static/schemas/source/media-buy/package-update.json
+++ b/static/schemas/source/media-buy/package-update.json
@@ -173,7 +173,20 @@
     },
     "creative_assignments": {
       "type": "array",
-      "description": "Replace creative assignments for this package with optional weights and placement routing. Uses replacement semantics - omit to leave assignments unchanged. When the same mutation narrows targeting_overlay.placement_selection, this complete replacement MUST remove or reroute every assignment reference that would otherwise be orphaned; the seller validates both changes atomically.",
+      "description": "Replace creative assignments for this package with optional rotation, grouping, weights, and placement routing. Uses replacement semantics - omit to leave assignments unchanged. rotation_mode is package-scoped: omission resolves to weighted, and every assignment MUST resolve to the same effective mode. In sequential mode, sequence_position MUST be unique within each package-local group. Sellers reject conflicts with VALIDATION_ERROR before mutation. When the same mutation narrows targeting_overlay.placement_selection, this complete replacement MUST remove or reroute every assignment reference that would otherwise be orphaned; the seller validates both changes atomically.",
+      "x-adcp-validation": {
+        "verifier_constraints": {
+          "package_rotation_policy": {
+            "effective_mode": "assignment.rotation_mode_or_weighted_default",
+            "mode_consistency": "all_assignments_equal",
+            "sequence_positions": "required_and_unique_per_effective_group_when_sequential",
+            "effective_group": "assignment.group_id_or_package_default",
+            "group_namespace": "package_id",
+            "on_violation": "reject_before_mutation_with_VALIDATION_ERROR"
+          }
+        },
+        "spec": "docs/reference/migration/creatives.mdx#rotation-modes-and-groups"
+      },
       "items": {
         "$ref": "/schemas/core/creative-assignment.json"
       }

--- a/tests/creative-rotation.test.cjs
+++ b/tests/creative-rotation.test.cjs
@@ -1,0 +1,114 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
+
+const SCHEMA_BASE_DIR = path.join(__dirname, '../static/schemas/source');
+
+function readSchema(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(SCHEMA_BASE_DIR, relativePath), 'utf8'));
+}
+
+async function compileCreativeAssignment() {
+  const ajv = new Ajv({ allErrors: true, strict: false, loadSchema: async uri => {
+    if (!uri.startsWith('/schemas/')) throw new Error(`Cannot load schema ${uri}`);
+    return readSchema(uri.replace('/schemas/', ''));
+  }});
+  addFormats(ajv);
+  return ajv.compileAsync(readSchema('core/creative-assignment.json'));
+}
+
+function packageRotationErrors(assignments) {
+  const errors = [];
+  const modes = new Set(assignments.map(item => item.rotation_mode ?? 'weighted'));
+  if (modes.size > 1) errors.push('conflicting effective rotation modes');
+
+  if (modes.size === 1 && modes.has('sequential')) {
+    const positionsByGroup = new Map();
+    for (const item of assignments) {
+      const group = item.group_id ?? '__package_default__';
+      const positions = positionsByGroup.get(group) ?? new Set();
+      if (positions.has(item.sequence_position)) errors.push(`duplicate position in ${group}`);
+      positions.add(item.sequence_position);
+      positionsByGroup.set(group, positions);
+    }
+  }
+  return errors;
+}
+
+test('legacy weighted assignments remain valid without rotation_mode', async () => {
+  const validate = await compileCreativeAssignment();
+  assert.equal(validate({ creative_id: 'host_read', weight: 70 }), true, JSON.stringify(validate.errors));
+  assert.equal(validate({ creative_id: 'produced_spot' }), true, JSON.stringify(validate.errors));
+});
+
+test('all package rotation modes validate with their allowed fields', async () => {
+  const validate = await compileCreativeAssignment();
+  const examples = [
+    { creative_id: 'weighted', rotation_mode: 'weighted', weight: 2 },
+    { creative_id: 'even', rotation_mode: 'even' },
+    { creative_id: 'random', rotation_mode: 'random', group_id: 'pool-a' },
+    { creative_id: 'sequential', rotation_mode: 'sequential', group_id: 'story', sequence_position: 1 }
+  ];
+  for (const example of examples) {
+    assert.equal(validate(example), true, `${example.rotation_mode}: ${JSON.stringify(validate.errors)}`);
+  }
+});
+
+test('sequential fields and weights are rejected in incompatible modes', async () => {
+  const validate = await compileCreativeAssignment();
+  const invalid = [
+    { creative_id: 'missing-position', rotation_mode: 'sequential' },
+    { creative_id: 'position-in-even', rotation_mode: 'even', sequence_position: 1 },
+    { creative_id: 'position-without-mode', sequence_position: 1 },
+    { creative_id: 'weighted-even', rotation_mode: 'even', weight: 50 },
+    { creative_id: 'weighted-random', rotation_mode: 'random', weight: 50 },
+    { creative_id: 'weighted-sequence', rotation_mode: 'sequential', sequence_position: 1, weight: 50 }
+  ];
+  for (const example of invalid) {
+    assert.equal(validate(example), false, `unexpectedly accepted ${JSON.stringify(example)}`);
+  }
+});
+
+test('package conformance rejects mode conflicts and duplicate positions per group', () => {
+  assert.deepEqual(packageRotationErrors([
+    { creative_id: 'a', weight: 60 },
+    { creative_id: 'b', rotation_mode: 'weighted', weight: 40 }
+  ]), []);
+
+  assert.deepEqual(packageRotationErrors([
+    { creative_id: 'a', rotation_mode: 'even' },
+    { creative_id: 'b' }
+  ]), ['conflicting effective rotation modes']);
+
+  assert.deepEqual(packageRotationErrors([
+    { creative_id: 'a', rotation_mode: 'sequential', group_id: 'story', sequence_position: 1 },
+    { creative_id: 'b', rotation_mode: 'sequential', group_id: 'story', sequence_position: 1 }
+  ]), ['duplicate position in story']);
+
+  assert.deepEqual(packageRotationErrors([
+    { creative_id: 'a', rotation_mode: 'sequential', group_id: 'story-a', sequence_position: 1 },
+    { creative_id: 'b', rotation_mode: 'sequential', group_id: 'story-b', sequence_position: 1 }
+  ]), []);
+});
+
+test('create, update, and read schemas publish the same package rotation rule', () => {
+  const locations = [
+    ['media-buy/package-request.json', schema => schema.properties.creative_assignments],
+    ['media-buy/package-update.json', schema => schema.properties.creative_assignments],
+    ['core/package.json', schema => schema.properties.creative_assignments]
+  ];
+
+  for (const [relativePath, select] of locations) {
+    const assignments = select(readSchema(relativePath));
+    const annotation = assignments['x-adcp-validation'];
+    const policy = annotation?.verifier_constraints?.package_rotation_policy;
+    assert.equal(policy?.effective_mode, 'assignment.rotation_mode_or_weighted_default', relativePath);
+    assert.equal(policy?.mode_consistency, 'all_assignments_equal', relativePath);
+    assert.equal(policy?.sequence_positions, 'required_and_unique_per_effective_group_when_sequential', relativePath);
+    assert.equal(policy?.group_namespace, 'package_id', relativePath);
+    assert.equal(annotation?.spec, 'docs/reference/migration/creatives.mdx#rotation-modes-and-groups', relativePath);
+  }
+});


### PR DESCRIPTION
## Summary
- add package-scoped `weighted`, `even`, `sequential`, and `random` rotation to creative assignments
- add package-local creative groups and schema-enforced sequential positions
- publish deterministic cross-assignment conflict rules for create, update, and readback
- document weighted and podcast storytelling examples and add focused conformance tests

Closes #6501

## Verification
- `node --test tests/creative-rotation.test.cjs`
- `npm run test:schemas`
- `npm run test:composed` (382 passed)
- `npm run test:mcp-schema-projection` (24 passed)
- `npm run typecheck`
- changeset scope, docs navigation, schema-link, and push storyboard matrices (current + 3.0 compatibility)
- pre-commit canonical suite: 1,043 passed
- pre-commit server suite: 6,126 passed; one unrelated order-dependent Slack route status test failed and passed 13/13 in isolation

## Compatibility
Omitting `rotation_mode` continues to mean weighted rotation, so existing weighted and unweighted assignment payloads retain their current behavior.