### PR TITLE
fix(schema): backport canonical enum references to 3.1.x

### DIFF
--- a/.changeset/backport-inline-enum-drift.md
+++ b/.changeset/backport-inline-enum-drift.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix three schema fields whose inline enums omitted values already present in their canonical enum definitions.

--- a/static/schemas/source/core/registry-event.json
+++ b/static/schemas/source/core/registry-event.json
@@ -474,8 +474,7 @@
           "additionalProperties": true
     },
     "badgeRole": {
-      "type": "string",
-      "enum": ["media-buy", "creative", "signals", "governance", "brand", "sponsored-intelligence"]
+      "$ref": "/schemas/enums/adcp-protocol.json"
     },
     "stringArray": {
       "type": "array",

--- a/static/schemas/source/formats/canonical/sponsored_placement.json
+++ b/static/schemas/source/formats/canonical/sponsored_placement.json
@@ -23,8 +23,7 @@
     "supported_catalog_types": {
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": ["product", "store", "offering", "hotel", "flight", "vehicle", "real_estate", "education", "destination", "app", "job", "inventory"]
+        "$ref": "/schemas/enums/catalog-type.json"
       },
       "description": "Catalog types this product accepts."
     },

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -248,18 +248,7 @@
                   "type": "array",
                   "description": "Surface types this seller supports via TMP.",
                   "items": {
-                    "type": "string",
-                    "enum": [
-                      "website",
-                      "mobile_app",
-                      "ctv_app",
-                      "desktop_app",
-                      "dooh",
-                      "podcast",
-                      "radio",
-                      "streaming_audio",
-                      "ai_assistant"
-                    ]
+                    "$ref": "/schemas/enums/property-type.json"
                   }
                 }
               }


### PR DESCRIPTION
## Summary

Backport the three schema corrections from #6555 to the stable `3.1.x` line:

- reference the canonical property-type enum for TMP surfaces, restoring `linear_tv`
- reference the canonical AdCP protocol enum for registry badge roles, restoring `measurement`
- reference the canonical catalog-type enum for sponsored placements, restoring `promotion`

The new heuristic lint from #6555 is intentionally omitted to keep this maintenance patch narrowly scoped.

## Impact

The released 3.1 schemas already publish these values in their canonical enum files, but the three inline copies reject them. This additive correction makes those fields consistent with the existing 3.1 protocol definitions without adding a new requirement.

Keep this PR in draft until #6555 lands on `main`.

## Validation

- `npm run test:schemas`
- `node scripts/check-changeset-protocol-scope.cjs origin/3.1.x`
- `npx --yes @changesets/cli@^2.31.0 status --since=origin/3.1.x`
- focused assertions for all three canonical `$ref` targets
- independent code, protocol, and security reviews
