### PR TITLE
fix(schema): backport linear TV capability to 3.0.x

### DIFF
--- a/.changeset/backport-linear-tv-capability.md
+++ b/.changeset/backport-linear-tv-capability.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix the trusted matching capabilities schema to accept `linear_tv`, which is already part of the canonical property type enum.

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -176,8 +176,7 @@
                   "type": "array",
                   "description": "Surface types this seller supports via TMP.",
                   "items": {
-                    "type": "string",
-                    "enum": ["website", "mobile_app", "ctv_app", "desktop_app", "dooh", "podcast", "radio", "streaming_audio", "ai_assistant"]
+                    "$ref": "/schemas/enums/property-type.json"
                   }
                 }
               }


### PR DESCRIPTION
## Summary

Backport the `linear_tv` schema correction from #6555 to the `3.0.x` line.

The TMP surfaces field now references the canonical property-type enum, which already includes `linear_tv` in 3.0. The other two corrections from #6555 are not included because their affected schemas or enum values are not present on this release line.

## Impact

The released 3.0 property-type enum publishes `linear_tv`, while the inline capabilities enum rejects it. This additive correction resolves that contradiction without adding a new protocol value or requirement.

Keep this PR in draft until #6555 lands on `main`.

## Validation

- `npm run test:schemas`
- `npx --yes @changesets/cli@^2.31.0 status --since=origin/3.0.x`
- focused assertions for the canonical property-type `$ref` and `linear_tv` value
- independent code, protocol, and security reviews
