### PR TITLE
test(mcp): refresh context baselines after combined schema growth

### DIFF
--- a/server/tests/unit/product-discovery-schema-parity.test.ts
+++ b/server/tests/unit/product-discovery-schema-parity.test.ts
@@ -113,8 +113,8 @@ describe('product discovery MCP schema parity', () => {
     );
     // Structured targeting is intentionally present on listing, proposal, and
     // revision requests. Standalone MCP schemas must bundle those refs, so
-    // retain strict validation while keeping the four-tool surface under 128 KiB.
-    expect(totalBytes).toBeLessThanOrEqual(128 * 1024);
+    // retain strict validation while keeping the four-tool surface under 132 KiB.
+    expect(totalBytes).toBeLessThanOrEqual(132 * 1024);
 
     const list = tools.find(tool => tool.name === 'list_products')!.inputSchema as JsonSchema;
     const criteria = resolveLocalRef(list, list.properties.criteria);

--- a/tests/mcp-schema-analysis.test.cjs
+++ b/tests/mcp-schema-analysis.test.cjs
@@ -34,9 +34,9 @@ test("input-field weight report attributes the largest transitive schema graphs"
   const report = analyzeInputSchemaWeights(schemas);
 
   assert.equal(report.tool_count, 16);
-  assert.equal(report.definition_instances, 562);
-  assert.equal(report.unique_definitions, 143);
-  assert.equal(report.repeated_definitions, 105);
+  assert.equal(report.definition_instances, 567);
+  assert.equal(report.unique_definitions, 146);
+  assert.equal(report.repeated_definitions, 106);
   assert.ok(report.repeated_definition_bytes > 180_000);
 
   assert.deepEqual(
@@ -155,7 +155,7 @@ test("shared dictionary resolves every experimental tool schema when explicitly 
   });
 
   assert.equal(view.dictionary.$id, DICTIONARY_ID);
-  assert.equal(Object.keys(view.dictionary.$defs).length, 143);
+  assert.equal(Object.keys(view.dictionary.$defs).length, 146);
   for (const tool of Object.values(view.tools)) {
     assert.equal(tool.inputSchema.$defs, undefined);
     assert.match(
@@ -215,7 +215,7 @@ test("experiment report keeps all alternatives smaller than standalone model con
   assert.equal(report.status, "non-normative");
   assert.equal(report.prompt_cleanup_adapter.required, true);
   assert.equal(report.selection.tools.length, 16);
-  assert.equal(variants.standalone.context_bytes, 292_717);
+  assert.equal(variants.standalone.context_bytes, 294_495);
   assert.ok(
     variants.prompt_cleanup.context_bytes <
       variants.standalone.context_bytes * 0.82
@@ -228,10 +228,10 @@ test("experiment report keeps all alternatives smaller than standalone model con
     variants.shared_dictionary_with_prompt_cleanup.context_bytes <
       variants.shared_dictionary.context_bytes
   );
-  assert.equal(variants.shared_dictionary.dictionary_definitions, 143);
+  assert.equal(variants.shared_dictionary.dictionary_definitions, 146);
   assert.equal(
     variants.shared_dictionary_with_prompt_cleanup.dictionary_definitions,
-    122
+    125
   );
 
   const { tools } = loadRepresentativeMediaBuyRuntime();

--- a/tests/mcp-schema-projection.test.cjs
+++ b/tests/mcp-schema-projection.test.cjs
@@ -970,8 +970,8 @@ test('generated role profiles are active validation catalogs with bounded model-
       modelContextBytes += Buffer.byteLength(JSON.stringify(readJson(modelInputPath)));
     }
     assert.ok(
-      modelContextBytes < 384 * 1024,
-      `${profileName} model-context inputs exceed 384 KiB: ${modelContextBytes}`
+      modelContextBytes < 388 * 1024,
+      `${profileName} model-context inputs exceed 388 KiB: ${modelContextBytes}`
     );
   }
 


### PR DESCRIPTION
## Summary

- refresh MCP context-analysis counts after the proposal-refinement schemas landed
- increase the media-buy model-context ceiling from 384 KiB to 388 KiB
- increase the compact product-discovery ceiling from 128 KiB to 132 KiB

These are the exact failures in the post-merge `main` Build Check: https://github.com/adcontextprotocol/adcp/actions/runs/31902278746. The contributing feature PRs passed independently against earlier base revisions, but their combined schema growth made `main` red.

## Validation

- `npm run test:mcp-schema-projection` (24/24 after the final baseline adjustment)
- `npx vitest run --config server/vitest.config.ts server/tests/unit/product-discovery-schema-parity.test.ts` (4/4)
- `npm run typecheck`
- full pre-commit suite