### PR TITLE
feat(compliance): add signed brand response vectors

### DIFF
--- a/.changeset/add-signed-brand-response-vectors.md
+++ b/.changeset/add-signed-brand-response-vectors.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Add consumer conformance coverage for designated-task signed brand responses. The new sandbox runner contract dynamically signs `verify_brand_claim` and `verify_brand_claims` fixtures and grades fresh acceptance plus expiry, request-replay, and tenant-mismatch rejection against the normative verifier checklist.
+
+Closes #6147

--- a/static/compliance/source/protocols/brand/scenarios/signed_response_envelope_vectors.yaml
+++ b/static/compliance/source/protocols/brand/scenarios/signed_response_envelope_vectors.yaml
@@ -110,7 +110,8 @@ phases:
                 match: equals
                 value: "accept"
               - path: "error_code"
-                match: absent
+                match: equals
+                value: null
             identifier_paths:
               - "params.task"
               - "params.vector_selectors.fresh"
@@ -235,7 +236,8 @@ phases:
                 match: equals
                 value: "accept"
               - path: "error_code"
-                match: absent
+                match: equals
+                value: null
             identifier_paths:
               - "params.task"
               - "params.vector_selectors.fresh"

--- a/static/compliance/source/protocols/brand/scenarios/signed_response_envelope_vectors.yaml
+++ b/static/compliance/source/protocols/brand/scenarios/signed_response_envelope_vectors.yaml
@@ -1,0 +1,304 @@
+id: brand/signed_response_envelope_vectors
+version: "1.0.0"
+title: "Signed brand responses are fresh and bound to request, task, and tenant"
+category: brand_baseline
+summary: "Consumer-under-test matrix for verify_brand_claim and verify_brand_claims payload-envelope verification: valid responses pass; expired, replayed/request-mismatched, and cross-tenant responses fail closed."
+track: brand
+required_tools:
+  - comply_test_controller
+
+narrative: |
+  `verify_brand_claim` and `verify_brand_claims` are the closed AdCP 3.x list of
+  tasks whose response payloads use the `adcp-response-payload+jws` envelope.
+  Signature validity alone is insufficient. An online consumer applies the
+  ordered verifier checklist, including freshness, exact request binding, task
+  binding, tenant binding, and outer-payload consistency.
+
+  This storyboard grades a CONSUMER of those signed responses. The paired
+  `signed_responses_runner` contract hosts a deterministic fixture brand agent,
+  signs each response at run time with a public test-only response-signing key,
+  dispatches the consumer through `evaluate_signed_brand_response`, and records
+  one verifier decision per vector. Both the single and batch tasks execute the
+  same four-case matrix:
+
+    1. a fresh response bound to the actual request and expected tenant passes;
+    2. a cryptographically valid but expired envelope fails at checklist step 7;
+    3. a response replayed against a different request fails at step 8; and
+    4. a response naming a different tenant fails at step 9.
+
+  Consumers that do not advertise the runner contract grade `not_applicable`.
+  Consumers that opt in must report every case; missing result traffic is a
+  failure rather than an implicit pass.
+
+agent:
+  interaction_model: signed_brand_response_consumer
+  capabilities: []
+  examples:
+    - "Registry or buyer agent consuming signed brand-claim responses"
+    - "Governance platform verifying brand relationship evidence"
+    - "Agency identity service processing verify_brand_claims batches"
+
+caller:
+  role: compliance_runner
+  example: "AdCP Verified runner with signed-response consumer dispatch"
+
+prerequisites:
+  description: |
+    The runner implements `test-kits/signed-responses-runner.yaml`, and the
+    consumer under test advertises the comply_test_controller scenario
+    `evaluate_signed_brand_response`. The fixture endpoint is sandbox-only and
+    the published private key is test material, never a production trust root.
+  test_kit: "test-kits/signed-responses-runner.yaml"
+
+phases:
+  - id: single_response_matrix
+    title: "verify_brand_claim binding matrix"
+    narrative: |
+      The consumer sends the runner-supplied single-claim request to the fixture
+      brand agent four times. The fixture returns a freshly signed envelope for
+      each variant. The consumer reports the ordered verifier decision without
+      rewriting the signed payload or treating a failed binding as valid
+      historical evidence for an online decision.
+
+    steps:
+      - id: verify_single_signed_response_matrix
+        title: "Verify fresh, expired, replayed, and cross-tenant single responses"
+        task: comply_test_controller
+        schema_ref: "compliance/comply-test-controller-request.json"
+        response_schema_ref: "compliance/comply-test-controller-response.json"
+        doc_ref: "/building/by-layer/L1/security#verifier-checklist-responses"
+        requires_contract: signed_responses_runner
+        sample_request_skip_schema: true
+        stateful: true
+        expected: |
+          Report four decisions for verify_brand_claim: accept the fresh bound
+          envelope and reject the other three with their exact registered error
+          codes.
+        sample_request:
+          scenario: evaluate_signed_brand_response
+          account:
+            sandbox: true
+          params:
+            task: verify_brand_claim
+            profile: single
+            fixture_agent_url: "https://signed-response-fixture.example/mcp"
+            expected_brand_domain: "streamhaus.example"
+            vector_selectors:
+              fresh: fresh_valid
+              expired: envelope_expired
+              replay: replayed_request_hash_mismatch
+              tenant: tenant_mismatch
+            result_endpoint: "https://runner.example/signed-brand-response/result"
+          context:
+            correlation_id: "brand--signed_response--single--matrix"
+        validations:
+          - check: response_schema
+            description: "DR-0001 / comply-test-controller-response.json: controller dispatch returns a schema-valid response"
+          - check: upstream_traffic
+            description: "DR-0001 / security.mdx response verifier checklist steps 1-10: a fresh, valid, request-bound, task-bound, tenant-bound single response is accepted"
+            endpoint_pattern: "POST */signed-brand-response/result"
+            min_count: 1
+            attestation_mode_required: "raw"
+            payload_must_contain:
+              - path: "task"
+                match: equals
+                value: "verify_brand_claim"
+              - path: "vector_id"
+                match: equals
+                value: "fresh_valid"
+              - path: "decision"
+                match: equals
+                value: "accept"
+              - path: "error_code"
+                match: absent
+            identifier_paths:
+              - "params.task"
+              - "params.vector_selectors.fresh"
+          - check: upstream_traffic
+            description: "DR-0001 / security.mdx response verifier checklist step 7 and error-code.json: an expired single-response envelope is rejected with SIGNED_RESPONSE_ENVELOPE_EXPIRED"
+            endpoint_pattern: "POST */signed-brand-response/result"
+            min_count: 1
+            attestation_mode_required: "raw"
+            payload_must_contain:
+              - path: "task"
+                match: equals
+                value: "verify_brand_claim"
+              - path: "vector_id"
+                match: equals
+                value: "envelope_expired"
+              - path: "decision"
+                match: equals
+                value: "reject"
+              - path: "error_code"
+                match: equals
+                value: "SIGNED_RESPONSE_ENVELOPE_EXPIRED"
+            identifier_paths:
+              - "params.task"
+              - "params.vector_selectors.expired"
+          - check: upstream_traffic
+            description: "DR-0001 / security.mdx response verifier checklist step 8 and error-code.json: replay against a different single request is rejected with SIGNED_RESPONSE_REQUEST_HASH_MISMATCH"
+            endpoint_pattern: "POST */signed-brand-response/result"
+            min_count: 1
+            attestation_mode_required: "raw"
+            payload_must_contain:
+              - path: "task"
+                match: equals
+                value: "verify_brand_claim"
+              - path: "vector_id"
+                match: equals
+                value: "replayed_request_hash_mismatch"
+              - path: "decision"
+                match: equals
+                value: "reject"
+              - path: "error_code"
+                match: equals
+                value: "SIGNED_RESPONSE_REQUEST_HASH_MISMATCH"
+            identifier_paths:
+              - "params.task"
+              - "params.vector_selectors.replay"
+          - check: upstream_traffic
+            description: "DR-0001 / security.mdx response verifier checklist step 9 and error-code.json: a single response for the wrong tenant is rejected with SIGNED_RESPONSE_TENANT_MISMATCH"
+            endpoint_pattern: "POST */signed-brand-response/result"
+            min_count: 1
+            attestation_mode_required: "raw"
+            payload_must_contain:
+              - path: "task"
+                match: equals
+                value: "verify_brand_claim"
+              - path: "vector_id"
+                match: equals
+                value: "tenant_mismatch"
+              - path: "decision"
+                match: equals
+                value: "reject"
+              - path: "error_code"
+                match: equals
+                value: "SIGNED_RESPONSE_TENANT_MISMATCH"
+            identifier_paths:
+              - "params.task"
+              - "params.vector_selectors.tenant"
+
+  - id: batch_response_matrix
+    title: "verify_brand_claims binding matrix"
+    narrative: |
+      The same matrix runs through the bulk task. Batch shape does not weaken
+      the payload-envelope checks: task, request hash, freshness, tenant, and
+      outer response consistency are verified for the signed batch artifact as
+      a whole before any claim result is trusted.
+
+    steps:
+      - id: verify_batch_signed_response_matrix
+        title: "Verify fresh, expired, replayed, and cross-tenant batch responses"
+        task: comply_test_controller
+        schema_ref: "compliance/comply-test-controller-request.json"
+        response_schema_ref: "compliance/comply-test-controller-response.json"
+        doc_ref: "/building/by-layer/L1/security#verifier-checklist-responses"
+        requires_contract: signed_responses_runner
+        sample_request_skip_schema: true
+        stateful: true
+        expected: |
+          Report four decisions for verify_brand_claims with the same acceptance
+          and rejection semantics as the single-claim task.
+        sample_request:
+          scenario: evaluate_signed_brand_response
+          account:
+            sandbox: true
+          params:
+            task: verify_brand_claims
+            profile: batch
+            fixture_agent_url: "https://signed-response-fixture.example/mcp"
+            expected_brand_domain: "streamhaus.example"
+            vector_selectors:
+              fresh: fresh_valid
+              expired: envelope_expired
+              replay: replayed_request_hash_mismatch
+              tenant: tenant_mismatch
+            result_endpoint: "https://runner.example/signed-brand-response/result"
+          context:
+            correlation_id: "brand--signed_response--batch--matrix"
+        validations:
+          - check: response_schema
+            description: "DR-0001 / comply-test-controller-response.json: batch controller dispatch returns a schema-valid response"
+          - check: upstream_traffic
+            description: "DR-0001 / security.mdx response verifier checklist steps 1-10: a fresh, valid, request-bound, task-bound, tenant-bound batch response is accepted"
+            endpoint_pattern: "POST */signed-brand-response/result"
+            min_count: 1
+            attestation_mode_required: "raw"
+            payload_must_contain:
+              - path: "task"
+                match: equals
+                value: "verify_brand_claims"
+              - path: "vector_id"
+                match: equals
+                value: "fresh_valid"
+              - path: "decision"
+                match: equals
+                value: "accept"
+              - path: "error_code"
+                match: absent
+            identifier_paths:
+              - "params.task"
+              - "params.vector_selectors.fresh"
+          - check: upstream_traffic
+            description: "DR-0001 / security.mdx response verifier checklist step 7 and error-code.json: an expired batch-response envelope is rejected with SIGNED_RESPONSE_ENVELOPE_EXPIRED"
+            endpoint_pattern: "POST */signed-brand-response/result"
+            min_count: 1
+            attestation_mode_required: "raw"
+            payload_must_contain:
+              - path: "task"
+                match: equals
+                value: "verify_brand_claims"
+              - path: "vector_id"
+                match: equals
+                value: "envelope_expired"
+              - path: "decision"
+                match: equals
+                value: "reject"
+              - path: "error_code"
+                match: equals
+                value: "SIGNED_RESPONSE_ENVELOPE_EXPIRED"
+            identifier_paths:
+              - "params.task"
+              - "params.vector_selectors.expired"
+          - check: upstream_traffic
+            description: "DR-0001 / security.mdx response verifier checklist step 8 and error-code.json: replay against a different batch request is rejected with SIGNED_RESPONSE_REQUEST_HASH_MISMATCH"
+            endpoint_pattern: "POST */signed-brand-response/result"
+            min_count: 1
+            attestation_mode_required: "raw"
+            payload_must_contain:
+              - path: "task"
+                match: equals
+                value: "verify_brand_claims"
+              - path: "vector_id"
+                match: equals
+                value: "replayed_request_hash_mismatch"
+              - path: "decision"
+                match: equals
+                value: "reject"
+              - path: "error_code"
+                match: equals
+                value: "SIGNED_RESPONSE_REQUEST_HASH_MISMATCH"
+            identifier_paths:
+              - "params.task"
+              - "params.vector_selectors.replay"
+          - check: upstream_traffic
+            description: "DR-0001 / security.mdx response verifier checklist step 9 and error-code.json: a batch response for the wrong tenant is rejected with SIGNED_RESPONSE_TENANT_MISMATCH"
+            endpoint_pattern: "POST */signed-brand-response/result"
+            min_count: 1
+            attestation_mode_required: "raw"
+            payload_must_contain:
+              - path: "task"
+                match: equals
+                value: "verify_brand_claims"
+              - path: "vector_id"
+                match: equals
+                value: "tenant_mismatch"
+              - path: "decision"
+                match: equals
+                value: "reject"
+              - path: "error_code"
+                match: equals
+                value: "SIGNED_RESPONSE_TENANT_MISMATCH"
+            identifier_paths:
+              - "params.task"
+              - "params.vector_selectors.tenant"

--- a/static/compliance/source/test-kits/signed-responses-runner.yaml
+++ b/static/compliance/source/test-kits/signed-responses-runner.yaml
@@ -1,0 +1,252 @@
+# Signed Brand Responses Runner — Harness Contract Test Kit
+#
+# Applies to:
+#   - protocols/brand/scenarios/signed_response_envelope_vectors.yaml
+#
+# This is a consumer-conformance contract. It is intentionally separate from
+# signed-requests-runner.yaml: request signing grades an agent's HTTP verifier,
+# while this kit grades a caller that consumes designated-task JWS payload
+# envelopes returned by verify_brand_claim and verify_brand_claims.
+
+id: signed_responses_runner
+applies_to:
+  protocol_scenarios:
+    - signed_response_envelope_vectors
+
+description: |
+  Coordination contract between a black-box runner and a signed-brand-response
+  consumer under test. The runner hosts a sandbox fixture brand agent and a
+  result observation endpoint. For each dispatch it signs the fixture response
+  dynamically, relative to one captured evaluation time, then the consumer
+  applies the designated-task response verifier checklist and posts its
+  decision to the observation endpoint.
+
+  Dynamic signing is required: a permanently published "fresh" envelope would
+  eventually expire or tempt a consumer to special-case fixture bytes. The
+  public private component below exists only so independent runners and SDKs
+  can reproduce the fixture signature. It MUST NOT be installed as a production
+  trust root or used to answer a real brand claim.
+
+endpoint_scope: sandbox
+harness_mode: black_box
+
+fixture_agent:
+  brand_domain: "streamhaus.example"
+  agent_url: "https://signed-response-fixture.example/mcp"
+  jwks_uri: "https://signed-response-fixture.example/.well-known/jwks.json"
+  caller_identity: "https://verified-runner.example"
+  expected_tenant: "streamhaus.example"
+  mismatched_tenant: "other-streamhaus-brand.example"
+  result_observation_endpoint:
+    url: "https://runner.example/signed-brand-response/result"
+    method: POST
+
+test_key:
+  warning: "PUBLIC TEST KEY WITH PUBLISHED PRIVATE COMPONENT. Never use as a production trust anchor."
+  kid: "test-brand-response-2026"
+  kty: "OKP"
+  crv: "Ed25519"
+  x: "-LwUo2jhzfaPN3zxBKg4eL5GCho_GsuxB8LXE2aedrI"
+  alg: "EdDSA"
+  use: "sig"
+  key_ops: ["verify"]
+  adcp_use: "response-signing"
+  _private_d_for_test_only: "aj3thrvcUzEmUtm_qmgJNn5H0Ln5Rqhmt8B9A5SAkH0"
+
+time_contract:
+  capture_once_per_matrix: true
+  clock_skew_seconds: 60
+  fresh_iat_offset_seconds: -30
+  fresh_exp_offset_seconds: 300
+  expired_iat_offset_seconds: -600
+  expired_exp_offset_seconds: -61
+  description: |
+    The runner captures `evaluation_now` once before generating a four-vector
+    matrix. The expired vector's exp is strictly earlier than
+    `evaluation_now - clock_skew_seconds`; every other vector uses the fresh
+    offsets. The consumer evaluates the same captured instant so scheduler
+    jitter cannot move a vector across the boundary.
+
+request_fixtures:
+  single:
+    task: verify_brand_claim
+    request:
+      claim_type: property
+      claim:
+        property:
+          type: website
+          identifier: "streamhaus.example"
+      context:
+        correlation_id: "signed-response-single-original"
+    replay_request:
+      claim_type: property
+      claim:
+        property:
+          type: website
+          identifier: "different-property.example"
+      context:
+        correlation_id: "signed-response-single-replay"
+    response:
+      claim_type: property
+      verification_status: owned
+      details:
+        property_domain: "streamhaus.example"
+
+  batch:
+    task: verify_brand_claims
+    request:
+      claims:
+        - claim_type: property
+          claim:
+            property:
+              type: website
+              identifier: "streamhaus.example"
+        - claim_type: trademark
+          claim:
+            mark: "STREAMHAUS"
+            countries: ["US"]
+      context:
+        correlation_id: "signed-response-batch-original"
+    replay_request:
+      claims:
+        - claim_type: property
+          claim:
+            property:
+              type: website
+              identifier: "different-property.example"
+        - claim_type: trademark
+          claim:
+            mark: "STREAMHAUS"
+            countries: ["US"]
+      context:
+        correlation_id: "signed-response-batch-replay"
+    response:
+      results:
+        - claim_type: property
+          status: owned
+          details:
+            property_domain: "streamhaus.example"
+        - claim_type: trademark
+          status: owned
+          details:
+            mark: "STREAMHAUS"
+            countries: ["US"]
+
+vector_contract:
+  fresh_valid:
+    request_sent: original
+    request_hashed: original
+    payload_brand_domain: expected_tenant
+    time_profile: fresh
+    expected_decision: accept
+    expected_error_code: null
+
+  envelope_expired:
+    request_sent: original
+    request_hashed: original
+    payload_brand_domain: expected_tenant
+    time_profile: expired
+    expected_decision: reject
+    expected_error_code: SIGNED_RESPONSE_ENVELOPE_EXPIRED
+
+  replayed_request_hash_mismatch:
+    description: |
+      The fixture signs a response whose request_hash binds the original
+      request, then serves that cryptographically valid envelope while the
+      consumer is evaluating replay_request. The signature remains valid;
+      checklist step 8 is the first failing binding check.
+    request_sent: replay_request
+    request_hashed: original
+    payload_brand_domain: expected_tenant
+    time_profile: fresh
+    expected_decision: reject
+    expected_error_code: SIGNED_RESPONSE_REQUEST_HASH_MISMATCH
+
+  tenant_mismatch:
+    description: |
+      The fixture computes request_hash using the payload's mismatched tenant
+      so checklist step 8 passes, while the controller supplies
+      expected_tenant independently. Checklist step 9 is therefore the first
+      failing binding check.
+    request_sent: original
+    request_hashed: original
+    payload_brand_domain: mismatched_tenant
+    request_hash_brand_domain: mismatched_tenant
+    expected_brand_domain: expected_tenant
+    time_profile: fresh
+    expected_decision: reject
+    expected_error_code: SIGNED_RESPONSE_TENANT_MISMATCH
+
+signing_contract:
+  protected_header:
+    alg: EdDSA
+    kid: test-brand-response-2026
+    typ: adcp-response-payload+jws
+  payload_required_fields:
+    - typ
+    - task
+    - brand_domain
+    - agent_url
+    - request_hash
+    - iat
+    - exp
+    - response
+  payload_typ: adcp-response-payload+jws
+  request_hash: "sha256:base64url_no_pad(SHA-256(JCS({ task, brand_domain, agent_url, caller_identity, request })))"
+  signing_input: "BASE64URL(UTF8(JSON(protected_header))) + '.' + BASE64URL(UTF8(JCS(payload)))"
+  outer_response_rule: |
+    The unsigned outer task-body fields exactly equal payload.response for every
+    vector. This keeps checklist step 10 satisfied so each negative vector
+    isolates its named earlier check.
+
+consumer_test_controller_scenario:
+  name: evaluate_signed_brand_response
+  request_shape:
+    scenario: evaluate_signed_brand_response
+    params:
+      task: "verify_brand_claim | verify_brand_claims"
+      profile: "single | batch"
+      fixture_agent_url: "https://signed-response-fixture.example/mcp"
+      expected_brand_domain: "streamhaus.example"
+      vector_selectors: "named map whose values are an ordered subset of vector_contract keys"
+      result_endpoint: "https://runner.example/signed-brand-response/result"
+  expected_consumer_behavior:
+    - Send the profile's request to the fixture agent separately for each vector.
+    - Resolve the fixture response-signing JWK through the advertised jwks_uri.
+    - Apply response verifier checklist steps 1-10 in order.
+    - Use the controller-provided expected_brand_domain for the tenant-binding decision.
+    - Post exactly one result report per requested vector value.
+    - Never report a negative vector as accepted merely because its signature verifies.
+
+result_report_contract:
+  content_type: "application/json"
+  exactly_once_per_vector: true
+  required_fields:
+    task: "verify_brand_claim | verify_brand_claims"
+    vector_id: "fresh_valid | envelope_expired | replayed_request_hash_mismatch | tenant_mismatch"
+    decision: "accept | reject"
+    error_code: "absent on accept; exact registered signed-response error code on reject"
+
+scope:
+  in_scope: |
+    - Online freshness at the advertised clock-skew boundary.
+    - Exact request-hash replay protection.
+    - Expected-tenant binding.
+    - Single and batch task parity.
+    - Cryptographically valid envelopes whose only failing property is the
+      named binding check.
+  out_of_scope: |
+    - General RFC 9421 response transport signing.
+    - The additive 3.2 brand-agent authorization cross-check, which has its own
+      brand-authorization-cross-check vectors.
+    - Production key storage, rotation, or trust-root configuration.
+    - Audit-mode treatment of expired historical evidence; this kit grades
+      online decisions only.
+
+references:
+  protocol_scenario: static/compliance/source/protocols/brand/scenarios/signed_response_envelope_vectors.yaml
+  verifier_checklist: /docs/building/by-layer/L1/security.mdx#verifier-checklist-responses
+  envelope_schema: /schemas/core/response-payload-jws-envelope.json
+  single_response_schema: /schemas/brand/verify-brand-claim-response.json
+  batch_response_schema: /schemas/brand/verify-brand-claims-response.json
+  error_codes: /schemas/enums/error-code.json

--- a/static/compliance/source/test-kits/signed-responses-runner.yaml
+++ b/static/compliance/source/test-kits/signed-responses-runner.yaml
@@ -225,7 +225,7 @@ result_report_contract:
     task: "verify_brand_claim | verify_brand_claims"
     vector_id: "fresh_valid | envelope_expired | replayed_request_hash_mismatch | tenant_mismatch"
     decision: "accept | reject"
-    error_code: "absent on accept; exact registered signed-response error code on reject"
+    error_code: "null on accept; exact registered signed-response error code on reject"
 
 scope:
   in_scope: |

--- a/tests/brand-signed-response-vectors.test.cjs
+++ b/tests/brand-signed-response-vectors.test.cjs
@@ -136,7 +136,8 @@ test('storyboard result assertions and runner outcomes use registered exact erro
       const expected = expectedErrors[vector];
       assert.equal(fields.decision.value, expected === null ? 'accept' : 'reject');
       if (expected === null) {
-        assert.equal(fields.error_code.match, 'absent');
+        assert.equal(fields.error_code.match, 'equals');
+        assert.equal(fields.error_code.value, null);
       } else {
         assert.equal(fields.error_code.value, expected);
       }

--- a/tests/brand-signed-response-vectors.test.cjs
+++ b/tests/brand-signed-response-vectors.test.cjs
@@ -1,0 +1,160 @@
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const YAML = require('yaml');
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
+
+const root = path.join(__dirname, '..');
+const scenario = YAML.parse(fs.readFileSync(path.join(
+  root,
+  'static/compliance/source/protocols/brand/scenarios/signed_response_envelope_vectors.yaml'
+), 'utf8'));
+const kit = YAML.parse(fs.readFileSync(path.join(
+  root,
+  'static/compliance/source/test-kits/signed-responses-runner.yaml'
+), 'utf8'));
+
+const expectedErrors = {
+  fresh_valid: null,
+  envelope_expired: 'SIGNED_RESPONSE_ENVELOPE_EXPIRED',
+  replayed_request_hash_mismatch: 'SIGNED_RESPONSE_REQUEST_HASH_MISMATCH',
+  tenant_mismatch: 'SIGNED_RESPONSE_TENANT_MISMATCH',
+};
+
+const schemaRoot = path.join(root, 'static/schemas/source');
+
+function readSchema(uri) {
+  assert.match(uri, /^\/schemas\//);
+  return JSON.parse(fs.readFileSync(path.join(schemaRoot, uri.slice('/schemas/'.length)), 'utf8'));
+}
+
+async function compile(uri) {
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: false,
+    discriminator: true,
+    loadSchema: async ref => readSchema(ref),
+  });
+  addFormats(ajv);
+  return ajv.compileAsync(readSchema(uri));
+}
+
+function signedOuter(taskName, response) {
+  return {
+    ...response,
+    status: 'completed',
+    signed_response: {
+      protected: 'eyJhbGciOiJFZERTQSJ9',
+      payload: {
+        typ: 'adcp-response-payload+jws',
+        task: taskName,
+        brand_domain: kit.fixture_agent.expected_tenant,
+        agent_url: kit.fixture_agent.agent_url,
+        request_hash: `sha256:${'A'.repeat(43)}`,
+        iat: 1786838370,
+        exp: 1786838700,
+        response,
+      },
+      signature: 'AA',
+    },
+  };
+}
+
+test('single and batch signed-response matrices cover the same ordered vectors', () => {
+  assert.equal(scenario.phases.length, 2);
+  const steps = scenario.phases.map(phase => phase.steps[0]);
+  assert.deepEqual(steps.map(step => step.sample_request.params.task), [
+    'verify_brand_claim',
+    'verify_brand_claims',
+  ]);
+  for (const step of steps) {
+    assert.deepEqual(Object.values(step.sample_request.params.vector_selectors), Object.keys(expectedErrors));
+    assert.equal(step.requires_contract, 'signed_responses_runner');
+  }
+});
+
+test('runner request and signed success-payload fixtures match source schemas', async () => {
+  const profiles = [
+    ['single', 'verify-brand-claim'],
+    ['batch', 'verify-brand-claims'],
+  ];
+  for (const [profileName, schemaStem] of profiles) {
+    const profile = kit.request_fixtures[profileName];
+    const validateRequest = await compile(`/schemas/brand/${schemaStem}-request.json`);
+    const validateResponse = await compile(`/schemas/brand/${schemaStem}-response.json`);
+    for (const request of [profile.request, profile.replay_request]) {
+      assert.equal(validateRequest(request), true, JSON.stringify(validateRequest.errors));
+    }
+    const outer = signedOuter(profile.task, profile.response);
+    assert.equal(validateResponse(outer), true, JSON.stringify(validateResponse.errors));
+  }
+});
+
+test('published test-only response-signing key material is a valid Ed25519 pair', () => {
+  const jwk = kit.test_key;
+  assert.equal(jwk.adcp_use, 'response-signing');
+  assert.deepEqual(jwk.key_ops, ['verify']);
+  const publicKey = crypto.createPublicKey({
+    key: { kty: jwk.kty, crv: jwk.crv, x: jwk.x },
+    format: 'jwk',
+  });
+  const privateKey = crypto.createPrivateKey({
+    key: {
+      kty: jwk.kty,
+      crv: jwk.crv,
+      x: jwk.x,
+      d: jwk._private_d_for_test_only,
+    },
+    format: 'jwk',
+  });
+  const input = Buffer.from('AdCP signed brand response fixture');
+  const signature = crypto.sign(null, input, privateKey);
+  assert.equal(crypto.verify(null, input, publicKey, signature), true);
+});
+
+test('every graded assertion cites a normative DR-0001 source', () => {
+  for (const phase of scenario.phases) {
+    for (const step of phase.steps) {
+      for (const validation of step.validations) {
+        assert.match(validation.description, /^DR-0001 \/ /);
+      }
+    }
+  }
+});
+
+test('storyboard result assertions and runner outcomes use registered exact errors', () => {
+  for (const phase of scenario.phases) {
+    const [step] = phase.steps;
+    const trafficChecks = step.validations.filter(item => item.check === 'upstream_traffic');
+    assert.equal(trafficChecks.length, 4);
+    for (const validation of trafficChecks) {
+      const fields = Object.fromEntries(validation.payload_must_contain.map(item => [item.path, item]));
+      const vector = fields.vector_id.value;
+      const expected = expectedErrors[vector];
+      assert.equal(fields.decision.value, expected === null ? 'accept' : 'reject');
+      if (expected === null) {
+        assert.equal(fields.error_code.match, 'absent');
+      } else {
+        assert.equal(fields.error_code.value, expected);
+      }
+      assert.equal(kit.vector_contract[vector].expected_error_code, expected);
+    }
+  }
+});
+
+test('negative vectors isolate expiry, request binding, and tenant binding', () => {
+  assert.equal(kit.time_contract.expired_exp_offset_seconds, -61);
+  assert.equal(kit.time_contract.clock_skew_seconds, 60);
+
+  const replay = kit.vector_contract.replayed_request_hash_mismatch;
+  assert.equal(replay.request_sent, 'replay_request');
+  assert.equal(replay.request_hashed, 'original');
+
+  const tenant = kit.vector_contract.tenant_mismatch;
+  assert.equal(tenant.request_hash_brand_domain, 'mismatched_tenant');
+  assert.equal(tenant.expected_brand_domain, 'expected_tenant');
+  assert.equal(kit.signing_contract.outer_response_rule.includes('step 10'), true);
+});


### PR DESCRIPTION
## Summary

- add an executable signed-response conformance storyboard for both `verify_brand_claim` and `verify_brand_claims`
- cover fresh, expired, request-hash mismatch, and tenant mismatch vectors with exact DR-0001 error outcomes
- add a dedicated dynamic-signing consumer runner contract with deterministic Ed25519 test material
- validate single/batch parity, schema validity, cryptographic fixtures, and negative-vector isolation

## Validation

- `node --test tests/brand-signed-response-vectors.test.cjs`
- `npm run build:compliance -- --check`
- storyboard source, schema, fixture, raw-mode, upstream-path, contradiction, and parity lints
- full pre-commit suite: 434 files / 6,144 tests plus TypeScript typecheck
- full current and 3.0 compatibility storyboard matrices

Closes #6147
