### PR TITLE
feat(media-buy): make portfolio routing scope authoritative

### DIFF
--- a/.changeset/authoritative-portfolio-routing.md
+++ b/.changeset/authoritative-portfolio-routing.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Define media-buy portfolio channels and countries as exhaustive routing allowlists when present, treat omission as unknown rather than global coverage, validate assigned country codes, and add advisory checks for missing or empty scope plus required checks for contradictory returned product channels.

--- a/docs/governance/property/authorized-properties.mdx
+++ b/docs/governance/property/authorized-properties.mdx
@@ -106,7 +106,14 @@ Sales agents use the [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilit
 
 1. **Transparency**: Buyers can see what publishers an agent represents
 2. **Validation enablement**: Provides publisher domains for buyers to verify authorization via `adagents.json`
-3. **Portfolio overview**: Includes primary channels, countries, and portfolio description
+3. **Brief routing**: Present primary-channel and primary-country arrays are exhaustive allowlists for briefs the agent accepts. Omission means unknown scope, not global coverage.
+
+The routing arrays do not guarantee inventory availability. Buyers may skip an
+agent when a brief has no country/channel intersection, but matching scope still
+requires `get_products` to resolve account access, dates, formats, policy, and
+current inventory. Intermediaries MUST NOT present inferred upstream scope as if
+the upstream sales agent declared it; they may advertise a narrower scope as
+their own operator-confirmed routing constraint.
 
 ### Property Declaration Example
 

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -873,13 +873,24 @@ Seller-level conversion tracking capabilities. Declares what the seller supports
 
 #### portfolio
 
-Inventory portfolio information:
+Inventory portfolio information. Media-buy sellers SHOULD declare both routing
+arrays. The existing `primary_*` names are retained for 3.x compatibility, but
+a present array is exhaustive for brief routing: buyers MAY skip the agent when
+a brief's requested countries or channels do not intersect it. Omission means
+unknown scope, never global coverage. These are routing pre-filters—not promises
+that a matching product is currently available.
+
+`primary_countries` is not executable geo-targeting capability. It answers
+whether the sales agent accepts a country-scoped discovery brief; the structured
+fields under `media_buy.execution.targeting` and each product's
+`overlay_support` determine whether and how a returned product can execute
+geographic targeting.
 
 | Field                  | Type     | Description                                            |
 | ---------------------- | -------- | ------------------------------------------------------ |
 | `publisher_domains`    | string[] | **Required.** Publisher domains this seller represents |
-| `primary_channels`     | string[] | Main advertising channels                              |
-| `primary_countries`    | string[] | Main countries (ISO codes)                             |
+| `primary_channels`     | string[] | Complete AdCP channel allowlist for briefs this agent accepts; omission means unknown |
+| `primary_countries`    | string[] | Complete ISO 3166-1 alpha-2 country allowlist for briefs this agent accepts; omission means unknown |
 | `description`          | string   | Markdown portfolio description                         |
 | `advertising_policies` | string   | Content policies and restrictions                      |
 

--- a/docs/reference/migration/channels.mdx
+++ b/docs/reference/migration/channels.mdx
@@ -135,7 +135,21 @@ When products are returned from `get_products`, each product's `channels` array 
 
 ## Declaring channel support in capabilities
 
-Buyers should call `get_adcp_capabilities` to discover which channels a seller supports before filtering `get_products` requests. The `portfolio.primary_channels` field lists the seller's main channels.
+Buyers should call `get_adcp_capabilities` before filtering `get_products`
+requests. When present, `portfolio.primary_channels` is the seller's complete
+brief-routing channel allowlist, so a buyer may skip the seller when no requested
+channel intersects it. Omission means unknown scope, not support for every
+channel. A match is not an availability guarantee; call `get_products` to
+resolve current inventory and the rest of the brief.
+
+AdCP 3.2 applies the same exhaustive routing meaning to
+`portfolio.primary_countries`. Sellers upgrading from 3.1 that populated either
+`primary_*` array with only representative values MUST expand it to the complete
+brief-routing scope or omit it until they can do so. Empty and duplicate arrays
+remain wire-valid in 3.2 for compatibility but produce Canary advisories; 4.0 is
+expected to require non-empty, unique declarations. The country array does not
+replace `media_buy.execution.targeting` geo capabilities or product
+`overlay_support`.
 
 ## Migration steps
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deploy:cdn-artifacts-cutover:dry-run": "wrangler deploy --config workers/artifact-cdn/wrangler.cutover.toml --dry-run",
     "verify:cdn-artifacts-cutover": "node scripts/verify-cdn-artifacts-cutover.mjs",
     "typecheck": "tsc --project server/tsconfig.json --noEmit",
-    "test:schemas": "node tests/schema-validation.test.cjs && node --test tests/trusted-match-offer-creative-data.test.cjs tests/accessibility-violation-details.test.cjs tests/schema-deprecation-metadata.test.cjs tests/creative-rotation.test.cjs tests/lint-schema-enum-drift.test.cjs tests/synthetic-depiction.test.cjs && npm run test:geo-region-targeting",
+    "test:schemas": "node tests/schema-validation.test.cjs && node --test tests/trusted-match-offer-creative-data.test.cjs tests/accessibility-violation-details.test.cjs tests/portfolio-routing-scope.test.cjs tests/schema-deprecation-metadata.test.cjs tests/creative-rotation.test.cjs tests/lint-schema-enum-drift.test.cjs tests/synthetic-depiction.test.cjs && npm run test:geo-region-targeting",
     "test:performance-feedback": "node --test --test-force-exit --test-timeout=30000 tests/performance-feedback-contract.test.cjs",
     "test:dist-schema-version-ids": "node --test --test-force-exit --test-timeout=30000 tests/dist-schema-version-ids.test.cjs",
     "test:examples": "node tests/example-validation-simple.test.cjs && npm run test:tmp-context-merge",

--- a/scripts/lint-storyboard-validations-paths.cjs
+++ b/scripts/lint-storyboard-validations-paths.cjs
@@ -50,6 +50,7 @@ const PATH_BEARING_CHECKS = new Set([
   'field_absent',
   'field_pattern',
   'field_contains',
+  'all_fields_in_context_array',
   'envelope_field_present',
   'envelope_field_absent',
   'envelope_field_pattern',
@@ -463,7 +464,11 @@ function lintDoc(doc, filePath, allowlist = []) {
     for (const { v, index: i } of pathValidations) {
       const rawPath = v.path;
       const segments = parsePath(rawPath);
-      if (segments.includes('*') && v.check !== 'field_contains') {
+      if (
+        segments.includes('*') &&
+        v.check !== 'field_contains' &&
+        v.check !== 'all_fields_in_context_array'
+      ) {
         violations.push({
           rule: 'wildcard_unsupported_check',
           filePath,
@@ -558,7 +563,7 @@ const RULE_MESSAGES = {
     'Verify the discriminator value against the response schema.',
   wildcard_unsupported_check: ({ validationPath, check }) =>
     `validations[].path \`${validationPath}\` uses [*] but check \`${check}\` does not support wildcard ` +
-    'runtime semantics. Use `field_contains` for wildcard membership checks, or use a concrete index.',
+    'runtime semantics. Use `field_contains` or `all_fields_in_context_array` for wildcard membership checks, or use a concrete index.',
 };
 
 function formatMessage(violation) {

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -40,6 +40,7 @@ requires_scenarios:
   - media_buy_seller/bidding_cost_binding
   - media_buy_seller/package_automatic_bidding
   - media_buy_seller/typed_proposal_negotiation
+  - media_buy_seller/portfolio_routing_scope
 
 narrative: |
   You run a sell-side platform — a publisher, SSP, retail media network, or any system that

--- a/static/compliance/source/protocols/media-buy/scenarios/portfolio_routing_scope.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/portfolio_routing_scope.yaml
@@ -1,0 +1,152 @@
+id: media_buy_seller/portfolio_routing_scope
+version: "1.1.0"
+title: "Seller declares brief-routing portfolio scope"
+category: media_buy_seller
+summary: "Advises when a media-buy seller omits its complete country or channel routing allowlist."
+track: media_buy
+introduced_in: "3.2"
+
+required_tools:
+  - get_adcp_capabilities
+  - get_products
+
+narrative: |
+  A present primary_countries or primary_channels array is exhaustive for brief
+  routing. Buyers may skip this agent when a brief does not intersect a declared
+  array. Omission means unknown scope, never global coverage. The declarations
+  are SHOULD-level during 3.2, so omission is an advisory finding rather than a
+  conformance failure. Product availability remains a get_products concern.
+  When a channel declaration is present, the gated phase also proves that a
+  synchronous product read is accepted and that every returned product channel
+  stays within the exhaustive channel allowlist. Empty product results remain
+  valid. Empty declared arrays are advisory in 3.2 rather than schema-invalid;
+  4.0 can require non-empty declarations.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - portfolio_routing
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer/router)"
+
+prerequisites:
+  description: |
+    The seller exposes get_adcp_capabilities and declares media_buy support.
+  test_kit: "test-kits/acme-outdoor.yaml"
+
+phases:
+  - id: capability_discovery
+    title: "Inspect seller brief-routing scope"
+    steps:
+      - id: get_capabilities
+        title: "Read portfolio routing allowlists"
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        comply_scenario: capability_discovery
+        stateful: false
+        expected: |
+          Return media_buy capabilities and, preferably, complete country and
+          channel routing allowlists.
+        sample_request:
+          context:
+            correlation_id: "portfolio_routing_scope--get_capabilities"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json"
+          - check: field_contains
+            path: "supported_protocols[*]"
+            value: "media_buy"
+            description: "Agent declares media_buy protocol support"
+          - check: field_present
+            path: "media_buy.portfolio.primary_countries"
+            severity: advisory
+            permanent_advisory:
+              reason: "Presence is a normative SHOULD in 3.2 and becomes a strict routing-scope requirement only in 4.0."
+            description: "Seller declares its complete brief-routing country allowlist"
+          - check: field_present
+            path: "media_buy.portfolio.primary_channels"
+            severity: advisory
+            permanent_advisory:
+              reason: "Presence is a normative SHOULD in 3.2 and becomes a strict routing-scope requirement only in 4.0."
+            description: "Seller declares its complete brief-routing channel allowlist"
+          - check: field_present
+            path: "media_buy.portfolio.primary_countries[0]"
+            severity: advisory
+            permanent_advisory:
+              reason: "Non-empty routing scope remains advisory in 3.2; 4.0 will require a non-empty declaration."
+            description: "Declared country routing scope contains at least one value"
+          - check: field_present
+            path: "media_buy.portfolio.primary_channels[0]"
+            severity: advisory
+            permanent_advisory:
+              reason: "Non-empty routing scope remains advisory in 3.2; 4.0 will require a non-empty declaration."
+            description: "Declared channel routing scope contains at least one value"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "portfolio_routing_scope--get_capabilities"
+            description: "Context correlation_id returned unchanged"
+
+  - id: declared_channel_scope
+    title: "Exercise a declared channel and detect contradictory products"
+    depends_on: []
+    requires_capability:
+      path: media_buy.portfolio.primary_channels
+      present: true
+    steps:
+      - id: capture_declared_channels
+        title: "Capture the exhaustive channel allowlist"
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        stateful: false
+        sample_request:
+          context:
+            correlation_id: "portfolio_routing_scope--capture_channels"
+        validations:
+          - check: response_schema
+            description: "Response matches get-adcp-capabilities-response.json"
+        context_outputs:
+          - name: portfolio_channels
+            path: "media_buy.portfolio.primary_channels"
+
+      - id: query_declared_channel
+        title: "Read products under the advertised channel scope"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        stateful: true
+        sample_request:
+          buying_mode: "wholesale"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          context:
+            correlation_id: "portfolio_routing_scope--declared_channel"
+        expected: |
+          Return a synchronous product page, which may be empty. Every channel
+          on every returned product remains inside the exhaustive portfolio
+          declaration. An explicitly empty allowlist therefore passes only with
+          an empty/no-channel product page and is separately surfaced as advisory.
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json"
+          - check: field_present
+            path: "products"
+            description: "Seller returns a synchronous success page; advisory errors remain allowed"
+          - check: all_fields_in_context_array
+            path: "products[*].channels[*]"
+            context_key: "portfolio_channels"
+            description: "Returned product channels do not contradict the exhaustive portfolio scope"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "portfolio_routing_scope--declared_channel"
+            description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -26,7 +26,7 @@
 # --- Schema definition ---
 
 id: runner_output_contract
-version: "2.10.0"
+version: "2.11.0"
 title: "Runner output contract"
 summary: "Required failure-detail shape that AdCP storyboard runners MUST emit so implementors can self-diagnose validation failures."
 
@@ -64,6 +64,7 @@ authored_check_kinds:
   - field_less_than
   - field_equals_context
   - field_in_context_array
+  - all_fields_in_context_array
   - upstream_traffic
   - canonical_format_satisfaction
 
@@ -198,6 +199,7 @@ validation_result:
                               # any_of | refs_resolve |
                               # a2a_submitted_artifact | field_less_than |
                               # field_equals_context | field_in_context_array |
+                              # all_fields_in_context_array |
                               # upstream_traffic |
                               # canonical_format_satisfaction |
                               # cross_response_field_equal |
@@ -285,9 +287,15 @@ validation_result:
                               #                          `validation.context_key` in the
                               #                          storyboard accumulator.
                               #   field_in_context_array → array captured from
+                              #                          `validation.context_key`; the
+                              #                          scalar observed field MUST be
+                              #                          a member.
+                              #   all_fields_in_context_array → array captured from
                               #                          `validation.context_key`;
-                              #                          the observed field MUST be
-                              #                          a member of this array.
+                              #                          EVERY terminal value resolved
+                              #                          by the wildcard path MUST be a
+                              #                          member. Zero terminal values
+                              #                          pass vacuously.
                               #   capture_path_not_resolvable → the context_outputs path
                               #                          string that failed to resolve
                               #                          (e.g. "signals[0].signal_agent_segment_id")
@@ -359,9 +367,10 @@ validation_result:
                               #   field_equals_context → the observed value at `path`
                               #                          (any JSON type, null when the
                               #                          field was missing).
-                              #   field_in_context_array → the observed value at
-                              #                          `path` (any JSON type, null
-                              #                          when the field was missing).
+                              #   field_in_context_array → the observed scalar value.
+                              #   all_fields_in_context_array → array of all resolved
+                              #                          terminal values (empty when
+                              #                          none resolve).
                               #   capture_path_not_resolvable → the value that was
                               #                          resolved at the path, or null
                               #                          when the path did not exist.
@@ -428,7 +437,8 @@ validation_result:
       signal_agent_segment_id"). For unresolved_substitution, json_pointer MUST
       be null (the substitution is pre-wire and no response path is implicated).
     cross_step_comparison_checks: |
-      field_less_than, field_equals_context, and field_in_context_array are
+      field_less_than, field_equals_context, field_in_context_array, and
+      all_fields_in_context_array are
       authored checks that compare
       a field on this step's response against a value from the storyboard
       accumulator (populated by prior steps' `context_outputs`). Three

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -1684,7 +1684,8 @@
 #       on_out_of_scope: warn
 #
 # Cross-step comparison — use `check: field_less_than` /
-# `field_equals_context` / `field_in_context_array`:
+# `field_equals_context` / `field_in_context_array` /
+# `all_fields_in_context_array`:
 #   These checks compare a field in THIS step's response against a value
 #   captured by a PRIOR step via `context_outputs`. Without them, every existing
 #   `check:` is single-step (`field_value` resolves the comparand at YAML
@@ -1705,12 +1706,13 @@
 #       a member of the supported_billing array captured during discovery.
 #
 #   Fields:
-#     check: field_less_than | field_equals_context | field_in_context_array
+#     check: field_less_than | field_equals_context | field_in_context_array | all_fields_in_context_array
 #     path: string                  # JSON path on this step's response.
 #     context_key: string           # name set by a prior step's
 #                                   # `context_outputs[].name`. Required for
 #                                   # `field_equals_context` and
-#                                   # `field_in_context_array`. Optional for
+#                                   # `field_in_context_array` and
+#                                   # `all_fields_in_context_array`. Optional for
 #                                   # `field_less_than` — when omitted, the
 #                                   # check falls back to the literal `value`
 #                                   # (so authors can compare against a
@@ -1718,7 +1720,7 @@
 #     value: number                 # Literal comparand for `field_less_than`
 #                                   # when `context_key` is not set. Ignored on
 #                                   # `field_equals_context` and
-#                                   # `field_in_context_array` (which always
+#                                   # membership checks (which always
 #                                   # read from context).
 #     description: string
 #
@@ -1727,8 +1729,14 @@
 #     or absent values fail the check with a type error in the validation_result.
 #     `field_equals_context` deep-equals the response value against the captured
 #     comparand using the same equality semantics as `field_value`.
-#     `field_in_context_array` requires the captured comparand to be an array
-#     and passes when the response value is deep-equal to one array member.
+#     `field_in_context_array` requires the captured comparand to be an array and
+#     a scalar path; it passes when the response value deep-equals one member.
+#     `all_fields_in_context_array` requires an array comparand and a wildcard
+#     path; it passes only when EVERY resolved terminal value belongs to the
+#     captured array. A path resolving no terminal values passes vacuously; pair
+#     it with field_present when an empty response is not allowed. Older runners
+#     that do not implement this additive check grade it not_applicable under the
+#     runner forward-compatibility contract rather than producing a false failure.
 #
 #   Absent context_key — context_key_absent observation:
 #     When `context_key` is set but the named entry is missing from the
@@ -1778,6 +1786,12 @@
 #       path: "accounts[0].billing"
 #       context_key: "supported_billing"
 #       description: "Applied billing belongs to the advertised set"
+#
+#     # Exhaustive routing scope: every returned product channel was advertised.
+#     - check: all_fields_in_context_array
+#       path: "products[*].channels[*]"
+#       context_key: "portfolio_channels"
+#       description: "Returned product channels stay inside portfolio scope"
 #
 #     # Static threshold (single-step form — no context_key).
 #     # NOTE: `field_less_than` is primarily a cross-step check; the literal-

--- a/static/schemas/source/protocol/get-adcp-capabilities-response.json
+++ b/static/schemas/source/protocol/get-adcp-capabilities-response.json
@@ -1543,7 +1543,7 @@
         },
         "portfolio": {
           "type": "object",
-          "description": "Information about the seller's media inventory portfolio. Expected for media_buy sellers — buyers use this to understand inventory coverage and verify authorization via adagents.json.",
+          "description": "Information about the seller's media inventory portfolio. Media-buy sellers SHOULD publish primary_channels and primary_countries as their complete brief-routing scope. Buyers use publisher_domains to verify authorization via adagents.json. Omitted routing arrays mean unknown scope and MUST NOT be interpreted as global coverage.",
           "properties": {
             "publisher_domains": {
               "type": "array",
@@ -1556,14 +1556,14 @@
             },
             "primary_channels": {
               "type": "array",
-              "description": "Primary advertising channels in this portfolio",
+              "description": "Complete list of AdCP media channels for which this sales agent accepts and can meaningfully answer product-discovery briefs. When present, this is an exhaustive brief-routing allowlist: buyers MAY skip the agent when a brief's requested channels do not intersect it. Omission means channel scope is unknown and MUST NOT be interpreted as support for every channel. This is a routing pre-filter, not a promise of current product availability.",
               "items": {
                 "$ref": "/schemas/enums/channels.json"
               }
             },
             "primary_countries": {
               "type": "array",
-              "description": "Primary countries (ISO 3166-1 alpha-2) where inventory is concentrated",
+              "description": "Complete list of ISO 3166-1 alpha-2 countries for which this sales agent accepts and can meaningfully answer product-discovery briefs. When present, this is an exhaustive brief-routing allowlist: buyers MAY skip the agent when a brief's requested countries do not intersect it. Omission means country scope is unknown and MUST NOT be interpreted as global coverage. This is a routing pre-filter, not a promise of current product availability and not an executable geo-targeting declaration; media_buy.execution.targeting geo capabilities and each product's overlay_support remain authoritative for targeting execution.",
               "items": {
                 "type": "string",
                 "pattern": "^[A-Z]{2}$"

--- a/tests/lint-storyboard-check-enum.test.cjs
+++ b/tests/lint-storyboard-check-enum.test.cjs
@@ -65,7 +65,7 @@ test('field-strip notice attributes noncanonical fields to the request payload',
   const contract = yaml.load(fs.readFileSync(contractPath, 'utf8'));
   const notice = contract.notice.canonical_codes.input_schema_field_stripped;
 
-  assert.equal(contract.version, '2.10.0');
+  assert.equal(contract.version, '2.11.0');
   assert.equal(notice.severity, 'info');
   assert.equal('spec_source' in notice, false, 'the notice is task-neutral and must not cite one creative schema');
   assert.match(notice.message_template, /neither the agent's MCP inputSchema nor the canonical/);

--- a/tests/lint-storyboard-validations-paths.test.cjs
+++ b/tests/lint-storyboard-validations-paths.test.cjs
@@ -566,6 +566,7 @@ test('PATH_BEARING_CHECKS is the documented set', () => {
   assert.ok(PATH_BEARING_CHECKS.has('field_absent'));
   assert.ok(PATH_BEARING_CHECKS.has('field_pattern'));
   assert.ok(PATH_BEARING_CHECKS.has('field_contains'));
+  assert.ok(PATH_BEARING_CHECKS.has('all_fields_in_context_array'));
   assert.ok(PATH_BEARING_CHECKS.has('envelope_field_present'));
   assert.ok(PATH_BEARING_CHECKS.has('envelope_field_absent'));
   assert.ok(PATH_BEARING_CHECKS.has('envelope_field_pattern'));

--- a/tests/portfolio-routing-scope.test.cjs
+++ b/tests/portfolio-routing-scope.test.cjs
@@ -1,0 +1,73 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const { runValidations } = require("@adcp/sdk/testing");
+
+const ROOT = path.join(__dirname, "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+}
+
+test("portfolio routing scope is authoritative when present and advisory in 3.2", () => {
+  const capabilities = JSON.parse(
+    read("static/schemas/source/protocol/get-adcp-capabilities-response.json")
+  );
+  const portfolio = capabilities.properties.media_buy.properties.portfolio;
+  for (const field of ["primary_channels", "primary_countries"]) {
+    assert.match(portfolio.properties[field].description, /exhaustive/i, field);
+    assert.equal(portfolio.properties[field].minItems, undefined, field);
+    assert.equal(portfolio.properties[field].uniqueItems, undefined, field);
+  }
+  assert.match(portfolio.description, /omitted.*unknown/is);
+  assert.match(portfolio.description, /MUST NOT be interpreted as global/i);
+  assert.equal(portfolio.properties.primary_countries.items.type, "string");
+  assert.equal(
+    portfolio.properties.primary_countries.items.pattern,
+    "^[A-Z]{2}$"
+  );
+
+  const scenario = read(
+    "static/compliance/source/protocols/media-buy/scenarios/portfolio_routing_scope.yaml"
+  );
+  assert.match(scenario, /introduced_in: "3\.2"/);
+  assert.equal((scenario.match(/severity: advisory/g) || []).length, 4);
+  assert.equal((scenario.match(/permanent_advisory:/g) || []).length, 4);
+  assert.match(scenario, /task: get_products/);
+  assert.match(scenario, /products\[\*\]\.channels\[\*\]/);
+  assert.match(scenario, /check: all_fields_in_context_array/);
+  assert.doesNotMatch(scenario, /targeting_overlay:\s*\n\s*geo_countries/);
+  assert.equal((scenario.match(/depends_on: \[\]/g) || []).length, 1);
+  assert.equal(
+    (scenario.match(/check: field_present\n\s+path: "products"/g) || []).length,
+    1
+  );
+
+  const [legacyRunnerResult] = runValidations(
+    [
+      {
+        check: "all_fields_in_context_array",
+        path: "products[*].channels[*]",
+        context_key: "portfolio_channels",
+        description: "Every product channel stays within declared scope",
+      },
+    ],
+    {
+      taskName: "get_products",
+      taskResult: {
+        success: true,
+        data: { products: [{ channels: ["display"] }] },
+      },
+      agentUrl: "https://seller.example",
+      contributions: new Set(),
+      storyboardContext: { portfolio_channels: ["display"] },
+    }
+  );
+  assert.equal(legacyRunnerResult.passed, true);
+  assert.equal(
+    legacyRunnerResult.not_applicable,
+    true,
+    "pre-implementation SDKs must skip the additive check, not false-fail it"
+  );
+});


### PR DESCRIPTION
## Summary

- make advertised portfolio routing countries authoritative when present
- preserve 3.2 compatibility by introducing an additive array-aware compliance check
- distinguish routing availability from executable geo-targeting support
- add migration guidance and a portfolio routing compliance scenario

Related to #6157

## Release dependency

The corresponding SDK support is tracked in adcontextprotocol/adcp-client#2553 and must ship before 3.2 GA. This PR intentionally does not close #6157 on merge.

## Validation

- `node --test tests/portfolio-routing-scope.test.cjs`
- `npm run build:compliance -- --check`

