### PR TITLE
test(mcp): replace exact context-bytes pins with tolerance bands

### DIFF
--- a/tests/mcp-schema-analysis.test.cjs
+++ b/tests/mcp-schema-analysis.test.cjs
@@ -215,7 +215,18 @@ test("experiment report keeps all alternatives smaller than standalone model con
   assert.equal(report.status, "non-normative");
   assert.equal(report.prompt_cleanup_adapter.required, true);
   assert.equal(report.selection.tools.length, 16);
-  assert.equal(variants.standalone.context_bytes, 287_357);
+  // Tolerance band, not an exact pin: every schema-touching PR shifts this
+  // number, and an exact equality forced each one to re-pin the constant —
+  // guaranteeing merge conflicts between any two in-flight schema PRs (#6571).
+  // The meaningful invariants are that the standalone context stays large
+  // enough for the experiment comparisons to matter and below the projection
+  // budget; the ratio and payload-consistency assertions below carry the
+  // actual signal.
+  assert.ok(
+    variants.standalone.context_bytes > 200_000 &&
+      variants.standalone.context_bytes < 400 * 1024,
+    `standalone context outside [200 KiB, 400 KiB]: ${variants.standalone.context_bytes}`
+  );
   assert.ok(
     variants.prompt_cleanup.context_bytes <
       variants.standalone.context_bytes * 0.82
@@ -228,10 +239,14 @@ test("experiment report keeps all alternatives smaller than standalone model con
     variants.shared_dictionary_with_prompt_cleanup.context_bytes <
       variants.shared_dictionary.context_bytes
   );
-  assert.equal(variants.shared_dictionary.dictionary_definitions, 148);
-  assert.equal(
-    variants.shared_dictionary_with_prompt_cleanup.dictionary_definitions,
-    127
+  assert.ok(
+    variants.shared_dictionary.dictionary_definitions > 100,
+    `shared dictionary unexpectedly small: ${variants.shared_dictionary.dictionary_definitions} definitions`
+  );
+  assert.ok(
+    variants.shared_dictionary_with_prompt_cleanup.dictionary_definitions <
+      variants.shared_dictionary.dictionary_definitions,
+    "prompt cleanup should strictly reduce dictionary definitions"
   );
 
   const { tools } = loadRepresentativeMediaBuyRuntime();


### PR DESCRIPTION
The exact-equality pins on `standalone.context_bytes` and the dictionary-definition counts in `tests/mcp-schema-analysis.test.cjs` force every schema-touching PR to re-pin the constants — guaranteeing merge conflicts between any two in-flight schema PRs. PR #6279 was knocked from MERGEABLE back to CONFLICTING four times in two days by exactly this line.

This replaces the pins with the invariants that matter:
- standalone context within **[200 KiB, 400 KiB]** (large enough for the experiment comparisons to mean something, below the projection budget)
- shared dictionary stays substantial (>100 definitions)
- prompt cleanup **strictly reduces** definitions

The ratio comparisons (cleanup < 0.82×, shared dictionary < 0.37×) and the payload-consistency equality are unchanged — they carry the experiment's real signal.

Closes the snapshot-pin half of #6571; the budget-headroom half stays open pending the shared-dictionary graduation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)