### PR TITLE
fix(admin): show accurate account lifecycle badges

### DIFF
--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -107,6 +107,14 @@
       background: var(--color-success-600);
       color: var(--color-text-on-dark);
     }
+    .member-badge.engaged {
+      background: var(--color-brand);
+      color: var(--color-text-on-dark);
+    }
+    .member-badge.registered {
+      background: var(--color-info-500);
+      color: var(--color-text-on-dark);
+    }
     .member-badge.trial {
       background: var(--color-warning-500);
       color: var(--color-text-on-dark);
@@ -1582,11 +1590,13 @@
       } else {
         const statusLabels = {
           member: 'Member',
+          engaged: 'Active',
+          registered: 'Registered',
           trial: 'Trial',
           lapsed: 'Lapsed',
           prospect: 'Prospect'
         };
-        memberBadge.textContent = statusLabels[a.member_status] || 'Prospect';
+        memberBadge.textContent = statusLabels[a.member_status] || 'Unknown';
       }
 
       // Inherited membership notice

--- a/server/src/services/account-lifecycle.ts
+++ b/server/src/services/account-lifecycle.ts
@@ -100,8 +100,9 @@ export function computeEngagementTier(org: {
   has_users?: boolean;
   has_engaged_users?: boolean;
 }): EngagementTier {
-  // Member: active, non-canceled subscription (includes comped members)
-  if (org.subscription_status === 'active' && !org.subscription_canceled_at) {
+  // Active subscriptions remain memberships through the end of their paid
+  // period, even when cancellation is scheduled. Trials are memberships too.
+  if (org.subscription_status === 'active' || org.subscription_status === 'trialing') {
     return 'member';
   }
 

--- a/server/tests/unit/account-lifecycle.test.ts
+++ b/server/tests/unit/account-lifecycle.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { computeEngagementTier } from '../../src/services/account-lifecycle.js';
+
+describe('computeEngagementTier', () => {
+  it('keeps an active subscription in the member tier when cancellation is scheduled', () => {
+    expect(computeEngagementTier({
+      subscription_status: 'active',
+      subscription_canceled_at: new Date('2026-09-01T00:00:00Z'),
+    })).toBe('member');
+  });
+
+  it('treats a trialing subscription as a member', () => {
+    expect(computeEngagementTier({
+      subscription_status: 'trialing',
+    })).toBe('member');
+  });
+
+  it('falls back to user engagement when there is no active subscription', () => {
+    expect(computeEngagementTier({
+      subscription_status: null,
+      has_users: true,
+      has_engaged_users: true,
+    })).toBe('engaged');
+
+    expect(computeEngagementTier({
+      subscription_status: null,
+      has_users: true,
+      has_engaged_users: false,
+    })).toBe('registered');
+  });
+});
+
+describe('admin account lifecycle badge', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'server/public/admin-account-detail.html'),
+    'utf8',
+  );
+
+  it('labels every engagement tier without falling back to prospect', () => {
+    expect(source).toContain("engaged: 'Active'");
+    expect(source).toContain("registered: 'Registered'");
+    expect(source).toContain("statusLabels[a.member_status] || 'Unknown'");
+    expect(source).toContain('.member-badge.engaged');
+    expect(source).toContain('.member-badge.registered');
+  });
+});


### PR DESCRIPTION
## Summary

- keep active subscriptions in the member tier through scheduled cancellation
- treat trialing subscriptions as members
- render engaged and registered lifecycle badges explicitly instead of falling back to Prospect
- add service and UI regression coverage

## Validation

- `npx vitest run --config server/vitest.config.ts server/tests/unit/account-lifecycle.test.ts`
- `npm run typecheck`
- `npm run test:release-workflow`
- `npm run test:immutable-release-artifacts`
- local pre-commit unit suites

Closes #6534.
