### PR TITLE
fix(compliance): backport rate-limit exhaustion grading

### DIFF
--- a/.changeset/clarify-rate-limit-exhaustion-grading.md
+++ b/.changeset/clarify-rate-limit-exhaustion-grading.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Clarify that exhausting the rate-limit trip runner without observing a
+`RATE_LIMITED` response is a coverage gap reported with
+`skip_result.reason: not_applicable` and
+`skip_result.detail: rate_limit_not_triggered`, not a seller conformance
+failure.

--- a/static/compliance/source/test-kits/rate-limit-trip-runner.yaml
+++ b/static/compliance/source/test-kits/rate-limit-trip-runner.yaml
@@ -62,8 +62,9 @@ harness_mode: black_box
 #      proceeds to the wait + replay phase.
 #
 #   2. `max_attempts` requests complete without producing RATE_LIMITED.
-#      The runner grades the step as `not_applicable` with reason
-#      `rate_limit_not_triggered` — sellers may legitimately configure
+#      The runner grades the step with `skip_result.reason: not_applicable`
+#      and `skip_result.detail: rate_limit_not_triggered` — sellers may
+#      legitimately configure
 #      a sandbox limiter at a higher ceiling than this contract's
 #      max_attempts. The remainder of the storyboard is unaffected.
 #
@@ -84,6 +85,8 @@ burst_step_contract:
     - rate_limit_trip.replay_max_wait_seconds
   max_attempts_min: 50
   max_attempts_max: 500
+  exhausted_outcome: not_applicable
+  exhausted_detail: rate_limit_not_triggered
   # 50 ≤ max_attempts ≤ 500. Below 50 won't reliably trip a 60/sec-sustained
   # limiter even with HTTP/2 multiplexing; above 500 inflates runtime
   # materially without improving signal. Storyboards SHOULD start at 200
@@ -137,7 +140,11 @@ replay_invariant_check_kinds:
 # `replay_not_cached_rate_limit` semantics: the runner compares
 # `trip_response.error.code` against `replay_response.error.code` (when
 # the replay carries an error envelope) or against the absence of error
-# (when the replay carries a success envelope). If both responses carry
+# (when the replay carries a success envelope). When the burst exhausts
+# `max_attempts` without observing RATE_LIMITED, the runner MUST stop before
+# dispatching `validations[]` and grade the step `not_applicable` with
+# `skip_result.reason: not_applicable` and
+# `skip_result.detail: rate_limit_not_triggered`. If both responses carry
 # error_code = RATE_LIMITED, the replay was served from the idempotency
 # cache and the invariant fails. Any other replay response shape passes
 # the invariant — either the handler succeeded (RATE_LIMITED was not

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -718,10 +718,11 @@ phases:
       Runners without `rate_limit_trip_runner` skip this phase with a
       stable `not_applicable` marker. Runners with the contract that
       exhaust `max_attempts` without observing `RATE_LIMITED` also grade
-      `not_applicable` (reason: `rate_limit_not_triggered`) — a sandbox
-      limiter sitting above the contract's burst ceiling is not a seller
-      conformance fault, only a configuration choice that prevents the
-      invariant from being verified end-to-end.
+      with `skip_result.reason: not_applicable` and
+      `skip_result.detail: rate_limit_not_triggered` — a sandbox limiter
+      sitting above the contract's burst ceiling is not a seller conformance
+      fault, only a configuration choice that prevents the invariant from
+      being verified end-to-end.
 
       The 60/300 req/sec ceiling itself is NOT attested here. Burst-volume
       measurement is structurally non-deterministic in CI environments and
@@ -788,9 +789,10 @@ phases:
             `replay_not_cached_rate_limit` check passes.
 
           - All `max_attempts` requests complete without producing
-            `RATE_LIMITED`. The step grades `not_applicable` with reason
-            `rate_limit_not_triggered`. The rest of the storyboard is
-            unaffected.
+            `RATE_LIMITED`. The step grades with
+            `skip_result.reason: not_applicable` and
+            `skip_result.detail: rate_limit_not_triggered`. The rest of the
+            storyboard is unaffected.
 
         validations:
           - check: replay_not_cached_rate_limit

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -247,21 +247,57 @@ skip_result:
     the skip is informative (the agent did not claim the protocol) or
     masking (the runner could not apply the storyboard even though the
     agent claimed the protocol).
+
+    Selection is separate from skipping. If the caller asks for a narrower
+    suite or run mode (for example, "Sandbox only") and the runner excludes
+    live-only storyboards before execution, those items are `not_selected`,
+    not `skipped`. A `skip_result` is emitted only after an item was selected
+    for this run and the runner could not execute it because an applicability
+    gate, required tool, test controller, prerequisite, or harness contract
+    was unavailable, or because a bounded observation contract exhausted its
+    attempts without observing the condition it was designed to test.
   required_fields:
     - reason                  # not_applicable | no_phases |
                               # prerequisite_failed | missing_tool |
                               # missing_test_controller |
                               # unsatisfied_contract | peer_branch_taken |
                               # peer_substituted
-    - detail                  # human-readable explanation citing the
-                              # declared supported_protocols / specialisms
-                              # and, if relevant, the missing tool,
-                              # prerequisite step id, or contract key.
+    - detail                  # explanation citing the declared
+                              # supported_protocols / specialisms and, if
+                              # relevant, the missing tool, prerequisite step
+                              # id, or contract key. Some reasons define an
+                              # exact machine-readable detail registered in
+                              # canonical_detail_sub_reasons below.
+  canonical_detail_sub_reasons:
+    not_applicable:
+      rate_limit_not_triggered:
+        spec_source: test-kits/rate-limit-trip-runner.yaml
+        description: |
+          The rate-limit trip runner exhausted max_attempts without observing
+          RATE_LIMITED. This is a coverage gap caused by the seller's permitted
+          limiter configuration, not a seller conformance failure.
   reasons:
     not_applicable: |
-      The agent did not declare the protocol or specialism this storyboard
-      targets. detail MUST cite the agent's declared supported_protocols
-      and specialisms.
+      The item was selected for this run, but either an applicability gate
+      evaluated false or a bounded observation contract exhausted without
+      observing its trigger. Applicability-gate examples include the agent not
+      declaring the protocol or specialism this storyboard targets. For this
+      form, detail MUST cite the failed gate and the agent's relevant declared
+      supported_protocols or specialisms.
+
+      Observation exhaustion is distinct from an applicability-gate failure.
+      When rate_limit_trip_runner reaches max_attempts without observing
+      RATE_LIMITED, the runner MUST emit reason: not_applicable with detail
+      exactly `rate_limit_not_triggered`. It MUST do so before dispatching the
+      step's validations, MUST emit an empty validations array, and MUST count
+      the step in steps_skipped and, when emitted, skipped_by_reason.not_applicable.
+      It MUST NOT increment steps_passed, steps_failed, any validation counter,
+      or validations_not_applicable.
+
+      When the runner excludes an item before execution because it is outside
+      the caller's requested suite, run mode, AdCP version, or verification
+      profile, use selection_result instead. Do not report run-mode exclusions
+      as not_applicable skips.
 
       Branch-set grading uses `peer_branch_taken` (see below), not this
       reason — keeping the two distinct lets dashboards filter coverage

--- a/tests/lint-storyboard-test-kits.test.cjs
+++ b/tests/lint-storyboard-test-kits.test.cjs
@@ -16,6 +16,7 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const yaml = require('js-yaml');
 
 const { lint, classify, RULE_MESSAGES } = require('../scripts/lint-storyboard-test-kits.cjs');
 
@@ -27,6 +28,38 @@ test('source tree passes the test-kits lint', () => {
     'real test kits violate the bimodal partition:\n' +
       violations.map((v) => `  ${v.file} — ${v.rule}`).join('\n'),
   );
+});
+
+test('rate-limit trip exhaustion uses the canonical not-applicable result', () => {
+  const sourceRoot = path.join(__dirname, '..', 'static', 'compliance', 'source');
+  const loadYaml = (...segments) => yaml.load(
+    fs.readFileSync(path.join(sourceRoot, ...segments), 'utf8'),
+  );
+  const testKit = loadYaml('test-kits', 'rate-limit-trip-runner.yaml');
+  const outputContract = loadYaml('universal', 'runner-output-contract.yaml');
+  const storyboard = loadYaml('universal', 'idempotency.yaml');
+  const phase = storyboard.phases.find(({ id }) => id === 'rate_limit_replay_invariant');
+  const step = phase.steps.find(({ id }) => id === 'expect_rate_limit_not_replayed');
+
+  assert.deepEqual(
+    {
+      reason: testKit.burst_step_contract.exhausted_outcome,
+      detail: testKit.burst_step_contract.exhausted_detail,
+    },
+    { reason: 'not_applicable', detail: 'rate_limit_not_triggered' },
+  );
+  assert.ok(
+    outputContract.skip_result.canonical_detail_sub_reasons
+      .not_applicable.rate_limit_not_triggered,
+    'runner output contract registers the exhaustion detail',
+  );
+  assert.equal(step.requires_contract, testKit.id);
+  assert.deepEqual(
+    step.validations.map(({ check }) => check),
+    ['replay_not_cached_rate_limit'],
+  );
+  assert.match(step.expected, /skip_result\.reason: not_applicable/);
+  assert.match(step.expected, /skip_result\.detail: rate_limit_not_triggered/);
 });
 
 test('classify: brand kit (auth.api_key only)', () => {


### PR DESCRIPTION
## Summary
- backport the P0 rate-limit exhaustion grading clarification to the 3.0 maintenance line
- define rate_limit_not_triggered as a canonical not_applicable detail
- add regression coverage and a patch changeset

## Validation
- npm run test:storyboard-test-kits
- npm run build:compliance