### PR TITLE
fix(compliance): backport rate-limit exhaustion grading

### DIFF
--- a/.changeset/clarify-rate-limit-exhaustion-grading.md
+++ b/.changeset/clarify-rate-limit-exhaustion-grading.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": patch
+---
+
+Clarify that exhausting the rate-limit trip runner without observing a
+`RATE_LIMITED` response is a coverage gap reported with
+`skip_result.reason: not_applicable` and
+`skip_result.detail: rate_limit_not_triggered`, not a seller conformance
+failure.

--- a/static/compliance/source/test-kits/rate-limit-trip-runner.yaml
+++ b/static/compliance/source/test-kits/rate-limit-trip-runner.yaml
@@ -63,8 +63,9 @@ harness_mode: black_box
 #      proceeds to the wait + replay phase.
 #
 #   2. `max_attempts` requests complete without producing RATE_LIMITED.
-#      The runner grades the step as `not_applicable` with reason
-#      `rate_limit_not_triggered` — sellers may legitimately configure
+#      The runner grades the step with `skip_result.reason: not_applicable`
+#      and `skip_result.detail: rate_limit_not_triggered` — sellers may
+#      legitimately configure
 #      a sandbox limiter at a higher ceiling than this contract's
 #      max_attempts. The remainder of the storyboard is unaffected.
 #
@@ -85,6 +86,8 @@ burst_step_contract:
     - rate_limit_trip.replay_max_wait_seconds
   max_attempts_min: 50
   max_attempts_max: 500
+  exhausted_outcome: not_applicable
+  exhausted_detail: rate_limit_not_triggered
   # 50 ≤ max_attempts ≤ 500. Below 50 won't reliably trip a 60/sec-sustained
   # limiter even with HTTP/2 multiplexing; above 500 inflates runtime
   # materially without improving signal. Storyboards SHOULD start at 200
@@ -138,7 +141,11 @@ replay_invariant_check_kinds:
 # `replay_not_cached_rate_limit` semantics: the runner compares
 # `trip_response.error.code` against `replay_response.error.code` (when
 # the replay carries an error envelope) or against the absence of error
-# (when the replay carries a success envelope). If both responses carry
+# (when the replay carries a success envelope). When the burst exhausts
+# `max_attempts` without observing RATE_LIMITED, the runner MUST stop before
+# dispatching `validations[]` and grade the step `not_applicable` with
+# `skip_result.reason: not_applicable` and
+# `skip_result.detail: rate_limit_not_triggered`. If both responses carry
 # error_code = RATE_LIMITED, the replay was served from the idempotency
 # cache and the invariant fails. Any other replay response shape passes
 # the invariant — either the handler succeeded (RATE_LIMITED was not

--- a/static/compliance/source/universal/idempotency.yaml
+++ b/static/compliance/source/universal/idempotency.yaml
@@ -725,10 +725,11 @@ phases:
       Runners without `rate_limit_trip_runner` skip this phase with a
       stable `not_applicable` marker. Runners with the contract that
       exhaust `max_attempts` without observing `RATE_LIMITED` also grade
-      `not_applicable` (reason: `rate_limit_not_triggered`) — a sandbox
-      limiter sitting above the contract's burst ceiling is not a seller
-      conformance fault, only a configuration choice that prevents the
-      invariant from being verified end-to-end.
+      with `skip_result.reason: not_applicable` and
+      `skip_result.detail: rate_limit_not_triggered` — a sandbox limiter
+      sitting above the contract's burst ceiling is not a seller conformance
+      fault, only a configuration choice that prevents the invariant from
+      being verified end-to-end.
 
       The 60/300 req/sec ceiling itself is NOT attested here. Burst-volume
       measurement is structurally non-deterministic in CI environments and
@@ -795,9 +796,10 @@ phases:
             `replay_not_cached_rate_limit` check passes.
 
           - All `max_attempts` requests complete without producing
-            `RATE_LIMITED`. The step grades `not_applicable` with reason
-            `rate_limit_not_triggered`. The rest of the storyboard is
-            unaffected.
+            `RATE_LIMITED`. The step grades with
+            `skip_result.reason: not_applicable` and
+            `skip_result.detail: rate_limit_not_triggered`. The rest of the
+            storyboard is unaffected.
 
         validations:
           - check: replay_not_cached_rate_limit

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -792,25 +792,48 @@ skip_result:
     not `skipped`. A `skip_result` is emitted only after an item was selected
     for this run and the runner could not execute it because an applicability
     gate, required tool, test controller, prerequisite, or harness contract
-    was unavailable.
+    was unavailable, or because a bounded observation contract exhausted its
+    attempts without observing the condition it was designed to test.
   required_fields:
     - reason                  # not_applicable | no_phases |
                               # prerequisite_failed | missing_tool |
                               # missing_test_controller |
-                              # unsatisfied_contract | peer_branch_taken |
-                              # peer_substituted | requirement_unmet
-    - detail                  # human-readable explanation citing the
-                              # declared supported_protocols / specialisms
-                              # and, if relevant, the missing tool,
-                              # prerequisite step id, or contract key.
+                              # fixture_unavailable | unsatisfied_contract |
+                              # peer_branch_taken |
+                              # peer_substituted | requirement_unmet |
+                              # fixture_unsatisfied
+    - detail                  # explanation citing the declared
+                              # supported_protocols / specialisms and, if
+                              # relevant, the missing tool, prerequisite step
+                              # id, or contract key. Some reasons define an
+                              # exact machine-readable detail registered in
+                              # canonical_detail_sub_reasons below.
+  canonical_detail_sub_reasons:
+    not_applicable:
+      rate_limit_not_triggered:
+        spec_source: test-kits/rate-limit-trip-runner.yaml
+        description: |
+          The rate-limit trip runner exhausted max_attempts without observing
+          RATE_LIMITED. This is a coverage gap caused by the seller's permitted
+          limiter configuration, not a seller conformance failure.
   reasons:
     not_applicable: |
-      The item was selected for this run, but an applicability gate evaluated
-      false. Examples: the agent did not declare the protocol or specialism
-      this storyboard targets, or a scenario's requires_capability check found
-      an optional capability set to false. detail MUST cite the failed gate
-      and the agent's relevant declared supported_protocols, specialisms, or
-      capability value.
+      The item was selected for this run, but either an applicability gate
+      evaluated false or a bounded observation contract exhausted without
+      observing its trigger. Applicability-gate examples include the agent not
+      declaring the protocol or specialism this storyboard targets, or a
+      scenario's requires_capability check finding an optional capability set
+      to false. For this form, detail MUST cite the failed gate and the agent's
+      relevant declared supported_protocols, specialisms, or capability value.
+
+      Observation exhaustion is distinct from an applicability-gate failure.
+      When rate_limit_trip_runner reaches max_attempts without observing
+      RATE_LIMITED, the runner MUST emit reason: not_applicable with detail
+      exactly `rate_limit_not_triggered`. It MUST do so before dispatching the
+      step's validations, MUST emit an empty validations array, and MUST count
+      the step in steps_skipped and, when emitted, skipped_by_reason.not_applicable.
+      It MUST NOT increment steps_passed, steps_failed, any validation counter,
+      or validations_not_applicable.
 
       When the runner excludes an item before execution because it is outside
       the caller's requested suite, run mode, AdCP version, or verification
@@ -1179,16 +1202,16 @@ cascade_rules:
 
     Note on `not_applicable`: unlike `missing_tool` and
     `missing_test_controller` (where the agent declared the specialism but
-    lacks the tool/controller), `not_applicable` means the agent did not
-    declare the specialism at all. The cascade exemption still applies because
-    the structural condition — no peer available to establish substitute state —
-    is identical. A sole-stateful-step `not_applicable` that cascades to all
-    downstream phases would collapse coverage for agents that legitimately omit
-    a pathway; the exemption prevents this collapse regardless of the specific
-    skip reason. Dashboard consumers that need to distinguish "agent does not
-    support the specialism" from "agent supports it via an alternate tool"
-    should read the step's `reason` field rather than inferring from whether
-    downstream phases ran.
+    lacks the tool/controller), `not_applicable` is an explicit coverage-gap
+    signal. It most commonly means the agent did not declare the specialism,
+    but a canonical detail may identify another non-fault gap such as a bounded
+    observation contract exhausting without its trigger. The cascade exemption
+    still applies because the structural condition — no peer available to
+    establish substitute state — is identical. A sole-stateful-step
+    `not_applicable` that cascades to all downstream phases would collapse
+    useful coverage; the exemption prevents this regardless of the specific
+    skip detail. Dashboard consumers should read both `reason` and `detail`
+    rather than inferring the cause from whether downstream phases ran.
 
     References: adcp-client#1146 (original `not_applicable` exemption);
     adcp-client#1545 (extension to `missing_tool` / `missing_test_controller`);

--- a/static/compliance/source/universal/runner-output-contract.yaml
+++ b/static/compliance/source/universal/runner-output-contract.yaml
@@ -798,10 +798,8 @@ skip_result:
     - reason                  # not_applicable | no_phases |
                               # prerequisite_failed | missing_tool |
                               # missing_test_controller |
-                              # fixture_unavailable | unsatisfied_contract |
-                              # peer_branch_taken |
-                              # peer_substituted | requirement_unmet |
-                              # fixture_unsatisfied
+                              # unsatisfied_contract | peer_branch_taken |
+                              # peer_substituted | requirement_unmet
     - detail                  # explanation citing the declared
                               # supported_protocols / specialisms and, if
                               # relevant, the missing tool, prerequisite step

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -2189,9 +2189,9 @@
 #   replay returned the cached RATE_LIMITED response shape.
 #
 #   When `max_attempts` requests complete without producing a RATE_LIMITED
-#   response, the step grades as `not_applicable` with reason
-#   `rate_limit_not_triggered` — a seller's sandbox limiter may legitimately
-#   sit above the contract's burst ceiling. Runner delegates the burst,
+#   response, the step grades with `skip_result.reason: not_applicable` and
+#   `skip_result.detail: rate_limit_not_triggered` — a seller's sandbox limiter
+#   may legitimately sit above the contract's burst ceiling. Runner delegates the burst,
 #   wait, and replay mechanics to the `@adcp/client` RateLimitTripObserver
 #   primitive (see test-kit rate-limit-trip-runner.yaml).
 #
@@ -2210,9 +2210,12 @@
 #                                       # invariant itself.
 #     requires_contract: rate_limit_trip_runner
 #
-#   Error modes: rate_limit_response_cached_as_replay,
-#   missing_retry_after, replay_wait_exceeded, rate_limit_not_triggered
-#   (the not_applicable case, surfaced for runner output transparency).
+#   Failure outcomes: rate_limit_response_cached_as_replay,
+#   missing_retry_after, replay_wait_exceeded.
+#
+#   Not-applicable outcome: rate_limit_not_triggered. This is emitted when
+#   max_attempts exhausts without observing RATE_LIMITED and MUST NOT be
+#   counted as a seller conformance failure.
 #
 # --- shared_receiver (deferred / out of scope v1) ---
 #

--- a/tests/lint-storyboard-test-kits.test.cjs
+++ b/tests/lint-storyboard-test-kits.test.cjs
@@ -16,6 +16,7 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const yaml = require('js-yaml');
 
 const { lint, classify, RULE_MESSAGES } = require('../scripts/lint-storyboard-test-kits.cjs');
 
@@ -27,6 +28,38 @@ test('source tree passes the test-kits lint', () => {
     'real test kits violate the bimodal partition:\n' +
       violations.map((v) => `  ${v.file} — ${v.rule}`).join('\n'),
   );
+});
+
+test('rate-limit trip exhaustion uses the canonical not-applicable result', () => {
+  const sourceRoot = path.join(__dirname, '..', 'static', 'compliance', 'source');
+  const loadYaml = (...segments) => yaml.load(
+    fs.readFileSync(path.join(sourceRoot, ...segments), 'utf8'),
+  );
+  const testKit = loadYaml('test-kits', 'rate-limit-trip-runner.yaml');
+  const outputContract = loadYaml('universal', 'runner-output-contract.yaml');
+  const storyboard = loadYaml('universal', 'idempotency.yaml');
+  const phase = storyboard.phases.find(({ id }) => id === 'rate_limit_replay_invariant');
+  const step = phase.steps.find(({ id }) => id === 'expect_rate_limit_not_replayed');
+
+  assert.deepEqual(
+    {
+      reason: testKit.burst_step_contract.exhausted_outcome,
+      detail: testKit.burst_step_contract.exhausted_detail,
+    },
+    { reason: 'not_applicable', detail: 'rate_limit_not_triggered' },
+  );
+  assert.ok(
+    outputContract.skip_result.canonical_detail_sub_reasons
+      .not_applicable.rate_limit_not_triggered,
+    'runner output contract registers the exhaustion detail',
+  );
+  assert.equal(step.requires_contract, testKit.id);
+  assert.deepEqual(
+    step.validations.map(({ check }) => check),
+    ['replay_not_cached_rate_limit'],
+  );
+  assert.match(step.expected, /skip_result\.reason: not_applicable/);
+  assert.match(step.expected, /skip_result\.detail: rate_limit_not_triggered/);
 });
 
 test('classify: brand kit (auth.api_key only)', () => {


### PR DESCRIPTION
## Summary
- backport the P0 rate-limit exhaustion grading clarification to the 3.1 maintenance line
- define rate_limit_not_triggered as a canonical not_applicable detail
- add regression coverage and a patch changeset

## Validation
- npm run test:storyboard-test-kits
- npm run test:storyboard-check-enum
- npm run test:compliance-source-authority
- npm run build:compliance