### PR TITLE
ci(review): skip Ladon for release bot PRs

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -97,3 +97,4 @@ jobs:
           app-private-key: ${{ secrets.SECRETARIAT_APP_PRIVATE_KEY }}
           # Optional; defaults to the review action's pinned model.
           model: claude-opus-4-8
+          skip-bot-authors: dependabot[bot],renovate[bot],github-actions[bot],aao-release-bot[bot]


### PR DESCRIPTION
## Summary
- skip Ladon execution for generated release PRs authored by the AAO release bot
- preserve Ladon review for human-authored and other non-excluded PRs

## Root cause
The shared reviewer rejects bot-triggered execution before writing its findings file, leaving generated Version Packages PRs red without a code finding.

## Validation
- npx prettier --check .github/workflows/ai-review.yml
- git diff --check