### PR TITLE
fix(compliance): harden published bundle checks

### DIFF
--- a/scripts/check-published-compliance-versions.cjs
+++ b/scripts/check-published-compliance-versions.cjs
@@ -1,39 +1,91 @@
 #!/usr/bin/env node
 
-const { execFileSync } = require('node:child_process');
-const { existsSync, mkdtempSync, readFileSync, rmSync } = require('node:fs');
-const { tmpdir } = require('node:os');
-const { join, resolve } = require('node:path');
+const { execFileSync } = require("node:child_process");
+const { existsSync, mkdtempSync, readFileSync, rmSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join, resolve } = require("node:path");
 
 const COMPLIANCE_VERSION_RE = /^\d+\.\d+\.\d+(?:-(?:beta|rc)\.\d+)?$/;
 const PACKAGED_INDEX_RE = /^package\/compliance\/cache\/([^/]+)\/index\.json$/;
+const COMMAND_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 
 function validateManifest(manifest) {
   if (manifest?.schema_version !== 1) {
-    throw new Error('published-versions.json must use schema_version 1');
+    throw new Error("published-versions.json must use schema_version 1");
   }
   if (!Array.isArray(manifest.npm_tags) || manifest.npm_tags.length === 0) {
-    throw new Error('published-versions.json must declare at least one npm_tags entry');
+    throw new Error(
+      "published-versions.json must declare at least one npm_tags entry"
+    );
   }
-  if (!Array.isArray(manifest.published_versions) || manifest.published_versions.length === 0) {
-    throw new Error('published-versions.json must declare at least one published_versions entry');
+  if (
+    !Array.isArray(manifest.published_versions) ||
+    manifest.published_versions.length === 0
+  ) {
+    throw new Error(
+      "published-versions.json must declare at least one published_versions entry"
+    );
+  }
+  if (
+    manifest.package_only_versions !== undefined &&
+    !Array.isArray(manifest.package_only_versions)
+  ) {
+    throw new Error(
+      "published-versions.json package_only_versions must be an array when present"
+    );
   }
 
   for (const [field, values] of [
-    ['npm_tags', manifest.npm_tags],
-    ['published_versions', manifest.published_versions],
+    ["npm_tags", manifest.npm_tags],
+    ["published_versions", manifest.published_versions],
+    ["package_only_versions", manifest.package_only_versions ?? []],
   ]) {
-    if (values.some(value => typeof value !== 'string' || value.length === 0)) {
-      throw new Error(`published-versions.json ${field} entries must be non-empty strings`);
+    if (
+      values.some((value) => typeof value !== "string" || value.length === 0)
+    ) {
+      throw new Error(
+        `published-versions.json ${field} entries must be non-empty strings`
+      );
     }
     if (new Set(values).size !== values.length) {
-      throw new Error(`published-versions.json ${field} entries must be unique`);
+      throw new Error(
+        `published-versions.json ${field} entries must be unique`
+      );
     }
   }
 
-  const invalidVersions = manifest.published_versions.filter(version => !COMPLIANCE_VERSION_RE.test(version));
+  const invalidVersions = manifest.published_versions.filter(
+    (version) => !COMPLIANCE_VERSION_RE.test(version)
+  );
   if (invalidVersions.length > 0) {
-    throw new Error(`Invalid compliance versions in publication manifest: ${invalidVersions.join(', ')}`);
+    throw new Error(
+      `Invalid compliance versions in publication manifest: ${invalidVersions.join(
+        ", "
+      )}`
+    );
+  }
+
+  const invalidPackageOnlyVersions = (
+    manifest.package_only_versions ?? []
+  ).filter((version) => !COMPLIANCE_VERSION_RE.test(version));
+  if (invalidPackageOnlyVersions.length > 0) {
+    throw new Error(
+      `Invalid package-only compliance versions: ${invalidPackageOnlyVersions.join(
+        ", "
+      )}`
+    );
+  }
+
+  const published = new Set(manifest.published_versions);
+  const overlap = (manifest.package_only_versions ?? []).filter((version) =>
+    published.has(version)
+  );
+  if (overlap.length > 0) {
+    throw new Error(
+      `Compliance versions cannot be both published and package-only: ${overlap.join(
+        ", "
+      )}`
+    );
   }
 
   return manifest;
@@ -48,61 +100,92 @@ function packagedComplianceVersions(tarListing) {
   return versions;
 }
 
-function missingPublishedVersions(manifestVersions, packageVersions) {
-  const registered = new Set(manifestVersions);
-  return [...packageVersions].filter(version => !registered.has(version)).sort();
+function missingPublishedVersions(
+  manifestVersions,
+  packageVersions,
+  packageOnlyVersions = []
+) {
+  const registered = new Set([...manifestVersions, ...packageOnlyVersions]);
+  return [...packageVersions]
+    .filter((version) => !registered.has(version))
+    .sort();
 }
 
 function packSdkTag(tag, destination) {
   const output = execFileSync(
-    'npm',
+    "npm",
     [
-      'pack',
+      "pack",
       `@adcp/sdk@${tag}`,
-      '--json',
-      '--pack-destination', destination,
-      '--fetch-retries=4',
-      '--fetch-retry-mintimeout=1000',
-      '--fetch-retry-maxtimeout=5000',
-      '--fetch-timeout=20000',
+      "--json",
+      "--pack-destination",
+      destination,
+      "--fetch-retries=4",
+      "--fetch-retry-mintimeout=1000",
+      "--fetch-retry-maxtimeout=5000",
+      "--fetch-timeout=20000",
     ],
-    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] },
+    {
+      encoding: "utf8",
+      maxBuffer: COMMAND_MAX_BUFFER_BYTES,
+      stdio: ["ignore", "pipe", "inherit"],
+    }
   );
   const result = JSON.parse(output);
   const filename = result?.[0]?.filename;
-  if (!filename) throw new Error(`npm pack did not return an archive for @adcp/sdk@${tag}`);
+  if (!filename)
+    throw new Error(`npm pack did not return an archive for @adcp/sdk@${tag}`);
 
   const archivePath = join(destination, filename);
-  const tarListing = execFileSync('tar', ['-tzf', archivePath], { encoding: 'utf8' });
+  const tarListing = execFileSync("tar", ["-tzf", archivePath], {
+    encoding: "utf8",
+    maxBuffer: COMMAND_MAX_BUFFER_BYTES,
+  });
   return packagedComplianceVersions(tarListing);
 }
 
 function run() {
-  const repoRoot = resolve(__dirname, '..');
-  const manifestPath = join(repoRoot, 'static', 'compliance', 'published-versions.json');
-  const manifest = validateManifest(JSON.parse(readFileSync(manifestPath, 'utf8')));
+  const repoRoot = resolve(__dirname, "..");
+  const manifestPath = join(
+    repoRoot,
+    "static",
+    "compliance",
+    "published-versions.json"
+  );
+  const manifest = validateManifest(
+    JSON.parse(readFileSync(manifestPath, "utf8"))
+  );
 
-  const missingLocalBundles = manifest.published_versions.filter(version => (
-    !existsSync(join(repoRoot, 'dist', 'compliance', version, 'index.json'))
-  ));
+  const missingLocalBundles = manifest.published_versions.filter(
+    (version) =>
+      !existsSync(join(repoRoot, "dist", "compliance", version, "index.json"))
+  );
   if (missingLocalBundles.length > 0) {
     throw new Error(
-      `Publication manifest references compliance bundles absent from dist/compliance: ${missingLocalBundles.join(', ')}`,
+      `Publication manifest references compliance bundles absent from dist/compliance: ${missingLocalBundles.join(
+        ", "
+      )}`
     );
   }
 
-  const destination = mkdtempSync(join(tmpdir(), 'adcp-published-compliance-'));
+  const destination = mkdtempSync(join(tmpdir(), "adcp-published-compliance-"));
   try {
     const packageVersions = new Set();
     for (const tag of manifest.npm_tags) {
-      for (const version of packSdkTag(tag, destination)) packageVersions.add(version);
+      for (const version of packSdkTag(tag, destination))
+        packageVersions.add(version);
     }
 
-    const missing = missingPublishedVersions(manifest.published_versions, packageVersions);
+    const missing = missingPublishedVersions(
+      manifest.published_versions,
+      packageVersions,
+      manifest.package_only_versions
+    );
     if (missing.length > 0) {
       throw new Error(
-        `Published @adcp/sdk bundles are missing from ${manifestPath}: ${missing.join(', ')}. ` +
-        'Update the manifest in the same release integration change.',
+        `Published @adcp/sdk bundles are missing from ${manifestPath}: ${missing.join(
+          ", "
+        )}. ` + "Update the manifest in the same release integration change."
       );
     }
   } finally {
@@ -110,7 +193,9 @@ function run() {
   }
 
   console.log(
-    `Published compliance manifest is current for npm tags: ${manifest.npm_tags.join(', ')}.`,
+    `Published compliance manifest is current for npm tags: ${manifest.npm_tags.join(
+      ", "
+    )}.`
   );
 }
 
@@ -124,6 +209,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  COMMAND_MAX_BUFFER_BYTES,
   missingPublishedVersions,
   packagedComplianceVersions,
   validateManifest,

--- a/static/compliance/published-versions.json
+++ b/static/compliance/published-versions.json
@@ -1,7 +1,8 @@
 {
   "schema_version": 1,
-  "description": "Compliance bundles available from a published @adcp/sdk npm package. Hosted grading must not use any other checked-in bundle.",
+  "description": "Compliance bundles available from a published @adcp/sdk npm package. Hosted grading must use published_versions; package_only_versions are SDK opt-in surfaces that are not hosted protocol releases.",
   "npm_tags": ["adcp-3.0", "latest", "rc"],
+  "package_only_versions": ["3.2.0"],
   "published_versions": [
     "3.0.0",
     "3.0.1",

--- a/tests/published-compliance-versions.test.cjs
+++ b/tests/published-compliance-versions.test.cjs
@@ -1,39 +1,74 @@
-const assert = require('node:assert/strict');
-const test = require('node:test');
+const assert = require("node:assert/strict");
+const test = require("node:test");
 const {
+  COMMAND_MAX_BUFFER_BYTES,
   missingPublishedVersions,
   packagedComplianceVersions,
   validateManifest,
-} = require('../scripts/check-published-compliance-versions.cjs');
+} = require("../scripts/check-published-compliance-versions.cjs");
 
-test('extracts compliance cache versions from an SDK package listing', () => {
-  const versions = packagedComplianceVersions([
-    'package/compliance/cache/3.1.11/index.json',
-    'package/compliance/cache/3.1.11.previous/index.json',
-    'package/compliance/cache/3.1.0-beta.7/index.json',
-    'package/compliance/cache/latest/index.json',
-  ].join('\n'));
-
-  assert.deepEqual([...versions], ['3.1.11', '3.1.0-beta.7']);
+test("allows large SDK package and tar listings", () => {
+  assert.ok(COMMAND_MAX_BUFFER_BYTES >= 64 * 1024 * 1024);
 });
 
-test('reports a newly published cache missing from the manifest', () => {
+test("extracts compliance cache versions from an SDK package listing", () => {
+  const versions = packagedComplianceVersions(
+    [
+      "package/compliance/cache/3.1.11/index.json",
+      "package/compliance/cache/3.1.11.previous/index.json",
+      "package/compliance/cache/3.1.0-beta.7/index.json",
+      "package/compliance/cache/latest/index.json",
+    ].join("\n")
+  );
+
+  assert.deepEqual([...versions], ["3.1.11", "3.1.0-beta.7"]);
+});
+
+test("reports a newly published cache missing from the manifest", () => {
   assert.deepEqual(
-    missingPublishedVersions(['3.1.11'], new Set(['3.1.11', '3.1.12'])),
-    ['3.1.12'],
+    missingPublishedVersions(["3.1.11"], new Set(["3.1.11", "3.1.12"])),
+    ["3.1.12"]
   );
 });
 
-test('rejects duplicate or malformed publication metadata', () => {
-  assert.throws(() => validateManifest({
-    schema_version: 1,
-    npm_tags: ['rc', 'rc'],
-    published_versions: ['3.1.11'],
-  }), /npm_tags entries must be unique/);
+test("accepts an explicitly package-only SDK bundle", () => {
+  assert.deepEqual(
+    missingPublishedVersions(["3.1.13"], new Set(["3.1.13", "3.2.0"]), [
+      "3.2.0",
+    ]),
+    []
+  );
+});
 
-  assert.throws(() => validateManifest({
-    schema_version: 1,
-    npm_tags: ['rc'],
-    published_versions: ['latest'],
-  }), /Invalid compliance versions/);
+test("rejects duplicate or malformed publication metadata", () => {
+  assert.throws(
+    () =>
+      validateManifest({
+        schema_version: 1,
+        npm_tags: ["rc", "rc"],
+        published_versions: ["3.1.11"],
+      }),
+    /npm_tags entries must be unique/
+  );
+
+  assert.throws(
+    () =>
+      validateManifest({
+        schema_version: 1,
+        npm_tags: ["rc"],
+        published_versions: ["latest"],
+      }),
+    /Invalid compliance versions/
+  );
+
+  assert.throws(
+    () =>
+      validateManifest({
+        schema_version: 1,
+        npm_tags: ["rc"],
+        published_versions: ["3.1.13"],
+        package_only_versions: ["3.1.13"],
+      }),
+    /both published and package-only/
+  );
 });


### PR DESCRIPTION
## Summary
- raise child-process buffers for large SDK package and tar listings
- model the intentional AdCP 3.2.0 SDK cache as package-only rather than a hosted protocol release
- add regression coverage for both conditions

## Validation
- node --test tests/published-compliance-versions.test.cjs
- npm run check:published-compliance
- Prettier check
- git diff --check