### PR TITLE
feat(training): add proposal negotiation profiles

### DIFF
--- a/.changeset/bright-otters-negotiate.md
+++ b/.changeset/bright-otters-negotiate.md
@@ -1,5 +1,0 @@
----
-"adcontextprotocol": minor
----
-
-Add beta-gated deterministic proposal-negotiation training profiles backed by the SDK's 3.2 preflight, verification, immutable-successor, and atomic transaction primitives. The typed and constrained sellers exercise every typed dimension and reason code, exact replay, hold limits, acceptance, amendments, and cancellations while the existing public sales route remains ask-only.

--- a/.changeset/bright-otters-negotiate.md
+++ b/.changeset/bright-otters-negotiate.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add beta-gated deterministic proposal-negotiation training profiles backed by the SDK's 3.2 preflight, verification, immutable-successor, and atomic transaction primitives. The typed and constrained sellers exercise every typed dimension and reason code, exact replay, hold limits, acceptance, amendments, and cancellations while the existing public sales route remains ask-only.

--- a/docs/media-buy/product-discovery/proposal-negotiation.mdx
+++ b/docs/media-buy/product-discovery/proposal-negotiation.mdx
@@ -455,9 +455,19 @@ Record the authenticated buyer, source IDs, successor IDs, idempotency fingerpri
 
 The canonical compliance scenario is `media_buy_seller/typed_proposal_negotiation`. It exercises capability gating, satisfied and unsatisfied constraints, alternatives, immutable lineage, finalize atomicity, exact replay, acceptance, amendment, cancellation, double-finalize rejection, and multi-source ordering.
 
-The public deterministic training profiles are tracked in [#6558](https://github.com/adcontextprotocol/adcp/issues/6558). They intentionally depend on the TypeScript SDK negotiation primitives; the training seller must not grow a separate validator. Official SDK orchestration helpers are tracked from [#6556](https://github.com/adcontextprotocol/adcp/issues/6556).
+The deterministic training profiles use the proposal-negotiation primitives published in `@adcp/sdk` 13.0.0-rc.26. The ordinary `/sales/mcp` route remains the backward-compatible ask-only seller. Three capability-distinct routes are available to local tests and will become public with the 3.2 beta deployment:
 
-Until a language SDK publishes those helpers, implement against the wire schemas and keep the following boundaries in your adapter:
+| Profile | Route | Deterministic behavior |
+| --- | --- | --- |
+| Typed negotiation | `/sales/profiles/typed-negotiation/mcp` | All typed dimensions, up to three alternatives, successful atomic finalize |
+| Constrained seller | `/sales/profiles/constrained-seller/mcp` | USD floors, product conflicts, and at most two available alternatives |
+| Finalization failure | `/sales/profiles/finalization-failure/mcp` | `hold_unavailable` plus `batch_aborted` siblings with no committed successors |
+
+The constrained route is the canonical three-to-two exercise: request a USD 50,000 cap, include and omit products, apply US/Canada criteria, and request three alternatives. Retry the returned `partial` / `alternatives_unavailable` result with two alternatives before selecting and finalizing one. Exact retries reuse the same idempotency key; a changed alternatives count is a new logical request and needs a new key.
+
+For reason-code labs, the semantic ask markers `[commercially-declined]` and `[unsupported-dimension]` select those bounded fixture outcomes. An ordinary untyped ask reaches `uninterpreted`; impossible typed terms reach `constraint_unsatisfiable`; an unknown source reaches `source_unavailable`. The training seller caps each principal at three concurrent unexpired holds.
+
+Keep the following boundaries in your adapter:
 
 - capability preflight is separate from mutation;
 - exact replay is separate from changed-request retry;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.1.1",
       "dependencies": {
-        "@adcp/sdk": "13.0.0-rc.25",
+        "@adcp/sdk": "13.0.0-rc.26",
         "@anthropic-ai/sdk": "^0.115.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.8.3",
@@ -131,9 +131,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "13.0.0-rc.25",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-13.0.0-rc.25.tgz",
-      "integrity": "sha512-FTU2K1GOCfAuKCHW25/Q3Not4g7fj2P2dok+vNBmZ9d93V+d+OkPRgZk4B4rzGwQVg+2jMqAzvYCZbS8CgFi+A==",
+      "version": "13.0.0-rc.26",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-13.0.0-rc.26.tgz",
+      "integrity": "sha512-EKHz3GaqhNdtrcWvhvdSPDLppsdaQ7kmvyHbnnGzRV/ENuusupGX+wOJcOYJv2KrKq3fyi0UyYR8gF2Vd5N8OQ==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "13.0.0-rc.25",
+    "@adcp/sdk": "13.0.0-rc.26",
     "@anthropic-ai/sdk": "^0.115.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.8.3",

--- a/server/src/training-agent/proposal-negotiation-profiles.ts
+++ b/server/src/training-agent/proposal-negotiation-profiles.ts
@@ -1,0 +1,502 @@
+import { createHash } from "node:crypto";
+import type {
+  CanonicalProposal,
+  ProposalCommercialTerms,
+  ProposalEvaluationContext,
+  ProposalPurchase,
+  ProposalRefinementCapabilities,
+  ProposalRefinementResult,
+} from "@adcp/sdk";
+import {
+  classifyProposalRefinementFailure,
+  createProposalSuccessor,
+  defineProposalRefinementCapabilities,
+} from "@adcp/sdk/server";
+import type { ProposalNegotiationProfile } from "./types.js";
+
+const TYPED_DIMENSIONS = [
+  "total_budget",
+  "cpm",
+  "impressions",
+  "flight",
+  "product_changes",
+  "criteria",
+  "alternatives",
+] as const;
+
+export const ASK_ONLY_PROPOSAL_CAPABILITIES =
+  defineProposalRefinementCapabilities({
+    supported_dimensions: [],
+  });
+
+export const TYPED_PROPOSAL_CAPABILITIES = defineProposalRefinementCapabilities(
+  {
+    supported_dimensions: TYPED_DIMENSIONS,
+    max_alternatives: 3,
+  }
+);
+
+export function proposalCapabilitiesForProfile(
+  profile: ProposalNegotiationProfile | undefined
+): ProposalRefinementCapabilities {
+  return !profile || profile === "ask-only"
+    ? ASK_ONLY_PROPOSAL_CAPABILITIES
+    : TYPED_PROPOSAL_CAPABILITIES;
+}
+
+export interface TrainingProposalPolicyContext {
+  profile: Exclude<ProposalNegotiationProfile, "ask-only">;
+  now: Date;
+  activeHoldCount: number;
+  purchaseForProduct(
+    productId: string,
+    source: CanonicalProposal
+  ): ProposalPurchase | undefined;
+}
+
+type Evaluation = ProposalEvaluationContext<
+  CanonicalProposal,
+  TrainingProposalPolicyContext
+>;
+type TrainingProposalPurchase = ProposalPurchase & {
+  budget?: number;
+  ext?: Record<string, unknown>;
+};
+type TrainingCommercialTerms =
+  ProposalCommercialTerms<TrainingProposalPurchase> & {
+    cancellation_terms?: { effective_at: string; reason?: string };
+  };
+
+function successorId(evaluation: Evaluation, alternative: number): string {
+  const digest = createHash("sha256")
+    .update(evaluation.request.idempotency_key)
+    .update("\0")
+    .update(evaluation.refinement.proposal_id)
+    .update("\0")
+    .update(evaluation.refinement.action)
+    .update("\0")
+    .update(String(alternative))
+    .digest("hex")
+    .slice(0, 24);
+  return `proposal_training_${digest}`;
+}
+
+function futureIso(now: Date, milliseconds: number): string {
+  return new Date(now.getTime() + milliseconds).toISOString();
+}
+
+function unable(
+  sourceProposalId: string,
+  failure: Parameters<typeof classifyProposalRefinementFailure>[0],
+  reason: string,
+  extra: Partial<Extract<ProposalRefinementResult, { outcome: "unable" }>> = {}
+): Extract<ProposalRefinementResult, { outcome: "unable" }> {
+  return {
+    source_proposal_id: sourceProposalId,
+    outcome: "unable",
+    reason_code: classifyProposalRefinementFailure(failure),
+    reason,
+    ...extra,
+  };
+}
+
+function trainingScenario(
+  ask: string | undefined
+): "commercially-declined" | "unsupported-dimension" | undefined {
+  if (!ask) return undefined;
+  if (/\[commercially-declined\]/i.test(ask)) return "commercially-declined";
+  if (/\[unsupported-dimension\]/i.test(ask)) return "unsupported-dimension";
+  return undefined;
+}
+
+function applyBudgetConstraint(
+  terms: ProposalCommercialTerms,
+  constraint: { currency: string; min?: number; max?: number },
+  profile: TrainingProposalPolicyContext["profile"]
+): boolean {
+  const floor = profile === "constrained-seller" ? 40_000 : 10_000;
+  const ceiling = profile === "constrained-seller" ? 150_000 : 250_000;
+  if (constraint.currency !== "USD") return false;
+  const lower = Math.max(floor, constraint.min ?? floor);
+  const upper = Math.min(ceiling, constraint.max ?? ceiling);
+  if (lower > upper) return false;
+  const amount = Math.min(upper, Math.max(lower, 50_000));
+  terms.total_budget = { amount, currency: "USD" };
+  const share =
+    terms.purchases.length > 0 ? amount / terms.purchases.length : amount;
+  for (const purchase of terms.purchases)
+    (purchase as TrainingProposalPurchase).budget = share;
+  return true;
+}
+
+function applyCpmConstraint(
+  terms: ProposalCommercialTerms,
+  constraint: { max: number; currency: string },
+  profile: TrainingProposalPolicyContext["profile"]
+): boolean {
+  const floor = profile === "constrained-seller" ? 8 : 2;
+  if (constraint.currency !== "USD" || constraint.max < floor) return false;
+  for (const purchase of terms.purchases) {
+    purchase.pricing = {
+      ...purchase.pricing,
+      pricing_model: "cpm",
+      currency: "USD",
+      fixed_price: floor,
+    };
+    delete purchase.pricing.floor_price;
+  }
+  return true;
+}
+
+function applyImpressionsConstraint(
+  terms: ProposalCommercialTerms,
+  constraint: { min: number },
+  profile: TrainingProposalPolicyContext["profile"]
+): boolean {
+  const ceiling = profile === "constrained-seller" ? 2_000_000 : 10_000_000;
+  if (constraint.min > ceiling || terms.purchases.length === 0) return false;
+  const perPurchase = Math.ceil(constraint.min / terms.purchases.length);
+  for (const purchase of terms.purchases) purchase.impressions = perPurchase;
+  return true;
+}
+
+function applyFlightConstraint(
+  terms: ProposalCommercialTerms,
+  constraint: { start_no_later_than?: string; end_no_earlier_than?: string }
+): boolean {
+  if (constraint.start_no_later_than !== undefined) {
+    const deadline = Date.parse(constraint.start_no_later_than);
+    if (!Number.isFinite(deadline)) return false;
+    const current =
+      terms.start_time === "asap"
+        ? Number.POSITIVE_INFINITY
+        : Date.parse(terms.start_time);
+    if (!Number.isFinite(current) || current > deadline) {
+      terms.start_time = constraint.start_no_later_than;
+      for (const purchase of terms.purchases)
+        purchase.start_time = constraint.start_no_later_than;
+    }
+  }
+  if (constraint.end_no_earlier_than !== undefined) {
+    const boundary = Date.parse(constraint.end_no_earlier_than);
+    if (!Number.isFinite(boundary)) return false;
+    const current = Date.parse(terms.end_time);
+    if (!Number.isFinite(current) || current < boundary) {
+      terms.end_time = constraint.end_no_earlier_than;
+      for (const purchase of terms.purchases)
+        purchase.end_time = constraint.end_no_earlier_than;
+    }
+  }
+  return true;
+}
+
+function applyProductChanges(
+  terms: ProposalCommercialTerms,
+  evaluation: Evaluation
+): Record<string, "include" | "omit"> {
+  const changes =
+    evaluation.refinement.action === "revise"
+      ? evaluation.refinement.product_changes ?? {}
+      : {};
+  const unsatisfied: Record<string, "include" | "omit"> = {};
+  const purchases = new Map(
+    terms.purchases.map((purchase) => [purchase.product_id, purchase])
+  );
+  for (const [productId, action] of Object.entries(changes)) {
+    if (action === "omit") purchases.delete(productId);
+  }
+  for (const [productId, action] of Object.entries(changes)) {
+    if (action !== "include" || purchases.has(productId)) continue;
+    const purchase = evaluation.context.purchaseForProduct(
+      productId,
+      evaluation.source!
+    );
+    if (
+      !purchase ||
+      (evaluation.context.profile === "constrained-seller" &&
+        productId.toLowerCase().includes("premium"))
+    ) {
+      unsatisfied[productId] = action;
+      continue;
+    }
+    purchases.set(productId, structuredClone(purchase));
+  }
+  if (
+    evaluation.context.profile === "constrained-seller" &&
+    purchases.size > 3
+  ) {
+    for (const [productId, action] of Object.entries(changes)) {
+      if (
+        action === "include" &&
+        !terms.purchases.some((purchase) => purchase.product_id === productId)
+      ) {
+        unsatisfied[productId] = action;
+        purchases.delete(productId);
+      }
+    }
+  }
+  if (purchases.size === 0) {
+    const omitted = Object.entries(changes).find(
+      ([, action]) => action === "omit"
+    );
+    if (omitted) unsatisfied[omitted[0]] = "omit";
+  } else {
+    terms.purchases = Array.from(purchases.values());
+  }
+  return unsatisfied;
+}
+
+function targetingResolution(
+  evaluation: Evaluation
+): Record<string, unknown> | undefined {
+  if (
+    evaluation.refinement.action !== "revise" ||
+    !evaluation.refinement.criteria
+  )
+    return undefined;
+  const criteria = evaluation.refinement.criteria;
+  return {
+    applied: true,
+    ...(criteria.product_ids && { product_ids: [...criteria.product_ids] }),
+    ...(criteria.targeting_overlay && {
+      targeting_overlay: structuredClone(criteria.targeting_overlay),
+    }),
+    ...(criteria.required_overlay_support && {
+      required_overlay_support: structuredClone(
+        criteria.required_overlay_support
+      ),
+    }),
+  };
+}
+
+function finalize(evaluation: Evaluation): ProposalRefinementResult {
+  const sourceId = evaluation.refinement.proposal_id;
+  const source = evaluation.source;
+  if (!source)
+    return unable(
+      sourceId,
+      { source_unavailable: true },
+      "The source proposal does not exist."
+    );
+  if (evaluation.context.profile === "finalization-failure") {
+    if (evaluation.index === 0) {
+      return unable(
+        sourceId,
+        { hold_unavailable: true },
+        "The deterministic hold policy rejected this inventory hold."
+      );
+    }
+    return unable(
+      sourceId,
+      { batch_aborted: true },
+      "The batch was aborted because a sibling hold could not be created."
+    );
+  }
+  const finalizeCount = evaluation.request.refinements.filter(
+    (entry) => entry.action === "finalize"
+  ).length;
+  if (evaluation.context.activeHoldCount + finalizeCount > 3) {
+    if (evaluation.index === 0) {
+      return unable(
+        sourceId,
+        { hold_unavailable: true },
+        "The buyer has reached the deterministic three-hold concurrency cap."
+      );
+    }
+    return unable(
+      sourceId,
+      { batch_aborted: true },
+      "The batch was aborted because a sibling exceeded the hold-policy cap."
+    );
+  }
+  return {
+    source_proposal_id: sourceId,
+    outcome: "finalized",
+    proposal: createProposalSuccessor(source, {
+      ...source,
+      proposal_id: successorId(evaluation, 0),
+      proposal_status: "committed",
+      expires_at: futureIso(evaluation.context.now, 15 * 60 * 1000),
+      commercial_terms: structuredClone(source.commercial_terms),
+    }),
+  };
+}
+
+export function evaluateTrainingProposal(
+  evaluation: Evaluation
+): ProposalRefinementResult {
+  if (evaluation.refinement.action === "finalize") return finalize(evaluation);
+  const sourceId = evaluation.refinement.proposal_id;
+  const source = evaluation.source;
+  if (!source)
+    return unable(
+      sourceId,
+      { source_unavailable: true },
+      "The source proposal does not exist."
+    );
+
+  const scenario = trainingScenario(evaluation.refinement.ask);
+  if (scenario === "commercially-declined") {
+    return unable(
+      sourceId,
+      { commercially_declined: true },
+      "The seller declined the requested commercial change."
+    );
+  }
+  if (scenario === "unsupported-dimension") {
+    return unable(
+      sourceId,
+      { unsupported_dimension: true },
+      "The selected fixture does not implement that criteria subtype."
+    );
+  }
+
+  const terms = structuredClone(source.commercial_terms);
+  const unsatisfiedConstraints: string[] = [];
+  // Resolve membership first so every typed boundary is evaluated against
+  // the exact purchase set that will be returned.
+  const unsatisfiedProductChanges = applyProductChanges(terms, evaluation);
+  const constraints = evaluation.refinement.constraints;
+  if (
+    constraints?.total_budget &&
+    !applyBudgetConstraint(
+      terms,
+      constraints.total_budget,
+      evaluation.context.profile
+    )
+  ) {
+    unsatisfiedConstraints.push("total_budget");
+  }
+  if (
+    constraints?.cpm &&
+    !applyCpmConstraint(terms, constraints.cpm, evaluation.context.profile)
+  ) {
+    unsatisfiedConstraints.push("cpm");
+  }
+  if (
+    constraints?.impressions &&
+    !applyImpressionsConstraint(
+      terms,
+      constraints.impressions,
+      evaluation.context.profile
+    )
+  ) {
+    unsatisfiedConstraints.push("impressions");
+  }
+  if (
+    constraints?.flight &&
+    !applyFlightConstraint(terms, constraints.flight)
+  ) {
+    unsatisfiedConstraints.push("flight");
+  }
+  if (
+    unsatisfiedConstraints.length > 0 ||
+    Object.keys(unsatisfiedProductChanges).length > 0
+  ) {
+    return unable(
+      sourceId,
+      {
+        unsatisfied_constraints: unsatisfiedConstraints,
+        unsatisfied_product_changes: unsatisfiedProductChanges,
+      },
+      "One or more typed commercial constraints cannot be satisfied by this profile.",
+      {
+        ...(unsatisfiedConstraints.length > 0 && {
+          unsatisfied_constraints: unsatisfiedConstraints,
+        }),
+        ...(Object.keys(unsatisfiedProductChanges).length > 0 && {
+          unsatisfied_product_changes: unsatisfiedProductChanges,
+        }),
+        suggestions: [
+          "Relax the listed constraint or choose another deterministic seller profile.",
+        ],
+      }
+    );
+  }
+
+  const requestedCount = evaluation.refinement.alternatives?.count ?? 1;
+  const availableCount =
+    evaluation.context.profile === "constrained-seller"
+      ? Math.min(requestedCount, 2)
+      : requestedCount;
+  const kind =
+    evaluation.refinement.change_kind === "cancellation"
+      ? "media_buy_cancellation"
+      : source.proposal_status === "accepted"
+      ? "media_buy_update"
+      : source.proposal_kind;
+  const proposals = Array.from({ length: availableCount }, (_, alternative) => {
+    const alternativeTerms = structuredClone(terms);
+    const firstPurchase = alternativeTerms.purchases[0] as
+      | TrainingProposalPurchase
+      | undefined;
+    if (firstPurchase) {
+      firstPurchase.ext = {
+        ...(firstPurchase.ext ?? {}),
+        training_alternative: alternative + 1,
+      };
+    }
+    if (kind === "media_buy_cancellation") {
+      (alternativeTerms as TrainingCommercialTerms).cancellation_terms = {
+        effective_at: futureIso(evaluation.context.now, 60 * 60 * 1000),
+        ...(evaluation.refinement.action === "revise" &&
+          evaluation.refinement.ask && {
+            reason: evaluation.refinement.ask.slice(0, 500),
+          }),
+      };
+    }
+    return createProposalSuccessor(source, {
+      ...source,
+      proposal_id: successorId(evaluation, alternative),
+      proposal_kind: kind,
+      proposal_status: "draft",
+      expires_at: futureIso(evaluation.context.now, 24 * 60 * 60 * 1000),
+      commercial_terms: alternativeTerms,
+      ...(source.proposal_status === "accepted" && {
+        media_buy_id: source.media_buy_id,
+        base_media_buy_revision: source.base_media_buy_revision,
+      }),
+      accepted_at: undefined,
+      insertion_order: undefined,
+    });
+  });
+
+  if (requestedCount > availableCount) {
+    return {
+      source_proposal_id: sourceId,
+      outcome: "partial",
+      proposals,
+      reason_code: classifyProposalRefinementFailure({
+        alternatives_unavailable: true,
+      }),
+      reason: `The constrained profile produced ${availableCount} of ${requestedCount} requested alternatives.`,
+      suggestions: [`Retry with alternatives.count set to ${availableCount}.`],
+      ...(targetingResolution(evaluation) && {
+        targeting_resolution: targetingResolution(evaluation),
+      }),
+    };
+  }
+  if (
+    evaluation.refinement.ask &&
+    !constraints &&
+    !evaluation.refinement.product_changes &&
+    !evaluation.refinement.criteria &&
+    !evaluation.refinement.alternatives &&
+    !evaluation.refinement.change_kind
+  ) {
+    return {
+      source_proposal_id: sourceId,
+      outcome: "partial",
+      proposals,
+      reason_code: classifyProposalRefinementFailure({}),
+      reason:
+        "The deterministic seller could not fully interpret the free-text ask.",
+      suggestions: ["Express the request with typed constraints."],
+    };
+  }
+  return {
+    source_proposal_id: sourceId,
+    outcome: "revised",
+    proposals,
+  };
+}

--- a/server/src/training-agent/state.ts
+++ b/server/src/training-agent/state.ts
@@ -270,6 +270,7 @@ function createSession(): SessionState {
     rightsGrants: new Map(),
     negotiatedPricingOptions: new Map(),
     proposalLifecycleLinks: new Map(),
+    proposalRefinementRecords: new Map(),
     creatives: new Map(),
     signalActivations: new Map(),
     buildVariantTargets: new Map(),
@@ -496,6 +497,7 @@ function deserializeSession(data: Record<string, unknown>): SessionState {
     rightsGrants: asMap(hydrated.rightsGrants, fresh.rightsGrants),
     negotiatedPricingOptions: asMap(hydrated.negotiatedPricingOptions, fresh.negotiatedPricingOptions),
     proposalLifecycleLinks: asMap(hydrated.proposalLifecycleLinks, fresh.proposalLifecycleLinks),
+    proposalRefinementRecords: asMap(hydrated.proposalRefinementRecords, fresh.proposalRefinementRecords),
     buildVariantTargets: asMap(hydrated.buildVariantTargets, fresh.buildVariantTargets),
     usageRecords: Array.isArray(hydrated.usageRecords) ? hydrated.usageRecords : [],
     complyExtensions: {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -18,6 +18,12 @@ import {
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { canonicalize, PostgresTaskStore } from '@adcp/sdk';
 import {
+  createProposalRefinementHandler,
+  type ProposalRefinementScope,
+  type ProposalRefinementStore,
+  type ProposalSourceExpectation,
+} from '@adcp/sdk/server';
+import {
   canonicalFormatLegacyResolverFromCatalogSnapshots,
   canonicalFormatLegacyResolverFromRoutes,
   legacyRoutesForProduct,
@@ -63,10 +69,18 @@ import type {
   LegacyPreviewCreativeResponse as PreviewCreativeResponse,
   LegacyBuildCreativeResponse as BuildCreativeResponse,
   LegacyCreativeManifest as AdcpCreativeManifest,
+  CanonicalProposal,
+  ProposalPurchase,
+  RefineProposalsRequest,
 } from '@adcp/sdk';
 import { CreativeAssetSchema, CreativeManifestSchema, GetProductsRequestSchema } from '@adcp/sdk/schemas';
 import { verifyGovernedServiceAuthorization } from './governance-verify.js';
 import { getCanonicalBase } from './canonical-base.js';
+import {
+  evaluateTrainingProposal,
+  proposalCapabilitiesForProfile,
+  type TrainingProposalPolicyContext,
+} from './proposal-negotiation-profiles.js';
 
 /** Escape HTML special characters to prevent injection in generated HTML responses. */
 function escapeHtmlAttr(s: string): string {
@@ -4562,6 +4576,7 @@ export function projectProductDiscoveryResult(
 ): Record<string, unknown> {
   if (!isProductDiscoveryTool(toolName) || toolName === 'get_products') return result;
   if (Array.isArray(result.errors) && result.errors.length > 0 && !Array.isArray(result.products)) return result;
+  if (toolName === 'refine_proposals' && Array.isArray(result.results)) return result;
   if (toolName === 'request_proposals' && result.status === 'rejected') {
     return {
       outcome: 'rejected',
@@ -6662,6 +6677,21 @@ async function handleGetProductsUnlocked(
   for (const proposal of retainedCommittedProposals.values()) {
     if (!persistedProposalIds.has(proposal.proposal_id)) persistedProposals.push(proposal);
   }
+  if (usesTypedProposalNegotiation(ctx)) {
+    const canonicalProducts = new Map(
+      registryProducts.map(product => [product.product_id, product]),
+    );
+    for (const proposal of persistedProposals) {
+      if (session.proposalRefinementRecords.has(proposal.proposal_id)) continue;
+      session.proposalRefinementRecords.set(proposal.proposal_id, {
+        proposal: outwardProposal(
+          proposal as unknown as Record<string, unknown>,
+          canonicalProducts,
+        ) as unknown as CanonicalProposal,
+        version: 1,
+      });
+    }
+  }
   // Only refine requests establish durable context for later refinements.
   // Brief/wholesale discovery must remain read-only so concurrent reads cannot
   // overwrite a proposal committed by a serialized refine request.
@@ -7711,6 +7741,7 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
   }
   const mediaBuyCurrency = accountCurrency ?? req.total_budget?.currency ?? 'USD';
   let executedCompactProposal: Proposal | undefined;
+  let executedCompactProposalSession: SessionState | undefined;
 
   // Consume any single-shot directive registered by
   // comply_test_controller.force_create_media_buy_arm. Runs before all other
@@ -8081,7 +8112,10 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
       const candidate = proposalSession.lastGetProductsContext?.proposals?.find(
         p => p.proposal_id === req.proposal_id,
       );
-      if (candidate) proposal = candidate;
+      if (candidate) {
+        proposal = candidate;
+        executedCompactProposalSession = proposalSession;
+      }
     }
     if (proposal) {
       const internal = proposal as unknown as Record<string, unknown>;
@@ -8222,7 +8256,12 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
         ...(bidPrice !== undefined && { bid_price: bidPrice }),
       };
     });
-    if (compactProposal) executedCompactProposal = proposal;
+    if (compactProposal) {
+      executedCompactProposal = proposal;
+      if (!executedCompactProposalSession && session.proposalRefinementRecords.has(proposal.proposal_id)) {
+        executedCompactProposalSession = session;
+      }
+    }
   }
 
   if (!req.packages?.length) {
@@ -8587,6 +8626,27 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
         status: 'closed',
         close_reason: 'accepted_with_seller',
       };
+    }
+    const proposalSession = executedCompactProposalSession ?? session;
+    const record = proposalSession.proposalRefinementRecords.get(executedCompactProposal.proposal_id);
+    if (record) {
+      proposalSession.proposalRefinementRecords.set(executedCompactProposal.proposal_id, {
+        ...record,
+        version: record.version + 1,
+        accepted: {
+          accepted_at: now,
+          media_buy_id: mediaBuyId,
+          media_buy_revision: mediaBuy.revision,
+        },
+      });
+      for (const [proposalId, source] of proposalSession.proposalRefinementRecords) {
+        if (source.activeHold?.proposal_id !== executedCompactProposal.proposal_id) continue;
+        proposalSession.proposalRefinementRecords.set(proposalId, {
+          ...source,
+          version: source.version + 1,
+          activeHold: undefined,
+        });
+      }
     }
   }
   session.mediaBuys.set(mediaBuyId, mediaBuy);
@@ -10285,7 +10345,7 @@ export async function handleGetAdcpCapabilities(args: ToolArgs, ctx: TrainingCon
       buying_modes: wholesaleProfile.productWholesale ? ['brief', 'wholesale', 'refine'] : ['brief', 'refine'],
       ...(supportsGetProductsRejected(servedAdcpVersion) && {
         lifecycle_tools: [...PRODUCT_DISCOVERY_TOOLS],
-        proposal_refinement: { supported_dimensions: [] },
+        proposal_refinement: proposalCapabilitiesForProfile(ctx.proposalNegotiationProfile),
       }),
       supports_proposals: true,
       performance_feedback: {
@@ -12179,6 +12239,276 @@ export async function handleReportUsage(args: ToolArgs, ctx: TrainingContext) {
 
 type ToolHandler = (args: ToolArgs, ctx: TrainingContext) => object | Promise<object>;
 
+type TrainingProposalRecord = SessionState['proposalRefinementRecords'] extends Map<string, infer T>
+  ? T
+  : never;
+
+function canonicalProposalFromRecord(record: TrainingProposalRecord): CanonicalProposal {
+  if (!record.accepted) return structuredClone(record.proposal);
+  return {
+    ...structuredClone(record.proposal),
+    proposal_status: 'accepted',
+    accepted_at: record.accepted.accepted_at,
+    media_buy_id: record.accepted.media_buy_id,
+    base_media_buy_revision: record.accepted.media_buy_revision,
+  };
+}
+
+function internalProposalFromCanonical(successor: CanonicalProposal, source: Proposal): Proposal {
+  const totalBudget = successor.commercial_terms.total_budget;
+  const purchaseBudgets = successor.commercial_terms.purchases.map(
+    purchase => (purchase as ProposalPurchase & { budget?: number }).budget ?? 0,
+  );
+  const explicitBudgetTotal = purchaseBudgets.reduce((sum, amount) => sum + amount, 0);
+  const allocations = successor.commercial_terms.purchases.map((purchase, index, purchases) => ({
+    product_id: purchase.product_id,
+    pricing_option_id: purchase.pricing_option_id,
+    allocation_percentage: explicitBudgetTotal > 0
+      ? purchaseBudgets[index]! / explicitBudgetTotal * 100
+      : 100 / purchases.length,
+  }));
+  const internal = {
+    ...structuredClone(source),
+    proposal_id: successor.proposal_id,
+    name: successor.name,
+    ...(successor.description !== undefined && { description: successor.description }),
+    ...(successor.brief_alignment !== undefined && { brief_alignment: successor.brief_alignment }),
+    allocations,
+    ...(totalBudget && {
+      total_budget_guidance: {
+        min: totalBudget.amount,
+        max: totalBudget.amount,
+        recommended: totalBudget.amount,
+        currency: totalBudget.currency,
+      },
+    }),
+    proposal_status: successor.proposal_status,
+    ...(successor.expires_at !== undefined && { expires_at: successor.expires_at }),
+    ...(successor.insertion_order !== undefined && { insertion_order: structuredClone(successor.insertion_order) }),
+    __source_proposal_id: successor.parent_proposal_id,
+    __parent_proposal_id: successor.parent_proposal_id,
+    __proposal_kind: successor.proposal_kind,
+    ...(successor.media_buy_id !== undefined && { __media_buy_id: successor.media_buy_id }),
+    ...(successor.base_media_buy_revision !== undefined && {
+      __base_media_buy_revision: successor.base_media_buy_revision,
+    }),
+    __canonical_commercial_terms: structuredClone(successor.commercial_terms),
+    __canonical_terms_digest: successor.terms_digest,
+  } as unknown as Record<string, unknown>;
+  delete internal.__executed;
+  delete internal.__accepted_at;
+  delete internal.__media_buy_revision;
+  delete internal.__opportunity_update;
+  return internal as unknown as Proposal;
+}
+
+function purchaseForTrainingProduct(productId: string, source: CanonicalProposal): ProposalPurchase | undefined {
+  const product = getCatalog().find(entry => entry.product.product_id === productId)?.product;
+  if (!product) return undefined;
+  const pricing = product.pricing_options?.[0];
+  if (!pricing) return undefined;
+  const pricingOptionId = pricing.pricing_option_id;
+  return {
+    product_id: productId,
+    pricing_option_id: pricingOptionId,
+    pricing: canonicalPricingSnapshot(pricing, pricingOptionId) as unknown as ProposalPurchase['pricing'],
+    start_time: source.commercial_terms.start_time,
+    end_time: source.commercial_terms.end_time,
+  };
+}
+
+function proposalProductsForResults(results: readonly object[]): Array<{ product_id: string; name: string }> {
+  const productIds = new Set<string>();
+  for (const rawResult of results) {
+    const result = rawResult as { outcome?: string; proposal?: CanonicalProposal; proposals?: CanonicalProposal[] };
+    const proposals = result.outcome === 'finalized'
+      ? result.proposal ? [result.proposal] : []
+      : result.proposals ?? [];
+    for (const proposal of proposals) {
+      for (const purchase of proposal.commercial_terms.purchases) productIds.add(purchase.product_id);
+    }
+  }
+  return getCatalog()
+    .map(entry => entry.product)
+    .filter(product => productIds.has(product.product_id))
+    .map(product => ({ product_id: product.product_id, name: product.name }));
+}
+
+function proposalStoreForSession(
+  session: SessionState,
+  now: Date,
+): ProposalRefinementStore<CanonicalProposal> {
+  return {
+    get(_scope: Readonly<ProposalRefinementScope>, proposalId: string) {
+      const record = session.proposalRefinementRecords.get(proposalId);
+      if (!record) return null;
+      const activeHold = record.activeHold && Date.parse(record.activeHold.expires_at) > now.getTime()
+        ? structuredClone(record.activeHold)
+        : undefined;
+      return {
+        proposal: canonicalProposalFromRecord(record),
+        version: String(record.version),
+        ...(activeHold && { active_hold: activeHold }),
+      };
+    },
+    begin(
+      _scope: Readonly<ProposalRefinementScope>,
+      expectedSources: readonly ProposalSourceExpectation[],
+    ) {
+      let staged: readonly CanonicalProposal[] = [];
+      return {
+        stage(proposals) {
+          const ids = new Set<string>();
+          for (const proposal of proposals) {
+            if (ids.has(proposal.proposal_id) || session.proposalRefinementRecords.has(proposal.proposal_id)) {
+              throw new Error(`Proposal successor already exists: ${proposal.proposal_id}`);
+            }
+            ids.add(proposal.proposal_id);
+          }
+          staged = structuredClone(proposals);
+        },
+        commit() {
+          const nextRecords = new Map(session.proposalRefinementRecords);
+          const currentInternal = session.lastGetProductsContext?.proposals ?? [];
+          const nextInternal = [...currentInternal];
+          const internalById = new Map(currentInternal.map(proposal => [proposal.proposal_id, proposal]));
+          for (const expected of expectedSources) {
+            const current = nextRecords.get(expected.proposal_id);
+            const version = current ? String(current.version) : null;
+            if (version !== expected.version) {
+              throw new Error(`Proposal source version changed: ${expected.proposal_id}`);
+            }
+            if (
+              expected.action === 'finalize'
+              && current?.activeHold
+              && Date.parse(current.activeHold.expires_at) > now.getTime()
+            ) {
+              throw new Error(`Proposal source already has an active hold: ${expected.proposal_id}`);
+            }
+          }
+          for (const proposal of staged) {
+            const sourceId = proposal.parent_proposal_id;
+            const sourceInternal = sourceId ? internalById.get(sourceId) : undefined;
+            if (!sourceInternal) throw new Error(`Internal source proposal is missing: ${sourceId ?? 'unknown'}`);
+            const internal = internalProposalFromCanonical(proposal, sourceInternal);
+            nextInternal.push(internal);
+            internalById.set(proposal.proposal_id, internal);
+            nextRecords.set(proposal.proposal_id, {
+              proposal: structuredClone(proposal),
+              version: 1,
+            });
+          }
+          for (const expected of expectedSources) {
+            const current = nextRecords.get(expected.proposal_id)!;
+            const hold = expected.action === 'finalize'
+              ? staged.find(proposal => proposal.parent_proposal_id === expected.proposal_id)
+              : undefined;
+            nextRecords.set(expected.proposal_id, {
+              ...current,
+              version: current.version + 1,
+              ...(hold?.expires_at && {
+                activeHold: { proposal_id: hold.proposal_id, expires_at: hold.expires_at },
+              }),
+            });
+          }
+          session.proposalRefinementRecords = nextRecords;
+          session.lastGetProductsContext = {
+            products: session.lastGetProductsContext?.products,
+            proposals: nextInternal,
+          };
+        },
+        rollback() {
+          staged = [];
+        },
+      };
+    },
+  };
+}
+
+async function handleTypedProposalRefinement(args: ToolArgs, ctx: TrainingContext): Promise<object> {
+  const profile = ctx.proposalNegotiationProfile;
+  if (!profile || profile === 'ask-only') {
+    return { errors: [{ code: 'UNSUPPORTED_FEATURE', message: 'Typed proposal negotiation is not enabled.' }] };
+  }
+  const sessionScope = sessionKeyFromArgs({}, ctx.mode, ctx.userId, ctx.moduleId, ctx.principal ?? 'anonymous');
+  const sessionHash = createHash('sha256').update(sessionScope).digest('hex');
+  const lockPrincipal = 'get-products-session-mutex';
+  const lockKey = `get-products-session:${sessionHash}`;
+  const lockStore = getIdempotencyStore();
+  const claim = await lockStore.check({
+    principal: lockPrincipal,
+    key: lockKey,
+    payload: { session: sessionHash },
+  });
+  if (claim.kind !== 'miss') {
+    return {
+      errors: [{
+        code: 'CONFLICT',
+        message: 'Another proposal lifecycle request is already updating this session. Retry shortly.',
+        recovery: 'transient',
+      }],
+    };
+  }
+  try {
+    evictSessionFromRequestCache(sessionScope);
+    const session = await getSession(sessionScope);
+    const now = new Date();
+    const activeHoldCount = Array.from(session.proposalRefinementRecords.values())
+      .filter(record => record.activeHold && Date.parse(record.activeHold.expires_at) > now.getTime())
+      .length;
+    const policyContext: TrainingProposalPolicyContext = {
+      profile,
+      now,
+      activeHoldCount,
+      purchaseForProduct: purchaseForTrainingProduct,
+    };
+    const handler = createProposalRefinementHandler<
+      CanonicalProposal,
+      { product_id: string; name: string },
+      TrainingProposalPolicyContext
+    >({
+      capabilities: proposalCapabilitiesForProfile(profile),
+      store: proposalStoreForSession(session, now),
+      scope: (): ProposalRefinementScope => ({
+        tenant_id: ctx.tenantId ?? 'sales',
+        principal_id: ctx.principal ?? 'anonymous',
+      }),
+      evaluate: evaluation => evaluateTrainingProposal(evaluation),
+      products: results => proposalProductsForResults(results),
+      now: () => now,
+    });
+    const response = await handler({
+      ...(args as unknown as RefineProposalsRequest),
+      adcp_version: '3.2',
+      adcp_major_version: 3,
+    }, policyContext);
+    await flushDirtySessions();
+    return response;
+  } catch (error) {
+    const structured = error as Error & {
+      code?: string;
+      field?: string;
+      recovery?: string;
+      details?: Record<string, unknown>;
+    };
+    return {
+      errors: [{
+        code: structured.code ?? 'INVALID_STATE',
+        message: structured.message,
+        ...(structured.field && { field: structured.field }),
+        ...(structured.recovery && { recovery: structured.recovery }),
+        ...(structured.details && { details: structured.details }),
+      }],
+    };
+  } finally {
+    await lockStore.release({
+      principal: lockPrincipal,
+      key: lockKey,
+      claimToken: claim.claimToken,
+    });
+  }
+}
+
 const HANDLER_MAP: Record<string, ToolHandler> = {
   get_products: handleGetProducts,
   list_products: handleGetProducts,
@@ -12367,6 +12697,11 @@ type UnsupportedTrainingRefinement = {
   index: number;
 };
 
+function usesTypedProposalNegotiation(ctx: TrainingContext): boolean {
+  return ctx.proposalNegotiationProfile !== undefined
+    && ctx.proposalNegotiationProfile !== 'ask-only';
+}
+
 function unsupportedTrainingProposalRefinement(
   toolName: string,
   args: Record<string, unknown>,
@@ -12424,7 +12759,9 @@ async function executeTrainingAgentToolInContext(
   ) {
     return { success: false, error: `Unknown tool: ${toolName}` };
   }
-  const handler = HANDLER_MAP[toolName];
+  const handler = toolName === 'refine_proposals' && usesTypedProposalNegotiation(ctx)
+    ? handleTypedProposalRefinement
+    : HANDLER_MAP[toolName];
   if (!handler) {
     return { success: false, error: `Unknown tool: ${toolName}` };
   }
@@ -12446,14 +12783,18 @@ async function executeTrainingAgentToolInContext(
   if (aliasValidationError) {
     return { success: false, error: aliasValidationError.message };
   }
-  const unsupportedRefinement = unsupportedTrainingProposalRefinement(toolName, initialHandlerArgs);
+  const unsupportedRefinement = usesTypedProposalNegotiation(ctx)
+    ? undefined
+    : unsupportedTrainingProposalRefinement(toolName, initialHandlerArgs);
   if (unsupportedRefinement) {
     return {
       success: false,
       error: `UNSUPPORTED_FEATURE at refinements.${unsupportedRefinement.index}.${unsupportedRefinement.field}: The training seller does not support the ${unsupportedRefinement.dimension} typed proposal-refinement dimension.`,
     };
   }
-  const normalizedHandlerArgs = normalizeProductDiscoveryArgs(toolName, initialHandlerArgs);
+  const normalizedHandlerArgs = toolName === 'refine_proposals' && usesTypedProposalNegotiation(ctx)
+    ? initialHandlerArgs
+    : normalizeProductDiscoveryArgs(toolName, initialHandlerArgs);
   const authPrincipal = ctx.principal ?? ctx.userId ?? 'anonymous';
   let accountScope: string | undefined;
   try {
@@ -12477,10 +12818,9 @@ async function executeTrainingAgentToolInContext(
   // The read-only legacy/list surfaces permit keyless calls, but they still
   // share the canonical get_products request contract. Validate the logical
   // request before deciding whether this attempt participates in replay.
-  const productValidationError = validateIdempotencyProtectedInput(
-    canonicalProductDiscoveryTool(toolName),
-    handlerArgs,
-  );
+  const productValidationError = toolName === 'refine_proposals' && usesTypedProposalNegotiation(ctx)
+    ? undefined
+    : validateIdempotencyProtectedInput(canonicalProductDiscoveryTool(toolName), handlerArgs);
   if (productValidationError) {
     return { success: false, error: productValidationError.message };
   }
@@ -12633,7 +12973,9 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
     const { context: callerContext, ...initialHandlerArgs } = rawArgs;
     const versionResolution = resolveServedAdcpVersionForTool(name, initialHandlerArgs);
 
-    const handler = HANDLER_MAP[name];
+    const handler = name === 'refine_proposals' && usesTypedProposalNegotiation(ctx)
+      ? handleTypedProposalRefinement
+      : HANDLER_MAP[name];
 
     if (!versionResolution.ok) {
       return {
@@ -12700,7 +13042,9 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
       };
     }
 
-    const unsupportedRefinement = unsupportedTrainingProposalRefinement(name, initialHandlerArgs);
+    const unsupportedRefinement = usesTypedProposalNegotiation(ctx)
+      ? undefined
+      : unsupportedTrainingProposalRefinement(name, initialHandlerArgs);
     if (unsupportedRefinement) {
       return {
         result: adcpError('UNSUPPORTED_FEATURE', {
@@ -12715,7 +13059,9 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
         flushable: true,
       };
     }
-    const normalizedHandlerArgs = normalizeProductDiscoveryArgs(name, initialHandlerArgs);
+    const normalizedHandlerArgs = name === 'refine_proposals' && usesTypedProposalNegotiation(ctx)
+      ? initialHandlerArgs
+      : normalizeProductDiscoveryArgs(name, initialHandlerArgs);
 
     // Check for task-augmented request (explicit `task` field in params).
     // Dry-run requests always return synchronously — there's no reason to
@@ -12776,10 +13122,9 @@ export function createTrainingAgentServer(ctx: TrainingContext): Server {
     // Product reads may omit an idempotency key, but keylessness must never
     // weaken their request validation. The split names normalize to the same
     // canonical get_products contract before this check.
-    const productValidationError = validateIdempotencyProtectedInput(
-      canonicalProductDiscoveryTool(name),
-      handlerArgs,
-    );
+    const productValidationError = name === 'refine_proposals' && usesTypedProposalNegotiation(ctx)
+      ? undefined
+      : validateIdempotencyProtectedInput(canonicalProductDiscoveryTool(name), handlerArgs);
     if (productValidationError) {
       return {
         result: adcpError('INVALID_REQUEST', {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -12493,9 +12493,9 @@ async function handleTypedProposalRefinement(args: ToolArgs, ctx: TrainingContex
     };
     const classifiedDomainFailure =
       Boolean(structured.code) ||
-      structured.message.startsWith('Proposal source version changed:') ||
-      structured.message.startsWith('Proposal source already has an active hold:') ||
-      structured.message.startsWith('Proposal successor already exists:');
+      structured.message?.startsWith('Proposal source version changed:') ||
+      structured.message?.startsWith('Proposal source already has an active hold:') ||
+      structured.message?.startsWith('Proposal successor already exists:');
     if (!classifiedDomainFailure) {
       logger.error({ error, profile, sessionHash }, 'Unexpected proposal refinement failure');
     }

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -12491,6 +12491,14 @@ async function handleTypedProposalRefinement(args: ToolArgs, ctx: TrainingContex
       recovery?: string;
       details?: Record<string, unknown>;
     };
+    const classifiedDomainFailure =
+      Boolean(structured.code) ||
+      structured.message.startsWith('Proposal source version changed:') ||
+      structured.message.startsWith('Proposal source already has an active hold:') ||
+      structured.message.startsWith('Proposal successor already exists:');
+    if (!classifiedDomainFailure) {
+      logger.error({ error, profile, sessionHash }, 'Unexpected proposal refinement failure');
+    }
     return {
       errors: [{
         code: structured.code ?? 'INVALID_STATE',

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -245,7 +245,12 @@ function setCORSHeaders(res: Response): void {
  * (`test-agent.adcontextprotocol.org/sales/mcp`) and the local mount
  * (`/api/training-agent/sales/mcp`).
  */
-function tenantMcpHandler(holder: RegistryHolder, tenantId: string, storyboardCompat?: TrainingContext['storyboardCompat']) {
+function tenantMcpHandler(
+  holder: RegistryHolder,
+  tenantId: string,
+  storyboardCompat?: TrainingContext['storyboardCompat'],
+  proposalNegotiationProfile?: TrainingContext['proposalNegotiationProfile'],
+) {
   return async (req: Request, res: Response): Promise<void> => {
     setCORSHeaders(res);
 
@@ -375,7 +380,14 @@ function tenantMcpHandler(holder: RegistryHolder, tenantId: string, storyboardCo
       if (await tryHandleLocalComplyScenario(req, res, resolved.tenantId, principal, storyboardCompat)) {
         return;
       }
-      if (await tryHandleProductDiscoveryRequest(req, res, resolved.tenantId, principal, storyboardCompat)) {
+      if (await tryHandleProductDiscoveryRequest(
+        req,
+        res,
+        resolved.tenantId,
+        principal,
+        storyboardCompat,
+        proposalNegotiationProfile,
+      )) {
         return;
       }
 
@@ -416,6 +428,7 @@ async function tryHandleProductDiscoveryRequest(
   tenantId: string,
   principal: string | undefined,
   storyboardCompat?: TrainingContext['storyboardCompat'],
+  proposalNegotiationProfile?: TrainingContext['proposalNegotiationProfile'],
 ): Promise<boolean> {
   if (tenantId !== 'sales') return false;
   if (storyboardCompat?.version === '3.0') return false;
@@ -491,6 +504,7 @@ async function tryHandleProductDiscoveryRequest(
         tenantId: 'sales' as const,
         principal: principal ?? 'anonymous',
       };
+    nativeContext.proposalNegotiationProfile = proposalNegotiationProfile ?? 'ask-only';
   } catch (error) {
     logger.error({ error, toolName }, 'Native sales request context resolution failed');
     res.json({
@@ -976,6 +990,24 @@ export interface TenantRouteMiddleware {
   storyboardCompat?: TrainingContext['storyboardCompat'];
 }
 
+export const PROPOSAL_NEGOTIATION_PROFILE_ROUTES = [
+  { path: '/sales/profiles/typed-negotiation/mcp', profile: 'typed-negotiation' },
+  { path: '/sales/profiles/constrained-seller/mcp', profile: 'constrained-seller' },
+  { path: '/sales/profiles/finalization-failure/mcp', profile: 'finalization-failure' },
+] as const satisfies ReadonlyArray<{
+  path: string;
+  profile: Exclude<NonNullable<TrainingContext['proposalNegotiationProfile']>, 'ask-only'>;
+}>;
+
+/** Keep the new training surfaces dark in production until the 3.2 beta cut. */
+export function proposalNegotiationProfilesEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const configured = env.ENABLE_ADCP_3_2_PROPOSAL_PROFILES;
+  if (configured !== undefined) return configured === '1' || configured.toLowerCase() === 'true';
+  return env.NODE_ENV !== 'production';
+}
+
 export function mountTenantRoutes(
   parent: Router,
   tenantIds: readonly string[],
@@ -1026,6 +1058,33 @@ export function mountTenantRoutes(
         error: { code: -32000, message: 'Method not allowed. Use POST for MCP requests.' },
       });
     });
+  }
+
+  if (
+    tenantIds.includes('sales')
+    && middleware.storyboardCompat?.version !== '3.0'
+    && proposalNegotiationProfilesEnabled()
+  ) {
+    for (const { path, profile } of PROPOSAL_NEGOTIATION_PROFILE_ROUTES) {
+      parent.options(path, (_req, res) => {
+        setCORSHeaders(res);
+        res.status(204).end();
+      });
+      parent.post(
+        path,
+        ...mw,
+        tenantMcpHandler(holder, 'sales', middleware.storyboardCompat, profile),
+      );
+      parent.get(path, (_req, res) => {
+        setCORSHeaders(res);
+        res.setHeader('Allow', 'POST, OPTIONS');
+        res.status(405).json({
+          jsonrpc: '2.0',
+          id: null,
+          error: { code: -32000, message: 'Method not allowed. Use POST for MCP requests.' },
+        });
+      });
+    }
   }
 
   // brand.json discovery is mounted at the parent training-agent router in

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -9,6 +9,7 @@ import type {
   LegacyFormatID as FormatID,
   LegacyCreateMediaBuyRequest as CreateMediaBuyRequest,
   EventType,
+  CanonicalProposal,
 } from '@adcp/sdk';
 
 // SpecialCategory for episodes (e.g., premiere, finale) — not yet in @adcp/sdk types
@@ -20,6 +21,14 @@ export type TalentRole = typeof TALENT_ROLES[number];
 
 /** First wire release that carries the get_products business-rejection arm. */
 export const GET_PRODUCTS_REJECTED_ADCP_VERSION = '3.2-beta.0' as const;
+
+export const PROPOSAL_NEGOTIATION_PROFILES = [
+  'ask-only',
+  'typed-negotiation',
+  'constrained-seller',
+  'finalization-failure',
+] as const;
+export type ProposalNegotiationProfile = (typeof PROPOSAL_NEGOTIATION_PROFILES)[number];
 
 export function supportsGetProductsRejected(servedVersion: string | undefined): boolean {
   if (!servedVersion) return false;
@@ -68,6 +77,10 @@ export interface TrainingContext {
    *  presence-gated signing at the auth layer. Default `/mcp` does not
    *  advertise request signing, so unsigned bearer callers keep working. */
   strict?: boolean;
+  /** Deterministic proposal-negotiation policy selected by the trusted route.
+   * The public `/sales/mcp` endpoint remains ask-only; beta-gated profile
+   * routes set one of the other values without trusting buyer input. */
+  proposalNegotiationProfile?: ProposalNegotiationProfile;
   /** Local storyboard-runner compatibility shims. Never set in deployed routes. */
   storyboardCompat?: { version: '3.0' };
   /** Whether creative usage is billed through AdCP. Defaults to true for legacy/shared routes. */
@@ -373,6 +386,15 @@ export interface SessionState {
     operation: 'finalize';
     idempotencyKey: string;
     successorProposalId: string;
+  }>;
+  /** Canonical proposal snapshots consumed by the SDK negotiation engine.
+   * Sources are immutable; only the compare-and-swap version and active hold
+   * metadata advance when a successor batch commits. */
+  proposalRefinementRecords: Map<string, {
+    proposal: CanonicalProposal;
+    version: number;
+    activeHold?: { proposal_id: string; expires_at: string };
+    accepted?: { accepted_at: string; media_buy_id: string; media_buy_revision: number };
   }>;
   usageRecords: UsageRecord[];
   /** Maps build_variant_id → the FormatID target used to produce it.

--- a/server/tests/unit/proposal-negotiation-profiles.test.ts
+++ b/server/tests/unit/proposal-negotiation-profiles.test.ts
@@ -1,0 +1,643 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type {
+  CanonicalProposal,
+  ProposalEvaluationContext,
+  ProposalPurchase,
+  ProposalRefinement,
+  RefineProposalsRequest,
+} from "@adcp/sdk";
+import {
+  proposalTermsDigest,
+  validateRefineProposalsRequest,
+  verifyRefineProposalsResponse,
+} from "@adcp/sdk";
+import {
+  ASK_ONLY_PROPOSAL_CAPABILITIES,
+  TYPED_PROPOSAL_CAPABILITIES,
+  evaluateTrainingProposal,
+  proposalCapabilitiesForProfile,
+  type TrainingProposalPolicyContext,
+} from "../../src/training-agent/proposal-negotiation-profiles.js";
+import {
+  PROPOSAL_NEGOTIATION_PROFILE_ROUTES,
+  proposalNegotiationProfilesEnabled,
+} from "../../src/training-agent/tenants/router.js";
+import { buildCatalog } from "../../src/training-agent/product-factory.js";
+import {
+  executeTrainingAgentTool,
+  invalidateCache,
+} from "../../src/training-agent/task-handlers.js";
+import { clearSessions } from "../../src/training-agent/state.js";
+import { clearIdempotencyCache } from "../../src/training-agent/idempotency.js";
+import type { TrainingContext } from "../../src/training-agent/types.js";
+
+const NOW = new Date("2030-01-01T00:00:00.000Z");
+
+function purchase(productId: string): ProposalPurchase {
+  return {
+    product_id: productId,
+    pricing_option_id: `${productId}_cpm`,
+    pricing: {
+      pricing_option_id: `${productId}_cpm`,
+      pricing_model: "cpm",
+      currency: "USD",
+      fixed_price: 12,
+    },
+    start_time: "2030-01-02T00:00:00.000Z",
+    end_time: "2030-02-01T00:00:00.000Z",
+  };
+}
+
+function sourceProposal(
+  id = "proposal_source_0001",
+  status: CanonicalProposal["proposal_status"] = "draft"
+): CanonicalProposal {
+  const commercialTerms = {
+    brand: { domain: "buyer.example" },
+    purchases: [purchase("product_alpha"), purchase("product_beta")],
+    start_time: "2030-01-02T00:00:00.000Z",
+    end_time: "2030-02-01T00:00:00.000Z",
+    total_budget: { amount: 75_000, currency: "USD" },
+  };
+  return {
+    proposal_id: id,
+    proposal_kind: "new_media_buy",
+    proposal_status: status,
+    ...(status === "accepted" && {
+      accepted_at: "2030-01-01T00:00:00.000Z",
+      media_buy_id: "media_buy_0001",
+      base_media_buy_revision: 1,
+    }),
+    expires_at: "2030-01-02T00:00:00.000Z",
+    name: "Deterministic proposal",
+    commercial_terms: commercialTerms,
+    terms_digest: proposalTermsDigest(commercialTerms),
+  };
+}
+
+function requestFor(
+  refinements: ProposalRefinement[],
+  idempotencyKey = "idem-training-00000001"
+): RefineProposalsRequest {
+  return {
+    idempotency_key: idempotencyKey,
+    refinements,
+    adcp_version: "3.2",
+    adcp_major_version: 3,
+  };
+}
+
+function evaluate(
+  refinement: ProposalRefinement,
+  options: {
+    profile?: TrainingProposalPolicyContext["profile"];
+    source?: CanonicalProposal | null;
+    refinements?: ProposalRefinement[];
+    index?: number;
+    activeHoldCount?: number;
+  } = {}
+) {
+  const profile = options.profile ?? "typed-negotiation";
+  const refinements = options.refinements ?? [refinement];
+  const context: TrainingProposalPolicyContext = {
+    profile,
+    now: NOW,
+    activeHoldCount: options.activeHoldCount ?? 0,
+    purchaseForProduct: (productId) => purchase(productId),
+  };
+  const evaluation: ProposalEvaluationContext<
+    CanonicalProposal,
+    TrainingProposalPolicyContext
+  > = {
+    refinement,
+    source:
+      options.source === undefined
+        ? sourceProposal(refinement.proposal_id)
+        : options.source,
+    index: options.index ?? 0,
+    request: requestFor(refinements),
+    context,
+  };
+  return evaluateTrainingProposal(evaluation);
+}
+
+describe("deterministic proposal negotiation profiles", () => {
+  beforeEach(() => {
+    invalidateCache();
+    clearSessions();
+    clearIdempotencyCache();
+  });
+  it("keeps ask-only discovery distinct from the complete typed profile", () => {
+    expect(proposalCapabilitiesForProfile("ask-only")).toEqual(
+      ASK_ONLY_PROPOSAL_CAPABILITIES
+    );
+    expect(proposalCapabilitiesForProfile("typed-negotiation")).toEqual(
+      TYPED_PROPOSAL_CAPABILITIES
+    );
+    expect(TYPED_PROPOSAL_CAPABILITIES).toEqual({
+      supported_dimensions: [
+        "total_budget",
+        "cpm",
+        "impressions",
+        "flight",
+        "product_changes",
+        "criteria",
+        "alternatives",
+      ],
+      max_alternatives: 3,
+    });
+  });
+
+  it("runs the required constrained three-to-two alternative scenario", () => {
+    const refinement: ProposalRefinement = {
+      proposal_id: "proposal_source_0001",
+      action: "revise",
+      constraints: { total_budget: { currency: "USD", max: 50_000 } },
+      product_changes: { product_gamma: "include", product_beta: "omit" },
+      criteria: {
+        targeting_overlay: { geo_countries: ["US", "CA"] },
+      },
+      alternatives: { count: 3 },
+    };
+    const result = evaluate(refinement, { profile: "constrained-seller" });
+    expect(result.outcome).toBe("partial");
+    if (result.outcome !== "partial") throw new Error("expected partial");
+    expect(result.reason_code).toBe("alternatives_unavailable");
+    expect(result.proposals).toHaveLength(2);
+    expect(
+      new Set(result.proposals.map((proposal) => proposal.terms_digest)).size
+    ).toBe(2);
+    for (const proposal of result.proposals) {
+      expect(proposal.parent_proposal_id).toBe(refinement.proposal_id);
+      expect(proposal.commercial_terms.total_budget).toEqual({
+        amount: 50_000,
+        currency: "USD",
+      });
+      expect(
+        proposal.commercial_terms.purchases.map((entry) => entry.product_id)
+      ).toContain("product_gamma");
+      expect(
+        proposal.commercial_terms.purchases.map((entry) => entry.product_id)
+      ).not.toContain("product_beta");
+    }
+    expect(
+      verifyRefineProposalsResponse(
+        requestFor([refinement]),
+        { status: "completed", results: [result], products: [] },
+        { now: NOW }
+      )
+    ).toEqual({ ok: true, issues: [] });
+  });
+
+  it("lets SDK response verification reject duplicate alternative terms and digests", () => {
+    const refinement: ProposalRefinement = {
+      proposal_id: "proposal_duplicate_terms",
+      action: "revise",
+      alternatives: { count: 3 },
+    };
+    const result = evaluate(refinement, { profile: "constrained-seller" });
+    if (result.outcome !== "partial") throw new Error("expected partial");
+    const invalid = structuredClone(result);
+    invalid.proposals[1] = {
+      ...invalid.proposals[1]!,
+      commercial_terms: structuredClone(invalid.proposals[0]!.commercial_terms),
+      terms_digest: invalid.proposals[0]!.terms_digest,
+    };
+    const verification = verifyRefineProposalsResponse(
+      requestFor([refinement]),
+      { status: "completed", results: [invalid], products: [] },
+      { now: NOW }
+    );
+    expect(verification.ok).toBe(false);
+    expect(verification.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining(["duplicate_terms", "duplicate_digest"])
+    );
+  });
+
+  it("applies cpm, impressions, flight, amendment, and cancellation semantics", () => {
+    const refinement: ProposalRefinement = {
+      proposal_id: "proposal_accepted_0001",
+      action: "revise",
+      change_kind: "amendment",
+      constraints: {
+        cpm: { currency: "USD", max: 9 },
+        impressions: { min: 1_000_000 },
+        flight: {
+          start_no_later_than: "2030-01-01T12:00:00.000Z",
+          end_no_earlier_than: "2030-03-01T00:00:00.000Z",
+        },
+      },
+    };
+    const result = evaluate(refinement, {
+      source: sourceProposal(refinement.proposal_id, "accepted"),
+    });
+    expect(result.outcome).toBe("revised");
+    if (result.outcome !== "revised") throw new Error("expected revised");
+    const proposal = result.proposals[0]!;
+    expect(proposal.proposal_kind).toBe("media_buy_update");
+    expect(proposal.proposal_status).toBe("draft");
+    expect(proposal.commercial_terms.start_time).toBe(
+      "2030-01-01T12:00:00.000Z"
+    );
+    expect(proposal.commercial_terms.end_time).toBe("2030-03-01T00:00:00.000Z");
+    expect(
+      proposal.commercial_terms.purchases.every(
+        (entry) => entry.pricing.fixed_price === 2
+      )
+    ).toBe(true);
+    expect(
+      proposal.commercial_terms.purchases.reduce(
+        (sum, entry) => sum + (entry.impressions ?? 0),
+        0
+      )
+    ).toBeGreaterThanOrEqual(1_000_000);
+
+    const cancellation = evaluate(
+      {
+        proposal_id: refinement.proposal_id,
+        action: "revise",
+        change_kind: "cancellation",
+        ask: "Cancel at the next deterministic boundary.",
+      },
+      { source: sourceProposal(refinement.proposal_id, "accepted") }
+    );
+    expect(cancellation.outcome).toBe("revised");
+    if (cancellation.outcome === "revised") {
+      expect(cancellation.proposals[0]?.proposal_kind).toBe(
+        "media_buy_cancellation"
+      );
+      expect(cancellation.proposals[0]?.commercial_terms).toHaveProperty(
+        "cancellation_terms"
+      );
+    }
+  });
+
+  it("creates a committed immutable successor on finalize", () => {
+    const source = sourceProposal();
+    const refinement: ProposalRefinement = {
+      proposal_id: source.proposal_id,
+      action: "finalize",
+    };
+    const result = evaluate(refinement, { source });
+    expect(result.outcome).toBe("finalized");
+    if (result.outcome !== "finalized") throw new Error("expected finalized");
+    expect(result.proposal.parent_proposal_id).toBe(source.proposal_id);
+    expect(result.proposal.proposal_status).toBe("committed");
+    expect(result.proposal.commercial_terms).toEqual(source.commercial_terms);
+    expect(result.proposal.terms_digest).toBe(source.terms_digest);
+    expect(source.proposal_status).toBe("draft");
+  });
+
+  it("makes every reason code reachable with deterministic inputs", () => {
+    const sourceId = "proposal_reason_codes";
+    const holdBatch: ProposalRefinement[] = [
+      { proposal_id: sourceId, action: "finalize" },
+      { proposal_id: `${sourceId}_sibling`, action: "finalize" },
+    ];
+    const results = [
+      evaluate({ proposal_id: sourceId, action: "revise" }, { source: null }),
+      evaluate({
+        proposal_id: sourceId,
+        action: "revise",
+        ask: "[commercially-declined]",
+      }),
+      evaluate({
+        proposal_id: sourceId,
+        action: "revise",
+        ask: "[unsupported-dimension]",
+      }),
+      evaluate({
+        proposal_id: sourceId,
+        action: "revise",
+        ask: "Make this somehow better.",
+      }),
+      evaluate({
+        proposal_id: sourceId,
+        action: "revise",
+        constraints: { total_budget: { currency: "EUR", max: 50_000 } },
+      }),
+      evaluate(
+        { proposal_id: sourceId, action: "revise", alternatives: { count: 3 } },
+        {
+          profile: "constrained-seller",
+        }
+      ),
+      evaluate(holdBatch[0]!, {
+        profile: "finalization-failure",
+        refinements: holdBatch,
+        index: 0,
+      }),
+      evaluate(holdBatch[1]!, {
+        profile: "finalization-failure",
+        refinements: holdBatch,
+        index: 1,
+      }),
+    ];
+    expect(
+      results.map((result) =>
+        "reason_code" in result ? result.reason_code : undefined
+      )
+    ).toEqual([
+      "source_unavailable",
+      "commercially_declined",
+      "unsupported_dimension",
+      "uninterpreted",
+      "constraint_unsatisfiable",
+      "alternatives_unavailable",
+      "hold_unavailable",
+      "batch_aborted",
+    ]);
+  });
+
+  it("uses SDK preflight for the ten-alternative and 25-refinement boundaries", () => {
+    expect(() =>
+      validateRefineProposalsRequest(
+        requestFor([
+          {
+            proposal_id: "proposal_source_0001",
+            action: "revise",
+            alternatives: { count: 10 },
+          },
+        ]),
+        TYPED_PROPOSAL_CAPABILITIES
+      )
+    ).toThrow(/max_alternatives|at most 3/i);
+
+    const twentyFive = Array.from(
+      { length: 25 },
+      (_, index): ProposalRefinement => ({
+        proposal_id: `proposal_boundary_${String(index).padStart(2, "0")}`,
+        action: "revise",
+        constraints: { total_budget: { currency: "USD", max: 50_000 } },
+      })
+    );
+    expect(() =>
+      validateRefineProposalsRequest(
+        requestFor(twentyFive),
+        TYPED_PROPOSAL_CAPABILITIES
+      )
+    ).not.toThrow();
+    expect(() =>
+      validateRefineProposalsRequest(
+        requestFor([
+          ...twentyFive,
+          { proposal_id: "proposal_boundary_25", action: "revise" },
+        ]),
+        TYPED_PROPOSAL_CAPABILITIES
+      )
+    ).toThrow(/25/);
+  });
+
+  it("rejects missing, wrong-currency, and out-of-policy budgets", () => {
+    expect(() =>
+      validateRefineProposalsRequest(
+        requestFor([
+          {
+            proposal_id: "proposal_budget_missing_currency",
+            action: "revise",
+            constraints: {
+              total_budget: { max: 50_000 } as {
+                currency: string;
+                max: number;
+              },
+            },
+          },
+        ]),
+        TYPED_PROPOSAL_CAPABILITIES
+      )
+    ).toThrow(/currency/i);
+
+    for (const totalBudget of [
+      { currency: "EUR", max: 50_000 },
+      { currency: "USD", max: 5_000 },
+      { currency: "USD", min: 300_000 },
+    ]) {
+      const result = evaluate({
+        proposal_id: "proposal_budget_policy",
+        action: "revise",
+        constraints: { total_budget: totalBudget },
+      });
+      expect(result).toMatchObject({
+        outcome: "unable",
+        reason_code: "constraint_unsatisfiable",
+        unsatisfied_constraints: ["total_budget"],
+      });
+    }
+  });
+
+  it("keeps profile routes dark by default in production and stable elsewhere", () => {
+    expect(proposalNegotiationProfilesEnabled({ NODE_ENV: "production" })).toBe(
+      false
+    );
+    expect(
+      proposalNegotiationProfilesEnabled({
+        NODE_ENV: "production",
+        ENABLE_ADCP_3_2_PROPOSAL_PROFILES: "1",
+      })
+    ).toBe(true);
+    expect(proposalNegotiationProfilesEnabled({ NODE_ENV: "test" })).toBe(true);
+    expect(
+      PROPOSAL_NEGOTIATION_PROFILE_ROUTES.map((route) => route.path)
+    ).toEqual([
+      "/sales/profiles/typed-negotiation/mcp",
+      "/sales/profiles/constrained-seller/mcp",
+      "/sales/profiles/finalization-failure/mcp",
+    ]);
+  });
+
+  it("executes request, constrained retry, finalize, accept, amendment, and cancellation end to end", async () => {
+    const context: TrainingContext = {
+      mode: "open",
+      tenantId: "sales",
+      principal: "typed-profile-integration",
+      authenticatedAgentUrl: "https://buyer.example",
+      proposalNegotiationProfile: "constrained-seller",
+    };
+    const brand = { domain: "buyer.example" };
+    const account = { brand, operator: "buyer.example" };
+    const requested = await executeTrainingAgentTool(
+      "request_proposals",
+      {
+        idempotency_key: "typed-request-proposals-0001",
+        brand,
+        brief: "social engagement display",
+      },
+      context
+    );
+    expect(requested.success, requested.error).toBe(true);
+    const requestedProposals = requested.data?.proposals as CanonicalProposal[];
+    const source = requestedProposals[0]!;
+    expect(requestedProposals.length).toBeGreaterThanOrEqual(2);
+    const failedFinalize = await executeTrainingAgentTool(
+      "refine_proposals",
+      {
+        idempotency_key: "typed-atomic-finalize-failure-0001",
+        refinements: requestedProposals.slice(0, 2).map((proposal) => ({
+          proposal_id: proposal.proposal_id,
+          action: "finalize" as const,
+        })),
+      },
+      { ...context, proposalNegotiationProfile: "finalization-failure" }
+    );
+    expect(failedFinalize.success, failedFinalize.error).toBe(true);
+    expect(
+      (failedFinalize.data?.results as Array<{ reason_code: string }>).map(
+        (result) => result.reason_code
+      )
+    ).toEqual(["hold_unavailable", "batch_aborted"]);
+    const sourceProductIds = new Set(
+      source.commercial_terms.purchases.map((entry) => entry.product_id)
+    );
+    const includedProduct = buildCatalog()
+      .map((entry) => entry.product.product_id)
+      .find(
+        (productId) =>
+          !sourceProductIds.has(productId) && !productId.includes("premium")
+      );
+    expect(includedProduct).toBeTruthy();
+    const omittedProduct = source.commercial_terms.purchases[0]!.product_id;
+    const threeAlternativeRequest = {
+      idempotency_key: "typed-refine-three-0001",
+      refinements: [
+        {
+          proposal_id: source.proposal_id,
+          action: "revise" as const,
+          constraints: { total_budget: { currency: "USD", max: 50_000 } },
+          product_changes: {
+            [includedProduct!]: "include" as const,
+            [omittedProduct]: "omit" as const,
+          },
+          criteria: { targeting_overlay: { geo_countries: ["US", "CA"] } },
+          alternatives: { count: 3 },
+        },
+      ],
+    };
+    const partial = await executeTrainingAgentTool(
+      "refine_proposals",
+      threeAlternativeRequest,
+      context
+    );
+    expect(partial.success, partial.error).toBe(true);
+    expect(partial.data, JSON.stringify(partial.data)).toHaveProperty(
+      "results"
+    );
+    const partialResult = (
+      partial.data?.results as Array<Record<string, unknown>>
+    )[0]!;
+    expect(partialResult).toMatchObject({
+      outcome: "partial",
+      reason_code: "alternatives_unavailable",
+      proposals: [{ proposal_status: "draft" }, { proposal_status: "draft" }],
+    });
+
+    const replay = await executeTrainingAgentTool(
+      "refine_proposals",
+      threeAlternativeRequest,
+      context
+    );
+    expect(replay.success, replay.error).toBe(true);
+    expect(replay.data).toMatchObject({
+      replayed: true,
+      results: partial.data?.results,
+    });
+    const conflict = await executeTrainingAgentTool(
+      "refine_proposals",
+      {
+        ...threeAlternativeRequest,
+        refinements: [
+          {
+            ...threeAlternativeRequest.refinements[0],
+            alternatives: { count: 2 },
+          },
+        ],
+      },
+      context
+    );
+    expect(conflict).toMatchObject({
+      success: false,
+      error: "IDEMPOTENCY_CONFLICT",
+    });
+
+    const selectedDraft = (partialResult.proposals as CanonicalProposal[])[0]!;
+    const finalized = await executeTrainingAgentTool(
+      "refine_proposals",
+      {
+        idempotency_key: "typed-finalize-selected-0001",
+        refinements: [
+          { proposal_id: selectedDraft.proposal_id, action: "finalize" },
+        ],
+      },
+      context
+    );
+    expect(finalized.success, finalized.error).toBe(true);
+    const committed = (
+      finalized.data?.results as Array<{ proposal: CanonicalProposal }>
+    )[0]!.proposal;
+    expect(committed).toMatchObject({
+      proposal_status: "committed",
+      parent_proposal_id: selectedDraft.proposal_id,
+    });
+
+    const accepted = await executeTrainingAgentTool(
+      "create_media_buy",
+      {
+        idempotency_key: "typed-accept-selected-0001",
+        account,
+        brand,
+        proposal_id: committed.proposal_id,
+        total_budget: { amount: 50_000, currency: "USD" },
+        start_time: committed.commercial_terms.start_time,
+        end_time: committed.commercial_terms.end_time,
+      },
+      context
+    );
+    expect(accepted.success, accepted.error).toBe(true);
+    expect(accepted.data).toMatchObject({
+      proposal_id: committed.proposal_id,
+      media_buy_id: expect.any(String),
+    });
+
+    for (const [changeKind, key] of [
+      ["amendment", "typed-amendment-0001"],
+      ["cancellation", "typed-cancellation-0001"],
+    ] as const) {
+      const changed = await executeTrainingAgentTool(
+        "refine_proposals",
+        {
+          idempotency_key: key,
+          refinements: [
+            {
+              proposal_id: committed.proposal_id,
+              action: "revise",
+              change_kind: changeKind,
+              ...(changeKind === "cancellation"
+                ? { ask: "Cancel at the next deterministic boundary." }
+                : {
+                    constraints: {
+                      total_budget: { currency: "USD", max: 45_000 },
+                    },
+                  }),
+            },
+          ],
+        },
+        context
+      );
+      expect(changed.success, changed.error).toBe(true);
+      const result = (
+        changed.data?.results as Array<{
+          outcome: string;
+          proposals: CanonicalProposal[];
+        }>
+      )[0]!;
+      expect(result.outcome).toBe("revised");
+      expect(result.proposals[0]).toMatchObject({
+        parent_proposal_id: committed.proposal_id,
+        proposal_kind:
+          changeKind === "cancellation"
+            ? "media_buy_cancellation"
+            : "media_buy_update",
+        proposal_status: "draft",
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- upgrade the training agent to `@adcp/sdk@13.0.0-rc.26`
- add deterministic typed-negotiation, constrained-seller, and finalization-failure profiles for proposal refinement
- persist immutable proposal records, CAS versions, holds, idempotent replay, and accepted-media-buy linkage
- document the stable profile routes and beta gate

The new routes remain disabled in production until `ENABLE_ADCP_3_2_PROPOSAL_PROFILES=true`, so the code can land before the AdCP 3.2 beta without exposing an unreleased protocol surface.

This is an app/training-agent change, so it intentionally carries no protocol-package changeset.

Closes #6558

## Validation
- `npm run typecheck`
- `npx vitest run server/tests/unit/proposal-negotiation-profiles.test.ts` (10 passed)
- `npm run test:server-unit` (436 files, 6,167 passed, 30 skipped)
- changeset scope check
- documentation navigation and owned-link checks