### PR TITLE
chore(deps): update @adcp/sdk to 13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.1.1",
       "dependencies": {
-        "@adcp/sdk": "13.0.0-rc.26",
+        "@adcp/sdk": "13.0.0",
         "@anthropic-ai/sdk": "^0.115.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.8.3",
@@ -131,9 +131,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "13.0.0-rc.26",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-13.0.0-rc.26.tgz",
-      "integrity": "sha512-EKHz3GaqhNdtrcWvhvdSPDLppsdaQ7kmvyHbnnGzRV/ENuusupGX+wOJcOYJv2KrKq3fyi0UyYR8gF2Vd5N8OQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-13.0.0.tgz",
+      "integrity": "sha512-Hrqd0wStEQNaY6ehHT1bfOvbSOk2OXNYBt7j+2fVUFmkJqGkfdn1TFucmtTsLlxz6yzD+/wWi6kfD7u5qeEo7A==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "13.0.0-rc.26",
+    "@adcp/sdk": "13.0.0",
     "@anthropic-ai/sdk": "^0.115.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.8.3",

--- a/static/compliance/published-versions.json
+++ b/static/compliance/published-versions.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "description": "Compliance bundles available from a published @adcp/sdk npm package. Hosted grading must use published_versions; package_only_versions are SDK opt-in surfaces that are not hosted protocol releases.",
   "npm_tags": ["adcp-3.0", "latest", "rc"],
-  "package_only_versions": ["3.2.0"],
+  "package_only_versions": ["3.1.15", "3.2.0"],
   "published_versions": [
     "3.0.0",
     "3.0.1",

--- a/tests/portfolio-routing-scope.test.cjs
+++ b/tests/portfolio-routing-scope.test.cjs
@@ -44,30 +44,36 @@ test("portfolio routing scope is authoritative when present and advisory in 3.2"
     1
   );
 
-  const [legacyRunnerResult] = runValidations(
-    [
-      {
-        check: "all_fields_in_context_array",
-        path: "products[*].channels[*]",
-        context_key: "portfolio_channels",
-        description: "Every product channel stays within declared scope",
-      },
-    ],
-    {
-      taskName: "get_products",
-      taskResult: {
-        success: true,
-        data: { products: [{ channels: ["display"] }] },
-      },
-      agentUrl: "https://seller.example",
-      contributions: new Set(),
-      storyboardContext: { portfolio_channels: ["display"] },
-    }
-  );
-  assert.equal(legacyRunnerResult.passed, true);
-  assert.equal(
-    legacyRunnerResult.not_applicable,
-    true,
-    "pre-implementation SDKs must skip the additive check, not false-fail it"
-  );
+  const validation = {
+    check: "all_fields_in_context_array",
+    path: "products[*].channels[*]",
+    context_key: "portfolio_channels",
+    description: "Every product channel stays within declared scope",
+  };
+  const runnerContext = {
+    taskName: "get_products",
+    agentUrl: "https://seller.example",
+    contributions: new Set(),
+    storyboardContext: { portfolio_channels: ["display"] },
+  };
+
+  const [inScopeRunnerResult] = runValidations([validation], {
+    ...runnerContext,
+    taskResult: {
+      success: true,
+      data: { products: [{ channels: ["display"] }] },
+    },
+  });
+  assert.equal(inScopeRunnerResult.passed, true);
+
+  const [outOfScopeRunnerResult] = runValidations([validation], {
+    ...runnerContext,
+    taskResult: {
+      success: true,
+      data: { products: [{ channels: ["audio"] }] },
+    },
+  });
+  assert.equal(outOfScopeRunnerResult.passed, false);
+  assert.deepEqual(outOfScopeRunnerResult.expected, ["display"]);
+  assert.deepEqual(outOfScopeRunnerResult.actual, ["audio"]);
 });


### PR DESCRIPTION
## Summary

- replace the `@adcp/sdk` 13.0.0 release candidate with the 13.0.0 GA package
- refresh the lockfile to the published GA tarball and integrity hash
- register the published 3.1.15 compliance cache as package-only on `main`

## Why

SDK 13.0.0 is now the published `latest` release and contains the finalized AdCP 3.2 proposal-negotiation primitives used by the training profiles.

The GA package also exposes the 3.1.15 maintenance cache. Its generated release files remain on the maintenance branch, so the publication manifest records it as package-only rather than forwarding those artifacts into `main`.

## Validation

- `npm run typecheck`
- `npm run test:sdk-shims`
- `node --test tests/proposal-negotiation-guide.test.cjs`
- `npx vitest run server/tests/unit/proposal-negotiation-profiles.test.ts --pool=threads`
- `npm run check:published-compliance`
- `node --test tests/published-compliance-versions.test.cjs`
- `node scripts/run-test-stage-shard.mjs --shard 3/4 --exclude test:server-unit` (with CI placeholder credentials)
- `git diff --check`
