### PR TITLE
fix(git): isolate hooks per worktree

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,7 +1,7 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
 [scripts]
-setup = "SETUP_NVM_SCRIPT=\"${NVM_DIR:-$HOME/.nvm}/nvm.sh\"; if [ -s \"$SETUP_NVM_SCRIPT\" ]; then . \"$SETUP_NVM_SCRIPT\" && nvm install 24.19.0 && nvm use 24.19.0; fi && node -e 'if (process.versions.node !== `24.19.0`) { console.error(`Node 24.19.0 is required; found ${process.versions.node}`); process.exit(1) }' && git config core.hooksPath .husky && npx --yes npm@10.9.4 ci && uv sync --frozen"
+setup = "sh scripts/configure-git-hooks.sh && SETUP_NVM_SCRIPT=\"${NVM_DIR:-$HOME/.nvm}/nvm.sh\"; if [ -s \"$SETUP_NVM_SCRIPT\" ]; then . \"$SETUP_NVM_SCRIPT\" && nvm install 24.19.0 && nvm use 24.19.0; fi && node -e 'if (process.versions.node !== `24.19.0`) { console.error(`Node 24.19.0 is required; found ${process.versions.node}`); process.exit(1) }' && npx --yes npm@10.9.4 ci && uv sync --frozen"
 run_mode = "concurrent"
 
 [scripts.run.run]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,9 @@
 #!/bin/sh
 
+HUSKY_INIT="${XDG_CONFIG_HOME:-$HOME/.config}/husky/init.sh"
+[ -f "$HUSKY_INIT" ] && . "$HUSKY_INIT"
+[ "${HUSKY-}" = "0" ] && exit 0
+export PATH="node_modules/.bin:$PATH"
+
 bash scripts/check-image-quality.sh
 npm run precommit

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+HUSKY_INIT="${XDG_CONFIG_HOME:-$HOME/.config}/husky/init.sh"
+[ -f "$HUSKY_INIT" ] && . "$HUSKY_INIT"
+[ "${HUSKY-}" = "0" ] && exit 0
+export PATH="node_modules/.bin:$PATH"
+
 # Verify version sync before pushing
 npm run verify-version-sync
 

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "precommit": "bash scripts/with-timeout.sh 180 npm run test:unit && npm run test:test-dynamic-imports && npm run test:format-identity-boundaries && npm run test:callapi-state-change && bash scripts/with-timeout.sh 240 npm run precommit:server-unit && npm run typecheck",
     "test:storyboards": "bash scripts/run-storyboards-matrix.sh",
     "test:storyboards:3.0-compat": "bash scripts/run-storyboards-3-0-compat.sh",
-    "prepare": "husky",
+    "prepare": "sh scripts/configure-git-hooks.sh",
     "changeset": "changeset",
     "version": "changeset version && npm install --package-lock-only --ignore-scripts && npm run build:schemas -- --release && npm run build:compliance -- --release && npm run build:protocol-tarball -- --release && npm run sign:protocol-tarball",
     "sign:protocol-tarball": "bash scripts/sign-protocol-tarball.sh",

--- a/scripts/configure-git-hooks.sh
+++ b/scripts/configure-git-hooks.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -eu
+
+# Match Husky's behavior for source archives and other installs without Git
+# metadata: dependency installation should still succeed, just without hooks.
+if [ ! -e .git ] || ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+# core.hooksPath is otherwise shared by every linked worktree. A per-worktree
+# value prevents a stale checkout from redirecting another worktree's hooks.
+# Point directly at the tracked hooks so a failed dependency install cannot
+# leave hooks disabled because Husky's ignored shim directory was not generated.
+git config extensions.worktreeConfig true
+git config --worktree core.hooksPath .husky


### PR DESCRIPTION
## What changed

- configure `core.hooksPath` at worktree scope instead of repository scope
- point directly at the tracked `.husky` hooks so dependency-install failures cannot disable them
- run the same guarded setup from Conductor workspace setup and `npm prepare`
- preserve Husky init, PATH, and `HUSKY=0` behavior in the tracked hooks

## Why

Git stores ordinary repository configuration in the common Git directory shared by every linked worktree. An absolute `core.hooksPath` from a stale main checkout therefore caused pushes from every Conductor workspace to execute that checkout's outdated hooks. Those hooks ran obsolete whole-repository documentation checks and destructive snapshot rebuilds.

Using Git's worktree configuration extension gives each checkout its own relative hook path, preventing one checkout from redirecting another checkout's hooks.

## Impact

New Conductor workspaces and dependency installs configure their own hook path. Existing checkouts can migrate once with `npm run prepare` after pulling this change.

## Validation

- three independent expert reviews: code quality, Git/worktree failure modes, and security/operational safety
- stale shared-path overwrite reproduction with linked worktrees
- nested source-archive guard
- `HUSKY=0` pre-commit and pre-push bypasses
- shell syntax and `git diff --check`
- full pre-commit suite: 437 server test files, 6,171 tests, and TypeScript checks
- current and released-3.0 storyboard compatibility matrices across all seven tenants
