### PR TITLE
test(compliance): add timezone resolution storyboard matrix

### DIFF
--- a/.changeset/account-budget-timezone-storyboards.md
+++ b/.changeset/account-budget-timezone-storyboards.md
@@ -1,0 +1,9 @@
+---
+"adcontextprotocol": minor
+---
+
+Add capability-gated compliance storyboards for seller-fixed, buyer-selected,
+and seller-assigned account timezones; account-based and feature-fixed daily
+budget-cap boundaries; buyer cap-timezone overrides; and independent account,
+reporting, and billing clocks. Reject unadvertised buyer timezone overrides
+with the canonical unsupported-feature error.

--- a/.changeset/account-budget-timezone-storyboards.md
+++ b/.changeset/account-budget-timezone-storyboards.md
@@ -1,9 +1,12 @@
 ---
-"adcontextprotocol": minor
+"adcontextprotocol": patch
 ---
 
 Add capability-gated compliance storyboards for seller-fixed, buyer-selected,
 and seller-assigned account timezones; account-based and feature-fixed daily
 budget-cap boundaries; buyer cap-timezone overrides; and independent account,
-reporting, and billing clocks. Reject unadvertised buyer timezone overrides
-with the canonical unsupported-feature error.
+reporting, and billing clocks. Cover buyer-preference mismatches against a
+seller-fixed UTC clock, portable natural-key reconnects, and selecting a second
+advertised timezone as a separate immutable account identity. Reject
+unadvertised buyer timezone overrides with the canonical unsupported-feature
+error.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deploy:cdn-artifacts-cutover:dry-run": "wrangler deploy --config workers/artifact-cdn/wrangler.cutover.toml --dry-run",
     "verify:cdn-artifacts-cutover": "node scripts/verify-cdn-artifacts-cutover.mjs",
     "typecheck": "tsc --project server/tsconfig.json --noEmit",
-    "test:schemas": "node tests/schema-validation.test.cjs && node --test tests/trusted-match-offer-creative-data.test.cjs tests/accessibility-violation-details.test.cjs tests/portfolio-routing-scope.test.cjs tests/catalog-item-availability-updates.test.cjs tests/schema-deprecation-metadata.test.cjs tests/creative-rotation.test.cjs tests/lint-schema-enum-drift.test.cjs tests/synthetic-depiction.test.cjs && npm run test:geo-region-targeting",
+    "test:schemas": "node tests/schema-validation.test.cjs && node --test tests/trusted-match-offer-creative-data.test.cjs tests/accessibility-violation-details.test.cjs tests/portfolio-routing-scope.test.cjs tests/catalog-item-availability-updates.test.cjs tests/timezone-resolution-storyboards.test.cjs tests/schema-deprecation-metadata.test.cjs tests/creative-rotation.test.cjs tests/lint-schema-enum-drift.test.cjs tests/synthetic-depiction.test.cjs && npm run test:geo-region-targeting",
     "test:performance-feedback": "node --test --test-force-exit --test-timeout=30000 tests/performance-feedback-contract.test.cjs",
     "test:dist-schema-version-ids": "node --test --test-force-exit --test-timeout=30000 tests/dist-schema-version-ids.test.cjs",
     "test:examples": "node tests/example-validation-simple.test.cjs && npm run test:tmp-context-merge",

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -203,7 +203,7 @@ phases:
         stateful: true
         expected: |
           Return the account with:
-          - account_id: your platform's identifier for this relationship
+          - account_id: your platform's identifier for this relationship, when the seller echoes one during provisioning
           - action: created or updated
           - status: active (instant approval) or pending_approval (requires human review)
           - account_scope: operator, brand, operator_brand, or agent
@@ -223,10 +223,6 @@ phases:
           context:
             correlation_id: "media_buy_seller--sync_accounts"
 
-        context_outputs:
-          - name: account_id
-            path: "accounts[0].account_id"
-
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -234,9 +230,6 @@ phases:
             path: "accounts[0].action"
             allowed_values: ["created", "updated", "unchanged"]
             description: "Account setup succeeds instead of returning a per-account failure"
-          - check: field_present
-            path: "accounts[0].account_id"
-            description: "Account has a platform-assigned ID"
           - check: field_present
             path: "accounts[0].status"
             description: "Account has a status (active or pending_approval)"
@@ -257,8 +250,9 @@ phases:
     narrative: |
       Buyer-selected account-fixed sellers require one advertised timezone in
       the provisioning natural key. The buyer discovers that allowlist before
-      establishing the account and carries the returned account ID into later
-      account-scoped calls.
+      establishing the account, resolves the new account through its complete
+      natural key, and carries that complete natural key through the rest of
+      this lifecycle.
     steps:
       - id: discover_buyer_selected_timezone
         title: "Choose an advertised account timezone"
@@ -297,9 +291,6 @@ phases:
           idempotency_key: "$generate:uuid_v4#media_buy_seller_buyer_selected_account_setup"
           context:
             correlation_id: "media_buy_seller--sync_accounts_buyer_selected"
-        context_outputs:
-          - name: account_id
-            path: "accounts[0].account_id"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -311,12 +302,13 @@ phases:
             path: "accounts[0].timezone"
             context_key: "account_timezone"
             description: "Seller echoes the chosen immutable timezone"
-          - check: field_present
-            path: "accounts[0].account_id"
-            description: "Seller returns an account handle for later calls"
 
   - id: governance_setup
     title: "Governance agent registration"
+    depends_on: [account_setup]
+    requires_capability:
+      path: account.timezone.supported_timezones
+      present: false
     narrative: |
       The buyer registers their governance agent with your platform. This tells your
       platform where to call check_governance before confirming media buys.
@@ -341,7 +333,11 @@ phases:
         sample_request:
           accounts:
             - account:
-                account_id: "$context.account_id"
+                &media_buy_lifecycle_account
+                brand:
+                  domain: "acmeoutdoor.example"
+                operator: "pinnacle-agency.example"
+                sandbox: true
               governance_agents:
                 - url: "$context.governance_agent_url"
                   authentication:
@@ -367,6 +363,10 @@ phases:
 
   - id: product_discovery
     title: "Product discovery"
+    depends_on: [account_setup]
+    requires_capability:
+      path: account.timezone.supported_timezones
+      present: false
     narrative: |
       The buyer sends a natural-language brief describing what they want to buy.
       Your platform interprets the brief against your inventory and returns products —
@@ -416,8 +416,7 @@ phases:
           brief: "Premium video inventory on sports and outdoor lifestyle publishers. Q2 flight, $50K budget. Adults 25-54, US and Canada."
           pagination:
             max_results: 5
-          account:
-            account_id: "$context.account_id"
+          account: *media_buy_lifecycle_account
           context:
             correlation_id: "media_buy_seller--get_products_brief"
 
@@ -459,6 +458,10 @@ phases:
             description: "Products include publisher_properties"
   - id: create_buy
     title: "Create the media buy"
+    depends_on: [product_discovery]
+    requires_capability:
+      path: account.timezone.supported_timezones
+      present: false
     narrative: |
       The buyer is satisfied with the products and creates a media buy. This is the
       equivalent of signing an IO — the buyer commits to specific products, budgets,
@@ -527,8 +530,7 @@ phases:
         sample_request:
           brand:
             domain: "acmeoutdoor.example"
-          account:
-            account_id: "$context.account_id"
+          account: *media_buy_lifecycle_account
           start_time: "asap"
           end_time: "2099-06-30T23:59:59Z"
           packages:
@@ -594,8 +596,7 @@ phases:
           - valid_actions should include sync_creatives
 
         sample_request:
-          account:
-            account_id: "$context.account_id"
+          account: *media_buy_lifecycle_account
           media_buy_ids:
             - "$context.media_buy_id"
           context:
@@ -625,6 +626,10 @@ phases:
 
   - id: creative_sync
     title: "Creative sync"
+    depends_on: [create_buy]
+    requires_capability:
+      path: account.timezone.supported_timezones
+      present: false
     narrative: |
       With the media buy confirmed, the buyer syncs creative assets to your platform.
       Each package in the buy has creative format requirements — the buyer discovered
@@ -665,8 +670,7 @@ phases:
           The first creative uses the canonical format_kind extracted from get_products.
 
         sample_request:
-          account:
-            account_id: "$context.account_id"
+          account: *media_buy_lifecycle_account
           creatives:
             - creative_id: "video_30s_trail_pro"
               name: "Trail Pro 3000 - 30s CTV Spot"
@@ -709,6 +713,10 @@ phases:
 
   - id: delivery_monitoring
     title: "Delivery and reporting"
+    depends_on: [create_buy, creative_sync]
+    requires_capability:
+      path: account.timezone.supported_timezones
+      present: false
     narrative: |
       The campaign is live. The buyer monitors delivery through two tasks:
       get_media_buys for status and get_media_buy_delivery for performance metrics.
@@ -741,14 +749,327 @@ phases:
           - Budget utilization: spent vs. committed
 
         sample_request:
-          account:
-            account_id: "$context.account_id"
+          account: *media_buy_lifecycle_account
           media_buy_ids:
             - "$context.media_buy_id"
           include_package_daily_breakdown: true
           context:
             correlation_id: "media_buy_seller--get_delivery"
 
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buy-delivery-response.json schema"
+          - check: field_present
+            path: "media_buy_deliveries"
+            description: "Response contains media buy delivery data"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--get_delivery"
+            description: "Context correlation_id returned unchanged"
+
+  # The buyer-selected branch repeats the lifecycle with the complete
+  # timezone-bearing natural AccountRef. The request bodies are explicit so
+  # authored-storyboard consumers do not need YAML merge-key support.
+  - id: buyer_selected_governance_setup
+    title: "Buyer-selected timezone governance registration"
+    depends_on: [buyer_selected_account_setup]
+    requires_capability:
+      path: account.timezone.account_selection
+      equals: buyer_selected
+    steps:
+      - id: sync_governance_buyer_selected_timezone
+        title: "Register governance agents for the timezone-bound account"
+        task: sync_governance
+        schema_ref: "account/sync-governance-request.json"
+        response_schema_ref: "account/sync-governance-response.json"
+        doc_ref: "/accounts/tasks/sync_governance"
+        requires_tool: sync_governance
+        stateful: true
+        sample_request:
+          accounts:
+            - account:
+                brand:
+                  domain: "acmeoutdoor.example"
+                operator: "pinnacle-agency.example"
+                timezone: "$context.account_timezone"
+                sandbox: true
+              governance_agents:
+                - url: "$context.governance_agent_url"
+                  authentication:
+                    schemes: ["Bearer"]
+                    credentials: "gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_buyer_timezone_sync_governance"
+          context:
+            correlation_id: "media_buy_seller--sync_governance"
+          ext:
+            test_platform:
+              governance_tier: "standard"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-governance-response.json schema"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--sync_governance"
+            description: "Context correlation_id returned unchanged"
+
+  - id: buyer_selected_product_discovery
+    title: "Buyer-selected timezone product discovery"
+    depends_on: [buyer_selected_account_setup]
+    requires_capability:
+      path: account.timezone.account_selection
+      equals: buyer_selected
+    steps:
+      - id: get_products_brief_buyer_selected_timezone
+        title: "Send a brief for the timezone-bound account"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: full_sales_flow
+        stateful: false
+        sample_request:
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_buyer_timezone_get_products"
+          buying_mode: "brief"
+          brief: "Premium video inventory on sports and outdoor lifestyle publishers. Q2 flight, $50K budget. Adults 25-54, US and Canada."
+          pagination:
+            max_results: 5
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            timezone: "$context.account_timezone"
+            sandbox: true
+          context:
+            correlation_id: "media_buy_seller--get_products_brief"
+        context_outputs:
+          - name: product_format_kind
+            path: 'products[0].format_options[0].format_kind'
+          - name: product_id
+            path: 'products[0].product_id'
+          - name: pricing_option_id
+            path: 'products[0].pricing_options[0].pricing_option_id'
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products"
+            description: "Response contains a products array"
+          - check: field_present
+            path: "products[0].product_id"
+            description: "Each product has a product_id"
+          - check: field_present
+            path: "products[0].delivery_type"
+            description: "Each product declares guaranteed or non_guaranteed delivery"
+          - check: field_present
+            path: "products[0].format_options"
+            description: "Products include canonical format_options for creative requirements"
+          - check: field_present
+            path: "products[0].format_options[0].format_kind"
+            description: "Every canonical product option declares format_kind"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--get_products_brief"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].publisher_properties"
+            description: "Products include publisher_properties"
+
+  - id: buyer_selected_create_buy
+    title: "Buyer-selected timezone media buy"
+    depends_on: [buyer_selected_product_discovery]
+    requires_capability:
+      path: account.timezone.account_selection
+      equals: buyer_selected
+    steps:
+      - id: create_media_buy_buyer_selected_timezone
+        title: "Create a buy for the timezone-bound account"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        stateful: true
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            timezone: "$context.account_timezone"
+            sandbox: true
+          start_time: "asap"
+          end_time: "2099-06-30T23:59:59Z"
+          packages:
+            - product_id: "sports_preroll_q2"
+              budget: 25000
+              pricing_option_id: "cpm_non_guaranteed"
+              creative_assignments:
+                - creative_id: "video_30s_trail_pro"
+            - product_id: "lifestyle_display_q2"
+              budget: 15000
+              pricing_option_id: "cpm_standard"
+          push_notification_config:
+            url: "https://buyer.example/webhooks/adcp"
+            authentication:
+              schemes:
+                - "HMAC-SHA256"
+              credentials: "media-buy-seller-webhook-secret-token"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_buyer_timezone_create_media_buy"
+          context:
+            correlation_id: "media_buy_seller--create_media_buy"
+        context_outputs:
+          - name: media_buy_id
+            path: 'media_buy_id'
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--create_media_buy"
+            description: "Context correlation_id returned unchanged"
+
+      - id: check_buy_status_buyer_selected_timezone
+        title: "Check the timezone-bound media buy"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        comply_scenario: media_buy_lifecycle
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            timezone: "$context.account_timezone"
+            sandbox: true
+          media_buy_ids:
+            - "$context.media_buy_id"
+          context:
+            correlation_id: "media_buy_seller--check_buy_status"
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json schema"
+          - check: field_present
+            path: "media_buys[0].status"
+            description: "Each media buy has a status"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--check_buy_status"
+            description: "Context correlation_id returned unchanged"
+          - check: field_equals_context
+            path: "media_buys[0].media_buy_id"
+            context_key: "media_buy_id"
+            description: "get_media_buys returns the media_buy_id created earlier"
+          - check: field_value
+            path: "media_buys[0].context.correlation_id"
+            value: "media_buy_seller--create_media_buy"
+            description: "get_media_buys includes persisted media-buy context from create_media_buy"
+
+  - id: buyer_selected_creative_sync
+    title: "Buyer-selected timezone creative sync"
+    depends_on: [buyer_selected_create_buy]
+    requires_capability:
+      path: account.timezone.account_selection
+      equals: buyer_selected
+    steps:
+      - id: sync_creatives_buyer_selected_timezone
+        title: "Push creative assets for the timezone-bound account"
+        task: sync_creatives
+        schema_ref: "creative/sync-creatives-request.json"
+        response_schema_ref: "creative/sync-creatives-response.json"
+        doc_ref: "/creative/task-reference/sync_creatives"
+        comply_scenario: creative_sync
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            timezone: "$context.account_timezone"
+            sandbox: true
+          creatives:
+            - creative_id: "video_30s_trail_pro"
+              name: "Trail Pro 3000 - 30s CTV Spot"
+              format_kind: "$context.product_format_kind"
+              assets:
+                video:
+                  asset_type: "video"
+                  url: "https://cdn.pinnacle-agency.example/trail-pro-30s.mp4"
+                  width: 1920
+                  height: 1080
+                  duration_ms: 30000
+                  mime_type: "video/mp4"
+            - creative_id: "display_trail_pro_300x250"
+              name: "Trail Pro 3000 - Display 300x250"
+              format_kind: "image"
+              assets:
+                image:
+                  asset_type: "image"
+                  url: "https://cdn.pinnacle-agency.example/trail-pro-300x250.png"
+                  width: 300
+                  height: 250
+                  mime_type: "image/png"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_buyer_timezone_sync_creatives"
+          context:
+            correlation_id: "media_buy_seller--sync_creatives"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-creatives-response.json schema"
+          - check: field_present
+            path: "creatives[0].action"
+            description: "Each creative has an action (created/updated)"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--sync_creatives"
+            description: "Context correlation_id returned unchanged"
+
+  - id: buyer_selected_delivery_monitoring
+    title: "Buyer-selected timezone delivery and reporting"
+    depends_on: [buyer_selected_create_buy, buyer_selected_creative_sync]
+    requires_capability:
+      path: account.timezone.account_selection
+      equals: buyer_selected
+    steps:
+      - id: get_delivery_buyer_selected_timezone
+        title: "Check delivery for the timezone-bound account"
+        task: get_media_buy_delivery
+        schema_ref: "media-buy/get-media-buy-delivery-request.json"
+        response_schema_ref: "media-buy/get-media-buy-delivery-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buy_delivery"
+        comply_scenario: reporting_flow
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            timezone: "$context.account_timezone"
+            sandbox: true
+          media_buy_ids:
+            - "$context.media_buy_id"
+          include_package_daily_breakdown: true
+          context:
+            correlation_id: "media_buy_seller--get_delivery"
         validations:
           - check: response_schema
             description: "Response matches get-media-buy-delivery-response.json schema"

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -42,6 +42,13 @@ requires_scenarios:
   - media_buy_seller/typed_proposal_negotiation
   - media_buy_seller/portfolio_routing_scope
   - media_buy_seller/catalog_item_availability_updates
+  - media_buy_seller/account_timezone_seller_fixed
+  - media_buy_seller/account_timezone_buyer_selected
+  - media_buy_seller/account_timezone_seller_assigned
+  - media_buy_seller/budget_cap_timezone_account
+  - media_buy_seller/budget_cap_timezone_fixed
+  - media_buy_seller/budget_cap_timezone_override
+  - media_buy_seller/budget_cap_timezone_override_rejected
 
 narrative: |
   You run a sell-side platform — a publisher, SSP, retail media network, or any system that
@@ -162,6 +169,10 @@ phases:
 
   - id: account_setup
     title: "Account setup"
+    depends_on: []
+    requires_capability:
+      path: account.timezone.supported_timezones
+      present: false
     narrative: |
       Before buying anything, the buyer establishes an account relationship with
       your platform. This is the handshake: the buyer tells you which brand and
@@ -207,13 +218,22 @@ phases:
               operator: "pinnacle-agency.example"
               billing: "operator"
               payment_terms: "net_30"
+              sandbox: true
           idempotency_key: "$generate:uuid_v4#media_buy_seller_account_setup_sync_accounts"
           context:
             correlation_id: "media_buy_seller--sync_accounts"
 
+        context_outputs:
+          - name: account_id
+            path: "accounts[0].account_id"
+
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
+          - check: field_value
+            path: "accounts[0].action"
+            allowed_values: ["created", "updated", "unchanged"]
+            description: "Account setup succeeds instead of returning a per-account failure"
           - check: field_present
             path: "accounts[0].account_id"
             description: "Account has a platform-assigned ID"
@@ -227,6 +247,73 @@ phases:
             path: "context.correlation_id"
             value: "media_buy_seller--sync_accounts"
             description: "Context correlation_id returned unchanged"
+
+  - id: buyer_selected_account_setup
+    title: "Buyer-selected timezone account setup"
+    depends_on: []
+    requires_capability:
+      path: account.timezone.account_selection
+      equals: buyer_selected
+    narrative: |
+      Buyer-selected account-fixed sellers require one advertised timezone in
+      the provisioning natural key. The buyer discovers that allowlist before
+      establishing the account and carries the returned account ID into later
+      account-scoped calls.
+    steps:
+      - id: discover_buyer_selected_timezone
+        title: "Choose an advertised account timezone"
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        stateful: false
+        sample_request: {}
+        context_outputs:
+          - name: account_timezone
+            path: "account.timezone.supported_timezones[0]"
+        validations:
+          - check: response_schema
+            description: "Capability response matches the canonical schema"
+          - check: field_present
+            path: "account.timezone.supported_timezones[0]"
+            description: "Buyer has at least one valid provisioning timezone"
+
+      - id: sync_accounts_buyer_selected_timezone
+        title: "Establish the timezone-bound account relationship"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              timezone: "$context.account_timezone"
+              billing: "operator"
+              payment_terms: "net_30"
+              sandbox: true
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_buyer_selected_account_setup"
+          context:
+            correlation_id: "media_buy_seller--sync_accounts_buyer_selected"
+        context_outputs:
+          - name: account_id
+            path: "accounts[0].account_id"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_value
+            path: "accounts[0].action"
+            allowed_values: ["created", "updated", "unchanged"]
+            description: "Timezone-bound account setup succeeds"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "account_timezone"
+            description: "Seller echoes the chosen immutable timezone"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Seller returns an account handle for later calls"
 
   - id: governance_setup
     title: "Governance agent registration"
@@ -254,9 +341,7 @@ phases:
         sample_request:
           accounts:
             - account:
-                brand:
-                  domain: "acmeoutdoor.example"
-                operator: "pinnacle-agency.example"
+                account_id: "$context.account_id"
               governance_agents:
                 - url: "$context.governance_agent_url"
                   authentication:
@@ -332,9 +417,7 @@ phases:
           pagination:
             max_results: 5
           account:
-            brand:
-              domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.example"
+            account_id: "$context.account_id"
           context:
             correlation_id: "media_buy_seller--get_products_brief"
 
@@ -445,10 +528,7 @@ phases:
           brand:
             domain: "acmeoutdoor.example"
           account:
-            brand:
-              domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.example"
-            sandbox: true
+            account_id: "$context.account_id"
           start_time: "asap"
           end_time: "2099-06-30T23:59:59Z"
           packages:
@@ -515,9 +595,7 @@ phases:
 
         sample_request:
           account:
-            brand:
-              domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.example"
+            account_id: "$context.account_id"
           media_buy_ids:
             - "$context.media_buy_id"
           context:
@@ -588,9 +666,7 @@ phases:
 
         sample_request:
           account:
-            brand:
-              domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.example"
+            account_id: "$context.account_id"
           creatives:
             - creative_id: "video_30s_trail_pro"
               name: "Trail Pro 3000 - 30s CTV Spot"
@@ -666,9 +742,7 @@ phases:
 
         sample_request:
           account:
-            brand:
-              domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.example"
+            account_id: "$context.account_id"
           media_buy_ids:
             - "$context.media_buy_id"
           include_package_daily_breakdown: true

--- a/static/compliance/source/protocols/media-buy/scenarios/account_timezone_buyer_selected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/account_timezone_buyer_selected.yaml
@@ -2,7 +2,7 @@ id: media_buy_seller/account_timezone_buyer_selected
 version: "1.0.0"
 title: "Buyer-selected account timezone resolution"
 category: media_buy_seller
-summary: "Verifies advertised timezone selection, provisioning echo, list readback, and natural AccountRef round-trip."
+summary: "Verifies advertised timezone reconciliation, cold-start reconnect, and separate account identities when a buyer selects another timezone."
 track: media_buy
 introduced_in: "3.2"
 
@@ -17,9 +17,15 @@ required_tools:
 
 narrative: |
   In buyer-selected account-fixed mode, the buyer chooses one advertised
-  timezone while provisioning. That immutable value participates in the
-  natural account key and must survive sync_accounts, list_accounts, and a
-  subsequent exact natural-key lookup.
+  timezone while provisioning. A buyer whose preferred local clock is not in
+  supported_timezones must choose an advertised value (for example UTC) or
+  decline to provision; it cannot ask the seller to coerce an off-list value.
+
+  The selected timezone is immutable and participates in the natural account
+  key. Reconnecting therefore reuses the complete timezone-bearing key. If the
+  seller advertises a second timezone, selecting it creates a second account
+  identity rather than changing the first account in place; both exact keys
+  must remain independently resolvable.
 
 agent:
   interaction_model: media_buy_seller
@@ -50,6 +56,10 @@ phases:
         context_outputs:
           - name: account_timezone
             path: "account.timezone.supported_timezones[0]"
+          - name: supported_account_timezones
+            path: "account.timezone.supported_timezones"
+          - name: timezone_test_operator_unit_id
+            generate: uuid_v4
         validations:
           - check: response_schema
             description: "Capability response matches the canonical schema"
@@ -80,23 +90,32 @@ phases:
             - brand:
                 domain: "acmeoutdoor.example"
               operator: "pinnacle-agency.example"
+              operator_unit:
+                id: "$context.timezone_test_operator_unit_id"
+                name: "Timezone reconciliation test"
               timezone: "$context.account_timezone"
               billing: "operator"
+              sandbox: true
           idempotency_key: "$generate:uuid_v4#account_timezone_buyer_selected_provision"
-        context_outputs:
-          - name: account_id
-            path: "accounts[0].account_id"
         validations:
           - check: response_schema
             description: "Provisioning response matches the canonical schema"
           - check: field_value
             path: "accounts[0].action"
-            allowed_values: ["created", "updated", "unchanged"]
-            description: "Provisioning succeeds instead of returning a per-account failure"
+            value: "created"
+            description: "The per-run natural key creates a fresh account identity"
           - check: field_equals_context
             path: "accounts[0].timezone"
             context_key: "account_timezone"
             description: "Provisioning echoes the buyer-selected timezone"
+          - check: field_in_context_array
+            path: "accounts[0].timezone"
+            context_key: "supported_account_timezones"
+            description: "The accepted timezone belongs to the advertised allowlist"
+          - check: field_equals_context
+            path: "accounts[0].operator_unit.id"
+            context_key: "timezone_test_operator_unit_id"
+            description: "Provisioning preserves the per-run natural-key qualifier"
 
   - id: natural_key_roundtrip
     title: "Round-trip the timezone-bearing natural AccountRef"
@@ -114,14 +133,26 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            operator_unit:
+              id: "$context.timezone_test_operator_unit_id"
             timezone: "$context.account_timezone"
+            sandbox: true
+        context_outputs:
+          - name: original_account_id
+            path: "accounts[0].account_id"
+          - name: recovered_brand_domain
+            path: "accounts[0].brand.domain"
+          - name: recovered_operator
+            path: "accounts[0].operator"
+          - name: recovered_operator_unit_id
+            path: "accounts[0].operator_unit.id"
+          - name: recovered_account_timezone
+            path: "accounts[0].timezone"
+          - name: recovered_sandbox
+            path: "accounts[0].sandbox"
         validations:
           - check: response_schema
             description: "Natural-key read matches the canonical schema"
-          - check: field_equals_context
-            path: "accounts[0].account_id"
-            context_key: "account_id"
-            description: "The selected timezone resolves the original account"
           - check: field_equals_context
             path: "accounts[0].timezone"
             context_key: "account_timezone"
@@ -134,3 +165,254 @@ phases:
             path: "accounts[0].operator"
             value: "pinnacle-agency.example"
             description: "Readback exposes the reusable operator key"
+          - check: field_equals_context
+            path: "accounts[0].operator_unit.id"
+            context_key: "timezone_test_operator_unit_id"
+            description: "Readback exposes the reusable operator-unit key"
+          - check: field_value
+            path: "accounts[0].sandbox"
+            value: true
+            description: "Readback exposes the reusable sandbox qualifier"
+
+  - id: reconnect_existing
+    title: "Reconnect to the existing timezone-bound account"
+    depends_on: [natural_key_roundtrip]
+    narrative: |
+      A buyer recovering from a cold start reuses the canonical natural key it
+      recovered from list_accounts rather than relying on provisioning memory.
+      Its own current timezone preference does not mutate the existing account
+      or remove the timezone qualifier.
+    steps:
+      - id: reconnect_existing_timezone
+        title: "Re-sync the exact existing natural key"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        sample_request:
+          accounts:
+            - brand:
+                domain: "$context.recovered_brand_domain"
+              operator: "$context.recovered_operator"
+              operator_unit:
+                id: "$context.recovered_operator_unit_id"
+                name: "Timezone reconciliation test"
+              timezone: "$context.recovered_account_timezone"
+              billing: "operator"
+              sandbox: "$context.recovered_sandbox"
+          idempotency_key: "$generate:uuid_v4#account_timezone_buyer_selected_reconnect"
+        validations:
+          - check: response_schema
+            description: "Reconnect response matches the canonical schema"
+          - check: field_value
+            path: "accounts[0].action"
+            value: "unchanged"
+            description: "The exact timezone-bearing key reconnects instead of provisioning another account"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "recovered_account_timezone"
+            description: "Reconnect preserves the existing immutable timezone"
+          - check: field_equals_context
+            path: "accounts[0].operator_unit.id"
+            context_key: "recovered_operator_unit_id"
+            description: "Reconnect preserves the complete natural key"
+
+  - id: verify_reconnect
+    title: "Verify the reconnected natural key"
+    depends_on: [reconnect_existing]
+    steps:
+      - id: read_reconnected_timezone_key
+        title: "Read the recovered natural key again"
+        task: list_accounts
+        schema_ref: "account/list-accounts-request.json"
+        response_schema_ref: "account/list-accounts-response.json"
+        doc_ref: "/accounts/tasks/list_accounts"
+        stateful: false
+        sample_request:
+          account:
+            brand:
+              domain: "$context.recovered_brand_domain"
+            operator: "$context.recovered_operator"
+            operator_unit:
+              id: "$context.recovered_operator_unit_id"
+            timezone: "$context.recovered_account_timezone"
+            sandbox: "$context.recovered_sandbox"
+        validations:
+          - check: response_schema
+            description: "Reconnect read matches the canonical schema"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "recovered_account_timezone"
+            description: "Reconnect leaves the recovered immutable timezone unchanged"
+          - check: field_equals_context
+            path: "accounts[0].operator_unit.id"
+            context_key: "recovered_operator_unit_id"
+            description: "Reconnect leaves the recovered natural key unchanged"
+
+  - id: select_second_timezone
+    title: "Select a second advertised timezone as a separate account"
+    depends_on: [verify_reconnect]
+    requires_capability:
+      path: account.timezone.supported_timezones.1
+      present: true
+    narrative: |
+      Account timezone cannot be changed in settings-update mode. When a buyer
+      needs another advertised clock, the different timezone forms a different
+      natural key. This phase runs only when the seller advertises a second
+      choice; a seller that offers only UTC has no account-timezone switch.
+    steps:
+      - id: discover_second_timezone
+        title: "Read the second advertised timezone"
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        stateful: false
+        sample_request: {}
+        context_outputs:
+          - name: second_account_timezone
+            path: "account.timezone.supported_timezones[1]"
+        validations:
+          - check: response_schema
+            description: "Capability response matches the canonical schema"
+          - check: field_present
+            path: "account.timezone.supported_timezones[1]"
+            description: "A second selectable timezone is advertised"
+
+      - id: provision_second_timezone
+        title: "Provision the second timezone-bearing natural key"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              operator_unit:
+                id: "$context.timezone_test_operator_unit_id"
+                name: "Timezone reconciliation test"
+              timezone: "$context.second_account_timezone"
+              billing: "operator"
+              sandbox: true
+          idempotency_key: "$generate:uuid_v4#account_timezone_buyer_selected_second"
+        validations:
+          - check: response_schema
+            description: "Second provisioning response matches the canonical schema"
+          - check: field_value
+            path: "accounts[0].action"
+            value: "created"
+            description: "A different timezone creates a separate natural-key account"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "second_account_timezone"
+            description: "The second account uses the newly selected timezone"
+          - check: field_in_context_array
+            path: "accounts[0].timezone"
+            context_key: "supported_account_timezones"
+            description: "The second selection also belongs to the advertised allowlist"
+
+  - id: verify_both_timezone_keys
+    title: "Verify both immutable timezone identities"
+    depends_on: [select_second_timezone]
+    requires_capability:
+      path: account.timezone.supported_timezones.1
+      present: true
+    steps:
+      - id: read_original_after_second_timezone
+        title: "Read the original timezone-bearing key again"
+        task: list_accounts
+        schema_ref: "account/list-accounts-request.json"
+        response_schema_ref: "account/list-accounts-response.json"
+        doc_ref: "/accounts/tasks/list_accounts"
+        stateful: false
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            operator_unit:
+              id: "$context.timezone_test_operator_unit_id"
+            timezone: "$context.account_timezone"
+            sandbox: true
+        validations:
+          - check: response_schema
+            description: "Original-key read matches the canonical schema"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "account_timezone"
+            description: "Creating a second key did not mutate the original timezone"
+          - check: field_equals_context
+            path: "accounts[0].operator_unit.id"
+            context_key: "timezone_test_operator_unit_id"
+            description: "The original complete natural key remains resolvable"
+
+      - id: read_second_timezone_key
+        title: "Read the second timezone-bearing key"
+        task: list_accounts
+        schema_ref: "account/list-accounts-request.json"
+        response_schema_ref: "account/list-accounts-response.json"
+        doc_ref: "/accounts/tasks/list_accounts"
+        stateful: false
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            operator_unit:
+              id: "$context.timezone_test_operator_unit_id"
+            timezone: "$context.second_account_timezone"
+            sandbox: true
+        context_outputs:
+          - name: second_account_id
+            path: "accounts[0].account_id"
+        validations:
+          - check: response_schema
+            description: "Second-key read matches the canonical schema"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "second_account_timezone"
+            description: "The second natural key resolves its own immutable timezone"
+          - check: field_equals_context
+            path: "accounts[0].operator_unit.id"
+            context_key: "timezone_test_operator_unit_id"
+            description: "The second complete natural key remains resolvable"
+
+      - id: read_original_by_account_id
+        title: "Resolve the original canonical account handle"
+        task: list_accounts
+        schema_ref: "account/list-accounts-request.json"
+        response_schema_ref: "account/list-accounts-response.json"
+        doc_ref: "/accounts/tasks/list_accounts"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "$context.original_account_id"
+        validations:
+          - check: response_schema
+            description: "Original-handle read matches the canonical schema"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "account_timezone"
+            description: "The original handle still resolves the original immutable timezone"
+
+      - id: read_second_by_account_id
+        title: "Resolve the second canonical account handle"
+        task: list_accounts
+        schema_ref: "account/list-accounts-request.json"
+        response_schema_ref: "account/list-accounts-response.json"
+        doc_ref: "/accounts/tasks/list_accounts"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "$context.second_account_id"
+        validations:
+          - check: response_schema
+            description: "Second-handle read matches the canonical schema"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "second_account_timezone"
+            description: "The second handle resolves the second immutable timezone"

--- a/static/compliance/source/protocols/media-buy/scenarios/account_timezone_buyer_selected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/account_timezone_buyer_selected.yaml
@@ -1,0 +1,136 @@
+id: media_buy_seller/account_timezone_buyer_selected
+version: "1.0.0"
+title: "Buyer-selected account timezone resolution"
+category: media_buy_seller
+summary: "Verifies advertised timezone selection, provisioning echo, list readback, and natural AccountRef round-trip."
+track: media_buy
+introduced_in: "3.2"
+
+requires_capability:
+  path: account.timezone.account_selection
+  equals: buyer_selected
+
+required_tools:
+  - get_adcp_capabilities
+  - sync_accounts
+  - list_accounts
+
+narrative: |
+  In buyer-selected account-fixed mode, the buyer chooses one advertised
+  timezone while provisioning. That immutable value participates in the
+  natural account key and must survive sync_accounts, list_accounts, and a
+  subsequent exact natural-key lookup.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - buyer_selected_account_timezone
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: "The seller advertises account_fixed timezone selection by the buyer."
+  test_kit: "test-kits/acme-outdoor.yaml"
+
+phases:
+  - id: discover_and_provision
+    title: "Choose an advertised account timezone"
+    steps:
+      - id: discover_supported_timezones
+        title: "Read the account timezone allowlist"
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        stateful: false
+        sample_request: {}
+        context_outputs:
+          - name: account_timezone
+            path: "account.timezone.supported_timezones[0]"
+        validations:
+          - check: response_schema
+            description: "Capability response matches the canonical schema"
+          - check: field_value
+            path: "account.timezone.mode"
+            value: "account_fixed"
+            description: "Buyer selection is an account-fixed mode"
+          - check: field_value
+            path: "account.timezone.account_selection"
+            value: "buyer_selected"
+            description: "Buyer selects the immutable account timezone"
+          - check: field_present
+            path: "account.timezone.supported_timezones[0]"
+            description: "At least one selectable timezone is advertised"
+          - check: field_absent
+            path: "account.timezone.fixed_timezone"
+            description: "Account-fixed mode does not declare a seller-wide timezone"
+
+      - id: provision_selected_timezone
+        title: "Provision with one advertised timezone"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              timezone: "$context.account_timezone"
+              billing: "operator"
+          idempotency_key: "$generate:uuid_v4#account_timezone_buyer_selected_provision"
+        context_outputs:
+          - name: account_id
+            path: "accounts[0].account_id"
+        validations:
+          - check: response_schema
+            description: "Provisioning response matches the canonical schema"
+          - check: field_value
+            path: "accounts[0].action"
+            allowed_values: ["created", "updated", "unchanged"]
+            description: "Provisioning succeeds instead of returning a per-account failure"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "account_timezone"
+            description: "Provisioning echoes the buyer-selected timezone"
+
+  - id: natural_key_roundtrip
+    title: "Round-trip the timezone-bearing natural AccountRef"
+    depends_on: [discover_and_provision]
+    steps:
+      - id: list_by_natural_key
+        title: "Resolve the account by its complete natural key"
+        task: list_accounts
+        schema_ref: "account/list-accounts-request.json"
+        response_schema_ref: "account/list-accounts-response.json"
+        doc_ref: "/accounts/tasks/list_accounts"
+        stateful: false
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            timezone: "$context.account_timezone"
+        validations:
+          - check: response_schema
+            description: "Natural-key read matches the canonical schema"
+          - check: field_equals_context
+            path: "accounts[0].account_id"
+            context_key: "account_id"
+            description: "The selected timezone resolves the original account"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "account_timezone"
+            description: "Readback preserves the natural-key timezone"
+          - check: field_value
+            path: "accounts[0].brand.domain"
+            value: "acmeoutdoor.example"
+            description: "Readback exposes the reusable brand key"
+          - check: field_value
+            path: "accounts[0].operator"
+            value: "pinnacle-agency.example"
+            description: "Readback exposes the reusable operator key"

--- a/static/compliance/source/protocols/media-buy/scenarios/account_timezone_seller_assigned.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/account_timezone_seller_assigned.yaml
@@ -79,6 +79,7 @@ phases:
                 domain: "acmeoutdoor.example"
               operator: "pinnacle-agency.example"
               billing: "operator"
+              sandbox: true
           idempotency_key: "$generate:uuid_v4#account_timezone_seller_assigned_provision"
         context_outputs:
           - name: account_timezone
@@ -118,6 +119,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
         validations:
           - check: response_schema
             description: "Account read matches the canonical schema"

--- a/static/compliance/source/protocols/media-buy/scenarios/account_timezone_seller_assigned.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/account_timezone_seller_assigned.yaml
@@ -1,0 +1,121 @@
+id: media_buy_seller/account_timezone_seller_assigned
+version: "1.0.0"
+title: "Seller-assigned account timezone discovery"
+category: media_buy_seller
+summary: "Verifies that buyers omit timezone input and discover the seller-assigned immutable value from account readback."
+track: media_buy
+introduced_in: "3.2"
+
+requires_capability:
+  path: account.timezone.account_selection
+  equals: seller_assigned
+
+required_tools:
+  - get_adcp_capabilities
+  - sync_accounts
+  - list_accounts
+
+narrative: |
+  In seller-assigned account-fixed mode, the buyer does not choose a timezone.
+  The seller assigns the upstream account clock, returns it from provisioning,
+  and keeps it stable on later account reads.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - seller_assigned_account_timezone
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: "The seller advertises account_fixed timezone assignment by the seller."
+  test_kit: "test-kits/acme-outdoor.yaml"
+
+phases:
+  - id: discover_and_provision
+    title: "Provision without buyer timezone input"
+    steps:
+      - id: discover_assignment_mode
+        title: "Confirm seller assignment"
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        stateful: false
+        sample_request: {}
+        validations:
+          - check: response_schema
+            description: "Capability response matches the canonical schema"
+          - check: field_value
+            path: "account.timezone.mode"
+            value: "account_fixed"
+            description: "Seller assignment is an account-fixed mode"
+          - check: field_value
+            path: "account.timezone.account_selection"
+            value: "seller_assigned"
+            description: "Seller owns timezone assignment"
+          - check: field_absent
+            path: "account.timezone.supported_timezones"
+            description: "Seller assignment exposes no buyer allowlist"
+          - check: field_absent
+            path: "account.timezone.fixed_timezone"
+            description: "Different accounts may use different assigned timezones"
+
+      - id: provision_without_timezone
+        title: "Let the seller assign the account timezone"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+          idempotency_key: "$generate:uuid_v4#account_timezone_seller_assigned_provision"
+        context_outputs:
+          - name: account_id
+            path: "accounts[0].account_id"
+          - name: account_timezone
+            path: "accounts[0].timezone"
+        validations:
+          - check: response_schema
+            description: "Provisioning response matches the canonical schema"
+          - check: field_value
+            path: "accounts[0].action"
+            allowed_values: ["created", "updated", "unchanged"]
+            description: "Provisioning succeeds instead of returning a per-account failure"
+          - check: field_present
+            path: "accounts[0].timezone"
+            description: "Seller returns the assigned immutable timezone"
+
+  - id: readback
+    title: "Discover the assigned timezone again"
+    depends_on: [discover_and_provision]
+    steps:
+      - id: list_seller_assigned_account
+        title: "Read the provisioned account"
+        task: list_accounts
+        schema_ref: "account/list-accounts-request.json"
+        response_schema_ref: "account/list-accounts-response.json"
+        doc_ref: "/accounts/tasks/list_accounts"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "$context.account_id"
+        validations:
+          - check: response_schema
+            description: "Account read matches the canonical schema"
+          - check: field_equals_context
+            path: "accounts[0].account_id"
+            context_key: "account_id"
+            description: "Read resolves the provisioned account"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "account_timezone"
+            description: "Readback preserves the assigned timezone"

--- a/static/compliance/source/protocols/media-buy/scenarios/account_timezone_seller_assigned.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/account_timezone_seller_assigned.yaml
@@ -17,8 +17,10 @@ required_tools:
 
 narrative: |
   In seller-assigned account-fixed mode, the buyer does not choose a timezone.
-  The seller assigns the upstream account clock, returns it from provisioning,
-  and keeps it stable on later account reads.
+  The seller assigns or recovers the upstream account clock, returns it from
+  provisioning, and keeps it stable on later account reads. A buyer connecting
+  to an existing upstream account must use the returned canonical timezone even
+  when its own current preference differs.
 
 agent:
   interaction_model: media_buy_seller
@@ -79,8 +81,6 @@ phases:
               billing: "operator"
           idempotency_key: "$generate:uuid_v4#account_timezone_seller_assigned_provision"
         context_outputs:
-          - name: account_id
-            path: "accounts[0].account_id"
           - name: account_timezone
             path: "accounts[0].timezone"
         validations:
@@ -93,6 +93,14 @@ phases:
           - check: field_present
             path: "accounts[0].timezone"
             description: "Seller returns the assigned immutable timezone"
+          - check: field_value
+            path: "accounts[0].brand.domain"
+            value: "acmeoutdoor.example"
+            description: "Provisioning echoes the reusable brand natural key"
+          - check: field_value
+            path: "accounts[0].operator"
+            value: "pinnacle-agency.example"
+            description: "Provisioning echoes the reusable operator natural key"
 
   - id: readback
     title: "Discover the assigned timezone again"
@@ -107,14 +115,12 @@ phases:
         stateful: false
         sample_request:
           account:
-            account_id: "$context.account_id"
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
         validations:
           - check: response_schema
             description: "Account read matches the canonical schema"
-          - check: field_equals_context
-            path: "accounts[0].account_id"
-            context_key: "account_id"
-            description: "Read resolves the provisioned account"
           - check: field_equals_context
             path: "accounts[0].timezone"
             context_key: "account_timezone"

--- a/static/compliance/source/protocols/media-buy/scenarios/account_timezone_seller_fixed.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/account_timezone_seller_fixed.yaml
@@ -19,6 +19,9 @@ narrative: |
   A seller-fixed account clock is one seller-wide operational timezone. The
   capability must declare that value, buyers omit timezone during provisioning,
   and the seller echoes the effective value on both sync and list surfaces.
+  Buyer-local labels or preferences such as West Coast and East Coast never
+  override this contract: when the seller is fixed to UTC, both buyer teams use
+  UTC for the account even though their own local clocks differ.
 
 agent:
   interaction_model: media_buy_seller
@@ -80,9 +83,6 @@ phases:
               operator: "pinnacle-agency.example"
               billing: "operator"
           idempotency_key: "$generate:uuid_v4#account_timezone_seller_fixed_provision"
-        context_outputs:
-          - name: account_id
-            path: "accounts[0].account_id"
         validations:
           - check: response_schema
             description: "Provisioning response matches the canonical schema"
@@ -90,13 +90,18 @@ phases:
             path: "accounts[0].action"
             allowed_values: ["created", "updated", "unchanged"]
             description: "Provisioning succeeds instead of returning a per-account failure"
-          - check: field_present
-            path: "accounts[0].account_id"
-            description: "Seller returns an account handle"
           - check: field_equals_context
             path: "accounts[0].timezone"
             context_key: "account_timezone"
             description: "Provisioning echoes the seller-wide timezone"
+          - check: field_value
+            path: "accounts[0].brand.domain"
+            value: "acmeoutdoor.example"
+            description: "Provisioning echoes the reusable brand natural key"
+          - check: field_value
+            path: "accounts[0].operator"
+            value: "pinnacle-agency.example"
+            description: "Provisioning echoes the reusable operator natural key"
 
   - id: readback
     title: "Read back the immutable account timezone"
@@ -111,14 +116,12 @@ phases:
         stateful: false
         sample_request:
           account:
-            account_id: "$context.account_id"
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
         validations:
           - check: response_schema
             description: "Account read matches the canonical schema"
-          - check: field_equals_context
-            path: "accounts[0].account_id"
-            context_key: "account_id"
-            description: "Read resolves the provisioned account"
           - check: field_equals_context
             path: "accounts[0].timezone"
             context_key: "account_timezone"

--- a/static/compliance/source/protocols/media-buy/scenarios/account_timezone_seller_fixed.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/account_timezone_seller_fixed.yaml
@@ -82,6 +82,7 @@ phases:
                 domain: "acmeoutdoor.example"
               operator: "pinnacle-agency.example"
               billing: "operator"
+              sandbox: true
           idempotency_key: "$generate:uuid_v4#account_timezone_seller_fixed_provision"
         validations:
           - check: response_schema
@@ -119,6 +120,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
+            sandbox: true
         validations:
           - check: response_schema
             description: "Account read matches the canonical schema"

--- a/static/compliance/source/protocols/media-buy/scenarios/account_timezone_seller_fixed.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/account_timezone_seller_fixed.yaml
@@ -1,0 +1,125 @@
+id: media_buy_seller/account_timezone_seller_fixed
+version: "1.0.0"
+title: "Seller-fixed account timezone resolution"
+category: media_buy_seller
+summary: "Verifies that seller-fixed account capabilities declare one timezone and every account write and read echoes it."
+track: media_buy
+introduced_in: "3.2"
+
+requires_capability:
+  path: account.timezone.mode
+  equals: seller_fixed
+
+required_tools:
+  - get_adcp_capabilities
+  - sync_accounts
+  - list_accounts
+
+narrative: |
+  A seller-fixed account clock is one seller-wide operational timezone. The
+  capability must declare that value, buyers omit timezone during provisioning,
+  and the seller echoes the effective value on both sync and list surfaces.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - seller_fixed_account_timezone
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: "The seller advertises account.timezone.mode seller_fixed."
+  test_kit: "test-kits/acme-outdoor.yaml"
+
+phases:
+  - id: discover_and_provision
+    title: "Discover and apply the seller-wide timezone"
+    steps:
+      - id: discover_seller_timezone
+        title: "Read the seller-fixed timezone"
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        stateful: false
+        sample_request: {}
+        context_outputs:
+          - name: account_timezone
+            path: "account.timezone.fixed_timezone"
+        validations:
+          - check: response_schema
+            description: "Capability response matches the canonical schema"
+          - check: field_value
+            path: "account.timezone.mode"
+            value: "seller_fixed"
+            description: "Seller declares the seller-fixed mode"
+          - check: field_present
+            path: "account.timezone.fixed_timezone"
+            description: "Seller-fixed mode declares its mandatory timezone"
+          - check: field_absent
+            path: "account.timezone.account_selection"
+            description: "Seller-fixed mode does not expose per-account selection"
+          - check: field_absent
+            path: "account.timezone.supported_timezones"
+            description: "Seller-fixed mode does not expose a buyer selection list"
+
+      - id: provision_without_timezone
+        title: "Provision without buyer timezone input"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+          idempotency_key: "$generate:uuid_v4#account_timezone_seller_fixed_provision"
+        context_outputs:
+          - name: account_id
+            path: "accounts[0].account_id"
+        validations:
+          - check: response_schema
+            description: "Provisioning response matches the canonical schema"
+          - check: field_value
+            path: "accounts[0].action"
+            allowed_values: ["created", "updated", "unchanged"]
+            description: "Provisioning succeeds instead of returning a per-account failure"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Seller returns an account handle"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "account_timezone"
+            description: "Provisioning echoes the seller-wide timezone"
+
+  - id: readback
+    title: "Read back the immutable account timezone"
+    depends_on: [discover_and_provision]
+    steps:
+      - id: list_seller_fixed_account
+        title: "Read the provisioned account"
+        task: list_accounts
+        schema_ref: "account/list-accounts-request.json"
+        response_schema_ref: "account/list-accounts-response.json"
+        doc_ref: "/accounts/tasks/list_accounts"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "$context.account_id"
+        validations:
+          - check: response_schema
+            description: "Account read matches the canonical schema"
+          - check: field_equals_context
+            path: "accounts[0].account_id"
+            context_key: "account_id"
+            description: "Read resolves the provisioned account"
+          - check: field_equals_context
+            path: "accounts[0].timezone"
+            context_key: "account_timezone"
+            description: "Readback preserves the seller-wide timezone"

--- a/static/compliance/source/protocols/media-buy/scenarios/budget_cap_timezone_account.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/budget_cap_timezone_account.yaml
@@ -1,0 +1,308 @@
+id: media_buy_seller/budget_cap_timezone_account
+version: "1.0.0"
+title: "Account-based budget-cap timezone resolution"
+category: media_buy_seller
+summary: "Verifies that aggregate and package daily caps default to Account.timezone and remain stable on readback."
+track: media_buy
+introduced_in: "3.2"
+
+requires_capability:
+  path: media_buy.budget_capping.timezone_basis
+  equals: account
+
+requires:
+  - controller
+
+required_tools:
+  - get_adcp_capabilities
+  - list_accounts
+  - create_media_buy
+  - get_media_buys
+  - comply_test_controller
+
+narrative: |
+  When daily budget caps use the account clock, omitting a buyer override must
+  resolve the media buy's shared cap boundary to Account.timezone. Aggregate
+  and package scopes are exercised independently when advertised. The same
+  scenario deliberately seeds a different product reporting timezone; no
+  equality between the operational and reporting clocks is inferred.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - daily_budget_caps
+    - account_based_cap_timezone
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: "The controller seeds a sandbox account and product with deliberately distinct account and reporting clocks."
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  accounts:
+    - account_id: "acct_timezone_account_basis"
+      brand:
+        domain: "acmeoutdoor.example"
+      operator: "pinnacle-agency.example"
+      billing: "operator"
+      status: "active"
+      sandbox: true
+      timezone: "America/New_York"
+  products:
+    - product_id: "timezone_account_display"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_options:
+        - format_option_id: "display_300x250"
+          format_kind: "image"
+          params:
+            width: 300
+            height: 250
+      reporting_capabilities:
+        available_reporting_frequencies: ["daily"]
+        expected_delay_minutes: 60
+        timezone: "Europe/London"
+        supports_webhooks: false
+        available_metrics: ["impressions", "spend"]
+        date_range_support: "date_range"
+  pricing_options:
+    - product_id: "timezone_account_display"
+      pricing_option_id: "timezone_account_cpm"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 5
+
+phases:
+  - id: establish_clocks
+    title: "Read the independently declared clocks"
+    steps:
+      - id: confirm_account_basis
+        title: "Confirm account-based cap resolution"
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        stateful: false
+        sample_request: {}
+        validations:
+          - check: response_schema
+            description: "Capability response matches the canonical schema"
+          - check: field_value
+            path: "media_buy.budget_capping.timezone_basis"
+            value: "account"
+            description: "Daily caps resolve from Account.timezone"
+          - check: field_absent
+            path: "media_buy.budget_capping.fixed_timezone"
+            description: "Account basis does not declare a feature-fixed timezone"
+
+      - id: read_seeded_account
+        title: "Read the operational account clock"
+        task: list_accounts
+        schema_ref: "account/list-accounts-request.json"
+        response_schema_ref: "account/list-accounts-response.json"
+        doc_ref: "/accounts/tasks/list_accounts"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_account_basis"
+        validations:
+          - check: response_schema
+            description: "Account response matches the canonical schema"
+          - check: field_value
+            path: "accounts[0].timezone"
+            value: "America/New_York"
+            description: "Account exposes its operational day boundary"
+
+      - id: read_reporting_clock
+        title: "Read the product reporting clock independently"
+        task: list_products
+        requires_tool: list_products
+        schema_ref: "media-buy/list-products-request.json"
+        response_schema_ref: "media-buy/list-products-response.json"
+        doc_ref: "/media-buy/task-reference/list_products"
+        stateful: false
+        sample_request:
+          idempotency_key: "$generate:uuid_v4#budget_cap_timezone_account_get_products"
+          account:
+            account_id: "acct_timezone_account_basis"
+          criteria:
+            product_ids: ["timezone_account_display"]
+          fields: ["product_id", "reporting_capabilities"]
+          max_results: 1
+        validations:
+          - check: response_schema
+            description: "Product response matches the canonical schema"
+          - check: field_value
+            path: "products[0].product_id"
+            value: "timezone_account_display"
+            description: "Exact product lookup returns the seeded product"
+          - check: field_value
+            path: "products[0].reporting_capabilities.timezone"
+            value: "Europe/London"
+            description: "Reporting retains its explicit clock instead of inheriting Account.timezone"
+
+  - id: aggregate_cap
+    title: "Resolve an aggregate daily cap"
+    depends_on: [establish_clocks]
+    requires_capability:
+      path: media_buy.budget_capping.supported_scopes
+      contains: media_buy
+    steps:
+      - id: create_aggregate_cap_buy
+        title: "Create an aggregate-capped buy without an override"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        sample_request:
+          account:
+            account_id: "acct_timezone_account_basis"
+          brand:
+            domain: "acmeoutdoor.example"
+          total_budget:
+            amount: 3000
+            currency: "USD"
+          daily_budget_cap: 100
+          packages:
+            - product_id: "timezone_account_display"
+              pricing_option_id: "timezone_account_cpm"
+              budget: 3000
+          start_time: "asap"
+          end_time: "2099-12-31T23:59:59Z"
+          idempotency_key: "$generate:uuid_v4#budget_cap_timezone_account_aggregate_create"
+        context_outputs:
+          - name: aggregate_media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Create response matches the canonical schema"
+          - check: field_value
+            path: "daily_budget_cap"
+            value: 100
+            description: "Aggregate hard cap is accepted"
+          - check: field_value
+            path: "budget_cap_timezone"
+            value: "America/New_York"
+            description: "Omitted override resolves to Account.timezone"
+
+      - id: read_aggregate_cap_buy
+        title: "Read back the aggregate cap boundary"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_account_basis"
+          media_buy_ids: ["$context.aggregate_media_buy_id"]
+        validations:
+          - check: response_schema
+            description: "Read response matches the canonical schema"
+          - check: field_value
+            path: "media_buys[0].daily_budget_cap"
+            value: 100
+            description: "Aggregate cap survives readback"
+          - check: field_value
+            path: "media_buys[0].budget_cap_timezone"
+            value: "America/New_York"
+            description: "Resolved account boundary survives readback"
+
+  - id: package_cap
+    title: "Resolve a package daily cap"
+    depends_on: [establish_clocks]
+    requires_capability:
+      path: media_buy.budget_capping.supported_scopes
+      contains: package
+    steps:
+      - id: create_package_cap_buy
+        title: "Create a package-capped buy without an override"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        sample_request:
+          account:
+            account_id: "acct_timezone_account_basis"
+          brand:
+            domain: "acmeoutdoor.example"
+          total_budget:
+            amount: 3000
+            currency: "USD"
+          packages:
+            - product_id: "timezone_account_display"
+              pricing_option_id: "timezone_account_cpm"
+              budget: 3000
+              daily_budget_cap: 80
+          start_time: "asap"
+          end_time: "2099-12-31T23:59:59Z"
+          idempotency_key: "$generate:uuid_v4#budget_cap_timezone_account_package_create"
+        context_outputs:
+          - name: package_media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Create response matches the canonical schema"
+          - check: field_value
+            path: "packages[0].daily_budget_cap"
+            value: 80
+            description: "Package hard cap is accepted"
+          - check: field_value
+            path: "budget_cap_timezone"
+            value: "America/New_York"
+            description: "Package-only cap still resolves to Account.timezone"
+
+      - id: read_package_cap_buy
+        title: "Read back the package cap boundary"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_account_basis"
+          media_buy_ids: ["$context.package_media_buy_id"]
+        validations:
+          - check: response_schema
+            description: "Read response matches the canonical schema"
+          - check: field_value
+            path: "media_buys[0].packages[0].daily_budget_cap"
+            value: 80
+            description: "Package cap survives readback"
+          - check: field_value
+            path: "media_buys[0].budget_cap_timezone"
+            value: "America/New_York"
+            description: "Resolved account boundary survives readback"
+
+  - id: billing_clock
+    title: "Consume the explicit billing clock"
+    depends_on: [establish_clocks]
+    requires_capability:
+      path: account.account_financials
+      equals: true
+    steps:
+      - id: read_financial_timezone
+        title: "Read the financial period timezone"
+        task: get_account_financials
+        requires_tool: get_account_financials
+        schema_ref: "account/get-account-financials-request.json"
+        response_schema_ref: "account/get-account-financials-response.json"
+        doc_ref: "/accounts/tasks/get_account_financials"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_account_basis"
+        validations:
+          - check: response_schema
+            description: "Financial response matches the canonical schema"
+          - check: field_present
+            path: "timezone"
+            description: "Billing declares its own period timezone; no equality with account, cap, or reporting clocks is inferred"

--- a/static/compliance/source/protocols/media-buy/scenarios/budget_cap_timezone_fixed.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/budget_cap_timezone_fixed.yaml
@@ -1,0 +1,311 @@
+id: media_buy_seller/budget_cap_timezone_fixed
+version: "1.0.0"
+title: "Feature-fixed budget-cap timezone resolution"
+category: media_buy_seller
+summary: "Verifies that aggregate and package daily caps default to the budget capability's fixed timezone and remain stable on readback."
+track: media_buy
+introduced_in: "3.2"
+
+requires_capability:
+  path: media_buy.budget_capping.timezone_basis
+  equals: fixed
+
+requires:
+  - controller
+
+required_tools:
+  - get_adcp_capabilities
+  - list_accounts
+  - create_media_buy
+  - get_media_buys
+  - comply_test_controller
+
+narrative: |
+  When daily budget caps use a feature-fixed clock, omitting a buyer override
+  must resolve the shared cap boundary to budget_capping.fixed_timezone rather
+  than Account.timezone. Aggregate and package scopes are exercised
+  independently when advertised. Reporting and billing retain their own
+  explicit clock fields and are never inferred from the cap boundary.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - daily_budget_caps
+    - fixed_cap_timezone
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: "The controller seeds a sandbox account and product with explicit account and reporting clocks."
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  accounts:
+    - account_id: "acct_timezone_fixed_basis"
+      brand:
+        domain: "acmeoutdoor.example"
+      operator: "pinnacle-agency.example"
+      billing: "operator"
+      status: "active"
+      sandbox: true
+      timezone: "America/New_York"
+  products:
+    - product_id: "timezone_fixed_display"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_options:
+        - format_option_id: "display_300x250"
+          format_kind: "image"
+          params:
+            width: 300
+            height: 250
+      reporting_capabilities:
+        available_reporting_frequencies: ["daily"]
+        expected_delay_minutes: 60
+        timezone: "Europe/London"
+        supports_webhooks: false
+        available_metrics: ["impressions", "spend"]
+        date_range_support: "date_range"
+  pricing_options:
+    - product_id: "timezone_fixed_display"
+      pricing_option_id: "timezone_fixed_cpm"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 5
+
+phases:
+  - id: establish_clocks
+    title: "Read the independently declared clocks"
+    steps:
+      - id: confirm_fixed_basis
+        title: "Read the feature-fixed cap timezone"
+        task: get_adcp_capabilities
+        schema_ref: "protocol/get-adcp-capabilities-request.json"
+        response_schema_ref: "protocol/get-adcp-capabilities-response.json"
+        doc_ref: "/protocol/get_adcp_capabilities"
+        stateful: false
+        sample_request: {}
+        context_outputs:
+          - name: cap_timezone
+            path: "media_buy.budget_capping.fixed_timezone"
+        validations:
+          - check: response_schema
+            description: "Capability response matches the canonical schema"
+          - check: field_value
+            path: "media_buy.budget_capping.timezone_basis"
+            value: "fixed"
+            description: "Daily caps use a feature-fixed boundary"
+          - check: field_present
+            path: "media_buy.budget_capping.fixed_timezone"
+            description: "Fixed basis declares its mandatory timezone"
+
+      - id: read_seeded_account
+        title: "Read the distinct operational account clock"
+        task: list_accounts
+        schema_ref: "account/list-accounts-request.json"
+        response_schema_ref: "account/list-accounts-response.json"
+        doc_ref: "/accounts/tasks/list_accounts"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_fixed_basis"
+        validations:
+          - check: response_schema
+            description: "Account response matches the canonical schema"
+          - check: field_value
+            path: "accounts[0].timezone"
+            value: "America/New_York"
+            description: "Account keeps its operational clock even though caps use a fixed feature clock"
+
+      - id: read_reporting_clock
+        title: "Read the product reporting clock independently"
+        task: list_products
+        requires_tool: list_products
+        schema_ref: "media-buy/list-products-request.json"
+        response_schema_ref: "media-buy/list-products-response.json"
+        doc_ref: "/media-buy/task-reference/list_products"
+        stateful: false
+        sample_request:
+          idempotency_key: "$generate:uuid_v4#budget_cap_timezone_fixed_get_products"
+          account:
+            account_id: "acct_timezone_fixed_basis"
+          criteria:
+            product_ids: ["timezone_fixed_display"]
+          fields: ["product_id", "reporting_capabilities"]
+          max_results: 1
+        validations:
+          - check: response_schema
+            description: "Product response matches the canonical schema"
+          - check: field_value
+            path: "products[0].product_id"
+            value: "timezone_fixed_display"
+            description: "Exact product lookup returns the seeded product"
+          - check: field_value
+            path: "products[0].reporting_capabilities.timezone"
+            value: "Europe/London"
+            description: "Reporting retains its explicit clock instead of inheriting the cap clock"
+
+  - id: aggregate_cap
+    title: "Resolve an aggregate daily cap"
+    depends_on: [establish_clocks]
+    requires_capability:
+      path: media_buy.budget_capping.supported_scopes
+      contains: media_buy
+    steps:
+      - id: create_aggregate_cap_buy
+        title: "Create an aggregate-capped buy without an override"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        sample_request:
+          account:
+            account_id: "acct_timezone_fixed_basis"
+          brand:
+            domain: "acmeoutdoor.example"
+          total_budget:
+            amount: 3000
+            currency: "USD"
+          daily_budget_cap: 100
+          packages:
+            - product_id: "timezone_fixed_display"
+              pricing_option_id: "timezone_fixed_cpm"
+              budget: 3000
+          start_time: "asap"
+          end_time: "2099-12-31T23:59:59Z"
+          idempotency_key: "$generate:uuid_v4#budget_cap_timezone_fixed_aggregate_create"
+        context_outputs:
+          - name: aggregate_media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Create response matches the canonical schema"
+          - check: field_value
+            path: "daily_budget_cap"
+            value: 100
+            description: "Aggregate hard cap is accepted"
+          - check: field_equals_context
+            path: "budget_cap_timezone"
+            context_key: "cap_timezone"
+            description: "Omitted override resolves to the advertised fixed timezone"
+
+      - id: read_aggregate_cap_buy
+        title: "Read back the aggregate cap boundary"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_fixed_basis"
+          media_buy_ids: ["$context.aggregate_media_buy_id"]
+        validations:
+          - check: response_schema
+            description: "Read response matches the canonical schema"
+          - check: field_value
+            path: "media_buys[0].daily_budget_cap"
+            value: 100
+            description: "Aggregate cap survives readback"
+          - check: field_equals_context
+            path: "media_buys[0].budget_cap_timezone"
+            context_key: "cap_timezone"
+            description: "Resolved fixed boundary survives readback"
+
+  - id: package_cap
+    title: "Resolve a package daily cap"
+    depends_on: [establish_clocks]
+    requires_capability:
+      path: media_buy.budget_capping.supported_scopes
+      contains: package
+    steps:
+      - id: create_package_cap_buy
+        title: "Create a package-capped buy without an override"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        sample_request:
+          account:
+            account_id: "acct_timezone_fixed_basis"
+          brand:
+            domain: "acmeoutdoor.example"
+          total_budget:
+            amount: 3000
+            currency: "USD"
+          packages:
+            - product_id: "timezone_fixed_display"
+              pricing_option_id: "timezone_fixed_cpm"
+              budget: 3000
+              daily_budget_cap: 80
+          start_time: "asap"
+          end_time: "2099-12-31T23:59:59Z"
+          idempotency_key: "$generate:uuid_v4#budget_cap_timezone_fixed_package_create"
+        context_outputs:
+          - name: package_media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Create response matches the canonical schema"
+          - check: field_value
+            path: "packages[0].daily_budget_cap"
+            value: 80
+            description: "Package hard cap is accepted"
+          - check: field_equals_context
+            path: "budget_cap_timezone"
+            context_key: "cap_timezone"
+            description: "Package-only cap resolves to the advertised fixed timezone"
+
+      - id: read_package_cap_buy
+        title: "Read back the package cap boundary"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_fixed_basis"
+          media_buy_ids: ["$context.package_media_buy_id"]
+        validations:
+          - check: response_schema
+            description: "Read response matches the canonical schema"
+          - check: field_value
+            path: "media_buys[0].packages[0].daily_budget_cap"
+            value: 80
+            description: "Package cap survives readback"
+          - check: field_equals_context
+            path: "media_buys[0].budget_cap_timezone"
+            context_key: "cap_timezone"
+            description: "Resolved fixed boundary survives readback"
+
+  - id: billing_clock
+    title: "Consume the explicit billing clock"
+    depends_on: [establish_clocks]
+    requires_capability:
+      path: account.account_financials
+      equals: true
+    steps:
+      - id: read_financial_timezone
+        title: "Read the financial period timezone"
+        task: get_account_financials
+        requires_tool: get_account_financials
+        schema_ref: "account/get-account-financials-request.json"
+        response_schema_ref: "account/get-account-financials-response.json"
+        doc_ref: "/accounts/tasks/get_account_financials"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_fixed_basis"
+        validations:
+          - check: response_schema
+            description: "Financial response matches the canonical schema"
+          - check: field_present
+            path: "timezone"
+            description: "Billing declares its own period timezone; no equality with account, cap, or reporting clocks is inferred"

--- a/static/compliance/source/protocols/media-buy/scenarios/budget_cap_timezone_override.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/budget_cap_timezone_override.yaml
@@ -1,0 +1,235 @@
+id: media_buy_seller/budget_cap_timezone_override
+version: "1.0.0"
+title: "Buyer budget-cap timezone override"
+category: media_buy_seller
+summary: "Verifies that an advertised buyer timezone override applies to aggregate and package caps and is echoed on readback."
+track: media_buy
+introduced_in: "3.2"
+
+requires_capability:
+  path: media_buy.budget_capping.buyer_timezone_override
+  equals: true
+
+requires:
+  - controller
+
+required_tools:
+  - list_accounts
+  - create_media_buy
+  - get_media_buys
+  - comply_test_controller
+
+narrative: |
+  Sellers advertising buyer_timezone_override accept a buyer-selected IANA
+  boundary on capped media buys. The selected value is shared by every cap on
+  the buy. Aggregate and package scopes are exercised independently when each
+  is advertised, and durable readback must echo the accepted override.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - buyer_budget_cap_timezone_override
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: "The controller seeds a sandbox account and one non-guaranteed product."
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  accounts:
+    - account_id: "acct_timezone_override"
+      brand:
+        domain: "acmeoutdoor.example"
+      operator: "pinnacle-agency.example"
+      billing: "operator"
+      status: "active"
+      sandbox: true
+      timezone: "America/New_York"
+  products:
+    - product_id: "timezone_override_display"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_options:
+        - format_option_id: "display_300x250"
+          format_kind: "image"
+          params:
+            width: 300
+            height: 250
+      reporting_capabilities:
+        available_reporting_frequencies: ["daily"]
+        expected_delay_minutes: 60
+        timezone: "Europe/London"
+        supports_webhooks: false
+        available_metrics: ["impressions", "spend"]
+        date_range_support: "date_range"
+  pricing_options:
+    - product_id: "timezone_override_display"
+      pricing_option_id: "timezone_override_cpm"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 5
+
+phases:
+  - id: account_readback
+    title: "Confirm the account's default differs from the override"
+    steps:
+      - id: read_override_account
+        title: "Read the operational account clock"
+        task: list_accounts
+        schema_ref: "account/list-accounts-request.json"
+        response_schema_ref: "account/list-accounts-response.json"
+        doc_ref: "/accounts/tasks/list_accounts"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_override"
+        validations:
+          - check: response_schema
+            description: "Account response matches the canonical schema"
+          - check: field_value
+            path: "accounts[0].timezone"
+            value: "America/New_York"
+            description: "Account default is explicit before the buyer overrides it"
+
+  - id: aggregate_override
+    title: "Override an aggregate daily cap"
+    depends_on: [account_readback]
+    requires_capability:
+      path: media_buy.budget_capping.supported_scopes
+      contains: media_buy
+    steps:
+      - id: create_aggregate_override_buy
+        title: "Create an aggregate-capped buy with a buyer boundary"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        sample_request:
+          account:
+            account_id: "acct_timezone_override"
+          brand:
+            domain: "acmeoutdoor.example"
+          total_budget:
+            amount: 3000
+            currency: "USD"
+          daily_budget_cap: 100
+          budget_cap_timezone: "Pacific/Honolulu"
+          packages:
+            - product_id: "timezone_override_display"
+              pricing_option_id: "timezone_override_cpm"
+              budget: 3000
+          start_time: "asap"
+          end_time: "2099-12-31T23:59:59Z"
+          idempotency_key: "$generate:uuid_v4#budget_cap_timezone_override_aggregate_create"
+        context_outputs:
+          - name: aggregate_override_media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Create response matches the canonical schema"
+          - check: field_value
+            path: "daily_budget_cap"
+            value: 100
+            description: "Aggregate hard cap is accepted"
+          - check: field_value
+            path: "budget_cap_timezone"
+            value: "Pacific/Honolulu"
+            description: "Seller accepts and echoes the buyer override"
+
+      - id: read_aggregate_override_buy
+        title: "Read back the aggregate override"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_override"
+          media_buy_ids: ["$context.aggregate_override_media_buy_id"]
+        validations:
+          - check: response_schema
+            description: "Read response matches the canonical schema"
+          - check: field_value
+            path: "media_buys[0].daily_budget_cap"
+            value: 100
+            description: "Aggregate cap survives readback"
+          - check: field_value
+            path: "media_buys[0].budget_cap_timezone"
+            value: "Pacific/Honolulu"
+            description: "Aggregate override survives readback"
+
+  - id: package_override
+    title: "Override a package daily cap"
+    depends_on: [account_readback]
+    requires_capability:
+      path: media_buy.budget_capping.supported_scopes
+      contains: package
+    steps:
+      - id: create_package_override_buy
+        title: "Create a package-capped buy with the same buyer boundary"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        sample_request:
+          account:
+            account_id: "acct_timezone_override"
+          brand:
+            domain: "acmeoutdoor.example"
+          total_budget:
+            amount: 3000
+            currency: "USD"
+          budget_cap_timezone: "Pacific/Honolulu"
+          packages:
+            - product_id: "timezone_override_display"
+              pricing_option_id: "timezone_override_cpm"
+              budget: 3000
+              daily_budget_cap: 80
+          start_time: "asap"
+          end_time: "2099-12-31T23:59:59Z"
+          idempotency_key: "$generate:uuid_v4#budget_cap_timezone_override_package_create"
+        context_outputs:
+          - name: package_override_media_buy_id
+            path: "media_buy_id"
+        validations:
+          - check: response_schema
+            description: "Create response matches the canonical schema"
+          - check: field_value
+            path: "packages[0].daily_budget_cap"
+            value: 80
+            description: "Package hard cap is accepted"
+          - check: field_value
+            path: "budget_cap_timezone"
+            value: "Pacific/Honolulu"
+            description: "The buyer override applies to a package-only cap"
+
+      - id: read_package_override_buy
+        title: "Read back the package override"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_override"
+          media_buy_ids: ["$context.package_override_media_buy_id"]
+        validations:
+          - check: response_schema
+            description: "Read response matches the canonical schema"
+          - check: field_value
+            path: "media_buys[0].packages[0].daily_budget_cap"
+            value: 80
+            description: "Package cap survives readback"
+          - check: field_value
+            path: "media_buys[0].budget_cap_timezone"
+            value: "Pacific/Honolulu"
+            description: "Package override survives readback"

--- a/static/compliance/source/protocols/media-buy/scenarios/budget_cap_timezone_override_rejected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/budget_cap_timezone_override_rejected.yaml
@@ -1,0 +1,155 @@
+id: media_buy_seller/budget_cap_timezone_override_rejected
+version: "1.0.0"
+title: "Unadvertised budget-cap timezone override rejection"
+category: media_buy_seller
+summary: "Verifies that an aggregate-cap timezone override is rejected when buyer override support is false or absent."
+track: media_buy
+introduced_in: "3.2"
+
+requires_capability:
+  path: media_buy.budget_capping.supported_scopes
+  contains: media_buy
+
+requires:
+  - controller
+
+required_tools:
+  - get_adcp_capabilities
+  - create_media_buy
+  - comply_test_controller
+
+narrative: |
+  A seller that supports aggregate daily caps but does not advertise
+  buyer_timezone_override must reject a submitted cap-day override with
+  UNSUPPORTED_FEATURE. Explicit false and omitted capability values are
+  exercised as separate applicability branches; exactly one runs for a seller.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - daily_budget_caps
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: "The controller seeds a sandbox account and non-guaranteed product for an aggregate-cap rejection probe."
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  accounts:
+    - account_id: "acct_timezone_override_rejected"
+      brand:
+        domain: "acmeoutdoor.example"
+      operator: "pinnacle-agency.example"
+      billing: "operator"
+      status: "active"
+      sandbox: true
+      timezone: "America/New_York"
+  products:
+    - product_id: "timezone_override_rejected_display"
+      delivery_type: "non_guaranteed"
+      channels: ["display"]
+      format_options:
+        - format_option_id: "display_300x250"
+          format_kind: "image"
+          params:
+            width: 300
+            height: 250
+      reporting_capabilities:
+        available_reporting_frequencies: ["daily"]
+        expected_delay_minutes: 60
+        timezone: "Europe/London"
+        supports_webhooks: false
+        available_metrics: ["impressions", "spend"]
+        date_range_support: "date_range"
+  pricing_options:
+    - product_id: "timezone_override_rejected_display"
+      pricing_option_id: "timezone_override_rejected_cpm"
+      pricing_model: "cpm"
+      currency: "USD"
+      floor_price: 5
+
+phases:
+  - id: explicitly_disabled
+    title: "Reject an override when capability is false"
+    depends_on: []
+    requires_capability:
+      path: media_buy.budget_capping.buyer_timezone_override
+      equals: false
+    steps:
+      - id: reject_explicitly_disabled_override
+        title: "Submit an aggregate cap with a disabled buyer override"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_override_rejected"
+          brand:
+            domain: "acmeoutdoor.example"
+          total_budget:
+            amount: 3000
+            currency: "USD"
+          daily_budget_cap: 100
+          budget_cap_timezone: "Pacific/Honolulu"
+          packages:
+            - product_id: "timezone_override_rejected_display"
+              pricing_option_id: "timezone_override_rejected_cpm"
+              budget: 3000
+          start_time: "asap"
+          end_time: "2099-12-31T23:59:59Z"
+          idempotency_key: "$generate:uuid_v4#budget_cap_timezone_override_explicitly_disabled"
+        validations:
+          - check: response_schema
+            description: "Error response matches the canonical create schema"
+          - check: error_code
+            value: "UNSUPPORTED_FEATURE"
+            description: "Explicit false capability rejects the buyer timezone override"
+
+  - id: not_advertised
+    title: "Reject an override when capability is absent"
+    depends_on: []
+    requires_capability:
+      path: media_buy.budget_capping.buyer_timezone_override
+      present: false
+    steps:
+      - id: reject_unadvertised_override
+        title: "Submit an aggregate cap with an unadvertised buyer override"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: false
+        sample_request:
+          account:
+            account_id: "acct_timezone_override_rejected"
+          brand:
+            domain: "acmeoutdoor.example"
+          total_budget:
+            amount: 3000
+            currency: "USD"
+          daily_budget_cap: 100
+          budget_cap_timezone: "Pacific/Honolulu"
+          packages:
+            - product_id: "timezone_override_rejected_display"
+              pricing_option_id: "timezone_override_rejected_cpm"
+              budget: 3000
+          start_time: "asap"
+          end_time: "2099-12-31T23:59:59Z"
+          idempotency_key: "$generate:uuid_v4#budget_cap_timezone_override_not_advertised"
+        validations:
+          - check: response_schema
+            description: "Error response matches the canonical create schema"
+          - check: error_code
+            value: "UNSUPPORTED_FEATURE"
+            description: "Absent capability rejects the buyer timezone override"

--- a/tests/timezone-resolution-storyboards.test.cjs
+++ b/tests/timezone-resolution-storyboards.test.cjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const YAML = require('yaml');
+const { runStoryboard, runValidations } = require('@adcp/sdk/testing');
+
+const scenariosDir = path.join(
+  __dirname,
+  '..',
+  'static',
+  'compliance',
+  'source',
+  'protocols',
+  'media-buy',
+  'scenarios'
+);
+
+function load(name) {
+  return YAML.parse(fs.readFileSync(path.join(scenariosDir, `${name}.yaml`), 'utf8'));
+}
+
+function loadMediaBuyIndex() {
+  return YAML.parse(fs.readFileSync(path.join(scenariosDir, '..', 'index.yaml'), 'utf8'));
+}
+
+function step(doc, id) {
+  return doc.phases.flatMap(phase => phase.steps).find(candidate => candidate.id === id);
+}
+
+function validation(candidate, check, fieldPath) {
+  return candidate.validations.find(item => item.check === check && item.path === fieldPath);
+}
+
+test('account timezone scenarios cover all three advertised authority modes', () => {
+  const sellerFixed = load('account_timezone_seller_fixed');
+  const buyerSelected = load('account_timezone_buyer_selected');
+  const sellerAssigned = load('account_timezone_seller_assigned');
+
+  assert.deepEqual(sellerFixed.requires_capability, {
+    path: 'account.timezone.mode',
+    equals: 'seller_fixed',
+  });
+  assert.deepEqual(buyerSelected.requires_capability, {
+    path: 'account.timezone.account_selection',
+    equals: 'buyer_selected',
+  });
+  assert.deepEqual(sellerAssigned.requires_capability, {
+    path: 'account.timezone.account_selection',
+    equals: 'seller_assigned',
+  });
+
+  assert.equal(step(sellerFixed, 'provision_without_timezone').sample_request.accounts[0].timezone, undefined);
+  assert.equal(
+    step(buyerSelected, 'provision_selected_timezone').sample_request.accounts[0].timezone,
+    '$context.account_timezone'
+  );
+  assert.equal(step(sellerAssigned, 'provision_without_timezone').sample_request.accounts[0].timezone, undefined);
+  assert.equal(
+    step(buyerSelected, 'list_by_natural_key').sample_request.account.timezone,
+    '$context.account_timezone'
+  );
+
+  for (const [doc, stepId] of [
+    [sellerFixed, 'provision_without_timezone'],
+    [buyerSelected, 'provision_selected_timezone'],
+    [sellerAssigned, 'provision_without_timezone'],
+  ]) {
+    const actionCheck = validation(step(doc, stepId), 'field_value', 'accounts[0].action');
+    assert.deepEqual(actionCheck.allowed_values, ['created', 'updated', 'unchanged']);
+
+    const validationContext = {
+      taskName: 'sync_accounts',
+      agentUrl: 'https://seller.example',
+      contributions: new Set(),
+    };
+    const [failedAction] = runValidations([actionCheck], {
+      ...validationContext,
+      taskResult: { success: true, data: { accounts: [{ action: 'failed' }] } },
+    });
+    const [createdAction] = runValidations([actionCheck], {
+      ...validationContext,
+      taskResult: { success: true, data: { accounts: [{ action: 'created' }] } },
+    });
+    assert.equal(failedAction.passed, false);
+    assert.equal(createdAction.passed, true);
+  }
+});
+
+test('parent media-buy account setup routes buyer-selected timezone provisioning', () => {
+  const doc = loadMediaBuyIndex();
+  const defaultSetup = doc.phases.find(phase => phase.id === 'account_setup');
+  const buyerSetup = doc.phases.find(phase => phase.id === 'buyer_selected_account_setup');
+
+  assert.deepEqual(defaultSetup.requires_capability, {
+    path: 'account.timezone.supported_timezones',
+    present: false,
+  });
+  assert.deepEqual(buyerSetup.requires_capability, {
+    path: 'account.timezone.account_selection',
+    equals: 'buyer_selected',
+  });
+  assert.equal(
+    step({ phases: [buyerSetup] }, 'sync_accounts_buyer_selected_timezone').sample_request.accounts[0].timezone,
+    '$context.account_timezone'
+  );
+  assert.equal(
+    validation(
+      step({ phases: [buyerSetup] }, 'sync_accounts_buyer_selected_timezone'),
+      'field_value',
+      'accounts[0].action'
+    ).allowed_values.includes('failed'),
+    false
+  );
+
+  const downstream = doc.phases.filter(phase => !['account_setup', 'buyer_selected_account_setup'].includes(phase.id));
+  assert.doesNotMatch(JSON.stringify(downstream), /"operator":"pinnacle-agency\.example"/);
+  assert.match(JSON.stringify(downstream), /"account_id":"\$context\.account_id"/);
+});
+
+test('default cap timezone scenarios gate each supported scope and assert durable resolution', () => {
+  const cases = [
+    ['budget_cap_timezone_account', 'account'],
+    ['budget_cap_timezone_fixed', 'fixed'],
+  ];
+
+  for (const [name, basis] of cases) {
+    const doc = load(name);
+    assert.deepEqual(doc.requires_capability, {
+      path: 'media_buy.budget_capping.timezone_basis',
+      equals: basis,
+    });
+    assert.deepEqual(doc.phases.find(phase => phase.id === 'aggregate_cap').requires_capability, {
+      path: 'media_buy.budget_capping.supported_scopes',
+      contains: 'media_buy',
+    });
+    assert.deepEqual(doc.phases.find(phase => phase.id === 'package_cap').requires_capability, {
+      path: 'media_buy.budget_capping.supported_scopes',
+      contains: 'package',
+    });
+    assert.ok(validation(step(doc, 'create_aggregate_cap_buy'), basis === 'account' ? 'field_value' : 'field_equals_context', 'budget_cap_timezone'));
+    assert.ok(validation(step(doc, 'read_package_cap_buy'), basis === 'account' ? 'field_value' : 'field_equals_context', 'media_buys[0].budget_cap_timezone'));
+
+    const reporting = validation(step(doc, 'read_reporting_clock'), 'field_value', 'products[0].reporting_capabilities.timezone');
+    assert.equal(reporting.value, 'Europe/London');
+    assert.equal(step(doc, 'read_reporting_clock').task, 'list_products');
+    assert.deepEqual(step(doc, 'read_reporting_clock').sample_request.criteria.product_ids, [
+      basis === 'account' ? 'timezone_account_display' : 'timezone_fixed_display',
+    ]);
+    assert.ok(validation(step(doc, 'read_financial_timezone'), 'field_present', 'timezone'));
+  }
+});
+
+test('buyer override scenario covers aggregate and package caps with one shared boundary', () => {
+  const doc = load('budget_cap_timezone_override');
+  assert.deepEqual(doc.requires_capability, {
+    path: 'media_buy.budget_capping.buyer_timezone_override',
+    equals: true,
+  });
+
+  for (const phaseId of ['aggregate_override', 'package_override']) {
+    const phase = doc.phases.find(candidate => candidate.id === phaseId);
+    assert.equal(phase.requires_capability.path, 'media_buy.budget_capping.supported_scopes');
+  }
+
+  const aggregate = step(doc, 'create_aggregate_override_buy');
+  const packageOnly = step(doc, 'create_package_override_buy');
+  assert.equal(aggregate.sample_request.budget_cap_timezone, 'Pacific/Honolulu');
+  assert.equal(packageOnly.sample_request.budget_cap_timezone, 'Pacific/Honolulu');
+  assert.equal(packageOnly.sample_request.packages[0].daily_budget_cap, 80);
+  assert.equal(
+    validation(step(doc, 'read_aggregate_override_buy'), 'field_value', 'media_buys[0].budget_cap_timezone').value,
+    'Pacific/Honolulu'
+  );
+  assert.equal(
+    validation(step(doc, 'read_package_override_buy'), 'field_value', 'media_buys[0].budget_cap_timezone').value,
+    'Pacific/Honolulu'
+  );
+});
+
+test('unadvertised buyer override is an executable negative conformance path', async () => {
+  const doc = load('budget_cap_timezone_override_rejected');
+  assert.deepEqual(doc.requires_capability, {
+    path: 'media_buy.budget_capping.supported_scopes',
+    contains: 'media_buy',
+  });
+  assert.deepEqual(doc.phases.map(phase => phase.requires_capability), [
+    { path: 'media_buy.budget_capping.buyer_timezone_override', equals: false },
+    { path: 'media_buy.budget_capping.buyer_timezone_override', present: false },
+  ]);
+
+  const negativePhase = doc.phases.find(phase => phase.id === 'not_advertised');
+  const executablePhase = {
+    ...negativePhase,
+    steps: negativePhase.steps.map(candidate => ({
+      ...candidate,
+      validations: candidate.validations.filter(item => item.check === 'error_code'),
+    })),
+  };
+  const tools = ['get_adcp_capabilities', 'create_media_buy', 'comply_test_controller'];
+  const baseOptions = {
+    _profile: {
+      tools,
+      raw_capabilities: {
+        media_buy: {
+          budget_capping: {
+            supported_scopes: ['media_buy'],
+            supported_periods: ['daily'],
+            timezone_basis: 'account',
+          },
+        },
+      },
+    },
+    agentTools: tools,
+    skip_controller_seeding: true,
+  };
+  const storyboard = {
+    ...doc,
+    prerequisites: undefined,
+    fixtures: undefined,
+    phases: [executablePhase],
+  };
+
+  const rejected = await runStoryboard('https://agent.example/mcp', storyboard, {
+    ...baseOptions,
+    _client: {
+      resetContext() {},
+      async createMediaBuy() {
+        return {
+          success: false,
+          data: {
+            errors: [{ code: 'UNSUPPORTED_FEATURE', message: 'Buyer timezone override is not supported' }],
+          },
+        };
+      },
+    },
+  });
+  assert.equal(rejected.overall_passed, true);
+  assert.equal(rejected.passed_count, 1);
+
+  const incorrectlyAccepted = await runStoryboard('https://agent.example/mcp', storyboard, {
+    ...baseOptions,
+    _client: {
+      resetContext() {},
+      async createMediaBuy() {
+        return { success: true, data: { media_buy_id: 'incorrectly_accepted' } };
+      },
+    },
+  });
+  assert.equal(incorrectlyAccepted.overall_passed, false);
+  assert.equal(incorrectlyAccepted.failed_count, 1);
+});

--- a/tests/timezone-resolution-storyboards.test.cjs
+++ b/tests/timezone-resolution-storyboards.test.cjs
@@ -127,6 +127,11 @@ test('account timezone scenarios cover all three advertised authority modes', ()
     '$context.account_timezone'
   );
   assert.equal(step(sellerAssigned, 'provision_without_timezone').sample_request.accounts[0].timezone, undefined);
+  for (const scenario of [sellerFixed, sellerAssigned]) {
+    assert.equal(step(scenario, 'provision_without_timezone').sample_request.accounts[0].sandbox, true);
+  }
+  assert.equal(step(sellerFixed, 'list_seller_fixed_account').sample_request.account.sandbox, true);
+  assert.equal(step(sellerAssigned, 'list_seller_assigned_account').sample_request.account.sandbox, true);
   assert.equal(
     step(buyerSelected, 'list_by_natural_key').sample_request.account.timezone,
     '$context.account_timezone'
@@ -300,6 +305,7 @@ test('seller-fixed UTC ignores West/East buyer preferences on both write and rea
     assert.deepEqual(valid.listRequests[0].account, {
       brand: { domain: 'acmeoutdoor.example' },
       operator: 'pinnacle-agency.example',
+      sandbox: true,
     });
   }
 

--- a/tests/timezone-resolution-storyboards.test.cjs
+++ b/tests/timezone-resolution-storyboards.test.cjs
@@ -6,7 +6,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const YAML = require('yaml');
-const { runStoryboard, runValidations } = require('@adcp/sdk/testing');
+const { loadStoryboardFile, runStoryboard, runValidations } = require('@adcp/sdk/testing');
 
 const scenariosDir = path.join(
   __dirname,
@@ -23,6 +23,15 @@ function load(name) {
   return YAML.parse(fs.readFileSync(path.join(scenariosDir, `${name}.yaml`), 'utf8'));
 }
 
+function loadExecutable(name) {
+  const doc = loadStoryboardFile(path.join(scenariosDir, `${name}.yaml`));
+  return {
+    ...doc,
+    prerequisites: undefined,
+    fixtures: undefined,
+  };
+}
+
 function loadMediaBuyIndex() {
   return YAML.parse(fs.readFileSync(path.join(scenariosDir, '..', 'index.yaml'), 'utf8'));
 }
@@ -33,6 +42,65 @@ function step(doc, id) {
 
 function validation(candidate, check, fieldPath) {
   return candidate.validations.find(item => item.check === check && item.path === fieldPath);
+}
+
+function accountRefsIn(phases) {
+  const refs = [];
+  function visit(value) {
+    if (!value || typeof value !== 'object') return;
+    if (!Array.isArray(value) && value.account && typeof value.account === 'object') {
+      refs.push(value.account);
+    }
+    for (const child of Object.values(value)) visit(child);
+  }
+  visit(phases);
+  return refs;
+}
+
+function accountResult(account, timezone, action) {
+  return {
+    account_id: `account-${timezone.replaceAll('/', '-')}`,
+    name: `Timezone test account (${timezone})`,
+    brand: account.brand,
+    operator: account.operator,
+    ...(account.operator_unit && { operator_unit: account.operator_unit }),
+    timezone,
+    billing: account.billing ?? 'operator',
+    sandbox: account.sandbox ?? true,
+    status: 'active',
+    ...(action && { action }),
+  };
+}
+
+function capabilityResult(accountTimezone) {
+  return {
+    status: 'completed',
+    adcp: {
+      major_versions: [3],
+      supported_versions: ['3.1'],
+      idempotency: { supported: false },
+    },
+    supported_protocols: ['media_buy'],
+    account: {
+      supported_billing: ['operator'],
+      timezone: accountTimezone,
+    },
+  };
+}
+
+function timezoneProfile(accountTimezone) {
+  const tools = ['get_adcp_capabilities', 'sync_accounts', 'list_accounts'];
+  return {
+    tools,
+    options: {
+      _profile: {
+        tools,
+        raw_capabilities: { account: { timezone: accountTimezone } },
+      },
+      agentTools: tools,
+      skip_controller_seeding: true,
+    },
+  };
 }
 
 test('account timezone scenarios cover all three advertised authority modes', () => {
@@ -64,13 +132,13 @@ test('account timezone scenarios cover all three advertised authority modes', ()
     '$context.account_timezone'
   );
 
-  for (const [doc, stepId] of [
-    [sellerFixed, 'provision_without_timezone'],
-    [buyerSelected, 'provision_selected_timezone'],
-    [sellerAssigned, 'provision_without_timezone'],
+  for (const [doc, stepId, allowedActions] of [
+    [sellerFixed, 'provision_without_timezone', ['created', 'updated', 'unchanged']],
+    [buyerSelected, 'provision_selected_timezone', ['created']],
+    [sellerAssigned, 'provision_without_timezone', ['created', 'updated', 'unchanged']],
   ]) {
     const actionCheck = validation(step(doc, stepId), 'field_value', 'accounts[0].action');
-    assert.deepEqual(actionCheck.allowed_values, ['created', 'updated', 'unchanged']);
+    assert.deepEqual(actionCheck.allowed_values ?? [actionCheck.value], allowedActions);
 
     const validationContext = {
       taskName: 'sync_accounts',
@@ -90,10 +158,12 @@ test('account timezone scenarios cover all three advertised authority modes', ()
   }
 });
 
-test('parent media-buy account setup routes buyer-selected timezone provisioning', () => {
+test('parent flow carries the correct complete natural AccountRef through each timezone branch', () => {
   const doc = loadMediaBuyIndex();
   const defaultSetup = doc.phases.find(phase => phase.id === 'account_setup');
   const buyerSetup = doc.phases.find(phase => phase.id === 'buyer_selected_account_setup');
+  const defaultSync = step({ phases: [defaultSetup] }, 'sync_accounts');
+  const buyerSync = step({ phases: [buyerSetup] }, 'sync_accounts_buyer_selected_timezone');
 
   assert.deepEqual(defaultSetup.requires_capability, {
     path: 'account.timezone.supported_timezones',
@@ -103,22 +173,291 @@ test('parent media-buy account setup routes buyer-selected timezone provisioning
     path: 'account.timezone.account_selection',
     equals: 'buyer_selected',
   });
+  assert.equal(defaultSync.context_outputs, undefined);
+  assert.equal(validation(defaultSync, 'field_present', 'accounts[0].account_id'), undefined);
+  assert.equal(defaultSync.sample_request.accounts[0].sandbox, true);
+  assert.equal(buyerSync.context_outputs, undefined);
+  assert.equal(validation(buyerSync, 'field_present', 'accounts[0].account_id'), undefined);
+  assert.equal(buyerSync.sample_request.accounts[0].timezone, '$context.account_timezone');
+  assert.equal(buyerSync.sample_request.accounts[0].sandbox, true);
+
+  const defaultLifecycle = doc.phases.filter(phase =>
+    ['governance_setup', 'product_discovery', 'create_buy', 'creative_sync', 'delivery_monitoring'].includes(phase.id)
+  );
+  const buyerLifecycle = doc.phases.filter(phase => phase.id.startsWith('buyer_selected_') && phase.id !== 'buyer_selected_account_setup');
+  const defaultAccount = {
+    brand: { domain: 'acmeoutdoor.example' },
+    operator: 'pinnacle-agency.example',
+    sandbox: true,
+  };
+  const buyerAccount = { ...defaultAccount, timezone: '$context.account_timezone' };
+
+  assert.deepEqual(accountRefsIn(defaultLifecycle), Array(6).fill(defaultAccount));
+  assert.deepEqual(accountRefsIn(buyerLifecycle), Array(6).fill(buyerAccount));
+  assert.doesNotMatch(JSON.stringify(doc), /\$context\.account_id/);
+  assert.equal(doc.phases.flatMap(phase => phase.steps).some(candidate => candidate.task === 'list_accounts'), false);
+});
+
+test('buyer-selected storyboard covers cold-start reconnect and an immutable timezone switch', () => {
+  const doc = load('account_timezone_buyer_selected');
+  const discovery = step(doc, 'discover_supported_timezones');
+  const provision = step(doc, 'provision_selected_timezone');
+  const reconnect = step(doc, 'reconnect_existing_timezone');
+  const second = step(doc, 'provision_second_timezone');
+  const switchPhase = doc.phases.find(phase => phase.id === 'select_second_timezone');
+
+  assert.deepEqual(
+    discovery.context_outputs.find(output => output.name === 'timezone_test_operator_unit_id'),
+    { name: 'timezone_test_operator_unit_id', generate: 'uuid_v4' }
+  );
+  assert.equal(provision.sample_request.accounts[0].sandbox, true);
   assert.equal(
-    step({ phases: [buyerSetup] }, 'sync_accounts_buyer_selected_timezone').sample_request.accounts[0].timezone,
+    validation(provision, 'field_value', 'accounts[0].action').value,
+    'created'
+  );
+  assert.deepEqual(reconnect.sample_request.accounts[0], {
+    brand: { domain: '$context.recovered_brand_domain' },
+    operator: '$context.recovered_operator',
+    operator_unit: {
+      id: '$context.recovered_operator_unit_id',
+      name: 'Timezone reconciliation test',
+    },
+    timezone: '$context.recovered_account_timezone',
+    billing: 'operator',
+    sandbox: '$context.recovered_sandbox',
+  });
+  assert.equal(
+    validation(reconnect, 'field_value', 'accounts[0].action').value,
+    'unchanged'
+  );
+  assert.deepEqual(switchPhase.requires_capability, {
+    path: 'account.timezone.supported_timezones.1',
+    present: true,
+  });
+  assert.deepEqual(doc.phases.find(phase => phase.id === 'verify_both_timezone_keys').requires_capability, {
+    path: 'account.timezone.supported_timezones.1',
+    present: true,
+  });
+  assert.equal(second.sample_request.accounts[0].timezone, '$context.second_account_timezone');
+  assert.equal(
+    validation(second, 'field_value', 'accounts[0].action').value,
+    'created'
+  );
+  assert.equal(
+    step(doc, 'read_original_after_second_timezone').sample_request.account.timezone,
     '$context.account_timezone'
   );
   assert.equal(
-    validation(
-      step({ phases: [buyerSetup] }, 'sync_accounts_buyer_selected_timezone'),
-      'field_value',
-      'accounts[0].action'
-    ).allowed_values.includes('failed'),
-    false
+    step(doc, 'read_second_timezone_key').sample_request.account.timezone,
+    '$context.second_account_timezone'
+  );
+  assert.doesNotMatch(JSON.stringify(doc), /\$context\.account_id/);
+});
+
+test('seller-fixed UTC ignores West/East buyer preferences on both write and read', async () => {
+  const storyboard = loadExecutable('account_timezone_seller_fixed');
+  const accountTimezone = { mode: 'seller_fixed', fixed_timezone: 'UTC' };
+  const { options } = timezoneProfile(accountTimezone);
+  async function execute({ buyerPreference, syncTimezone = 'UTC', listTimezone = 'UTC' }) {
+    const syncRequests = [];
+    const listRequests = [];
+    const result = await runStoryboard('https://agent.example/mcp', storyboard, {
+      ...options,
+      context: { buyer_local_timezone: buyerPreference },
+      _client: {
+        resetContext() {},
+        async getAdcpCapabilities() {
+          return { success: true, data: capabilityResult(accountTimezone) };
+        },
+        async syncAccounts(request) {
+          syncRequests.push(request);
+          return {
+            success: true,
+            data: {
+              status: 'completed',
+              accounts: [accountResult(request.accounts[0], syncTimezone, 'created')],
+            },
+          };
+        },
+        async listAccounts(request) {
+          listRequests.push(request);
+          return {
+            success: true,
+            data: { status: 'completed', accounts: [accountResult(request.account, listTimezone)] },
+          };
+        },
+      },
+    });
+    return { result, syncRequests, listRequests };
+  }
+
+  for (const buyerPreference of ['America/Los_Angeles', 'America/New_York']) {
+    const valid = await execute({ buyerPreference });
+    assert.equal(valid.result.overall_passed, true, JSON.stringify(valid.result, null, 2));
+    assert.equal(valid.syncRequests.length, 1);
+    assert.equal(valid.syncRequests[0].accounts[0].timezone, undefined);
+    assert.doesNotMatch(JSON.stringify(valid.syncRequests[0]), new RegExp(buyerPreference));
+    assert.deepEqual(valid.listRequests[0].account, {
+      brand: { domain: 'acmeoutdoor.example' },
+      operator: 'pinnacle-agency.example',
+    });
+  }
+
+  const wrongSyncClock = await execute({
+    buyerPreference: 'America/Los_Angeles',
+    syncTimezone: 'America/New_York',
+  });
+  assert.equal(wrongSyncClock.result.overall_passed, false);
+
+  const wrongReadClock = await execute({
+    buyerPreference: 'America/New_York',
+    listTimezone: 'America/New_York',
+  });
+  assert.equal(wrongReadClock.result.overall_passed, false);
+});
+
+test('buyer-selected UTC-only seller reconciles a local preference and reconnects exactly', async () => {
+  const storyboard = loadExecutable('account_timezone_buyer_selected');
+  const accountTimezone = {
+    mode: 'account_fixed',
+    account_selection: 'buyer_selected',
+    supported_timezones: ['UTC'],
+  };
+  const { options } = timezoneProfile(accountTimezone);
+  const syncRequests = [];
+  const listRequests = [];
+  let syncCount = 0;
+
+  const result = await runStoryboard('https://agent.example/mcp', storyboard, {
+    ...options,
+    _client: {
+      resetContext() {},
+      async getAdcpCapabilities() {
+        return { success: true, data: capabilityResult(accountTimezone) };
+      },
+      async syncAccounts(request) {
+        syncRequests.push(request);
+        const action = syncCount++ === 0 ? 'created' : 'unchanged';
+        return {
+          success: true,
+          data: { status: 'completed', accounts: [accountResult(request.accounts[0], 'UTC', action)] },
+        };
+      },
+      async listAccounts(request) {
+        listRequests.push(request);
+        return {
+          success: true,
+          data: { status: 'completed', accounts: [accountResult(request.account, 'UTC')] },
+        };
+      },
+    },
+  });
+
+  assert.equal(result.overall_passed, true, JSON.stringify(result, null, 2));
+  assert.equal(syncRequests.length, 2);
+  assert.equal(listRequests.length, 2);
+  assert.deepEqual(syncRequests.map(request => request.accounts[0].timezone), ['UTC', 'UTC']);
+  assert.equal(syncRequests[0].accounts[0].operator_unit.id, syncRequests[1].accounts[0].operator_unit.id);
+  assert.match(syncRequests[0].accounts[0].operator_unit.id, /^[0-9a-f-]{36}$/);
+  assert.equal(syncRequests[0].accounts[0].sandbox, true);
+  const expectedNaturalKey = {
+    brand: { domain: 'acmeoutdoor.example' },
+    operator: 'pinnacle-agency.example',
+    operator_unit: { id: syncRequests[0].accounts[0].operator_unit.id },
+    timezone: 'UTC',
+    sandbox: true,
+  };
+  assert.deepEqual(listRequests.map(request => request.account), [expectedNaturalKey, expectedNaturalKey]);
+  const skippedSwitchPhases = result.phases.filter(phase =>
+    ['select_second_timezone', 'verify_both_timezone_keys'].includes(phase.phase_id)
+  );
+  assert.equal(result.skipped_count, 6);
+  assert.deepEqual(
+    skippedSwitchPhases.flatMap(phase => phase.steps.map(candidate => candidate.skip_reason)),
+    Array(6).fill('not_applicable')
+  );
+});
+
+test('buyer-selected timezone switch creates a second key without mutating the first', async () => {
+  const storyboard = loadExecutable('account_timezone_buyer_selected');
+  const accountTimezone = {
+    mode: 'account_fixed',
+    account_selection: 'buyer_selected',
+    supported_timezones: ['America/New_York', 'UTC'],
+  };
+  const { options } = timezoneProfile(accountTimezone);
+
+  async function execute({ mutateOriginal = false, reuseAccountId = false } = {}) {
+    const syncRequests = [];
+    const listRequests = [];
+    const timezoneByAccountId = new Map();
+    let syncCount = 0;
+    let secondProvisioned = false;
+    const result = await runStoryboard('https://agent.example/mcp', storyboard, {
+      ...options,
+      _client: {
+        resetContext() {},
+        async getAdcpCapabilities() {
+          return { success: true, data: capabilityResult(accountTimezone) };
+        },
+        async syncAccounts(request) {
+          syncRequests.push(request);
+          const action = syncCount++ === 1 ? 'unchanged' : 'created';
+          if (request.accounts[0].timezone === 'UTC') secondProvisioned = true;
+          return {
+            success: true,
+            data: {
+              status: 'completed',
+              accounts: [accountResult(request.accounts[0], request.accounts[0].timezone, action)],
+            },
+          };
+        },
+        async listAccounts(request) {
+          listRequests.push(request);
+          const requestedTimezone =
+            request.account.timezone ?? timezoneByAccountId.get(request.account.account_id);
+          const returnedTimezone =
+            mutateOriginal && secondProvisioned && requestedTimezone === 'America/New_York'
+              ? 'UTC'
+              : requestedTimezone;
+          const account = accountResult(request.account, returnedTimezone);
+          if (request.account.account_id) account.account_id = request.account.account_id;
+          if (reuseAccountId) account.account_id = 'REUSED-ID';
+          timezoneByAccountId.set(account.account_id, returnedTimezone);
+          return {
+            success: true,
+            data: { status: 'completed', accounts: [account] },
+          };
+        },
+      },
+    });
+    return { result, syncRequests, listRequests };
+  }
+
+  const valid = await execute();
+  assert.equal(valid.result.overall_passed, true, JSON.stringify(valid.result, null, 2));
+  assert.deepEqual(
+    valid.syncRequests.map(request => request.accounts[0].timezone),
+    ['America/New_York', 'America/New_York', 'UTC']
+  );
+  assert.deepEqual(
+    valid.listRequests.map(request => request.account.timezone),
+    ['America/New_York', 'America/New_York', 'America/New_York', 'UTC', undefined, undefined]
+  );
+  assert.notEqual(
+    valid.listRequests[4].account.account_id,
+    valid.listRequests[5].account.account_id
+  );
+  assert.equal(
+    new Set(valid.syncRequests.map(request => request.accounts[0].operator_unit.id)).size,
+    1
   );
 
-  const downstream = doc.phases.filter(phase => !['account_setup', 'buyer_selected_account_setup'].includes(phase.id));
-  assert.doesNotMatch(JSON.stringify(downstream), /"operator":"pinnacle-agency\.example"/);
-  assert.match(JSON.stringify(downstream), /"account_id":"\$context\.account_id"/);
+  const mutated = await execute({ mutateOriginal: true });
+  assert.equal(mutated.result.overall_passed, false);
+
+  const reusedIdentity = await execute({ reuseAccountId: true });
+  assert.equal(reusedIdentity.result.overall_passed, false);
 });
 
 test('default cap timezone scenarios gate each supported scope and assert durable resolution', () => {


### PR DESCRIPTION
## Summary

- add capability-gated account timezone storyboards for seller-fixed, buyer-selected, and seller-assigned modes
- cover buyer/seller mismatches explicitly: West and East Coast buyer preferences against a UTC-only seller
- verify cold reconnect to an existing account from response-derived natural keys, without relying on provisioning memory
- verify a buyer timezone switch creates a second account identity and never mutates the first account clock
- add account-based, feature-fixed, and buyer-override budget-cap timezone storyboards covering aggregate and package scopes
- reject unadvertised buyer timezone overrides with `UNSUPPORTED_FEATURE`
- register all seven scenarios and add structural plus executable runner regression coverage

## Why

The timezone authority chain added by #5990 spans capabilities, account provisioning, account lookup, media-buy creation/readback, reporting, and billing. These storyboards make that cross-surface contract executable for AdCP 3.2, including mismatched local preferences, reconnects, and immutable timezone-key switching.

## Validation

- `node --test tests/timezone-resolution-storyboards.test.cjs` (9/9)
- `npm run build:compliance -- --check`
- schema, sample-request, response-schema, context-output-path, and validation-path tests
- current and released-3.0 storyboard matrices across all seven tenants
- protocol, code, and test expert review

Closes #6010
