### PR TITLE
ci: migrate changesets release tooling to v3

### DIFF
--- a/.agents/playbook.md
+++ b/.agents/playbook.md
@@ -320,7 +320,7 @@ the same gates CI uses:
 ```bash
 git add .changeset/<descriptive-name>.md
 node scripts/check-changeset-protocol-scope.cjs origin/main
-npx --yes @changesets/cli@^2.31.0 status --since=origin/main
+npx --yes @changesets/cli@^3.0.0 status --since=origin/main
 ```
 
 The changesets CLI ignores untracked files, so the local check can still fail

--- a/.agents/shortcuts/cut-major.md
+++ b/.agents/shortcuts/cut-major.md
@@ -73,7 +73,7 @@ CHANGELOG source-of-truth changes to `main` via regular PRs first.
 
 ## 4. Merge the Version Packages PR
 
-On merge, `release.yml` runs `changeset tag` + `createGithubReleases: true`.
+On merge, `release.yml` runs `changeset git-tag` + `create-github-releases: true`.
 Verify afterward:
 
 ```bash
@@ -91,7 +91,7 @@ curl -s https://adcontextprotocol.org/protocol/ | jq '.versions[].version'
 gh pr list --search "snapshot docs for v3.0.0" --state all
 ```
 
-If `changeset tag` didn't create the tag (silent no-op), the most likely
+If `changeset git-tag` didn't create the tag (silent no-op), the most likely
 cause is `privatePackages.tag` not set to `true` in `.changeset/config.json`
 — private packages are skipped by default. If that's the issue, fix config
 and create the tag/release manually:

--- a/.agents/shortcuts/prep-for-pr.md
+++ b/.agents/shortcuts/prep-for-pr.md
@@ -21,7 +21,7 @@ request.
      `.changeset/*.md` files instead of adding empty ones.
    - If a changeset is present, stage it because the CLI ignores untracked
      files, then run:
-     `git add .changeset/<name>.md && node scripts/check-changeset-protocol-scope.cjs origin/main && npx --yes @changesets/cli@^2.31.0 status --since=origin/main`.
+     `git add .changeset/<name>.md && node scripts/check-changeset-protocol-scope.cjs origin/main && npx --yes @changesets/cli@^3.0.0 status --since=origin/main`.
    - If no changeset is expected, run:
      `node scripts/check-changeset-protocol-scope.cjs origin/main`.
 5. Run code review and address the findings.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],

--- a/.changeset/migrate-changesets-v3.md
+++ b/.changeset/migrate-changesets-v3.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Migrate release automation to Changesets CLI v3 and changesets/action v2 without changing the published protocol contract.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,8 +1,4 @@
 {
   "mode": "pre",
-  "tag": "beta",
-  "initialVersions": {
-    "adcontextprotocol": "3.1.1"
-  },
-  "changesets": []
+  "tag": "beta"
 }

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -62,4 +62,4 @@ jobs:
             echo "Skipping changesets status because this PR does not touch the protocol release surface."
             exit 0
           fi
-          npx --yes @changesets/cli@^2.31.0 status --since=origin/${{ github.base_ref }}
+          npx --yes @changesets/cli@^3.0.0 status --since=origin/${{ github.base_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,15 +113,15 @@ jobs:
       - name: Create Release Pull Request or Tag Release
         if: steps.release-relevance.outputs.relevant == 'true' && steps.release-artifacts.outputs.has_release_artifacts != 'true'
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v2
         with:
-          version: npm run version
-          publish: npx --no-install changeset tag
-          commit: 'Version Packages'
-          title: 'Version Packages'
-          createGithubReleases: true
+          github-token: ${{ steps.app-token.outputs.token }}
+          version-script: npm run version
+          publish-script: npx --no-install changeset git-tag
+          commit-message: 'Version Packages'
+          pr-title: 'Version Packages'
+          create-github-releases: true
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HUSKY: '0'
 
       - name: Sign local protocol tarball if needed

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -30,7 +30,7 @@ case "$BRANCH_NAME" in
         grep -Eq '^\.changeset/[^/]+\.md$'; then
         echo "Missing protocol changeset. Add one with 'npx changeset' before pushing."
         echo "Run the full CI-equivalent check with:"
-        echo "  npx --yes @changesets/cli@^2.31.0 status --since=$CHANGESET_BASE"
+        echo "  npx --yes @changesets/cli@^3.0.0 status --since=$CHANGESET_BASE"
         exit 1
       else
         echo "✅ Protocol changeset present"

--- a/docs/reference/verifying-protocol-tarballs.mdx
+++ b/docs/reference/verifying-protocol-tarballs.mdx
@@ -113,7 +113,7 @@ If you maintain a fourth-party SDK, mirror the regex above. Stay away from liter
 If you're contributing to the spec workflow itself: cosign signing happens during `npm run version` (chained from the `sign-protocol-tarball.sh` step) inside `release.yml`. The OIDC token is minted at signing time, so the cert subject reflects the trigger ref of that workflow run. Tag-based signing would require either:
 
 - A second workflow that runs on `release: published` and re-signs the tarball using the post-tag OIDC subject, or
-- Restructuring the release pipeline so signing happens after `changeset tag` and within a context where `refs/tags/*` is the active ref.
+- Restructuring the release pipeline so signing happens after `changeset git-tag` and within a context where `refs/tags/*` is the active ref.
 
 Today's signed-from-branch shape is intentional — it lets every consumer verify a single canonical artifact without reasoning about tag-vs-branch identity. The regex's `refs/(heads|tags)/.*` is forward-compat in case that changes.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
-        "@changesets/cli": "^2.31.1",
+        "@changesets/cli": "^3.0.0",
         "@types/cookie-parser": "^1.4.10",
         "@types/escape-html": "^1.0.4",
         "@types/express": "^5.0.6",
@@ -552,245 +552,302 @@
       "license": "MIT"
     },
     "node_modules/@changesets/apply-release-plan": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
-      "integrity": "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-8.0.0.tgz",
+      "integrity": "sha512-kUd2pbf1w5/AYmBMb0Tt+rkIPCjFJdT0SZMrkOjJT/WV/QbtmvkyB5jkV0oaNPheavprZk+SfUiozUti7TIL2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/config": "^3.1.4",
-        "@changesets/get-version-range-type": "^0.4.0",
-        "@changesets/git": "^3.0.4",
-        "@changesets/should-skip-package": "^0.1.2",
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "detect-indent": "^6.0.0",
-        "fs-extra": "^7.0.1",
-        "lodash.startcase": "^4.4.0",
-        "outdent": "^0.5.0",
-        "prettier": "^2.7.1",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.3"
+        "@changesets/config": "^4.0.0",
+        "@changesets/format": "^0.1.1",
+        "@changesets/git": "^4.0.0",
+        "@changesets/should-skip-package": "^1.0.0",
+        "@changesets/types": "^7.0.0",
+        "import-meta-resolve": "^4.2.0",
+        "jsonc-parser": "^3.3.1",
+        "semver": "^7.8.1"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/assemble-release-plan": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.10.tgz",
-      "integrity": "sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-7.0.0.tgz",
+      "integrity": "sha512-oEW8BxdA604kGGtDSCiHr5w9Tv4UWe9I2k61IBNZzCOE1kbYaJj4v+lFQNgcEZFkUc2pV/+hASErGDvpJOZCTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.4",
-        "@changesets/should-skip-package": "^0.1.2",
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "semver": "^7.5.3"
+        "@changesets/errors": "^1.0.0",
+        "@changesets/get-dependents-graph": "^3.0.0",
+        "@changesets/should-skip-package": "^1.0.0",
+        "@changesets/types": "^7.0.0",
+        "semver": "^7.8.1"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/changelog-git": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
-      "integrity": "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-1.0.0.tgz",
+      "integrity": "sha512-3Dst2Ime2Op5nd4XmWJLPIgp11ZFqJqSkVug9izK6TDcIV4YlhPS4ECbEVR+eGI0bk0r1ItogD4j2Oli87bJrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/types": "^6.1.0"
+        "@changesets/types": "^7.0.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/cli": {
-      "version": "2.31.1",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.1.tgz",
-      "integrity": "sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-3.0.0.tgz",
+      "integrity": "sha512-V7Gm+GP5OT3mJinMI2YcJD/JyO/a4WChnaMCCzTRhWHgu1zhtsyY7zCjP6n5W6zsgSjJKs+yPmvtREvE0F2g8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/apply-release-plan": "^7.1.1",
-        "@changesets/assemble-release-plan": "^6.0.10",
-        "@changesets/changelog-git": "^0.2.1",
-        "@changesets/config": "^3.1.4",
-        "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.4",
-        "@changesets/get-release-plan": "^4.0.16",
-        "@changesets/git": "^3.0.4",
-        "@changesets/logger": "^0.1.1",
-        "@changesets/pre": "^2.0.2",
-        "@changesets/read": "^0.6.7",
-        "@changesets/should-skip-package": "^0.1.2",
-        "@changesets/types": "^6.1.0",
-        "@changesets/write": "^0.4.0",
-        "@inquirer/external-editor": "^1.0.2",
-        "@manypkg/get-packages": "^1.1.3",
-        "ansi-colors": "^4.1.3",
-        "enquirer": "^2.4.1",
-        "fs-extra": "^7.0.1",
-        "mri": "^1.2.0",
-        "package-manager-detector": "^0.2.0",
-        "picocolors": "^1.1.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.3",
-        "spawndamnit": "^3.0.1",
-        "term-size": "^2.1.0"
+        "@changesets/apply-release-plan": "^8.0.0",
+        "@changesets/assemble-release-plan": "^7.0.0",
+        "@changesets/changelog-git": "^1.0.0",
+        "@changesets/config": "^4.0.0",
+        "@changesets/errors": "^1.0.0",
+        "@changesets/get-dependents-graph": "^3.0.0",
+        "@changesets/git": "^4.0.0",
+        "@changesets/pre": "^3.0.0",
+        "@changesets/read": "^1.0.0",
+        "@changesets/should-skip-package": "^1.0.0",
+        "@changesets/types": "^7.0.0",
+        "@changesets/write": "^1.0.0",
+        "@clack/prompts": "^1.7.0",
+        "@manypkg/get-packages": "^3.1.0",
+        "@pnpm/deps.graph-sequencer": "^1100.0.1",
+        "cac": "^7.0.0",
+        "import-meta-resolve": "^4.2.0",
+        "launch-editor": "^2.14.1",
+        "package-manager-detector": "^1.6.0",
+        "semver": "^7.8.1",
+        "tinyexec": "^1.3.0"
       },
       "bin": {
         "changeset": "bin.js"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26",
+        "npm": ">=10.9.0",
+        "pnpm": ">=10.0.0",
+        "yarn": ">=4.5.2"
       }
     },
     "node_modules/@changesets/config": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
-      "integrity": "sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-4.0.0.tgz",
+      "integrity": "sha512-mw95/YrkOuhZZxfnVAA4bSXOFUi+KlhzOBTM8C4x777NhUU6HWIl9Z+K+nME+E4PVsv5NQVQwTfiHihAS1A/ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.4",
-        "@changesets/logger": "^0.1.1",
-        "@changesets/should-skip-package": "^0.1.2",
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "fs-extra": "^7.0.1",
-        "micromatch": "^4.0.8"
+        "@changesets/get-dependents-graph": "^3.0.0",
+        "@changesets/should-skip-package": "^1.0.0",
+        "@changesets/types": "^7.0.0",
+        "@manypkg/get-packages": "^3.1.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
+      }
+    },
+    "node_modules/@changesets/config/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@changesets/errors": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
-      "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-1.0.0.tgz",
+      "integrity": "sha512-ElN/mEzn6zmETgjwf5MclCMa9ef59sAR0lfO8VSYIsiRvbC2FbLB/92EoYw10Sl0kGixxHFiJZUSv7dA+YpR8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
+      }
+    },
+    "node_modules/@changesets/format": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/format/-/format-0.1.2.tgz",
+      "integrity": "sha512-Caez5XtNXCFS/G5bwyav3wuXL0tMxVd2ZGbaumWbzN08tyzO21asCw7JZhNtVsAZDCvDRUzZN+Iit9SyRITSYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "extendable-error": "^0.1.5"
+        "package-manager-detector": "^1.8.0",
+        "tinyexec": "^1.3.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/get-dependents-graph": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.4.tgz",
-      "integrity": "sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-3.0.0.tgz",
+      "integrity": "sha512-ji/t5wFA1zREKXRUePE6Qi+Qu2UgxCeSSGQrphezwvQZrp49B7sJ+8+wvM0tA7zPeSxYKCojDy3WWgrl+s+awg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "picocolors": "^1.1.0",
-        "semver": "^7.5.3"
+        "@changesets/types": "^7.0.0",
+        "semver": "^7.8.1"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
-    },
-    "node_modules/@changesets/get-release-plan": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.16.tgz",
-      "integrity": "sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@changesets/assemble-release-plan": "^6.0.10",
-        "@changesets/config": "^3.1.4",
-        "@changesets/pre": "^2.0.2",
-        "@changesets/read": "^0.6.7",
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3"
-      }
-    },
-    "node_modules/@changesets/get-version-range-type": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
-      "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@changesets/git": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz",
-      "integrity": "sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-4.0.0.tgz",
+      "integrity": "sha512-uIEswpPUgzBBqrC0qg13byNaPorzhf05LE2T+gRizEKCXvMsJC6NPJp5iNDSV/gYj4Viqh09UiOF5E7XWeH5lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/errors": "^0.2.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "is-subdir": "^1.1.1",
-        "micromatch": "^4.0.8",
-        "spawndamnit": "^3.0.1"
+        "@changesets/errors": "^1.0.0",
+        "@changesets/types": "^7.0.0",
+        "@manypkg/get-packages": "^3.1.0",
+        "picomatch": "^4.0.4",
+        "tinyexec": "^1.3.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
-    "node_modules/@changesets/logger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
-      "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
+    "node_modules/@changesets/git/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "picocolors": "^1.1.0"
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@changesets/parse": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz",
-      "integrity": "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-1.0.0.tgz",
+      "integrity": "sha512-P0iaMb9p9CRYZiTgAllEIF9AUMQHIy1G72tKlcIqJp61icZSsKQNiOPdxAMZG8m/DvZwt/oz5xEbTpike//dWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/types": "^6.1.0",
-        "js-yaml": "^4.1.1"
+        "@changesets/types": "^7.0.0",
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/pre": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
-      "integrity": "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-3.0.0.tgz",
+      "integrity": "sha512-Zm/6YliV/a2oeWTqHJf6KxLrQwgcK1i/BRDl2m0EKZvbnxV5fG9QRhwJJGshjsZTUTS6dkfURQ2K6aAvgNw/3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/errors": "^0.2.0",
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "fs-extra": "^7.0.1"
+        "@changesets/errors": "^1.0.0",
+        "@changesets/types": "^7.0.0",
+        "@manypkg/get-packages": "^3.1.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/read": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz",
-      "integrity": "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-1.0.0.tgz",
+      "integrity": "sha512-8TdE2PwG6yArPt5Ozej83Z6iHz1G8BDBKvIEKZ455MccR4K3GNbLR2XqjBxa+5yLFnEd3xAOPXYboBg1pt8stQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/git": "^3.0.4",
-        "@changesets/logger": "^0.1.1",
-        "@changesets/parse": "^0.4.3",
-        "@changesets/types": "^6.1.0",
-        "fs-extra": "^7.0.1",
-        "p-filter": "^2.1.0",
-        "picocolors": "^1.1.0"
+        "@changesets/git": "^4.0.0",
+        "@changesets/parse": "^1.0.0",
+        "@changesets/types": "^7.0.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/should-skip-package": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
-      "integrity": "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-1.0.0.tgz",
+      "integrity": "sha512-pwqoJmbONn1XgXmZXPEExgAaT+HdZLjALFTDgIm+PnS5KeO2nLtzA2/Q+4aMFY14kFMuXKG30MObhvDzWgzDgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3"
+        "@changesets/types": "^7.0.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/types": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
-      "integrity": "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-7.0.0.tgz",
+      "integrity": "sha512-c5GoiQyt3pxiXjrWSNoP8/GRf4kG+VnKzovx1OQM8dYYALlSwgedmkPmJ+ZqGxqwg9D3Bkj85Uo4KLd5BN3A0w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
+      }
     },
     "node_modules/@changesets/write": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz",
-      "integrity": "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-1.0.0.tgz",
+      "integrity": "sha512-xCK3/4C7Z7muQB/wguE6HcbjtY9iOtaK9orZKE+7xi573cMGD8rLZz7qlo6IvK7s+SIUIKajzj1l+F1QuP97tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/types": "^6.1.0",
-        "fs-extra": "^7.0.1",
-        "human-id": "^4.1.1",
-        "prettier": "^2.7.1"
+        "@changesets/format": "^0.1.1",
+        "@changesets/types": "^7.0.0",
+        "human-id": "^4.2.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.7.0.tgz",
+      "integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.3",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@contentauth/c2pa-node": {
@@ -2677,75 +2734,45 @@
       "license": "MIT"
     },
     "node_modules/@manypkg/find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-3.1.0.tgz",
+      "integrity": "sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@types/node": "^12.7.1",
-        "find-up": "^4.1.0",
-        "fs-extra": "^8.1.0"
-      }
-    },
-    "node_modules/@manypkg/find-root/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@manypkg/find-root/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "@manypkg/tools": "^2.1.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@manypkg/get-packages": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
-      "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-3.1.0.tgz",
+      "integrity": "sha512-0TbBVyvPrP7xGYBI/cP8UP+yl/z+HtbTttAD7FMAJgn/kXOTwh5/60TsqP9ZYY710forNfyV0N8P/IE/ujGZJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@changesets/types": "^4.0.1",
-        "@manypkg/find-root": "^1.1.0",
-        "fs-extra": "^8.1.0",
-        "globby": "^11.0.0",
-        "read-yaml-file": "^1.1.0"
-      }
-    },
-    "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "@manypkg/find-root": "^3.1.0",
+        "@manypkg/tools": "^2.1.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@manypkg/tools": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@manypkg/tools/-/tools-2.1.2.tgz",
+      "integrity": "sha512-6QEf6yqFbETdwGITKq57aYoPfX/3K8XFNwsAlx0C1M7o8cb79sv1M3w+tWuWvIcSbNqrLF7OD7YpZMVVz335hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jju": "^1.4.0",
+        "tinyglobby": "^0.2.13",
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@mdx-js/mdx": {
@@ -5325,6 +5352,19 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pnpm/deps.graph-sequencer": {
+      "version": "1100.0.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/deps.graph-sequencer/-/deps.graph-sequencer-1100.0.1.tgz",
+      "integrity": "sha512-pOr5+q1fLYKwFN3LAJuGZEnfXDcQ73zqgDHMtGy+K+uIoUqyY+6MeDCWFwfu+4EFuq76I5EPFofoNAI+Bmmq4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
       }
     },
     "node_modules/@posthog/core": {
@@ -9517,16 +9557,6 @@
         }
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -9694,16 +9724,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
@@ -10023,19 +10043,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/better-path-resolve": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
-      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-windows": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/bidi-js": {
@@ -10374,6 +10381,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cac": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -11786,16 +11803,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/detect-indent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -11870,19 +11877,6 @@
       "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
       "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -12195,20 +12189,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/entities": {
@@ -12880,13 +12860,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extendable-error": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
-      "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/extract-zip": {
@@ -13658,20 +13631,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/find-up-simple": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
@@ -13867,21 +13826,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -14257,27 +14201,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/google-auth-library": {
@@ -15075,9 +14998,9 @@
       }
     },
     "node_modules/human-id": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz",
-      "integrity": "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.0.tgz",
+      "integrity": "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -15143,16 +15066,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -15195,6 +15108,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/indent-string": {
@@ -16045,19 +15969,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-subdir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
-      "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "better-path-resolve": "1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-symbol": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
@@ -16136,16 +16047,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-wsl": {
@@ -16263,6 +16164,13 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jose": {
       "version": "6.2.8",
@@ -16431,16 +16339,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsonpath-plus": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
@@ -16599,6 +16497,17 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/launch-editor": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/lcm": {
@@ -16950,19 +16859,6 @@
       "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
       "license": "ISC"
     },
-    "node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -17016,13 +16912,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.startcase": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.topath": {
@@ -18542,16 +18431,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -19255,13 +19134,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/outdent": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
-      "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
@@ -19315,19 +19187,6 @@
         "node": ">=12.20"
       }
     },
-    "node_modules/p-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -19335,45 +19194,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/p-queue": {
@@ -19453,16 +19273,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -19470,14 +19280,11 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
-      "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "quansync": "^0.2.7"
-      }
+      "license": "MIT"
     },
     "node_modules/pako": {
       "version": "1.0.11",
@@ -19684,16 +19491,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -19846,16 +19643,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/pino": {
@@ -20232,22 +20019,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-bytes": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
@@ -20513,23 +20284,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/quansync": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
-      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/antfu"
-        },
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/sxzz"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -20850,22 +20604,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-yaml-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
-      "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.5",
-        "js-yaml": "^3.6.1",
-        "pify": "^4.0.1",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/readable-stream": {
@@ -21370,16 +21108,6 @@
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/responselike": {
       "version": "3.0.0",
@@ -22308,15 +22036,12 @@
         "is-arrayish": "^0.3.1"
       }
     },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "MIT"
     },
     "node_modules/slice-ansi": {
       "version": "7.1.2",
@@ -22520,17 +22245,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/spawndamnit": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
-      "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "cross-spawn": "^7.0.5",
-        "signal-exit": "^4.0.1"
       }
     },
     "node_modules/split2": {
@@ -22814,16 +22528,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/strip-json-comments": {
@@ -23336,19 +23040,6 @@
         "streamx": "^2.12.5"
       }
     },
-    "node_modules/term-size": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
-      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
@@ -23423,9 +23114,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -24129,16 +23820,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.31.1",
+    "@changesets/cli": "^3.0.0",
     "@types/cookie-parser": "^1.4.10",
     "@types/escape-html": "^1.0.4",
     "@types/express": "^5.0.6",


### PR DESCRIPTION
## Summary

- upgrade `@changesets/cli` to v3 and `changesets/action` to v2 atomically
- migrate the release workflow to the renamed action inputs, explicit app token, and `changeset git-tag`
- migrate prerelease state/config and align the live CI, hook, documentation, and agent guidance references

## Why

Dependabot PRs #6597 and #6598 are unsafe independently. CLI v3 removes `changeset tag`, while action v2 requires CLI v3 and renames its inputs/token configuration. Either standalone PR would break the release path despite green pull-request checks.

## Impact

The published protocol contract is unchanged. Release automation keeps the existing custom versioning, signing, tagging, and GitHub Release behavior on the supported v3 interfaces.

## Validation

- `npm ci --ignore-scripts` plus native dependency rebuild
- Changesets v3 status and `git-tag --help` under Node 24
- `actionlint -ignore 'SC2034|SC2155' .github/workflows/release.yml .github/workflows/changeset-check.yml`
- changeset protocol-scope tests and policy check
- pre-commit suite: 6,219 tests passed, 30 skipped; typecheck passed
- current and 3.0-compatible storyboard matrices passed
- schema-link and Mintlify navigation checks passed

Supersedes #6597 and #6598.
