### PR TITLE
fix(release): support large version package commits

### DIFF
--- a/.changeset/support-large-release-commits.md
+++ b/.changeset/support-large-release-commits.md
@@ -1,0 +1,5 @@
+---
+---
+
+Restore the git-backed Version Packages update path so large generated release
+commits do not exceed GitHub's GraphQL payload limit.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,15 +113,19 @@ jobs:
       - name: Create Release Pull Request or Tag Release
         if: steps.release-relevance.outputs.relevant == 'true' && steps.release-artifacts.outputs.has_release_artifacts != 'true'
         id: changesets
-        uses: changesets/action@v2
+        # v2 writes the entire release commit through one GraphQL mutation,
+        # which exceeds GitHub's 45 MB payload cap for beta-scale generated
+        # schema and compliance artifacts. v1 pushes the generated commit via
+        # git and supports the same Changesets v3 CLI commands below.
+        uses: changesets/action@v1
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          version-script: npm run version
-          publish-script: npx --no-install changeset git-tag
-          commit-message: 'Version Packages'
-          pr-title: 'Version Packages'
-          create-github-releases: true
+          version: npm run version
+          publish: npx --no-install changeset git-tag
+          commit: 'Version Packages'
+          title: 'Version Packages'
+          createGithubReleases: true
         env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HUSKY: '0'
 
       - name: Sign local protocol tarball if needed


### PR DESCRIPTION
## What changed

- restore `changesets/action@v1` for Version Packages branch updates
- retain the Changesets v3 `git-tag` publish command
- document why the v1 git transport is required for large generated releases

## Why

The AdCP 3.2.0-beta.0 Version Packages update contains tens of thousands of generated schema and compliance files. `changesets/action@v2` attempts to write that release commit through one GraphQL mutation, which GitHub rejects because the payload exceeds 45 MB. The previous v1 action successfully generated the same beta-scale artifact set by pushing the commit through git.

## Validation

- `npm run test:release-workflow`
- `npm run test:immutable-release-artifacts`
