### PR TITLE
chore(release): remove operational beta changesets

### DIFF
--- a/.changeset/migrate-changesets-v3.md
+++ b/.changeset/migrate-changesets-v3.md
@@ -1,5 +1,0 @@
----
-"adcontextprotocol": patch
----
-
-Migrate release automation to Changesets CLI v3 and changesets/action v2 without changing the published protocol contract.

--- a/.changeset/support-large-release-commits.md
+++ b/.changeset/support-large-release-commits.md
@@ -1,5 +1,0 @@
----
----
-
-Restore the git-backed Version Packages update path so large generated release
-commits do not exceed GitHub's GraphQL payload limit.


### PR DESCRIPTION
## Summary

- remove the CI-only Changesets migration entry from the 3.2 beta pool
- remove the empty large-release transport changeset
- keep the beta.0 protocol changelog limited to releasable protocol surfaces

## Why

The beta release runbook excludes CI-only and empty changesets. The generated Version Packages candidate exposed both during the required changelog audit.

## Validation

- `npx --no-install changeset status --output ...` → `adcontextprotocol@3.2.0-beta.0`
- `npm run test:release-workflow`
- `npm run test:immutable-release-artifacts`
- pre-commit unit, dynamic-import, format-boundary, callApi, and TypeScript checks