### PR TITLE
feat(media-buy): define PackageRequest selector compatibility

### DIFF
--- a/.changeset/strict-package-format-selectors.md
+++ b/.changeset/strict-package-format-selectors.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Define deterministic PackageRequest format-selector normalization, reject
+conflicting canonical and legacy projections, require fixed image dimensions to
+travel together, and add compliance coverage for the 3.x compatibility paths.

--- a/docs/media-buy/task-reference/create_media_buy.mdx
+++ b/docs/media-buy/task-reference/create_media_buy.mdx
@@ -184,10 +184,10 @@ An unexpired `committed` proposal carries an inventory hold and cannot be reject
 |-----------|------|----------|-------------|
 | `product_id` | string | Yes | Opaque product ID from `get_products`. Non-custom wholesale IDs are stable for the same logical offer within seller and declared cache scope; custom IDs are stable only in their issuing discovery/refinement lineage. Selecting it accepts any `targeting_resolution` disclosed on that product. Sellers MUST echo it on every response package object representing the request. |
 | `pricing_option_id` | string | Yes | Pricing option ID from product's `pricing_options` array |
-| `format_option_refs` | FormatOptionRef[] | No | Canonical 3.2 selector into the product's `format_options[]`: publisher-scoped or product-scoped. |
-| `format_kind` | CanonicalFormatKind | No | Direct canonical selector. Pair with enough `params` to satisfy the product declaration. |
-| `format_ids` | FormatID[] | Deprecated | Named-format compatibility selector accepted only from older 3.x peers. New buyers do not dual-emit it. |
-| `params` | object | No | Parameters for the direct canonical selector in `format_kind`. Follows the selected canonical's parameter vocabulary. Requires `format_kind`; `params` alone is schema-invalid. A broad selector such as `{format_kind: "image"}` does not satisfy a product whose `format_options[]` fixes `params.width` and `params.height`; sellers reject under-specified direct selectors with [`UNSUPPORTED_FEATURE`](/docs/building/verification/compliance-catalog#error-code-unsupported-feature) or an equivalent format-selector error. |
+| `format_option_refs` | FormatOptionRef[] | No | Canonical 3.2 selector into the product's `format_options[]`: publisher-scoped or product-scoped. New buyers use it as their only selector route. |
+| `format_kind` | CanonicalFormatKind | No | Direct canonical selector. Pair with enough `params` to satisfy the product declaration and omit `format_option_refs`. |
+| `format_ids` | FormatID[] | Deprecated | Named-format compatibility selector accepted from older 3.x peers. New buyers MUST NOT emit it. Receivers normalize it and equivalence-check it against every co-present canonical route. |
+| `params` | object | No | Parameters for the direct canonical selector in `format_kind`. Follows the selected canonical's parameter vocabulary. Requires `format_kind`; `params` alone is schema-invalid. For fixed-size image selectors, `width` and `height` must co-occur. A broad selector such as `{format_kind: "image"}` does not satisfy a product whose `format_options[]` fixes both dimensions; sellers reject under-specified direct selectors with [`UNSUPPORTED_FEATURE`](/docs/building/verification/compliance-catalog#error-code-unsupported-feature). |
 | `budget` | number | Conditional | Hard lifetime package spend cap in the media-buy currency. Required in fixed mode. Optional in seller-optimized mode; it remains a ceiling, not a current or reserved allocation. |
 | `min_spend_target` | number | No | Soft lifetime package spend target in the media-buy currency for seller-optimized allocation. The seller should attempt to reach it, but it is not a billing or delivery guarantee. |
 | `impressions` | number | No | Impression goal for this package |
@@ -1088,6 +1088,7 @@ Common errors and resolutions:
 | [`PRODUCT_EXPIRED`](/docs/building/verification/compliance-catalog#error-code-product-expired) | Configured product passed `expires_at` and remains recognizable to the seller | Re-run [`get_products`](/docs/media-buy/task-reference/get_products) and select a current configuration |
 | [`PRODUCT_UNAVAILABLE`](/docs/building/verification/compliance-catalog#error-code-product-unavailable) | The product or a supported targeting selection has no current inventory | Re-run [`get_products`](/docs/media-buy/task-reference/get_products) with the concrete targeting values or choose another product; the seller does not silently substitute values or reprice |
 | [`UNSUPPORTED_FEATURE`](/docs/building/verification/compliance-catalog#error-code-unsupported-feature) | Canonical or legacy compatibility selector does not resolve or satisfy the product's closed accepted set | Re-author against the product's `format_options[]`, include required canonical parameters, or select a published `format_option_id`. |
+| [`CONFLICTING_SELECTORS`](/docs/building/verification/compliance-catalog#error-code-conflicting-selectors) | Co-present, resolvable package format selector routes select different product format contracts | Emit one canonical selector route, or correct the required legacy projection so it selects the same contract under the canonical v2-narrows-v1 comparison. |
 | [`BUDGET_TOO_LOW`](/docs/building/verification/compliance-catalog#error-code-budget-too-low) | Budget below product minimum | Increase budget or choose different product |
 | [`VALIDATION_ERROR`](/docs/building/verification/compliance-catalog#error-code-validation-error) | Targeting constraints or a submitted `creative_id` violate seller/product business rules | Follow `error.field` and `error.message`; broaden targeting criteria or use a different package-scoped `creative_id` as indicated |
 | [`POLICY_VIOLATION`](/docs/building/verification/compliance-catalog#error-code-policy-violation) | Brand/product violates policy | Review publisher's content policies |
@@ -1118,7 +1119,28 @@ Each package SHOULD specify the formats it will use via `format_option_refs[]` o
 - Validate that the product supports the requested formats
 - Track which assets are missing
 
-Selector precedence is deterministic: `format_option_refs[]` wins when present; otherwise direct `format_kind`/`params` is used; otherwise the package defaults to all product options. Deprecated `format_ids[]` is interpreted only on the negotiated legacy compatibility path and must normalize to the same canonical contract.
+New 3.2 buyers author one canonical route: `format_option_refs[]`, or direct
+`format_kind` with optional `params`. They MUST NOT combine those routes and
+MUST NOT newly emit deprecated `format_ids[]`. Omitting all selectors defaults
+to all product options; legacy-only `format_ids[]` remains valid throughout the
+3.x compatibility window.
+
+Receivers also accept multi-route requests from older 3.x peers, but precedence
+is applied only after resolution and equivalence checking. The seller first
+resolves every present route independently through the canonical mapping path.
+An unresolved option reference or unprojectable legacy ID returns
+[`UNSUPPORTED_FEATURE`](/docs/building/verification/compliance-catalog#error-code-unsupported-feature)
+before equivalence is evaluated. Once all routes resolve, the seller derives
+the product `format_options[]` entries selected by each route using directional
+product satisfaction and requires those sets to match. Legacy parameter
+compatibility follows the asymmetric [v2 narrows v1](/docs/creative/canonical-formats#narrows-formal-definition-normative)
+relation rather than raw object equality. Equivalent routes use
+`format_option_refs[]` as authoritative, then direct `format_kind`/`params`,
+then `format_ids[]`. Any disagreement is rejected with
+[`CONFLICTING_SELECTORS`](/docs/building/verification/compliance-catalog#error-code-conflicting-selectors);
+a canonical selector never silently hides a conflicting legacy projection. For
+fixed-size images, width and height travel together and both dimensions must
+match in any permitted dual projection.
 
 Before purchase, buyers SHOULD also inspect the selected declaration's optional
 `locale_policy.accepted_language_ranges`. These seller ranges use RFC 4647

--- a/docs/protocol/format-references.mdx
+++ b/docs/protocol/format-references.mdx
@@ -65,6 +65,8 @@ The value comes from the selected creative agent's `get_adcp_capabilities.creati
 
 ## Deprecated named references
 
-The compound `{agent_url, id}` `format_id` shape and `format_ids[]` arrays are deprecated in 3.2. Implementations may read or project them for older 3.x peers, but new examples and authored resources use canonical declarations. When canonical and legacy fields coexist, canonical fields are authoritative and both projections must describe the same underlying contract.
+The compound `{agent_url, id}` `format_id` shape and `format_ids[]` arrays are deprecated in 3.2. Implementations may read or project them for older 3.x peers, but new examples and authored resources use exactly one canonical selector route. New buyers MUST NOT dual-emit `format_ids[]`.
+
+Receivers remain compatible with older 3.x multi-route requests. They resolve every present route independently before applying precedence. An unresolved option reference or unprojectable legacy ID is rejected with [`UNSUPPORTED_FEATURE`](/docs/building/verification/compliance-catalog#error-code-unsupported-feature). Once all routes resolve, receivers derive the product options selected by each route and require those sets to match; legacy parameter compatibility follows the asymmetric [v2 narrows v1](/docs/creative/canonical-formats#narrows-formal-definition-normative) relation instead of raw object equality. Conflicts are rejected with [`CONFLICTING_SELECTORS`](/docs/building/verification/compliance-catalog#error-code-conflicting-selectors); they are never resolved by silently ignoring the legacy projection. Fixed-size image width and height are atomic and both dimensions participate in compatibility.
 
 See [Canonical formats](/docs/creative/canonical-formats) for matching, narrowing, publisher resolution, and migration details.

--- a/docs/snippets/compliance-error-codes.mdx
+++ b/docs/snippets/compliance-error-codes.mdx
@@ -43,6 +43,7 @@ description: "Canonical AdCP error codes with recovery classifications, remediat
 | `COMPLIANCE_UNSATISFIED` | correctable | choose a format that supports the required disclosure positions and persistence modes, or remove the disclosure requirement |
 | `CONFIGURATION_ERROR` | terminal | surface to a human at the seller — the buyer cannot resolve a seller-side deployment misconfiguration and MUST NOT auto-retry |
 | `CONFLICT` | transient | re-read the resource and retry with current state |
+| `CONFLICTING_SELECTORS` | correctable | emit one canonical format selector route, or make every required legacy 3.x compatibility projection select the same product format contract under the canonical v2-narrows-v1 comparison |
 | `CREATIVE_DEADLINE_EXCEEDED` | correctable | check creative_deadline via get_media_buys before submitting changes, or negotiate a deadline extension with the seller |
 | `CREATIVE_INACCESSIBLE` | correctable | verify the asset URLs in creative_manifest are reachable without agent-side credentials, then re-submit |
 | `CREATIVE_LOCALE_NOT_ACCEPTED` | correctable | supply or assign a creative variant matching every in-scope format option's accepted_language_ranges, narrow placement scope, choose a compatible format option, or change an ineligible serve_default |
@@ -401,6 +402,15 @@ The seller's deployment is misconfigured in a way that prevents handling the req
 **Suggested action:** re-read the resource and retry with current state
 
 Concurrent modification detected. The resource was modified by another request between read and write. Recovery: transient (re-read the resource and retry with current state).
+
+</Accordion>
+<a id="error-code-conflicting-selectors"></a>
+
+<Accordion title="CONFLICTING_SELECTORS — correctable">
+
+**Suggested action:** emit one canonical format selector route, or make every required legacy 3.x compatibility projection select the same product format contract under the canonical v2-narrows-v1 comparison
+
+A 3.x package request carries multiple resolvable format selector routes that select different canonical product format declaration sets. Sellers MUST first resolve every present route independently (<code>{"format_option_refs"}</code>, direct <code>{"format_kind"}</code> plus <code>{"params"}</code>, and deprecated <code>{"format_ids"}</code>) without applying precedence. An unresolved option reference or an unprojectable legacy ID is rejected with <code>{"UNSUPPORTED_FEATURE"}</code>, not this code. Once all routes resolve, sellers derive the product <code>{"format_options[]"}</code> entries selected by each route using directional product satisfaction and require those sets to match. Legacy parameter compatibility uses the asymmetric v2-narrows-v1 relation defined by canonical formats, not raw object equality. For fixed-size image selectors, both width and height participate in compatibility. Sellers MUST reject different format shapes, selected option sets, or incompatible dimensions rather than silently choosing the canonical route. <code>{"error.field"}</code> SHOULD point at the conflicting package, and <code>{"error.details"}</code> SHOULD identify the supplied selector routes and their normalized canonical summaries. Recovery: correctable (emit one canonical selector route, or make a required legacy 3.x compatibility projection select the same product format contract).
 
 </Accordion>
 <a id="error-code-creative-deadline-exceeded"></a>

--- a/scripts/error-code-drift-dispositions.json
+++ b/scripts/error-code-drift-dispositions.json
@@ -21,6 +21,11 @@
       "target_version": "3.2",
       "note": "Canonical 3.2 bidding-policy migration guard. Returned when a package combines the new bidding block with legacy bid_price or legacy monetary optimization targets, leaving execution policy ambiguous. New wire code — held for 3.2."
     },
+    "CONFLICTING_SELECTORS": {
+      "disposition": "held-for-next-minor",
+      "target_version": "3.2",
+      "note": "Canonical 3.2 PackageRequest migration guard. Returned when multiple resolvable format selector routes select different product format contracts. New wire code — held for 3.2."
+    },
     "BIDDING_PLACEMENT_CONFLICT": {
       "disposition": "held-for-next-minor",
       "target_version": "3.2",

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -17,6 +17,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { canonicalize, PostgresTaskStore } from '@adcp/sdk';
+import { canonicalTargetUri } from '@adcp/sdk/signing';
 import {
   createProposalRefinementHandler,
   type ProposalRefinementScope,
@@ -435,66 +436,6 @@ function persistInlineCreatives(
   }
 }
 
-function validateDirectCanonicalPackageSelector(pkg: PackageInput, product: Product, index: number): TaskError | undefined {
-  if (typeof pkg.format_kind !== 'string') return undefined;
-  if (Array.isArray(pkg.format_option_refs) && pkg.format_option_refs.length > 0) return undefined;
-  if (Array.isArray(pkg.format_ids) && pkg.format_ids.length > 0) return undefined;
-
-  const declarations = Array.isArray(product.format_options)
-    ? product.format_options.filter(isRecord)
-    : [];
-  if (declarations.length === 0) {
-    return {
-      code: 'UNSUPPORTED_FEATURE',
-      message: `Package ${index}: format selector format_kind "${pkg.format_kind}" cannot be resolved because product ${pkg.product_id} has no format_options[] declarations`,
-      field: `packages[${index}].format_kind`,
-      recovery: 'correctable',
-    };
-  }
-
-  const candidates = declarations.filter(decl => decl.format_kind === pkg.format_kind);
-  if (candidates.length === 0) {
-    return {
-      code: 'UNSUPPORTED_FEATURE',
-      message: `Package ${index}: format selector format_kind "${pkg.format_kind}" is not supported by product ${pkg.product_id}`,
-      field: `packages[${index}].format_kind`,
-      details: { supported_format_kinds: declarations.map(decl => decl.format_kind).filter(Boolean) },
-      recovery: 'correctable',
-    };
-  }
-
-  const requestParams = isRecord(pkg.params) ? pkg.params : {};
-  const satisfied = candidates.some(candidate => {
-    const productParams = isRecord(candidate.params) ? candidate.params : {};
-    return Object.entries(productParams).every(([key, value]) => {
-      if (value === undefined) return true;
-      if (!(key in requestParams)) return false;
-      return JSON.stringify(requestParams[key]) === JSON.stringify(value);
-    });
-  });
-  if (satisfied) return undefined;
-
-  const requiredParams = candidates
-    .map(candidate => isRecord(candidate.params) ? Object.keys(candidate.params) : [])
-    .find(keys => keys.length > 0) ?? [];
-  const missingParams = requiredParams.filter(key => !(key in requestParams));
-  return {
-    code: 'UNSUPPORTED_FEATURE',
-    message: missingParams.length > 0
-      ? `Package ${index}: format selector "${pkg.format_kind}" omits product-required params: ${missingParams.join(', ')}`
-      : `Package ${index}: format selector "${pkg.format_kind}" params do not satisfy product ${pkg.product_id}`,
-    field: missingParams.length > 0
-      ? `packages[${index}].params`
-      : `packages[${index}].format_kind`,
-    details: {
-      format_kind: pkg.format_kind,
-      required_params: candidates.map(candidate => isRecord(candidate.params) ? candidate.params : {}),
-      received_params: requestParams,
-    },
-    recovery: 'correctable',
-  };
-}
-
 type CanonicalPackageFormat = Record<string, unknown> & {
   format_kind?: string;
   format_option_id?: string;
@@ -514,6 +455,276 @@ type IndexedDeclarations = {
 };
 type ProductFormatOptionIndex = Map<string, IndexedDeclarations>;
 type ProductFormatOptionIndexCache = WeakMap<Product, ProductFormatOptionIndex>;
+
+type ConstraintRange = { minimum: number | null; maximum: number | null };
+type DimensionRegion = {
+  minimumWidth: number;
+  maximumWidth: number;
+  minimumHeight: number;
+  maximumHeight: number;
+};
+
+function constraintRange(parameter: string, value: unknown): ConstraintRange | undefined {
+  if (isRecord(value) && value.kind === 'range') {
+    const minimum = value.min === null || typeof value.min === 'number' ? value.min : undefined;
+    const maximum = value.max === null || typeof value.max === 'number' ? value.max : undefined;
+    if (minimum !== undefined && maximum !== undefined) return { minimum, maximum };
+  }
+  if (parameter.endsWith('_range') && Array.isArray(value) && value.length === 2) {
+    const [minimum, maximum] = value;
+    if ((minimum === null || typeof minimum === 'number') && (maximum === null || typeof maximum === 'number')) {
+      return { minimum, maximum };
+    }
+  }
+  return undefined;
+}
+
+function rangeContains(baseline: ConstraintRange, narrower: ConstraintRange): boolean {
+  return (baseline.minimum === null || (narrower.minimum !== null && narrower.minimum >= baseline.minimum))
+    && (baseline.maximum === null || (narrower.maximum !== null && narrower.maximum <= baseline.maximum));
+}
+
+/** Directional comparison: `value` must be no broader than `baseline`. */
+function valueNarrowsBaseline(parameter: string, value: unknown, baseline: unknown): boolean {
+  if (baseline === undefined) return true;
+  if (isRecord(baseline) && baseline.kind === 'exact') {
+    return isDeepStrictEqual(value, baseline.value);
+  }
+  if (isRecord(baseline) && baseline.kind === 'set' && Array.isArray(baseline.values)) {
+    const allowedValues = baseline.values as unknown[];
+    const values = Array.isArray(value) ? value : [value];
+    return values.every(entry => allowedValues.some(candidate => isDeepStrictEqual(entry, candidate)));
+  }
+
+  const baselineRange = constraintRange(parameter, baseline);
+  if (baselineRange) {
+    if (typeof value === 'number') {
+      return (baselineRange.minimum === null || value >= baselineRange.minimum)
+        && (baselineRange.maximum === null || value <= baselineRange.maximum);
+    }
+    const narrowerRange = constraintRange(parameter, value);
+    return narrowerRange !== undefined && rangeContains(baselineRange, narrowerRange);
+  }
+
+  if (Array.isArray(baseline)) {
+    const values = Array.isArray(value) ? value : [value];
+    return values.every(entry => baseline.some(candidate => isDeepStrictEqual(entry, candidate)));
+  }
+  if (typeof value === 'number' && typeof baseline === 'number') {
+    if (parameter.startsWith('max_') || parameter.endsWith('_max_chars')) return value <= baseline;
+    if (parameter.startsWith('min_')) return value >= baseline;
+  }
+  return isDeepStrictEqual(value, baseline);
+}
+
+function durationParamsNarrowBaseline(
+  narrower: Record<string, unknown>,
+  baseline: Record<string, unknown>,
+): boolean {
+  const baselineExact = baseline.duration_ms_exact;
+  const baselineRange = constraintRange('duration_ms_range', baseline.duration_ms_range);
+  if (baselineExact === undefined && baselineRange === undefined) return true;
+
+  const narrowerExact = narrower.duration_ms_exact;
+  if (typeof narrowerExact === 'number') {
+    if (typeof baselineExact === 'number') return narrowerExact === baselineExact;
+    return baselineRange !== undefined
+      && valueNarrowsBaseline('duration_ms_range', narrowerExact, baseline.duration_ms_range);
+  }
+  const narrowerRange = constraintRange('duration_ms_range', narrower.duration_ms_range);
+  if (!narrowerRange) return false;
+  if (typeof baselineExact === 'number') {
+    return narrowerRange.minimum === baselineExact && narrowerRange.maximum === baselineExact;
+  }
+  return baselineRange !== undefined && rangeContains(baselineRange, narrowerRange);
+}
+
+function dimensionRegions(params: Record<string, unknown>): DimensionRegion[] {
+  if (typeof params.width === 'number' && typeof params.height === 'number') {
+    return [{
+      minimumWidth: params.width,
+      maximumWidth: params.width,
+      minimumHeight: params.height,
+      maximumHeight: params.height,
+    }];
+  }
+  if (Array.isArray(params.sizes)) {
+    const sizes = params.sizes.flatMap(size => isRecord(size)
+      && typeof size.width === 'number'
+      && typeof size.height === 'number'
+      ? [{
+          minimumWidth: size.width,
+          maximumWidth: size.width,
+          minimumHeight: size.height,
+          maximumHeight: size.height,
+        }]
+      : []);
+    if (sizes.length > 0) return sizes;
+  }
+
+  const hasResponsiveBounds = ['min_width', 'max_width', 'min_height', 'max_height']
+    .some(parameter => typeof params[parameter] === 'number');
+  if (!hasResponsiveBounds) return [];
+  return [{
+    minimumWidth: typeof params.min_width === 'number' ? params.min_width : Number.NEGATIVE_INFINITY,
+    maximumWidth: typeof params.max_width === 'number' ? params.max_width : Number.POSITIVE_INFINITY,
+    minimumHeight: typeof params.min_height === 'number' ? params.min_height : Number.NEGATIVE_INFINITY,
+    maximumHeight: typeof params.max_height === 'number' ? params.max_height : Number.POSITIVE_INFINITY,
+  }];
+}
+
+function dimensionRegionContains(baseline: DimensionRegion, narrower: DimensionRegion): boolean {
+  return narrower.minimumWidth >= baseline.minimumWidth
+    && narrower.maximumWidth <= baseline.maximumWidth
+    && narrower.minimumHeight >= baseline.minimumHeight
+    && narrower.maximumHeight <= baseline.maximumHeight;
+}
+
+function dimensionsNarrowBaseline(
+  narrower: Record<string, unknown>,
+  baseline: Record<string, unknown>,
+  requireWhenBaselineConstrained: boolean,
+): boolean {
+  const baselineRegions = dimensionRegions(baseline);
+  const narrowerRegions = dimensionRegions(narrower);
+  if (narrowerRegions.length === 0) {
+    return !requireWhenBaselineConstrained || baselineRegions.length === 0;
+  }
+  if (baselineRegions.length === 0) return true;
+  return narrowerRegions.every(region =>
+    baselineRegions.some(accepted => dimensionRegionContains(accepted, region))
+  );
+}
+
+function directOptionSatisfiesSelector(
+  option: CanonicalPackageFormat,
+  selector: CanonicalPackageFormat,
+): boolean {
+  if (option.format_kind !== selector.format_kind) return false;
+  const optionParams = isRecord(option.params) ? option.params : {};
+  const selectorParams = isRecord(selector.params) ? selector.params : {};
+
+  if (!dimensionsNarrowBaseline(selectorParams, optionParams, true)) return false;
+  if (!durationParamsNarrowBaseline(selectorParams, optionParams)) return false;
+
+  return Object.entries(selectorParams).every(([parameter, value]) => {
+    if (parameter === 'duration_ms_exact' || parameter === 'duration_ms_range') return true;
+    if (['width', 'height', 'sizes', 'min_width', 'max_width', 'min_height', 'max_height'].includes(parameter)) {
+      return true;
+    }
+    return valueNarrowsBaseline(parameter, value, optionParams[parameter]);
+  });
+}
+
+/** Normative one-way v2-narrows-v1 comparison for a projected legacy route. */
+function canonicalOptionNarrowsLegacy(
+  option: CanonicalPackageFormat,
+  legacyProjection: CanonicalPackageFormat,
+): boolean {
+  if (option.format_kind !== legacyProjection.format_kind) return false;
+  const optionParams = isRecord(option.params) ? option.params : {};
+  const legacyParams = isRecord(legacyProjection.params) ? legacyProjection.params : {};
+  if (!dimensionsNarrowBaseline(optionParams, legacyParams, false)) return false;
+  if (
+    (optionParams.duration_ms_exact !== undefined || optionParams.duration_ms_range !== undefined)
+    && !durationParamsNarrowBaseline(optionParams, legacyParams)
+  ) return false;
+  return Object.entries(optionParams).every(([parameter, value]) => {
+    if (parameter === 'duration_ms_exact' || parameter === 'duration_ms_range') return true;
+    if (['width', 'height', 'sizes', 'min_width', 'max_width', 'min_height', 'max_height'].includes(parameter)) {
+      return true;
+    }
+    return valueNarrowsBaseline(parameter, value, legacyParams[parameter]);
+  });
+}
+
+function directSelectorResolution(
+  pkg: PackageInput,
+  product: Product,
+  packageIndex: number,
+): { selector?: CanonicalPackageFormat; selected: Set<number>; error?: TaskError } {
+  if (typeof pkg.format_kind !== 'string') return { selected: new Set() };
+  if (!VALID_CANONICAL_FORMAT_KINDS.has(pkg.format_kind)) {
+    return {
+      selected: new Set(),
+      error: {
+        code: 'UNSUPPORTED_FEATURE',
+        message: `Package ${packageIndex}: format selector format_kind "${pkg.format_kind}" cannot be resolved`,
+        field: `packages[${packageIndex}].format_kind`,
+        recovery: 'correctable',
+      },
+    };
+  }
+
+  const requestParams = isRecord(pkg.params) ? pkg.params : {};
+  if (
+    pkg.format_kind === 'image'
+    && (('width' in requestParams) !== ('height' in requestParams))
+  ) {
+    return {
+      selected: new Set(),
+      error: {
+        code: 'INVALID_REQUEST',
+        message: `Package ${packageIndex}: fixed-size image width and height must be provided together`,
+        field: `packages[${packageIndex}].params`,
+        recovery: 'correctable',
+      },
+    };
+  }
+
+  const selector: CanonicalPackageFormat = {
+    format_kind: pkg.format_kind,
+    params: requestParams,
+  };
+  const declarations = (Array.isArray(product.format_options) ? product.format_options : [])
+    .filter(isRecord) as CanonicalPackageFormat[];
+  const selected = new Set<number>();
+  declarations.forEach((declaration, index) => {
+    if (directOptionSatisfiesSelector(declaration, selector)) selected.add(index);
+  });
+  return { selector, selected };
+}
+
+function validateDirectCanonicalPackageSelector(pkg: PackageInput, product: Product, index: number): TaskError | undefined {
+  if (typeof pkg.format_kind !== 'string') return undefined;
+  const resolution = directSelectorResolution(pkg, product, index);
+  if (resolution.error) return resolution.error;
+  if (resolution.selected.size > 0) return undefined;
+
+  const declarations = (Array.isArray(product.format_options) ? product.format_options : [])
+    .filter(isRecord) as CanonicalPackageFormat[];
+  const sameKind = declarations.filter(declaration => declaration.format_kind === pkg.format_kind);
+  const requestParams = isRecord(pkg.params) ? pkg.params : {};
+  const missingParams = [...new Set(sameKind.flatMap(declaration => {
+    const params = isRecord(declaration.params) ? declaration.params : {};
+    const required = dimensionRegions(params).length > 0 ? ['width/height dimensions'] : [];
+    if ('duration_ms_exact' in params || 'duration_ms_range' in params) {
+      required.push('duration_ms_exact or duration_ms_range');
+    }
+    return required.filter(key => {
+      if (key === 'width/height dimensions') return dimensionRegions(requestParams).length === 0;
+      if (key.includes(' or ')) {
+        return !('duration_ms_exact' in requestParams) && !('duration_ms_range' in requestParams);
+      }
+      return !(key in requestParams);
+    });
+  }))];
+  return {
+    code: 'UNSUPPORTED_FEATURE',
+    message: missingParams.length > 0
+      ? `Package ${index}: format selector "${pkg.format_kind}" omits product-required params: ${missingParams.join(', ')}`
+      : `Package ${index}: format selector "${pkg.format_kind}" params do not satisfy product ${pkg.product_id}`,
+    field: missingParams.length > 0
+      ? `packages[${index}].params`
+      : `packages[${index}].format_kind`,
+    details: {
+      format_kind: pkg.format_kind,
+      product_options: sameKind,
+      received_params: requestParams,
+    },
+    recovery: 'correctable',
+  };
+}
 
 function cloneCanonicalFormat(format: CanonicalPackageFormat): CanonicalPackageFormat {
   return JSON.parse(JSON.stringify(format)) as CanonicalPackageFormat;
@@ -734,8 +945,7 @@ function snapshotPackageFormats(
     }
     if (Array.isArray(pkg.format_ids) && pkg.format_ids.length > 0) {
       const unavailable = pkg.format_ids.filter(requested => !advertisedLegacyIds.some(advertised =>
-        advertised.id === requested.id
-        && (requested.agent_url === undefined || advertised.agent_url === requested.agent_url)
+        legacyFormatIdMatches(requested, advertised)
       ));
       if (unavailable.length > 0) {
         return {
@@ -876,17 +1086,15 @@ function snapshotPackageFormats(
     };
   }
 
-  if (Array.isArray(pkg.format_ids) && pkg.format_ids.length > 0) {
+  if (Array.isArray(pkg.format_ids) && pkg.format_ids.length > 0 && typeof pkg.format_kind !== 'string') {
     const selected = declarations.filter(declaration => {
       const legacyRefs = Array.isArray(declaration.v1_format_ref) ? declaration.v1_format_ref : [];
       return pkg.format_ids!.some(requested => legacyRefs.some(ref =>
-        ref?.id === requested.id
-        && (requested.agent_url === undefined || ref.agent_url === requested.agent_url)
+        ref && legacyFormatIdMatches(requested, ref)
       ));
     });
     const unavailable = pkg.format_ids.filter(requested => !advertisedLegacyIds.some(advertised =>
-      advertised.id === requested.id
-      && (requested.agent_url === undefined || advertised.agent_url === requested.agent_url)
+      legacyFormatIdMatches(requested, advertised)
     ));
     if (unavailable.length > 0) {
       return {
@@ -917,11 +1125,257 @@ function snapshotPackageFormats(
           ? JSON.parse(JSON.stringify(pkg.params)) as Record<string, unknown>
           : {},
       }],
+      ...(Array.isArray(pkg.format_ids) && pkg.format_ids.length > 0 && {
+        legacyFormatIds: pkg.format_ids.map(cloneLegacyFormatId),
+        selectedLegacyFormatIds: pkg.format_ids.map(cloneLegacyFormatId),
+      }),
     };
   }
 
   // Omitting selectors means every product format option is active.
   return { formats: declarations.map(cloneCanonicalFormat) };
+}
+
+function canonicalFormatIdentifierUrl(raw: string): string | undefined {
+  try {
+    return canonicalTargetUri(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function legacyFormatVariant(format: FormatID): [unknown, unknown, unknown, unknown] {
+  const record = format as unknown as Record<string, unknown>;
+  const hasDimensions = typeof record.width === 'number' && typeof record.height === 'number';
+  return [
+    record.width ?? null,
+    record.height ?? null,
+    record.duration_ms ?? null,
+    hasDimensions ? (record.pixel_ratio ?? 1) : null,
+  ];
+}
+
+function legacyFormatIdMatches(left: FormatID, right: FormatID): boolean {
+  if (left.id !== right.id || !isDeepStrictEqual(legacyFormatVariant(left), legacyFormatVariant(right))) {
+    return false;
+  }
+  if (left.agent_url === undefined || right.agent_url === undefined) return true;
+  const leftUrl = canonicalFormatIdentifierUrl(left.agent_url);
+  const rightUrl = canonicalFormatIdentifierUrl(right.agent_url);
+  return leftUrl !== undefined && rightUrl !== undefined && leftUrl === rightUrl;
+}
+
+function legacyFormatIdKey(format: FormatID): string {
+  const agentUrl = format.agent_url ? canonicalFormatIdentifierUrl(format.agent_url) : '';
+  return JSON.stringify([agentUrl ?? `invalid:${format.agent_url}`, format.id, ...legacyFormatVariant(format)]);
+}
+
+function selectedProductOptionsForFormats(
+  formats: CanonicalPackageFormat[],
+  productDeclarations: CanonicalPackageFormat[],
+): Set<number> {
+  const selected = new Set<number>();
+  for (const format of formats) {
+    const index = productDeclarations.findIndex(declaration => isDeepStrictEqual(declaration, format));
+    if (index >= 0) selected.add(index);
+  }
+  return selected;
+}
+
+function legacySelectorResolution(
+  pkg: PackageInput,
+  product: Product,
+  packageIndex: number,
+): {
+  selected: Set<number>;
+  unmatchedEntries: number[];
+  projectedSelectors: CanonicalPackageFormat[];
+  error?: TaskError;
+} {
+  const requested = Array.isArray(pkg.format_ids) ? pkg.format_ids : [];
+  const declarations = (Array.isArray(product.format_options) ? product.format_options : [])
+    .filter(isRecord) as CanonicalPackageFormat[];
+  const selected = new Set<number>();
+  const unmatchedEntries: number[] = [];
+  const projectedSelectors: CanonicalPackageFormat[] = [];
+
+  for (let i = 0; i < requested.length; i++) {
+    const legacy = requested[i]!;
+    const linkedIndexes = declarations.flatMap((declaration, declarationIndex) => {
+      const refs = Array.isArray(declaration.v1_format_ref) ? declaration.v1_format_ref : [];
+      return refs.some(ref => legacyFormatIdMatches(legacy, ref)) ? [declarationIndex] : [];
+    });
+    const projected = projectV1ProductToV2({
+      product_id: `package_${packageIndex}_legacy_${i}`,
+      name: 'Package legacy selector projection',
+      description: 'Ephemeral package selector compatibility projection',
+      format_ids: [{
+        ...legacy,
+        agent_url: legacy.agent_url ?? 'https://creative.adcontextprotocol.org/',
+      }],
+    }).v2.format_options?.filter(isRecord) as CanonicalPackageFormat[] | undefined;
+    if (!projected?.length && linkedIndexes.length === 0) {
+      return {
+        selected,
+        unmatchedEntries,
+        projectedSelectors,
+        error: {
+          code: 'UNSUPPORTED_FEATURE',
+          message: `Package ${packageIndex}: format_ids[${i}] cannot be normalized through the canonical mapping path`,
+          field: `packages[${packageIndex}].format_ids[${i}]`,
+          recovery: 'correctable',
+        },
+      };
+    }
+    if (projected?.length) projectedSelectors.push(...projected);
+
+    // Seller-authored v1_format_ref links are authoritative for custom IDs,
+    // but registry-backed links must still agree dimensionally with the
+    // canonical declaration they name.
+    const candidateIndexes = linkedIndexes.length > 0
+      ? linkedIndexes
+      : declarations.map((_, declarationIndex) => declarationIndex);
+    const matchedIndexes = candidateIndexes.filter(declarationIndex => {
+      if (!projected?.length) return true;
+      return projected.some(selector => canonicalOptionNarrowsLegacy(declarations[declarationIndex]!, selector));
+    });
+    if (matchedIndexes.length === 0) {
+      unmatchedEntries.push(i);
+    } else {
+      matchedIndexes.forEach(declarationIndex => {
+        selected.add(declarationIndex);
+      });
+    }
+  }
+  return { selected, unmatchedEntries, projectedSelectors };
+}
+
+function sameNumberSet(left: Set<number>, right: Set<number>): boolean {
+  return left.size === right.size && [...left].every(value => right.has(value));
+}
+
+function validatePackageSelectorCompatibility(
+  pkg: PackageInput,
+  product: Product,
+  packageIndex: number,
+  optionIndexCache: ProductFormatOptionIndexCache,
+): TaskError | undefined {
+  const hasOptions = Array.isArray(pkg.format_option_refs) && pkg.format_option_refs.length > 0;
+  const hasDirect = typeof pkg.format_kind === 'string';
+  const hasLegacy = Array.isArray(pkg.format_ids) && pkg.format_ids.length > 0;
+  const routeCount = Number(hasOptions) + Number(hasDirect) + Number(hasLegacy);
+  if (routeCount === 0) return undefined;
+
+  const declarations = (Array.isArray(product.format_options) ? product.format_options : [])
+    .filter(isRecord) as CanonicalPackageFormat[];
+
+  // Preserve the legacy-only 3.x path. An advertised named format may be
+  // intentionally non-projectable; equivalence is required only when another
+  // route is co-present. The SDK can also surface a legacy-only request as a
+  // temporary migrated option ref when the product has no canonical options.
+  if (routeCount === 1 && hasLegacy) {
+    return snapshotPackageFormats(pkg, product, packageIndex, optionIndexCache).error;
+  }
+  if (routeCount === 1 && hasOptions && declarations.length === 0) {
+    return snapshotPackageFormats(pkg, product, packageIndex, optionIndexCache).error;
+  }
+
+  if (declarations.length === 0 && hasOptions && hasLegacy && !hasDirect) {
+    const optionSnapshot = snapshotPackageFormats({ ...pkg, format_ids: undefined }, product, packageIndex, optionIndexCache);
+    if (optionSnapshot.error) return optionSnapshot.error;
+    const legacySnapshot = snapshotPackageFormats({ ...pkg, format_option_refs: undefined }, product, packageIndex, optionIndexCache);
+    if (legacySnapshot.error) return legacySnapshot.error;
+    const optionSet = new Set((optionSnapshot.selectedLegacyFormatIds ?? []).map(legacyFormatIdKey));
+    const legacySet = new Set((legacySnapshot.selectedLegacyFormatIds ?? []).map(legacyFormatIdKey));
+    if (optionSet.size > 0 && optionSet.size === legacySet.size && [...optionSet].every(key => legacySet.has(key))) {
+      return undefined;
+    }
+    return {
+      code: 'CONFLICTING_SELECTORS',
+      message: `Package ${packageIndex}: co-present legacy compatibility selector routes select different product formats`,
+      field: `packages[${packageIndex}]`,
+      recovery: 'correctable',
+    };
+  }
+
+  const routes: Array<{ name: string; selected: Set<number>; unmatchedEntries?: number[] }> = [];
+  let directSelector: CanonicalPackageFormat | undefined;
+  let legacyProjectedSelectors: CanonicalPackageFormat[] = [];
+
+  if (hasOptions) {
+    const optionSnapshot = snapshotPackageFormats({
+      ...pkg,
+      format_kind: undefined,
+      params: undefined,
+      format_ids: undefined,
+    }, product, packageIndex, optionIndexCache);
+    if (optionSnapshot.error) return optionSnapshot.error;
+    routes.push({
+      name: 'format_option_refs',
+      selected: selectedProductOptionsForFormats(optionSnapshot.formats ?? [], declarations),
+    });
+  }
+
+  if (hasDirect) {
+    const direct = directSelectorResolution(pkg, product, packageIndex);
+    if (direct.error) return direct.error;
+    directSelector = direct.selector;
+    routes.push({ name: 'format_kind', selected: direct.selected });
+  }
+
+  if (hasLegacy) {
+    const legacy = legacySelectorResolution(pkg, product, packageIndex);
+    if (legacy.error) return legacy.error;
+    legacyProjectedSelectors = legacy.projectedSelectors;
+    routes.push({ name: 'format_ids', selected: legacy.selected, unmatchedEntries: legacy.unmatchedEntries });
+  }
+
+  if (routes.length === 1) {
+    if (routes[0]!.selected.size > 0) return undefined;
+    if (hasDirect) return validateDirectCanonicalPackageSelector(pkg, product, packageIndex);
+    return {
+      code: 'UNSUPPORTED_FEATURE',
+      message: `Package ${packageIndex}: ${routes[0]!.name} resolves but does not satisfy product ${pkg.product_id}`,
+      field: `packages[${packageIndex}].${routes[0]!.name}`,
+      recovery: 'correctable',
+    };
+  }
+
+  const expected = routes[0]!.selected;
+  const allRoutesUnsatisfied = routes.every(route => route.selected.size === 0);
+  const equivalentUnsatisfiedDirectLegacy = !hasOptions
+    && allRoutesUnsatisfied
+    && directSelector !== undefined
+    && legacyProjectedSelectors.length > 0
+    && legacyProjectedSelectors.every(projected => directOptionSatisfiesSelector(projected, directSelector!));
+  if ((!equivalentUnsatisfiedDirectLegacy && routes.some(route => route.unmatchedEntries?.length))
+    || routes.slice(1).some(route => !sameNumberSet(expected, route.selected))) {
+    return {
+      code: 'CONFLICTING_SELECTORS',
+      message: `Package ${packageIndex}: co-present format selector routes select different product format options`,
+      field: `packages[${packageIndex}]`,
+      details: {
+        routes: routes.map(route => ({
+          selector: route.name,
+          selected_format_option_ids: [...route.selected].map(index =>
+            declarations[index]?.format_option_id ?? `product.format_options[${index}]`
+          ),
+          ...(route.unmatchedEntries?.length && { unmatched_selector_indexes: route.unmatchedEntries }),
+        })),
+      },
+      recovery: 'correctable',
+    };
+  }
+
+  if (expected.size === 0) {
+    return {
+      code: 'UNSUPPORTED_FEATURE',
+      message: `Package ${packageIndex}: resolved format selectors do not satisfy product ${pkg.product_id}`,
+      field: `packages[${packageIndex}]`,
+      recovery: 'correctable',
+    };
+  }
+  return undefined;
 }
 
 function packageFormatSelectorForState(
@@ -5416,7 +5870,7 @@ const TOOLS = [
         canceled: { type: 'boolean', const: true, description: 'Cancel the media buy (one-way, cannot be undone)' },
         cancellation_reason: { type: 'string', description: 'Reason for cancellation' },
         packages: { type: 'array' },
-        new_packages: { type: 'array', items: { type: 'object', properties: { product_id: { type: 'string' }, pricing_option_id: { type: 'string' }, budget: { type: 'number' }, bid_price: { type: 'number' }, impressions: { type: 'number' }, paused: { type: 'boolean' }, start_time: { type: 'string' }, end_time: { type: 'string' }, format_ids: { type: 'array' } }, required: ['product_id', 'pricing_option_id', 'budget'] }, description: 'Add new packages to the media buy' },
+        new_packages: { type: 'array', items: { type: 'object', properties: { product_id: { type: 'string' }, pricing_option_id: { type: 'string' }, budget: { type: 'number' }, bid_price: { type: 'number' }, impressions: { type: 'number' }, paused: { type: 'boolean' }, start_time: { type: 'string' }, end_time: { type: 'string' }, format_option_refs: { type: 'array' }, format_kind: { type: 'string' }, params: { type: 'object' }, format_ids: { type: 'array' } }, required: ['product_id', 'pricing_option_id', 'budget'] }, description: 'Add new packages to the media buy' },
         end_time: { type: 'string' },
         action: { type: 'string', description: 'Action to perform (pause, resume, cancel, extend)' },
         governance_context: { type: 'string', maxLength: 4096, description: 'Opaque intent authorization for a governed update. The seller computes the actual positive delta from its current revision and enforces the signed ceiling.' },
@@ -8347,9 +8801,14 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
       continue;
     }
 
-    const directFormatError = validateDirectCanonicalPackageSelector(pkg, product, i);
-    if (directFormatError) {
-      errors.push(directFormatError);
+    const selectorCompatibilityError = validatePackageSelectorCompatibility(
+      pkg,
+      product,
+      i,
+      productFormatOptionIndexes,
+    );
+    if (selectorCompatibilityError) {
+      errors.push(selectorCompatibilityError);
       continue;
     }
     const formatSnapshot = snapshotPackageFormats(pkg, product, i, productFormatOptionIndexes);
@@ -10084,8 +10543,13 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       if (!product) {
         return { errors: [{ code: 'PACKAGE_NOT_FOUND', message: `Product not found for new package: ${productId}` }] };
       }
-      const directFormatError = validateDirectCanonicalPackageSelector(npkg, product, i);
-      if (directFormatError) return { errors: [directFormatError] };
+      const selectorCompatibilityError = validatePackageSelectorCompatibility(
+        npkg,
+        product,
+        i,
+        productFormatOptionIndexes,
+      );
+      if (selectorCompatibilityError) return { errors: [selectorCompatibilityError] };
       const formatSnapshot = snapshotPackageFormats(npkg, product, i, productFormatOptionIndexes);
       if (formatSnapshot.error) return { errors: [formatSnapshot.error] };
       const formatSelector = packageFormatSelectorForState(

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -62,6 +62,49 @@ interface TrainingSalesConfig {
   strict: boolean;
 }
 
+const PACKAGE_SELECTOR_FIELDS = [
+  'format_option_refs',
+  'format_kind',
+  'params',
+  'format_ids',
+] as const;
+
+/**
+ * The SDK's canonical platform signature intentionally omits deprecated
+ * selector fields. During the 3.x compatibility window we still need the raw
+ * co-present routes so the receiver can resolve and equivalence-check them
+ * before canonical precedence is applied.
+ */
+export function restoreRawPackageSelectors(
+  normalized: Record<string, unknown>,
+  rawInput: unknown,
+  packageFields: readonly string[],
+): Record<string, unknown> {
+  if (!rawInput || typeof rawInput !== 'object' || Array.isArray(rawInput)) return normalized;
+  const rawRecord = rawInput as Record<string, unknown>;
+  const restored = { ...normalized };
+  for (const packageField of packageFields) {
+    const normalizedPackages = normalized[packageField];
+    const rawPackages = rawRecord[packageField];
+    if (!Array.isArray(normalizedPackages) || !Array.isArray(rawPackages)) continue;
+    restored[packageField] = normalizedPackages.map((pkg, index) => {
+      const rawPackage = rawPackages[index];
+      if (!pkg || typeof pkg !== 'object' || Array.isArray(pkg)
+        || !rawPackage || typeof rawPackage !== 'object' || Array.isArray(rawPackage)) {
+        return pkg;
+      }
+      const next = { ...(pkg as Record<string, unknown>) };
+      for (const selectorField of PACKAGE_SELECTOR_FIELDS) {
+        if (selectorField in rawPackage) {
+          next[selectorField] = (rawPackage as Record<string, unknown>)[selectorField];
+        }
+      }
+      return next;
+    });
+  }
+  return restored;
+}
+
 export const TRAINING_SALES_CAPABILITIES = {
   specialisms: ['sales-non-guaranteed', 'sales-guaranteed'] as const,
   creative_agents: [],
@@ -538,13 +581,18 @@ export class TrainingSalesPlatform
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sales: SalesPlatform<TrainingSalesMeta> = {
     createMediaBuy: async (req, ctx) => {
+      const requestWithRawSelectors = restoreRawPackageSelectors(
+        req as unknown as Record<string, unknown>,
+        ctx.input,
+        ['packages'],
+      );
       const args = this.storyboardCompat?.version === '3.0'
         ? withResolvedAccountScope(
-          req as unknown as Record<string, unknown>,
+          requestWithRawSelectors,
           ctx.account,
           this.storyboardCompat,
         )
-        : withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account);
+        : withCurrentAccountScope(requestWithRawSelectors, ctx.account);
       const v5Result = await handleCreateMediaBuy(args, buildTrainingCtx(ctx, this.storyboardCompat));
       // Detect the submitted-arm envelope the v5 handler returns when the
       // `force_create_media_buy_arm` test-controller directive is set.
@@ -579,9 +627,14 @@ export class TrainingSalesPlatform
       const currentArgs = brandDomain
         ? { media_buy_id: buyId, ...(patch as unknown as Record<string, unknown>), brand: { domain: brandDomain } }
         : { media_buy_id: buyId, ...(patch as unknown as Record<string, unknown>) };
+      const requestWithRawSelectors = restoreRawPackageSelectors(
+        currentArgs,
+        ctx.input,
+        ['new_packages'],
+      );
       const args = this.storyboardCompat?.version === '3.0'
-        ? withResolvedAccountScope(currentArgs, ctx.account, this.storyboardCompat)
-        : withCurrentAccountScope(currentArgs, ctx.account);
+        ? withResolvedAccountScope(requestWithRawSelectors, ctx.account, this.storyboardCompat)
+        : withCurrentAccountScope(requestWithRawSelectors, ctx.account);
       const v5Result = await handleUpdateMediaBuy(args, buildTrainingCtx(ctx, this.storyboardCompat));
       return translateV5Result(canonicalMediaBuyPlatformResult(v5Result));
     },

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -167,6 +167,14 @@ const KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new Map([
     'creative_transformers/refine_variant',
     'Same blocker as creative_transformers/build_variants: refinement depends on the skipped parent build_variant_id and returns the same BuildCreativeVariantSuccess creatives[]/variants[] response shape. Remove when the packaged storyboard runner accepts that variant arm.',
   ],
+  [
+    'media_buy_seller/canonical_formats/reject_conflicting_dual_emission',
+    'adcontextprotocol/adcp-client#2392: the packaged SDK canonicalizes away a co-present deprecated format_ids route before both platform execution and canonical_format_satisfaction grading. Raw receiver behavior is covered by training-agent unit tests. Remove when the SDK preserves and equivalence-checks every selector route.',
+  ],
+  [
+    'media_buy_seller/canonical_formats/reject_unprojectable_legacy_dual_emission',
+    'adcontextprotocol/adcp-client#2392: the packaged SDK drops an unprojectable deprecated format_ids route before the platform can return UNSUPPORTED_FEATURE. Raw receiver behavior is covered by training-agent unit tests. Remove when the SDK exposes unresolved legacy routes to the receiver.',
+  ],
 ]);
 
 const THREE_ZERO_COMPAT_KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new Map([
@@ -279,7 +287,7 @@ function normalizeThreeZeroStaleStoryboardDates(value: unknown): void {
   }
 }
 
-function patchThreeZeroStoryboard(sb: Storyboard): Storyboard {
+function patchStoryboardForLocalRunner(sb: Storyboard): Storyboard {
   let patched = sb;
   if (sb.id === 'creative/creative_lifecycle_webhooks') {
     patched = structuredClone(sb) as Storyboard;
@@ -295,6 +303,34 @@ function patchThreeZeroStoryboard(sb: Storyboard): Storyboard {
             subscriber_id: 'buyer-primary',
           },
         };
+      }
+    }
+  }
+
+  if (sb.id === 'media_buy_seller/canonical_formats') {
+    patched = structuredClone(patched) as Storyboard;
+    for (const phase of patched.phases ?? []) {
+      for (const step of phase.steps ?? []) {
+        if (
+          step.id === 'reject_conflicting_dual_emission'
+          || step.id === 'reject_unprojectable_legacy_dual_emission'
+        ) {
+          // These locally skipped probes remain stateful in the published
+          // contract; only prevent their SDK-blocked skip from cascading to
+          // later independent steps in this in-process runner.
+          step.stateful = false;
+        }
+        if (
+          step.id !== 'create_media_buy_with_direct_canonical_selector'
+          && step.id !== 'reject_conflicting_canonical_routes'
+        ) continue;
+        // adcontextprotocol/adcp-client#2392: the packaged local grader still
+        // requires every product param for direct satisfaction and applies
+        // option-ref precedence before grading a co-present direct route. The
+        // receiver call and all other assertions still run; only the stale
+        // local semantic assertion is suppressed until the SDK is directional.
+        step.validations = (step.validations ?? [])
+          .filter(validation => validation.check !== 'canonical_format_satisfaction');
       }
     }
   }
@@ -580,7 +616,7 @@ async function main() {
   const jwksResolver = new StaticJwksResolver(getPublicJwks().keys as AdcpJsonWebKey[]);
 
   for (const sb of all) {
-    const storyboard = patchThreeZeroStoryboard(sb);
+    const storyboard = patchStoryboardForLocalRunner(sb);
     // Isolate storyboards from each other: a previous storyboard may have
     // seeded governance plans, media buys, creatives, etc. into a session
     // keyed by the same brand domain. Without this reset the next

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -53,7 +53,7 @@ import {
   HUMAN_REVIEW_POLICY_IDS,
 } from '../../src/training-agent/governance-handlers.js';
 import { clearAccountStore } from '../../src/training-agent/account-handlers.js';
-import { TrainingSalesPlatform } from '../../src/training-agent/v6-sales-platform.js';
+import { TrainingSalesPlatform, restoreRawPackageSelectors } from '../../src/training-agent/v6-sales-platform.js';
 import { TrainingCreativePlatform } from '../../src/training-agent/v6-creative-platform.js';
 import { TrainingCreativeBuilderPlatform } from '../../src/training-agent/v6-creative-builder-platform.js';
 import { clearAudienceStore } from '../../src/training-agent/audience-handlers.js';
@@ -1593,6 +1593,24 @@ describe('createTrainingAgentServer', () => {
     expect((platform.capabilities as Record<string, unknown>).performance_feedback).toEqual({
       reports_application_status: true,
     });
+  });
+
+  it('restores raw selector routes for v6 create and update package adapters', () => {
+    const normalizedPackage = {
+      product_id: 'product',
+      pricing_option_id: 'pricing',
+      budget: 100,
+      format_option_refs: [{ scope: 'product', format_option_id: 'mrec' }],
+    };
+    const legacy = [{ agent_url: 'https://creative.adcontextprotocol.org/', id: 'display_300x250_image' }];
+    for (const packageField of ['packages', 'new_packages']) {
+      const restored = restoreRawPackageSelectors(
+        { [packageField]: [normalizedPackage] },
+        { [packageField]: [{ ...normalizedPackage, format_ids: legacy }] },
+        [packageField],
+      );
+      expect((restored[packageField] as Array<Record<string, unknown>>)[0]?.format_ids).toEqual(legacy);
+    }
   });
 
   it('returns error for unknown tool', async () => {
@@ -3989,7 +4007,7 @@ describe('create_media_buy handler', () => {
           channels: ['display'],
           format_options: [{
             format_kind: 'image',
-            params: { width: 300, height: 250 },
+            params: { width: 300, height: 250, image_formats: ['jpg', 'png'] },
             v1_format_ref: [{ agent_url: TEST_AGENT_URL, id: 'display_300x250_image' }],
           }],
           format_ids: [{ agent_url: TEST_AGENT_URL, id: 'display_300x250_image' }],
@@ -4028,6 +4046,486 @@ describe('create_media_buy handler', () => {
     expect(result.field).toBe('packages[0].params');
     expect(result.message).toContain('format selector');
     expect(result.message).toContain('width');
+
+    const widthOnly = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'canonical-direct.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        format_kind: 'image',
+        params: { width: 300 },
+      }],
+    });
+    expect(widthOnly.isError).toBe(true);
+    expect(widthOnly.result.code).toBe('INVALID_REQUEST');
+    expect(widthOnly.result.field).toBe('packages[0].params');
+
+    const narrowerSet = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'canonical-direct.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        format_kind: 'image',
+        params: { width: 300, height: 250, image_formats: ['jpg'] },
+      }],
+    });
+    expect(narrowerSet.isError).not.toBe(true);
+
+    const dimensionsOnly = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: 'canonical-direct.example' },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        format_kind: 'image',
+        params: { width: 300, height: 250 },
+      }],
+    });
+    expect(dimensionsOnly.isError).not.toBe(true);
+  });
+
+  it('applies directional containment to direct duration selectors', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'canonical-range.example' }, operator: 'canonical-range.example' };
+    const productId = 'canonical_duration_range';
+    const pricingOptionId = 'canonical_duration_range_cpm';
+
+    await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      brand: account.brand,
+      scenario: 'seed_product',
+      params: {
+        product_id: productId,
+        fixture: {
+          name: 'Canonical duration range',
+          description: 'Hosted video accepting 15 to 60 seconds',
+          delivery_type: 'guaranteed',
+          channels: ['olv'],
+          format_options: [{
+            format_kind: 'video_hosted',
+            params: { duration_ms_range: [15000, 60000], video_codecs: ['h264', 'vp9'] },
+          }],
+        },
+      },
+    });
+    await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      brand: account.brand,
+      scenario: 'seed_pricing_option',
+      params: {
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        fixture: { pricing_model: 'cpm', currency: 'USD', fixed_price: 12 },
+      },
+    });
+    const request = (params: Record<string, unknown>) => simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: account.brand,
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        format_kind: 'video_hosted',
+        params,
+      }],
+    });
+
+    expect((await request({ duration_ms_exact: 30000, video_codecs: ['h264'] })).isError).not.toBe(true);
+    expect((await request({ duration_ms_range: [30000, 45000] })).isError).not.toBe(true);
+    const overlapping = await request({ duration_ms_range: [30000, 90000] });
+    expect(overlapping.isError).toBe(true);
+    expect(overlapping.result.code).toBe('UNSUPPORTED_FEATURE');
+  });
+
+  it('normalizes fixed, enumerated, and responsive dimensions for direct satisfaction', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'canonical-dimensions.example' }, operator: 'canonical-dimensions.example' };
+    const seed = async (productId: string, params: Record<string, unknown>) => {
+      await simulateCallTool(server, 'comply_test_controller', {
+        account,
+        brand: account.brand,
+        scenario: 'seed_product',
+        params: {
+          product_id: productId,
+          fixture: {
+            name: productId,
+            description: 'Canonical dimension containment probe',
+            delivery_type: 'guaranteed',
+            channels: ['display'],
+            format_options: [{ format_kind: 'image', params }],
+          },
+        },
+      });
+      await simulateCallTool(server, 'comply_test_controller', {
+        account,
+        brand: account.brand,
+        scenario: 'seed_pricing_option',
+        params: {
+          product_id: productId,
+          pricing_option_id: `${productId}_cpm`,
+          fixture: { pricing_model: 'cpm', currency: 'USD', fixed_price: 12 },
+        },
+      });
+    };
+    await seed('canonical_sizes', { sizes: [{ width: 300, height: 250 }, { width: 728, height: 90 }] });
+    await seed('canonical_fixed', { width: 300, height: 250 });
+    await seed('canonical_responsive', {
+      min_width: 300,
+      max_width: 970,
+      min_height: 90,
+      max_height: 250,
+    });
+    const request = (productId: string, params: Record<string, unknown>) => simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: account.brand,
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: `${productId}_cpm`,
+        budget: 10000,
+        format_kind: 'image',
+        params,
+      }],
+    });
+
+    expect((await request('canonical_sizes', { width: 300, height: 250 })).isError).not.toBe(true);
+    expect((await request('canonical_fixed', { sizes: [{ width: 300, height: 250 }] })).isError).not.toBe(true);
+    expect((await request('canonical_responsive', { width: 300, height: 90 })).isError).not.toBe(true);
+    expect((await request('canonical_responsive', { width: 970, height: 250 })).isError).not.toBe(true);
+
+    for (const rejected of [
+      await request('canonical_sizes', { width: 320, height: 50 }),
+      await request('canonical_fixed', { sizes: [{ width: 300, height: 250 }, { width: 728, height: 90 }] }),
+      await request('canonical_responsive', { width: 2000, height: 250 }),
+      await request('canonical_responsive', {}),
+    ]) {
+      expect(rejected.isError).toBe(true);
+      expect(rejected.result.code).toBe('UNSUPPORTED_FEATURE');
+    }
+  });
+
+  it('lets v2 declarations inherit omitted legacy duration constraints', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'legacy-duration.example' }, operator: 'legacy-duration.example' };
+    const productId = 'legacy_duration_inheritance';
+    const pricingOptionId = 'legacy_duration_inheritance_cpm';
+    const legacyRef = {
+      agent_url: 'https://creative.adcontextprotocol.org/',
+      id: 'video_30s',
+    };
+    await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      brand: account.brand,
+      scenario: 'seed_product',
+      params: {
+        product_id: productId,
+        fixture: {
+          name: 'Legacy duration inheritance',
+          description: 'The v2 declaration inherits the v1 duration',
+          delivery_type: 'guaranteed',
+          channels: ['olv'],
+          format_options: [{
+            format_kind: 'video_hosted',
+            format_option_id: 'legacy_duration_video',
+            params: { video_codecs: ['h264'] },
+            v1_format_ref: [legacyRef],
+          }],
+          format_ids: [legacyRef],
+        },
+      },
+    });
+    await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      brand: account.brand,
+      scenario: 'seed_pricing_option',
+      params: {
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        fixture: { pricing_model: 'cpm', currency: 'USD', fixed_price: 12 },
+      },
+    });
+    const result = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: account.brand,
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        format_option_refs: [{ scope: 'product', format_option_id: 'legacy_duration_video' }],
+        format_ids: [legacyRef],
+      }],
+    });
+    expect(result.isError).not.toBe(true);
+  });
+
+  it('equivalence-checks every co-present package format selector route before precedence', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = { brand: { domain: 'selector-equivalence.example' }, operator: 'selector-equivalence.example' };
+    const productId = 'selector_equivalence_mrec';
+    const pricingOptionId = 'selector_equivalence_mrec_cpm';
+    const mrecLegacy = {
+      agent_url: 'https://creative.adcontextprotocol.org/',
+      id: 'display_300x250_image',
+    };
+
+    await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      brand: account.brand,
+      scenario: 'seed_product',
+      params: {
+        product_id: productId,
+        fixture: {
+          name: 'Selector equivalence MREC',
+          description: 'Fixed 300x250 selector equivalence probe',
+          delivery_type: 'guaranteed',
+          channels: ['display'],
+          format_options: [{
+            format_kind: 'image',
+            format_option_id: 'selector_equivalence_image_mrec',
+            params: { width: 300, height: 250 },
+            v1_format_ref: [mrecLegacy],
+          }],
+          format_ids: [mrecLegacy],
+        },
+      },
+    });
+    await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      brand: account.brand,
+      scenario: 'seed_pricing_option',
+      params: {
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        fixture: { pricing_model: 'cpm', currency: 'USD', fixed_price: 12 },
+      },
+    });
+
+    const baseRequest = {
+      account,
+      brand: account.brand,
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+    };
+    const basePackage = {
+      product_id: productId,
+      pricing_option_id: pricingOptionId,
+      budget: 10000,
+    };
+    const optionRef = { scope: 'product', format_option_id: 'selector_equivalence_image_mrec' };
+
+    const equivalentOptionLegacy = await simulateCallTool(server, 'create_media_buy', {
+      ...baseRequest,
+      packages: [{ ...basePackage, format_option_refs: [optionRef], format_ids: [mrecLegacy] }],
+    });
+    expect(equivalentOptionLegacy.isError).not.toBe(true);
+
+    const equivalentCanonicalUrl = await simulateCallTool(server, 'create_media_buy', {
+      ...baseRequest,
+      packages: [{
+        ...basePackage,
+        format_option_refs: [optionRef],
+        format_ids: [{
+          agent_url: 'https://CREATIVE.adcontextprotocol.org:443/./#ignored',
+          id: 'display_300x250_image',
+        }],
+      }],
+    });
+    expect(equivalentCanonicalUrl.isError).not.toBe(true);
+
+    const equivalentDirectLegacy = await simulateCallTool(server, 'create_media_buy', {
+      ...baseRequest,
+      packages: [{
+        ...basePackage,
+        format_kind: 'image',
+        params: { width: 300, height: 250 },
+        format_ids: [mrecLegacy],
+      }],
+    });
+    expect(equivalentDirectLegacy.isError).not.toBe(true);
+
+    const conflictingLegacy = await simulateCallTool(server, 'create_media_buy', {
+      ...baseRequest,
+      packages: [{
+        ...basePackage,
+        format_option_refs: [optionRef],
+        format_ids: [{
+          agent_url: 'https://creative.adcontextprotocol.org/',
+          id: 'display_728x90',
+        }],
+      }],
+    });
+    expect(conflictingLegacy.isError).toBe(true);
+    expect(conflictingLegacy.result.code).toBe('CONFLICTING_SELECTORS');
+
+    const mixedLegacy = await simulateCallTool(server, 'create_media_buy', {
+      ...baseRequest,
+      packages: [{
+        ...basePackage,
+        format_option_refs: [optionRef],
+        format_ids: [mrecLegacy, {
+          agent_url: 'https://creative.adcontextprotocol.org/',
+          id: 'display_728x90',
+        }],
+      }],
+    });
+    expect(mixedLegacy.isError).toBe(true);
+    expect(mixedLegacy.result.code).toBe('CONFLICTING_SELECTORS');
+
+    const conflictingCanonical = await simulateCallTool(server, 'create_media_buy', {
+      ...baseRequest,
+      packages: [{
+        ...basePackage,
+        format_option_refs: [optionRef],
+        format_kind: 'image',
+        params: { width: 728, height: 90 },
+      }],
+    });
+    expect(conflictingCanonical.isError).toBe(true);
+    expect(conflictingCanonical.result.code).toBe('CONFLICTING_SELECTORS');
+
+    const equivalentButUnsupported = await simulateCallTool(server, 'create_media_buy', {
+      ...baseRequest,
+      packages: [{
+        ...basePackage,
+        format_kind: 'image',
+        params: { width: 728, height: 90 },
+        format_ids: [{
+          agent_url: 'https://creative.adcontextprotocol.org/',
+          id: 'display_728x90',
+        }],
+      }],
+    });
+    expect(equivalentButUnsupported.isError).toBe(true);
+    expect(equivalentButUnsupported.result.code).toBe('UNSUPPORTED_FEATURE');
+
+    const broadDirectConflictsWithFixedLegacy = await simulateCallTool(server, 'create_media_buy', {
+      ...baseRequest,
+      packages: [{
+        ...basePackage,
+        format_kind: 'image',
+        format_ids: [{
+          agent_url: 'https://creative.adcontextprotocol.org/',
+          id: 'display_728x90',
+        }],
+      }],
+    });
+    expect(broadDirectConflictsWithFixedLegacy.isError).toBe(true);
+    expect(broadDirectConflictsWithFixedLegacy.result.code).toBe('CONFLICTING_SELECTORS');
+
+    const unprojectableLegacy = await simulateCallTool(server, 'create_media_buy', {
+      ...baseRequest,
+      packages: [{
+        ...basePackage,
+        format_option_refs: [optionRef],
+        format_ids: [{
+          agent_url: 'https://creative.adcontextprotocol.org/',
+          id: 'unmapped_legacy_selector_6648',
+        }],
+      }],
+    });
+    expect(unprojectableLegacy.isError).toBe(true);
+    expect(unprojectableLegacy.result.code).toBe('UNSUPPORTED_FEATURE');
+
+    const conflictingAddedPackage = await simulateCallTool(server, 'update_media_buy', {
+      account,
+      media_buy_id: equivalentOptionLegacy.result.media_buy_id,
+      new_packages: [{
+        ...basePackage,
+        format_option_refs: [optionRef],
+        format_ids: [{
+          agent_url: 'https://creative.adcontextprotocol.org/',
+          id: 'display_728x90',
+        }],
+      }],
+    });
+    expect(conflictingAddedPackage.result.code).toBe('CONFLICTING_SELECTORS');
+
+    const platform = new TrainingSalesPlatform();
+    const platformAccount = {
+      mode: 'sandbox',
+      ctx_metadata: {
+        brand_domain: account.brand.domain,
+        operator: account.operator,
+        account_ref: { ...account, sandbox: true },
+      },
+    };
+    const rawConflictingPackage = {
+      ...basePackage,
+      format_option_refs: [optionRef],
+      format_ids: [{
+        agent_url: 'https://creative.adcontextprotocol.org/',
+        id: 'display_728x90',
+      }],
+    };
+    await expect(platform.sales.createMediaBuy!(
+      { ...baseRequest, packages: [{ ...basePackage, format_option_refs: [optionRef] }] } as never,
+      { account: platformAccount, input: { ...baseRequest, packages: [rawConflictingPackage] } } as never,
+    )).rejects.toMatchObject({ code: 'CONFLICTING_SELECTORS' });
+    const divergentProductId = 'selector_divergent_legacy_link';
+    const divergentPricingId = 'selector_divergent_legacy_link_cpm';
+    const leaderboardLegacy = {
+      agent_url: 'https://creative.adcontextprotocol.org/',
+      id: 'display_728x90',
+    };
+    await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      brand: account.brand,
+      scenario: 'seed_product',
+      params: {
+        product_id: divergentProductId,
+        fixture: {
+          name: 'Divergent legacy link',
+          description: 'Seller link must agree with the registry projection',
+          delivery_type: 'guaranteed',
+          channels: ['display'],
+          format_options: [{
+            format_kind: 'image',
+            format_option_id: 'selector_divergent_mrec',
+            params: { width: 300, height: 250 },
+            v1_format_ref: [leaderboardLegacy],
+          }],
+          format_ids: [leaderboardLegacy],
+        },
+      },
+    });
+    await simulateCallTool(server, 'comply_test_controller', {
+      account,
+      brand: account.brand,
+      scenario: 'seed_pricing_option',
+      params: {
+        product_id: divergentProductId,
+        pricing_option_id: divergentPricingId,
+        fixture: { pricing_model: 'cpm', currency: 'USD', fixed_price: 12 },
+      },
+    });
+    const divergentLink = await simulateCallTool(server, 'create_media_buy', {
+      ...baseRequest,
+      packages: [{
+        product_id: divergentProductId,
+        pricing_option_id: divergentPricingId,
+        budget: 10000,
+        format_option_refs: [{ scope: 'product', format_option_id: 'selector_divergent_mrec' }],
+        format_ids: [leaderboardLegacy],
+      }],
+    });
+    expect(divergentLink.isError).toBe(true);
+    expect(divergentLink.result.code).toBe('CONFLICTING_SELECTORS');
   });
 
   it('scopes SDK-projected legacy aliases without widening ambiguous selections', async () => {
@@ -4107,8 +4605,6 @@ describe('create_media_buy handler', () => {
           publisher_domain: 'publisher.example',
           format_option_id: projected.format_option_id,
         }],
-        // Informational echo only: option refs have protocol precedence.
-        format_kind: 'audio_hosted',
       }],
     });
 
@@ -4117,7 +4613,6 @@ describe('create_media_buy handler', () => {
       formats_to_provide?: Array<{ format_option_id?: string }>;
       format_ids?: Array<Record<string, unknown>>;
       format_option_refs?: Array<Record<string, unknown>>;
-      format_kind?: string;
     }>)[0];
     expect(publisherPackage.formats_to_provide?.map(format => format.format_option_id)).toEqual([
       'stable_publisher_mrec',
@@ -4128,13 +4623,11 @@ describe('create_media_buy handler', () => {
       format_option_id: 'stable_publisher_mrec',
     }]);
     expect(publisherPackage.format_ids).toEqual([legacyRef]);
-    expect(publisherPackage.format_kind).toBe('audio_hosted');
     const mediaBuyId = publisherScoped.result.media_buy_id as string;
     const persistedPackage = (await getSession(sessionKeyFromArgs({ account }, DEFAULT_CTX.mode)))
       .mediaBuys.get(mediaBuyId)?.packages[0];
     expect(persistedPackage?.formatIds).toEqual([legacyRef]);
     expect(persistedPackage?.formatOptionRefs).toEqual(publisherPackage.format_option_refs);
-    expect(persistedPackage?.formatKind).toBe('audio_hosted');
     // Each declaration is projected once while building the product index;
     // alias recovery reuses its indexed legacy tuple.
     expect(projectV1ProductToV2Spy).toHaveBeenCalledTimes(3);
@@ -4224,10 +4717,6 @@ describe('create_media_buy handler', () => {
       width: 300,
       height: 250,
     };
-    const informationalLegacyRef = {
-      agent_url: 'https://legacy-info.example/',
-      id: 'informational_legacy_only',
-    };
     const migratedRef = projectV1ProductToV2({
       product_id: productId,
       name: 'Legacy-only package',
@@ -4281,6 +4770,38 @@ describe('create_media_buy handler', () => {
     expect(wrongPublisherScope.result.code).toBe('UNSUPPORTED_FEATURE');
     expect(wrongPublisherScope.result.message).toContain('product scope');
 
+    const mismatchedVariant = { ...legacyRef, width: 728, height: 90 };
+    const mismatchedLegacyOnly = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: account.brand.domain },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        format_ids: [mismatchedVariant],
+      }],
+    });
+    expect(mismatchedLegacyOnly.isError).toBe(true);
+    expect(mismatchedLegacyOnly.result.code).toBe('UNSUPPORTED_FEATURE');
+
+    const mismatchedDualRoute = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: { domain: account.brand.domain },
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: pricingOptionId,
+        budget: 10000,
+        format_option_refs: [{ scope: 'product', format_option_id: migratedRef.format_option_id }],
+        format_ids: [mismatchedVariant],
+      }],
+    });
+    expect(mismatchedDualRoute.isError).toBe(true);
+    expect(mismatchedDualRoute.result.code).toBe('UNSUPPORTED_FEATURE');
+
     const create = await simulateCallTool(server, 'create_media_buy', {
       account,
       brand: { domain: account.brand.domain },
@@ -4291,12 +4812,12 @@ describe('create_media_buy handler', () => {
         pricing_option_id: pricingOptionId,
         budget: 10000,
         format_option_refs: [{ scope: 'product', format_option_id: migratedRef.format_option_id }],
-        format_ids: [informationalLegacyRef],
+        format_ids: [legacyRef],
       }],
     });
     expect(create.isError).not.toBe(true);
     const createdPackage = (create.result.packages as Array<Record<string, unknown>>)[0];
-    expect(createdPackage.format_ids).toEqual([informationalLegacyRef]);
+    expect(createdPackage.format_ids).toEqual([legacyRef]);
     expect(createdPackage).not.toHaveProperty('format_option_refs');
     expect(createdPackage).not.toHaveProperty('formats_to_provide');
 
@@ -4309,19 +4830,19 @@ describe('create_media_buy handler', () => {
         pricing_option_id: pricingOptionId,
         budget: 5000,
         format_option_refs: [{ scope: 'product', format_option_id: migratedRef.format_option_id }],
-        format_ids: [informationalLegacyRef],
+        format_ids: [legacyRef],
       }],
     });
     expect(update.isError).not.toBe(true);
     const addedPackage = (update.result.packages as Array<Record<string, unknown>>)
       .find(pkg => pkg.package_id === 'pkg-1')!;
-    expect(addedPackage.format_ids).toEqual([informationalLegacyRef]);
+    expect(addedPackage.format_ids).toEqual([legacyRef]);
     expect(addedPackage).not.toHaveProperty('format_option_refs');
     const persisted = (await getSession(sessionKeyFromArgs({ account }, DEFAULT_CTX.mode)))
       .mediaBuys.get(mediaBuyId)?.packages;
     expect(persisted?.map(pkg => pkg.formatIds)).toEqual([
-      [informationalLegacyRef],
-      [informationalLegacyRef],
+      [legacyRef],
+      [legacyRef],
     ]);
     expect(persisted?.map(pkg => pkg.selectedLegacyFormatIds)).toEqual([[legacyRef], [legacyRef]]);
     expect(persisted?.every(pkg => pkg.formatOptionRefs === undefined)).toBe(true);

--- a/static/compliance/source/protocols/media-buy/scenarios/canonical_formats.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/canonical_formats.yaml
@@ -1,5 +1,5 @@
 id: media_buy_seller/canonical_formats
-version: "1.0.0"
+version: "1.1.0"
 title: "Canonical formats and deprecated named-format compatibility"
 category: media_buy_seller
 summary: "Validates canonical product formats and the optional, explicitly deprecated named-format compatibility projection."
@@ -729,12 +729,15 @@ phases:
     title: "Canonical create-time format satisfaction"
     narrative: |
       The buyer rereads the fixed-size seeded product so the runner's product
-      context points at `canonical_formats_mrec_display`, then submits two
-      create_media_buy requests. The first uses the legacy
-      `display_300x250_image` selector and MUST be accepted after v1-to-canonical
-      normalization. The second uses a bare canonical `format_kind: image`
-      selector with no dimensions and MUST be rejected because it under-specifies
-      the product's 300x250 constraint.
+      context points at `canonical_formats_mrec_display`, then exercises every
+      PackageRequest selector migration path. Both canonical-only routes and
+      legacy-only requests are accepted. Equivalent canonical-plus-legacy dual
+      emission is accepted for older 3.x peers, while conflicting resolvable
+      routes are rejected with CONFLICTING_SELECTORS and an unprojectable route
+      is rejected first with UNSUPPORTED_FEATURE. A bare canonical image and a
+      width-only image selector are rejected because they under-specify the
+      product's fixed 300x250 constraint; the width-only case is also
+      schema-invalid because fixed-size image dimensions are atomic.
 
     steps:
       - id: get_canonical_product_for_create_satisfaction
@@ -783,6 +786,93 @@ phases:
             value: 250
             description: "Product fixes image height at 250"
 
+      - id: create_media_buy_with_canonical_format_option
+        title: "Accept canonical-only format option selector"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Accept the buy. The package uses only the product-local canonical
+          format_option_ref published by the fixed 300x250 product.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "2099-06-01T00:00:00Z"
+          end_time: "2099-06-30T23:59:59Z"
+          packages:
+            - product_id: "canonical_formats_mrec_display"
+              budget: 1000
+              pricing_option_id: "canonical_formats_mrec_cpm"
+              format_option_refs:
+                - scope: "product"
+                  format_option_id: "canonical_formats_image_mrec"
+              context:
+                buyer_ref: "canonical_formats_option_ref_positive"
+          context:
+            correlation_id: "canonical_formats--create_media_buy_with_canonical_format_option"
+          idempotency_key: "$generate:uuid_v4#canonical_formats_create_media_buy_with_canonical_format_option"
+
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Accepted canonical-only create allocates a media_buy_id"
+          - check: canonical_format_satisfaction
+            value: true
+            description: "Product-local format_option_ref satisfies the fixed canonical image declaration"
+
+      - id: create_media_buy_with_direct_canonical_selector
+        title: "Accept direct canonical format selector"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Accept the buy. The package uses only a direct canonical image
+          selector with the complete dimensions required by the product.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "2099-06-01T00:00:00Z"
+          end_time: "2099-06-30T23:59:59Z"
+          packages:
+            - product_id: "canonical_formats_mrec_display"
+              budget: 1000
+              pricing_option_id: "canonical_formats_mrec_cpm"
+              format_kind: "image"
+              params:
+                width: 300
+                height: 250
+              context:
+                buyer_ref: "canonical_formats_direct_selector_positive"
+          context:
+            correlation_id: "canonical_formats--create_media_buy_with_direct_canonical_selector"
+          idempotency_key: "$generate:uuid_v4#canonical_formats_create_media_buy_with_direct_canonical_selector"
+
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Accepted direct-canonical create allocates a media_buy_id"
+          - check: canonical_format_satisfaction
+            value: true
+            description: "Complete direct image dimensions satisfy the fixed canonical declaration"
+
       - id: create_media_buy_with_legacy_mrec_format
         title: "Accept legacy fixed MREC selector after canonical normalization"
         task: create_media_buy
@@ -827,6 +917,246 @@ phases:
             value: true
             description: "Legacy display_300x250_image selector satisfies the fixed canonical image declaration after normalization"
 
+      - id: create_media_buy_with_equivalent_dual_emission
+        title: "Accept equivalent legacy dual emission"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Accept the older 3.x request after independently resolving both
+          selector routes. The product-local canonical option and legacy
+          display_300x250_image selector normalize to the same declaration.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "2099-06-01T00:00:00Z"
+          end_time: "2099-06-30T23:59:59Z"
+          packages:
+            - product_id: "canonical_formats_mrec_display"
+              budget: 1000
+              pricing_option_id: "canonical_formats_mrec_cpm"
+              format_option_refs:
+                - scope: "product"
+                  format_option_id: "canonical_formats_image_mrec"
+              format_ids:
+                - agent_url: "https://creative.adcontextprotocol.org/"
+                  id: "display_300x250_image"
+              context:
+                buyer_ref: "canonical_formats_equivalent_dual_positive"
+          context:
+            correlation_id: "canonical_formats--create_media_buy_with_equivalent_dual_emission"
+          idempotency_key: "$generate:uuid_v4#canonical_formats_create_media_buy_with_equivalent_dual_emission"
+
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Equivalent dual emission remains valid during the 3.x compatibility window"
+          - check: canonical_format_satisfaction
+            value: true
+            description: "Both selector routes normalize to the fixed 300x250 image declaration"
+
+      - id: create_media_buy_with_equivalent_direct_legacy_emission
+        title: "Accept equivalent direct and legacy selectors"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        stateful: true
+        expected: |
+          Accept the older 3.x request. The direct image selector and legacy
+          display_300x250_image selector both select the product's fixed MREC
+          declaration under the canonical v2-narrows-v1 comparison.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "2099-06-01T00:00:00Z"
+          end_time: "2099-06-30T23:59:59Z"
+          packages:
+            - product_id: "canonical_formats_mrec_display"
+              budget: 1000
+              pricing_option_id: "canonical_formats_mrec_cpm"
+              format_kind: "image"
+              params:
+                width: 300
+                height: 250
+              format_ids:
+                - agent_url: "https://creative.adcontextprotocol.org/"
+                  id: "display_300x250_image"
+              context:
+                buyer_ref: "canonical_formats_direct_legacy_positive"
+          context:
+            correlation_id: "canonical_formats--create_media_buy_with_equivalent_direct_legacy_emission"
+          idempotency_key: "$generate:uuid_v4#canonical_formats_create_media_buy_with_equivalent_direct_legacy_emission"
+
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Equivalent direct-plus-legacy emission remains valid for older 3.x peers"
+          - check: canonical_format_satisfaction
+            value: true
+            description: "Direct and legacy routes select the same fixed 300x250 image declaration"
+
+      - id: reject_conflicting_dual_emission
+        title: "Reject conflicting canonical and legacy selectors"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: true
+        expected: |
+          Reject with CONFLICTING_SELECTORS. The canonical option selects the
+          product's 300x250 image declaration while the registry-backed legacy
+          display_728x90 selector normalizes to a 728x90 image. Canonical precedence must not hide the
+          dimensional conflict.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "2099-06-01T00:00:00Z"
+          end_time: "2099-06-30T23:59:59Z"
+          packages:
+            - product_id: "canonical_formats_mrec_display"
+              budget: 1000
+              pricing_option_id: "canonical_formats_mrec_cpm"
+              format_option_refs:
+                - scope: "product"
+                  format_option_id: "canonical_formats_image_mrec"
+              format_ids:
+                - agent_url: "https://creative.adcontextprotocol.org/"
+                  id: "display_728x90"
+              context:
+                buyer_ref: "canonical_formats_conflicting_dual_negative"
+          context:
+            correlation_id: "canonical_formats--reject_conflicting_dual_emission"
+          idempotency_key: "$generate:uuid_v4#canonical_formats_reject_conflicting_dual_emission"
+
+        validations:
+          - check: error_code
+            value: "CONFLICTING_SELECTORS"
+            description: "Seller rejects disagreeing canonical and legacy selector projections"
+          - check: canonical_format_satisfaction
+            value: false
+            description: "The registry-backed 728x90 legacy projection does not select the same product contract as the 300x250 canonical route"
+
+      - id: reject_conflicting_canonical_routes
+        title: "Reject conflicting canonical selector routes"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: true
+        expected: |
+          Reject with CONFLICTING_SELECTORS. The product-local option selects
+          the fixed 300x250 declaration while the co-present direct selector
+          describes a 728x90 image. Canonical precedence must not hide a
+          conflict between two resolvable canonical routes.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "2099-06-01T00:00:00Z"
+          end_time: "2099-06-30T23:59:59Z"
+          packages:
+            - product_id: "canonical_formats_mrec_display"
+              budget: 1000
+              pricing_option_id: "canonical_formats_mrec_cpm"
+              format_option_refs:
+                - scope: "product"
+                  format_option_id: "canonical_formats_image_mrec"
+              format_kind: "image"
+              params:
+                width: 728
+                height: 90
+              context:
+                buyer_ref: "canonical_formats_conflicting_canonical_negative"
+          context:
+            correlation_id: "canonical_formats--reject_conflicting_canonical_routes"
+          idempotency_key: "$generate:uuid_v4#canonical_formats_reject_conflicting_canonical_routes"
+
+        validations:
+          - check: error_code
+            value: "CONFLICTING_SELECTORS"
+            description: "Seller rejects canonical routes that select different product format contracts"
+          - check: canonical_format_satisfaction
+            value: false
+            description: "The two canonical routes describe incompatible fixed image dimensions"
+
+      - id: reject_unprojectable_legacy_dual_emission
+        title: "Reject an unprojectable legacy route before equivalence"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: true
+        expected: |
+          Reject with UNSUPPORTED_FEATURE. The canonical option resolves, but
+          the legacy ID has no product link or canonical registry mapping.
+          Resolution failure is reported before selector equivalence and must
+          not be mislabeled CONFLICTING_SELECTORS.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "2099-06-01T00:00:00Z"
+          end_time: "2099-06-30T23:59:59Z"
+          packages:
+            - product_id: "canonical_formats_mrec_display"
+              budget: 1000
+              pricing_option_id: "canonical_formats_mrec_cpm"
+              format_option_refs:
+                - scope: "product"
+                  format_option_id: "canonical_formats_image_mrec"
+              format_ids:
+                - agent_url: "https://creative.adcontextprotocol.org/"
+                  id: "unmapped_legacy_selector_6648"
+              context:
+                buyer_ref: "canonical_formats_unprojectable_legacy_negative"
+          context:
+            correlation_id: "canonical_formats--reject_unprojectable_legacy_dual_emission"
+          idempotency_key: "$generate:uuid_v4#canonical_formats_reject_unprojectable_legacy_dual_emission"
+
+        validations:
+          - check: error_code
+            value: "UNSUPPORTED_FEATURE"
+            description: "Seller reports route resolution failure before attempting equivalence"
+          - check: canonical_format_satisfaction
+            value: false
+            description: "The legacy selector cannot be normalized to a canonical declaration"
+
       - id: reject_bare_image_selector_for_fixed_mrec
         title: "Reject bare canonical image selector for fixed-size product"
         task: create_media_buy
@@ -868,3 +1198,43 @@ phases:
           - check: canonical_format_satisfaction
             value: false
             description: "Bare canonical image selector lacks the dimensions required by the fixed canonical image declaration"
+
+      - id: reject_image_width_without_height
+        title: "Reject fixed-size image width without height"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: schema_invalid
+        stateful: true
+        expected: |
+          Reject with INVALID_REQUEST. Fixed-size image dimensions are atomic,
+          so params.width without params.height is schema-invalid.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          start_time: "2099-06-01T00:00:00Z"
+          end_time: "2099-06-30T23:59:59Z"
+          packages:
+            - product_id: "canonical_formats_mrec_display"
+              budget: 1000
+              pricing_option_id: "canonical_formats_mrec_cpm"
+              format_kind: "image"
+              params:
+                width: 300
+              context:
+                buyer_ref: "canonical_formats_width_only_negative"
+          context:
+            correlation_id: "canonical_formats--reject_image_width_without_height"
+          idempotency_key: "$generate:uuid_v4#canonical_formats_reject_image_width_without_height"
+
+        validations:
+          - check: error_code
+            value: "INVALID_REQUEST"
+            description: "Seller rejects a schema-invalid fixed-size image selector"

--- a/static/compliance/source/universal/storyboard-schema.yaml
+++ b/static/compliance/source/universal/storyboard-schema.yaml
@@ -1604,12 +1604,29 @@
 #   setup error. `value: true` means the request should be accepted; `value:
 #   false` means the request should be rejected for a format-selector cause.
 #
-#   The check normalizes legacy `format_ids[]` through `v1_format_ref[]` and the
-#   v1-to-canonical registry, resolves `format_option_refs[]`, and applies
-#   directional product gating for fixed dimensions, duration declarations,
-#   canonical params, and range containment. Negative cases only pass when the
-#   observed rejection is attributable to formats, so unrelated auth or tenant
-#   failures do not mask selector bugs.
+#   The check evaluates each present selector route independently before
+#   applying precedence:
+#   1. Resolve `format_option_refs[]`, normalize legacy `format_ids[]` through
+#      `v1_format_ref[]` and the v1-to-canonical registry, and materialize the
+#      direct `format_kind`/`params` declaration. If any option reference is
+#      unresolved or any legacy ID is unprojectable, local_satisfied is false;
+#      a negative step asserting this path pairs the check with an
+#      `error_code: UNSUPPORTED_FEATURE` validation.
+#   2. For every resolved route, derive the target product's selected
+#      `format_options[]` entries using directional product gating for fixed
+#      dimensions, duration declarations, canonical params, and range
+#      containment. Legacy compatibility uses the asymmetric v2-narrows-v1
+#      relation from canonical-formats.mdx, not raw declaration equality.
+#   3. When multiple routes are present, their selected product-option sets
+#      MUST match. Different format shapes, option sets, or incompatible
+#      dimensions make local_satisfied false; a negative step asserting this
+#      path pairs the check with `error_code: CONFLICTING_SELECTORS`.
+#   4. Only after every route resolves and the selected sets agree does the
+#      runner apply package precedence: format_option_refs, then direct
+#      format_kind/params, then format_ids.
+#
+#   Negative cases only pass when the observed rejection is attributable to
+#   formats, so unrelated auth or tenant failures do not mask selector bugs.
 #
 #   Fields:
 #     check: canonical_format_satisfaction

--- a/static/schemas/source/enums/error-code.json
+++ b/static/schemas/source/enums/error-code.json
@@ -66,6 +66,7 @@
     "TERMS_REJECTED",
     "BIDDING_PLACEMENT_CONFLICT",
     "AMBIGUOUS_BIDDING_POLICY",
+    "CONFLICTING_SELECTORS",
     "REQUOTE_REQUIRED",
     "VERSION_UNSUPPORTED",
     "CAMPAIGN_SUSPENDED",
@@ -176,6 +177,7 @@
     "TERMS_REJECTED": "Buyer-proposed measurement_terms were rejected by the seller. The error details SHOULD identify which specific term was rejected and the seller's acceptable range or supported vendors. Recovery: correctable (adjust the proposed terms and retry, or omit measurement_terms to accept the product's defaults).",
     "BIDDING_PLACEMENT_CONFLICT": "The authored media-buy/package bidding scopes cannot be represented by the provider's native campaign, package, or shared-strategy placement rules. Sellers MUST detect this before any provider mutation and SHOULD identify the conflicting scopes and provider constraint in error.details. Recovery: correctable (remove or align package overrides, move the policy to the supported scope, or choose a compatible budget mode/product combination).",
     "AMBIGUOUS_BIDDING_POLICY": "The same effective package combines the canonical bidding block with legacy bid_price or monetary optimization-goal target fields, so two bidding interpretations are present. Sellers MUST reject rather than choosing a winner. Recovery: correctable (emit only the 3.2 bidding block or only one legacy representation).",
+    "CONFLICTING_SELECTORS": "A 3.x package request carries multiple resolvable format selector routes that select different canonical product format declaration sets. Sellers MUST first resolve every present route independently (`format_option_refs`, direct `format_kind` plus `params`, and deprecated `format_ids`) without applying precedence. An unresolved option reference or an unprojectable legacy ID is rejected with `UNSUPPORTED_FEATURE`, not this code. Once all routes resolve, sellers derive the product `format_options[]` entries selected by each route using directional product satisfaction and require those sets to match. Legacy parameter compatibility uses the asymmetric v2-narrows-v1 relation defined by canonical formats, not raw object equality. For fixed-size image selectors, both width and height participate in compatibility. Sellers MUST reject different format shapes, selected option sets, or incompatible dimensions rather than silently choosing the canonical route. `error.field` SHOULD point at the conflicting package, and `error.details` SHOULD identify the supplied selector routes and their normalized canonical summaries. Recovery: correctable (emit one canonical selector route, or make a required legacy 3.x compatibility projection select the same product format contract).",
     "REQUOTE_REQUIRED": "A control_media_buy request, or the 3.x update_media_buy facade, would exceed the accepted commercial envelope. The seller is declining the requested shape at the current terms. Distinct from TERMS_REJECTED (measurement) and POLICY_VIOLATION (content). Sellers SHOULD populate error.details.envelope_field with the field path(s) that breached the envelope. AdCP 3.2 callers refine the MediaBuy's accepted_proposal_id to obtain a typed amendment; legacy 3.1 callers adjust the update, rediscover terms, or create a separate buy.",
     "VERSION_UNSUPPORTED": "The declared adcp_version (release-precision) or adcp_major_version (deprecated) is not supported by this seller. The error details SHOULD follow `error-details/version-unsupported.json` — `supported_versions` (release-precision strings) is authoritative for retry; `supported_majors` is deprecated. Recovery: correctable (re-pin to a release in supported_versions and retry; or call get_adcp_capabilities without a version pin to discover supported_versions).",
     "CAMPAIGN_SUSPENDED": "Campaign governance has been suspended pending human review; the governance agent MUST reject `check_governance` and `report_plan_outcome` calls on the affected plan until the escalation is resolved. Distinct from `ACCOUNT_SUSPENDED` (account-wide) — this is scoped to a single plan/campaign. Recovery: transient (wait for the escalation to resolve; contact the plan operator if the suspension persists).",
@@ -469,6 +471,10 @@
     "AMBIGUOUS_BIDDING_POLICY": {
       "recovery": "correctable",
       "suggestion": "remove either the canonical bidding block or all legacy bidding fields from the effective package"
+    },
+    "CONFLICTING_SELECTORS": {
+      "recovery": "correctable",
+      "suggestion": "emit one canonical format selector route, or make every required legacy 3.x compatibility projection select the same product format contract under the canonical v2-narrows-v1 comparison"
     },
     "REQUOTE_REQUIRED": {
       "recovery": "correctable",

--- a/static/schemas/source/media-buy/package-request.json
+++ b/static/schemas/source/media-buy/package-request.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/media-buy/package-request.json",
   "title": "Package Request",
-  "description": "Package configuration for media buy creation",
+  "description": "Package configuration for media buy creation.\n\n**Format selector contract (normative).** New 3.2 buyers author at most one canonical selector route: `format_option_refs`, or `format_kind` with optional `params`; omitting both selects all formats supported by the product. New buyers MUST NOT emit deprecated `format_ids`. During the 3.x compatibility window, receivers MUST continue to accept legacy-only `format_ids` and older requests that carry more than one selector route.\n\nReceivers process selectors in this order: (1) independently resolve each present route to canonical declarations, without applying route precedence; an unresolved `format_option_ref` or a legacy `format_id` that cannot be normalized through the canonical mapping path MUST be rejected with `UNSUPPORTED_FEATURE`; (2) when every route resolves, derive the product `format_options[]` entries selected by each route using directional product satisfaction, and require the selected option sets to match; legacy-to-canonical parameter compatibility uses the asymmetric [v2 narrows v1](/docs/creative/canonical-formats#narrows-formal-definition-normative) relation, not raw object equality; (3) reject different format shapes, selected option sets, or incompatible dimensions with `CONFLICTING_SELECTORS`; and only then (4) apply precedence: `format_option_refs`, then `format_kind` plus `params`, then `format_ids`. Equivalent legacy dual emission remains valid. A single resolved route that does not satisfy the product is rejected with `UNSUPPORTED_FEATURE`. `params` requires `format_kind`; for fixed-size image selectors, `width` and `height` MUST either both be present or both be absent.",
   "type": "object",
   "allOf": [
     {
@@ -29,6 +29,24 @@
           }
         }
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "format_kind": { "const": "image" }
+        },
+        "required": ["format_kind", "params"]
+      },
+      "then": {
+        "properties": {
+          "params": {
+            "dependencies": {
+              "width": ["height"],
+              "height": ["width"]
+            }
+          }
+        }
+      }
     }
   ],
   "not": {
@@ -47,7 +65,7 @@
     "format_ids": {
       "type": "array",
       "deprecated": true,
-      "description": "Deprecated in AdCP 3.2; removed in AdCP 4.0. Legacy named-format selector retained for older 3.x peers. New buyers select canonical product contracts with `format_option_refs` or `format_kind` plus `params`. Sellers MUST normalize this field through the canonical mapping path before product satisfaction checks. If omitted and no canonical selector is present, it defaults to all formats supported by the product.",
+      "description": "Deprecated in AdCP 3.2; removed in AdCP 4.0. Legacy named-format selector retained for older 3.x peers. New buyers MUST NOT emit this field. Sellers MUST normalize every entry through the canonical mapping path before product satisfaction checks; an entry that cannot be normalized is rejected with `UNSUPPORTED_FEATURE` before any equivalence check. When this field coexists with `format_option_refs` or `format_kind` plus `params`, sellers MUST compare the product option sets selected by each resolved route. Legacy parameter compatibility follows the asymmetric v2-narrows-v1 relation defined by canonical formats, not raw object equality. Different format shapes, selected option sets, or incompatible dimensions are rejected with `CONFLICTING_SELECTORS`; sellers MUST NOT silently ignore the legacy projection. Equivalent dual emission remains valid during the 3.x compatibility window. If omitted and no canonical selector is present, all formats supported by the product are active.",
       "items": {
         "$ref": "/schemas/core/format-id.json"
       },
@@ -55,7 +73,7 @@
     },
     "format_option_refs": {
       "type": "array",
-      "description": "Canonical 3.2 format-option selector. Each reference matches one target product `format_options[]` entry. Publisher-backed options match `{ scope: \"publisher\", publisher_domain, format_option_id }`; product-local options match `{ scope: \"product\", format_option_id }`. If omitted with direct `format_kind`, all product options are active. Sellers reject unresolved options with `UNSUPPORTED_FEATURE` and a field path to the failing entry. New buyers do not dual-emit deprecated named-format selectors.",
+      "description": "Canonical 3.2 format-option selector. Each reference matches one target product `format_options[]` entry. Publisher-backed options match `{ scope: \"publisher\", publisher_domain, format_option_id }`; product-local options match `{ scope: \"product\", format_option_id }`. Sellers reject unresolved options with `UNSUPPORTED_FEATURE` and a field path to the failing entry before comparing co-present routes. New buyers MUST use this route by itself and MUST NOT dual-emit either a direct canonical selector or deprecated `format_ids`. Receivers handling older 3.x multi-route requests MUST resolve every present route, require each route to select the same product option set, and reject disagreement with `CONFLICTING_SELECTORS` before treating `format_option_refs` as authoritative.",
       "items": {
         "$ref": "/schemas/core/format-option-ref.json"
       },
@@ -63,11 +81,11 @@
     },
     "format_kind": {
       "$ref": "/schemas/core/canonical-format-kind.json",
-      "description": "Canonical 3.2 direct selector. Names the canonical format shape this package targets when the buyer is not selecting a published `format_option_ref`. Pair with `params` for dimensions, duration, codecs, or other constraints. Product satisfaction is directional: broad `{ format_kind: \"image\" }` does not satisfy a fixed-size product declaration."
+      "description": "Canonical 3.2 direct selector. Names the canonical format shape this package targets when the buyer is not selecting a published `format_option_ref`. Pair with `params` for dimensions, duration, codecs, or other constraints. New buyers MUST NOT combine this route with `format_option_refs` or deprecated `format_ids`. Receivers handling older 3.x multi-route requests MUST equivalence-check every present route before applying precedence and reject disagreement with `CONFLICTING_SELECTORS`. Product satisfaction is directional: broad `{ format_kind: \"image\" }` does not satisfy a fixed-size product declaration."
     },
     "params": {
       "type": "object",
-      "description": "Parameters for the direct canonical selector in `format_kind`. Shape follows the selected canonical's parameter vocabulary: dimensions (`width`, `height`, `sizes`), duration (`duration_ms_exact`, `duration_ms_range`), codecs, asset-source and slot narrowing, or other canonical-specific constraints. Omit when selecting by `format_option_refs` or `format_ids`; those selectors resolve their parameters from the product declaration or legacy catalog projection.",
+      "description": "Parameters for the direct canonical selector in `format_kind`. Shape follows the selected canonical's parameter vocabulary: dimensions (`width`, `height`, `sizes`), duration (`duration_ms_exact`, `duration_ms_range`), codecs, asset-source and slot narrowing, or other canonical-specific constraints. Requires `format_kind`. For fixed-size image selectors, `width` and `height` MUST co-occur; a selector containing only one dimension is schema-invalid. New buyers omit `params` when selecting by `format_option_refs` or `format_ids`; older multi-route requests are accepted only when every route selects the same product option set.",
       "additionalProperties": true
     },
     "budget": {

--- a/tests/placement-catalog-schema.test.cjs
+++ b/tests/placement-catalog-schema.test.cjs
@@ -494,6 +494,71 @@ test('format options can be referenced by publisher domain or product-local ID',
       product_id: 'homepage_sponsorship',
       pricing_option_id: 'cpm_fixed',
       budget: 1000,
+      format_kind: 'image',
+      params: {
+        width: 300,
+        height: 250
+      }
+    }),
+    true,
+    JSON.stringify(validatePackage.errors, null, 2)
+  );
+
+  assert.equal(
+    validatePackage({
+      product_id: 'homepage_sponsorship',
+      pricing_option_id: 'cpm_fixed',
+      budget: 1000,
+      format_kind: 'image',
+      params: {
+        width: 300
+      }
+    }),
+    false,
+    'Fixed-size image selectors reject width without height'
+  );
+
+  assert.equal(
+    validatePackage({
+      product_id: 'homepage_sponsorship',
+      pricing_option_id: 'cpm_fixed',
+      budget: 1000,
+      format_kind: 'image',
+      params: {
+        height: 250
+      }
+    }),
+    false,
+    'Fixed-size image selectors reject height without width'
+  );
+
+  assert.equal(
+    validatePackage({
+      product_id: 'homepage_sponsorship',
+      pricing_option_id: 'cpm_fixed',
+      budget: 1000,
+      format_option_refs: [
+        {
+          scope: 'product',
+          format_option_id: 'seller_takeover_image'
+        }
+      ],
+      format_ids: [
+        {
+          agent_url: 'https://creative.adcontextprotocol.org/',
+          id: 'display_970x250_image'
+        }
+      ]
+    }),
+    true,
+    'Legacy and canonical selector co-presence remains schema-valid for 3.x receivers; equivalence is application-level'
+  );
+
+  assert.equal(
+    validatePackage({
+      product_id: 'homepage_sponsorship',
+      pricing_option_id: 'cpm_fixed',
+      budget: 1000,
       format_option_refs: [
         {
           scope: 'product',


### PR DESCRIPTION
## Summary

- define deterministic resolution, equivalence, and error precedence when a `PackageRequest` contains multiple format selector routes
- add `CONFLICTING_SELECTORS` and enforce atomic fixed-image dimensions
- enforce the contract in the training seller for create and add-package updates, including set/range narrowing, URL-canonical legacy matching, and legacy-only compatibility
- expand and version the canonical-format compliance storyboard, including an explicit runner contract

## Why

AdCP 3.2 authoring guidance stopped recommending dual emission, but receiver behavior remained ambiguous for older 3.x requests that contain both canonical and legacy selectors. This change preserves compatible legacy traffic while making mismatches and unresolved selectors deterministic.

## Compatibility

- legacy-only requests remain supported
- equivalent canonical and legacy selectors remain supported
- new buyers should emit exactly one canonical selector route
- mismatched resolvable routes return `CONFLICTING_SELECTORS`; unresolved routes return `UNSUPPORTED_FEATURE`

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run test:schemas`
- `npm run test:composed`
- focused placement schema and compliance generation/checks
- training-agent unit suite (`647/647`)
- tenant smoke suite (`30/30`)
- focused canonical-format storyboard (`21 passed`, `2 skipped` for the linked SDK blocker)
- three expert review passes covering protocol correctness, implementation quality, and test coverage

## Integration note

The packaged SDK currently canonicalizes away deprecated co-present `format_ids` and still grades direct selectors with non-directional precedence. The local runner narrowly exempts those checks while raw receiver unit coverage remains active. Remove the exemptions when [adcp-client#2392](https://github.com/adcontextprotocol/adcp-client/issues/2392) lands.

Closes #6648
