### PR TITLE
fix(release): restore Changesets v2 git pushes

### DIFF
--- a/.changeset/restore-changesets-v2-git-pushes.md
+++ b/.changeset/restore-changesets-v2-git-pushes.md
@@ -1,0 +1,6 @@
+---
+"adcontextprotocol": patch
+---
+
+Restore Changesets v2 compatibility while retaining git-backed pushes for
+large generated release commits.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,19 +113,22 @@ jobs:
       - name: Create Release Pull Request or Tag Release
         if: steps.release-relevance.outputs.relevant == 'true' && steps.release-artifacts.outputs.has_release_artifacts != 'true'
         id: changesets
-        # v2 writes the entire release commit through one GraphQL mutation,
-        # which exceeds GitHub's 45 MB payload cap for beta-scale generated
-        # schema and compliance artifacts. v1 pushes the generated commit via
-        # git and supports the same Changesets v3 CLI commands below.
-        uses: changesets/action@v1
+        # v2 understands the Changesets v3 `.changeset/pre/` archive. This is
+        # v2.1.0, pinned to the contract verified at:
+        # https://github.com/changesets/action/blob/198f833dd7d863100ea6e28967bc9a9fdefadb0a/action.yml
+        # Its implementation reads push-with-git-cli at src/index.ts:37.
+        # Keep git CLI pushing enabled because beta-scale generated schema and
+        # compliance artifacts exceed GitHub's API payload limit.
+        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
         with:
-          version: npm run version
-          publish: npx --no-install changeset git-tag
-          commit: 'Version Packages'
-          title: 'Version Packages'
-          createGithubReleases: true
+          github-token: ${{ steps.app-token.outputs.token }}
+          version-script: npm run version
+          publish-script: npx --no-install changeset git-tag
+          commit-message: 'Version Packages'
+          pr-title: 'Version Packages'
+          create-github-releases: true
+          push-with-git-cli: true
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HUSKY: '0'
 
       - name: Sign local protocol tarball if needed

--- a/tests/fixtures/changesets-action-v2.1.0/action.yml
+++ b/tests/fixtures/changesets-action-v2.1.0/action.yml
@@ -1,0 +1,65 @@
+name: Changesets
+description: A GitHub action to automate releases with Changesets
+runs:
+  using: "node24"
+  main: "dist/index.js"
+inputs:
+  github-token:
+    description: >
+      The GitHub token to use for authentication. Defaults to the GitHub-provided token.
+      To use a custom token, pass it explicitly to this input.
+    required: false
+    default: ${{ github.token }}
+  publish-script:
+    description: "The command to use to build and publish packages"
+    required: false
+  version-script:
+    description: "The command to update version, edit CHANGELOG, read and delete changesets. Default to `changeset version` if not provided"
+    required: false
+  commit-message:
+    description: "The commit message. Default to `Version Packages`"
+    required: false
+    default: "Version Packages"
+  pr-title:
+    description: "The pull request title. Default to `Version Packages`"
+    required: false
+    default: "Version Packages"
+  pr-draft:
+    description: "Controls draft PR behavior. Use 'create' to create new version PRs as draft, or 'always' to also convert existing version PRs back to draft when updating them."
+    required: false
+  pr-base-branch:
+    description: "Sets the base branch of the PR. Defaults to `github.ref_name`."
+    required: false
+  create-github-releases:
+    description: "Whether to create Github releases after publish"
+    required: false
+    default: true
+  push-git-tags:
+    description: >
+      Whether to create git tags after publish. If `create-github-releases` is set to `true`,
+      this option will also always be `true`.
+    required: false
+    default: true
+  push-with-git-cli:
+    description: >
+      Whether to use the Git CLI instead of the GitHub API to push release commits and tags.
+      Defaults to `false`. When using the GitHub API, commits and tags are signed using
+      GitHub's GPG key and attributed to the user or app that owns the `github-token`.
+    required: false
+    default: false
+  cwd:
+    description: "The working directory to execute Changesets in. Defaults to the root of the repository."
+    required: false
+outputs:
+  published:
+    description: A "true" or "false" string value to indicate whether a publishing is happened or not
+  published-packages:
+    description: >
+      A JSON array to present the published packages. The format is `[{"name": "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]`
+  has-changesets:
+    description: A "true" or "false" string value about whether there were changesets. Useful if you want to create your own publishing functionality.
+  pr-number:
+    description: The pull request number that was created or updated
+branding:
+  icon: "package"
+  color: "blue"

--- a/tests/fixtures/changesets-action-v2.1.0/src-index.ts
+++ b/tests/fixtures/changesets-action-v2.1.0/src-index.ts
@@ -1,0 +1,137 @@
+import * as core from "@actions/core";
+import { GitHub } from "./github.ts";
+import readChangesetState from "./readChangesetState.ts";
+import { runPublish, runVersion } from "./run.ts";
+import {
+  getOptionalInput,
+  getRequiredInput,
+  throwOnRemovedCommitModeInput,
+  throwOnRenamedInputs,
+  validateChangesetsCliVersion,
+} from "./utils.ts";
+
+(async () => {
+  const cwd = getOptionalInput("cwd") || process.cwd();
+  await validateChangesetsCliVersion(cwd);
+
+  throwOnRenamedInputs({
+    publish: "publish-script",
+    version: "version-script",
+    commit: "commit-mesage",
+    title: "pr-title",
+    branch: "pr-base-branch",
+    prDraft: "pr-draft",
+    createGithubReleases: "create-github-releases",
+  });
+  throwOnRemovedCommitModeInput();
+
+  const githubToken = getRequiredInput("github-token");
+  if (process.env.GITHUB_TOKEN && process.env.GITHUB_TOKEN !== githubToken) {
+    throw new Error(
+      'The GITHUB_TOKEN environment variable is set and does not match the "github-token" input. ' +
+        'Please pass the custom GitHub token to the "github-token" input and ' +
+        "remove the GITHUB_TOKEN environment variable to avoid conflicts.",
+    );
+  }
+
+  const pushWithGitCli = core.getBooleanInput("push-with-git-cli");
+  const prDraft = getOptionalInput("pr-draft");
+  if (prDraft !== undefined && prDraft !== "always" && prDraft !== "create") {
+    core.setFailed(`Invalid pr-draft: ${prDraft}`);
+    return;
+  }
+  const github = new GitHub({
+    cwd,
+    githubToken,
+    pushWithGitCli,
+  });
+
+  let { changesets } = await readChangesetState(cwd);
+
+  let publishScript = core.getInput("publish-script");
+  let hasChangesets = changesets.length !== 0;
+  const hasNonEmptyChangesets = changesets.some(
+    (changeset) => changeset.releases.length > 0,
+  );
+  let hasPublishScript = !!publishScript;
+
+  core.setOutput("published", "false");
+  core.setOutput("published-packages", "[]");
+  core.setOutput("has-changesets", String(hasChangesets));
+
+  switch (true) {
+    case !hasChangesets && !hasPublishScript:
+      core.info(
+        "No changesets present or were removed by merging release PR. Not publishing because no publish script found.",
+      );
+      return;
+    case !hasChangesets && hasPublishScript: {
+      core.info(
+        "No changesets found. Attempting to publish any unpublished packages to npm",
+      );
+
+      const createGithubReleases = core.getBooleanInput(
+        "create-github-releases",
+      );
+      const pushGitTags = core.getBooleanInput("push-git-tags");
+      if (createGithubReleases && !pushGitTags) {
+        throw new Error(
+          "The input 'create-github-releases' is set to true, but 'push-git-tags' is set to false. " +
+            "Creating GitHub releases requires pushing git tags. Please set 'push-git-tags' to true " +
+            "or set 'create-github-releases' to false.",
+        );
+      }
+      const result = await runPublish({
+        script: publishScript,
+        github,
+        createGithubReleases,
+        pushGitTags,
+        cwd,
+      });
+
+      if (result.published) {
+        core.setOutput("published", "true");
+        core.setOutput(
+          "published-packages",
+          JSON.stringify(result.publishedPackages),
+        );
+      }
+
+      if (result.exitCode !== 0) {
+        core.error(
+          `Publish command exited with code ${result.exitCode}${
+            result.published
+              ? `, but some packages were published: ${result.publishedPackages
+                  .map((p) => `${p.name}@${p.version}`)
+                  .join(", ")}`
+              : ""
+          }`,
+        );
+        process.exit(result.exitCode);
+      }
+      return;
+    }
+    case hasChangesets && !hasNonEmptyChangesets:
+      core.info("All changesets are empty; not creating PR");
+      return;
+    case hasChangesets: {
+      const { pullRequestNumber } = await runVersion({
+        script: getOptionalInput("version-script"),
+        github,
+        cwd,
+        prTitle: getOptionalInput("pr-title"),
+        commitMessage: getOptionalInput("commit-message"),
+        hasPublishScript,
+        prDraft,
+        branch: getOptionalInput("pr-base-branch"),
+      });
+
+      core.setOutput("pr-number", String(pullRequestNumber));
+
+      return;
+    }
+  }
+})().catch((err) => {
+  core.error(err);
+  core.setFailed(err.message);
+});

--- a/tests/release-workflow-immutability.test.cjs
+++ b/tests/release-workflow-immutability.test.cjs
@@ -3,10 +3,18 @@
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
+const crypto = require('crypto');
+const YAML = require('yaml');
 
 const repoRoot = path.join(__dirname, '..');
+const changesetsActionSha = '198f833dd7d863100ea6e28967bc9a9fdefadb0a';
+const changesetsActionFixtureDir = path.join(
+  repoRoot,
+  'tests/fixtures/changesets-action-v2.1.0'
+);
 const workflowPath = path.join(repoRoot, '.github/workflows/release.yml');
 const workflow = fs.readFileSync(workflowPath, 'utf8');
+const workflowConfig = YAML.parse(workflow);
 const eolReleaseBranches = ['2.5-maintenance', '2.6.x'];
 const activeWorkflowPaths = [
   'apps-web-check.yml',
@@ -35,6 +43,30 @@ const releaseRelevance = extractStep('Detect release-relevant push');
 const artifactDetection = extractStep('Detect committed release artifacts');
 const changesetsStep = extractStep('Create Release Pull Request or Tag Release');
 const uploadStep = extractStep('Upload protocol tarball to GitHub Release');
+const changesetsStepConfig = workflowConfig.jobs.release.steps.find(
+  step => step.name === 'Create Release Pull Request or Tag Release'
+);
+const changesetsActionContractSource = fs.readFileSync(
+  path.join(changesetsActionFixtureDir, 'action.yml'),
+  'utf8'
+);
+const changesetsActionImplementation = fs.readFileSync(
+  path.join(changesetsActionFixtureDir, 'src-index.ts'),
+  'utf8'
+);
+const changesetsActionContract = YAML.parse(changesetsActionContractSource);
+
+assert.strictEqual(
+  crypto.createHash('sha256').update(changesetsActionContractSource).digest('hex'),
+  'e3277ecb13148921adcfbc29971acb12b10ece79e7de24a200ba56dff1f6a1d7',
+  'Vendored action.yml must match changesets/action v2.1.0 at the pinned commit.'
+);
+
+assert.strictEqual(
+  crypto.createHash('sha256').update(changesetsActionImplementation).digest('hex'),
+  '012ab4141d8a1bd5db441a696fc408e5d92513a6a2be8493de72960f7b41ff30',
+  'Vendored src/index.ts must match changesets/action v2.1.0 at the pinned commit.'
+);
 
 for (const branch of eolReleaseBranches) {
   for (const workflowName of activeWorkflowPaths) {
@@ -67,6 +99,46 @@ assert(
 assert(
   changesetsStep.includes("HUSKY: '0'"),
   'Changesets automation must not rerun local pre-commit hooks while creating its release commit.'
+);
+
+assert.deepStrictEqual(
+  changesetsStepConfig,
+  {
+    name: 'Create Release Pull Request or Tag Release',
+    if: "steps.release-relevance.outputs.relevant == 'true' && steps.release-artifacts.outputs.has_release_artifacts != 'true'",
+    id: 'changesets',
+    uses: `changesets/action@${changesetsActionSha}`,
+    with: {
+      'github-token': '${{ steps.app-token.outputs.token }}',
+      'version-script': 'npm run version',
+      'publish-script': 'npx --no-install changeset git-tag',
+      'commit-message': 'Version Packages',
+      'pr-title': 'Version Packages',
+      'create-github-releases': true,
+      'push-with-git-cli': true,
+    },
+    env: {
+      HUSKY: '0',
+    },
+  },
+  'Release automation must preserve the pinned Changesets v2.1.0 input contract and git-CLI push mode.'
+);
+
+for (const inputName of Object.keys(changesetsStepConfig.with)) {
+  assert(
+    Object.hasOwn(changesetsActionContract.inputs, inputName),
+    `Pinned Changesets action does not declare configured input: ${inputName}`
+  );
+}
+
+assert(
+  changesetsActionImplementation.includes('getRequiredInput("github-token")'),
+  'Pinned Changesets action must read the configured GitHub App token input.'
+);
+
+assert(
+  changesetsActionImplementation.includes('core.getBooleanInput("push-with-git-cli")'),
+  'Pinned Changesets action must implement the configured git-CLI push mode.'
 );
 
 assert(


### PR DESCRIPTION
## What changed

- Restore `changesets/action@v2` and its Changesets v3-compatible input names.
- Enable `push-with-git-cli` so beta-scale generated release commits avoid GitHub's API payload limit.
- Add a release-workflow regression check for both requirements.

## Why

The release workflow failed before creating the beta.1 Version Packages PR because action v1 interpreted the CLI v3 `.changeset/pre/` archive as a legacy changeset directory and tried to read `.changeset/pre/changes.md`. The earlier v2 rollback avoided a large GraphQL payload, but current v2 supports git-CLI pushes directly.

## Validation

- `npm run test:release-workflow`
- `npx --yes @changesets/cli@^3.0.0 status --since=origin/main`
- pre-commit suite: 1,046 unit tests, dynamic-import lint, format identity lint, call API lint, and TypeScript typecheck
- `git diff --check`
