### PR TITLE
fix(billing): persist Stripe drift escalations

### DIFF
--- a/server/src/addie/jobs/integrity-invariants.ts
+++ b/server/src/addie/jobs/integrity-invariants.ts
@@ -11,12 +11,26 @@
  * environment from spamming the channel.
  */
 
-import { runAllInvariants, ALL_INVARIANTS, type InvariantContext } from '../../audit/integrity/index.js';
+import {
+  runAllInvariants,
+  ALL_INVARIANTS,
+  type InvariantContext,
+  type Violation,
+} from '../../audit/integrity/index.js';
 import { detectEnvMismatch } from '../../audit/integrity/env-mismatch.js';
 import { getPool } from '../../db/client.js';
 import { stripe } from '../../billing/stripe-client.js';
 import { getWorkos } from '../../auth/workos-client.js';
+import {
+  claimEscalationNotification,
+  createEscalation,
+  markNotificationSent,
+  releaseEscalationNotificationClaim,
+  type Escalation,
+} from '../../db/escalation-db.js';
+import { getEscalationChannel } from '../../db/system-settings-db.js';
 import { createLogger } from '../../logger.js';
+import { sendChannelMessage } from '../../slack/client.js';
 import { notifySystemError } from '../error-notifier.js';
 
 const logger = createLogger('integrity-invariants-job');
@@ -27,6 +41,9 @@ export interface IntegrityInvariantsJobResult {
   totalViolations: number;
   criticalViolations: number;
   warningViolations: number;
+  durableEscalations: number;
+  escalationNotifications: number;
+  escalationErrors: number;
   durationMs: number;
 }
 
@@ -42,8 +59,142 @@ function skippedResult(skippedReason: string): IntegrityInvariantsJobResult {
     totalViolations: 0,
     criticalViolations: 0,
     warningViolations: 0,
+    durableEscalations: 0,
+    escalationNotifications: 0,
+    escalationErrors: 0,
     durationMs: 0,
   };
+}
+
+const STRIPE_REFLECTION_INVARIANT = 'stripe-sub-reflected-in-org-row';
+
+function isStripeReflectionBlocker(
+  violation: Violation,
+): boolean {
+  return violation.invariant === STRIPE_REFLECTION_INVARIANT
+    && violation.severity === 'critical'
+    && violation.subject_type === 'organization';
+}
+
+function stripeReflectionEscalationText(
+  escalation: Escalation,
+  organizationId: string,
+): string {
+  const encodedOrganizationId = encodeURIComponent(organizationId);
+  return [
+    `:rotating_light: *Member organization billing sync needs action: escalation #${escalation.id}*`,
+    '',
+    'Stripe has an entitled membership subscription that is not fully reflected in the organization row.',
+    `*Organization:* \`${organizationId.replace(/[`<>&]/g, '')}\``,
+    '*Action:* Open the account, run “Sync from Stripe,” and verify the membership tier before resolving this escalation.',
+    '',
+    `<https://agenticadvertising.org/admin/accounts/${encodedOrganizationId}|Open account>`,
+    '<https://agenticadvertising.org/admin/escalations|Open escalation dashboard>',
+  ].join('\n');
+}
+
+async function ensureStripeReflectionEscalation(
+  violation: Violation,
+): Promise<{ ensured: boolean; notified: boolean; error: boolean }> {
+  let escalation: Escalation;
+  try {
+    escalation = await createEscalation({
+      category: 'needs_human_action',
+      priority: 'urgent',
+      summary: `Member organization billing state is not synchronized for organization ${violation.subject_id}`,
+      addie_context: [
+        violation.message,
+        violation.remediation_hint ??
+          `Run POST /api/admin/accounts/${violation.subject_id}/sync and verify the resolved membership tier.`,
+      ].join('\n\n'),
+      dedup_key: `integrity:${STRIPE_REFLECTION_INVARIANT}:${violation.subject_id}`,
+    });
+  } catch (err) {
+    logger.error(
+      { err, organizationId: violation.subject_id },
+      'Failed to persist Stripe reflection escalation',
+    );
+    return { ensured: false, notified: false, error: true };
+  }
+
+  // A prior run already routed this active escalation. In-flight claims are
+  // checked atomically below so stale claims can recover after a worker crash.
+  if (escalation.notification_sent_at || escalation.notification_message_ts) {
+    return { ensured: true, notified: false, error: false };
+  }
+
+  try {
+    const claimed = await claimEscalationNotification(escalation.id);
+    if (!claimed) {
+      return { ensured: true, notified: false, error: false };
+    }
+  } catch (err) {
+    logger.error(
+      { err, escalationId: escalation.id, organizationId: violation.subject_id },
+      'Failed to claim Stripe reflection escalation notification',
+    );
+    return { ensured: true, notified: false, error: true };
+  }
+
+  try {
+    const channel = await getEscalationChannel();
+    if (!channel.channel_id) {
+      await releaseEscalationNotificationClaim(escalation.id);
+      logger.warn(
+        { escalationId: escalation.id, organizationId: violation.subject_id },
+        'Stripe reflection escalation persisted but no escalation channel is configured',
+      );
+      return { ensured: true, notified: false, error: false };
+    }
+
+    const sent = await sendChannelMessage(
+      channel.channel_id,
+      { text: stripeReflectionEscalationText(escalation, violation.subject_id) },
+      { requirePrivate: true },
+    );
+    if (!sent.ok || !sent.ts) {
+      await releaseEscalationNotificationClaim(escalation.id);
+      logger.warn(
+        {
+          escalationId: escalation.id,
+          organizationId: violation.subject_id,
+          channelId: channel.channel_id,
+          error: sent.error,
+        },
+        'Failed to route Stripe reflection escalation to Slack',
+      );
+      return { ensured: true, notified: false, error: true };
+    }
+
+    try {
+      await markNotificationSent(escalation.id, channel.channel_id, sent.ts);
+      return { ensured: true, notified: true, error: false };
+    } catch (err) {
+      // Keep the short-lived claim: Slack accepted the message, so an
+      // immediate retry would duplicate the thread. If persistence remains
+      // unavailable, the claim eventually expires and the durable escalation
+      // plus SLA routing still prevent the member organization from vanishing.
+      logger.error(
+        { err, escalationId: escalation.id, organizationId: violation.subject_id },
+        'Stripe reflection escalation reached Slack but its message timestamp was not recorded',
+      );
+      return { ensured: true, notified: true, error: true };
+    }
+  } catch (err) {
+    try {
+      await releaseEscalationNotificationClaim(escalation.id);
+    } catch (releaseErr) {
+      logger.error(
+        { err: releaseErr, escalationId: escalation.id },
+        'Failed to release Stripe reflection notification claim after routing failure',
+      );
+    }
+    logger.error(
+      { err, escalationId: escalation.id, organizationId: violation.subject_id },
+      'Failed to route Stripe reflection escalation',
+    );
+    return { ensured: true, notified: false, error: true };
+  }
 }
 
 export async function runIntegrityInvariantsJob(): Promise<IntegrityInvariantsJobResult> {
@@ -69,6 +220,9 @@ export async function runIntegrityInvariantsJob(): Promise<IntegrityInvariantsJo
 
   const critical = report.violations.filter((v) => v.severity === 'critical');
   const warning = report.violations.filter((v) => v.severity === 'warning');
+  let durableEscalations = 0;
+  let escalationNotifications = 0;
+  let escalationErrors = 0;
 
   if (critical.length > 0) {
     // Group by invariant for a compact summary. The error-notifier truncates
@@ -90,10 +244,23 @@ export async function runIntegrityInvariantsJob(): Promise<IntegrityInvariantsJo
     });
   }
 
+  // Generic system-error posts are transient and can be lost in a busy
+  // channel. A missed subscription webhook blocks a paying member, so also
+  // create a durable, deduplicated escalation with urgent SLA handling.
+  for (const violation of critical.filter(isStripeReflectionBlocker)) {
+    const escalationResult = await ensureStripeReflectionEscalation(violation);
+    if (escalationResult.ensured) durableEscalations += 1;
+    if (escalationResult.notified) escalationNotifications += 1;
+    if (escalationResult.error) escalationErrors += 1;
+  }
+
   logger.info(
     {
       totalViolations: report.total_violations,
       bySeverity: report.violations_by_severity,
+      durableEscalations,
+      escalationNotifications,
+      escalationErrors,
       durationMs,
     },
     'Integrity invariants run completed'
@@ -104,6 +271,9 @@ export async function runIntegrityInvariantsJob(): Promise<IntegrityInvariantsJo
     totalViolations: report.total_violations,
     criticalViolations: critical.length,
     warningViolations: warning.length,
+    durableEscalations,
+    escalationNotifications,
+    escalationErrors,
     durationMs,
   };
 }

--- a/server/src/db/escalation-db.ts
+++ b/server/src/db/escalation-db.ts
@@ -44,6 +44,7 @@ export interface Escalation {
   original_request: string | null;
   addie_context: string | null;
   notification_channel_id: string | null;
+  notification_claimed_at: Date | null;
   notification_sent_at: Date | null;
   notification_message_ts: string | null;
   status: EscalationStatus;
@@ -635,6 +636,46 @@ export async function setEscalationGithubIssue(
 }
 
 /**
+ * Atomically claim the right to send an escalation's initial notification.
+ * Claims expire so a worker crash before Slack delivery does not suppress
+ * notifications forever. `notification_sent_at` remains reserved for
+ * confirmed delivery because it drives the admin UI's "Team notified" state.
+ */
+export async function claimEscalationNotification(id: number): Promise<boolean> {
+  const result = await query<{ id: number }>(
+    `UPDATE addie_escalations
+     SET notification_claimed_at = NOW(),
+         updated_at = NOW()
+     WHERE id = $1
+       AND notification_sent_at IS NULL
+       AND (
+         notification_claimed_at IS NULL
+         OR notification_claimed_at < NOW() - INTERVAL '15 minutes'
+       )
+     RETURNING id`,
+    [id],
+  );
+  return result.rows.length === 1;
+}
+
+/**
+ * Release a notification claim when delivery definitely did not happen so a
+ * later invariant run can retry. Once a Slack message timestamp exists, the
+ * claim is never cleared.
+ */
+export async function releaseEscalationNotificationClaim(id: number): Promise<void> {
+  await query(
+    `UPDATE addie_escalations
+     SET notification_claimed_at = NULL,
+         updated_at = NOW()
+     WHERE id = $1
+       AND notification_sent_at IS NULL
+       AND notification_message_ts IS NULL`,
+    [id],
+  );
+}
+
+/**
  * Mark notification as sent
  */
 export async function markNotificationSent(
@@ -645,6 +686,7 @@ export async function markNotificationSent(
   await query(
     `UPDATE addie_escalations
      SET notification_channel_id = $2,
+         notification_claimed_at = NULL,
          notification_sent_at = NOW(),
          notification_message_ts = $3,
          updated_at = NOW()

--- a/server/src/db/migrations/547_escalation_notification_claim.sql
+++ b/server/src/db/migrations/547_escalation_notification_claim.sql
@@ -1,0 +1,9 @@
+-- Separate an in-flight notification claim from confirmed Slack delivery.
+-- notification_sent_at drives the admin UI's "Team notified" badge and must
+-- remain NULL until Slack has accepted the message.
+
+ALTER TABLE addie_escalations
+  ADD COLUMN notification_claimed_at TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN addie_escalations.notification_claimed_at IS
+  'Short-lived claim used to serialize initial Slack notification delivery; cleared after delivery or a definite send failure.';

--- a/server/tests/integration/escalation-dedup.test.ts
+++ b/server/tests/integration/escalation-dedup.test.ts
@@ -11,7 +11,13 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import type { Pool } from 'pg';
 import { initializeDatabase, closeDatabase, query } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
-import { createEscalation } from '../../src/db/escalation-db.js';
+import {
+  claimEscalationNotification,
+  createEscalation,
+  getEscalation,
+  markNotificationSent,
+  releaseEscalationNotificationClaim,
+} from '../../src/db/escalation-db.js';
 
 const SUFFIX = `${process.pid}-${Date.now()}`;
 const DEDUP_KEY = `test:slack:not_in_channel:C-${SUFFIX}`;
@@ -116,5 +122,61 @@ describe('createEscalation dedup_key behavior', () => {
       a.id,
       b.id,
     ]);
+  });
+
+  it('atomically grants only one initial-notification claim', async () => {
+    const escalation = await createEscalation({
+      category: 'needs_human_action',
+      summary: 'notification claim race',
+      dedup_key: DEDUP_KEY,
+    });
+
+    const claims = await Promise.all([
+      claimEscalationNotification(escalation.id),
+      claimEscalationNotification(escalation.id),
+    ]);
+
+    expect(claims.sort()).toEqual([false, true]);
+    const claimed = await getEscalation(escalation.id);
+    expect(claimed?.notification_claimed_at).not.toBeNull();
+    expect(claimed?.notification_sent_at).toBeNull();
+
+    await releaseEscalationNotificationClaim(escalation.id);
+    expect((await getEscalation(escalation.id))?.notification_claimed_at).toBeNull();
+  });
+
+  it('does not release a claim after a Slack message timestamp is recorded', async () => {
+    const escalation = await createEscalation({
+      category: 'needs_human_action',
+      summary: 'completed notification claim',
+      dedup_key: DEDUP_KEY,
+    });
+    expect(await claimEscalationNotification(escalation.id)).toBe(true);
+    await markNotificationSent(escalation.id, 'C_TEST', '123.456');
+
+    await releaseEscalationNotificationClaim(escalation.id);
+
+    const persisted = await getEscalation(escalation.id);
+    expect(persisted?.notification_claimed_at).toBeNull();
+    expect(persisted?.notification_sent_at).not.toBeNull();
+    expect(persisted?.notification_message_ts).toBe('123.456');
+  });
+
+  it('reclaims an initial-notification claim after the worker-crash timeout', async () => {
+    const escalation = await createEscalation({
+      category: 'needs_human_action',
+      summary: 'stale notification claim',
+      dedup_key: DEDUP_KEY,
+    });
+    expect(await claimEscalationNotification(escalation.id)).toBe(true);
+    await pool.query(
+      `UPDATE addie_escalations
+       SET notification_claimed_at = NOW() - INTERVAL '16 minutes'
+       WHERE id = $1`,
+      [escalation.id],
+    );
+
+    expect(await claimEscalationNotification(escalation.id)).toBe(true);
+    expect((await getEscalation(escalation.id))?.notification_claimed_at).not.toBeNull();
   });
 });

--- a/server/tests/unit/integrity-invariants-job.test.ts
+++ b/server/tests/unit/integrity-invariants-job.test.ts
@@ -4,6 +4,12 @@ const mocks = vi.hoisted(() => ({
   detectEnvMismatch: vi.fn(),
   runAllInvariants: vi.fn(),
   notifySystemError: vi.fn(),
+  claimEscalationNotification: vi.fn(),
+  createEscalation: vi.fn(),
+  markNotificationSent: vi.fn(),
+  releaseEscalationNotificationClaim: vi.fn(),
+  getEscalationChannel: vi.fn(),
+  sendChannelMessage: vi.fn(),
   getPool: vi.fn(() => ({ query: vi.fn() })),
   getWorkos: vi.fn(() => ({})),
 }));
@@ -30,6 +36,18 @@ async function loadJob(stripeValue: unknown = { customers: {} }) {
   vi.doMock('../../src/addie/error-notifier.js', () => ({
     notifySystemError: mocks.notifySystemError,
   }));
+  vi.doMock('../../src/db/escalation-db.js', () => ({
+    claimEscalationNotification: mocks.claimEscalationNotification,
+    createEscalation: mocks.createEscalation,
+    markNotificationSent: mocks.markNotificationSent,
+    releaseEscalationNotificationClaim: mocks.releaseEscalationNotificationClaim,
+  }));
+  vi.doMock('../../src/db/system-settings-db.js', () => ({
+    getEscalationChannel: mocks.getEscalationChannel,
+  }));
+  vi.doMock('../../src/slack/client.js', () => ({
+    sendChannelMessage: mocks.sendChannelMessage,
+  }));
 
   return import('../../src/addie/jobs/integrity-invariants.js');
 }
@@ -43,6 +61,20 @@ describe('runIntegrityInvariantsJob', () => {
       violations_by_severity: { critical: 0, warning: 0, info: 0 },
       violations: [],
     });
+    mocks.createEscalation.mockResolvedValue({
+      id: 42,
+      notification_claimed_at: null,
+      notification_sent_at: null,
+      notification_message_ts: null,
+    });
+    mocks.claimEscalationNotification.mockResolvedValue(true);
+    mocks.markNotificationSent.mockResolvedValue(undefined);
+    mocks.releaseEscalationNotificationClaim.mockResolvedValue(undefined);
+    mocks.getEscalationChannel.mockResolvedValue({
+      channel_id: 'C_ESCALATIONS',
+      channel_name: 'admin-escalations',
+    });
+    mocks.sendChannelMessage.mockResolvedValue({ ok: true, ts: '123.456' });
   });
 
   it('notifies when the invariant runner is skipped due to environment mismatch', async () => {
@@ -103,5 +135,254 @@ describe('runIntegrityInvariantsJob', () => {
       source: 'integrity-invariants',
       errorMessage: expect.stringContaining('stripe-customer-resolves'),
     });
+  });
+
+  it('persists and routes paying-member Stripe reflection blockers as urgent escalations', async () => {
+    mocks.runAllInvariants.mockResolvedValue({
+      total_violations: 1,
+      violations_by_severity: { critical: 1, warning: 0, info: 0 },
+      violations: [{
+        invariant: 'stripe-sub-reflected-in-org-row',
+        severity: 'critical',
+        subject_type: 'organization',
+        subject_id: 'org_123',
+        message: 'Stripe is active but the organization row has no subscription status.',
+        remediation_hint: 'Run the canonical account sync.',
+      }],
+    });
+    const { runIntegrityInvariantsJob } = await loadJob();
+
+    const result = await runIntegrityInvariantsJob();
+
+    expect(result).toEqual(expect.objectContaining({
+      durableEscalations: 1,
+      escalationNotifications: 1,
+      escalationErrors: 0,
+    }));
+    expect(mocks.createEscalation).toHaveBeenCalledWith(expect.objectContaining({
+      category: 'needs_human_action',
+      priority: 'urgent',
+      dedup_key: 'integrity:stripe-sub-reflected-in-org-row:org_123',
+    }));
+    expect(mocks.claimEscalationNotification).toHaveBeenCalledWith(42);
+    expect(mocks.sendChannelMessage).toHaveBeenCalledWith(
+      'C_ESCALATIONS',
+      { text: expect.stringContaining('/admin/accounts/org_123') },
+      { requirePrivate: true },
+    );
+    expect(mocks.markNotificationSent).toHaveBeenCalledWith(42, 'C_ESCALATIONS', '123.456');
+  });
+
+  it('does not create a second Slack thread for an existing active escalation', async () => {
+    mocks.runAllInvariants.mockResolvedValue({
+      total_violations: 1,
+      violations_by_severity: { critical: 1, warning: 0, info: 0 },
+      violations: [{
+        invariant: 'stripe-sub-reflected-in-org-row',
+        severity: 'critical',
+        subject_type: 'organization',
+        subject_id: 'org_123',
+        message: 'Stripe is active but the organization row has no subscription status.',
+      }],
+    });
+    mocks.createEscalation.mockResolvedValue({
+      id: 42,
+      notification_claimed_at: null,
+      notification_sent_at: new Date('2026-08-19T00:00:00Z'),
+      notification_message_ts: 'existing-thread-ts',
+    });
+    const { runIntegrityInvariantsJob } = await loadJob();
+
+    const result = await runIntegrityInvariantsJob();
+
+    expect(result).toEqual(expect.objectContaining({
+      durableEscalations: 1,
+      escalationNotifications: 0,
+      escalationErrors: 0,
+    }));
+    expect(mocks.getEscalationChannel).not.toHaveBeenCalled();
+    expect(mocks.claimEscalationNotification).not.toHaveBeenCalled();
+    expect(mocks.sendChannelMessage).not.toHaveBeenCalled();
+  });
+
+  it('keeps the escalation durable when no Slack escalation channel is configured', async () => {
+    mocks.runAllInvariants.mockResolvedValue({
+      total_violations: 1,
+      violations_by_severity: { critical: 1, warning: 0, info: 0 },
+      violations: [{
+        invariant: 'stripe-sub-reflected-in-org-row',
+        severity: 'critical',
+        subject_type: 'organization',
+        subject_id: 'org_123',
+        message: 'Stripe is active but the organization row has no subscription status.',
+      }],
+    });
+    mocks.getEscalationChannel.mockResolvedValue({
+      channel_id: null,
+      channel_name: null,
+    });
+    const { runIntegrityInvariantsJob } = await loadJob();
+
+    const result = await runIntegrityInvariantsJob();
+
+    expect(result).toEqual(expect.objectContaining({
+      durableEscalations: 1,
+      escalationNotifications: 0,
+      escalationErrors: 0,
+    }));
+    expect(mocks.createEscalation).toHaveBeenCalledOnce();
+    expect(mocks.releaseEscalationNotificationClaim).toHaveBeenCalledWith(42);
+    expect(mocks.sendChannelMessage).not.toHaveBeenCalled();
+    expect(mocks.markNotificationSent).not.toHaveBeenCalled();
+  });
+
+  it('atomically routes only one Slack notification across concurrent runs', async () => {
+    mocks.runAllInvariants.mockResolvedValue({
+      total_violations: 1,
+      violations_by_severity: { critical: 1, warning: 0, info: 0 },
+      violations: [{
+        invariant: 'stripe-sub-reflected-in-org-row',
+        severity: 'critical',
+        subject_type: 'organization',
+        subject_id: 'org_123',
+        message: 'Stripe is active but the organization row has no subscription status.',
+      }],
+    });
+    mocks.claimEscalationNotification
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const { runIntegrityInvariantsJob } = await loadJob();
+
+    const [first, second] = await Promise.all([
+      runIntegrityInvariantsJob(),
+      runIntegrityInvariantsJob(),
+    ]);
+
+    expect(first.durableEscalations + second.durableEscalations).toBe(2);
+    expect(first.escalationNotifications + second.escalationNotifications).toBe(1);
+    expect(mocks.createEscalation).toHaveBeenCalledTimes(2);
+    expect(mocks.claimEscalationNotification).toHaveBeenCalledTimes(2);
+    expect(mocks.sendChannelMessage).toHaveBeenCalledOnce();
+    expect(mocks.markNotificationSent).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the notification claim when Slack succeeds but recording its timestamp fails', async () => {
+    mocks.runAllInvariants.mockResolvedValue({
+      total_violations: 1,
+      violations_by_severity: { critical: 1, warning: 0, info: 0 },
+      violations: [{
+        invariant: 'stripe-sub-reflected-in-org-row',
+        severity: 'critical',
+        subject_type: 'organization',
+        subject_id: 'org_123',
+        message: 'Stripe is active but the organization row has no subscription status.',
+      }],
+    });
+    mocks.markNotificationSent.mockRejectedValue(new Error('database unavailable'));
+    const { runIntegrityInvariantsJob } = await loadJob();
+
+    const result = await runIntegrityInvariantsJob();
+
+    expect(result).toEqual(expect.objectContaining({
+      durableEscalations: 1,
+      escalationNotifications: 1,
+      escalationErrors: 1,
+    }));
+    expect(mocks.releaseEscalationNotificationClaim).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['channel lookup throws', () => {
+      mocks.getEscalationChannel.mockRejectedValue(new Error('settings unavailable'));
+    }],
+    ['Slack rejects the message', () => {
+      mocks.sendChannelMessage.mockResolvedValue({ ok: false, error: 'not_in_channel' });
+    }],
+  ])('preserves the durable escalation and releases the claim when %s', async (_name, arrange) => {
+    mocks.runAllInvariants.mockResolvedValue({
+      total_violations: 1,
+      violations_by_severity: { critical: 1, warning: 0, info: 0 },
+      violations: [{
+        invariant: 'stripe-sub-reflected-in-org-row',
+        severity: 'critical',
+        subject_type: 'organization',
+        subject_id: 'org_123',
+        message: 'Stripe is active but the organization row has no subscription status.',
+      }],
+    });
+    arrange();
+    const { runIntegrityInvariantsJob } = await loadJob();
+
+    const result = await runIntegrityInvariantsJob();
+
+    expect(result).toEqual(expect.objectContaining({
+      durableEscalations: 1,
+      escalationNotifications: 0,
+      escalationErrors: 1,
+    }));
+    expect(mocks.releaseEscalationNotificationClaim).toHaveBeenCalledWith(42);
+    expect(mocks.markNotificationSent).not.toHaveBeenCalled();
+  });
+
+  it('continues processing after one escalation cannot be persisted', async () => {
+    mocks.runAllInvariants.mockResolvedValue({
+      total_violations: 2,
+      violations_by_severity: { critical: 2, warning: 0, info: 0 },
+      violations: [
+        {
+          invariant: 'stripe-sub-reflected-in-org-row',
+          severity: 'critical',
+          subject_type: 'organization',
+          subject_id: 'org_failed',
+          message: 'First organization is stale.',
+        },
+        {
+          invariant: 'stripe-sub-reflected-in-org-row',
+          severity: 'critical',
+          subject_type: 'organization',
+          subject_id: 'org_succeeded',
+          message: 'Second organization is stale.',
+        },
+      ],
+    });
+    mocks.createEscalation
+      .mockRejectedValueOnce(new Error('insert failed'))
+      .mockResolvedValueOnce({
+        id: 43,
+        notification_claimed_at: null,
+        notification_sent_at: null,
+        notification_message_ts: null,
+      });
+    const { runIntegrityInvariantsJob } = await loadJob();
+
+    const result = await runIntegrityInvariantsJob();
+
+    expect(result).toEqual(expect.objectContaining({
+      durableEscalations: 1,
+      escalationNotifications: 1,
+      escalationErrors: 1,
+    }));
+    expect(mocks.createEscalation).toHaveBeenCalledTimes(2);
+    expect(mocks.markNotificationSent).toHaveBeenCalledWith(43, 'C_ESCALATIONS', '123.456');
+  });
+
+  it('does not escalate warning-level orphan customers', async () => {
+    mocks.runAllInvariants.mockResolvedValue({
+      total_violations: 1,
+      violations_by_severity: { critical: 0, warning: 1, info: 0 },
+      violations: [{
+        invariant: 'stripe-sub-reflected-in-org-row',
+        severity: 'warning',
+        subject_type: 'customer',
+        subject_id: 'customer_orphan',
+        message: 'Membership customer is not linked to an organization.',
+      }],
+    });
+    const { runIntegrityInvariantsJob } = await loadJob();
+
+    const result = await runIntegrityInvariantsJob();
+
+    expect(result.durableEscalations).toBe(0);
+    expect(mocks.createEscalation).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What changed

- Persist critical Stripe subscription drift findings as urgent admin escalations.
- Deduplicate findings by organization and route the initial alert to the configured private escalation channel.
- Add atomic notification claims so concurrent integrity workers cannot create duplicate Slack threads.
- Keep notification state accurate across missing channels, send failures, retries, and worker crashes.
- Link responders directly to the affected account and escalation dashboard.

## Why

The integrity invariant already detected subscriptions that Stripe considered active while the member organization row did not. Those findings only emitted a generic Slack error, so they could disappear without a durable owner or remediation trail.

## Impact

Critical drift now remains visible in the admin escalation queue even when Slack is unavailable. Successful Slack notifications are recorded separately from short-lived delivery claims, and stale claims can be retried after 15 minutes.

## Validation

- `npm run typecheck`
- `npm run test:migrations`
- `npx vitest run --config server/vitest.config.ts server/tests/unit/integrity-invariants-job.test.ts` (12 passed)
- `npx vitest run --config server/vitest.config.ts server/tests/unit/admin-certification-badge-backfill.test.ts server/tests/unit/perspective-external-url-validation.test.ts` (21 passed)
- Root unit suite: 1,046 passed
- Full server unit suite: 6,327 passed; two unrelated route tests failed from suite-order pollution and both passed together in isolation
- Reviewed by code quality, testing, and internal-operations experts

Closes #6654
