### PR TITLE
docs: start 3.2 cycle and publish training profiles

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -229,7 +229,7 @@ jobs:
           flyctl machines list
           exit 1
 
-      # Smoke each training-agent tenant URL after the rolling restart.
+      # Smoke each public training-agent route after the rolling restart.
       # Catches production-only failures that don't surface in CI: SDK
       # init guards that throw under NODE_ENV=production (PR #3869),
       # in-memory task registry refusal (PR #3854), missing migrations,
@@ -238,7 +238,7 @@ jobs:
       # is sufficient: a healthy MCP endpoint returns 200 (when the
       # public token is set) or 401 (when it isn't). 4xx other than 401
       # and any 5xx are deploy-fatal.
-      - name: Smoke training-agent tenants
+      - name: Smoke training-agent routes
         env:
           PUBLIC_TEST_AGENT_TOKEN: ${{ secrets.PUBLIC_TEST_AGENT_TOKEN }}
         run: |
@@ -246,6 +246,9 @@ jobs:
           base="https://test-agent.adcontextprotocol.org"
           paths=(
             "/sales/mcp"
+            "/sales/profiles/typed-negotiation/mcp"
+            "/sales/profiles/constrained-seller/mcp"
+            "/sales/profiles/finalization-failure/mcp"
             "/signals/mcp"
             "/governance/mcp"
             "/creative/mcp"

--- a/docs/governance/campaign/tasks/sync_plans.mdx
+++ b/docs/governance/campaign/tasks/sync_plans.mdx
@@ -109,7 +109,7 @@ Push campaign plans to the governance agent. A plan defines the authorized param
 
 Plans originate in external systems -- an agency's planning tool, a brand's budget system, an insertion order. `sync_plans` pushes them to the governance agent so it knows what to validate against.
 
-Syncing a plan that already exists (same `plan_id`) updates it. The governance agent increments the version and re-evaluates any active campaigns against the updated rules. This handles mid-flight amendments like budget increases or channel additions. Content-standards versions follow a separate pinned-at-buy rule — see [content standards versioning](/docs/governance/content-standards/index#versioning-and-mid-flight-amendments).
+Syncing a plan that already exists (same `plan_id`) updates it. The governance agent increments the version and re-evaluates any active campaigns against the updated rules. This handles mid-flight amendments like budget increases or channel additions. Content-standards configurations are separate resources, and their wire contract does not define how running media buys adopt later updates; see [updating content-standards policies](/docs/governance/content-standards/index#updating-policies).
 
 Multiple campaigns (identified by `governance_context` in [`check_governance`](/docs/governance/campaign/tasks/check_governance) and [`report_plan_outcome`](/docs/governance/campaign/tasks/report_plan_outcome)) can reference the same plan. The governance agent tracks budget across all campaigns tied to a plan.
 

--- a/docs/governance/content-standards/index.mdx
+++ b/docs/governance/content-standards/index.mdx
@@ -187,7 +187,35 @@ The threshold answers the key buyer question: "If I accept your local model, how
 
 ## Policies
 
-Content Standards uses **addressable policies** — an array of policy entries, each with a policy_id, enforcement, and natural-language policy text. Same shape as registry-published policies, so bespoke buyer rules and shared registry policies are interchangeable. Validation findings reference `policy_id` to identify which policy triggered:
+Content Standards uses **addressable policies** — an array of policy entries, each with a `policy_id`, enforcement level, and natural-language policy text. Policies embedded in AdCP task payloads are inline; registry-published policies use the same policy-entry shape but are served through the policy registry. Validation findings reference `policy_id` to identify which policy triggered:
+
+### Policy fields
+
+| Field | Required | Description |
+|---|---|---|
+| `policy_id` | Yes | Unique policy identifier. Registry IDs are canonical; buyer-authored IDs are unique within their containing standards configuration, plan, or portfolio. |
+| `enforcement` | Yes | Violation handling: `must` rejects, `should` warns without blocking, and `may` records informational results. |
+| `policy` | Yes | Natural-language requirement, prohibition, or recommendation evaluated by the governance agent. |
+| `source` | No | Policy origin: `registry` or `inline` (the default). Policies embedded in task payloads are inline. |
+| `version` | No | Semantic version of the policy text; inline policies default to `1.0.0`. |
+| `name` | No | Human-readable policy name. |
+| `description` | No | Brief summary of the policy, up to 500 characters. |
+| `category` | No | Whether the obligation is a `regulation` or a `standard`. |
+| `requires_human_review` | No | Whether plans resolved against the policy require human review. Defaults to `false`. |
+| `jurisdictions` | No | ISO 3166-1 alpha-2 country codes where the policy applies. |
+| `region_aliases` | No | Named jurisdiction groups used when matching the policy to a plan. |
+| `policy_categories` | No | One or more regulatory or suitability categories used for automatic matching. |
+| `channels` | No | Advertising channels to which the policy applies; omission means all channels. |
+| `governance_domains` | No | Governance agent domains that can evaluate the policy. |
+| `effective_date` | No | ISO 8601 date when enforcement begins; before this date findings are informational. |
+| `sunset_date` | No | ISO 8601 date after which the policy is no longer evaluated. |
+| `source_url` | No | Link to the source regulation, standard, or legislation. |
+| `source_name` | No | Name of the issuing body. |
+| `guidance` | No | Implementation notes for governance-agent developers; not included in evaluation prompts. |
+| `exemplars` | No | Structured `pass` and `fail` scenarios used to calibrate policy interpretation. |
+| `ext` | No | Vendor-namespaced extension data for partner-specific metadata. |
+
+Policy entries are closed objects: fields outside this table fail schema validation rather than being silently ignored. Put partner-specific, buyer-visible metadata under a vendor key in `ext` (for example, `ext.acme`) instead of adding sibling fields or encoding structured metadata inside the natural-language `policy` value.
 
 ```json
 {
@@ -221,17 +249,11 @@ The policy prompt enables AI-powered verification agents to understand context a
 
 See [Artifacts](./artifacts) for details on artifact structure and secured asset access.
 
-## Versioning and mid-flight amendments
+## Updating policies
 
-Content standards carry a `version` field and MAY be amended while campaigns are running. `update_content_standards` creates a new version for audit purposes rather than mutating the previous one.
+[`update_content_standards`](./tasks/update_content_standards) updates the supplied scope, registry policy references, bespoke policies, or calibration exemplars for an existing `standards_id`. A supplied `policies` array replaces the existing bespoke policies. Keep each `policy_id` stable across updates so findings and audit records continue to identify the same rule. Use the optional policy-level `version` when consumers need to distinguish revisions of that rule's text.
 
-AdCP 3.0 default: **pinned at buy time.** Unless otherwise declared, a media buy references the version of the standards that was in effect when its `create_media_buy` was approved, and subsequent amendments do **not** retroactively apply to in-flight delivery on that buy. This is the conservative default because it prevents a mid-campaign amendment from silently re-characterizing already-approved delivery.
-
-Governance agents MAY mark an individual policy as continuously re-evaluated by declaring `evaluation_mode: continuous` on the policy entry (default is `pinned`). Use `continuous` for policies that must track regulatory changes without re-approval — emerging regulatory disclosures, new legal prohibitions, accessibility requirements. Use the default `pinned` for brand-voice, taxonomy, and commercial preferences where stability across a flight is the desired behavior.
-
-When a policy is `continuous`, a finding generated against a newer version **MUST** carry both the evaluation-time version and the pinned-at-buy version on the finding, so downstream audit can reconstruct which version applied. The governance agent **MUST** emit the finding to the buying agent via the media buy's `push_notification_config` when one is configured, and the finding **MUST** be retrievable through the buy's standard status surface regardless. Delivery-adjustment decisions remain with the buyer. When a policy is `pinned`, the pinned version applies for the life of the buy; the governance agent **MAY** still surface advisory findings based on later versions but **MUST NOT** mark them as enforcement failures against the pinned buy.
-
-AdCP 3.0 does not define a mid-flight re-pin mechanism. A buyer that wants to adopt a newer standards version across all pinned policies replaces the buy — cancel the existing buy via [`update_media_buy`](/docs/media-buy/task-reference/update_media_buy) and issue a new [`create_media_buy`](/docs/media-buy/task-reference/create_media_buy) whose governance block references the current version. This is a heavyweight path: a new approval is required, pacing history resets, and in-flight delivery may have makegood implications. It is deliberately the only 3.0 mechanism; `standards_version` on `update_media_buy` and partial re-pin are out of scope for 3.0.
+The current wire schemas do not define configuration-level version semantics, a policy-level `evaluation_mode`, or media-buy behavior for pinning and adopting later standards revisions. Policy entries accept `version` for revisions of that rule's text, but their closed schema rejects `evaluation_mode`. Unknown configuration or media-buy controls have no interoperable AdCP meaning even where a containing schema permits additional properties. Deployments that require partner-specific revision or mid-flight adoption controls can exchange them under the vendor-namespaced `ext` object, but those controls are outside the interoperable AdCP contract.
 
 ## Scoped Standards
 

--- a/docs/governance/overview.mdx
+++ b/docs/governance/overview.mdx
@@ -170,7 +170,7 @@ The campaign is live. Governance doesn't stop at purchase — it monitors delive
 
 - **Budget tracking**: As `report_plan_outcome` data flows in, the governance agent tracks actual spend against committed budget
 - **Drift detection**: If delivery diverges from the plan — wrong publisher, unexpected creative, budget overrun — governance flags it
-- **Policy updates**: If a new regulation takes effect mid-flight, governance applies it to active plans. Content-standards versions follow a separate rule — pinned-at-buy by default, with a per-policy `evaluation_mode: continuous` opt-in for regulatory policies. See [content standards versioning](/docs/governance/content-standards/index#versioning-and-mid-flight-amendments).
+- **Policy updates**: Governance can re-evaluate active plans when their synced plan changes. Content-standards updates do not define interoperable mid-flight adoption or pinning behavior; see [updating content-standards policies](/docs/governance/content-standards/index#updating-policies).
 
 First, the orchestrator reports that the seller accepted the purchase and committed budget:
 

--- a/docs/media-buy/product-discovery/proposal-negotiation.mdx
+++ b/docs/media-buy/product-discovery/proposal-negotiation.mdx
@@ -455,7 +455,7 @@ Record the authenticated buyer, source IDs, successor IDs, idempotency fingerpri
 
 The canonical compliance scenario is `media_buy_seller/typed_proposal_negotiation`. It exercises capability gating, satisfied and unsatisfied constraints, alternatives, immutable lineage, finalize atomicity, exact replay, acceptance, amendment, cancellation, double-finalize rejection, and multi-source ordering.
 
-The deterministic training profiles use the proposal-negotiation primitives published in `@adcp/sdk` 13.0.0-rc.26. The ordinary `/sales/mcp` route remains the backward-compatible ask-only seller. Three capability-distinct routes are available to local tests and will become public with the 3.2 beta deployment:
+The deterministic training profiles use the proposal-negotiation primitives published in `@adcp/sdk` 13.0.0. The ordinary `/sales/mcp` route remains the backward-compatible ask-only seller. Use the [public test token](/docs/quickstart#setup) with `https://test-agent.adcontextprotocol.org` and one of these capability-distinct routes:
 
 | Profile | Route | Deterministic behavior |
 | --- | --- | --- |

--- a/fly.toml
+++ b/fly.toml
@@ -24,6 +24,8 @@ primary_region = 'iad'
   # Disabled - migrations now run via release_command
   RUN_MIGRATIONS = "false"
   PUBLISHER_CRAWL_QUEUE_ENABLED = "true"
+  # AdCP 3.2 beta is public; expose the deterministic proposal-negotiation labs.
+  ENABLE_ADCP_3_2_PROPOSAL_PROFILES = "true"
   # Use pre-cloned repos from Docker build, skip runtime git fetch.
   # Production image has no git binary — unsetting this degrades gracefully
   # (repos skip indexing) but does not crash.

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -1022,7 +1022,7 @@ export const PROPOSAL_NEGOTIATION_PROFILE_ROUTES = [
   profile: Exclude<NonNullable<TrainingContext['proposalNegotiationProfile']>, 'ask-only'>;
 }>;
 
-/** Keep the new training surfaces dark in production until the 3.2 beta cut. */
+/** Production deployments opt in so private installations do not expose public lab routes unintentionally. */
 export function proposalNegotiationProfilesEnabled(
   env: Record<string, string | undefined> = process.env,
 ): boolean {


### PR DESCRIPTION
## Summary

- document all schema-supported content-standards policy fields and the `ext` path
- remove unsupported `evaluation_mode` and mid-flight pinning guidance across governance docs
- expose the three deterministic proposal-negotiation profiles for the 3.2 beta
- smoke the public profile routes after every production deployment

## Why

The first 3.2 documentation pass uncovered two release-readiness gaps: policy extensibility was only implicit in examples, and the proposal profiles remained production-gated after beta. The same review found stale governance text that described fields and pinning semantics absent from the wire schemas.

## Impact

After deployment, implementers can call the typed, constrained, and finalization-failure profiles at the public training seller. Private installations remain opt-in because the application default stays off unless the deployment sets the environment variable.

Closes #6440
Refs #6557

## Validation

- expert review: documentation, protocol, and code/deployment
- proposal-negotiation guide tests: 4 passed
- proposal profile tests: 10 passed
- documentation navigation: 28 passed
- policy table/schema parity: 21 of 21 fields
- current 3.2 storyboard matrix: passed across all seven domains
- released 3.0 compatibility storyboard matrix: passed across all seven domains
- changeset protocol scope check: passed
- pre-commit general suite: 1,046 tests passed
- local full server-unit phase exceeded the 240-second hook cap; focused profile tests passed and required CI will run the complete matrix