### PR TITLE
test(compliance): chain pricing_version and prove snapshot identity in compact direct-buy storyboard

### DIFF
--- a/.changeset/chain-pricing-version-snapshot-identity.md
+++ b/.changeset/chain-pricing-version-snapshot-identity.md
@@ -1,0 +1,10 @@
+---
+"adcontextprotocol": patch
+---
+
+Complete direct-buy storyboard pricing and snapshot chaining.
+
+Adds two missing conformance checks to `compact_direct_buy_lifecycle`:
+
+1. Chains `pricing_version` through list → buy → accepted-snapshot validation, exercising the existing MUST requirement in `buy-products-request.json`.
+2. Captures `accepted_proposal.proposal_id` and `accepted_proposal.terms_digest` from the buy response and compares both against `accepted_proposal_id` and `accepted_proposal_terms_digest` on readback, proving snapshot identity survives the operational-control phase.

--- a/static/compliance/source/protocols/media-buy/scenarios/compact_direct_buy_lifecycle.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/compact_direct_buy_lifecycle.yaml
@@ -137,6 +137,8 @@ phases:
             path: "products[0].pricing_options[0].pricing_option_id"
           - name: direct_feed_version
             path: "feed_version"
+          - name: direct_pricing_version
+            path: "pricing_version"
         validations:
           - check: response_schema
             description: "Response matches list-products-response.json"
@@ -155,6 +157,9 @@ phases:
           - check: field_present
             path: "feed_version"
             description: "The offer carries the feed version required by buy_products"
+          - check: field_present
+            path: "pricing_version"
+            description: "The offer carries the pricing version required by buy_products"
           - check: field_contains
             path: "products[0].allowed_actions[*]"
             value:
@@ -181,6 +186,7 @@ phases:
             operator: "pinnacle-agency.example"
             sandbox: true
           feed_version: "$context.direct_feed_version"
+          pricing_version: "$context.direct_pricing_version"
           purchases:
             - product_id: "$context.direct_product_id"
               pricing_option_id: "$context.direct_pricing_option_id"
@@ -194,6 +200,10 @@ phases:
             path: "revision"
           - name: direct_buy_status
             path: "media_buy_status"
+          - name: direct_accepted_proposal_id
+            path: "accepted_proposal.proposal_id"
+          - name: direct_terms_digest
+            path: "accepted_proposal.terms_digest"
         validations:
           - check: response_schema
             description: "Response matches buy-products-response.json"
@@ -214,6 +224,10 @@ phases:
             path: "accepted_proposal.commercial_terms.source_feed_version"
             context_key: "direct_feed_version"
             description: "The accepted snapshot binds the listed feed version"
+          - check: field_equals_context
+            path: "accepted_proposal.commercial_terms.source_pricing_version"
+            context_key: "direct_pricing_version"
+            description: "The accepted snapshot binds the listed pricing version"
           - check: field_equals_context
             path: "accepted_proposal.commercial_terms.purchases[0].product_id"
             context_key: "direct_product_id"
@@ -331,3 +345,15 @@ phases:
             path: "media_buys[0].accepted_proposal.commercial_terms.source_feed_version"
             context_key: "direct_feed_version"
             description: "Readback preserves the purchased feed version"
+          - check: field_equals_context
+            path: "media_buys[0].accepted_proposal.commercial_terms.source_pricing_version"
+            context_key: "direct_pricing_version"
+            description: "Readback preserves the purchased pricing version"
+          - check: field_equals_context
+            path: "media_buys[0].accepted_proposal_id"
+            context_key: "direct_accepted_proposal_id"
+            description: "Readback preserves the accepted proposal identity"
+          - check: field_equals_context
+            path: "media_buys[0].accepted_proposal_terms_digest"
+            context_key: "direct_terms_digest"
+            description: "Readback preserves the commercial terms digest — a seller cannot substitute a different snapshot while preserving the same feed version"

--- a/tests/compact-product-lifecycle-storyboards.test.cjs
+++ b/tests/compact-product-lifecycle-storyboards.test.cjs
@@ -360,10 +360,11 @@ test("compact direct-buy lifecycle threads versioned offers through control read
       ["direct_product_id", "products[0].product_id"],
       ["direct_pricing_option_id", "products[0].pricing_options[0].pricing_option_id"],
       ["direct_feed_version", "feed_version"],
+      ["direct_pricing_version", "pricing_version"],
     ])
   );
   assert.equal(buy.sample_request.feed_version, "$context.direct_feed_version");
-  assert.equal(buy.sample_request.pricing_version, undefined);
+  assert.equal(buy.sample_request.pricing_version, "$context.direct_pricing_version");
   assert.equal(
     buy.sample_request.purchases[0].product_id,
     "$context.direct_product_id"
@@ -380,6 +381,14 @@ test("compact direct-buy lifecycle threads versioned offers through control read
       "accepted_proposal.commercial_terms.source_feed_version"
     )?.context_key,
     "direct_feed_version"
+  );
+  assert.equal(
+    validation(
+      buy,
+      "field_equals_context",
+      "accepted_proposal.commercial_terms.source_pricing_version"
+    )?.context_key,
+    "direct_pricing_version"
   );
   assert.equal(
     validation(
@@ -440,6 +449,30 @@ test("compact direct-buy lifecycle threads versioned offers through control read
   assert.equal(
     validation(readback, "field_value", "media_buys[0].daily_budget_cap")?.value,
     100
+  );
+  assert.equal(
+    validation(
+      readback,
+      "field_equals_context",
+      "media_buys[0].accepted_proposal.commercial_terms.source_pricing_version"
+    )?.context_key,
+    "direct_pricing_version"
+  );
+  assert.equal(
+    validation(
+      readback,
+      "field_equals_context",
+      "media_buys[0].accepted_proposal_id"
+    )?.context_key,
+    "direct_accepted_proposal_id"
+  );
+  assert.equal(
+    validation(
+      readback,
+      "field_equals_context",
+      "media_buys[0].accepted_proposal_terms_digest"
+    )?.context_key,
+    "direct_terms_digest"
   );
 });
 


### PR DESCRIPTION
## Summary

Closes #6670

Adds two missing conformance checks to `compact_direct_buy_lifecycle` (v3.2.0-beta.2):

- **`pricing_version` chaining** — captures `pricing_version` from `list_products`, passes it as `pricing_version` in `buy_products`, and asserts `accepted_proposal.commercial_terms.source_pricing_version` matches in both the buy response and the readback. This exercises the existing MUST requirement in `buy-products-request.json` that has been present since the schema was written.
- **Snapshot identity continuity** — captures `accepted_proposal.proposal_id` and `accepted_proposal.terms_digest` from the buy response and asserts both against `accepted_proposal_id` and `accepted_proposal_terms_digest` on readback. This proves snapshot identity survives the `control_media_buy` phase, closing the gap where the previous storyboard could not detect a seller substituting a different pricing snapshot while holding the same feed version.

## Why non-breaking

Both fields are already required by the normative schemas (`buy-products-response.json`, `get-media-buys-response.json`). This is a test harness addition only — no spec, schema, or server code is changed. Any implementation that was passing the previous storyboard steps correctly will pass these new checks without modification.

Changeset: `patch` bump on `adcontextprotocol` (conformance harness addition).

## Pre-PR review

- `npm run build:compliance` — all storyboard lints pass (idempotency_key, contradictions, pagination-invariant, context-entity, auth-shape, branch-set, check-enum, doc-parity)
- `npm run typecheck` — clean
- `npm run test:unit` — 67 files, 1046 tests, all pass
- `npm run test:server-unit` — 451 files, 6329 pass / 30 skipped (all pass; no failures)
- Expert review (code-reviewer + ad-tech-protocol-expert) — approved; description wording nit and readback symmetry gap fixed; changeset added

> **Note on precommit hook:** The server unit suite takes ~400s on this CI machine against a 240s `with-timeout.sh` limit, causing SIGTERM before completion. All individual test suites pass when run without the wrapper. GitHub Actions will be the authoritative gate for this PR.

## Triage-managed PR

- Issue: #6670
- Outcome: Execute PR (low-entropy allowlist — small test fixture/expectation update for existing behavior, no product or spec judgment)
- Session: https://claude.ai/code/session_01EAYS9HRfyA7xm2j2X5t1Ts

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAYS9HRfyA7xm2j2X5t1Ts)_