### PR TITLE
fix(compliance): chain direct-buy snapshot identity

### DIFF
--- a/.changeset/complete-direct-buy-snapshot-chaining.md
+++ b/.changeset/complete-direct-buy-snapshot-chaining.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Require the compact direct-buy compliance storyboard to chain the listed pricing version and verify the accepted proposal identity and terms digest during MediaBuy readback.

--- a/docs/building/by-layer/L3/comply-test-controller.mdx
+++ b/docs/building/by-layer/L3/comply-test-controller.mdx
@@ -321,19 +321,24 @@ For requests that select exactly that product, the seller MUST make the direct
 lifecycle deterministic:
 
 - `list_products` returns synchronous `outcome: "listed"` with the prepared
-  product, one stable pricing option, and `feed_version`; the fixture does not
-  require a separate optional `pricing_version` layer;
+  product, one stable pricing option, `feed_version`, and a separate
+  `pricing_version`;
 - the product and resulting MediaBuy expose a self-serve decrease-only budget
   control through `control_media_buy`;
 - `buy_products` returns synchronous `status: "completed"` with a non-terminal
   MediaBuy, its current `revision`, and an accepted proposal that preserves the
-  selected product, pricing option, and feed version;
+  selected product and pricing option, binds `source_feed_version` and
+  `source_pricing_version`, and carries stable `proposal_id` and `terms_digest`
+  values;
 - a valid `control_media_buy` request that applies a lower `daily_budget_cap`
   returns synchronous `status: "completed"`, increments the MediaBuy revision,
   and preserves the MediaBuy's lifecycle status; and
 - `get_media_buys` immediately reads back the applied cap, lifecycle status,
   revision returned by `control_media_buy`, and the creation/control revision
-  history needed to prove that the mutation incremented the token.
+  history needed to prove that the mutation incremented the token. Its
+  `accepted_proposal_id`, `accepted_proposal_terms_digest`, and embedded
+  accepted proposal preserve the exact proposal identity and digest returned by
+  `buy_products`.
 
 Exact retries continue to use each business tool's normal idempotency cache.
 Preparing the product does not override replay semantics or make an

--- a/static/compliance/source/protocols/media-buy/scenarios/compact_direct_buy_lifecycle.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/compact_direct_buy_lifecycle.yaml
@@ -1,5 +1,5 @@
 id: media_buy_seller/compact_direct_buy_lifecycle
-version: "1.0.0"
+version: "1.0.1"
 title: "Seller completes the compact direct-buy lifecycle"
 category: media_buy_seller
 summary: "Verifies published-offer discovery, direct purchase, revision-checked operational control, and authoritative readback through AdCP 3.2 compact tools."
@@ -22,9 +22,10 @@ required_tools:
 
 narrative: |
   The buyer discovers a versioned published offer, purchases that exact product
-  and pricing option, applies a decrease-only daily budget cap with the latest
-  MediaBuy revision, and reads back the persisted state. Every business
-  boundary uses an AdCP 3.2 compact tool. The deprecated get_products,
+  and pricing option against both the feed and pricing versions, applies a
+  decrease-only daily budget cap with the latest MediaBuy revision, and reads
+  back the persisted state and immutable accepted-proposal identity. Every
+  business boundary uses an AdCP 3.2 compact tool. The deprecated get_products,
   create_media_buy, and update_media_buy compatibility facades remain covered
   by their existing storyboards and are not required here.
 
@@ -137,6 +138,8 @@ phases:
             path: "products[0].pricing_options[0].pricing_option_id"
           - name: direct_feed_version
             path: "feed_version"
+          - name: direct_pricing_version
+            path: "pricing_version"
         validations:
           - check: response_schema
             description: "Response matches list-products-response.json"
@@ -155,6 +158,9 @@ phases:
           - check: field_present
             path: "feed_version"
             description: "The offer carries the feed version required by buy_products"
+          - check: field_present
+            path: "pricing_version"
+            description: "The prepared offer carries a separate pricing version required by buy_products"
           - check: field_contains
             path: "products[0].allowed_actions[*]"
             value:
@@ -181,6 +187,7 @@ phases:
             operator: "pinnacle-agency.example"
             sandbox: true
           feed_version: "$context.direct_feed_version"
+          pricing_version: "$context.direct_pricing_version"
           purchases:
             - product_id: "$context.direct_product_id"
               pricing_option_id: "$context.direct_pricing_option_id"
@@ -194,6 +201,10 @@ phases:
             path: "revision"
           - name: direct_buy_status
             path: "media_buy_status"
+          - name: direct_accepted_proposal_id
+            path: "accepted_proposal.proposal_id"
+          - name: direct_accepted_terms_digest
+            path: "accepted_proposal.terms_digest"
         validations:
           - check: response_schema
             description: "Response matches buy-products-response.json"
@@ -214,6 +225,10 @@ phases:
             path: "accepted_proposal.commercial_terms.source_feed_version"
             context_key: "direct_feed_version"
             description: "The accepted snapshot binds the listed feed version"
+          - check: field_equals_context
+            path: "accepted_proposal.commercial_terms.source_pricing_version"
+            context_key: "direct_pricing_version"
+            description: "The accepted snapshot binds the listed pricing version"
           - check: field_equals_context
             path: "accepted_proposal.commercial_terms.purchases[0].product_id"
             context_key: "direct_product_id"
@@ -331,3 +346,19 @@ phases:
             path: "media_buys[0].accepted_proposal.commercial_terms.source_feed_version"
             context_key: "direct_feed_version"
             description: "Readback preserves the purchased feed version"
+          - check: field_equals_context
+            path: "media_buys[0].accepted_proposal_id"
+            context_key: "direct_accepted_proposal_id"
+            description: "Readback preserves the accepted proposal identity"
+          - check: field_equals_context
+            path: "media_buys[0].accepted_proposal_terms_digest"
+            context_key: "direct_accepted_terms_digest"
+            description: "Readback preserves the accepted proposal terms digest"
+          - check: field_equals_context
+            path: "media_buys[0].accepted_proposal.proposal_id"
+            context_key: "direct_accepted_proposal_id"
+            description: "The embedded accepted snapshot preserves its proposal identity"
+          - check: field_equals_context
+            path: "media_buys[0].accepted_proposal.terms_digest"
+            context_key: "direct_accepted_terms_digest"
+            description: "The embedded accepted snapshot preserves its terms digest"

--- a/tests/compact-product-lifecycle-storyboards.test.cjs
+++ b/tests/compact-product-lifecycle-storyboards.test.cjs
@@ -328,6 +328,7 @@ test("compact direct-buy lifecycle threads versioned offers through control read
   const readback = byTask("get_media_buys");
   const phasesById = new Map(storyboard.phases.map((phase) => [phase.id, phase]));
 
+  assert.equal(storyboard.version, "1.0.1");
   assert.deepEqual(storyboard.requires_capability, {
     path: "compliance_testing.scenarios",
     contains: "compact_direct_buy_lifecycle_probe",
@@ -360,10 +361,12 @@ test("compact direct-buy lifecycle threads versioned offers through control read
       ["direct_product_id", "products[0].product_id"],
       ["direct_pricing_option_id", "products[0].pricing_options[0].pricing_option_id"],
       ["direct_feed_version", "feed_version"],
+      ["direct_pricing_version", "pricing_version"],
     ])
   );
   assert.equal(buy.sample_request.feed_version, "$context.direct_feed_version");
-  assert.equal(buy.sample_request.pricing_version, undefined);
+  assert.equal(buy.sample_request.pricing_version, "$context.direct_pricing_version");
+  assert.ok(validation(list, "field_present", "pricing_version"));
   assert.equal(
     buy.sample_request.purchases[0].product_id,
     "$context.direct_product_id"
@@ -385,6 +388,14 @@ test("compact direct-buy lifecycle threads versioned offers through control read
     validation(
       buy,
       "field_equals_context",
+      "accepted_proposal.commercial_terms.source_pricing_version"
+    )?.context_key,
+    "direct_pricing_version"
+  );
+  assert.equal(
+    validation(
+      buy,
+      "field_equals_context",
       "accepted_proposal.commercial_terms.purchases[0].product_id"
     )?.context_key,
     "direct_product_id"
@@ -396,6 +407,16 @@ test("compact direct-buy lifecycle threads versioned offers through control read
       "accepted_proposal.commercial_terms.purchases[0].pricing_option_id"
     )?.context_key,
     "direct_pricing_option_id"
+  );
+  assert.equal(
+    new Map(buy.context_outputs.map(({ name, path: outputPath }) => [name, outputPath]))
+      .get("direct_accepted_proposal_id"),
+    "accepted_proposal.proposal_id"
+  );
+  assert.equal(
+    new Map(buy.context_outputs.map(({ name, path: outputPath }) => [name, outputPath]))
+      .get("direct_accepted_terms_digest"),
+    "accepted_proposal.terms_digest"
   );
 
   assert.equal(control.sample_request.media_buy_id, "$context.direct_media_buy_id");
@@ -441,6 +462,55 @@ test("compact direct-buy lifecycle threads versioned offers through control read
     validation(readback, "field_value", "media_buys[0].daily_budget_cap")?.value,
     100
   );
+  assert.equal(
+    validation(readback, "field_equals_context", "media_buys[0].accepted_proposal_id")
+      ?.context_key,
+    "direct_accepted_proposal_id"
+  );
+  assert.equal(
+    validation(
+      readback,
+      "field_equals_context",
+      "media_buys[0].accepted_proposal_terms_digest"
+    )?.context_key,
+    "direct_accepted_terms_digest"
+  );
+  assert.equal(
+    validation(
+      readback,
+      "field_equals_context",
+      "media_buys[0].accepted_proposal.proposal_id"
+    )?.context_key,
+    "direct_accepted_proposal_id"
+  );
+  assert.equal(
+    validation(
+      readback,
+      "field_equals_context",
+      "media_buys[0].accepted_proposal.terms_digest"
+    )?.context_key,
+    "direct_accepted_terms_digest"
+  );
+});
+
+test("compact direct-buy controller docs publish the pricing and snapshot contract", () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, "docs", "building", "by-layer", "L3", "comply-test-controller.mdx"),
+    "utf8"
+  );
+  const sectionStart = source.indexOf("### `compact_direct_buy_lifecycle_probe`");
+  const sectionEnd = source.indexOf("**Params:**", sectionStart);
+  assert.ok(sectionStart >= 0 && sectionEnd > sectionStart);
+  const contract = source.slice(sectionStart, sectionEnd);
+
+  for (const field of [
+    "pricing_version",
+    "source_pricing_version",
+    "accepted_proposal_id",
+    "accepted_proposal_terms_digest",
+  ]) {
+    assert.match(contract, new RegExp(`\\b${field}\\b`));
+  }
 });
 
 test("compact direct-buy task pages remain testable", () => {


### PR DESCRIPTION
## Summary

- require the deterministic compact direct-buy listing to return and capture `pricing_version`
- pass that token to `buy_products` and verify the accepted commercial snapshot binds it
- capture the accepted proposal ID and terms digest and verify both top-level and embedded readback identities
- align the controller documentation and bump the storyboard contract to `1.0.1`

## Why

The direct-buy storyboard only chained the feed version and only compared that feed version during readback. A seller could therefore omit a returned pricing version or substitute a different accepted snapshot while still passing conformance.

This closes #6670.

## Validation

- two independent expert reviews: protocol/workflow correctness and code/test quality
- `npm run test:schemas`
- `npm run build:compliance -- --check`
- focused storyboard schema, path, entity, and source-authority lints
- documentation JSON/snippet validation
- repository precommit suite (1,046 unit tests, server unit tests, typecheck)
- changeset protocol-scope and status checks
