### PR TITLE
fix(training): serve proposal profile capabilities

### DIFF
--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -4703,12 +4703,15 @@ function signalMatchesRef(
 
 // ── Tool definitions ──────────────────────────────────────────────
 
-const PRODUCT_DISCOVERY_TOOLS = new Set([
-  'get_products',
+const PRODUCT_DISCOVERY_LIFECYCLE_TOOLS = [
   'list_products',
   'request_proposals',
   'refine_proposals',
   'decline_proposals',
+] as const;
+const PRODUCT_DISCOVERY_TOOLS = new Set([
+  'get_products',
+  ...PRODUCT_DISCOVERY_LIFECYCLE_TOOLS,
 ]);
 
 function isProductDiscoveryTool(toolName: string): boolean {
@@ -10803,7 +10806,7 @@ export async function handleGetAdcpCapabilities(args: ToolArgs, ctx: TrainingCon
     media_buy: {
       buying_modes: wholesaleProfile.productWholesale ? ['brief', 'wholesale', 'refine'] : ['brief', 'refine'],
       ...(supportsGetProductsRejected(servedAdcpVersion) && {
-        lifecycle_tools: [...PRODUCT_DISCOVERY_TOOLS],
+        lifecycle_tools: [...PRODUCT_DISCOVERY_LIFECYCLE_TOOLS],
         proposal_refinement: proposalCapabilitiesForProfile(ctx.proposalNegotiationProfile),
       }),
       supports_proposals: true,

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -34,6 +34,7 @@ import { GET_PRODUCTS_REJECTED_ADCP_VERSION, supportsGetProductsRejected, type T
 import { getAgentUrl } from '../config.js';
 import { redactConflictEnvelopeInBody } from '../conflict-envelope.js';
 import { canonicalizeAccountRef } from '../account-scope.js';
+import { proposalCapabilitiesForProfile } from '../proposal-negotiation-profiles.js';
 
 const logger = createLogger('training-agent-tenant-router');
 const PRODUCT_WHOLESALE_EVENTS = ['product.created', 'product.updated', 'product.priced', 'product.removed'] as const;
@@ -130,12 +131,15 @@ const SALES_CURRENT_SCENARIOS = [
 
 const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', GET_PRODUCTS_REJECTED_ADCP_VERSION] as const;
 const TRAINING_AGENT_DEFAULT_ADCP_VERSION = '3.0';
-const PRODUCT_DISCOVERY_TOOL_NAMES = [
-  'get_products',
+const PRODUCT_DISCOVERY_LIFECYCLE_TOOL_NAMES = [
   'list_products',
   'request_proposals',
   'refine_proposals',
   'decline_proposals',
+] as const;
+const PRODUCT_DISCOVERY_TOOL_NAMES = [
+  'get_products',
+  ...PRODUCT_DISCOVERY_LIFECYCLE_TOOL_NAMES,
 ] as const;
 
 function bearerToken(req: Request): string | undefined {
@@ -255,7 +259,13 @@ function tenantMcpHandler(
     setCORSHeaders(res);
 
     wrapTenantToolDiscoveryProjection(req, res, tenantId, storyboardCompat);
-    wrapTenantCapabilitiesProjection(req, res, tenantId, storyboardCompat);
+    wrapTenantCapabilitiesProjection(
+      req,
+      res,
+      tenantId,
+      storyboardCompat,
+      proposalNegotiationProfile,
+    );
 
     // Bridge `res.locals.trainingPrincipal` (set by the upstream
     // `requireAuth` middleware) onto `req.auth` so the framework's MCP
@@ -617,9 +627,19 @@ function wrapTenantCapabilitiesProjection(
   res: Response,
   tenantId: string,
   storyboardCompat?: TrainingContext['storyboardCompat'],
+  proposalNegotiationProfile?: TrainingContext['proposalNegotiationProfile'],
 ): void {
   if (req.body?.method !== 'tools/call') return;
   if (req.body?.params?.name !== 'get_adcp_capabilities') return;
+
+  const capabilityArgs = (req.body.params.arguments ?? {}) as Record<string, unknown>;
+  const hasVersionSelector = capabilityArgs.adcp_version !== undefined
+    || capabilityArgs.adcp_major_version !== undefined;
+  const requestedVersion = proposalNegotiationProfile
+    ? hasVersionSelector
+      ? resolveServedAdcpVersion(capabilityArgs)
+      : { ok: true as const, servedVersion: GET_PRODUCTS_REJECTED_ADCP_VERSION }
+    : undefined;
 
   const origEnd = res.end.bind(res);
   const chunks: Buffer[] = [];
@@ -635,7 +655,13 @@ function wrapTenantCapabilitiesProjection(
   (res as unknown as { end: (...args: unknown[]) => Response }).end = (chunk?: unknown, ...rest: unknown[]) => {
     if (chunk !== null && chunk !== undefined) chunks.push(toBuffer(chunk));
     const body = Buffer.concat(chunks);
-    const patched = projectTenantCapabilities(body, tenantId, storyboardCompat);
+    const patched = projectTenantCapabilities(
+      body,
+      tenantId,
+      storyboardCompat,
+      proposalNegotiationProfile,
+      requestedVersion?.ok ? requestedVersion.servedVersion : undefined,
+    );
     if (patched !== body && !res.headersSent) {
       res.setHeader('content-length', String(patched.length));
     }
@@ -780,6 +806,8 @@ function projectTenantCapabilities(
   body: Buffer,
   tenantId: string,
   storyboardCompat?: TrainingContext['storyboardCompat'],
+  proposalNegotiationProfile?: TrainingContext['proposalNegotiationProfile'],
+  servedVersionOverride?: string,
 ): Buffer {
   try {
     const parsed = JSON.parse(body.toString('utf8')) as {
@@ -803,9 +831,13 @@ function projectTenantCapabilities(
     };
     const structured = parsed.result?.structuredContent;
     if (!structured || typeof structured !== 'object') return body;
-    const servedVersion = typeof structured.adcp_version === 'string'
-      ? structured.adcp_version
-      : TRAINING_AGENT_DEFAULT_ADCP_VERSION;
+    // Dedicated profile routes default unpinned capability discovery to their
+    // exact beta contract. Pinned requests use the normal resolver, so a
+    // stable `3.2` selector is never silently mapped to this prerelease.
+    const servedVersion = servedVersionOverride
+      ?? (typeof structured.adcp_version === 'string'
+        ? structured.adcp_version
+        : TRAINING_AGENT_DEFAULT_ADCP_VERSION);
     structured.adcp_version = servedVersion;
     const adcp = structured.adcp && typeof structured.adcp === 'object'
       ? structured.adcp
@@ -873,7 +905,11 @@ function projectTenantCapabilities(
         ...mediaBuy,
         ...salesProjection,
         ...(supportsGetProductsRejected(servedVersion) && {
-          lifecycle_tools: [...PRODUCT_DISCOVERY_TOOL_NAMES],
+          lifecycle_tools: [...PRODUCT_DISCOVERY_LIFECYCLE_TOOL_NAMES],
+        }),
+        ...(proposalNegotiationProfile && supportsGetProductsRejected(servedVersion) && {
+          supports_proposals: true,
+          proposal_refinement: proposalCapabilitiesForProfile(proposalNegotiationProfile),
         }),
         features: {
           ...(

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -138,6 +138,19 @@ async function callTenantTool(url: string, id: number, name: string, args: Recor
   return response.json() as Promise<Record<string, unknown>>;
 }
 
+async function listTenantTools(url: string, id: number): Promise<Record<string, unknown>> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json',
+      authorization: 'Bearer test-token',
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id, method: 'tools/list' }),
+  });
+  return response.json() as Promise<Record<string, unknown>>;
+}
+
 describe('tenant routing smoke', () => {
   beforeEach(() => {
     clearSessions();
@@ -425,6 +438,114 @@ describe('tenant routing smoke', () => {
           expect(capabilities?.specialisms).toContain('creative-transformers');
         }
       }
+    } finally {
+      await close();
+    }
+  }, 30000);
+
+  it('serves proposal-profile capabilities and SDK-shaped 3.2 refinement over HTTP', async () => {
+    const { baseUrl, close } = await bootServer();
+    try {
+      const url = `${baseUrl}/sales/profiles/constrained-seller/mcp`;
+      await initializeTenant(url);
+
+      const toolsResponse = await listTenantTools(url, 2) as {
+        result?: { tools?: Array<{ name?: string }> };
+      };
+      expect(toolsResponse.result?.tools?.map(tool => tool.name)).toEqual(
+        expect.arrayContaining(['request_proposals', 'refine_proposals', 'decline_proposals']),
+      );
+
+      const capabilitiesResponse = await callTenantTool(url, 3, 'get_adcp_capabilities', {
+        adcp_version: '3.2-beta.0',
+        adcp_major_version: 3,
+      }) as {
+        result?: { structuredContent?: {
+          adcp_version?: string;
+          adcp?: { supported_versions?: string[] };
+          media_buy?: {
+            supports_proposals?: boolean;
+            lifecycle_tools?: string[];
+            proposal_refinement?: { supported_dimensions?: string[]; max_alternatives?: number };
+          };
+        } };
+      };
+      expect(capabilitiesResponse.result?.structuredContent?.adcp_version).toBe('3.2-beta.0');
+      expect(capabilitiesResponse.result?.structuredContent?.adcp?.supported_versions).toContain('3.2-beta.0');
+      const mediaBuy = capabilitiesResponse.result?.structuredContent?.media_buy;
+      expect(mediaBuy?.supports_proposals).toBe(true);
+      expect(mediaBuy?.lifecycle_tools).toEqual([
+        'list_products',
+        'request_proposals',
+        'refine_proposals',
+        'decline_proposals',
+      ]);
+      expect(mediaBuy?.proposal_refinement).toEqual({
+        supported_dimensions: [
+          'total_budget',
+          'cpm',
+          'impressions',
+          'flight',
+          'product_changes',
+          'criteria',
+          'alternatives',
+        ],
+        max_alternatives: 3,
+      });
+
+      for (const [id, adcpVersion] of [[31, '3.2'], [32, '3.0']] as const) {
+        const nonBetaCapabilities = await callTenantTool(url, id, 'get_adcp_capabilities', {
+          adcp_version: adcpVersion,
+          adcp_major_version: 3,
+        }) as {
+          result?: { structuredContent?: {
+            adcp_version?: string;
+            media_buy?: { lifecycle_tools?: string[]; proposal_refinement?: unknown };
+          } };
+        };
+        expect(nonBetaCapabilities.result?.structuredContent?.adcp_version).toBe('3.0');
+        expect(nonBetaCapabilities.result?.structuredContent?.media_buy?.lifecycle_tools).toBeUndefined();
+        expect(nonBetaCapabilities.result?.structuredContent?.media_buy?.proposal_refinement).toBeUndefined();
+      }
+
+      const requested = await callTenantTool(url, 4, 'request_proposals', {
+        adcp_version: '3.2-beta.0',
+        adcp_major_version: 3,
+        idempotency_key: 'tenant-profile-request-0001',
+        brand: { domain: 'buyer.example' },
+        brief: 'social engagement display',
+      }) as {
+        result?: { structuredContent?: {
+          adcp_version?: string;
+          proposals?: Array<{ proposal_id?: string }>;
+        } };
+      };
+      expect(requested.result?.structuredContent?.adcp_version).toBe('3.2-beta.0');
+      const sourceProposalId = requested.result?.structuredContent?.proposals?.[0]?.proposal_id;
+      expect(sourceProposalId).toBeTruthy();
+
+      const refined = await callTenantTool(url, 5, 'refine_proposals', {
+        adcp_version: '3.2-beta.0',
+        adcp_major_version: 3,
+        idempotency_key: 'tenant-profile-refine-0001',
+        refinements: [{
+          proposal_id: sourceProposalId,
+          action: 'revise',
+          constraints: { total_budget: { currency: 'USD', max: 50_000 } },
+          alternatives: { count: 2 },
+        }],
+      }) as {
+        result?: { structuredContent?: {
+          adcp_version?: string;
+          adcp_error?: { message?: string };
+          results?: Array<{ outcome?: string; proposals?: unknown[] }>;
+        } };
+      };
+      const refinement = refined.result?.structuredContent;
+      expect(refinement?.adcp_version).toBe('3.2-beta.0');
+      expect(refinement?.adcp_error).toBeUndefined();
+      expect(refinement?.results?.[0]?.outcome).toBe('revised');
+      expect(refinement?.results?.[0]?.proposals).toHaveLength(2);
     } finally {
       await close();
     }


### PR DESCRIPTION
## Summary

- preserve the proposal-negotiation profile while projecting public training-agent capabilities
- advertise the schema-valid compact proposal lifecycle tools instead of legacy handler names
- honor exact `3.2-beta.0` capability negotiation while keeping stable `3.2` and explicit `3.0` requests on the stable compatibility response
- add HTTP-level coverage for discovery, capability negotiation, proposal requests, and proposal refinement

## Why

The public proposal profile exposed the proposal tools, but its capability wrapper dropped the profile context. That caused the endpoint to report `supports_proposals: false`, omit proposal-refinement dimensions, and advertise a lifecycle list that did not match the 3.2 schema.

This keeps the public profile truthful without silently mapping a stable version pin to beta. The request-side SDK beta-pin limitation is tracked separately in adcontextprotocol/adcp-client#2609; this PR does not claim to resolve that client issue or the broader native lifecycle work in #6646.

## Validation

- code-review expert: no remaining blockers
- protocol-review expert: no remaining protocol blockers
- focused Vitest: 41 tests passed
- full pre-commit server suite: 451 files, 6,329 passed, 30 skipped
- TypeScript typecheck passed
- pre-push current and 3.0 compatibility storyboard matrices passed for all tenant profiles

