### PR TITLE
test(compliance): add universal macro translation vectors

### DIFF
--- a/.changeset/universal-macro-translation-vectors.md
+++ b/.changeset/universal-macro-translation-vectors.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Publish schema-validated language-neutral universal-macro translation vectors with deterministic diagnostics for settled behavior.

--- a/.changeset/universal-macro-translation-vectors.md
+++ b/.changeset/universal-macro-translation-vectors.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": minor
 ---
 
-Publish schema-validated language-neutral universal-macro translation vectors with deterministic diagnostics for settled behavior.
+Publish schema-validated language-neutral universal-macro translation vectors for ratified behavior, including control-character rejection, frozen-consent diagnostics, and bare-query normalization.

--- a/docs/creative/universal-macros.mdx
+++ b/docs/creative/universal-macros.mdx
@@ -567,7 +567,19 @@ Behavior:
   (`%%…%%`, `{{…}}`, `${…}`, `[UPPER_SNAKE]`) — almost always a mapping that should have
   used the `native` arm.
 - Only query-parameter **values** are translated; a macro in a key position is left
-  untouched.
+  untouched. The path and fragment also pass through byte-for-byte.
+- Substitution is single-pass. Macro-shaped text inside a substituted `value` is data,
+  percent-encoded once, and never re-expanded.
+- Diagnostic ordering is deterministic: `dropped_params` follows query occurrence
+  order (including repeated keys); `unmapped_macros` and `dropped_consent_macros`
+  follow first occurrence and are deduplicated; `suspect_native_values` follows
+  mapping property order and is deduplicated.
+
+The language-neutral golden fixture at
+[`/compliance/latest/test-vectors/universal-macro-translation.json`](https://adcontextprotocol.org/compliance/latest/test-vectors/universal-macro-translation.json)
+pins the output URL, every diagnostic array, and settled edge-case ordering.
+SDK implementations MUST run the applicable versioned fixture rather than maintain an
+independent behavioral table.
 
 ### 4. Impression Time
 

--- a/docs/creative/universal-macros.mdx
+++ b/docs/creative/universal-macros.mdx
@@ -535,26 +535,38 @@ const mapping = {
   '{DEVICE_ID}': { native: '%%ADVERTISING_IDENTIFIER_PLAIN%%' },
 };
 
-const { url, dropped_params, unmapped_macros, dropped_consent_macros, suspect_native_values } =
-  translateUniversalMacros(
-    'https://track.brand.com/imp?buy={MEDIA_BUY_ID}&pkg={PACKAGE_ID}&cb={CACHEBUSTER}&device={DEVICE_ID}',
-    mapping,
-  );
+const {
+  url,
+  dropped_params,
+  unmapped_macros,
+  dropped_consent_macros,
+  frozen_consent_macros,
+  suspect_native_values,
+} = translateUniversalMacros(
+  'https://track.brand.com/imp?buy={MEDIA_BUY_ID}&pkg={PACKAGE_ID}&cb={CACHEBUSTER}&device={DEVICE_ID}',
+  mapping,
+);
 
 // url:
 //   https://track.brand.com/imp?buy=mb_spring_2025&pkg=pkg_ctv_prime&cb=%%CACHEBUSTER%%&device=%%ADVERTISING_IDENTIFIER_PLAIN%%
 // dropped_params: []           (every macro was mapped)
 // unmapped_macros: []
 // dropped_consent_macros: []   (no consent macro was dropped)
+// frozen_consent_macros: []    (no consent macro was supplied as a fixed value)
 // suspect_native_values: []    (no value entry looks like a native token)
 ```
 
 Behavior:
 
 - **`native` entries are inserted verbatim** — `%%CACHEBUSTER%%` is not percent-encoded,
-  so the ad server still recognizes it.
+  so the ad server still recognizes it. A native mapping containing U+0000–U+001F
+  or U+007F is invalid: the helper raises a typed `unsafe_native_mapping` error and
+  emits no translated URL.
 - **`value` entries are RFC-3986 percent-encoded**, so a value containing reserved
   characters can't break or inject into the URL.
+- A consent/privacy macro supplied through **`value`** is still encoded, but it is
+  also surfaced in **`frozen_consent_macros`**. Inspect this advisory field: fixing a
+  consent string at translation time can produce a stale-consent pixel.
 - **A parameter whose universal macro the agent does not support is dropped entirely**
   (its key is reported in `dropped_params`, the macro in `unmapped_macros`) — better to
   omit a tracker the agent can't fill than to emit a broken one. A dropped
@@ -570,14 +582,16 @@ Behavior:
   untouched. The path and fragment also pass through byte-for-byte.
 - Substitution is single-pass. Macro-shaped text inside a substituted `value` is data,
   percent-encoded once, and never re-expanded.
+- A URL ending in a bare trailing `?` is normalized by removing the delimiter.
 - Diagnostic ordering is deterministic: `dropped_params` follows query occurrence
   order (including repeated keys); `unmapped_macros` and `dropped_consent_macros`
-  follow first occurrence and are deduplicated; `suspect_native_values` follows
-  mapping property order and is deduplicated.
+  follow first occurrence and are deduplicated; `frozen_consent_macros` and
+  `suspect_native_values` follow mapping property order and are deduplicated.
 
 The language-neutral golden fixture at
 [`/compliance/latest/test-vectors/universal-macro-translation.json`](https://adcontextprotocol.org/compliance/latest/test-vectors/universal-macro-translation.json)
-pins the output URL, every diagnostic array, and settled edge-case ordering.
+pins the output URL, every diagnostic array, typed rejection cases, and ratified
+edge-case ordering.
 SDK implementations MUST run the applicable versioned fixture rather than maintain an
 independent behavioral table.
 

--- a/governance/decisions/DR-0012-reject-native-control-characters.md
+++ b/governance/decisions/DR-0012-reject-native-control-characters.md
@@ -1,0 +1,30 @@
+---
+id: DR-0012
+title: Universal macro native mappings reject control characters
+class: normative
+status: ratified
+date: 2026-08-19
+decided: 2026-08-19
+decided_by: maintainer approval
+refs: ["#6674", "PR #6679"]
+dissent: none
+---
+
+## Decision
+
+`translateUniversalMacros` must reject any `{ native: ... }` mapping that
+contains control characters (U+0000–U+001F, U+007F) and surface a typed error.
+Verbatim insertion is not permitted.
+
+## Rationale
+
+The `native` arm bypasses all encoding; CRLF in a native value produces a
+split-header-ready payload with no downstream safety net. No legitimate
+ad-server token (`%%…%%`, `{{…}}`, `${…}`, `[UPPER_SNAKE]`) ever contains
+control characters — rejection has zero false-positive cost.
+
+## Implications
+
+This is non-breaking because the behavior was unspecified and constrains only
+invalid input. Implementations must include control-character rejection in the
+golden fixture and expose a language-appropriate typed error.

--- a/governance/decisions/DR-0013-surface-frozen-consent-macros.md
+++ b/governance/decisions/DR-0013-surface-frozen-consent-macros.md
@@ -1,0 +1,31 @@
+---
+id: DR-0013
+title: Surface consent macros supplied through value mappings
+class: normative
+status: ratified
+date: 2026-08-19
+decided: 2026-08-19
+decided_by: maintainer approval
+refs: ["#6674", "PR #6679"]
+dissent: none
+---
+
+## Decision
+
+When a `{ value: ... }` mapping is supplied for a consent macro
+(`{GDPR_CONSENT}`, `{US_PRIVACY}`, `{GPP_STRING}`, etc.), the helper must encode
+the value and add the macro name to a new `frozen_consent_macros` return field
+(parallel to `dropped_consent_macros`). Silent encoding without surfacing is
+not permitted.
+
+## Rationale
+
+Freezing consent strings at build time produces stale-consent pixels — a
+privacy defect. The advisory-field pattern already used for
+`dropped_consent_macros` / `suspect_native_values` keeps behavior fail-open for
+test harnesses while making the defect impossible to miss in production.
+
+## Implications
+
+This is non-breaking because it adds an optional return field.
+`frozen_consent_macros` vectors must be in the golden fixture.

--- a/governance/decisions/DR-0014-normalize-bare-query-delimiter.md
+++ b/governance/decisions/DR-0014-normalize-bare-query-delimiter.md
@@ -1,0 +1,30 @@
+---
+id: DR-0014
+title: Universal macro translation removes a bare trailing query delimiter
+class: normative
+status: ratified
+date: 2026-08-19
+decided: 2026-08-19
+decided_by: maintainer approval
+refs: ["#6674", "PR #6679"]
+dissent: none
+---
+
+## Decision
+
+`translateUniversalMacros` normalizes a URL ending in a bare trailing `?` by
+removing that delimiter. For example, `https://pixel.example/i?` becomes
+`https://pixel.example/i`.
+
+## Rationale
+
+The JavaScript helper already ships this behavior, and normalization produces
+one deterministic result for an empty query. DR-0008 does not independently
+settle this question because that record applies to wire shape, while macro
+translation is a non-wire-observable helper semantic under DR-0005. The helper
+behavior is therefore ratified explicitly here.
+
+## Implications
+
+The golden fixture must include bare-query normalization. This decision does
+not authorize other URL canonicalization or changes to non-empty query strings.

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "test:language-tag-refs": "node --test --test-force-exit --test-timeout=30000 tests/lint-language-tag-refs.test.cjs && node scripts/lint-language-tag-refs.cjs",
     "test:compliance-snippets": "node --test --test-force-exit --test-timeout=30000 tests/generate-compliance-snippets.node.mjs tests/link-compliance-symbols.node.mjs && npm run build:compliance -- --check",
     "test:doc-compliance-drift": "node --test --test-force-exit --test-timeout=30000 tests/lint-doc-compliance-drift.test.cjs",
-    "test:substitution-vector-names": "node scripts/lint-substitution-vector-names.cjs",
+    "test:substitution-vector-names": "node scripts/lint-substitution-vector-names.cjs && node --test --test-force-exit --test-timeout=30000 tests/universal-macro-translation-vectors.test.cjs",
     "test:unit": "npm run test:canonical-pixel-ratio && npm run test:governance-jws-vectors && vitest run --dir tests/ --pool=threads",
     "test:redteam": "tsx server/src/addie/testing/redteam-cli.ts",
     "test:server-unit": "vitest run --config server/vitest.config.ts tests/unit/",

--- a/static/compliance/source/test-vectors/universal-macro-translation.json
+++ b/static/compliance/source/test-vectors/universal-macro-translation.json
@@ -4,11 +4,12 @@
   "version": "3.2",
   "name": "Universal macro translation — cross-SDK conformance fixtures",
   "spec_reference": "docs/creative/universal-macros.mdx#implementing-translation-with-the-sdk",
-  "description": "Language-neutral golden vectors for settled producer-side universal-macro translation behavior. Successful cases pin the current result shape.",
+  "description": "Language-neutral golden vectors for ratified producer-side universal-macro translation behavior, including typed rejection cases and the complete successful result shape.",
   "ordering": {
     "dropped_params": "Query-parameter occurrence order; repeated keys remain repeated.",
     "unmapped_macros": "First occurrence in query order, deduplicated.",
     "dropped_consent_macros": "First occurrence in query order, deduplicated subset of unmapped_macros.",
+    "frozen_consent_macros": "Mapping property order, deduplicated consent macros supplied through value entries.",
     "suspect_native_values": "Mapping property order, deduplicated. JSON fixture consumers MUST preserve the mapping order shown here."
   },
   "vectors": [
@@ -21,6 +22,7 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -33,6 +35,7 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -45,6 +48,7 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -62,6 +66,7 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -77,6 +82,7 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -89,6 +95,7 @@
         "dropped_params": ["ids"],
         "unmapped_macros": ["{UNKNOWN}"],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -101,6 +108,7 @@
         "dropped_params": ["first", "same", "same", "mix"],
         "unmapped_macros": ["{Z}", "{A}", "{B}"],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -113,6 +121,7 @@
         "dropped_params": ["g", "u", "g2", "c"],
         "unmapped_macros": ["{GPP_STRING}", "{US_PRIVACY}", "{GDPR_CONSENT}"],
         "dropped_consent_macros": ["{GPP_STRING}", "{US_PRIVACY}", "{GDPR_CONSENT}"],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -129,6 +138,7 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -141,6 +151,7 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -153,6 +164,7 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -168,6 +180,7 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -180,6 +193,7 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -195,6 +209,7 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
       }
     },
@@ -213,6 +228,7 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": ["{PERCENT}", "{DOUBLE_BRACE}", "{DOLLAR_BRACE}", "{BRACKET}"]
       }
     },
@@ -228,7 +244,64 @@
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
         "suspect_native_values": []
+      }
+    },
+    {
+      "name": "privacy-value-mappings-are-encoded-and-reported",
+      "input_pixel_url": "https://pixel.example/i?g={GPP_STRING}&u={US_PRIVACY}",
+      "mapping": {
+        "{GPP_STRING}": { "value": "DBABMA~CPXxRfA/PXxRfA" },
+        "{US_PRIVACY}": { "value": "1YNN" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?g=DBABMA~CPXxRfA%2FPXxRfA&u=1YNN",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": ["{GPP_STRING}", "{US_PRIVACY}"],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "bare-query-normalized-away",
+      "input_pixel_url": "https://pixel.example/i?",
+      "mapping": {},
+      "expected": {
+        "url": "https://pixel.example/i",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "native-c0-null-rejected",
+      "input_pixel_url": "https://pixel.example/i?cb={CACHEBUSTER}",
+      "mapping": { "{CACHEBUSTER}": { "native": "%%CACHE\u0000BUSTER%%" } },
+      "expected_error": {
+        "code": "unsafe_native_mapping",
+        "macro": "{CACHEBUSTER}"
+      }
+    },
+    {
+      "name": "native-c0-unit-separator-rejected",
+      "input_pixel_url": "https://pixel.example/i?cb={CACHEBUSTER}",
+      "mapping": { "{CACHEBUSTER}": { "native": "%%CACHE\u001fBUSTER%%" } },
+      "expected_error": {
+        "code": "unsafe_native_mapping",
+        "macro": "{CACHEBUSTER}"
+      }
+    },
+    {
+      "name": "native-del-rejected",
+      "input_pixel_url": "https://pixel.example/i?cb={CACHEBUSTER}",
+      "mapping": { "{CACHEBUSTER}": { "native": "%%CACHE\u007fBUSTER%%" } },
+      "expected_error": {
+        "code": "unsafe_native_mapping",
+        "macro": "{CACHEBUSTER}"
       }
     }
   ]

--- a/static/compliance/source/test-vectors/universal-macro-translation.json
+++ b/static/compliance/source/test-vectors/universal-macro-translation.json
@@ -1,0 +1,235 @@
+{
+  "$schema": "./universal-macro-translation.schema.json",
+  "$schema_version": "1.0",
+  "version": "3.2",
+  "name": "Universal macro translation — cross-SDK conformance fixtures",
+  "spec_reference": "docs/creative/universal-macros.mdx#implementing-translation-with-the-sdk",
+  "description": "Language-neutral golden vectors for settled producer-side universal-macro translation behavior. Successful cases pin the current result shape.",
+  "ordering": {
+    "dropped_params": "Query-parameter occurrence order; repeated keys remain repeated.",
+    "unmapped_macros": "First occurrence in query order, deduplicated.",
+    "dropped_consent_macros": "First occurrence in query order, deduplicated subset of unmapped_macros.",
+    "suspect_native_values": "Mapping property order, deduplicated. JSON fixture consumers MUST preserve the mapping order shown here."
+  },
+  "vectors": [
+    {
+      "name": "value-reserved-characters",
+      "input_pixel_url": "https://pixel.example/i?v={VALUE}",
+      "mapping": { "{VALUE}": { "value": "/?&=% {}#" } },
+      "expected": {
+        "url": "https://pixel.example/i?v=%2F%3F%26%3D%25%20%7B%7D%23",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "value-unreserved-characters",
+      "input_pixel_url": "https://pixel.example/i?v={VALUE}",
+      "mapping": { "{VALUE}": { "value": "AZaz09-._~" } },
+      "expected": {
+        "url": "https://pixel.example/i?v=AZaz09-._~",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "value-non-ascii-utf8",
+      "input_pixel_url": "https://pixel.example/i?store={STORE_ID}",
+      "mapping": { "{STORE_ID}": { "value": "café" } },
+      "expected": {
+        "url": "https://pixel.example/i?store=caf%C3%A9",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "native-token-forms-inserted-verbatim",
+      "input_pixel_url": "https://pixel.example/i?a={A}&b={B}&c={C}&d={D}",
+      "mapping": {
+        "{A}": { "native": "%%TOKEN%%" },
+        "{B}": { "native": "{{token}}" },
+        "{C}": { "native": "${token}" },
+        "{D}": { "native": "[TOKEN]" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?a=%%TOKEN%%&b={{token}}&c=${token}&d=[TOKEN]",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "multiple-mapped-macros-in-one-parameter",
+      "input_pixel_url": "https://pixel.example/i?ids=pre-{A}-{B}-{A}",
+      "mapping": {
+        "{A}": { "value": "a/b" },
+        "{B}": { "native": "%%B%%" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?ids=pre-a%2Fb-%%B%%-a%2Fb",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "mapped-plus-unmapped-drops-whole-parameter",
+      "input_pixel_url": "https://pixel.example/i?ids={MEDIA_BUY_ID}-{UNKNOWN}&literal=keep",
+      "mapping": { "{MEDIA_BUY_ID}": { "value": "mb_1" } },
+      "expected": {
+        "url": "https://pixel.example/i?literal=keep",
+        "dropped_params": ["ids"],
+        "unmapped_macros": ["{UNKNOWN}"],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "repeated-keys-and-first-seen-report-order",
+      "input_pixel_url": "https://pixel.example/i?first={Z}&same={A}&same={Z}&mix={B}{A}&ok=1",
+      "mapping": {},
+      "expected": {
+        "url": "https://pixel.example/i?ok=1",
+        "dropped_params": ["first", "same", "same", "mix"],
+        "unmapped_macros": ["{Z}", "{A}", "{B}"],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "privacy-drops-and-deduplicated-order",
+      "input_pixel_url": "https://pixel.example/i?g={GPP_STRING}&u={US_PRIVACY}&g2={GPP_STRING}&c={GDPR_CONSENT}",
+      "mapping": {},
+      "expected": {
+        "url": "https://pixel.example/i",
+        "dropped_params": ["g", "u", "g2", "c"],
+        "unmapped_macros": ["{GPP_STRING}", "{US_PRIVACY}", "{GDPR_CONSENT}"],
+        "dropped_consent_macros": ["{GPP_STRING}", "{US_PRIVACY}", "{GDPR_CONSENT}"],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "privacy-native-mappings-allowed",
+      "input_pixel_url": "https://pixel.example/i?g={GPP_STRING}&u={US_PRIVACY}&c={GDPR_CONSENT}",
+      "mapping": {
+        "{GPP_STRING}": { "native": "%%GPP_STRING%%" },
+        "{US_PRIVACY}": { "native": "%%US_PRIVACY%%" },
+        "{GDPR_CONSENT}": { "native": "%%GDPR_CONSENT%%" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?g=%%GPP_STRING%%&u=%%US_PRIVACY%%&c=%%GDPR_CONSENT%%",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "literal-parameters-pass-through-byte-for-byte",
+      "input_pixel_url": "https://pixel.example/i?encoded=%2f+%7e&flag&empty=&equals=a=b",
+      "mapping": {},
+      "expected": {
+        "url": "https://pixel.example/i?encoded=%2f+%7e&flag&empty=&equals=a=b",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "path-and-no-query-left-untouched",
+      "input_pixel_url": "https://pixel.example/{MEDIA_BUY_ID}",
+      "mapping": { "{MEDIA_BUY_ID}": { "value": "mb_1" } },
+      "expected": {
+        "url": "https://pixel.example/{MEDIA_BUY_ID}",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "fragment-left-untouched",
+      "input_pixel_url": "https://pixel.example/i?buy={MEDIA_BUY_ID}#frag={CREATIVE_ID}",
+      "mapping": {
+        "{MEDIA_BUY_ID}": { "value": "mb_1" },
+        "{CREATIVE_ID}": { "value": "cr_1" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?buy=mb_1#frag={CREATIVE_ID}",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "macro-in-key-left-untouched",
+      "input_pixel_url": "https://pixel.example/i?{MEDIA_BUY_ID}=literal",
+      "mapping": { "{MEDIA_BUY_ID}": { "value": "mb_1" } },
+      "expected": {
+        "url": "https://pixel.example/i?{MEDIA_BUY_ID}=literal",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "substitution-is-single-pass",
+      "input_pixel_url": "https://pixel.example/i?buy={MEDIA_BUY_ID}",
+      "mapping": {
+        "{MEDIA_BUY_ID}": { "value": "{PACKAGE_ID}" },
+        "{PACKAGE_ID}": { "value": "pkg_1" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?buy=%7BPACKAGE_ID%7D",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "suspect-native-values-are-mapping-scoped-and-ordered",
+      "input_pixel_url": "https://pixel.example/i?ok={NORMAL}",
+      "mapping": {
+        "{PERCENT}": { "value": "%%TOKEN%%" },
+        "{DOUBLE_BRACE}": { "value": "{{token}}" },
+        "{DOLLAR_BRACE}": { "value": "${token}" },
+        "{BRACKET}": { "value": "[TOKEN]" },
+        "{NORMAL}": { "value": "ok" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?ok=ok",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": ["{PERCENT}", "{DOUBLE_BRACE}", "{DOLLAR_BRACE}", "{BRACKET}"]
+      }
+    },
+    {
+      "name": "ordinary-bracketed-values-not-suspect",
+      "input_pixel_url": "https://pixel.example/i?a={A}&b={B}",
+      "mapping": {
+        "{A}": { "value": "[1,2,3]" },
+        "{B}": { "value": "[redacted]" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?a=%5B1%2C2%2C3%5D&b=%5Bredacted%5D",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "suspect_native_values": []
+      }
+    }
+  ]
+}

--- a/static/compliance/source/test-vectors/universal-macro-translation.schema.json
+++ b/static/compliance/source/test-vectors/universal-macro-translation.schema.json
@@ -28,12 +28,14 @@
         "dropped_params",
         "unmapped_macros",
         "dropped_consent_macros",
+        "frozen_consent_macros",
         "suspect_native_values"
       ],
       "properties": {
         "dropped_params": { "type": "string", "minLength": 1 },
         "unmapped_macros": { "type": "string", "minLength": 1 },
         "dropped_consent_macros": { "type": "string", "minLength": 1 },
+        "frozen_consent_macros": { "type": "string", "minLength": 1 },
         "suspect_native_values": { "type": "string", "minLength": 1 }
       }
     },
@@ -82,6 +84,7 @@
         "dropped_params",
         "unmapped_macros",
         "dropped_consent_macros",
+        "frozen_consent_macros",
         "suspect_native_values"
       ],
       "properties": {
@@ -92,13 +95,27 @@
         },
         "unmapped_macros": { "$ref": "#/definitions/macroArray" },
         "dropped_consent_macros": { "$ref": "#/definitions/macroArray" },
+        "frozen_consent_macros": { "$ref": "#/definitions/macroArray" },
         "suspect_native_values": { "$ref": "#/definitions/macroArray" }
+      }
+    },
+    "expectedError": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "macro"],
+      "properties": {
+        "code": { "const": "unsafe_native_mapping" },
+        "macro": { "$ref": "#/definitions/macro" }
       }
     },
     "vector": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "input_pixel_url", "mapping", "expected"],
+      "required": ["name", "input_pixel_url", "mapping"],
+      "oneOf": [
+        { "required": ["expected"] },
+        { "required": ["expected_error"] }
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -106,7 +123,8 @@
         },
         "input_pixel_url": { "type": "string", "minLength": 1 },
         "mapping": { "$ref": "#/definitions/mapping" },
-        "expected": { "$ref": "#/definitions/expected" }
+        "expected": { "$ref": "#/definitions/expected" },
+        "expected_error": { "$ref": "#/definitions/expectedError" }
       }
     }
   }

--- a/static/compliance/source/test-vectors/universal-macro-translation.schema.json
+++ b/static/compliance/source/test-vectors/universal-macro-translation.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "universal-macro-translation.schema.json",
+  "title": "Universal macro translation fixture",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "$schema_version",
+    "version",
+    "name",
+    "spec_reference",
+    "description",
+    "ordering",
+    "vectors"
+  ],
+  "properties": {
+    "$schema": { "type": "string" },
+    "$schema_version": { "const": "1.0" },
+    "version": { "const": "3.2" },
+    "name": { "type": "string", "minLength": 1 },
+    "spec_reference": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "ordering": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dropped_params",
+        "unmapped_macros",
+        "dropped_consent_macros",
+        "suspect_native_values"
+      ],
+      "properties": {
+        "dropped_params": { "type": "string", "minLength": 1 },
+        "unmapped_macros": { "type": "string", "minLength": 1 },
+        "dropped_consent_macros": { "type": "string", "minLength": 1 },
+        "suspect_native_values": { "type": "string", "minLength": 1 }
+      }
+    },
+    "vectors": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/vector" }
+    }
+  },
+  "definitions": {
+    "macro": {
+      "type": "string",
+      "pattern": "^\\{[A-Z][A-Z0-9_]*\\}$"
+    },
+    "mappingEntry": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["native"],
+          "properties": { "native": { "type": "string" } }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["value"],
+          "properties": { "value": { "type": "string" } }
+        }
+      ]
+    },
+    "mapping": {
+      "type": "object",
+      "propertyNames": { "$ref": "#/definitions/macro" },
+      "additionalProperties": { "$ref": "#/definitions/mappingEntry" }
+    },
+    "macroArray": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/macro" }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url",
+        "dropped_params",
+        "unmapped_macros",
+        "dropped_consent_macros",
+        "suspect_native_values"
+      ],
+      "properties": {
+        "url": { "type": "string" },
+        "dropped_params": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "unmapped_macros": { "$ref": "#/definitions/macroArray" },
+        "dropped_consent_macros": { "$ref": "#/definitions/macroArray" },
+        "suspect_native_values": { "$ref": "#/definitions/macroArray" }
+      }
+    },
+    "vector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "input_pixel_url", "mapping", "expected"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "input_pixel_url": { "type": "string", "minLength": 1 },
+        "mapping": { "$ref": "#/definitions/mapping" },
+        "expected": { "$ref": "#/definitions/expected" }
+      }
+    }
+  }
+}

--- a/tests/universal-macro-translation-vectors.test.cjs
+++ b/tests/universal-macro-translation-vectors.test.cjs
@@ -18,10 +18,11 @@ const EXPECTED_RESULT_KEYS = [
   'dropped_params',
   'unmapped_macros',
   'dropped_consent_macros',
+  'frozen_consent_macros',
   'suspect_native_values',
 ];
 
-const REQUIRED_SETTLED_CASES = [
+const REQUIRED_SUCCESS_CASES = [
   'value-reserved-characters',
   'value-unreserved-characters',
   'value-non-ascii-utf8',
@@ -38,6 +39,14 @@ const REQUIRED_SETTLED_CASES = [
   'substitution-is-single-pass',
   'suspect-native-values-are-mapping-scoped-and-ordered',
   'ordinary-bracketed-values-not-suspect',
+  'privacy-value-mappings-are-encoded-and-reported',
+  'bare-query-normalized-away',
+];
+
+const REQUIRED_REJECTION_CASES = [
+  'native-c0-null-rejected',
+  'native-c0-unit-separator-rejected',
+  'native-del-rejected',
 ];
 
 describe('universal macro translation compliance fixture', () => {
@@ -47,25 +56,35 @@ describe('universal macro translation compliance fixture', () => {
     assert.equal(fixture.version, '3.2');
   });
 
-  it('pins every settled edge case and the complete diagnostic result shape', () => {
+  it('pins every ratified edge case and the complete successful result shape', () => {
     const vectorsByName = new Map(fixture.vectors.map((vector) => [vector.name, vector]));
     assert.equal(vectorsByName.size, fixture.vectors.length, 'vector names must be unique');
 
-    for (const name of REQUIRED_SETTLED_CASES) {
+    for (const name of REQUIRED_SUCCESS_CASES) {
       const vector = vectorsByName.get(name);
-      assert.ok(vector, `missing required settled vector: ${name}`);
+      assert.ok(vector, `missing required success vector: ${name}`);
       assert.deepEqual(Object.keys(vector.expected), EXPECTED_RESULT_KEYS, name);
+    }
+
+    for (const name of REQUIRED_REJECTION_CASES) {
+      const vector = vectorsByName.get(name);
+      assert.ok(vector, `missing required rejection vector: ${name}`);
+      assert.deepEqual(vector.expected_error, {
+        code: 'unsafe_native_mapping',
+        macro: '{CACHEBUSTER}',
+      });
     }
   });
 
-  it('does not claim unresolved rejection or bare-query policies', () => {
-    assert.equal(
-      fixture.vectors.some((vector) => vector.name.includes('rejected')),
-      false,
+  it('pins the ratified consent advisory and bare-query normalization', () => {
+    const vectorsByName = new Map(fixture.vectors.map((vector) => [vector.name, vector]));
+    assert.deepEqual(
+      vectorsByName.get('privacy-value-mappings-are-encoded-and-reported').expected.frozen_consent_macros,
+      ['{GPP_STRING}', '{US_PRIVACY}'],
     );
     assert.equal(
-      fixture.vectors.some((vector) => vector.input_pixel_url.endsWith('?')),
-      false,
+      vectorsByName.get('bare-query-normalized-away').expected.url,
+      'https://pixel.example/i',
     );
   });
 });

--- a/tests/universal-macro-translation-vectors.test.cjs
+++ b/tests/universal-macro-translation-vectors.test.cjs
@@ -1,0 +1,71 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { describe, it } = require('node:test');
+const Ajv = require('ajv');
+
+const fixture = JSON.parse(fs.readFileSync(
+  path.join(__dirname, '..', 'static', 'compliance', 'source', 'test-vectors', 'universal-macro-translation.json'),
+  'utf8',
+));
+const fixtureSchema = JSON.parse(fs.readFileSync(
+  path.join(__dirname, '..', 'static', 'compliance', 'source', 'test-vectors', 'universal-macro-translation.schema.json'),
+  'utf8',
+));
+
+const EXPECTED_RESULT_KEYS = [
+  'url',
+  'dropped_params',
+  'unmapped_macros',
+  'dropped_consent_macros',
+  'suspect_native_values',
+];
+
+const REQUIRED_SETTLED_CASES = [
+  'value-reserved-characters',
+  'value-unreserved-characters',
+  'value-non-ascii-utf8',
+  'native-token-forms-inserted-verbatim',
+  'multiple-mapped-macros-in-one-parameter',
+  'mapped-plus-unmapped-drops-whole-parameter',
+  'repeated-keys-and-first-seen-report-order',
+  'privacy-drops-and-deduplicated-order',
+  'privacy-native-mappings-allowed',
+  'literal-parameters-pass-through-byte-for-byte',
+  'path-and-no-query-left-untouched',
+  'fragment-left-untouched',
+  'macro-in-key-left-untouched',
+  'substitution-is-single-pass',
+  'suspect-native-values-are-mapping-scoped-and-ordered',
+  'ordinary-bracketed-values-not-suspect',
+];
+
+describe('universal macro translation compliance fixture', () => {
+  it('is a schema-valid 3.2 fixture', () => {
+    const validate = new Ajv({ allErrors: true, strict: false }).compile(fixtureSchema);
+    assert.equal(validate(fixture), true, JSON.stringify(validate.errors));
+    assert.equal(fixture.version, '3.2');
+  });
+
+  it('pins every settled edge case and the complete diagnostic result shape', () => {
+    const vectorsByName = new Map(fixture.vectors.map((vector) => [vector.name, vector]));
+    assert.equal(vectorsByName.size, fixture.vectors.length, 'vector names must be unique');
+
+    for (const name of REQUIRED_SETTLED_CASES) {
+      const vector = vectorsByName.get(name);
+      assert.ok(vector, `missing required settled vector: ${name}`);
+      assert.deepEqual(Object.keys(vector.expected), EXPECTED_RESULT_KEYS, name);
+    }
+  });
+
+  it('does not claim unresolved rejection or bare-query policies', () => {
+    assert.equal(
+      fixture.vectors.some((vector) => vector.name.includes('rejected')),
+      false,
+    );
+    assert.equal(
+      fixture.vectors.some((vector) => vector.input_pixel_url.endsWith('?')),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- publish a schema-validated, language-neutral 3.2 universal-macro translation fixture
- ratify and record DR-0012 through DR-0014
- pin control-character rejection, frozen-consent diagnostics, and bare-query normalization
- pin the complete successful result shape and deterministic diagnostic ordering
- preserve the existing legacy fixture URL unchanged
- add structural checks for required cases without duplicating the shipping SDK helper in this repository

## Ratified policy

- DR-0012 rejects `native` mappings containing U+0000–U+001F or U+007F with a typed error.
- DR-0013 encodes consent macros supplied through `value` and reports them in `frozen_consent_macros`.
- DR-0014 normalizes a bare trailing `?` away.

The stronger alternatives raised during expert review—broader character rejection, rejecting impression-scoped value mappings, and failing an entire translation for an unmapped consent macro—are deliberately not adopted.

This draft does **not** close #6674. SDK acceptance still needs to run this fixture against each shipping helper rather than a test-local implementation.

## Validation

- `npm run test:substitution-vector-names`
- `npm run test:compliance-source-authority`
- `npm run test:immutable-release-artifacts`
- `npm run build:compliance -- --check`
- `npm run test:docs-nav`
- `npm run check:owned-links`
- targeted snippet validation for `docs/creative/universal-macros.mdx`
- legacy fixture matches `origin/main` byte-for-byte
- changeset status: minor

The repository-wide snippet suite was also attempted locally; it remains red on unrelated environment-dependent examples, including a missing Python `adcp` module. The changed macro page has no testable snippets and passes its targeted check.

Progress on #6674
