### PR TITLE
fix(mcp): project host-compatible input schemas

### DIFF
--- a/.changeset/project-mcp-discovery-inputs.md
+++ b/.changeset/project-mcp-discovery-inputs.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": minor
+---
+
+Generate MCP tool discovery input schemas with plain object roots for strict
+hosts, while retaining canonical request schemas as the call-time validation
+authority.

--- a/docs/building/by-layer/L0/schemas.mdx
+++ b/docs/building/by-layer/L0/schemas.mdx
@@ -214,16 +214,22 @@ change a server's MCP registration. MCP disables automatic network
 dereferencing by default, so each projected schema is a compact, self-contained
 document containing only local fragment references.
 
-The 3.2 projection changes schema syntax, not the AdCP payload contract. It is
-generated from the canonical draft-07 schemas and MUST preserve the same
-validation outcomes. In particular, it does not add
-`unevaluatedProperties: false` or otherwise close extension points. The build
-tests inspect every projected schema for dialect, local-reference integrity,
-and self-containment; enforce AdCP-defined defensive depth, schema-object, and
-compact-serialization byte bounds following MCP guidance; compile
-representative schemas from every protocol; and compare the source and
-projected dialects across representative instances. Repeated shared schemas are
-stored once under `$defs` rather than recursively inlined.
+The 3.2 projection separates MCP discovery from canonical validation. Projected
+`outputSchema` files preserve the canonical draft-07 validation outcomes.
+Projected `inputSchema` files are host-compatible `tools/list` hints: the build
+flattens unconditional object properties and optional version fields into the
+root, but omits root `allOf`, `anyOf`, `oneOf`, conditionals, and negations that
+strict tool hosts reject. Nested combinators remain intact. Servers MUST
+validate every call against the canonical draft-07 request schema referenced by
+the version-root manifest; a payload accepted by discovery can still receive a
+structured `INVALID_REQUEST` at call time.
+
+The build tests inspect every projected schema for dialect, local-reference
+integrity, and self-containment; enforce AdCP-defined defensive depth,
+schema-object, and compact-serialization byte bounds following MCP guidance;
+and assert that discovery inputs retain their structural property surfaces.
+Repeated shared schemas are stored once under `$defs` rather than recursively
+inlined.
 
 #### Production surface profile
 
@@ -233,12 +239,13 @@ The MCP projection also publishes a filtered production profile:
 https://adcontextprotocol.org/schemas/{version}/mcp/2026-07-28/profiles/production/manifest.json
 ```
 
-For AdCP 3.2, this is the clean active structural catalog: it excludes the
+For AdCP 3.2, this is the clean active discovery catalog: it excludes the
 compliance-only controller and tools deprecated by 3.2, including the
 `get_products` and `list_creative_formats` compatibility facades. Its schemas
-remove only presentation annotations (`description`, `enumDescriptions`,
-`title`, `examples`, and `$comment`), so validation semantics are identical to
-the full MCP projection.
+remove low-signal presentation annotations while retaining descriptions needed
+to explain root constraints omitted from discovery. Output validation semantics
+remain identical to the full MCP projection; input schemas remain permissive
+discovery hints.
 Each manifest tool retains its `protocol` classification for deterministic
 selection.
 
@@ -247,8 +254,9 @@ agent context. It currently spans 66 tools across the protocol families. A
 production host MUST expose only the protocols and tools it implements and
 SHOULD further select the smallest capability-appropriate subset for each
 agent session. Use the full projection for documentation, compatibility, and
-conformance; use this profile as the filtered catalog and structural validation
-source from which a host builds that subset. Removing descriptions makes the
+conformance; use this profile as the filtered catalog from which a host builds
+that subset, and use the canonical draft-07 schemas for request validation.
+Removing descriptions makes the
 artifacts smaller, but does not by itself solve `tools/list` context cost.
 
 #### Active role catalogs

--- a/docs/spec-guidelines.md
+++ b/docs/spec-guidelines.md
@@ -351,11 +351,13 @@ When making breaking changes:
 ### Dialect roadmap
 
 AdCP 3.x source schemas remain JSON Schema draft-07. The 3.2 build generates a
-semantics-preserving JSON Schema 2020-12 projection under
-`/schemas/{version}/mcp/2026-07-28/` for MCP tool `inputSchema` and
-`outputSchema` declarations. Do not author 2020-12-only validation behavior in
-3.x source schemas; the two dialects must continue to accept and reject the
-same AdCP payloads.
+JSON Schema 2020-12 projection under `/schemas/{version}/mcp/2026-07-28/` for
+MCP tool declarations. Projected `outputSchema` files preserve canonical
+validation semantics. Projected `inputSchema` files are intentionally
+permissive discovery hints: unconditional object surfaces are flattened, while
+strict-host-incompatible root combinators are omitted and enforced by canonical
+draft-07 validation at call time. Do not author 2020-12-only validation behavior
+in 3.x source schemas.
 
 AdCP 4.0 will move the canonical source dialect directly to JSON Schema
 2020-12. Contract tightening such as selective `unevaluatedProperties: false`

--- a/scripts/build-schemas.cjs
+++ b/scripts/build-schemas.cjs
@@ -2229,6 +2229,9 @@ function generateMcpProjectionForVersion(versionDir, urlVersion) {
     targetDir,
     manifestPath,
     urlVersion,
+    manifestMetadata: {
+      canonical_wire_manifest: '../../manifest.json',
+    },
   });
   console.log(
     `   ✓ MCP ${MCP_PROTOCOL_VERSION} projection: ${stats.toolCount} tools, ${stats.schemaCount} schemas, `
@@ -2262,7 +2265,8 @@ function generateMcpProjectionForVersion(versionDir, urlVersion) {
         exclude_protocols: ['compliance'],
         exclude_deprecated: true,
       },
-      canonical_projection: '../../manifest.json',
+      complete_discovery_projection: '../../manifest.json',
+      canonical_wire_manifest: '../../../../manifest.json',
     },
   });
   console.log(
@@ -2306,8 +2310,9 @@ function generateMcpProjectionForVersion(versionDir, urlVersion) {
           include_tools: toolNames,
           exclude_deprecated: true,
         },
-        delivery: 'active 3.2 role-filtered validation artifacts; not a complete 3.x tools/list registration',
-        canonical_projection: '../../manifest.json',
+        delivery: 'active 3.2 role-filtered discovery inputs and response schemas; canonical wire schemas remain the call-validation authority',
+        complete_discovery_projection: '../../manifest.json',
+        canonical_wire_manifest: '../../../../manifest.json',
       },
     });
     if (profileStats.toolCount !== toolNames.length) {
@@ -2336,14 +2341,15 @@ function generateMcpProjectionForVersion(versionDir, urlVersion) {
           include_tools: toolNames,
           exclude_deprecated: true,
         },
-        delivery: 'client-side prompt input projection; servers continue to advertise outputSchema and clients validate with the parent profile',
-        validation_profile: '../manifest.json',
-        canonical_projection: '../../../manifest.json',
+        delivery: 'client-side prompt input projection; the parent profile supplies tools/list discovery inputs, while canonical wire schemas validate calls',
+        discovery_profile: '../manifest.json',
+        complete_discovery_projection: '../../../manifest.json',
+        canonical_wire_manifest: '../../../../../manifest.json',
       },
     });
     console.log(
       `   ✓ ${profileName} ${surfaceVersion} profile: ${profileStats.toolCount} tools, `
-        + `${(profileStats.totalBytes / (1024 * 1024)).toFixed(2)} MiB validation, `
+        + `${(profileStats.totalBytes / (1024 * 1024)).toFixed(2)} MiB discovery/response schemas, `
         + `${(modelContextStats.totalBytes / 1024).toFixed(0)} KiB model context`
     );
   }

--- a/scripts/mcp-schema-projection.cjs
+++ b/scripts/mcp-schema-projection.cjs
@@ -510,6 +510,238 @@ function resolvePointer(document, ref) {
   return current;
 }
 
+const MCP_DISCOVERY_ROOT_CONSTRAINTS = [
+  'allOf',
+  'anyOf',
+  'oneOf',
+  'not',
+  'if',
+  'then',
+  'else',
+];
+
+function collectRootConstraintPropertyNames(schema) {
+  const propertyNames = new Set();
+
+  function visit(node) {
+    if (!node || typeof node !== 'object' || Array.isArray(node)) return;
+    if (Array.isArray(node.required)) {
+      for (const name of node.required) {
+        if (typeof name === 'string') propertyNames.add(name);
+      }
+    }
+    if (node.properties && typeof node.properties === 'object' && !Array.isArray(node.properties)) {
+      for (const name of Object.keys(node.properties)) propertyNames.add(name);
+    }
+    for (const keyword of MCP_DISCOVERY_ROOT_CONSTRAINTS) {
+      const value = node[keyword];
+      if (Array.isArray(value)) value.forEach(visit);
+      else visit(value);
+    }
+  }
+
+  for (const keyword of MCP_DISCOVERY_ROOT_CONSTRAINTS) {
+    const value = schema[keyword];
+    if (Array.isArray(value)) value.forEach(visit);
+    else visit(value);
+  }
+  return propertyNames;
+}
+
+function rootConstraintDescriptions(schema, propertyNames) {
+  return new Map([...propertyNames].flatMap(name => {
+    const description = schema.properties?.[name]?.description;
+    return typeof description === 'string' ? [[name, description]] : [];
+  }));
+}
+
+function restoreRootConstraintDescriptions(schema, descriptions) {
+  for (const [name, description] of descriptions) {
+    const property = schema.properties?.[name];
+    if (property && typeof property === 'object' && !Array.isArray(property)) {
+      property.description = description;
+    }
+  }
+  return schema;
+}
+
+function uniqueSchemas(schemas) {
+  const seen = new Set();
+  return schemas.filter(schema => {
+    const key = JSON.stringify(schema);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function combinePropertySchemas(schemas, keyword) {
+  const unique = uniqueSchemas(schemas);
+  if (unique.length === 1) return clone(unique[0]);
+  return { [keyword]: clone(unique) };
+}
+
+function directObjectSurface(schema, root, seenRefs = new Set()) {
+  const propertyCandidates = new Map();
+  const required = new Set();
+
+  function collect(node, refs) {
+    if (!node || typeof node !== 'object' || Array.isArray(node)) return;
+    if (typeof node.$ref === 'string') {
+      if (!refs.has(node.$ref)) {
+        const target = resolvePointer(root, node.$ref);
+        if (!target || typeof target !== 'object' || Array.isArray(target)) {
+          throw new Error(`MCP discovery object branch does not resolve: ${node.$ref}`);
+        }
+        collect(target, new Set([...refs, node.$ref]));
+      }
+    }
+    if (node.properties && typeof node.properties === 'object' && !Array.isArray(node.properties)) {
+      for (const [name, propertySchema] of Object.entries(node.properties)) {
+        if (!propertyCandidates.has(name)) propertyCandidates.set(name, []);
+        propertyCandidates.get(name).push(propertySchema);
+      }
+    }
+    if (Array.isArray(node.required)) {
+      for (const name of node.required) required.add(name);
+    }
+    if (Array.isArray(node.allOf)) {
+      for (const branch of node.allOf) collect(branch, refs);
+    }
+  }
+
+  collect(schema, seenRefs);
+  return {
+    properties: Object.fromEntries([...propertyCandidates].map(([name, candidates]) => [
+      name,
+      combinePropertySchemas(candidates, 'allOf'),
+    ])),
+    required,
+  };
+}
+
+function unionObjectSurface(branches, root) {
+  const surfaces = branches.map(branch => directObjectSurface(branch, root));
+  const propertyNames = new Set();
+  for (const surface of surfaces) {
+    for (const name of Object.keys(surface.properties)) propertyNames.add(name);
+  }
+  const required = surfaces.length === 0
+    ? new Set()
+    : new Set([...surfaces[0].required].filter(name => (
+      surfaces.every(surface => surface.required.has(name))
+    )));
+  return {
+    properties: Object.fromEntries([...propertyNames].map(name => [
+      name,
+      combinePropertySchemas(surfaces.map(surface => (
+        Object.hasOwn(surface.properties, name) ? surface.properties[name] : {}
+      )), 'anyOf'),
+    ])),
+    required,
+  };
+}
+
+function mergeDiscoverySurface(projected, surface, propertyKeyword) {
+  projected.properties ||= {};
+  for (const [name, propertySchema] of Object.entries(surface.properties)) {
+    if (!Object.hasOwn(projected.properties, name)) {
+      projected.properties[name] = propertyKeyword
+        ? combinePropertySchemas([propertySchema], propertyKeyword)
+        : clone(propertySchema);
+    }
+  }
+  const required = new Set(Array.isArray(projected.required) ? projected.required : []);
+  for (const name of surface.required) required.add(name);
+  if (required.size > 0) projected.required = [...required];
+}
+
+/**
+ * Project a canonical request schema into an MCP tools/list discovery hint.
+ *
+ * Anthropic rejects tool input schemas with root allOf/anyOf/oneOf. The wire
+ * schema remains authoritative at call time, so this host-facing view:
+ *   1. inlines the optional version-envelope properties;
+ *   2. drops root conditionals and negations that cannot be expressed safely;
+ *   3. leaves every nested combinator intact.
+ *
+ * Do not use this projection for canonical request validation.
+ */
+function projectMcpDiscoveryInputSchemaWithGuidance(schema) {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema) || schema.type !== 'object') {
+    throw new Error('MCP discovery input schemas must have an object root');
+  }
+
+  const projected = clone(schema);
+  const rootConstraintProperties = collectRootConstraintPropertyNames(projected);
+  const allOfPropertyCandidates = new Map();
+  const allOfRequired = new Set();
+  for (const branch of projected.allOf || []) {
+    if (!branch || typeof branch !== 'object' || Array.isArray(branch)) continue;
+    if (typeof branch.$ref === 'string' && branch.$ref.includes('version-envelope.json')) {
+      const envelope = resolvePointer(projected, branch.$ref);
+      if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)) {
+        throw new Error(`MCP discovery version envelope does not resolve: ${branch.$ref}`);
+      }
+      const envelopeProperties = envelope.properties;
+      if (!envelopeProperties || typeof envelopeProperties !== 'object' || Array.isArray(envelopeProperties)) {
+        throw new Error(`MCP discovery version envelope has no properties: ${branch.$ref}`);
+      }
+      for (const name of Object.keys(envelopeProperties)) rootConstraintProperties.add(name);
+      projected.properties = {
+        ...clone(envelopeProperties),
+        ...(projected.properties || {}),
+      };
+      continue;
+    }
+
+    const surface = directObjectSurface(branch, projected);
+    for (const [name, propertySchema] of Object.entries(surface.properties)) {
+      rootConstraintProperties.add(name);
+      if (!allOfPropertyCandidates.has(name)) allOfPropertyCandidates.set(name, []);
+      allOfPropertyCandidates.get(name).push(propertySchema);
+    }
+    for (const name of surface.required) allOfRequired.add(name);
+    for (const keyword of ['anyOf', 'oneOf']) {
+      if (!Array.isArray(branch[keyword])) continue;
+      const unionSurface = unionObjectSurface(branch[keyword], projected);
+      for (const [name, propertySchema] of Object.entries(unionSurface.properties)) {
+        rootConstraintProperties.add(name);
+        if (!allOfPropertyCandidates.has(name)) allOfPropertyCandidates.set(name, []);
+        allOfPropertyCandidates.get(name).push(propertySchema);
+      }
+      for (const name of unionSurface.required) allOfRequired.add(name);
+    }
+  }
+
+  mergeDiscoverySurface(projected, {
+    properties: Object.fromEntries([...allOfPropertyCandidates].map(([name, candidates]) => [
+      name,
+      combinePropertySchemas(candidates, 'allOf'),
+    ])),
+    required: allOfRequired,
+  });
+  for (const keyword of ['anyOf', 'oneOf']) {
+    if (Array.isArray(projected[keyword])) {
+      mergeDiscoverySurface(projected, unionObjectSurface(projected[keyword], projected));
+    }
+  }
+
+  for (const keyword of MCP_DISCOVERY_ROOT_CONSTRAINTS) delete projected[keyword];
+  // A discriminator is only meaningful alongside its root oneOf. Leaving it
+  // behind makes otherwise-permissive validators such as Ajv reject the schema
+  // at compile time after the discovery-only oneOf is removed.
+  delete projected.discriminator;
+  return {
+    schema: projected,
+    rootConstraintProperties,
+  };
+}
+
+function projectMcpDiscoveryInputSchema(schema) {
+  return projectMcpDiscoveryInputSchemaWithGuidance(schema).schema;
+}
+
 function assertLocalRefsResolve(schema) {
   let count = 0;
   walkSchema(schema, node => {
@@ -595,12 +827,28 @@ function projectSourceSchema(
   relativePath,
   annotationMode = 'full',
   schemaUrlPrefix = `${urlVersion}/mcp/${MCP_PROTOCOL_VERSION}`,
+  discoveryInput = false,
 ) {
   const compact = compactDraft07Schema(schema, rootFile, sourceDir);
   let projected = projectDraft07Node(compact);
+  let discoveryDescriptions = new Map();
+  let discoveryRootDescription;
+  if (discoveryInput) {
+    const discovery = projectMcpDiscoveryInputSchemaWithGuidance(projected);
+    discoveryRootDescription = discovery.schema.description;
+    discoveryDescriptions = rootConstraintDescriptions(
+      discovery.schema,
+      discovery.rootConstraintProperties,
+    );
+    projected = discovery.schema;
+  }
   if (annotationMode === 'structural') projected = stripPresentationAnnotations(projected);
   else if (annotationMode === 'model-context') projected = stripModelContextAnnotations(projected);
   else if (annotationMode !== 'full') throw new Error(`Unknown annotation mode ${JSON.stringify(annotationMode)}`);
+  if (discoveryInput && annotationMode !== 'model-context') {
+    restoreRootConstraintDescriptions(projected, discoveryDescriptions);
+    if (typeof discoveryRootDescription === 'string') projected.description = discoveryRootDescription;
+  }
   projected.$schema = JSON_SCHEMA_2020_12;
   projected.$id = `${SCHEMA_ORIGIN}/schemas/${schemaUrlPrefix}/${relativePath}`;
   if (annotationMode === 'model-context') {
@@ -746,7 +994,7 @@ function generateMcpSchemaProjection({
   }
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
   const projectedTools = {};
-  const generated = new Set();
+  const generated = new Map();
   let schemaCount = 0;
   let totalBytes = 0;
   let largestSchemaBytes = 0;
@@ -754,12 +1002,19 @@ function generateMcpSchemaProjection({
   fs.rmSync(targetDir, { recursive: true, force: true });
   fs.mkdirSync(targetDir, { recursive: true });
 
-  function projectSchema(relativePath, label = relativePath) {
+  function projectSchema(relativePath, label = relativePath, discoveryInput = false) {
     const sourcePath = path.join(sourceDir, relativePath);
     if (!fs.existsSync(sourcePath)) {
       throw new Error(`Missing source schema for ${label}: ${relativePath}`);
     }
-    if (generated.has(relativePath)) return;
+    if (generated.has(relativePath)) {
+      if (generated.get(relativePath) !== discoveryInput) {
+        throw new Error(
+          `${relativePath} cannot be both an MCP discovery input and a semantics-preserving output`
+        );
+      }
+      return;
+    }
 
     const sourceSchema = JSON.parse(fs.readFileSync(sourcePath, 'utf8'));
     let projectedSchema;
@@ -772,6 +1027,7 @@ function generateMcpSchemaProjection({
         relativePath,
         annotationMode,
         schemaUrlPrefix,
+        discoveryInput,
       );
     } catch (error) {
       throw new Error(`${relativePath}: ${error.message}`);
@@ -781,7 +1037,7 @@ function generateMcpSchemaProjection({
     totalBytes += bytes;
     largestSchemaBytes = Math.max(largestSchemaBytes, bytes);
     schemaCount++;
-    generated.add(relativePath);
+    generated.set(relativePath, discoveryInput);
   }
 
   for (const [toolName, tool] of Object.entries(manifest.tools || {})) {
@@ -794,7 +1050,7 @@ function generateMcpSchemaProjection({
       ['inputSchema', tool.request_schema],
       ['outputSchema', tool.response_schema],
     ].filter(([field]) => schemaFields.includes(field))) {
-      projectSchema(relativePath, `${toolName}.${field}`);
+      projectSchema(relativePath, `${toolName}.${field}`, field === 'inputSchema');
       projectedTool[field] = relativePath;
     }
     projectedTools[toolName] = projectedTool;
@@ -821,8 +1077,8 @@ function generateMcpSchemaProjection({
     mcp_protocol_version: MCP_PROTOCOL_VERSION,
     schema_dialect: JSON_SCHEMA_2020_12,
     source_schema_dialect: JSON_SCHEMA_DRAFT_07,
-    compatibility: 'semantics-preserving projection; no 4.0 strictness rules applied',
-    delivery: 'downloadable schema artifacts; servers choose which schemas to embed in tools/list',
+    compatibility: 'host-compatible discovery inputs with canonical call-time validation; semantics-preserving outputs',
+    delivery: 'downloadable schema artifacts; inputSchema is a tools/list hint and canonical wire schemas remain authoritative',
     annotation_mode: annotationMode,
     schema_fields: schemaFields,
     ...(taskResultResolution ? { task_result_resolution: taskResultResolution } : {}),
@@ -854,6 +1110,7 @@ module.exports = {
   enforceSchemaBounds,
   generateMcpSchemaProjection,
   measureSchema,
+  projectMcpDiscoveryInputSchema,
   projectDraft07Node,
   projectSourceSchema,
   selectRuntimeToolNames,

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -13707,6 +13707,21 @@ describe('proposal lifecycle', () => {
     return finalized.proposal as Record<string, unknown>;
   }
 
+  it('returns structured INVALID_REQUEST when canonical root constraints reject a discovery-valid call', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result, isError } = await simulateCallTool(server, 'request_proposals', {
+      idempotency_key: 'discovery-root-deferral-0001',
+      brief: 'social engagement display',
+    });
+
+    expect(isError).toBe(true);
+    expect(result).toMatchObject({
+      code: 'INVALID_REQUEST',
+      field: 'brand',
+      recovery: 'correctable',
+    });
+  });
+
   it('serializes concurrent proposal requests without losing returned snapshots', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const requests = await Promise.all([

--- a/static/schemas/source/creative/sync-creatives-request.json
+++ b/static/schemas/source/creative/sync-creatives-request.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/creative/sync-creatives-request.json",
   "title": "Sync Creatives Request",
-  "description": "Request parameters for syncing creative assets with upsert semantics - supports bulk operations, scoped updates, and assignment management",
+  "description": "Request parameters for syncing creative assets with upsert semantics. Provide at least one of creatives, assignments, or assignment_operations. assignments and assignment_operations are mutually exclusive; delete_missing: true requires creatives; assignment_operations requires validation_mode: strict.",
   "x-tool-summary": "List or synchronize creative assets, scoped updates, and media-buy assignments.",
   "type": "object",
   "allOf": [

--- a/static/schemas/source/media-buy/buy-products-request.json
+++ b/static/schemas/source/media-buy/buy-products-request.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/media-buy/buy-products-request.json",
   "title": "Buy Products Request",
-  "description": "Create a MediaBuy directly from published product offers. This buyer-composed path accepts published commercial terms, supports targeting and delivery controls, and never accepts inline creatives or creative assignments. The seller records an immutable accepted proposal snapshot so later commercial amendments can use refine_proposals.",
+  "description": "Create a MediaBuy directly from published product offers. Provide exactly one brand source: top-level brand when account is ID-only, or brand and operator inside a natural-key account. This buyer-composed path accepts published commercial terms, supports targeting and delivery controls, and never accepts inline creatives or creative assignments. The seller records an immutable accepted proposal snapshot so later commercial amendments can use refine_proposals.",
   "x-tool-summary": "Create a media buy directly from published seller products and record its accepted commercial snapshot.",
   "type": "object",
   "x-mutates-state": true,
@@ -28,7 +28,8 @@
       "description": "Execution account. A natural-key account is the single brand source and MUST NOT be combined with top-level brand."
     },
     "brand": {
-      "$ref": "/schemas/core/brand-key.json"
+      "$ref": "/schemas/core/brand-key.json",
+      "description": "Brand source required when account is ID-only. Omit when account already contains brand and operator."
     },
     "advertiser_industry": {
       "$ref": "/schemas/enums/advertiser-industry.json",

--- a/static/schemas/source/media-buy/control-media-buy-request.json
+++ b/static/schemas/source/media-buy/control-media-buy-request.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/media-buy/control-media-buy-request.json",
   "title": "Control Media Buy Request",
-  "description": "Apply operational delivery controls inside the MediaBuy's accepted proposal envelope. Sellers return REQUOTE_REQUIRED when budget, targeting, or another control would change the commercial envelope; the buyer then forks the accepted proposal through refine_proposals. Creative mutation, new products/packages, flight changes, pricing changes, and billing-term changes are not accepted here.",
+  "description": "Apply operational delivery controls inside the MediaBuy's accepted proposal envelope. Provide at least one control field. cancellation_reason requires canceled: true; cancellation is mutually exclusive with every other control. Sellers return REQUOTE_REQUIRED when budget, targeting, or another control would change the commercial envelope; the buyer then forks the accepted proposal through refine_proposals. Creative mutation, new products/packages, flight changes, pricing changes, and billing-term changes are not accepted here.",
   "x-tool-summary": "Pause, resume, cancel, or adjust delivery controls without changing accepted commercial terms.",
   "type": "object",
   "x-mutates-state": true,

--- a/static/schemas/source/media-buy/create-media-buy-request.json
+++ b/static/schemas/source/media-buy/create-media-buy-request.json
@@ -80,7 +80,7 @@
     "proposal_id": {
       "type": "string",
       "x-entity": "proposal",
-      "description": "ID of the exact committed proposal snapshot to execute. With total_budget, the publisher creates packages using the proposal's fixed percentages or seller-optimized constraints. Alternative to providing packages. AdCP 3.2 request_proposals and ordinary refine_proposals revisions issue drafts; refine_proposals action finalize creates the executable committed hold. Sellers reject draft, declined, or previously executed snapshots, while exact retries with the original idempotency key replay historical success. Changed commercial terms are issued under a new proposal_id, so no separate proposal version is required."
+      "description": "ID of the exact committed proposal snapshot to execute. With total_budget, the publisher creates packages using the proposal's fixed percentages or seller-optimized constraints. Mutually exclusive: provide packages or proposal_id, not both. AdCP 3.2 request_proposals and ordinary refine_proposals revisions issue drafts; refine_proposals action finalize creates the executable committed hold. Sellers reject draft, declined, or previously executed snapshots, while exact retries with the original idempotency key replay historical success. Changed commercial terms are issued under a new proposal_id, so no separate proposal version is required."
     },
     "opportunity": {
       "allOf": [
@@ -139,7 +139,7 @@
     },
     "packages": {
       "type": "array",
-      "description": "Array of package configurations. Required when not using proposal_id. Fixed allocation requires budget on every package. Seller-optimized allocation permits package budget to be omitted or to act as a hard cap. When executing a proposal, omit packages; the seller derives them from the committed proposal.",
+      "description": "Array of package configurations. Required when not using proposal_id. Mutually exclusive: provide packages or proposal_id, not both. Fixed allocation requires budget on every package. Seller-optimized allocation permits package budget to be omitted or to act as a hard cap. When executing a proposal, omit packages; the seller derives them from the committed proposal.",
       "items": {
         "$ref": "/schemas/media-buy/package-request.json"
       },

--- a/static/schemas/source/media-buy/list-products-request.json
+++ b/static/schemas/source/media-buy/list-products-request.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/media-buy/list-products-request.json",
   "title": "List Products Request",
-  "description": "Read seller offers with structured discovery criteria. Each invocation completes synchronously, while durable wholesale product-feed webhooks registered through sync_accounts keep buyer mirrors current without polling. list_products is the authoritative bootstrap and repair read for those subscriptions; proposal creation is handled by request_proposals.",
+  "description": "Read seller offers with structured discovery criteria. When criteria includes catalog, provide exactly one brand source: top-level brand or a natural-key account containing brand and operator. Each invocation completes synchronously, while durable wholesale product-feed webhooks registered through sync_accounts keep buyer mirrors current without polling. list_products is the authoritative bootstrap and repair read for those subscriptions; proposal creation is handled by request_proposals.",
   "x-tool-summary": "List seller products that match structured discovery criteria.",
   "type": "object",
   "x-operation-family": "list_products",

--- a/static/schemas/source/media-buy/request-proposals-request.json
+++ b/static/schemas/source/media-buy/request-proposals-request.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/media-buy/request-proposals-request.json",
   "title": "Request Proposals Request",
-  "description": "Ask a seller to create one or more indicative media-plan proposals from a brief. Each returned proposal_id identifies one immutable draft snapshot; revise or finalize it through refine_proposals, or decline it through decline_proposals.",
+  "description": "Ask a seller to create one or more indicative media-plan proposals from a brief. Provide exactly one brand source: either top-level brand or a natural-key account containing brand and operator. Each returned proposal_id identifies one immutable draft snapshot; revise or finalize it through refine_proposals, or decline it through decline_proposals.",
   "x-tool-summary": "Ask a seller to create one or more draft media-plan proposals from a campaign brief.",
   "type": "object",
   "x-mutates-state": true,
@@ -31,9 +31,12 @@
     },
     "account": {
       "allOf": [{ "$ref": "/schemas/core/canonical-account-ref.json" }],
-      "description": "Account scope for proposal terms. A natural-key account is the single brand source and MUST NOT be combined with top-level brand."
+      "description": "Alternative brand source for proposal terms. Provide either this natural-key account containing brand and operator or top-level brand, not both."
     },
-    "brand": { "$ref": "/schemas/core/brand-key.json" },
+    "brand": {
+      "$ref": "/schemas/core/brand-key.json",
+      "description": "Alternative brand source for proposal terms. Provide either top-level brand or a natural-key account containing brand and operator, not both."
+    },
     "brief": {
       "type": "string",
       "minLength": 1,

--- a/tests/mcp-schema-projection.test.cjs
+++ b/tests/mcp-schema-projection.test.cjs
@@ -31,6 +31,7 @@ const {
   compactDraft07Schema,
   measureSchema,
   projectDraft07Node,
+  projectMcpDiscoveryInputSchema,
   selectRuntimeToolNames,
   stripPresentationAnnotations,
   stripModelContextAnnotations,
@@ -309,6 +310,119 @@ test('draft-07 and 2020-12 validators preserve high-risk conversion boundaries',
   }
 });
 
+test('MCP discovery inputs inline version fields and drop only root constraints', () => {
+  const versionRef = '#/$defs/external:core~1version-envelope.json';
+  const source = {
+    type: 'object',
+    properties: {
+      packages: {
+        type: 'array',
+        description: 'Provide packages or proposal_id, not both.',
+        items: {
+          oneOf: [{ type: 'string' }, { type: 'number' }],
+        },
+      },
+      proposal_id: {
+        type: 'string',
+        description: 'Provide proposal_id or packages, not both.',
+      },
+    },
+    allOf: [
+      { $ref: versionRef },
+      {
+        type: 'object',
+        properties: { account: { type: 'string' } },
+        required: ['account'],
+      },
+      { not: { required: ['packages', 'proposal_id'] } },
+      { if: { required: ['proposal_id'] }, then: { required: ['total_budget'] } },
+    ],
+    anyOf: [{ required: ['packages'] }, { required: ['proposal_id'] }],
+    discriminator: { propertyName: 'mode' },
+    not: { required: ['legacy_field'] },
+    $defs: {
+      'external:core/version-envelope.json': {
+        type: 'object',
+        properties: {
+          adcp_version: { type: 'string', description: 'Optional release pin.' },
+          adcp_major_version: { type: 'integer', description: 'Optional legacy major pin.' },
+        },
+      },
+    },
+  };
+
+  const projected = projectMcpDiscoveryInputSchema(source);
+  assert.equal(projected.type, 'object');
+  assert.deepEqual(
+    Object.keys(projected.properties).slice(0, 2),
+    ['adcp_version', 'adcp_major_version']
+  );
+  assert.ok(!projected.required?.includes('adcp_version'));
+  assert.ok(!projected.required?.includes('adcp_major_version'));
+  assert.equal(projected.properties.account.type, 'string');
+  assert.ok(projected.required.includes('account'));
+  for (const keyword of ['allOf', 'anyOf', 'oneOf', 'not', 'if', 'then', 'else']) {
+    assert.equal(projected[keyword], undefined, `root ${keyword} must be omitted`);
+  }
+  assert.equal(projected.discriminator, undefined);
+  assert.deepEqual(projected.properties.packages.items.oneOf, [
+    { type: 'string' },
+    { type: 'number' },
+  ]);
+});
+
+test('MCP discovery recurses through allOf and remains permissive across union branches', () => {
+  const canonical = {
+    type: 'object',
+    allOf: [{
+      allOf: [{
+        properties: { nested_value: { type: 'string' } },
+        required: ['nested_value'],
+      }],
+    }],
+    anyOf: [{
+      properties: { choice_a: { type: 'string' } },
+      required: ['choice_a'],
+    }, {
+      properties: { choice_b: { type: 'number' } },
+      required: ['choice_b'],
+    }],
+  };
+  const projected = projectMcpDiscoveryInputSchema(canonical);
+  const canonicalValidMixedBranch = {
+    nested_value: 'present',
+    choice_a: 7,
+    choice_b: 1,
+  };
+
+  assert.equal(projected.properties.nested_value.type, 'string');
+  assert.ok(projected.required.includes('nested_value'));
+  assert.deepEqual(projected.properties.choice_a.anyOf, [{ type: 'string' }, {}]);
+  assert.deepEqual(projected.properties.choice_b.anyOf, [{}, { type: 'number' }]);
+  assert.equal(createValidator(AjvDraft07).compile(canonical)(canonicalValidMixedBranch), true);
+  assert.equal(createValidator(Ajv2020).compile(projected)(canonicalValidMixedBranch), true);
+});
+
+test('MCP discovery defers omitted root constraints to canonical call validation', () => {
+  const profileDir = path.join(PROJECTION_DIR, 'profiles', 'media-buy');
+  const manifest = readJson(path.join(profileDir, 'manifest.json'));
+  const projected = readJson(path.join(
+    profileDir,
+    manifest.tools.request_proposals.inputSchema
+  ));
+  const sourcePath = path.join(SOURCE_DIR, 'media-buy', 'request-proposals-request.json');
+  const canonical = compactDraft07Schema(readJson(sourcePath), sourcePath, SOURCE_DIR);
+  const discoveryValidCanonicalInvalid = {
+    idempotency_key: 'discovery-root-deferral-0001',
+    brief: 'Reach relevant buyers',
+  };
+
+  const validateDiscovery = createValidator(Ajv2020).compile(projected);
+  const validateCanonical = createValidator(AjvDraft07).compile(canonical);
+  assert.equal(validateDiscovery(discoveryValidCanonicalInvalid), true);
+  assert.equal(validateCanonical(discoveryValidCanonicalInvalid), false);
+});
+
 test('projection rewrites only definitions keyword segments in local refs', () => {
   const projected = projectDraft07Node({
     $schema: 'http://json-schema.org/draft-07/schema#',
@@ -500,6 +614,7 @@ test('generated MCP projection covers every tool within AdCP safety bounds', () 
   assert.equal(projectionManifest.mcp_protocol_version, MCP_PROTOCOL_VERSION);
   assert.equal(projectionManifest.schema_dialect, JSON_SCHEMA_2020_12);
   assert.equal(projectionManifest.annotation_mode, 'full');
+  assert.equal(projectionManifest.canonical_wire_manifest, '../../manifest.json');
   assert.deepEqual(projectionManifest.schema_fields, ['inputSchema', 'outputSchema']);
   assert.match(projectionManifest.delivery, /downloadable schema artifacts/);
   assert.deepEqual(canonicalManifest.task_result_resolution, {
@@ -614,6 +729,31 @@ test('generated MCP projection covers every tool within AdCP safety bounds', () 
       `${compatibilityTool} must be absent from the clean 3.2 production profile`
     );
   }
+  const createMediaBuyInput = readJson(path.join(
+    PROJECTION_DIR,
+    projectionManifest.tools.create_media_buy.inputSchema
+  ));
+  assert.match(createMediaBuyInput.properties.packages.description, /Mutually exclusive.*packages or proposal_id/);
+  assert.match(createMediaBuyInput.properties.proposal_id.description, /Mutually exclusive.*packages or proposal_id/);
+  const verifyBrandClaimInput = readJson(path.join(
+    PRODUCTION_PROFILE_DIR,
+    productionManifest.tools.verify_brand_claim.inputSchema
+  ));
+  assert.deepEqual(
+    Object.keys(verifyBrandClaimInput.properties).sort(),
+    ['adcp_major_version', 'adcp_version', 'claim', 'claim_type']
+  );
+  assert.deepEqual(verifyBrandClaimInput.required, ['claim_type', 'claim']);
+  assert.equal(verifyBrandClaimInput.properties.claim_type.anyOf.length, 4);
+  assert.equal(verifyBrandClaimInput.properties.claim.anyOf.length, 4);
+  const performanceFeedbackInput = readJson(path.join(
+    PRODUCTION_PROFILE_DIR,
+    productionManifest.tools.provide_performance_feedback.inputSchema
+  ));
+  for (const property of ['media_buy_id', 'measurement_period', 'performance_index']) {
+    assert.ok(performanceFeedbackInput.properties[property], property);
+    assert.ok(performanceFeedbackInput.required.includes(property), property);
+  }
 
   const projectedListProductsOutput = readJson(path.join(
     PROJECTION_DIR,
@@ -691,6 +831,13 @@ test('generated MCP projection covers every tool within AdCP safety bounds', () 
 
       if (field === 'inputSchema') {
         assert.equal(projectedSchema.type, 'object', `${toolName} inputSchema must have an object root`);
+        for (const keyword of ['allOf', 'anyOf', 'oneOf']) {
+          assert.equal(
+            projectedSchema[keyword],
+            undefined,
+            `${toolName} inputSchema must not expose root ${keyword}`
+          );
+        }
       }
 
       const fixtures = storyboardFixtures.get(relativePath);
@@ -783,6 +930,8 @@ test('generated production profile exposes the active 3.2 surface without compli
   assert.equal(profile.profile, 'production');
   assert.equal(profile.surface_version, '3.2.0');
   assert.equal(profile.annotation_mode, 'structural');
+  assert.equal(profile.complete_discovery_projection, '../../manifest.json');
+  assert.equal(profile.canonical_wire_manifest, '../../../../manifest.json');
   assert.deepEqual(profile.filters, {
     exclude_protocols: ['compliance'],
     exclude_deprecated: true,
@@ -883,6 +1032,9 @@ test('representative capability-selected media-buy runtime exposes only selected
     assert.equal(tool.outputSchema, undefined);
     assert.equal(tool.inputSchema.$schema, JSON_SCHEMA_2020_12);
     assert.deepEqual(collectExternalRefs(tool.inputSchema), []);
+    for (const keyword of ['allOf', 'anyOf', 'oneOf']) {
+      assert.equal(tool.inputSchema[keyword], undefined, `${tool.name} exposes root ${keyword}`);
+    }
   }
 
   const storyboardFixtures = collectStoryboardRequestFixtures();
@@ -911,7 +1063,7 @@ test('representative capability-selected media-buy runtime exposes only selected
   assert.ok(parityCases >= 25, `expected at least 25 selected-schema parity cases, saw ${parityCases}`);
 });
 
-test('generated role profiles are active validation catalogs with bounded model-context views', () => {
+test('generated role profiles are host-compatible discovery catalogs with bounded model-context views', () => {
   const canonicalManifest = readJson(path.join(LATEST_DIR, 'manifest.json'));
 
   for (const [profileName, expectedTools] of Object.entries(MCP_ROLE_PROFILE_TOOLS)) {
@@ -930,16 +1082,20 @@ test('generated role profiles are active validation catalogs with bounded model-
       include_tools: expectedTools,
       exclude_deprecated: true,
     });
+    assert.equal(profile.complete_discovery_projection, '../../manifest.json');
+    assert.equal(profile.canonical_wire_manifest, '../../../../manifest.json');
     assert.deepEqual(Object.keys(profile.tools).sort(), [...expectedTools].sort());
 
     assert.equal(modelContext.profile, profileName);
     assert.equal(modelContext.view, 'client-prompt-inputs');
     assert.equal(modelContext.annotation_mode, 'model-context');
-    assert.equal(modelContext.validation_profile, '../manifest.json');
+    assert.equal(modelContext.discovery_profile, '../manifest.json');
     assert.equal(
-      path.resolve(modelContextDir, modelContext.validation_profile),
+      path.resolve(modelContextDir, modelContext.discovery_profile),
       path.join(profileDir, 'manifest.json')
     );
+    assert.equal(modelContext.complete_discovery_projection, '../../../manifest.json');
+    assert.equal(modelContext.canonical_wire_manifest, '../../../../../manifest.json');
     assert.deepEqual(modelContext.schema_fields, ['inputSchema']);
     assert.deepEqual(Object.keys(modelContext.tools).sort(), [...expectedTools].sort());
 
@@ -976,6 +1132,10 @@ test('generated role profiles are active validation catalogs with bounded model-
       assert.equal(modelTool.outputSchema, undefined);
       assert.ok(fs.existsSync(path.join(profileDir, fullTool.inputSchema)));
       assert.ok(fs.existsSync(path.join(profileDir, fullTool.outputSchema)));
+      const discoveryInput = readJson(path.join(profileDir, fullTool.inputSchema));
+      for (const keyword of ['allOf', 'anyOf', 'oneOf']) {
+        assert.equal(discoveryInput[keyword], undefined, `${profileName}.${toolName} exposes root ${keyword}`);
+      }
       const modelInputPath = path.join(modelContextDir, modelTool.inputSchema);
       assert.ok(fs.existsSync(modelInputPath));
       modelContextBytes += Buffer.byteLength(JSON.stringify(readJson(modelInputPath)));


### PR DESCRIPTION
Fixes #6682

## Summary

- project MCP input discovery schemas to plain object roots accepted by strict hosts
- retain canonical Draft 7 request schemas as the call-time validation authority
- preserve useful structural fields from version envelopes, unions, and unconditional `allOf` branches without narrowing the canonical request surface
- document discovery-vs-validation semantics and add repair guidance for constraints that cannot be represented at the root

## Validation

- three independent expert reviews: code, protocol/schema, and adopter workflow
- `npm run test:mcp-schema-projection`
- `npm run test:schemas`
- focused training-agent structured-error test
- full pre-commit suite: 451 files, 6,332 passed, 30 skipped
- TypeScript typecheck
- changeset and push-policy checks

## Compatibility

Generated MCP discovery inputs no longer expose root `allOf`, `anyOf`, `oneOf`, `not`, or conditional keywords. Nested constraints remain intact, and server dispatch continues to validate calls against the unchanged canonical wire schemas.
