### PR TITLE
feat(training): adopt SDK 14 media-buy lifecycle

### DIFF
--- a/.changeset/align-training-sdk14-lifecycle.md
+++ b/.changeset/align-training-sdk14-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Update the public training agent for the SDK 14 media-buy lifecycle while preserving the frozen AdCP 3.0 compatibility surface.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -80,10 +80,15 @@ jobs:
             tenant: signals
             min_clean_storyboards: 74
             min_passing_steps: 111
+          # SDK 14's compact media-buy profile plus the sandbox controller
+          # executes a much broader current-source surface than the legacy
+          # profile. The deprecated create_media_buy probe remains skipped;
+          # native compact lifecycle gates below require nonzero execution.
+          # Observed: 144 clean / 315 passing. +1 buffer for flake tolerance.
           - surface: current
             tenant: sales
-            min_clean_storyboards: 74
-            min_passing_steps: 380
+            min_clean_storyboards: 143
+            min_passing_steps: 314
           - surface: current
             tenant: governance
             min_clean_storyboards: 73
@@ -101,13 +106,13 @@ jobs:
             min_clean_storyboards: 73
             min_passing_steps: 96
           # /si runs through the SDK's first-class SponsoredIntelligencePlatform.
-          # Observed current baseline: 95 clean / 100 passing; floors retain
+          # Observed current baseline: 158 clean / 92 passing; floors retain
           # the matrix's one-count tolerance while required-clean gates below
           # protect both graded SI protocol storyboards directly.
           - surface: current
             tenant: si
-            min_clean_storyboards: 94
-            min_passing_steps: 99
+            min_clean_storyboards: 157
+            min_passing_steps: 91
           - surface: 3.0-compat
             tenant: signals
             min_clean_storyboards: 65
@@ -131,15 +136,15 @@ jobs:
           - surface: 3.0-compat
             tenant: brand
             min_clean_storyboards: 65
-            min_passing_steps: 80
+            min_passing_steps: 78
           # 3.0 predates the sponsored-intelligence specialism enum and its
-          # response projection omits the current offering context output.
-          # Keep the frozen surface as a non-regression floor, not a claim of
-          # current SI conformance. Observed: 63 clean / 85 passing.
+          # response projection therefore omits that newer claim. Keep the
+          # frozen surface as a non-regression floor, not a claim of current
+          # SI specialism conformance. Observed: 64 clean / 78 passing.
           - surface: 3.0-compat
             tenant: si
-            min_clean_storyboards: 62
-            min_passing_steps: 84
+            min_clean_storyboards: 63
+            min_passing_steps: 77
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -327,7 +332,6 @@ jobs:
           required_clean=(
             "media_buy_seller/billing_finality_delivery"
             "media_buy_seller/canonical_formats"
-            "media_buy_seller/vendor_metric_catalog_precondition"
             "canonical_format_validate_input"
             "notification_config_event_scope"
             "notification_config_lifecycle"
@@ -342,6 +346,26 @@ jobs:
             else
               echo "::error::Required-clean storyboard did not pass on /sales current surface: ${storyboard_id}"
               echo "Last matching log lines:"
+              grep -F "${storyboard_id}" /tmp/storyboards.log || true
+              exit 1
+            fi
+          done
+          required_exact=(
+            "media_buy_seller/compact_direct_buy_lifecycle:7:0"
+            "media_buy_seller/compact_product_lifecycle:9:0"
+            "media_buy_seller/declined_proposal_refinement:6:0"
+            "media_buy_seller/declined_proposal_execution:7:1"
+            "media_buy_seller/expired_proposal_execution:7:1"
+          )
+          for requirement in "${required_exact[@]}"; do
+            storyboard_id="${requirement%%:*}"
+            counts="${requirement#*:}"
+            expected_passed="${counts%%:*}"
+            expected_skipped="${counts##*:}"
+            if grep -E "^[[:space:]]+${storyboard_id}[[:space:]]+✓[[:space:]]+${expected_passed}P / ${expected_skipped}S" /tmp/storyboards.log >/dev/null; then
+              echo "Required-exact storyboard passed: ${storyboard_id} (${expected_passed}P / ${expected_skipped}S)"
+            else
+              echo "::error::Required-exact storyboard counts changed on /sales current surface: ${storyboard_id}"
               grep -F "${storyboard_id}" /tmp/storyboards.log || true
               exit 1
             fi

--- a/docs/media-buy/product-discovery/proposal-negotiation.mdx
+++ b/docs/media-buy/product-discovery/proposal-negotiation.mdx
@@ -455,13 +455,114 @@ Record the authenticated buyer, source IDs, successor IDs, idempotency fingerpri
 
 The canonical compliance scenario is `media_buy_seller/typed_proposal_negotiation`. It exercises capability gating, satisfied and unsatisfied constraints, alternatives, immutable lineage, finalize atomicity, exact replay, acceptance, amendment, cancellation, double-finalize rejection, and multi-source ordering.
 
-The deterministic training profiles use the proposal-negotiation primitives published in `@adcp/sdk` 13.0.0. The ordinary `/sales/mcp` route remains the backward-compatible ask-only seller. Use the [public test token](/docs/quickstart#setup) with `https://test-agent.adcontextprotocol.org` and one of these capability-distinct routes:
+The deterministic training profiles expose the exact `3.2-beta.0` proposal-negotiation wire contract. The ordinary `/sales/mcp` route remains the backward-compatible ask-only seller. Use the [public test token](/docs/quickstart#setup) with `https://test-agent.adcontextprotocol.org` and one of these capability-distinct routes:
 
 | Profile | Route | Deterministic behavior |
 | --- | --- | --- |
 | Typed negotiation | `/sales/profiles/typed-negotiation/mcp` | All typed dimensions, up to three alternatives, successful atomic finalize |
 | Constrained seller | `/sales/profiles/constrained-seller/mcp` | USD floors, product conflicts, and at most two available alternatives |
 | Finalization failure | `/sales/profiles/finalization-failure/mcp` | `hold_unavailable` plus `batch_aborted` siblings with no committed successors |
+
+Pin the beta exactly on every call. A stable `3.2` selector intentionally negotiates to the seller's stable compatibility response instead of silently opting into beta behavior. The bundled `ADCPMultiAgentClient.simple()` proposal path cannot yet target a different exact beta ordinal. Until [adcp-client#2609](https://github.com/adcontextprotocol/adcp-client/issues/2609) ships, construct a lower-level client with `wireAdcpVersion: "3.2-beta.0"` or send raw calls as below.
+
+### Run the constrained profile
+
+This live example proves the three-to-two counteroffer and the changed-request retry rule against the public seller. It first requests three alternatives and receives a deterministic `partial` result containing two. It then changes the count to two, uses a new idempotency key, and receives `revised`.
+
+```javascript test=true integration requires-env=ADCP_AUTH_TOKEN
+const endpoint = 'https://test-agent.adcontextprotocol.org/sales/profiles/constrained-seller/mcp';
+const token = process.env.ADCP_AUTH_TOKEN;
+if (!token) throw new Error('Set ADCP_AUTH_TOKEN to the public test token');
+
+function parseRpc(raw) {
+  const dataLine = raw.split(/\r?\n/).find((line) => line.startsWith('data:'));
+  return JSON.parse(dataLine ? dataLine.replace(/^data:\s*/, '') : raw);
+}
+
+async function callTool(id, name, args) {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json, text/event-stream',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    }),
+  });
+  const raw = await response.text();
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${raw.slice(0, 200)}`);
+  }
+  const payload = parseRpc(raw);
+  const result = payload.result?.structuredContent;
+  if (payload.error || !result || result.adcp_error) {
+    throw new Error(JSON.stringify(payload.error ?? result?.adcp_error ?? 'missing structuredContent'));
+  }
+  return result;
+}
+
+const version = {
+  adcp_version: '3.2-beta.0',
+  adcp_major_version: 3,
+};
+const nonce = crypto.randomUUID();
+
+const capabilities = await callTool(1, 'get_adcp_capabilities', version);
+if (
+  capabilities.adcp_version !== '3.2-beta.0'
+  || capabilities.media_buy?.supports_proposals !== true
+  || !capabilities.media_buy?.lifecycle_tools?.includes('refine_proposals')
+) {
+  throw new Error('The seller did not negotiate the proposal profile');
+}
+
+const requested = await callTool(2, 'request_proposals', {
+  ...version,
+  idempotency_key: `docs-request-${nonce}`,
+  brand: { domain: 'acmeoutdoor.example' },
+  brief: 'social engagement display',
+});
+const proposalId = requested.proposals?.[0]?.proposal_id;
+if (!proposalId) throw new Error('The seller returned no source proposal');
+
+const refinement = {
+  proposal_id: proposalId,
+  action: 'revise',
+  constraints: { total_budget: { currency: 'USD', max: 50000 } },
+};
+const partial = await callTool(3, 'refine_proposals', {
+  ...version,
+  idempotency_key: `docs-refine-three-${nonce}`,
+  refinements: [{ ...refinement, alternatives: { count: 3 } }],
+});
+const retried = await callTool(4, 'refine_proposals', {
+  ...version,
+  idempotency_key: `docs-refine-two-${nonce}`,
+  refinements: [{ ...refinement, alternatives: { count: 2 } }],
+});
+
+const first = partial.results?.[0];
+const second = retried.results?.[0];
+if (
+  first?.outcome !== 'partial'
+  || first.reason_code !== 'alternatives_unavailable'
+  || first.proposals?.length !== 2
+  || second?.outcome !== 'revised'
+  || second.proposals?.length !== 2
+) {
+  throw new Error('The public profile did not return the documented outcomes');
+}
+
+console.log({
+  first: { outcome: first.outcome, alternatives: first.proposals.length },
+  retry: { outcome: second.outcome, alternatives: second.proposals.length },
+});
+```
 
 The constrained route is the canonical three-to-two exercise: request a USD 50,000 cap, include and omit products, apply US/Canada criteria, and request three alternatives. Retry the returned `partial` / `alternatives_unavailable` result with two alternatives before selecting and finalizing one. Exact retries reuse the same idempotency key; a changed alternatives count is a new logical request and needs a new key.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.2.0-beta.2",
       "dependencies": {
-        "@adcp/sdk": "13.0.0",
+        "@adcp/sdk": "14.0.0-beta.3",
         "@anthropic-ai/sdk": "^0.117.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.8.3",
@@ -131,9 +131,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-13.0.0.tgz",
-      "integrity": "sha512-Hrqd0wStEQNaY6ehHT1bfOvbSOk2OXNYBt7j+2fVUFmkJqGkfdn1TFucmtTsLlxz6yzD+/wWi6kfD7u5qeEo7A==",
+      "version": "14.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-14.0.0-beta.3.tgz",
+      "integrity": "sha512-Lt0D/3R3nFqpEOa3iGu6t0LMOEJAGcAg6V8WCVFT1V6c5g0+dHjE3r66ViI26H3TebJEltSkMcnpJwqI6WPN0A==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "13.0.0",
+    "@adcp/sdk": "14.0.0-beta.3",
     "@anthropic-ai/sdk": "^0.117.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.8.3",

--- a/scripts/overlay-compliance-cache.sh
+++ b/scripts/overlay-compliance-cache.sh
@@ -56,11 +56,10 @@ if [ "${SRC}" = "dist/compliance/latest" ]; then
   CACHE_VERSION="${PINNED_VERSION:-$(basename "$DST")}"
   SCHEMA_STAGE_DIR=$(mktemp -d -t "adcp-schema-overlay.XXXXXX")
   (cd "dist/schemas/latest" && tar -cf - .) | (cd "$SCHEMA_STAGE_DIR" && tar -xf -)
-  # MCP projections are downloadable JSON Schema 2020-12 artifacts, not part of
-  # the v3 draft-07 SDK validation bundle. The legacy SDK recursively loads this
-  # staging tree, so including mcp/ would make its draft-07 Ajv compile the
-  # projection with the wrong dialect.
-  rm -rf "$SCHEMA_STAGE_DIR/mcp"
+  # SDK 14 resolves compact tools/list schemas from the MCP 2026-07-28 profile
+  # under this bundle. Keep that projection beside the draft-07 validation
+  # schemas; the current loader follows index references for validation and
+  # reads mcp/ only through its dialect-aware discovery path.
   node - <<'NODE' "$SCHEMA_STAGE_DIR" "$CACHE_VERSION"
 const fs = require('node:fs');
 const path = require('node:path');

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -246,18 +246,18 @@ if [ "${FLOOR_SET}" = "3.0-compat" ]; then
     "governance:65:135"
     "creative:65:137"
     "creative-builder:65:121"
-    "brand:65:80"
-    "si:62:84"
+    "brand:65:78"
+    "si:63:77"
   )
 else
   TENANTS=(
     "signals:74:111"
-    "sales:74:380"
+    "sales:143:314"
     "governance:73:151"
     "creative:73:169"
     "creative-builder:70:146"
     "brand:73:96"
-    "si:94:99"
+    "si:157:91"
   )
 fi
 
@@ -266,7 +266,6 @@ SUMMARY=""
 REQUIRED_CLEAN_CURRENT_SALES=(
   "media_buy_seller/billing_finality_delivery"
   "media_buy_seller/canonical_formats"
-  "media_buy_seller/vendor_metric_catalog_precondition"
   "canonical_format_validate_input"
   "notification_config_event_scope"
   "notification_config_lifecycle"
@@ -274,6 +273,13 @@ REQUIRED_CLEAN_CURRENT_SALES=(
   "wholesale_feed_products"
   "wholesale_feed_product_webhooks"
   "wholesale_feed_bulk_webhooks"
+)
+REQUIRED_EXACT_CURRENT_SALES=(
+  "media_buy_seller/compact_direct_buy_lifecycle:7:0"
+  "media_buy_seller/compact_product_lifecycle:9:0"
+  "media_buy_seller/declined_proposal_refinement:6:0"
+  "media_buy_seller/declined_proposal_execution:7:1"
+  "media_buy_seller/expired_proposal_execution:7:1"
 )
 REQUIRED_CLEAN_CURRENT_SIGNALS=(
   "wholesale_feed_signals"
@@ -327,6 +333,21 @@ storyboard_passed() {
       if (found) exit 0
       exit 1
     }
+  ' "${log_file}"
+}
+
+storyboard_executed_exactly() {
+  local storyboard_id="$1"
+  local expected_passed="$2"
+  local expected_skipped="$3"
+  local log_file="$4"
+  awk -v id="${storyboard_id}" -v passed="${expected_passed}" -v skipped="${expected_skipped}" '
+    $0 ~ "^[[:space:]]+" id "([[:space:]]|$)" {
+      pattern = "[[:space:]]✓[[:space:]]+" passed "P / " skipped "S"
+      if ($0 ~ pattern) found = 1
+      exit
+    }
+    END { exit found ? 0 : 1 }
   ' "${log_file}"
 }
 
@@ -385,6 +406,18 @@ for entry in "${TENANTS[@]}"; do
         else
           failed_floor="required-clean ${storyboard_id} did not pass"
         fi
+      fi
+    done
+    for requirement in "${REQUIRED_EXACT_CURRENT_SALES[@]}"; do
+      storyboard_id="${requirement%%:*}"
+      counts="${requirement#*:}"
+      expected_passed="${counts%%:*}"
+      expected_skipped="${counts##*:}"
+      if storyboard_executed_exactly "${storyboard_id}" "${expected_passed}" "${expected_skipped}" "${log}"; then
+        echo "  ✓ required-exact ${storyboard_id} (${expected_passed}P / ${expected_skipped}S)"
+      else
+        status="✗"
+        failed_floor="${failed_floor:+${failed_floor}; }required-exact ${storyboard_id} did not pass ${expected_passed} steps with ${expected_skipped} skips"
       fi
     done
   fi

--- a/server/src/mcp-tools.ts
+++ b/server/src/mcp-tools.ts
@@ -926,7 +926,10 @@ export class MCPToolHandler {
           }], withSdkSafeTransport({}));
           const client = multiClient.agent("query");
 
-          const result = await client.executeTask("get_products", params);
+          const result = await client.executeTask(
+            "get_products",
+            params as unknown as Parameters<typeof client.executeTask<"get_products">>[1],
+          );
 
           if (!result.success) {
             return {

--- a/server/src/training-agent/FRAMEWORK_MIGRATION.md
+++ b/server/src/training-agent/FRAMEWORK_MIGRATION.md
@@ -1,142 +1,90 @@
-# createAdcpServer framework migration — plan and blockers
+# Training-agent SDK framework migration
 
-Status: not started in production code. This document captures the concrete
-blockers and the staged plan that should drive a dedicated migration PR.
+Status: active. The public per-tenant MCP routes are built with the
+`@adcp/sdk` decisioning framework. `task-handlers.ts` remains the shared
+training-domain engine used by the framework adapters and by Addie's in-process
+training calls; it is no longer the public route dispatcher.
 
-## Why migrate
+## Current architecture
 
-The training agent currently uses a hand-rolled MCP dispatch in
-`task-handlers.ts` (~3,300 lines). `@adcp/client` 5.3 ships `createAdcpServer`
-which provides:
+- `tenants/registry.ts` constructs one SDK server registry per public profile.
+- `v6-*-platform.ts` files implement the SDK platform specialisms.
+- `tenants/router.ts` owns authentication, version projection, profile routes,
+  and the stateless HTTP transport.
+- `task-handlers.ts` owns deterministic sandbox state and legacy domain logic.
+  Platform methods call domain handlers directly and translate domain errors to
+  `AdcpError` at the platform boundary.
+- `executeTrainingAgentTool` remains for trusted in-process training flows. It
+  must not be called from an SDK platform method because doing so would create a
+  second idempotency/task-dispatch layer inside the framework-owned one.
 
-- **Native idempotency integration.** `config.idempotency` accepts the
-  `IdempotencyStore` we already instantiate; the framework handles
-  `check()` / `save()` / `release()` around every mutating tool.
-  Eliminates the dispatch-level claim/save state machine in task-handlers.ts.
-- **`ctx.emitWebhook` on handler context.** `config.webhooks = { signerKey }`
-  populates a bound emitter; handlers call `ctx.emitWebhook(...)` without
-  plumbing the emitter through closures.
-- **Auto-wired RFC 9421 verifier.** `config.signedRequests = { jwks, ... }`
-  mounts `preTransport`; the current `request-signing.ts` Express middleware
-  becomes redundant.
-- **`get_adcp_capabilities` auto-generation** from the registered domain
-  handlers — keeps the capability block truthful as tools are added/removed.
-- **Framework-level `context` echo** on every response (success + error).
-- **50%+ LOC reduction** in the core dispatch.
+## AdCP 3.2 media-buy lifecycle
 
-## Blockers that require design decisions before a clean migration
+SDK 14 registers the primary seven-tool lifecycle through
+`TrainingSalesPlatform.mediaBuyLifecycle`:
 
-### 1. Response shape: framework `wrap` vs our envelopes
+- `list_products`
+- `request_proposals`
+- `refine_proposals`
+- `decline_proposals`
+- `buy_products`
+- `accept_proposal`
+- `control_media_buy`
 
-Framework's per-tool `wrap` functions (`mediaBuyResponse`, `updateMediaBuyResponse`, etc.) expect handler return values shaped like the AdCP response DATA (e.g. `{ media_buy_id, status, packages }`). Our handlers already return that shape — so we should be able to remove our hand-rolled envelope wrapping and let the framework do it.
+The four discovery/proposal adapters reuse the deterministic product catalog
+and proposal state machine. The three commitment/control adapters reuse the
+existing media-buy state engine while returning the compact SDK 14 response
+shapes. SDK 14 owns request validation, caller authentication, idempotency,
+and response projection for all seven tools.
 
-**But** `update_media_buy` and any tool that returns `{errors: [...]}` as a well-formed body (the ERROR_IN_BODY pattern) conflicts with the framework's wrap — it would stamp `content: "Media buy undefined updated"` because `data.media_buy_id` is absent. Options:
+Proposal state is partitioned by the SDK-resolved authenticated principal.
+Each proposal record also retains its trusted originating account so
+`accept_proposal` returns `PROPOSAL_NOT_FOUND` for a cross-account attempt
+without disclosing whether the proposal exists.
 
-a) Detect the errors-body case in each handler and return a pre-formatted `McpToolResponse` (framework's `isFormattedResponse` check passes through). This is the safest path.
-b) Refactor error-in-body tools to use `adcpError` envelope, breaking the current `ERROR_IN_BODY_TOOLS` contract. Requires a separate spec check.
+Accepted direct purchases and committed proposals persist an immutable
+canonical proposal snapshot on the media buy. `get_media_buys` returns that
+snapshot and its digest, allowing later amendments and cancellations to bind
+to the exact accepted terms.
 
-Recommended: (a) — wrap only the error-body path per-handler.
+## 3.x compatibility policy
 
-### 2. Type issues in `server.tool()` for custom (non-AdcpToolMap) tools
+The deprecated `SalesPlatform` methods remain registered so explicit 3.0 and
+3.1 calls to `get_products`, `create_media_buy`, and `update_media_buy` keep
+working during the 3.x compatibility window.
 
-For tools outside `AdcpToolMap` (`creative_approval`, `update_rights`, `comply_test_controller`, `validate_property_delivery`, the five collection-list endpoints), registration goes through `McpServer.tool(name, description, zodSchema, handler)`. The `handler` return type is a strict MCP tool response shape that requires `structuredContent: Record<string, unknown>` (not `| undefined`). Our `toMcpResponse` adapter emits `structuredContent` always for success, but never for errors — needs a branch.
+- Default 3.2 discovery advertises the native lifecycle, not the deprecated
+  aliases.
+- 3.0 compatibility registries omit `mediaBuyLifecycle` entirely because SDK
+  proposal negotiation is a 3.2 feature.
+- Capability projection removes lifecycle and proposal-refinement metadata for
+  pre-3.2 callers.
+- The current wire bundle is `3.2-beta.2`; `3.2-beta.0` remains only as the
+  historical feature-introduction boundary for rejected discovery responses.
 
-Also: the framework's `McpServer` comes from the SDK's CJS build while our imports resolve to ESM. These two declarations are structurally identical but TypeScript treats them as distinct (private `_serverInfo` field). The McpServer we return from `createFrameworkTrainingAgentServer` has CJS type; callers using ESM import fail to assign. Fix: either use `as McpServer` cast at the boundary or force the import resolution via `tsconfig` path mapping.
+## Invariants for future changes
 
-### 3. VERSION_UNSUPPORTED enforcement
+1. Platform adapters call domain handlers directly; never recursively dispatch
+   through `executeTrainingAgentTool`.
+2. Mutation identity comes from SDK context (`callerMutationScope`,
+   `proposalRefinementScope`, and resolved account metadata), never buyer input.
+3. Failed mutations must leave revisions and persisted state unchanged.
+4. Compact-to-legacy adapters preserve every accepted commercial term or reject
+   the request before commitment.
+5. Never synthesize package identifiers in a compact response; bind only to IDs
+   returned by the media-buy engine.
+6. Profile capability metadata is construction-time policy. A request or auth
+   extension cannot change the platform's negotiation profile.
+7. Keep the static tenant tool catalog aligned with the SDK's live `tools/list`
+   response and update the drift test with every registration change.
 
-Legacy dispatch rejects unsupported `adcp_major_version` at the request layer (`task-handlers.ts:~3177`). Framework doesn't read this field. Either:
-- Validate in a `preTransport` hook (runs before MCP dispatch)
-- Validate in each handler adapter
-- Accept that unsupported major versions fall through to per-tool Zod validation
+## Required regression coverage
 
-Recommended: preTransport hook (one place, doesn't duplicate per handler).
+Changes to the sales platform should cover:
 
-### 4. `dry_run` short-circuit on task-augmented requests
-
-Legacy dispatch skips task augmentation when `dry_run === true` (`task-handlers.ts:~3196`). The framework's task-capable server flow doesn't know about `dry_run`. Handlers need to short-circuit themselves OR we add a preTransport that rewrites the `task` field to undefined when `dry_run` is set.
-
-### 5. Stateless-HTTP task store workaround
-
-Legacy code uses the RAW task store (not `extra.taskStore`) to avoid `notifications/tasks/status` failing in stateless mode. The framework uses `createTaskCapableServer` which may or may not hit this problem. Needs empirical verification — spin up the framework server, send a task-augmented `create_media_buy`, watch for "fresh transport" failures in logs.
-
-### 6. `resolveIdempotencyPrincipal` threading
-
-The framework's hook receives `(ctx, params, toolName)`. Our `scopedPrincipal(auth, accountScope)` composition needs `accountScope` derived from `params` — easy. But the framework invokes this *before* the handler; the legacy path derived it inline. Verify that `params` at that point is the full un-stripped request (including `account.account_id`).
-
-### 7. AsyncLocalStorage session cache
-
-`runWithSessionContext` / `flushDirtySessions` (in `state.ts`) wrap each HTTP request to give handlers a request-scoped session cache. This is independent of the framework — it lives in the Express route in `index.ts`. The route already does:
-
-```ts
-return runWithSessionContext(async () => {
-  const { result, flushable } = await dispatchCallTool(request, extra);
-  if (flushable) await flushDirtySessions();
-  return result;
-});
-```
-
-Under the framework, the Express route would instead call `transport.handleRequest(...)` and let the framework dispatch. The `runWithSessionContext` wrap still works — it wraps the whole transport call. `flushDirtySessions` needs to run after the framework returns but before the response closes. Doable but needs careful placement.
-
-### 8. Test harness
-
-`simulateCallTool(server, name, args)` in unit tests reaches into `(server as any)._requestHandlers.get('tools/call')` directly. `createAdcpServer` returns `McpServer` which wraps the low-level `Server` at `.server._requestHandlers`. Every test file using this pattern needs updating:
-
-- `server/tests/unit/training-agent.test.ts` (600+ tests)
-- `server/tests/unit/account-handlers.test.ts`
-- `server/tests/unit/comply-test-controller.test.ts`
-- `server/tests/unit/collection-lists-storyboard.test.ts`
-
-Mechanical change but 4 files, high line count.
-
-### 9. `TrainingContext` vs `HandlerContext`
-
-Framework's `HandlerContext` is `{ account, sessionKey, store, authInfo, emitWebhook }`. Our handlers take `TrainingContext` = `{ mode, principal, userId?, moduleId?, trackId?, learnerLevel? }`. A trivial adapter:
-
-```ts
-const trainingCtx: TrainingContext = {
-  mode: 'open',
-  principal: ctx.authInfo?.clientId ?? 'anonymous',
-};
-```
-
-The `mode`/`userId`/`moduleId`/`trackId`/`learnerLevel` fields are only populated in the Addie-embedded path (`executeTrainingAgentTool` in-process usage), not in the MCP route. Keep `executeTrainingAgentTool` unchanged.
-
-### 10. Custom capabilities block
-
-Our `handleGetAdcpCapabilities` returns a bespoke shape with `publisher_domains`, `compliance_testing.scenarios[]`, `request_signing`, etc. The framework auto-generates capabilities from registered tools — useful, but doesn't know about the training-agent-specific fields.
-
-Resolution: override `get_adcp_capabilities` via `server.tool(...)` after `createAdcpServer` returns. Our override wins (McpServer's `.tool()` replaces prior registrations). Straightforward once the `server.tool()` typing issues are resolved (blocker #2).
-
-## Recommended staged plan
-
-1. **PR 1 — infrastructure prep (low risk).**
-   - [x] Export `getWebhookSigningKey()` from `webhooks.ts` (already done).
-   - [ ] Update `simulateCallTool` helper in every test file to traverse both `server._requestHandlers` (legacy) and `server.server._requestHandlers` (McpServer).
-   - [ ] Add a feature flag `TRAINING_AGENT_USE_FRAMEWORK` (default off) in `index.ts`.
-
-2. **PR 2 — scaffold framework server (behind flag).**
-   - [ ] Add `framework-server.ts` with `createFrameworkTrainingAgentServer(ctx)`.
-   - [ ] Resolve type issues in blocker #2 (McpToolResponse nullability, CJS/ESM assignment).
-   - [ ] Wire every domain handler through an `adapt()` helper that produces `McpToolResponse` directly (bypasses framework `wrap`, preserves byte-level response shape).
-   - [ ] Register 9 custom tools (non-AdcpToolMap) via `server.tool(...)`.
-   - [ ] Flag routes `index.ts` to the framework server when set.
-   - [ ] Run the storyboard suite under both paths; diff response shapes for any tool where the framework shape differs.
-
-3. **PR 3 — resolve edge cases (behind flag).**
-   - [ ] VERSION_UNSUPPORTED preTransport.
-   - [ ] dry_run short-circuit.
-   - [ ] Stateless-HTTP task-store verification; use raw store if framework behavior differs.
-   - [ ] Context echo parity check (framework's `injectContextIntoResponse` vs our manual).
-
-4. **PR 4 — flip default + delete legacy.**
-   - [ ] `TRAINING_AGENT_USE_FRAMEWORK=1` becomes default.
-   - [ ] Remove legacy dispatch wrapper, `HANDLER_MAP`, `TOOLS` array from `task-handlers.ts`.
-   - [ ] Delete `request-signing.ts` (framework's `signedRequests` config replaces it).
-   - [ ] Confirm storyboard pass count unchanged or improved.
-
-## Estimated scope
-
-~2-3 days of focused work across 4 PRs. Single-session full migration is not
-realistic without shipping something fragile — the type-system issues alone
-took half a session to diagnose.
+- tool discovery for default 3.2 and explicit 3.0/3.1 compatibility;
+- list -> direct buy -> read -> control, including accepted snapshot readback;
+- request -> refine/finalize -> accept -> read;
+- proposal digest mismatch and cross-account non-disclosure;
+- failed control atomicity (no revision increment or partial package change);
+- tenant tool-catalog drift, typecheck, and the tenant-routing suite.

--- a/server/src/training-agent/account-scope.ts
+++ b/server/src/training-agent/account-scope.ts
@@ -1,7 +1,7 @@
 import type { AccountRef, OperatorUnit } from './types.js';
 
 const ACCOUNT_ID_KEYS = new Set(['account_id']);
-const NATURAL_ACCOUNT_KEYS = new Set(['brand', 'operator', 'operator_unit', 'currency', 'sandbox']);
+const NATURAL_ACCOUNT_KEYS = new Set(['brand', 'operator', 'operator_unit', 'currency', 'timezone', 'sandbox']);
 const BRAND_REF_KEYS = new Set([
   'domain',
   'brand_id',
@@ -27,6 +27,7 @@ export type CanonicalAccountRef =
       operator: string;
       operator_unit?: OperatorUnit;
       currency?: string;
+      timezone?: string;
       sandbox: boolean;
     };
 
@@ -158,6 +159,13 @@ export function canonicalizeAccountRef(value: unknown): CanonicalAccountRef {
     }
     currency = value.currency;
   }
+  let timezone: string | undefined;
+  if (Object.prototype.hasOwnProperty.call(value, 'timezone')) {
+    if (typeof value.timezone !== 'string' || value.timezone.length === 0) {
+      invalid('account.timezone must be a non-empty IANA timezone name.');
+    }
+    timezone = value.timezone;
+  }
   if (value.sandbox !== undefined && typeof value.sandbox !== 'boolean') {
     invalid('account.sandbox must be a boolean when provided.');
   }
@@ -172,6 +180,7 @@ export function canonicalizeAccountRef(value: unknown): CanonicalAccountRef {
     operator,
     ...(operatorUnit !== undefined && { operator_unit: operatorUnit }),
     ...(currency !== undefined && { currency }),
+    ...(timezone !== undefined && { timezone }),
     sandbox: value.sandbox ?? false,
   };
 }
@@ -185,6 +194,7 @@ export function accountScopeFromRef(value: AccountRef | unknown): string {
     operator: account.operator,
     operator_unit_id: account.operator_unit?.id ?? null,
     currency: account.currency ?? null,
+    timezone: account.timezone ?? null,
     sandbox: account.sandbox,
   })}`;
 }

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -43,13 +43,17 @@ import {
   sessionKeyFromArgs,
 } from './state.js';
 import { getAgentUrl } from './config.js';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import {
   getAccountNotificationSubscribers,
   sandboxAccountRefForId,
   seedAccountFixture,
 } from './account-handlers.js';
-import { canonicalizeAccountRef, type CanonicalAccountRef } from './account-scope.js';
+import {
+  accountScopeFromRef,
+  canonicalizeAccountRef,
+  type CanonicalAccountRef,
+} from './account-scope.js';
 import { verifyGovernanceToken, mintRevokedDemoToken, mintWrongAudDemoToken } from './governance-verify.js';
 import { emitAccountNotificationWebhook } from './webhooks.js';
 import { buildCatalog } from './product-factory.js';
@@ -1149,6 +1153,8 @@ const LOCAL_SCENARIOS = [
   'seed_rights_grant',
   'seed_creative_format',
   'seed_measurement_catalog',
+  'compact_product_lifecycle_probe',
+  'compact_direct_buy_lifecycle_probe',
   'query_provenance_audit_observations',
   'evaluate_distributed_brand_resolution',
   'verify_governance_token',
@@ -1158,6 +1164,104 @@ function localScenariosFor(ctx: TrainingContext): string[] {
   return ctx.storyboardCompat?.version === '3.0'
     ? LOCAL_SCENARIOS.filter(s => s !== 'force_creative_purge' && s !== 'force_wholesale_feed_webhook' && s !== 'seed_rights_grant' && s !== 'query_provenance_audit_observations')
     : [...LOCAL_SCENARIOS];
+}
+
+async function handleCompactLifecycleProbe(
+  rawArgs: Record<string, unknown>,
+  ctx: TrainingContext,
+  session: SessionState,
+): Promise<object> {
+  const params = isRecord(rawArgs.params) ? rawArgs.params : {};
+  const operation = params.operation;
+  const productId = typeof params.product_id === 'string' ? params.product_id : undefined;
+  if (operation === 'prepare' && productId) {
+    const seededProduct = session.complyExtensions.seededProducts.get(productId);
+    if (seededProduct && !Array.isArray(seededProduct.allowed_actions)) {
+      seededProduct.allowed_actions = [{ action: 'decrease_budget', modes: ['self_serve'] }];
+    }
+    return {
+      success: true,
+      simulated: { prepared: true, product_id: productId },
+    };
+  }
+  if (rawArgs.scenario !== 'compact_product_lifecycle_probe' || operation !== 'expire_proposal') {
+    return {
+      success: false,
+      error: 'INVALID_PARAMS',
+      error_detail: 'Unsupported compact lifecycle probe operation.',
+    };
+  }
+
+  const proposalId = typeof params.proposal_id === 'string' ? params.proposal_id : undefined;
+  if (!proposalId || !rawArgs.account) {
+    return {
+      success: false,
+      error: 'INVALID_PARAMS',
+      error_detail: 'compact_product_lifecycle_probe expire_proposal requires proposal_id and account.',
+    };
+  }
+
+  let accountId: string;
+  try {
+    const canonical = canonicalizeAccountRef(rawArgs.account);
+    accountId = ctx.proposalRefinementScope?.account_id
+      ?? (ctx.principal?.startsWith('static:')
+        ? 'public_sandbox'
+        : canonical.kind === 'account_id'
+          ? canonical.account_id
+          : `synthetic_${createHash('sha256').update(accountScopeFromRef(rawArgs.account)).digest('hex').slice(0, 32)}`);
+  } catch {
+    return {
+      success: false,
+      error: 'INVALID_PARAMS',
+      error_detail: 'compact lifecycle probe requires a valid account reference.',
+    };
+  }
+
+  const proposalSessionKey = sessionKeyFromArgs(
+    { account: { account_id: accountId } },
+    ctx.mode,
+    ctx.userId,
+    ctx.moduleId,
+    ctx.proposalRefinementScope?.principal_id
+      ?? (ctx.authenticatedAgentUrl ? `agent:${ctx.authenticatedAgentUrl}` : ctx.principal)
+      ?? 'anonymous',
+  );
+  const proposalSession = await getSession(proposalSessionKey);
+  const record = proposalSession.proposalRefinementRecords.get(proposalId);
+  if (!record) {
+    return {
+      success: false,
+      error: 'NOT_FOUND',
+      error_detail: `Proposal not found: ${proposalId}`,
+    };
+  }
+
+  const targetTime = new Date();
+  const expiredAt = new Date(targetTime.getTime() - 1).toISOString();
+  proposalSession.proposalRefinementRecords.set(proposalId, {
+    ...record,
+    version: record.version + 1,
+    proposal: { ...record.proposal, expires_at: expiredAt },
+  });
+  if (proposalSession.lastGetProductsContext?.proposals) {
+    proposalSession.lastGetProductsContext = {
+      ...proposalSession.lastGetProductsContext,
+      proposals: proposalSession.lastGetProductsContext.proposals.map(proposal => (
+        proposal.proposal_id === proposalId
+          ? { ...proposal, expires_at: expiredAt }
+          : proposal
+      )),
+    };
+  }
+  return {
+    success: true,
+    simulated: {
+      expiry_processed: true,
+      proposal_id: proposalId,
+      target_time: targetTime.toISOString(),
+    },
+  };
 }
 
 /**
@@ -1309,7 +1413,11 @@ export async function handleComplyTestController(args: ToolArgs, ctx: TrainingCo
     || (scenario === 'force_upstream_unavailable' && params.tool === 'get_products');
   const targetsControllerFixtureState = scenario === 'seed_product'
     || scenario === 'seed_pricing_option'
-    || scenario === 'seed_measurement_catalog';
+    || scenario === 'seed_measurement_catalog'
+    || (
+      (scenario === 'compact_product_lifecycle_probe' || scenario === 'compact_direct_buy_lifecycle_probe')
+      && params.operation === 'prepare'
+    );
   const targetsPublicTaskState = scenario === 'seed_media_buy'
     || scenario === 'seed_creative';
   // The frozen 3.0 runner injects a synthetic natural account into controller
@@ -1459,6 +1567,9 @@ export async function handleComplyTestController(args: ToolArgs, ctx: TrainingCo
   }
   if (scenario === 'force_task_completion') {
     return handleForceTaskCompletion(sessionKey, rawArgs);
+  }
+  if (scenario === 'compact_product_lifecycle_probe' || scenario === 'compact_direct_buy_lifecycle_probe') {
+    return handleCompactLifecycleProbe(rawArgs, ctx, session);
   }
   if (scenario === 'evaluate_distributed_brand_resolution') {
     const params = isRecord(rawArgs.params) ? rawArgs.params : {};

--- a/server/src/training-agent/governance-handlers.ts
+++ b/server/src/training-agent/governance-handlers.ts
@@ -6,7 +6,7 @@
  * governance schema.
  */
 
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import type {
   TrainingContext,
   ToolArgs,
@@ -20,7 +20,7 @@ import type {
   GovernanceCondition,
   SessionState,
 } from './types.js';
-import type { BrandReference } from '@adcp/sdk';
+import { canonicalize, type BrandReference } from '@adcp/sdk';
 import {
   getSession,
   sessionKeyFromArgs,
@@ -65,10 +65,18 @@ function buildPolicyDecisions(
 const VALID_PURCHASE_TYPES = new Set(['media_buy', 'rights_license', 'signal_activation', 'creative_services']);
 const EXPLICIT_COMMITMENT_TOOLS = new Set([
   'update_media_buy',
+  'buy_products',
+  'accept_proposal',
+  'control_media_buy',
   'acquire_rights',
   'update_rights',
   'activate_signal',
   'build_creative',
+]);
+const INCREMENTAL_COMMITMENT_TOOLS = new Set([
+  'update_media_buy',
+  'accept_proposal',
+  'control_media_buy',
 ]);
 const VALID_OUTCOME_TYPES = new Set(['completed', 'failed', 'delivery']);
 const VALID_ADJUSTMENT_TYPES = new Set<GovernanceAdjustmentType>([
@@ -265,6 +273,7 @@ interface CheckGovernanceInput extends ToolArgs {
   execution_commitment?: { amount: number; currency: string };
   tool?: string;
   payload?: CheckPayload;
+  proposal?: GovernanceCanonicalProposal;
   governance_context?: string;
   consultation_context?: string;
   phase?: string;
@@ -275,7 +284,17 @@ interface CheckGovernanceInput extends ToolArgs {
   modification_summary?: string;
 }
 
+interface GovernanceCanonicalProposal {
+  proposal_id: string;
+  proposal_kind: 'new_media_buy' | 'media_buy_update' | 'media_buy_cancellation';
+  proposal_status: string;
+  commercial_terms: Record<string, unknown>;
+  terms_digest: string;
+}
+
 interface CheckPayload {
+  proposal_id?: string;
+  proposal_terms_digest?: string;
   packages?: Array<{
     package_id?: string;
     budget?: number;
@@ -302,11 +321,97 @@ interface CheckPayload {
   ext?: { governance_policy_acknowledgements?: string[] };
 }
 
+function governanceProposalDigest(commercialTerms: Record<string, unknown>): string {
+  return `sha256:${createHash('sha256').update(canonicalize(commercialTerms)).digest('base64url')}`;
+}
+
+export function governanceProposalCommitment(
+  proposal: Pick<GovernanceCanonicalProposal, 'proposal_kind' | 'commercial_terms'>,
+): { amount?: number; currency?: string } {
+  const terms = proposal.commercial_terms;
+  const cancellationTerms = terms.cancellation_terms;
+  if (proposal.proposal_kind === 'media_buy_cancellation') {
+    if (cancellationTerms && typeof cancellationTerms === 'object' && !Array.isArray(cancellationTerms)) {
+      const fee = (cancellationTerms as Record<string, unknown>).fee;
+      if (fee && typeof fee === 'object' && !Array.isArray(fee)) {
+        const amount = (fee as Record<string, unknown>).amount;
+        const currency = (fee as Record<string, unknown>).currency;
+        if (typeof amount === 'number' && typeof currency === 'string') return { amount, currency };
+      }
+    }
+    return { amount: 0 };
+  }
+  const totalBudget = terms.total_budget;
+  if (totalBudget && typeof totalBudget === 'object' && !Array.isArray(totalBudget)) {
+    const amount = (totalBudget as Record<string, unknown>).amount;
+    const currency = (totalBudget as Record<string, unknown>).currency;
+    if (typeof amount === 'number' && typeof currency === 'string') return { amount, currency };
+  }
+  const purchases = Array.isArray(terms.purchases) ? terms.purchases : [];
+  let amount = 0;
+  let sawBudget = false;
+  let currency: string | undefined;
+  for (const purchase of purchases) {
+    if (!purchase || typeof purchase !== 'object' || Array.isArray(purchase)) continue;
+    const record = purchase as Record<string, unknown>;
+    if (typeof record.budget === 'number') {
+      amount += record.budget;
+      sawBudget = true;
+    }
+    const pricing = record.pricing;
+    if (pricing && typeof pricing === 'object' && !Array.isArray(pricing)) {
+      const candidate = (pricing as Record<string, unknown>).currency;
+      if (typeof candidate === 'string') currency ??= candidate;
+    }
+  }
+  return { ...(sawBudget && { amount }), ...(currency && { currency }) };
+}
+
+function governanceProposalPolicyPayload(
+  payload: CheckPayload,
+  proposal: GovernanceCanonicalProposal,
+): CheckPayload {
+  const terms = proposal.commercial_terms;
+  const countries = new Set<string>();
+  const channels = new Set<string>();
+  for (const purchase of Array.isArray(terms.purchases) ? terms.purchases : []) {
+    if (!purchase || typeof purchase !== 'object' || Array.isArray(purchase)) continue;
+    const record = purchase as Record<string, unknown>;
+    const targeting = record.targeting_overlay;
+    if (targeting && typeof targeting === 'object' && !Array.isArray(targeting)) {
+      const geoCountries = (targeting as Record<string, unknown>).geo_countries;
+      if (Array.isArray(geoCountries)) {
+        geoCountries.forEach(country => {
+          if (typeof country === 'string') countries.add(country);
+        });
+      }
+    }
+    const purchaseChannels = record.channels;
+    if (Array.isArray(purchaseChannels)) {
+      purchaseChannels.forEach(channel => {
+        if (typeof channel === 'string') channels.add(channel);
+      });
+    }
+  }
+  return {
+    ...payload,
+    ...(terms.total_budget !== undefined && { total_budget: terms.total_budget as CheckPayload['total_budget'] }),
+    ...(typeof terms.start_time === 'string' && { start_time: terms.start_time }),
+    ...(typeof terms.end_time === 'string' && { end_time: terms.end_time }),
+    ...(countries.size > 0 && { countries: [...countries] }),
+    ...(channels.size > 0 && { channels: [...channels] }),
+  };
+}
+
 interface PlannedDeliveryInput {
   // Seller-assigned ID: optional during purchase prepare, required later.
   media_buy_id?: string;
+  proposal_id?: string;
+  proposal_terms_digest?: string;
   geo?: { countries?: string[] };
   channels?: string[];
+  start_time?: string;
+  end_time?: string;
   total_budget?: number;
   currency?: string;
 }
@@ -540,6 +645,10 @@ export const GOVERNANCE_TOOLS = [
         },
         tool: { type: 'string', description: 'The AdCP tool being checked. Present on intent checks (orchestrator).' },
         payload: { type: 'object', description: 'The full tool arguments. Present on intent checks.' },
+        proposal: {
+          type: 'object',
+          description: 'Exact committed CanonicalProposal required when authorizing accept_proposal.',
+        },
         governance_context: { type: 'string', description: 'Opaque governance context from a prior check_governance response. Pass on subsequent checks for lifecycle continuity.' },
         consultation_context: { type: 'string', description: 'Non-authorizing handle from an intent conditions response. Pass only on the adjusted intent re-check.' },
 
@@ -1076,6 +1185,103 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
       }],
     };
   }
+  if (tool === 'accept_proposal' && req.proposal === undefined) {
+    return {
+      errors: [{
+        code: 'VALIDATION_ERROR',
+        message: 'proposal is required when authorizing accept_proposal.',
+        field: 'proposal',
+      }],
+    };
+  }
+  if (req.proposal !== undefined && tool !== 'accept_proposal') {
+    return {
+      errors: [{
+        code: 'VALIDATION_ERROR',
+        message: 'proposal is valid only when authorizing accept_proposal.',
+        field: 'proposal',
+      }],
+    };
+  }
+  if (req.proposal !== undefined) {
+    const proposal = req.proposal;
+    if (
+      typeof proposal.proposal_id !== 'string'
+      || !['new_media_buy', 'media_buy_update', 'media_buy_cancellation'].includes(proposal.proposal_kind)
+      || proposal.proposal_status !== 'committed'
+      || !proposal.commercial_terms
+      || typeof proposal.commercial_terms !== 'object'
+      || Array.isArray(proposal.commercial_terms)
+      || typeof proposal.terms_digest !== 'string'
+    ) {
+      return {
+        errors: [{
+          code: 'VALIDATION_ERROR',
+          message: 'proposal must be a committed CanonicalProposal with typed commercial_terms and terms_digest.',
+          field: 'proposal',
+        }],
+      };
+    }
+    let computedDigest: string;
+    try {
+      computedDigest = governanceProposalDigest(proposal.commercial_terms);
+    } catch {
+      return {
+        errors: [{
+          code: 'VALIDATION_ERROR',
+          message: 'proposal.commercial_terms must be finite canonical JSON.',
+          field: 'proposal.commercial_terms',
+        }],
+      };
+    }
+    if (proposal.terms_digest !== computedDigest) {
+      return {
+        errors: [{
+          code: 'VALIDATION_ERROR',
+          message: 'proposal.terms_digest does not match proposal.commercial_terms.',
+          field: 'proposal.terms_digest',
+        }],
+      };
+    }
+    if (
+      payload?.proposal_id !== proposal.proposal_id
+      || payload?.proposal_terms_digest !== proposal.terms_digest
+    ) {
+      return {
+        errors: [{
+          code: 'VALIDATION_ERROR',
+          message: 'accept_proposal payload must bind the supplied proposal_id and proposal_terms_digest.',
+          field: 'payload.proposal_terms_digest',
+        }],
+      };
+    }
+    const envelope = governanceProposalCommitment(proposal);
+    const proposed = req.proposed_commitment;
+    if (
+      proposed
+      && (
+        (envelope.currency !== undefined && proposed.currency !== envelope.currency)
+        || (
+          proposal.proposal_kind !== 'media_buy_update'
+          && envelope.amount !== undefined
+          && proposed.amount !== envelope.amount
+        )
+        || (
+          proposal.proposal_kind === 'media_buy_update'
+          && envelope.amount !== undefined
+          && proposed.amount > envelope.amount
+        )
+      )
+    ) {
+      return {
+        errors: [{
+          code: 'VALIDATION_ERROR',
+          message: 'proposed_commitment does not match the supplied proposal commercial envelope.',
+          field: 'proposed_commitment',
+        }],
+      };
+    }
+  }
   if (req.execution_commitment !== undefined && !hasExecutionShape) {
     return {
       errors: [{
@@ -1385,7 +1591,7 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
   if (
     req.proposed_commitment
     && payloadCommitment !== undefined
-    && tool !== 'update_media_buy'
+    && !INCREMENTAL_COMMITMENT_TOOLS.has(tool ?? '')
     && req.proposed_commitment.amount !== payloadCommitment
   ) {
     return {
@@ -1409,25 +1615,25 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
   }
   if (
     binding === 'committed'
-    && originalIntentCheck?.tool === 'update_media_buy'
+    && INCREMENTAL_COMMITMENT_TOOLS.has(originalIntentCheck?.tool ?? '')
     && req.execution_commitment === undefined
   ) {
     return {
       errors: [{
         code: 'VALIDATION_ERROR',
-        message: 'execution_commitment is required when executing an update_media_buy intent.',
+        message: `execution_commitment is required when executing a ${originalIntentCheck?.tool} intent.`,
       }],
     };
   }
   if (
     binding === 'committed'
-    && originalIntentCheck?.tool !== 'update_media_buy'
+    && !INCREMENTAL_COMMITMENT_TOOLS.has(originalIntentCheck?.tool ?? '')
     && req.execution_commitment !== undefined
   ) {
     return {
       errors: [{
         code: 'VALIDATION_ERROR',
-        message: 'execution_commitment is valid only when executing an update_media_buy intent.',
+        message: 'execution_commitment is valid only for an incremental media-buy execution intent.',
       }],
     };
   }
@@ -1516,8 +1722,11 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
   // Delegation budget/market limits are checked here because the proposed payload
   // contains the budget and countries. For committed binding, planned_delivery
   // validation handles these constraints instead.
-  if (binding === 'proposed' && payload) {
-    const extracted = extractFromPayload(payload);
+  const policyPayload = payload && req.proposal
+    ? governanceProposalPolicyPayload(payload, req.proposal)
+    : payload;
+  if (binding === 'proposed' && policyPayload) {
+    const extracted = extractFromPayload(policyPayload);
     const payloadBudget = req.proposed_commitment?.amount ?? payloadCommitment;
     const budgetFieldPath = req.proposed_commitment
       ? 'proposed_commitment.amount'
@@ -1734,6 +1943,20 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
   if (binding === 'committed' && plannedDelivery) {
     categoriesEvaluated.push('geo_compliance', 'channel_compliance', 'flight_compliance');
 
+    if (
+      originalIntentCheck?.authorizedProposalId
+      && (
+        plannedDelivery.proposal_id !== originalIntentCheck.authorizedProposalId
+        || plannedDelivery.proposal_terms_digest !== originalIntentCheck.authorizedProposalTermsDigest
+      )
+    ) {
+      findings.push({
+        categoryId: 'proposal_binding',
+        severity: 'critical',
+        explanation: 'Planned delivery does not match the proposal snapshot authorized at intent time.',
+      });
+    }
+
     const pdCountries = plannedDelivery.geo?.countries || [];
     if (pdCountries.length > 0 && plan.countries?.length) {
       const planCountrySet = new Set(plan.countries);
@@ -1760,13 +1983,24 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
       }
     }
 
+    if (
+      (plannedDelivery.start_time && new Date(plannedDelivery.start_time) < new Date(plan.flight.start))
+      || (plannedDelivery.end_time && new Date(plannedDelivery.end_time) > new Date(plan.flight.end))
+    ) {
+      findings.push({
+        categoryId: 'flight_compliance',
+        severity: 'critical',
+        explanation: 'Planned delivery flight falls outside the governed plan flight.',
+      });
+    }
+
     const pdBudget = plannedDelivery.total_budget;
     // A delivery check reports evidence about an already-authorized
     // commitment. Treating planned_delivery.total_budget as a fresh
     // commitment here would charge the same media buy against the plan twice.
     executionCommitment = phase === 'delivery'
       ? undefined
-      : originalIntentCheck?.tool === 'update_media_buy'
+      : INCREMENTAL_COMMITMENT_TOOLS.has(originalIntentCheck?.tool ?? '')
         ? req.execution_commitment?.amount
         : pdBudget;
     if (executionCommitment !== undefined) {
@@ -1946,6 +2180,12 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
     }
   }
   const authorizedTask = tool ?? originalIntentCheck?.tool;
+  const authorizedProposalId = binding === 'proposed'
+    ? req.proposal?.proposal_id
+    : originalIntentCheck?.authorizedProposalId;
+  const authorizedProposalTermsDigest = binding === 'proposed'
+    ? req.proposal?.terms_digest
+    : originalIntentCheck?.authorizedProposalTermsDigest;
   const evaluatedBudget = binding === 'committed'
     ? executionCommitment
     : req.proposed_commitment?.amount
@@ -2018,6 +2258,8 @@ export async function handleCheckGovernance(args: ToolArgs, ctx: TrainingContext
     caller,
     tool: authorizedTask,
     ...(authorizedPayloadHash ? { authorizedPayloadHash } : {}),
+    ...(authorizedProposalId ? { authorizedProposalId } : {}),
+    ...(authorizedProposalTermsDigest ? { authorizedProposalTermsDigest } : {}),
     purchaseType,
     ...(status === 'approved' && authorizedBudget !== undefined ? { authorizedBudget } : {}),
     ...(status === 'approved' && authorizedCurrency !== undefined

--- a/server/src/training-agent/mcp-task-store.ts
+++ b/server/src/training-agent/mcp-task-store.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { createHash } from 'node:crypto';
 import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks';
 import type {
   CreateTaskOptions,
@@ -9,15 +11,108 @@ import { getPool, isDatabaseInitialized } from '../db/client.js';
 
 export type TrainingTaskStore = InMemoryTaskStore | PostgresTaskStore;
 
+class ScopedInMemoryTaskStore extends InMemoryTaskStore {
+  private readonly owners = new Map<string, string>();
+
+  private async pruneExpiredOwners(): Promise<void> {
+    for (const taskId of this.owners.keys()) {
+      if (await super.getTask(taskId) === null) this.owners.delete(taskId);
+    }
+  }
+
+  override async createTask(
+    options: CreateTaskOptions,
+    requestId: RequestId,
+    request: Request,
+    sessionId?: string,
+  ): Promise<Task> {
+    await this.pruneExpiredOwners();
+    const task = await super.createTask(options, requestId, request, sessionId);
+    if (sessionId) this.owners.set(task.taskId, sessionId);
+    return task;
+  }
+
+  private owned(taskId: string, sessionId?: string): boolean {
+    return !sessionId || this.owners.get(taskId) === sessionId;
+  }
+
+  override async getTask(taskId: string, sessionId?: string): Promise<Task | null> {
+    if (!this.owned(taskId, sessionId)) return Promise.resolve(null);
+    const task = await super.getTask(taskId, sessionId);
+    if (task === null) this.owners.delete(taskId);
+    return task;
+  }
+
+  override async storeTaskResult(
+    taskId: string,
+    status: 'completed' | 'failed',
+    result: Result,
+    sessionId?: string,
+  ): Promise<void> {
+    if (!this.owned(taskId, sessionId)) throw new Error(`Task with ID ${taskId} not found`);
+    await super.storeTaskResult(taskId, status, result, sessionId);
+  }
+
+  override async getTaskResult(taskId: string, sessionId?: string): Promise<Result> {
+    if (!this.owned(taskId, sessionId)) throw new Error(`Task with ID ${taskId} not found`);
+    return super.getTaskResult(taskId, sessionId);
+  }
+
+  override async updateTaskStatus(
+    taskId: string,
+    status: Task['status'],
+    statusMessage?: string,
+    sessionId?: string,
+  ): Promise<void> {
+    if (!this.owned(taskId, sessionId)) throw new Error(`Task with ID ${taskId} not found`);
+    await super.updateTaskStatus(taskId, status, statusMessage, sessionId);
+  }
+
+  override async listTasks(cursor?: string, sessionId?: string): Promise<{ tasks: Task[]; nextCursor?: string }> {
+    if (!sessionId) return super.listTasks(cursor, sessionId);
+    await this.pruneExpiredOwners();
+    const ownedIds = [...this.owners.entries()]
+      .filter(([, owner]) => owner === sessionId)
+      .map(([taskId]) => taskId);
+    const startIndex = cursor === undefined ? 0 : ownedIds.indexOf(cursor) + 1;
+    if (cursor !== undefined && startIndex === 0) throw new Error(`Invalid cursor: ${cursor}`);
+    const pageIds = ownedIds.slice(startIndex, startIndex + 10);
+    const tasks = (await Promise.all(pageIds.map(taskId => super.getTask(taskId, sessionId))))
+      .filter((task): task is Task => task !== null);
+    const nextCursor = startIndex + 10 < ownedIds.length ? pageIds.at(-1) : undefined;
+    return { tasks, ...(nextCursor && { nextCursor }) };
+  }
+
+  override cleanup(): void {
+    this.owners.clear();
+    super.cleanup();
+  }
+}
+
 let taskStore: TrainingTaskStore | null = null;
+const taskScopeStorage = new AsyncLocalStorage<string>();
+
+export function trainingTaskScope(tenantId: string, principal: string): string {
+  return `training_${createHash('sha256').update(`${tenantId}\0${principal}`).digest('hex')}`;
+}
+
+export function runWithTrainingTaskScope<T>(scope: string, callback: () => T): T {
+  return taskScopeStorage.run(scope, callback);
+}
+
+function requiredClientScope(sessionId: string | undefined): string {
+  const scope = sessionId ?? taskScopeStorage.getStore();
+  if (!scope) throw new Error('Training task access requires a trusted caller scope');
+  return scope;
+}
 
 /** Resolve the backing store only when the first task operation runs. Route
  * construction precedes database initialization in production. */
 export function getTrainingTaskStore(): TrainingTaskStore {
   if (!taskStore) {
     taskStore = isDatabaseInitialized()
-      ? new PostgresTaskStore(getPool())
-      : new InMemoryTaskStore();
+      ? new PostgresTaskStore(getPool(), { allowUnscopedAccess: true })
+      : new ScopedInMemoryTaskStore();
   }
   return taskStore;
 }
@@ -31,10 +126,10 @@ export const sharedTrainingTaskStore: TaskStore = {
     request: Request,
     sessionId?: string,
   ): Promise<Task> {
-    return getTrainingTaskStore().createTask(options, requestId, request, sessionId);
+    return getTrainingTaskStore().createTask(options, requestId, request, requiredClientScope(sessionId));
   },
   getTask(taskId: string, sessionId?: string): Promise<Task | null> {
-    return getTrainingTaskStore().getTask(taskId, sessionId);
+    return getTrainingTaskStore().getTask(taskId, requiredClientScope(sessionId));
   },
   storeTaskResult(
     taskId: string,
@@ -42,10 +137,10 @@ export const sharedTrainingTaskStore: TaskStore = {
     result: Result,
     sessionId?: string,
   ): Promise<void> {
-    return getTrainingTaskStore().storeTaskResult(taskId, status, result, sessionId);
+    return getTrainingTaskStore().storeTaskResult(taskId, status, result, requiredClientScope(sessionId));
   },
   getTaskResult(taskId: string, sessionId?: string): Promise<Result> {
-    return getTrainingTaskStore().getTaskResult(taskId, sessionId);
+    return getTrainingTaskStore().getTaskResult(taskId, requiredClientScope(sessionId));
   },
   updateTaskStatus(
     taskId: string,
@@ -53,12 +148,46 @@ export const sharedTrainingTaskStore: TaskStore = {
     statusMessage?: string,
     sessionId?: string,
   ): Promise<void> {
-    return getTrainingTaskStore().updateTaskStatus(taskId, status, statusMessage, sessionId);
+    return getTrainingTaskStore().updateTaskStatus(taskId, status, statusMessage, requiredClientScope(sessionId));
   },
   listTasks(cursor?: string, sessionId?: string): Promise<{ tasks: Task[]; nextCursor?: string }> {
-    return getTrainingTaskStore().listTasks(cursor, sessionId);
+    return getTrainingTaskStore().listTasks(cursor, requiredClientScope(sessionId));
   },
 };
+
+/** Per-request facade for the legacy server. A Proxy preserves the concrete
+ * store identity used by the deterministic Postgres receipt recovery path. */
+export function getScopedTrainingTaskStore(scope: string): TrainingTaskStore {
+  const store = getTrainingTaskStore();
+  return new Proxy(store, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      if (typeof value !== 'function') return value;
+      if (property === 'createTask') {
+        return (options: CreateTaskOptions, requestId: RequestId, request: Request, sessionId?: string) =>
+          target.createTask(options, requestId, request, sessionId ?? scope);
+      }
+      if (property === 'getTask') {
+        return (taskId: string, sessionId?: string) => target.getTask(taskId, sessionId ?? scope);
+      }
+      if (property === 'storeTaskResult') {
+        return (taskId: string, status: 'completed' | 'failed', result: Result, sessionId?: string) =>
+          target.storeTaskResult(taskId, status, result, sessionId ?? scope);
+      }
+      if (property === 'getTaskResult') {
+        return (taskId: string, sessionId?: string) => target.getTaskResult(taskId, sessionId ?? scope);
+      }
+      if (property === 'updateTaskStatus') {
+        return (taskId: string, status: Task['status'], statusMessage?: string, sessionId?: string) =>
+          target.updateTaskStatus(taskId, status, statusMessage, sessionId ?? scope);
+      }
+      if (property === 'listTasks') {
+        return (cursor?: string, sessionId?: string) => target.listTasks(cursor, sessionId ?? scope);
+      }
+      return value.bind(target);
+    },
+  });
+}
 
 export function resetTrainingTaskStore(): void {
   taskStore?.cleanup();

--- a/server/src/training-agent/product-factory.ts
+++ b/server/src/training-agent/product-factory.ts
@@ -199,12 +199,18 @@ function buildPricingOption(
       };
       break;
     case 'cpa':
+      if (template.eventType === 'custom' && !template.customEventName) {
+        throw new Error(`CPA pricing template ${id} requires customEventName when eventType is custom`);
+      }
       option = {
         pricing_option_id: id,
         pricing_model: 'cpa',
         currency: template.currency,
         fixed_price: template.fixedPrice ?? 0,
         event_type: template.eventType ?? 'purchase',
+        ...(template.eventType === 'custom' && template.customEventName && {
+          custom_event_name: template.customEventName,
+        }),
         ...(template.minSpendPerPackage !== undefined && { min_spend_per_package: template.minSpendPerPackage }),
       };
       break;

--- a/server/src/training-agent/product-factory.ts
+++ b/server/src/training-agent/product-factory.ts
@@ -41,7 +41,9 @@ type CanonicalFormatProjection = {
   format_kind: ProductFormatDeclaration['format_kind'];
   params: ProductFormatDeclaration['params'];
 };
-type TrainingProduct = Omit<Product, 'product_card' | 'product_card_detailed'> & {
+type TrainingProduct = Omit<Product,
+  'product_card' | 'product_card_detailed' | 'collections' | 'installments'
+> & {
   product_card?: Product['product_card'] | ProductCardManifest;
   product_card_detailed?: Product['product_card_detailed'] | ProductCardManifest;
   collections?: CollectionSelector[];
@@ -665,7 +667,7 @@ function buildProduct(
         ? ['individuals', 'households', 'devices', 'accounts']
         : undefined;
       metricOptimization = {
-        supported_metrics: metrics,
+        supported_metrics: metrics as [SupportedMetric, ...SupportedMetric[]],
         ...(supportedReachUnits && { supported_reach_units: supportedReachUnits }),
         ...(supportedViewDurations && { supported_view_durations: supportedViewDurations }),
         supported_targets: ['cost_per'],
@@ -779,16 +781,16 @@ function buildProduct(
     product_id: productId,
     name: template.name,
     description: template.description,
-    publisher_properties: publisherPropertySelectors(pub, template.channels),
+    publisher_properties: publisherPropertySelectors(pub, template.channels) as Product['publisher_properties'],
     channels: template.channels as MediaChannel[],
     format_ids: formatIds,
-    ...(formatOptions.length > 0 ? { format_options: formatOptions } : {}),
+    ...(formatOptions.length > 0 ? { format_options: formatOptions as Product['format_options'] } : {}),
     delivery_type: template.deliveryType as DeliveryType,
     delivery_measurement: {
       provider: pub.measurementProvider,
       notes: pub.measurementNotes,
     },
-    pricing_options: effectivePricing.map((t, i) => buildPricingOption(t, productId, i)),
+    pricing_options: effectivePricing.map((t, i) => buildPricingOption(t, productId, i)) as unknown as Product['pricing_options'],
     reporting_capabilities: {
       available_reporting_frequencies: pub.reportingFrequencies as NonNullable<Product['reporting_capabilities']>['available_reporting_frequencies'],
       expected_delay_minutes: 240,
@@ -804,7 +806,7 @@ function buildProduct(
         vendor_metrics: pub.vendorMetrics,
       }),
     } as NonNullable<Product['reporting_capabilities']>,
-    ...(pub.catalogTypes?.length && { catalog_types: pub.catalogTypes as CatalogType[] }),
+    ...(pub.catalogTypes?.length && { catalog_types: pub.catalogTypes as unknown as Product['catalog_types'] }),
     ...(metricOptimization && { metric_optimization: metricOptimization }),
     // Vendor-metric optimization is a publisher/inventory capability, not
     // auction-only. Guaranteed products can still steer allocation/pacing
@@ -990,7 +992,7 @@ export function buildProposals(catalog: CatalogProduct[]): Proposal[] {
   const proposals: Proposal[] = [];
 
   for (const def of PROPOSAL_DEFINITIONS) {
-    const allocations: Proposal['allocations'] = [];
+    const allocations: Array<Proposal['allocations'][number]> = [];
     let valid = true;
 
     for (const alloc of def.allocations) {
@@ -1029,7 +1031,7 @@ export function buildProposals(catalog: CatalogProduct[]): Proposal[] {
       return {
         product_id: a.product_id,
         product_name: cp?.product.name,
-        allocation_percentage: a.allocation_percentage,
+        allocation_percentage: a.allocation_percentage ?? 0,
         rationale: a.rationale,
       };
     });
@@ -1040,7 +1042,7 @@ export function buildProposals(catalog: CatalogProduct[]): Proposal[] {
           const cp = catalog.find(c => c.product.product_id === a.product_id);
           const firstPricing = cp?.product.pricing_options[0] as { fixed_price?: number; floor_price?: number } | undefined;
           const price = firstPricing?.fixed_price ?? firstPricing?.floor_price ?? 10;
-          return sum + (def.budgetGuidance.recommended * (a.allocation_percentage / 100) / price * 1000);
+          return sum + (def.budgetGuidance.recommended * ((a.allocation_percentage ?? 0) / 100) / price * 1000);
         }, 0))
       : undefined;
 
@@ -1069,7 +1071,7 @@ export function buildProposals(catalog: CatalogProduct[]): Proposal[] {
       description: def.description,
       brief_alignment: def.briefAlignment,
       total_budget_guidance: def.budgetGuidance,
-      allocations,
+      allocations: allocations as Proposal['allocations'],
       ...(hasGuaranteed && {
         proposal_status: 'draft' as const,
         expires_at: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
@@ -1219,7 +1221,7 @@ export function buildCatalog(): CatalogProduct[] {
         ...alias.source.product,
         product_id: alias.id,
         name: alias.name,
-        ...(aliasedPricing && { pricing_options: aliasedPricing }),
+        ...(aliasedPricing && { pricing_options: aliasedPricing as Product['pricing_options'] }),
         ...('product_card' in alias.source.product && alias.source.product.product_card
           ? { product_card: { ...alias.source.product.product_card, title: truncateLabel(alias.name, 60) } }
           : {}),

--- a/server/src/training-agent/proposal-negotiation-profiles.ts
+++ b/server/src/training-agent/proposal-negotiation-profiles.ts
@@ -438,7 +438,7 @@ export function evaluateTrainingProposal(
     }
     if (kind === "media_buy_cancellation") {
       (alternativeTerms as TrainingCommercialTerms).cancellation_terms = {
-        effective_at: futureIso(evaluation.context.now, 60 * 60 * 1000),
+        effective_at: evaluation.context.now.toISOString(),
         ...(evaluation.refinement.action === "revise" &&
           evaluation.refinement.ask && {
             reason: evaluation.refinement.ask.slice(0, 500),

--- a/server/src/training-agent/publishers.ts
+++ b/server/src/training-agent/publishers.ts
@@ -591,7 +591,7 @@ export const PUBLISHERS: PublisherProfile[] = [
     pricingTemplates: [
       { model: 'cpm', currency: 'USD', floorPrice: 18, priceGuidance: { suggested: 30, range: { min: 18, max: 50 } } },
       { model: 'cpc', currency: 'USD', floorPrice: 2, priceGuidance: { suggested: 4, range: { min: 2, max: 8 } } },
-      { model: 'cpa', currency: 'USD', fixedPrice: 8, eventType: 'custom' },
+      { model: 'cpa', currency: 'USD', fixedPrice: 8, eventType: 'custom', customEventName: 'agent_session' },
       { model: 'cpm', currency: 'USD', fixedPrice: 35, minSpendPerPackage: 10000 },
       { model: 'flat_rate', currency: 'USD', fixedPrice: 50000, minSpendPerPackage: 50000 },
     ],

--- a/server/src/training-agent/si-handlers.ts
+++ b/server/src/training-agent/si-handlers.ts
@@ -172,7 +172,7 @@ const SANDBOX_OFFERINGS: Record<string, Record<string, unknown>> = {
   },
 };
 
-export async function handleSiGetOffering(args: ToolArgs, _ctx: TrainingContext): Promise<unknown> {
+export async function handleSiGetOffering(args: ToolArgs, ctx: TrainingContext): Promise<unknown> {
   const a = args as ToolArgs & Record<string, unknown>;
   const offeringId = a.offering_id as string | undefined;
   if (!offeringId) {
@@ -209,6 +209,10 @@ export async function handleSiGetOffering(args: ToolArgs, _ctx: TrainingContext)
 
   return {
     available: true,
+    // The released 3.0 SI storyboard captures this legacy top-level field
+    // before passing it into the session lifecycle. Current responses keep
+    // the canonical identifier nested on `offering`.
+    ...(ctx.storyboardCompat?.version === '3.0' && { offering_id: offeringId }),
     offering_token: `tok_${offeringId}_sandbox`,
     ttl_seconds: 3600,
     checked_at: new Date().toISOString(),

--- a/server/src/training-agent/state.ts
+++ b/server/src/training-agent/state.ts
@@ -443,6 +443,15 @@ export function getComplianceMediaBuy(id: string): MediaBuyState | undefined {
  */
 function serializeSession(session: SessionState): Record<string, unknown> {
   const localFixtures = projectedFixtureMaps.get(session);
+  const proposalContext = session.lastGetProductsContext;
+  const proposalProductIds = new Set(
+    (proposalContext?.proposals ?? []).flatMap(proposal =>
+      proposal.allocations.map(allocation => allocation.product_id),
+    ),
+  );
+  const proposalProducts = (proposalContext?.products ?? []).filter(product =>
+    proposalProductIds.has(product.product_id),
+  );
   const persisted = {
     ...session,
     ...(localFixtures && {
@@ -451,11 +460,15 @@ function serializeSession(session: SessionState): Record<string, unknown> {
         ...localFixtures,
       },
     }),
-    // `products` is deterministic from the catalog — dropped from persistence
-    // so callers re-derive on the next request. Only `proposals` (session-
-    // specific drafts from refine workflows) ride along.
-    lastGetProductsContext: session.lastGetProductsContext?.proposals?.length
-      ? { proposals: session.lastGetProductsContext.proposals }
+    // Persist only the immutable product snapshots that support session-
+    // specific proposals. Ordinary catalog results remain deterministic and
+    // are re-derived, while controller-seeded proposal inputs survive the
+    // request boundary required by account-less compact refinement.
+    lastGetProductsContext: proposalContext?.proposals?.length
+      ? {
+          proposals: proposalContext.proposals,
+          ...(proposalProducts.length > 0 && { products: proposalProducts }),
+        }
       : undefined,
   };
   return structuredSerialize(persisted) as Record<string, unknown>;

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -10510,7 +10510,66 @@ function getCreativePricing(account: { account_id?: string }, creative: import('
   };
 }
 
+interface MediaBuyMutationMutexClaim {
+  principal: string;
+  key: string;
+  claimToken: string;
+  sessionScope: string;
+}
+
+async function acquireMediaBuyMutationMutex(
+  args: ToolArgs,
+  ctx: TrainingContext,
+): Promise<MediaBuyMutationMutexClaim | undefined> {
+  const sessionScope = sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId);
+  const sessionHash = createHash('sha256').update(sessionScope).digest('hex');
+  const principal = 'media-buy-mutation-mutex';
+  const key = `media-buy-session:${sessionHash}`;
+  const store = getIdempotencyStore();
+  let claim = await store.check({ principal, key, payload: { session: sessionHash } });
+  const deadline = Date.now() + 2_000;
+  let backoffMs = 5;
+  while (claim.kind !== 'miss' && Date.now() < deadline) {
+    await new Promise(resolve => setTimeout(resolve, backoffMs));
+    claim = await store.check({ principal, key, payload: { session: sessionHash } });
+    backoffMs = Math.min(backoffMs * 2, 100);
+  }
+  if (claim.kind !== 'miss') return undefined;
+  return { principal, key, claimToken: claim.claimToken, sessionScope };
+}
+
+async function releaseMediaBuyMutationMutex(claim: MediaBuyMutationMutexClaim): Promise<void> {
+  await getIdempotencyStore().release(claim);
+}
+
+function mediaBuyMutationConflict(): Record<string, unknown> {
+  return {
+    errors: [{
+      code: 'CONFLICT',
+      message: 'Another request is already updating a MediaBuy in this account. Retry after a short delay.',
+      recovery: 'transient',
+    }] as TaskError[],
+  };
+}
+
 export async function handleUpdateMediaBuy(
+  args: ToolArgs,
+  ctx: TrainingContext,
+  options: { acceptedProposalExecution?: boolean; governance?: TrustedGovernedExecution } = {},
+): Promise<Record<string, unknown>> {
+  const mutex = await acquireMediaBuyMutationMutex(args, ctx);
+  if (!mutex) return mediaBuyMutationConflict();
+  try {
+    evictSessionFromRequestCache(mutex.sessionScope);
+    const result = await handleUpdateMediaBuyUnlocked(args, ctx, options);
+    await flushDirtySessions();
+    return result;
+  } finally {
+    await releaseMediaBuyMutationMutex(mutex);
+  }
+}
+
+async function handleUpdateMediaBuyUnlocked(
   args: ToolArgs,
   ctx: TrainingContext,
   options: { acceptedProposalExecution?: boolean; governance?: TrustedGovernedExecution } = {},
@@ -14075,8 +14134,11 @@ async function acceptExistingMediaBuyProposal(
     return { errors: [{ code: 'CONFLICT', message: 'Another proposal lifecycle request is already updating this session. Retry after a short delay.', recovery: 'transient' }] };
   }
 
+  let mediaBuyMutex: MediaBuyMutationMutexClaim | undefined;
   try {
     const mediaBuySessionKey = sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId);
+    mediaBuyMutex = await acquireMediaBuyMutationMutex(args, ctx);
+    if (!mediaBuyMutex) return mediaBuyMutationConflict();
     evictSessionFromRequestCache(proposalSessionKey);
     evictSessionFromRequestCache(mediaBuySessionKey);
     const proposalSession = await getSession(proposalSessionKey);
@@ -14196,7 +14258,7 @@ async function acceptExistingMediaBuyProposal(
           ),
           currency: mediaBuy.currency,
         };
-    const updateResult = await handleUpdateMediaBuy({
+    const updateResult = await handleUpdateMediaBuyUnlocked({
       ...(args as unknown as Record<string, unknown>),
       ...operationalPatch,
       media_buy_id: mediaBuyId,
@@ -14278,7 +14340,11 @@ async function acceptExistingMediaBuyProposal(
       ),
     };
   } finally {
-    await store.release({ principal, key, claimToken: claim.claimToken });
+    try {
+      if (mediaBuyMutex) await releaseMediaBuyMutationMutex(mediaBuyMutex);
+    } finally {
+      await store.release({ principal, key, claimToken: claim.claimToken });
+    }
   }
 }
 
@@ -14381,6 +14447,22 @@ export async function handleAcceptProposal(
 
 /** Native SDK 14 operational-control adapter. */
 export async function handleControlMediaBuy(
+  args: ControlMediaBuyRequest & ToolArgs,
+  ctx: TrainingContext,
+): Promise<Record<string, unknown>> {
+  const mutex = await acquireMediaBuyMutationMutex(args, ctx);
+  if (!mutex) return mediaBuyMutationConflict();
+  try {
+    evictSessionFromRequestCache(mutex.sessionScope);
+    const result = await handleControlMediaBuyUnlocked(args, ctx);
+    await flushDirtySessions();
+    return result;
+  } finally {
+    await releaseMediaBuyMutationMutex(mutex);
+  }
+}
+
+async function handleControlMediaBuyUnlocked(
   args: ControlMediaBuyRequest & ToolArgs,
   ctx: TrainingContext,
 ): Promise<Record<string, unknown>> {
@@ -14596,7 +14678,7 @@ export async function handleControlMediaBuy(
       }
     }
   }
-  const updateResult = await handleUpdateMediaBuy(args as unknown as ToolArgs, ctx, {
+  const updateResult = await handleUpdateMediaBuyUnlocked(args as unknown as ToolArgs, ctx, {
     ...(mediaBuy && {
       governance: {
         task: 'control_media_buy' as const,

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -145,6 +145,51 @@ type GetProductsReadDirectives = {
   staleDirective?: { tool: string; upstreamName?: string; createdAt: string };
 };
 type PricingOption = Product['pricing_options'][number];
+type CompactProductPurchase = ProposalPurchase & {
+  budget?: number;
+  format_option_refs?: unknown[];
+  catalog_ids?: string[];
+  impressions?: number;
+  daily_budget_cap?: number;
+  min_spend_target?: number;
+  pacing?: string;
+  bidding?: Record<string, unknown>;
+  targeting_overlay?: PackageTargeting;
+  optimization_goals?: Array<Record<string, unknown>>;
+  audience_evidence_requirements?: Record<string, unknown>;
+  audience_evidence_pins?: Array<Record<string, unknown>>;
+  agency_estimate_number?: string;
+  measurement_terms?: Record<string, unknown>;
+  performance_standards?: Array<Record<string, unknown>>;
+  context?: Record<string, unknown>;
+  ext?: Record<string, unknown>;
+};
+type BuyProductsRequest = ToolArgs & {
+  feed_version: string;
+  pricing_version?: string;
+  purchases: CompactProductPurchase[];
+  total_budget?: { amount: number; currency: string };
+  daily_budget_cap?: number;
+  budget_cap_timezone?: string;
+  budget_allocation?: Record<string, unknown>;
+  pacing?: string;
+  bidding?: Record<string, unknown>;
+  start_time: string;
+  end_time: string;
+  purchase_order_ref?: string;
+  agency_estimate_number?: string;
+  advertiser_industry?: string;
+};
+type AcceptProposalRequest = ToolArgs & {
+  proposal_id: string;
+  proposal_terms_digest: string;
+  total_budget?: { amount: number; currency: string };
+};
+type ControlMediaBuyRequest = ToolArgs & {
+  media_buy_id: string;
+  revision: number;
+  packages?: Array<Record<string, unknown>>;
+};
 type PricingStructure = 'fixed' | 'auction' | 'contingent';
 type PricingOptionView = {
   pricing_option_id?: string;
@@ -341,6 +386,11 @@ interface PackageInput {
   budget: number;
   bid_price?: number;
   impressions?: number;
+  daily_budget_cap?: number;
+  min_spend_target?: number;
+  pacing?: string;
+  bidding?: Record<string, unknown>;
+  catalog_ids?: string[];
   paused?: boolean;
   start_time?: string;
   end_time?: string;
@@ -353,6 +403,12 @@ interface PackageInput {
   creative_assignments?: Array<{ creative_id?: string }>;
   creatives?: InlineCreativeInput[];
   context?: Record<string, unknown>;
+  measurement_terms?: Record<string, unknown>;
+  performance_standards?: Array<Record<string, unknown>>;
+  audience_evidence_requirements?: Record<string, unknown>;
+  audience_evidence_pins?: Array<Record<string, unknown>>;
+  agency_estimate_number?: string;
+  ext?: Record<string, unknown>;
   committed_metrics?: Array<{
     scope: 'standard' | 'vendor';
     metric_id: string;
@@ -1781,7 +1837,7 @@ function applyFixedPriceFilter(product: Product, fixedPrice: boolean): Product |
   const requested: PricingStructure = fixedPrice ? 'fixed' : 'auction';
   const pricing_options = product.pricing_options.filter(po => pricingStructureForOption(po) === requested);
   if (pricing_options.length === 0) return null;
-  return { ...product, pricing_options };
+  return { ...product, pricing_options: pricing_options as Product['pricing_options'] };
 }
 
 export function applyFixedPriceFilterToProducts(products: Product[], fixedPrice: boolean): Product[] {
@@ -1793,7 +1849,7 @@ export function applyFixedPriceFilterToProducts(products: Product[], fixedPrice:
 function applyPricingStructuresFilter(product: Product, structures: Set<PricingStructure>): Product | null {
   const pricing_options = product.pricing_options.filter(option => structures.has(pricingStructureForOption(option)));
   if (pricing_options.length === 0) return null;
-  return { ...product, pricing_options };
+  return { ...product, pricing_options: pricing_options as Product['pricing_options'] };
 }
 
 export function applyPricingStructuresFilterToProducts(products: Product[], structures: PricingStructure[]): Product[] {
@@ -1816,7 +1872,7 @@ function applyPricingCurrenciesFilter(product: Product, currencies: Set<string>)
   });
   if (pricingOptions.length === 0) return null;
   if (!mandatoryProductSignalChargesSatisfied(product, currencies)) return null;
-  return { ...product, pricing_options: pricingOptions };
+  return { ...product, pricing_options: pricingOptions as Product['pricing_options'] };
 }
 
 function applyPricingCurrenciesFilterToProducts(products: Product[], currencies: string[]): Product[] {
@@ -2075,7 +2131,7 @@ function concreteCpmPricing(
   }
 
   return {
-    product: { ...product, pricing_options: pricingOptions },
+    product: { ...product, pricing_options: pricingOptions as Product['pricing_options'] },
     pricingOption: effectiveOption,
     pricingOptionId,
     fixedPrice,
@@ -2183,6 +2239,7 @@ import {
   handleReportPlanOutcome,
   handleReportPlanAdjustment,
   handleGetPlanAuditLogs,
+  governanceProposalCommitment,
 } from './governance-handlers.js';
 import {
   BRAND_TOOLS,
@@ -2264,8 +2321,9 @@ import {
 import { maybeEmitCompletionWebhook } from './webhooks.js';
 import { selectSigningCapability } from './request-signing.js';
 import {
-  getTrainingTaskStore,
+  getScopedTrainingTaskStore,
   resetTrainingTaskStore,
+  trainingTaskScope,
   type TrainingTaskStore,
 } from './mcp-task-store.js';
 import {
@@ -2274,9 +2332,9 @@ import {
 } from './source-schema.js';
 
 const SUPPORTED_MAJOR_VERSIONS = [3] as const;
-const SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', GET_PRODUCTS_REJECTED_ADCP_VERSION] as const;
+const SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.2'] as const;
 const DEFAULT_ADCP_VERSION = '3.0';
-const CURRENT_ADCP_VERSION = '3.1-rc.15';
+const CURRENT_ADCP_VERSION = '3.2-beta.2';
 const MAX_PACKAGES_PER_BUY = 50;
 
 interface ParsedAdcpReleaseVersion {
@@ -2463,7 +2521,7 @@ export function resolveServedAdcpVersionForTool(toolName: string, args: Record<s
   ) {
     return resolveServedAdcpVersion({
       ...args,
-      adcp_version: splitProductTool ? GET_PRODUCTS_REJECTED_ADCP_VERSION : CURRENT_ADCP_VERSION,
+      adcp_version: CURRENT_ADCP_VERSION,
     });
   }
   return resolveServedAdcpVersion(args);
@@ -2677,9 +2735,9 @@ function installTaskProtocolVersionNegotiation(server: Server): void {
  * survive across Fly.io instances. In tests (no database), falls back
  * to InMemoryTaskStore.
  *
- * Note: no session isolation — any session can see/cancel tasks from
- * another. This is intentional for the training agent where all sessions
- * are sandboxed. Production servers should scope tasks by sessionId.
+ * Client access is scoped by tenant and trusted principal. The raw store is
+ * shared only so durable task recovery works across stateless MCP requests and
+ * Fly.io instances; client-facing facades inject and enforce that scope.
  */
 const inMemoryTaskIdsByNaturalKey = new Map<string, string>();
 const IDEMPOTENT_TASK_MAX_GENERATIONS = 64;
@@ -3029,12 +3087,12 @@ function projectedPackageBudgetTotal(mb: MediaBuyState, req: UpdateMediaBuyArgs)
     if (!packageId || !currentBudgets.has(packageId)) continue;
     if ((update as PackageUpdateExt).canceled === true) {
       currentBudgets.set(packageId, 0);
-    } else if (update.budget !== undefined) {
+    } else if (typeof update.budget === 'number') {
       currentBudgets.set(packageId, update.budget);
     }
   }
   const nextExisting = [...currentBudgets.values()].reduce((sum, budget) => sum + budget, 0);
-  const added = (req.new_packages ?? []).reduce((sum, pkg) => sum + pkg.budget, 0);
+  const added = (req.new_packages ?? []).reduce((sum, pkg) => sum + (pkg.budget ?? 0), 0);
   return nextExisting + added;
 }
 
@@ -3072,6 +3130,8 @@ function proportionalFixedPackageBudgets(
 
 interface MediaBuyAggregateUpdate {
   total_budget?: { amount: number; currency: string };
+  daily_budget_cap?: number | null;
+  budget_cap_timezone?: string | null;
   budget_allocation?: Record<string, unknown>;
   pacing?: string;
   bidding?: Record<string, unknown> | null;
@@ -3359,11 +3419,26 @@ function validActionsForStatus(status: string): string[] {
 }
 
 function availableActionsForStatus(status: string, explicit?: MediaBuyAvailableActionState[]): MediaBuyAvailableActionState[] {
-  if (explicit !== undefined) return explicit;
-  return validActionsForStatus(status).map(action => ({
+  const actions = explicit ?? validActionsForStatus(status).map(action => ({
     action,
     mode: 'self_serve' as const,
   }));
+  return actions.flatMap(action => canonicalMediaBuyActionNames(action.action).map(canonicalAction => ({
+    ...action,
+    task: canonicalTaskForMediaBuyAction(canonicalAction),
+    action: canonicalAction,
+  })));
+}
+
+/** Translate deprecated coarse 3.x availability labels into SDK 14 actions. */
+function canonicalMediaBuyActionNames(action: string): string[] {
+  switch (action) {
+    case 'update_budget': return ['increase_budget', 'decrease_budget'];
+    case 'update_dates': return ['update_flight_dates'];
+    case 'update_packages': return ['remove_packages'];
+    case 'sync_creatives': return ['update_creative_assignments'];
+    default: return [action];
+  }
 }
 
 const NON_TERMINAL_MEDIA_BUY_STATUSES = new Set(['pending_creatives', 'pending_start', 'active', 'paused']);
@@ -3445,12 +3520,13 @@ function deriveAvailableActionsFromProductAllowedActions(
   if (!allowedActions) return undefined;
   return allowedActions
     .filter(action => allowedActionAppliesToStatus(action, status))
-    .map(action => ({
-      action: action.action,
+    .flatMap(action => canonicalMediaBuyActionNames(action.action).map(canonicalAction => ({
+      task: canonicalTaskForMediaBuyAction(canonicalAction),
+      action: canonicalAction,
       mode: action.modes[0],
       ...(action.sla && { sla: action.sla }),
       ...(action.terms_ref && { terms_ref: action.terms_ref }),
-    }));
+    })));
 }
 
 function availableActionsForMediaBuy(mb: MediaBuyState, status: string): MediaBuyAvailableActionState[] {
@@ -3458,8 +3534,22 @@ function availableActionsForMediaBuy(mb: MediaBuyState, status: string): MediaBu
   const actions = productDerived !== undefined
     ? productDerived
     : availableActionsForStatus(status, mb.availableActions);
-  if (!hasLatentMediaBuyPause(mb, status) || actions.some(action => action.action === 'resume')) return actions;
-  return [{ action: 'resume', mode: 'self_serve' }, ...actions];
+  const canonical = actions.map(action => ({
+    ...action,
+    task: action.task ?? canonicalTaskForMediaBuyAction(action.action),
+  }));
+  if (!hasLatentMediaBuyPause(mb, status) || canonical.some(action => action.action === 'resume')) return canonical;
+  return [{ task: 'control_media_buy', action: 'resume', mode: 'self_serve' }, ...canonical];
+}
+
+function canonicalTaskForMediaBuyAction(action: string): MediaBuyAvailableActionState['task'] {
+  if (['extend_flight', 'shorten_flight', 'update_flight_dates', 'add_packages'].includes(action)) {
+    return 'refine_proposals';
+  }
+  if (['replace_creative', 'update_creative_assignments', 'remove_creative'].includes(action)) {
+    return 'sync_creatives';
+  }
+  return 'control_media_buy';
 }
 
 type AttemptedMediaBuyAction =
@@ -3526,8 +3616,8 @@ function actionsForUpdateRequest(mb: MediaBuyState, req: UpdateMediaBuyArgs): At
       const pkg = mb.packages.find(p => p.packageId === pkgId);
       if (!pkg) continue;
       totalBefore += pkg.budget;
-      totalAfter += update.budget ?? pkg.budget;
-      if (update.budget !== undefined) {
+      totalAfter += typeof update.budget === 'number' ? update.budget : pkg.budget;
+      if (typeof update.budget === 'number') {
         sawBudget = true;
         if (update.budget > pkg.budget) addAction('increase_budget', pkgId);
         if (update.budget < pkg.budget) addAction('decrease_budget', pkgId);
@@ -4309,7 +4399,7 @@ function overlayNegotiatedPricingOptions(
     } else {
       pricingOptions.push(option);
     }
-    productMap.set(productId, { ...product, pricing_options: pricingOptions });
+    productMap.set(productId, { ...product, pricing_options: pricingOptions as Product['pricing_options'] });
   }
 }
 
@@ -4709,6 +4799,7 @@ const PRODUCT_DISCOVERY_LIFECYCLE_TOOLS = [
   'refine_proposals',
   'decline_proposals',
 ] as const;
+type ProductDiscoveryLifecycleTool = (typeof PRODUCT_DISCOVERY_LIFECYCLE_TOOLS)[number];
 const PRODUCT_DISCOVERY_TOOLS = new Set([
   'get_products',
   ...PRODUCT_DISCOVERY_LIFECYCLE_TOOLS,
@@ -4947,7 +5038,7 @@ function buildCanonicalCommercialTerms(
       start_time: startTime,
       end_time: endTime,
       ...(typeof recommendedBudget === 'number' && {
-        budget: recommendedBudget * allocation.allocation_percentage / 100,
+        budget: recommendedBudget * (allocation.allocation_percentage ?? 0) / 100,
       }),
       ...(isRecord((product as unknown as Record<string, unknown> | undefined)?.measurement_terms)
         && { measurement_terms: structuredClone((product as unknown as Record<string, unknown>).measurement_terms) }),
@@ -5205,14 +5296,29 @@ export function projectProductDiscoveryResult(
   return result;
 }
 
-/** Compact proposal operations address proposals by opaque ID under the
- * authenticated principal. They deliberately do not repeat account or brand
- * on every lifecycle call. The legacy facade retains its account-derived
- * session partition for 3.x compatibility. */
+/** Compact proposal operations are partitioned by authenticated principal and
+ * the SDK-restored account reference. */
 function productDiscoverySessionKey(args: ToolArgs, ctx: TrainingContext): string {
   const compactLifecycle = (args as unknown as Record<string, unknown>).__compact_proposal_lifecycle === true;
   if (compactLifecycle) {
-    return sessionKeyFromArgs({}, ctx.mode, ctx.userId, ctx.moduleId, ctx.principal ?? 'anonymous');
+    // refine_proposals and decline_proposals intentionally omit account from
+    // their wire schemas: proposal identity plus the authenticated caller is
+    // the lookup key. Keep all compact proposal snapshots in the same
+    // principal-owned SDK proposal scope, while recording the originating
+    // account on each snapshot for accept_proposal authorization.
+    const trustedAccountId = ctx.proposalRefinementScope?.account_id ?? 'public_sandbox';
+    const trustedPrincipal = ctx.proposalRefinementScope?.principal_id
+      ?? (ctx.authenticatedAgentUrl ? `agent:${ctx.authenticatedAgentUrl}` : ctx.principal);
+    if (trustedAccountId && trustedPrincipal) {
+      return sessionKeyFromArgs(
+        { account: { account_id: trustedAccountId } },
+        ctx.mode,
+        ctx.userId,
+        ctx.moduleId,
+        trustedPrincipal,
+      );
+    }
+    return sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId, ctx.principal ?? 'anonymous');
   }
   return getProductsSessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId);
 }
@@ -6139,7 +6245,7 @@ async function handleGetProductsUnlocked(
 ): Promise<GetProductsResponse | GetProductsRejectedResponse | { errors: TaskError[] }> {
   const req = args as unknown as GetProductsRequest & ToolArgs;
   const buyingMode = req.buying_mode || 'brief';
-  const brief = (req as Record<string, unknown>).brief;
+  const brief = (req as unknown as Record<string, unknown>).brief;
   if (brief !== undefined && typeof brief !== 'string') {
     return {
       errors: [{
@@ -6779,6 +6885,7 @@ async function handleGetProductsUnlocked(
                 ? {}
                 : {
                     __declined: true,
+                    __declined_at: new Date().toISOString(),
                     ...(typeof op.reason === 'string' && { __decline_reason: op.reason }),
                     ...(typeof op.detail === 'string' && { __decline_detail: op.detail }),
                   }
@@ -6883,7 +6990,7 @@ async function handleGetProductsUnlocked(
   ];
 
   const productsById = new Map(products.map(p => [p.product_id, p]));
-  let proposals = sourceProposals
+  let proposals: Proposal[] = sourceProposals
     .map(proposal => refinedProposalOverrides.get(proposal.proposal_id) ?? proposal)
     .filter(proposal =>
       proposal.allocations.every(a => productIds.has(a.product_id)) &&
@@ -6908,7 +7015,7 @@ async function handleGetProductsUnlocked(
             : alloc;
         }),
       };
-    });
+    }) as Proposal[];
   const requireProposals = buyingMode === 'brief'
     && (req as unknown as Record<string, unknown>).__require_proposals === true;
   if (requireProposals) {
@@ -7135,19 +7242,46 @@ async function handleGetProductsUnlocked(
   for (const proposal of retainedCommittedProposals.values()) {
     if (!persistedProposalIds.has(proposal.proposal_id)) persistedProposals.push(proposal);
   }
-  if (usesTypedProposalNegotiation(ctx)) {
+  if (requireProposals || usesTypedProposalNegotiation(ctx)) {
     const canonicalProducts = new Map(
       registryProducts.map(product => [product.product_id, product]),
     );
     for (const proposal of persistedProposals) {
-      if (session.proposalRefinementRecords.has(proposal.proposal_id)) continue;
-      session.proposalRefinementRecords.set(proposal.proposal_id, {
-        proposal: outwardProposal(
-          proposal as unknown as Record<string, unknown>,
-          canonicalProducts,
-        ) as unknown as CanonicalProposal,
-        version: 1,
-      });
+      const internal = proposal as unknown as Record<string, unknown>;
+      const existing = session.proposalRefinementRecords.get(proposal.proposal_id);
+      if (!existing) {
+        session.proposalRefinementRecords.set(proposal.proposal_id, {
+          proposal: outwardProposal(
+            internal,
+            canonicalProducts,
+          ) as unknown as CanonicalProposal,
+          version: 1,
+          ...(ctx.resolvedAccountId && { ownerAccountId: ctx.resolvedAccountId }),
+          ...(internal.__declined === true && {
+            declined: {
+              declined_at: typeof internal.__declined_at === 'string'
+                ? internal.__declined_at
+                : new Date().toISOString(),
+              ...(typeof internal.__decline_reason === 'string' && { reason: internal.__decline_reason }),
+              ...(typeof internal.__decline_detail === 'string' && { detail: internal.__decline_detail }),
+            },
+          }),
+        });
+        continue;
+      }
+      if (internal.__declined === true && !existing.declined && !existing.accepted) {
+        session.proposalRefinementRecords.set(proposal.proposal_id, {
+          ...existing,
+          version: existing.version + 1,
+          declined: {
+            declined_at: typeof internal.__declined_at === 'string'
+              ? internal.__declined_at
+              : new Date().toISOString(),
+            ...(typeof internal.__decline_reason === 'string' && { reason: internal.__decline_reason }),
+            ...(typeof internal.__decline_detail === 'string' && { detail: internal.__decline_detail }),
+          },
+        });
+      }
     }
   }
   // Only refine requests establish durable context for later refinements.
@@ -8124,21 +8258,48 @@ export async function handleValidateInput(args: ToolArgs, ctx: TrainingContext):
   return { status: 'completed', results };
 }
 
-export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext) {
+interface TrustedGovernedExecution {
+  task: 'buy_products' | 'accept_proposal' | 'control_media_buy';
+  commitment: { amount: number; currency: string };
+}
+
+interface MediaBuyExecutionOptions {
+  governance?: TrustedGovernedExecution;
+}
+
+export async function handleCreateMediaBuy(
+  args: ToolArgs,
+  ctx: TrainingContext,
+  options: MediaBuyExecutionOptions = {},
+) {
   const proposalId = (args as unknown as Record<string, unknown>).proposal_id;
-  if (typeof proposalId !== 'string') return handleCreateMediaBuyUnlocked(args, ctx);
+  if (typeof proposalId !== 'string') return handleCreateMediaBuyUnlocked(args, ctx, options);
 
   // Proposal execution, legacy get_products finalization, and decline all
   // transition the same principal-owned snapshot. Serialize them on the
   // compact lifecycle session and persist before releasing so different
   // idempotency keys cannot both execute one proposal.
-  const sessionScope = sessionKeyFromArgs(
-    {},
-    ctx.mode,
-    ctx.userId,
-    ctx.moduleId,
-    ctx.principal ?? 'anonymous',
-  );
+  const compactSessionScope = productDiscoverySessionKey({
+    ...(args as unknown as Record<string, unknown>),
+    __compact_proposal_lifecycle: true,
+  } as ToolArgs, ctx);
+  let compactProposalExecution = (args as unknown as Record<string, unknown>).__compact_proposal_lifecycle === true;
+  if (!compactProposalExecution) {
+    const compactSession = await getSession(compactSessionScope);
+    compactProposalExecution = compactSession.proposalRefinementRecords.has(proposalId)
+      || Boolean(compactSession.lastGetProductsContext?.proposals?.some(
+        proposal => proposal.proposal_id === proposalId,
+      ));
+  }
+  const sessionScope = compactProposalExecution
+    ? compactSessionScope
+    : sessionKeyFromArgs(
+        args,
+        ctx.mode,
+        ctx.userId,
+        ctx.moduleId,
+        ctx.principal ?? 'anonymous',
+      );
   const sessionHash = createHash('sha256').update(sessionScope).digest('hex');
   const principal = 'get-products-session-mutex';
   const key = `get-products-session:${sessionHash}`;
@@ -8163,7 +8324,24 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
 
   try {
     evictSessionFromRequestCache(sessionScope);
-    const result = await handleCreateMediaBuyUnlocked(args, ctx);
+    const result = await handleCreateMediaBuyUnlocked(args, ctx, options);
+    const resultRecord = result as Record<string, unknown>;
+    if (
+      compactProposalExecution
+      && !Array.isArray(resultRecord.errors)
+      && typeof resultRecord.media_buy_id === 'string'
+    ) {
+      const proposalSession = await getSession(compactSessionScope);
+      const acceptedRecord = proposalSession.proposalRefinementRecords.get(proposalId);
+      const mediaBuySession = await getSession(
+        sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId),
+        controllerFixtureSessionKey(args, ctx),
+      );
+      const mediaBuy = mediaBuySession.mediaBuys.get(resultRecord.media_buy_id);
+      if (acceptedRecord?.accepted && mediaBuy) {
+        mediaBuy.acceptedProposal = canonicalProposalFromRecord(acceptedRecord);
+      }
+    }
     await flushDirtySessions();
     return result;
   } finally {
@@ -8171,7 +8349,11 @@ export async function handleCreateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   }
 }
 
-async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext) {
+async function handleCreateMediaBuyUnlocked(
+  args: ToolArgs,
+  ctx: TrainingContext,
+  options: MediaBuyExecutionOptions,
+) {
   const req = args as unknown as CreateMediaBuyRequest & ToolArgs & { paused?: boolean };
   const sessionKey = sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId);
   const session = await getSession(
@@ -8264,11 +8446,11 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
     const commitmentError = await governedCommitmentError(
       govCtx,
       ctx.authenticatedAgentUrl,
-      'create_media_buy',
+      options.governance?.task ?? 'create_media_buy',
       `${getCanonicalBase()}/sales`,
       governedRequestPayload(ctx, req as unknown as Record<string, unknown>),
-      buyBudget ?? 0,
-      mediaBuyCurrency,
+      options.governance?.commitment.amount ?? buyBudget ?? 0,
+      options.governance?.commitment.currency ?? mediaBuyCurrency,
     );
     if (commitmentError) return { errors: [commitmentError] };
   } else if (session.governancePlans.size > 0 || governanceAgents.length > 0) {
@@ -8564,9 +8746,10 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
       // Resolve that principal-owned proposal here, then verify its internal
       // account/brand binding against the billed account without exposing
       // whether a cross-account proposal exists.
-      const proposalSession = await getSession(
-        sessionKeyFromArgs({}, ctx.mode, ctx.userId, ctx.moduleId, ctx.principal ?? 'anonymous'),
-      );
+      const proposalSession = await getSession(productDiscoverySessionKey({
+        ...(req as unknown as Record<string, unknown>),
+        __compact_proposal_lifecycle: true,
+      } as ToolArgs, ctx));
       const candidate = proposalSession.lastGetProductsContext?.proposals?.find(
         p => p.proposal_id === req.proposal_id,
       );
@@ -8617,6 +8800,20 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
       || typeof internalProposal.__brand_id === 'string'
       || Array.isArray(internalProposal.__brand_countries)
       || typeof internalProposal.__account_id === 'string';
+    const suppliedTermsDigest = (req as unknown as { proposal_terms_digest?: unknown }).proposal_terms_digest;
+    if (typeof suppliedTermsDigest === 'string') {
+      const expectedTermsDigest = outwardProposal(internalProposal, productMap).terms_digest;
+      if (suppliedTermsDigest !== expectedTermsDigest) {
+        return {
+          errors: [{
+            code: 'INVALID_REQUEST',
+            message: 'proposal_terms_digest does not match the committed proposal snapshot.',
+            field: 'proposal_terms_digest',
+            recovery: 'correctable',
+          }] as TaskError[],
+        };
+      }
+    }
     if (internalProposal.__declined === true) {
       return {
         errors: [{
@@ -8694,26 +8891,35 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
         errors: [{ code: 'INVALID_REQUEST', message: 'total_budget.amount is required when using proposal_id' }] as TaskError[],
       };
     }
-    // Expand proposal allocations into packages
-    (req as { packages?: unknown[] }).packages = proposal.allocations.map((alloc, i) => {
-      const product = productMap.get(alloc.product_id);
-      const pricingOptionId = alloc.pricing_option_id || product?.pricing_options[0]?.pricing_option_id || '';
-      const pricing = product?.pricing_options.find(po => po.pricing_option_id === pricingOptionId);
+    const committedTerms = isRecord(internalProposal.__canonical_commercial_terms)
+      ? internalProposal.__canonical_commercial_terms
+      : undefined;
+    const committedPurchases = Array.isArray(committedTerms?.purchases)
+      ? committedTerms.purchases as unknown as CompactProductPurchase[]
+      : undefined;
+    // Compact 3.2 proposals commit complete per-purchase terms. Preserve that
+    // immutable envelope in operational package state; legacy proposals still
+    // expand their percentage allocations as before.
+    (req as { packages?: unknown[] }).packages = compactProposal && committedPurchases?.length
+      ? legacyPackagesFromPurchases(committedPurchases, totalBudget, productMap)
+      : proposal.allocations.map(alloc => {
+          const product = productMap.get(alloc.product_id);
+          const pricingOptionId = alloc.pricing_option_id || product?.pricing_options[0]?.pricing_option_id || '';
+          const pricing = product?.pricing_options.find(po => po.pricing_option_id === pricingOptionId);
 
-      // Auction pricing needs a bid_price — use price_guidance p50 or floor_price
-      let bidPrice: number | undefined;
-      if (pricing && pricingStructureForOption(pricing) === 'auction') {
-        const po = pricing as unknown as PricingOptionView;
-        bidPrice = po.price_guidance?.p50 ?? po.floor_price;
-      }
+          let bidPrice: number | undefined;
+          if (pricing && pricingStructureForOption(pricing) === 'auction') {
+            const po = pricing as unknown as PricingOptionView;
+            bidPrice = po.price_guidance?.p50 ?? po.floor_price;
+          }
 
-      return {
-        product_id: alloc.product_id,
-        pricing_option_id: pricingOptionId,
-        budget: Math.round(totalBudget * alloc.allocation_percentage / 100),
-        ...(bidPrice !== undefined && { bid_price: bidPrice }),
-      };
-    });
+          return {
+            product_id: alloc.product_id,
+            pricing_option_id: pricingOptionId,
+            budget: Math.round(totalBudget * (alloc.allocation_percentage ?? 0) / 100),
+            ...(bidPrice !== undefined && { bid_price: bidPrice }),
+          };
+        });
     if (compactProposal) {
       executedCompactProposal = proposal;
       if (!executedCompactProposalSession && session.proposalRefinementRecords.has(proposal.proposal_id)) {
@@ -8987,6 +9193,11 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
       pricingOptionId: pkg.pricing_option_id,
       bidPrice: storedBidPrice,
       impressions: pkg.impressions,
+      ...(pkg.daily_budget_cap !== undefined && { dailyBudgetCap: pkg.daily_budget_cap }),
+      ...(pkg.min_spend_target !== undefined && { minSpendTarget: pkg.min_spend_target }),
+      ...(pkg.pacing !== undefined && { pacing: pkg.pacing }),
+      ...(pkg.bidding !== undefined && { bidding: structuredClone(pkg.bidding) }),
+      ...(pkg.catalog_ids !== undefined && { catalogIds: [...pkg.catalog_ids] }),
       paused: pkg.paused || false,
       startTime: resolvedStart,
       endTime,
@@ -8998,6 +9209,12 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
       creativeAssignments,
       targeting: targetingResult.targeting,
       ...(isRecord(pkg.context) && { context: pkg.context }),
+      ...(isRecord(pkg.measurement_terms) && { measurementTerms: structuredClone(pkg.measurement_terms) }),
+      ...(Array.isArray(pkg.performance_standards) && { performanceStandards: structuredClone(pkg.performance_standards) }),
+      ...(isRecord(pkg.audience_evidence_requirements) && { audienceEvidenceRequirements: structuredClone(pkg.audience_evidence_requirements) }),
+      ...(Array.isArray(pkg.audience_evidence_pins) && { audienceEvidencePins: structuredClone(pkg.audience_evidence_pins) }),
+      ...(typeof pkg.agency_estimate_number === 'string' && { agencyEstimateNumber: pkg.agency_estimate_number }),
+      ...(isRecord(pkg.ext) && { ext: structuredClone(pkg.ext) }),
       ...(optimizationGoals && optimizationGoals.length > 0 && { optimizationGoals }),
       ...(committedMetrics && committedMetrics.length > 0 && { committedMetrics }),
     });
@@ -9038,6 +9255,12 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
     currency: mediaBuyCurrency,
     totalBudget: req.total_budget?.amount
       ?? createdPackages.reduce((sum, pkg) => sum + (pkg.budget || 0), 0),
+    ...((req as unknown as { daily_budget_cap?: number }).daily_budget_cap !== undefined && {
+      dailyBudgetCap: (req as unknown as { daily_budget_cap: number }).daily_budget_cap,
+    }),
+    ...((req as unknown as { budget_cap_timezone?: string }).budget_cap_timezone && {
+      budgetCapTimezone: (req as unknown as { budget_cap_timezone: string }).budget_cap_timezone,
+    }),
     ...((req as unknown as { budget_allocation?: Record<string, unknown> }).budget_allocation
       ? { budgetAllocation: structuredClone((req as unknown as { budget_allocation: Record<string, unknown> }).budget_allocation) }
       : {}),
@@ -9047,6 +9270,8 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
     ...((req as unknown as { bidding?: Record<string, unknown> }).bidding
       ? { aggregateBidding: structuredClone((req as unknown as { bidding: Record<string, unknown> }).bidding) }
       : {}),
+    ...(isRecord((req as unknown as Record<string, unknown>).reporting_webhook)
+      && { reportingWebhook: structuredClone((req as unknown as Record<string, unknown>).reporting_webhook as Record<string, unknown>) }),
     packages: createdPackages,
     ...(productAllowedActions && { productAllowedActions }),
     startTime: resolvedStart,
@@ -9131,6 +9356,8 @@ async function handleCreateMediaBuyUnlocked(args: ToolArgs, ctx: TrainingContext
     confirmed_at: mediaBuy.confirmedAt,
     currency: mediaBuy.currency,
     total_budget: mediaBuy.totalBudget,
+    ...(mediaBuy.dailyBudgetCap !== undefined && { daily_budget_cap: mediaBuy.dailyBudgetCap }),
+    ...(mediaBuy.budgetCapTimezone && { budget_cap_timezone: mediaBuy.budgetCapTimezone }),
     ...(mediaBuy.budgetAllocation && { budget_allocation: mediaBuy.budgetAllocation }),
     ...(mediaBuy.aggregatePacing && { pacing: mediaBuy.aggregatePacing }),
     ...(mediaBuy.aggregateBidding && { bidding: mediaBuy.aggregateBidding }),
@@ -9231,6 +9458,11 @@ export async function handleGetMediaBuys(args: ToolArgs, ctx: TrainingContext): 
       const openImpairments = mb.impairments ?? [];
       const buy = {
         media_buy_id: mb.mediaBuyId,
+        ...(mb.acceptedProposal && {
+          accepted_proposal_id: mb.acceptedProposal.proposal_id,
+          accepted_proposal_terms_digest: mb.acceptedProposal.terms_digest,
+          accepted_proposal: structuredClone(mb.acceptedProposal),
+        }),
         status,
         revision: mb.revision,
         confirmed_at: mb.confirmedAt,
@@ -9240,6 +9472,8 @@ export async function handleGetMediaBuys(args: ToolArgs, ctx: TrainingContext): 
         available_actions: availableActionsForMediaBuy(mb, status),
         currency: mb.currency,
         total_budget: totalBudget,
+        ...(mb.dailyBudgetCap !== undefined && { daily_budget_cap: mb.dailyBudgetCap }),
+        ...(mb.budgetCapTimezone && { budget_cap_timezone: mb.budgetCapTimezone }),
         ...(mb.budgetAllocation && { budget_allocation: mb.budgetAllocation }),
         ...(mb.aggregatePacing && { pacing: mb.aggregatePacing }),
         ...(mb.aggregateBidding && { bidding: mb.aggregateBidding }),
@@ -9271,9 +9505,14 @@ export async function handleGetMediaBuys(args: ToolArgs, ctx: TrainingContext): 
             package_id: pkg.packageId,
             ...(pkg.legacyOmitProductId ? {} : { product_id: pkg.productId }),
             budget: pkg.budget,
+            ...(pkg.dailyBudgetCap !== undefined && { daily_budget_cap: pkg.dailyBudgetCap }),
+            ...(pkg.minSpendTarget !== undefined && { min_spend_target: pkg.minSpendTarget }),
             pricing_option_id: pkg.pricingOptionId,
             ...(pkg.bidPrice !== undefined && { bid_price: pkg.bidPrice }),
             ...(pkg.impressions !== undefined && { impressions: pkg.impressions }),
+            ...(pkg.pacing !== undefined && { pacing: pkg.pacing }),
+            ...(pkg.bidding !== undefined && { bidding: pkg.bidding }),
+            ...(pkg.catalogIds !== undefined && { catalog_ids: pkg.catalogIds }),
             paused: pkg.paused,
             start_time: pkg.startTime,
             end_time: pkg.endTime,
@@ -9285,6 +9524,13 @@ export async function handleGetMediaBuys(args: ToolArgs, ctx: TrainingContext): 
             })),
             ...(pkg.targeting && { targeting_overlay: targetingForWire(pkg.targeting) }),
             ...(pkg.context && { context: pkg.context }),
+            ...(pkg.measurementTerms && { measurement_terms: pkg.measurementTerms }),
+            ...(pkg.performanceStandards && { performance_standards: pkg.performanceStandards }),
+            ...(pkg.audienceEvidenceRequirements && { audience_evidence_requirements: pkg.audienceEvidenceRequirements }),
+            ...(pkg.audienceEvidencePins && { audience_evidence_pins: pkg.audienceEvidencePins }),
+            ...(pkg.agencyEstimateNumber && { agency_estimate_number: pkg.agencyEstimateNumber }),
+            ...(pkg.ext && { ext: pkg.ext }),
+            ...(pkg.optimizationGoals && { optimization_goals: pkg.optimizationGoals }),
             ...(pkg.committedMetrics && { committed_metrics: pkg.committedMetrics }),
             ...(pkg.canceledAt && {
               cancellation: {
@@ -10205,14 +10451,18 @@ function getCreativePricing(account: { account_id?: string }, creative: import('
   };
 }
 
-export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext): Promise<Record<string, unknown>> {
+export async function handleUpdateMediaBuy(
+  args: ToolArgs,
+  ctx: TrainingContext,
+  options: { acceptedProposalExecution?: boolean; governance?: TrustedGovernedExecution } = {},
+): Promise<Record<string, unknown>> {
   const req = args as unknown as UpdateMediaBuyArgs;
   const session = await getSession(
     sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId),
     controllerFixtureSessionKey(req as unknown as ToolArgs, ctx),
   );
   const mediaBuyId = req.media_buy_id || '';
-  const mb = session.mediaBuys.get(mediaBuyId);
+  let mb = session.mediaBuys.get(mediaBuyId);
 
   if (!mb) {
     return { errors: [{ code: 'MEDIA_BUY_NOT_FOUND', message: `Media buy not found: ${mediaBuyId}` }] };
@@ -10233,7 +10483,9 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   const productMap = new Map(getCatalog().map(cp => [cp.product.product_id, cp.product]));
   overlaySeededProducts(session, productMap);
 
-  const actionRejection = rejectUnavailableAction(mb, req, currentStatus, productMap);
+  const actionRejection = options.acceptedProposalExecution
+    ? undefined
+    : rejectUnavailableAction(mb, req, currentStatus, productMap);
   if (actionRejection) return actionRejection;
 
   const pausedValue = req.paused;
@@ -10260,8 +10512,8 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   // revision, then enforce the buyer intent's signed ceiling before mutating
   // any state. The buyer's post-update totals are never trusted as the delta.
   const submittedBudgets = [
-    ...(req.packages ?? []).flatMap(update => update.budget === undefined ? [] : [update.budget]),
-    ...(req.new_packages ?? []).map(pkg => pkg.budget),
+    ...(req.packages ?? []).flatMap(update => typeof update.budget === 'number' ? [update.budget] : []),
+    ...(req.new_packages ?? []).flatMap(pkg => typeof pkg.budget === 'number' ? [pkg.budget] : []),
   ];
   if (submittedBudgets.some(budget => !Number.isFinite(budget) || budget < 0)) {
     return { errors: [{ code: 'VALIDATION_ERROR', message: 'Package budgets must be finite, non-negative numbers.' }] };
@@ -10318,11 +10570,11 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     const commitmentError = await governedCommitmentError(
       updateGovernanceContext,
       ctx.authenticatedAgentUrl,
-      'update_media_buy',
+      options.governance?.task ?? 'update_media_buy',
       `${getCanonicalBase()}/sales`,
       governedRequestPayload(ctx, req as unknown as Record<string, unknown>),
-      updateDelta,
-      mb.currency,
+      options.governance?.commitment.amount ?? updateDelta,
+      options.governance?.commitment.currency ?? mb.currency,
     );
     if (commitmentError) return { errors: [commitmentError] };
   } else if (requiresGovernance && (session.governancePlans.size > 0 || updateGovernanceAgents.length > 0)) {
@@ -10337,7 +10589,10 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   const now = new Date().toISOString();
   const affectedPackageIds = new Set<string>();
 
-  // Increment revision once before mutations
+  // Apply the update to a detached working copy. Failed validation after this
+  // point returns without replacing the authoritative map entry, so revisions
+  // and partial package changes remain atomic.
+  mb = structuredClone(mb);
   mb.revision += 1;
 
   // Media buy cancellation
@@ -10349,6 +10604,7 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     mb.cancellationReason = reason;
     mb.history.push({ revision: mb.revision, timestamp: now, actor: 'buyer', action: 'canceled', summary: reason || 'Media buy canceled by buyer' });
     mb.updatedAt = now;
+    session.mediaBuys.set(mediaBuyId, mb);
 
     const status = deriveStatus(mb, session);
     // `media_buy_status` is the canonical 3.1 body field (#4895); legacy
@@ -10376,6 +10632,15 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   }
 
   // Update end_time with validation
+  if (req.start_time) {
+    if (isNaN(new Date(req.start_time).getTime())) {
+      return { errors: [{ code: 'VALIDATION_ERROR', message: `Invalid start_time: "${req.start_time}". Use ISO 8601 format.` }] };
+    }
+    const oldStart = mb.startTime;
+    mb.startTime = req.start_time;
+    mb.history.push({ revision: mb.revision, timestamp: now, actor: 'buyer', action: 'start_time_updated', summary: `Start time changed from ${oldStart} to ${req.start_time}` });
+  }
+
   if (req.end_time) {
     if (isNaN(new Date(req.end_time).getTime())) {
       return { errors: [{ code: 'VALIDATION_ERROR', message: `Invalid end_time: "${req.end_time}". Use ISO 8601 format.` }] };
@@ -10446,7 +10711,7 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
         mb.history.push({ revision: mb.revision, timestamp: now, actor: 'buyer', action, summary: `Package ${pkgId} ${update.paused ? 'paused' : 'resumed'}`, packageId: pkgId });
       }
 
-      if (update.budget !== undefined) {
+      if (typeof update.budget === 'number') {
         if (update.budget < 0) {
           return { errors: [{ code: 'VALIDATION_ERROR', message: `Negative budget rejected for package ${pkgId}. Budget must be non-negative.` }] };
         }
@@ -10454,6 +10719,112 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
         pkg.budget = update.budget;
         affectedPackageIds.add(pkgId);
         mb.history.push({ revision: mb.revision, timestamp: now, actor: 'buyer', action: 'budget_updated', summary: `Package ${pkgId} budget changed from ${oldBudget} to ${update.budget}`, packageId: pkgId });
+      } else if ((update as unknown as Record<string, unknown>).budget === null) {
+        const oldBudget = pkg.budget;
+        pkg.budget = 0;
+        affectedPackageIds.add(pkgId);
+        mb.history.push({ revision: mb.revision, timestamp: now, actor: 'buyer', action: 'budget_updated', summary: `Package ${pkgId} budget cap removed from ${oldBudget}`, packageId: pkgId });
+      }
+
+      const compactControl = update as unknown as Record<string, unknown>;
+      if (typeof compactControl.start_time === 'string') {
+        if (isNaN(new Date(compactControl.start_time).getTime())) {
+          return { errors: [{ code: 'VALIDATION_ERROR', message: `Invalid start_time for package ${pkgId}: "${compactControl.start_time}".` }] };
+        }
+        pkg.startTime = compactControl.start_time;
+        affectedPackageIds.add(pkgId);
+      }
+      if (Object.hasOwn(compactControl, 'daily_budget_cap')) {
+        if (compactControl.daily_budget_cap === null) delete pkg.dailyBudgetCap;
+        else if (typeof compactControl.daily_budget_cap === 'number') pkg.dailyBudgetCap = compactControl.daily_budget_cap;
+        affectedPackageIds.add(pkgId);
+      }
+      if (Object.hasOwn(compactControl, 'min_spend_target')) {
+        if (compactControl.min_spend_target === null) delete pkg.minSpendTarget;
+        else if (typeof compactControl.min_spend_target === 'number') pkg.minSpendTarget = compactControl.min_spend_target;
+        affectedPackageIds.add(pkgId);
+      }
+      if (typeof compactControl.impressions === 'number') {
+        pkg.impressions = compactControl.impressions;
+        affectedPackageIds.add(pkgId);
+      }
+      if (typeof compactControl.pacing === 'string') {
+        pkg.pacing = compactControl.pacing;
+        affectedPackageIds.add(pkgId);
+      }
+      if (Object.hasOwn(compactControl, 'bidding')) {
+        if (compactControl.bidding === null) delete pkg.bidding;
+        else if (isRecord(compactControl.bidding)) pkg.bidding = structuredClone(compactControl.bidding);
+        affectedPackageIds.add(pkgId);
+      }
+      if (Array.isArray(compactControl.catalog_ids)) {
+        pkg.catalogIds = compactControl.catalog_ids.filter((id): id is string => typeof id === 'string');
+        affectedPackageIds.add(pkgId);
+      }
+      if (Array.isArray(compactControl.optimization_goals)) {
+        pkg.optimizationGoals = compactControl.optimization_goals.filter(isRecord).map(goal => structuredClone(goal));
+        affectedPackageIds.add(pkgId);
+      }
+      if (Object.hasOwn(compactControl, 'measurement_terms')) {
+        if (compactControl.measurement_terms === null) delete pkg.measurementTerms;
+        else if (isRecord(compactControl.measurement_terms)) pkg.measurementTerms = structuredClone(compactControl.measurement_terms);
+        affectedPackageIds.add(pkgId);
+      }
+      if (Object.hasOwn(compactControl, 'performance_standards')) {
+        if (compactControl.performance_standards === null) delete pkg.performanceStandards;
+        else if (Array.isArray(compactControl.performance_standards)) {
+          pkg.performanceStandards = compactControl.performance_standards.filter(isRecord).map(value => structuredClone(value));
+        }
+        affectedPackageIds.add(pkgId);
+      }
+      if (Object.hasOwn(compactControl, 'audience_evidence_requirements')) {
+        if (compactControl.audience_evidence_requirements === null) delete pkg.audienceEvidenceRequirements;
+        else if (isRecord(compactControl.audience_evidence_requirements)) {
+          pkg.audienceEvidenceRequirements = structuredClone(compactControl.audience_evidence_requirements);
+        }
+        affectedPackageIds.add(pkgId);
+      }
+      if (Object.hasOwn(compactControl, 'audience_evidence_pins')) {
+        if (compactControl.audience_evidence_pins === null) delete pkg.audienceEvidencePins;
+        else if (Array.isArray(compactControl.audience_evidence_pins)) {
+          pkg.audienceEvidencePins = compactControl.audience_evidence_pins.filter(isRecord).map(value => structuredClone(value));
+        }
+        affectedPackageIds.add(pkgId);
+      }
+      if (Object.hasOwn(compactControl, 'agency_estimate_number')) {
+        if (compactControl.agency_estimate_number === null) delete pkg.agencyEstimateNumber;
+        else if (typeof compactControl.agency_estimate_number === 'string') pkg.agencyEstimateNumber = compactControl.agency_estimate_number;
+        affectedPackageIds.add(pkgId);
+      }
+      if (Object.hasOwn(compactControl, 'context')) {
+        if (compactControl.context === null) delete pkg.context;
+        else if (isRecord(compactControl.context)) pkg.context = structuredClone(compactControl.context);
+        affectedPackageIds.add(pkgId);
+      }
+      if (Object.hasOwn(compactControl, 'ext')) {
+        if (compactControl.ext === null) delete pkg.ext;
+        else if (isRecord(compactControl.ext)) pkg.ext = structuredClone(compactControl.ext);
+        affectedPackageIds.add(pkgId);
+      }
+
+      const keywordDeltaFields = [
+        ['keyword_targets_add', 'keyword_targets', true],
+        ['keyword_targets_remove', 'keyword_targets', false],
+        ['negative_keywords_add', 'negative_keywords', true],
+        ['negative_keywords_remove', 'negative_keywords', false],
+      ] as const;
+      for (const [wireField, stateField, add] of keywordDeltaFields) {
+        const delta = compactControl[wireField];
+        if (!Array.isArray(delta)) continue;
+        const targeting = (pkg.targeting ??= {});
+        const current = Array.isArray(targeting[stateField])
+          ? (targeting[stateField] as unknown[]).filter(isRecord)
+          : [];
+        const keys = new Set(delta.filter(isRecord).map(entry => canonicalize(entry)));
+        targeting[stateField] = add
+          ? [...current, ...delta.filter(isRecord).filter(entry => !new Set(current.map(value => canonicalize(value))).has(canonicalize(entry)))]
+          : current.filter(entry => !keys.has(canonicalize(entry)));
+        affectedPackageIds.add(pkgId);
       }
 
       if (update.end_time) {
@@ -10575,6 +10946,23 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
         pricingOptionId: npkg.pricing_option_id,
         bidPrice: npkg.bid_price,
         impressions: npkg.impressions,
+        dailyBudgetCap: npkg.daily_budget_cap,
+        minSpendTarget: npkg.min_spend_target,
+        pacing: npkg.pacing,
+        bidding: npkg.bidding ? structuredClone(npkg.bidding) : undefined,
+        catalogIds: npkg.catalog_ids ? [...npkg.catalog_ids] : undefined,
+        measurementTerms: npkg.measurement_terms ? structuredClone(npkg.measurement_terms) : undefined,
+        performanceStandards: npkg.performance_standards?.map(
+          value => structuredClone(value) as unknown as Record<string, unknown>,
+        ),
+        audienceEvidenceRequirements: npkg.audience_evidence_requirements
+          ? structuredClone(npkg.audience_evidence_requirements)
+          : undefined,
+        audienceEvidencePins: npkg.audience_evidence_pins?.map(
+          value => structuredClone(value) as unknown as Record<string, unknown>,
+        ),
+        agencyEstimateNumber: npkg.agency_estimate_number,
+        ext: npkg.ext ? structuredClone(npkg.ext) : undefined,
         paused: npkg.paused || false,
         startTime: npkg.start_time || mb.startTime,
         endTime: npkg.end_time || mb.endTime,
@@ -10585,6 +10973,7 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
         }),
         creativeAssignments: [],
         targeting: targetingResult.targeting,
+        context: npkg.context ? structuredClone(npkg.context) : undefined,
       };
       mb.packages.push(newPkg);
       affectedPackageIds.add(pkgId);
@@ -10630,6 +11019,14 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       0,
     );
   }
+  if (aggregateUpdate.daily_budget_cap === null) delete mb.dailyBudgetCap;
+  else if (aggregateUpdate.daily_budget_cap !== undefined) {
+    mb.dailyBudgetCap = aggregateUpdate.daily_budget_cap;
+  }
+  if (aggregateUpdate.budget_cap_timezone === null) delete mb.budgetCapTimezone;
+  else if (aggregateUpdate.budget_cap_timezone !== undefined) {
+    mb.budgetCapTimezone = aggregateUpdate.budget_cap_timezone;
+  }
   if (aggregateUpdate.budget_allocation !== undefined) {
     mb.budgetAllocation = structuredClone(aggregateUpdate.budget_allocation);
   }
@@ -10638,6 +11035,8 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
   else if (aggregateUpdate.bidding !== undefined) {
     mb.aggregateBidding = structuredClone(aggregateUpdate.bidding);
   }
+  const reportingWebhook = (req as unknown as Record<string, unknown>).reporting_webhook;
+  if (isRecord(reportingWebhook)) mb.reportingWebhook = structuredClone(reportingWebhook);
 
   mb.updatedAt = now;
 
@@ -10675,6 +11074,12 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
       currency: mb.currency,
       total_budget: mb.totalBudget,
     }),
+    ...(aggregateUpdate.daily_budget_cap !== undefined && {
+      daily_budget_cap: mb.dailyBudgetCap ?? null,
+    }),
+    ...(aggregateUpdate.budget_cap_timezone !== undefined && {
+      budget_cap_timezone: mb.budgetCapTimezone ?? null,
+    }),
     ...(aggregateUpdate.budget_allocation !== undefined && mb.budgetAllocation
       ? { budget_allocation: mb.budgetAllocation }
       : {}),
@@ -10692,6 +11097,7 @@ export async function handleUpdateMediaBuy(args: ToolArgs, ctx: TrainingContext)
     ...(warnings.length > 0 && { warnings }),
     ...(req.context !== undefined && { context: req.context }),
   };
+  session.mediaBuys.set(mediaBuyId, mb);
   return result;
 }
 
@@ -10746,7 +11152,13 @@ export async function handleGetAdcpCapabilities(args: ToolArgs, ctx: TrainingCon
     ...(!isThreeZeroStoryboardCompat(ctx) ? ['query_provenance_audit_observations'] : []),
   ];
   const governanceEnforcementTasks = ctx.tenantId === 'sales'
-    ? [{ task: 'create_media_buy', modes: ['signed_context'] }]
+    ? supportsGetProductsRejected(servedAdcpVersion)
+      ? [
+          { task: 'buy_products', modes: ['signed_context'] },
+          { task: 'accept_proposal', modes: ['signed_context'] },
+          { task: 'control_media_buy', modes: ['signed_context'] },
+        ]
+      : [{ task: 'create_media_buy', modes: ['signed_context'] }]
     : ctx.tenantId === 'signals'
       ? [{ task: 'activate_signal', modes: ['signed_context'] }]
       : ctx.tenantId === 'brand'
@@ -12786,7 +13198,6 @@ function canonicalProposalFromRecord(record: TrainingProposalRecord): CanonicalP
     proposal_status: 'accepted',
     accepted_at: record.accepted.accepted_at,
     media_buy_id: record.accepted.media_buy_id,
-    base_media_buy_revision: record.accepted.media_buy_revision,
   };
 }
 
@@ -12870,19 +13281,128 @@ function proposalProductsForResults(results: readonly object[]): Array<{ product
     .map(product => ({ product_id: product.product_id, name: product.name }));
 }
 
+function proposalForCurrentMediaBuy(
+  source: CanonicalProposal,
+  mediaBuy: MediaBuyState,
+): CanonicalProposal {
+  // The accepted proposal is an immutable audit snapshot, while self-serve
+  // controls legitimately move operational state within that envelope. A new
+  // amendment must fork the live state or it can silently restore stale terms.
+  const latestAccepted = mediaBuy.acceptedProposal ?? source;
+  const commercialTerms = structuredClone(latestAccepted.commercial_terms) as unknown as Record<string, unknown>;
+  const sourcePurchases = new Map<string, CompactProductPurchase[]>();
+  for (const purchase of latestAccepted.commercial_terms.purchases as CompactProductPurchase[]) {
+    const key = productPricingKey(purchase.product_id, purchase.pricing_option_id);
+    const queue = sourcePurchases.get(key) ?? [];
+    queue.push(purchase);
+    sourcePurchases.set(key, queue);
+  }
+
+  commercialTerms.purchases = mediaBuy.packages
+    .filter(pkg => !pkg.canceled)
+    .map(pkg => {
+      const key = productPricingKey(pkg.productId, pkg.pricingOptionId);
+      const quoted = sourcePurchases.get(key)?.shift();
+      if (!quoted) {
+        throw new Error(`The live media buy package ${pkg.packageId} has no accepted proposal purchase snapshot.`);
+      }
+      const purchase = structuredClone(quoted) as unknown as Record<string, unknown>;
+      for (const field of [
+        'budget',
+        'impressions',
+        'start_time',
+        'end_time',
+        'daily_budget_cap',
+        'min_spend_target',
+        'pacing',
+        'bidding',
+        'catalog_ids',
+        'targeting_overlay',
+        'optimization_goals',
+        'measurement_terms',
+        'performance_standards',
+        'audience_evidence_requirements',
+        'audience_evidence_pins',
+        'agency_estimate_number',
+        'context',
+        'ext',
+      ]) delete purchase[field];
+      return {
+        ...purchase,
+        budget: pkg.budget,
+        start_time: pkg.startTime,
+        end_time: pkg.endTime,
+        ...(pkg.impressions !== undefined && { impressions: pkg.impressions }),
+        ...(pkg.dailyBudgetCap !== undefined && { daily_budget_cap: pkg.dailyBudgetCap }),
+        ...(pkg.minSpendTarget !== undefined && { min_spend_target: pkg.minSpendTarget }),
+        ...(pkg.pacing !== undefined && { pacing: pkg.pacing }),
+        ...(pkg.bidding !== undefined && { bidding: structuredClone(pkg.bidding) }),
+        ...(pkg.catalogIds !== undefined && { catalog_ids: [...pkg.catalogIds] }),
+        ...(pkg.targeting !== undefined && { targeting_overlay: targetingForWire(pkg.targeting) }),
+        ...(pkg.optimizationGoals !== undefined && { optimization_goals: structuredClone(pkg.optimizationGoals) }),
+        ...(pkg.measurementTerms !== undefined && { measurement_terms: structuredClone(pkg.measurementTerms) }),
+        ...(pkg.performanceStandards !== undefined && { performance_standards: structuredClone(pkg.performanceStandards) }),
+        ...(pkg.audienceEvidenceRequirements !== undefined && {
+          audience_evidence_requirements: structuredClone(pkg.audienceEvidenceRequirements),
+        }),
+        ...(pkg.audienceEvidencePins !== undefined && { audience_evidence_pins: structuredClone(pkg.audienceEvidencePins) }),
+        ...(pkg.agencyEstimateNumber !== undefined && { agency_estimate_number: pkg.agencyEstimateNumber }),
+        ...(pkg.context !== undefined && { context: structuredClone(pkg.context) }),
+        ...(pkg.ext !== undefined && { ext: structuredClone(pkg.ext) }),
+      };
+    });
+  commercialTerms.start_time = mediaBuy.startTime;
+  commercialTerms.end_time = mediaBuy.endTime;
+  for (const field of [
+    'total_budget',
+    'daily_budget_cap',
+    'budget_cap_timezone',
+    'budget_allocation',
+    'pacing',
+    'bidding',
+  ]) delete commercialTerms[field];
+  if (mediaBuy.totalBudget !== undefined) {
+    commercialTerms.total_budget = { amount: mediaBuy.totalBudget, currency: mediaBuy.currency };
+  }
+  if (mediaBuy.dailyBudgetCap !== undefined) commercialTerms.daily_budget_cap = mediaBuy.dailyBudgetCap;
+  if (mediaBuy.budgetCapTimezone !== undefined) commercialTerms.budget_cap_timezone = mediaBuy.budgetCapTimezone;
+  if (mediaBuy.budgetAllocation !== undefined) commercialTerms.budget_allocation = structuredClone(mediaBuy.budgetAllocation);
+  if (mediaBuy.aggregatePacing !== undefined) commercialTerms.pacing = mediaBuy.aggregatePacing;
+  if (mediaBuy.aggregateBidding !== undefined) commercialTerms.bidding = structuredClone(mediaBuy.aggregateBidding);
+
+  return {
+    ...source,
+    base_media_buy_revision: mediaBuy.revision,
+    commercial_terms: commercialTerms as unknown as CanonicalProposal['commercial_terms'],
+    terms_digest: proposalTermsDigest(commercialTerms),
+  };
+}
+
 function proposalStoreForSession(
   session: SessionState,
   now: Date,
+  currentMediaBuys: ReadonlyMap<string, MediaBuyState> = new Map(),
 ): ProposalRefinementStore<CanonicalProposal> {
   return {
     get(_scope: Readonly<ProposalRefinementScope>, proposalId: string) {
       const record = session.proposalRefinementRecords.get(proposalId);
-      if (!record) return null;
+      if (!record || record.declined) return null;
       const activeHold = record.activeHold && Date.parse(record.activeHold.expires_at) > now.getTime()
         ? structuredClone(record.activeHold)
         : undefined;
+      const proposal = canonicalProposalFromRecord(record);
+      const currentMediaBuy = record.accepted
+        ? currentMediaBuys.get(record.accepted.media_buy_id)
+        : undefined;
       return {
-        proposal: canonicalProposalFromRecord(record),
+        // Accepted wire snapshots preserve their historical base (and a new
+        // buy has none). The refinement engine instead needs the latest
+        // trusted accepted revision when it forks the next lifecycle change.
+        proposal: currentMediaBuy
+          ? proposalForCurrentMediaBuy(proposal, currentMediaBuy)
+          : record.accepted
+            ? { ...proposal, base_media_buy_revision: record.accepted.media_buy_revision }
+            : proposal,
         version: String(record.version),
         ...(activeHold && { active_hold: activeHold }),
       };
@@ -12929,9 +13449,11 @@ function proposalStoreForSession(
             const internal = internalProposalFromCanonical(proposal, sourceInternal);
             nextInternal.push(internal);
             internalById.set(proposal.proposal_id, internal);
+            const sourceRecord = sourceId ? nextRecords.get(sourceId) : undefined;
             nextRecords.set(proposal.proposal_id, {
               proposal: structuredClone(proposal),
               version: 1,
+              ...(sourceRecord?.ownerAccountId && { ownerAccountId: sourceRecord.ownerAccountId }),
             });
           }
           for (const expected of expectedSources) {
@@ -12966,7 +13488,10 @@ async function handleTypedProposalRefinement(args: ToolArgs, ctx: TrainingContex
   if (!profile || profile === 'ask-only') {
     return { errors: [{ code: 'UNSUPPORTED_FEATURE', message: 'Typed proposal negotiation is not enabled.' }] };
   }
-  const sessionScope = sessionKeyFromArgs({}, ctx.mode, ctx.userId, ctx.moduleId, ctx.principal ?? 'anonymous');
+  const sessionScope = productDiscoverySessionKey({
+    ...(args as unknown as Record<string, unknown>),
+    __compact_proposal_lifecycle: true,
+  } as ToolArgs, ctx);
   const sessionHash = createHash('sha256').update(sessionScope).digest('hex');
   const lockPrincipal = 'get-products-session-mutex';
   const lockKey = `get-products-session:${sessionHash}`;
@@ -12988,6 +13513,17 @@ async function handleTypedProposalRefinement(args: ToolArgs, ctx: TrainingContex
   try {
     evictSessionFromRequestCache(sessionScope);
     const session = await getSession(sessionScope);
+    const mediaBuyArgs = {
+      account: ctx.resolvedAccount ?? (
+        ctx.requestInput?.account && typeof ctx.requestInput.account === 'object'
+          ? ctx.requestInput.account as ToolArgs['account']
+          : args.account
+      ),
+    } as ToolArgs;
+    const mediaBuySession = await getSession(
+      sessionKeyFromArgs(mediaBuyArgs, ctx.mode, ctx.userId, ctx.moduleId),
+      controllerFixtureSessionKey(mediaBuyArgs, ctx),
+    );
     const now = new Date();
     const activeHoldCount = Array.from(session.proposalRefinementRecords.values())
       .filter(record => record.activeHold && Date.parse(record.activeHold.expires_at) > now.getTime())
@@ -13004,8 +13540,8 @@ async function handleTypedProposalRefinement(args: ToolArgs, ctx: TrainingContex
       TrainingProposalPolicyContext
     >({
       capabilities: proposalCapabilitiesForProfile(profile),
-      store: proposalStoreForSession(session, now),
-      scope: (): ProposalRefinementScope => ({
+      store: proposalStoreForSession(session, now, mediaBuySession.mediaBuys),
+      scope: (): ProposalRefinementScope => ctx.proposalRefinementScope ?? ({
         tenant_id: ctx.tenantId ?? 'sales',
         principal_id: ctx.principal ?? 'anonymous',
       }),
@@ -13051,6 +13587,938 @@ async function handleTypedProposalRefinement(args: ToolArgs, ctx: TrainingContex
       claimToken: claim.claimToken,
     });
   }
+}
+
+/**
+ * Execute one compact product-discovery operation inside the SDK 14 platform
+ * boundary. The SDK has already validated the wire request and owns request
+ * idempotency, so this deliberately bypasses the legacy MCP wrapper while
+ * retaining the training agent's shared catalog and proposal state machine.
+ */
+export async function executeProductDiscoveryPlatformTool(
+  toolName: ProductDiscoveryLifecycleTool,
+  args: Record<string, unknown>,
+  ctx: TrainingContext,
+): Promise<Record<string, unknown>> {
+  const sourceSchemaName = productDiscoverySourceSchemaName(toolName);
+  const sourceArgs = { ...args };
+  if (isRecord(sourceArgs.account) && isRecord(sourceArgs.account.brand)) {
+    delete sourceArgs.brand;
+  }
+  if (isRecord(sourceArgs.account)) delete sourceArgs.account_id;
+  if (toolName === 'refine_proposals' || toolName === 'decline_proposals') {
+    delete sourceArgs.account;
+    delete sourceArgs.account_id;
+    delete sourceArgs.brand;
+  }
+  const validationError = sourceSchemaName
+    ? validateProductDiscoverySourceInput(sourceSchemaName, sourceArgs)
+    : undefined;
+  if (validationError) {
+    return {
+      errors: [{
+        code: 'INVALID_REQUEST',
+        message: validationError.message,
+        ...(validationError.field && { field: validationError.field }),
+        recovery: 'correctable',
+      }],
+    };
+  }
+  const typedRefinement = toolName === 'refine_proposals' && usesTypedProposalNegotiation(ctx);
+  const handler = typedRefinement
+    ? handleTypedProposalRefinement
+    : handleGetProducts;
+  const normalized = typedRefinement
+    ? (() => {
+        const {
+          account: _account,
+          account_id: _accountId,
+          brand: _brand,
+          ...proposalArgs
+        } = args;
+        return proposalArgs;
+      })()
+    : normalizeProductDiscoveryArgs(toolName, args);
+  const result = await Promise.resolve(handler(normalized as ToolArgs, {
+    ...ctx,
+    servedAdcpVersion: ctx.servedAdcpVersion ?? CURRENT_ADCP_VERSION,
+  }));
+  await flushDirtySessions();
+  if (typedRefinement) return result as Record<string, unknown>;
+  return projectProductDiscoveryResult(toolName, result as Record<string, unknown>, args);
+}
+
+function legacyPackagesFromPurchases(
+  purchases: readonly CompactProductPurchase[],
+  totalBudget: number | undefined,
+  productMap?: ReadonlyMap<string, Product>,
+): Array<Record<string, unknown>> {
+  const catalog = productMap ?? new Map(getCatalog().map(entry => [entry.product.product_id, entry.product]));
+  const fallbackBudget = totalBudget === undefined ? 0 : totalBudget / Math.max(1, purchases.length);
+  return purchases.map(purchase => {
+    const product = catalog.get(purchase.product_id);
+    const pricing = product?.pricing_options.find(
+      option => option.pricing_option_id === purchase.pricing_option_id,
+    );
+    const pricingView = pricing as unknown as PricingOptionView | undefined;
+    const bidding = purchase.bidding as Record<string, unknown> | undefined;
+    const bidPrice = typeof bidding?.bid_amount === 'number'
+      ? bidding.bid_amount
+      : typeof bidding?.max_bid === 'number'
+        ? bidding.max_bid
+        : pricingView?.price_guidance?.p50 ?? pricingView?.floor_price;
+    return {
+      product_id: purchase.product_id,
+      pricing_option_id: purchase.pricing_option_id,
+      budget: purchase.budget ?? fallbackBudget,
+      ...(bidPrice !== undefined && pricing && pricingStructureForOption(pricing) === 'auction'
+        ? { bid_price: bidPrice }
+        : {}),
+      ...(purchase.impressions !== undefined && { impressions: purchase.impressions }),
+      ...(purchase.start_time !== undefined && { start_time: purchase.start_time }),
+      ...(purchase.end_time !== undefined && { end_time: purchase.end_time }),
+      ...(purchase.format_option_refs !== undefined && { format_option_refs: purchase.format_option_refs }),
+      ...(purchase.catalog_ids !== undefined && { catalog_ids: purchase.catalog_ids }),
+      ...(purchase.daily_budget_cap !== undefined && { daily_budget_cap: purchase.daily_budget_cap }),
+      ...(purchase.min_spend_target !== undefined && { min_spend_target: purchase.min_spend_target }),
+      ...(purchase.pacing !== undefined && { pacing: purchase.pacing }),
+      ...(purchase.bidding !== undefined && { bidding: purchase.bidding }),
+      ...(purchase.targeting_overlay !== undefined && { targeting_overlay: purchase.targeting_overlay }),
+      ...(purchase.optimization_goals !== undefined && { optimization_goals: purchase.optimization_goals }),
+      ...(purchase.audience_evidence_requirements !== undefined && { audience_evidence_requirements: purchase.audience_evidence_requirements }),
+      ...(purchase.audience_evidence_pins !== undefined && { audience_evidence_pins: purchase.audience_evidence_pins }),
+      ...(purchase.agency_estimate_number !== undefined && { agency_estimate_number: purchase.agency_estimate_number }),
+      ...(purchase.measurement_terms !== undefined && { measurement_terms: purchase.measurement_terms }),
+      ...(purchase.performance_standards !== undefined && { performance_standards: purchase.performance_standards }),
+      ...(purchase.context !== undefined && { context: purchase.context }),
+      ...(purchase.ext !== undefined && { ext: purchase.ext }),
+    };
+  });
+}
+
+function purchaseBindings(
+  purchases: readonly CompactProductPurchase[],
+  response: Record<string, unknown>,
+): Array<{ purchase_index: number; product_id: string; package_id: string }> {
+  const packages = Array.isArray(response.packages) ? response.packages.filter(isRecord) : [];
+  if (
+    packages.length !== purchases.length
+    || packages.some(pkg => typeof pkg.package_id !== 'string' || pkg.package_id.length === 0)
+  ) {
+    throw new Error('Media-buy creation did not return one canonical package_id for every purchase.');
+  }
+  return purchases.map((purchase, index) => ({
+    purchase_index: index,
+    product_id: purchase.product_id,
+    package_id: packages[index]!.package_id as string,
+  }));
+}
+
+/** Native SDK 14 direct-purchase adapter backed by the shared MediaBuy state engine. */
+export async function handleBuyProducts(
+  args: BuyProductsRequest & ToolArgs,
+  ctx: TrainingContext,
+): Promise<Record<string, unknown>> {
+  const session = await getSession(
+    sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId),
+    controllerFixtureSessionKey(args, ctx),
+  );
+  const feed = productWholesaleFeedMeta(args, session);
+  if (args.feed_version !== feed.wholesale_feed_version) {
+    return { errors: [{
+      code: 'INVALID_REQUEST',
+      message: `feed_version must equal ${feed.wholesale_feed_version}.`,
+      field: 'feed_version',
+      recovery: 'correctable',
+      details: { current_feed_version: feed.wholesale_feed_version },
+    }] };
+  }
+  if (args.pricing_version !== feed.pricing_version) {
+    return { errors: [{
+      code: 'INVALID_REQUEST',
+      message: `pricing_version must equal ${feed.pricing_version}.`,
+      field: 'pricing_version',
+      recovery: 'correctable',
+      details: { current_pricing_version: feed.pricing_version },
+    }] };
+  }
+
+  const catalog = new Map(getCatalog().map(entry => [entry.product.product_id, entry.product]));
+  overlaySeededProducts(session, catalog);
+  const canonicalPurchases: CompactProductPurchase[] = [];
+  for (let index = 0; index < args.purchases.length; index++) {
+    const purchase = args.purchases[index]!;
+    const product = catalog.get(purchase.product_id);
+    const pricing = product?.pricing_options.find(
+      option => option.pricing_option_id === purchase.pricing_option_id,
+    );
+    if (!product || !pricing) {
+      return {
+        errors: [{
+          code: !product ? 'PRODUCT_NOT_FOUND' : 'INVALID_PRICING_OPTION',
+          message: !product
+            ? `Product not found: ${purchase.product_id}`
+            : `Pricing option not found: ${purchase.pricing_option_id}`,
+          field: `purchases[${index}].${!product ? 'product_id' : 'pricing_option_id'}`,
+          ...(!product ? {} : {
+            details: {
+              rejected_value: purchase.pricing_option_id,
+              accepted_values: product.pricing_options.map(option => option.pricing_option_id),
+            },
+          }),
+        }],
+      };
+    }
+    const canonicalPricing = canonicalPricingSnapshot(pricing, purchase.pricing_option_id);
+    if (
+      purchase.pricing !== undefined
+      && canonicalize(purchase.pricing) !== canonicalize(canonicalPricing)
+    ) {
+      return {
+        errors: [{
+          code: 'INVALID_REQUEST',
+          message: 'Supplied pricing must exactly match the selected published pricing option.',
+          field: `purchases[${index}].pricing`,
+          recovery: 'correctable',
+        }],
+      };
+    }
+    const productTerms = product as unknown as Record<string, unknown>;
+    for (const field of ['measurement_terms', 'performance_standards'] as const) {
+      const supplied = purchase[field];
+      const published = productTerms[field];
+      if (supplied !== undefined && canonicalize(supplied) !== canonicalize(published)) {
+        return {
+          errors: [{
+            code: 'INVALID_REQUEST',
+            message: `${field} must exactly match the selected published product offer.`,
+            field: `purchases[${index}].${field}`,
+            recovery: 'correctable',
+          }],
+        };
+      }
+    }
+    canonicalPurchases.push({
+      ...structuredClone(purchase),
+      pricing: canonicalPricing as unknown as CompactProductPurchase['pricing'],
+      start_time: purchase.start_time ?? args.start_time,
+      end_time: purchase.end_time ?? args.end_time,
+      ...(purchase.measurement_terms === undefined
+        && isRecord(productTerms.measurement_terms)
+        && { measurement_terms: structuredClone(productTerms.measurement_terms) }),
+      ...(purchase.performance_standards === undefined
+        && Array.isArray(productTerms.performance_standards)
+        && { performance_standards: structuredClone(productTerms.performance_standards).filter(isRecord) }),
+    });
+  }
+
+  const createResult = await handleCreateMediaBuy({
+    ...(args as unknown as Record<string, unknown>),
+    packages: legacyPackagesFromPurchases(canonicalPurchases, args.total_budget?.amount, catalog),
+  } as ToolArgs, ctx, {
+    governance: {
+      task: 'buy_products',
+      commitment: {
+        amount: args.total_budget?.amount
+          ?? canonicalPurchases.reduce((sum, purchase) => sum + (purchase.budget ?? 0), 0),
+        currency: resolveAccountCurrencyForRef(
+          sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId),
+          ctx.principal,
+          ctx.resolvedAccount ?? args.account,
+        ) ?? args.total_budget?.currency ?? 'USD',
+      },
+    },
+  }) as Record<string, unknown>;
+  if (Array.isArray(createResult.errors) && createResult.errors.length > 0) return createResult;
+
+  const mediaBuyId = String(createResult.media_buy_id);
+  const acceptedAt = new Date().toISOString();
+  const accountBrand = isRecord(args.account) && isRecord(args.account.brand)
+    ? args.account.brand
+    : undefined;
+  const brand = args.brand ?? accountBrand ?? { domain: 'advertiser.example' };
+  const commercialTerms = {
+    source_feed_version: args.feed_version,
+    ...(args.pricing_version !== undefined && { source_pricing_version: args.pricing_version }),
+    brand,
+    ...(args.advertiser_industry !== undefined && { advertiser_industry: args.advertiser_industry }),
+    purchases: canonicalPurchases,
+    start_time: args.start_time,
+    end_time: args.end_time,
+    ...(args.total_budget !== undefined && { total_budget: args.total_budget }),
+    ...(args.daily_budget_cap !== undefined && { daily_budget_cap: args.daily_budget_cap }),
+    ...(args.budget_cap_timezone !== undefined && { budget_cap_timezone: args.budget_cap_timezone }),
+    ...(args.budget_allocation !== undefined && { budget_allocation: args.budget_allocation }),
+    ...(args.pacing !== undefined && { pacing: args.pacing }),
+    ...(args.bidding !== undefined && { bidding: args.bidding }),
+    ...(args.purchase_order_ref !== undefined && { purchase_order_ref: args.purchase_order_ref }),
+    ...(args.agency_estimate_number !== undefined && { agency_estimate_number: args.agency_estimate_number }),
+  } as Record<string, unknown>;
+  const acceptedProposal = {
+    proposal_id: `proposal_direct_${randomUUID().slice(0, 12)}`,
+    proposal_kind: 'new_media_buy',
+    proposal_status: 'accepted',
+    accepted_at: acceptedAt,
+    media_buy_id: mediaBuyId,
+    name: 'Direct product purchase',
+    commercial_terms: commercialTerms,
+    terms_digest: proposalTermsDigest(commercialTerms),
+  } as unknown as CanonicalProposal;
+  const mediaBuy = session.mediaBuys.get(mediaBuyId);
+  if (mediaBuy) mediaBuy.acceptedProposal = structuredClone(acceptedProposal);
+  const proposalSession = await getSession(productDiscoverySessionKey({
+    ...(args as unknown as Record<string, unknown>),
+    __compact_proposal_lifecycle: true,
+  } as ToolArgs, ctx));
+  proposalSession.proposalRefinementRecords.set(acceptedProposal.proposal_id, {
+    proposal: structuredClone(acceptedProposal),
+    version: 1,
+    ...(ctx.resolvedAccountId && { ownerAccountId: ctx.resolvedAccountId }),
+    accepted: {
+      accepted_at: acceptedAt,
+      media_buy_id: mediaBuyId,
+      media_buy_revision: Number(createResult.revision),
+    },
+  });
+  const directInternalProposal = {
+    proposal_id: acceptedProposal.proposal_id,
+    name: acceptedProposal.name,
+    allocations: canonicalPurchases.map((purchase, index) => ({
+      product_id: purchase.product_id,
+      pricing_option_id: purchase.pricing_option_id,
+      allocation_percentage: 100 / canonicalPurchases.length,
+      rationale: `Direct purchase ${index + 1}`,
+    })) as Proposal['allocations'],
+    proposal_status: 'accepted',
+    __executed: true,
+    __accepted_at: acceptedAt,
+    __media_buy_id: mediaBuyId,
+    __media_buy_revision: createResult.revision,
+    __canonical_commercial_terms: commercialTerms,
+    __canonical_terms_digest: acceptedProposal.terms_digest,
+  } as unknown as Proposal;
+  proposalSession.lastGetProductsContext = {
+    ...(proposalSession.lastGetProductsContext ?? {}),
+    proposals: [
+      ...(proposalSession.lastGetProductsContext?.proposals ?? []),
+      directInternalProposal,
+    ],
+  };
+  return {
+    status: 'completed',
+    media_buy_id: mediaBuyId,
+    revision: createResult.revision,
+    ...(createResult.media_buy_status !== undefined && { media_buy_status: createResult.media_buy_status }),
+    ...(createResult.confirmed_at !== undefined && { confirmed_at: createResult.confirmed_at }),
+    accepted_proposal: acceptedProposal,
+    purchase_bindings: purchaseBindings(args.purchases, createResult),
+    available_actions: Array.isArray(createResult.available_actions) ? createResult.available_actions : [],
+  };
+}
+
+function proposalAcceptanceSnapshot(
+  record: TrainingProposalRecord | undefined,
+  args: AcceptProposalRequest,
+  ctx: TrainingContext,
+): { proposal: CanonicalProposal } | { response: Record<string, unknown> } {
+  if (!record || (record.ownerAccountId && record.ownerAccountId !== ctx.resolvedAccountId)) {
+    return { response: { errors: [{ code: 'PROPOSAL_NOT_FOUND', message: `Proposal not found: ${args.proposal_id}`, field: 'proposal_id' }] } };
+  }
+  if (record.declined) {
+    return { response: { errors: [{ code: 'INVALID_STATE', message: `Proposal ${args.proposal_id} was declined and cannot be accepted.`, field: 'proposal_id' }] } };
+  }
+  const proposal = canonicalProposalFromRecord(record);
+  if (record.accepted) {
+    return { response: { errors: [{ code: 'INVALID_STATE', message: `Proposal ${args.proposal_id} was already accepted.`, field: 'proposal_id' }] } };
+  }
+  if (proposal.proposal_status !== 'committed') {
+    return { response: { errors: [{ code: 'PROPOSAL_NOT_COMMITTED', message: `Proposal ${args.proposal_id} is not committed.`, field: 'proposal_id' }] } };
+  }
+  if (proposal.expires_at && Date.parse(proposal.expires_at) <= Date.now()) {
+    return { response: { errors: [{ code: 'PROPOSAL_EXPIRED', message: `Proposal ${args.proposal_id} expired at ${proposal.expires_at}.`, field: 'proposal_id' }] } };
+  }
+  if (proposal.terms_digest !== args.proposal_terms_digest) {
+    return { response: { errors: [{ code: 'INVALID_REQUEST', message: 'proposal_terms_digest does not match the committed proposal snapshot.', field: 'proposal_terms_digest' }] } };
+  }
+  return { proposal };
+}
+
+function compactPackagePatch(purchase: CompactProductPurchase, packageId: string): Record<string, unknown> {
+  return {
+    package_id: packageId,
+    ...(purchase.budget !== undefined && { budget: purchase.budget }),
+    ...(purchase.impressions !== undefined && { impressions: purchase.impressions }),
+    ...(purchase.start_time !== undefined && { start_time: purchase.start_time }),
+    ...(purchase.end_time !== undefined && { end_time: purchase.end_time }),
+    ...(purchase.daily_budget_cap !== undefined && { daily_budget_cap: purchase.daily_budget_cap }),
+    ...(purchase.min_spend_target !== undefined && { min_spend_target: purchase.min_spend_target }),
+    ...(purchase.pacing !== undefined && { pacing: purchase.pacing }),
+    ...(purchase.bidding !== undefined && { bidding: purchase.bidding }),
+    ...(purchase.catalog_ids !== undefined && { catalog_ids: purchase.catalog_ids }),
+    ...(purchase.targeting_overlay !== undefined && { targeting_overlay: purchase.targeting_overlay }),
+    ...(purchase.optimization_goals !== undefined && { optimization_goals: purchase.optimization_goals }),
+    ...(purchase.measurement_terms !== undefined && { measurement_terms: purchase.measurement_terms }),
+    ...(purchase.performance_standards !== undefined && { performance_standards: purchase.performance_standards }),
+    ...(purchase.audience_evidence_requirements !== undefined && { audience_evidence_requirements: purchase.audience_evidence_requirements }),
+    ...(purchase.audience_evidence_pins !== undefined && { audience_evidence_pins: purchase.audience_evidence_pins }),
+    ...(purchase.agency_estimate_number !== undefined && { agency_estimate_number: purchase.agency_estimate_number }),
+    ...(purchase.context !== undefined && { context: purchase.context }),
+    ...(purchase.ext !== undefined && { ext: purchase.ext }),
+  };
+}
+
+function productPricingKey(productId: string, pricingOptionId: string): string {
+  return `${productId}\u0000${pricingOptionId}`;
+}
+
+async function acceptExistingMediaBuyProposal(
+  args: AcceptProposalRequest & ToolArgs,
+  ctx: TrainingContext,
+  proposalSessionKey: string,
+): Promise<Record<string, unknown>> {
+  const sessionHash = createHash('sha256').update(proposalSessionKey).digest('hex');
+  const principal = 'get-products-session-mutex';
+  const key = `get-products-session:${sessionHash}`;
+  const store = getIdempotencyStore();
+  let claim = await store.check({ principal, key, payload: { session: sessionHash } });
+  const deadline = Date.now() + 2_000;
+  let backoffMs = 5;
+  while (claim.kind !== 'miss' && Date.now() < deadline) {
+    await new Promise(resolve => setTimeout(resolve, backoffMs));
+    claim = await store.check({ principal, key, payload: { session: sessionHash } });
+    backoffMs = Math.min(backoffMs * 2, 100);
+  }
+  if (claim.kind !== 'miss') {
+    return { errors: [{ code: 'CONFLICT', message: 'Another proposal lifecycle request is already updating this session. Retry after a short delay.', recovery: 'transient' }] };
+  }
+
+  try {
+    const mediaBuySessionKey = sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId);
+    evictSessionFromRequestCache(proposalSessionKey);
+    evictSessionFromRequestCache(mediaBuySessionKey);
+    const proposalSession = await getSession(proposalSessionKey);
+    const validation = proposalAcceptanceSnapshot(
+      proposalSession.proposalRefinementRecords.get(args.proposal_id),
+      args,
+      ctx,
+    );
+    if ('response' in validation) return validation.response;
+    const proposal = validation.proposal;
+    const record = proposalSession.proposalRefinementRecords.get(args.proposal_id)!;
+    const mediaBuyId = proposal.media_buy_id;
+    const mediaBuySession = await getSession(
+      mediaBuySessionKey,
+      controllerFixtureSessionKey(args, ctx),
+    );
+    const mediaBuy = mediaBuyId ? mediaBuySession.mediaBuys.get(mediaBuyId) : undefined;
+    if (!mediaBuyId || !mediaBuy) {
+      return { errors: [{ code: 'PROPOSAL_NOT_FOUND', message: `Proposal not found: ${args.proposal_id}`, field: 'proposal_id' }] };
+    }
+    if (proposal.base_media_buy_revision === undefined) {
+      return { errors: [{ code: 'INVALID_STATE', message: 'The proposal is missing base_media_buy_revision.', field: 'proposal_id' }] };
+    }
+
+    const terms = proposal.commercial_terms;
+    const compactTerms = terms as unknown as Record<string, unknown>;
+    const compactPurchases = terms.purchases as unknown as CompactProductPurchase[];
+    const cancellationTerms = isRecord(compactTerms.cancellation_terms) ? compactTerms.cancellation_terms : undefined;
+    const bindingIds = new Map<number, string>();
+    const priorPackageIds = new Set(mediaBuy.packages.map(pkg => pkg.packageId));
+    const newPurchaseIndexes: number[] = [];
+    let operationalPatch: Record<string, unknown>;
+    if (proposal.proposal_kind === 'media_buy_cancellation') {
+      const packageQueues = new Map<string, PackageState[]>();
+      for (const pkg of mediaBuy.packages.filter(candidate => !candidate.canceled)) {
+        const matchKey = productPricingKey(pkg.productId, pkg.pricingOptionId);
+        const queue = packageQueues.get(matchKey) ?? [];
+        queue.push(pkg);
+        packageQueues.set(matchKey, queue);
+      }
+      for (const [index, purchase] of compactPurchases.entries()) {
+        const existing = packageQueues.get(
+          productPricingKey(purchase.product_id, purchase.pricing_option_id),
+        )?.shift();
+        if (!existing) {
+          return { errors: [{
+            code: 'INVALID_STATE',
+            message: 'The cancellation proposal no longer matches the media buy package set.',
+            field: `accepted_proposal.commercial_terms.purchases[${index}]`,
+          }] };
+        }
+        bindingIds.set(index, existing.packageId);
+      }
+      operationalPatch = {
+        canceled: true,
+        cancellation_reason: cancellationTerms?.reason ?? 'Negotiated cancellation accepted',
+      };
+    } else {
+      const packageQueues = new Map<string, PackageState[]>();
+      for (const pkg of mediaBuy.packages.filter(candidate => !candidate.canceled)) {
+        const matchKey = productPricingKey(pkg.productId, pkg.pricingOptionId);
+        const queue = packageQueues.get(matchKey) ?? [];
+        queue.push(pkg);
+        packageQueues.set(matchKey, queue);
+      }
+      const matchedPackageIds = new Set<string>();
+      const packageUpdates: Record<string, unknown>[] = [];
+      const productMap = new Map(getCatalog().map(entry => [entry.product.product_id, entry.product]));
+      overlaySeededProducts(mediaBuySession, productMap);
+      const packageViews = legacyPackagesFromPurchases(compactPurchases, (args.total_budget ?? terms.total_budget)?.amount, productMap);
+      const newPackages: Record<string, unknown>[] = [];
+      compactPurchases.forEach((purchase, index) => {
+        const existing = packageQueues.get(productPricingKey(purchase.product_id, purchase.pricing_option_id))?.shift();
+        if (existing) {
+          matchedPackageIds.add(existing.packageId);
+          bindingIds.set(index, existing.packageId);
+          packageUpdates.push(compactPackagePatch(purchase, existing.packageId));
+        } else {
+          newPurchaseIndexes.push(index);
+          newPackages.push(packageViews[index]!);
+        }
+      });
+      for (const pkg of mediaBuy.packages.filter(candidate => !candidate.canceled && !matchedPackageIds.has(candidate.packageId))) {
+        packageUpdates.push({
+          package_id: pkg.packageId,
+          canceled: true,
+          cancellation_reason: 'Removed by accepted proposal amendment',
+        });
+      }
+      const totalBudget = args.total_budget ?? terms.total_budget;
+      operationalPatch = {
+        ...(totalBudget && { total_budget: totalBudget }),
+        ...(terms.start_time !== undefined && { start_time: terms.start_time }),
+        ...(terms.end_time !== undefined && { end_time: terms.end_time }),
+        ...(compactTerms.daily_budget_cap !== undefined && { daily_budget_cap: compactTerms.daily_budget_cap }),
+        ...(compactTerms.budget_cap_timezone !== undefined && { budget_cap_timezone: compactTerms.budget_cap_timezone }),
+        ...(compactTerms.budget_allocation !== undefined && { budget_allocation: compactTerms.budget_allocation }),
+        ...(compactTerms.pacing !== undefined && { pacing: compactTerms.pacing }),
+        ...(compactTerms.bidding !== undefined && { bidding: compactTerms.bidding }),
+        packages: packageUpdates,
+        ...(newPackages.length > 0 && { new_packages: newPackages }),
+      };
+    }
+
+    const proposalCommitment = governanceProposalCommitment(
+      proposal as unknown as Parameters<typeof governanceProposalCommitment>[0],
+    );
+    const acceptedCommitment = proposal.proposal_kind === 'media_buy_cancellation'
+      ? {
+          amount: proposalCommitment.amount ?? 0,
+          currency: proposalCommitment.currency ?? mediaBuy.currency,
+        }
+      : {
+          amount: positiveMediaBuyUpdateDelta(
+            mediaBuy,
+            operationalPatch as unknown as UpdateMediaBuyArgs,
+          ),
+          currency: mediaBuy.currency,
+        };
+    const updateResult = await handleUpdateMediaBuy({
+      ...(args as unknown as Record<string, unknown>),
+      ...operationalPatch,
+      media_buy_id: mediaBuyId,
+      revision: proposal.base_media_buy_revision,
+    } as ToolArgs, ctx, {
+      acceptedProposalExecution: true,
+      governance: {
+        task: 'accept_proposal',
+        commitment: acceptedCommitment,
+      },
+    });
+    if (Array.isArray(updateResult.errors) && updateResult.errors.length > 0) return updateResult;
+
+    const updatedMediaBuy = mediaBuySession.mediaBuys.get(mediaBuyId)!;
+    const addedPackages = updatedMediaBuy.packages.filter(pkg => !priorPackageIds.has(pkg.packageId));
+    if (addedPackages.length !== newPurchaseIndexes.length) {
+      throw new Error('Accepted amendment did not persist one canonical package for every added purchase.');
+    }
+    newPurchaseIndexes.forEach((purchaseIndex, index) => {
+      bindingIds.set(purchaseIndex, addedPackages[index]!.packageId);
+    });
+    const acceptedAt = new Date().toISOString();
+    const acceptedProposal = {
+      ...structuredClone(proposal),
+      proposal_status: 'accepted',
+      accepted_at: acceptedAt,
+      media_buy_id: mediaBuyId,
+    } as CanonicalProposal;
+    proposalSession.proposalRefinementRecords.set(args.proposal_id, {
+      ...record,
+      version: record.version + 1,
+      proposal: structuredClone(acceptedProposal),
+      accepted: {
+        accepted_at: acceptedAt,
+        media_buy_id: mediaBuyId,
+        media_buy_revision: Number(updateResult.revision),
+      },
+    });
+    for (const [proposalId, source] of proposalSession.proposalRefinementRecords) {
+      if (source.activeHold?.proposal_id !== args.proposal_id) continue;
+      proposalSession.proposalRefinementRecords.set(proposalId, {
+        ...source,
+        version: source.version + 1,
+        activeHold: undefined,
+      });
+    }
+    if (proposalSession.lastGetProductsContext?.proposals) {
+      proposalSession.lastGetProductsContext = {
+        ...proposalSession.lastGetProductsContext,
+        proposals: proposalSession.lastGetProductsContext.proposals.map(candidate => (
+          candidate.proposal_id === args.proposal_id
+            ? {
+                ...candidate,
+                __executed: true,
+                __accepted_at: acceptedAt,
+                __media_buy_id: mediaBuyId,
+                __media_buy_revision: Number(updateResult.revision),
+              } as unknown as Proposal
+            : candidate
+        )),
+      };
+    }
+    updatedMediaBuy.acceptedProposal = structuredClone(acceptedProposal);
+    await flushDirtySessions();
+    return {
+      status: 'completed',
+      media_buy_id: mediaBuyId,
+      revision: updateResult.revision,
+      ...(updateResult.media_buy_status !== undefined && { media_buy_status: updateResult.media_buy_status }),
+      accepted_proposal: acceptedProposal,
+      purchase_bindings: compactPurchases.map((purchase, index) => ({
+        purchase_index: index,
+        product_id: purchase.product_id,
+        package_id: bindingIds.get(index),
+      })),
+      available_actions: availableActionsForMediaBuy(
+        updatedMediaBuy,
+        String(updateResult.media_buy_status ?? updatedMediaBuy.status),
+      ),
+    };
+  } finally {
+    await store.release({ principal, key, claimToken: claim.claimToken });
+  }
+}
+
+/** Native SDK 14 committed-proposal acceptance adapter. */
+export async function handleAcceptProposal(
+  args: AcceptProposalRequest & ToolArgs,
+  ctx: TrainingContext,
+): Promise<Record<string, unknown>> {
+  const proposalSessionKey = productDiscoverySessionKey({
+    ...(args as unknown as Record<string, unknown>),
+    __compact_proposal_lifecycle: true,
+  } as ToolArgs, ctx);
+  const proposalSession = await getSession(proposalSessionKey);
+  const validation = proposalAcceptanceSnapshot(
+    proposalSession.proposalRefinementRecords.get(args.proposal_id),
+    args,
+    ctx,
+  );
+  if ('response' in validation) return validation.response;
+  const proposal = validation.proposal;
+  if (proposal.proposal_kind !== 'new_media_buy') {
+    return acceptExistingMediaBuyProposal(args, ctx, proposalSessionKey);
+  }
+
+  const terms = proposal.commercial_terms;
+  const totalBudget = args.total_budget ?? terms.total_budget;
+  if (!totalBudget) {
+    return { errors: [{ code: 'INVALID_REQUEST', message: 'total_budget is required when the proposal does not commit a fixed total.', field: 'total_budget' }] };
+  }
+  const createResult = await handleCreateMediaBuy({
+    ...(args as unknown as Record<string, unknown>),
+    __compact_proposal_lifecycle: true,
+    total_budget: totalBudget,
+    start_time: terms.start_time,
+    end_time: terms.end_time,
+    ...((terms as unknown as Record<string, unknown>).daily_budget_cap !== undefined && {
+      daily_budget_cap: (terms as unknown as Record<string, unknown>).daily_budget_cap,
+    }),
+    ...((terms as unknown as Record<string, unknown>).budget_cap_timezone !== undefined && {
+      budget_cap_timezone: (terms as unknown as Record<string, unknown>).budget_cap_timezone,
+    }),
+    ...((terms as unknown as Record<string, unknown>).budget_allocation !== undefined && {
+      budget_allocation: (terms as unknown as Record<string, unknown>).budget_allocation,
+    }),
+    ...((terms as unknown as Record<string, unknown>).pacing !== undefined && {
+      pacing: (terms as unknown as Record<string, unknown>).pacing,
+    }),
+    ...((terms as unknown as Record<string, unknown>).bidding !== undefined && {
+      bidding: (terms as unknown as Record<string, unknown>).bidding,
+    }),
+    ...((terms as unknown as Record<string, unknown>).purchase_order_ref !== undefined && {
+      purchase_order_ref: (terms as unknown as Record<string, unknown>).purchase_order_ref,
+    }),
+    ...((terms as unknown as Record<string, unknown>).agency_estimate_number !== undefined && {
+      agency_estimate_number: (terms as unknown as Record<string, unknown>).agency_estimate_number,
+    }),
+    proposal_id: args.proposal_id,
+  } as ToolArgs, ctx, {
+    governance: {
+      task: 'accept_proposal',
+      commitment: { amount: totalBudget.amount, currency: totalBudget.currency },
+    },
+  }) as Record<string, unknown>;
+  if (Array.isArray(createResult.errors) && createResult.errors.length > 0) return createResult;
+  const acceptedProposalSession = await getSession(proposalSessionKey);
+  const acceptedRecord = acceptedProposalSession.proposalRefinementRecords.get(args.proposal_id);
+  const acceptedProposal = acceptedRecord
+    ? canonicalProposalFromRecord(acceptedRecord)
+    : { ...proposal, proposal_status: 'accepted', media_buy_id: createResult.media_buy_id };
+  return {
+    status: 'completed',
+    media_buy_id: createResult.media_buy_id,
+    revision: createResult.revision,
+    ...(createResult.media_buy_status !== undefined && { media_buy_status: createResult.media_buy_status }),
+    ...(createResult.confirmed_at !== undefined && { confirmed_at: createResult.confirmed_at }),
+    accepted_proposal: acceptedProposal,
+    purchase_bindings: purchaseBindings(terms.purchases, createResult),
+    available_actions: Array.isArray(createResult.available_actions) ? createResult.available_actions : [],
+  };
+}
+
+/** Native SDK 14 operational-control adapter. */
+export async function handleControlMediaBuy(
+  args: ControlMediaBuyRequest & ToolArgs,
+  ctx: TrainingContext,
+): Promise<Record<string, unknown>> {
+  if (Array.isArray(args.packages)) {
+    const seenPackageIds = new Set<string>();
+    for (const [index, rawPackage] of args.packages.entries()) {
+      const pkg = rawPackage as unknown as Record<string, unknown>;
+      const packageId = typeof pkg.package_id === 'string' ? pkg.package_id : '';
+      if (seenPackageIds.has(packageId)) {
+        return { errors: [{
+          code: 'INVALID_REQUEST',
+          message: 'packages must contain unique package_id values.',
+          field: `packages[${index}].package_id`,
+          recovery: 'correctable',
+        }] };
+      }
+      seenPackageIds.add(packageId);
+      for (const [addField, removeField] of [
+        ['keyword_targets_add', 'keyword_targets_remove'],
+        ['negative_keywords_add', 'negative_keywords_remove'],
+      ] as const) {
+        const additions = Array.isArray(pkg[addField]) ? pkg[addField] as unknown[] : [];
+        const removals = new Set(
+          (Array.isArray(pkg[removeField]) ? pkg[removeField] as unknown[] : []).map(value => canonicalize(value)),
+        );
+        if (additions.some(value => removals.has(canonicalize(value)))) {
+          return { errors: [{
+            code: 'INVALID_REQUEST',
+            message: `${addField} and ${removeField} must be disjoint.`,
+            field: `packages[${index}].${addField}`,
+            recovery: 'correctable',
+          }] };
+        }
+      }
+    }
+  }
+  const session = await getSession(
+    sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId),
+    controllerFixtureSessionKey(args, ctx),
+  );
+  const mediaBuy = session.mediaBuys.get(args.media_buy_id);
+  if (mediaBuy?.acceptedProposal && args.revision === mediaBuy.revision) {
+    const acceptedTerms = mediaBuy.acceptedProposal.commercial_terms as unknown as Record<string, unknown>;
+    const acceptedTotal = (isRecord(acceptedTerms.total_budget)
+      && typeof acceptedTerms.total_budget.amount === 'number'
+      ? acceptedTerms.total_budget.amount
+      : undefined) ?? mediaBuy.totalBudget;
+    const requestedTotal = isRecord((args as unknown as Record<string, unknown>).total_budget)
+      && typeof ((args as unknown as Record<string, unknown>).total_budget as Record<string, unknown>).amount === 'number'
+      ? ((args as unknown as Record<string, unknown>).total_budget as Record<string, unknown>).amount as number
+      : undefined;
+    if (acceptedTotal !== undefined && requestedTotal !== undefined && requestedTotal > acceptedTotal) {
+      return { errors: [{
+        code: 'REQUOTE_REQUIRED',
+        message: 'The requested total budget exceeds the accepted proposal envelope.',
+        field: 'total_budget.amount',
+        recovery: 'correctable',
+        details: { envelope_field: 'total_budget.amount', accepted_maximum: acceptedTotal },
+      }] };
+    }
+
+    const requestedPackages = Array.isArray(args.packages) ? args.packages : [];
+    const requote = (envelopeField: string, message: string): Record<string, unknown> => ({
+      errors: [{
+        code: 'REQUOTE_REQUIRED',
+        message,
+        field: envelopeField,
+        recovery: 'correctable',
+        details: { envelope_field: envelopeField },
+      }],
+    });
+    const aggregateControl = args as unknown as Record<string, unknown>;
+    for (const field of ['budget_allocation', 'pacing', 'bidding', 'start_time', 'end_time'] as const) {
+      if (aggregateControl[field] === undefined) continue;
+      if (
+        acceptedTerms[field] !== undefined
+        && canonicalize(aggregateControl[field]) !== canonicalize(acceptedTerms[field])
+      ) {
+        return requote(field, `The requested ${field} changes the accepted proposal envelope.`);
+      }
+    }
+    if (typeof aggregateControl.daily_budget_cap === 'number') {
+      const acceptedCap = typeof acceptedTerms.daily_budget_cap === 'number'
+        ? acceptedTerms.daily_budget_cap
+        : undefined;
+      if (acceptedCap !== undefined && aggregateControl.daily_budget_cap > acceptedCap) {
+        return requote('daily_budget_cap', 'The requested daily budget cap exceeds the accepted proposal envelope.');
+      }
+    }
+
+    const acceptedPurchases = Array.isArray(acceptedTerms.purchases)
+      ? acceptedTerms.purchases.filter(isRecord)
+      : [];
+    const acceptedQueues = new Map<string, Array<Record<string, unknown>>>();
+    for (const purchase of acceptedPurchases) {
+      if (typeof purchase.product_id !== 'string' || typeof purchase.pricing_option_id !== 'string') continue;
+      const matchKey = productPricingKey(purchase.product_id, purchase.pricing_option_id);
+      const queue = acceptedQueues.get(matchKey) ?? [];
+      queue.push(purchase);
+      acceptedQueues.set(matchKey, queue);
+    }
+    const acceptedByPackageId = new Map<string, Record<string, unknown>>();
+    for (const pkg of mediaBuy.packages.filter(candidate => !candidate.canceled)) {
+      const purchase = acceptedQueues.get(productPricingKey(pkg.productId, pkg.pricingOptionId))?.shift();
+      if (purchase) acceptedByPackageId.set(pkg.packageId, purchase);
+    }
+    for (const [index, pkg] of requestedPackages.entries()) {
+      const packageId = typeof pkg.package_id === 'string' ? pkg.package_id : '';
+      const acceptedPurchase = acceptedByPackageId.get(packageId);
+      if (!acceptedPurchase) continue;
+      for (const field of [
+        'targeting_overlay',
+        'catalog_ids',
+        'optimization_goals',
+        'bidding',
+        'pacing',
+        'start_time',
+        'end_time',
+        'measurement_terms',
+        'performance_standards',
+        'audience_evidence_requirements',
+        'audience_evidence_pins',
+      ] as const) {
+        if (pkg[field] === undefined) continue;
+        if (
+          acceptedPurchase[field] !== undefined
+          && canonicalize(pkg[field]) !== canonicalize(acceptedPurchase[field])
+        ) {
+          const envelopeField = `packages[${index}].${field}`;
+          return requote(envelopeField, `The requested ${field} changes the accepted purchase envelope.`);
+        }
+      }
+      for (const field of ['impressions', 'daily_budget_cap', 'min_spend_target'] as const) {
+        if (typeof pkg[field] !== 'number') continue;
+        const acceptedMaximum = typeof acceptedPurchase[field] === 'number'
+          ? acceptedPurchase[field] as number
+          : undefined;
+        if (acceptedMaximum !== undefined && pkg[field] > acceptedMaximum) {
+          const envelopeField = `packages[${index}].${field}`;
+          return requote(envelopeField, `The requested ${field} exceeds the accepted purchase envelope.`);
+        }
+      }
+      for (const field of [
+        'keyword_targets_add',
+        'keyword_targets_remove',
+        'negative_keywords_add',
+        'negative_keywords_remove',
+      ] as const) {
+        if (
+          acceptedPurchase.targeting_overlay === undefined
+          || !Array.isArray(pkg[field])
+          || pkg[field].length === 0
+        ) continue;
+        const envelopeField = `packages[${index}].${field}`;
+        return requote(envelopeField, 'Keyword targeting changes require a refined proposal.');
+      }
+    }
+    if (requestedPackages.some(pkg => typeof pkg.budget === 'number' || pkg.canceled === true)) {
+      const projectedBudgets = new Map(
+        mediaBuy.packages
+          .filter(pkg => !pkg.canceled)
+          .map(pkg => [pkg.packageId, pkg.budget]),
+      );
+      for (const pkg of requestedPackages) {
+        const packageId = typeof pkg.package_id === 'string' ? pkg.package_id : '';
+        if (pkg.canceled === true) projectedBudgets.delete(packageId);
+        else if (typeof pkg.budget === 'number' && projectedBudgets.has(packageId)) {
+          projectedBudgets.set(packageId, pkg.budget);
+        }
+      }
+      const projectedTotal = [...projectedBudgets.values()].reduce((sum, budget) => sum + budget, 0);
+      if (acceptedTotal !== undefined && projectedTotal > acceptedTotal) {
+        const changedIndex = requestedPackages.findIndex(pkg => typeof pkg.budget === 'number');
+        const envelopeField = changedIndex >= 0 ? `packages[${changedIndex}].budget` : 'packages';
+        return { errors: [{
+          code: 'REQUOTE_REQUIRED',
+          message: 'The requested package budgets exceed the accepted proposal envelope.',
+          field: envelopeField,
+          recovery: 'correctable',
+          details: { envelope_field: envelopeField, accepted_maximum: acceptedTotal },
+        }] };
+      }
+
+      const acceptedByProductPricing = new Map<string, number>();
+      for (const purchase of acceptedPurchases) {
+        if (
+          typeof purchase.product_id !== 'string'
+          || typeof purchase.pricing_option_id !== 'string'
+          || typeof purchase.budget !== 'number'
+        ) continue;
+        const matchKey = productPricingKey(purchase.product_id, purchase.pricing_option_id);
+        acceptedByProductPricing.set(matchKey, (acceptedByProductPricing.get(matchKey) ?? 0) + purchase.budget);
+      }
+      for (const [matchKey, acceptedBudget] of acceptedByProductPricing) {
+        const projectedBudget = mediaBuy.packages
+          .filter(pkg => !pkg.canceled && productPricingKey(pkg.productId, pkg.pricingOptionId) === matchKey)
+          .reduce((sum, pkg) => sum + (projectedBudgets.get(pkg.packageId) ?? 0), 0);
+        if (projectedBudget <= acceptedBudget) continue;
+        const changedIndex = requestedPackages.findIndex(pkg => {
+          const state = mediaBuy.packages.find(candidate => candidate.packageId === pkg.package_id);
+          return state
+            ? productPricingKey(state.productId, state.pricingOptionId) === matchKey
+            : false;
+        });
+        const envelopeField = changedIndex >= 0 ? `packages[${changedIndex}].budget` : 'packages';
+        return { errors: [{
+          code: 'REQUOTE_REQUIRED',
+          message: 'The requested package budget exceeds its accepted purchase allocation.',
+          field: envelopeField,
+          recovery: 'correctable',
+          details: { envelope_field: envelopeField, accepted_maximum: acceptedBudget },
+        }] };
+      }
+    }
+  }
+  const updateResult = await handleUpdateMediaBuy(args as unknown as ToolArgs, ctx, {
+    ...(mediaBuy && {
+      governance: {
+        task: 'control_media_buy' as const,
+        commitment: {
+          amount: positiveMediaBuyUpdateDelta(mediaBuy, args as unknown as UpdateMediaBuyArgs),
+          currency: mediaBuy.currency,
+        },
+      },
+    }),
+  });
+  if (Array.isArray(updateResult.errors) && updateResult.errors.length > 0) return updateResult;
+  const affectedPackages = Array.isArray(updateResult.affected_packages)
+    ? updateResult.affected_packages.filter(isRecord)
+    : [];
+  return {
+    status: 'completed',
+    media_buy_id: updateResult.media_buy_id,
+    revision: updateResult.revision,
+    ...(updateResult.media_buy_status !== undefined && { media_buy_status: updateResult.media_buy_status }),
+    affected_package_ids: affectedPackages
+      .map(pkg => pkg.package_id)
+      .filter((id): id is string => typeof id === 'string'),
+    ...(Array.isArray(updateResult.available_actions) && { available_actions: updateResult.available_actions }),
+  };
 }
 
 const HANDLER_MAP: Record<string, ToolHandler> = {
@@ -13472,7 +14940,10 @@ async function executeTrainingAgentToolInContext(
  * Create a per-request MCP Server with training agent tools.
  */
 export function createTrainingAgentServer(ctx: TrainingContext): Server {
-  const taskStore = getTrainingTaskStore();
+  const taskStore = getScopedTrainingTaskStore(trainingTaskScope(
+    ctx.tenantId ?? 'legacy',
+    ctx.principal ?? 'anonymous',
+  ));
   const server = new Server(
     { name: 'adcp-training-agent', version: '1.0.0' },
     {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -5310,13 +5310,14 @@ function productDiscoverySessionKey(args: ToolArgs, ctx: TrainingContext): strin
     const trustedPrincipal = ctx.proposalRefinementScope?.principal_id
       ?? (ctx.authenticatedAgentUrl ? `agent:${ctx.authenticatedAgentUrl}` : ctx.principal);
     if (trustedAccountId && trustedPrincipal) {
-      return sessionKeyFromArgs(
+      const key = sessionKeyFromArgs(
         { account: { account_id: trustedAccountId } },
         ctx.mode,
         ctx.userId,
         ctx.moduleId,
         trustedPrincipal,
       );
+      return key;
     }
     return sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId, ctx.principal ?? 'anonymous');
   }
@@ -6331,6 +6332,8 @@ async function handleGetProductsUnlocked(
   }
 
   let products: Product[] = getCatalog().map(cp => ({ ...cp.product }));
+  const compactLifecycleRequest = buyingMode === 'refine'
+    && (req as unknown as Record<string, unknown>).__compact_proposal_lifecycle === true;
 
   // Overlay seeded products from comply_test_controller fixtures so
   // storyboard-seeded fields (e.g. creative_policy.provenance_requirements,
@@ -6340,6 +6343,17 @@ async function handleGetProductsUnlocked(
   // to repeat boilerplate. Catalog products are not touched.
   const productMap = new Map(products.map(p => [p.product_id, p]));
   overlaySeededProducts(session, productMap);
+  // Compact refine_proposals calls intentionally omit account context. Carry
+  // forward the immutable product snapshots that supported the preceding
+  // request_proposals response so an exact seeded selection remains
+  // executable even when its controller fixture is no longer addressable.
+  if (compactLifecycleRequest) {
+    for (const product of session.lastGetProductsContext?.products ?? []) {
+      if (!productMap.has(product.product_id)) {
+        productMap.set(product.product_id, structuredClone(product));
+      }
+    }
+  }
   if (buyingMode !== 'wholesale') overlayNegotiatedPricingOptions(session, productMap);
   products = Array.from(productMap.values());
   const registryProducts = products;
@@ -6486,8 +6500,7 @@ async function handleGetProductsUnlocked(
 
   const immutableRefine = buyingMode === 'refine'
     && (req as unknown as Record<string, unknown>).__immutable_refine === true;
-  const compactLifecycle = buyingMode === 'refine'
-    && (req as unknown as Record<string, unknown>).__compact_proposal_lifecycle === true;
+  const compactLifecycle = compactLifecycleRequest;
   const declineProposals = buyingMode === 'refine'
     && (req as unknown as Record<string, unknown>).__decline_proposals === true;
   const compactFinalizeSourceIds = new Set(
@@ -6577,8 +6590,19 @@ async function handleGetProductsUnlocked(
           }] as TaskError[],
         };
       }
+      const proposalInternal = proposal as unknown as Record<string, unknown>;
+      if (compactLifecycle && !declineProposals && proposalInternal.__declined === true) {
+        return {
+          errors: [{
+            code: 'INVALID_STATE',
+            message: `Proposal was declined and cannot be refined: ${op.proposal_id}`,
+            field: `refine[${opIndex}].proposal_id`,
+            recovery: 'correctable',
+          }] as TaskError[],
+        };
+      }
       if (op.action === 'decline') {
-        const internal = proposal as unknown as Record<string, unknown>;
+        const internal = proposalInternal;
         if (internal.__executed === true) everyDeclineApplicable = false;
         if (
           typeof declineOpportunity?.opportunity_id === 'string'
@@ -7027,6 +7051,37 @@ async function handleGetProductsUnlocked(
       proposals = proposals.filter(proposal => proposal.allocations.every(allocation => (
         exactProductIds.has(allocation.product_id)
       )));
+      // Exact product selection asks the seller to quote those published
+      // offers. Seeded/conformance products have no pre-authored proposal
+      // catalog row, so construct one indicative plan before assigning the
+      // caller-scoped immutable proposal ID below.
+      if (proposals.length === 0) {
+        const selectedProducts = products.filter(product => exactProductIds.has(product.product_id));
+        if (selectedProducts.length === exactProductIds.size && selectedProducts.length > 0) {
+          const allocationPercentage = 100 / selectedProducts.length;
+          proposals = [{
+            proposal_id: 'selected_product_plan',
+            name: selectedProducts.length === 1
+              ? `Proposal for ${selectedProducts[0]!.name}`
+              : 'Proposal for selected products',
+            description: 'Indicative plan constructed from the buyer-selected published offers.',
+            brief_alignment: typeof brief === 'string' ? brief : 'Matches the selected published offers.',
+            total_budget_guidance: {
+              min: 1,
+              recommended: 1000,
+              currency: selectedProducts[0]!.pricing_options[0]?.currency ?? 'USD',
+            },
+            allocations: selectedProducts.map(product => ({
+              product_id: product.product_id,
+              allocation_percentage: allocationPercentage,
+              rationale: 'Buyer-selected published offer',
+              ...(product.pricing_options[0] && {
+                pricing_option_id: product.pricing_options[0].pricing_option_id,
+              }),
+            })) as Proposal['allocations'],
+          } as Proposal];
+        }
+      }
     }
     const key = typeof (req as unknown as Record<string, unknown>).idempotency_key === 'string'
       ? (req as unknown as Record<string, unknown>).idempotency_key as string
@@ -7242,7 +7297,7 @@ async function handleGetProductsUnlocked(
   for (const proposal of retainedCommittedProposals.values()) {
     if (!persistedProposalIds.has(proposal.proposal_id)) persistedProposals.push(proposal);
   }
-  if (requireProposals || usesTypedProposalNegotiation(ctx)) {
+  if (requireProposals || compactLifecycle || usesTypedProposalNegotiation(ctx)) {
     const canonicalProducts = new Map(
       registryProducts.map(product => [product.product_id, product]),
     );
@@ -7250,13 +7305,17 @@ async function handleGetProductsUnlocked(
       const internal = proposal as unknown as Record<string, unknown>;
       const existing = session.proposalRefinementRecords.get(proposal.proposal_id);
       if (!existing) {
+        const sourceRecord = typeof internal.__source_proposal_id === 'string'
+          ? session.proposalRefinementRecords.get(internal.__source_proposal_id)
+          : undefined;
+        const ownerAccountId = ctx.resolvedAccountId ?? sourceRecord?.ownerAccountId;
         session.proposalRefinementRecords.set(proposal.proposal_id, {
           proposal: outwardProposal(
             internal,
             canonicalProducts,
           ) as unknown as CanonicalProposal,
           version: 1,
-          ...(ctx.resolvedAccountId && { ownerAccountId: ctx.resolvedAccountId }),
+          ...(ownerAccountId && { ownerAccountId }),
           ...(internal.__declined === true && {
             declined: {
               declined_at: typeof internal.__declined_at === 'string'
@@ -11038,6 +11097,25 @@ export async function handleUpdateMediaBuy(
   const reportingWebhook = (req as unknown as Record<string, unknown>).reporting_webhook;
   if (isRecord(reportingWebhook)) mb.reportingWebhook = structuredClone(reportingWebhook);
 
+  // Every successful revision is observable through get_media_buys history.
+  // Aggregate-only controls (for example daily_budget_cap) do not pass through
+  // a package branch, so give them the same append-only audit semantics.
+  if (!mb.history.some(entry => entry.revision === mb.revision)) {
+    const budgetUpdated = aggregateUpdate.total_budget !== undefined
+      || aggregateUpdate.daily_budget_cap !== undefined
+      || aggregateUpdate.budget_cap_timezone !== undefined
+      || aggregateUpdate.budget_allocation !== undefined;
+    mb.history.push({
+      revision: mb.revision,
+      timestamp: now,
+      actor: 'buyer',
+      action: budgetUpdated ? 'updated_budget' : 'updated_packages',
+      summary: budgetUpdated
+        ? 'Media buy budget controls updated'
+        : 'Media buy operational controls updated',
+    });
+  }
+
   mb.updatedAt = now;
 
   const status = deriveStatus(mb, session);
@@ -13921,7 +13999,12 @@ function proposalAcceptanceSnapshot(
   args: AcceptProposalRequest,
   ctx: TrainingContext,
 ): { proposal: CanonicalProposal } | { response: Record<string, unknown> } {
-  if (!record || (record.ownerAccountId && record.ownerAccountId !== ctx.resolvedAccountId)) {
+  const callerAccountIds = new Set([
+    ctx.resolvedAccountId,
+    ctx.proposalRefinementScope?.account_id ?? 'public_sandbox',
+    ctx.callerMutationScope?.account_id,
+  ].filter((value): value is string => typeof value === 'string'));
+  if (!record || (record.ownerAccountId && !callerAccountIds.has(record.ownerAccountId))) {
     return { response: { errors: [{ code: 'PROPOSAL_NOT_FOUND', message: `Proposal not found: ${args.proposal_id}`, field: 'proposal_id' }] } };
   }
   if (record.declined) {
@@ -14265,6 +14348,25 @@ export async function handleAcceptProposal(
   const acceptedProposal = acceptedRecord
     ? canonicalProposalFromRecord(acceptedRecord)
     : { ...proposal, proposal_status: 'accepted', media_buy_id: createResult.media_buy_id };
+  let availableActions = Array.isArray(createResult.available_actions) ? createResult.available_actions : [];
+  const mediaBuySession = await getSession(
+    sessionKeyFromArgs(args, ctx.mode, ctx.userId, ctx.moduleId),
+    controllerFixtureSessionKey(args, ctx),
+  );
+  const mediaBuy = mediaBuySession.mediaBuys.get(String(createResult.media_buy_id));
+  if (mediaBuy) {
+    const proposalProducts = new Map(
+      (proposalSession.lastGetProductsContext?.products ?? []).map(product => [product.product_id, product]),
+    );
+    const proposalAllowedActions = deriveProductAllowedActionsForPackages(mediaBuy.packages, proposalProducts);
+    if (proposalAllowedActions) {
+      mediaBuy.productAllowedActions = proposalAllowedActions;
+      availableActions = availableActionsForMediaBuy(
+        mediaBuy,
+        String(createResult.media_buy_status ?? mediaBuy.status),
+      );
+    }
+  }
   return {
     status: 'completed',
     media_buy_id: createResult.media_buy_id,
@@ -14273,7 +14375,7 @@ export async function handleAcceptProposal(
     ...(createResult.confirmed_at !== undefined && { confirmed_at: createResult.confirmed_at }),
     accepted_proposal: acceptedProposal,
     purchase_bindings: purchaseBindings(terms.purchases, createResult),
-    available_actions: Array.isArray(createResult.available_actions) ? createResult.available_actions : [],
+    available_actions: availableActions,
   };
 }
 

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -4703,12 +4703,15 @@ function signalMatchesRef(
 
 // ── Tool definitions ──────────────────────────────────────────────
 
-const PRODUCT_DISCOVERY_TOOLS = new Set([
-  'get_products',
+const PRODUCT_DISCOVERY_LIFECYCLE_TOOLS = [
   'list_products',
   'request_proposals',
   'refine_proposals',
   'decline_proposals',
+] as const;
+const PRODUCT_DISCOVERY_TOOLS = new Set([
+  'get_products',
+  ...PRODUCT_DISCOVERY_LIFECYCLE_TOOLS,
 ]);
 
 function isProductDiscoveryTool(toolName: string): boolean {
@@ -10803,7 +10806,7 @@ export async function handleGetAdcpCapabilities(args: ToolArgs, ctx: TrainingCon
     media_buy: {
       buying_modes: wholesaleProfile.productWholesale ? ['brief', 'wholesale', 'refine'] : ['brief', 'refine'],
       ...(supportsGetProductsRejected(servedAdcpVersion) && {
-        lifecycle_tools: [...PRODUCT_DISCOVERY_TOOLS],
+        lifecycle_tools: [...PRODUCT_DISCOVERY_LIFECYCLE_TOOLS],
         proposal_refinement: proposalCapabilitiesForProfile(ctx.proposalNegotiationProfile),
       }),
       supports_proposals: true,

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -259,7 +259,10 @@ export interface RegistryHolder {
   get(): Promise<TenantRegistry>;
 }
 
-export function createRegistryHolder(options: { storyboardCompat?: TrainingContext['storyboardCompat'] } = {}): RegistryHolder {
+export function createRegistryHolder(options: {
+  storyboardCompat?: TrainingContext['storyboardCompat'];
+  proposalNegotiationProfile?: TrainingContext['proposalNegotiationProfile'];
+} = {}): RegistryHolder {
   let registry: TenantRegistry | null = null;
   let pendingInit: Promise<TenantRegistry> | null = null;
 

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -16,8 +16,14 @@ import { createLogger } from '../../logger.js';
 import { runWithSessionContext, flushDirtySessions } from '../state.js';
 import { createRegistryHolder, getCanonicalBase, resolveTenantHost, type RegistryHolder } from './registry.js';
 import { buildSignedRevocationList } from '../governance-revocations.js';
-import { salesCapabilityProjection } from '../v6-sales-platform.js';
-import { handleComplyTestController } from '../comply-test-controller.js';
+import {
+  resolveTrainingSalesRequestContext,
+  salesCapabilityProjection,
+} from '../v6-sales-platform.js';
+import {
+  COMPLY_TEST_CONTROLLER_TOOL,
+  handleComplyTestController,
+} from '../comply-test-controller.js';
 import {
   adcpError,
   resolveServedAdcpVersion,
@@ -118,6 +124,8 @@ const SALES_CURRENT_SCENARIOS = [
   'seed_media_buy',
   'seed_creative_format',
   'seed_measurement_catalog',
+  'compact_product_lifecycle_probe',
+  'compact_direct_buy_lifecycle_probe',
   'query_provenance_audit_observations',
   'evaluate_distributed_brand_resolution',
 ] as const;
@@ -125,6 +133,27 @@ const SALES_CURRENT_SCENARIOS = [
 const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.2'] as const;
 const TRAINING_AGENT_CURRENT_ADCP_VERSION = '3.2-beta.2';
 const TRAINING_AGENT_DEFAULT_ADCP_VERSION = '3.0';
+const THREE_ZERO_COMPLIANCE_SCENARIOS = new Set([
+  'force_creative_status',
+  'force_account_status',
+  'force_media_buy_status',
+  'force_session_status',
+  'simulate_delivery',
+  'simulate_budget_spend',
+]);
+const THREE_ZERO_POSTAL_TARGETING_KEYS = new Set([
+  'us_zip',
+  'us_zip_plus_four',
+  'gb_outward',
+  'gb_full',
+  'ca_fsa',
+  'ca_full',
+  'de_plz',
+  'fr_code_postal',
+  'au_postcode',
+  'ch_plz',
+  'at_plz',
+]);
 const PRODUCT_DISCOVERY_LIFECYCLE_TOOL_NAMES = [
   'list_products',
   'request_proposals',
@@ -437,6 +466,8 @@ async function tryHandleLocalComplyScenario(
     && rawArgs.scenario !== 'force_creative_purge'
     && rawArgs.scenario !== 'query_provenance_audit_observations'
     && rawArgs.scenario !== 'evaluate_distributed_brand_resolution'
+    && rawArgs.scenario !== 'compact_product_lifecycle_probe'
+    && rawArgs.scenario !== 'compact_direct_buy_lifecycle_probe'
     && rawArgs.scenario !== 'list_scenarios'
     && !isRejectedGetProductsDirective
   ) return false;
@@ -447,6 +478,8 @@ async function tryHandleLocalComplyScenario(
       || rawArgs.scenario === 'force_creative_purge'
       || rawArgs.scenario === 'query_provenance_audit_observations'
       || rawArgs.scenario === 'evaluate_distributed_brand_resolution'
+      || rawArgs.scenario === 'compact_product_lifecycle_probe'
+      || rawArgs.scenario === 'compact_direct_buy_lifecycle_probe'
       || isRejectedGetProductsDirective
     )
   ) return false;
@@ -467,14 +500,25 @@ async function tryHandleLocalComplyScenario(
   }
 
   const result = await runWithSessionContext(async () => {
+    const isCompactLifecycleScenario = rawArgs.scenario === 'compact_product_lifecycle_probe'
+      || rawArgs.scenario === 'compact_direct_buy_lifecycle_probe';
+    const auth = (req as unknown as {
+      auth?: { clientId?: string; scopes?: string[]; extra?: Record<string, unknown> };
+    }).auth;
+    const localContext = isCompactLifecycleScenario
+      ? await resolveTrainingSalesRequestContext(handlerArgs, auth, storyboardCompat)
+      : {
+          mode: 'open' as const,
+          principal: principal ?? 'anonymous',
+          ...(storyboardCompat && { storyboardCompat }),
+        };
     const body = rawArgs.scenario === 'list_scenarios'
       ? {
           success: true,
           scenarios: salesComplyScenarios(storyboardCompat),
         }
       : await handleComplyTestController(handlerArgs, {
-          mode: 'open',
-          principal: principal ?? 'anonymous',
+          ...localContext,
           servedAdcpVersion: versionResolution.servedVersion,
         });
     await flushDirtySessions();
@@ -597,6 +641,18 @@ function projectTenantToolDiscovery(
     const tools = parsed.result?.tools;
     if (!Array.isArray(tools)) return body;
     if (tenantId === 'sales') {
+      // SDK 14's compact media-buy discovery profile intentionally excludes
+      // test-harness extensions. The training agent is itself a sandbox and
+      // its compliance scenarios require the controller to be discoverable;
+      // dispatch still enforces account.sandbox=true. Keep the seven native
+      // lifecycle tools as the advertised protocol surface and add this one
+      // cross-cutting harness tool alongside them.
+      if (
+        storyboardCompat?.version !== '3.0'
+        && !tools.some(tool => tool.name === COMPLY_TEST_CONTROLLER_TOOL.name)
+      ) {
+        tools.push({ ...COMPLY_TEST_CONTROLLER_TOOL });
+      }
       const getProducts = tools.find(tool => tool.name === 'get_products');
       if (getProducts) {
         const inputSchema = getProducts.inputSchema ?? {};
@@ -685,6 +741,7 @@ function projectTenantCapabilities(
         structuredContent?: {
           adcp_version?: unknown;
           adcp?: Record<string, unknown>;
+          specialisms?: unknown;
           supported_protocols?: unknown;
           experimental_features?: unknown;
           creative?: Record<string, unknown>;
@@ -828,6 +885,34 @@ function projectTenantCapabilities(
         ...complianceTesting,
         scenarios: [...scenarios],
       };
+    }
+    if (storyboardCompat?.version === '3.0') {
+      // SDK 14 emits current capability vocabulary even when an adopter
+      // projects a request onto the frozen 3.0 wire contract. Keep the
+      // current platform internally intact, but remove vocabulary that the
+      // released 3.0 schema cannot represent at this response boundary.
+      if (tenantId === 'si') delete structured.specialisms;
+      const complianceTesting = structured.compliance_testing;
+      if (complianceTesting && Array.isArray(complianceTesting.scenarios)) {
+        complianceTesting.scenarios = complianceTesting.scenarios.filter(
+          (scenario): scenario is string => (
+            typeof scenario === 'string' && THREE_ZERO_COMPLIANCE_SCENARIOS.has(scenario)
+          ),
+        );
+      }
+      const mediaBuy = structured.media_buy;
+      const execution = mediaBuy?.execution;
+      const targeting = execution && typeof execution === 'object'
+        ? (execution as Record<string, unknown>).targeting
+        : undefined;
+      const postalAreas = targeting && typeof targeting === 'object'
+        ? (targeting as Record<string, unknown>).geo_postal_areas
+        : undefined;
+      if (postalAreas && typeof postalAreas === 'object' && !Array.isArray(postalAreas)) {
+        (targeting as Record<string, unknown>).geo_postal_areas = Object.fromEntries(
+          Object.entries(postalAreas).filter(([key]) => THREE_ZERO_POSTAL_TARGETING_KEYS.has(key)),
+        );
+      }
     }
     projectWholesaleCapabilities(structured, tenantId, storyboardCompat);
     const firstText = parsed.result?.content?.[0];

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -34,6 +34,7 @@ import { GET_PRODUCTS_REJECTED_ADCP_VERSION, supportsGetProductsRejected, type T
 import { getAgentUrl } from '../config.js';
 import { redactConflictEnvelopeInBody } from '../conflict-envelope.js';
 import { canonicalizeAccountRef } from '../account-scope.js';
+import { proposalCapabilitiesForProfile } from '../proposal-negotiation-profiles.js';
 
 const logger = createLogger('training-agent-tenant-router');
 const PRODUCT_WHOLESALE_EVENTS = ['product.created', 'product.updated', 'product.priced', 'product.removed'] as const;
@@ -130,12 +131,15 @@ const SALES_CURRENT_SCENARIOS = [
 
 const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', GET_PRODUCTS_REJECTED_ADCP_VERSION] as const;
 const TRAINING_AGENT_DEFAULT_ADCP_VERSION = '3.0';
-const PRODUCT_DISCOVERY_TOOL_NAMES = [
-  'get_products',
+const PRODUCT_DISCOVERY_LIFECYCLE_TOOL_NAMES = [
   'list_products',
   'request_proposals',
   'refine_proposals',
   'decline_proposals',
+] as const;
+const PRODUCT_DISCOVERY_TOOL_NAMES = [
+  'get_products',
+  ...PRODUCT_DISCOVERY_LIFECYCLE_TOOL_NAMES,
 ] as const;
 
 function bearerToken(req: Request): string | undefined {
@@ -255,7 +259,13 @@ function tenantMcpHandler(
     setCORSHeaders(res);
 
     wrapTenantToolDiscoveryProjection(req, res, tenantId, storyboardCompat);
-    wrapTenantCapabilitiesProjection(req, res, tenantId, storyboardCompat);
+    wrapTenantCapabilitiesProjection(
+      req,
+      res,
+      tenantId,
+      storyboardCompat,
+      proposalNegotiationProfile,
+    );
 
     // Bridge `res.locals.trainingPrincipal` (set by the upstream
     // `requireAuth` middleware) onto `req.auth` so the framework's MCP
@@ -617,9 +627,19 @@ function wrapTenantCapabilitiesProjection(
   res: Response,
   tenantId: string,
   storyboardCompat?: TrainingContext['storyboardCompat'],
+  proposalNegotiationProfile?: TrainingContext['proposalNegotiationProfile'],
 ): void {
   if (req.body?.method !== 'tools/call') return;
   if (req.body?.params?.name !== 'get_adcp_capabilities') return;
+
+  const capabilityArgs = (req.body.params.arguments ?? {}) as Record<string, unknown>;
+  const hasVersionSelector = capabilityArgs.adcp_version !== undefined
+    || capabilityArgs.adcp_major_version !== undefined;
+  const requestedVersion = proposalNegotiationProfile
+    ? hasVersionSelector
+      ? resolveServedAdcpVersion(capabilityArgs)
+      : { ok: true as const, servedVersion: GET_PRODUCTS_REJECTED_ADCP_VERSION }
+    : undefined;
 
   const origEnd = res.end.bind(res);
   const chunks: Buffer[] = [];
@@ -635,7 +655,13 @@ function wrapTenantCapabilitiesProjection(
   (res as unknown as { end: (...args: unknown[]) => Response }).end = (chunk?: unknown, ...rest: unknown[]) => {
     if (chunk !== null && chunk !== undefined) chunks.push(toBuffer(chunk));
     const body = Buffer.concat(chunks);
-    const patched = projectTenantCapabilities(body, tenantId, storyboardCompat);
+    const patched = projectTenantCapabilities(
+      body,
+      tenantId,
+      storyboardCompat,
+      proposalNegotiationProfile,
+      requestedVersion?.ok ? requestedVersion.servedVersion : undefined,
+    );
     if (patched !== body && !res.headersSent) {
       res.setHeader('content-length', String(patched.length));
     }
@@ -780,6 +806,8 @@ function projectTenantCapabilities(
   body: Buffer,
   tenantId: string,
   storyboardCompat?: TrainingContext['storyboardCompat'],
+  proposalNegotiationProfile?: TrainingContext['proposalNegotiationProfile'],
+  servedVersionOverride?: string,
 ): Buffer {
   try {
     const parsed = JSON.parse(body.toString('utf8')) as {
@@ -803,9 +831,13 @@ function projectTenantCapabilities(
     };
     const structured = parsed.result?.structuredContent;
     if (!structured || typeof structured !== 'object') return body;
-    const servedVersion = typeof structured.adcp_version === 'string'
-      ? structured.adcp_version
-      : TRAINING_AGENT_DEFAULT_ADCP_VERSION;
+    // Dedicated profile routes default unpinned capability discovery to their
+    // exact beta contract. Pinned requests use the normal resolver, so a
+    // stable `3.2` selector is never silently mapped to this prerelease.
+    const servedVersion = servedVersionOverride
+      ?? (typeof structured.adcp_version === 'string'
+        ? structured.adcp_version
+        : TRAINING_AGENT_DEFAULT_ADCP_VERSION);
     structured.adcp_version = servedVersion;
     const adcp = structured.adcp && typeof structured.adcp === 'object'
       ? structured.adcp
@@ -873,7 +905,11 @@ function projectTenantCapabilities(
         ...mediaBuy,
         ...salesProjection,
         ...(supportsGetProductsRejected(servedVersion) && {
-          lifecycle_tools: [...PRODUCT_DISCOVERY_TOOL_NAMES],
+          lifecycle_tools: [...PRODUCT_DISCOVERY_LIFECYCLE_TOOL_NAMES],
+        }),
+        ...(proposalNegotiationProfile && supportsGetProductsRejected(servedVersion) && {
+          supports_proposals: true,
+          proposal_refinement: proposalCapabilitiesForProfile(proposalNegotiationProfile),
         }),
         features: {
           ...(

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -16,25 +16,18 @@ import { createLogger } from '../../logger.js';
 import { runWithSessionContext, flushDirtySessions } from '../state.js';
 import { createRegistryHolder, getCanonicalBase, resolveTenantHost, type RegistryHolder } from './registry.js';
 import { buildSignedRevocationList } from '../governance-revocations.js';
-import {
-  resolveTrainingSalesRequestContext,
-  salesCapabilityProjection,
-} from '../v6-sales-platform.js';
+import { salesCapabilityProjection } from '../v6-sales-platform.js';
 import { handleComplyTestController } from '../comply-test-controller.js';
 import {
   adcpError,
-  createTrainingAgentServer,
-  productDiscoveryAliasToolDefinitions,
   resolveServedAdcpVersion,
-  resolveServedAdcpVersionForTool,
   supportedCanonicalFormatsCapability,
-  validateProductDiscoveryAliasInput,
 } from '../task-handlers.js';
 import { GET_PRODUCTS_REJECTED_ADCP_VERSION, supportsGetProductsRejected, type TrainingContext } from '../types.js';
 import { getAgentUrl } from '../config.js';
 import { redactConflictEnvelopeInBody } from '../conflict-envelope.js';
-import { canonicalizeAccountRef } from '../account-scope.js';
 import { proposalCapabilitiesForProfile } from '../proposal-negotiation-profiles.js';
+import { runWithTrainingTaskScope, trainingTaskScope } from '../mcp-task-store.js';
 
 const logger = createLogger('training-agent-tenant-router');
 const PRODUCT_WHOLESALE_EVENTS = ['product.created', 'product.updated', 'product.priced', 'product.removed'] as const;
@@ -129,17 +122,17 @@ const SALES_CURRENT_SCENARIOS = [
   'evaluate_distributed_brand_resolution',
 ] as const;
 
-const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', GET_PRODUCTS_REJECTED_ADCP_VERSION] as const;
+const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.2'] as const;
+const TRAINING_AGENT_CURRENT_ADCP_VERSION = '3.2-beta.2';
 const TRAINING_AGENT_DEFAULT_ADCP_VERSION = '3.0';
 const PRODUCT_DISCOVERY_LIFECYCLE_TOOL_NAMES = [
   'list_products',
   'request_proposals',
   'refine_proposals',
   'decline_proposals',
-] as const;
-const PRODUCT_DISCOVERY_TOOL_NAMES = [
-  'get_products',
-  ...PRODUCT_DISCOVERY_LIFECYCLE_TOOL_NAMES,
+  'buy_products',
+  'accept_proposal',
+  'control_media_buy',
 ] as const;
 
 function bearerToken(req: Request): string | undefined {
@@ -390,17 +383,6 @@ function tenantMcpHandler(
       if (await tryHandleLocalComplyScenario(req, res, resolved.tenantId, principal, storyboardCompat)) {
         return;
       }
-      if (await tryHandleProductDiscoveryRequest(
-        req,
-        res,
-        resolved.tenantId,
-        principal,
-        storyboardCompat,
-        proposalNegotiationProfile,
-      )) {
-        return;
-      }
-
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
         enableJsonResponse: true,
@@ -410,10 +392,13 @@ function tenantMcpHandler(
         await resolved.server.connect(transport);
         logger.debug({ tenantId: resolved.tenantId, method: req.body?.method }, 'tenant MCP request');
         installConflictEnvelopeRedaction(res);
-        await runWithSessionContext(async () => {
-          await transport.handleRequest(req, res, req.body);
-          await flushDirtySessions();
-        });
+        await runWithTrainingTaskScope(
+          trainingTaskScope(resolved.tenantId, principal ?? 'anonymous'),
+          () => runWithSessionContext(async () => {
+            await transport.handleRequest(req, res, req.body);
+            await flushDirtySessions();
+          }),
+        );
       } catch (err) {
         logger.error({ err, tenantId: resolved.tenantId }, 'tenant MCP error');
         if (!res.headersSent) {
@@ -430,116 +415,6 @@ function tenantMcpHandler(
       }
     });
   };
-}
-
-async function tryHandleProductDiscoveryRequest(
-  req: Request,
-  res: Response,
-  tenantId: string,
-  principal: string | undefined,
-  storyboardCompat?: TrainingContext['storyboardCompat'],
-  proposalNegotiationProfile?: TrainingContext['proposalNegotiationProfile'],
-): Promise<boolean> {
-  if (tenantId !== 'sales') return false;
-  if (storyboardCompat?.version === '3.0') return false;
-
-  const method = req.body?.method;
-  const toolName = req.body?.params?.name;
-  const rawArgs = (req.body?.params?.arguments ?? {}) as Record<string, unknown>;
-  const requestedProductVersion = method === 'tools/call' && PRODUCT_DISCOVERY_TOOL_NAMES.includes(toolName)
-    ? resolveServedAdcpVersionForTool(toolName, rawArgs)
-    : undefined;
-  const isProductCall = (
-    method === 'tools/call'
-    && PRODUCT_DISCOVERY_TOOL_NAMES.includes(toolName)
-    && (
-      toolName !== 'get_products'
-      || (requestedProductVersion?.ok === true && supportsGetProductsRejected(requestedProductVersion.servedVersion))
-    )
-  );
-  const isTaskLifecycleCall = (
-    method === 'tasks/get'
-    || method === 'tasks/result'
-    || method === 'tasks/list'
-    || method === 'tasks/cancel'
-  );
-  if (!isProductCall && !isTaskLifecycleCall) return false;
-
-  if (isProductCall && toolName !== 'get_products') {
-    const validationError = validateProductDiscoveryAliasInput(toolName, rawArgs);
-    if (validationError) {
-      res.json({
-        jsonrpc: '2.0',
-        id: req.body.id ?? null,
-        error: {
-          code: -32602,
-          message: validationError.message,
-          data: validationError.field ? { field: validationError.field } : undefined,
-        },
-      });
-      return true;
-    }
-
-  }
-
-  if (isProductCall && rawArgs.account !== undefined) {
-    try {
-      canonicalizeAccountRef(rawArgs.account as never);
-    } catch (error) {
-      res.json({
-        jsonrpc: '2.0',
-        id: req.body.id ?? null,
-        result: adcpError('INVALID_REQUEST', {
-          message: error instanceof Error ? error.message : 'account is malformed',
-          field: 'account',
-          recovery: 'correctable',
-        }, rawArgs.context, requestedProductVersion?.ok ? requestedProductVersion.servedVersion : undefined),
-      });
-      return true;
-    }
-  }
-
-  let nativeContext: TrainingContext;
-  try {
-    nativeContext = isProductCall
-      ? await resolveTrainingSalesRequestContext(
-        req.body.params.arguments as Record<string, unknown>,
-        (req as unknown as {
-          auth?: { clientId?: string; scopes?: string[]; extra?: Record<string, unknown> };
-        }).auth,
-        storyboardCompat,
-      )
-      : {
-        mode: 'open' as const,
-        tenantId: 'sales' as const,
-        principal: principal ?? 'anonymous',
-      };
-    nativeContext.proposalNegotiationProfile = proposalNegotiationProfile ?? 'ask-only';
-  } catch (error) {
-    logger.error({ error, toolName }, 'Native sales request context resolution failed');
-    res.json({
-      jsonrpc: '2.0',
-      id: req.body.id ?? null,
-      result: adcpError('SERVICE_UNAVAILABLE', {
-        message: 'Unable to resolve the sales request context',
-        recovery: 'transient',
-      }, rawArgs.context, requestedProductVersion?.ok ? requestedProductVersion.servedVersion : undefined),
-    });
-    return true;
-  }
-  const nativeServer = createTrainingAgentServer(nativeContext);
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: undefined,
-    enableJsonResponse: true,
-  });
-  try {
-    await nativeServer.connect(transport);
-    installConflictEnvelopeRedaction(res);
-    await transport.handleRequest(req, res, req.body);
-  } finally {
-    await nativeServer.close().catch(() => {});
-  }
-  return true;
 }
 
 async function tryHandleLocalComplyScenario(
@@ -638,7 +513,7 @@ function wrapTenantCapabilitiesProjection(
   const requestedVersion = proposalNegotiationProfile
     ? hasVersionSelector
       ? resolveServedAdcpVersion(capabilityArgs)
-      : { ok: true as const, servedVersion: GET_PRODUCTS_REJECTED_ADCP_VERSION }
+      : { ok: true as const, servedVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION }
     : undefined;
 
   const origEnd = res.end.bind(res);
@@ -752,12 +627,6 @@ function projectTenantToolDiscovery(
           idempotentHint: true,
         };
 
-        if (!isThreeZeroCompat) {
-          const splitTools = productDiscoveryAliasToolDefinitions();
-          for (const splitTool of splitTools) {
-            if (!tools.some(tool => tool.name === splitTool.name)) tools.push(splitTool);
-          }
-        }
       }
     }
     if (storyboardCompat?.version === '3.0') {
@@ -850,7 +719,13 @@ function projectTenantCapabilities(
     };
     if (storyboardCompat?.version !== '3.0') {
       const governanceTasks: Record<string, Array<{ task: string; modes: ['signed_context'] }>> = {
-        sales: [{ task: 'create_media_buy', modes: ['signed_context'] }],
+        sales: supportsGetProductsRejected(servedVersion)
+          ? [
+              { task: 'buy_products', modes: ['signed_context'] },
+              { task: 'accept_proposal', modes: ['signed_context'] },
+              { task: 'control_media_buy', modes: ['signed_context'] },
+            ]
+          : [{ task: 'create_media_buy', modes: ['signed_context'] }],
         signals: [{ task: 'activate_signal', modes: ['signed_context'] }],
         brand: [{ task: 'acquire_rights', modes: ['signed_context'] }],
         creative: [{ task: 'build_creative', modes: ['signed_context'] }],
@@ -900,6 +775,11 @@ function projectTenantCapabilities(
       const mediaBuy = structured.media_buy && typeof structured.media_buy === 'object'
         ? structured.media_buy
         : {};
+      if (!supportsGetProductsRejected(servedVersion)) {
+        delete mediaBuy.lifecycle_tools;
+        delete mediaBuy.proposal_refinement;
+        delete mediaBuy.supports_proposals;
+      }
       const salesProjection = salesCapabilityProjection();
       structured.media_buy = {
         ...mediaBuy,
@@ -1073,6 +953,15 @@ export function mountTenantRoutes(
   middleware: TenantRouteMiddleware = {},
 ): void {
   const holder = createRegistryHolder({ storyboardCompat: middleware.storyboardCompat });
+  const profileHolders = new Map(
+    PROPOSAL_NEGOTIATION_PROFILE_ROUTES.map(({ profile }) => [
+      profile,
+      createRegistryHolder({
+        storyboardCompat: middleware.storyboardCompat,
+        proposalNegotiationProfile: profile,
+      }),
+    ]),
+  );
   // Eagerly start the 6-tenant registry init at mount time (server boot)
   // instead of waiting for the first request. On a fresh Fly machine the
   // cold init takes 30–60s — longer than the post-deploy smoke's 16s
@@ -1099,6 +988,13 @@ export function mountTenantRoutes(
       'Eager tenant registry init failed at boot; per-request init will retry',
     );
   });
+  if (middleware.storyboardCompat?.version !== '3.0' && proposalNegotiationProfilesEnabled()) {
+    for (const [profile, profileHolder] of profileHolders) {
+      profileHolder.get().catch(err => {
+        logger.error({ err, profile }, 'Proposal-profile tenant registry prewarm failed');
+      });
+    }
+  }
   const mw: RequestHandler[] = [];
   if (middleware.rateLimit) mw.push(middleware.rateLimit);
   if (middleware.requireAuth) mw.push(middleware.requireAuth);
@@ -1132,7 +1028,7 @@ export function mountTenantRoutes(
       parent.post(
         path,
         ...mw,
-        tenantMcpHandler(holder, 'sales', middleware.storyboardCompat, profile),
+        tenantMcpHandler(profileHolders.get(profile)!, 'sales', middleware.storyboardCompat, profile),
       );
       parent.get(path, (_req, res) => {
         setCORSHeaders(res);

--- a/server/src/training-agent/tenants/sales.ts
+++ b/server/src/training-agent/tenants/sales.ts
@@ -58,7 +58,10 @@ const SYNC_CATALOGS_SCHEMA = {
 
 export function buildSalesTenantConfig(
   host: string,
-  options: { storyboardCompat?: TrainingContext['storyboardCompat'] } = {},
+  options: {
+    storyboardCompat?: TrainingContext['storyboardCompat'];
+    proposalNegotiationProfile?: TrainingContext['proposalNegotiationProfile'];
+  } = {},
   taskRegistry?: TaskRegistry,
 ): {
   tenantId: string;
@@ -71,8 +74,10 @@ export function buildSalesTenantConfig(
       agentUrl: `${host}/${TENANT_ID}`,
       signingKey: material.signingKey,
       label: 'Training agent — sales',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      platform: new TrainingSalesPlatform(options.storyboardCompat) as any,
+      platform: new TrainingSalesPlatform(
+        options.storyboardCompat,
+        options.proposalNegotiationProfile ?? 'ask-only',
+      ),
       serverOptions: {
         // These operations intentionally remain the legacy wire facade for
         // AdCP 3.0 callers. Current application paths use canonical format

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -524,10 +524,34 @@ describe('tenant routing smoke', () => {
       const sourceProposalId = requested.result?.structuredContent?.proposals?.[0]?.proposal_id;
       expect(sourceProposalId).toBeTruthy();
 
-      const refined = await callTenantTool(url, 5, 'refine_proposals', {
+      const partial = await callTenantTool(url, 5, 'refine_proposals', {
         adcp_version: '3.2-beta.0',
         adcp_major_version: 3,
-        idempotency_key: 'tenant-profile-refine-0001',
+        idempotency_key: 'tenant-profile-refine-three-0001',
+        refinements: [{
+          proposal_id: sourceProposalId,
+          action: 'revise',
+          constraints: { total_budget: { currency: 'USD', max: 50_000 } },
+          alternatives: { count: 3 },
+        }],
+      }) as {
+        result?: { structuredContent?: {
+          adcp_version?: string;
+          adcp_error?: { message?: string };
+          results?: Array<{ outcome?: string; reason_code?: string; proposals?: unknown[] }>;
+        } };
+      };
+      const counteroffer = partial.result?.structuredContent;
+      expect(counteroffer?.adcp_version).toBe('3.2-beta.0');
+      expect(counteroffer?.adcp_error).toBeUndefined();
+      expect(counteroffer?.results?.[0]?.outcome).toBe('partial');
+      expect(counteroffer?.results?.[0]?.reason_code).toBe('alternatives_unavailable');
+      expect(counteroffer?.results?.[0]?.proposals).toHaveLength(2);
+
+      const refined = await callTenantTool(url, 6, 'refine_proposals', {
+        adcp_version: '3.2-beta.0',
+        adcp_major_version: 3,
+        idempotency_key: 'tenant-profile-refine-two-0001',
         refinements: [{
           proposal_id: sourceProposalId,
           action: 'revise',

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -138,6 +138,19 @@ async function callTenantTool(url: string, id: number, name: string, args: Recor
   return response.json() as Promise<Record<string, unknown>>;
 }
 
+async function listTenantTools(url: string, id: number): Promise<Record<string, unknown>> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json',
+      authorization: 'Bearer test-token',
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id, method: 'tools/list' }),
+  });
+  return response.json() as Promise<Record<string, unknown>>;
+}
+
 describe('tenant routing smoke', () => {
   beforeEach(() => {
     clearSessions();
@@ -425,6 +438,114 @@ describe('tenant routing smoke', () => {
           expect(capabilities?.specialisms).toContain('creative-transformers');
         }
       }
+    } finally {
+      await close();
+    }
+  }, 30000);
+
+  it('serves proposal-profile capabilities and SDK-shaped 3.2 refinement over HTTP', async () => {
+    const { baseUrl, close } = await bootServer();
+    try {
+      const url = `${baseUrl}/sales/profiles/constrained-seller/mcp`;
+      await initializeTenant(url);
+
+      const toolsResponse = await listTenantTools(url, 2) as {
+        result?: { tools?: Array<{ name?: string }> };
+      };
+      expect(toolsResponse.result?.tools?.map(tool => tool.name)).toEqual(
+        expect.arrayContaining(['request_proposals', 'refine_proposals', 'decline_proposals']),
+      );
+
+      const capabilitiesResponse = await callTenantTool(url, 3, 'get_adcp_capabilities', {
+        adcp_version: '3.2-beta.0',
+        adcp_major_version: 3,
+      }) as {
+        result?: { structuredContent?: {
+          adcp_version?: string;
+          adcp?: { supported_versions?: string[] };
+          media_buy?: {
+            supports_proposals?: boolean;
+            lifecycle_tools?: string[];
+            proposal_refinement?: { supported_dimensions?: string[]; max_alternatives?: number };
+          };
+        } };
+      };
+      expect(capabilitiesResponse.result?.structuredContent?.adcp_version).toBe('3.2-beta.0');
+      expect(capabilitiesResponse.result?.structuredContent?.adcp?.supported_versions).toContain('3.2-beta.0');
+      const mediaBuy = capabilitiesResponse.result?.structuredContent?.media_buy;
+      expect(mediaBuy?.supports_proposals).toBe(true);
+      expect(mediaBuy?.lifecycle_tools).toEqual([
+        'list_products',
+        'request_proposals',
+        'refine_proposals',
+        'decline_proposals',
+      ]);
+      expect(mediaBuy?.proposal_refinement).toEqual({
+        supported_dimensions: [
+          'total_budget',
+          'cpm',
+          'impressions',
+          'flight',
+          'product_changes',
+          'criteria',
+          'alternatives',
+        ],
+        max_alternatives: 3,
+      });
+
+      for (const [id, adcpVersion] of [[31, '3.2'], [32, '3.0']] as const) {
+        const nonBetaCapabilities = await callTenantTool(url, id, 'get_adcp_capabilities', {
+          adcp_version: adcpVersion,
+          adcp_major_version: 3,
+        }) as {
+          result?: { structuredContent?: {
+            adcp_version?: string;
+            media_buy?: { lifecycle_tools?: string[]; proposal_refinement?: unknown };
+          } };
+        };
+        expect(nonBetaCapabilities.result?.structuredContent?.adcp_version).toBe('3.0');
+        expect(nonBetaCapabilities.result?.structuredContent?.media_buy?.lifecycle_tools).toBeUndefined();
+        expect(nonBetaCapabilities.result?.structuredContent?.media_buy?.proposal_refinement).toBeUndefined();
+      }
+
+      const requested = await callTenantTool(url, 4, 'request_proposals', {
+        adcp_version: '3.2-beta.0',
+        adcp_major_version: 3,
+        idempotency_key: 'tenant-profile-request-0001',
+        brand: { domain: 'buyer.example' },
+        brief: 'social engagement display',
+      }) as {
+        result?: { structuredContent?: {
+          adcp_version?: string;
+          proposals?: Array<{ proposal_id?: string }>;
+        } };
+      };
+      expect(requested.result?.structuredContent?.adcp_version).toBe('3.2-beta.0');
+      const sourceProposalId = requested.result?.structuredContent?.proposals?.[0]?.proposal_id;
+      expect(sourceProposalId).toBeTruthy();
+
+      const refined = await callTenantTool(url, 5, 'refine_proposals', {
+        adcp_version: '3.2-beta.0',
+        adcp_major_version: 3,
+        idempotency_key: 'tenant-profile-refine-0001',
+        refinements: [{
+          proposal_id: sourceProposalId,
+          action: 'revise',
+          constraints: { total_budget: { currency: 'USD', max: 50_000 } },
+          alternatives: { count: 2 },
+        }],
+      }) as {
+        result?: { structuredContent?: {
+          adcp_version?: string;
+          adcp_error?: { message?: string };
+          results?: Array<{ outcome?: string; proposals?: unknown[] }>;
+        } };
+      };
+      const refinement = refined.result?.structuredContent;
+      expect(refinement?.adcp_version).toBe('3.2-beta.0');
+      expect(refinement?.adcp_error).toBeUndefined();
+      expect(refinement?.results?.[0]?.outcome).toBe('revised');
+      expect(refinement?.results?.[0]?.proposals).toHaveLength(2);
     } finally {
       await close();
     }

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -46,6 +46,8 @@ const SALES_CURRENT_SCENARIOS = [
   'seed_media_buy',
   'seed_creative_format',
   'seed_measurement_catalog',
+  'compact_product_lifecycle_probe',
+  'compact_direct_buy_lifecycle_probe',
   'query_provenance_audit_observations',
 ];
 
@@ -3065,6 +3067,8 @@ describe('tenant routing smoke', () => {
         'update_media_buy',
       ]));
       expect(discoveredNames).toEqual(expect.arrayContaining([
+        'comply_test_controller',
+        'get_media_buys',
         'list_products',
         'request_proposals',
         'refine_proposals',

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import http from 'node:http';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
@@ -22,6 +23,7 @@ import {
 import { clearSiSessions } from '../si-handlers.js';
 import { clearForcedTaskCompletions } from '../comply-test-controller.js';
 import { getAgentUrl } from '../config.js';
+import { getCanonicalBase } from '../canonical-base.js';
 import { projectV1ProductToV2 } from '@adcp/sdk/v2/projection';
 import { TrainingBrandPlatform } from '../v6-brand-platform.js';
 import { TrainingCreativeBuilderPlatform } from '../v6-creative-builder-platform.js';
@@ -413,7 +415,7 @@ describe('tenant routing smoke', () => {
     const { baseUrl, close } = await bootServer();
     try {
       const expected: Record<string, string[]> = {
-        sales: ['create_media_buy'],
+        sales: ['buy_products', 'accept_proposal', 'control_media_buy'],
         signals: ['activate_signal'],
         brand: ['acquire_rights'],
         creative: ['build_creative'],
@@ -457,7 +459,7 @@ describe('tenant routing smoke', () => {
       );
 
       const capabilitiesResponse = await callTenantTool(url, 3, 'get_adcp_capabilities', {
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         adcp_major_version: 3,
       }) as {
         result?: { structuredContent?: {
@@ -470,8 +472,8 @@ describe('tenant routing smoke', () => {
           };
         } };
       };
-      expect(capabilitiesResponse.result?.structuredContent?.adcp_version).toBe('3.2-beta.0');
-      expect(capabilitiesResponse.result?.structuredContent?.adcp?.supported_versions).toContain('3.2-beta.0');
+      expect(capabilitiesResponse.result?.structuredContent?.adcp_version).toBe('3.2-beta.2');
+      expect(capabilitiesResponse.result?.structuredContent?.adcp?.supported_versions).toContain('3.2-beta.2');
       const mediaBuy = capabilitiesResponse.result?.structuredContent?.media_buy;
       expect(mediaBuy?.supports_proposals).toBe(true);
       expect(mediaBuy?.lifecycle_tools).toEqual([
@@ -479,6 +481,9 @@ describe('tenant routing smoke', () => {
         'request_proposals',
         'refine_proposals',
         'decline_proposals',
+        'buy_products',
+        'accept_proposal',
+        'control_media_buy',
       ]);
       expect(mediaBuy?.proposal_refinement).toEqual({
         supported_dimensions: [
@@ -500,19 +505,26 @@ describe('tenant routing smoke', () => {
         }) as {
           result?: { structuredContent?: {
             adcp_version?: string;
+            adcp?: { governance_enforcement?: { tasks?: Array<{ task?: string; modes?: string[] }> } };
             media_buy?: { lifecycle_tools?: string[]; proposal_refinement?: unknown };
           } };
         };
         expect(nonBetaCapabilities.result?.structuredContent?.adcp_version).toBe('3.0');
+        expect(nonBetaCapabilities.result?.structuredContent?.adcp?.governance_enforcement?.tasks).toEqual([
+          { task: 'create_media_buy', modes: ['signed_context'] },
+        ]);
         expect(nonBetaCapabilities.result?.structuredContent?.media_buy?.lifecycle_tools).toBeUndefined();
         expect(nonBetaCapabilities.result?.structuredContent?.media_buy?.proposal_refinement).toBeUndefined();
       }
 
       const requested = await callTenantTool(url, 4, 'request_proposals', {
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-request-0001',
-        brand: { domain: 'buyer.example' },
+        account: {
+          brand: { domain: 'buyer.example' },
+          operator: 'buyer.example',
+        },
         brief: 'social engagement display',
       }) as {
         result?: { structuredContent?: {
@@ -520,14 +532,18 @@ describe('tenant routing smoke', () => {
           proposals?: Array<{ proposal_id?: string }>;
         } };
       };
-      expect(requested.result?.structuredContent?.adcp_version).toBe('3.2-beta.0');
+      expect(requested.result?.structuredContent?.adcp_version).toBe('3.2-beta.2');
       const sourceProposalId = requested.result?.structuredContent?.proposals?.[0]?.proposal_id;
-      expect(sourceProposalId).toBeTruthy();
+      expect(sourceProposalId, JSON.stringify(requested)).toBeTruthy();
 
       const partial = await callTenantTool(url, 5, 'refine_proposals', {
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-refine-three-0001',
+        account: {
+          brand: { domain: 'buyer.example' },
+          operator: 'buyer.example',
+        },
         refinements: [{
           proposal_id: sourceProposalId,
           action: 'revise',
@@ -542,16 +558,20 @@ describe('tenant routing smoke', () => {
         } };
       };
       const counteroffer = partial.result?.structuredContent;
-      expect(counteroffer?.adcp_version).toBe('3.2-beta.0');
+      expect(counteroffer?.adcp_version).toBe('3.2-beta.2');
       expect(counteroffer?.adcp_error).toBeUndefined();
-      expect(counteroffer?.results?.[0]?.outcome).toBe('partial');
+      expect(counteroffer?.results?.[0]?.outcome, JSON.stringify(counteroffer)).toBe('partial');
       expect(counteroffer?.results?.[0]?.reason_code).toBe('alternatives_unavailable');
       expect(counteroffer?.results?.[0]?.proposals).toHaveLength(2);
 
       const refined = await callTenantTool(url, 6, 'refine_proposals', {
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-refine-two-0001',
+        account: {
+          brand: { domain: 'buyer.example' },
+          operator: 'buyer.example',
+        },
         refinements: [{
           proposal_id: sourceProposalId,
           action: 'revise',
@@ -562,14 +582,907 @@ describe('tenant routing smoke', () => {
         result?: { structuredContent?: {
           adcp_version?: string;
           adcp_error?: { message?: string };
-          results?: Array<{ outcome?: string; proposals?: unknown[] }>;
+          results?: Array<{ outcome?: string; proposals?: Array<{ proposal_id?: string }> }>;
         } };
       };
       const refinement = refined.result?.structuredContent;
-      expect(refinement?.adcp_version).toBe('3.2-beta.0');
+      expect(refinement?.adcp_version).toBe('3.2-beta.2');
       expect(refinement?.adcp_error).toBeUndefined();
       expect(refinement?.results?.[0]?.outcome).toBe('revised');
       expect(refinement?.results?.[0]?.proposals).toHaveLength(2);
+
+      const revisedProposalId = refinement?.results?.[0]?.proposals?.[0]?.proposal_id;
+      expect(revisedProposalId).toEqual(expect.any(String));
+      const finalized = await callTenantTool(url, 7, 'refine_proposals', {
+        adcp_version: '3.2-beta.2',
+        adcp_major_version: 3,
+        idempotency_key: 'tenant-profile-finalize-0001',
+        refinements: [{ proposal_id: revisedProposalId, action: 'finalize' }],
+      }) as {
+        result?: { structuredContent?: {
+          adcp_error?: { code?: string };
+          results?: Array<{
+            outcome?: string;
+            proposal?: {
+              proposal_id?: string;
+              proposal_status?: string;
+              terms_digest?: string;
+              commercial_terms?: {
+                purchases?: Array<{ product_id?: string; pricing_option_id?: string }>;
+              };
+            };
+          }>;
+        } };
+      };
+      const committed = finalized.result?.structuredContent?.results?.[0]?.proposal;
+      expect(finalized.result?.structuredContent?.adcp_error, JSON.stringify(finalized)).toBeUndefined();
+      expect(finalized.result?.structuredContent?.results?.[0]?.outcome).toBe('finalized');
+      expect(committed).toMatchObject({
+        proposal_id: expect.any(String),
+        proposal_status: 'committed',
+        terms_digest: expect.stringMatching(/^sha256:/),
+      });
+
+      const crossAccountAccept = await callTenantTool(url, 8, 'accept_proposal', {
+        idempotency_key: 'tenant-profile-cross-account-0001',
+        account: {
+          brand: { domain: 'buyer.example' },
+          operator: 'alternate-operator.example',
+        },
+        proposal_id: committed!.proposal_id,
+        proposal_terms_digest: committed!.terms_digest,
+      }) as { result?: { structuredContent?: { adcp_error?: { code?: string } } } };
+      expect(crossAccountAccept.result?.structuredContent?.adcp_error?.code).toBe('PROPOSAL_NOT_FOUND');
+
+      const accepted = await callTenantTool(url, 9, 'accept_proposal', {
+        idempotency_key: 'tenant-profile-accept-0000001',
+        account: {
+          brand: { domain: 'buyer.example' },
+          operator: 'buyer.example',
+        },
+        proposal_id: committed!.proposal_id,
+        proposal_terms_digest: committed!.terms_digest,
+      }) as {
+        result?: { structuredContent?: {
+          adcp_error?: { code?: string; message?: string };
+          status?: string;
+          media_buy_id?: string;
+          revision?: number;
+          accepted_proposal?: { proposal_id?: string; proposal_status?: string; terms_digest?: string };
+          purchase_bindings?: Array<{ product_id?: string; package_id?: string }>;
+        } };
+      };
+      expect(accepted.result?.structuredContent?.adcp_error, JSON.stringify(accepted)).toBeUndefined();
+      expect(accepted.result?.structuredContent).toMatchObject({
+        status: 'completed',
+        media_buy_id: expect.any(String),
+        revision: 1,
+        accepted_proposal: {
+          proposal_id: committed!.proposal_id,
+          proposal_status: 'accepted',
+        },
+      });
+
+      const account = {
+        brand: { domain: 'buyer.example' },
+        operator: 'buyer.example',
+      };
+      const mediaBuyId = accepted.result!.structuredContent!.media_buy_id!;
+      const acceptedRead = await callTenantTool(url, 91, 'get_media_buys', {
+        account,
+        media_buy_ids: [mediaBuyId],
+      }) as { result?: { structuredContent?: { media_buys?: Array<{
+        accepted_proposal_id?: string;
+        accepted_proposal_terms_digest?: string;
+        accepted_proposal?: { proposal_id?: string; terms_digest?: string };
+      }> } } };
+      expect(acceptedRead.result?.structuredContent?.media_buys?.[0]).toMatchObject({
+        accepted_proposal_id: committed!.proposal_id,
+        accepted_proposal_terms_digest: committed!.terms_digest,
+        accepted_proposal: {
+          proposal_id: committed!.proposal_id,
+          terms_digest: committed!.terms_digest,
+        },
+      });
+      const originalBindings = accepted.result!.structuredContent!.purchase_bindings ?? [];
+      const originalProductIds = committed!.commercial_terms!.purchases!.map(purchase => purchase.product_id!);
+      expect(originalProductIds.length).toBeGreaterThanOrEqual(2);
+      const omittedProductId = originalProductIds[0]!;
+      const retainedProductId = originalProductIds[1]!;
+      const retainedPackageId = originalBindings.find(binding => binding.product_id === retainedProductId)!.package_id!;
+
+      const listed = await callTenantTool(url, 10, 'list_products', {
+        account,
+        fields: ['pricing_options'],
+      }) as { result?: { structuredContent?: { products?: Array<{
+        product_id?: string;
+        pricing_options?: Array<{ pricing_option_id?: string }>;
+      }> } } };
+      const addedProduct = listed.result?.structuredContent?.products?.find(product => (
+        product.product_id
+        && !originalProductIds.includes(product.product_id)
+        && !product.product_id.toLowerCase().includes('premium')
+        && product.pricing_options?.[0]?.pricing_option_id
+      ));
+      expect(addedProduct?.product_id).toEqual(expect.any(String));
+      const amendedStart = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      const amendedEnd = '2030-03-01T00:00:00.000Z';
+      const amendmentDraftResponse = await callTenantTool(url, 11, 'refine_proposals', {
+        idempotency_key: 'tenant-profile-amendment-draft-01',
+        account,
+        refinements: [{
+          proposal_id: committed!.proposal_id,
+          action: 'revise',
+          change_kind: 'amendment',
+          constraints: {
+            flight: {
+              start_no_later_than: amendedStart,
+              end_no_earlier_than: amendedEnd,
+            },
+          },
+          product_changes: {
+            [omittedProductId]: 'omit',
+            [addedProduct!.product_id!]: 'include',
+          },
+        }],
+      }) as { result?: { structuredContent?: {
+        adcp_error?: { code?: string };
+        results?: Array<{ outcome?: string; proposals?: Array<{
+          proposal_id?: string;
+          proposal_kind?: string;
+          base_media_buy_revision?: number;
+          commercial_terms?: { start_time?: string; end_time?: string; purchases?: Array<{ product_id?: string }> };
+        }> }>;
+      } } };
+      const amendmentDraft = amendmentDraftResponse.result?.structuredContent?.results?.[0]?.proposals?.[0];
+      expect(amendmentDraftResponse.result?.structuredContent?.adcp_error, JSON.stringify(amendmentDraftResponse)).toBeUndefined();
+      expect(amendmentDraft).toMatchObject({
+        proposal_kind: 'media_buy_update',
+        base_media_buy_revision: 1,
+        commercial_terms: { start_time: amendedStart, end_time: amendedEnd },
+      });
+      expect(amendmentDraft!.commercial_terms!.purchases!.map(purchase => purchase.product_id))
+        .toEqual(expect.arrayContaining([retainedProductId, addedProduct!.product_id]));
+      expect(amendmentDraft!.commercial_terms!.purchases!.map(purchase => purchase.product_id))
+        .not.toContain(omittedProductId);
+
+      const finalizedAmendment = await callTenantTool(url, 12, 'refine_proposals', {
+        idempotency_key: 'tenant-profile-amendment-final-01',
+        refinements: [{ proposal_id: amendmentDraft!.proposal_id, action: 'finalize' }],
+      }) as { result?: { structuredContent?: { results?: Array<{ proposal?: {
+        proposal_id?: string;
+        terms_digest?: string;
+        base_media_buy_revision?: number;
+      } }> } } };
+      const amendment = finalizedAmendment.result?.structuredContent?.results?.[0]?.proposal;
+      expect(amendment).toMatchObject({
+        proposal_id: expect.any(String),
+        terms_digest: expect.stringMatching(/^sha256:/),
+        base_media_buy_revision: 1,
+      });
+
+      const amendmentAttempts = await Promise.all([
+        callTenantTool(url, 13, 'accept_proposal', {
+          idempotency_key: 'tenant-profile-amendment-accept-01',
+          account,
+          proposal_id: amendment!.proposal_id,
+          proposal_terms_digest: amendment!.terms_digest,
+        }),
+        callTenantTool(url, 14, 'accept_proposal', {
+          idempotency_key: 'tenant-profile-amendment-accept-02',
+          account,
+          proposal_id: amendment!.proposal_id,
+          proposal_terms_digest: amendment!.terms_digest,
+        }),
+      ]) as Array<{ result?: { structuredContent?: {
+        adcp_error?: { code?: string };
+        revision?: number;
+        accepted_proposal?: { base_media_buy_revision?: number; terms_digest?: string };
+        purchase_bindings?: Array<{ product_id?: string; package_id?: string }>;
+      } } }>;
+      const amendmentSuccesses = amendmentAttempts.filter(attempt => !attempt.result?.structuredContent?.adcp_error);
+      expect(amendmentSuccesses).toHaveLength(1);
+      expect(amendmentAttempts.filter(attempt => attempt.result?.structuredContent?.adcp_error)).toHaveLength(1);
+      expect(amendmentSuccesses[0]!.result?.structuredContent).toMatchObject({
+        revision: 2,
+        accepted_proposal: { base_media_buy_revision: 1, terms_digest: amendment!.terms_digest },
+      });
+      expect(amendmentSuccesses[0]!.result?.structuredContent?.purchase_bindings)
+        .toEqual(expect.arrayContaining([
+          expect.objectContaining({ product_id: retainedProductId, package_id: retainedPackageId }),
+          expect.objectContaining({ product_id: addedProduct!.product_id, package_id: expect.any(String) }),
+        ]));
+
+      const amendedRead = await callTenantTool(url, 15, 'get_media_buys', {
+        account,
+        media_buy_ids: [mediaBuyId],
+      }) as { result?: { structuredContent?: { media_buys?: Array<{
+        revision?: number;
+        start_time?: string;
+        end_time?: string;
+        accepted_proposal_terms_digest?: string;
+        packages?: Array<{ package_id?: string; product_id?: string; cancellation?: unknown; start_time?: string; end_time?: string }>;
+      }> } } };
+      const amendedBuy = amendedRead.result?.structuredContent?.media_buys?.[0];
+      expect(amendedBuy).toMatchObject({
+        revision: 2,
+        start_time: amendedStart,
+        end_time: amendedEnd,
+        accepted_proposal_terms_digest: amendment!.terms_digest,
+      });
+      expect(amendedBuy!.packages).toEqual(expect.arrayContaining([
+        expect.objectContaining({ package_id: retainedPackageId, product_id: retainedProductId, start_time: amendedStart, end_time: amendedEnd }),
+        expect.objectContaining({ product_id: addedProduct!.product_id, start_time: amendedStart, end_time: amendedEnd }),
+        expect.objectContaining({ product_id: omittedProductId, cancellation: expect.any(Object) }),
+      ]));
+
+      const cancellationDraftResponse = await callTenantTool(url, 16, 'refine_proposals', {
+        idempotency_key: 'tenant-profile-cancel-draft-0001',
+        account,
+        refinements: [{
+          proposal_id: amendment!.proposal_id,
+          action: 'revise',
+          change_kind: 'cancellation',
+          ask: 'Cancel by mutual agreement.',
+        }],
+      }) as { result?: { structuredContent?: { results?: Array<{ proposals?: Array<{
+        proposal_id?: string;
+        commercial_terms?: { cancellation_terms?: { effective_at?: string } };
+      }> }> } } };
+      const cancellationDraft = cancellationDraftResponse.result?.structuredContent?.results?.[0]?.proposals?.[0];
+      expect(Date.parse(cancellationDraft!.commercial_terms!.cancellation_terms!.effective_at!)).toBeLessThanOrEqual(Date.now());
+      const finalizedCancellation = await callTenantTool(url, 17, 'refine_proposals', {
+        idempotency_key: 'tenant-profile-cancel-final-0001',
+        refinements: [{ proposal_id: cancellationDraft!.proposal_id, action: 'finalize' }],
+      }) as { result?: { structuredContent?: { results?: Array<{ proposal?: {
+        proposal_id?: string;
+        terms_digest?: string;
+        base_media_buy_revision?: number;
+      } }> } } };
+      const cancellation = finalizedCancellation.result?.structuredContent?.results?.[0]?.proposal;
+      expect(cancellation?.base_media_buy_revision).toBe(2);
+      const cancellationAccept = await callTenantTool(url, 18, 'accept_proposal', {
+        idempotency_key: 'tenant-profile-cancel-accept-001',
+        account,
+        proposal_id: cancellation!.proposal_id,
+        proposal_terms_digest: cancellation!.terms_digest,
+      }) as { result?: { structuredContent?: {
+        adcp_error?: { code?: string };
+        revision?: number;
+        media_buy_status?: string;
+        purchase_bindings?: Array<{ package_id?: string }>;
+        accepted_proposal?: { base_media_buy_revision?: number; terms_digest?: string };
+      } } };
+      expect(cancellationAccept.result?.structuredContent?.adcp_error, JSON.stringify(cancellationAccept)).toBeUndefined();
+      expect(cancellationAccept.result?.structuredContent).toMatchObject({
+        revision: 3,
+        media_buy_status: 'canceled',
+        accepted_proposal: { base_media_buy_revision: 2, terms_digest: cancellation!.terms_digest },
+      });
+      expect(cancellationAccept.result?.structuredContent?.purchase_bindings?.every(binding => binding.package_id)).toBe(true);
+    } finally {
+      await close();
+    }
+  }, 30000);
+
+  it('executes the native 3.2 direct-buy lifecycle with atomic controls and accepted-snapshot readback', async () => {
+    const { baseUrl, close } = await bootServer();
+    try {
+      const url = `${baseUrl}/sales/mcp`;
+      await initializeTenant(url);
+      const account = {
+        brand: { domain: 'tenant-native-buy.example' },
+        operator: 'tenant-native-buy.example',
+      };
+      const listed = await callTenantTool(url, 2, 'list_products', {
+        account,
+        fields: ['pricing_options', 'format_options', 'measurement_terms', 'performance_standards'],
+      }) as {
+        result?: { structuredContent?: {
+          outcome?: string;
+          feed_version?: string;
+          pricing_version?: string;
+          products?: Array<{
+            product_id?: string;
+            pricing_options?: Array<{ pricing_option_id?: string }>;
+          }>;
+        } };
+      };
+      const catalog = listed.result?.structuredContent;
+      const product = catalog?.products?.find(candidate => candidate.pricing_options?.[0]?.pricing_option_id);
+      expect(catalog?.outcome).toBe('listed');
+      expect(catalog?.feed_version).toEqual(expect.any(String));
+      expect(catalog?.pricing_version).toEqual(expect.any(String));
+      expect(product?.product_id).toEqual(expect.any(String));
+      expect(product?.pricing_options?.[0]?.pricing_option_id).toEqual(expect.any(String));
+
+      const startTime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+      const endTime = new Date(Date.now() + 31 * 24 * 60 * 60 * 1000).toISOString();
+      const bought = await callTenantTool(url, 3, 'buy_products', {
+        idempotency_key: 'tenant-native-buy-products-0001',
+        account,
+        feed_version: catalog!.feed_version,
+        pricing_version: catalog!.pricing_version,
+        purchases: [{
+          product_id: product!.product_id,
+          pricing_option_id: product!.pricing_options![0]!.pricing_option_id,
+          budget: 50_000,
+          targeting_overlay: { geo_countries: ['US'] },
+          context: { correlation_id: 'native-purchase-0' },
+        }],
+        total_budget: { amount: 50_000, currency: 'USD' },
+        start_time: startTime,
+        end_time: endTime,
+      }) as {
+        result?: { structuredContent?: {
+          adcp_error?: { code?: string; message?: string };
+          status?: string;
+          media_buy_id?: string;
+          revision?: number;
+          accepted_proposal?: {
+            proposal_id?: string;
+            proposal_status?: string;
+            terms_digest?: string;
+            commercial_terms?: { purchases?: Array<{ context?: unknown }> };
+          };
+          purchase_bindings?: Array<{ package_id?: string }>;
+        } };
+      };
+      const commitment = bought.result?.structuredContent;
+      expect(commitment?.adcp_error, JSON.stringify(commitment)).toBeUndefined();
+      expect(commitment).toMatchObject({
+        status: 'completed',
+        media_buy_id: expect.any(String),
+        revision: 1,
+        accepted_proposal: {
+          proposal_status: 'accepted',
+          terms_digest: expect.stringMatching(/^sha256:/),
+        },
+        purchase_bindings: [{ package_id: expect.any(String) }],
+      });
+      expect(commitment?.accepted_proposal?.commercial_terms?.purchases?.[0]?.context)
+        .toEqual({ correlation_id: 'native-purchase-0' });
+
+      const read = await callTenantTool(url, 4, 'get_media_buys', {
+        account,
+        media_buy_ids: [commitment!.media_buy_id],
+      }) as {
+        result?: { structuredContent?: { media_buys?: Array<{
+          media_buy_id?: string;
+          revision?: number;
+          accepted_proposal_id?: string;
+          accepted_proposal_terms_digest?: string;
+          accepted_proposal?: { proposal_id?: string };
+          packages?: Array<{ targeting_overlay?: unknown; context?: unknown }>;
+        }> } };
+      };
+      expect(read.result?.structuredContent?.media_buys?.[0]).toMatchObject({
+        media_buy_id: commitment!.media_buy_id,
+        revision: 1,
+        accepted_proposal_id: commitment!.accepted_proposal!.proposal_id,
+        accepted_proposal_terms_digest: commitment!.accepted_proposal!.terms_digest,
+        accepted_proposal: { proposal_id: commitment!.accepted_proposal!.proposal_id },
+      });
+      expect(read.result?.structuredContent?.media_buys?.[0]?.packages?.[0]).toMatchObject({
+        targeting_overlay: { geo_countries: ['US'] },
+        context: { correlation_id: 'native-purchase-0' },
+      });
+
+      const requote = await callTenantTool(url, 41, 'control_media_buy', {
+        idempotency_key: 'tenant-native-control-requote-0001',
+        account,
+        media_buy_id: commitment!.media_buy_id,
+        revision: 1,
+        total_budget: { amount: 60_000, currency: 'USD' },
+      }) as {
+        result?: { structuredContent?: {
+          adcp_error?: { code?: string; details?: { envelope_field?: string } };
+        } };
+      };
+      expect(requote.result?.structuredContent?.adcp_error).toMatchObject({
+        code: 'REQUOTE_REQUIRED',
+        details: { envelope_field: 'total_budget.amount' },
+      });
+
+      const staleRequote = await callTenantTool(url, 411, 'control_media_buy', {
+        idempotency_key: 'tenant-native-control-stale-requote-01',
+        account,
+        media_buy_id: commitment!.media_buy_id,
+        revision: 0,
+        total_budget: { amount: 60_000, currency: 'USD' },
+      }) as { result?: { structuredContent?: { adcp_error?: { code?: string } } } };
+      expect(staleRequote.result?.structuredContent?.adcp_error?.code).toBe('CONFLICT');
+
+      const unchanged = await callTenantTool(url, 42, 'get_media_buys', {
+        account,
+        media_buy_ids: [commitment!.media_buy_id],
+      }) as {
+        result?: { structuredContent?: { media_buys?: Array<{
+          revision?: number;
+          total_budget?: number;
+          accepted_proposal_terms_digest?: string;
+        }> } };
+      };
+      expect(unchanged.result?.structuredContent?.media_buys?.[0]).toMatchObject({
+        revision: 1,
+        total_budget: 50_000,
+        accepted_proposal_terms_digest: commitment!.accepted_proposal!.terms_digest,
+      });
+
+      const invalidControl = await callTenantTool(url, 5, 'control_media_buy', {
+        idempotency_key: 'tenant-native-control-invalid-0001',
+        account,
+        media_buy_id: commitment!.media_buy_id,
+        revision: 1,
+        packages: [{ package_id: 'pkg-does-not-exist', paused: true }],
+      }) as { result?: { structuredContent?: { adcp_error?: { code?: string } } } };
+      expect(invalidControl.result?.structuredContent?.adcp_error?.code).toBe('PACKAGE_NOT_FOUND');
+
+      const targetingRequote = await callTenantTool(url, 51, 'control_media_buy', {
+        idempotency_key: 'tenant-native-targeting-requote-01',
+        account,
+        media_buy_id: commitment!.media_buy_id,
+        revision: 1,
+        packages: [{
+          package_id: commitment!.purchase_bindings![0]!.package_id,
+          targeting_overlay: { geo_countries: ['CA'] },
+        }],
+      }) as { result?: { structuredContent?: { adcp_error?: {
+        code?: string;
+        details?: { envelope_field?: string };
+      } } } };
+      expect(targetingRequote.result?.structuredContent?.adcp_error).toMatchObject({
+        code: 'REQUOTE_REQUIRED',
+        details: { envelope_field: 'packages[0].targeting_overlay' },
+      });
+
+      const controlled = await callTenantTool(url, 6, 'control_media_buy', {
+        idempotency_key: 'tenant-native-control-valid-00001',
+        account,
+        media_buy_id: commitment!.media_buy_id,
+        revision: 1,
+        daily_budget_cap: 2_500,
+      }) as {
+        result?: { structuredContent?: {
+          adcp_error?: { code?: string };
+          status?: string;
+          media_buy_id?: string;
+          revision?: number;
+        } };
+      };
+      expect(controlled.result?.structuredContent).toMatchObject({
+        status: 'completed',
+        media_buy_id: commitment!.media_buy_id,
+        revision: 2,
+      });
+      expect(controlled.result?.structuredContent?.adcp_error).toBeUndefined();
+    } finally {
+      await close();
+    }
+  }, 30000);
+
+  it('binds governed native 3.2 purchases, proposal acceptance, and positive controls to their advertised tasks', async () => {
+    const { baseUrl, close } = await bootServer();
+    try {
+      const salesUrl = `${baseUrl}/sales/profiles/constrained-seller/mcp`;
+      const governanceUrl = `${baseUrl}/governance/mcp`;
+      await initializeTenant(salesUrl);
+      await initializeTenant(governanceUrl);
+      const brand = { domain: 'tenant-governed-native.example' };
+      const account = { brand, operator: brand.domain };
+      const planId = 'plan-tenant-governed-native';
+      const caller = `https://training-agent.adcontextprotocol.org/authenticated/${createHash('sha256')
+        .update('test-token')
+        .digest('hex')
+        .slice(0, 32)}`;
+      const targetAgent = `${getCanonicalBase()}/sales`;
+      const structured = (response: Record<string, unknown>) => (
+        response as { result?: { structuredContent?: Record<string, unknown> } }
+      ).result?.structuredContent;
+
+      const synced = structured(await callTenantTool(governanceUrl, 100, 'sync_plans', {
+        idempotency_key: 'tenant-governed-native-plan-sync',
+        brand,
+        plans: [{
+          plan_id: planId,
+          brand,
+          objectives: 'Exercise every governed native media-buy mutation.',
+          budget: { total: 500_000, currency: 'USD', reallocation_threshold: 500_000 },
+          flight: { start: '2027-01-01T00:00:00Z', end: '2027-12-31T23:59:59Z' },
+        }],
+      }));
+      expect(synced?.adcp_error, JSON.stringify(synced)).toBeUndefined();
+
+      const authorize = async (
+        id: number,
+        tool: 'buy_products' | 'accept_proposal' | 'control_media_buy',
+        payload: Record<string, unknown>,
+        amount: number,
+        proposal?: Record<string, unknown>,
+      ): Promise<string> => {
+        const approved = structured(await callTenantTool(governanceUrl, id, 'check_governance', {
+          idempotency_key: `tenant-governed-native-check-${id}`,
+          brand,
+          plan_id: planId,
+          caller,
+          target_agent: targetAgent,
+          tool,
+          payload,
+          proposed_commitment: { amount, currency: 'USD' },
+          ...(proposal && { proposal }),
+        }));
+        expect(approved?.adcp_error, JSON.stringify(approved)).toBeUndefined();
+        expect(approved?.governance_context).toEqual(expect.any(String));
+        return approved!.governance_context as string;
+      };
+
+      const listed = structured(await callTenantTool(salesUrl, 101, 'list_products', {
+        account,
+        fields: ['pricing_options'],
+      })) as {
+        feed_version?: string;
+        pricing_version?: string;
+        products?: Array<{ product_id?: string; pricing_options?: Array<{ pricing_option_id?: string }> }>;
+      };
+      const product = listed.products?.find(candidate => candidate.pricing_options?.[0]?.pricing_option_id);
+      expect(product?.product_id).toEqual(expect.any(String));
+
+      const buyPayload = {
+        idempotency_key: 'tenant-governed-native-buy-0001',
+        account,
+        feed_version: listed.feed_version,
+        pricing_version: listed.pricing_version,
+        purchases: [{
+          product_id: product!.product_id,
+          pricing_option_id: product!.pricing_options![0]!.pricing_option_id,
+          budget: 50_000,
+        }],
+        total_budget: { amount: 50_000, currency: 'USD' },
+        start_time: '2027-06-01T00:00:00Z',
+        end_time: '2027-06-30T23:59:59Z',
+      };
+      const buyContext = await authorize(102, 'buy_products', buyPayload, 50_000);
+      const bought = structured(await callTenantTool(salesUrl, 103, 'buy_products', {
+        ...buyPayload,
+        governance_context: buyContext,
+      })) as {
+        adcp_error?: { code?: string };
+        media_buy_id?: string;
+        revision?: number;
+        accepted_proposal?: { proposal_id?: string };
+      };
+      expect(bought?.adcp_error, JSON.stringify(bought)).toBeUndefined();
+      expect(bought).toMatchObject({ media_buy_id: expect.any(String), revision: 1 });
+
+      const amendmentDraft = structured(await callTenantTool(salesUrl, 104, 'refine_proposals', {
+        idempotency_key: 'tenant-governed-native-amend-draft',
+        account,
+        refinements: [{
+          proposal_id: bought.accepted_proposal!.proposal_id,
+          action: 'revise',
+          change_kind: 'amendment',
+          constraints: { flight: { end_no_earlier_than: '2027-07-15T23:59:59Z' } },
+        }],
+      })) as { results?: Array<{ proposals?: Array<{ proposal_id?: string }> }> };
+      const draftProposalId = amendmentDraft.results?.[0]?.proposals?.[0]?.proposal_id;
+      expect(draftProposalId).toEqual(expect.any(String));
+      const finalized = structured(await callTenantTool(salesUrl, 105, 'refine_proposals', {
+        idempotency_key: 'tenant-governed-native-amend-final',
+        account,
+        refinements: [{ proposal_id: draftProposalId, action: 'finalize' }],
+      })) as { results?: Array<{ proposal?: Record<string, unknown> & {
+        proposal_id?: string;
+        terms_digest?: string;
+      } }> };
+      const amendment = finalized.results?.[0]?.proposal;
+      expect(amendment).toMatchObject({
+        proposal_id: expect.any(String),
+        terms_digest: expect.stringMatching(/^sha256:/),
+      });
+
+      const acceptPayload = {
+        idempotency_key: 'tenant-governed-native-accept-01',
+        account,
+        proposal_id: amendment!.proposal_id,
+        proposal_terms_digest: amendment!.terms_digest,
+      };
+      const acceptContext = await authorize(106, 'accept_proposal', acceptPayload, 0, amendment);
+      const accepted = structured(await callTenantTool(salesUrl, 107, 'accept_proposal', {
+        ...acceptPayload,
+        governance_context: acceptContext,
+      })) as { adcp_error?: { code?: string }; media_buy_id?: string; revision?: number };
+      expect(accepted?.adcp_error, JSON.stringify(accepted)).toBeUndefined();
+      expect(accepted).toMatchObject({ media_buy_id: bought.media_buy_id, revision: 2 });
+
+      const decreased = structured(await callTenantTool(salesUrl, 108, 'control_media_buy', {
+        idempotency_key: 'tenant-governed-native-decrease-01',
+        account,
+        media_buy_id: bought.media_buy_id,
+        revision: 2,
+        total_budget: { amount: 40_000, currency: 'USD' },
+      })) as { adcp_error?: { code?: string }; revision?: number };
+      expect(decreased?.adcp_error, JSON.stringify(decreased)).toBeUndefined();
+      expect(decreased?.revision).toBe(3);
+
+      const controlPayload = {
+        idempotency_key: 'tenant-governed-native-increase-01',
+        account,
+        media_buy_id: bought.media_buy_id,
+        revision: 3,
+        total_budget: { amount: 45_000, currency: 'USD' },
+      };
+      const controlContext = await authorize(109, 'control_media_buy', controlPayload, 5_000);
+      const controlled = structured(await callTenantTool(salesUrl, 110, 'control_media_buy', {
+        ...controlPayload,
+        governance_context: controlContext,
+      })) as { adcp_error?: { code?: string }; media_buy_id?: string; revision?: number };
+      expect(controlled?.adcp_error, JSON.stringify(controlled)).toBeUndefined();
+      expect(controlled).toMatchObject({ media_buy_id: bought.media_buy_id, revision: 4 });
+
+      const postControlDraft = structured(await callTenantTool(salesUrl, 111, 'refine_proposals', {
+        idempotency_key: 'tenant-governed-native-post-control-draft',
+        account,
+        refinements: [{
+          proposal_id: amendment!.proposal_id,
+          action: 'revise',
+          change_kind: 'amendment',
+          constraints: { flight: { end_no_earlier_than: '2027-07-31T23:59:59Z' } },
+        }],
+      })) as { results?: Array<{ proposals?: Array<{ proposal_id?: string }> }> };
+      const postControlDraftId = postControlDraft.results?.[0]?.proposals?.[0]?.proposal_id;
+      expect(postControlDraftId).toEqual(expect.any(String));
+      const postControlFinalized = structured(await callTenantTool(salesUrl, 112, 'refine_proposals', {
+        idempotency_key: 'tenant-governed-native-post-control-final',
+        account,
+        refinements: [{ proposal_id: postControlDraftId, action: 'finalize' }],
+      })) as { results?: Array<{ proposal?: Record<string, unknown> & {
+        proposal_id?: string;
+        terms_digest?: string;
+        commercial_terms?: { total_budget?: { amount?: number; currency?: string } };
+      } }> };
+      const postControlAmendment = postControlFinalized.results?.[0]?.proposal;
+      expect(postControlAmendment?.commercial_terms?.total_budget).toEqual({ amount: 45_000, currency: 'USD' });
+      const postControlPayload = {
+        idempotency_key: 'tenant-governed-native-post-control-accept',
+        account,
+        proposal_id: postControlAmendment!.proposal_id,
+        proposal_terms_digest: postControlAmendment!.terms_digest,
+      };
+      const postControlContext = await authorize(
+        113,
+        'accept_proposal',
+        postControlPayload,
+        0,
+        postControlAmendment,
+      );
+      const postControlAccepted = structured(await callTenantTool(salesUrl, 114, 'accept_proposal', {
+        ...postControlPayload,
+        governance_context: postControlContext,
+      })) as { adcp_error?: { code?: string }; media_buy_id?: string; revision?: number };
+      expect(postControlAccepted?.adcp_error, JSON.stringify(postControlAccepted)).toBeUndefined();
+      expect(postControlAccepted).toMatchObject({ media_buy_id: bought.media_buy_id, revision: 5 });
+
+      const cancellationDraft = structured(await callTenantTool(salesUrl, 115, 'refine_proposals', {
+        idempotency_key: 'tenant-governed-native-cancel-draft',
+        account,
+        refinements: [{
+          proposal_id: postControlAmendment!.proposal_id,
+          action: 'revise',
+          change_kind: 'cancellation',
+          ask: 'Cancel without a fee by mutual agreement.',
+        }],
+      })) as { results?: Array<{ proposals?: Array<{ proposal_id?: string }> }> };
+      const cancellationDraftId = cancellationDraft.results?.[0]?.proposals?.[0]?.proposal_id;
+      expect(cancellationDraftId).toEqual(expect.any(String));
+      const cancellationFinalized = structured(await callTenantTool(salesUrl, 116, 'refine_proposals', {
+        idempotency_key: 'tenant-governed-native-cancel-final',
+        account,
+        refinements: [{ proposal_id: cancellationDraftId, action: 'finalize' }],
+      })) as { results?: Array<{ proposal?: Record<string, unknown> & {
+        proposal_id?: string;
+        terms_digest?: string;
+      } }> };
+      const cancellation = cancellationFinalized.results?.[0]?.proposal;
+      const cancelPayload = {
+        idempotency_key: 'tenant-governed-native-cancel-accept',
+        account,
+        proposal_id: cancellation!.proposal_id,
+        proposal_terms_digest: cancellation!.terms_digest,
+      };
+      const cancelContext = await authorize(117, 'accept_proposal', cancelPayload, 0, cancellation);
+      const canceled = structured(await callTenantTool(salesUrl, 118, 'accept_proposal', {
+        ...cancelPayload,
+        governance_context: cancelContext,
+      })) as { adcp_error?: { code?: string }; media_buy_status?: string; revision?: number };
+      expect(canceled?.adcp_error, JSON.stringify(canceled)).toBeUndefined();
+      expect(canceled).toMatchObject({ media_buy_status: 'canceled', revision: 6 });
+    } finally {
+      await close();
+    }
+  }, 30000);
+
+  it('buys seeded offers and accepts repeated approval-required amendments', async () => {
+    const { baseUrl, close } = await bootServer();
+    try {
+      const url = `${baseUrl}/sales/profiles/constrained-seller/mcp`;
+      await initializeTenant(url);
+      const account = {
+        brand: { domain: 'tenant-seeded-native-buy.example' },
+        operator: 'tenant-seeded-native-buy.example',
+        sandbox: true,
+      };
+      const productId = 'seeded_native_buy_product';
+      const pricingOptionId = 'seeded_native_buy_cpm';
+      await callTenantTool(url, 70, 'comply_test_controller', {
+        account,
+        scenario: 'seed_product',
+        params: {
+          product_id: productId,
+          fixture: {
+            name: 'Seeded native buy product',
+            description: 'A deterministic seeded offer',
+            delivery_type: 'guaranteed',
+            channels: ['display'],
+            allowed_actions: [{
+              action: 'extend_flight',
+              modes: ['requires_approval'],
+              sla: { response_max: 'PT4H', completion_max: 'P2D' },
+            }],
+            format_ids: [{
+              agent_url: 'https://creative.adcontextprotocol.org/',
+              id: 'display_300x250_image',
+              width: 300,
+              height: 250,
+            }],
+          },
+        },
+      });
+      await callTenantTool(url, 71, 'comply_test_controller', {
+        account,
+        scenario: 'seed_pricing_option',
+        params: {
+          product_id: productId,
+          pricing_option_id: pricingOptionId,
+          fixture: { pricing_model: 'cpm', currency: 'USD', fixed_price: 12 },
+        },
+      });
+
+      const listed = await callTenantTool(url, 72, 'list_products', {
+        account,
+        criteria: { product_ids: [productId] },
+        fields: ['pricing_options', 'format_options'],
+      }) as { result?: { structuredContent?: {
+        feed_version?: string;
+        pricing_version?: string;
+        products?: Array<{
+          product_id?: string;
+          pricing_options?: Array<{ pricing_option_id?: string; fixed_price?: number }>;
+        }>;
+      } } };
+      const offer = listed.result?.structuredContent;
+      expect(offer?.products?.[0]).toMatchObject({
+        product_id: productId,
+        pricing_options: [{ pricing_option_id: pricingOptionId, fixed_price: 12 }],
+      });
+
+      const initialRead = await callTenantTool(url, 721, 'get_media_buys', { account }) as {
+        result?: { structuredContent?: { media_buys?: unknown[] } };
+      };
+      const initialBuyCount = initialRead.result?.structuredContent?.media_buys?.length;
+
+      const invalidPricing = await callTenantTool(url, 73, 'buy_products', {
+        idempotency_key: 'tenant-seeded-invalid-price-0001',
+        account,
+        feed_version: offer!.feed_version,
+        pricing_version: offer!.pricing_version,
+        purchases: [{ product_id: productId, pricing_option_id: 'not-advertised', budget: 1_000 }],
+        total_budget: { amount: 1_000, currency: 'USD' },
+        start_time: '2027-06-01T00:00:00Z',
+        end_time: '2027-07-01T00:00:00Z',
+      }) as { result?: { structuredContent?: { adcp_error?: {
+        code?: string;
+        field?: string;
+        details?: { rejected_value?: string; accepted_values?: string[] };
+      } } } };
+      expect(invalidPricing.result?.structuredContent?.adcp_error).toMatchObject({
+        code: 'INVALID_PRICING_OPTION',
+        field: 'purchases[0].pricing_option_id',
+        details: { rejected_value: 'not-advertised', accepted_values: [pricingOptionId] },
+      });
+
+      const stalePricing = await callTenantTool(url, 74, 'buy_products', {
+        idempotency_key: 'tenant-seeded-stale-price-00001',
+        account,
+        feed_version: offer!.feed_version,
+        pricing_version: `${offer!.pricing_version}-stale`,
+        purchases: [{ product_id: productId, pricing_option_id: pricingOptionId, budget: 1_000 }],
+        total_budget: { amount: 1_000, currency: 'USD' },
+        start_time: '2027-06-01T00:00:00Z',
+        end_time: '2027-07-01T00:00:00Z',
+      }) as { result?: { structuredContent?: { adcp_error?: { code?: string; field?: string } } } };
+      expect(stalePricing.result?.structuredContent?.adcp_error).toMatchObject({
+        code: 'INVALID_REQUEST',
+        field: 'pricing_version',
+      });
+
+      const unchangedRead = await callTenantTool(url, 741, 'get_media_buys', { account }) as {
+        result?: { structuredContent?: { media_buys?: unknown[] } };
+      };
+      expect(unchangedRead.result?.structuredContent?.media_buys).toHaveLength(initialBuyCount ?? 0);
+
+      const bought = await callTenantTool(url, 75, 'buy_products', {
+        idempotency_key: 'tenant-seeded-native-buy-00001',
+        account,
+        feed_version: offer!.feed_version,
+        pricing_version: offer!.pricing_version,
+        purchases: [{ product_id: productId, pricing_option_id: pricingOptionId, budget: 1_000 }],
+        total_budget: { amount: 1_000, currency: 'USD' },
+        start_time: '2027-06-01T00:00:00Z',
+        end_time: '2027-07-01T00:00:00Z',
+      }) as { result?: { structuredContent?: {
+        adcp_error?: unknown;
+        media_buy_id?: string;
+        revision?: number;
+        accepted_proposal?: {
+          proposal_id?: string;
+          commercial_terms?: { purchases?: Array<{
+            product_id?: string;
+            pricing_option_id?: string;
+            pricing?: { fixed_price?: number };
+          }> };
+        };
+      } } };
+      expect(bought.result?.structuredContent?.adcp_error, JSON.stringify(bought)).toBeUndefined();
+      expect(bought.result?.structuredContent).toMatchObject({
+        media_buy_id: expect.any(String),
+        revision: 1,
+        accepted_proposal: { commercial_terms: { purchases: [{
+          product_id: productId,
+          pricing_option_id: pricingOptionId,
+          pricing: { fixed_price: 12 },
+        }] } },
+      });
+
+      let sourceProposalId = bought.result!.structuredContent!.accepted_proposal!.proposal_id!;
+      for (let iteration = 0; iteration < 4; iteration += 1) {
+        const endTime = new Date(Date.UTC(2027, 6, 2 + iteration)).toISOString();
+        const draftResponse = await callTenantTool(url, 760 + iteration * 3, 'refine_proposals', {
+          idempotency_key: `tenant-seeded-amend-draft-000${iteration}`,
+          account,
+          refinements: [{
+            proposal_id: sourceProposalId,
+            action: 'revise',
+            change_kind: 'amendment',
+            constraints: { flight: { end_no_earlier_than: endTime } },
+          }],
+        }) as { result?: { structuredContent?: { results?: Array<{ proposals?: Array<{ proposal_id?: string }> }> } } };
+        const draftId = draftResponse.result?.structuredContent?.results?.[0]?.proposals?.[0]?.proposal_id;
+        expect(draftId, JSON.stringify(draftResponse)).toEqual(expect.any(String));
+
+        const finalizedResponse = await callTenantTool(url, 761 + iteration * 3, 'refine_proposals', {
+          idempotency_key: `tenant-seeded-amend-final-000${iteration}`,
+          refinements: [{ proposal_id: draftId, action: 'finalize' }],
+        }) as { result?: { structuredContent?: { results?: Array<{ proposal?: {
+          proposal_id?: string;
+          terms_digest?: string;
+        } }> } } };
+        const committedAmendment = finalizedResponse.result?.structuredContent?.results?.[0]?.proposal;
+        expect(committedAmendment?.terms_digest, JSON.stringify(finalizedResponse)).toMatch(/^sha256:/);
+
+        const acceptedAmendment = await callTenantTool(url, 762 + iteration * 3, 'accept_proposal', {
+          idempotency_key: `tenant-seeded-amend-accept-00${iteration}`,
+          account,
+          proposal_id: committedAmendment!.proposal_id,
+          proposal_terms_digest: committedAmendment!.terms_digest,
+        }) as { result?: { structuredContent?: {
+          adcp_error?: { code?: string };
+          revision?: number;
+          accepted_proposal?: { proposal_id?: string };
+        } } };
+        expect(acceptedAmendment.result?.structuredContent?.adcp_error, JSON.stringify(acceptedAmendment)).toBeUndefined();
+        expect(acceptedAmendment.result?.structuredContent?.revision).toBe(iteration + 2);
+        sourceProposalId = acceptedAmendment.result!.structuredContent!.accepted_proposal!.proposal_id!;
+      }
     } finally {
       await close();
     }
@@ -810,9 +1723,9 @@ describe('tenant routing smoke', () => {
         };
       };
       const mediaBuy = body.result?.structuredContent?.media_buy;
-      expect(body.result?.structuredContent?.adcp_version).toBe('3.1');
+      expect(body.result?.structuredContent?.adcp_version).toBe('3.2-beta.2');
       expect(body.result?.structuredContent?.adcp?.major_versions).toContain(3);
-      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.0']);
+      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.2']);
       expect(mediaBuy?.features?.inline_creative_management).toBe(true);
       expect(mediaBuy?.supported_optimization_metrics).toContain('clicks');
       expect(mediaBuy?.vendor_metric_optimization?.supported_targets).toContain('threshold_rate');
@@ -1716,7 +2629,7 @@ describe('tenant routing smoke', () => {
         field: 'adcp_version',
         details: {
           adcp_version: '4.0',
-          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.0'],
+          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.2'],
         },
       });
       expect(unsupportedBody.result?.structuredContent?.context?.correlation_id).toBe('tenant-local-version-unsupported');
@@ -2106,7 +3019,7 @@ describe('tenant routing smoke', () => {
       await close();
     }
   }, 20000);
-  it('keeps get_products compatible while exposing independent AdCP 3.2 split tasks', async () => {
+  it('keeps get_products callable while discovering the native AdCP 3.2 lifecycle', async () => {
     const { baseUrl, close } = await bootServer();
     try {
       const url = `${baseUrl}/sales/mcp`;
@@ -2117,7 +3030,7 @@ describe('tenant routing smoke', () => {
       };
       const payload = {
         idempotency_key: 'tenant-products-idempotency-0001',
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         buying_mode: 'wholesale',
         account,
       };
@@ -2145,27 +3058,26 @@ describe('tenant routing smoke', () => {
           }>;
         };
       };
-      const discovered = listBody.result?.tools?.find(tool => tool.name === 'get_products');
-      expect(discovered?.inputSchema?.required).not.toContain('idempotency_key');
-      expect(discovered?.inputSchema?.properties?.idempotency_key).toMatchObject({
-        type: 'string',
-        minLength: 16,
-        maxLength: 255,
-        pattern: '^[A-Za-z0-9_.:-]{16,255}$',
-      });
-      expect(discovered?.annotations).toMatchObject({ readOnlyHint: false, idempotentHint: true });
-
-      expect(listBody.result?.tools?.map(tool => tool.name)).toEqual(expect.arrayContaining([
+      const discoveredNames = listBody.result?.tools?.map(tool => tool.name) ?? [];
+      expect(discoveredNames).not.toEqual(expect.arrayContaining([
+        'get_products',
+        'create_media_buy',
+        'update_media_buy',
+      ]));
+      expect(discoveredNames).toEqual(expect.arrayContaining([
         'list_products',
         'request_proposals',
         'refine_proposals',
         'decline_proposals',
+        'buy_products',
+        'accept_proposal',
+        'control_media_buy',
       ]));
       const listAlias = listBody.result?.tools?.find(tool => tool.name === 'list_products');
       const recommendAlias = listBody.result?.tools?.find(tool => tool.name === 'request_proposals');
       expect(listAlias?.execution).toEqual({ taskSupport: 'forbidden' });
-      expect(listAlias?.inputSchema).toMatchObject({ dependencies: { if_pricing_version: ['if_feed_version'] } });
-      expect(recommendAlias?.execution).toEqual({ taskSupport: 'optional' });
+      expect(listAlias?.inputSchema).toMatchObject({ dependentRequired: { if_pricing_version: ['if_feed_version'] } });
+      expect(recommendAlias?.execution).toEqual({ taskSupport: 'forbidden' });
       expect(recommendAlias?.inputSchema).toMatchObject({
         properties: { brief: { type: 'string', minLength: 1 } },
       });
@@ -2173,9 +3085,9 @@ describe('tenant routing smoke', () => {
       expect(refineAlias?.inputSchema?.properties?.refinements).toMatchObject({
         type: 'array',
         minItems: 1,
-        items: { $ref: '#/$defs/media-buy~1proposal-refinement.json' },
+        items: { $ref: '#/$defs/external:media-buy~1proposal-refinement.json' },
       });
-      expect(refineAlias?.inputSchema?.$defs?.['media-buy/proposal-refinement.json'])
+      expect(refineAlias?.inputSchema?.$defs?.['external:media-buy/proposal-refinement.json'])
         .toMatchObject({
           type: 'object',
           required: ['proposal_id'],
@@ -2209,10 +3121,10 @@ describe('tenant routing smoke', () => {
 
       const malformedAccount = await callTenantTool(url, 33, 'list_products', {
         account: 'not-an-account',
-      }) as { error?: { code?: number; data?: { field?: string } } };
-      expect(malformedAccount.error).toMatchObject({
-        code: -32602,
-        data: { field: 'account' },
+      }) as { result?: { structuredContent?: { adcp_error?: { code?: string; field?: string } } } };
+      expect(malformedAccount.result?.structuredContent?.adcp_error).toMatchObject({
+        code: 'INVALID_REQUEST',
+        field: 'account',
       });
 
       const unsupportedAliasVersion = await callTenantTool(url, 34, 'list_products', {
@@ -2221,13 +3133,12 @@ describe('tenant routing smoke', () => {
       }) as {
         result?: {
           structuredContent?: {
-            adcp_error?: { code?: string; field?: string; details?: { supported_versions?: string[] } };
+            adcp_error?: { code?: string; details?: { supported_versions?: string[] } };
           };
         };
       };
       expect(unsupportedAliasVersion.result?.structuredContent?.adcp_error).toMatchObject({
         code: 'VERSION_UNSUPPORTED',
-        field: 'adcp_version',
         details: { supported_versions: expect.any(Array) },
       });
 
@@ -2247,109 +3158,21 @@ describe('tenant routing smoke', () => {
         brand: account.brand,
       }) as { result?: { structuredContent?: { adcp_version?: string; products?: unknown[]; replayed?: boolean } } };
       expect(aliasReplay.result?.structuredContent).not.toHaveProperty('adcp_error');
-      expect(aliasReplay.result?.structuredContent?.adcp_version).toBe('3.2-beta.0');
+      expect(aliasReplay.result?.structuredContent?.adcp_version).toBe('3.2-beta.2');
       expect(aliasReplay.result?.structuredContent?.products).toEqual(first.result?.structuredContent?.products);
       expect(aliasReplay.result?.structuredContent?.replayed).toBeUndefined();
-
-      const taskKey = 'tenant-products-task-receipt-0001';
-      const taskCall = async (id: number): Promise<Record<string, unknown>> => {
-        const response = await fetch(url, {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            accept: 'application/json',
-            authorization: 'Bearer test-token',
-          },
-          body: JSON.stringify({
-            jsonrpc: '2.0',
-            id,
-            method: 'tools/call',
-            params: {
-              name: 'request_proposals',
-              arguments: {
-                idempotency_key: taskKey,
-                brand: account.brand,
-                brief: 'Reach sports fans',
-              },
-              task: { ttl: 120000 },
-            },
-          }),
-        });
-        return response.json() as Promise<Record<string, unknown>>;
-      };
-      const taskFirst = await taskCall(62) as { result?: { task?: { taskId?: string; status?: string } } };
-      const taskReplay = await taskCall(63) as { result?: { task?: { taskId?: string; status?: string } } };
-      expect(taskFirst.result?.task).toMatchObject({ status: 'completed', taskId: expect.any(String) });
-      expect(taskReplay.result?.task?.taskId).toBe(taskFirst.result?.task?.taskId);
-
-      const taskGetResponse = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          accept: 'application/json',
-          authorization: 'Bearer test-token',
-        },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: 64,
-          method: 'tasks/get',
-          params: { taskId: taskFirst.result?.task?.taskId, adcp_version: '3.2-beta.0' },
-        }),
-      });
-      const taskGet = await taskGetResponse.json() as { result?: { taskId?: string; status?: string } };
-      expect(taskGet.result).toMatchObject({ taskId: taskFirst.result?.task?.taskId, status: 'completed' });
-
-      const taskListResponse = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          accept: 'application/json',
-          authorization: 'Bearer test-token',
-        },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: 641,
-          method: 'tasks/list',
-          params: { adcp_version: '3.2-beta.0' },
-        }),
-      });
-      const taskList = await taskListResponse.json() as { result?: { tasks?: Array<{ taskId?: string }> } };
-      expect(taskList.result?.tasks).toEqual(expect.arrayContaining([
-        expect.objectContaining({ taskId: taskFirst.result?.task?.taskId }),
-      ]));
-
-      const forbiddenListTask = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          accept: 'application/json',
-          authorization: 'Bearer test-token',
-        },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: 65,
-          method: 'tools/call',
-          params: {
-            name: 'list_products',
-            arguments: { brand: account.brand },
-            task: { ttl: 120000 },
-          },
-        }),
-      });
-      const forbiddenListTaskBody = await forbiddenListTask.json() as { error?: { code?: number; message?: string } };
-      expect(forbiddenListTaskBody.error?.message).toContain('does not support task augmentation');
 
       const missingAliasKey = await callTenantTool(url, 61, 'request_proposals', {
         brand: account.brand,
         brief: 'Reach sports fans',
-      }) as { error?: { code?: number; data?: { field?: string } } };
-      expect(missingAliasKey.error).toMatchObject({
-        code: -32602,
-        data: { field: 'idempotency_key' },
-      });
+      }) as { result?: { structuredContent?: { adcp_error?: { code?: string } } } };
+      expect(['INVALID_REQUEST', 'VALIDATION_ERROR']).toContain(
+        missingAliasKey.result?.structuredContent?.adcp_error?.code,
+      );
 
       const invalid = await callTenantTool(url, 7, 'get_products', {
         ...payload,
+        idempotency_key: 'tenant-products-idempotency-invalid-0001',
         buying_mode: 'not-a-mode',
       }) as { result?: { structuredContent?: { adcp_error?: { code?: string; field?: string } } } };
       expect(invalid.result?.structuredContent?.adcp_error).toMatchObject({
@@ -2359,6 +3182,7 @@ describe('tenant routing smoke', () => {
 
       const mixedFinalize = await callTenantTool(url, 8, 'get_products', {
         ...payload,
+        idempotency_key: 'tenant-products-idempotency-finalize-0001',
         buying_mode: 'refine',
         refine: [
           { scope: 'proposal', action: 'finalize', proposal_id: 'pinnacle_cross_channel' },
@@ -2367,7 +3191,7 @@ describe('tenant routing smoke', () => {
       }) as { result?: { structuredContent?: { adcp_error?: { code?: string; field?: string } } } };
       expect(mixedFinalize.result?.structuredContent?.adcp_error).toMatchObject({
         code: 'INVALID_REQUEST',
-        field: 'refine[1]',
+        field: 'refine',
       });
 
       const conflict = await callTenantTool(url, 9, 'get_products', {
@@ -2384,7 +3208,7 @@ describe('tenant routing smoke', () => {
     } finally {
       await close();
     }
-  }, 15000);
+  }, 30000);
 
   it('adapts omitted get_products keys only on the frozen 3.0 compatibility route', async () => {
     const { baseUrl, close } = await bootServer({ storyboardCompat: { version: '3.0' } });

--- a/server/src/training-agent/tenants/tool-catalog.ts
+++ b/server/src/training-agent/tenants/tool-catalog.ts
@@ -38,6 +38,9 @@ export const TOOL_CATALOG: Readonly<Record<string, readonly string[]>> = {
   request_proposals: ['sales'],
   refine_proposals: ['sales'],
   decline_proposals: ['sales'],
+  buy_products: ['sales'],
+  accept_proposal: ['sales'],
+  control_media_buy: ['sales'],
   create_media_buy: ['sales'],
   update_media_buy: ['sales'],
   get_media_buys: ['sales'],
@@ -50,21 +53,21 @@ export const TOOL_CATALOG: Readonly<Record<string, readonly string[]>> = {
   // list_creative_formats is framework-registered for any tenant claiming
   // creative (sales, creative, creative-builder) — the SDK auto-advertises
   // it. Catalog mirrors that advertisement so the drift test stays green.
-  list_creative_formats: ['sales', 'creative', 'creative-builder'],
+  list_creative_formats: ['creative', 'creative-builder'],
 
   // creative — exposed on multiple tenants
   // list_creatives / get_creative_delivery are sales-side / ad-server-side
   // operations. SDK 7.0's `CreativeBuilderPlatform` interface dropped them
   // (they live on `CreativeAdServerPlatform`); the /creative-builder tenant
   // no longer advertises them in tools/list.
-  validate_input: ['sales', 'creative', 'creative-builder'],
+  validate_input: ['creative', 'creative-builder'],
   // list_transformers (account-scoped transformer discovery) rides customTools
   // on the creative tenants, gated off 3.0-compat like validate_input.
   list_transformers: ['creative', 'creative-builder'],
   list_creatives: ['sales', 'creative'],
   sync_creatives: ['sales', 'creative', 'creative-builder'],
-  build_creative: ['sales', 'creative', 'creative-builder'],
-  preview_creative: ['sales', 'creative', 'creative-builder'],
+  build_creative: ['creative', 'creative-builder'],
+  preview_creative: ['creative', 'creative-builder'],
   get_creative_delivery: ['creative'],
 
   // sync_governance is exposed by each service role that advertises a
@@ -131,6 +134,11 @@ export function toolsForTenant(
     .filter(tool => {
       const is30 = options.storyboardCompat?.version === '3.0'
         || options.adcpVersion?.startsWith('3.0');
+      const is31 = options.adcpVersion?.startsWith('3.1') === true;
+      const usesLegacyLifecycle = is30 || is31;
+      if (!usesLegacyLifecycle && ['get_products', 'create_media_buy', 'update_media_buy'].includes(tool)) {
+        return false;
+      }
       if (!is30) return true;
       // 3.0-compat exclusions. The split product-discovery tools are introduced
       // in 3.2, while validate_input / list_transformers are gated off on every
@@ -143,6 +151,9 @@ export function toolsForTenant(
         || tool === 'request_proposals'
         || tool === 'refine_proposals'
         || tool === 'decline_proposals'
+        || tool === 'buy_products'
+        || tool === 'accept_proposal'
+        || tool === 'control_media_buy'
       ) return false;
       if (tool === 'validate_input' || tool === 'list_transformers') return false;
       if (tool === 'sync_governance' && tenantId !== 'signals') return false;

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -428,8 +428,8 @@ export interface SessionState {
    * single-request case with the InMemoryStateStore. */
   complyExtensions: ComplyExtensions;
   lastGetProductsContext?: {
-    /** Products are deterministic from the catalog — not persisted across requests.
-     * After a cross-machine rehydration, this is undefined and callers must re-derive. */
+    /** Immutable snapshots for products referenced by persisted proposals.
+     * Ordinary catalog discovery is re-derived instead of persisted. */
     products?: Product[];
     proposals?: Proposal[];
   };

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -66,6 +66,8 @@ export interface TrainingContext {
    * context. Used to authorize principal-bound sandbox fixture projection
    * after the SDK removes the envelope account from domain-level arguments. */
   resolvedAccount?: AccountRef;
+  /** Trusted account identifier produced by the SDK account resolver. */
+  resolvedAccountId?: string;
   /** Frozen 3.0 creative-library session scope. Legacy requests historically
    * shared creative state by brand even when the SDK retained a natural
    * account envelope on some creative operations. */
@@ -81,6 +83,10 @@ export interface TrainingContext {
    * The public `/sales/mcp` endpoint remains ask-only; beta-gated profile
    * routes set one of the other values without trusting buyer input. */
   proposalNegotiationProfile?: ProposalNegotiationProfile;
+  /** Framework-derived mutation namespace; never sourced from buyer input. */
+  callerMutationScope?: Readonly<{ tenant_id: string; principal_id: string; account_id?: string }>;
+  /** Framework-derived proposal namespace; never sourced from buyer input. */
+  proposalRefinementScope?: Readonly<{ tenant_id: string; principal_id: string; account_id?: string }>;
   /** Local storyboard-runner compatibility shims. Never set in deployed routes. */
   storyboardCompat?: { version: '3.0' };
   /** Whether creative usage is billed through AdCP. Defaults to true for legacy/shared routes. */
@@ -396,7 +402,10 @@ export interface SessionState {
   proposalRefinementRecords: Map<string, {
     proposal: CanonicalProposal;
     version: number;
+    /** Trusted SDK-resolved account that originated this proposal. */
+    ownerAccountId?: string;
     activeHold?: { proposal_id: string; expires_at: string };
+    declined?: { declined_at: string; reason?: string; detail?: string };
     accepted?: { accepted_at: string; media_buy_id: string; media_buy_revision: number };
   }>;
   usageRecords: UsageRecord[];
@@ -464,6 +473,7 @@ export interface AccountRef {
   operator?: string;
   operator_unit?: OperatorUnit;
   currency?: string;
+  timezone?: string;
   sandbox?: boolean;
 }
 
@@ -488,6 +498,7 @@ export interface MediaBuyHistoryEntry {
 }
 
 export interface MediaBuyAvailableActionState {
+  task?: 'control_media_buy' | 'refine_proposals' | 'sync_creatives';
   action: string;
   mode: 'self_serve' | 'conditional_self_serve' | 'requires_approval';
   sla?: {
@@ -516,9 +527,16 @@ export interface MediaBuyState {
   currency: string;
   /** Seller-authoritative hard lifetime cap; falls back to package sum for legacy fixtures. */
   totalBudget?: number;
+  /** Immutable compact proposal snapshot currently governing this buy. */
+  acceptedProposal?: CanonicalProposal;
+  /** Hard aggregate daily spend ceiling shared by all packages. */
+  dailyBudgetCap?: number;
+  /** Buyer-selected IANA timezone for aggregate and package cap days. */
+  budgetCapTimezone?: string;
   budgetAllocation?: Record<string, unknown>;
   aggregatePacing?: string;
   aggregateBidding?: Record<string, unknown>;
+  reportingWebhook?: Record<string, unknown>;
   packages: PackageState[];
   productAllowedActions?: MediaBuyProductAllowedActionState[];
   availableActions?: MediaBuyAvailableActionState[];
@@ -563,9 +581,20 @@ export interface PackageState {
   packageId: string;
   productId: string;
   budget: number;
+  dailyBudgetCap?: number;
+  minSpendTarget?: number;
   pricingOptionId: string;
   bidPrice?: number;
   impressions?: number;
+  pacing?: string;
+  bidding?: Record<string, unknown>;
+  catalogIds?: string[];
+  measurementTerms?: Record<string, unknown>;
+  performanceStandards?: Array<Record<string, unknown>>;
+  audienceEvidenceRequirements?: Record<string, unknown>;
+  audienceEvidencePins?: Array<Record<string, unknown>>;
+  agencyEstimateNumber?: string;
+  ext?: Record<string, unknown>;
   paused: boolean;
   canceled?: boolean;
   canceledAt?: string;
@@ -615,6 +644,7 @@ export interface PackageTargeting {
   collection_list_exclude?: ListReference;
   audience_include?: string[];
   audience_exclude?: string[];
+  [key: string]: unknown;
 }
 
 /** A single asset slot inside a creative manifest (e.g., headline, hero_image). */
@@ -798,6 +828,9 @@ export interface GovernanceCheckState {
   tool?: string;
   /** JCS/SHA-256 binding of the task payload authorized by the intent. */
   authorizedPayloadHash?: string;
+  /** Canonical proposal snapshot inspected for an accept_proposal intent. */
+  authorizedProposalId?: string;
+  authorizedProposalTermsDigest?: string;
   purchaseType?: string;
   /** Budget approved from the governance agent's own evaluated input. */
   authorizedBudget?: number;

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -198,6 +198,8 @@ export interface PricingTemplate {
   };
   /** For CPA: the event type that triggers billing */
   eventType?: EventType;
+  /** For CPA: the event name when eventType is custom */
+  customEventName?: string;
   /** For CPP: demographic targeting parameters */
   cppParameters?: { demographic: string };
   /** For CPV: view threshold parameters */

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -11,10 +11,12 @@
  * bodies that throw `AdcpError` directly) is a follow-up.
  */
 
+import { createHash } from 'node:crypto';
 import {
   AdcpError,
   type DecisioningPlatform,
   type SalesPlatform,
+  type MediaBuyLifecyclePlatform,
   type LegacyMediaBuyHandlers,
   type AccountStore,
   type AudiencePlatform,
@@ -27,6 +29,10 @@ import {
 } from '@adcp/sdk/v2/projection';
 import {
   executeTrainingAgentTool,
+  executeProductDiscoveryPlatformTool,
+  handleBuyProducts,
+  handleAcceptProposal,
+  handleControlMediaBuy,
   handleCreateMediaBuy,
   handleUpdateMediaBuy,
   handleGetMediaBuys,
@@ -50,6 +56,8 @@ import { trainingBuyerAgentRegistry } from './buyer-agent-registry.js';
 import { waitForForcedTaskCompletion } from './comply-test-controller.js';
 import { sessionKeyFromArgs } from './state.js';
 import type { ToolArgs, TrainingContext } from './types.js';
+import { proposalCapabilitiesForProfile } from './proposal-negotiation-profiles.js';
+import { accountScopeFromRef, canonicalizeAccountRef } from './account-scope.js';
 
 interface TrainingSalesMeta {
   brand_domain?: string;
@@ -170,8 +178,11 @@ function buildTrainingCtx(
     authInfo?: { clientId?: string };
     agent?: { agent_url: string };
     input?: unknown;
+    callerMutationScope?: Readonly<{ tenant_id: string; principal_id: string; account_id?: string }>;
+    proposalRefinementScope?: Readonly<{ tenant_id: string; principal_id: string; account_id?: string }>;
   } | undefined,
   storyboardCompat?: TrainingContext['storyboardCompat'],
+  proposalNegotiationProfile?: TrainingContext['proposalNegotiationProfile'],
 ): TrainingContext {
   const account = ctx?.account as { authInfo?: { principal?: string } } | undefined;
   const legacySessionBrandDomain = storyboardCompat?.version === '3.0'
@@ -193,8 +204,13 @@ function buildTrainingCtx(
       ? { requestInput: ctx.input as Record<string, unknown> }
       : {}),
     ...(resolvedAccount && { resolvedAccount }),
+    ...(typeof (ctx?.account as { id?: unknown } | undefined)?.id === 'string'
+      && { resolvedAccountId: (ctx!.account as { id: string }).id }),
     ...(legacySessionBrandDomain && { legacySessionBrandDomain }),
     ...(storyboardCompat && { storyboardCompat }),
+    ...(ctx?.callerMutationScope && { callerMutationScope: ctx.callerMutationScope }),
+    ...(ctx?.proposalRefinementScope && { proposalRefinementScope: ctx.proposalRefinementScope }),
+    ...(proposalNegotiationProfile && { proposalNegotiationProfile }),
   };
 }
 
@@ -434,14 +450,29 @@ const trainingSalesAccounts: AccountStore<TrainingSalesMeta> = {
         authInfo: { kind: 'public', ...(principal && { principal }) },
       };
     }
-    const brandDomain =
-      'brand' in ref && ref.brand && typeof ref.brand === 'object' && 'domain' in ref.brand
-        ? (ref.brand.domain as string | undefined)
-        : undefined;
-    const accountId =
-      'account_id' in ref && typeof ref.account_id === 'string' ? ref.account_id : undefined;
-    const id = accountId ?? `synthetic_${brandDomain ?? 'anon'}`;
-    const operator = 'operator' in ref && typeof ref.operator === 'string' ? ref.operator : undefined;
+    if (typeof ref !== 'object' || Array.isArray(ref)) {
+      throw new AdcpError('INVALID_REQUEST', {
+        message: 'account must be an object',
+        field: 'account',
+        recovery: 'correctable',
+      });
+    }
+    const canonical = canonicalizeAccountRef(ref);
+    const accountRef: ToolArgs['account'] = canonical.kind === 'account_id'
+      ? { account_id: canonical.account_id }
+      : {
+          brand: canonical.brand,
+          operator: canonical.operator,
+          ...(canonical.operator_unit && { operator_unit: canonical.operator_unit }),
+          ...(canonical.currency && { currency: canonical.currency }),
+          ...(canonical.timezone && { timezone: canonical.timezone }),
+          ...(canonical.sandbox && { sandbox: true }),
+        };
+    const brandDomain = canonical.kind === 'natural' ? canonical.brand.domain : undefined;
+    const operator = canonical.kind === 'natural' ? canonical.operator : undefined;
+    const id = canonical.kind === 'account_id'
+      ? canonical.account_id
+      : `synthetic_${createHash('sha256').update(accountScopeFromRef(accountRef)).digest('hex').slice(0, 32)}`;
     return {
       id,
       name: brandDomain ?? id,
@@ -450,7 +481,7 @@ const trainingSalesAccounts: AccountStore<TrainingSalesMeta> = {
       ...(brandDomain != null && { brand: { domain: brandDomain } }),
       ...(operator && { operator }),
       ctx_metadata: {
-        account_ref: ref as ToolArgs['account'],
+        account_ref: accountRef,
         brand_domain: brandDomain,
         ...(operator && { operator }),
       },
@@ -570,7 +601,10 @@ export function legacyListCreativesHandler(
 export class TrainingSalesPlatform
   implements DecisioningPlatform<TrainingSalesConfig, TrainingSalesMeta>
 {
-  constructor(private readonly storyboardCompat?: TrainingContext['storyboardCompat']) {}
+  constructor(
+    private readonly storyboardCompat?: TrainingContext['storyboardCompat'],
+    private readonly proposalNegotiationProfile: NonNullable<TrainingContext['proposalNegotiationProfile']> = 'ask-only',
+  ) {}
 
   capabilities = TRAINING_SALES_CAPABILITIES;
 
@@ -705,6 +739,89 @@ export class TrainingSalesPlatform
       return translateV5Result(result);
     },
   } as SalesPlatform<TrainingSalesMeta>;
+
+  /** SDK 14's primary AdCP 3.2 surface. Legacy `sales` remains registered so
+   * 3.0/3.1 callers can invoke the deprecated tool names explicitly. */
+  get mediaBuyLifecycle(): MediaBuyLifecyclePlatform<TrainingSalesMeta> | undefined {
+    if (this.storyboardCompat?.version === '3.0') return undefined;
+    return {
+    proposalRefinement: proposalCapabilitiesForProfile(this.proposalNegotiationProfile),
+
+    listProducts: async (req, ctx) => translateV5Result(
+      await executeProductDiscoveryPlatformTool(
+        'list_products',
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as unknown as Record<string, unknown>,
+        buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
+      ),
+      { allowAdvisories: true },
+    ),
+
+    requestProposals: async (req, ctx) => translateV5Result(
+      await executeProductDiscoveryPlatformTool(
+        'request_proposals',
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as unknown as Record<string, unknown>,
+        buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
+      ),
+      { allowAdvisories: true },
+    ),
+
+    refineProposals: async (req, ctx) => {
+      const trainingCtx = buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile);
+      return translateV5Result(
+        await executeProductDiscoveryPlatformTool(
+          'refine_proposals',
+          withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as unknown as Record<string, unknown>,
+          trainingCtx,
+        ),
+        { allowAdvisories: true },
+      );
+    },
+
+    declineProposals: async (req, ctx) => translateV5Result(
+      await executeProductDiscoveryPlatformTool(
+        'decline_proposals',
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as unknown as Record<string, unknown>,
+        buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
+      ),
+      { allowAdvisories: true },
+    ),
+
+    buyProducts: async (req, ctx) => translateV5Result(
+      await handleBuyProducts(
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as Parameters<typeof handleBuyProducts>[0],
+        buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
+      ),
+    ),
+
+    acceptProposal: async (req, ctx) => translateV5Result(
+      await handleAcceptProposal(
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as Parameters<typeof handleAcceptProposal>[0],
+        buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
+      ),
+    ),
+
+    controlMediaBuy: async (req, ctx) => translateV5Result(
+      await handleControlMediaBuy(
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as Parameters<typeof handleControlMediaBuy>[0],
+        buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
+      ),
+    ),
+
+    getMediaBuys: async (req, ctx) => translateV5Result(canonicalMediaBuyPlatformResult(
+      await handleGetMediaBuys(
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account),
+        buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
+      ),
+    )),
+
+    getMediaBuyDelivery: async (req, ctx) => translateV5Result(
+      await handleGetMediaBuyDelivery(
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account),
+        buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
+      ),
+    ),
+    } as MediaBuyLifecyclePlatform<TrainingSalesMeta>;
+  }
 
   // Audience-targeting capability is declared above; expose sync_audiences
   // so audience_buy_flow can register audiences before referencing them in

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -281,9 +281,36 @@ function withResolvedAccountScope(
 function withCurrentAccountScope(
   input: Record<string, unknown>,
   account: unknown,
+  rawInput?: unknown,
 ): ToolArgs {
-  const accountRef = accountRefFromCtx(account);
+  let accountRef = accountRefFromCtx(account);
   const brandDomain = brandDomainFromCtx(account);
+  const principal = (account as { authInfo?: { principal?: unknown } } | undefined)?.authInfo?.principal;
+  const rawAccount = rawInput && typeof rawInput === 'object' && !Array.isArray(rawInput)
+    ? (rawInput as Record<string, unknown>).account
+    : undefined;
+  const explicitlySandboxed = rawAccount !== null
+    && typeof rawAccount === 'object'
+    && !Array.isArray(rawAccount)
+    && (rawAccount as Record<string, unknown>).sandbox === true;
+  // Public training credentials address one brand-owned sandbox. The
+  // storyboard runner legitimately alternates between the buyer operator and
+  // the brand domain while preserving the same brand identity; normalize that
+  // public-only account before deriving session state so compact write/read
+  // chains do not fork. Authenticated tenant principals retain full operator
+  // isolation, and opaque account IDs are never rewritten.
+  if (
+    explicitlySandboxed
+    && typeof principal === 'string'
+    && principal.startsWith('static:')
+    && accountRef?.brand?.domain
+  ) {
+    accountRef = {
+      ...accountRef,
+      operator: accountRef.brand.domain,
+      sandbox: true,
+    };
+  }
   return {
     ...input,
     ...(accountRef && { account: accountRef }),
@@ -750,7 +777,7 @@ export class TrainingSalesPlatform
     listProducts: async (req, ctx) => translateV5Result(
       await executeProductDiscoveryPlatformTool(
         'list_products',
-        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as unknown as Record<string, unknown>,
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account, ctx.input) as unknown as Record<string, unknown>,
         buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
       ),
       { allowAdvisories: true },
@@ -759,7 +786,7 @@ export class TrainingSalesPlatform
     requestProposals: async (req, ctx) => translateV5Result(
       await executeProductDiscoveryPlatformTool(
         'request_proposals',
-        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as unknown as Record<string, unknown>,
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account, ctx.input) as unknown as Record<string, unknown>,
         buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
       ),
       { allowAdvisories: true },
@@ -770,7 +797,7 @@ export class TrainingSalesPlatform
       return translateV5Result(
         await executeProductDiscoveryPlatformTool(
           'refine_proposals',
-          withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as unknown as Record<string, unknown>,
+          withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account, ctx.input) as unknown as Record<string, unknown>,
           trainingCtx,
         ),
         { allowAdvisories: true },
@@ -780,7 +807,7 @@ export class TrainingSalesPlatform
     declineProposals: async (req, ctx) => translateV5Result(
       await executeProductDiscoveryPlatformTool(
         'decline_proposals',
-        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as unknown as Record<string, unknown>,
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account, ctx.input) as unknown as Record<string, unknown>,
         buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
       ),
       { allowAdvisories: true },
@@ -788,35 +815,61 @@ export class TrainingSalesPlatform
 
     buyProducts: async (req, ctx) => translateV5Result(
       await handleBuyProducts(
-        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as Parameters<typeof handleBuyProducts>[0],
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account, ctx.input) as Parameters<typeof handleBuyProducts>[0],
         buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
       ),
     ),
 
     acceptProposal: async (req, ctx) => translateV5Result(
       await handleAcceptProposal(
-        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as Parameters<typeof handleAcceptProposal>[0],
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account, ctx.input) as Parameters<typeof handleAcceptProposal>[0],
         buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
       ),
     ),
 
     controlMediaBuy: async (req, ctx) => translateV5Result(
       await handleControlMediaBuy(
-        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account) as Parameters<typeof handleControlMediaBuy>[0],
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account, ctx.input) as Parameters<typeof handleControlMediaBuy>[0],
         buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
       ),
     ),
 
-    getMediaBuys: async (req, ctx) => translateV5Result(canonicalMediaBuyPlatformResult(
-      await handleGetMediaBuys(
+    getMediaBuys: async (req, ctx) => {
+      const trainingCtx = buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile);
+      let result = await handleGetMediaBuys(
         withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account),
-        buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
-      ),
-    )),
+        trainingCtx,
+      );
+      const requestedIds = (req as unknown as { media_buy_ids?: unknown }).media_buy_ids;
+      const returnedBuys = (result as { media_buys?: unknown }).media_buys;
+      const principal = (ctx.account as { authInfo?: { principal?: unknown } } | undefined)?.authInfo?.principal;
+      // SDK 14 removes the controller-only sandbox assertion from compact
+      // read AccountRefs. Retry an exact-ID miss in the brand-owned public
+      // sandbox partition; successful ordinary reads never cross scopes.
+      if (
+        Array.isArray(requestedIds)
+        && requestedIds.length > 0
+        && Array.isArray(returnedBuys)
+        && returnedBuys.length === 0
+        && typeof principal === 'string'
+        && principal.startsWith('static:')
+        && brandDomainFromCtx(ctx.account)
+      ) {
+        result = await handleGetMediaBuys(
+          withCurrentAccountScope(
+            req as unknown as Record<string, unknown>,
+            ctx.account,
+            { account: { sandbox: true } },
+          ),
+          trainingCtx,
+        );
+      }
+      return translateV5Result(canonicalMediaBuyPlatformResult(result));
+    },
 
     getMediaBuyDelivery: async (req, ctx) => translateV5Result(
       await handleGetMediaBuyDelivery(
-        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account),
+        withCurrentAccountScope(req as unknown as Record<string, unknown>, ctx.account, ctx.input),
         buildTrainingCtx(ctx, this.storyboardCompat, this.proposalNegotiationProfile),
       ),
     ),

--- a/server/tests/integration/training-agent-3-0-compat-tools.test.ts
+++ b/server/tests/integration/training-agent-3-0-compat-tools.test.ts
@@ -170,6 +170,51 @@ describe('training-agent 3.0 compat tool visibility', () => {
     }
   });
 
+  it('projects SDK 14 capabilities onto the frozen 3.0 vocabulary', async () => {
+    const { baseUrl, close } = await bootCompatRouter();
+    try {
+      const allowedScenarios = new Set([
+        'force_creative_status',
+        'force_account_status',
+        'force_media_buy_status',
+        'force_session_status',
+        'simulate_delivery',
+        'simulate_budget_spend',
+      ]);
+      const signals = await callTenantTool(baseUrl, 'signals', 'get_adcp_capabilities', {});
+      expect(signals.media_buy).toMatchObject({
+        execution: { targeting: { geo_postal_areas: { us_zip: true } } },
+      });
+      const signalsMediaBuy = signals.media_buy as {
+        execution: { targeting: { geo_postal_areas: Record<string, boolean> } };
+      };
+      expect(
+        Object.keys(signalsMediaBuy.execution.targeting.geo_postal_areas),
+      ).toEqual(['us_zip']);
+
+      for (const tenant of ['governance', 'creative']) {
+        const capabilities = await callTenantTool(baseUrl, tenant, 'get_adcp_capabilities', {});
+        const scenarios = (capabilities.compliance_testing as { scenarios?: string[] } | undefined)?.scenarios ?? [];
+        expect(scenarios).not.toHaveLength(0);
+        expect(scenarios.every(scenario => allowedScenarios.has(scenario))).toBe(true);
+      }
+
+      const si = await callTenantTool(baseUrl, 'si', 'get_adcp_capabilities', {});
+      expect(si.specialisms).toBeUndefined();
+
+      const offering = await callTenantTool(baseUrl, 'si', 'si_get_offering', {
+        offering_id: 'novamotors_conversational_v1',
+      });
+      expect(offering).toMatchObject({
+        available: true,
+        offering_id: 'novamotors_conversational_v1',
+        offering: { offering_id: 'novamotors_conversational_v1' },
+      });
+    } finally {
+      await close();
+    }
+  });
+
   it('keeps validate_input callable but undiscovered on the current compact media-buy profile', async () => {
     const { baseUrl, close } = await bootRouter();
     try {
@@ -183,6 +228,14 @@ describe('training-agent 3.0 compat tool visibility', () => {
       expect(unpinned.results).toEqual([
         { target: { kind: 'canonical', id: 'image' }, result_kind: 'validated_pass' },
       ]);
+
+      const currentOffering = await callTenantTool(baseUrl, 'si', 'si_get_offering', {
+        offering_id: 'novamotors_conversational_v1',
+      });
+      expect(currentOffering.offering_id).toBeUndefined();
+      expect(currentOffering.offering).toMatchObject({
+        offering_id: 'novamotors_conversational_v1',
+      });
 
       const pinnedThreeOne = await callTenantTool(baseUrl, 'sales', 'validate_input', {
         adcp_version: '3.1-beta.5',

--- a/server/tests/integration/training-agent-3-0-compat-tools.test.ts
+++ b/server/tests/integration/training-agent-3-0-compat-tools.test.ts
@@ -21,7 +21,7 @@ const { stopSessionCleanup } = await import('../../src/training-agent/state.js')
 
 const COMPAT_CTX = { mode: 'open' as const, storyboardCompat: { version: '3.0' as const } };
 const AUTH = 'Bearer compat-tools-token';
-const CURRENT_ADCP_VERSION = '3.1-rc.15';
+const CURRENT_ADCP_VERSION = '3.2-beta.2';
 
 async function simulateListTools(server: ReturnType<typeof createTrainingAgentServer>): Promise<string[]> {
   const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;
@@ -170,10 +170,10 @@ describe('training-agent 3.0 compat tool visibility', () => {
     }
   });
 
-  it('serves validate_input on current tenant routes only on the current envelope', async () => {
+  it('keeps validate_input callable but undiscovered on the current compact media-buy profile', async () => {
     const { baseUrl, close } = await bootRouter();
     try {
-      await expect(listTenantTools(baseUrl, 'sales')).resolves.toContain('validate_input');
+      await expect(listTenantTools(baseUrl, 'sales')).resolves.not.toContain('validate_input');
 
       const unpinned = await callTenantTool(baseUrl, 'sales', 'validate_input', {
         manifest: validImageManifest,

--- a/server/tests/integration/training-agent-legacy-mcp.test.ts
+++ b/server/tests/integration/training-agent-legacy-mcp.test.ts
@@ -68,6 +68,59 @@ describe('Training Agent legacy /mcp back-compat alias', () => {
     expect(res.headers['link']).toContain('successor-version');
   });
 
+  it('isolates stateless MCP task receipts by authenticated principal', async () => {
+    const firstBearer = 'Bearer demo-task-owner-v1';
+    const secondBearer = 'Bearer demo-task-other-v1';
+    const created = await request(app)
+      .post('/api/training-agent/mcp')
+      .set('Authorization', firstBearer)
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({
+        jsonrpc: '2.0',
+        id: 20,
+        method: 'tools/call',
+        params: {
+          name: 'get_products',
+          task: { ttl: 60_000 },
+          arguments: {
+            adcp_version: '3.1-rc.15',
+            idempotency_key: `principal-task-${randomUUID()}`,
+            account: { brand: { domain: 'task-owner.example' }, operator: 'task-owner.example' },
+            buying_mode: 'wholesale',
+          },
+        },
+      });
+    expect(created.status).toBe(200);
+    const taskId = created.body.result?.task?.taskId as string | undefined;
+    expect(taskId).toEqual(expect.any(String));
+
+    const ownList = await request(app)
+      .post('/api/training-agent/mcp')
+      .set('Authorization', firstBearer)
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({ jsonrpc: '2.0', id: 21, method: 'tasks/list', params: {} });
+    expect(ownList.body.result?.tasks?.map((task: { taskId: string }) => task.taskId)).toContain(taskId);
+
+    const otherList = await request(app)
+      .post('/api/training-agent/mcp')
+      .set('Authorization', secondBearer)
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({ jsonrpc: '2.0', id: 22, method: 'tasks/list', params: {} });
+    expect(otherList.body.result?.tasks?.map((task: { taskId: string }) => task.taskId) ?? [])
+      .not.toContain(taskId);
+
+    const otherGet = await request(app)
+      .post('/api/training-agent/mcp')
+      .set('Authorization', secondBearer)
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({ jsonrpc: '2.0', id: 23, method: 'tasks/get', params: { taskId } });
+    expect(otherGet.body.error).toBeDefined();
+  });
+
   it('ignores malformed request-signing headers on the public legacy sandbox', async () => {
     const res = await request(app)
       .post('/api/training-agent/mcp')
@@ -150,8 +203,8 @@ describe('Tenant routes via host-based dispatch (no /api/training-agent prefix)'
     const tools = (res.body.result?.tools ?? []) as Array<{ name: string }>;
     const names = new Set(tools.map(t => t.name));
     // Sales tenant carries the media-buy tools.
-    expect(names.has('get_products')).toBe(true);
-    expect(names.has('create_media_buy')).toBe(true);
+    expect(names.has('list_products')).toBe(true);
+    expect(names.has('buy_products')).toBe(true);
   });
 
   it('routes /signals/mcp to the signals tenant', async () => {
@@ -191,7 +244,7 @@ describe('Tenant routes via host-based dispatch (no /api/training-agent prefix)'
     expect(body._training_agent_tenants.find(t => t.tenant_id === 'governance')?.specialisms).toContain('content-standards');
     expect(body._training_agent_tenants.find(t => t.tenant_id === 'si')?.specialisms).toContain('sponsored-intelligence');
     // Tools surface so a developer can pick the right URL without trial.
-    expect(body._training_agent_tenants.find(t => t.tenant_id === 'sales')?.tools).toContain('get_products');
+    expect(body._training_agent_tenants.find(t => t.tenant_id === 'sales')?.tools).toContain('list_products');
     expect(body._training_agent_tenants.find(t => t.tenant_id === 'signals')?.tools).toContain('get_signals');
     expect(body._training_agent_tenants.find(t => t.tenant_id === 'creative-builder')?.tools).toContain('build_creative');
     expect(body._training_agent_tenants.find(t => t.tenant_id === 'creative-builder')?.tools).not.toContain('get_products');

--- a/server/tests/integration/training-agent-tool-catalog-drift.test.ts
+++ b/server/tests/integration/training-agent-tool-catalog-drift.test.ts
@@ -150,6 +150,9 @@ describe('tool-catalog drift detection', () => {
       'request_proposals',
       'refine_proposals',
       'decline_proposals',
+      'buy_products',
+      'accept_proposal',
+      'control_media_buy',
     ];
     for (const tool of splitTools) {
       expect(compatibilityCatalog).not.toContain(tool);

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -224,7 +224,7 @@ describe('comply_test_controller', () => {
 
     it('advertises force_get_products_arm for the 3.2 beta release', async () => {
       const { result } = await simulateCallTool(server, 'comply_test_controller', {
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         adcp_major_version: 3,
         scenario: 'list_scenarios',
         account: ACCOUNT,
@@ -790,6 +790,7 @@ describe('comply_test_controller', () => {
       });
       const buy = (buys as any).media_buys?.[0];
       expect(buy.available_actions).toEqual([{
+        task: 'refine_proposals',
         action: 'extend_flight',
         mode: 'requires_approval',
         sla: { response_max: 'PT4H', completion_max: 'P2D' },
@@ -808,6 +809,7 @@ describe('comply_test_controller', () => {
         attempted_action: 'extend_flight',
         reason: 'mode_mismatch',
         currently_available_actions: [{
+          task: 'refine_proposals',
           action: 'extend_flight',
           mode: 'requires_approval',
           sla: { response_max: 'PT4H', completion_max: 'P2D' },
@@ -1064,11 +1066,13 @@ describe('comply_test_controller', () => {
       expect((created as any).errors).toBeUndefined();
       expect(created.available_actions).toEqual([
         {
+          task: 'control_media_buy',
           action: 'increase_budget',
           mode: 'self_serve',
           sla: { response_max: 'PT5M', completion_max: 'PT1H' },
         },
         {
+          task: 'refine_proposals',
           action: 'extend_flight',
           mode: 'requires_approval',
           sla: { response_max: 'PT4H', completion_max: 'P2D' },
@@ -1172,7 +1176,11 @@ describe('comply_test_controller', () => {
         ],
       });
       expect((created as any).errors).toBeUndefined();
-      expect(created.available_actions).toEqual([{ action: 'increase_budget', mode: 'self_serve' }]);
+      expect(created.available_actions).toEqual([{
+        task: 'control_media_buy',
+        action: 'increase_budget',
+        mode: 'self_serve',
+      }]);
 
       const packages = (created as any).packages as Array<{ package_id: string }>;
       const { result: rejected } = await simulateCallTool(server, 'update_media_buy', {
@@ -1229,7 +1237,11 @@ describe('comply_test_controller', () => {
           budget: 10000,
         }],
       });
-      expect(created.available_actions).toEqual([{ action: 'cancel', mode: 'self_serve' }]);
+      expect(created.available_actions).toEqual([{
+        task: 'control_media_buy',
+        action: 'cancel',
+        mode: 'self_serve',
+      }]);
 
       const { result: canceled } = await simulateCallTool(server, 'update_media_buy', {
         account: ACCOUNT,

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -211,13 +211,15 @@ describe('comply_test_controller', () => {
         'seed_rights_grant',
         'seed_creative_format',
         'seed_measurement_catalog',
+        'compact_product_lifecycle_probe',
+        'compact_direct_buy_lifecycle_probe',
         'query_provenance_audit_observations',
         'evaluate_distributed_brand_resolution',
         'verify_governance_token',
       ]));
       // Catch silent drift in either direction (entries removed, or new ones
       // not yet documented in this assertion).
-      expect(scenarios.length).toBe(24);
+      expect(scenarios.length).toBe(26);
       // Dedup invariant — see the list_scenarios response merge in the wrapper.
       expect(new Set(scenarios).size).toBe(scenarios.length);
     });

--- a/server/tests/unit/idempotent-task-postgres-recovery.test.ts
+++ b/server/tests/unit/idempotent-task-postgres-recovery.test.ts
@@ -37,8 +37,8 @@ class ExpiryAwareTaskDb implements PgQueryable {
     rows: Record<string, unknown>[];
     rowCount: number;
   }> {
-    const taskId = String(values[0]);
     if (text.includes('SELECT *') && text.includes('WHERE task_id = $1')) {
+      const taskId = String(values[0]);
       const row = this.rows.get(taskId);
       return {
         rows: row && !this.expiredIds.has(taskId) ? [row] : [],
@@ -46,6 +46,7 @@ class ExpiryAwareTaskDb implements PgQueryable {
       };
     }
     if (text.includes('INSERT INTO')) {
+      const taskId = String(values[1]);
       if (this.rows.has(taskId)) {
         throw Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
       }
@@ -72,7 +73,7 @@ describe('Postgres idempotent task receipt generations', () => {
     db.rows.set(gen0, taskRow(gen0, 'completed'));
     db.expiredIds.add(gen0);
     db.rows.set(gen1, taskRow(gen1, 'completed'));
-    const store = new PostgresTaskStore(db);
+    const store = new PostgresTaskStore(db, { allowUnscopedAccess: true });
 
     await expect(getIdempotentTask(store, naturalKey))
       .resolves.toMatchObject({ taskId: gen1, status: 'completed' });
@@ -88,7 +89,7 @@ describe('Postgres idempotent task receipt generations', () => {
     const db = new ExpiryAwareTaskDb();
     db.rows.set(gen0, taskRow(gen0, 'completed'));
     db.expiredIds.add(gen0);
-    const store = new PostgresTaskStore(db);
+    const store = new PostgresTaskStore(db, { allowUnscopedAccess: true });
 
     await expect(createOrReuseIdempotentTask(store, naturalKey, 60_000, request))
       .resolves.toMatchObject({ taskId: gen1, status: 'working' });

--- a/server/tests/unit/proposal-negotiation-profiles.test.ts
+++ b/server/tests/unit/proposal-negotiation-profiles.test.ts
@@ -445,6 +445,62 @@ describe("deterministic proposal negotiation profiles", () => {
     ]);
   });
 
+  it("refines a proposal whose CPA purchase uses a named custom event", async () => {
+    const context: TrainingContext = {
+      mode: "open",
+      tenantId: "sales",
+      principal: "typed-profile-custom-event",
+      authenticatedAgentUrl: "https://buyer.example",
+      proposalNegotiationProfile: "constrained-seller",
+    };
+    const requested = await executeTrainingAgentTool(
+      "request_proposals",
+      {
+        idempotency_key: "typed-custom-event-request-0001",
+        brand: { domain: "buyer.example" },
+        brief: "US and Canada display campaign",
+      },
+      context
+    );
+    expect(requested.success, requested.error).toBe(true);
+    const source = (requested.data?.proposals as CanonicalProposal[])[0]!;
+    expect(source.commercial_terms.purchases[0]?.pricing).toMatchObject({
+      pricing_model: "cpa",
+      event_type: "custom",
+      custom_event_name: "agent_session",
+    });
+
+    const refined = await executeTrainingAgentTool(
+      "refine_proposals",
+      {
+        idempotency_key: "typed-custom-event-refine-0001",
+        refinements: [{
+          proposal_id: source.proposal_id,
+          action: "revise",
+          constraints: { total_budget: { currency: "USD", max: 50_000 } },
+          alternatives: { count: 2 },
+        }],
+      },
+      context
+    );
+    expect(refined.success, refined.error).toBe(true);
+    expect(refined.data?.results).toEqual([
+      expect.objectContaining({
+        outcome: "revised",
+        proposals: [expect.any(Object), expect.any(Object)],
+      }),
+    ]);
+    const successors = (refined.data?.results as Array<{
+      proposals: CanonicalProposal[];
+    }>)[0]!.proposals;
+    for (const successor of successors) {
+      expect(successor.commercial_terms.purchases[0]?.pricing).toMatchObject({
+        event_type: "custom",
+        custom_event_name: "agent_session",
+      });
+    }
+  });
+
   it("executes request, constrained retry, finalize, accept, amendment, and cancellation end to end", async () => {
     const context: TrainingContext = {
       mode: "open",

--- a/server/tests/unit/training-agent-account-scope.test.ts
+++ b/server/tests/unit/training-agent-account-scope.test.ts
@@ -30,7 +30,7 @@ describe('canonical AccountRef scope', () => {
     expect(accountScopeFromRef({
       brand: { domain: 'House.Example', brand_id: 'spark' },
       operator: 'Pinnacle.Example',
-    })).toBe('n:{"brand":{"domain":"house.example","brand_id":"spark"},"operator":"pinnacle.example","operator_unit_id":null,"currency":null,"sandbox":false}');
+    })).toBe('n:{"brand":{"domain":"house.example","brand_id":"spark"},"operator":"pinnacle.example","operator_unit_id":null,"currency":null,"timezone":null,"sandbox":false}');
   });
 
   it('partitions every natural-key discriminator', () => {
@@ -43,8 +43,9 @@ describe('canonical AccountRef scope', () => {
       accountScopeFromRef({ ...base, brand: { ...base.brand, countries: ['NL'] } }),
       accountScopeFromRef({ ...base, operator_unit: { id: '234284238', name: 'Nova EMEA' } }),
       accountScopeFromRef({ ...base, currency: 'EUR' }),
+      accountScopeFromRef({ ...base, timezone: 'Europe/Amsterdam' }),
     ]);
-    expect(scopes.size).toBe(7);
+    expect(scopes.size).toBe(8);
   });
 
   it('represents a country-scoped brand under an operator unit and fixed currency', () => {
@@ -53,6 +54,7 @@ describe('canonical AccountRef scope', () => {
       operator: 'Nova-Athletics.Example',
       operator_unit: { id: '234284238', name: 'Nova EMEA' },
       currency: 'EUR',
+      timezone: 'Europe/Amsterdam',
     };
     expect(canonicalizeAccountRef(account)).toEqual({
       kind: 'natural',
@@ -60,10 +62,11 @@ describe('canonical AccountRef scope', () => {
       operator: 'nova-athletics.example',
       operator_unit: { id: '234284238', name: 'Nova EMEA' },
       currency: 'EUR',
+      timezone: 'Europe/Amsterdam',
       sandbox: false,
     });
     expect(accountScopeFromRef(account))
-      .toBe('n:{"brand":{"domain":"nova-athletics.example","countries":["BE","NL"]},"operator":"nova-athletics.example","operator_unit_id":"234284238","currency":"EUR","sandbox":false}');
+      .toBe('n:{"brand":{"domain":"nova-athletics.example","countries":["BE","NL"]},"operator":"nova-athletics.example","operator_unit_id":"234284238","currency":"EUR","timezone":"Europe/Amsterdam","sandbox":false}');
     expect(accountScopeFromRef({
       ...account,
       brand: { ...account.brand, countries: ['BE', 'NL'] },
@@ -96,6 +99,7 @@ describe('canonical AccountRef scope', () => {
     [{ brand: { domain: 'house.example', countries: ['NL', 'NL'] }, operator: 'one.example' }, 'unique'],
     [{ brand: { domain: 'house.example' }, operator: 'one.example', operator_unit: { id: '' } }, 'stable operator-defined'],
     [{ brand: { domain: 'house.example' }, operator: 'one.example', currency: 'eur' }, 'ISO 4217'],
+    [{ brand: { domain: 'house.example' }, operator: 'one.example', timezone: '' }, 'IANA timezone'],
     [{ account_id: 'acct_123', unexpected: true }, "field 'unexpected'"],
   ])('rejects invalid closed-union shape %#', (value, message) => {
     expect(() => canonicalizeAccountRef(value)).toThrow(AccountRefValidationError);
@@ -184,9 +188,9 @@ describe('custom-tool account scoping', () => {
       sandbox: true,
     };
     expect(deriveAccountScope({ account }))
-      .toBe('n:{"brand":{"domain":"house.example","brand_id":"spark"},"operator":"pinnacle.example","operator_unit_id":null,"currency":null,"sandbox":true}');
+      .toBe('n:{"brand":{"domain":"house.example","brand_id":"spark"},"operator":"pinnacle.example","operator_unit_id":null,"currency":null,"timezone":null,"sandbox":true}');
     expect(deriveAccountScope({ usage: [{ account }] }))
-      .toBe('n:{"brand":{"domain":"house.example","brand_id":"spark"},"operator":"pinnacle.example","operator_unit_id":null,"currency":null,"sandbox":true}');
+      .toBe('n:{"brand":{"domain":"house.example","brand_id":"spark"},"operator":"pinnacle.example","operator_unit_id":null,"currency":null,"timezone":null,"sandbox":true}');
   });
 
   it('does not silently fall through an explicit invalid top-level account', () => {

--- a/server/tests/unit/training-agent-get-products-rejected.test.ts
+++ b/server/tests/unit/training-agent-get-products-rejected.test.ts
@@ -54,7 +54,7 @@ describe('get_products rejected compliance arm', () => {
     const reason = 'The requested budget is below the minimum for this inventory.';
 
     const forced = await call('comply_test_controller', {
-      adcp_version: '3.2-beta.0',
+      adcp_version: '3.2-beta.2',
       account: controllerAccount('primary-account'),
       scenario: 'force_get_products_arm',
       params: {
@@ -68,12 +68,12 @@ describe('get_products rejected compliance arm', () => {
       data: {
         success: true,
         forced: { arm: 'rejected', reason },
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
       },
     });
 
     const otherAccountResult = await call('get_products', {
-      adcp_version: '3.2-beta.0',
+      adcp_version: '3.2-beta.2',
       idempotency_key: 'rejected-other-account-0001',
       account: otherAccount,
       buying_mode: 'brief',
@@ -82,7 +82,7 @@ describe('get_products rejected compliance arm', () => {
     expect(otherAccountResult.data).not.toMatchObject({ status: 'rejected' });
 
     const otherPrincipalResult = await call('get_products', {
-      adcp_version: '3.2-beta.0',
+      adcp_version: '3.2-beta.2',
       idempotency_key: 'rejected-other-principal-0001',
       account: primaryAccount,
       buying_mode: 'brief',
@@ -91,7 +91,7 @@ describe('get_products rejected compliance arm', () => {
     expect(otherPrincipalResult.data).not.toMatchObject({ status: 'rejected' });
 
     const wholesaleResult = await call('get_products', {
-      adcp_version: '3.2-beta.0',
+      adcp_version: '3.2-beta.2',
       idempotency_key: 'rejected-wholesale-0001',
       account: primaryAccount,
       buying_mode: 'wholesale',
@@ -99,7 +99,7 @@ describe('get_products rejected compliance arm', () => {
     expect(wholesaleResult.data).not.toMatchObject({ status: 'rejected' });
 
     const rejected = await call('get_products', {
-      adcp_version: '3.2-beta.0',
+      adcp_version: '3.2-beta.2',
       idempotency_key: 'rejected-primary-0001',
       account: primaryAccount,
       buying_mode: 'brief',
@@ -110,7 +110,7 @@ describe('get_products rejected compliance arm', () => {
       success: true,
       data: {
         status: 'rejected',
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         reason,
         suggestions: ['Increase the campaign budget.'],
         context: { correlation_id: 'rejected-once' },
@@ -118,7 +118,7 @@ describe('get_products rejected compliance arm', () => {
     });
 
     const consumed = await call('get_products', {
-      adcp_version: '3.2-beta.0',
+      adcp_version: '3.2-beta.2',
       idempotency_key: 'rejected-consumed-0001',
       account: primaryAccount,
       buying_mode: 'brief',
@@ -131,7 +131,7 @@ describe('get_products rejected compliance arm', () => {
     const primaryAccount = account('parallel-rejection-account');
     const reason = 'Only one concurrent request may consume this rejection.';
     const forced = await call('comply_test_controller', {
-      adcp_version: '3.2-beta.0',
+      adcp_version: '3.2-beta.2',
       account: controllerAccount('parallel-rejection-account'),
       scenario: 'force_get_products_arm',
       params: { arm: 'rejected', reason },
@@ -140,7 +140,7 @@ describe('get_products rejected compliance arm', () => {
 
     const replayScope = randomUUID();
     const outcomes = await Promise.all([0, 1].map(index => call('get_products', {
-      adcp_version: '3.2-beta.0',
+      adcp_version: '3.2-beta.2',
       idempotency_key: `parallel-rejection-${replayScope}-${index}`,
       account: primaryAccount,
       buying_mode: 'brief',
@@ -157,7 +157,7 @@ describe('get_products rejected compliance arm', () => {
 
   it('rejects empty suggestion arrays instead of emitting a schema-invalid response', async () => {
     const result = await call('comply_test_controller', {
-      adcp_version: '3.2-beta.0',
+      adcp_version: '3.2-beta.2',
       account: controllerAccount('invalid-suggestions'),
       scenario: 'force_get_products_arm',
       params: { arm: 'rejected', reason: 'Declined.', suggestions: [] },

--- a/server/tests/unit/training-agent-governance-intent-binding.test.ts
+++ b/server/tests/unit/training-agent-governance-intent-binding.test.ts
@@ -8,7 +8,12 @@ import {
   handleCheckGovernance,
   handleSyncPlans,
 } from '../../src/training-agent/governance-handlers.js';
-import { clearSessions, getSession, runWithSessionContext } from '../../src/training-agent/state.js';
+import {
+  clearSessions,
+  flushDirtySessions,
+  getSession,
+  runWithSessionContext,
+} from '../../src/training-agent/state.js';
 import { resetGovernanceSigning } from '../../src/training-agent/governance-signing.js';
 import { computeDeliveryStatementDigest } from '../../src/training-agent/governance-payload-hash.js';
 import { getCanonicalBase } from '../../src/training-agent/tenants/registry.js';
@@ -198,6 +203,7 @@ describe('check_governance request-shape binding', () => {
         updatedAt: '2027-01-01T00:00:00Z',
         history: [],
       });
+      await flushDirtySessions();
       const intent = await check({
         tool: 'update_media_buy',
         proposed_commitment: { amount: 300, currency: 'USD' },
@@ -219,8 +225,9 @@ describe('check_governance request-shape binding', () => {
       }, CTX) as Record<string, any>;
 
       expect(result.errors?.[0]?.code).toBe('PERMISSION_DENIED');
-      expect(session.mediaBuys.get('mb_seller_delta')?.revision).toBe(3);
-      expect(session.mediaBuys.get('mb_seller_delta')?.packages[0]?.budget).toBe(1_000);
+      const deniedSession = await getSession('open:intent-binding.example');
+      expect(deniedSession.mediaBuys.get('mb_seller_delta')?.revision).toBe(3);
+      expect(deniedSession.mediaBuys.get('mb_seller_delta')?.packages[0]?.budget).toBe(1_000);
 
       const wrongAudienceIntent = await check({
         tool: 'update_media_buy',
@@ -266,7 +273,8 @@ describe('check_governance request-shape binding', () => {
         new_packages: [{ product_id: 'display_standard', pricing_option_id: 'cpm_standard', budget: 0 }],
       }, CTX) as Record<string, any>;
       expect(zeroBudgetAddition.errors?.[0]?.code).toBe('GOVERNANCE_DENIED');
-      expect(session.mediaBuys.get('mb_seller_delta')?.revision).toBe(3);
+      const finalSession = await getSession('open:intent-binding.example');
+      expect(finalSession.mediaBuys.get('mb_seller_delta')?.revision).toBe(3);
     });
   });
 
@@ -314,6 +322,7 @@ describe('check_governance request-shape binding', () => {
         updatedAt: '2027-01-01T00:00:00Z',
         history: [],
       });
+      await flushDirtySessions();
       const businessPayload = {
         account: { brand: { domain: 'intent-binding.example' } },
         media_buy_id: 'mb_shared_budget',
@@ -322,7 +331,8 @@ describe('check_governance request-shape binding', () => {
       };
       const withoutContext = await handleUpdateMediaBuy(businessPayload, CTX) as Record<string, any>;
       expect(withoutContext.errors?.[0]?.code).toBe('GOVERNANCE_DENIED');
-      expect(session.mediaBuys.get('mb_shared_budget')?.revision).toBe(1);
+      const rejectedSession = await getSession('open:intent-binding.example');
+      expect(rejectedSession.mediaBuys.get('mb_shared_budget')?.revision).toBe(1);
 
       const intent = await check({
         tool: 'update_media_buy',
@@ -338,8 +348,9 @@ describe('check_governance request-shape binding', () => {
 
       expect(result.errors, JSON.stringify(result)).toBeUndefined();
       expect(result.total_budget).toBe(1_000);
-      expect(session.mediaBuys.get('mb_shared_budget')?.totalBudget).toBe(1_000);
-      expect(session.mediaBuys.get('mb_shared_budget')?.packages.map(pkg => pkg.budget)).toEqual([900, 800]);
+      const updatedSession = await getSession('open:intent-binding.example');
+      expect(updatedSession.mediaBuys.get('mb_shared_budget')?.totalBudget).toBe(1_000);
+      expect(updatedSession.mediaBuys.get('mb_shared_budget')?.packages.map(pkg => pkg.budget)).toEqual([900, 800]);
     });
   });
 
@@ -376,6 +387,7 @@ describe('check_governance request-shape binding', () => {
         updatedAt: '2027-01-01T00:00:00Z',
         history: [],
       });
+      await flushDirtySessions();
 
       const result = await handleUpdateMediaBuy({
         account: { brand: { domain: 'intent-binding.example' } },
@@ -385,7 +397,8 @@ describe('check_governance request-shape binding', () => {
       }, CTX) as Record<string, any>;
 
       expect(result.errors?.[0]?.code).toBe('GOVERNANCE_DENIED');
-      expect(session.mediaBuys.get('mb_aggregate_controls')?.revision).toBe(1);
+      const rejectedSession = await getSession('open:intent-binding.example');
+      expect(rejectedSession.mediaBuys.get('mb_aggregate_controls')?.revision).toBe(1);
     });
   });
 

--- a/server/tests/unit/training-agent-idempotency.test.ts
+++ b/server/tests/unit/training-agent-idempotency.test.ts
@@ -27,7 +27,10 @@ import {
   getIdempotencyStore,
 } from '../../src/training-agent/idempotency.js';
 import type { TrainingContext } from '../../src/training-agent/types.js';
-import { getTrainingTaskStore } from '../../src/training-agent/mcp-task-store.js';
+import {
+  getScopedTrainingTaskStore,
+  getTrainingTaskStore,
+} from '../../src/training-agent/mcp-task-store.js';
 
 const CTX: TrainingContext = { mode: 'open', principal: 'test-principal' };
 
@@ -116,6 +119,28 @@ describe('training agent idempotency middleware', () => {
     clearTaskStore();
     clearIdempotencyCache();
     server = createTrainingAgentServer(CTX);
+  });
+
+  it('prunes expired scoped task ownership before paginating live tasks', async () => {
+    vi.useFakeTimers();
+    try {
+      const store = getScopedTrainingTaskStore('tenant-principal-scope');
+      const request = {
+        method: 'tools/call',
+        params: { name: 'get_signals', arguments: {} },
+      } as any;
+      await store.createTask({ ttl: 1 }, 1, request);
+      for (let index = 0; index < 10; index += 1) {
+        await store.createTask({ ttl: null }, index + 2, request);
+      }
+      await vi.advanceTimersByTimeAsync(2);
+
+      const page = await store.listTasks();
+      expect(page.tasks).toHaveLength(10);
+      expect(page.nextCursor).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   describe('missing / malformed key', () => {
@@ -484,7 +509,7 @@ describe('training agent idempotency middleware', () => {
     it('keeps keyless list_products independent from legacy discovery replay identity', async () => {
       const key = `products-list-alias-${randomUUID()}`;
       const identity = {
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         brand: BRAND,
       };
 
@@ -516,7 +541,7 @@ describe('training agent idempotency middleware', () => {
 
       const conflict = await call(server, 'get_products', {
         idempotency_key: key,
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         buying_mode: 'wholesale',
         account: ACCOUNT,
       });
@@ -542,7 +567,7 @@ describe('training agent idempotency middleware', () => {
       const key = `products-recommend-task-alias-${randomUUID()}`;
       const shared = {
         idempotency_key: key,
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         account: ACCOUNT,
         brand: BRAND,
         brief: 'cross-channel news video and display',
@@ -558,7 +583,7 @@ describe('training agent idempotency middleware', () => {
 
       const split = await call(server, 'request_proposals', {
         idempotency_key: key,
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         brand: BRAND,
         brief: shared.brief,
       });
@@ -569,7 +594,7 @@ describe('training agent idempotency middleware', () => {
     it('projects one cached product result across inline then task execution modes', async () => {
       const shared = {
         idempotency_key: `products-inline-task-${randomUUID()}`,
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         brand: BRAND,
         brief: 'cross-channel sports',
       };
@@ -589,7 +614,7 @@ describe('training agent idempotency middleware', () => {
     it('projects one cached product result across task then inline execution modes', async () => {
       const shared = {
         idempotency_key: `products-task-inline-${randomUUID()}`,
-        adcp_version: '3.2-beta.0',
+        adcp_version: '3.2-beta.2',
         brand: BRAND,
         brief: 'cross-channel news',
       };

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -25,6 +25,8 @@ import {
   executeTrainingAgentTool,
   handleBuildCreative,
   handleListTransformers,
+  handleControlMediaBuy,
+  handleAcceptProposal,
   canonicalParamsSatisfied,
   invalidateCache,
   clearTaskStore,
@@ -8663,6 +8665,118 @@ describe('update_media_buy handler', () => {
     clearSessions();
   });
 
+  it('serializes controls that target the same MediaBuy revision', async () => {
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'control-race.example' }, operator: 'control-race.example' };
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: created, isError } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      brand: account.brand,
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      packages: [{
+        product_id: product.product_id,
+        pricing_option_id: pricingOptions[0].pricing_option_id,
+        budget: 10000,
+      }],
+    });
+    expect(isError, JSON.stringify(created)).toBeFalsy();
+
+    const baseControl = {
+      account,
+      media_buy_id: created.media_buy_id as string,
+      revision: created.revision as number,
+    };
+    const results = await Promise.all([2_000, 3_000].map(dailyBudgetCap => (
+      runWithSessionContext(() => handleControlMediaBuy({
+        ...baseControl,
+        idempotency_key: `control-race-${dailyBudgetCap}`,
+        daily_budget_cap: dailyBudgetCap,
+      }, { ...DEFAULT_CTX, servedAdcpVersion: CURRENT_ADCP_VERSION }))
+    )));
+
+    const successes = results.filter(result => !Array.isArray(result.errors));
+    const conflicts = results.filter(result => Array.isArray(result.errors));
+    expect(successes).toHaveLength(1);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({ errors: [{ code: 'CONFLICT' }] });
+
+    const { result: readback } = await simulateCallTool(
+      createTrainingAgentServer(DEFAULT_CTX),
+      'get_media_buys',
+      { account, media_buy_ids: [created.media_buy_id] },
+    );
+    const storedBuy = (readback.media_buys as Array<Record<string, unknown>>)[0];
+    expect(storedBuy).toMatchObject({
+      media_buy_id: created.media_buy_id,
+      revision: (created.revision as number) + 1,
+    });
+    expect([2_000, 3_000]).toContain(storedBuy.daily_budget_cap);
+  });
+
+  it('revalidates a future-current control against the newly accepted envelope', async () => {
+    const catalog = buildCatalog();
+    const product = catalog[0].product;
+    const pricingOptions = product.pricing_options as Array<Record<string, unknown>>;
+    const account = { brand: { domain: 'control-envelope-race.example' }, operator: 'control-envelope-race.example' };
+    const { result: created } = await simulateCallTool(
+      createTrainingAgentServer(DEFAULT_CTX),
+      'create_media_buy',
+      {
+        account,
+        brand: account.brand,
+        start_time: '2027-06-01T00:00:00Z',
+        end_time: '2027-07-01T00:00:00Z',
+        total_budget: { amount: 10_000, currency: 'USD' },
+        packages: [{
+          product_id: product.product_id,
+          pricing_option_id: pricingOptions[0].pricing_option_id,
+          budget: 10_000,
+        }],
+      },
+    );
+    const sessionKey = sessionKeyFromArgs({ account }, DEFAULT_CTX.mode);
+
+    await runWithSessionContext(async () => {
+      // Prime this request with revision 1, then simulate another request
+      // accepting a tighter envelope and committing revision 2.
+      await getSession(sessionKey);
+      await runWithSessionContext(async () => {
+        const currentSession = await getSession(sessionKey);
+        const mediaBuy = currentSession.mediaBuys.get(created.media_buy_id as string)!;
+        mediaBuy.revision = 2;
+        mediaBuy.acceptedProposal = {
+          proposal_id: 'proposal_control_envelope_race',
+          proposal_kind: 'media_buy_update',
+          proposal_status: 'accepted',
+          name: 'Accepted lower-budget envelope',
+          commercial_terms: {
+            brand: account.brand,
+            purchases: [],
+            start_time: '2027-06-01T00:00:00Z',
+            end_time: '2027-07-01T00:00:00Z',
+            total_budget: { amount: 1_000, currency: 'USD' },
+          },
+          terms_digest: 'sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        } as NonNullable<typeof mediaBuy.acceptedProposal>;
+        await flushDirtySessions();
+      });
+
+      const controlled = await handleControlMediaBuy({
+        idempotency_key: `test-${randomUUID()}`,
+        account,
+        media_buy_id: created.media_buy_id as string,
+        revision: 2,
+        total_budget: { amount: 2_000, currency: 'USD' },
+      }, { ...DEFAULT_CTX, servedAdcpVersion: CURRENT_ADCP_VERSION });
+      expect(controlled).toMatchObject({
+        errors: [{ code: 'REQUOTE_REQUIRED', field: 'total_budget.amount' }],
+      });
+    });
+  });
+
   it('updates package budget', async () => {
     const catalog = buildCatalog();
     const product = catalog[0].product;
@@ -14186,6 +14300,89 @@ describe('proposal lifecycle', () => {
     if (create.isError) expect(create.result).toMatchObject({ code: 'INVALID_STATE' });
     else if (decline.isError) expect(decline.result).toMatchObject({ code: 'CONFLICT' });
     else expect(declineOutcome).toBe('unable');
+  });
+
+  it('serializes operational control against proposal acceptance on one revision', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result: requested } = await simulateCallTool(server, 'request_proposals', {
+      brand: account.brand,
+      brief: 'social engagement display',
+    });
+    const draft = (requested.proposals as Array<Record<string, unknown>>)[0];
+    const committed = await finalizeCompactProposal(server, draft);
+    const createArgs = {
+      account,
+      brand: account.brand,
+      start_time: '2027-06-01T00:00:00Z',
+      end_time: '2027-07-01T00:00:00Z',
+      proposal_id: committed.proposal_id,
+      total_budget: { amount: 50000, currency: 'USD' },
+      ...(committed.insertion_order && {
+        io_acceptance: {
+          io_id: (committed.insertion_order as Record<string, unknown>).io_id,
+          accepted_at: new Date().toISOString(),
+          signatory: 'control-accept-race-test',
+        },
+      }),
+    };
+    const { result: created, isError: createError } = await simulateCallTool(
+      server,
+      'create_media_buy',
+      createArgs,
+    );
+    expect(createError, JSON.stringify(created)).toBeFalsy();
+
+    const { result: refined, isError: refineError } = await simulateCallTool(server, 'refine_proposals', {
+      refinements: [{
+        proposal_id: committed.proposal_id,
+        action: 'revise',
+        change_kind: 'amendment',
+        ask: 'Preserve the accepted flight while updating its operating terms.',
+      }],
+    });
+    expect(refineError, JSON.stringify(refined)).toBeFalsy();
+    const amendmentDraft = (
+      (refined.results as Array<Record<string, unknown>>)[0].proposals as Array<Record<string, unknown>>
+    )[0];
+    expect(amendmentDraft).toMatchObject({
+      proposal_kind: 'media_buy_update',
+      base_media_buy_revision: created.revision,
+    });
+    const amendment = await finalizeCompactProposal(server, amendmentDraft);
+
+    const results = await Promise.all([
+      runWithSessionContext(() => handleControlMediaBuy({
+        idempotency_key: `test-${randomUUID()}`,
+        account,
+        media_buy_id: created.media_buy_id as string,
+        revision: created.revision as number,
+        daily_budget_cap: 2_500,
+      }, { ...DEFAULT_CTX, servedAdcpVersion: CURRENT_ADCP_VERSION })),
+      runWithSessionContext(() => handleAcceptProposal({
+        idempotency_key: `test-${randomUUID()}`,
+        account,
+        proposal_id: amendment.proposal_id as string,
+        proposal_terms_digest: amendment.terms_digest as string,
+      }, { ...DEFAULT_CTX, servedAdcpVersion: CURRENT_ADCP_VERSION })),
+    ]);
+
+    const successes = results.filter(result => !Array.isArray(result.errors));
+    const conflicts = results.filter(result => Array.isArray(result.errors));
+    expect(successes).toHaveLength(1);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({ errors: [{ code: 'CONFLICT' }] });
+
+    const { result: readback } = await simulateCallTool(
+      createTrainingAgentServer(DEFAULT_CTX),
+      'get_media_buys',
+      { account, media_buy_ids: [created.media_buy_id] },
+    );
+    expect(readback.media_buys).toEqual([
+      expect.objectContaining({
+        media_buy_id: created.media_buy_id,
+        revision: (created.revision as number) + 1,
+      }),
+    ]);
   });
 
   it('makes proposal decline terminal, semantically idempotent, and opportunity-aware', async () => {

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -13893,6 +13893,28 @@ describe('proposal lifecycle', () => {
     expect(listed.result).not.toHaveProperty('next_cursor');
   });
 
+  it('constructs a compact proposal for an exact published product selection', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const productId = 'pinnacle_news_display_premium';
+    const requested = await simulateCallTool(server, 'request_proposals', {
+      idempotency_key: 'exact-product-proposal-0001',
+      brand: account.brand,
+      brief: 'Plan a USD 1,000 campaign using the selected published offer.',
+      criteria: { product_ids: [productId] },
+    });
+
+    expect(requested.isError, JSON.stringify(requested.result)).toBeFalsy();
+    expect(requested.result).toMatchObject({
+      outcome: 'proposed',
+      proposals: [{
+        proposal_status: 'draft',
+        commercial_terms: {
+          purchases: [{ product_id: productId }],
+        },
+      }],
+    });
+  });
+
   it('connects the compact request, refine, and purchase lifecycle', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const lifecycleOpportunity = {
@@ -14287,10 +14309,8 @@ describe('proposal lifecycle', () => {
         ask: 'Try a different allocation after terminal decline.',
       }],
     });
-    expect(refineAfterDecline.isError).toBeFalsy();
-    expect(refineAfterDecline.result).toMatchObject({
-      results: [{ source_proposal_id: committed.proposal_id, outcome: 'unable' }],
-    });
+    expect(refineAfterDecline.isError).toBe(true);
+    expect(refineAfterDecline.result).toMatchObject({ code: 'INVALID_STATE' });
 
     const purchase = await simulateCallTool(server, 'create_media_buy', {
       account,

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -694,7 +694,30 @@ describe('NovaMind AI publisher', () => {
     const cpa = novamind.pricingTemplates.find(t => t.model === 'cpa');
     expect(cpa).toBeDefined();
     expect(cpa!.eventType).toBe('custom');
+    expect(cpa!.customEventName).toBe('agent_session');
     expect(cpa!.fixedPrice).toBeGreaterThan(0);
+
+    const generatedCpa = buildCatalog()
+      .filter(cp => cp.publisherId === 'novamind')
+      .flatMap(cp => cp.product.pricing_options)
+      .find(option => option.pricing_model === 'cpa');
+    expect(generatedCpa).toMatchObject({
+      event_type: 'custom',
+      custom_event_name: 'agent_session',
+    });
+  });
+
+  it('rejects a custom CPA pricing template without a custom event name', () => {
+    const cpa = novamind.pricingTemplates.find(t => t.model === 'cpa')!;
+    const customEventName = cpa.customEventName;
+    try {
+      delete cpa.customEventName;
+      expect(() => buildCatalog()).toThrow(
+        /requires customEventName when eventType is custom/,
+      );
+    } finally {
+      cpa.customEventName = customEventName;
+    }
   });
 
   it('has flat_rate pricing for exclusive sponsorships', () => {

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -51,6 +51,7 @@ import type { TrainingContext } from '../../src/training-agent/types.js';
 import {
   HUMAN_REVIEW_CATEGORIES,
   HUMAN_REVIEW_POLICY_IDS,
+  governanceProposalCommitment,
 } from '../../src/training-agent/governance-handlers.js';
 import { clearAccountStore } from '../../src/training-agent/account-handlers.js';
 import { TrainingSalesPlatform, restoreRawPackageSelectors } from '../../src/training-agent/v6-sales-platform.js';
@@ -87,7 +88,7 @@ const VALID_PRICING_MODELS = [
 ] as const;
 
 const TEST_AGENT_URL = 'http://localhost:3000/api/training-agent';
-const CURRENT_ADCP_VERSION = '3.1-rc.15';
+const CURRENT_ADCP_VERSION = '3.2-beta.2';
 const GET_PRODUCTS_REJECTED_ADCP_VERSION = '3.2-beta.0';
 
 const DEFAULT_CTX: TrainingContext = { mode: 'open', authenticatedAgentUrl: 'https://buyer.example' };
@@ -12624,7 +12625,7 @@ describe('get_adcp_capabilities handler', () => {
 
     expect(result.adcp).toMatchObject({
       major_versions: [3],
-      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', GET_PRODUCTS_REJECTED_ADCP_VERSION],
+      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', CURRENT_ADCP_VERSION],
       idempotency: { supported: true, replay_ttl_seconds: 86400 },
     });
     expect(result.adcp_version).toBe('3.0');
@@ -12635,10 +12636,10 @@ describe('get_adcp_capabilities handler', () => {
   it('advertises known refinement support when lifecycle tools are available', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const { result } = await simulateCallTool(server, 'get_adcp_capabilities', {
-      adcp_version: GET_PRODUCTS_REJECTED_ADCP_VERSION,
+      adcp_version: CURRENT_ADCP_VERSION,
     });
 
-    expect(result.adcp_version).toBe(GET_PRODUCTS_REJECTED_ADCP_VERSION);
+    expect(result.adcp_version).toBe(CURRENT_ADCP_VERSION);
     expect(result.media_buy).toMatchObject({
       lifecycle_tools: expect.arrayContaining(['refine_proposals']),
       proposal_refinement: { supported_dimensions: [] },
@@ -12776,11 +12777,15 @@ describe('get_adcp_capabilities handler', () => {
 
   it('advertises the governed commitment tasks the training seller enforces', async () => {
     const server = createTrainingAgentServer({ ...DEFAULT_CTX, tenantId: 'sales' });
-    const { result } = await simulateCallTool(server, 'get_adcp_capabilities', {});
+    const { result } = await simulateCallTool(server, 'get_adcp_capabilities', {
+      adcp_version: CURRENT_ADCP_VERSION,
+    });
 
     expect((result.adcp as Record<string, any>).governance_enforcement).toEqual({
       tasks: [
-        { task: 'create_media_buy', modes: ['signed_context'] },
+        { task: 'buy_products', modes: ['signed_context'] },
+        { task: 'accept_proposal', modes: ['signed_context'] },
+        { task: 'control_media_buy', modes: ['signed_context'] },
       ],
     });
     expect(result.experimental_features).toContain('governance.campaign');
@@ -13555,7 +13560,7 @@ describe('MCP Tasks protocol', () => {
         code: -32602,
         data: {
           adcp_version: '99.0',
-          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', GET_PRODUCTS_REJECTED_ADCP_VERSION],
+          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', CURRENT_ADCP_VERSION],
           supported_majors: [3],
           context: { correlation_id: 'task-version-unsupported' },
           adcp_error: {
@@ -13685,6 +13690,13 @@ describe('proposal lifecycle', () => {
   });
 
   const account = { brand: { domain: 'proposal-test.example' }, operator: 'proposal-test.example' };
+  const proposalSessionKey = sessionKeyFromArgs(
+    { account: { account_id: 'public_sandbox' } },
+    DEFAULT_CTX.mode,
+    undefined,
+    undefined,
+    `agent:${DEFAULT_CTX.authenticatedAgentUrl}`,
+  );
 
   async function finalizeCompactProposal(
     server: ReturnType<typeof createTrainingAgentServer>,
@@ -13743,7 +13755,7 @@ describe('proposal lifecycle', () => {
 
     await runWithSessionContext(async () => {
       const session = await getSession(
-        sessionKeyFromArgs({}, DEFAULT_CTX.mode, undefined, undefined, 'anonymous'),
+        proposalSessionKey,
       );
       const storedIds = new Set(
         (session.lastGetProductsContext?.proposals ?? []).map(proposal => proposal.proposal_id),
@@ -13784,7 +13796,7 @@ describe('proposal lifecycle', () => {
 
     const storedDraftsBeforeFinalize = await runWithSessionContext(async () => {
       const session = await getSession(
-        sessionKeyFromArgs({}, DEFAULT_CTX.mode, undefined, undefined, 'anonymous'),
+        proposalSessionKey,
       );
       return structuredClone(session.lastGetProductsContext?.proposals?.filter(
         proposal => drafts.some(draft => draft.proposal_id === proposal.proposal_id),
@@ -13806,7 +13818,7 @@ describe('proposal lifecycle', () => {
 
     await runWithSessionContext(async () => {
       const session = await getSession(
-        sessionKeyFromArgs({}, DEFAULT_CTX.mode, undefined, undefined, 'anonymous'),
+        proposalSessionKey,
       );
       for (const [index, draft] of drafts.entries()) {
         const storedSource = session.lastGetProductsContext?.proposals?.find(
@@ -13987,7 +13999,7 @@ describe('proposal lifecycle', () => {
 
     await runWithSessionContext(async () => {
       const session = await getSession(
-        sessionKeyFromArgs({}, DEFAULT_CTX.mode, undefined, undefined, 'anonymous'),
+        proposalSessionKey,
       );
       const stored = session.lastGetProductsContext?.proposals?.find(
         proposal => proposal.proposal_id === committed.proposal_id,
@@ -14178,7 +14190,7 @@ describe('proposal lifecycle', () => {
     });
     expect(refineError).toBeFalsy();
     const revision = (((refined.results as Array<Record<string, unknown>>)[0].proposals as Array<Record<string, unknown>>)[0]);
-    const compactSessionKey = sessionKeyFromArgs({}, DEFAULT_CTX.mode, undefined, undefined, 'anonymous');
+    const compactSessionKey = proposalSessionKey;
     await runWithSessionContext(async () => {
       const session = await getSession(compactSessionKey);
       const storedRevision = session.lastGetProductsContext?.proposals?.find(
@@ -14328,7 +14340,7 @@ describe('proposal lifecycle', () => {
 
     await runWithSessionContext(async () => {
       const session = await getSession(
-        sessionKeyFromArgs({}, DEFAULT_CTX.mode, undefined, undefined, 'anonymous'),
+        proposalSessionKey,
       );
       const stored = session.lastGetProductsContext?.proposals?.find(
         candidate => candidate.proposal_id === proposal.proposal_id,
@@ -14661,7 +14673,7 @@ describe('proposal lifecycle', () => {
 
     const storedProposalIds = () => runWithSessionContext(async () => {
       const session = await getSession(
-        sessionKeyFromArgs({}, DEFAULT_CTX.mode, undefined, undefined, 'anonymous'),
+        proposalSessionKey,
       );
       return (session.lastGetProductsContext?.proposals ?? []).map(proposal => proposal.proposal_id);
     });
@@ -14701,7 +14713,7 @@ describe('proposal lifecycle', () => {
 
     const storedProposalIds = () => runWithSessionContext(async () => {
       const session = await getSession(
-        sessionKeyFromArgs({}, DEFAULT_CTX.mode, undefined, undefined, 'anonymous'),
+        proposalSessionKey,
       );
       return (session.lastGetProductsContext?.proposals ?? []).map(proposal => proposal.proposal_id);
     });
@@ -14757,7 +14769,7 @@ describe('proposal lifecycle', () => {
 
       const storedProposalIds = () => runWithSessionContext(async () => {
         const session = await getSession(
-          sessionKeyFromArgs({}, DEFAULT_CTX.mode, undefined, undefined, 'anonymous'),
+          proposalSessionKey,
         );
         return (session.lastGetProductsContext?.proposals ?? []).map(proposal => proposal.proposal_id);
       });
@@ -15912,6 +15924,198 @@ describe('storyboard governance sample_requests accepted by training agent', () 
     await simulateCallTool(server, 'sync_plans', { plans: [UNIVERSAL_PLAN] });
   }
 
+  function governedProposal(
+    proposalKind: 'new_media_buy' | 'media_buy_update' = 'media_buy_update',
+    endTime = '2027-06-15T23:59:59Z',
+  ): Record<string, unknown> {
+    const proposal: Record<string, unknown> = {
+      proposal_id: `proposal_governed_${proposalKind}`,
+      proposal_kind: proposalKind,
+      proposal_status: 'committed',
+      name: 'Governed proposal fixture',
+      expires_at: '2027-12-31T23:59:59Z',
+      commercial_terms: {
+        brand: { domain: 'acmeoutdoor.com' },
+        purchases: [{
+          product_id: 'sports_preroll_q2',
+          pricing_option_id: 'sports_preroll_cpm',
+          pricing: { pricing_option_id: 'sports_preroll_cpm', currency: 'USD' },
+          budget: 40_000,
+          start_time: '2027-04-01T00:00:00Z',
+          end_time: endTime,
+          targeting_overlay: { geo_countries: ['US'] },
+        }],
+        start_time: '2027-04-01T00:00:00Z',
+        end_time: endTime,
+        total_budget: { amount: 40_000, currency: 'USD' },
+      },
+      ...(proposalKind === 'media_buy_update' && {
+        parent_proposal_id: 'proposal_governed_parent',
+        media_buy_id: 'mb_governed_fixture',
+        base_media_buy_revision: 1,
+      }),
+    };
+    resignTermsDigest(proposal);
+    return proposal;
+  }
+
+  it('requires and verifies the canonical proposal for accept_proposal governance', async () => {
+    const caller = 'https://buying.pinnacle-agency.example';
+    const server = createTrainingAgentServer({ ...DEFAULT_CTX, authenticatedAgentUrl: caller });
+    await setupPlan(server);
+    const proposal = governedProposal();
+    const payload = {
+      idempotency_key: 'governed-proposal-accept-0001',
+      account: { brand: { domain: 'acmeoutdoor.com' }, operator: 'pinnacle-agency.com' },
+      proposal_id: proposal.proposal_id,
+      proposal_terms_digest: proposal.terms_digest,
+    };
+    const base = {
+      plan_id: UNIVERSAL_PLAN.plan_id,
+      caller,
+      target_agent: caller,
+      tool: 'accept_proposal',
+      payload,
+      proposed_commitment: { amount: 0, currency: 'USD' },
+    };
+
+    const missing = await simulateCallTool(server, 'check_governance', base);
+    expect(missing.isError).toBe(true);
+    expect(missing.result).toMatchObject({ code: 'VALIDATION_ERROR', field: 'proposal' });
+
+    const tampered = structuredClone(proposal);
+    (tampered.commercial_terms as Record<string, unknown>).end_time = '2027-06-20T23:59:59Z';
+    const invalidDigest = await simulateCallTool(server, 'check_governance', {
+      ...base,
+      proposal: tampered,
+    });
+    expect(invalidDigest.isError).toBe(true);
+    expect(invalidDigest.result).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      field: 'proposal.terms_digest',
+    });
+
+    const newProposal = governedProposal('new_media_buy');
+    const wrongCommitment = await simulateCallTool(server, 'check_governance', {
+      ...base,
+      payload: {
+        ...payload,
+        proposal_id: newProposal.proposal_id,
+        proposal_terms_digest: newProposal.terms_digest,
+      },
+      proposal: newProposal,
+    });
+    expect(wrongCommitment.isError).toBe(true);
+    expect(wrongCommitment.result).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      field: 'proposed_commitment',
+    });
+
+    const cancellation = governedProposal();
+    cancellation.proposal_id = 'proposal_governed_cancellation';
+    cancellation.proposal_kind = 'media_buy_cancellation';
+    (cancellation.commercial_terms as Record<string, unknown>).cancellation_terms = {
+      effective_at: '2027-05-01T00:00:00Z',
+      reason: 'Mutually agreed cancellation',
+    };
+    expect(governanceProposalCommitment(cancellation as any)).toEqual({ amount: 0 });
+    const feeCancellation = structuredClone(cancellation);
+    ((feeCancellation.commercial_terms as Record<string, unknown>).cancellation_terms as Record<string, unknown>).fee = {
+      amount: 750,
+      currency: 'USD',
+    };
+    expect(governanceProposalCommitment(feeCancellation as any)).toEqual({ amount: 750, currency: 'USD' });
+    resignTermsDigest(cancellation);
+    const cancellationCheck = await simulateCallTool(server, 'check_governance', {
+      ...base,
+      payload: {
+        ...payload,
+        proposal_id: cancellation.proposal_id,
+        proposal_terms_digest: cancellation.terms_digest,
+      },
+      proposal: cancellation,
+    });
+    expect(cancellationCheck.isError).toBeFalsy();
+    expect(cancellationCheck.result.status).toBe('approved');
+  });
+
+  it('inspects proposal terms and enforces accept_proposal execution binding', async () => {
+    const caller = 'https://buying.pinnacle-agency.example';
+    const server = createTrainingAgentServer({ ...DEFAULT_CTX, authenticatedAgentUrl: caller });
+    await setupPlan(server);
+    const outsideFlight = governedProposal('media_buy_update', '2027-07-15T23:59:59Z');
+    const outsidePayload = {
+      idempotency_key: 'governed-proposal-outside-0001',
+      account: { brand: { domain: 'acmeoutdoor.com' }, operator: 'pinnacle-agency.com' },
+      proposal_id: outsideFlight.proposal_id,
+      proposal_terms_digest: outsideFlight.terms_digest,
+    };
+    const denied = await simulateCallTool(server, 'check_governance', {
+      plan_id: UNIVERSAL_PLAN.plan_id,
+      caller,
+      target_agent: caller,
+      tool: 'accept_proposal',
+      payload: outsidePayload,
+      proposal: outsideFlight,
+      proposed_commitment: { amount: 0, currency: 'USD' },
+    });
+    expect(denied.result.status).toBe('denied');
+    expect(denied.result.findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ category_id: 'flight_compliance', severity: 'critical' }),
+    ]));
+
+    const proposal = governedProposal();
+    const payload = {
+      ...outsidePayload,
+      idempotency_key: 'governed-proposal-approved-0001',
+      proposal_id: proposal.proposal_id,
+      proposal_terms_digest: proposal.terms_digest,
+    };
+    const approved = await simulateCallTool(server, 'check_governance', {
+      plan_id: UNIVERSAL_PLAN.plan_id,
+      caller,
+      target_agent: caller,
+      tool: 'accept_proposal',
+      payload,
+      proposal,
+      proposed_commitment: { amount: 0, currency: 'USD' },
+    });
+    expect(approved.result.status).toBe('approved');
+
+    const missingExecutionCommitment = await simulateCallTool(server, 'check_governance', {
+      caller,
+      governance_context: approved.result.governance_context,
+      phase: 'modification',
+      planned_delivery: {
+        media_buy_id: 'mb_governed_fixture',
+        proposal_id: proposal.proposal_id,
+        proposal_terms_digest: proposal.terms_digest,
+        total_budget: 40_000,
+        currency: 'USD',
+      },
+    });
+    expect(missingExecutionCommitment.isError).toBe(true);
+    expect(missingExecutionCommitment.result.code).toBe('VALIDATION_ERROR');
+
+    const wrongProposalBinding = await simulateCallTool(server, 'check_governance', {
+      caller,
+      governance_context: approved.result.governance_context,
+      phase: 'modification',
+      execution_commitment: { amount: 0, currency: 'USD' },
+      planned_delivery: {
+        media_buy_id: 'mb_governed_fixture',
+        proposal_id: proposal.proposal_id,
+        proposal_terms_digest: 'sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        total_budget: 40_000,
+        currency: 'USD',
+      },
+    });
+    expect(wrongProposalBinding.result.status).toBe('denied');
+    expect(wrongProposalBinding.result.findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ category_id: 'proposal_binding', severity: 'critical' }),
+    ]));
+  });
+
   it('media_buy_seller: check_governance with tool+payload pattern', async () => {
     const server = createTrainingAgentServer({ ...DEFAULT_CTX, authenticatedAgentUrl: 'https://buying.pinnacle-agency.example' });
     await setupPlan(server);
@@ -16607,7 +16811,7 @@ describe('AdCP protocol compliance', () => {
       brief: 'test',
     });
     expect(isError).toBeFalsy();
-    expect(result.adcp_version).toBe(GET_PRODUCTS_REJECTED_ADCP_VERSION);
+    expect(result.adcp_version).toBe(CURRENT_ADCP_VERSION);
     expect(Array.isArray(result.products)).toBe(true);
   });
 
@@ -16619,7 +16823,7 @@ describe('AdCP protocol compliance', () => {
     expect(parsed.adcp_version).toBe('3.0');
     expect(parsed.adcp).toMatchObject({
       major_versions: [3],
-      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', GET_PRODUCTS_REJECTED_ADCP_VERSION],
+      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', CURRENT_ADCP_VERSION],
     });
   });
 
@@ -16684,7 +16888,7 @@ describe('AdCP protocol compliance', () => {
       details: {
         adcp_version: '4.0',
         adcp_major_version: 4,
-        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', GET_PRODUCTS_REJECTED_ADCP_VERSION],
+        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', CURRENT_ADCP_VERSION],
         supported_majors: [3],
       },
     });
@@ -16705,7 +16909,7 @@ describe('AdCP protocol compliance', () => {
       field: 'adcp_version',
       details: {
         adcp_version: '3.1-beta',
-        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', GET_PRODUCTS_REJECTED_ADCP_VERSION],
+        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', CURRENT_ADCP_VERSION],
         supported_majors: [3],
       },
     });

--- a/tests/compact-version-envelope.test.cjs
+++ b/tests/compact-version-envelope.test.cjs
@@ -10,10 +10,11 @@ const { ProtocolClient } = require('@adcp/sdk');
 
 const SOURCE_DIR = path.resolve(__dirname, '..', 'static', 'schemas', 'source');
 const ADCP_VERSION = '3.2.0-beta.0';
-const EXPECTED_ENVELOPE = {
-  adcp_major_version: 3,
-  adcp_version: '3.2-beta.0',
-};
+const COMPACT_SCHEMAS_WITHOUT_MAJOR = new Set([
+  'buy_products',
+  'accept_proposal',
+  'control_media_buy',
+]);
 
 function readSchema(uri) {
   if (!uri.startsWith('/schemas/')) {
@@ -106,13 +107,13 @@ test('SDK auto version envelope passes every strict compact lifecycle request sc
 
   for (const [tool, request] of Object.entries(compactRequests)) {
     await ProtocolClient.callTool(agent, tool, request, { adcpVersion: ADCP_VERSION });
-    assert.deepEqual(
-      {
-        adcp_major_version: outbound.get(tool).adcp_major_version,
-        adcp_version: outbound.get(tool).adcp_version,
-      },
-      EXPECTED_ENVELOPE,
-      `${tool} did not receive the SDK's default auto envelope`,
-    );
+    const expectedEnvelope = {
+      adcp_major_version: COMPACT_SCHEMAS_WITHOUT_MAJOR.has(tool) ? undefined : 3,
+      adcp_version: '3.2-beta.0',
+    };
+    assert.deepEqual({
+      adcp_major_version: outbound.get(tool).adcp_major_version,
+      adcp_version: outbound.get(tool).adcp_version,
+    }, expectedEnvelope, `${tool} did not receive the SDK's compatible auto envelope`);
   }
 });


### PR DESCRIPTION
Closes #6646

## Summary

- upgrade the public training agent to `@adcp/sdk` 14 and the AdCP 3.2 beta envelope
- make the seven compact media-buy lifecycle tools the default discovery surface while retaining frozen 3.0 compatibility
- implement native product purchase, proposal acceptance, amendment, cancellation, media-buy controls, action discovery, and feed/pricing versioning
- preserve proposal products, accepted snapshots, revisions, caller identity, and trusted account scope across compact lifecycle requests
- serialize all media-buy mutations across operational controls, legacy updates, and accepted amendments, including authoritative reload and governance revalidation under the shared lock
- add exact compliance gates for the five compact lifecycle variants

## Validation

- expert code review: approved, no blockers
- expert protocol review: approved, no blockers
- full pre-commit suite: 451 files, 6,340 passed, 30 skipped
- training-agent unit suite: 655 passed
- governance intent-binding suite: 35 passed
- controller unit suite: 78 passed
- training-agent tenant smoke: 34 passed
- 3.0 compatibility integration: 8 passed
- current storyboard matrix: all tenants green; sales 144 clean / 315 passing; all five exact lifecycle gates green
- released 3.0.24 storyboard matrix: all tenants green; sales 65 clean / 302 passing
- typecheck, changeset policy, shell syntax, version sync, and diff checks: passed

## Release note

Includes a patch Changeset for the public training-agent lifecycle update.
