### PR TITLE
docs(media-buy): update training-seller pin from 3.2-beta.0 to 3.2-beta.2

### DIFF
--- a/docs/media-buy/index.mdx
+++ b/docs/media-buy/index.mdx
@@ -46,7 +46,7 @@ delivery constraints use structured criteria:
 const proposals = await Promise.all(
   sellers.map((seller) =>
     seller.requestProposals({
-      adcp_version: '3.2-beta.0',
+      adcp_version: '3.2-beta.2',
       idempotency_key: 'acme-q2-proposals-001',
       account: { account_id: 'account_123' },
       brand: { domain: 'acme-outdoor.example' },
@@ -108,7 +108,7 @@ draft with typed constraints:
 
 ```javascript
 const refined = await streamHaus.refineProposals({
-  adcp_version: '3.2-beta.0',
+  adcp_version: '3.2-beta.2',
   idempotency_key: 'acme-q2-refine-001',
   refinements: [
     {
@@ -154,7 +154,7 @@ creates a committed successor and an inventory hold:
 
 ```javascript
 const finalized = await streamHaus.refineProposals({
-  adcp_version: '3.2-beta.0',
+  adcp_version: '3.2-beta.2',
   idempotency_key: 'acme-q2-finalize-001',
   refinements: [
     {
@@ -170,7 +170,7 @@ accepts that exact snapshot:
 
 ```javascript
 const buy = await streamHaus.acceptProposal({
-  adcp_version: '3.2-beta.0',
+  adcp_version: '3.2-beta.2',
   idempotency_key: 'acme-q2-accept-001',
   account: { account_id: 'account_123' },
   proposal_id: 'proposal_streamhaus_003',
@@ -200,7 +200,7 @@ required format has coverage, then moves to `pending_start` or `active`.
 
 ```javascript
 await streamHaus.syncCreatives({
-  adcp_version: '3.2-beta.0',
+  adcp_version: '3.2-beta.2',
   idempotency_key: 'acme-q2-creatives-001',
   account: { account_id: 'account_123' },
   creatives: [
@@ -255,7 +255,7 @@ a package or adjust a budget inside the accepted commercial envelope, he uses
 
 ```javascript
 const controlled = await streamHaus.controlMediaBuy({
-  adcp_version: '3.2-beta.0',
+  adcp_version: '3.2-beta.2',
   idempotency_key: 'acme-q2-control-001',
   account: { account_id: 'account_123' },
   media_buy_id: buy.media_buy_id,

--- a/docs/media-buy/product-discovery/index.mdx
+++ b/docs/media-buy/product-discovery/index.mdx
@@ -79,7 +79,7 @@ without asking the seller to author a media plan:
 
 ```javascript
 const result = await seller.listProducts({
-  adcp_version: '3.2-beta.0',
+  adcp_version: '3.2-beta.2',
   account: { account_id: 'account_123' },
   criteria: {
     offer_filters: {
@@ -114,7 +114,7 @@ structured criteria to StreamHaus while keeping strategy in prose:
 
 ```javascript
 const response = await seller.requestProposals({
-  adcp_version: '3.2-beta.0',
+  adcp_version: '3.2-beta.2',
   idempotency_key: 'acme-q2-proposals-001',
   account: { account_id: 'account_123' },
   brand: { domain: 'acme-outdoor.example' },

--- a/docs/media-buy/product-discovery/proposal-negotiation.mdx
+++ b/docs/media-buy/product-discovery/proposal-negotiation.mdx
@@ -486,7 +486,7 @@ Record the authenticated buyer, source IDs, successor IDs, idempotency fingerpri
 
 The canonical compliance scenario is `media_buy_seller/typed_proposal_negotiation`. It exercises capability gating, satisfied and unsatisfied constraints, alternatives, immutable lineage, finalize atomicity, exact replay, acceptance, amendment, cancellation, double-finalize rejection, and multi-source ordering.
 
-The deterministic training profiles expose the exact `3.2-beta.0` proposal-negotiation wire contract. The ordinary `/sales/mcp` route remains the backward-compatible ask-only seller. Use the [public test token](/docs/quickstart#setup) with `https://test-agent.adcontextprotocol.org` and one of these capability-distinct routes:
+The deterministic training profiles expose the exact `3.2-beta.2` proposal-negotiation wire contract. The ordinary `/sales/mcp` route remains the backward-compatible ask-only seller. Use the [public test token](/docs/quickstart#setup) with `https://test-agent.adcontextprotocol.org` and one of these capability-distinct routes:
 
 | Profile | Route | Deterministic behavior |
 | --- | --- | --- |
@@ -494,7 +494,7 @@ The deterministic training profiles expose the exact `3.2-beta.0` proposal-negot
 | Constrained seller | `/sales/profiles/constrained-seller/mcp` | USD floors, product conflicts, and at most two available alternatives |
 | Finalization failure | `/sales/profiles/finalization-failure/mcp` | `hold_unavailable` plus `batch_aborted` siblings with no committed successors |
 
-Pin the beta exactly on every call. A stable `3.2` selector intentionally negotiates to the seller's stable compatibility response instead of silently opting into beta behavior. The bundled `ADCPMultiAgentClient.simple()` proposal path cannot yet target a different exact beta ordinal. Until [adcp-client#2609](https://github.com/adcontextprotocol/adcp-client/issues/2609) ships, construct a lower-level client with `wireAdcpVersion: "3.2-beta.0"` or send raw calls as below.
+Pin the beta exactly on every call. A stable `3.2` selector intentionally negotiates to the seller's stable compatibility response instead of silently opting into beta behavior. The bundled `ADCPMultiAgentClient.simple()` proposal path cannot yet target a different exact beta ordinal. Until [adcp-client#2609](https://github.com/adcontextprotocol/adcp-client/issues/2609) ships, construct a lower-level client with `wireAdcpVersion: "3.2-beta.2"` or send raw calls as below.
 
 ### Run the constrained profile
 
@@ -538,14 +538,14 @@ async function callTool(id, name, args) {
 }
 
 const version = {
-  adcp_version: '3.2-beta.0',
+  adcp_version: '3.2-beta.2',
   adcp_major_version: 3,
 };
 const nonce = crypto.randomUUID();
 
 const capabilities = await callTool(1, 'get_adcp_capabilities', version);
 if (
-  capabilities.adcp_version !== '3.2-beta.0'
+  capabilities.adcp_version !== '3.2-beta.2'
   || capabilities.media_buy?.supports_proposals !== true
   || !capabilities.media_buy?.lifecycle_tools?.includes('refine_proposals')
 ) {


### PR DESCRIPTION
Refs #6557

The public router no longer supports the `3.2-beta.0` ordinal — it downshifts to 3.1, which causes the runnable constrained-seller integration example's capability assertion (`capabilities.adcp_version !== '3.2-beta.0'`) to throw. @bokelley confirmed in [this comment](https://github.com/adcontextprotocol/adcp/issues/6557#issuecomment-5347474859) that the constrained seller is healthy at `3.2-beta.2` and fully reproduces the documented three-to-two flow.

**Non-breaking justification:** docs-only change; updates example version strings and one prose reference in three MDX files — no schema, task definition, or normative language changed; existing implementations are unaffected.

**Changes:**
- `docs/media-buy/product-discovery/proposal-negotiation.mdx` — 4 changes: prose pin, `wireAdcpVersion` workaround note, `const version` object, and capability assertion check
- `docs/media-buy/index.mdx` — 6 narrative example calls (requestProposals, refineProposals ×2, acceptProposal, syncCreatives, controlMediaBuy)
- `docs/media-buy/product-discovery/index.mdx` — 2 narrative example calls (listProducts, requestProposals)

**Follow-up required after merge:** `dist/docs/3.2.0-beta.2/media-buy/` is an immutable versioned snapshot and cannot be patched in place — it still carries the stale `3.2-beta.0` pin across 8+ occurrences. A `3.2.0-beta.3` cut is needed after this lands so the version picker regenerates the snapshot from the corrected source.

**Note:** The `adcp-client#2609` workaround note (line 497 of `proposal-negotiation.mdx`) now references `3.2-beta.2`. If that issue has since shipped and `ADCPMultiAgentClient.simple()` can now target exact beta ordinals, a follow-up should remove the workaround note entirely.

**Pre-PR review:**
- docs-expert: approved — no blockers; nit on adcp-client#2609 workaround validity noted above; no changeset needed for docs-only change
- code-reviewer: approved — diff complete and correct; zero `3.2-beta.0` tokens remain in `docs/media-buy/`; retained `3.2-beta.0` references elsewhere (server types, storyboard tests, `dist/docs/3.2.0-beta.0/` snapshot) are all intentional

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or request a new first draft PR:** comment `/triage execute`
>   on the source issue only when no triage-managed PR is already
>   open. Triage does not update existing PRs.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01KreMofDsUsj2aNwK3tuH7x