### PR TITLE
fix(compliance): gate property-list storyboards

### DIFF
--- a/.changeset/gate-inventory-list-storyboards.md
+++ b/.changeset/gate-inventory-list-storyboards.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Gate property-list compliance scenarios on declared execution support and require an actionable no-inventory rejection for empty intersections.

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
@@ -105,9 +105,8 @@ phases:
         negative_path: payload_well_formed
         stateful: true
         expected: |
-          Reject with PRODUCT_UNAVAILABLE and point error.field at the property
-          list that matched no inventory. Return a well-formed AdCP error rather
-          than crashing.
+          Reject with PRODUCT_UNAVAILABLE. Return a well-formed AdCP error
+          rather than crashing.
         sample_request:
           brand:
             domain: "acmeoutdoor.example"
@@ -134,10 +133,6 @@ phases:
           - check: error_code
             value: "PRODUCT_UNAVAILABLE"
             description: "Seller reports the canonical no-inventory failure"
-          - check: field_value
-            path: "errors[0].field"
-            value: "packages[0].targeting_overlay.property_list"
-            description: "Error identifies the property list whose inventory intersection is empty"
           - check: field_present
             path: "context"
             description: "Rejected response echoes back the context object"

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
@@ -1,37 +1,39 @@
 id: media_buy_seller/inventory_list_no_match
-version: "1.0.0"
-title: "Seller handles property_list / collection_list references that match zero inventory"
+version: "1.0.1"
+title: "Seller handles a property_list reference that matches zero inventory"
 category: media_buy_seller
-summary: "Verifies a seller returns a zero-forecast product or a clear error — not a crash — when a buyer references inventory lists that resolve to nothing in the seller's catalog."
+summary: "Verifies a seller returns a clear unavailable-product error — not a crash — when a buyer references a property list that resolves to nothing in the seller's catalog."
 track: media_buy
 required_tools:
   - get_products
   - create_media_buy
 
+requires_capability:
+  path: "media_buy.execution.targeting.property_list"
+  equals: true
+
 narrative: |
   Not every buyer list matches every seller's inventory. A buyer may point at a
-  property_list of domains this seller does not carry, or a collection_list of
-  programs this seller does not syndicate. The seller must handle that gracefully:
+  property_list of domains this seller does not carry. The seller must handle
+  that gracefully:
 
-  - Return a product with a zero forecast and explain the mismatch, OR
-  - Return an informative error on create_media_buy (INSUFFICIENT_INVENTORY or
-    similar) with findings the buyer can act on.
+  - Return PRODUCT_UNAVAILABLE on create_media_buy.
+  - Identify the offending property-list field so the buyer can revise it.
 
   What the seller must NOT do: crash, return a misleading non-zero forecast, or
   silently drop the targeting and deliver against unintended inventory. Each of
   those is a real failure mode we've seen in adapter integrations.
 
   This scenario exercises the no-match path using the test kit's pre-populated
-  no_match_properties and no_match_collections lists.
+  no_match_properties list.
 
 agent:
   interaction_model: media_buy_seller
   capabilities:
     - sells_media
     - supports_property_list_targeting
-    - supports_collection_list_targeting
   examples:
-    - "Sellers that validate inventory against buyer-supplied lists"
+    - "Sellers that validate inventory against a buyer-supplied property list"
 
 caller:
   role: buyer_agent
@@ -39,8 +41,8 @@ caller:
 
 prerequisites:
   description: |
-    The seller must resolve PropertyListReference / CollectionListReference against
-    its own inventory and report a truthful outcome when nothing matches.
+    The seller must resolve PropertyListReference against its own inventory and
+    report a truthful outcome when nothing matches.
   test_kit: "test-kits/acme-outdoor.yaml"
 
 phases:
@@ -63,6 +65,8 @@ phases:
           brief: "Outdoor lifestyle programming. Q3 flight."
           filters:
             is_fixed_price: true
+          required_overlay_support:
+            property_list: true
           account:
             brand:
               domain: "acmeoutdoor.example"
@@ -83,38 +87,27 @@ phases:
             description: "The captured pricing option is fixed-price; fixed-price storyboards do not send bid_price"
 
   - id: no_match_attempt
-    title: "Create buy with lists that match no inventory"
+    title: "Reject the buy with an actionable inventory error"
     narrative: |
-      The buyer references the no-match property list and the no-match collection
-      list. Neither list resolves to anything in the seller's catalog. The seller
-      must either (a) accept the buy and surface a zero-delivery expectation, or
-      (b) reject it with an informative error. Silent success with undefined
-      delivery behaviour is not acceptable.
+      The seller rejects the empty inventory intersection. The error must use the
+      canonical unavailable-product code and identify the offending property-list
+      field so the buyer can revise the request.
 
     steps:
-      - id: create_buy_no_match
-        title: "create_media_buy against empty intersections"
+      - id: reject_buy_no_match
+        title: "Reject empty intersections with an informative error"
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/create_media_buy"
         comply_scenario: create_media_buy
+        expect_error: true
+        negative_path: payload_well_formed
         stateful: true
         expected: |
-          One of two acceptable outcomes:
-
-          1. Buy accepted with zero-forecast reporting — status may be
-             pending_creatives/pending_start/active, but the seller returns
-             packages with forecast indicating zero deliverable inventory and
-             a message explaining the list mismatch.
-
-          2. Buy rejected with an informative error — typically
-             INSUFFICIENT_INVENTORY or INVALID_TARGETING — including findings
-             that identify which list(s) matched nothing.
-
-          What is NOT acceptable: a silently-successful buy with normal forecast
-          numbers, or a crash / non-AdCP error shape.
-
+          Reject with PRODUCT_UNAVAILABLE and point error.field at the property
+          list that matched no inventory. Return a well-formed AdCP error rather
+          than crashing.
         sample_request:
           brand:
             domain: "acmeoutdoor.example"
@@ -122,7 +115,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#inventory_list_no_match_create_buy"
+          idempotency_key: "$generate:uuid_v4#inventory_list_no_match_reject_buy"
           start_time: "asap"
           end_time: "2099-09-30T23:59:59Z"
           packages:
@@ -133,17 +126,22 @@ phases:
                 property_list:
                   agent_url: "https://governance.pinnacle-agency.example"
                   list_id: "acme_outdoor_no_match_v1"
-                collection_list:
-                  agent_url: "https://governance.pinnacle-agency.example"
-                  list_id: "acme_outdoor_no_match_collections_v1"
-
           context:
-            correlation_id: "inventory_list_no_match--create_buy_no_match"
+            correlation_id: "inventory_list_no_match--reject_buy_no_match"
         validations:
+          - check: response_schema
+            description: "Rejected response matches create-media-buy-response.json"
+          - check: error_code
+            value: "PRODUCT_UNAVAILABLE"
+            description: "Seller reports the canonical no-inventory failure"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].targeting_overlay.property_list"
+            description: "Error identifies the property list whose inventory intersection is empty"
           - check: field_present
             path: "context"
-            description: "Response echoes back the context object (success or error)"
+            description: "Rejected response echoes back the context object"
           - check: field_value
             path: "context.correlation_id"
-            value: "inventory_list_no_match--create_buy_no_match"
+            value: "inventory_list_no_match--reject_buy_no_match"
             description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
@@ -1,38 +1,40 @@
 id: media_buy_seller/inventory_list_targeting
-version: "1.0.0"
-title: "Seller honors property_list and collection_list targeting on create and update"
+version: "1.0.1"
+title: "Seller honors property_list targeting on create and update"
 category: media_buy_seller
-summary: "Verifies that a seller accepts PropertyListReference and CollectionListReference in package targeting on create_media_buy AND update_media_buy, with parity between both paths."
+summary: "Verifies that a seller accepts PropertyListReference in package targeting on create_media_buy AND update_media_buy, with parity between both paths."
 track: media_buy
 required_tools:
   - get_products
   - create_media_buy
   - update_media_buy
+  - get_media_buys
+
+requires_capability:
+  path: "media_buy.execution.targeting.property_list"
+  equals: true
 
 narrative: |
   AdCP 3.0 targets inventory through agent-hosted reference lists rather than inline
   property arrays. Buyers point a package's targeting at a `PropertyListReference`
-  and/or `CollectionListReference`; the seller resolves the list against its own
-  inventory at serve time.
+  reference; the seller resolves the list against its own inventory at serve time.
 
   A common integration regression is create/update parity: a seller accepts list
   references on create_media_buy but silently drops them on update_media_buy, so a
-  buyer who edits a live buy loses their list targeting. This scenario writes both
-  list types on create, then swaps both on update, and finally reads the buy back
-  to confirm the updated references are what the seller persisted.
+  buyer who edits a live buy loses their list targeting. This scenario writes the
+  property list on create, swaps it on update, and finally reads the buy back to
+  confirm the updated reference is what the seller persisted.
 
-  The buyer references pre-populated inventory lists from the test kit — one for
-  matching properties and one for matching collections — so the seller's test
-  engine can resolve them without needing a live governance/inventory agent.
+  The buyer references a pre-populated property list from the test kit so the
+  seller's test engine can resolve it without needing a live governance agent.
 
 agent:
   interaction_model: media_buy_seller
   capabilities:
     - sells_media
     - supports_property_list_targeting
-    - supports_collection_list_targeting
   examples:
-    - "Sellers that accept PropertyListReference / CollectionListReference in package targeting"
+    - "Sellers that accept PropertyListReference in package targeting"
 
 caller:
   role: buyer_agent
@@ -40,14 +42,14 @@ caller:
 
 prerequisites:
   description: |
-    The seller must accept PropertyListReference and CollectionListReference in
-    package targeting on both create_media_buy and update_media_buy. List contents
-    come from test-kits/acme-outdoor.yaml → inventory_targets.
+    The seller must accept PropertyListReference in package targeting on both
+    create_media_buy and update_media_buy. List contents come from
+    test-kits/acme-outdoor.yaml → inventory_targets.
   test_kit: "test-kits/acme-outdoor.yaml"
 
 phases:
   - id: discover_product
-    title: "Discover a product that supports list targeting"
+    title: "Discover a product that supports property-list targeting"
     steps:
       - id: get_products_brief
         title: "Discover product"
@@ -58,8 +60,8 @@ phases:
         comply_scenario: full_sales_flow
         stateful: false
         expected: |
-          Return at least one product whose targeting supports property_list and
-          collection_list references.
+          Return at least one product whose targeting supports a property_list
+          reference.
 
         sample_request:
           idempotency_key: "$generate:uuid_v4#media_buy_seller_inventory_list_targeting_discover_product_get_products_brief"
@@ -67,6 +69,8 @@ phases:
           brief: "Outdoor lifestyle programming. Q3 flight, $30K budget."
           filters:
             is_fixed_price: true
+          required_overlay_support:
+            property_list: true
           account:
             brand:
               domain: "acmeoutdoor.example"
@@ -90,16 +94,16 @@ phases:
             path: "products[0].pricing_options[0].fixed_price"
             description: "The captured pricing option is fixed-price; fixed-price storyboards do not send bid_price"
 
-  - id: create_with_both_lists
-    title: "Create media buy with property_list AND collection_list targeting"
+  - id: create_with_property_list
+    title: "Create media buy with property_list targeting"
     narrative: |
-      The buyer references the matching-property list and the matching-collection
-      list from the test kit. The seller accepts both references, creates the buy,
-      and echoes the resolved targeting back on the package.
+      The buyer references the matching-property list from the test kit. The
+      seller accepts the reference, creates the buy, and echoes the resolved
+      targeting back on the package.
 
     steps:
       - id: create_buy_with_lists
-        title: "create_media_buy with both list references"
+        title: "create_media_buy with a property-list reference"
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
@@ -107,10 +111,9 @@ phases:
         comply_scenario: create_media_buy
         stateful: true
         expected: |
-          The seller accepts the list references without error. The response
-          includes a media_buy_id and the package retains both the property_list
-          and collection_list targeting fields so subsequent get / update calls
-          can read them back.
+          The seller accepts the list reference without error. The response
+          includes a media_buy_id and the package retains the property_list
+          targeting field so subsequent get / update calls can read it back.
 
         sample_request:
           brand:
@@ -131,9 +134,6 @@ phases:
                 property_list:
                   agent_url: "https://governance.pinnacle-agency.example"
                   list_id: "acme_outdoor_allowlist_v1"
-                collection_list:
-                  agent_url: "https://governance.pinnacle-agency.example"
-                  list_id: "acme_outdoor_collections_v1"
 
           context:
             correlation_id: "inventory_list_targeting--create_buy_with_lists"
@@ -155,9 +155,9 @@ phases:
   - id: verify_create_persisted
     title: "Verify list targeting persisted after create"
     narrative: |
-      Read the buy back to confirm the seller stored both list references — not just
-      echoed them back in the create response. This catches sellers that parse list
-      references on create but never persist them to their internal package model.
+      Read the buy back to confirm the seller stored the list reference — not just
+      echoed it back in the create response. This catches sellers that parse the
+      list reference on create but never persist it to their internal package model.
 
     steps:
       - id: get_after_create
@@ -170,7 +170,7 @@ phases:
         stateful: true
         expected: |
           Return the media buy with packages[0].targeting_overlay.property_list
-          and .collection_list populated with the list_id values sent on create.
+          populated with the list_id value sent on create.
 
         sample_request:
           account:
@@ -190,22 +190,17 @@ phases:
             path: "media_buys[0].packages[0].targeting_overlay.property_list.list_id"
             value: "acme_outdoor_allowlist_v1"
             description: "property_list.list_id persisted after create"
-          - check: field_value
-            path: "media_buys[0].packages[0].targeting_overlay.collection_list.list_id"
-            value: "acme_outdoor_collections_v1"
-            description: "collection_list.list_id persisted after create"
-
   - id: update_swap_lists
-    title: "Swap property_list and collection_list via update_media_buy"
+    title: "Swap property_list via update_media_buy"
     narrative: |
-      The buyer swaps both list references. This is the create/update parity check:
-      a seller that accepts list references on create but silently drops them on
+      The buyer swaps the list reference. This is the create/update parity check:
+      a seller that accepts the reference on create but silently drops it on
       update would fail to update the persisted targeting. We exercise update
       explicitly to catch that class of regression.
 
     steps:
       - id: update_buy_swap_lists
-        title: "update_media_buy replaces both list references"
+        title: "update_media_buy replaces the property-list reference"
         task: update_media_buy
         schema_ref: "media-buy/update-media-buy-request.json"
         response_schema_ref: "media-buy/update-media-buy-response.json"
@@ -213,8 +208,8 @@ phases:
         comply_scenario: media_buy_lifecycle
         stateful: true
         expected: |
-          The seller acknowledges the updated targeting. Both property_list and
-          collection_list are replaced (not merged) with the new list_id values.
+          The seller acknowledges the updated targeting. property_list is
+          replaced (not merged) with the new list_id value.
 
         sample_request:
           account:
@@ -228,10 +223,7 @@ phases:
               targeting_overlay:
                 property_list:
                   agent_url: "https://governance.pinnacle-agency.example"
-                  list_id: "acme_outdoor_no_match_v1"
-                collection_list:
-                  agent_url: "https://governance.pinnacle-agency.example"
-                  list_id: "acme_outdoor_no_match_collections_v1"
+                  list_id: "acme_outdoor_allowlist_v2"
 
           idempotency_key: "$generate:uuid_v4#media_buy_seller_inventory_list_targeting_update_swap_lists_update_buy_swap_lists"
           context:
@@ -251,10 +243,7 @@ phases:
               targeting_overlay:
                 property_list:
                   agent_url: "https://governance.pinnacle-agency.example"
-                  list_id: "acme_outdoor_no_match_v1"
-                collection_list:
-                  agent_url: "https://governance.pinnacle-agency.example"
-                  list_id: "acme_outdoor_no_match_collections_v1"
+                  list_id: "acme_outdoor_allowlist_v2"
             description: "Update response returns the affected package with complete post-update targeting state"
 
       - id: get_after_update
@@ -286,9 +275,5 @@ phases:
             description: "Response matches get-media-buys-response.json schema"
           - check: field_value
             path: "media_buys[0].packages[0].targeting_overlay.property_list.list_id"
-            value: "acme_outdoor_no_match_v1"
+            value: "acme_outdoor_allowlist_v2"
             description: "property_list.list_id updated after update_media_buy"
-          - check: field_value
-            path: "media_buys[0].packages[0].targeting_overlay.collection_list.list_id"
-            value: "acme_outdoor_no_match_collections_v1"
-            description: "collection_list.list_id updated after update_media_buy"

--- a/static/compliance/source/test-kits/acme-outdoor.yaml
+++ b/static/compliance/source/test-kits/acme-outdoor.yaml
@@ -205,6 +205,16 @@ inventory_targets:
       - type: domain
         value: "mountaineering.example"
 
+  alternate_matching_properties:
+    agent_url: "https://governance.pinnacle-agency.example"
+    list_id: "acme_outdoor_allowlist_v2"
+    description: "Alternate outdoor properties used to verify property-list replacement."
+    expected_identifiers:
+      - type: domain
+        value: "outdoormagazine.example"
+      - type: domain
+        value: "campinggear.example"
+
   matching_collections:
     agent_url: "https://governance.pinnacle-agency.example"
     list_id: "acme_outdoor_collections_v1"

--- a/tests/sdk-runner-capability-gates.test.cjs
+++ b/tests/sdk-runner-capability-gates.test.cjs
@@ -107,7 +107,7 @@ test('inventory-list no-match requires canonical rejection and fails accepted bu
     'inventory_list_no_match.yaml'
   );
   const source = YAML.parse(fs.readFileSync(storyboardPath, 'utf8'));
-  const keepChecks = new Set(['field_value', 'error_code']);
+  const keepChecks = new Set(['error_code']);
   const storyboard = {
     ...source,
     prerequisites: undefined,
@@ -146,7 +146,6 @@ test('inventory-list no-match requires canonical rejection and fails accepted bu
             errors: [{
               code: 'PRODUCT_UNAVAILABLE',
               message: 'The property list matches no inventory',
-              field: 'packages[0].targeting_overlay.property_list',
             }],
             context: request.context,
           },

--- a/tests/sdk-runner-capability-gates.test.cjs
+++ b/tests/sdk-runner-capability-gates.test.cjs
@@ -54,6 +54,129 @@ test('runStoryboard skips an equals-gated storyboard when the capability path is
   assert.match(result.phases[0].steps[0].error, /agent did not declare support/);
 });
 
+test('inventory-list storyboards skip sellers that declare property-list support false', async () => {
+  const scenariosPath = path.join(
+    __dirname,
+    '..',
+    'static',
+    'compliance',
+    'source',
+    'protocols',
+    'media-buy',
+    'scenarios'
+  );
+
+  for (const name of ['inventory_list_targeting', 'inventory_list_no_match']) {
+    const storyboard = YAML.parse(
+      fs.readFileSync(path.join(scenariosPath, `${name}.yaml`), 'utf8')
+    );
+    assert.deepEqual(storyboard.requires_capability, {
+      path: 'media_buy.execution.targeting.property_list',
+      equals: true,
+    });
+
+    const tools = ['get_adcp_capabilities', ...storyboard.required_tools];
+    const result = await runStoryboard('https://agent.example/mcp', storyboard, {
+      _profile: {
+        tools,
+        raw_capabilities: {
+          media_buy: { execution: { targeting: { property_list: false } } },
+        },
+      },
+      agentTools: tools,
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.phases[0].phase_id, 'capability_unsupported');
+    assert.equal(result.phases[0].steps[0].skip_reason, 'capability_unsupported');
+    assert.match(result.phases[0].steps[0].error, /execution\.targeting\.property_list/);
+  }
+});
+
+test('inventory-list no-match requires canonical rejection and fails accepted buys', async () => {
+  const storyboardPath = path.join(
+    __dirname,
+    '..',
+    'static',
+    'compliance',
+    'source',
+    'protocols',
+    'media-buy',
+    'scenarios',
+    'inventory_list_no_match.yaml'
+  );
+  const source = YAML.parse(fs.readFileSync(storyboardPath, 'utf8'));
+  const keepChecks = new Set(['field_value', 'error_code']);
+  const storyboard = {
+    ...source,
+    prerequisites: undefined,
+    phases: source.phases.slice(1).map(phase => ({
+      ...phase,
+      steps: phase.steps.map(step => ({
+        ...step,
+        validations: step.validations.filter(validation => keepChecks.has(validation.check)),
+      })),
+    })),
+  };
+  const tools = ['get_adcp_capabilities', 'create_media_buy'];
+  const baseOptions = {
+    agentTools: tools,
+    context: {
+      product_id: 'property-list-product',
+      pricing_option_id: 'fixed-price',
+    },
+    skip_controller_seeding: true,
+    _profile: {
+      tools,
+      raw_capabilities: {
+        media_buy: { execution: { targeting: { property_list: true } } },
+      },
+    },
+  };
+
+  const rejection = await runStoryboard('https://agent.example/mcp', storyboard, {
+    ...baseOptions,
+    _client: {
+      resetContext() {},
+      async createMediaBuy(request) {
+        return {
+          success: false,
+          data: {
+            errors: [{
+              code: 'PRODUCT_UNAVAILABLE',
+              message: 'The property list matches no inventory',
+              field: 'packages[0].targeting_overlay.property_list',
+            }],
+            context: request.context,
+          },
+        };
+      },
+    },
+  });
+  assert.equal(rejection.overall_passed, true);
+  assert.equal(rejection.passed_count, 1);
+
+  const accepted = await runStoryboard('https://agent.example/mcp', storyboard, {
+    ...baseOptions,
+    _client: {
+      resetContext() {},
+      async createMediaBuy(request) {
+        return {
+          success: true,
+          data: {
+            media_buy_id: 'silent-buy',
+            packages: [{ targeting_overlay: request.packages[0].targeting_overlay }],
+            context: request.context,
+          },
+        };
+      },
+    },
+  });
+  assert.equal(accepted.overall_passed, false);
+  assert.equal(accepted.failed_count, 1);
+});
+
 test('runStoryboard skips a contains-gated phase when the array omits the required value', async () => {
   const storyboard = {
     id: 'phase_contains_regression',


### PR DESCRIPTION
## Summary

- gate property-list storyboards on the authoritative 3.2 execution capability
- require product-scoped property-list support during discovery
- make zero-inventory handling deterministic with `PRODUCT_UNAVAILABLE`
- add a second matching fixture so update parity remains a positive path
- add runner regressions for clean skip, rejection pass, and accepted-response failure

## Why

Honest sellers that declare no property-list execution support were still graded on these storyboards. The existing no-match path also described outcomes the current create response cannot represent, and the positive update path used a no-match fixture.

## Scope note

These existing storyboards are now property-list-specific because property and collection lists are independently advertised capabilities and `requires_capability` supports one predicate. Independently gated collection-list siblings are follow-up work.

## Validation

- code-review expert: no remaining must-fix findings
- protocol-review expert: no remaining must-fix findings
- `npm run build:compliance`
- `npm run test:sdk-runner-capability-gates`
- storyboard lint and fixture suites
- full server unit suite: 451 files, 6,340 passed, 30 skipped
- TypeScript typecheck
- pre-push current and 3.0 compatibility storyboard matrices

Closes #6669
