### PR TITLE
fix(compliance): gate inventory-list storyboards on 3.0

### DIFF
--- a/.changeset/gate-inventory-list-storyboards-3-0.md
+++ b/.changeset/gate-inventory-list-storyboards-3-0.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Gate inventory-list compliance scenarios on the stable property-list capability and accept either documented no-match outcome.

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -148,7 +148,7 @@ To use property list filtering:
 2. Create a property list via `create_property_list` with your feature requirements
 3. Pass the resulting `property_list_id` to `get_products` to filter inventory
 
-The seller must declare `features.property_list_filtering: true` in [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities) to support this filter. See the [Property Governance overview](/docs/governance/property/index) for the full workflow.
+The seller must declare `features.property_list_filtering: true` in [`get_adcp_capabilities`](/docs/protocol/get_adcp_capabilities) to support this filter. In AdCP 3.0 this legacy flag also declares support for `targeting_overlay.property_list` on media-buy create and update requests. See the [Property Governance overview](/docs/governance/property/index) for the full workflow.
 </Note>
 
 ### Filters Object

--- a/docs/protocol/get_adcp_capabilities.mdx
+++ b/docs/protocol/get_adcp_capabilities.mdx
@@ -196,7 +196,7 @@ Optional media-buy features. **If declared true, seller MUST honor requests usin
 | Feature | Description |
 |---------|-------------|
 | `inline_creative_management` | Accepts creatives inline in `create_media_buy` requests |
-| `property_list_filtering` | Honors `property_list` parameter in `get_products` |
+| `property_list_filtering` | Legacy 3.0 property-list support flag: honors `property_list` in `get_products` and `targeting_overlay.property_list` in media-buy create/update requests |
 | `catalog_management` | Supports `sync_catalogs` for catalog feed management |
 
 #### content_standards

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
@@ -7,6 +7,7 @@ track: media_buy
 required_tools:
   - get_products
   - create_media_buy
+  - get_media_buys
 
 requires_capability:
   path: "media_buy.features.property_list_filtering"
@@ -100,11 +101,10 @@ phases:
         doc_ref: "/media-buy/task-reference/create_media_buy"
         comply_scenario: create_media_buy
         stateful: true
-        contributes: true
         expected: |
-          Accept the buy with a valid media-buy artifact that retains the
-          property-list targeting. The seller remains responsible for surfacing
-          the zero-delivery expectation through its reporting behavior.
+          Accept the buy with a valid media-buy artifact. The seller remains
+          responsible for surfacing the zero-delivery expectation through its
+          reporting behavior.
         sample_request:
           brand:
             domain: "acmeoutdoor.example"
@@ -125,16 +125,15 @@ phases:
                   list_id: "acme_outdoor_no_match_v1"
           context:
             correlation_id: "inventory_list_no_match--accept"
+        context_outputs:
+          - path: "media_buy_id"
+            key: "no_match_media_buy_id"
         validations:
           - check: response_schema
             description: "Accepted response matches create-media-buy-response.json"
           - check: field_present
             path: "media_buy_id"
             description: "Accepted response returns a media_buy_id"
-          - check: field_value
-            path: "packages[0].targeting_overlay.property_list.list_id"
-            value: "acme_outdoor_no_match_v1"
-            description: "Accepted response preserves the no-match property-list targeting"
           - check: field_present
             path: "context"
             description: "Accepted response echoes back the context object"
@@ -142,6 +141,35 @@ phases:
             path: "context.correlation_id"
             value: "inventory_list_no_match--accept"
             description: "Context correlation_id returned unchanged"
+
+      - id: get_buy_no_match_accept
+        title: "Confirm the accepted no-match targeting persisted"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        comply_scenario: media_buy_lifecycle
+        stateful: true
+        contributes: true
+        expected: |
+          Return the accepted buy with its no-match property-list reference
+          persisted on the package.
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          media_buy_ids:
+            - "$context.no_match_media_buy_id"
+          context:
+            correlation_id: "inventory_list_no_match--get_accept"
+        validations:
+          - check: response_schema
+            description: "Readback matches get-media-buys-response.json"
+          - check: field_value
+            path: "media_buys[0].packages[0].targeting_overlay.property_list.list_id"
+            value: "acme_outdoor_no_match_v1"
+            description: "Readback preserves the accepted no-match property-list targeting"
 
   - id: no_match_reject_path
     title: "Reject the no-match buy with a structured error"

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_no_match.yaml
@@ -1,35 +1,38 @@
 id: media_buy_seller/inventory_list_no_match
-version: "1.0.0"
-title: "Seller handles property_list / collection_list references that match zero inventory"
+version: "1.0.1"
+title: "Seller handles a property_list reference that matches zero inventory"
 category: media_buy_seller
-summary: "Verifies a seller returns a zero-forecast product or a clear error — not a crash — when a buyer references inventory lists that resolve to nothing in the seller's catalog."
+summary: "Verifies a seller preserves a no-match property list on an accepted buy or returns a structured error."
 track: media_buy
 required_tools:
   - get_products
   - create_media_buy
 
+requires_capability:
+  path: "media_buy.features.property_list_filtering"
+  equals: true
+
 narrative: |
   Not every buyer list matches every seller's inventory. A buyer may point at a
-  property_list of domains this seller does not carry, or a collection_list of
-  programs this seller does not syndicate. The seller must handle that gracefully:
+  property_list of domains this seller does not carry. The seller must handle
+  that gracefully:
 
-  - Return a product with a zero forecast and explain the mismatch, OR
-  - Return an informative error on create_media_buy (INSUFFICIENT_INVENTORY or
-    similar) with findings the buyer can act on.
+  - Accept the buy and surface a zero-delivery expectation through reporting, OR
+  - Return an informative typed AdCP error on create_media_buy with findings the
+    buyer can act on.
 
   What the seller must NOT do: crash, return a misleading non-zero forecast, or
   silently drop the targeting and deliver against unintended inventory. Each of
   those is a real failure mode we've seen in adapter integrations.
 
   This scenario exercises the no-match path using the test kit's pre-populated
-  no_match_properties and no_match_collections lists.
+  no_match_properties list.
 
 agent:
   interaction_model: media_buy_seller
   capabilities:
     - sells_media
     - supports_property_list_targeting
-    - supports_collection_list_targeting
   examples:
     - "Sellers that validate inventory against buyer-supplied lists"
 
@@ -39,8 +42,8 @@ caller:
 
 prerequisites:
   description: |
-    The seller must resolve PropertyListReference / CollectionListReference against
-    its own inventory and report a truthful outcome when nothing matches.
+    The seller must resolve PropertyListReference against its own inventory and
+    report a truthful outcome when nothing matches.
   test_kit: "test-kits/acme-outdoor.yaml"
 
 phases:
@@ -76,39 +79,32 @@ phases:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
 
-  - id: no_match_attempt
-    title: "Create buy with lists that match no inventory"
+  - id: no_match_accept_path
+    title: "Accept and preserve the no-match property list"
+    optional: true
+    branch_set:
+      id: property_list_no_match_handled
+      semantics: any_of
     narrative: |
-      The buyer references the no-match property list and the no-match collection
-      list. Neither list resolves to anything in the seller's catalog. The seller
-      must either (a) accept the buy and surface a zero-delivery expectation, or
-      (b) reject it with an informative error. Silent success with undefined
-      delivery behaviour is not acceptable.
+      A seller may accept the buy when it preserves the property-list targeting
+      and its downstream reporting makes the zero-delivery expectation clear.
+      This is one of the two conformant outcomes in the 3.0 contract; the peer
+      branch covers structured rejection.
 
     steps:
-      - id: create_buy_no_match
-        title: "create_media_buy against empty intersections"
+      - id: create_buy_no_match_accept
+        title: "Accept create_media_buy against an empty intersection"
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/create_media_buy"
         comply_scenario: create_media_buy
         stateful: true
+        contributes: true
         expected: |
-          One of two acceptable outcomes:
-
-          1. Buy accepted with zero-forecast reporting — status may be
-             pending_creatives/pending_start/active, but the seller returns
-             packages with forecast indicating zero deliverable inventory and
-             a message explaining the list mismatch.
-
-          2. Buy rejected with an informative error — typically
-             INSUFFICIENT_INVENTORY or INVALID_TARGETING — including findings
-             that identify which list(s) matched nothing.
-
-          What is NOT acceptable: a silently-successful buy with normal forecast
-          numbers, or a crash / non-AdCP error shape.
-
+          Accept the buy with a valid media-buy artifact that retains the
+          property-list targeting. The seller remains responsible for surfacing
+          the zero-delivery expectation through its reporting behavior.
         sample_request:
           brand:
             domain: "acmeoutdoor.example"
@@ -116,7 +112,7 @@ phases:
             brand:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#inventory_list_no_match_create_buy"
+          idempotency_key: "$generate:uuid_v4#inventory_list_no_match_accept"
           start_time: "2099-07-01T00:00:00Z"
           end_time: "2099-09-30T23:59:59Z"
           packages:
@@ -127,17 +123,102 @@ phases:
                 property_list:
                   agent_url: "https://governance.pinnacle-agency.example"
                   list_id: "acme_outdoor_no_match_v1"
-                collection_list:
-                  agent_url: "https://governance.pinnacle-agency.example"
-                  list_id: "acme_outdoor_no_match_collections_v1"
-
           context:
-            correlation_id: "inventory_list_no_match--create_buy_no_match"
+            correlation_id: "inventory_list_no_match--accept"
         validations:
+          - check: response_schema
+            description: "Accepted response matches create-media-buy-response.json"
+          - check: field_present
+            path: "media_buy_id"
+            description: "Accepted response returns a media_buy_id"
+          - check: field_value
+            path: "packages[0].targeting_overlay.property_list.list_id"
+            value: "acme_outdoor_no_match_v1"
+            description: "Accepted response preserves the no-match property-list targeting"
           - check: field_present
             path: "context"
-            description: "Response echoes back the context object (success or error)"
+            description: "Accepted response echoes back the context object"
           - check: field_value
             path: "context.correlation_id"
-            value: "inventory_list_no_match--create_buy_no_match"
+            value: "inventory_list_no_match--accept"
             description: "Context correlation_id returned unchanged"
+
+  - id: no_match_reject_path
+    title: "Reject the no-match buy with a structured error"
+    optional: true
+    branch_set:
+      id: property_list_no_match_handled
+      semantics: any_of
+    narrative: |
+      A seller may instead reject the same well-formed request. This branch makes
+      that documented 3.0 outcome reachable by marking the error as expected and
+      requiring a typed AdCP error response with preserved correlation context.
+
+    steps:
+      - id: create_buy_no_match_reject
+        title: "Reject create_media_buy against an empty intersection"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: true
+        contributes: true
+        expected: |
+          Reject with a well-formed AdCP error explaining that the property list
+          matches no available inventory. The 3.0 contract does not mandate one
+          specific error code for this condition.
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          idempotency_key: "$generate:uuid_v4#inventory_list_no_match_reject"
+          start_time: "2099-07-01T00:00:00Z"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.product_id"
+              budget: 10000
+              pricing_option_id: "$context.pricing_option_id"
+              targeting_overlay:
+                property_list:
+                  agent_url: "https://governance.pinnacle-agency.example"
+                  list_id: "acme_outdoor_no_match_v1"
+          context:
+            correlation_id: "inventory_list_no_match--reject"
+        validations:
+          - check: response_schema
+            description: "Rejected response matches create-media-buy-response.json"
+          - check: error_code
+            description: "Rejected response carries a typed AdCP error code"
+          - check: field_present
+            path: "context"
+            description: "Rejected response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "inventory_list_no_match--reject"
+            description: "Context correlation_id returned unchanged"
+
+  - id: no_match_outcome_assertion
+    title: "Require one documented no-match outcome"
+    narrative: |
+      Synthetic assertion over the accept and reject branches. Either a valid
+      zero-delivery acceptance path or a structured rejection satisfies the 3.0
+      no-match contract.
+    steps:
+      - id: assert_property_list_no_match_handled
+        title: "Require handling from either branch"
+        task: assert_contribution
+        comply_scenario: create_media_buy
+        stateful: false
+        expected: |
+          At least one no-match outcome contributed
+          property_list_no_match_handled.
+        validations:
+          - check: any_of
+            allowed_values: ["property_list_no_match_handled"]
+            description: "Seller must either accept while preserving the targeting or return a structured rejection."

--- a/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/inventory_list_targeting.yaml
@@ -1,38 +1,40 @@
 id: media_buy_seller/inventory_list_targeting
-version: "1.0.0"
-title: "Seller honors property_list and collection_list targeting on create and update"
+version: "1.0.1"
+title: "Seller honors property_list targeting on create and update"
 category: media_buy_seller
-summary: "Verifies that a seller accepts PropertyListReference and CollectionListReference in package targeting on create_media_buy AND update_media_buy, with parity between both paths."
+summary: "Verifies that a seller accepts PropertyListReference in package targeting on create_media_buy AND update_media_buy, with parity between both paths."
 track: media_buy
 required_tools:
   - get_products
   - create_media_buy
   - update_media_buy
+  - get_media_buys
+
+requires_capability:
+  path: "media_buy.features.property_list_filtering"
+  equals: true
 
 narrative: |
   AdCP 3.0 targets inventory through agent-hosted reference lists rather than inline
-  property arrays. Buyers point a package's targeting at a `PropertyListReference`
-  and/or `CollectionListReference`; the seller resolves the list against its own
-  inventory at serve time.
+  property arrays. Buyers point a package's targeting at a `PropertyListReference`;
+  the seller resolves the list against its own inventory at serve time.
 
   A common integration regression is create/update parity: a seller accepts list
   references on create_media_buy but silently drops them on update_media_buy, so a
-  buyer who edits a live buy loses their list targeting. This scenario writes both
-  list types on create, then swaps both on update, and finally reads the buy back
-  to confirm the updated references are what the seller persisted.
+  buyer who edits a live buy loses their list targeting. This scenario writes the
+  property list on create, swaps it on update, and finally reads the buy back to
+  confirm the updated reference is what the seller persisted.
 
-  The buyer references pre-populated inventory lists from the test kit — one for
-  matching properties and one for matching collections — so the seller's test
-  engine can resolve them without needing a live governance/inventory agent.
+  The buyer references a pre-populated property list from the test kit so the
+  seller's test engine can resolve it without needing a live governance agent.
 
 agent:
   interaction_model: media_buy_seller
   capabilities:
     - sells_media
     - supports_property_list_targeting
-    - supports_collection_list_targeting
   examples:
-    - "Sellers that accept PropertyListReference / CollectionListReference in package targeting"
+    - "Sellers that accept PropertyListReference in package targeting"
 
 caller:
   role: buyer_agent
@@ -40,14 +42,14 @@ caller:
 
 prerequisites:
   description: |
-    The seller must accept PropertyListReference and CollectionListReference in
-    package targeting on both create_media_buy and update_media_buy. List contents
-    come from test-kits/acme-outdoor.yaml → inventory_targets.
+    The seller must accept PropertyListReference in package targeting on both
+    create_media_buy and update_media_buy. List contents come from
+    test-kits/acme-outdoor.yaml → inventory_targets.
   test_kit: "test-kits/acme-outdoor.yaml"
 
 phases:
   - id: discover_product
-    title: "Discover a product that supports list targeting"
+    title: "Discover a product that supports property-list targeting"
     steps:
       - id: get_products_brief
         title: "Discover product"
@@ -58,8 +60,8 @@ phases:
         comply_scenario: full_sales_flow
         stateful: false
         expected: |
-          Return at least one product whose targeting supports property_list and
-          collection_list references.
+          Return at least one product whose targeting supports a property_list
+          reference.
 
         sample_request:
           buying_mode: "brief"
@@ -84,16 +86,16 @@ phases:
             path: "products[0].product_id"
             description: "Product has a product_id"
 
-  - id: create_with_both_lists
-    title: "Create media buy with property_list AND collection_list targeting"
+  - id: create_with_property_list
+    title: "Create media buy with property_list targeting"
     narrative: |
-      The buyer references the matching-property list and the matching-collection
-      list from the test kit. The seller accepts both references, creates the buy,
-      and echoes the resolved targeting back on the package.
+      The buyer references the matching-property list from the test kit. The
+      seller accepts the reference, creates the buy, and echoes the resolved
+      targeting back on the package.
 
     steps:
       - id: create_buy_with_lists
-        title: "create_media_buy with both list references"
+        title: "create_media_buy with a property-list reference"
         task: create_media_buy
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
@@ -101,10 +103,9 @@ phases:
         comply_scenario: create_media_buy
         stateful: true
         expected: |
-          The seller accepts the list references without error. The response
-          includes a media_buy_id and the package retains both the property_list
-          and collection_list targeting fields so subsequent get / update calls
-          can read them back.
+          The seller accepts the list reference without error. The response
+          includes a media_buy_id and the package retains the property_list
+          targeting field so subsequent get / update calls can read it back.
 
         sample_request:
           brand:
@@ -125,10 +126,6 @@ phases:
                 property_list:
                   agent_url: "https://governance.pinnacle-agency.example"
                   list_id: "acme_outdoor_allowlist_v1"
-                collection_list:
-                  agent_url: "https://governance.pinnacle-agency.example"
-                  list_id: "acme_outdoor_collections_v1"
-
           context:
             correlation_id: "inventory_list_targeting--create_buy_with_lists"
         context_outputs:
@@ -149,9 +146,9 @@ phases:
   - id: verify_create_persisted
     title: "Verify list targeting persisted after create"
     narrative: |
-      Read the buy back to confirm the seller stored both list references — not just
-      echoed them back in the create response. This catches sellers that parse list
-      references on create but never persist them to their internal package model.
+      Read the buy back to confirm the seller stored the list reference — not just
+      echoed it back in the create response. This catches sellers that parse the
+      list reference on create but never persist it to their internal package model.
 
     steps:
       - id: get_after_create
@@ -164,7 +161,7 @@ phases:
         stateful: true
         expected: |
           Return the media buy with packages[0].targeting_overlay.property_list
-          and .collection_list populated with the list_id values sent on create.
+          populated with the list_id value sent on create.
 
         sample_request:
           account:
@@ -184,22 +181,18 @@ phases:
             path: "media_buys[0].packages[0].targeting_overlay.property_list.list_id"
             value: "acme_outdoor_allowlist_v1"
             description: "property_list.list_id persisted after create"
-          - check: field_value
-            path: "media_buys[0].packages[0].targeting_overlay.collection_list.list_id"
-            value: "acme_outdoor_collections_v1"
-            description: "collection_list.list_id persisted after create"
 
   - id: update_swap_lists
-    title: "Swap property_list and collection_list via update_media_buy"
+    title: "Swap property_list via update_media_buy"
     narrative: |
-      The buyer swaps both list references. This is the create/update parity check:
-      a seller that accepts list references on create but silently drops them on
+      The buyer swaps the list reference. This is the create/update parity check:
+      a seller that accepts the reference on create but silently drops it on
       update would fail to update the persisted targeting. We exercise update
       explicitly to catch that class of regression.
 
     steps:
       - id: update_buy_swap_lists
-        title: "update_media_buy replaces both list references"
+        title: "update_media_buy replaces the property-list reference"
         task: update_media_buy
         schema_ref: "media-buy/update-media-buy-request.json"
         response_schema_ref: "media-buy/update-media-buy-response.json"
@@ -207,8 +200,8 @@ phases:
         comply_scenario: media_buy_lifecycle
         stateful: true
         expected: |
-          The seller acknowledges the updated targeting. Both property_list and
-          collection_list are replaced (not merged) with the new list_id values.
+          The seller acknowledges the updated targeting. property_list is
+          replaced (not merged) with the new list_id value.
 
         sample_request:
           account:
@@ -222,10 +215,7 @@ phases:
               targeting_overlay:
                 property_list:
                   agent_url: "https://governance.pinnacle-agency.example"
-                  list_id: "acme_outdoor_no_match_v1"
-                collection_list:
-                  agent_url: "https://governance.pinnacle-agency.example"
-                  list_id: "acme_outdoor_no_match_collections_v1"
+                  list_id: "acme_outdoor_allowlist_v2"
 
           idempotency_key: "$generate:uuid_v4#media_buy_seller_inventory_list_targeting_update_swap_lists_update_buy_swap_lists"
           context:
@@ -263,9 +253,5 @@ phases:
             description: "Response matches get-media-buys-response.json schema"
           - check: field_value
             path: "media_buys[0].packages[0].targeting_overlay.property_list.list_id"
-            value: "acme_outdoor_no_match_v1"
+            value: "acme_outdoor_allowlist_v2"
             description: "property_list.list_id updated after update_media_buy"
-          - check: field_value
-            path: "media_buys[0].packages[0].targeting_overlay.collection_list.list_id"
-            value: "acme_outdoor_no_match_collections_v1"
-            description: "collection_list.list_id updated after update_media_buy"

--- a/static/compliance/source/test-kits/acme-outdoor.yaml
+++ b/static/compliance/source/test-kits/acme-outdoor.yaml
@@ -164,6 +164,16 @@ inventory_targets:
       - type: domain
         value: "mountaineering.example"
 
+  alternate_matching_properties:
+    agent_url: "https://governance.pinnacle-agency.example"
+    list_id: "acme_outdoor_allowlist_v2"
+    description: "Alternate outdoor properties used to verify property-list replacement."
+    expected_identifiers:
+      - type: domain
+        value: "outdoormagazine.example"
+      - type: domain
+        value: "campinggear.example"
+
   matching_collections:
     agent_url: "https://governance.pinnacle-agency.example"
     list_id: "acme_outdoor_collections_v1"

--- a/static/schemas/source/core/media-buy-features.json
+++ b/static/schemas/source/core/media-buy-features.json
@@ -11,7 +11,7 @@
     },
     "property_list_filtering": {
       "type": "boolean",
-      "description": "Honors property_list parameter in get_products to filter results to buyer-approved properties"
+      "description": "Honors property_list references in get_products filtering and in targeting_overlay on create_media_buy and update_media_buy"
     },
     "catalog_management": {
       "type": "boolean",

--- a/tests/lint-storyboard-sample-request-schema.test.cjs
+++ b/tests/lint-storyboard-sample-request-schema.test.cjs
@@ -120,6 +120,22 @@ test('inventory-list no-match preserves both stable-line outcomes', () => {
     outcomePhases.map((phase) => phase.steps[0].expect_error === true),
     [false, true],
   );
+
+  const acceptPhase = outcomePhases[0];
+  assert.deepEqual(
+    acceptPhase.steps.map((step) => step.task),
+    ['create_media_buy', 'get_media_buys'],
+  );
+  assert.equal(acceptPhase.steps[0].contributes, undefined);
+  assert.equal(acceptPhase.steps[1].contributes, true);
+  assert.ok(
+    acceptPhase.steps[1].validations.some(
+      (validation) =>
+        validation.check === 'field_value' &&
+        validation.path ===
+          'media_buys[0].packages[0].targeting_overlay.property_list.list_id',
+    ),
+  );
 });
 
 test('fingerprintError produces stable output for common error shapes', () => {

--- a/tests/lint-storyboard-sample-request-schema.test.cjs
+++ b/tests/lint-storyboard-sample-request-schema.test.cjs
@@ -86,6 +86,42 @@ test('proposal finalize gates absent and false supports_proposals separately', (
   }
 });
 
+test('inventory-list storyboards use the stable property-list gate', () => {
+  const scenariosPath = path.join(
+    STORYBOARD_DIR,
+    'protocols/media-buy/scenarios',
+  );
+
+  for (const name of ['inventory_list_targeting', 'inventory_list_no_match']) {
+    const storyboard = YAML.parse(
+      fs.readFileSync(path.join(scenariosPath, `${name}.yaml`), 'utf8'),
+    );
+    assert.deepEqual(storyboard.requires_capability, {
+      path: 'media_buy.features.property_list_filtering',
+      equals: true,
+    });
+  }
+});
+
+test('inventory-list no-match preserves both stable-line outcomes', () => {
+  const file = path.join(
+    STORYBOARD_DIR,
+    'protocols/media-buy/scenarios/inventory_list_no_match.yaml',
+  );
+  const storyboard = YAML.parse(fs.readFileSync(file, 'utf8'));
+  const outcomePhases = storyboard.phases.filter(
+    (phase) => phase.branch_set?.id === 'property_list_no_match_handled',
+  );
+
+  assert.equal(outcomePhases.length, 2);
+  assert.ok(outcomePhases.every((phase) => phase.optional === true));
+  assert.ok(outcomePhases.every((phase) => phase.branch_set.semantics === 'any_of'));
+  assert.deepEqual(
+    outcomePhases.map((phase) => phase.steps[0].expect_error === true),
+    [false, true],
+  );
+});
+
 test('fingerprintError produces stable output for common error shapes', () => {
   assert.equal(
     fingerprintError({ keyword: 'required', path: '/', params: { missingProperty: 'caller' } }),


### PR DESCRIPTION
Backport of #6691 for the 3.0 release line; addresses #6669 on this release line.

## Summary

- gate both inventory-list storyboards on the stable `media_buy.features.property_list_filtering` capability
- keep stable no-match behavior interoperable by accepting either a successful preserved overlay or a well-formed rejection
- add a second matching property list, clarify the legacy capability in schema/docs, and add regression coverage
- keep collection-list and 3.2-specific error semantics out of the stable line

## Validation

- `npm run build:schemas`
- `npm run build:compliance`
- `npm run test:error-codes`
- storyboard branch-set, contradiction, sample-request, and response-schema tests
- repository pre-commit and pre-push gates

Does not modify immutable release artifacts; ships in the next 3.0 patch.