### PR TITLE
fix: Gate creative fate storyboard on library support

### DIFF
--- a/.changeset/gate-creative-library-storyboard.md
+++ b/.changeset/gate-creative-library-storyboard.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Gate the `creative_fate_after_cancellation` compliance storyboard on sellers advertising `creative.has_creative_library: true`. Sellers without declared creative-library support now exclude this scenario from runnable coverage, which can correct compliance badge and completeness-score denominators.

--- a/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
@@ -1,9 +1,14 @@
 id: media_buy_seller/creative_fate_after_cancellation
-version: "1.0.0"
+version: "1.0.1"
 title: "Creative lifecycle is decoupled from media buy lifecycle"
 category: media_buy_seller
 summary: "Validates that canceling a media buy releases package-creative assignments but leaves the underlying creatives in the library with their review state intact, and that buyers can reuse released creatives on a new buy."
 track: media_buy
+
+requires_capability:
+  path: creative.has_creative_library
+  equals: true
+
 required_tools:
   - get_products
   - create_media_buy

--- a/tests/sdk-runner-capability-gates.test.cjs
+++ b/tests/sdk-runner-capability-gates.test.cjs
@@ -94,6 +94,69 @@ test('inventory-list storyboards skip sellers that declare property-list support
   }
 });
 
+test('creative fate storyboard requires advertised creative library support', async () => {
+  const storyboardPath = path.join(
+    __dirname,
+    '..',
+    'static',
+    'compliance',
+    'source',
+    'protocols',
+    'media-buy',
+    'scenarios',
+    'creative_fate_after_cancellation.yaml'
+  );
+  const storyboard = YAML.parse(fs.readFileSync(storyboardPath, 'utf8'));
+  const tools = ['get_adcp_capabilities', ...storyboard.required_tools];
+
+  assert.deepEqual(storyboard.requires_capability, {
+    path: 'creative.has_creative_library',
+    equals: true,
+  });
+
+  const unsupportedProfiles = [
+    {
+      rawCapabilities: { creative: { has_creative_library: false } },
+      errorPattern: /creative\.has_creative_library/,
+    },
+    {
+      rawCapabilities: {},
+      errorPattern: /agent did not declare support/,
+    },
+  ];
+
+  for (const { rawCapabilities, errorPattern } of unsupportedProfiles) {
+    const result = await runStoryboard('https://agent.example/mcp', storyboard, {
+      _profile: { tools, raw_capabilities: rawCapabilities },
+      agentTools: tools,
+    });
+
+    assert.equal(result.overall_passed, true);
+    assert.equal(result.failed_count, 0);
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.phases.length, 1);
+    assert.equal(result.phases[0].phase_id, 'capability_unsupported');
+    assert.equal(result.phases[0].steps[0].skip_reason, 'capability_unsupported');
+    assert.match(result.phases[0].steps[0].error, errorPattern);
+  }
+
+  const supported = await runStoryboard(
+    'https://agent.example/mcp',
+    { ...storyboard, prerequisites: undefined, phases: [] },
+    {
+      _profile: {
+        tools,
+        raw_capabilities: { creative: { has_creative_library: true } },
+      },
+      agentTools: tools,
+    }
+  );
+
+  assert.equal(supported.overall_passed, true);
+  assert.equal(supported.phases[0].phase_id, 'no_phases');
+  assert.equal(supported.phases[0].steps[0].skip_reason, 'no_phases');
+});
+
 test('inventory-list no-match requires canonical rejection and fails accepted buys', async () => {
   const storyboardPath = path.join(
     __dirname,


### PR DESCRIPTION
## Summary

Add the existing `requires_capability` predicate for `creative.has_creative_library == true` at storyboard level in `creative_fate_after_cancellation.yaml`, and increment the storyboard's patch version because its applicability contract changes. Extend the existing SDK-backed capability-gate regression suite to load the real storyboard and prove that an explicit false declaration skips the whole storyboard even when all required tools are auto-registered, while a true declaration passes the gate; strip executable phases only for the affirmative check so the test exercises selection without network calls. Add a descriptive protocol patch changeset explaining that library-less sellers now exclude this storyboard from runnable coverage and therefore may see corrected badge/completeness denominators.

## Validation

- With `creative.has_creative_library: false` and every storyboard tool present in `agentTools`, running the real storyboard returns one whole-storyboard `capability_unsupported`/`not_applicable` skip, performs no scenario steps, and records no failure.
- With `creative.has_creative_library: true`, the same storyboard satisfies the gate; a non-executable copy with prerequisites and phases removed reaches the normal `no_phases` result instead of capability rejection.
- With the capability path absent, the storyboard remains not applicable rather than inferring support from `sync_creatives` or `list_creatives` tool registration.
- The compliance source build/check accepts the gated storyboard and the changeset communicates the expected runnable-scenario and badge/completeness-score shift without modifying a released semver artifact.

## Why

`media_buy_seller/creative_fate_after_cancellation` calls `sync_creatives` and `list_creatives` but has no storyboard-level applicability gate, so a seller explicitly declaring `creative.has_creative_library: false` can be selected and then fail outside its advertised scope. The repository contract says an unsatisfied storyboard-level `requires_capability` gate must produce a clean `not_applicable` result before tool and phase execution. This plan covers the independently mergeable patch for that storyboard only; it does not introduce the compound gate needed by the other three scenarios or rewrite immutable 3.0/3.1 release artifacts.

Closes #6701
