### PR TITLE
feat(media-buy): disclose package targeting cardinality

### DIFF
--- a/.changeset/disclose-package-targeting-cardinality.md
+++ b/.changeset/disclose-package-targeting-cardinality.md
@@ -1,0 +1,6 @@
+---
+"adcontextprotocol": minor
+---
+
+Allow products to disclose per-package cardinality limits for country
+inclusion, country exclusion, and proximity targeting.

--- a/docs/media-buy/advanced-topics/targeting.mdx
+++ b/docs/media-buy/advanced-topics/targeting.mdx
@@ -744,6 +744,28 @@ Geographic targeting supports both inclusion (restrict to) and exclusion (exclud
 - **Examples**: `["RU", "CN"]`
 - **Use cases**: Regulatory compliance, sanctions
 
+Country inclusion and exclusion support are declared independently on each
+Product. A buyer uses `required_overlay_support.geo_countries: true` or
+`required_overlay_support.geo_countries_exclude: true` to require future
+package-level selection. The matching Product can return either legacy `true`
+or structured support such as
+`{ "max_values_per_package": 1 }`. The structured form supports
+protocol-valid country codes but caps how many values may appear in that field
+on one package; it is not a country allowlist and does not guarantee inventory
+for every country.
+
+Numeric seller limits do not participate in requirement matching. A seller
+MUST reject a create or update that exceeds the disclosed limit with
+`UNSUPPORTED_FEATURE`, identify the overflowing targeting field, and leave
+existing state unchanged. Legacy `true` remains valid and declares positive
+support without a protocol-level cardinality cap.
+
+Numeric limits are ignored only when matching future-support requirements.
+Concrete targeting is still bound by them: every returned Product's accepted
+effective targeting MUST satisfy its disclosed maximum. A seller MUST exclude
+an over-limit candidate unless it returns a distinct configured Product with a
+disclosed, compliant targeting modification.
+
 ### geo_regions
 - **Description**: Restrict delivery to canonical ISO 3166-2 subdivisions, including states, provinces, regions, departments, and overseas subdivisions
 - **Format**: ISO 3166-2 subdivision codes
@@ -1132,7 +1154,7 @@ For travel time entries, the platform resolves the isochrone to a geographic bou
 
 For campaigns targeting 10+ locations, consider using `store_catchments` with a location catalog instead, which supports ongoing management and per-location reporting. `geo_proximity` does not have an exclusion variant — this is by design, as excluding "everyone near a point" is rarely a meaningful targeting constraint.
 
-Sellers SHOULD enforce minimum area thresholds consistent with their privacy policies and applicable regulations. The seller must declare `geo_proximity` support in `get_adcp_capabilities`, specifying which methods (`radius`, `travel_time`, `geometry`) and transport modes are supported.
+Sellers SHOULD enforce minimum area thresholds consistent with their privacy policies and applicable regulations. The seller must declare `geo_proximity` support in `get_adcp_capabilities`, specifying which methods (`radius`, `travel_time`, `geometry`) and transport modes are supported. Product `overlay_support.geo_proximity` is the binding package-level contract and may also include `max_values_per_package`. Buyers request the needed methods and transport modes in `required_overlay_support.geo_proximity`; the response-only numeric limit does not participate in matching. Because multiple proximity entries use OR, a create or update with more entries than the disclosed limit MUST be rejected with `UNSUPPORTED_FEATURE` before any mutation is applied.
 
 Validated examples:
 

--- a/docs/media-buy/task-reference/get_products.mdx
+++ b/docs/media-buy/task-reference/get_products.mdx
@@ -260,6 +260,22 @@ place-type and catalog-version arrays must be subsets of the corresponding
 product support arrays. Unrequested object fields and numeric seller limits do
 not participate. Missing or unknown requirements do not match.
 
+For country inclusion, country exclusion, and proximity targeting, Product
+support may disclose `max_values_per_package`. Country support uses either
+legacy `true` or `{ "max_values_per_package": N }`; proximity support places
+the limit alongside its supported methods and transport modes. The numeric
+limit never belongs in `required_overlay_support`. It applies independently to
+one targeting field on one package and is not a value allowlist,
+media-buy-wide constraint, or inventory promise. A create or update that
+exceeds the limit fails atomically with [`UNSUPPORTED_FEATURE`](/docs/building/verification/compliance-catalog#error-code-unsupported-feature) and identifies
+the overflowing targeting field.
+
+Although numeric limits do not participate in requirement matching, every
+returned Product's accepted effective targeting must satisfy the limits it
+discloses. A candidate whose concrete `targeting_overlay` exceeds a maximum is
+excluded unless the seller returns a distinct configured Product with a
+disclosed, compliant targeting modification.
+
 Support guarantees the ability to select a value subject to disclosed limits;
 it does not guarantee inventory or forecast every possible value. Forecasts
 returned when only future support was requested describe the product's

--- a/docs/reference/migration/targeting-aware-discovery.mdx
+++ b/docs/reference/migration/targeting-aware-discovery.mdx
@@ -113,6 +113,43 @@ value-specific forecast for every later selection. Rediscover with concrete
 floors remain binding for supported selections; price guidance remains
 non-binding.
 
+Products can disclose per-package cardinality without changing the requirement
+shape. For example, a buyer can require future country and radius selection:
+
+```json
+{
+  "required_overlay_support": {
+    "geo_countries": true,
+    "geo_proximity": { "radius": true }
+  }
+}
+```
+
+A matching Product can respond with constrained support:
+
+```json
+{
+  "overlay_support": {
+    "geo_countries": { "max_values_per_package": 1 },
+    "geo_proximity": {
+      "radius": true,
+      "max_values_per_package": 5
+    }
+  }
+}
+```
+
+These limits apply to each package field independently. They are not buyer
+requirements, value allowlists, inventory guarantees, or cross-package
+constraints. Sellers reject an over-limit create or update atomically with
+`UNSUPPORTED_FEATURE`. Legacy support `true` remains valid.
+
+Numeric limits are ignored for future-support matching, not for concrete
+targeting acceptance. A returned Product's accepted effective targeting must
+already satisfy every maximum it discloses. Sellers exclude an over-limit
+candidate unless they return a distinct configured Product with a disclosed,
+compliant targeting modification.
+
 ISO subdivision support follows the same split but can be country/value aware:
 
 ```json

--- a/docs/reference/whats-new-in-3-2.mdx
+++ b/docs/reference/whats-new-in-3-2.mdx
@@ -57,7 +57,9 @@ match the request.
 
 The 3.2 surface includes portable demographics, country-aware subdivisions,
 named places, browser families, property exclusions, audience evidence, and
-exact package readback. See [Targeting-aware product discovery](/docs/reference/migration/targeting-aware-discovery).
+exact package readback. Products can also disclose per-package cardinality for
+country inclusion, country exclusion, and proximity targeting before a buyer
+creates or updates a package. See [Targeting-aware product discovery](/docs/reference/migration/targeting-aware-discovery).
 
 ### Commercial terms and controls are explicit
 

--- a/specs/targeting-aware-product-discovery.md
+++ b/specs/targeting-aware-product-discovery.md
@@ -398,6 +398,39 @@ limits such as `max_values_per_package` and `max_packages` are
 seller-response disclosures only. They do not appear in the buyer requirement
 or participate in matching.
 
+Country inclusion, country exclusion, and proximity support can disclose a
+package-local cardinality limit. Country support is either `true` or an object
+containing `max_values_per_package`. The object does not enumerate or restrict
+individual ISO 3166-1 alpha-2 values. Proximity support can add the same limit
+alongside its supported methods and transport modes. For example:
+
+```json
+{
+  "overlay_support": {
+    "geo_countries": { "max_values_per_package": 1 },
+    "geo_countries_exclude": { "max_values_per_package": 1 },
+    "geo_proximity": {
+      "radius": true,
+      "max_values_per_package": 5
+    }
+  }
+}
+```
+
+Each limit applies independently to that targeting field on one package. It is
+not a value allowlist, inventory promise, cross-package equality rule, or
+media-buy-wide constraint. A create or update that exceeds a disclosed limit
+MUST fail atomically with `UNSUPPORTED_FEATURE`, and `error.field` MUST identify
+the overflowing targeting field. Legacy support `true` remains valid and has no
+protocol-level cardinality cap.
+
+Requirement matching ignores numeric limits, but concrete targeting acceptance
+does not. A returned Product's accepted effective targeting MUST already satisfy
+every maximum it discloses. A seller MUST exclude a candidate whose concrete
+`targeting_overlay` exceeds its maximum unless it returns a distinct configured
+Product with a disclosed, compliant targeting modification. It MUST NOT return
+a configured Product that can only be purchased in an already-invalid state.
+
 This applies equally to audience and inventory dimensions. For example, a buyer
 may require the ability to select publisher-scoped placements, a property list,
 or a collection list later without knowing the eventual references during

--- a/static/compliance/source/protocols/media-buy/scenarios/targeting_aware_discovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/targeting_aware_discovery.yaml
@@ -52,6 +52,7 @@ caller:
 prerequisites:
   description: |
     The controller seeds a non-guaranteed video product with US inventory,
+    one-country package targeting, one-entry radius proximity targeting,
     Nielsen DMA support, two targetable publisher-scoped placements, list
     targeting support, enumerated age intervals, and deterministic browser
     inventory. Chrome, Firefox, and unclassifiable browser traffic are
@@ -87,6 +88,13 @@ fixtures:
         - action: "update_targeting"
           modes: ["self_serve"]
       overlay_support:
+        geo_countries:
+          max_values_per_package: 1
+        geo_countries_exclude:
+          max_values_per_package: 1
+        geo_proximity:
+          radius: true
+          max_values_per_package: 1
         geo_metros:
           systems: ["nielsen_dma"]
         placement_selection:
@@ -389,6 +397,10 @@ phases:
                 - publisher_domain: "pinnacle-media.example"
                   placement_id: "feed"
           required_overlay_support:
+            geo_countries: true
+            geo_countries_exclude: true
+            geo_proximity:
+              radius: true
             geo_metros:
               systems: ["nielsen_dma"]
             placement_selection: true
@@ -408,10 +420,11 @@ phases:
           are scoped to US feed inventory, the selected property and collection
           lists, the Fire OS exclusion, and Chrome or unclassified browser
           traffic with Safari excluded. Exact acceptance omits
-          targeting_resolution. overlay_support confirms later DMA, placement,
-          property-list, collection-list, platform, and independent browser
-          inclusion/exclusion control without returning one product per possible
-          value.
+          targeting_resolution. overlay_support confirms later country,
+          radius-proximity, DMA, placement, property-list, collection-list,
+          platform, and independent browser inclusion/exclusion control without
+          returning one product per possible value. Country and proximity
+          cardinality limits are disclosed after capability matching.
         context_outputs:
           - key: "exact_product_id"
             path: "products[0].product_id"
@@ -436,6 +449,18 @@ phases:
           - check: field_present
             path: "products[0].overlay_support.geo_metros"
             description: "Product supports later Nielsen DMA targeting as requested"
+          - check: field_value
+            path: "products[0].overlay_support.geo_countries.max_values_per_package"
+            value: 1
+            description: "Country inclusion support discloses its per-package cardinality limit"
+          - check: field_value
+            path: "products[0].overlay_support.geo_countries_exclude.max_values_per_package"
+            value: 1
+            description: "Country exclusion support independently discloses its per-package cardinality limit"
+          - check: field_value
+            path: "products[0].overlay_support.geo_proximity.max_values_per_package"
+            value: 1
+            description: "Radius proximity support discloses its per-package entry limit"
           - check: field_value
             path: "products[0].overlay_support.placement_selection.max_values_per_package"
             value: 2
@@ -973,6 +998,61 @@ phases:
   - id: inventory_targeting_lifecycle
     title: "Persist purchased inventory and platform targeting through create and update"
     steps:
+      - id: reject_country_exclusion_cardinality_on_create
+        title: "Reject too many country exclusions on create"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: true
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          idempotency_key: "$generate:uuid_v4#targeting_aware_discovery_country_exclusion_create"
+          start_time: "asap"
+          end_time: "2099-09-30T23:59:59Z"
+          packages:
+            - product_id: "$context.exact_product_id"
+              pricing_option_id: "$context.exact_pricing_option_id"
+              bid_price: 14.0
+              budget: 5000
+              targeting_overlay:
+                geo_countries: ["US"]
+                geo_countries_exclude: ["CA", "MX"]
+                device_platform_exclude: ["fire_os"]
+                browser: ["chrome", "safari", "unknown"]
+                browser_exclude: ["safari"]
+                property_list:
+                  agent_url: "https://governance.pinnacle-agency.example"
+                  list_id: "acme_outdoor_allowlist_v1"
+                collection_list:
+                  agent_url: "https://governance.pinnacle-agency.example"
+                  list_id: "acme_outdoor_collections_v1"
+                placement_selection:
+                  mode: "selected"
+                  placement_refs:
+                    - publisher_domain: "pinnacle-media.example"
+                      placement_id: "feed"
+        expected: |
+          Reject with UNSUPPORTED_FEATURE before creating a media buy because
+          two country exclusions exceed the advertised one-value package
+          limit.
+        validations:
+          - check: error_code
+            value: "UNSUPPORTED_FEATURE"
+            description: "Create enforces the product's country exclusion limit"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].targeting_overlay.geo_countries_exclude"
+            description: "Error.field identifies the overflowing exclusion field"
+
       - id: create_feed_package
         title: "Create from exact discovery result"
         task: create_media_buy
@@ -1137,6 +1217,87 @@ phases:
             path: "affected_packages[0].targeting_overlay.browser_exclude[1]"
             description: "Update returns exactly one browser exclusion"
 
+      - id: reject_country_cardinality_overflow
+        title: "Reject more country values than the product supports"
+        task: update_media_buy
+        schema_ref: "media-buy/update-media-buy-request.json"
+        response_schema_ref: "media-buy/update-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/update_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          media_buy_id: "$context.placement_media_buy_id"
+          idempotency_key: "$generate:uuid_v4#targeting_aware_discovery_country_cardinality"
+          packages:
+            - package_id: "$context.placement_package_id"
+              targeting_overlay:
+                geo_countries: ["US", "CA"]
+                device_platform_exclude: ["fire_os"]
+                browser: ["chrome", "firefox"]
+                browser_exclude: ["unknown"]
+                property_list:
+                  agent_url: "https://governance.pinnacle-agency.example"
+                  list_id: "acme_outdoor_allowlist_v1"
+                collection_list:
+                  agent_url: "https://governance.pinnacle-agency.example"
+                  list_id: "acme_outdoor_collections_v1"
+                placement_selection:
+                  mode: "selected"
+                  placement_refs:
+                    - publisher_domain: "pinnacle-media.example"
+                      placement_id: "short_video"
+        expected: |
+          Reject atomically with UNSUPPORTED_FEATURE because two country values
+          exceed the advertised one-value package limit. The prior US-only
+          package targeting remains committed.
+        validations:
+          - check: error_code
+            value: "UNSUPPORTED_FEATURE"
+            description: "A package cannot exceed the product's disclosed country limit"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].targeting_overlay.geo_countries"
+            description: "Error.field identifies the targeting field that exceeded its limit"
+
+      - id: read_after_rejected_country_overflow
+        title: "Verify rejected country update was atomic"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          media_buy_ids: ["$context.placement_media_buy_id"]
+        expected: |
+          Return the prior US-only package state immediately after the rejected
+          update, before any later successful targeting replacement can mask an
+          invalid partial mutation.
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json"
+          - check: field_equals_context
+            path: "media_buys[0].packages[0].package_id"
+            context_key: "placement_package_id"
+            description: "Readback targets the package whose update was rejected"
+          - check: field_value
+            path: "media_buys[0].packages[0].targeting_overlay.geo_countries[0]"
+            value: "US"
+            description: "Rejected overflow left the committed country unchanged"
+          - check: field_absent
+            path: "media_buys[0].packages[0].targeting_overlay.geo_countries[1]"
+            description: "Rejected overflow did not append a second country"
+
       - id: reject_incompatible_browser_platform
         title: "Reject an incompatible browser and device combination"
         task: update_media_buy
@@ -1257,6 +1418,122 @@ phases:
             allowed_values: ["INVALID_REQUEST"]
             description: "Duplicate placement references are rejected"
 
+      - id: update_to_single_proximity
+        title: "Add one supported radius target"
+        task: update_media_buy
+        schema_ref: "media-buy/update-media-buy-request.json"
+        response_schema_ref: "media-buy/update-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/update_media_buy"
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          media_buy_id: "$context.placement_media_buy_id"
+          idempotency_key: "$generate:uuid_v4#targeting_aware_discovery_single_proximity"
+          packages:
+            - package_id: "$context.placement_package_id"
+              targeting_overlay:
+                geo_countries: ["US"]
+                geo_proximity:
+                  - lat: 40.7128
+                    lng: -74.006
+                    label: "North venue"
+                    radius: { value: 5, unit: "km" }
+                device_platform_exclude: ["fire_os"]
+                browser: ["chrome", "firefox"]
+                browser_exclude: ["unknown"]
+                property_list:
+                  agent_url: "https://governance.pinnacle-agency.example"
+                  list_id: "acme_outdoor_allowlist_v1"
+                collection_list:
+                  agent_url: "https://governance.pinnacle-agency.example"
+                  list_id: "acme_outdoor_collections_v1"
+                placement_selection:
+                  mode: "selected"
+                  placement_refs:
+                    - publisher_domain: "pinnacle-media.example"
+                      placement_id: "short_video"
+        expected: |
+          Accept one radius entry because it is within the Product's
+          advertised one-entry package limit.
+        validations:
+          - check: response_schema
+            description: "Response matches update-media-buy-response.json"
+          - check: field_contains
+            path: "affected_packages[*]"
+            value:
+              package_id: "$context.placement_package_id"
+              targeting_overlay:
+                geo_proximity:
+                  - lat: 40.7128
+                    lng: -74.006
+                    label: "North venue"
+                    radius: { value: 5, unit: "km" }
+            description: "Update echoes the accepted one-entry proximity target"
+          - check: field_absent
+            path: "affected_packages[0].targeting_overlay.geo_proximity[1]"
+            description: "Accepted proximity targeting has exactly one entry"
+
+      - id: reject_proximity_cardinality_overflow
+        title: "Reject more proximity entries than the product supports"
+        task: update_media_buy
+        schema_ref: "media-buy/update-media-buy-request.json"
+        response_schema_ref: "media-buy/update-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/update_media_buy"
+        expect_error: true
+        negative_path: payload_well_formed
+        stateful: true
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
+          media_buy_id: "$context.placement_media_buy_id"
+          idempotency_key: "$generate:uuid_v4#targeting_aware_discovery_proximity_cardinality"
+          packages:
+            - package_id: "$context.placement_package_id"
+              targeting_overlay:
+                geo_countries: ["US"]
+                geo_proximity:
+                  - lat: 40.7128
+                    lng: -74.006
+                    label: "North venue"
+                    radius: { value: 5, unit: "km" }
+                  - lat: 34.0522
+                    lng: -118.2437
+                    label: "South venue"
+                    radius: { value: 5, unit: "km" }
+                device_platform_exclude: ["fire_os"]
+                browser: ["chrome", "firefox"]
+                browser_exclude: ["unknown"]
+                property_list:
+                  agent_url: "https://governance.pinnacle-agency.example"
+                  list_id: "acme_outdoor_allowlist_v1"
+                collection_list:
+                  agent_url: "https://governance.pinnacle-agency.example"
+                  list_id: "acme_outdoor_collections_v1"
+                placement_selection:
+                  mode: "selected"
+                  placement_refs:
+                    - publisher_domain: "pinnacle-media.example"
+                      placement_id: "short_video"
+        expected: |
+          Reject atomically with UNSUPPORTED_FEATURE because two proximity
+          entries exceed the advertised one-entry package limit. The accepted
+          North venue radius remains committed.
+        validations:
+          - check: error_code
+            value: "UNSUPPORTED_FEATURE"
+            description: "A package cannot exceed the product's disclosed proximity limit"
+          - check: field_value
+            path: "errors[0].field"
+            value: "packages[0].targeting_overlay.geo_proximity"
+            description: "Error.field identifies the overflowing proximity field"
+
       - id: read_updated_placement
         title: "Verify purchased placement state"
         task: get_media_buys
@@ -1274,7 +1551,7 @@ phases:
         expected: |
           Return complete effective targeting with short_video selected. The
           stored package does not expose a separate effective-placement source
-          of truth. All three rejected updates were atomic and left this state
+          of truth. All five rejected updates were atomic and left this state
           unchanged.
         validations:
           - check: response_schema
@@ -1299,6 +1576,20 @@ phases:
             path: "media_buys[0].packages[0].targeting_overlay.device_platform_exclude[0]"
             value: "fire_os"
             description: "Readback preserves the purchased platform exclusion"
+          - check: field_value
+            path: "media_buys[0].packages[0].targeting_overlay.geo_countries[0]"
+            value: "US"
+            description: "Rejected country overflow left the committed country unchanged"
+          - check: field_absent
+            path: "media_buys[0].packages[0].targeting_overlay.geo_countries[1]"
+            description: "Rejected country overflow did not append a second country"
+          - check: field_value
+            path: "media_buys[0].packages[0].targeting_overlay.geo_proximity[0].radius.value"
+            value: 5
+            description: "Readback preserves the accepted one-entry radius target"
+          - check: field_absent
+            path: "media_buys[0].packages[0].targeting_overlay.geo_proximity[1]"
+            description: "Rejected proximity overflow did not append a second entry"
           - check: field_contains
             path: "media_buys[0].packages[0].targeting_overlay.browser[*]"
             value: "chrome"

--- a/static/schemas/source/core/targeting-overlay-support.json
+++ b/static/schemas/source/core/targeting-overlay-support.json
@@ -9,6 +9,29 @@
       "type": "boolean",
       "const": true
     },
+    "countrySupport": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/supported"
+        },
+        {
+          "type": "object",
+          "description": "Binding support for protocol-valid ISO 3166-1 alpha-2 country values, subject to the declared per-package cardinality limit. This object does not enumerate or restrict individual country codes.",
+          "properties": {
+            "max_values_per_package": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Maximum number of country values accepted in this targeting field on one package."
+            },
+            "ext": {
+              "$ref": "/schemas/core/ext.json"
+            }
+          },
+          "required": ["max_values_per_package"],
+          "additionalProperties": false
+        }
+      ]
+    },
     "metroSupport": {
       "anyOf": [
         {
@@ -147,8 +170,8 @@
     }
   },
   "properties": {
-    "geo_countries": { "$ref": "#/definitions/supported" },
-    "geo_countries_exclude": { "$ref": "#/definitions/supported" },
+    "geo_countries": { "$ref": "#/definitions/countrySupport" },
+    "geo_countries_exclude": { "$ref": "#/definitions/countrySupport" },
     "geo_regions": {
       "anyOf": [
         { "$ref": "#/definitions/supported" },
@@ -191,6 +214,11 @@
               "items": { "$ref": "/schemas/enums/transport-mode.json" },
               "minItems": 1,
               "uniqueItems": true
+            },
+            "max_values_per_package": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Maximum number of proximity entries accepted on one package."
             },
             "ext": { "$ref": "/schemas/core/ext.json" }
           },

--- a/tests/targeting-aware-discovery.test.cjs
+++ b/tests/targeting-aware-discovery.test.cjs
@@ -643,6 +643,23 @@ test("targeting-aware storyboard grades filters and configured targeting end to 
     true,
     "requirement true must match constrained object support without comparing numeric limits"
   );
+  assert.deepEqual(
+    step("get_exact_targeted_product").sample_request.required_overlay_support
+      .geo_proximity,
+    { radius: true },
+    "discovery must require the proximity method without expressing a seller limit"
+  );
+  for (const path of [
+    "products[0].overlay_support.geo_countries.max_values_per_package",
+    "products[0].overlay_support.geo_countries_exclude.max_values_per_package",
+    "products[0].overlay_support.geo_proximity.max_values_per_package",
+  ]) {
+    assert.equal(
+      hasCheck("get_exact_targeted_product", "field_value", path, 1),
+      true,
+      `${path} must disclose the seeded per-package limit`
+    );
+  }
   assert.equal(
     hasCheck(
       "get_exact_targeted_product",
@@ -823,6 +840,22 @@ test("targeting-aware storyboard grades filters and configured targeting end to 
       `${id} must grade persistence of the concrete platform exclusion`
     );
   }
+  assert.deepEqual(
+    step("reject_country_exclusion_cardinality_on_create").sample_request
+      .packages[0].targeting_overlay.geo_countries_exclude,
+    ["CA", "MX"],
+    "create must exercise the advertised one-value country exclusion limit"
+  );
+  assert.equal(
+    hasCheck(
+      "reject_country_exclusion_cardinality_on_create",
+      "field_value",
+      "errors[0].field",
+      "packages[0].targeting_overlay.geo_countries_exclude"
+    ),
+    true,
+    "create-time cardinality errors must identify the overflowing exclusion field"
+  );
   for (const [id, path, value] of [
     ["create_feed_package", "packages[0].targeting_overlay.browser[*]", "chrome"],
     ["create_feed_package", "packages[0].targeting_overlay.browser[*]", "safari"],
@@ -863,6 +896,109 @@ test("targeting-aware storyboard grades filters and configured targeting end to 
     ["unknown"],
     "update must exercise later package-level browser exclusion"
   );
+  assert.deepEqual(
+    step("reject_country_cardinality_overflow").sample_request.packages[0]
+      .targeting_overlay.geo_countries,
+    ["US", "CA"],
+    "the negative path must exceed the advertised one-country package limit"
+  );
+  assert.equal(
+    hasCheck(
+      "reject_country_cardinality_overflow",
+      "error_code",
+      undefined,
+      "UNSUPPORTED_FEATURE"
+    ),
+    true,
+    "a package that exceeds a disclosed country limit must be rejected"
+  );
+  assert.equal(
+    hasCheck(
+      "reject_country_cardinality_overflow",
+      "field_value",
+      "errors[0].field",
+      "packages[0].targeting_overlay.geo_countries"
+    ),
+    true,
+    "the cardinality error must identify the overflowing targeting field"
+  );
+  for (const [check, path, value] of [
+    [
+      "field_value",
+      "media_buys[0].packages[0].targeting_overlay.geo_countries[0]",
+      "US",
+    ],
+    [
+      "field_absent",
+      "media_buys[0].packages[0].targeting_overlay.geo_countries[1]",
+      undefined,
+    ],
+  ]) {
+    assert.equal(
+      hasCheck("read_after_rejected_country_overflow", check, path, value),
+      true,
+      `immediate readback must prove country rejection was atomic at ${path}`
+    );
+  }
+  assert.equal(
+    step("update_to_single_proximity").sample_request.packages[0]
+      .targeting_overlay.geo_proximity.length,
+    1,
+    "the positive path must exercise one supported proximity entry"
+  );
+  assert.equal(
+    hasCheck(
+      "update_to_single_proximity",
+      "field_absent",
+      "affected_packages[0].targeting_overlay.geo_proximity[1]"
+    ),
+    true,
+    "the accepted update must grade one-entry proximity cardinality"
+  );
+  assert.equal(
+    step("reject_proximity_cardinality_overflow").sample_request.packages[0]
+      .targeting_overlay.geo_proximity.length,
+    2,
+    "the negative path must exceed the advertised one-entry proximity limit"
+  );
+  assert.equal(
+    hasCheck(
+      "reject_proximity_cardinality_overflow",
+      "field_value",
+      "errors[0].field",
+      "packages[0].targeting_overlay.geo_proximity"
+    ),
+    true,
+    "proximity cardinality errors must identify the overflowing field"
+  );
+  for (const [check, path, value] of [
+    [
+      "field_value",
+      "media_buys[0].packages[0].targeting_overlay.geo_countries[0]",
+      "US",
+    ],
+    [
+      "field_absent",
+      "media_buys[0].packages[0].targeting_overlay.geo_countries[1]",
+      undefined,
+    ],
+    [
+      "field_value",
+      "media_buys[0].packages[0].targeting_overlay.geo_proximity[0].radius.value",
+      5,
+    ],
+    [
+      "field_absent",
+      "media_buys[0].packages[0].targeting_overlay.geo_proximity[1]",
+      undefined,
+    ],
+  ]) {
+    assert.equal(
+      hasCheck("read_updated_placement", check, path, value),
+      true,
+      `readback must prove rejected cardinality updates were atomic at ${path}`
+    );
+  }
   assert.equal(
     hasCheck(
       "reject_incompatible_browser_platform",
@@ -1223,6 +1359,51 @@ test("required overlay requirements exclude seller limit fields", async () => {
     true,
     errors(validateSupport)
   );
+
+  for (const legacyCountrySupport of [
+    { geo_countries: true },
+    { geo_countries_exclude: true },
+  ]) {
+    assert.equal(
+      validateSupport(legacyCountrySupport),
+      true,
+      errors(validateSupport)
+    );
+  }
+
+  for (const constrainedSupport of [
+    { geo_countries: { max_values_per_package: 1 } },
+    { geo_countries_exclude: { max_values_per_package: 2 } },
+    { geo_proximity: { radius: true, max_values_per_package: 3 } },
+  ]) {
+    assert.equal(
+      validateSupport(constrainedSupport),
+      true,
+      errors(validateSupport)
+    );
+    assert.equal(
+      validate(constrainedSupport),
+      false,
+      "seller cardinality limits are response-only"
+    );
+  }
+
+  for (const invalidConstrainedSupport of [
+    { geo_countries: {} },
+    { geo_countries: { ext: { vendor: "hint" } } },
+    { geo_countries: { max_values_per_package: 0 } },
+    { geo_countries: { max_values_per_package: 1, unknown: true } },
+    { geo_proximity: { radius: true, max_values_per_package: 0 } },
+    { geo_proximity: { max_values_per_package: 1 } },
+  ]) {
+    assert.equal(
+      validateSupport(invalidConstrainedSupport),
+      false,
+      `support rejects invalid cardinality declaration ${JSON.stringify(
+        invalidConstrainedSupport
+      )}`
+    );
+  }
 
   const requirements = JSON.parse(
     fs.readFileSync(


### PR DESCRIPTION
## Summary

- allow sellers to disclose per-package country and proximity cardinality limits through structured targeting support
- define how product discovery and media-buy mutations behave when concrete targeting exceeds a declared limit
- add conformance coverage for accepted and rejected country/proximity mutations, including atomic rejection
- document the 3.2 scope and preserve legacy `true` support declarations

## Why

Some underlying buying platforms allow only one country or one proximity target per campaign/package. Buyers need those restrictions during discovery so they can choose compatible products and avoid avoidable booking failures.

This PR intentionally limits 3.2 to `max_values_per_package` for country include/exclude and proximity targeting. Cross-package, conditional, and other platform constraints remain deferred to 3.3 in #6706–#6710.

## Compatibility

This is an additive schema change. Existing boolean support declarations remain valid, and numeric limits are seller response metadata rather than buyer requirements.

## Validation

- schema suite
- targeting-aware discovery tests
- storyboard request, response, and validation-path linters
- compliance source-authority, snippets, and documentation drift checks
- root unit suite: 1,046 tests
- server unit suite: 6,345 passed, 30 skipped
- TypeScript typecheck
- changeset protocol-scope and status checks
- expert buyer-workflow, code, and protocol review

Closes #6705
