### PR TITLE
fix(compliance): backport optional media-buy scoping to 3.1

### DIFF
--- a/.changeset/scope-optional-media-buy-compliance-3-1.md
+++ b/.changeset/scope-optional-media-buy-compliance-3-1.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Gate creative-library and product-refinement compliance paths on advertised 3.1 capabilities, and keep measurement-term acceptance outside the universal rejection scenario.

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -1,5 +1,5 @@
 id: media_buy_seller
-version: "1.0.0"
+version: "1.0.1"
 title: "Media buy seller agent"
 category: media_buy_seller
 summary: "Seller agent that receives briefs, returns products, accepts media buys, and reports delivery."
@@ -587,6 +587,9 @@ phases:
 
   - id: creative_sync
     title: "Creative sync"
+    requires_capability:
+      path: creative.has_creative_library
+      equals: true
     narrative: |
       With the media buy confirmed, the buyer syncs creative assets to your platform.
       Each package in the buy has creative format requirements — the buyer discovered
@@ -745,6 +748,7 @@ phases:
 
   - id: delivery_monitoring
     title: "Delivery and reporting"
+    depends_on: [create_buy]
     narrative: |
       The campaign is live. The buyer monitors delivery through two tasks:
       get_media_buys for status and get_media_buy_delivery for performance metrics.

--- a/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
@@ -1,5 +1,5 @@
 id: media_buy_seller/creative_fate_after_cancellation
-version: "1.0.0"
+version: "1.0.1"
 title: "Creative lifecycle is decoupled from media buy lifecycle"
 category: media_buy_seller
 summary: "Validates that canceling a media buy releases package-creative assignments but leaves the underlying creatives in the library with their review state intact, and that buyers can reuse released creatives on a new buy."
@@ -11,6 +11,10 @@ required_tools:
   - update_media_buy
   - sync_creatives
   - list_creatives
+
+requires_capability:
+  path: creative.has_creative_library
+  equals: true
 
 narrative: |
   Per the creative library model (docs/creative/creative-libraries#creative-state-and-assignment-state-are-separate)

--- a/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment.yaml
@@ -1,5 +1,5 @@
 id: media_buy_seller/dependency_impairment
-version: "2.0.0"
+version: "2.0.1"
 title: "Dependency impairment end-to-end — resource transition propagates to media buy health"
 category: media_buy_seller
 summary: "Forces a creative from approved → rejected on a non-terminal media buy, verifies the buy reflects health: impaired with a matching impairments[] entry, and recovers via assignment swap to a different creative (canonical recovery vector — re-approval of the same creative_id is uncommon in production)."
@@ -13,19 +13,13 @@ required_tools:
   - update_media_buy
   - comply_test_controller
 
-# Capability gate: this scenario grades the snapshot-coherence surface, so it
-# runs only for sellers that declare media_buy.propagation_surfaces including
-# "snapshot". Webhook-only or out_of_band sellers grade not_applicable instead
-# of false-failing on a contract that does not apply to them — the opt-out the
-# propagation_surfaces schema already documents (get-adcp-capabilities-response.json)
-# but that was never wired into this scenario. Requires the `contains:` matcher
-# (@adcp/sdk >= 7.70). Sellers that OMIT propagation_surfaces inherit the
-# ["snapshot"] default and are graded here only on @adcp/sdk >= 9.2.0, which
-# materializes capability-gate schema defaults; earlier runners skip them as
-# not_applicable (adcp-client#2278).
+# The 3.1 runner supports one storyboard-level capability predicate. Gate the
+# whole creative workflow on the library declaration, then repeat the snapshot
+# predicate on every phase so webhook-only and out_of_band sellers remain out
+# of scope as well.
 requires_capability:
-  path: media_buy.propagation_surfaces
-  contains: "snapshot"
+  path: creative.has_creative_library
+  equals: true
 
 narrative: |
   Per the dependency-impairment surface ([adcp#2855](https://github.com/adcontextprotocol/adcp/issues/2855)
@@ -118,6 +112,9 @@ prerequisites:
 
 phases:
   - id: setup
+    requires_capability: &snapshot_gate
+      path: media_buy.propagation_surfaces
+      contains: "snapshot"
     title: "Create an active buy with a creative assignment"
     narrative: |
       Discover a product, create a media buy, sync one creative into the library
@@ -339,6 +336,7 @@ phases:
             description: "Controller acknowledged the directive"
 
   - id: baseline_healthy
+    requires_capability: *snapshot_gate
     title: "Baseline: buy reads as healthy, no impairments"
     narrative: |
       With the creative at approved and assigned, the buy MUST report
@@ -383,6 +381,7 @@ phases:
             description: "impairments[] is empty (or absent) in the baseline — no resources are offline yet"
 
   - id: transition_offline
+    requires_capability: *snapshot_gate
     title: "Force the creative to rejected"
     narrative: |
       The seller transitions the creative from approved → rejected via
@@ -422,6 +421,7 @@ phases:
             description: "Controller acknowledged the rejection directive"
 
   - id: verify_impaired
+    requires_capability: *snapshot_gate
     title: "Buy reads as impaired with a matching impairments[] entry"
     narrative: |
       After the rejection, the buy MUST report `health: impaired` and
@@ -520,6 +520,7 @@ phases:
             description: "At least one impairment entry matches the rejected creative, affected package, and rejected transition (forward rule)"
 
   - id: swap_recovery
+    requires_capability: *snapshot_gate
     title: "Recover via assignment swap — different creative replaces the rejected one"
     narrative: |
       Sync a second creative (B) into the library as approved, then use

--- a/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_cardinality.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/dependency_impairment_cardinality.yaml
@@ -1,5 +1,5 @@
 id: media_buy_seller/dependency_impairment_cardinality
-version: "1.0.0"
+version: "1.0.1"
 title: "Dependency impairment cardinality — impairments[] tracks each offline resource independently"
 category: media_buy_seller
 summary: "Two creatives on two packages of the same buy. Rejects them sequentially and verifies impairments[] grows 0 → 1 → 2; recovers them sequentially via swap-assignment and verifies impairments[] shrinks 2 → 1 → 0. Pressure-tests the inverse rule under cardinality — a seller emitting any impairment entry rather than the right one fails."
@@ -13,19 +13,13 @@ required_tools:
   - update_media_buy
   - comply_test_controller
 
-# Capability gate: this scenario grades the snapshot-coherence surface, so it
-# runs only for sellers that declare media_buy.propagation_surfaces including
-# "snapshot". Webhook-only or out_of_band sellers grade not_applicable instead
-# of false-failing on a contract that does not apply to them — the opt-out the
-# propagation_surfaces schema already documents (get-adcp-capabilities-response.json)
-# but that was never wired into this scenario. Requires the `contains:` matcher
-# (@adcp/sdk >= 7.70). Sellers that OMIT propagation_surfaces inherit the
-# ["snapshot"] default and are graded here only on @adcp/sdk >= 9.2.0, which
-# materializes capability-gate schema defaults; earlier runners skip them as
-# not_applicable (adcp-client#2278).
+# The 3.1 runner supports one storyboard-level capability predicate. Gate the
+# whole creative workflow on the library declaration, then repeat the snapshot
+# predicate on every phase so webhook-only and out_of_band sellers remain out
+# of scope as well.
 requires_capability:
-  path: media_buy.propagation_surfaces
-  contains: "snapshot"
+  path: creative.has_creative_library
+  equals: true
 
 narrative: |
   The base dependency_impairment scenario tests forward + inverse + health-iff
@@ -98,6 +92,9 @@ prerequisites:
 
 phases:
   - id: setup
+    requires_capability: &snapshot_gate
+      path: media_buy.propagation_surfaces
+      contains: "snapshot"
     title: "Create a buy with two packages, two creatives, two assignments"
     narrative: |
       Discover a product, create a buy with two packages (same product is
@@ -396,6 +393,7 @@ phases:
             description: "impairments[] is empty (cardinality zero baseline)"
 
   - id: reject_first_cardinality_one
+    requires_capability: *snapshot_gate
     title: "Reject creative A — impairments[] cardinality 1, scoped to package_a"
     narrative: |
       Force creative A to rejected. The buy MUST report exactly ONE
@@ -525,6 +523,7 @@ phases:
           # an `array_length` check kind — tracked in a follow-up.
 
   - id: reject_second_cardinality_two
+    requires_capability: *snapshot_gate
     title: "Reject creative B — impairments[] grows to cardinality 2"
     narrative: |
       Force creative B to rejected. The buy MUST report exactly TWO
@@ -643,6 +642,7 @@ phases:
           # a creative that isn't offline, failing the invariant.
 
   - id: recover_first_via_swap
+    requires_capability: *snapshot_gate
     title: "Swap package_a's binding to a fresh creative C — cardinality back to 1"
     narrative: |
       Sync creative C (approved), then update_media_buy to swap
@@ -800,6 +800,7 @@ phases:
             description: "impairments[1] MUST NOT exist — the swap recovered A's dependency; only B remains rejected. Cardinality decrement check."
 
   - id: recover_second_via_swap
+    requires_capability: *snapshot_gate
     title: "Swap package_b's binding to a fresh creative D — cardinality back to 0"
     narrative: |
       Sync creative D (approved), swap package_b's binding from B → D, read

--- a/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -1,25 +1,20 @@
 id: media_buy_seller/measurement_terms_rejected
-version: "1.0.0"
+version: "1.0.1"
 title: "Seller rejects unworkable measurement_terms"
 category: media_buy_seller
-summary: "Buyer proposes measurement_terms the seller will not accept; seller returns TERMS_REJECTED; buyer retries with seller-compatible terms."
+summary: "Buyer proposes unworkable measurement_terms and the seller returns TERMS_REJECTED."
 track: media_buy
 required_tools:
   - get_products
   - create_media_buy
 
 narrative: |
-  measurement_terms negotiation is a round-trip. The buyer proposes a measurement vendor,
-  window, and variance tolerance on each package; the seller either accepts (returning
-  measurement_terms echoed in the response) or rejects with TERMS_REJECTED and a message
-  explaining what is unacceptable. The buyer mints a fresh idempotency_key and retries
-  create_media_buy with the adjusted payload — reusing the prior key against a different
-  body MUST be rejected with IDEMPOTENCY_CONFLICT per spec.
+  The buyer proposes a measurement vendor, window, and variance tolerance on each
+  package. This universal scenario sends intentionally unworkable terms and verifies
+  that the seller rejects them with TERMS_REJECTED and an explanatory message.
 
-  This scenario sends an intentionally aggressive first proposal (max_variance_percent: 0
-  with a window the seller does not guarantee), verifies the seller rejects with
-  TERMS_REJECTED, then retries with a relaxed proposal that falls inside the seller's
-  stated tolerance and expects a successful create_media_buy.
+  AdCP 3.1 has no capability bit for measurement-term acceptance, so the optional
+  relaxed-terms success arm is deliberately not graded on this maintenance line.
 
 agent:
   interaction_model: media_buy_seller
@@ -140,64 +135,3 @@ phases:
             path: "context.correlation_id"
             value: "measurement_terms_rejected--aggressive"
             description: "Context correlation_id returned unchanged"
-
-  - id: accept_terms
-    title: "Buyer retries with acceptable terms"
-    narrative: |
-      The buyer relaxes measurement_terms to match the seller's stated capability
-      (c7 window, 10% variance, makegood remedies) and retries. The seller accepts and
-      returns the confirmed terms echoed in the response.
-
-    steps:
-      - id: create_media_buy_relaxed_terms
-        title: "Propose seller-compatible measurement_terms"
-        task: create_media_buy
-        schema_ref: "media-buy/create-media-buy-request.json"
-        response_schema_ref: "media-buy/create-media-buy-response.json"
-        doc_ref: "/media-buy/task-reference/create_media_buy"
-        comply_scenario: create_media_buy
-        stateful: true
-        expected: |
-          The buy succeeds. The response echoes the accepted measurement_terms (possibly
-          normalized by the seller).
-
-        sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
-          account:
-            brand:
-              domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_accept_terms_create_media_buy_relaxed_terms"
-          start_time: "asap"
-          end_time: "2099-09-30T23:59:59Z"
-          packages:
-            - product_id: "$context.product_id"
-              budget: 25000
-              pricing_option_id: "$context.pricing_option_id"
-              measurement_terms:
-                billing_measurement:
-                  vendor:
-                    domain: "videoamp.example"
-                  measurement_window: "c7"
-                  max_variance_percent: 10
-                makegood_policy:
-                  available_remedies: ["additional_delivery", "credit"]
-
-          context:
-            correlation_id: "measurement_terms_rejected--relaxed"
-        validations:
-          - check: response_schema
-            description: "Response matches create-media-buy-response.json schema"
-          - check: field_present
-            path: "media_buy_id"
-            description: "Seller returns a media_buy_id after accepting terms"
-          - check: field_present
-            path: "context"
-            description: "Response echoes back the context object"
-          - check: field_value
-            path: "context.correlation_id"
-            value: "measurement_terms_rejected--relaxed"
-            description: "Context correlation_id returned unchanged"
-        reviewer_checks:
-          - "Reviewer MUST confirm the seller releases the idempotency claim after a TERMS_REJECTED response. Probe: send the aggressive-terms request (same key, step 1), then retry with the same key and corrected terms (this step) — the seller MUST return a fresh media_buy_id, not IDEMPOTENCY_CONFLICT. A seller that caches rejected requests would make this two-step retry pattern impossible. See security.mdx#idempotency rule 3 ('Only successful responses are cached')."

--- a/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
@@ -1,17 +1,16 @@
 id: media_buy_seller/pending_creatives_to_start
-version: "1.0.0"
+version: "1.0.1"
 title: "Creative sync unblocks pending_creatives → pending_start"
 category: media_buy_seller
 summary: "Verifies that a media buy created without creatives sits in pending_creatives until sync_creatives completes, then transitions to pending_start."
 track: media_buy
 
-# This scenario requires an explicit auto-approval declaration. Sellers that
-# declare `require_human`, or omit the field because approval behavior is
-# legacy-unspecified, grade not_applicable rather than false-failing on a
-# manual-review workflow.
+# This scenario requires a creative library. The 3.1 runner supports one
+# storyboard-level capability predicate, so the auto-approval predicate is
+# repeated on each phase below to preserve both applicability conditions.
 requires_capability:
-  path: media_buy.creative_approval_mode
-  equals: auto_approve
+  path: creative.has_creative_library
+  equals: true
 
 required_tools:
   - get_products
@@ -52,6 +51,9 @@ prerequisites:
 
 phases:
   - id: setup
+    requires_capability: &auto_approval_gate
+      path: media_buy.creative_approval_mode
+      equals: auto_approve
     title: "Discover products and formats"
     steps:
       - id: get_products_brief
@@ -91,6 +93,7 @@ phases:
             description: "The captured pricing option is fixed-price; fixed-price storyboards do not send bid_price"
 
   - id: create_without_creatives
+    requires_capability: *auto_approval_gate
     title: "Create media buy without creative_assignments"
     narrative: |
       The buyer intentionally omits creative_assignments. The seller must accept the
@@ -168,6 +171,7 @@ phases:
             description: "Created package echoes package-level context for legacy package correlation"
 
   - id: supply_creatives
+    requires_capability: *auto_approval_gate
     title: "Supply creatives and assign to the package"
     narrative: |
       The buyer syncs a creative with the format the product requires, then updates the
@@ -260,6 +264,7 @@ phases:
             description: "Envelope task-status is completed on synchronous update success (protocol-envelope.json required: [status])"
 
   - id: verify_transition
+    requires_capability: *auto_approval_gate
     title: "Verify the status transition"
     narrative: |
       Independently of the update_media_buy response, call get_media_buys to confirm the

--- a/static/compliance/source/protocols/media-buy/scenarios/refine_products.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/refine_products.yaml
@@ -1,11 +1,15 @@
 id: media_buy_seller/refine_products
-version: "1.0.0"
+version: "1.0.1"
 title: "Seller handles product refinement"
 category: media_buy_seller
 summary: "Verifies that a media buy seller supports buying_mode: refine with product-level and request-level changes."
 track: media_buy
 required_tools:
   - get_products
+
+requires_capability:
+  path: media_buy.buying_modes
+  contains: refine
 
 narrative: |
   After a buyer receives products from a brief, they refine the results without starting

--- a/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
+++ b/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
@@ -1,5 +1,5 @@
 id: sales_broadcast_tv
-version: "1.0.0"
+version: "1.0.1"
 title: "Broadcast linear TV seller agent"
 protocol: media-buy
 category: sales_broadcast_tv
@@ -422,6 +422,9 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: creative_sync
     title: "Creative sync"
+    requires_capability:
+      path: creative.has_creative_library
+      equals: true
     narrative: |
       Broadcast creative sync differs from digital in three ways. First, assets are
       broadcast-grade video files — no VAST wrappers, no impression trackers, no click
@@ -559,6 +562,7 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: delivery_monitoring
     title: "Delivery and reporting"
+    depends_on: [create_buy]
     narrative: |
       Broadcast delivery reporting operates on a fundamentally different timeline than
       digital. Live ratings are available within 24 hours, but the numbers that matter
@@ -680,6 +684,7 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: reconciliation
     title: "Post-flight reconciliation"
+    depends_on: [delivery_monitoring]
     narrative: |
       Broadcast reconciliation cannot happen until C7 data has matured for every air
       date in the flight. For a flight ending December 31, final C7 data for the last

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -1,5 +1,5 @@
 id: sales_guaranteed
-version: "1.0.0"
+version: "1.0.1"
 title: "Guaranteed media buy with human IO approval"
 protocol: media-buy
 category: sales_guaranteed
@@ -506,6 +506,9 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: creative_sync
     title: "Creative sync"
+    requires_capability:
+      path: creative.has_creative_library
+      equals: true
     narrative: |
       With the IO signed and the media buy active, the buyer syncs creative assets
       to your platform. Each package has creative format requirements that the buyer
@@ -568,6 +571,7 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: delivery_monitoring
     title: "Delivery and reporting"
+    depends_on: [confirm_active]
     narrative: |
       The campaign is live with guaranteed delivery commitments. The buyer monitors
       delivery to ensure the seller is meeting the SLA guarantees from the IO.

--- a/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
+++ b/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
@@ -1,5 +1,5 @@
 id: sales_proposal_mode
-version: "1.0.0"
+version: "1.0.1"
 title: "Media buy via proposal acceptance"
 protocol: media-buy
 category: sales_proposal_mode
@@ -426,6 +426,9 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: creative_sync
     title: "Creative sync"
+    requires_capability:
+      path: creative.has_creative_library
+      equals: true
     narrative: |
       With the proposal accepted and the media buy confirmed, the buyer syncs creative
       assets. The buyer first checks what formats the accepted products require, then
@@ -543,6 +546,7 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: delivery
     title: "Delivery and reporting"
+    depends_on: [accept_proposal]
     narrative: |
       The campaign from the accepted proposal is live. The buyer monitors delivery
       to verify the proposal's forecasts are tracking.

--- a/tests/sdk-runner-capability-gates.test.cjs
+++ b/tests/sdk-runner-capability-gates.test.cjs
@@ -9,6 +9,23 @@ const YAML = require('yaml');
 
 const { runStoryboard } = require('@adcp/sdk/testing');
 
+const mediaBuyScenarioRoot = path.join(
+  __dirname,
+  '..',
+  'static',
+  'compliance',
+  'source',
+  'protocols',
+  'media-buy',
+  'scenarios'
+);
+
+function loadMediaBuyScenario(name) {
+  return YAML.parse(
+    fs.readFileSync(path.join(mediaBuyScenarioRoot, `${name}.yaml`), 'utf8')
+  );
+}
+
 test('runStoryboard skips an equals-gated storyboard when the capability path is absent', async () => {
   const storyboard = {
     id: 'equals_absent_regression',
@@ -323,4 +340,102 @@ test('create_media_buy async storyboard requires its advertised controller scena
 
   assert.equal(advertisedResult.overall_passed, true);
   assert.equal(advertisedResult.phases[0].phase_id, 'no_phases');
+});
+
+test('creative-dependent seller scenarios fail closed for library-less sellers', async () => {
+  for (const name of [
+    'pending_creatives_to_start',
+    'creative_fate_after_cancellation',
+    'dependency_impairment',
+    'dependency_impairment_cardinality',
+  ]) {
+    const storyboard = loadMediaBuyScenario(name);
+    assert.deepEqual(storyboard.requires_capability, {
+      path: 'creative.has_creative_library',
+      equals: true,
+    });
+
+    const tools = ['get_adcp_capabilities', ...storyboard.required_tools];
+    const result = await runStoryboard('https://agent.example/mcp', storyboard, {
+      _profile: {
+        tools,
+        raw_capabilities: { creative: { has_creative_library: false } },
+      },
+      agentTools: tools,
+    });
+
+    assert.equal(result.overall_passed, true, name);
+    assert.equal(result.skipped_count, 1, name);
+    assert.equal(result.phases[0].phase_id, 'capability_unsupported', name);
+    assert.match(result.phases[0].steps[0].error, /creative\.has_creative_library/, name);
+  }
+});
+
+test('3.1 compound applicability remains enforced through phase gates', () => {
+  const expected = new Map([
+    ['pending_creatives_to_start', {
+      path: 'media_buy.creative_approval_mode',
+      equals: 'auto_approve',
+    }],
+    ['dependency_impairment', {
+      path: 'media_buy.propagation_surfaces',
+      contains: 'snapshot',
+    }],
+    ['dependency_impairment_cardinality', {
+      path: 'media_buy.propagation_surfaces',
+      contains: 'snapshot',
+    }],
+  ]);
+
+  for (const [name, gate] of expected) {
+    const storyboard = loadMediaBuyScenario(name);
+    assert.ok(storyboard.phases.length > 0, name);
+    for (const phase of storyboard.phases) {
+      assert.deepEqual(phase.requires_capability, gate, `${name}/${phase.id}`);
+    }
+  }
+});
+
+test('3.1 scopes refinement and keeps only universal measurement rejection', async () => {
+  const refinement = loadMediaBuyScenario('refine_products');
+  assert.deepEqual(refinement.requires_capability, {
+    path: 'media_buy.buying_modes',
+    contains: 'refine',
+  });
+
+  const tools = ['get_adcp_capabilities', ...refinement.required_tools];
+  const result = await runStoryboard('https://agent.example/mcp', refinement, {
+    _profile: {
+      tools,
+      raw_capabilities: { media_buy: { buying_modes: ['brief'] } },
+    },
+    agentTools: tools,
+  });
+  assert.equal(result.overall_passed, true);
+  assert.equal(result.phases[0].phase_id, 'capability_unsupported');
+
+  const measurement = loadMediaBuyScenario('measurement_terms_rejected');
+  assert.deepEqual(measurement.phases.map(phase => phase.id), [
+    'discover_products',
+    'reject_terms',
+  ]);
+});
+
+test('direct creative-sync phases have authoritative library gates', () => {
+  const sourceRoot = path.join(__dirname, '..', 'static', 'compliance', 'source');
+  const indexPaths = [
+    path.join(sourceRoot, 'protocols', 'media-buy', 'index.yaml'),
+    ...['sales-broadcast-tv', 'sales-guaranteed', 'sales-proposal-mode'].map(name =>
+      path.join(sourceRoot, 'specialisms', name, 'index.yaml')
+    ),
+  ];
+
+  for (const indexPath of indexPaths) {
+    const index = YAML.parse(fs.readFileSync(indexPath, 'utf8'));
+    const phase = index.phases.find(candidate => candidate.id === 'creative_sync');
+    assert.deepEqual(phase.requires_capability, {
+      path: 'creative.has_creative_library',
+      equals: true,
+    }, index.id);
+  }
 });

--- a/tests/sdk-runner-capability-gates.test.cjs
+++ b/tests/sdk-runner-capability-gates.test.cjs
@@ -439,3 +439,95 @@ test('direct creative-sync phases have authoritative library gates', () => {
     }, index.id);
   }
 });
+
+test('library-less sellers still execute delivery from the create-buy anchor', async () => {
+  const indexPath = path.join(
+    __dirname,
+    '..',
+    'static',
+    'compliance',
+    'source',
+    'protocols',
+    'media-buy',
+    'index.yaml'
+  );
+  const source = YAML.parse(fs.readFileSync(indexPath, 'utf8'));
+  const sourcePhases = new Map(source.phases.map(phase => [phase.id, phase]));
+  const creativeSource = sourcePhases.get('creative_sync');
+  const deliverySource = sourcePhases.get('delivery_monitoring');
+
+  assert.deepEqual(deliverySource.depends_on, ['create_buy']);
+
+  const storyboard = {
+    id: 'libraryless_delivery_anchor_regression',
+    version: '1.0.0',
+    title: 'Library-less delivery anchor regression',
+    category: 'media_buy_seller',
+    summary: 'Regression',
+    narrative: 'Regression',
+    agent: { interaction_model: 'media_buy_seller', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'create_buy',
+        title: 'Create buy',
+        steps: [{
+          id: 'create_state',
+          title: 'Create state',
+          task: 'get_products',
+          stateful: true,
+          sample_request: { brief: 'create state' },
+        }],
+      },
+      {
+        id: creativeSource.id,
+        title: creativeSource.title,
+        requires_capability: creativeSource.requires_capability,
+        steps: [{
+          id: 'creative_state',
+          title: 'Creative state',
+          task: 'sync_creatives',
+          stateful: true,
+          sample_request: { creatives: [] },
+        }],
+      },
+      {
+        id: deliverySource.id,
+        title: deliverySource.title,
+        depends_on: deliverySource.depends_on,
+        steps: [{
+          id: 'delivery_state',
+          title: 'Delivery state',
+          task: 'get_products',
+          stateful: true,
+          sample_request: { brief: 'delivery state' },
+        }],
+      },
+    ],
+  };
+
+  let getProductsCalls = 0;
+  const tools = ['get_adcp_capabilities', 'get_products', 'sync_creatives'];
+  const result = await runStoryboard('https://agent.example/mcp', storyboard, {
+    _profile: {
+      tools,
+      raw_capabilities: { creative: { has_creative_library: false } },
+    },
+    agentTools: tools,
+    _client: {
+      resetContext() {},
+      async getProducts() {
+        getProductsCalls++;
+        return { success: true, data: { products: [] } };
+      },
+    },
+  });
+
+  assert.equal(result.overall_passed, true);
+  assert.equal(getProductsCalls, 2);
+  const creativeResult = result.phases.find(phase => phase.phase_id === 'creative_sync');
+  const deliveryResult = result.phases.find(phase => phase.phase_id === 'delivery_monitoring');
+  assert.equal(creativeResult.steps[0].skip_reason, 'not_applicable');
+  assert.notEqual(deliveryResult.steps[0].skipped, true);
+  assert.equal(deliveryResult.steps[0].passed, true);
+});


### PR DESCRIPTION
## Summary

- Backport the patch-eligible compliance scoping fixes from #6739 to the active 3.1 line.
- Skip creative-dependent seller scenarios and direct creative-sync phases when `creative.has_creative_library` is false.
- Preserve 3.1's existing auto-approval and snapshot applicability checks through supported phase-level gates.
- Gate `refine_products` on the advertised `refine` buying mode.
- Keep measurement-term rejection universal while removing the optional acceptance arm, because 3.1 has no stable capability bit for acceptance.

## Release safety

This intentionally does not backport the new 3.2 capability field or acceptance scenario. It changes only conformance selection/coverage behavior and carries a patch changeset for 3.1.19.

## Validation

- Full precommit: 1,012 unit tests, lint checks, and typecheck passed.
- Full staged server suite: 4,360 tests passed, 30 skipped; typecheck passed.
- Focused SDK capability-gate regressions: 11 passed.
- Compliance build and storyboard scoping/branch-set linters passed.

Backport of #6739. Resolves the 3.1 portions of #6701 and #6702.
