### PR TITLE
fix(compliance): backport optional media-buy scoping to 3.0

### DIFF
--- a/.changeset/scope-optional-media-buy-compliance-3-0.md
+++ b/.changeset/scope-optional-media-buy-compliance-3-0.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Gate creative-library compliance paths on the stable 3.0 capability, keep measurement acceptance out of the universal rejection scenario, and exclude refinement from badge requirements where 3.0 has no matching capability field.

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -1,5 +1,5 @@
 id: media_buy_seller
-version: "1.0.0"
+version: "1.0.1"
 title: "Media buy seller agent"
 category: media_buy_seller
 summary: "Seller agent that receives briefs, returns products, accepts media buys, and reports delivery."
@@ -8,7 +8,6 @@ required_tools:
   - get_products
   - create_media_buy
 requires_scenarios:
-  - media_buy_seller/refine_products
   - media_buy_seller/delivery_reporting
   - media_buy_seller/measurement_terms_rejected
   - media_buy_seller/pending_creatives_to_start
@@ -559,6 +558,9 @@ phases:
 
   - id: creative_sync
     title: "Creative sync"
+    requires_capability:
+      path: creative.has_creative_library
+      equals: true
     narrative: |
       With the media buy confirmed, the buyer syncs creative assets to your platform.
       Each package in the buy has creative format requirements — the buyer discovered
@@ -712,6 +714,7 @@ phases:
 
   - id: delivery_monitoring
     title: "Delivery and reporting"
+    depends_on: [create_buy]
     narrative: |
       The campaign is live. The buyer monitors delivery through two tasks:
       get_media_buys for status and get_media_buy_delivery for performance metrics.

--- a/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/creative_fate_after_cancellation.yaml
@@ -1,5 +1,5 @@
 id: media_buy_seller/creative_fate_after_cancellation
-version: "1.0.0"
+version: "1.0.1"
 title: "Creative lifecycle is decoupled from media buy lifecycle"
 category: media_buy_seller
 summary: "Validates that canceling a media buy releases package-creative assignments but leaves the underlying creatives in the library with their review state intact, and that buyers can reuse released creatives on a new buy."
@@ -10,6 +10,10 @@ required_tools:
   - update_media_buy
   - sync_creatives
   - list_creatives
+
+requires_capability:
+  path: creative.has_creative_library
+  equals: true
 
 narrative: |
   Per the creative library model (docs/creative/creative-libraries#creative-state-and-assignment-state-are-separate)

--- a/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/measurement_terms_rejected.yaml
@@ -1,26 +1,20 @@
 id: media_buy_seller/measurement_terms_rejected
-version: "1.0.0"
+version: "1.0.1"
 title: "Seller rejects unworkable measurement_terms"
 category: media_buy_seller
-summary: "Buyer proposes measurement_terms the seller will not accept; seller returns TERMS_REJECTED; buyer retries with seller-compatible terms."
+summary: "Buyer proposes unworkable measurement_terms and the seller returns TERMS_REJECTED."
 track: media_buy
 required_tools:
   - get_products
   - create_media_buy
 
 narrative: |
-  measurement_terms negotiation is a round-trip. The buyer proposes a measurement vendor,
-  window, and variance tolerance on each package; the seller either accepts (returning
-  measurement_terms echoed in the response) or rejects with TERMS_REJECTED and a message
-  explaining what is unacceptable. Because only successful responses are cached,
-  the buyer may retry the corrected payload with the same idempotency_key after a
-  TERMS_REJECTED response; if the first request had succeeded, reusing that key
-  against a different body would be rejected with IDEMPOTENCY_CONFLICT.
+  The buyer proposes a measurement vendor, window, and variance tolerance on each
+  package. This universal scenario sends intentionally unworkable terms and verifies
+  that the seller rejects them with TERMS_REJECTED and an explanatory message.
 
-  This scenario sends an intentionally aggressive first proposal (max_variance_percent: 0
-  with a window the seller does not guarantee), verifies the seller rejects with
-  TERMS_REJECTED, then retries with a relaxed proposal that falls inside the seller's
-  stated tolerance and expects a successful create_media_buy.
+  AdCP 3.0 has no capability bit for measurement-term acceptance, so the optional
+  relaxed-terms success arm is deliberately not graded on this maintenance line.
 
 agent:
   interaction_model: media_buy_seller
@@ -141,64 +135,3 @@ phases:
             path: "context.correlation_id"
             value: "measurement_terms_rejected--aggressive"
             description: "Context correlation_id returned unchanged"
-
-  - id: accept_terms
-    title: "Buyer retries with acceptable terms"
-    narrative: |
-      The buyer relaxes measurement_terms to match the seller's stated capability
-      (c7 window, 10% variance, makegood remedies) and retries. The seller accepts and
-      returns the confirmed terms echoed in the response.
-
-    steps:
-      - id: create_media_buy_relaxed_terms
-        title: "Propose seller-compatible measurement_terms"
-        task: create_media_buy
-        schema_ref: "media-buy/create-media-buy-request.json"
-        response_schema_ref: "media-buy/create-media-buy-response.json"
-        doc_ref: "/media-buy/task-reference/create_media_buy"
-        comply_scenario: create_media_buy
-        stateful: true
-        expected: |
-          The buy succeeds. The response echoes the accepted measurement_terms (possibly
-          normalized by the seller).
-
-        sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
-          account:
-            brand:
-              domain: "acmeoutdoor.example"
-            operator: "pinnacle-agency.example"
-          idempotency_key: "$generate:uuid_v4#media_buy_seller_measurement_terms_rejected_accept_terms_create_media_buy_relaxed_terms"
-          start_time: "2099-07-01T00:00:00Z"
-          end_time: "2099-09-30T23:59:59Z"
-          packages:
-            - product_id: "$context.product_id"
-              budget: 25000
-              pricing_option_id: "$context.pricing_option_id"
-              measurement_terms:
-                billing_measurement:
-                  vendor:
-                    domain: "videoamp.example"
-                  measurement_window: "c7"
-                  max_variance_percent: 10
-                makegood_policy:
-                  available_remedies: ["additional_delivery", "credit"]
-
-          context:
-            correlation_id: "measurement_terms_rejected--relaxed"
-        validations:
-          - check: response_schema
-            description: "Response matches create-media-buy-response.json schema"
-          - check: field_present
-            path: "media_buy_id"
-            description: "Seller returns a media_buy_id after accepting terms"
-          - check: field_present
-            path: "context"
-            description: "Response echoes back the context object"
-          - check: field_value
-            path: "context.correlation_id"
-            value: "measurement_terms_rejected--relaxed"
-            description: "Context correlation_id returned unchanged"
-        reviewer_checks:
-          - "Reviewer MUST confirm the seller releases the idempotency claim after a TERMS_REJECTED response. Probe: send the aggressive-terms request (same key, step 1), then retry with the same key and corrected terms (this step) — the seller MUST return a fresh media_buy_id, not IDEMPOTENCY_CONFLICT. A seller that caches rejected requests would make this two-step retry pattern impossible. See security.mdx#idempotency rule 3 ('Only successful responses are cached')."

--- a/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/pending_creatives_to_start.yaml
@@ -1,5 +1,5 @@
 id: media_buy_seller/pending_creatives_to_start
-version: "1.0.0"
+version: "1.0.1"
 title: "Creative sync unblocks pending_creatives → pending_start"
 category: media_buy_seller
 summary: "Verifies that a media buy created without creatives sits in pending_creatives until sync_creatives completes, then transitions to pending_start."
@@ -9,6 +9,10 @@ required_tools:
   - create_media_buy
   - sync_creatives
   - get_media_buys
+
+requires_capability:
+  path: creative.has_creative_library
+  equals: true
 
 narrative: |
   When a buyer creates a media buy without creative_assignments, the seller cannot start

--- a/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
+++ b/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
@@ -1,5 +1,5 @@
 id: creative_generative/seller
-version: "1.0.0"
+version: "1.0.1"
 title: "Generative seller agent"
 category: creative_generative
 summary: "Seller agent that generates creatives from briefs at buy time — no pre-built assets required."
@@ -11,7 +11,6 @@ required_tools:
   - sync_creatives
   - get_media_buy_delivery
 requires_scenarios:
-  - media_buy_seller/refine_products
   - media_buy_seller/delivery_reporting
 
 # Cross-step assertion (adcp#2664). status.monotonic rejects resource

--- a/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
+++ b/static/compliance/source/specialisms/sales-broadcast-tv/index.yaml
@@ -1,5 +1,5 @@
 id: sales_broadcast_tv
-version: "1.0.0"
+version: "1.0.1"
 title: "Broadcast linear TV seller agent"
 protocol: media-buy
 category: sales_broadcast_tv
@@ -9,7 +9,6 @@ required_tools:
   - get_products
   - create_media_buy
 requires_scenarios:
-  - media_buy_seller/refine_products
   - media_buy_seller/delivery_reporting
   - media_buy_seller/measurement_terms_rejected
   - media_buy_seller/pending_creatives_to_start
@@ -364,6 +363,9 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: creative_sync
     title: "Creative sync"
+    requires_capability:
+      path: creative.has_creative_library
+      equals: true
     narrative: |
       Broadcast creative sync differs from digital in three ways. First, assets are
       broadcast-grade video files — no VAST wrappers, no impression trackers, no click
@@ -501,6 +503,7 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: delivery_monitoring
     title: "Delivery and reporting"
+    depends_on: [create_buy]
     narrative: |
       Broadcast delivery reporting operates on a fundamentally different timeline than
       digital. Live ratings are available within 24 hours, but the numbers that matter
@@ -621,6 +624,7 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: reconciliation
     title: "Post-flight reconciliation"
+    depends_on: [delivery_monitoring]
     narrative: |
       Broadcast reconciliation cannot happen until C7 data has matured for every air
       date in the flight. For a flight ending December 31, final C7 data for the last

--- a/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
+++ b/static/compliance/source/specialisms/sales-catalog-driven/index.yaml
@@ -1,5 +1,5 @@
 id: sales_catalog_driven
-version: "1.0.0"
+version: "1.0.1"
 title: "Catalog-driven creative and conversion tracking"
 protocol: media-buy
 category: sales_catalog_driven
@@ -9,7 +9,6 @@ required_tools:
   - get_products
   - create_media_buy
 requires_scenarios:
-  - media_buy_seller/refine_products
   - media_buy_seller/delivery_reporting
   - media_buy_seller/pending_creatives_to_start
   - media_buy_seller/invalid_transitions

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -1,5 +1,5 @@
 id: sales_guaranteed
-version: "1.0.0"
+version: "1.0.1"
 title: "Guaranteed media buy with human IO approval"
 protocol: media-buy
 category: sales_guaranteed
@@ -9,7 +9,6 @@ required_tools:
   - get_products
   - create_media_buy
 requires_scenarios:
-  - media_buy_seller/refine_products
   - media_buy_seller/delivery_reporting
   - media_buy_seller/measurement_terms_rejected
   - media_buy_seller/pending_creatives_to_start
@@ -391,6 +390,9 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: creative_sync
     title: "Creative sync"
+    requires_capability:
+      path: creative.has_creative_library
+      equals: true
     narrative: |
       With the IO signed and the media buy active, the buyer syncs creative assets
       to your platform. Each package has creative format requirements that the buyer
@@ -453,6 +455,7 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: delivery_monitoring
     title: "Delivery and reporting"
+    depends_on: [confirm_active]
     narrative: |
       The campaign is live with guaranteed delivery commitments. The buyer monitors
       delivery to ensure the seller is meeting the SLA guarantees from the IO.

--- a/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
+++ b/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
@@ -1,5 +1,5 @@
 id: sales_proposal_mode
-version: "1.0.0"
+version: "1.0.1"
 title: "Media buy via proposal acceptance"
 protocol: media-buy
 category: sales_proposal_mode
@@ -352,6 +352,9 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: creative_sync
     title: "Creative sync"
+    requires_capability:
+      path: creative.has_creative_library
+      equals: true
     narrative: |
       With the proposal accepted and the media buy confirmed, the buyer syncs creative
       assets. The buyer first checks what formats the accepted products require, then
@@ -469,6 +472,7 @@ phases:
             description: "Context correlation_id returned unchanged"
   - id: delivery
     title: "Delivery and reporting"
+    depends_on: [accept_proposal]
     narrative: |
       The campaign from the accepted proposal is live. The buyer monitors delivery
       to verify the proposal's forecasts are tracking.

--- a/tests/maintenance-capability-scoping.test.cjs
+++ b/tests/maintenance-capability-scoping.test.cjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const YAML = require('yaml');
+
+const sourceRoot = path.join(__dirname, '..', 'static', 'compliance', 'source');
+const scenarioRoot = path.join(sourceRoot, 'protocols', 'media-buy', 'scenarios');
+
+function load(file) {
+  return YAML.parse(fs.readFileSync(file, 'utf8'));
+}
+
+test('3.0 creative-dependent seller scenarios require a creative library', () => {
+  for (const name of ['pending_creatives_to_start', 'creative_fate_after_cancellation']) {
+    const storyboard = load(path.join(scenarioRoot, `${name}.yaml`));
+    assert.deepEqual(storyboard.requires_capability, {
+      path: 'creative.has_creative_library',
+      equals: true,
+    }, name);
+  }
+});
+
+test('3.0 keeps only universal measurement-term rejection', () => {
+  const storyboard = load(path.join(scenarioRoot, 'measurement_terms_rejected.yaml'));
+  assert.deepEqual(storyboard.phases.map(phase => phase.id), [
+    'discover_products',
+    'reject_terms',
+  ]);
+});
+
+test('3.0 does not make refinement badge-required without a capability field', () => {
+  const indexFiles = [
+    path.join(sourceRoot, 'protocols', 'media-buy', 'index.yaml'),
+    path.join(sourceRoot, 'specialisms', 'sales-guaranteed', 'index.yaml'),
+    path.join(sourceRoot, 'specialisms', 'sales-broadcast-tv', 'index.yaml'),
+    path.join(sourceRoot, 'specialisms', 'sales-catalog-driven', 'index.yaml'),
+    path.join(sourceRoot, 'specialisms', 'creative-generative', 'generative-seller.yaml'),
+  ];
+
+  for (const file of indexFiles) {
+    const index = load(file);
+    assert.ok(
+      !index.requires_scenarios.includes('media_buy_seller/refine_products'),
+      index.id
+    );
+  }
+});
+
+test('3.0 direct creative-sync phases have authoritative library gates', () => {
+  const indexFiles = [
+    path.join(sourceRoot, 'protocols', 'media-buy', 'index.yaml'),
+    ...['sales-broadcast-tv', 'sales-guaranteed', 'sales-proposal-mode'].map(name =>
+      path.join(sourceRoot, 'specialisms', name, 'index.yaml')
+    ),
+  ];
+
+  for (const file of indexFiles) {
+    const index = load(file);
+    const phase = index.phases.find(candidate => candidate.id === 'creative_sync');
+    assert.deepEqual(phase.requires_capability, {
+      path: 'creative.has_creative_library',
+      equals: true,
+    }, index.id);
+  }
+});


### PR DESCRIPTION
## Summary

- Backport the patch-eligible compliance scoping fixes from #6739 to the active 3.0 line.
- Skip creative-dependent seller scenarios and direct creative-sync phases when `creative.has_creative_library` is false.
- Keep measurement-term rejection universal while removing the optional acceptance arm.
- Remove `refine_products` from badge-required scenario lists because AdCP 3.0 has no `media_buy.buying_modes` capability field; the scenario remains available for explicit diagnostic runs.

## Release safety

This intentionally adds no protocol fields. It changes conformance selection and badge coverage only, using the existing stable 3.0 creative capability, and carries a patch changeset for 3.0.26.

## Validation

- Full precommit: 834 unit tests, dynamic-import lint, and typecheck passed.
- Focused maintenance scoping regressions: 4 passed.
- Compliance build and storyboard scoping/branch-set linters passed.

Backport of #6739. Resolves the 3.0 portions of #6701 and #6702.
