### PR TITLE
chore(deps): adopt @adcp/sdk 14.0.0-beta.5 and move pins to 3.2-beta.4

### DIFF
--- a/.changeset/upgrade-training-agent-sdk-beta-5.md
+++ b/.changeset/upgrade-training-agent-sdk-beta-5.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Align the AdCP 3.2 beta compliance surface and training agent with `@adcp/sdk@14.0.0-beta.5`. The beta.5 validators carry the flexible-window availability vocabulary, so the `availability_windows` `list_with_horizon` step is no longer registered known-failing (closes the adcp-client#2637 exclusion) and the scenario grades all eight steps. Wire pins move from `3.2-beta.3` to `3.2-beta.4` across the training agent, compliance scenarios, and versioned reference docs.

--- a/dist/schemas/index.json
+++ b/dist/schemas/index.json
@@ -9,7 +9,7 @@
   "aliases": {
     "v3": "3.1.18",
     "v3.1": "3.1.18",
-    "v3.0": "3.0.18",
+    "v3.0": "3.0.25",
     "v2": "2.5.3",
     "v2.5": "2.5.3"
   },
@@ -19,7 +19,7 @@
   },
   "latest_by_minor": {
     "3.1": "3.1.18",
-    "3.0": "3.0.18",
+    "3.0": "3.0.25",
     "2.5": "2.5.3"
   },
   "versions": [
@@ -422,6 +422,14 @@
       "superseded_by": "3.1.0",
       "path": "/schemas/3.1.0-beta.0/",
       "index": "/schemas/3.1.0-beta.0/index.json"
+    },
+    {
+      "version": "3.0.25",
+      "stability": "stable",
+      "prerelease": false,
+      "deprecated": false,
+      "path": "/schemas/3.0.25/",
+      "index": "/schemas/3.0.25/index.json"
     },
     {
       "version": "3.0.18",

--- a/docs/building/by-layer/L4/choose-your-sdk.mdx
+++ b/docs/building/by-layer/L4/choose-your-sdk.mdx
@@ -17,14 +17,14 @@ What "shipped" means at each layer is the [L0–L3 checklist](/docs/building/cro
 
 | SDK | Current package | 3.2 beta support | L0 | L1 | L2 | L3 |
 |---|---|---|:-:|:-:|:-:|:-:|
-| **`@adcp/sdk`** (TypeScript) | `14.0.0-beta.4` | Exact `3.2.0-beta.3` support | ✅ | ✅ | ✅ | ✅ |
+| **`@adcp/sdk`** (TypeScript) | `14.0.0-beta.5` | Exact `3.2.0-beta.4` support | ✅ | ✅ | ✅ | ✅ |
 | **`adcp`** (Python) | `7.0.2` | Pending exact 3.2 support | ✅ | ⚠️ | ⚠️ | ⚠️ |
 | **`adcp/v3`** (Go) | `v3.0.0` | Pending exact 3.2 support | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
 
 Legend: ✅ shipped · ⚠️ partial / role-dependent · ❌ not yet covered. The L0–L3 columns describe the current package, not a 3.2 support claim.
 
 <Warning>
-**3.2 packages are prereleases.** The TypeScript beta supports the exact beta.3
+**3.2 packages are prereleases.** The TypeScript beta supports the exact beta.4
 protocol checkpoint; it does not imply compatibility with a future beta.4.
 Python and Go have not published exact 3.2 support statements yet. See the
 [3.2 beta program](/docs/reference/3-2-beta).
@@ -49,7 +49,7 @@ and the [Slack community](/docs/community/joining-slack).
 [![npm version](https://img.shields.io/npm/v/@adcp/sdk)](https://www.npmjs.com/package/@adcp/sdk)
 
 ```bash
-npm install @adcp/sdk@14.0.0-beta.4
+npm install @adcp/sdk@14.0.0-beta.5
 ```
 
 ```javascript
@@ -63,7 +63,7 @@ const client = createSingleAgentClient({
 });
 
 const products = await client.listProducts({
-  adcp_version: '3.2-beta.3',
+  adcp_version: '3.2-beta.4',
   account: { account_id: 'account_123' },
   criteria: {
     offer_filters: { channels: ['ctv'] },
@@ -158,11 +158,11 @@ Both SDKs share the same positional shape: `adcp <agent> [tool] [payload]`. The 
 ### JavaScript CLI
 
 ```bash
-npx @adcp/sdk@14.0.0-beta.4 --help
-npx @adcp/sdk@14.0.0-beta.4 --save-auth my-agent https://sales.example.com/mcp
-npx @adcp/sdk@14.0.0-beta.4 my-agent list_products '{"adcp_version":"3.2-beta.3","account":{"account_id":"account_123"}}'
+npx @adcp/sdk@14.0.0-beta.5 --help
+npx @adcp/sdk@14.0.0-beta.5 --save-auth my-agent https://sales.example.com/mcp
+npx @adcp/sdk@14.0.0-beta.5 my-agent list_products '{"adcp_version":"3.2-beta.4","account":{"account_id":"account_123"}}'
 # or against the built-in public test agent:
-npx @adcp/sdk@14.0.0-beta.4 test-mcp list_products '{"adcp_version":"3.2-beta.3"}'
+npx @adcp/sdk@14.0.0-beta.5 test-mcp list_products '{"adcp_version":"3.2-beta.4"}'
 ```
 
 The CLI also drives storyboards (`adcp storyboard run`), conformance grading (`adcp grade`), and registry diagnostics. See `--help` for the full surface.

--- a/docs/building/by-layer/L4/choose-your-sdk.mdx
+++ b/docs/building/by-layer/L4/choose-your-sdk.mdx
@@ -25,7 +25,7 @@ Legend: ✅ shipped · ⚠️ partial / role-dependent · ❌ not yet covered. T
 
 <Warning>
 **3.2 packages are prereleases.** The TypeScript beta supports the exact beta.4
-protocol checkpoint; it does not imply compatibility with a future beta.4.
+protocol checkpoint; it does not imply compatibility with a later beta.
 Python and Go have not published exact 3.2 support statements yet. See the
 [3.2 beta program](/docs/reference/3-2-beta).
 </Warning>

--- a/docs/media-buy/index.mdx
+++ b/docs/media-buy/index.mdx
@@ -46,7 +46,7 @@ delivery constraints use structured criteria:
 const proposals = await Promise.all(
   sellers.map((seller) =>
     seller.requestProposals({
-      adcp_version: '3.2-beta.3',
+      adcp_version: '3.2-beta.4',
       idempotency_key: 'acme-q2-proposals-001',
       account: { account_id: 'account_123' },
       brand: { domain: 'acme-outdoor.example' },
@@ -108,7 +108,7 @@ draft with typed constraints:
 
 ```javascript
 const refined = await streamHaus.refineProposals({
-  adcp_version: '3.2-beta.3',
+  adcp_version: '3.2-beta.4',
   idempotency_key: 'acme-q2-refine-001',
   refinements: [
     {
@@ -154,7 +154,7 @@ creates a committed successor and an inventory hold:
 
 ```javascript
 const finalized = await streamHaus.refineProposals({
-  adcp_version: '3.2-beta.3',
+  adcp_version: '3.2-beta.4',
   idempotency_key: 'acme-q2-finalize-001',
   refinements: [
     {
@@ -170,7 +170,7 @@ accepts that exact snapshot:
 
 ```javascript
 const buy = await streamHaus.acceptProposal({
-  adcp_version: '3.2-beta.3',
+  adcp_version: '3.2-beta.4',
   idempotency_key: 'acme-q2-accept-001',
   account: { account_id: 'account_123' },
   proposal_id: 'proposal_streamhaus_003',
@@ -200,7 +200,7 @@ required format has coverage, then moves to `pending_start` or `active`.
 
 ```javascript
 await streamHaus.syncCreatives({
-  adcp_version: '3.2-beta.3',
+  adcp_version: '3.2-beta.4',
   idempotency_key: 'acme-q2-creatives-001',
   account: { account_id: 'account_123' },
   creatives: [
@@ -255,7 +255,7 @@ a package or adjust a budget inside the accepted commercial envelope, he uses
 
 ```javascript
 const controlled = await streamHaus.controlMediaBuy({
-  adcp_version: '3.2-beta.3',
+  adcp_version: '3.2-beta.4',
   idempotency_key: 'acme-q2-control-001',
   account: { account_id: 'account_123' },
   media_buy_id: buy.media_buy_id,

--- a/docs/media-buy/product-discovery/index.mdx
+++ b/docs/media-buy/product-discovery/index.mdx
@@ -79,7 +79,7 @@ without asking the seller to author a media plan:
 
 ```javascript
 const result = await seller.listProducts({
-  adcp_version: '3.2-beta.3',
+  adcp_version: '3.2-beta.4',
   account: { account_id: 'account_123' },
   criteria: {
     offer_filters: {
@@ -114,7 +114,7 @@ structured criteria to StreamHaus while keeping strategy in prose:
 
 ```javascript
 const response = await seller.requestProposals({
-  adcp_version: '3.2-beta.3',
+  adcp_version: '3.2-beta.4',
   idempotency_key: 'acme-q2-proposals-001',
   account: { account_id: 'account_123' },
   brand: { domain: 'acme-outdoor.example' },

--- a/docs/media-buy/product-discovery/proposal-negotiation.mdx
+++ b/docs/media-buy/product-discovery/proposal-negotiation.mdx
@@ -488,7 +488,7 @@ Record the authenticated buyer, source IDs, successor IDs, idempotency fingerpri
 
 The canonical compliance scenario is `media_buy_seller/typed_proposal_negotiation`. It exercises capability gating, satisfied and unsatisfied constraints, alternatives, immutable lineage, finalize atomicity, exact replay, acceptance, amendment, cancellation, double-finalize rejection, and multi-source ordering.
 
-The deterministic training profiles expose the exact `3.2-beta.3` proposal-negotiation wire contract. The ordinary `/sales/mcp` route remains the backward-compatible ask-only seller. Use the [public test token](/docs/quickstart#setup) with `https://test-agent.adcontextprotocol.org` and one of these capability-distinct routes:
+The deterministic training profiles expose the exact `3.2-beta.4` proposal-negotiation wire contract. The ordinary `/sales/mcp` route remains the backward-compatible ask-only seller. Use the [public test token](/docs/quickstart#setup) with `https://test-agent.adcontextprotocol.org` and one of these capability-distinct routes:
 
 | Profile | Route | Deterministic behavior |
 | --- | --- | --- |
@@ -496,7 +496,7 @@ The deterministic training profiles expose the exact `3.2-beta.3` proposal-negot
 | Constrained seller | `/sales/profiles/constrained-seller/mcp` | USD floors, product conflicts, and at most two available alternatives |
 | Finalization failure | `/sales/profiles/finalization-failure/mcp` | `hold_unavailable` plus `batch_aborted` siblings with no committed successors |
 
-Pin the beta exactly on every call. A stable `3.2` selector intentionally negotiates to the seller's stable compatibility response instead of silently opting into beta behavior. The bundled `ADCPMultiAgentClient.simple()` proposal path cannot yet target a different exact beta ordinal. Until [adcp-client#2609](https://github.com/adcontextprotocol/adcp-client/issues/2609) ships, construct a lower-level client with `wireAdcpVersion: "3.2-beta.3"` or send raw calls as below.
+Pin the beta exactly on every call. A stable `3.2` selector intentionally negotiates to the seller's stable compatibility response instead of silently opting into beta behavior. The bundled `ADCPMultiAgentClient.simple()` proposal path cannot yet target a different exact beta ordinal. Until [adcp-client#2609](https://github.com/adcontextprotocol/adcp-client/issues/2609) ships, construct a lower-level client with `wireAdcpVersion: "3.2-beta.4"` or send raw calls as below.
 
 ### Run the constrained profile
 
@@ -540,14 +540,14 @@ async function callTool(id, name, args) {
 }
 
 const version = {
-  adcp_version: '3.2-beta.3',
+  adcp_version: '3.2-beta.4',
   adcp_major_version: 3,
 };
 const nonce = crypto.randomUUID();
 
 const capabilities = await callTool(1, 'get_adcp_capabilities', version);
 if (
-  capabilities.adcp_version !== '3.2-beta.3'
+  capabilities.adcp_version !== '3.2-beta.4'
   || capabilities.media_buy?.supports_proposals !== true
   || !capabilities.media_buy?.lifecycle_tools?.includes('refine_proposals')
 ) {

--- a/docs/reference/3-2-beta.mdx
+++ b/docs/reference/3-2-beta.mdx
@@ -15,18 +15,19 @@ before GA.
 </Warning>
 
 The 3.2 beta cycle started with a protocol-first checkpoint. The current
-TypeScript SDK beta now consumes the exact signed beta.3 bundle:
+TypeScript SDK beta now consumes the exact signed beta.4 bundle:
 
 | Checkpoint | Purpose | Who should test |
 |---|---|---|
 | `3.2.0-beta.0` | Canonical schemas, compliance assets, skills, and protocol manifest for SDK implementation | SDK maintainers, code-generator maintainers, raw-wire implementers, and agent teams that can validate without generated 3.2 SDK types |
 | `3.2.0-beta.1` | First integration-correction checkpoint | Pinned adopters comparing beta.0 and beta.1 behavior |
 | `3.2.0-beta.2` | Second integration-correction checkpoint | Pinned adopters comparing beta.1 and beta.2 behavior |
-| `3.2.0-beta.3` | Current protocol checkpoint | Buyer and seller teams running end-to-end integrations |
+| `3.2.0-beta.3` | Third integration-correction checkpoint | Pinned adopters comparing beta.2 and beta.3 behavior |
+| `3.2.0-beta.4` | Current protocol checkpoint | Buyer and seller teams running end-to-end integrations |
 | SDK wave | `@adcp/sdk@14.0.0-beta.5` embeds `3.2.0-beta.4`; Python and Go remain pending | TypeScript adopters, Python and Go maintainers, and early integration teams |
 
 Earlier betas remain useful as pinned implementation checkpoints. For new
-TypeScript testing, pair SDK beta.4 with protocol beta.3. Do not combine a newer
+TypeScript testing, pair SDK beta.5 with protocol beta.4. Do not combine a newer
 wire pin with an SDK generated from an older bundle unless the SDK maintainer
 explicitly documents forward compatibility.
 
@@ -49,7 +50,7 @@ a stable `"3.2"` pin must not silently negotiate to a beta.
 
 ## Use the TypeScript SDK beta
 
-The TypeScript SDK is the first package with exact beta.3 support. The npm
+The TypeScript SDK is the first package with exact beta.4 support. The npm
 `latest` tag remains on SDK 13, so opt into the preview explicitly:
 
 ```bash
@@ -57,25 +58,25 @@ npm install @adcp/sdk@14.0.0-beta.5
 ```
 
 SDK 14 includes typed caller and server support for the compact media-buy
-lifecycle, the beta.3 schemas and compliance assets, version-aware request
+lifecycle, the beta.4 schemas and compliance assets, version-aware request
 signing, governance plan-adjustment reporting, and agent notification
 configuration. It retains 3.0 and 3.1 adaptation for mixed-version testing.
 See [Choose your SDK](/docs/building/by-layer/L4/choose-your-sdk) for the support
 matrix and install guidance.
 
-## Use the beta.3 artifact directly
+## Use the beta.4 artifact directly
 
-Download the signed beta.3 protocol bundle rather
+Download the signed beta.4 protocol bundle rather
 than copying schemas from `main` or from the moving `/schemas/latest/` path:
 
 ```bash
-curl -fLO https://adcontextprotocol.org/protocol/3.2.0-beta.3.tgz
-curl -fLO https://adcontextprotocol.org/protocol/3.2.0-beta.3.tgz.sha256
-shasum -a 256 -c 3.2.0-beta.3.tgz.sha256
-tar -xzf 3.2.0-beta.3.tgz
+curl -fLO https://adcontextprotocol.org/protocol/3.2.0-beta.4.tgz
+curl -fLO https://adcontextprotocol.org/protocol/3.2.0-beta.4.tgz.sha256
+shasum -a 256 -c 3.2.0-beta.4.tgz.sha256
+tar -xzf 3.2.0-beta.4.tgz
 ```
 
-The extracted `adcp-3.2.0-beta.3/` directory contains:
+The extracted `adcp-3.2.0-beta.4/` directory contains:
 
 - `manifest.json` — release version, bundle contents, skills, and file count;
 - `schemas/` — source-shaped and bundled request/response schemas, including
@@ -99,7 +100,7 @@ Useful direct-artifact tests are:
    one. Do not weaken production authentication to accommodate a beta runner.
 
 <Note>
-**No 3.2 verification badge is currently issued for beta.3.** Treat it as an
+**No 3.2 verification badge is currently issued for beta.4.** Treat it as an
 implementation input, not a certification target.
 </Note>
 
@@ -114,7 +115,7 @@ An SDK support claim must name all of the following:
 - install command and one tested validation command.
 
 The SDK compatibility matrix lives in [Choose your SDK](/docs/building/by-layer/L4/choose-your-sdk).
-Only the TypeScript row currently names exact beta.3 support. Treat generated
+Only the TypeScript row currently names exact beta.4 support. Treat generated
 3.2 types and validators in every other SDK as unavailable until its row names
 an exact package and protocol checkpoint. Raw JSON calls may still be possible,
 but they are not equivalent to SDK support.
@@ -125,15 +126,15 @@ SDK implementation bugs in the SDK's own repository. Accepted protocol fixes
 receive a changeset and ship in a later beta; published betas are never rebuilt
 in place.
 
-## Current beta.3 checkpoint
+## Current beta.4 checkpoint
 
-Protocol beta.1, beta.2, and beta.3 are published, and TypeScript SDK beta.4 embeds the
-exact beta.3 bundle. Before treating a test result as beta.3 integration
+Protocol beta.1 through beta.4 are published, and TypeScript SDK beta.5 embeds the
+exact beta.4 bundle. Before treating a test result as beta.4 integration
 evidence, confirm that:
 
-- the support matrix names the exact SDK package and beta.3 protocol bundle;
+- the support matrix names the exact SDK package and beta.4 protocol bundle;
 - both peers advertise `"3.2-beta.4"` before calls use that pin;
-- the integration scenarios below run against beta.3 and retain the exact
+- the integration scenarios below run against beta.4 and retain the exact
   package and bundle versions;
 - copy/paste installation and validation commands have been executed as
   published;
@@ -223,7 +224,7 @@ Include this information in a beta issue:
 - schema path or JSON Pointer involved;
 - expected and actual behavior;
 - minimal redacted payload and validation error;
-- whether the problem blocks beta.3 interoperability.
+- whether the problem blocks beta.4 interoperability.
 
 Never include credentials, signed URLs, bearer tokens, private keys, or live
 customer payloads.

--- a/docs/reference/3-2-beta.mdx
+++ b/docs/reference/3-2-beta.mdx
@@ -23,7 +23,7 @@ TypeScript SDK beta now consumes the exact signed beta.3 bundle:
 | `3.2.0-beta.1` | First integration-correction checkpoint | Pinned adopters comparing beta.0 and beta.1 behavior |
 | `3.2.0-beta.2` | Second integration-correction checkpoint | Pinned adopters comparing beta.1 and beta.2 behavior |
 | `3.2.0-beta.3` | Current protocol checkpoint | Buyer and seller teams running end-to-end integrations |
-| SDK wave | `@adcp/sdk@14.0.0-beta.4` embeds `3.2.0-beta.3`; Python and Go remain pending | TypeScript adopters, Python and Go maintainers, and early integration teams |
+| SDK wave | `@adcp/sdk@14.0.0-beta.5` embeds `3.2.0-beta.4`; Python and Go remain pending | TypeScript adopters, Python and Go maintainers, and early integration teams |
 
 Earlier betas remain useful as pinned implementation checkpoints. For new
 TypeScript testing, pair SDK beta.4 with protocol beta.3. Do not combine a newer
@@ -35,16 +35,16 @@ explicitly documents forward compatibility.
 The artifact version, wire pin, and documentation selector are related but not
 interchangeable:
 
-| Surface | beta.0 | beta.1 | beta.2 | beta.3 |
-|---|---|---|---|---|
-| Protocol artifact | `3.2.0-beta.0` | `3.2.0-beta.1` | `3.2.0-beta.2` | `3.2.0-beta.3` |
-| Git tag | `v3.2.0-beta.0` | `v3.2.0-beta.1` | `v3.2.0-beta.2` | `v3.2.0-beta.3` |
-| `adcp_version` wire pin | `"3.2-beta.0"` | `"3.2-beta.1"` | `"3.2-beta.2"` | `"3.2-beta.3"` |
-| Documentation selector | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` |
+| Surface | beta.0 | beta.1 | beta.2 | beta.3 | beta.4 |
+|---|---|---|---|---|---|
+| Protocol artifact | `3.2.0-beta.0` | `3.2.0-beta.1` | `3.2.0-beta.2` | `3.2.0-beta.3` | `3.2.0-beta.4` |
+| Git tag | `v3.2.0-beta.0` | `v3.2.0-beta.1` | `v3.2.0-beta.2` | `v3.2.0-beta.3` | `v3.2.0-beta.4` |
+| `adcp_version` wire pin | `"3.2-beta.0"` | `"3.2-beta.1"` | `"3.2-beta.2"` | `"3.2-beta.3"` | `"3.2-beta.4"` |
+| Documentation selector | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` |
 
 Only send a prerelease wire pin to a peer that advertises that exact value in
 `get_adcp_capabilities.adcp.supported_versions`. Prerelease pins are exact: a
-buyer pinned to `"3.2-beta.3"` must not silently negotiate to another beta, and
+buyer pinned to `"3.2-beta.4"` must not silently negotiate to another beta, and
 a stable `"3.2"` pin must not silently negotiate to a beta.
 
 ## Use the TypeScript SDK beta
@@ -53,7 +53,7 @@ The TypeScript SDK is the first package with exact beta.3 support. The npm
 `latest` tag remains on SDK 13, so opt into the preview explicitly:
 
 ```bash
-npm install @adcp/sdk@14.0.0-beta.4
+npm install @adcp/sdk@14.0.0-beta.5
 ```
 
 SDK 14 includes typed caller and server support for the compact media-buy
@@ -93,7 +93,7 @@ Useful direct-artifact tests are:
 1. Generate or refresh types from the pinned bundled schemas.
 2. Validate representative requests and responses for the roles you implement.
 3. Compare your advertised tools with `schemas/manifest.json`.
-4. Exercise raw MCP or A2A calls with `adcp_version: "3.2-beta.3"` against a
+4. Exercise raw MCP or A2A calls with `adcp_version: "3.2-beta.4"` against a
    staging peer that advertises the same pin.
 5. Run the compliance assets with a source-compatible runner if you maintain
    one. Do not weaken production authentication to accommodate a beta runner.
@@ -132,7 +132,7 @@ exact beta.3 bundle. Before treating a test result as beta.3 integration
 evidence, confirm that:
 
 - the support matrix names the exact SDK package and beta.3 protocol bundle;
-- both peers advertise `"3.2-beta.3"` before calls use that pin;
+- both peers advertise `"3.2-beta.4"` before calls use that pin;
 - the integration scenarios below run against beta.3 and retain the exact
   package and bundle versions;
 - copy/paste installation and validation commands have been executed as

--- a/docs/reference/migration/3-1-to-3-2.mdx
+++ b/docs/reference/migration/3-1-to-3-2.mdx
@@ -8,7 +8,7 @@ description: "Role-based migration checklist for adopting the AdCP 3.2 beta whil
 # Migrating from 3.1 to 3.2
 
 <Warning>
-**3.2 is in beta.** Beta.3 is the current protocol checkpoint, with exact
+**3.2 is in beta.** Beta.4 is the current protocol checkpoint, with exact
 TypeScript support in `@adcp/sdk@14.0.0-beta.5`. Python and Go support remain
 pending. Keep production traffic pinned to `"3.1"` while validating 3.2 in
 staging.
@@ -33,13 +33,13 @@ For prerelease artifacts and SDK timing, use the [3.2 beta program](/docs/refere
 | 5 | Media-buy implementations | Move create/update success handling completely to `media_buy_status`. |
 | 6 | Signing implementations | Require `content-digest` coverage and migrate request `Signature` and `Content-Digest` binary values to RFC 8941 padded Base64. |
 | 7 | Creative implementations | Adopt canonical format capability/product discovery and isolate legacy projection at compatibility boundaries. |
-| 8 | Compliance operators | Pair `@adcp/sdk@14.0.0-beta.5` with exact beta.3 for TypeScript testing; require an equally explicit support statement for every other SDK. |
+| 8 | Compliance operators | Pair `@adcp/sdk@14.0.0-beta.5` with exact beta.4 for TypeScript testing; require an equally explicit support statement for every other SDK. |
 
 ## Required to claim 3.2 behavior
 
 ### Serve and echo the exact release
 
-During beta, prerelease matching is exact. A seller serving beta.3 advertises
+During beta, prerelease matching is exact. A seller serving beta.4 advertises
 `"3.2-beta.4"`. Do not advertise stable `"3.2"` before GA, silently negotiate
 between beta ordinals, or treat a major-only declaration as evidence of 3.2
 support.

--- a/docs/reference/migration/3-1-to-3-2.mdx
+++ b/docs/reference/migration/3-1-to-3-2.mdx
@@ -9,7 +9,7 @@ description: "Role-based migration checklist for adopting the AdCP 3.2 beta whil
 
 <Warning>
 **3.2 is in beta.** Beta.3 is the current protocol checkpoint, with exact
-TypeScript support in `@adcp/sdk@14.0.0-beta.4`. Python and Go support remain
+TypeScript support in `@adcp/sdk@14.0.0-beta.5`. Python and Go support remain
 pending. Keep production traffic pinned to `"3.1"` while validating 3.2 in
 staging.
 </Warning>
@@ -33,14 +33,14 @@ For prerelease artifacts and SDK timing, use the [3.2 beta program](/docs/refere
 | 5 | Media-buy implementations | Move create/update success handling completely to `media_buy_status`. |
 | 6 | Signing implementations | Require `content-digest` coverage and migrate request `Signature` and `Content-Digest` binary values to RFC 8941 padded Base64. |
 | 7 | Creative implementations | Adopt canonical format capability/product discovery and isolate legacy projection at compatibility boundaries. |
-| 8 | Compliance operators | Pair `@adcp/sdk@14.0.0-beta.4` with exact beta.3 for TypeScript testing; require an equally explicit support statement for every other SDK. |
+| 8 | Compliance operators | Pair `@adcp/sdk@14.0.0-beta.5` with exact beta.3 for TypeScript testing; require an equally explicit support statement for every other SDK. |
 
 ## Required to claim 3.2 behavior
 
 ### Serve and echo the exact release
 
 During beta, prerelease matching is exact. A seller serving beta.3 advertises
-`"3.2-beta.3"`. Do not advertise stable `"3.2"` before GA, silently negotiate
+`"3.2-beta.4"`. Do not advertise stable `"3.2"` before GA, silently negotiate
 between beta ordinals, or treat a major-only declaration as evidence of 3.2
 support.
 

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -11,7 +11,7 @@ Authoritative version-by-version release record for AdCP, with cumulative change
 
 ## Version 3.2.0
 
-**Status:** Beta cycle — minor release targeting the 3.2.0 milestone. Beta.0 was the protocol-first cut used as the canonical input for SDK work. Beta.3 is the current checkpoint, with exact TypeScript support in `@adcp/sdk@14.0.0-beta.4`. Stable wire shapes remain backward compatible except for the ratified `media_buy_status` cleanup and request-signature encoding migration described below; explicitly experimental surfaces may carry noticed changes under the [experimental-status contract](/docs/reference/experimental-status).
+**Status:** Beta cycle — minor release targeting the 3.2.0 milestone. Beta.0 was the protocol-first cut used as the canonical input for SDK work. Beta.4 is the current checkpoint, with exact TypeScript support in `@adcp/sdk@14.0.0-beta.5`. Stable wire shapes remain backward compatible except for the ratified `media_buy_status` cleanup and request-signature encoding migration described below; explicitly experimental surfaces may carry noticed changes under the [experimental-status contract](/docs/reference/experimental-status).
 
 ### Beta checkpoints
 
@@ -20,7 +20,8 @@ Authoritative version-by-version release record for AdCP, with cumulative change
 | `3.2.0-beta.0` | Publish signed schemas, compliance assets, skills, and manifest for implementation feedback | SDK support follows this cut; beta.0 is not an SDK-backed certification target |
 | `3.2.0-beta.1` | Incorporate the first round of integration corrections | Superseded by beta.2 for new beta testing |
 | `3.2.0-beta.2` | Publish the second integration checkpoint | Superseded by beta.3 for new beta testing |
-| `3.2.0-beta.3` | Publish the current corrected protocol checkpoint | Exact TypeScript support in `@adcp/sdk@14.0.0-beta.4`; Python and Go remain pending |
+| `3.2.0-beta.4` | Publish the current protocol checkpoint (flexible-window availability, outcome_target reverse forecasting, availability conformance) | Exact TypeScript support in `@adcp/sdk@14.0.0-beta.5`; Python and Go remain pending |
+| `3.2.0-beta.3` | Corrected protocol checkpoint, superseded by beta.4 | Superseded; remains available for pinned prerelease adopters |
 
 Each beta is immutable. The `3.2-beta` documentation selector advances to the latest beta, while pinned protocol, schema, compliance, and documentation artifacts remain available. See the [3.2 beta program](/docs/reference/3-2-beta).
 
@@ -42,7 +43,7 @@ Each beta is immutable. The `3.2-beta` documentation selector advances to the la
 | A signing implementation | Require `content-digest` coverage for every signed request body on a 3.2 signing endpoint. |
 | A creative implementation | Prefer canonical capability and product format discovery; isolate named-format conversion at compatibility boundaries. |
 | An SDK maintainer | Generate from the current signed beta.3 tarball, publish an exact support statement, and route accepted protocol corrections into a later beta. |
-| A compliance operator | Pair `@adcp/sdk@14.0.0-beta.4` with beta.3 for TypeScript testing; do not infer Python or Go support or issue a 3.2 badge from beta.3. |
+| A compliance operator | Pair `@adcp/sdk@14.0.0-beta.5` with beta.4 for TypeScript testing; do not infer Python or Go support or issue a 3.2 badge from beta.4. |
 
 ### Required 3.2 migrations
 

--- a/docs/reference/versions.mdx
+++ b/docs/reference/versions.mdx
@@ -13,7 +13,7 @@ description: "Every published AdCP version, its status, and its end-of-life date
 
 | Status | Versions | Wire pin | What it means |
 |---|---|---|---|
-| **Beta** | 3.2 (current prerelease: `beta.3`) | `"3.2-beta.3"` | Development and staging only. TypeScript SDK support is available in `@adcp/sdk@14.0.0-beta.4`; follow the [3.2 beta program](/docs/reference/3-2-beta). |
+| **Beta** | 3.2 (current prerelease: `beta.4`) | `"3.2-beta.4"` | Development and staging only. TypeScript SDK support is available in `@adcp/sdk@14.0.0-beta.5`; follow the [3.2 beta program](/docs/reference/3-2-beta). |
 | **Active** | 3.1 (current stable: 3.1.15) | `"3.1"` | Current production minor release. See [What's New in AdCP 3.1](/docs/reference/whats-new-in-3-1) for the feature set. |
 | **Maintained** | 3.0 (current stable: 3.0.24) | `"3.0"` | Supported previous minor for existing production integrations. Receives compatibility and security patches. |
 | **End of life** | 2.0.0, 2.1.0, 2.5.0–2.5.3 | — | No patches. Migrate to 3.0. See [v2 sunset](/docs/reference/v2-sunset). |
@@ -45,7 +45,8 @@ Supported patches don't change the wire contract. Upgrading within 3.0.x is alwa
 
 | Version | Released | Notes |
 |---|---|---|
-| **3.2.0-beta.3** | 2026-08-19 | Current prerelease. `@adcp/sdk@14.0.0-beta.4` embeds this exact checkpoint. Use `"3.2-beta.3"` only when both peers explicitly advertise it. |
+| **3.2.0-beta.4** | 2026-08-20 | Current prerelease. `@adcp/sdk@14.0.0-beta.5` embeds this exact checkpoint. Use `"3.2-beta.4"` only when both peers explicitly advertise it. Adds flexible-window availability discovery and the outcome_target reverse-forecast input. |
+| 3.2.0-beta.3 | 2026-08-19 | Integration checkpoint, superseded by beta.4 for new beta testing. |
 | 3.2.0-beta.2 | 2026-08-19 | Integration checkpoint, superseded by beta.3 for new beta testing. |
 | 3.2.0-beta.1 | 2026-08-19 | Integration-correction checkpoint, superseded by beta.2 for new beta testing. |
 | 3.2.0-beta.0 | 2026-08-17 | Protocol-first beta input for SDK work. Remains available for pinned prerelease adopters. |
@@ -89,7 +90,7 @@ Targeted for early 2027. 3.x is mid-cycle — see the [planned releases table](/
 |---|---|
 | Building a new production integration today | **3.1**. Pin `"3.1"` on the wire. |
 | Implementing or testing 3.2 without an SDK | Use the signed **3.2 beta.3** artifacts with raw-wire or code-generation workflows. Follow the [beta program](/docs/reference/3-2-beta). |
-| Running an SDK-backed 3.2 integration test | Use `@adcp/sdk@14.0.0-beta.4` with exact wire pin `"3.2-beta.3"`, or another SDK only after its support matrix row names an exact checkpoint. |
+| Running an SDK-backed 3.2 integration test | Use `@adcp/sdk@14.0.0-beta.5` with exact wire pin `"3.2-beta.4"`, or another SDK only after its support matrix row names an exact checkpoint. |
 | Running an existing 3.0 integration | Stay on **3.0** while you migrate, or move to **3.1** when your SDK and validation are ready. |
 | Running a 2.5.x integration | Upgrade now — out of support. Start with the [migration guide](/docs/reference/migration). |
 | Running a 2.0 or 2.1 integration | Upgrade now — out of support. |

--- a/docs/reference/whats-new-in-3-2.mdx
+++ b/docs/reference/whats-new-in-3-2.mdx
@@ -8,8 +8,8 @@ description: "Adopter overview of AdCP 3.2: compact media buying, targeting-awar
 # What's new in AdCP 3.2
 
 <Warning>
-**3.2 is in beta.** The protocol beta.3 artifacts and
-`@adcp/sdk@14.0.0-beta.4` now support the same exact checkpoint. Python and Go
+**3.2 is in beta.** The protocol beta.4 artifacts and
+`@adcp/sdk@14.0.0-beta.5` now support the same exact checkpoint. Python and Go
 3.2 packages are still pending. Later betas require a fresh SDK support
 statement against their exact bundle. See the
 [3.2 beta program](/docs/reference/3-2-beta) before testing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.2.0-beta.4",
       "dependencies": {
-        "@adcp/sdk": "14.0.0-beta.4",
+        "@adcp/sdk": "14.0.0-beta.5",
         "@anthropic-ai/sdk": "^0.117.1",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.8.3",
@@ -131,9 +131,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "14.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-14.0.0-beta.4.tgz",
-      "integrity": "sha512-ueqkvDxIwCuqW8RZF4o21gBANWWmnpNkgYnA44l0P2AWpApngLG182xqvOaN8zi+Kakdwb9/Y9iSSnPtBq9xtA==",
+      "version": "14.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-14.0.0-beta.5.tgz",
+      "integrity": "sha512-SRUoJ8Qe6NlbFSQJzgEdH2nVpKHo2w4AeuAoq4BwgcyLCNsw9mdDWuI3GAhz8niFjmcMOclhNpmyIAI4Nbqe+g==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs"
   },
   "dependencies": {
-    "@adcp/sdk": "14.0.0-beta.4",
+    "@adcp/sdk": "14.0.0-beta.5",
     "@anthropic-ai/sdk": "^0.117.1",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.8.3",

--- a/server/src/training-agent/FRAMEWORK_MIGRATION.md
+++ b/server/src/training-agent/FRAMEWORK_MIGRATION.md
@@ -60,7 +60,7 @@ working during the 3.x compatibility window.
   proposal negotiation is a 3.2 feature.
 - Capability projection removes lifecycle and proposal-refinement metadata for
   pre-3.2 callers.
-- The current wire bundle is `3.2-beta.3`; `3.2-beta.0` remains only as the
+- The current wire bundle is `3.2-beta.4`; `3.2-beta.0` remains only as the
   historical feature-introduction boundary for rejected discovery responses.
 
 ## Invariants for future changes

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -2517,9 +2517,9 @@ import {
 } from './source-schema.js';
 
 const SUPPORTED_MAJOR_VERSIONS = [3] as const;
-const SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.3'] as const;
+const SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.4'] as const;
 const DEFAULT_ADCP_VERSION = '3.0';
-const CURRENT_ADCP_VERSION = '3.2-beta.3';
+const CURRENT_ADCP_VERSION = '3.2-beta.4';
 const MAX_PACKAGES_PER_BUY = 50;
 
 interface ParsedAdcpReleaseVersion {

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -189,7 +189,7 @@ function buildDefaultServerOptions(
   return {
     name: 'adcp-training-agent',
     version: '1.0.0',
-    adcpVersion: storyboardCompat?.version === '3.0' ? '3.0' : '3.2-beta.3',
+    adcpVersion: storyboardCompat?.version === '3.0' ? '3.0' : '3.2-beta.4',
     idempotency: getSdkIdempotencyStore(),
     webhooks: getWebhookSigningMaterial(),
     taskWebhookEmitter: {

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -127,8 +127,8 @@ const SALES_CURRENT_SCENARIOS = [
   'evaluate_distributed_brand_resolution',
 ] as const;
 
-const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.3'] as const;
-const TRAINING_AGENT_CURRENT_ADCP_VERSION = '3.2-beta.3';
+const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.4'] as const;
+const TRAINING_AGENT_CURRENT_ADCP_VERSION = '3.2-beta.4';
 const TRAINING_AGENT_DEFAULT_ADCP_VERSION = '3.0';
 const PRODUCT_DISCOVERY_LIFECYCLE_TOOL_NAMES = [
   'list_products',
@@ -744,7 +744,7 @@ function projectTenantCapabilities(
     };
     if (tenantId === 'sales' && storyboardCompat?.version !== '3.0') {
       structured.adcp.capability_changes = {
-        capabilities_version: 'training-agent-3.2-beta.3',
+        capabilities_version: 'training-agent-3.2-beta.4',
         last_modified: '2026-08-20T00:00:00.000Z',
         cache_ttl_seconds: 300,
         notifications: {

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -462,7 +462,7 @@ describe('tenant routing smoke', () => {
       );
 
       const capabilitiesResponse = await callTenantTool(url, 3, 'get_adcp_capabilities', {
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         adcp_major_version: 3,
       }) as {
         result?: { structuredContent?: {
@@ -475,8 +475,8 @@ describe('tenant routing smoke', () => {
           };
         } };
       };
-      expect(capabilitiesResponse.result?.structuredContent?.adcp_version).toBe('3.2-beta.3');
-      expect(capabilitiesResponse.result?.structuredContent?.adcp?.supported_versions).toContain('3.2-beta.3');
+      expect(capabilitiesResponse.result?.structuredContent?.adcp_version).toBe('3.2-beta.4');
+      expect(capabilitiesResponse.result?.structuredContent?.adcp?.supported_versions).toContain('3.2-beta.4');
       const mediaBuy = capabilitiesResponse.result?.structuredContent?.media_buy;
       expect(mediaBuy?.supports_proposals).toBe(true);
       expect(mediaBuy?.lifecycle_tools).toEqual([
@@ -521,7 +521,7 @@ describe('tenant routing smoke', () => {
       }
 
       const requested = await callTenantTool(url, 4, 'request_proposals', {
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-request-0001',
         account: {
@@ -535,12 +535,12 @@ describe('tenant routing smoke', () => {
           proposals?: Array<{ proposal_id?: string }>;
         } };
       };
-      expect(requested.result?.structuredContent?.adcp_version).toBe('3.2-beta.3');
+      expect(requested.result?.structuredContent?.adcp_version).toBe('3.2-beta.4');
       const sourceProposalId = requested.result?.structuredContent?.proposals?.[0]?.proposal_id;
       expect(sourceProposalId, JSON.stringify(requested)).toBeTruthy();
 
       const partial = await callTenantTool(url, 5, 'refine_proposals', {
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-refine-three-0001',
         account: {
@@ -561,14 +561,14 @@ describe('tenant routing smoke', () => {
         } };
       };
       const counteroffer = partial.result?.structuredContent;
-      expect(counteroffer?.adcp_version).toBe('3.2-beta.3');
+      expect(counteroffer?.adcp_version).toBe('3.2-beta.4');
       expect(counteroffer?.adcp_error).toBeUndefined();
       expect(counteroffer?.results?.[0]?.outcome, JSON.stringify(counteroffer)).toBe('partial');
       expect(counteroffer?.results?.[0]?.reason_code).toBe('alternatives_unavailable');
       expect(counteroffer?.results?.[0]?.proposals).toHaveLength(2);
 
       const refined = await callTenantTool(url, 6, 'refine_proposals', {
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-refine-two-0001',
         account: {
@@ -589,7 +589,7 @@ describe('tenant routing smoke', () => {
         } };
       };
       const refinement = refined.result?.structuredContent;
-      expect(refinement?.adcp_version).toBe('3.2-beta.3');
+      expect(refinement?.adcp_version).toBe('3.2-beta.4');
       expect(refinement?.adcp_error).toBeUndefined();
       expect(refinement?.results?.[0]?.outcome).toBe('revised');
       expect(refinement?.results?.[0]?.proposals).toHaveLength(2);
@@ -597,7 +597,7 @@ describe('tenant routing smoke', () => {
       const revisedProposalId = refinement?.results?.[0]?.proposals?.[0]?.proposal_id;
       expect(revisedProposalId).toEqual(expect.any(String));
       const finalized = await callTenantTool(url, 7, 'refine_proposals', {
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-finalize-0001',
         refinements: [{ proposal_id: revisedProposalId, action: 'finalize' }],
@@ -1736,9 +1736,9 @@ describe('tenant routing smoke', () => {
         };
       };
       const mediaBuy = body.result?.structuredContent?.media_buy;
-      expect(body.result?.structuredContent?.adcp_version).toBe('3.2-beta.3');
+      expect(body.result?.structuredContent?.adcp_version).toBe('3.2-beta.4');
       expect(body.result?.structuredContent?.adcp?.major_versions).toContain(3);
-      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.3']);
+      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.4']);
       expect(mediaBuy?.features?.inline_creative_management).toBe(true);
       expect(mediaBuy?.supported_optimization_metrics).toContain('clicks');
       expect(mediaBuy?.vendor_metric_optimization?.supported_targets).toContain('threshold_rate');
@@ -2642,7 +2642,7 @@ describe('tenant routing smoke', () => {
         field: 'adcp_version',
         details: {
           adcp_version: '4.0',
-          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.3'],
+          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.2-beta.4'],
         },
       });
       expect(unsupportedBody.result?.structuredContent?.context?.correlation_id).toBe('tenant-local-version-unsupported');
@@ -3043,7 +3043,7 @@ describe('tenant routing smoke', () => {
       };
       const payload = {
         idempotency_key: 'tenant-products-idempotency-0001',
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         buying_mode: 'wholesale',
         account,
       };
@@ -3161,7 +3161,7 @@ describe('tenant routing smoke', () => {
         brand: account.brand,
       }) as { result?: { structuredContent?: { adcp_version?: string; products?: Array<{ product_id?: string }>; replayed?: boolean } } };
       expect(aliasReplay.result?.structuredContent).not.toHaveProperty('adcp_error');
-      expect(aliasReplay.result?.structuredContent?.adcp_version).toBe('3.2-beta.3');
+      expect(aliasReplay.result?.structuredContent?.adcp_version).toBe('3.2-beta.4');
       expect(aliasReplay.result?.structuredContent?.products?.map(product => product.product_id))
         .toEqual(first.result?.structuredContent?.products?.map(product => product.product_id));
       expect(aliasReplay.result?.structuredContent?.replayed).toBeUndefined();
@@ -3330,7 +3330,7 @@ describe('tenant routing smoke', () => {
         sandbox: true,
       };
       const directive = await callTenantTool(url, 91, 'comply_test_controller', {
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         account,
         scenario: 'force_get_products_arm',
         params: {
@@ -3342,7 +3342,7 @@ describe('tenant routing smoke', () => {
       expect(directive.result?.structuredContent?.success).toBe(true);
 
       const rejected = await callTenantTool(url, 92, 'get_products', {
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         adcp_major_version: 3,
         idempotency_key: 'tenant-products-rejected-0001',
         buying_mode: 'brief',

--- a/server/tests/integration/training-agent-3-0-compat-tools.test.ts
+++ b/server/tests/integration/training-agent-3-0-compat-tools.test.ts
@@ -21,7 +21,7 @@ const { stopSessionCleanup } = await import('../../src/training-agent/state.js')
 
 const COMPAT_CTX = { mode: 'open' as const, storyboardCompat: { version: '3.0' as const } };
 const AUTH = 'Bearer compat-tools-token';
-const CURRENT_ADCP_VERSION = '3.2-beta.3';
+const CURRENT_ADCP_VERSION = '3.2-beta.4';
 
 async function simulateListTools(server: ReturnType<typeof createTrainingAgentServer>): Promise<string[]> {
   const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;

--- a/server/tests/manual/probe-agent.local.mts
+++ b/server/tests/manual/probe-agent.local.mts
@@ -1,0 +1,18 @@
+import express from 'express';
+import http from 'node:http';
+const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
+const app = express();
+app.use(express.json({ limit: '5mb' }));
+app.use('/api/training-agent', createTrainingAgentRouter({ disableRateLimit: true }));
+const srv = http.createServer(app);
+srv.listen(45998, '127.0.0.1', async () => {
+  const res = await fetch('http://127.0.0.1:45998/api/training-agent/sales/mcp', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'probe', version: '0' } } }),
+  });
+  console.log('STATUS', res.status);
+  const text = await res.text();
+  console.log('BODY', text.slice(0, 500));
+  process.exit(0);
+});

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -168,10 +168,6 @@ const KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new Map([
     'Same blocker as creative_transformers/build_variants: refinement depends on the skipped parent build_variant_id and returns the same BuildCreativeVariantSuccess creatives[]/variants[] response shape. Remove when the packaged storyboard runner accepts that variant arm.',
   ],
   [
-    'media_buy_seller/availability_windows/list_with_horizon',
-    'adcontextprotocol/adcp-client#2637: the packaged SDK response validators (through 14.0.0-beta.4) reject the flexible-window vocabulary (time forecast dimension, availability_status) this step asserts. The platform behavior is covered by training-agent unit tests (training-agent-availability-windows.test.ts). Remove when the SDK regenerates validators against a protocol release containing adcp#6644.',
-  ],
-  [
     'media_buy_seller/canonical_formats/reject_conflicting_dual_emission',
     'adcontextprotocol/adcp-client#2392: the packaged SDK canonicalizes away a co-present deprecated format_ids route before both platform execution and canonical_format_satisfaction grading. Raw receiver behavior is covered by training-agent unit tests. Remove when the SDK preserves and equivalence-checks every selector route.',
   ],

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -226,7 +226,7 @@ describe('comply_test_controller', () => {
 
     it('advertises force_get_products_arm for the 3.2 beta release', async () => {
       const { result } = await simulateCallTool(server, 'comply_test_controller', {
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         adcp_major_version: 3,
         scenario: 'list_scenarios',
         account: ACCOUNT,
@@ -1126,7 +1126,7 @@ describe('comply_test_controller', () => {
       });
 
       const rejectedCompactControl = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         account: ACCOUNT,
         media_buy_id: 'created_from_allowed_actions',
         revision: updated.revision,

--- a/server/tests/unit/training-agent-get-products-rejected.test.ts
+++ b/server/tests/unit/training-agent-get-products-rejected.test.ts
@@ -39,7 +39,7 @@ describe('get_products rejected compliance arm', () => {
     ['3.1', false],
     ['3.2-beta.1', false],
     ['3.2-beta.2', true],
-    ['3.2-beta.3', true],
+    ['3.2-beta.4', true],
     ['3.2', true],
   ] as const)('gates support at the exact %s release boundary', (version, expected) => {
     expect(supportsGetProductsRejected(version)).toBe(expected);
@@ -67,7 +67,7 @@ describe('get_products rejected compliance arm', () => {
     const reason = 'The requested budget is below the minimum for this inventory.';
 
     const forced = await call('comply_test_controller', {
-      adcp_version: '3.2-beta.3',
+      adcp_version: '3.2-beta.4',
       account: controllerAccount('primary-account'),
       scenario: 'force_get_products_arm',
       params: {
@@ -81,12 +81,12 @@ describe('get_products rejected compliance arm', () => {
       data: {
         success: true,
         forced: { arm: 'rejected', reason },
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
       },
     });
 
     const otherAccountResult = await call('get_products', {
-      adcp_version: '3.2-beta.3',
+      adcp_version: '3.2-beta.4',
       idempotency_key: 'rejected-other-account-0001',
       account: otherAccount,
       buying_mode: 'brief',
@@ -95,7 +95,7 @@ describe('get_products rejected compliance arm', () => {
     expect(otherAccountResult.data).not.toMatchObject({ status: 'rejected' });
 
     const otherPrincipalResult = await call('get_products', {
-      adcp_version: '3.2-beta.3',
+      adcp_version: '3.2-beta.4',
       idempotency_key: 'rejected-other-principal-0001',
       account: primaryAccount,
       buying_mode: 'brief',
@@ -104,7 +104,7 @@ describe('get_products rejected compliance arm', () => {
     expect(otherPrincipalResult.data).not.toMatchObject({ status: 'rejected' });
 
     const wholesaleResult = await call('get_products', {
-      adcp_version: '3.2-beta.3',
+      adcp_version: '3.2-beta.4',
       idempotency_key: 'rejected-wholesale-0001',
       account: primaryAccount,
       buying_mode: 'wholesale',
@@ -112,7 +112,7 @@ describe('get_products rejected compliance arm', () => {
     expect(wholesaleResult.data).not.toMatchObject({ status: 'rejected' });
 
     const rejected = await call('get_products', {
-      adcp_version: '3.2-beta.3',
+      adcp_version: '3.2-beta.4',
       idempotency_key: 'rejected-primary-0001',
       account: primaryAccount,
       buying_mode: 'brief',
@@ -123,7 +123,7 @@ describe('get_products rejected compliance arm', () => {
       success: true,
       data: {
         status: 'rejected',
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         reason,
         suggestions: ['Increase the campaign budget.'],
         context: { correlation_id: 'rejected-once' },
@@ -131,7 +131,7 @@ describe('get_products rejected compliance arm', () => {
     });
 
     const consumed = await call('get_products', {
-      adcp_version: '3.2-beta.3',
+      adcp_version: '3.2-beta.4',
       idempotency_key: 'rejected-consumed-0001',
       account: primaryAccount,
       buying_mode: 'brief',
@@ -144,7 +144,7 @@ describe('get_products rejected compliance arm', () => {
     const primaryAccount = account('parallel-rejection-account');
     const reason = 'Only one concurrent request may consume this rejection.';
     const forced = await call('comply_test_controller', {
-      adcp_version: '3.2-beta.3',
+      adcp_version: '3.2-beta.4',
       account: controllerAccount('parallel-rejection-account'),
       scenario: 'force_get_products_arm',
       params: { arm: 'rejected', reason },
@@ -153,7 +153,7 @@ describe('get_products rejected compliance arm', () => {
 
     const replayScope = randomUUID();
     const outcomes = await Promise.all([0, 1].map(index => call('get_products', {
-      adcp_version: '3.2-beta.3',
+      adcp_version: '3.2-beta.4',
       idempotency_key: `parallel-rejection-${replayScope}-${index}`,
       account: primaryAccount,
       buying_mode: 'brief',
@@ -170,7 +170,7 @@ describe('get_products rejected compliance arm', () => {
 
   it('rejects empty suggestion arrays instead of emitting a schema-invalid response', async () => {
     const result = await call('comply_test_controller', {
-      adcp_version: '3.2-beta.3',
+      adcp_version: '3.2-beta.4',
       account: controllerAccount('invalid-suggestions'),
       scenario: 'force_get_products_arm',
       params: { arm: 'rejected', reason: 'Declined.', suggestions: [] },

--- a/server/tests/unit/training-agent-idempotency.test.ts
+++ b/server/tests/unit/training-agent-idempotency.test.ts
@@ -509,7 +509,7 @@ describe('training agent idempotency middleware', () => {
     it('keeps keyless list_products independent from legacy discovery replay identity', async () => {
       const key = `products-list-alias-${randomUUID()}`;
       const identity = {
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         brand: BRAND,
       };
 
@@ -543,7 +543,7 @@ describe('training agent idempotency middleware', () => {
 
       const conflict = await call(server, 'get_products', {
         idempotency_key: key,
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         buying_mode: 'wholesale',
         account: ACCOUNT,
       });
@@ -569,7 +569,7 @@ describe('training agent idempotency middleware', () => {
       const key = `products-recommend-task-alias-${randomUUID()}`;
       const shared = {
         idempotency_key: key,
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         account: ACCOUNT,
         brand: BRAND,
         brief: 'cross-channel news video and display',
@@ -585,7 +585,7 @@ describe('training agent idempotency middleware', () => {
 
       const split = await call(server, 'request_proposals', {
         idempotency_key: key,
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         brand: BRAND,
         brief: shared.brief,
       });
@@ -596,7 +596,7 @@ describe('training agent idempotency middleware', () => {
     it('projects one cached product result across inline then task execution modes', async () => {
       const shared = {
         idempotency_key: `products-inline-task-${randomUUID()}`,
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         brand: BRAND,
         brief: 'cross-channel sports',
       };
@@ -616,7 +616,7 @@ describe('training agent idempotency middleware', () => {
     it('projects one cached product result across task then inline execution modes', async () => {
       const shared = {
         idempotency_key: `products-task-inline-${randomUUID()}`,
-        adcp_version: '3.2-beta.3',
+        adcp_version: '3.2-beta.4',
         brand: BRAND,
         brief: 'cross-channel news',
       };

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -99,7 +99,7 @@ const VALID_PRICING_MODELS = [
 ] as const;
 
 const TEST_AGENT_URL = 'http://localhost:3000/api/training-agent';
-const CURRENT_ADCP_VERSION = '3.2-beta.3';
+const CURRENT_ADCP_VERSION = '3.2-beta.4';
 
 const DEFAULT_CTX: TrainingContext = { mode: 'open', authenticatedAgentUrl: 'https://buyer.example' };
 

--- a/static/compliance/source/protocols/media-buy/scenarios/get_products_rejected.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/get_products_rejected.yaml
@@ -66,7 +66,7 @@ phases:
           - forced.arm: rejected
           - forced.reason echoes the sanitized buyer-facing reason
         sample_request:
-          adcp_version: "3.2-beta.3"
+          adcp_version: "3.2-beta.4"
           adcp_major_version: 3
           account:
             brand:
@@ -117,7 +117,7 @@ phases:
           - no products[], proposals[], errors[], or adcp_error
         sample_request:
           idempotency_key: "$generate:uuid_v4#get_products_rejected_rejected_discovery_response_get_products_rejected"
-          adcp_version: "3.2-beta.3"
+          adcp_version: "3.2-beta.4"
           adcp_major_version: 3
           buying_mode: "brief"
           brief: "Premium video inventory for a regional product launch with a limited test budget."


### PR DESCRIPTION
## Summary

Adopts `@adcp/sdk@14.0.0-beta.5`, which bundles protocol `3.2.0-beta.4` and **drops the `3.2-beta.3` schema bundle** — so every pin moves together:

- Training agent: served version, supported-release list, capabilities version tag (`task-handlers.ts`, `tenants/router.ts`, `tenants/registry.ts`)
- Compliance scenarios: `get_products_rejected` wire pins
- Tests: tenant smoke + server unit/integration pins (a missed local `CURRENT_ADCP_VERSION` in `server/tests` produced 42 `VERSION_UNSUPPORTED` failures until swept)
- Versioned reference docs: `versions.mdx` (new beta.4 history row), `3-2-beta.mdx` (checkpoint table column), `release-notes.mdx`, `whats-new-in-3-2.mdx`, migration guide, SDK chooser, and the media-buy guide wire pins

## Known-failing entry removed

Beta.5's regenerated validators carry the flexible-window availability vocabulary (`time` forecast dimension, `availability_status`), so `media_buy_seller/availability_windows/list_with_horizon` comes off the runner's known-failing list — resolving the adcp-client#2637 exclusion. The scenario now grades **all 8 steps** (was 7 passed + 1 excluded).

## Verification

- `availability_windows` filtered run: 8 passed / 0 failed / 0 skipped
- Full storyboard matrix: all 7 tenants meet floors (sales now grades 555 steps, up from 322 — beta.5 unlocked scenarios beyond ours)
- typecheck, tenant smoke (35/35), `test:schemas`, `test:mcp-schema-projection`, compliance links, changeset scope — all green
- Lockfile delta is exactly the SDK pin (4 lines); flaky-hook retries during this work are documented in #6740

🤖 Generated with [Claude Code](https://claude.com/claude-code)