### PR TITLE
test(compliance): add outcome_target reverse-forecast conformance

### DIFF
--- a/.changeset/outcome-target-conformance.md
+++ b/.changeset/outcome-target-conformance.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add conformance surface for outcome_target reverse forecasting. The new `media_buy_seller/outcome_target` scenario (required by the sales-proposal-mode specialism, gated on `media_buy.outcome_target`) grades the answer contract: `total_budget_guidance` on every returned proposal and a forecast whose points carry the goal's metric or event key, with `forecast_range_unit` `clicks`/`conversions` structuring the curves. Fixes the canonical-proposal gap the contract exposed (#6745): `core/canonical-proposal.json` gains optional `total_budget_guidance` and `forecast`, restoring parity with the legacy proposal's planning outputs so the compact `request_proposals` lifecycle can actually express the answer. The training agent implements a deterministic reverse-forecast reference model.

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -5619,6 +5619,99 @@ function outwardProposal(proposal: Record<string, unknown>, products: Map<string
       ? proposal.__canonical_terms_digest
       : proposalTermsDigest(terms),
     ...(isRecord(proposal.insertion_order) && { insertion_order: proposal.insertion_order }),
+    // Reverse-forecast planning (criteria.outcome_target): these are only
+    // populated when the source request_proposals call carried outcome_target
+    // (see computeOutcomeTargetPlan). Absent otherwise — outcome_target
+    // support must never change the shape of an unrelated proposal.
+    ...(isRecord(proposal.__outcome_target_guidance) && {
+      total_budget_guidance: structuredClone(proposal.__outcome_target_guidance),
+    }),
+    ...(isRecord(proposal.__outcome_target_forecast) && {
+      forecast: structuredClone(proposal.__outcome_target_forecast),
+    }),
+  };
+}
+
+// ── Reverse-forecast planning (criteria.outcome_target) ─────────────────────
+//
+// Deterministic reference model, not a market claim. A buyer states a
+// desired metric or event volume; the seller solves for the budget that
+// plans to deliver it. OUTCOME_TARGET_METRIC_RESPONSE_RATE models 1 click
+// per 1,000 impressions; OUTCOME_TARGET_EVENT_RESPONSE_RATE models 1
+// conversion event per 5,000 impressions (an added funnel step beyond a
+// click). Both are training-fixture constants, not real delivery estimates.
+const OUTCOME_TARGET_METRIC_RESPONSE_RATE = 0.001;
+const OUTCOME_TARGET_EVENT_RESPONSE_RATE = 0.0002;
+const OUTCOME_TARGET_DEFAULT_CPM = 10;
+const OUTCOME_TARGET_FORECAST_RATIOS = [0.5, 1, 1.5] as const;
+
+/** The metrics{} key a goal's forecast points carry: the metric name for a
+ * metric goal, or the event type (custom_event_name when custom) for an
+ * event goal — the same key the buyer will later use on optimization_goals. */
+function outcomeTargetGoalKey(goal: Record<string, unknown>): string {
+  if (goal.kind === 'event') {
+    return goal.event_type === 'custom' ? String(goal.custom_event_name) : String(goal.event_type);
+  }
+  return String(goal.metric);
+}
+
+/** A 'spend' metric goal restates the budget the seller is solving for —
+ * there is no plan to construct. Per outcome-target.json, declaring sellers
+ * MAY reject such a goal with INVALID_REQUEST. */
+function outcomeTargetIsUnplannable(goal: Record<string, unknown>): boolean {
+  return goal.kind === 'metric' && goal.metric === 'spend';
+}
+
+function outcomeTargetForecastRangeUnit(goal: Record<string, unknown>): string {
+  if (goal.kind === 'event') return 'conversions';
+  return goal.metric === 'clicks' ? 'clicks' : 'spend';
+}
+
+/** Solve a deterministic budget and delivery curve for one proposal against
+ * a request_proposals criteria.outcome_target goal. CPM comes from the
+ * proposal's first allocation's first pricing option (fixed_price, else
+ * floor_price, else a $10 reference CPM) so every goal has a defined
+ * answer even against auction-only or unpriced fixtures. */
+function computeOutcomeTargetPlan(
+  goal: Record<string, unknown>,
+  volume: number,
+  proposal: Proposal,
+  productsById: Map<string, Product>,
+): { totalBudgetGuidance: Record<string, unknown>; forecast: Record<string, unknown> } {
+  const goalKey = outcomeTargetGoalKey(goal);
+  const responseRate = goal.kind === 'event'
+    ? OUTCOME_TARGET_EVENT_RESPONSE_RATE
+    : OUTCOME_TARGET_METRIC_RESPONSE_RATE;
+  const impressions = volume / responseRate;
+  const firstAllocation = proposal.allocations[0];
+  const product = firstAllocation ? productsById.get(firstAllocation.product_id) : undefined;
+  const firstPricing = product?.pricing_options?.[0] as PricingOptionView | undefined;
+  const cpm = typeof firstPricing?.fixed_price === 'number'
+    ? firstPricing.fixed_price
+    : typeof firstPricing?.floor_price === 'number'
+      ? firstPricing.floor_price
+      : OUTCOME_TARGET_DEFAULT_CPM;
+  const budget = Math.round((impressions / 1000) * cpm);
+  const now = Date.now();
+  const points = OUTCOME_TARGET_FORECAST_RATIOS.map(ratio => ({
+    budget: Math.round(ratio * budget),
+    metrics: { [goalKey]: { mid: Math.round(ratio * volume) } },
+  }));
+  return {
+    totalBudgetGuidance: {
+      min: Math.round(0.8 * budget),
+      recommended: budget,
+      max: Math.round(1.25 * budget),
+      currency: 'USD',
+    },
+    forecast: {
+      points,
+      forecast_range_unit: outcomeTargetForecastRangeUnit(goal),
+      method: 'modeled',
+      currency: 'USD',
+      generated_at: toUtcSecondsIso(now),
+      valid_until: toUtcSecondsIso(now + 5 * 60 * 1000),
+    },
   };
 }
 
@@ -7613,6 +7706,23 @@ async function handleGetProductsUnlocked(
     }) as Proposal[];
   const requireProposals = buyingMode === 'brief'
     && (req as unknown as Record<string, unknown>).__require_proposals === true;
+  // criteria.outcome_target expands to a top-level field by
+  // expandProductDiscoveryCriteria; only request_proposals sets
+  // __require_proposals, so this is scoped to that tool.
+  const outcomeTarget = requireProposals && isRecord((req as unknown as Record<string, unknown>).outcome_target)
+    ? (req as unknown as Record<string, unknown>).outcome_target as Record<string, unknown>
+    : undefined;
+  const outcomeTargetGoal = outcomeTarget && isRecord(outcomeTarget.goal) ? outcomeTarget.goal : undefined;
+  if (outcomeTargetGoal && outcomeTargetIsUnplannable(outcomeTargetGoal)) {
+    return {
+      errors: [{
+        code: 'INVALID_REQUEST',
+        message: "The seller cannot plan against a 'spend' goal because it restates the budget being solved for.",
+        field: 'criteria.outcome_target.goal',
+        recovery: 'correctable',
+      }] as TaskError[],
+    };
+  }
   if (requireProposals) {
     const exactProductIds = Array.isArray((req as unknown as Record<string, unknown>).product_ids)
       ? new Set(((req as unknown as Record<string, unknown>).product_ids as unknown[])
@@ -7719,6 +7829,9 @@ async function handleGetProductsUnlocked(
         .digest('hex')
         .slice(0, 24);
       const proposalId = `proposal_request_${digest}`;
+      const outcomeTargetPlan = outcomeTargetGoal && typeof outcomeTarget?.volume === 'number'
+        ? computeOutcomeTargetPlan(outcomeTargetGoal, outcomeTarget.volume, proposal, productsById)
+        : undefined;
       const snapshot = {
         ...proposal,
         proposal_id: proposalId,
@@ -7730,6 +7843,10 @@ async function handleGetProductsUnlocked(
         ...(proposalAccountScope && { __account_scope: proposalAccountScope }),
         ...(typeof requestOpportunity?.opportunity_id === 'string'
           && { __opportunity_id: requestOpportunity.opportunity_id }),
+        ...(outcomeTargetPlan && {
+          __outcome_target_guidance: outcomeTargetPlan.totalBudgetGuidance,
+          __outcome_target_forecast: outcomeTargetPlan.forecast,
+        }),
       } as unknown as Proposal;
       return existingById.get(proposalId)
         ?? withCanonicalProposalEnvelope(
@@ -12386,6 +12503,11 @@ export async function handleGetAdcpCapabilities(args: ToolArgs, ctx: TrainingCon
       // forecast points carrying availability_status. See
       // applyAvailabilityHorizonForecasts / handleGetProductsUnlocked.
       availability_horizon: true,
+      // Reverse-forecast planning: parses criteria.outcome_target and
+      // answers with total_budget_guidance plus a forecast whose points
+      // carry the goal's metric/event key in metrics. See
+      // computeOutcomeTargetPlan / handleGetProductsUnlocked.
+      outcome_target: true,
       performance_feedback: {
         reports_application_status: true,
       },

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -825,6 +825,7 @@ function projectTenantCapabilities(
         delete mediaBuy.proposal_refinement;
         delete mediaBuy.supports_proposals;
         delete mediaBuy.availability_horizon;
+        delete mediaBuy.outcome_target;
       }
       const salesProjection = salesCapabilityProjection();
       structured.media_buy = {
@@ -836,6 +837,10 @@ function projectTenantCapabilities(
           // offer_filters.availability_horizon and answers with
           // time-dimensioned forecast points (see handleGetProductsUnlocked).
           availability_horizon: true,
+          // Reverse-forecast planning: the platform parses
+          // criteria.outcome_target and answers with total_budget_guidance
+          // plus a forecast (see computeOutcomeTargetPlan).
+          outcome_target: true,
         }),
         ...(proposalNegotiationProfile && supportsGetProductsRejected(servedVersion) && {
           supports_proposals: true,

--- a/server/tests/unit/training-agent-outcome-target.test.ts
+++ b/server/tests/unit/training-agent-outcome-target.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import crypto from 'node:crypto';
+import {
+  createTrainingAgentServer,
+  invalidateCache,
+  clearTaskStore,
+} from '../../src/training-agent/task-handlers.js';
+import { clearSessions } from '../../src/training-agent/state.js';
+import { MUTATING_TOOLS, clearIdempotencyCache } from '../../src/training-agent/idempotency.js';
+import type { TrainingContext } from '../../src/training-agent/types.js';
+
+const DEFAULT_CTX: TrainingContext = { mode: 'open' };
+const ACCOUNT = { brand: { domain: 'outcome-target.example.com' }, operator: 'outcome-tester', sandbox: true };
+const OUTCOME_TARGET_PRODUCT_ID = 'outcome_target_test_product';
+
+function withIdempotencyKey(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
+  if (!MUTATING_TOOLS.has(toolName)) return args;
+  if (args.idempotency_key !== undefined) return args;
+  return { ...args, idempotency_key: `test-${crypto.randomUUID()}` };
+}
+
+async function callTool(
+  server: ReturnType<typeof createTrainingAgentServer>,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const requestHandlers = (server as unknown as { _requestHandlers: Map<string, Function> })._requestHandlers;
+  const handler = requestHandlers.get('tools/call');
+  if (!handler) throw new Error('CallTool handler not found');
+  const response = await handler(
+    { method: 'tools/call', params: { name: toolName, arguments: withIdempotencyKey(toolName, args) } },
+    {},
+  );
+  const text = response.content?.[0]?.text;
+  const parsed: Record<string, unknown> = response.structuredContent
+    ? (response.structuredContent as Record<string, unknown>)
+    : (text ? JSON.parse(text) : {});
+  return (parsed.adcp_error as Record<string, unknown> | undefined) ?? parsed;
+}
+
+async function seedOutcomeTargetProduct(
+  server: ReturnType<typeof createTrainingAgentServer>,
+): Promise<void> {
+  const seed = await callTool(server, 'comply_test_controller', {
+    scenario: 'seed_product',
+    account: ACCOUNT,
+    params: {
+      product_id: OUTCOME_TARGET_PRODUCT_ID,
+      fixture: {
+        delivery_type: 'non_guaranteed',
+        channels: ['display'],
+        pricing_options: [{
+          pricing_option_id: 'po_outcome_target_fixed_cpm',
+          pricing_model: 'cpm',
+          currency: 'USD',
+          fixed_price: 40,
+        }],
+      },
+    },
+  });
+  expect(seed.success).toBe(true);
+}
+
+function requestProposalsArgs(outcomeTarget?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    account: ACCOUNT,
+    brief: 'Reverse-forecast planning test',
+    criteria: {
+      product_ids: [OUTCOME_TARGET_PRODUCT_ID],
+      ...(outcomeTarget && { outcome_target: outcomeTarget }),
+    },
+  };
+}
+
+describe('reverse-forecast outcome_target planning (training agent)', () => {
+  let server: ReturnType<typeof createTrainingAgentServer>;
+
+  beforeEach(async () => {
+    await clearSessions();
+    clearIdempotencyCache();
+    invalidateCache();
+    clearTaskStore();
+    server = createTrainingAgentServer(DEFAULT_CTX);
+  });
+
+  describe('get_adcp_capabilities', () => {
+    it('declares media_buy.outcome_target: true', async () => {
+      const caps = await callTool(server, 'get_adcp_capabilities', {});
+      expect((caps as { media_buy: { outcome_target?: boolean } }).media_buy.outcome_target).toBe(true);
+    });
+  });
+
+  describe('clicks metric goal', () => {
+    it('solves budget and a 3-point clicks forecast from volume 10000 on a fixed_price 40 product', async () => {
+      await seedOutcomeTargetProduct(server);
+
+      const result = await callTool(server, 'request_proposals', requestProposalsArgs({
+        goal: { kind: 'metric', metric: 'clicks' },
+        volume: 10000,
+      }));
+
+      expect(result.outcome).toBe('proposed');
+      const proposals = result.proposals as Array<Record<string, unknown>>;
+      expect(proposals).toHaveLength(1);
+      const proposal = proposals[0]!;
+
+      // impressions = 10000 / 0.001 = 10,000,000; B = 10,000,000/1000 * 40 = 400,000
+      expect(proposal.total_budget_guidance).toEqual({
+        min: 320000,
+        recommended: 400000,
+        max: 500000,
+        currency: 'USD',
+      });
+
+      const forecast = proposal.forecast as Record<string, unknown>;
+      expect(forecast.forecast_range_unit).toBe('clicks');
+      expect(forecast.method).toBe('modeled');
+      expect(forecast.currency).toBe('USD');
+      expect(typeof forecast.generated_at).toBe('string');
+      expect(typeof forecast.valid_until).toBe('string');
+
+      const points = forecast.points as Array<Record<string, unknown>>;
+      expect(points).toHaveLength(3);
+      expect(points[0]).toEqual({ budget: 200000, metrics: { clicks: { mid: 5000 } } });
+      expect(points[1]).toEqual({ budget: 400000, metrics: { clicks: { mid: 10000 } } });
+      expect(points[2]).toEqual({ budget: 600000, metrics: { clicks: { mid: 15000 } } });
+    });
+  });
+
+  describe('event goal', () => {
+    it('solves a conversions forecast carrying the event_type as the metrics key', async () => {
+      await seedOutcomeTargetProduct(server);
+
+      const result = await callTool(server, 'request_proposals', requestProposalsArgs({
+        goal: { kind: 'event', event_type: 'purchase' },
+        volume: 500,
+      }));
+
+      expect(result.outcome).toBe('proposed');
+      const proposals = result.proposals as Array<Record<string, unknown>>;
+      const proposal = proposals[0]!;
+
+      const guidance = proposal.total_budget_guidance as Record<string, unknown>;
+      expect(guidance.currency).toBe('USD');
+      expect(typeof guidance.recommended).toBe('number');
+
+      const forecast = proposal.forecast as Record<string, unknown>;
+      expect(forecast.forecast_range_unit).toBe('conversions');
+      const points = forecast.points as Array<Record<string, unknown>>;
+      expect(points).toHaveLength(3);
+      const midPoint = points[1] as { metrics: Record<string, { mid: number }> };
+      expect(midPoint.metrics.purchase.mid).toBe(500);
+    });
+  });
+
+  describe('unplannable spend goal', () => {
+    it('rejects a metric:"spend" goal with INVALID_REQUEST naming criteria.outcome_target.goal', async () => {
+      await seedOutcomeTargetProduct(server);
+
+      const result = await callTool(server, 'request_proposals', requestProposalsArgs({
+        goal: { kind: 'metric', metric: 'spend' },
+        volume: 1000,
+      }));
+
+      expect(result.code).toBe('INVALID_REQUEST');
+      expect(result.field).toBe('criteria.outcome_target.goal');
+      expect(result.proposals).toBeUndefined();
+    });
+  });
+
+  describe('no outcome_target', () => {
+    it('leaves proposals without total_budget_guidance or an outcome_target-shaped forecast', async () => {
+      await seedOutcomeTargetProduct(server);
+
+      const result = await callTool(server, 'request_proposals', requestProposalsArgs());
+
+      expect(result.outcome).toBe('proposed');
+      const proposals = result.proposals as Array<Record<string, unknown>>;
+      expect(proposals).toHaveLength(1);
+      expect(proposals[0]!.total_budget_guidance).toBeUndefined();
+    });
+  });
+});

--- a/static/compliance/source/protocols/media-buy/scenarios/outcome_target.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/outcome_target.yaml
@@ -1,0 +1,240 @@
+id: media_buy_seller/outcome_target
+version: "1.0.0"
+title: "Seller solves for budget from a structured outcome target"
+category: media_buy_seller
+summary: "Verifies criteria.outcome_target reverse forecasting: a metric or event goal plus desired volume answered with total_budget_guidance on proposals and a forecast whose points carry the goal's key in metrics."
+track: media_buy
+required_tools:
+  - request_proposals
+
+requires_capability:
+  path: media_buy.outcome_target
+  equals: true
+
+narrative: |
+  Forward planning fixes dates and budget and asks for a forecast. Reverse
+  forecasting inverts the question: "I need 10,000 clicks — what does my budget
+  need to be?" Sellers declaring `media_buy.outcome_target` parse the compact
+  goal in `criteria.outcome_target` — a delivery metric in the same
+  forecastable-metric vocabulary forecast points report, or a conversion event
+  in the event-type vocabulary — and solve for budget.
+
+  The answer contract this scenario grades: every returned proposal carries
+  `total_budget_guidance` (currency plus at least a recommended figure) and a
+  forecast whose points carry the goal's metric or event key in `metrics`,
+  with `forecast_range_unit` `clicks` structuring a clicks-goal curve and
+  `conversions` structuring an event-goal curve. Because the goal vocabulary
+  equals the forecast-metrics vocabulary, every permitted goal has a defined
+  answer — there is no goal a conformant seller can accept and then answer
+  with nothing.
+
+  An outcome_target is a planning input, not a delivery guarantee: obligations
+  arise only at proposal finalization, and the guidance band is indicative in
+  exactly the way draft pricing is.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - accepts_briefs
+    - generates_proposals
+  examples:
+    - "Full-service publisher with a planning engine"
+    - "Retail media network quoting budgets against conversion goals"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    The caller needs a brand identity and operator credentials. The runner
+    seeds one product with fixed pricing so the seller's reverse forecast has
+    a deterministic rate card to plan against.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "outcome_target_video"
+      name: "Outcome Target Planning Video"
+      description: "Compliance fixture: fixed-price video inventory for reverse-forecast planning."
+      delivery_type: "non_guaranteed"
+      channels: ["video"]
+      format_options:
+        - format_option_id: "outcome_target_video_30s"
+          format_kind: "video_hosted"
+          params:
+            duration_ms_exact: 30000
+  pricing_options:
+    - product_id: "outcome_target_video"
+      pricing_option_id: "outcome_target_fixed"
+      pricing_model: "cpm"
+      currency: "USD"
+      fixed_price: 40.0
+
+phases:
+  - id: setup
+    title: "Account setup"
+    steps:
+      - id: sync_accounts
+        title: "Establish account"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        expected: |
+          Return the account with account_id and status active.
+
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+              payment_terms: "net_30"
+
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_outcome_target_setup_sync_accounts"
+          context:
+            correlation_id: "outcome_target--sync_accounts"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Account has a platform-assigned ID"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "outcome_target--sync_accounts"
+            description: "Context correlation_id returned unchanged"
+
+  - id: metric_goal
+    title: "Solve for budget from a clicks goal"
+    depends_on: [setup]
+    narrative: |
+      The buyer states the outcome — 10,000 clicks — and the seller answers
+      with budget guidance and a clicks-structured forecast whose points carry
+      the goal's metric key.
+    steps:
+      - id: request_clicks_goal
+        title: "Request proposals for a 10,000-click target"
+        task: request_proposals
+        schema_ref: "media-buy/request-proposals-request.json"
+        response_schema_ref: "media-buy/request-proposals-response.json"
+        doc_ref: "/media-buy/task-reference/request_proposals"
+        stateful: true
+        expected: |
+          Return outcome proposed with at least one proposal carrying:
+          - total_budget_guidance with currency and a recommended figure
+          - forecast with forecast_range_unit "clicks" whose points carry
+            metrics.clicks
+
+        sample_request:
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_outcome_target_metric_goal_request_clicks_goal"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          brief: "Drive qualified traffic to the Trail Pro 3000 launch page using the seeded video placement."
+          criteria:
+            product_ids: ["outcome_target_video"]
+            outcome_target:
+              goal:
+                kind: "metric"
+                metric: "clicks"
+              volume: 10000
+          context:
+            correlation_id: "outcome_target--request_clicks_goal"
+        validations:
+          - check: response_schema
+            description: "Response matches request-proposals-response.json schema"
+          - check: field_value
+            path: "outcome"
+            value: "proposed"
+            description: "The seller returns at least one proposal"
+          - check: field_present
+            path: "proposals[0].total_budget_guidance.recommended"
+            description: "The seller solved for budget: a recommended figure answers the outcome target"
+          - check: field_present
+            path: "proposals[0].total_budget_guidance.currency"
+            description: "Budget guidance declares its currency"
+          - check: field_value
+            path: "proposals[0].forecast.forecast_range_unit"
+            value: "clicks"
+            description: "A clicks goal is answered with a clicks-structured outcome curve"
+          - check: field_present
+            path: "proposals[0].forecast.points[0].metrics.clicks.mid"
+            description: "Forecast points carry the goal's metric key — the vocabulary contract that makes every goal answerable"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "outcome_target--request_clicks_goal"
+            description: "Context correlation_id returned unchanged"
+
+  - id: event_goal
+    title: "Solve for budget from a conversion-event goal"
+    depends_on: [setup]
+    narrative: |
+      The buyer states a conversion outcome — 500 purchases — and the seller
+      answers with budget guidance and a conversions-structured forecast whose
+      points carry the event-type key.
+    steps:
+      - id: request_purchase_goal
+        title: "Request proposals for a 500-purchase target"
+        task: request_proposals
+        schema_ref: "media-buy/request-proposals-request.json"
+        response_schema_ref: "media-buy/request-proposals-response.json"
+        doc_ref: "/media-buy/task-reference/request_proposals"
+        stateful: true
+        expected: |
+          Return outcome proposed with at least one proposal carrying:
+          - total_budget_guidance with currency and a recommended figure
+          - forecast with forecast_range_unit "conversions" whose points carry
+            metrics.purchase
+
+        sample_request:
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_outcome_target_event_goal_request_purchase_goal"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          brief: "Drive Trail Pro 3000 purchases from the seeded video placement."
+          criteria:
+            product_ids: ["outcome_target_video"]
+            outcome_target:
+              goal:
+                kind: "event"
+                event_type: "purchase"
+              volume: 500
+          context:
+            correlation_id: "outcome_target--request_purchase_goal"
+        validations:
+          - check: response_schema
+            description: "Response matches request-proposals-response.json schema"
+          - check: field_value
+            path: "outcome"
+            value: "proposed"
+            description: "The seller returns at least one proposal"
+          - check: field_present
+            path: "proposals[0].total_budget_guidance.recommended"
+            description: "The seller solved for budget against the event goal"
+          - check: field_value
+            path: "proposals[0].forecast.forecast_range_unit"
+            value: "conversions"
+            description: "An event goal is answered with a conversions-structured outcome curve"
+          - check: field_present
+            path: "proposals[0].forecast.points[0].metrics.purchase.mid"
+            description: "Forecast points carry the goal's event-type key"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "outcome_target--request_purchase_goal"
+            description: "Context correlation_id returned unchanged"

--- a/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
+++ b/static/compliance/source/specialisms/sales-proposal-mode/index.yaml
@@ -12,6 +12,7 @@ requires_scenarios:
   - media_buy_seller/proposal_finalize
   - media_buy_seller/proposal_finalize_asap_timing
   - media_buy_seller/proposal_not_found_errors
+  - media_buy_seller/outcome_target
   - media_buy_seller/delivery_reporting
   - media_buy_seller/measurement_terms_rejected
   - media_buy_seller/measurement_terms_accepted

--- a/static/schemas/source/core/canonical-proposal.json
+++ b/static/schemas/source/core/canonical-proposal.json
@@ -43,7 +43,24 @@
       "pattern": "^sha256:[A-Za-z0-9_-]{43}$",
       "description": "Base64url SHA-256 digest of the RFC 8785 JCS serialization of commercial_terms, prefixed with sha256:."
     },
-    "insertion_order": { "$ref": "/schemas/core/insertion-order.json" }
+    "insertion_order": { "$ref": "/schemas/core/insertion-order.json" },
+    "total_budget_guidance": {
+      "type": "object",
+      "description": "Optional budget guidance for this proposal — the planning answer to criteria.outcome_target and to open-budget briefs. commercial_terms.total_budget remains the concrete figure the plan is priced at; this band expresses the seller's recommended range around it.",
+      "properties": {
+        "min": { "type": "number", "minimum": 0 },
+        "recommended": { "type": "number", "minimum": 0 },
+        "max": { "type": "number", "minimum": 0 },
+        "currency": { "type": "string", "pattern": "^[A-Z]{3}$" }
+      },
+      "required": ["currency"],
+      "anyOf": [{ "required": ["recommended"] }, { "required": ["min"] }, { "required": ["max"] }],
+      "additionalProperties": false
+    },
+    "forecast": {
+      "allOf": [{ "$ref": "/schemas/core/canonical-delivery-forecast.json" }],
+      "description": "Aggregate forecasted delivery for the proposal. For outcome_target requests, points carry the goal's metric or event key in metrics."
+    }
   },
   "required": ["proposal_id", "proposal_kind", "proposal_status", "name", "commercial_terms", "terms_digest"],
   "allOf": [


### PR DESCRIPTION
## Summary

Completes the conformance follow-up chain from #6644/#6727/#6728: makes `outcome_target` reverse forecasting gradeable end to end, on the SDK 14.0.0-beta.5 baseline (#6744).

- **`media_buy_seller/outcome_target` scenario**, required by the sales-proposal-mode specialism and gated on `media_buy.outcome_target`: a 10,000-click metric goal and a 500-purchase event goal, each graded on the answer contract — `total_budget_guidance` (currency + recommended) on every returned proposal, and a forecast whose points carry the goal's metric/event key in `metrics`, with `forecast_range_unit` `clicks`/`conversions` structuring the curves. Assertions grade only normative MUSTs (key presence, units), never the reference model's numbers, so live sellers aren't over-constrained.
- **Canonical-proposal gap fixed (Fixes #6745)**: implementing the scenario exposed that `core/canonical-proposal.json` — the compact `request_proposals` shape — could not carry `total_budget_guidance` or `forecast` at all (`additionalProperties: false`, fields absent), making the #6728 answer contract unexpressible on the lifecycle it was designed for. Both fields added additively, restoring parity with the legacy proposal's planning outputs. `commercial_terms.total_budget` remains the concrete figure; the guidance band expresses the seller's recommended range.
- **Training-agent reference implementation**: deterministic reverse-forecast solver (documented fixture constants, CPM from the seeded rate card), `media_buy.outcome_target: true` declared on both the legacy and v6 capability paths, `spend`-goal rejection with `INVALID_REQUEST`, and 5 unit tests.

## Verification

- Scenario through the real runner: 5 passed / 0 failed / 0 skipped — including the v6 response path with the new proposal fields
- Full storyboard matrix: all 7 tenants meet floors
- Unit suites: new file 5/5; availability windows 8/8; full training-agent 666/666; typecheck, schema validation, projection tests, storyboard lints, compliance links, changeset scope — all green

## Follow-up

The SDK's bundled canonical-proposal validator (14.0.0-beta.5, generated against protocol beta.4) predates the #6745 fields; the runner path tolerated them in practice, so no known-failing entry was needed — but the next SDK regeneration should pick them up from the beta that ships this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)