### PR TITLE
fix(addie): repair GitHub issue search

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.13';
+export const CODE_VERSION = '2026.08.14';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/jobs/secretariat-queues.ts
+++ b/server/src/addie/jobs/secretariat-queues.ts
@@ -179,6 +179,7 @@ async function searchIssues(token: string, repo: string, qualifiers: string, isP
     sort: 'created',
     order: 'asc',
     per_page: String(SEARCH_PAGE_SIZE),
+    advanced_search: 'true',
   });
   const resp = await ghFetch(token, `https://api.github.com/search/issues?${params.toString()}`);
   if (!resp.ok) {

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -1012,6 +1012,7 @@ const GITHUB_BODY_MAX_CHARS = 4000;
 const GITHUB_COMMENT_MAX_CHARS = 1000;
 const GITHUB_MAX_COMMENTS = 10;
 const GITHUB_DIFF_MAX_CHARS = 12000;
+const GITHUB_TOKEN_REPOS = new Set(['adcontextprotocol/adcp']);
 // Keep generated issue links below a conservative cross-client URL ceiling.
 // This reduces the risk of Slack splitting a query string or GitHub clearing
 // an oversized prefill. Longer drafts still get a complete copyable preview
@@ -1033,23 +1034,88 @@ function parseAllowedRepo(input: string | undefined): ParsedRepo {
   return { ok: true, org, repo };
 }
 
-function githubHeaders(): Record<string, string> {
-  const headers: Record<string, string> = { 'Accept': 'application/vnd.github.v3+json' };
+function githubHeaders(org: string, repo: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github.v3+json',
+    'User-Agent': 'adcp-addie/1.0',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
   const token = process.env.GITHUB_TOKEN;
-  if (token) headers['Authorization'] = `Bearer ${token}`;
+  if (token && GITHUB_TOKEN_REPOS.has(`${org}/${repo}`.toLowerCase())) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
   return headers;
 }
 
-function githubErrorMessage(response: Response, action: string): string {
+interface GitHubErrorDetails {
+  requestId?: string;
+  errorCodes: string[];
+}
+
+/**
+ * Extract diagnostics that are safe to place in logs and user-facing errors.
+ * GitHub's free-form error message can echo query text, so never persist it.
+ */
+async function readGitHubErrorDetails(response: Response): Promise<GitHubErrorDetails> {
+  const rawRequestId = response.headers.get('X-GitHub-Request-Id');
+  const requestId = rawRequestId && /^[A-Za-z0-9:-]{1,120}$/.test(rawRequestId)
+    ? rawRequestId
+    : undefined;
+  const errorCodes: string[] = [];
+
+  try {
+    const body = await response.json() as { errors?: unknown };
+    if (Array.isArray(body.errors)) {
+      for (const rawError of body.errors.slice(0, 10)) {
+        if (!rawError || typeof rawError !== 'object') continue;
+        const code = (rawError as { code?: unknown }).code;
+        if (typeof code === 'string' && /^[a-z][a-z0-9_]{0,40}$/.test(code)) {
+          errorCodes.push(code);
+        }
+      }
+    }
+  } catch {
+    // Some GitHub failures have an empty or non-JSON body. Status and request
+    // ID still provide enough correlation for a production investigation.
+  }
+
+  return {
+    ...(requestId && { requestId }),
+    errorCodes: [...new Set(errorCodes)],
+  };
+}
+
+async function githubErrorMessage(
+  response: Response,
+  action: string,
+  context: Record<string, string | number>,
+): Promise<string> {
+  const details = await readGitHubErrorDetails(response);
+  logger.warn(
+    {
+      status: response.status,
+      ...context,
+      ...(details.requestId && { githubRequestId: details.requestId }),
+      ...(details.errorCodes.length > 0 && { githubErrorCodes: details.errorCodes }),
+    },
+    `GitHub API error while trying to ${action}`,
+  );
+
+  const requestIdSuffix = details.requestId
+    ? ` GitHub request ID: ${details.requestId}.`
+    : '';
   if (response.status === 403 && response.headers.get('X-RateLimit-Remaining') === '0') {
     const reset = response.headers.get('X-RateLimit-Reset');
     const resetAt = reset ? new Date(Number(reset) * 1000).toISOString() : 'soon';
-    return `GitHub rate limit hit while trying to ${action}. Retry after ${resetAt}.`;
+    return `GitHub rate limit hit while trying to ${action}. Retry after ${resetAt}.${requestIdSuffix}`;
   }
   if (response.status === 401 || response.status === 403) {
-    return `GitHub auth failed (${response.status}) while trying to ${action}. GITHUB_TOKEN may be missing or invalid.`;
+    return `GitHub authentication is unavailable (${response.status}) while trying to ${action}.${requestIdSuffix}`;
   }
-  return `Failed to ${action} (${response.status}).`;
+  if (response.status === 422) {
+    return `GitHub rejected the request while trying to ${action} (422).${requestIdSuffix}`;
+  }
+  return `Failed to ${action} (${response.status}).${requestIdSuffix}`;
 }
 
 function truncate(text: string, max: number): string {
@@ -6830,7 +6896,7 @@ export function createMemberToolHandlers(
     const { org, repo } = parsed;
     const includeComments = Boolean(input.include_comments);
     const includeDiff = Boolean(input.include_diff);
-    const headers = githubHeaders();
+    const headers = githubHeaders(org, repo);
 
     try {
       const response = await fetch(
@@ -6841,8 +6907,7 @@ export function createMemberToolHandlers(
         if (response.status === 404) {
           return `Issue #${issueNumber} not found in ${org}/${repo}.`;
         }
-        logger.warn({ status: response.status, repo, issueNumber }, 'get_github_issue: GitHub API error');
-        return githubErrorMessage(response, `read issue #${issueNumber}`);
+        return githubErrorMessage(response, `read issue #${issueNumber}`, { repo, issueNumber });
       }
       const issue = await response.json() as {
         html_url: string;
@@ -6940,14 +7005,18 @@ export function createMemberToolHandlers(
       return 'Label names cannot contain quotes or newlines.';
     }
 
-    const headers = githubHeaders();
+    const headers = githubHeaders(org, repo);
 
     let apiUrl: string;
     if (query) {
-      const qualifiers = [`repo:${org}/${repo}`, `state:${state}`];
+      const qualifiers = [`repo:${org}/${repo}`];
+      // GitHub search has no `state:all` value. Omitting the qualifier searches
+      // both open and closed issues; the repository-list endpoint below does
+      // accept `state=all`, so its behavior remains unchanged.
+      if (state !== 'all') qualifiers.push(`state:${state}`);
       for (const label of labels) qualifiers.push(`label:"${label}"`);
       const q = `${query} ${qualifiers.join(' ')}`;
-      apiUrl = `https://api.github.com/search/issues?q=${encodeURIComponent(q)}&per_page=${limit}`;
+      apiUrl = `https://api.github.com/search/issues?q=${encodeURIComponent(q)}&per_page=${limit}&advanced_search=true`;
     } else {
       const params = new URLSearchParams({ state, per_page: String(limit) });
       if (labels.length > 0) params.set('labels', labels.join(','));
@@ -6957,8 +7026,7 @@ export function createMemberToolHandlers(
     try {
       const response = await fetch(apiUrl, { headers });
       if (!response.ok) {
-        logger.warn({ status: response.status, repo }, 'list_github_issues: GitHub API error');
-        return githubErrorMessage(response, 'list issues');
+        return githubErrorMessage(response, 'list issues', { repo });
       }
       const data = await response.json() as {
         items?: Array<unknown>;
@@ -6987,8 +7055,8 @@ export function createMemberToolHandlers(
       });
       const out = `## GitHub Issues in ${org}/${repo} (${items.length})\n\n`;
       return out + wrapUntrusted(`github:list:${org}/${repo}`, lines.join('\n')) + '\n';
-    } catch (error) {
-      logger.error({ error, repo }, 'list_github_issues: Failed to list issues');
+    } catch {
+      logger.error({ repo }, 'list_github_issues: Failed to list issues');
       return `Failed to list issues due to a network error.`;
     }
   });

--- a/server/tests/unit/secretariat-queues.test.ts
+++ b/server/tests/unit/secretariat-queues.test.ts
@@ -137,6 +137,17 @@ describe('secretariat queues snapshot', () => {
     );
   });
 
+  it('opts every GitHub issue search into advanced search', async () => {
+    const { buildQueuesSnapshot } = await import('../../src/addie/jobs/secretariat-queues.js');
+    await buildQueuesSnapshot(REPO);
+
+    const searchUrls = fetchMock.mock.calls
+      .map(([url]) => new URL(url as string))
+      .filter((url) => url.pathname === '/search/issues');
+    expect(searchUrls).toHaveLength(6);
+    expect(searchUrls.every((url) => url.searchParams.get('advanced_search') === 'true')).toBe(true);
+  });
+
   it('triage counts no:milestone total_count plus stuck-triaging issues that already carry a milestone', async () => {
     const noMilestoneA = fixtureIssue({ number: 10, created_at: daysAgoIso(8) });
     const noMilestoneB = fixtureIssue({ number: 11, created_at: daysAgoIso(2) });

--- a/tests/addie/member-tools.test.ts
+++ b/tests/addie/member-tools.test.ts
@@ -924,6 +924,142 @@ describe('createMemberToolHandlers', () => {
     });
   });
 
+  describe('GitHub read handlers', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    const issueSearchResult = {
+      items: [{
+        number: 42,
+        title: 'Broadcast support',
+        state: 'open',
+        html_url: 'https://github.com/adcontextprotocol/adcp/issues/42',
+        labels: [{ name: 'bug' }],
+        user: { login: 'reporter' },
+        updated_at: '2026-08-20T12:00:00Z',
+      }],
+    };
+
+    beforeEach(() => {
+      fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.unstubAllEnvs();
+    });
+
+    it('searches open issues with an explicit state qualifier and pinned API headers', async () => {
+      fetchMock.mockResolvedValue(new Response(JSON.stringify(issueSearchResult), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+
+      const handler = createMemberToolHandlers(null).get('list_github_issues')!;
+      const result = await handler({ query: 'broadcast', state: 'open', limit: 30 });
+
+      expect(result).toContain('Broadcast support');
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const parsed = new URL(url);
+      expect(parsed.pathname).toBe('/search/issues');
+      expect(parsed.searchParams.get('q')).toBe(
+        'broadcast repo:adcontextprotocol/adcp state:open',
+      );
+      expect(parsed.searchParams.get('per_page')).toBe('30');
+      expect(parsed.searchParams.get('advanced_search')).toBe('true');
+      expect(init.headers).toMatchObject({
+        'Accept': 'application/vnd.github.v3+json',
+        'User-Agent': 'adcp-addie/1.0',
+        'X-GitHub-Api-Version': '2022-11-28',
+      });
+    });
+
+    it('omits the state qualifier when a keyword search requests all states', async () => {
+      fetchMock.mockResolvedValue(new Response(JSON.stringify(issueSearchResult), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+
+      const handler = createMemberToolHandlers(null).get('list_github_issues')!;
+      await handler({ query: 'broadcast', state: 'all' });
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get('q')).toBe('broadcast repo:adcontextprotocol/adcp');
+      expect(parsed.searchParams.get('q')).not.toContain('state:all');
+      expect(parsed.searchParams.get('advanced_search')).toBe('true');
+    });
+
+    it('successfully searches with the default open state', async () => {
+      fetchMock.mockResolvedValue(new Response(JSON.stringify(issueSearchResult), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+
+      const handler = createMemberToolHandlers(null).get('list_github_issues')!;
+      const result = await handler({ query: 'broadcast' });
+
+      expect(result).toContain('Broadcast support');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get('q')).toBe(
+        'broadcast repo:adcontextprotocol/adcp state:open',
+      );
+      expect(parsed.searchParams.get('advanced_search')).toBe('true');
+    });
+
+    it('does not send the server token to caller-selected repositories', async () => {
+      vi.stubEnv('GITHUB_TOKEN', 'server-secret');
+      fetchMock.mockResolvedValue(new Response(JSON.stringify(issueSearchResult), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+
+      const handler = createMemberToolHandlers(null).get('list_github_issues')!;
+      await handler({ repo: 'microsoft/TypeScript', query: 'broadcast' });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init.headers).not.toHaveProperty('Authorization');
+    });
+
+    it('keeps state=all on the repository listing endpoint when no query is supplied', async () => {
+      fetchMock.mockResolvedValue(new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+
+      const handler = createMemberToolHandlers(null).get('list_github_issues')!;
+      await handler({ state: 'all' });
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const parsed = new URL(url);
+      expect(parsed.pathname).toBe('/repos/adcontextprotocol/adcp/issues');
+      expect(parsed.searchParams.get('state')).toBe('all');
+    });
+
+    it('returns a GitHub request ID for 422 diagnostics without echoing upstream text', async () => {
+      fetchMock.mockResolvedValue(new Response(JSON.stringify({
+        message: 'Validation failed for private query text',
+        errors: [{ resource: 'Search', field: 'q', code: 'invalid' }],
+      }), {
+        status: 422,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-GitHub-Request-Id': 'REQ:1234:ABCD',
+        },
+      }));
+
+      const handler = createMemberToolHandlers(null).get('list_github_issues')!;
+      const result = await handler({ query: 'broadcast' });
+
+      expect(result).toContain('GitHub rejected the request');
+      expect(result).toContain('422');
+      expect(result).toContain('REQ:1234:ABCD');
+      expect(result).not.toContain('private query text');
+    });
+  });
+
   describe('evaluate_agent_quality handler', () => {
     const ownerContext = {
       is_mapped: true,


### PR DESCRIPTION
Closes #6731

## Summary
- opt Addie and Secretariat issue searches into GitHub advanced search
- omit the invalid `state:all` search qualifier while preserving list endpoint semantics
- add safe 422 diagnostics with GitHub request IDs and pin REST API headers
- keep the server token scoped to the known project repository so arbitrary public-repo reads stay unauthenticated

## Verification
- expert code, security, and Node.js testing reviews
- focused suites: 77 passed
- pre-commit gate: 6,443 passed, 30 skipped
- TypeScript typecheck
- live GitHub smoke requests for reported query shapes and Secretariat searches returned 200