### PR TITLE
fix(ci): isolate storyboard execution processes

### DIFF
--- a/.changeset/isolate-storyboard-processes.md
+++ b/.changeset/isolate-storyboard-processes.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Run current sales compliance storyboards in isolated child process groups with per-storyboard timeout, RSS telemetry, and durable result capture.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
           changed_files="$(git show --format= --name-only --no-renames "${GITHUB_SHA}")"
-          if grep -Eq '^(\.changeset/|package(-lock)?[.]json$|dist/(schemas|compliance|protocol)/|static/(schemas|compliance)/source/|server/src/training-agent/|scripts/(build-schemas[.]cjs|build-compliance[.]cjs|build-protocol-tarball[.]cjs|sign-protocol-tarball[.]sh|run-storyboards-[^/]+[.]sh|run-storyboards-matrix[.]sh|stage-sdk-schema-bundle[.]sh|overlay-compliance-cache[.]sh)|[.]github/workflows/(release|training-agent-storyboards)[.]yml$)' <<< "${changed_files}"; then
+          if grep -Eq '^(\.changeset/|package(-lock)?[.]json$|dist/(schemas|compliance|protocol)/|static/(schemas|compliance)/source/|server/src/training-agent/|scripts/(build-schemas[.]cjs|build-compliance[.]cjs|build-protocol-tarball[.]cjs|sign-protocol-tarball[.]sh|run-storyboards-([^/]+[.]sh|isolated[.]mjs)|stage-sdk-schema-bundle[.]sh|overlay-compliance-cache[.]sh)|[.]github/workflows/(release|training-agent-storyboards)[.]yml$)' <<< "${changed_files}"; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             echo "Release-relevant files changed."
             exit 0

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -11,6 +11,7 @@ on:
       - 'package-lock.json'
       - 'scripts/build-compliance.cjs'
       - 'scripts/overlay-compliance-cache.sh'
+      - 'scripts/run-storyboards-isolated.mjs'
       - 'scripts/run-storyboards-matrix.sh'
       - 'scripts/run-storyboards-sharded.sh'
       - 'scripts/run-storyboards-3-0-compat.sh'
@@ -30,6 +31,7 @@ on:
       - 'package-lock.json'
       - 'scripts/build-compliance.cjs'
       - 'scripts/overlay-compliance-cache.sh'
+      - 'scripts/run-storyboards-isolated.mjs'
       - 'scripts/run-storyboards-matrix.sh'
       - 'scripts/run-storyboards-sharded.sh'
       - 'scripts/run-storyboards-3-0-compat.sh'
@@ -60,9 +62,9 @@ jobs:
         # are the frozen latest dist/compliance/3.0.x bundle baseline.
         # Rising is fine; regressing fails CI.
         tenant: [signals, sales, governance, creative, creative-builder, brand, si]
-        # Current /sales is large enough to exceed a hosted runner's resource envelope
-        # when its shards run sequentially. Dedicated shard jobs below keep
-        # each process isolated while preserving one aggregate required check.
+        # Current /sales uses the isolated orchestrators below so each
+        # storyboard gets a fresh process while one aggregate required check
+        # preserves the established branch-protection contract.
         exclude:
           - surface: current
             tenant: sales
@@ -420,17 +422,22 @@ jobs:
             fi
           done
 
-  sales_storyboard_shards:
-    name: Sales storyboard shard (${{ matrix.shard }}/48)
+  sales_storyboard_orchestrators:
+    name: Sales storyboard orchestrator (${{ matrix.orchestrator }}/8)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47]
+        orchestrator: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
-      SALES_SHARD_COUNT: 48
+      SALES_ORCHESTRATOR_COUNT: 8
+      # A 20-storyboard /sales calibration slice peaked at 2.06 GiB RSS and
+      # 28.7 seconds. These limits leave roughly 2x RSS and 4x time headroom
+      # while killing the observed 8–17 GiB pathologies before exhaustion.
+      STORYBOARD_RSS_LIMIT_MB: 4096
+      STORYBOARD_TIMEOUT_MS: 120000
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -448,62 +455,67 @@ jobs:
       - name: Overlay in-repo compliance source onto SDK cache
         run: bash scripts/overlay-compliance-cache.sh
 
-      - name: Run /sales storyboard shard
+      - name: Run isolated /sales storyboards
         env:
           TENANT_PATH: sales
           PUBLIC_TEST_AGENT_TOKEN: storyboard-ci-token
         run: |
-          set -uo pipefail
-          log="/tmp/storyboards-sales-${{ matrix.shard }}.log"
-          npx tsx server/tests/manual/run-storyboards.ts \
-            --shard-index "${{ matrix.shard }}" \
-            --shard-count "${SALES_SHARD_COUNT}" 2>&1 | tee "${log}" || true
-          set -e
+          set -euo pipefail
+          log="/tmp/storyboards-sales-${{ matrix.orchestrator }}.log"
+          node scripts/run-storyboards-isolated.mjs \
+            --shard-index "${{ matrix.orchestrator }}" \
+            --shard-count "${SALES_ORCHESTRATOR_COUNT}" \
+            --telemetry-file "/tmp/storyboards-sales-${{ matrix.orchestrator }}.telemetry.jsonl" \
+            --results-file "/tmp/storyboards-sales-${{ matrix.orchestrator }}.results.jsonl" \
+            2>&1 | tee "${log}"
           if ! grep -Eq '^[[:space:]]*storyboards: [0-9]+/[0-9]+ clean$' "${log}" ||
              ! grep -Eq '^[[:space:]]*steps: [0-9]+ passed \| [0-9]+ failed \| [0-9]+ skipped \| [0-9]+ not applicable$' "${log}"; then
-            echo "::error::Storyboard shard ${{ matrix.shard }}/${SALES_SHARD_COUNT} did not emit a complete totals block"
+            echo "::error::Storyboard orchestrator ${{ matrix.orchestrator }}/${SALES_ORCHESTRATOR_COUNT} did not emit a complete totals block"
             exit 1
           fi
 
-      - name: Upload /sales shard log
+      - name: Upload /sales orchestrator artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: storyboards-current-sales-shard-${{ matrix.shard }}
-          path: /tmp/storyboards-sales-${{ matrix.shard }}.log
+          name: storyboards-current-sales-orchestrator-${{ matrix.orchestrator }}
+          path: |
+            /tmp/storyboards-sales-${{ matrix.orchestrator }}.log
+            /tmp/storyboards-sales-${{ matrix.orchestrator }}.telemetry.jsonl
+            /tmp/storyboards-sales-${{ matrix.orchestrator }}.results.jsonl
           retention-days: 14
           if-no-files-found: error
 
   sales_storyboards:
     name: Storyboards (current /sales)
     if: always()
-    needs: sales_storyboard_shards
+    needs: sales_storyboard_orchestrators
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Download /sales shard logs
+      - name: Download /sales orchestrator artifacts
         uses: actions/download-artifact@v7
         with:
-          pattern: storyboards-current-sales-shard-*
-          path: /tmp/storyboards-sales-shards
+          pattern: storyboards-current-sales-orchestrator-*
+          path: /tmp/storyboards-sales-orchestrators
           merge-multiple: true
 
       - name: Aggregate /sales storyboard results
         id: aggregate
         env:
-          SHARD_RESULT: ${{ needs.sales_storyboard_shards.result }}
-          SALES_SHARD_COUNT: 48
+          ORCHESTRATOR_RESULT: ${{ needs.sales_storyboard_orchestrators.result }}
+          SALES_ORCHESTRATOR_COUNT: 8
         run: |
           set -euo pipefail
-          if [ "${SHARD_RESULT}" != "success" ]; then
-            echo "::error::At least one /sales storyboard shard failed: ${SHARD_RESULT}"
+          if [ "${ORCHESTRATOR_RESULT}" != "success" ]; then
+            echo "::error::At least one /sales storyboard orchestrator failed: ${ORCHESTRATOR_RESULT}"
             exit 1
           fi
 
           shopt -s nullglob
-          logs=(/tmp/storyboards-sales-shards/storyboards-sales-*.log)
-          if [ "${#logs[@]}" -ne "${SALES_SHARD_COUNT}" ]; then
-            echo "::error::Expected ${SALES_SHARD_COUNT} /sales shard logs, found ${#logs[@]}"
+          logs=(/tmp/storyboards-sales-orchestrators/storyboards-sales-*.log)
+          if [ "${#logs[@]}" -ne "${SALES_ORCHESTRATOR_COUNT}" ]; then
+            echo "::error::Expected ${SALES_ORCHESTRATOR_COUNT} /sales orchestrator logs, found ${#logs[@]}"
             exit 1
           fi
 

--- a/scripts/check-changeset-protocol-scope.cjs
+++ b/scripts/check-changeset-protocol-scope.cjs
@@ -26,7 +26,7 @@ const PROTOCOL_SCOPED_PATHS = [
   /^dist\/(?:schemas|compliance)\//,
   /^dist\/protocol\/[^/]+[.]tgz(?:[.](?:sha256|sig|crt))?$/,
   /^scripts\/(?:build-schemas|build-compliance|build-protocol-tarball|sign-protocol-tarball|stage-sdk-schema-bundle|overlay-compliance-cache|update-schema-versions|verify-version-sync|patch-3-0-compat-bundle)[.](?:cjs|mjs|sh)$/,
-  /^scripts\/(?:run-storyboards-[^/]+|run-storyboards-matrix)[.]sh$/,
+  /^scripts\/run-storyboards-(?:[^/]+[.]sh|isolated[.]mjs)$/,
   /^[.]github\/workflows\/(?:release|training-agent-storyboards)[.]yml$/,
 ];
 

--- a/scripts/run-storyboards-isolated-shards.sh
+++ b/scripts/run-storyboards-isolated-shards.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Run isolated storyboard orchestrators with bounded parallelism and emit one
+# aggregate totals block for local matrix grading.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+SHARD_COUNT=8
+MAX_PARALLEL=4
+RUNNER_ARGS=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --shard-count)
+      if [ -z "${2:-}" ]; then
+        echo "::error::--shard-count requires an integer argument" >&2
+        exit 2
+      fi
+      SHARD_COUNT="${2:-}"
+      shift 2
+      ;;
+    --max-parallel)
+      if [ -z "${2:-}" ]; then
+        echo "::error::--max-parallel requires an integer argument" >&2
+        exit 2
+      fi
+      MAX_PARALLEL="${2:-}"
+      shift 2
+      ;;
+    --shard-index)
+      echo "::error::--shard-index is managed by this script" >&2
+      exit 2
+      ;;
+    *)
+      RUNNER_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if ! [[ "${SHARD_COUNT}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::--shard-count must be a positive integer" >&2
+  exit 2
+fi
+if ! [[ "${MAX_PARALLEL}" =~ ^[1-9][0-9]*$ ]] || [ "${MAX_PARALLEL}" -gt "${SHARD_COUNT}" ]; then
+  echo "::error::--max-parallel must be a positive integer no greater than --shard-count" >&2
+  exit 2
+fi
+
+TEMP_DIR=$(mktemp -d -t "adcp-isolated-storyboard-shards.XXXXXX")
+cleanup() {
+  rm -rf "${TEMP_DIR}"
+}
+trap cleanup EXIT
+
+run_shard() {
+  local index="$1"
+  if [ -n "${STORYBOARD_ISOLATED_RUNNER_BIN:-}" ]; then
+    "${STORYBOARD_ISOLATED_RUNNER_BIN}" "${RUNNER_ARGS[@]}" --shard-index "${index}" --shard-count "${SHARD_COUNT}"
+  else
+    node scripts/run-storyboards-isolated.mjs "${RUNNER_ARGS[@]}" --shard-index "${index}" --shard-count "${SHARD_COUNT}"
+  fi
+}
+
+pids=()
+indexes=()
+statuses=()
+
+wait_for_batch() {
+  local offset pid index status
+  for ((offset = 0; offset < ${#pids[@]}; offset += 1)); do
+    pid="${pids[$offset]}"
+    index="${indexes[$offset]}"
+    wait "${pid}"
+    status=$?
+    statuses[$index]="${status}"
+  done
+  pids=()
+  indexes=()
+}
+
+for ((index = 0; index < SHARD_COUNT; index += 1)); do
+  run_shard "${index}" > "${TEMP_DIR}/shard-${index}.log" 2>&1 &
+  pids+=("$!")
+  indexes+=("${index}")
+  if [ "${#pids[@]}" -eq "${MAX_PARALLEL}" ]; then
+    wait_for_batch
+  fi
+done
+if [ "${#pids[@]}" -gt 0 ]; then
+  wait_for_batch
+fi
+
+clean_sum=0
+total_sum=0
+passed_sum=0
+failed_sum=0
+skipped_sum=0
+not_applicable_sum=0
+infrastructure_failure=0
+
+for ((index = 0; index < SHARD_COUNT; index += 1)); do
+  shard_number=$((index + 1))
+  shard_log="${TEMP_DIR}/shard-${index}.log"
+  echo ""
+  echo "=== Isolated storyboard shard ${shard_number}/${SHARD_COUNT} ==="
+  perl -pe 's/^(\s*)--- Totals ---/$1--- Shard result ---/; s/^(\s*)storyboards: ([0-9]+\/[0-9]+ clean)$/$1shard result: $2/; s/^(\s*)steps: (.*)$/$1shard step result: $2/' "${shard_log}"
+
+  storyboard_totals=$(sed -nE 's/^[[:space:]]*storyboards: ([0-9]+)\/([0-9]+) clean$/\1 \2/p' "${shard_log}")
+  step_totals=$(sed -nE 's/^[[:space:]]*steps: ([0-9]+) passed \| ([0-9]+) failed \| ([0-9]+) skipped \| ([0-9]+) not applicable$/\1 \2 \3 \4/p' "${shard_log}")
+  storyboard_totals_count=$(printf '%s\n' "${storyboard_totals}" | awk 'NF { count += 1 } END { print count + 0 }')
+  step_totals_count=$(printf '%s\n' "${step_totals}" | awk 'NF { count += 1 } END { print count + 0 }')
+
+  if [ "${storyboard_totals_count}" -ne 1 ] || [ "${step_totals_count}" -ne 1 ]; then
+    echo "::error::Isolated shard ${shard_number}/${SHARD_COUNT} emitted ${storyboard_totals_count} storyboard totals and ${step_totals_count} step totals; expected exactly one of each" >&2
+    exit 1
+  fi
+  if [ "${statuses[$index]}" -ne 0 ]; then
+    echo "::error::Isolated shard ${shard_number}/${SHARD_COUNT} exited ${statuses[$index]}" >&2
+    infrastructure_failure=1
+  fi
+
+  read -r shard_clean shard_total <<< "${storyboard_totals}"
+  read -r shard_passed shard_failed shard_skipped shard_not_applicable <<< "${step_totals}"
+  clean_sum=$((clean_sum + shard_clean))
+  total_sum=$((total_sum + shard_total))
+  passed_sum=$((passed_sum + shard_passed))
+  failed_sum=$((failed_sum + shard_failed))
+  skipped_sum=$((skipped_sum + shard_skipped))
+  not_applicable_sum=$((not_applicable_sum + shard_not_applicable))
+done
+
+echo ""
+echo "--- Totals ---"
+echo "  storyboards: ${clean_sum}/${total_sum} clean"
+echo "  steps: ${passed_sum} passed | ${failed_sum} failed | ${skipped_sum} skipped | ${not_applicable_sum} not applicable"
+exit "${infrastructure_failure}"

--- a/scripts/run-storyboards-isolated.mjs
+++ b/scripts/run-storyboards-isolated.mjs
@@ -1,0 +1,532 @@
+#!/usr/bin/env node
+
+/**
+ * Run each applicable storyboard in a fresh process group.
+ *
+ * This orchestrator deliberately has no dependency on the training agent or
+ * @adcp/sdk. The child runner discovers applicable IDs and executes exactly
+ * one ID per process, so SDK/module state cannot leak between storyboards.
+ */
+
+import { spawn } from 'node:child_process';
+import { appendFileSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const LIST_PREFIX = 'ADCP_STORYBOARD_LIST ';
+const RESULT_PREFIX = 'ADCP_STORYBOARD_RESULT ';
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_RSS_LIMIT_MB = 4_096;
+const DEFAULT_RSS_POLL_MS = 250;
+const DEFAULT_OUTPUT_LIMIT_MB = 16;
+const MAX_CHILD_LINE_BYTES = 1024 * 1024;
+const STORYBOARD_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,255}$/;
+let activeChildPid;
+
+function requiredPositiveInteger(raw, name, { allowZero = false } = {}) {
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || (allowZero ? value < 0 : value < 1)) {
+    throw new Error(`${name} requires ${allowZero ? 'a non-negative' : 'a positive'} integer`);
+  }
+  return value;
+}
+
+function optionValue(args, name, fallback) {
+  // Last value wins so explicit CLI options can override wrapper/default
+  // arguments in the same way they override environment defaults.
+  const index = args.lastIndexOf(name);
+  if (index === -1) return fallback;
+  if (args[index + 1] === undefined) throw new Error(`${name} requires a value`);
+  return args[index + 1];
+}
+
+function parseArgs(argv) {
+  const knownValueOptions = new Set([
+    '--shard-index',
+    '--shard-count',
+    '--timeout-ms',
+    '--rss-limit-mb',
+    '--rss-poll-ms',
+    '--output-limit-mb',
+    '--telemetry-file',
+    '--results-file',
+  ]);
+  const passthrough = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (knownValueOptions.has(arg)) {
+      index += 1;
+      if (argv[index] === undefined) throw new Error(`${arg} requires a value`);
+      continue;
+    }
+    passthrough.push(arg);
+  }
+
+  const shardIndexRaw = optionValue(argv, '--shard-index', undefined);
+  const shardCountRaw = optionValue(argv, '--shard-count', undefined);
+  if ((shardIndexRaw === undefined) !== (shardCountRaw === undefined)) {
+    throw new Error('--shard-index and --shard-count must be supplied together');
+  }
+  const shardCount = shardCountRaw === undefined
+    ? 1
+    : requiredPositiveInteger(shardCountRaw, '--shard-count');
+  const shardIndex = shardIndexRaw === undefined
+    ? 0
+    : requiredPositiveInteger(shardIndexRaw, '--shard-index', { allowZero: true });
+  if (shardIndex >= shardCount) {
+    throw new Error('--shard-index must be between 0 and --shard-count - 1');
+  }
+
+  const timeoutMs = requiredPositiveInteger(
+    optionValue(argv, '--timeout-ms', process.env.STORYBOARD_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS),
+    '--timeout-ms',
+  );
+  const rssLimitMb = requiredPositiveInteger(
+    optionValue(argv, '--rss-limit-mb', process.env.STORYBOARD_RSS_LIMIT_MB ?? DEFAULT_RSS_LIMIT_MB),
+    '--rss-limit-mb',
+  );
+  const rssPollMs = requiredPositiveInteger(
+    optionValue(argv, '--rss-poll-ms', process.env.STORYBOARD_RSS_POLL_MS ?? DEFAULT_RSS_POLL_MS),
+    '--rss-poll-ms',
+  );
+  const outputLimitMb = requiredPositiveInteger(
+    optionValue(argv, '--output-limit-mb', process.env.STORYBOARD_OUTPUT_LIMIT_MB ?? DEFAULT_OUTPUT_LIMIT_MB),
+    '--output-limit-mb',
+  );
+
+  return {
+    shardIndex,
+    shardCount,
+    timeoutMs,
+    rssLimitBytes: rssLimitMb * 1024 * 1024,
+    rssPollMs,
+    outputLimitBytes: outputLimitMb * 1024 * 1024,
+    telemetryFile: optionValue(argv, '--telemetry-file', process.env.STORYBOARD_TELEMETRY_FILE),
+    resultsFile: optionValue(argv, '--results-file', process.env.STORYBOARD_RESULTS_FILE),
+    passthrough,
+  };
+}
+
+function terminateActiveChild(signal) {
+  try {
+    killProcessGroup(activeChildPid);
+  } finally {
+    process.exit(signal === 'SIGINT' ? 130 : 143);
+  }
+}
+
+process.once('SIGINT', () => terminateActiveChild('SIGINT'));
+process.once('SIGTERM', () => terminateActiveChild('SIGTERM'));
+
+function childInvocation(extraArgs) {
+  const fixtureRunner = process.env.STORYBOARD_RUNNER_BIN;
+  if (fixtureRunner) {
+    const resolvedRunner = resolve(fixtureRunner);
+    if (/\.(?:c?js|mjs)$/.test(resolvedRunner)) {
+      return { command: process.execPath, args: [resolvedRunner, ...extraArgs] };
+    }
+    return { command: resolvedRunner, args: extraArgs };
+  }
+  return {
+    command: process.execPath,
+    args: ['--import', 'tsx', 'server/tests/manual/run-storyboards.ts', ...extraArgs],
+  };
+}
+
+function killProcessGroup(pid) {
+  if (!Number.isSafeInteger(pid) || pid < 1) return;
+  try {
+    process.kill(process.platform === 'win32' ? pid : -pid, 'SIGKILL');
+  } catch (error) {
+    if (error?.code !== 'ESRCH') throw error;
+  }
+}
+
+function linuxProcessGroupRssBytes(processGroupId) {
+  let totalKb = 0;
+  for (const entry of readdirSync('/proc', { withFileTypes: true })) {
+    if (!entry.isDirectory() || !/^\d+$/.test(entry.name)) continue;
+    try {
+      const stat = readFileSync(join('/proc', entry.name, 'stat'), 'utf8');
+      const afterCommand = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/);
+      if (Number(afterCommand[2]) !== processGroupId) continue;
+      const status = readFileSync(join('/proc', entry.name, 'status'), 'utf8');
+      const match = status.match(/^VmRSS:\s+(\d+)\s+kB$/m);
+      if (match) totalKb += Number(match[1]);
+    } catch (error) {
+      if (error?.code !== 'ENOENT' && error?.code !== 'ESRCH') throw error;
+    }
+  }
+  return totalKb * 1024;
+}
+
+async function portableProcessGroupRssBytes(processGroupId) {
+  if (process.platform === 'linux') return linuxProcessGroupRssBytes(processGroupId);
+  return await new Promise((resolveRss) => {
+    const ps = spawn('ps', ['-axo', 'pgid=,rss='], { stdio: ['ignore', 'pipe', 'ignore'] });
+    let output = '';
+    ps.stdout.setEncoding('utf8');
+    ps.stdout.on('data', chunk => { output += chunk; });
+    ps.once('error', () => resolveRss(0));
+    ps.once('close', () => {
+      let totalKb = 0;
+      for (const line of output.split('\n')) {
+        const [pgid, rss] = line.trim().split(/\s+/).map(Number);
+        if (pgid === processGroupId && Number.isFinite(rss)) totalKb += rss;
+      }
+      resolveRss(totalKb * 1024);
+    });
+  });
+}
+
+function telemetryLine(record) {
+  return `ADCP_STORYBOARD_TELEMETRY ${JSON.stringify(record)}`;
+}
+
+async function runManagedChild({
+  storyboardId,
+  childArgs,
+  expectedPrefix,
+  config,
+  validateEnvelope = () => true,
+  persistResult = false,
+  streamOutput = false,
+}) {
+  const invocation = childInvocation(childArgs);
+  const startedAt = Date.now();
+  const child = spawn(invocation.command, invocation.args, {
+    cwd: process.cwd(),
+    env: process.env,
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  activeChildPid = child.pid;
+  const exitPromise = new Promise((resolveExit, reject) => {
+    child.once('error', reject);
+    child.once('close', (code, closeSignal) => resolveExit({ exitCode: code, signal: closeSignal }));
+  });
+
+  let envelope;
+  let peakRssBytes = 0;
+  let timedOut = false;
+  let resourceLimited = false;
+  let outputLimited = false;
+  let outputBytes = 0;
+  let stdoutBuffer = '';
+  let stderrBuffer = '';
+  let sampling = false;
+  let completed = false;
+  let monitorError;
+  let teardownError;
+  let teardownErrorCode;
+
+  const requestGroupKill = () => {
+    try {
+      killProcessGroup(child.pid);
+    } catch (error) {
+      // A fast child may exit before its final pipe data is delivered. On
+      // macOS the now-vacant PGID can report EPERM instead of ESRCH; there is
+      // no owned process group left to tear down in that state.
+      if (error?.code === 'EPERM' && (child.exitCode !== null || child.signalCode !== null)) return;
+      teardownError ??= error instanceof Error ? error.message : String(error);
+      teardownErrorCode ??= error?.code;
+    }
+  };
+
+  const accountOutput = (chunk) => {
+    if (outputLimited) return false;
+    outputBytes += Buffer.byteLength(chunk);
+    if (outputBytes <= config.outputLimitBytes) return true;
+    if (!outputLimited) {
+      outputLimited = true;
+      process.stderr.write(
+        `::error::${storyboardId ?? 'discovery'} exceeded child output limit of ${config.outputLimitBytes} bytes\n`,
+      );
+      requestGroupKill();
+    }
+    return false;
+  };
+
+  const safeLogLine = (line) => {
+    const withoutControls = line
+      .replace(/\r/g, '')
+      .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, '\ufffd');
+    return /^\s*::/.test(withoutControls) ? `[child] ${withoutControls}` : withoutControls;
+  };
+
+  const persistEnvelope = (parsed) => {
+    if (persistResult && config.resultsFile) {
+      appendFileSync(config.resultsFile, `${JSON.stringify(parsed)}\n`, 'utf8');
+    }
+    envelope = parsed;
+    // The envelope has reached the orchestrator (and the result artifact when
+    // configured), so no child disposal path is needed for correctness.
+    requestGroupKill();
+  };
+
+  const handleLine = (line) => {
+    if (line.startsWith(expectedPrefix)) {
+      try {
+        const parsed = JSON.parse(line.slice(expectedPrefix.length));
+        if (!validateEnvelope(parsed)) throw new Error('envelope failed completeness validation');
+        persistEnvelope(parsed);
+      } catch (error) {
+        process.stderr.write(`Unable to accept result envelope from ${storyboardId ?? 'discovery'}: ${error.message}\n`);
+      }
+      return;
+    }
+    if (!streamOutput) return;
+    if (/^\s*--- Totals ---\s*$/.test(line)) {
+      process.stdout.write('--- Child result ---\n');
+    } else if (/^\s*storyboards:/.test(line)) {
+      process.stdout.write(line.replace('storyboards:', 'child storyboards:') + '\n');
+    } else if (/^\s*steps:/.test(line)) {
+      process.stdout.write(line.replace('steps:', 'child steps:') + '\n');
+    } else {
+      process.stdout.write(`${safeLogLine(line)}\n`);
+    }
+  };
+
+  const handleStderrLine = (line) => {
+    process.stderr.write(`[child stderr] ${safeLogLine(line)}\n`);
+  };
+
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    if (!accountOutput(chunk)) return;
+    stdoutBuffer += chunk;
+    if (Buffer.byteLength(stdoutBuffer) > MAX_CHILD_LINE_BYTES) {
+      outputLimited = true;
+      requestGroupKill();
+      return;
+    }
+    const lines = stdoutBuffer.split('\n');
+    stdoutBuffer = lines.pop() ?? '';
+    for (const line of lines) handleLine(line.replace(/\r$/, ''));
+  });
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => {
+    if (!accountOutput(chunk)) return;
+    stderrBuffer += chunk;
+    if (Buffer.byteLength(stderrBuffer) > MAX_CHILD_LINE_BYTES) {
+      outputLimited = true;
+      requestGroupKill();
+      return;
+    }
+    const lines = stderrBuffer.split('\n');
+    stderrBuffer = lines.pop() ?? '';
+    for (const line of lines) handleStderrLine(line.replace(/\r$/, ''));
+  });
+
+  const timeout = setTimeout(() => {
+    if (envelope !== undefined) return;
+    timedOut = true;
+    requestGroupKill();
+  }, config.timeoutMs);
+
+  let currentRssSample = Promise.resolve();
+  const sampleRss = () => {
+    if (completed || sampling || envelope !== undefined) return;
+    sampling = true;
+    currentRssSample = portableProcessGroupRssBytes(child.pid)
+      .then((rssBytes) => {
+        // Once a complete envelope is durable, disposal-time growth cannot
+        // retroactively turn the storyboard into a resource failure.
+        if (completed || envelope !== undefined) return;
+        peakRssBytes = Math.max(peakRssBytes, rssBytes);
+        if (rssBytes > config.rssLimitBytes) {
+          resourceLimited = true;
+          requestGroupKill();
+        }
+      })
+      .catch((error) => {
+        if (completed || envelope !== undefined) return;
+        monitorError = error instanceof Error ? error.message : String(error);
+        requestGroupKill();
+      })
+      .finally(() => {
+        sampling = false;
+      });
+    return currentRssSample;
+  };
+  let rssPoll;
+  let exit;
+  try {
+    await sampleRss();
+    rssPoll = setInterval(() => { void sampleRss(); }, config.rssPollMs);
+    exit = await exitPromise;
+  } finally {
+    completed = true;
+    clearTimeout(timeout);
+    if (rssPoll) clearInterval(rssPoll);
+    await currentRssSample;
+    requestGroupKill();
+    if (activeChildPid === child.pid) activeChildPid = undefined;
+  }
+  const { exitCode, signal } = exit;
+  if (stdoutBuffer && !outputLimited) handleLine(stdoutBuffer.replace(/\r$/, ''));
+  if (stderrBuffer && !outputLimited) handleStderrLine(stderrBuffer.replace(/\r$/, ''));
+
+  const effectiveTeardownError = teardownErrorCode === 'EPERM' && exitCode !== null
+    ? null
+    : teardownError ?? null;
+  const record = {
+    storyboard_id: storyboardId,
+    elapsed_ms: Date.now() - startedAt,
+    peak_rss_bytes: peakRssBytes,
+    output_bytes: outputBytes,
+    exit_code: exitCode,
+    signal,
+    timed_out: timedOut,
+    resource_limited: resourceLimited,
+    output_limited: outputLimited,
+    monitor_error: monitorError ?? null,
+    teardown_error: effectiveTeardownError,
+    result_received: envelope !== undefined,
+  };
+  process.stdout.write(`${telemetryLine(record)}\n`);
+  if (config.telemetryFile) appendFileSync(config.telemetryFile, `${JSON.stringify(record)}\n`, 'utf8');
+  return { envelope, record };
+}
+
+function totalsFromEnvelope(envelope, storyboardId) {
+  const totals = envelope?.totals;
+  const countFields = ['passed', 'failed', 'skipped', 'not_applicable'];
+  const expectedSummaryIds = storyboardId === 'signed_requests'
+    ? ['signed_requests-strict', 'signed_requests-strict-required', 'signed_requests-strict-forbidden']
+    : [storyboardId];
+  if (
+    envelope?.version !== 1
+    || envelope.storyboard_id !== storyboardId
+    || !Array.isArray(envelope.summaries)
+    || envelope.summaries.length !== expectedSummaryIds.length
+    || !totals
+    || !['clean', 'total', ...countFields].every(field => Number.isSafeInteger(totals[field]) && totals[field] >= 0)
+  ) {
+    return undefined;
+  }
+  const validSummaries = envelope.summaries.every(summary => (
+    summary
+    && typeof summary === 'object'
+    && expectedSummaryIds.includes(summary.id)
+    && countFields.every(field => Number.isSafeInteger(summary[field]) && summary[field] >= 0)
+    && typeof summary.has_error === 'boolean'
+  ));
+  if (!validSummaries || new Set(envelope.summaries.map(summary => summary.id)).size !== expectedSummaryIds.length) {
+    return undefined;
+  }
+
+  const expected = envelope.summaries.reduce((acc, summary) => {
+    for (const field of countFields) acc[field] += summary[field];
+    if (summary.failed === 0 && !summary.has_error) acc.clean += 1;
+    return acc;
+  }, { clean: 0, passed: 0, failed: 0, skipped: 0, not_applicable: 0 });
+  if (
+    totals.total !== envelope.summaries.length
+    || totals.clean !== expected.clean
+    || countFields.some(field => totals[field] !== expected[field])
+  ) return undefined;
+  return totals;
+}
+
+function addTotals(target, source) {
+  target.clean += source.clean;
+  target.total += source.total;
+  target.passed += source.passed;
+  target.failed += source.failed;
+  target.skipped += source.skipped;
+  target.not_applicable += source.not_applicable;
+}
+
+function validDiscoveryEnvelope(envelope) {
+  const applicableIds = envelope?.storyboard_ids;
+  return envelope?.version === 1
+    && Array.isArray(applicableIds)
+    && applicableIds.every(id => typeof id === 'string' && STORYBOARD_ID_PATTERN.test(id))
+    && new Set(applicableIds).size === applicableIds.length;
+}
+
+async function main() {
+  const config = parseArgs(process.argv.slice(2));
+  if (!config.resultsFile) {
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), 'adcp-storyboard-results-'));
+    config.resultsFile = join(temporaryDirectory, 'results.jsonl');
+    process.once('exit', () => rmSync(temporaryDirectory, { recursive: true, force: true }));
+  }
+  const secureCreateOptions = { encoding: 'utf8', flag: 'wx', mode: 0o600 };
+  if (config.telemetryFile) writeFileSync(config.telemetryFile, '', secureCreateOptions);
+  writeFileSync(config.resultsFile, '', secureCreateOptions);
+
+  const discovery = await runManagedChild({
+    storyboardId: null,
+    childArgs: [...config.passthrough, '--list-applicable-json'],
+    expectedPrefix: LIST_PREFIX,
+    config,
+    validateEnvelope: envelope => validDiscoveryEnvelope(envelope),
+  });
+  const applicableIds = discovery.envelope?.storyboard_ids;
+  if (!validDiscoveryEnvelope(discovery.envelope)) {
+    throw new Error('Storyboard discovery did not emit a complete ID envelope');
+  }
+
+  const start = Math.floor(applicableIds.length * config.shardIndex / config.shardCount);
+  const end = Math.floor(applicableIds.length * (config.shardIndex + 1) / config.shardCount);
+  const storyboardIds = applicableIds.slice(start, end);
+  process.stdout.write(
+    `\nIsolated orchestrator ${config.shardIndex + 1}/${config.shardCount}: `
+    + `${storyboardIds.length} of ${applicableIds.length} applicable storyboards\n`,
+  );
+
+  const aggregate = { clean: 0, total: 0, passed: 0, failed: 0, skipped: 0, not_applicable: 0 };
+  let infrastructureFailures = 0;
+  for (const storyboardId of storyboardIds) {
+    process.stdout.write(`\n=== Isolated storyboard: ${storyboardId} ===\n`);
+    const child = await runManagedChild({
+      storyboardId,
+      childArgs: [
+        ...config.passthrough,
+        '--storyboard-id', storyboardId,
+        '--emit-result-envelope',
+      ],
+      expectedPrefix: RESULT_PREFIX,
+      config,
+      validateEnvelope: envelope => totalsFromEnvelope(envelope, storyboardId) !== undefined,
+      persistResult: true,
+      streamOutput: true,
+    });
+    const totals = totalsFromEnvelope(child.envelope, storyboardId);
+    if (
+      !totals
+      || child.record.timed_out
+      || child.record.resource_limited
+      || child.record.output_limited
+      || child.record.monitor_error
+      || child.record.teardown_error
+    ) {
+      infrastructureFailures += 1;
+      aggregate.total += 1;
+      let reason = 'did not emit a complete result envelope';
+      if (child.record.timed_out) reason = `timed out after ${config.timeoutMs}ms`;
+      else if (child.record.resource_limited) reason = `exceeded RSS limit of ${config.rssLimitBytes} bytes`;
+      else if (child.record.output_limited) reason = `exceeded output limit of ${config.outputLimitBytes} bytes`;
+      else if (child.record.monitor_error) reason = `RSS monitoring failed: ${child.record.monitor_error}`;
+      else if (child.record.teardown_error) reason = `process-group teardown failed: ${child.record.teardown_error}`;
+      process.stderr.write(`::error::${storyboardId} ${reason}\n`);
+      continue;
+    }
+    addTotals(aggregate, totals);
+  }
+
+  process.stdout.write('\n--- Totals ---\n');
+  process.stdout.write(`  storyboards: ${aggregate.clean}/${aggregate.total} clean\n`);
+  process.stdout.write(
+    `  steps: ${aggregate.passed} passed | ${aggregate.failed} failed | `
+    + `${aggregate.skipped} skipped | ${aggregate.not_applicable} not applicable\n`,
+  );
+  process.exitCode = infrastructureFailures > 0 ? 1 : 0;
+}
+
+main().catch(error => {
+  process.stderr.write(`Fatal isolated storyboard runner error: ${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -366,19 +366,21 @@ for entry in "${TENANTS[@]}"; do
   echo "──────────────────────────────────────────────"
 
   log=$(mktemp -t "storyboards-${tenant}.XXXXXX.log")
+  orchestrator_failure=0
 
   if [ "${FLOOR_SET}" = "current" ] && [ "${tenant}" = "sales" ]; then
     TENANT_PATH="${tenant}" \
       PUBLIC_TEST_AGENT_TOKEN="${PUBLIC_TEST_AGENT_TOKEN:-storyboard-local-token}" \
-      bash scripts/run-storyboards-sharded.sh --shard-count 4 > "${log}" 2>&1 || true
+      bash scripts/run-storyboards-isolated-shards.sh \
+        --shard-count 8 --max-parallel 4 > "${log}" 2>&1 || orchestrator_failure=1
   else
     TENANT_PATH="${tenant}" \
       PUBLIC_TEST_AGENT_TOKEN="${PUBLIC_TEST_AGENT_TOKEN:-storyboard-local-token}" \
       npx tsx server/tests/manual/run-storyboards.ts > "${log}" 2>&1 || true
   fi
 
-  clean=$(grep -oE 'storyboards: [0-9]+/[0-9]+' "${log}" | tail -1 | grep -oE '^storyboards: [0-9]+' | grep -oE '[0-9]+$' || echo "")
-  passed=$(grep -oE 'steps: [0-9]+ passed' "${log}" | tail -1 | grep -oE '[0-9]+' || echo "")
+  clean=$(sed -nE 's/^[[:space:]]*storyboards: ([0-9]+)\/[0-9]+ clean$/\1/p' "${log}" | tail -1)
+  passed=$(sed -nE 's/^[[:space:]]*steps: ([0-9]+) passed .*/\1/p' "${log}" | tail -1)
 
   if [ -z "${clean}" ] || [ -z "${passed}" ]; then
     echo "::error::Failed to parse storyboard counts from runner output for /${tenant}."
@@ -391,6 +393,10 @@ for entry in "${TENANTS[@]}"; do
 
   status="✓"
   failed_floor=""
+  if [ "${orchestrator_failure}" -ne 0 ]; then
+    status="✗"
+    failed_floor="one or more isolated orchestrators failed"
+  fi
   if [ "${clean}" -lt "${min_clean}" ]; then
     status="✗"
     failed_floor="clean storyboards ${clean} < ${min_clean}"

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -5,6 +5,7 @@
  *   TRAINING_AGENT_PORT=4444 npx tsx server/tests/manual/run-storyboards.ts --filter signal-marketplace
  *   TRAINING_AGENT_PORT=4444 npx tsx server/tests/manual/run-storyboards.ts --filter governance --verbose
  *   TENANT_PATH=sales npx tsx server/tests/manual/run-storyboards.ts --shard-index 0 --shard-count 4
+ *   TENANT_PATH=sales node scripts/run-storyboards-isolated.mjs
  *
  * Expects a training agent already running at `http://127.0.0.1:${PORT}/api/training-agent/mcp`.
  * Start one in a separate terminal with:
@@ -63,6 +64,15 @@ const { getPublicJwks } = await import('../../src/training-agent/webhooks.js');
 const args = process.argv.slice(2);
 const verbose = args.includes('--verbose');
 const filter = args.includes('--filter') ? args[args.indexOf('--filter') + 1] : undefined;
+const storyboardId = args.includes('--storyboard-id') ? args[args.indexOf('--storyboard-id') + 1] : undefined;
+const listApplicableJson = args.includes('--list-applicable-json');
+const emitResultEnvelope = args.includes('--emit-result-envelope');
+if (args.includes('--storyboard-id') && !storyboardId) {
+  throw new Error('--storyboard-id requires a value');
+}
+if (emitResultEnvelope && !storyboardId) {
+  throw new Error('--emit-result-envelope requires --storyboard-id');
+}
 
 function optionalIntegerArg(name: string): number | undefined {
   const argIndex = args.indexOf(name);
@@ -514,6 +524,7 @@ function patchStoryboardForLocalRunner(sb: Storyboard): Storyboard {
 }
 
 function isApplicable(sb: Storyboard): boolean {
+  if (storyboardId && sb.id !== storyboardId) return false;
   if (filter && !sb.id.includes(filter) && !(sb.category ?? '').includes(filter)) return false;
   if (KNOWN_FAILING_STORYBOARDS.has(sb.id)) return false;
   if (releasedComplianceVersion === undefined && CURRENT_SOURCE_KNOWN_FAILING_STORYBOARDS.has(sb.id)) return false;
@@ -649,14 +660,29 @@ function summarize(sb: Storyboard, result: StoryboardResult | { error: string })
 }
 
 async function main() {
+  const everything = listAllComplianceStoryboards(complianceOptions);
+  const applicable = everything.filter(isApplicable);
+  if (storyboardId && applicable.length !== 1) {
+    throw new Error(`Storyboard ${storyboardId} is missing, filtered out, or on the known-failing list`);
+  }
+  if (listApplicableJson) {
+    // The long-lived orchestrator parses this envelope but never imports the
+    // SDK itself. Flush before exiting so discovery is deterministic even if
+    // the SDK has installed background handles during module initialization.
+    console.log(`ADCP_STORYBOARD_LIST ${JSON.stringify({
+      version: 1,
+      storyboard_ids: applicable.map(sb => sb.id),
+    })}`);
+    await new Promise<void>(resolve => process.stdout.write('', resolve));
+    process.exit(0);
+  }
+
   const { url: agentUrl, baseUrl: localAgentBaseUrl, close } = await startLocalAgent();
   // eslint-disable-next-line no-console
   console.log(`\nTraining agent running at ${agentUrl}`);
   // eslint-disable-next-line no-console
   console.log(`Filter: ${filter ?? '(all storyboards)'}\n`);
 
-  const everything = listAllComplianceStoryboards(complianceOptions);
-  const applicable = everything.filter(isApplicable);
   // Shard only after all applicability decisions so every unsharded run and
   // every union of shards execute the same storyboard set. The compliance
   // index has stable ordering. Balanced contiguous ranges preserve the
@@ -671,6 +697,7 @@ async function main() {
   }
   const skippedKnownFailing = everything
     .filter(sb => knownFailingReason(sb.id) !== undefined)
+    .filter(sb => !storyboardId || sb.id === storyboardId)
     .filter(sb => !filter || sb.id.includes(filter) || (sb.category ?? '').includes(filter));
   if (skippedKnownFailing.length > 0) {
     // eslint-disable-next-line no-console
@@ -682,10 +709,13 @@ async function main() {
     // eslint-disable-next-line no-console
     console.log('');
   }
-  if (KNOWN_FAILING_STEPS.size > 0) {
+  const relevantKnownFailingSteps = storyboardId
+    ? [...KNOWN_FAILING_STEPS].filter(([key]) => key.startsWith(`${storyboardId}/`))
+    : [...KNOWN_FAILING_STEPS];
+  if (relevantKnownFailingSteps.length > 0) {
     // eslint-disable-next-line no-console
     console.log('Skipping individual steps on the known-failing list:');
-    for (const [key, reason] of KNOWN_FAILING_STEPS) {
+    for (const [key, reason] of relevantKnownFailingSteps) {
       // eslint-disable-next-line no-console
       console.log(`  - ${key}: ${reason}`);
     }
@@ -912,6 +942,31 @@ async function main() {
   console.log(`  storyboards: ${results.length - failing.length}/${results.length} clean`);
   // eslint-disable-next-line no-console
   console.log(`  steps: ${totals.passed} passed | ${totals.failed} failed | ${totals.skipped} skipped | ${totals.not_applicable} not applicable`);
+
+  if (emitResultEnvelope) {
+    // The parent persists this complete envelope before terminating our
+    // process group, so correctness never depends on graceful SDK/V8 disposal.
+    console.log(`ADCP_STORYBOARD_RESULT ${JSON.stringify({
+      version: 1,
+      storyboard_id: storyboardId,
+      // Persist counts and status only. Full validation details can contain
+      // synthetic request/response values and belong in the bounded CI log,
+      // not the longer-lived machine-readable result artifact.
+      summaries: results.map(result => ({
+        id: result.id,
+        passed: result.passed,
+        failed: result.failed,
+        skipped: result.skipped,
+        not_applicable: result.not_applicable,
+        has_error: result.error !== undefined,
+      })),
+      totals: {
+        clean: results.length - failing.length,
+        total: results.length,
+        ...totals,
+      },
+    })}`);
+  }
 
   await close();
   const exitCode = totals.failed > 0 || failing.some(r => r.error) ? 1 : 0;

--- a/tests/changeset-protocol-scope.test.cjs
+++ b/tests/changeset-protocol-scope.test.cjs
@@ -72,6 +72,7 @@ assert.strictEqual(isProtocolScopedPath('static/openapi/registry.yaml'), false);
 assert.strictEqual(isProtocolScopedPath('static/schemas/source/core/registry-feed-response.json'), true);
 assert.strictEqual(isProtocolScopedPath('docs/reference/versioning.mdx'), true);
 assert.strictEqual(isProtocolScopedPath('docs/registry/index.mdx'), false);
+assert.strictEqual(isProtocolScopedPath('scripts/run-storyboards-isolated.mjs'), true);
 assert.strictEqual(isProtocolScopedPath('server/src/billing/subscription-sync.ts'), false);
 assert.strictEqual(isProtocolScopedPath('.changeset/billing-fix.md'), false);
 assert.strictEqual(

--- a/tests/fixtures/storyboard-isolation-runner.cjs
+++ b/tests/fixtures/storyboard-isolation-runner.cjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('node:fs');
+const { spawn } = require('node:child_process');
+
+const args = process.argv.slice(2);
+const storyboardIds = (process.env.FIXTURE_STORYBOARDS ?? 'healthy').split(',').filter(Boolean);
+
+if (args.includes('--list-applicable-json')) {
+  console.log(`ADCP_STORYBOARD_LIST ${JSON.stringify({ version: 1, storyboard_ids: storyboardIds })}`);
+  process.exit(0);
+}
+
+const idIndex = args.indexOf('--storyboard-id');
+const storyboardId = idIndex === -1 ? undefined : args[idIndex + 1];
+if (!storyboardId || !storyboardIds.includes(storyboardId)) process.exit(2);
+
+const result = {
+  version: 1,
+  storyboard_id: storyboardId,
+  summaries: [{
+    id: storyboardId,
+    title: storyboardId,
+    passed: 1,
+    failed: 0,
+    skipped: 0,
+    not_applicable: 0,
+    has_error: false,
+  }],
+  totals: {
+    clean: 1,
+    total: 1,
+    passed: 1,
+    failed: 0,
+    skipped: 0,
+    not_applicable: 0,
+  },
+};
+
+function spawnHangingDescendant() {
+  const descendant = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    stdio: 'ignore',
+  });
+  if (process.env.FIXTURE_DESCENDANT_PID_FILE) {
+    fs.writeFileSync(process.env.FIXTURE_DESCENDANT_PID_FILE, String(descendant.pid));
+  }
+}
+
+if (storyboardId === 'hang') {
+  spawnHangingDescendant();
+  setInterval(() => {}, 1_000);
+} else if (storyboardId === 'leak') {
+  const retained = [];
+  setInterval(() => {
+    // Allocate and touch every page so RSS, rather than virtual memory, grows.
+    retained.push(Buffer.alloc(16 * 1024 * 1024, 1));
+  }, 10);
+} else if (storyboardId === 'post_result_hang') {
+  spawnHangingDescendant();
+  console.log(`ADCP_STORYBOARD_RESULT ${JSON.stringify(result)}`);
+  setInterval(() => {}, 1_000);
+} else if (storyboardId === 'noisy') {
+  process.stdout.write('x'.repeat(2 * 1024 * 1024));
+  setInterval(() => {}, 1_000);
+} else if (storyboardId === 'log_commands') {
+  process.stdout.write('stdout prefix\r::error::forged stdout command\n');
+  process.stderr.write('stderr prefix\r::warning::forged stderr command\n');
+  console.log(`ADCP_STORYBOARD_RESULT ${JSON.stringify(result)}`);
+  process.exit(0);
+} else if (storyboardId === 'crash') {
+  process.exit(17);
+} else if (storyboardId === 'inconsistent_result') {
+  console.log(`ADCP_STORYBOARD_RESULT ${JSON.stringify({
+    ...result,
+    totals: { ...result.totals, passed: 999 },
+  })}`);
+  process.exit(0);
+} else if (storyboardId === 'signed_requests') {
+  console.log(`ADCP_STORYBOARD_RESULT ${JSON.stringify({
+    ...result,
+    summaries: [{ ...result.summaries[0], id: 'signed_requests-strict' }],
+  })}`);
+  process.exit(0);
+} else if (storyboardId === 'malformed_result') {
+  console.log(`ADCP_STORYBOARD_RESULT ${JSON.stringify({
+    version: 1,
+    storyboard_id: storyboardId,
+    totals: { clean: 1 },
+  })}`);
+  process.exit(0);
+} else {
+  console.log(`  ${storyboardId.padEnd(40)} ✓ 1P / 0S / 0N/A`);
+  console.log(`ADCP_STORYBOARD_RESULT ${JSON.stringify(result)}`);
+  process.exit(0);
+}

--- a/tests/run-storyboards-isolation.test.cjs
+++ b/tests/run-storyboards-isolation.test.cjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const ORCHESTRATOR = path.join(REPO_ROOT, 'scripts', 'run-storyboards-isolated.mjs');
+const FIXTURE = path.join(REPO_ROOT, 'tests', 'fixtures', 'storyboard-isolation-runner.cjs');
+
+function runFixture(t, storyboardIds, extraArgs = []) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-isolation-test-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const telemetryFile = path.join(directory, 'telemetry.jsonl');
+  const resultsFile = path.join(directory, 'results.jsonl');
+  const descendantPidFile = path.join(directory, 'descendant.pid');
+  const result = spawnSync(process.execPath, [
+    ORCHESTRATOR,
+    '--timeout-ms', '3000',
+    '--rss-limit-mb', '256',
+    '--rss-poll-ms', '20',
+    '--output-limit-mb', '4',
+    '--telemetry-file', telemetryFile,
+    '--results-file', resultsFile,
+    ...extraArgs,
+  ], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    timeout: 15_000,
+    env: {
+      ...process.env,
+      STORYBOARD_RUNNER_BIN: FIXTURE,
+      FIXTURE_STORYBOARDS: storyboardIds.join(','),
+      FIXTURE_DESCENDANT_PID_FILE: descendantPidFile,
+    },
+  });
+  assert.ok(fs.existsSync(telemetryFile), result.stderr || result.stdout);
+  assert.ok(fs.existsSync(resultsFile), result.stderr || result.stdout);
+  const telemetry = fs.readFileSync(telemetryFile, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line));
+  const results = fs.readFileSync(resultsFile, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line));
+  const descendantPid = fs.existsSync(descendantPidFile)
+    ? Number(fs.readFileSync(descendantPidFile, 'utf8'))
+    : undefined;
+  return { result, telemetry, results, descendantPid };
+}
+
+async function assertProcessExited(pid) {
+  assert.ok(Number.isSafeInteger(pid), 'fixture did not record a descendant PID');
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if (error.code === 'ESRCH') return;
+      throw error;
+    }
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {}
+  assert.fail(`descendant process ${pid} survived process-group teardown`);
+}
+
+test('orchestrator does not load the training agent or SDK', () => {
+  const source = fs.readFileSync(ORCHESTRATOR, 'utf8');
+  assert.doesNotMatch(source, /(?:import|require)\s*\(?['"][^'"]*@adcp\/sdk/);
+  assert.doesNotMatch(source, /server\/src\/training-agent/);
+  assert.match(source, /detached: true/);
+  assert.match(source, /process\.platform === 'win32' \? pid : -pid/);
+});
+
+test('a timed-out child group is reported without losing successful siblings', async (t) => {
+  const { result, telemetry, results, descendantPid } = runFixture(
+    t,
+    ['healthy_before', 'hang', 'healthy_after'],
+    ['--timeout-ms', '300'],
+  );
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stdout, /storyboards: 2\/3 clean/);
+  assert.match(result.stdout, /healthy_after/);
+  assert.deepEqual(results.map(entry => entry.storyboard_id), ['healthy_before', 'healthy_after']);
+  const hang = telemetry.find(entry => entry.storyboard_id === 'hang');
+  assert.equal(hang.timed_out, true);
+  assert.equal(hang.result_received, false);
+  assert.equal(hang.signal, 'SIGKILL');
+  await assertProcessExited(descendantPid);
+});
+
+test('a result is persisted before a post-result child group is killed', async (t) => {
+  const { result, telemetry, results, descendantPid } = runFixture(t, ['post_result_hang', 'healthy_after']);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /storyboards: 2\/2 clean/);
+  assert.deepEqual(results.map(entry => entry.storyboard_id), ['post_result_hang', 'healthy_after']);
+  const hanging = telemetry.find(entry => entry.storyboard_id === 'post_result_hang');
+  assert.equal(hanging.result_received, true);
+  assert.equal(hanging.timed_out, false);
+  assert.equal(hanging.signal, 'SIGKILL');
+  await assertProcessExited(descendantPid);
+});
+
+test('a malformed envelope fails closed without stopping siblings', (t) => {
+  const { result, telemetry, results } = runFixture(t, ['malformed_result', 'healthy_after']);
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stdout, /storyboards: 1\/2 clean/);
+  assert.deepEqual(results.map(entry => entry.storyboard_id), ['healthy_after']);
+  const malformed = telemetry.find(entry => entry.storyboard_id === 'malformed_result');
+  assert.equal(malformed.result_received, false);
+  assert.equal(malformed.exit_code, 0);
+});
+
+test('an internally inconsistent envelope fails closed', (t) => {
+  const { result, telemetry, results } = runFixture(t, ['inconsistent_result', 'healthy_after']);
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stdout, /storyboards: 1\/2 clean/);
+  assert.deepEqual(results.map(entry => entry.storyboard_id), ['healthy_after']);
+  assert.equal(telemetry.find(entry => entry.storyboard_id === 'inconsistent_result').result_received, false);
+});
+
+test('a coherent but partial multi-variant envelope fails closed', (t) => {
+  const { result, telemetry, results } = runFixture(t, ['signed_requests', 'healthy_after']);
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stdout, /storyboards: 1\/2 clean/);
+  assert.deepEqual(results.map(entry => entry.storyboard_id), ['healthy_after']);
+  assert.equal(telemetry.find(entry => entry.storyboard_id === 'signed_requests').result_received, false);
+});
+
+test('a child crash is isolated without losing successful siblings', (t) => {
+  const { result, telemetry, results } = runFixture(t, ['healthy_before', 'crash', 'healthy_after']);
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stdout, /storyboards: 2\/3 clean/);
+  assert.deepEqual(results.map(entry => entry.storyboard_id), ['healthy_before', 'healthy_after']);
+  assert.equal(telemetry.find(entry => entry.storyboard_id === 'crash').exit_code, 17);
+});
+
+test('excessive child output is bounded and siblings continue', (t) => {
+  const { result, telemetry, results } = runFixture(
+    t,
+    ['healthy_before', 'noisy', 'healthy_after'],
+    ['--output-limit-mb', '1', '--timeout-ms', '3000'],
+  );
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stdout, /storyboards: 2\/3 clean/);
+  assert.deepEqual(results.map(entry => entry.storyboard_id), ['healthy_before', 'healthy_after']);
+  assert.equal(telemetry.find(entry => entry.storyboard_id === 'noisy').output_limited, true);
+});
+
+test('embedded carriage returns cannot forge workflow log commands', (t) => {
+  const { result } = runFixture(t, ['log_commands']);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /\r/);
+  assert.doesNotMatch(result.stderr, /\r/);
+  assert.match(result.stdout, /stdout prefix::error::forged stdout command/);
+  assert.match(result.stderr, /stderr prefix::warning::forged stderr command/);
+});
+
+test('an RSS breach is isolated and reported without stopping siblings', (t) => {
+  const { result, telemetry, results } = runFixture(
+    t,
+    ['healthy_before', 'leak', 'healthy_after'],
+    ['--rss-limit-mb', '80', '--timeout-ms', '3000'],
+  );
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stdout, /storyboards: 2\/3 clean/);
+  assert.deepEqual(results.map(entry => entry.storyboard_id), ['healthy_before', 'healthy_after']);
+  const leak = telemetry.find(entry => entry.storyboard_id === 'leak');
+  assert.equal(leak.resource_limited, true);
+  assert.equal(leak.result_received, false);
+  assert.ok(leak.peak_rss_bytes > 80 * 1024 * 1024);
+});

--- a/tests/run-storyboards-sharding.test.cjs
+++ b/tests/run-storyboards-sharding.test.cjs
@@ -13,6 +13,7 @@ const assert = require('node:assert/strict');
 const REPO_ROOT = path.join(__dirname, '..');
 const RUNNER_FILE = path.join(REPO_ROOT, 'server', 'tests', 'manual', 'run-storyboards.ts');
 const SHARDED_RUNNER = path.join(REPO_ROOT, 'scripts', 'run-storyboards-sharded.sh');
+const ISOLATED_SHARDED_RUNNER = path.join(REPO_ROOT, 'scripts', 'run-storyboards-isolated-shards.sh');
 const MATRIX_RUNNER = path.join(REPO_ROOT, 'scripts', 'run-storyboards-matrix.sh');
 const STORYBOARD_WORKFLOW = path.join(REPO_ROOT, '.github', 'workflows', 'training-agent-storyboards.yml');
 
@@ -33,8 +34,26 @@ function finish() {
   if (process.env.SELF_KILL_AFTER_TOTALS === '1') process.kill(process.pid, 'SIGKILL');
   process.exit(1);
 }
+
 const delay = Number(process.env.FAKE_RUNNER_DELAY_MS ?? 0);
 if (delay > 0) setTimeout(finish, delay); else finish();
+`);
+  fs.chmodSync(runner, 0o755);
+  return { directory, runner };
+}
+
+function makeFakeIsolatedRunner() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-isolated-shard-test-'));
+  const runner = path.join(directory, 'fake-isolated-runner.cjs');
+  fs.writeFileSync(runner, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const index = Number(args[args.indexOf('--shard-index') + 1]);
+console.log('  child storyboards: 99/99 clean');
+console.log('  child steps: 999 passed | 0 failed | 0 skipped | 0 not applicable');
+if (process.env.MISSING_TOTALS_SHARD === String(index)) process.exit(0);
+console.log('  storyboards: 1/1 clean');
+console.log('  steps: ' + (10 + index) + ' passed | ' + index + ' failed | 0 skipped | 0 not applicable');
+process.exit(process.env.FAILING_SHARD === String(index) ? 1 : 0);
 `);
   fs.chmodSync(runner, 0o755);
   return { directory, runner };
@@ -67,8 +86,8 @@ test('proposal lifecycle quarantine is limited to current-source runs', () => {
 test('runner flushes complete shard totals before bypassing stalled platform disposal', () => {
   const source = fs.readFileSync(RUNNER_FILE, 'utf8');
   const totalsIndex = source.indexOf('console.log(`  steps: ${totals.passed} passed');
-  const flushIndex = source.indexOf("process.stdout.write('', resolve)");
-  const killIndex = source.indexOf("process.kill(process.pid, 'SIGKILL')");
+  const flushIndex = source.lastIndexOf("process.stdout.write('', resolve)");
+  const killIndex = source.lastIndexOf("process.kill(process.pid, 'SIGKILL')");
   assert.ok(totalsIndex >= 0, 'expected final totals output');
   assert.ok(flushIndex > totalsIndex, 'stdout must flush after final totals');
   assert.ok(killIndex > flushIndex, 'forced shard exit must follow stdout flush');
@@ -146,21 +165,72 @@ test('sharded runner aggregates complete totals from a self-terminated shard', (
   assert.match(result.stdout, /steps: 10 passed \| 0 failed \| 1 skipped \| 2 not applicable/);
 });
 
-test('current /sales runs isolated shard jobs behind one aggregate required check', () => {
+test('isolated shard coordinator aggregates only one top-level totals block per shard', (t) => {
+  const { directory, runner } = makeFakeIsolatedRunner();
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+  const result = spawnSync('bash', [ISOLATED_SHARDED_RUNNER, '--shard-count', '2', '--max-parallel', '2'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, STORYBOARD_ISOLATED_RUNNER_BIN: runner },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^  storyboards: 2\/2 clean$/m);
+  assert.match(result.stdout, /^  steps: 21 passed \| 1 failed \| 0 skipped \| 0 not applicable$/m);
+  assert.equal((result.stdout.match(/^\s*storyboards:/gm) ?? []).length, 1);
+  assert.equal((result.stdout.match(/^\s*steps:/gm) ?? []).length, 1);
+});
+
+test('isolated shard coordinator fails closed on missing totals or a nonzero shard', (t) => {
+  const { directory, runner } = makeFakeIsolatedRunner();
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const run = env => spawnSync('bash', [ISOLATED_SHARDED_RUNNER, '--shard-count', '2', '--max-parallel', '2'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, STORYBOARD_ISOLATED_RUNNER_BIN: runner, ...env },
+  });
+
+  const missing = run({ MISSING_TOTALS_SHARD: '1' });
+  assert.equal(missing.status, 1);
+  assert.match(missing.stderr, /expected exactly one of each/);
+
+  const failed = run({ FAILING_SHARD: '1' });
+  assert.equal(failed.status, 1);
+  assert.match(failed.stderr, /Isolated shard 2\/2 exited 1/);
+  assert.match(failed.stdout, /^  storyboards: 2\/2 clean$/m);
+});
+
+test('isolated shard coordinator rejects missing option values', () => {
+  for (const option of ['--shard-count', '--max-parallel']) {
+    const result = spawnSync('bash', [ISOLATED_SHARDED_RUNNER, option], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, new RegExp(`${option} requires an integer argument`));
+  }
+});
+
+test('current /sales runs fixed orchestrators with isolated children behind one aggregate required check', () => {
   const workflow = fs.readFileSync(STORYBOARD_WORKFLOW, 'utf8');
   const matrixRunner = fs.readFileSync(MATRIX_RUNNER, 'utf8');
 
   assert.match(workflow, /exclude:\n\s+- surface: current\n\s+tenant: sales/);
-  assert.match(workflow, /sales_storyboard_shards:/);
+  assert.match(workflow, /sales_storyboard_orchestrators:/);
   assert.match(workflow, /max-parallel: 4/);
-  assert.match(workflow, /shard: \[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47\]/);
-  assert.match(workflow, /SALES_SHARD_COUNT: 48/);
-  assert.match(workflow, /--shard-index "\$\{\{ matrix\.shard \}\}"/);
+  assert.match(workflow, /orchestrator: \[0, 1, 2, 3, 4, 5, 6, 7\]/);
+  assert.match(workflow, /SALES_ORCHESTRATOR_COUNT: 8/);
+  assert.match(workflow, /node scripts\/run-storyboards-isolated\.mjs/);
+  assert.match(workflow, /--shard-index "\$\{\{ matrix\.orchestrator \}\}"/);
   assert.match(workflow, /sales_storyboards:\n\s+name: Storyboards \(current \/sales\)/);
-  assert.match(workflow, /needs: sales_storyboard_shards/);
-  assert.match(workflow, /SHARD_RESULT: \$\{\{ needs\.sales_storyboard_shards\.result \}\}/);
+  assert.match(workflow, /needs: sales_storyboard_orchestrators/);
+  assert.match(workflow, /ORCHESTRATOR_RESULT: \$\{\{ needs\.sales_storyboard_orchestrators\.result \}\}/);
   assert.match(workflow, /MIN_CLEAN: 120/);
   assert.match(workflow, /MIN_PASSED: 524/);
   assert.match(matrixRunner, /"sales:120:524"/);
+  assert.match(matrixRunner, /bash scripts\/run-storyboards-isolated-shards\.sh/);
+  assert.match(matrixRunner, /--shard-count 8 --max-parallel 4/);
+  assert.match(matrixRunner, /orchestrator_failure=1/);
   assert.match(workflow, /media_buy_seller\/compact_direct_buy_lifecycle:7:0/);
 });


### PR DESCRIPTION
Closes #6778

## Summary

- run every applicable current `/sales` storyboard in its own detached process group through a plain-Node orchestrator
- enforce per-storyboard timeout, RSS, output, envelope, and teardown limits while persisting count-only results and resource telemetry
- replace 48 workflow jobs with 8 bounded orchestrators (maximum 4 concurrent) while preserving the aggregate required check, floors, quarantines, and released-version applicability
- keep the local matrix bounded at the same 8-shard/4-parallel shape with exact fail-closed aggregation
- cover hangs, descendants, leaks, crashes, excessive output, malformed/inconsistent/partial envelopes, and sibling continuation

## Validation

- code, security, and test expert reviews: clear
- repository pre-commit: 1,046 unit tests plus lint/type checks passed
- focused isolation/sharding/schema tests: passed; isolation stress 50/50
- full local pre-push policy: current-source and released-3.0 matrices passed
- real current `/sales` isolated sample: 20/20 durable envelopes; peak 2.06 GiB; max 28.7s
- real single storyboard after final hardening: 17/17 steps; peak 894 MiB
- changeset scope/status, actionlint, typecheck, and diff checks: passed

## Follow-up

Current-only proposal lifecycle quarantines remain gated on #6776 and upstream client fixes #2653/#2654. CI will provide the repeated full current `/sales` bounded-memory runs before merge.
