### PR TITLE
fix(docs): keep beta banner on published snapshot

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/schema.json",
   "name": "AdCP - Ad Context Protocol",
   "banner": {
-    "content": "AdCP 3.2 beta.0 and the TypeScript SDK beta are available — [start testing →](/docs/reference/3-2-beta)",
+    "content": "AdCP 3.2 beta and the TypeScript SDK beta are available — [start testing →](/dist/docs/3.2.0-beta.5/reference/3-2-beta)",
     "dismissible": true
   },
   "description": "AdCP (Ad Context Protocol) is the open standard for agentic advertising. It defines how AI agents buy media, generate creatives, activate audiences, and enforce governance across platforms.",

--- a/scripts/update-release-docs-nav.mjs
+++ b/scripts/update-release-docs-nav.mjs
@@ -12,6 +12,8 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
 const DIST_DOCS_PREFIX_RE = /^dist\/docs\/[^/]+\//;
+const PRERELEASE_DOCS_LABEL_RE = /^(\d+)\.(\d+)-([0-9A-Za-z]+)$/;
+const PRERELEASE_BANNER_VERSION_RE = /AdCP (\d+)\.(\d+) ([0-9A-Za-z]+)\.\d+/g;
 
 function clone(value) {
   // docs.json navigation is JSON-pure, so JSON clone is sufficient here.
@@ -42,6 +44,38 @@ function snapshotPath(releaseVersion, value) {
     return `dist/docs/${releaseVersion}/${value.slice('docs/'.length)}`;
   }
   return retargetExistingPath(releaseVersion, value);
+}
+
+function updatePrereleaseBanner(config, releaseVersion, majorMinor) {
+  const match = PRERELEASE_DOCS_LABEL_RE.exec(majorMinor);
+  const content = config?.banner?.content;
+  if (!match || typeof content !== 'string') return false;
+
+  const [, major, minor, prerelease] = match;
+  const slug = `${major}-${minor}-${prerelease}`;
+  const sourcePath = `/docs/reference/${slug}`;
+  const snapshotPathPattern = new RegExp(
+    `/dist/docs/[^/]+/reference/${slug.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`
+  );
+
+  if (!content.includes(sourcePath) && !snapshotPathPattern.test(content)) {
+    return false;
+  }
+
+  const destination = `/dist/docs/${releaseVersion}/reference/${slug}`;
+  config.banner.content = content
+    .replace(sourcePath, destination)
+    .replace(snapshotPathPattern, destination)
+    .replace(
+      PRERELEASE_BANNER_VERSION_RE,
+      (version, bannerMajor, bannerMinor, bannerPrerelease) =>
+        bannerMajor === major &&
+        bannerMinor === minor &&
+        bannerPrerelease === prerelease
+          ? `AdCP ${major}.${minor} ${prerelease}`
+          : version
+    );
+  return true;
 }
 
 function looseGroupName(pages, fallback) {
@@ -123,6 +157,7 @@ export function updateDocsConfig(config, releaseVersion, majorMinor) {
       entry.groups = flattenVersionGroups(entry.groups);
     }
     versions[existingIndex] = entry;
+    updatePrereleaseBanner(config, releaseVersion, majorMinor);
     return {
       config,
       action: 'updated',
@@ -145,6 +180,7 @@ export function updateDocsConfig(config, releaseVersion, majorMinor) {
   );
 
   versions.splice(sourceIndex + 1, 0, newEntry);
+  updatePrereleaseBanner(config, releaseVersion, majorMinor);
   return {
     config,
     action: 'added',

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -162,6 +162,34 @@ test('one release-labeled version owns the live docs tree', () => {
   }
 });
 
+test('prerelease banner links to the current versioned beta landing page', () => {
+  const betaVersion = navigation.versions.find(versionEntry =>
+    /-beta$/.test(versionEntry.version)
+  );
+  if (!betaVersion) return;
+
+  const [majorMinor] = betaVersion.version.split('-');
+  const [major, minor] = majorMinor.split('.');
+  const landingSuffix = `/reference/${major}-${minor}-beta`;
+  const landingPage = collectPages(betaVersion.groups).find(page =>
+    page.endsWith(landingSuffix)
+  );
+  if (!landingPage) {
+    throw new Error(`Version "${betaVersion.version}" has no beta landing page`);
+  }
+
+  const bannerContent = docsConfig.banner?.content || '';
+  const bannerLink = bannerContent.match(/\[[^\]]+\]\(([^)]+)\)/)?.[1];
+  if (bannerLink !== `/${landingPage}`) {
+    throw new Error(
+      `Beta banner must link to /${landingPage}; found ${bannerLink || 'no link'}`
+    );
+  }
+  if (new RegExp(`AdCP ${major}\\.${minor} beta\\.\\d+`).test(bannerContent)) {
+    throw new Error('Beta banner must not freeze a moving beta ordinal in its copy');
+  }
+});
+
 for (const versionEntry of navigation.versions) {
   const { version, groups } = versionEntry;
   log(`Version: ${version}`);

--- a/tests/update-release-docs-nav.test.cjs
+++ b/tests/update-release-docs-nav.test.cjs
@@ -12,6 +12,9 @@ function collectStrings(value) {
 
 function sampleConfig() {
   return {
+    banner: {
+      content: 'AdCP 3.1 beta.0 is available — [start testing →](/docs/reference/3-1-beta)',
+    },
     navigation: {
       versions: [
         {
@@ -93,6 +96,17 @@ function sampleConfig() {
     assert.equal(allStrings.some((value) => value.startsWith('docs/')), false);
   });
 
+  test('retargets the prerelease banner when adding a beta docs version', () => {
+    const config = sampleConfig();
+
+    updateDocsConfig(config, '3.1.0-beta.0', '3.1-beta');
+
+    assert.equal(
+      config.banner.content,
+      'AdCP 3.1 beta is available — [start testing →](/dist/docs/3.1.0-beta.0/reference/3-1-beta)'
+    );
+  });
+
   test('updates an existing snapshot version without changing its position', () => {
     const config = sampleConfig();
     config.navigation.versions.splice(1, 0, {
@@ -128,6 +142,32 @@ function sampleConfig() {
     assert.equal(
       updated.groups[1].openapi.directory,
       'dist/docs/3.1.0-rc.5/registry/api-reference'
+    );
+  });
+
+  test('retargets a prerelease banner to the latest immutable beta snapshot', () => {
+    const config = sampleConfig();
+    config.banner.content =
+      'AdCP 3.1 beta is available — [start testing →](/dist/docs/3.1.0-beta.4/reference/3-1-beta)';
+    config.navigation.versions.splice(1, 0, {
+      version: '3.1-beta',
+      groups: [
+        {
+          group: 'Getting Started',
+          pages: ['dist/docs/3.1.0-beta.4/intro'],
+        },
+        {
+          group: 'Reference',
+          pages: ['dist/docs/3.1.0-beta.4/reference/3-1-beta'],
+        },
+      ],
+    });
+
+    updateDocsConfig(config, '3.1.0-beta.5', '3.1-beta');
+
+    assert.equal(
+      config.banner.content,
+      'AdCP 3.1 beta is available — [start testing →](/dist/docs/3.1.0-beta.5/reference/3-1-beta)'
     );
   });
 


### PR DESCRIPTION
## Summary

- point the AdCP 3.2 beta banner at the published immutable beta snapshot
- retarget the banner automatically when later prerelease snapshots are published
- cover both initial and subsequent beta snapshot publication with regression tests

## Tests

- npm run test:release-docs-nav
- npm run test:docs-nav
- npm run test:owned-links
- node --test tests/compact-product-lifecycle-storyboards.test.cjs tests/refine-finalize-validation-ids.test.cjs
- pre-commit test, lint, and typecheck suite

## Existing validation issue

Full Mintlify validation remains blocked by the repository's existing front-matter/js-yaml dependency incompatibility while parsing archived 2.5 pages; the scoped navigation and owned-link checks pass.