### PR TITLE
fix(schemas): restore adcp_major_version in compact beta.0 request schemas

### DIFF
--- a/.changeset/fix-compact-version-envelope.md
+++ b/.changeset/fix-compact-version-envelope.md
@@ -1,0 +1,18 @@
+---
+"adcontextprotocol": patch
+---
+
+Restore `adcp_major_version` in compact MCP request schemas.
+
+The 3.2.0-beta.0 frozen snapshots for `buy-products`, `accept-proposal`,
+and `control-media-buy` request schemas were published before the source
+schemas gained the deprecated `adcp_major_version` field. Combined with
+`additionalProperties: false`, this caused conforming SDK buyers to fail
+MCP input validation when emitting both version fields (as the spec
+requires through 3.x).
+
+Patches the 18 affected dist schema files across all beta.0 output
+paths (bundled, MCP, profiles, model-context) and adds lint coverage to
+prevent the same drift in future version snapshots.
+
+Refs #6649

--- a/dist/schemas/3.2.0-beta.0/bundled/media-buy/accept-proposal-request.json
+++ b/dist/schemas/3.2.0-beta.0/bundled/media-buy/accept-proposal-request.json
@@ -39,6 +39,13 @@
         "3.1-rc.1"
       ]
     },
+    "adcp_major_version": {
+      "type": "integer",
+      "deprecated": true,
+      "description": "DEPRECATED in favor of adcp_version (release-precision string). Servers MUST continue to honor this field through 3.x. Removed in 4.0. Original semantics: the AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.",
+      "minimum": 1,
+      "maximum": 99
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/bundled/media-buy/buy-products-request.json
+++ b/dist/schemas/3.2.0-beta.0/bundled/media-buy/buy-products-request.json
@@ -27,6 +27,13 @@
         "3.1-rc.1"
       ]
     },
+    "adcp_major_version": {
+      "type": "integer",
+      "deprecated": true,
+      "description": "DEPRECATED in favor of adcp_version (release-precision string). Servers MUST continue to honor this field through 3.x. Removed in 4.0. Original semantics: the AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.",
+      "minimum": 1,
+      "maximum": 99
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/bundled/media-buy/control-media-buy-request.json
+++ b/dist/schemas/3.2.0-beta.0/bundled/media-buy/control-media-buy-request.json
@@ -38,6 +38,13 @@
         "3.1-rc.1"
       ]
     },
+    "adcp_major_version": {
+      "type": "integer",
+      "deprecated": true,
+      "description": "DEPRECATED in favor of adcp_version (release-precision string). Servers MUST continue to honor this field through 3.x. Removed in 4.0. Original semantics: the AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.",
+      "minimum": 1,
+      "maximum": 99
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/media-buy/accept-proposal-request.json
+++ b/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/media-buy/accept-proposal-request.json
@@ -31,6 +31,9 @@
     "adcp_version": {
       "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/media-buy/buy-products-request.json
+++ b/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/media-buy/buy-products-request.json
@@ -19,6 +19,9 @@
     "adcp_version": {
       "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/media-buy/control-media-buy-request.json
+++ b/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/media-buy/control-media-buy-request.json
@@ -30,6 +30,9 @@
     "adcp_version": {
       "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/media-buy/media-buy/accept-proposal-request.json
+++ b/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/media-buy/media-buy/accept-proposal-request.json
@@ -28,6 +28,9 @@
     "adcp_version": {
       "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/media-buy/media-buy/buy-products-request.json
+++ b/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/media-buy/media-buy/buy-products-request.json
@@ -16,6 +16,9 @@
     "adcp_version": {
       "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/media-buy/media-buy/control-media-buy-request.json
+++ b/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/media-buy/media-buy/control-media-buy-request.json
@@ -27,6 +27,9 @@
     "adcp_version": {
       "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/media-buy/model-context/media-buy/accept-proposal-request.json
+++ b/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/media-buy/model-context/media-buy/accept-proposal-request.json
@@ -4,6 +4,9 @@
     "adcp_version": {
       "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string"
     },

--- a/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/media-buy/model-context/media-buy/buy-products-request.json
+++ b/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/media-buy/model-context/media-buy/buy-products-request.json
@@ -4,6 +4,9 @@
     "adcp_version": {
       "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string"
     },

--- a/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/media-buy/model-context/media-buy/control-media-buy-request.json
+++ b/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/media-buy/model-context/media-buy/control-media-buy-request.json
@@ -4,6 +4,9 @@
     "adcp_version": {
       "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string"
     },

--- a/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/production/media-buy/accept-proposal-request.json
+++ b/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/production/media-buy/accept-proposal-request.json
@@ -28,6 +28,9 @@
     "adcp_version": {
       "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/production/media-buy/buy-products-request.json
+++ b/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/production/media-buy/buy-products-request.json
@@ -16,6 +16,9 @@
     "adcp_version": {
       "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/production/media-buy/control-media-buy-request.json
+++ b/dist/schemas/3.2.0-beta.0/mcp/2026-07-28/profiles/production/media-buy/control-media-buy-request.json
@@ -27,6 +27,9 @@
     "adcp_version": {
       "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "#/$defs/external:core~1version-envelope.json/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/media-buy/accept-proposal-request.json
+++ b/dist/schemas/3.2.0-beta.0/media-buy/accept-proposal-request.json
@@ -31,6 +31,9 @@
     "adcp_version": {
       "$ref": "https://adcontextprotocol.org/schemas/3.2.0-beta.0/core/version-envelope.json#/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "https://adcontextprotocol.org/schemas/3.2.0-beta.0/core/version-envelope.json#/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/media-buy/buy-products-request.json
+++ b/dist/schemas/3.2.0-beta.0/media-buy/buy-products-request.json
@@ -19,6 +19,9 @@
     "adcp_version": {
       "$ref": "https://adcontextprotocol.org/schemas/3.2.0-beta.0/core/version-envelope.json#/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "https://adcontextprotocol.org/schemas/3.2.0-beta.0/core/version-envelope.json#/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/dist/schemas/3.2.0-beta.0/media-buy/control-media-buy-request.json
+++ b/dist/schemas/3.2.0-beta.0/media-buy/control-media-buy-request.json
@@ -30,6 +30,9 @@
     "adcp_version": {
       "$ref": "https://adcontextprotocol.org/schemas/3.2.0-beta.0/core/version-envelope.json#/properties/adcp_version"
     },
+    "adcp_major_version": {
+      "$ref": "https://adcontextprotocol.org/schemas/3.2.0-beta.0/core/version-envelope.json#/properties/adcp_major_version"
+    },
     "idempotency_key": {
       "type": "string",
       "minLength": 16,

--- a/tests/compact-version-envelope.test.cjs
+++ b/tests/compact-version-envelope.test.cjs
@@ -10,11 +10,6 @@ const { ProtocolClient } = require('@adcp/sdk');
 
 const SOURCE_DIR = path.resolve(__dirname, '..', 'static', 'schemas', 'source');
 const ADCP_VERSION = '3.2.0-beta.0';
-const COMPACT_SCHEMAS_WITHOUT_MAJOR = new Set([
-  'buy_products',
-  'accept_proposal',
-  'control_media_buy',
-]);
 
 function readSchema(uri) {
   if (!uri.startsWith('/schemas/')) {
@@ -108,7 +103,7 @@ test('SDK auto version envelope passes every strict compact lifecycle request sc
   for (const [tool, request] of Object.entries(compactRequests)) {
     await ProtocolClient.callTool(agent, tool, request, { adcpVersion: ADCP_VERSION });
     const expectedEnvelope = {
-      adcp_major_version: COMPACT_SCHEMAS_WITHOUT_MAJOR.has(tool) ? undefined : 3,
+      adcp_major_version: 3,
       adcp_version: '3.2-beta.0',
     };
     assert.deepEqual({

--- a/tests/lint-version-envelope.test.cjs
+++ b/tests/lint-version-envelope.test.cjs
@@ -117,3 +117,51 @@ test('release-precision version grammar stays aligned across inlined negotiation
   );
   assert.equal(versionPatternCheck?.pattern, canonicalPattern);
 });
+
+test('every source request schema with adcp_version also has adcp_major_version', () => {
+  const violations = [];
+  for (const file of listJsonFiles(SOURCE_DIR)) {
+    if (!file.endsWith('-request.json')) continue;
+    let schema;
+    try { schema = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { continue; }
+    if (!schema.properties) continue;
+    const hasVersion = 'adcp_version' in schema.properties;
+    const hasMajor = 'adcp_major_version' in schema.properties;
+    if (hasVersion && !hasMajor) {
+      violations.push(path.relative(path.resolve(__dirname, '..'), file));
+    }
+  }
+  assert.deepEqual(
+    violations,
+    [],
+    'Request schemas that declare adcp_version MUST also declare ' +
+      'adcp_major_version (deprecated but required through 3.x). ' +
+      'Missing in:\n' + violations.map((v) => `  ${v}`).join('\n'),
+  );
+});
+
+const DIST_DIR = path.resolve(__dirname, '..', 'dist', 'schemas');
+
+test('every versioned dist request schema with adcp_version also has adcp_major_version', () => {
+  if (!fs.existsSync(DIST_DIR)) return;
+  const violations = [];
+  for (const ver of fs.readdirSync(DIST_DIR).filter((d) => d.match(/^\d/))) {
+    const bundled = path.join(DIST_DIR, ver, 'bundled');
+    if (!fs.existsSync(bundled)) continue;
+    for (const file of listJsonFiles(bundled)) {
+      if (!file.endsWith('-request.json')) continue;
+      let schema;
+      try { schema = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { continue; }
+      if (!schema.properties) continue;
+      if ('adcp_version' in schema.properties && !('adcp_major_version' in schema.properties)) {
+        violations.push(path.relative(path.resolve(__dirname, '..'), file));
+      }
+    }
+  }
+  assert.deepEqual(
+    violations,
+    [],
+    'Versioned bundled dist schemas must preserve adcp_major_version alongside ' +
+      'adcp_version. Missing in:\n' + violations.map((v) => `  ${v}`).join('\n'),
+  );
+});


### PR DESCRIPTION
## Summary

The 3.2.0-beta.0 frozen snapshots for `buy-products`, `accept-proposal`, and `control-media-buy` request schemas were published before `adcp_major_version` was added to the source schemas in #6647. Since these schemas set `additionalProperties: false`, conforming SDK buyers that emit both version fields (as the spec requires through 3.x) fail MCP input validation before the seller handler runs.

Subsequent betas (beta.1+) are not affected — the build picked up the source change correctly.

## Changes

- **18 dist schema files** across all beta.0 output paths (bundled, MCP, profiles/production, profiles/media-buy, model-context) patched to include `adcp_major_version` with the correct representation for each path type (fully inlined for bundled, `$ref` to `$defs` for MCP, absolute URL `$ref` for standalone)
- **`tests/compact-version-envelope.test.cjs`** — removed `COMPACT_SCHEMAS_WITHOUT_MAJOR` set that encoded the bug as expected behavior; all tools now expect `adcp_major_version: 3`
- **`tests/lint-version-envelope.test.cjs`** — added two regression guards:
  - Source lint: every request schema with `adcp_version` must also declare `adcp_major_version`
  - Dist lint: every versioned bundled dist schema must preserve both version fields

## Verification

- `compact-version-envelope.test.cjs` passes (SDK validates all 7 lifecycle tools against the patched beta.0 source schemas)
- `lint-version-envelope.test.cjs` passes (4 tests including both new guards)
- Full root unit suite passes (67 files, 1052 tests)
- Manually verified the `$ref` targets in MCP schemas resolve correctly (the `$defs["external:core/version-envelope.json"]` block already contained `adcp_major_version` in beta.0 — only the property-level reference was missing)

Refs #6649