### PR TITLE
chore(release): remove operational beta changesets

### DIFF
--- a/.changeset/instrument-3-2-surfaces.md
+++ b/.changeset/instrument-3-2-surfaces.md
@@ -1,5 +1,0 @@
----
-"adcontextprotocol": minor
----
-
-Instrument the AdCP 3.2 beta across the training agent, compliance surface, adopter documentation, and learning system. Targeting-aware product discovery now issues bounded configured-product offers, validates purchase-time narrowing against declared overlay support, preserves proposal acceptance and lifecycle readback, and enforces retry-safe idempotency. Webhook delivery uses durable, scoped request bindings and recoverable outbox snapshots with the SDK 14 beta emitter contract. A release manifest tracks all 16 feature families across documentation, training, compliance, and runtime, with explicit dispositions for deferred candidates.

--- a/.changeset/isolate-storyboard-processes.md
+++ b/.changeset/isolate-storyboard-processes.md
@@ -1,5 +1,0 @@
----
-"adcontextprotocol": patch
----
-
-Run current sales compliance storyboards in isolated child process groups with per-storyboard timeout, RSS telemetry, and durable result capture.

--- a/.changeset/restore-proposal-handoff.md
+++ b/.changeset/restore-proposal-handoff.md
@@ -1,5 +1,0 @@
----
-"adcontextprotocol": patch
----
-
-Preserve committed legacy proposal state through media-buy execution while enforcing principal and account ownership, and keep isolated lifecycle validation within its RSS guard.

--- a/.changeset/stabilize-storyboard-runner.md
+++ b/.changeset/stabilize-storyboard-runner.md
@@ -1,5 +1,0 @@
----
-"adcontextprotocol": patch
----
-
-Isolate the current sales storyboard matrix, quarantine issue-backed current-source failures without changing released bundle coverage, and terminate completed shard processes deterministically after their results are captured.


### PR DESCRIPTION
## Summary

Remove four operational-only changesets before the next 3.2 beta is generated:

- cross-surface training/hosted instrumentation
- storyboard process isolation
- hosted proposal handoff behavior
- storyboard runner stabilization

These changes remain on `main`; they simply no longer appear in the published protocol changelog. Protocol-facing changesets and the release-approval safeguard remain in the beta pool.

## Verification

- pre-commit suite passed when the commit was created
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- `npx --yes @changesets/cli@^3.0.0 status --since=origin/main`
- version synchronization passed during push
