### PR TITLE
docs: AAMP follow-ups — landscape entry, ARTF naming, snapshot drift watcher

### DIFF
--- a/.github/workflows/aamp-snapshot-check.yml
+++ b/.github/workflows/aamp-snapshot-check.yml
@@ -1,0 +1,67 @@
+name: AAMP snapshot check
+
+# The FAQ and Addie's knowledge rules make dated absence claims about
+# IAB Tech Lab's AAMP components ("no tagged specification release" as of
+# the pinned snapshot date). Those claims become false the day IAB
+# publishes. This weekly check compares the pinned snapshot in
+# scripts/aamp-snapshot.json against the IABTechLab GitHub org and opens
+# (or updates) a tracking issue when the docs need a refresh.
+
+on:
+  schedule:
+    - cron: '23 9 * * 1' # weekly, Monday 09:23 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: aamp-snapshot-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Compare snapshot to IABTechLab org
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Run snapshot check
+        id: drift
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          node scripts/check-aamp-snapshot.cjs > /tmp/drift-report.md
+          rc=$?
+          set -e
+          if [ "$rc" -eq 1 ]; then
+            echo "::error::Snapshot check failed to run."
+            cat /tmp/drift-report.md
+            exit 1
+          fi
+          echo "drift=$([ "$rc" -eq 3 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          cat /tmp/drift-report.md
+
+      - name: Open or update tracking issue
+        if: steps.drift.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          title="AAMP snapshot drift: dated comparison in FAQ and Addie rules needs refresh"
+          existing=$(gh issue list --repo "$REPO" --state open --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Updating existing issue #$existing"
+            gh issue comment "$existing" --repo "$REPO" --body-file /tmp/drift-report.md
+          else
+            gh issue create --repo "$REPO" --title "$title" --body-file /tmp/drift-report.md
+          fi

--- a/docs/building/concepts/industry-landscape.mdx
+++ b/docs/building/concepts/industry-landscape.mdx
@@ -71,7 +71,7 @@ AdCP uses A2A as its other transport layer. In an A2A setup, a buyer agent sends
 | Organization | Focus | Key outputs |
 |---|---|---|
 | **[AgenticAdvertising.org](https://agenticadvertising.org)** | AI agent advertising standards | AdCP specification, JSON schemas, client SDKs |
-| **[IAB Tech Lab](https://iabtechlab.com)** | Digital advertising standards | OpenRTB, VAST, ads.txt, sellers.json, content taxonomy |
+| **[IAB Tech Lab](https://iabtechlab.com)** | Digital advertising standards | OpenRTB, VAST, ads.txt, sellers.json, content taxonomy, AAMP |
 | **[Anthropic](https://anthropic.com)** | AI safety and research | MCP specification |
 | **[Google](https://google.github.io/A2A/)** | AI and cloud | A2A specification |
 | **[W3C](https://www.w3.org)** | Web standards | Privacy Sandbox APIs, Topics API |
@@ -82,6 +82,7 @@ AgenticAdvertising.org is an independent member organization. It is not a subsid
 
 | Standard | Purpose | Maintained by |
 |---|---|---|
+| **AAMP** | Agentic advertising framework — components include ARTF (Agentic Real Time Framework), Agentic Direct, Agentic Audiences, and the Agent Registry; overlaps AdCP in scope with different primitives (see the [FAQ comparison](/docs/faq#how-adcp-relates-to-other-standards)) | IAB Tech Lab |
 | **VAST** / **VPAID** | Video ad serving and interactive video | IAB Tech Lab |
 | **ads.txt** / **sellers.json** | Supply chain transparency | IAB Tech Lab |
 | **Open Measurement SDK** | Viewability and attention measurement | IAB Tech Lab |

--- a/docs/governance/content-standards/index.mdx
+++ b/docs/governance/content-standards/index.mdx
@@ -410,7 +410,7 @@ This pinhole is the interface that needs standardization - it defines exactly wh
 
 This provides the same privacy guarantees as local execution, but with cryptographic proof that the correct algorithm is running. The brand knows their standards are being enforced faithfully. The publisher proves compliance without exposing content.
 
-This architecture aligns with the [IAB Tech Lab ARTF (Agentic RTB Framework)](https://iabtechlab.com/standards/artf/), which defines how service providers can package offerings as containers deployed into host infrastructure. ARTF enables hosts to "provide greater access to data and more interaction opportunities to service agents without concerns about leakage, misappropriation or latency" - exactly the model Content Standards requires for privacy-preserving brand suitability.
+This architecture aligns with the [IAB Tech Lab ARTF (Agentic Real Time Framework)](https://iabtechlab.com/standards/artf/), which defines how service providers can package offerings as containers deployed into host infrastructure. ARTF enables hosts to "provide greater access to data and more interaction opportunities to service agents without concerns about leakage, misappropriation or latency" - exactly the model Content Standards requires for privacy-preserving brand suitability.
 
 ## Related
 

--- a/scripts/aamp-snapshot.json
+++ b/scripts/aamp-snapshot.json
@@ -1,0 +1,12 @@
+{
+  "asOf": "2026-08-23",
+  "claimSurfaces": [
+    "docs/faq.mdx (How does AdCP compare to AAMP?)",
+    "server/src/addie/rules/knowledge.md (AAO and IAB Tech Lab — dated snapshot)"
+  ],
+  "org": "IABTechLab",
+  "expectNoTags": ["AAMP", "agentic-direct", "agentic-audiences", "agentic-mobile"],
+  "expectLatestTag": {
+    "agentic-real-time-framework": "v1.0"
+  }
+}

--- a/scripts/check-aamp-snapshot.cjs
+++ b/scripts/check-aamp-snapshot.cjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Checks the dated AAMP claims published in docs/faq.mdx and Addie's
+ * knowledge rules against the observable state of the IABTechLab GitHub
+ * org. The claims are absence claims ("no tagged specification release")
+ * pinned to a date; when the external state changes, the docs must be
+ * refreshed or they become false statements about a third party.
+ *
+ * Reads scripts/aamp-snapshot.json for the pinned expectations.
+ * Prints a markdown drift report to stdout.
+ * Exit codes: 0 = no drift, 3 = drift detected, 1 = check failed to run.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const snapshot = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'aamp-snapshot.json'), 'utf8')
+);
+
+const API = 'https://api.github.com';
+
+async function gh(route) {
+  const headers = { 'User-Agent': 'adcp-aamp-snapshot-check', Accept: 'application/vnd.github+json' };
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API}${route}`, { headers });
+  if (!res.ok) {
+    throw new Error(`GitHub API ${route} -> HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  const drift = [];
+
+  for (const repo of snapshot.expectNoTags) {
+    const tags = await gh(`/repos/${snapshot.org}/${repo}/tags?per_page=5`);
+    if (tags.length > 0) {
+      const names = tags.map((t) => t.name).join(', ');
+      drift.push(
+        `- \`${snapshot.org}/${repo}\` now has tags (${names}); the "no tagged specification release" claim is stale.`
+      );
+    }
+  }
+
+  for (const [repo, expected] of Object.entries(snapshot.expectLatestTag)) {
+    const tags = await gh(`/repos/${snapshot.org}/${repo}/tags?per_page=5`);
+    const latest = tags[0]?.name;
+    if (latest !== expected) {
+      drift.push(
+        `- \`${snapshot.org}/${repo}\` latest tag is \`${latest ?? 'none'}\` (snapshot expected \`${expected}\`).`
+      );
+    }
+  }
+
+  if (drift.length === 0) {
+    console.log(`No drift: IABTechLab org state still matches the ${snapshot.asOf} snapshot.`);
+    return 0;
+  }
+
+  console.log(`## AAMP snapshot drift (pinned ${snapshot.asOf})`);
+  console.log('');
+  console.log('The published state of the IABTechLab GitHub org no longer matches the');
+  console.log('dated claims in:');
+  for (const surface of snapshot.claimSurfaces) console.log(`- ${surface}`);
+  console.log('');
+  console.log('Observed drift:');
+  for (const line of drift) console.log(line);
+  console.log('');
+  console.log('Refresh the dated comparison (and this snapshot in `scripts/aamp-snapshot.json`)');
+  console.log('so the absence claims stay accurate. Also re-check the AAMP conformance,');
+  console.log('security-model, and support-policy claims against iabtechlab.com while updating.');
+  return 3;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error(`aamp-snapshot check failed to run: ${err.message}`);
+    process.exit(1);
+  }
+);

--- a/scripts/check-aamp-snapshot.cjs
+++ b/scripts/check-aamp-snapshot.cjs
@@ -25,31 +25,47 @@ async function gh(route) {
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
   const res = await fetch(`${API}${route}`, { headers });
+  if (res.status === 404) return null;
   if (!res.ok) {
     throw new Error(`GitHub API ${route} -> HTTP ${res.status}`);
   }
   return res.json();
 }
 
+// A missing repo (renamed or removed) changes the org's shape, which is
+// itself drift the snapshot's claims depend on — report it, don't error.
+async function tagNames(repo) {
+  const tags = await gh(`/repos/${snapshot.org}/${repo}/tags?per_page=100`);
+  return tags === null ? null : tags.map((t) => t.name);
+}
+
 async function main() {
   const drift = [];
 
   for (const repo of snapshot.expectNoTags) {
-    const tags = await gh(`/repos/${snapshot.org}/${repo}/tags?per_page=5`);
-    if (tags.length > 0) {
-      const names = tags.map((t) => t.name).join(', ');
+    const names = await tagNames(repo);
+    if (names === null) {
       drift.push(
-        `- \`${snapshot.org}/${repo}\` now has tags (${names}); the "no tagged specification release" claim is stale.`
+        `- \`${snapshot.org}/${repo}\` was not found (renamed or removed); re-verify the snapshot's component claims.`
+      );
+    } else if (names.length > 0) {
+      drift.push(
+        `- \`${snapshot.org}/${repo}\` now has tags (${names.join(', ')}); the "no tagged specification release" claim is stale.`
       );
     }
   }
 
+  // Tag-list order is not guaranteed by the API, so compare the tag SET to
+  // the single expected tag instead of trusting element 0 to be newest.
   for (const [repo, expected] of Object.entries(snapshot.expectLatestTag)) {
-    const tags = await gh(`/repos/${snapshot.org}/${repo}/tags?per_page=5`);
-    const latest = tags[0]?.name;
-    if (latest !== expected) {
+    const names = await tagNames(repo);
+    if (names === null) {
       drift.push(
-        `- \`${snapshot.org}/${repo}\` latest tag is \`${latest ?? 'none'}\` (snapshot expected \`${expected}\`).`
+        `- \`${snapshot.org}/${repo}\` was not found (renamed or removed); re-verify the snapshot's component claims.`
+      );
+    } else if (names.length !== 1 || names[0] !== expected) {
+      drift.push(
+        `- \`${snapshot.org}/${repo}\` tags are now [${names.join(', ') || 'none'}] (snapshot expected exactly \`${expected}\`).`
       );
     }
   }

--- a/server/src/addie/jobs/geo-monitor.ts
+++ b/server/src/addie/jobs/geo-monitor.ts
@@ -28,6 +28,7 @@ const COMPETITOR_PATTERNS: Array<{ pattern: RegExp; name: string }> = [
   { pattern: /agentic advertising management protocols/i, name: 'AAMP' },
   { pattern: /\bartf\b/i, name: 'ARTF' },
   { pattern: /agentic rtb framework/i, name: 'ARTF' },
+  { pattern: /agentic real[- ]time framework/i, name: 'ARTF' },
   { pattern: /agentic audiences/i, name: 'Agentic Audiences' },
   { pattern: /iab tech lab agent registry/i, name: 'IAB Agent Registry' },
   { pattern: /iab tech lab/i, name: 'IAB Tech Lab' },


### PR DESCRIPTION
Follow-ups from #6801:

- **industry-landscape.mdx** now covers AAMP: added to IAB Tech Lab's key outputs and given a row in the ecosystem standards table pointing at the FAQ comparison, so the page the FAQ bills as "the full picture" no longer omits it.
- **ARTF naming** aligned with IAB Tech Lab's current expansion (Agentic Real Time Framework) in the content-standards doc, and the GEO monitor's competitor patterns now match the current name alongside the older "Agentic RTB Framework".
- **Freshness mechanism for the dated comparison**: the FAQ table and Addie's rules make dated absence claims ("no tagged specification release" as of 2026-08-23) that become false the day IAB publishes. A weekly workflow (`aamp-snapshot-check.yml`) compares the pinned snapshot in `scripts/aamp-snapshot.json` against the IABTechLab GitHub org and opens/updates a tracking issue on drift. Both the no-drift and drift paths were exercised against the live org (drift path via a deliberately wrong pinned tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)