### PR TITLE
fix(schemas): backport cattax mapping corrections to 3.1

### DIFF
--- a/.changeset/fix-iab-taxonomy-mappings-3-1.md
+++ b/.changeset/fix-iab-taxonomy-mappings-3-1.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Correct the OpenRTB/AdCOM `cattax` mappings documented for IAB Content Taxonomy 3.0 and 2.2.

--- a/static/schemas/source/enums/genre-taxonomy.json
+++ b/static/schemas/source/enums/genre-taxonomy.json
@@ -16,8 +16,8 @@
     "custom"
   ],
   "enumDescriptions": {
-    "iab_content_3.0": "IAB Tech Lab Content Taxonomy 3.0 — industry standard for digital content classification. Maps to OpenRTB cattax=6.",
-    "iab_content_2.2": "IAB Tech Lab Content Taxonomy 2.2 — previous version, still widely used. Maps to OpenRTB cattax=2.",
+    "iab_content_3.0": "IAB Tech Lab Content Taxonomy 3.0 — industry standard for digital content classification. Maps to OpenRTB/AdCOM cattax=7.",
+    "iab_content_2.2": "IAB Tech Lab Content Taxonomy 2.2 — previous version, still widely used. Maps to OpenRTB/AdCOM cattax=6.",
     "gracenote": "Gracenote genre classification — entertainment metadata standard for TV, film, and music. Supports multi-level genre hierarchies; hierarchy-aware matching is the seller's responsibility.",
     "eidr": "EIDR genre classification — ISO 10528 for audiovisual content identification",
     "apple_genres": "Apple App Store / Apple TV genre taxonomy",


### PR DESCRIPTION
Backports the `cattax` errata from #6801 to the stable 3.1 line: IAB Content Taxonomy 2.2 = cattax 6 and 3.0 = cattax 7 per AdCOM's Category Taxonomies list (the descriptions previously said 2 and 6). Until this releases, the published 3.1.x registry documents a mapping that would miscategorize OpenRTB content signals; `latest` and the trusted-match spec already say 7.

Changeset: patch, following the backport convention from #6742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)