### PR TITLE
fix(scripts): guard empty RUNNER_ARGS expansion for bash 3.2

### DIFF
--- a/.changeset/fix-bash-empty-array.md
+++ b/.changeset/fix-bash-empty-array.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Guard empty RUNNER_ARGS array expansion in sharded runner scripts for bash 3.2 compatibility

--- a/scripts/run-storyboards-isolated-shards.sh
+++ b/scripts/run-storyboards-isolated-shards.sh
@@ -59,9 +59,9 @@ trap cleanup EXIT
 run_shard() {
   local index="$1"
   if [ -n "${STORYBOARD_ISOLATED_RUNNER_BIN:-}" ]; then
-    "${STORYBOARD_ISOLATED_RUNNER_BIN}" "${RUNNER_ARGS[@]}" --shard-index "${index}" --shard-count "${SHARD_COUNT}"
+    "${STORYBOARD_ISOLATED_RUNNER_BIN}" ${RUNNER_ARGS[@]+"${RUNNER_ARGS[@]}"} --shard-index "${index}" --shard-count "${SHARD_COUNT}"
   else
-    node scripts/run-storyboards-isolated.mjs "${RUNNER_ARGS[@]}" --shard-index "${index}" --shard-count "${SHARD_COUNT}"
+    node scripts/run-storyboards-isolated.mjs ${RUNNER_ARGS[@]+"${RUNNER_ARGS[@]}"} --shard-index "${index}" --shard-count "${SHARD_COUNT}"
   fi
 }
 

--- a/scripts/run-storyboards-sharded.sh
+++ b/scripts/run-storyboards-sharded.sh
@@ -48,9 +48,9 @@ trap cleanup EXIT
 run_shard() {
   local index="$1"
   if [ -n "${STORYBOARD_RUNNER_BIN:-}" ]; then
-    "${STORYBOARD_RUNNER_BIN}" "${RUNNER_ARGS[@]}" --shard-index "${index}" --shard-count "${SHARD_COUNT}"
+    "${STORYBOARD_RUNNER_BIN}" ${RUNNER_ARGS[@]+"${RUNNER_ARGS[@]}"} --shard-index "${index}" --shard-count "${SHARD_COUNT}"
   else
-    npx tsx server/tests/manual/run-storyboards.ts "${RUNNER_ARGS[@]}" --shard-index "${index}" --shard-count "${SHARD_COUNT}"
+    npx tsx server/tests/manual/run-storyboards.ts ${RUNNER_ARGS[@]+"${RUNNER_ARGS[@]}"} --shard-index "${index}" --shard-count "${SHARD_COUNT}"
   fi
 }
 


### PR DESCRIPTION
## Summary

- `run-storyboards-sharded.sh` and `run-storyboards-isolated-shards.sh` both
  use `set -u` and expand `"${RUNNER_ARGS[@]}"` when no extra runner arguments
  are passed. Bash 3.2 (macOS default) treats an empty array expansion under
  `set -u` as an "unbound variable" error, aborting the `run_shard` function
  before the runner executes.

- Replaced `"${RUNNER_ARGS[@]}"` with the portable
  `${RUNNER_ARGS[@]+"${RUNNER_ARGS[@]}"}` idiom at all four call sites. This
  expands to nothing when the array is empty (bash 3.2–5.x) and preserves
  quoting when populated.

## Test plan

- [x] `node --test tests/run-storyboards-sharding.test.cjs` — 11/11 pass (was 5/11 before fix)
- [x] Confirmed the root cause: `bash -c 'set -u; arr=(); echo "${arr[@]}"'` → "unbound variable" on bash 3.2.57
- [x] Confirmed the fix: `bash -c 'set -u; arr=(); echo ${arr[@]+"${arr[@]}"}'` → succeeds