### PR TITLE
fix(tests): align tracking event enum test lists with current schemas

### DIFF
--- a/tests/tracking-event-enums.test.cjs
+++ b/tests/tracking-event-enums.test.cjs
@@ -82,8 +82,8 @@ async function compileSchema(schemaPath) {
 
 // VAST 4.2 tracking events (includes flattened Impression, Error, VideoClicks, ViewableImpression)
 const VAST_PLAYBACK_EVENTS = ['impression', 'creativeView', 'loaded', 'start', 'firstQuartile', 'midpoint', 'thirdQuartile', 'complete'];
-const VAST_INTERACTION_EVENTS = ['mute', 'unmute', 'pause', 'resume', 'rewind', 'skip', 'playerExpand', 'playerCollapse', 'fullscreen', 'exitFullscreen', 'otherAdInteraction', 'interactiveStart'];
-const VAST_PROGRESS_EVENTS = ['progress', 'notUsed'];
+const VAST_INTERACTION_EVENTS = ['mute', 'unmute', 'pause', 'resume', 'rewind', 'skip', 'playerExpand', 'playerCollapse', 'fullscreen', 'exitFullscreen', 'acceptInvitation', 'adExpand', 'adCollapse', 'minimize', 'overlayViewDuration', 'otherAdInteraction', 'interactiveStart'];
+const VAST_PROGRESS_EVENTS = ['progress'];
 const VAST_CLICK_CLOSE_EVENTS = ['clickTracking', 'customClick', 'close', 'closeLinear'];
 const VAST_VERIFICATION_EVENTS = ['error', 'viewable', 'notViewable', 'viewUndetermined', 'measurableImpression', 'viewableImpression'];
 
@@ -97,8 +97,8 @@ const ALL_VAST_EVENTS = [
 
 // DAAST tracking events (audio-appropriate subset)
 const ALL_DAAST_EVENTS = [
-  'impression', 'creativeView', 'loaded', 'start', 'firstQuartile', 'midpoint', 'thirdQuartile', 'complete',
-  'mute', 'unmute', 'pause', 'resume', 'skip',
+  'impression', 'creativeView', 'start', 'firstQuartile', 'midpoint', 'thirdQuartile', 'complete',
+  'mute', 'unmute', 'pause', 'resume', 'rewind', 'skip',
   'progress',
   'clickTracking', 'customClick', 'close',
   'error', 'viewable', 'notViewable', 'viewUndetermined', 'measurableImpression', 'viewableImpression'


### PR DESCRIPTION
## Summary

- The hardcoded VAST and DAAST event lists in
  `tests/tracking-event-enums.test.cjs` drifted from the authoritative
  enum schemas, causing 6 of 12 subtests to fail on main.

- **VAST** — added `acceptInvitation`, `adExpand`, `adCollapse`, `minimize`,
  `overlayViewDuration` (present in `vast-tracking-event.json`); removed
  `notUsed` (VAST 4.2 placeholder, never included in the AdCP enum).

- **DAAST** — added `rewind` (present in `daast-tracking-event.json`);
  removed `loaded` (deliberately excluded as audio-incompatible, per the
  schema description).

## Test plan

- [x] `node --test tests/tracking-event-enums.test.cjs` — 12/12 pass (was 6/12)
- [x] Verified each addition/removal against the source enum schema files