### PR TITLE
fix(tests): update example validation data to match current schemas

### DIFF
--- a/tests/example-validation.test.cjs
+++ b/tests/example-validation.test.cjs
@@ -152,7 +152,7 @@ const exampleData = {
   
   creativeAsset: {
     "creative_id": "hero_video_30s",
-    "name": "Nike Air Max Hero 30s",
+    "name": "Nova Motors Launch Hero 30s",
     "format_id": { "agent_url": "https://creative.example.com", "id": "video_16x9_30s" },
     "assets": {
       "main_video": {
@@ -212,7 +212,7 @@ const exampleData = {
   getProductsRequest: {
     "idempotency_key": "550e8400-e29b-41d4-a716-446655440000",
     "buying_mode": "brief",
-    "brief": "Nike Air Max 2024 - Premium video inventory for sports fans"
+    "brief": "Nova Motors EV launch - Premium video inventory for sports fans"
   },
   
   getProductsResponse: {
@@ -241,8 +241,8 @@ const exampleData = {
   
   createMediaBuyRequest: {
     "idempotency_key": "create-media-buy-001",
-    "account": { "account_id": "acc_nike_001" },
-    "brand": { "domain": "nike.com" },
+    "account": { "account_id": "acc_nova_motors_001" },
+    "brand": { "domain": "novamotors.example" },
     "packages": [
       {
         "product_id": "ctv_sports_premium",

--- a/tests/example-validation.test.cjs
+++ b/tests/example-validation.test.cjs
@@ -125,7 +125,15 @@ const exampleData = {
     "publisher_properties": [{ "publisher_domain": "sportsnetwork.com", "selection_type": "all" }],
     "format_ids": [{ "agent_url": "https://creative.example.com", "id": "video_16x9_30s" }],
     "delivery_type": "guaranteed",
-    "pricing_options": [{ "pricing_option_id": "cpm_fixed", "pricing_model": "cpm", "price": 45.00, "currency": "USD" }]
+    "pricing_options": [{ "pricing_option_id": "cpm_fixed", "pricing_model": "cpm", "price": 45.00, "currency": "USD" }],
+    "reporting_capabilities": {
+      "available_reporting_frequencies": ["daily"],
+      "expected_delay_minutes": 60,
+      "timezone": "America/New_York",
+      "supports_webhooks": false,
+      "available_metrics": ["impressions", "spend", "clicks"],
+      "date_range_support": "date_range"
+    }
   },
   
   mediaBuy: {
@@ -208,6 +216,8 @@ const exampleData = {
   },
   
   getProductsResponse: {
+    "status": "completed",
+    "cache_scope": "public",
     "products": [
       {
         "product_id": "ctv_sports_premium",
@@ -216,12 +226,21 @@ const exampleData = {
         "publisher_properties": [{ "publisher_domain": "sportsnetwork.com", "selection_type": "all" }],
         "format_ids": [{ "agent_url": "https://creative.example.com", "id": "video_16x9_30s" }],
         "delivery_type": "guaranteed",
-        "pricing_options": [{ "pricing_option_id": "cpm_fixed", "pricing_model": "cpm", "price": 45.00, "currency": "USD" }]
+        "pricing_options": [{ "pricing_option_id": "cpm_fixed", "pricing_model": "cpm", "price": 45.00, "currency": "USD" }],
+        "reporting_capabilities": {
+          "available_reporting_frequencies": ["daily"],
+          "expected_delay_minutes": 60,
+          "timezone": "America/New_York",
+          "supports_webhooks": false,
+          "available_metrics": ["impressions", "spend", "clicks"],
+          "date_range_support": "date_range"
+        }
       }
     ]
   },
   
   createMediaBuyRequest: {
+    "idempotency_key": "create-media-buy-001",
     "account": { "account_id": "acc_nike_001" },
     "brand": { "domain": "nike.com" },
     "packages": [
@@ -250,6 +269,7 @@ const exampleData = {
   },
 
   createMediaBuyRequestNoAccountId: {
+    "idempotency_key": "create-media-buy-no-account-001",
     "account": { "brand": { "domain": "acmecorp.com" }, "operator": "acmecorp.com" },
     "brand": { "domain": "acmecorp.com" },
     "packages": [
@@ -264,6 +284,7 @@ const exampleData = {
   },
 
   createMediaBuyRequestAsap: {
+    "idempotency_key": "create-media-buy-asap-001",
     "account": { "account_id": "acc_acme_001" },
     "brand": { "domain": "acmecorp.com" },
     "packages": [
@@ -321,6 +342,7 @@ const exampleData = {
   },
   
   activateSignalRequest: {
+    "idempotency_key": "activate-signal-001",
     "signal_agent_segment_id": "luxury_auto_intenders",
     "destinations": [
       { "type": "platform", "platform": "the-trade-desk" }
@@ -329,6 +351,7 @@ const exampleData = {
   },
   
   activateSignalResponse: {
+    "status": "completed",
     "deployments": [
       {
         "type": "platform",


### PR DESCRIPTION
## Summary

- The hardcoded example objects in `tests/example-validation.test.cjs`
  drifted from the schemas they validate against, causing 7 of 21 subtests
  to fail on main.

- **product / get_products response products[0]**: added required
  `reporting_capabilities` object (required since reporting-capabilities
  became mandatory on products).

- **get_products response**: added required `status` (from
  protocol-envelope allOf) and `cache_scope`.

- **create_media_buy requests** (3 variants): added required
  `idempotency_key`.

- **activate_signal request**: added required `idempotency_key`.

- **activate_signal response**: added required `status`.

## Test plan

- [x] `node --test tests/example-validation.test.cjs` — 21/21 pass (was 14/21)
- [x] Each added property verified against the source schema's `required` array and enum values