### PR TITLE
Fix versioned documentation search

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,18 @@ npm-debug.log*
 # Build outputs (rebuilt inside Docker)
 build
 dist
+!dist/docs
+dist/docs/*
+# Frozen documentation snapshots currently exposed by docs.json. The Addie
+# docs-version tests keep this allowlist synchronized with navigation.
+!dist/docs/2.5.3
+!dist/docs/2.5.3/**
+!dist/docs/3.0.26
+!dist/docs/3.0.26/**
+!dist/docs/3.1.19
+!dist/docs/3.1.19/**
+!dist/docs/3.2.0-beta.5
+!dist/docs/3.2.0-beta.5/**
 !dist/schemas
 dist/schemas/latest
 dist/schemas/v*

--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -6,12 +6,21 @@ on:
     paths:
       - 'docs/**'
       - 'dist/docs/**'
+      - 'dist/schemas/**'
       - 'mintlify-docs/**'
       - 'docs.json'
       - 'mint.json'
       - 'README.md'
+      - '.dockerignore'
+      - 'Dockerfile'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'server/src/addie/mcp/docs-indexer.ts'
       - 'server/src/addie/rules/**'
       - 'scripts/check-owned-links.js'
+      - 'scripts/smoke-docs-index-runtime.mjs'
+      - 'scripts/update-release-docs-nav.mjs'
+      - 'tests/docs-nav-validation.test.cjs'
       - '.markdown-link-check.json'
       - '.github/workflows/broken-links.yml'
   pull_request:
@@ -19,12 +28,21 @@ on:
     paths:
       - 'docs/**'
       - 'dist/docs/**'
+      - 'dist/schemas/**'
       - 'mintlify-docs/**'
       - 'docs.json'
       - 'mint.json'
       - 'README.md'
+      - '.dockerignore'
+      - 'Dockerfile'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'server/src/addie/mcp/docs-indexer.ts'
       - 'server/src/addie/rules/**'
       - 'scripts/check-owned-links.js'
+      - 'scripts/smoke-docs-index-runtime.mjs'
+      - 'scripts/update-release-docs-nav.mjs'
+      - 'tests/docs-nav-validation.test.cjs'
       - '.markdown-link-check.json'
       - '.github/workflows/broken-links.yml'
   workflow_run:
@@ -59,8 +77,13 @@ jobs:
     - name: Schema link convention (autofix with `npm run fix:schema-links`)
       run: npm run lint:schema-links
 
-    - name: Validate Mintlify navigation
-      run: node tests/docs-nav-validation.test.cjs
+    - name: Fetch stable docs release surface
+      run: git fetch --depth=1 origin +3.1.x:refs/remotes/origin/3.1.x
+
+    - name: Validate Mintlify navigation and locally indexable pages
+      run: npm run test:docs-nav
+      env:
+        REQUIRE_STABLE_DOCS_REF: '1'
 
     - name: Check browser-facing Agentic Advertising links
       # Pull requests are not deployed to the production domains. Checking
@@ -72,3 +95,31 @@ jobs:
 
     - name: Check README links
       run: npx markdown-link-check README.md --config .markdown-link-check.json
+
+  docs-index-runtime:
+    name: Production docs index smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Skip if triggered by sync workflow that failed
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7.0.1
+      with:
+        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+
+    - name: Build production image without external repository clones
+      run: >-
+        docker build
+        --build-arg SKIP_PRECLONE_REPOS=true
+        --tag adcp-docs-index-smoke
+        .
+
+    - name: Initialize every configured docs snapshot in the runtime image
+      run: >-
+        docker run --rm --interactive
+        --entrypoint node
+        adcp-docs-index-smoke
+        --input-type=module
+        < scripts/smoke-docs-index-runtime.mjs

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,6 +165,9 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/server/public ./server/public
 COPY --from=builder /app/static ./static
 COPY --from=builder /app/docs ./docs
+# Addie's version-aware docs search derives its public version/snapshot mapping
+# from the same Mintlify configuration used by the docs site.
+COPY --from=builder /app/docs.json ./docs.json
 
 # Skill docs read at runtime by Addie's ask_about_adcp_task / call_adcp_task loader.
 COPY --from=builder /app/skills ./skills

--- a/docs.json
+++ b/docs.json
@@ -73,66 +73,59 @@
           {
             "group": "Getting Started",
             "pages": [
-              "docs/intro",
-              "docs/quickstart"
+              "dist/docs/3.1.19/intro",
+              "dist/docs/3.1.19/quickstart"
             ]
           },
           {
             "group": "Building with AdCP",
             "expanded": false,
             "pages": [
-              "docs/building/index",
-              "docs/building/schemas-and-sdks",
+              "dist/docs/3.1.19/building/index",
+              "dist/docs/3.1.19/building/schemas-and-sdks",
               {
-                "group": "Release notes & migration",
+                "group": "AdCP 3.x",
                 "expanded": false,
                 "pages": [
-                  "docs/reference/whats-new-in-v3",
-                  "docs/reference/whats-new-in-3-1",
-                  "docs/reference/whats-new-in-3-2",
-                  "docs/reference/3-2-beta",
-                  "docs/reference/migration/v3-readiness",
-                  "docs/reference/migration/index",
-                  "docs/reference/migration/3-0-to-3-1",
-                  "docs/reference/migration/3-1-to-3-2",
-                  "docs/reference/migration/prerelease-upgrades",
-                  "docs/reference/migration/channels",
-                  "docs/reference/migration/pricing",
-                  "docs/reference/migration/geo-targeting",
-                  "docs/reference/migration/creatives",
-                  "docs/reference/migration/creative-transformers",
-                  "docs/reference/migration/catalogs",
-                  "docs/reference/migration/optimization-goals",
-                  "docs/reference/migration/brand-identity",
-                  "docs/reference/migration/signals",
-                  "docs/reference/migration/audiences",
-                  "docs/reference/migration/attribution",
-                  "docs/reference/migration/media-buy-status",
-                  "docs/reference/migration/targeting-aware-discovery",
-                  "docs/reference/migration/asset-access",
-                  "docs/reference/migration/cross-role-governance-enforcement"
+                  "dist/docs/3.1.19/reference/whats-new-in-v3",
+                  "dist/docs/3.1.19/reference/whats-new-in-3-1",
+                  "dist/docs/3.1.19/reference/migration/v3-readiness",
+                  "dist/docs/3.1.19/reference/migration/index",
+                  "dist/docs/3.1.19/reference/migration/3-0-to-3-1",
+                  "dist/docs/3.1.19/reference/migration/prerelease-upgrades",
+                  "dist/docs/3.1.19/reference/migration/channels",
+                  "dist/docs/3.1.19/reference/migration/pricing",
+                  "dist/docs/3.1.19/reference/migration/geo-targeting",
+                  "dist/docs/3.1.19/reference/migration/creatives",
+                  "dist/docs/3.1.19/reference/migration/creative-transformers",
+                  "dist/docs/3.1.19/reference/migration/catalogs",
+                  "dist/docs/3.1.19/reference/migration/optimization-goals",
+                  "dist/docs/3.1.19/reference/migration/brand-identity",
+                  "dist/docs/3.1.19/reference/migration/signals",
+                  "dist/docs/3.1.19/reference/migration/audiences",
+                  "dist/docs/3.1.19/reference/migration/attribution",
+                  "dist/docs/3.1.19/reference/migration/media-buy-status"
                 ]
               },
-              "docs/protocol/architecture",
-              "docs/protocol/design-principles",
-              "docs/protocol/language-and-localization",
-              "docs/protocol/capabilities-explorer",
-              "docs/spec-guidelines",
-              "docs/protocol/required-tasks",
-              "docs/protocol/calling-an-agent",
-              "docs/protocol/format-references",
-              "docs/protocol/snapshot-and-log",
+              "dist/docs/3.1.19/protocol/architecture",
+              "dist/docs/3.1.19/protocol/design-principles",
+              "dist/docs/3.1.19/protocol/capabilities-explorer",
+              "dist/docs/3.1.19/spec-guidelines",
+              "dist/docs/3.1.19/protocol/required-tasks",
+              "dist/docs/3.1.19/protocol/calling-an-agent",
+              "dist/docs/3.1.19/protocol/format-references",
+              "dist/docs/3.1.19/protocol/snapshot-and-log",
               {
                 "group": "Concepts",
                 "expanded": false,
                 "pages": [
-                  "docs/building/concepts/index",
-                  "docs/building/concepts/protocol-comparison",
-                  "docs/building/concepts/adcp-vs-openrtb",
-                  "docs/building/concepts/how-agents-communicate",
-                  "docs/building/concepts/security-model",
-                  "docs/building/concepts/industry-landscape",
-                  "docs/building/concepts/managing-response-size"
+                  "dist/docs/3.1.19/building/concepts/index",
+                  "dist/docs/3.1.19/building/concepts/protocol-comparison",
+                  "dist/docs/3.1.19/building/concepts/adcp-vs-openrtb",
+                  "dist/docs/3.1.19/building/concepts/how-agents-communicate",
+                  "dist/docs/3.1.19/building/concepts/security-model",
+                  "dist/docs/3.1.19/building/concepts/industry-landscape",
+                  "dist/docs/3.1.19/building/concepts/managing-response-size"
                 ]
               },
               {
@@ -141,60 +134,58 @@
                   {
                     "group": "L4 — Business logic",
                     "pages": [
-                      "docs/building/by-layer/L4/index",
-                      "docs/building/by-layer/L4/choose-your-sdk",
-                      "docs/building/by-layer/L4/build-an-agent",
-                      "docs/building/by-layer/L4/build-a-caller",
-                      "docs/building/by-layer/L4/migrate-from-hand-rolled"
+                      "dist/docs/3.1.19/building/by-layer/L4/index",
+                      "dist/docs/3.1.19/building/by-layer/L4/choose-your-sdk",
+                      "dist/docs/3.1.19/building/by-layer/L4/build-an-agent",
+                      "dist/docs/3.1.19/building/by-layer/L4/build-a-caller",
+                      "dist/docs/3.1.19/building/by-layer/L4/migrate-from-hand-rolled"
                     ]
                   },
                   {
                     "group": "L3 — Protocol semantics",
                     "expanded": false,
                     "pages": [
-                      "docs/building/by-layer/L3/index",
-                      "docs/building/by-layer/L3/task-lifecycle",
-                      "docs/building/by-layer/L3/async-operations",
-                      "docs/building/by-layer/L3/async-identity-and-convergence",
-                      "docs/building/by-layer/L3/webhooks",
-                      "docs/building/by-layer/L3/error-handling",
-                      "docs/building/by-layer/L3/comply-test-controller"
+                      "dist/docs/3.1.19/building/by-layer/L3/index",
+                      "dist/docs/3.1.19/building/by-layer/L3/task-lifecycle",
+                      "dist/docs/3.1.19/building/by-layer/L3/async-operations",
+                      "dist/docs/3.1.19/building/by-layer/L3/webhooks",
+                      "dist/docs/3.1.19/building/by-layer/L3/error-handling",
+                      "dist/docs/3.1.19/building/by-layer/L3/comply-test-controller"
                     ]
                   },
                   {
                     "group": "L2 — Auth & registry",
                     "expanded": false,
                     "pages": [
-                      "docs/building/by-layer/L2/index",
-                      "docs/building/by-layer/L2/authentication",
-                      "docs/building/by-layer/L2/account-state",
-                      "docs/building/by-layer/L2/accounts-and-agents",
-                      "docs/building/by-layer/L2/context-sessions"
+                      "dist/docs/3.1.19/building/by-layer/L2/index",
+                      "dist/docs/3.1.19/building/by-layer/L2/authentication",
+                      "dist/docs/3.1.19/building/by-layer/L2/account-state",
+                      "dist/docs/3.1.19/building/by-layer/L2/accounts-and-agents",
+                      "dist/docs/3.1.19/building/by-layer/L2/context-sessions"
                     ]
                   },
                   {
                     "group": "L1 — Identity & signing",
                     "expanded": false,
                     "pages": [
-                      "docs/building/by-layer/L1/index",
-                      "docs/building/by-layer/L1/security",
-                      "docs/building/by-layer/L1/request-signing",
-                      "docs/building/by-layer/L1/webhook-verifier-tuning"
+                      "dist/docs/3.1.19/building/by-layer/L1/index",
+                      "dist/docs/3.1.19/building/by-layer/L1/security",
+                      "dist/docs/3.1.19/building/by-layer/L1/request-signing",
+                      "dist/docs/3.1.19/building/by-layer/L1/webhook-verifier-tuning"
                     ]
                   },
                   {
                     "group": "L0 — Wire & transport",
                     "expanded": false,
                     "pages": [
-                      "docs/building/by-layer/L0/index",
-                      "docs/building/by-layer/L0/schemas",
-                      "docs/building/by-layer/L0/mcp-guide",
-                      "docs/building/by-layer/L0/a2a-guide",
-                      "docs/building/by-layer/L0/a2a-response-format",
-                      "docs/protocol/get_adcp_capabilities",
-                      "docs/protocol/sync_agent_notification_configs",
-                      "docs/building/by-layer/L0/mcp-response-extraction",
-                      "docs/building/by-layer/L0/a2a-response-extraction"
+                      "dist/docs/3.1.19/building/by-layer/L0/index",
+                      "dist/docs/3.1.19/building/by-layer/L0/schemas",
+                      "dist/docs/3.1.19/building/by-layer/L0/mcp-guide",
+                      "dist/docs/3.1.19/building/by-layer/L0/a2a-guide",
+                      "dist/docs/3.1.19/building/by-layer/L0/a2a-response-format",
+                      "dist/docs/3.1.19/protocol/get_adcp_capabilities",
+                      "dist/docs/3.1.19/building/by-layer/L0/mcp-response-extraction",
+                      "dist/docs/3.1.19/building/by-layer/L0/a2a-response-extraction"
                     ]
                   }
                 ]
@@ -203,50 +194,48 @@
                 "group": "Cross-cutting",
                 "expanded": false,
                 "pages": [
-                  "docs/building/cross-cutting/sdk-stack",
-                  "docs/building/cross-cutting/version-adaptation",
-                  "docs/building/cross-cutting/known-ambiguities"
+                  "dist/docs/3.1.19/building/cross-cutting/sdk-stack",
+                  "dist/docs/3.1.19/building/cross-cutting/version-adaptation",
+                  "dist/docs/3.1.19/building/cross-cutting/known-ambiguities"
                 ]
               },
               {
                 "group": "Verification & trust",
                 "expanded": false,
                 "pages": [
-                  "docs/building/verification/conformance",
-                  "docs/building/verification/compliance-catalog",
-                  "docs/building/verification/storyboards-vs-scenarios",
-                  "docs/building/verification/how-grading-works",
-                  "docs/building/verification/validate-your-agent",
-                  "docs/building/verification/validate-with-mock-fixtures",
-                  "docs/building/verification/addie-socket-mode",
-                  "docs/building/verification/grading",
-                  "docs/building/verification/get-test-ready",
-                  "docs/building/verification/aao-verified"
+                  "dist/docs/3.1.19/building/verification/conformance",
+                  "dist/docs/3.1.19/building/verification/compliance-catalog",
+                  "dist/docs/3.1.19/building/verification/storyboards-vs-scenarios",
+                  "dist/docs/3.1.19/building/verification/how-grading-works",
+                  "dist/docs/3.1.19/building/verification/validate-your-agent",
+                  "dist/docs/3.1.19/building/verification/validate-with-mock-fixtures",
+                  "dist/docs/3.1.19/building/verification/addie-socket-mode",
+                  "dist/docs/3.1.19/building/verification/grading",
+                  "dist/docs/3.1.19/building/verification/get-test-ready",
+                  "dist/docs/3.1.19/building/verification/aao-verified"
                 ]
               },
               {
                 "group": "Operating",
                 "expanded": false,
                 "pages": [
-                  "docs/building/operating/operating-an-agent",
-                  "docs/building/operating/orchestrator-design",
-                  "docs/building/operating/transport-errors",
-                  "docs/building/operating/seller-integration",
-                  "docs/building/operating/storyboard-troubleshooting",
-                  "docs/building/operating/support-recovery-runbooks"
+                  "dist/docs/3.1.19/building/operating/operating-an-agent",
+                  "dist/docs/3.1.19/building/operating/orchestrator-design",
+                  "dist/docs/3.1.19/building/operating/transport-errors",
+                  "dist/docs/3.1.19/building/operating/seller-integration",
+                  "dist/docs/3.1.19/building/operating/storyboard-troubleshooting"
                 ]
               },
               {
                 "group": "Accounts",
                 "expanded": false,
                 "pages": [
-                  "docs/accounts/overview",
-                  "docs/accounts/provisioning-walkthrough",
-                  "docs/accounts/tasks/sync_accounts",
-                  "docs/accounts/tasks/list_accounts",
-                  "docs/accounts/tasks/report_usage",
-                  "docs/accounts/tasks/sync_governance",
-                  "docs/accounts/tasks/get_account_financials"
+                  "dist/docs/3.1.19/accounts/overview",
+                  "dist/docs/3.1.19/accounts/tasks/sync_accounts",
+                  "dist/docs/3.1.19/accounts/tasks/list_accounts",
+                  "dist/docs/3.1.19/accounts/tasks/report_usage",
+                  "dist/docs/3.1.19/accounts/tasks/sync_governance",
+                  "dist/docs/3.1.19/accounts/tasks/get_account_financials"
                 ]
               }
             ]
@@ -259,76 +248,55 @@
                 "group": "Media Buy",
                 "expanded": false,
                 "pages": [
-                  "docs/media-buy/index",
-                  "docs/media-buy/commerce-media",
+                  "dist/docs/3.1.19/media-buy/index",
+                  "dist/docs/3.1.19/media-buy/commerce-media",
                   {
                     "group": "Concepts",
                     "pages": [
-                      "docs/media-buy/product-discovery/index",
-                      "docs/media-buy/product-discovery/brief-expectations",
-                      "docs/media-buy/product-discovery/example-briefs",
-                      "docs/media-buy/product-discovery/media-products",
-                      "docs/media-buy/product-discovery/collections-and-installments",
-                      "docs/media-buy/product-discovery/proposal-negotiation",
-                      "docs/media-buy/media-buys/index",
-                      "docs/media-buy/media-buys/lifecycle",
-                      "docs/media-buy/media-buys/indicators",
-                      "docs/media-buy/media-buys/optimization-reporting",
-                      "docs/media-buy/media-buys/policy-compliance",
-                      "docs/media-buy/creatives/index",
-                      "docs/media-buy/conversion-tracking/index",
-                      "docs/media-buy/advanced-topics/pricing-models",
-                      "docs/media-buy/advanced-topics/targeting",
-                      "docs/media-buy/advanced-topics/accountability",
-                      "docs/media-buy/advanced-topics/billing-authority",
-                      {
-                        "group": "3.x compatibility",
-                        "expanded": false,
-                        "pages": [
-                          "docs/media-buy/product-discovery/refinement"
-                        ]
-                      }
+                      "dist/docs/3.1.19/media-buy/product-discovery/index",
+                      "dist/docs/3.1.19/media-buy/product-discovery/brief-expectations",
+                      "dist/docs/3.1.19/media-buy/product-discovery/example-briefs",
+                      "dist/docs/3.1.19/media-buy/product-discovery/media-products",
+                      "dist/docs/3.1.19/media-buy/product-discovery/collections-and-installments",
+                      "dist/docs/3.1.19/media-buy/product-discovery/refinement",
+                      "dist/docs/3.1.19/media-buy/media-buys/index",
+                      "dist/docs/3.1.19/media-buy/media-buys/lifecycle",
+                      "dist/docs/3.1.19/media-buy/media-buys/optimization-reporting",
+                      "dist/docs/3.1.19/media-buy/media-buys/policy-compliance",
+                      "dist/docs/3.1.19/media-buy/creatives/index",
+                      "dist/docs/3.1.19/media-buy/conversion-tracking/index",
+                      "dist/docs/3.1.19/media-buy/advanced-topics/pricing-models",
+                      "dist/docs/3.1.19/media-buy/advanced-topics/targeting",
+                      "dist/docs/3.1.19/media-buy/advanced-topics/accountability",
+                      "dist/docs/3.1.19/media-buy/advanced-topics/billing-authority"
                     ]
                   },
                   {
                     "group": "Building",
                     "pages": [
-                      "docs/media-buy/capability-discovery/index",
-                      "docs/media-buy/capability-discovery/implementing-standard-formats",
-                      "docs/media-buy/advanced-topics/agentic-execution-engine",
-                      "docs/media-buy/advanced-topics/accounts-and-security",
-                      "docs/media-buy/advanced-topics/sandbox"
+                      "dist/docs/3.1.19/media-buy/capability-discovery/index",
+                      "dist/docs/3.1.19/media-buy/capability-discovery/implementing-standard-formats",
+                      "dist/docs/3.1.19/media-buy/advanced-topics/agentic-execution-engine",
+                      "dist/docs/3.1.19/media-buy/advanced-topics/accounts-and-security",
+                      "dist/docs/3.1.19/media-buy/advanced-topics/sandbox"
                     ]
                   },
                   {
                     "group": "Reference",
                     "expanded": false,
                     "pages": [
-                      "docs/media-buy/specification",
-                      "docs/media-buy/task-reference/index",
-                      "docs/media-buy/task-reference/list_products",
-                      "docs/media-buy/task-reference/request_proposals",
-                      "docs/media-buy/task-reference/refine_proposals",
-                      "docs/media-buy/task-reference/decline_proposals",
-                      "docs/media-buy/task-reference/buy_products",
-                      "docs/media-buy/task-reference/accept_proposal",
-                      "docs/media-buy/task-reference/control_media_buy",
-                      "docs/media-buy/task-reference/sync_catalogs",
-                      "docs/media-buy/task-reference/get_media_buys",
-                      "docs/media-buy/task-reference/get_media_buy_delivery",
-                      "docs/media-buy/task-reference/provide_performance_feedback",
-                      "docs/media-buy/task-reference/sync_event_sources",
-                      "docs/media-buy/task-reference/log_event",
-                      "docs/media-buy/task-reference/sync_audiences",
-                      {
-                        "group": "3.x compatibility",
-                        "expanded": false,
-                        "pages": [
-                          "docs/media-buy/task-reference/get_products",
-                          "docs/media-buy/task-reference/create_media_buy",
-                          "docs/media-buy/task-reference/update_media_buy"
-                        ]
-                      }
+                      "dist/docs/3.1.19/media-buy/specification",
+                      "dist/docs/3.1.19/media-buy/task-reference/index",
+                      "dist/docs/3.1.19/media-buy/task-reference/get_products",
+                      "dist/docs/3.1.19/media-buy/task-reference/create_media_buy",
+                      "dist/docs/3.1.19/media-buy/task-reference/sync_catalogs",
+                      "dist/docs/3.1.19/media-buy/task-reference/get_media_buys",
+                      "dist/docs/3.1.19/media-buy/task-reference/get_media_buy_delivery",
+                      "dist/docs/3.1.19/media-buy/task-reference/update_media_buy",
+                      "dist/docs/3.1.19/media-buy/task-reference/provide_performance_feedback",
+                      "dist/docs/3.1.19/media-buy/task-reference/sync_event_sources",
+                      "dist/docs/3.1.19/media-buy/task-reference/log_event",
+                      "dist/docs/3.1.19/media-buy/task-reference/sync_audiences"
                     ]
                   }
                 ]
@@ -337,73 +305,69 @@
                 "group": "Creative",
                 "expanded": false,
                 "pages": [
-                  "docs/creative/index",
+                  "dist/docs/3.1.19/creative/index",
                   {
                     "group": "Concepts",
                     "pages": [
-                      "docs/creative/key-concepts",
-                      "docs/creative/ai-creative-overview",
-                      "docs/creative/generative-creative",
-                      "docs/creative/creative-libraries",
-                      "docs/creative/catalogs",
-                      "docs/creative/catalog-schemas"
+                      "dist/docs/3.1.19/creative/key-concepts",
+                      "dist/docs/3.1.19/creative/ai-creative-overview",
+                      "dist/docs/3.1.19/creative/generative-creative",
+                      "dist/docs/3.1.19/creative/creative-libraries",
+                      "dist/docs/3.1.19/creative/catalogs",
+                      "dist/docs/3.1.19/creative/catalog-schemas"
                     ]
                   },
                   {
                     "group": "Building Creative Agents",
                     "pages": [
-                      "docs/creative/implementing-creative-agents",
-                      "docs/creative/sales-agent-creative-capabilities",
-                      "docs/creative/multi-agent-orchestration",
-                      "docs/creative/creative-manifests",
-                      "docs/creative/private-assets",
-                      "docs/creative/buyer-attached-inputs"
+                      "dist/docs/3.1.19/creative/implementing-creative-agents",
+                      "dist/docs/3.1.19/creative/sales-agent-creative-capabilities",
+                      "dist/docs/3.1.19/creative/multi-agent-orchestration",
+                      "dist/docs/3.1.19/creative/creative-manifests",
+                      "dist/docs/3.1.19/creative/private-assets"
                     ]
                   },
                   {
                     "group": "Formats and Assets",
                     "pages": [
-                      "docs/creative/formats",
-                      "docs/creative/asset-types",
-                      "docs/creative/template-format-ids",
-                      "docs/creative/universal-macros"
+                      "dist/docs/3.1.19/creative/formats",
+                      "dist/docs/3.1.19/creative/asset-types",
+                      "dist/docs/3.1.19/creative/template-format-ids",
+                      "dist/docs/3.1.19/creative/universal-macros"
                     ]
                   },
                   {
                     "group": "Channel Guides",
                     "pages": [
-                      "docs/creative/channels/video",
-                      "docs/creative/channels/ctv",
-                      "docs/creative/channels/broadcast",
-                      "docs/creative/channels/display",
-                      "docs/creative/channels/audio",
-                      "docs/creative/channels/radio",
-                      "docs/creative/channels/dooh",
-                      "docs/creative/channels/print",
-                      "docs/creative/channels/carousels",
-                      "docs/creative/channels/social-native"
+                      "dist/docs/3.1.19/creative/channels/video",
+                      "dist/docs/3.1.19/creative/channels/ctv",
+                      "dist/docs/3.1.19/creative/channels/broadcast",
+                      "dist/docs/3.1.19/creative/channels/display",
+                      "dist/docs/3.1.19/creative/channels/audio",
+                      "dist/docs/3.1.19/creative/channels/dooh",
+                      "dist/docs/3.1.19/creative/channels/carousels",
+                      "dist/docs/3.1.19/creative/channels/social-native"
                     ]
                   },
                   {
                     "group": "Compliance",
                     "pages": [
-                      "docs/creative/accessibility",
-                      "docs/creative/provenance"
+                      "dist/docs/3.1.19/creative/accessibility",
+                      "dist/docs/3.1.19/creative/provenance"
                     ]
                   },
                   {
                     "group": "Reference",
                     "expanded": false,
                     "pages": [
-                      "docs/creative/specification",
-                      "docs/creative/task-reference/build_creative",
-                      "docs/creative/task-reference/preview_creative",
-                      "docs/creative/task-reference/preview_creative-advanced",
-                      "docs/creative/task-reference/list_creative_formats",
-                      "docs/creative/task-reference/list_transformers",
-                      "docs/creative/task-reference/list_creatives",
-                      "docs/creative/task-reference/sync_creatives",
-                      "docs/creative/task-reference/get_creative_delivery"
+                      "dist/docs/3.1.19/creative/specification",
+                      "dist/docs/3.1.19/creative/task-reference/build_creative",
+                      "dist/docs/3.1.19/creative/task-reference/preview_creative",
+                      "dist/docs/3.1.19/creative/task-reference/preview_creative-advanced",
+                      "dist/docs/3.1.19/creative/task-reference/list_creative_formats",
+                      "dist/docs/3.1.19/creative/task-reference/list_creatives",
+                      "dist/docs/3.1.19/creative/task-reference/sync_creatives",
+                      "dist/docs/3.1.19/creative/task-reference/get_creative_delivery"
                     ]
                   }
                 ]
@@ -412,28 +376,28 @@
                 "group": "Governance",
                 "expanded": false,
                 "pages": [
-                  "docs/governance/overview",
-                  "docs/governance/rfc-process",
-                  "docs/governance/embedded-human-judgment",
-                  "docs/governance/policy-registry",
-                  "docs/governance/policy-registry-sync",
-                  "docs/governance/policy-attribution",
-                  "docs/governance/annex-iii-obligations",
-                  "docs/governance/working-group-charter",
+                  "dist/docs/3.1.19/governance/overview",
+                  "dist/docs/3.1.19/governance/rfc-process",
+                  "dist/docs/3.1.19/governance/embedded-human-judgment",
+                  "dist/docs/3.1.19/governance/policy-registry",
+                  "dist/docs/3.1.19/governance/policy-registry-sync",
+                  "dist/docs/3.1.19/governance/policy-attribution",
+                  "dist/docs/3.1.19/governance/annex-iii-obligations",
+                  "dist/docs/3.1.19/governance/working-group-charter",
                   {
                     "group": "Property Governance",
                     "pages": [
-                      "docs/governance/property/index",
-                      "docs/governance/property/adagents",
-                      "docs/governance/property/managed-networks",
-                      "docs/governance/property/authorized-properties",
-                      "docs/governance/property/specification",
+                      "dist/docs/3.1.19/governance/property/index",
+                      "dist/docs/3.1.19/governance/property/adagents",
+                      "dist/docs/3.1.19/governance/property/managed-networks",
+                      "dist/docs/3.1.19/governance/property/authorized-properties",
+                      "dist/docs/3.1.19/governance/property/specification",
                       {
                         "group": "Tasks",
                         "pages": [
-                          "docs/governance/property/tasks/index",
-                          "docs/governance/property/tasks/property_lists",
-                          "docs/governance/property/tasks/validate_property_delivery"
+                          "dist/docs/3.1.19/governance/property/tasks/index",
+                          "dist/docs/3.1.19/governance/property/tasks/property_lists",
+                          "dist/docs/3.1.19/governance/property/tasks/validate_property_delivery"
                         ]
                       }
                     ]
@@ -441,26 +405,26 @@
                   {
                     "group": "Collection Governance",
                     "pages": [
-                      "docs/governance/collection/index",
-                      "docs/governance/collection/tasks/collection_lists"
+                      "dist/docs/3.1.19/governance/collection/index",
+                      "dist/docs/3.1.19/governance/collection/tasks/collection_lists"
                     ]
                   },
                   {
                     "group": "Content Standards",
                     "pages": [
-                      "docs/governance/content-standards/index",
-                      "docs/governance/content-standards/artifacts",
-                      "docs/governance/content-standards/implementation-guide",
+                      "dist/docs/3.1.19/governance/content-standards/index",
+                      "dist/docs/3.1.19/governance/content-standards/artifacts",
+                      "dist/docs/3.1.19/governance/content-standards/implementation-guide",
                       {
                         "group": "Tasks",
                         "pages": [
-                          "docs/governance/content-standards/tasks/list_content_standards",
-                          "docs/governance/content-standards/tasks/get_content_standards",
-                          "docs/governance/content-standards/tasks/create_content_standards",
-                          "docs/governance/content-standards/tasks/update_content_standards",
-                          "docs/governance/content-standards/tasks/calibrate_content",
-                          "docs/governance/content-standards/tasks/get_media_buy_artifacts",
-                          "docs/governance/content-standards/tasks/validate_content_delivery"
+                          "dist/docs/3.1.19/governance/content-standards/tasks/list_content_standards",
+                          "dist/docs/3.1.19/governance/content-standards/tasks/get_content_standards",
+                          "dist/docs/3.1.19/governance/content-standards/tasks/create_content_standards",
+                          "dist/docs/3.1.19/governance/content-standards/tasks/update_content_standards",
+                          "dist/docs/3.1.19/governance/content-standards/tasks/calibrate_content",
+                          "dist/docs/3.1.19/governance/content-standards/tasks/get_media_buy_artifacts",
+                          "dist/docs/3.1.19/governance/content-standards/tasks/validate_content_delivery"
                         ]
                       }
                     ]
@@ -468,29 +432,26 @@
                   {
                     "group": "Creative Governance",
                     "pages": [
-                      "docs/governance/creative/index",
-                      "docs/governance/creative/get_creative_features",
-                      "docs/governance/creative/policy-backed-rejections",
-                      "docs/governance/creative/provenance-verification"
+                      "dist/docs/3.1.19/governance/creative/index",
+                      "dist/docs/3.1.19/governance/creative/get_creative_features",
+                      "dist/docs/3.1.19/governance/creative/provenance-verification"
                     ]
                   },
                   {
                     "group": "Campaign Governance",
                     "pages": [
-                      "docs/governance/campaign/index",
-                      "docs/governance/campaign/responsibilities",
-                      "docs/governance/campaign/safety-model",
-                      "docs/governance/campaign/specification",
-                      "docs/governance/campaign/audit-trail",
+                      "dist/docs/3.1.19/governance/campaign/index",
+                      "dist/docs/3.1.19/governance/campaign/safety-model",
+                      "dist/docs/3.1.19/governance/campaign/specification",
+                      "dist/docs/3.1.19/governance/campaign/audit-trail",
                       {
                         "group": "Tasks",
                         "pages": [
-                          "docs/governance/campaign/tasks/index",
-                          "docs/governance/campaign/tasks/sync_plans",
-                          "docs/governance/campaign/tasks/report_plan_outcome",
-                          "docs/governance/campaign/tasks/report_plan_adjustment",
-                          "docs/governance/campaign/tasks/check_governance",
-                          "docs/governance/campaign/tasks/get_plan_audit_logs"
+                          "dist/docs/3.1.19/governance/campaign/tasks/index",
+                          "dist/docs/3.1.19/governance/campaign/tasks/sync_plans",
+                          "dist/docs/3.1.19/governance/campaign/tasks/report_plan_outcome",
+                          "dist/docs/3.1.19/governance/campaign/tasks/check_governance",
+                          "dist/docs/3.1.19/governance/campaign/tasks/get_plan_audit_logs"
                         ]
                       }
                     ]
@@ -501,35 +462,35 @@
                 "group": "Sponsored Intelligence",
                 "expanded": false,
                 "pages": [
-                  "docs/sponsored-intelligence/overview",
-                  "docs/sponsored-intelligence/monetizing-ai",
+                  "dist/docs/3.1.19/sponsored-intelligence/overview",
+                  "dist/docs/3.1.19/sponsored-intelligence/monetizing-ai",
                   {
                     "group": "Concepts",
                     "pages": [
-                      "docs/sponsored-intelligence/product-spectrum",
-                      "docs/sponsored-intelligence/networks",
-                      "docs/sponsored-intelligence/workflow",
-                      "docs/sponsored-intelligence/measurement"
+                      "dist/docs/3.1.19/sponsored-intelligence/product-spectrum",
+                      "dist/docs/3.1.19/sponsored-intelligence/networks",
+                      "dist/docs/3.1.19/sponsored-intelligence/workflow",
+                      "dist/docs/3.1.19/sponsored-intelligence/measurement"
                     ]
                   },
                   {
                     "group": "SI Chat Protocol",
                     "pages": [
-                      "docs/sponsored-intelligence/si-chat-protocol",
-                      "docs/sponsored-intelligence/implementing-si-agents",
-                      "docs/sponsored-intelligence/implementing-si-hosts"
+                      "dist/docs/3.1.19/sponsored-intelligence/si-chat-protocol",
+                      "dist/docs/3.1.19/sponsored-intelligence/implementing-si-agents",
+                      "dist/docs/3.1.19/sponsored-intelligence/implementing-si-hosts"
                     ]
                   },
                   {
                     "group": "Reference",
                     "expanded": false,
                     "pages": [
-                      "docs/sponsored-intelligence/specification",
-                      "docs/sponsored-intelligence/tasks/index",
-                      "docs/sponsored-intelligence/tasks/si_get_offering",
-                      "docs/sponsored-intelligence/tasks/si_initiate_session",
-                      "docs/sponsored-intelligence/tasks/si_send_message",
-                      "docs/sponsored-intelligence/tasks/si_terminate_session"
+                      "dist/docs/3.1.19/sponsored-intelligence/specification",
+                      "dist/docs/3.1.19/sponsored-intelligence/tasks/index",
+                      "dist/docs/3.1.19/sponsored-intelligence/tasks/si_get_offering",
+                      "dist/docs/3.1.19/sponsored-intelligence/tasks/si_initiate_session",
+                      "dist/docs/3.1.19/sponsored-intelligence/tasks/si_send_message",
+                      "dist/docs/3.1.19/sponsored-intelligence/tasks/si_terminate_session"
                     ]
                   }
                 ]
@@ -538,25 +499,24 @@
                 "group": "Brand",
                 "expanded": false,
                 "pages": [
-                  "docs/brand-protocol/index",
-                  "docs/brand-protocol/key-concepts",
-                  "docs/brand-protocol/walkthrough-rights-licensing",
-                  "docs/brand-protocol/for-advertisers",
-                  "docs/brand-protocol/for-rights-holders",
-                  "docs/brand-protocol/seller-setup",
-                  "docs/brand-protocol/brand-json",
-                  "docs/brand-protocol/building-a-brand-agent",
-                  "docs/brand-protocol/ui-guidance",
+                  "dist/docs/3.1.19/brand-protocol/index",
+                  "dist/docs/3.1.19/brand-protocol/key-concepts",
+                  "dist/docs/3.1.19/brand-protocol/walkthrough-rights-licensing",
+                  "dist/docs/3.1.19/brand-protocol/for-advertisers",
+                  "dist/docs/3.1.19/brand-protocol/for-rights-holders",
+                  "dist/docs/3.1.19/brand-protocol/seller-setup",
+                  "dist/docs/3.1.19/brand-protocol/brand-json",
+                  "dist/docs/3.1.19/brand-protocol/building-a-brand-agent",
+                  "dist/docs/3.1.19/brand-protocol/ui-guidance",
                   {
                     "group": "Tasks",
                     "pages": [
-                      "docs/brand-protocol/tasks/search_brands",
-                      "docs/brand-protocol/tasks/get_brand_identity",
-                      "docs/brand-protocol/tasks/verify_brand_claim",
-                      "docs/brand-protocol/tasks/verify_brand_claims",
-                      "docs/brand-protocol/tasks/get_rights",
-                      "docs/brand-protocol/tasks/acquire_rights",
-                      "docs/brand-protocol/tasks/update_rights"
+                      "dist/docs/3.1.19/brand-protocol/tasks/get_brand_identity",
+                      "dist/docs/3.1.19/brand-protocol/tasks/verify_brand_claim",
+                      "dist/docs/3.1.19/brand-protocol/tasks/verify_brand_claims",
+                      "dist/docs/3.1.19/brand-protocol/tasks/get_rights",
+                      "dist/docs/3.1.19/brand-protocol/tasks/acquire_rights",
+                      "dist/docs/3.1.19/brand-protocol/tasks/update_rights"
                     ]
                   }
                 ]
@@ -565,17 +525,17 @@
                 "group": "Signals",
                 "expanded": false,
                 "pages": [
-                  "docs/signals/overview",
-                  "docs/signals/key-concepts",
-                  "docs/signals/ecosystem",
-                  "docs/signals/data-providers",
+                  "dist/docs/3.1.19/signals/overview",
+                  "dist/docs/3.1.19/signals/key-concepts",
+                  "dist/docs/3.1.19/signals/ecosystem",
+                  "dist/docs/3.1.19/signals/data-providers",
                   {
                     "group": "Reference",
                     "expanded": false,
                     "pages": [
-                      "docs/signals/specification",
-                      "docs/signals/tasks/get_signals",
-                      "docs/signals/tasks/activate_signal"
+                      "dist/docs/3.1.19/signals/specification",
+                      "dist/docs/3.1.19/signals/tasks/get_signals",
+                      "dist/docs/3.1.19/signals/tasks/activate_signal"
                     ]
                   }
                 ]
@@ -584,24 +544,24 @@
                 "group": "Trusted Match",
                 "expanded": false,
                 "pages": [
-                  "docs/trusted-match/index",
-                  "docs/trusted-match/ai-mediation",
-                  "docs/trusted-match/buyer-guide",
-                  "docs/trusted-match/execution-gap",
-                  "docs/trusted-match/context-and-identity",
-                  "docs/trusted-match/specification",
-                  "docs/trusted-match/router-architecture",
-                  "docs/trusted-match/privacy-architecture",
-                  "docs/trusted-match/data-protection-roles",
-                  "docs/trusted-match/migration-from-axe",
+                  "dist/docs/3.1.19/trusted-match/index",
+                  "dist/docs/3.1.19/trusted-match/ai-mediation",
+                  "dist/docs/3.1.19/trusted-match/buyer-guide",
+                  "dist/docs/3.1.19/trusted-match/execution-gap",
+                  "dist/docs/3.1.19/trusted-match/context-and-identity",
+                  "dist/docs/3.1.19/trusted-match/specification",
+                  "dist/docs/3.1.19/trusted-match/router-architecture",
+                  "dist/docs/3.1.19/trusted-match/privacy-architecture",
+                  "dist/docs/3.1.19/trusted-match/data-protection-roles",
+                  "dist/docs/3.1.19/trusted-match/migration-from-axe",
                   {
                     "group": "Surface Guides",
                     "pages": [
-                      "docs/trusted-match/surfaces/web",
-                      "docs/trusted-match/surfaces/ctv",
-                      "docs/trusted-match/surfaces/mobile",
-                      "docs/trusted-match/surfaces/retail-media",
-                      "docs/trusted-match/surfaces/ai-assistants"
+                      "dist/docs/3.1.19/trusted-match/surfaces/web",
+                      "dist/docs/3.1.19/trusted-match/surfaces/ctv",
+                      "dist/docs/3.1.19/trusted-match/surfaces/mobile",
+                      "dist/docs/3.1.19/trusted-match/surfaces/retail-media",
+                      "dist/docs/3.1.19/trusted-match/surfaces/ai-assistants"
                     ]
                   }
                 ]
@@ -609,30 +569,20 @@
             ]
           },
           {
-            "group": "Using AAO",
-            "pages": [
-              "docs/aao/connect-addie",
-              "docs/aao/users",
-              "docs/aao/org-admins",
-              "docs/aao/addie-tools",
-              "docs/aao/directory-api"
-            ]
-          },
-          {
             "group": "FAQ",
             "pages": [
-              "docs/faq"
+              "dist/docs/3.1.19/faq"
             ]
           },
           {
             "group": "Trust & Security",
             "expanded": false,
             "pages": [
-              "docs/trust",
-              "docs/verification/overview",
-              "docs/ai-disclosure",
-              "docs/reference/privacy-considerations",
-              "docs/reference/known-limitations"
+              "dist/docs/3.1.19/trust",
+              "dist/docs/3.1.19/verification/overview",
+              "dist/docs/3.1.19/ai-disclosure",
+              "dist/docs/3.1.19/reference/privacy-considerations",
+              "dist/docs/3.1.19/reference/known-limitations"
             ]
           },
           {
@@ -642,103 +592,83 @@
               {
                 "group": "Registry API",
                 "openapi": {
-                  "source": "https://agenticadvertising.org/openapi/registry.yaml",
-                  "directory": "docs/registry/api-reference"
+                  "source": "static/openapi/registry.yaml",
+                  "directory": "dist/docs/3.1.19/registry/api-reference"
                 },
                 "pages": [
-                  "docs/registry/index",
-                  "docs/registry/registering-an-agent",
-                  "docs/registry/maintaining-your-agent"
+                  "dist/docs/3.1.19/registry/index",
+                  "dist/docs/3.1.19/registry/registering-an-agent",
+                  "dist/docs/3.1.19/registry/maintaining-your-agent"
                 ]
               },
-              "docs/reference/gmsf-reference",
-              "docs/reference/media-channel-taxonomy",
-              "docs/measurement/taxonomy",
-              "docs/reference/roadmap",
-              "docs/reference/versions",
-              "docs/reference/versioning",
-              "docs/reference/specification-lifecycle",
-              "docs/reference/url-canonicalization",
-              "docs/reference/verifying-protocol-tarballs",
-              "docs/reference/test-vectors/index",
-              "docs/reference/experimental-status",
-              "docs/reference/schema-extensions",
-              "docs/reference/v2-sunset",
-              "docs/reference/release-notes",
-              "docs/reference/changelog",
-              "docs/reference/implementor-faq",
-              "docs/reference/glossary",
-              "docs/community/working-group",
-              "docs/community/joining-slack"
+              "dist/docs/3.1.19/reference/gmsf-reference",
+              "dist/docs/3.1.19/reference/media-channel-taxonomy",
+              "dist/docs/3.1.19/measurement/taxonomy",
+              "dist/docs/3.1.19/reference/roadmap",
+              "dist/docs/3.1.19/reference/versions",
+              "dist/docs/3.1.19/reference/versioning",
+              "dist/docs/3.1.19/reference/specification-lifecycle",
+              "dist/docs/3.1.19/reference/url-canonicalization",
+              "dist/docs/3.1.19/reference/verifying-protocol-tarballs",
+              "dist/docs/3.1.19/reference/test-vectors/index",
+              "dist/docs/3.1.19/reference/experimental-status",
+              "dist/docs/3.1.19/reference/schema-extensions",
+              "dist/docs/3.1.19/reference/v2-sunset",
+              "dist/docs/3.1.19/reference/release-notes",
+              "dist/docs/3.1.19/reference/changelog",
+              "dist/docs/3.1.19/reference/implementor-faq",
+              "dist/docs/3.1.19/reference/glossary",
+              "dist/docs/3.1.19/community/working-group",
+              "dist/docs/3.1.19/community/joining-slack"
             ]
           },
           {
             "group": "Certification",
             "expanded": false,
             "pages": [
-              "docs/learning/overview",
-              "docs/learning/instructional-design",
-              "docs/learning/failure-mode-scope",
+              "dist/docs/3.1.19/learning/overview",
+              "dist/docs/3.1.19/learning/instructional-design",
+              "dist/docs/3.1.19/learning/failure-mode-scope",
               {
                 "group": "Basics (free)",
                 "pages": [
-                  "docs/learning/foundations/a1-agentic-advertising",
-                  "docs/learning/foundations/a2-protocol-architecture",
-                  "docs/learning/foundations/a2b-testing-your-first-agent",
-                  "docs/learning/foundations/a3-ecosystem-governance"
-                ]
-              },
-              {
-                "group": "For decision-makers",
-                "pages": [
-                  "docs/learning/decision-makers/overview",
-                  "docs/learning/decision-makers/l1-agentic-advertising",
-                  "docs/learning/decision-makers/l2-data-brand-governance",
-                  "docs/learning/decision-makers/l3-deciding-and-leading",
-                  "docs/learning/decision-makers/explaining-agentic-advertising"
+                  "dist/docs/3.1.19/learning/foundations/a1-agentic-advertising",
+                  "dist/docs/3.1.19/learning/foundations/a2-protocol-architecture",
+                  "dist/docs/3.1.19/learning/foundations/a2b-testing-your-first-agent",
+                  "dist/docs/3.1.19/learning/foundations/a3-ecosystem-governance"
                 ]
               },
               {
                 "group": "Role tracks",
                 "pages": [
-                  "docs/learning/tracks/publisher",
-                  "docs/learning/tracks/buyer",
-                  "docs/learning/tracks/platform"
+                  "dist/docs/3.1.19/learning/tracks/publisher",
+                  "dist/docs/3.1.19/learning/tracks/buyer",
+                  "dist/docs/3.1.19/learning/tracks/platform"
                 ]
               },
               {
                 "group": "Specialist modules",
                 "pages": [
-                  "docs/learning/specialist/media-buy",
-                  "docs/learning/specialist/creative",
-                  "docs/learning/specialist/signals",
-                  "docs/learning/specialist/governance",
-                  "docs/learning/specialist/sponsored-intelligence",
-                  "docs/learning/specialist/security",
-                  "docs/learning/specialist/brand"
-                ]
-              },
-              {
-                "group": "Supplements",
-                "expanded": false,
-                "pages": [
-                  "docs/learning/supplements/buyer-briefs-and-get-products",
-                  "docs/learning/supplements/governance-protocol-by-role",
-                  "docs/learning/supplements/creative-agent-workflows"
+                  "dist/docs/3.1.19/learning/specialist/media-buy",
+                  "dist/docs/3.1.19/learning/specialist/creative",
+                  "dist/docs/3.1.19/learning/specialist/signals",
+                  "dist/docs/3.1.19/learning/specialist/governance",
+                  "dist/docs/3.1.19/learning/specialist/sponsored-intelligence",
+                  "dist/docs/3.1.19/learning/specialist/security"
                 ]
               },
               {
                 "group": "Policies",
                 "expanded": false,
                 "pages": [
-                  "docs/learning/policies/nondiscrimination",
-                  "docs/learning/policies/learner-records",
-                  "docs/learning/policies/recertification",
-                  "docs/learning/policies/complaints",
-                  "docs/learning/policies/conflict-of-interest",
-                  "docs/learning/policies/intellectual-property",
-                  "docs/learning/policies/personnel-qualifications",
-                  "docs/learning/policies/refund"
+                  "dist/docs/3.1.19/learning/policies/nondiscrimination",
+                  "dist/docs/3.1.19/learning/policies/learner-records",
+                  "dist/docs/3.1.19/learning/policies/recertification",
+                  "dist/docs/3.1.19/learning/policies/complaints",
+                  "dist/docs/3.1.19/learning/policies/conflict-of-interest",
+                  "dist/docs/3.1.19/learning/policies/intellectual-property",
+                  "dist/docs/3.1.19/learning/policies/personnel-qualifications",
+                  "dist/docs/3.1.19/learning/policies/refund"
                 ]
               }
             ]
@@ -1952,7 +1882,7 @@
                 "group": "Registry API",
                 "openapi": {
                   "source": "https://agenticadvertising.org/openapi/registry.yaml",
-                  "directory": "dist/docs/3.0.21/registry/api-reference"
+                  "directory": "dist/docs/3.0.26/registry/api-reference"
                 },
                 "pages": [
                   "dist/docs/3.0.26/registry/index",
@@ -2281,1612 +2211,1512 @@
     },
     {
       "source": "/docs/intro",
-      "destination": "/dist/docs/3.1.2/intro",
+      "destination": "/dist/docs/3.1.19/intro",
       "permanent": false
     },
     {
       "source": "/docs/quickstart",
-      "destination": "/dist/docs/3.1.2/quickstart",
+      "destination": "/dist/docs/3.1.19/quickstart",
       "permanent": false
     },
     {
       "source": "/docs/building/index",
-      "destination": "/dist/docs/3.1.2/building/index",
+      "destination": "/dist/docs/3.1.19/building/index",
       "permanent": false
     },
     {
       "source": "/docs/building/schemas-and-sdks",
-      "destination": "/dist/docs/3.1.2/building/schemas-and-sdks",
+      "destination": "/dist/docs/3.1.19/building/schemas-and-sdks",
       "permanent": false
     },
     {
       "source": "/docs/reference/whats-new-in-v3",
-      "destination": "/dist/docs/3.1.2/reference/whats-new-in-v3",
+      "destination": "/dist/docs/3.1.19/reference/whats-new-in-v3",
       "permanent": false
     },
     {
       "source": "/docs/reference/whats-new-in-3-1",
-      "destination": "/dist/docs/3.1.2/reference/whats-new-in-3-1",
+      "destination": "/dist/docs/3.1.19/reference/whats-new-in-3-1",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/v3-readiness",
-      "destination": "/dist/docs/3.1.2/reference/migration/v3-readiness",
+      "destination": "/dist/docs/3.1.19/reference/migration/v3-readiness",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/index",
-      "destination": "/dist/docs/3.1.2/reference/migration/index",
+      "destination": "/dist/docs/3.1.19/reference/migration/index",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/3-0-to-3-1",
-      "destination": "/dist/docs/3.1.2/reference/migration/3-0-to-3-1",
+      "destination": "/dist/docs/3.1.19/reference/migration/3-0-to-3-1",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/prerelease-upgrades",
-      "destination": "/dist/docs/3.1.2/reference/migration/prerelease-upgrades",
+      "destination": "/dist/docs/3.1.19/reference/migration/prerelease-upgrades",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/channels",
-      "destination": "/dist/docs/3.1.2/reference/migration/channels",
+      "destination": "/dist/docs/3.1.19/reference/migration/channels",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/pricing",
-      "destination": "/dist/docs/3.1.2/reference/migration/pricing",
+      "destination": "/dist/docs/3.1.19/reference/migration/pricing",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/geo-targeting",
-      "destination": "/dist/docs/3.1.2/reference/migration/geo-targeting",
+      "destination": "/dist/docs/3.1.19/reference/migration/geo-targeting",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/creatives",
-      "destination": "/dist/docs/3.1.2/reference/migration/creatives",
+      "destination": "/dist/docs/3.1.19/reference/migration/creatives",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/creative-transformers",
-      "destination": "/dist/docs/3.1.2/reference/migration/creative-transformers",
+      "destination": "/dist/docs/3.1.19/reference/migration/creative-transformers",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/catalogs",
-      "destination": "/dist/docs/3.1.2/reference/migration/catalogs",
+      "destination": "/dist/docs/3.1.19/reference/migration/catalogs",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/optimization-goals",
-      "destination": "/dist/docs/3.1.2/reference/migration/optimization-goals",
+      "destination": "/dist/docs/3.1.19/reference/migration/optimization-goals",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/brand-identity",
-      "destination": "/dist/docs/3.1.2/reference/migration/brand-identity",
+      "destination": "/dist/docs/3.1.19/reference/migration/brand-identity",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/signals",
-      "destination": "/dist/docs/3.1.2/reference/migration/signals",
+      "destination": "/dist/docs/3.1.19/reference/migration/signals",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/audiences",
-      "destination": "/dist/docs/3.1.2/reference/migration/audiences",
+      "destination": "/dist/docs/3.1.19/reference/migration/audiences",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/attribution",
-      "destination": "/dist/docs/3.1.2/reference/migration/attribution",
+      "destination": "/dist/docs/3.1.19/reference/migration/attribution",
       "permanent": false
     },
     {
       "source": "/docs/reference/migration/media-buy-status",
-      "destination": "/dist/docs/3.1.2/reference/migration/media-buy-status",
+      "destination": "/dist/docs/3.1.19/reference/migration/media-buy-status",
       "permanent": false
     },
     {
       "source": "/docs/protocol/architecture",
-      "destination": "/dist/docs/3.1.2/protocol/architecture",
+      "destination": "/dist/docs/3.1.19/protocol/architecture",
       "permanent": false
     },
     {
       "source": "/docs/protocol/design-principles",
-      "destination": "/dist/docs/3.1.2/protocol/design-principles",
+      "destination": "/dist/docs/3.1.19/protocol/design-principles",
       "permanent": false
     },
     {
       "source": "/docs/protocol/capabilities-explorer",
-      "destination": "/dist/docs/3.1.2/protocol/capabilities-explorer",
+      "destination": "/dist/docs/3.1.19/protocol/capabilities-explorer",
       "permanent": false
     },
     {
       "source": "/docs/spec-guidelines",
-      "destination": "/dist/docs/3.1.2/spec-guidelines",
+      "destination": "/dist/docs/3.1.19/spec-guidelines",
       "permanent": false
     },
     {
       "source": "/docs/protocol/required-tasks",
-      "destination": "/dist/docs/3.1.2/protocol/required-tasks",
+      "destination": "/dist/docs/3.1.19/protocol/required-tasks",
       "permanent": false
     },
     {
       "source": "/docs/protocol/calling-an-agent",
-      "destination": "/dist/docs/3.1.2/protocol/calling-an-agent",
+      "destination": "/dist/docs/3.1.19/protocol/calling-an-agent",
       "permanent": false
     },
     {
       "source": "/docs/protocol/format-references",
-      "destination": "/dist/docs/3.1.2/protocol/format-references",
+      "destination": "/dist/docs/3.1.19/protocol/format-references",
       "permanent": false
     },
     {
       "source": "/docs/protocol/snapshot-and-log",
-      "destination": "/dist/docs/3.1.2/protocol/snapshot-and-log",
+      "destination": "/dist/docs/3.1.19/protocol/snapshot-and-log",
       "permanent": false
     },
     {
       "source": "/docs/building/concepts/index",
-      "destination": "/dist/docs/3.1.2/building/concepts/index",
+      "destination": "/dist/docs/3.1.19/building/concepts/index",
       "permanent": false
     },
     {
       "source": "/docs/building/concepts/protocol-comparison",
-      "destination": "/dist/docs/3.1.2/building/concepts/protocol-comparison",
+      "destination": "/dist/docs/3.1.19/building/concepts/protocol-comparison",
       "permanent": false
     },
     {
       "source": "/docs/building/concepts/adcp-vs-openrtb",
-      "destination": "/dist/docs/3.1.2/building/concepts/adcp-vs-openrtb",
+      "destination": "/dist/docs/3.1.19/building/concepts/adcp-vs-openrtb",
       "permanent": false
     },
     {
       "source": "/docs/building/concepts/how-agents-communicate",
-      "destination": "/dist/docs/3.1.2/building/concepts/how-agents-communicate",
+      "destination": "/dist/docs/3.1.19/building/concepts/how-agents-communicate",
       "permanent": false
     },
     {
       "source": "/docs/building/concepts/security-model",
-      "destination": "/dist/docs/3.1.2/building/concepts/security-model",
+      "destination": "/dist/docs/3.1.19/building/concepts/security-model",
       "permanent": false
     },
     {
       "source": "/docs/building/concepts/industry-landscape",
-      "destination": "/dist/docs/3.1.2/building/concepts/industry-landscape",
+      "destination": "/dist/docs/3.1.19/building/concepts/industry-landscape",
       "permanent": false
     },
     {
       "source": "/docs/building/concepts/managing-response-size",
-      "destination": "/dist/docs/3.1.2/building/concepts/managing-response-size",
+      "destination": "/dist/docs/3.1.19/building/concepts/managing-response-size",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L4/index",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L4/index",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L4/index",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L4/choose-your-sdk",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L4/choose-your-sdk",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L4/choose-your-sdk",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L4/build-an-agent",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L4/build-an-agent",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L4/build-an-agent",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L4/build-a-caller",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L4/build-a-caller",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L4/build-a-caller",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L4/migrate-from-hand-rolled",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L4/migrate-from-hand-rolled",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L4/migrate-from-hand-rolled",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L3/index",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L3/index",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L3/index",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L3/task-lifecycle",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L3/task-lifecycle",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L3/task-lifecycle",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L3/async-operations",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L3/async-operations",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L3/async-operations",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L3/webhooks",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L3/webhooks",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L3/webhooks",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L3/error-handling",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L3/error-handling",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L3/error-handling",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L3/comply-test-controller",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L3/comply-test-controller",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L3/comply-test-controller",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L2/index",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L2/index",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L2/index",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L2/authentication",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L2/authentication",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L2/authentication",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L2/account-state",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L2/account-state",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L2/account-state",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L2/accounts-and-agents",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L2/accounts-and-agents",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L2/accounts-and-agents",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L2/context-sessions",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L2/context-sessions",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L2/context-sessions",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L1/index",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L1/index",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L1/index",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L1/security",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L1/security",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L1/security",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L1/request-signing",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L1/request-signing",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L1/request-signing",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L1/webhook-verifier-tuning",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L1/webhook-verifier-tuning",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L1/webhook-verifier-tuning",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L0/index",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L0/index",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L0/index",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L0/schemas",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L0/schemas",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L0/schemas",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L0/mcp-guide",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L0/mcp-guide",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L0/mcp-guide",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L0/a2a-guide",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L0/a2a-guide",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L0/a2a-guide",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L0/a2a-response-format",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L0/a2a-response-format",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L0/a2a-response-format",
       "permanent": false
     },
     {
       "source": "/docs/protocol/get_adcp_capabilities",
-      "destination": "/dist/docs/3.1.2/protocol/get_adcp_capabilities",
+      "destination": "/dist/docs/3.1.19/protocol/get_adcp_capabilities",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L0/mcp-response-extraction",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L0/mcp-response-extraction",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L0/mcp-response-extraction",
       "permanent": false
     },
     {
       "source": "/docs/building/by-layer/L0/a2a-response-extraction",
-      "destination": "/dist/docs/3.1.2/building/by-layer/L0/a2a-response-extraction",
+      "destination": "/dist/docs/3.1.19/building/by-layer/L0/a2a-response-extraction",
       "permanent": false
     },
     {
       "source": "/docs/building/cross-cutting/sdk-stack",
-      "destination": "/dist/docs/3.1.2/building/cross-cutting/sdk-stack",
+      "destination": "/dist/docs/3.1.19/building/cross-cutting/sdk-stack",
       "permanent": false
     },
     {
       "source": "/docs/building/cross-cutting/version-adaptation",
-      "destination": "/dist/docs/3.1.2/building/cross-cutting/version-adaptation",
+      "destination": "/dist/docs/3.1.19/building/cross-cutting/version-adaptation",
       "permanent": false
     },
     {
       "source": "/docs/building/cross-cutting/known-ambiguities",
-      "destination": "/dist/docs/3.1.2/building/cross-cutting/known-ambiguities",
+      "destination": "/dist/docs/3.1.19/building/cross-cutting/known-ambiguities",
       "permanent": false
     },
     {
       "source": "/docs/building/verification/conformance",
-      "destination": "/dist/docs/3.1.2/building/verification/conformance",
+      "destination": "/dist/docs/3.1.19/building/verification/conformance",
       "permanent": false
     },
     {
       "source": "/docs/building/verification/compliance-catalog",
-      "destination": "/dist/docs/3.1.2/building/verification/compliance-catalog",
+      "destination": "/dist/docs/3.1.19/building/verification/compliance-catalog",
       "permanent": false
     },
     {
       "source": "/docs/building/verification/storyboards-vs-scenarios",
-      "destination": "/dist/docs/3.1.2/building/verification/storyboards-vs-scenarios",
+      "destination": "/dist/docs/3.1.19/building/verification/storyboards-vs-scenarios",
       "permanent": false
     },
     {
       "source": "/docs/building/verification/how-grading-works",
-      "destination": "/dist/docs/3.1.2/building/verification/how-grading-works",
+      "destination": "/dist/docs/3.1.19/building/verification/how-grading-works",
       "permanent": false
     },
     {
       "source": "/docs/building/verification/validate-your-agent",
-      "destination": "/dist/docs/3.1.2/building/verification/validate-your-agent",
+      "destination": "/dist/docs/3.1.19/building/verification/validate-your-agent",
       "permanent": false
     },
     {
       "source": "/docs/building/verification/validate-with-mock-fixtures",
-      "destination": "/dist/docs/3.1.2/building/verification/validate-with-mock-fixtures",
+      "destination": "/dist/docs/3.1.19/building/verification/validate-with-mock-fixtures",
       "permanent": false
     },
     {
       "source": "/docs/building/verification/addie-socket-mode",
-      "destination": "/dist/docs/3.1.2/building/verification/addie-socket-mode",
+      "destination": "/dist/docs/3.1.19/building/verification/addie-socket-mode",
       "permanent": false
     },
     {
       "source": "/docs/building/verification/grading",
-      "destination": "/dist/docs/3.1.2/building/verification/grading",
+      "destination": "/dist/docs/3.1.19/building/verification/grading",
       "permanent": false
     },
     {
       "source": "/docs/building/verification/get-test-ready",
-      "destination": "/dist/docs/3.1.2/building/verification/get-test-ready",
+      "destination": "/dist/docs/3.1.19/building/verification/get-test-ready",
       "permanent": false
     },
     {
       "source": "/docs/building/verification/aao-verified",
-      "destination": "/dist/docs/3.1.2/building/verification/aao-verified",
+      "destination": "/dist/docs/3.1.19/building/verification/aao-verified",
       "permanent": false
     },
     {
       "source": "/docs/building/operating/operating-an-agent",
-      "destination": "/dist/docs/3.1.2/building/operating/operating-an-agent",
+      "destination": "/dist/docs/3.1.19/building/operating/operating-an-agent",
       "permanent": false
     },
     {
       "source": "/docs/building/operating/orchestrator-design",
-      "destination": "/dist/docs/3.1.2/building/operating/orchestrator-design",
+      "destination": "/dist/docs/3.1.19/building/operating/orchestrator-design",
       "permanent": false
     },
     {
       "source": "/docs/building/operating/transport-errors",
-      "destination": "/dist/docs/3.1.2/building/operating/transport-errors",
+      "destination": "/dist/docs/3.1.19/building/operating/transport-errors",
       "permanent": false
     },
     {
       "source": "/docs/building/operating/seller-integration",
-      "destination": "/dist/docs/3.1.2/building/operating/seller-integration",
+      "destination": "/dist/docs/3.1.19/building/operating/seller-integration",
       "permanent": false
     },
     {
       "source": "/docs/building/operating/storyboard-troubleshooting",
-      "destination": "/dist/docs/3.1.2/building/operating/storyboard-troubleshooting",
-      "permanent": false
-    },
-    {
-      "source": "/docs/building/operating/support-recovery-runbooks",
-      "destination": "/dist/docs/3.1.2/building/operating/support-recovery-runbooks",
+      "destination": "/dist/docs/3.1.19/building/operating/storyboard-troubleshooting",
       "permanent": false
     },
     {
       "source": "/docs/accounts/overview",
-      "destination": "/dist/docs/3.1.2/accounts/overview",
+      "destination": "/dist/docs/3.1.19/accounts/overview",
       "permanent": false
     },
     {
       "source": "/docs/accounts/tasks/sync_accounts",
-      "destination": "/dist/docs/3.1.2/accounts/tasks/sync_accounts",
+      "destination": "/dist/docs/3.1.19/accounts/tasks/sync_accounts",
       "permanent": false
     },
     {
       "source": "/docs/accounts/tasks/list_accounts",
-      "destination": "/dist/docs/3.1.2/accounts/tasks/list_accounts",
+      "destination": "/dist/docs/3.1.19/accounts/tasks/list_accounts",
       "permanent": false
     },
     {
       "source": "/docs/accounts/tasks/report_usage",
-      "destination": "/dist/docs/3.1.2/accounts/tasks/report_usage",
+      "destination": "/dist/docs/3.1.19/accounts/tasks/report_usage",
       "permanent": false
     },
     {
       "source": "/docs/accounts/tasks/sync_governance",
-      "destination": "/dist/docs/3.1.2/accounts/tasks/sync_governance",
+      "destination": "/dist/docs/3.1.19/accounts/tasks/sync_governance",
       "permanent": false
     },
     {
       "source": "/docs/accounts/tasks/get_account_financials",
-      "destination": "/dist/docs/3.1.2/accounts/tasks/get_account_financials",
+      "destination": "/dist/docs/3.1.19/accounts/tasks/get_account_financials",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/index",
-      "destination": "/dist/docs/3.1.2/media-buy/index",
+      "destination": "/dist/docs/3.1.19/media-buy/index",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/commerce-media",
-      "destination": "/dist/docs/3.1.2/media-buy/commerce-media",
+      "destination": "/dist/docs/3.1.19/media-buy/commerce-media",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/product-discovery/index",
-      "destination": "/dist/docs/3.1.2/media-buy/product-discovery/index",
+      "destination": "/dist/docs/3.1.19/media-buy/product-discovery/index",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/product-discovery/brief-expectations",
-      "destination": "/dist/docs/3.1.2/media-buy/product-discovery/brief-expectations",
+      "destination": "/dist/docs/3.1.19/media-buy/product-discovery/brief-expectations",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/product-discovery/example-briefs",
-      "destination": "/dist/docs/3.1.2/media-buy/product-discovery/example-briefs",
+      "destination": "/dist/docs/3.1.19/media-buy/product-discovery/example-briefs",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/product-discovery/media-products",
-      "destination": "/dist/docs/3.1.2/media-buy/product-discovery/media-products",
+      "destination": "/dist/docs/3.1.19/media-buy/product-discovery/media-products",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/product-discovery/collections-and-installments",
-      "destination": "/dist/docs/3.1.2/media-buy/product-discovery/collections-and-installments",
+      "destination": "/dist/docs/3.1.19/media-buy/product-discovery/collections-and-installments",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/product-discovery/refinement",
-      "destination": "/dist/docs/3.1.2/media-buy/product-discovery/refinement",
+      "destination": "/dist/docs/3.1.19/media-buy/product-discovery/refinement",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/media-buys/index",
-      "destination": "/dist/docs/3.1.2/media-buy/media-buys/index",
+      "destination": "/dist/docs/3.1.19/media-buy/media-buys/index",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/media-buys/lifecycle",
-      "destination": "/dist/docs/3.1.2/media-buy/media-buys/lifecycle",
+      "destination": "/dist/docs/3.1.19/media-buy/media-buys/lifecycle",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/media-buys/optimization-reporting",
-      "destination": "/dist/docs/3.1.2/media-buy/media-buys/optimization-reporting",
+      "destination": "/dist/docs/3.1.19/media-buy/media-buys/optimization-reporting",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/media-buys/policy-compliance",
-      "destination": "/dist/docs/3.1.2/media-buy/media-buys/policy-compliance",
+      "destination": "/dist/docs/3.1.19/media-buy/media-buys/policy-compliance",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/creatives/index",
-      "destination": "/dist/docs/3.1.2/media-buy/creatives/index",
+      "destination": "/dist/docs/3.1.19/media-buy/creatives/index",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/conversion-tracking/index",
-      "destination": "/dist/docs/3.1.2/media-buy/conversion-tracking/index",
+      "destination": "/dist/docs/3.1.19/media-buy/conversion-tracking/index",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/advanced-topics/pricing-models",
-      "destination": "/dist/docs/3.1.2/media-buy/advanced-topics/pricing-models",
+      "destination": "/dist/docs/3.1.19/media-buy/advanced-topics/pricing-models",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/advanced-topics/targeting",
-      "destination": "/dist/docs/3.1.2/media-buy/advanced-topics/targeting",
+      "destination": "/dist/docs/3.1.19/media-buy/advanced-topics/targeting",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/advanced-topics/accountability",
-      "destination": "/dist/docs/3.1.2/media-buy/advanced-topics/accountability",
+      "destination": "/dist/docs/3.1.19/media-buy/advanced-topics/accountability",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/advanced-topics/billing-authority",
-      "destination": "/dist/docs/3.1.2/media-buy/advanced-topics/billing-authority",
+      "destination": "/dist/docs/3.1.19/media-buy/advanced-topics/billing-authority",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/capability-discovery/index",
-      "destination": "/dist/docs/3.1.2/media-buy/capability-discovery/index",
+      "destination": "/dist/docs/3.1.19/media-buy/capability-discovery/index",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/capability-discovery/implementing-standard-formats",
-      "destination": "/dist/docs/3.1.2/media-buy/capability-discovery/implementing-standard-formats",
+      "destination": "/dist/docs/3.1.19/media-buy/capability-discovery/implementing-standard-formats",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/advanced-topics/agentic-execution-engine",
-      "destination": "/dist/docs/3.1.2/media-buy/advanced-topics/agentic-execution-engine",
+      "destination": "/dist/docs/3.1.19/media-buy/advanced-topics/agentic-execution-engine",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/advanced-topics/accounts-and-security",
-      "destination": "/dist/docs/3.1.2/media-buy/advanced-topics/accounts-and-security",
+      "destination": "/dist/docs/3.1.19/media-buy/advanced-topics/accounts-and-security",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/advanced-topics/sandbox",
-      "destination": "/dist/docs/3.1.2/media-buy/advanced-topics/sandbox",
+      "destination": "/dist/docs/3.1.19/media-buy/advanced-topics/sandbox",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/specification",
-      "destination": "/dist/docs/3.1.2/media-buy/specification",
+      "destination": "/dist/docs/3.1.19/media-buy/specification",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/task-reference/index",
-      "destination": "/dist/docs/3.1.2/media-buy/task-reference/index",
+      "destination": "/dist/docs/3.1.19/media-buy/task-reference/index",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/task-reference/get_products",
-      "destination": "/dist/docs/3.1.2/media-buy/task-reference/get_products",
+      "destination": "/dist/docs/3.1.19/media-buy/task-reference/get_products",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/task-reference/create_media_buy",
-      "destination": "/dist/docs/3.1.2/media-buy/task-reference/create_media_buy",
+      "destination": "/dist/docs/3.1.19/media-buy/task-reference/create_media_buy",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/task-reference/sync_catalogs",
-      "destination": "/dist/docs/3.1.2/media-buy/task-reference/sync_catalogs",
+      "destination": "/dist/docs/3.1.19/media-buy/task-reference/sync_catalogs",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/task-reference/get_media_buys",
-      "destination": "/dist/docs/3.1.2/media-buy/task-reference/get_media_buys",
+      "destination": "/dist/docs/3.1.19/media-buy/task-reference/get_media_buys",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/task-reference/get_media_buy_delivery",
-      "destination": "/dist/docs/3.1.2/media-buy/task-reference/get_media_buy_delivery",
+      "destination": "/dist/docs/3.1.19/media-buy/task-reference/get_media_buy_delivery",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/task-reference/update_media_buy",
-      "destination": "/dist/docs/3.1.2/media-buy/task-reference/update_media_buy",
+      "destination": "/dist/docs/3.1.19/media-buy/task-reference/update_media_buy",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/task-reference/provide_performance_feedback",
-      "destination": "/dist/docs/3.1.2/media-buy/task-reference/provide_performance_feedback",
+      "destination": "/dist/docs/3.1.19/media-buy/task-reference/provide_performance_feedback",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/task-reference/sync_event_sources",
-      "destination": "/dist/docs/3.1.2/media-buy/task-reference/sync_event_sources",
+      "destination": "/dist/docs/3.1.19/media-buy/task-reference/sync_event_sources",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/task-reference/log_event",
-      "destination": "/dist/docs/3.1.2/media-buy/task-reference/log_event",
+      "destination": "/dist/docs/3.1.19/media-buy/task-reference/log_event",
       "permanent": false
     },
     {
       "source": "/docs/media-buy/task-reference/sync_audiences",
-      "destination": "/dist/docs/3.1.2/media-buy/task-reference/sync_audiences",
+      "destination": "/dist/docs/3.1.19/media-buy/task-reference/sync_audiences",
       "permanent": false
     },
     {
       "source": "/docs/creative/index",
-      "destination": "/dist/docs/3.1.2/creative/index",
+      "destination": "/dist/docs/3.1.19/creative/index",
       "permanent": false
     },
     {
       "source": "/docs/creative/key-concepts",
-      "destination": "/dist/docs/3.1.2/creative/key-concepts",
+      "destination": "/dist/docs/3.1.19/creative/key-concepts",
       "permanent": false
     },
     {
       "source": "/docs/creative/ai-creative-overview",
-      "destination": "/dist/docs/3.1.2/creative/ai-creative-overview",
+      "destination": "/dist/docs/3.1.19/creative/ai-creative-overview",
       "permanent": false
     },
     {
       "source": "/docs/creative/generative-creative",
-      "destination": "/dist/docs/3.1.2/creative/generative-creative",
+      "destination": "/dist/docs/3.1.19/creative/generative-creative",
       "permanent": false
     },
     {
       "source": "/docs/creative/creative-libraries",
-      "destination": "/dist/docs/3.1.2/creative/creative-libraries",
+      "destination": "/dist/docs/3.1.19/creative/creative-libraries",
       "permanent": false
     },
     {
       "source": "/docs/creative/catalogs",
-      "destination": "/dist/docs/3.1.2/creative/catalogs",
+      "destination": "/dist/docs/3.1.19/creative/catalogs",
       "permanent": false
     },
     {
       "source": "/docs/creative/catalog-schemas",
-      "destination": "/dist/docs/3.1.2/creative/catalog-schemas",
+      "destination": "/dist/docs/3.1.19/creative/catalog-schemas",
       "permanent": false
     },
     {
       "source": "/docs/creative/implementing-creative-agents",
-      "destination": "/dist/docs/3.1.2/creative/implementing-creative-agents",
+      "destination": "/dist/docs/3.1.19/creative/implementing-creative-agents",
       "permanent": false
     },
     {
       "source": "/docs/creative/sales-agent-creative-capabilities",
-      "destination": "/dist/docs/3.1.2/creative/sales-agent-creative-capabilities",
+      "destination": "/dist/docs/3.1.19/creative/sales-agent-creative-capabilities",
       "permanent": false
     },
     {
       "source": "/docs/creative/multi-agent-orchestration",
-      "destination": "/dist/docs/3.1.2/creative/multi-agent-orchestration",
+      "destination": "/dist/docs/3.1.19/creative/multi-agent-orchestration",
       "permanent": false
     },
     {
       "source": "/docs/creative/creative-manifests",
-      "destination": "/dist/docs/3.1.2/creative/creative-manifests",
+      "destination": "/dist/docs/3.1.19/creative/creative-manifests",
       "permanent": false
     },
     {
       "source": "/docs/creative/private-assets",
-      "destination": "/dist/docs/3.1.2/creative/private-assets",
-      "permanent": false
-    },
-    {
-      "source": "/docs/creative/buyer-attached-inputs",
-      "destination": "/dist/docs/3.1.2/creative/buyer-attached-inputs",
+      "destination": "/dist/docs/3.1.19/creative/private-assets",
       "permanent": false
     },
     {
       "source": "/docs/creative/formats",
-      "destination": "/dist/docs/3.1.2/creative/formats",
+      "destination": "/dist/docs/3.1.19/creative/formats",
       "permanent": false
     },
     {
       "source": "/docs/creative/asset-types",
-      "destination": "/dist/docs/3.1.2/creative/asset-types",
+      "destination": "/dist/docs/3.1.19/creative/asset-types",
       "permanent": false
     },
     {
       "source": "/docs/creative/template-format-ids",
-      "destination": "/dist/docs/3.1.2/creative/template-format-ids",
+      "destination": "/dist/docs/3.1.19/creative/template-format-ids",
       "permanent": false
     },
     {
       "source": "/docs/creative/universal-macros",
-      "destination": "/dist/docs/3.1.2/creative/universal-macros",
+      "destination": "/dist/docs/3.1.19/creative/universal-macros",
       "permanent": false
     },
     {
       "source": "/docs/creative/channels/video",
-      "destination": "/dist/docs/3.1.2/creative/channels/video",
+      "destination": "/dist/docs/3.1.19/creative/channels/video",
       "permanent": false
     },
     {
       "source": "/docs/creative/channels/ctv",
-      "destination": "/dist/docs/3.1.2/creative/channels/ctv",
+      "destination": "/dist/docs/3.1.19/creative/channels/ctv",
       "permanent": false
     },
     {
       "source": "/docs/creative/channels/broadcast",
-      "destination": "/dist/docs/3.1.2/creative/channels/broadcast",
+      "destination": "/dist/docs/3.1.19/creative/channels/broadcast",
       "permanent": false
     },
     {
       "source": "/docs/creative/channels/display",
-      "destination": "/dist/docs/3.1.2/creative/channels/display",
+      "destination": "/dist/docs/3.1.19/creative/channels/display",
       "permanent": false
     },
     {
       "source": "/docs/creative/channels/audio",
-      "destination": "/dist/docs/3.1.2/creative/channels/audio",
+      "destination": "/dist/docs/3.1.19/creative/channels/audio",
       "permanent": false
     },
     {
       "source": "/docs/creative/channels/dooh",
-      "destination": "/dist/docs/3.1.2/creative/channels/dooh",
-      "permanent": false
-    },
-    {
-      "source": "/docs/creative/channels/print",
-      "destination": "/dist/docs/3.1.2/creative/channels/print",
+      "destination": "/dist/docs/3.1.19/creative/channels/dooh",
       "permanent": false
     },
     {
       "source": "/docs/creative/channels/carousels",
-      "destination": "/dist/docs/3.1.2/creative/channels/carousels",
+      "destination": "/dist/docs/3.1.19/creative/channels/carousels",
       "permanent": false
     },
     {
       "source": "/docs/creative/channels/social-native",
-      "destination": "/dist/docs/3.1.2/creative/channels/social-native",
+      "destination": "/dist/docs/3.1.19/creative/channels/social-native",
       "permanent": false
     },
     {
       "source": "/docs/creative/accessibility",
-      "destination": "/dist/docs/3.1.2/creative/accessibility",
+      "destination": "/dist/docs/3.1.19/creative/accessibility",
       "permanent": false
     },
     {
       "source": "/docs/creative/provenance",
-      "destination": "/dist/docs/3.1.2/creative/provenance",
+      "destination": "/dist/docs/3.1.19/creative/provenance",
       "permanent": false
     },
     {
       "source": "/docs/creative/specification",
-      "destination": "/dist/docs/3.1.2/creative/specification",
+      "destination": "/dist/docs/3.1.19/creative/specification",
       "permanent": false
     },
     {
       "source": "/docs/creative/task-reference/build_creative",
-      "destination": "/dist/docs/3.1.2/creative/task-reference/build_creative",
+      "destination": "/dist/docs/3.1.19/creative/task-reference/build_creative",
       "permanent": false
     },
     {
       "source": "/docs/creative/task-reference/preview_creative",
-      "destination": "/dist/docs/3.1.2/creative/task-reference/preview_creative",
+      "destination": "/dist/docs/3.1.19/creative/task-reference/preview_creative",
       "permanent": false
     },
     {
       "source": "/docs/creative/task-reference/preview_creative-advanced",
-      "destination": "/dist/docs/3.1.2/creative/task-reference/preview_creative-advanced",
+      "destination": "/dist/docs/3.1.19/creative/task-reference/preview_creative-advanced",
       "permanent": false
     },
     {
       "source": "/docs/creative/task-reference/list_creative_formats",
-      "destination": "/dist/docs/3.1.2/creative/task-reference/list_creative_formats",
-      "permanent": false
-    },
-    {
-      "source": "/docs/creative/task-reference/list_transformers",
-      "destination": "/dist/docs/3.1.2/creative/task-reference/list_transformers",
+      "destination": "/dist/docs/3.1.19/creative/task-reference/list_creative_formats",
       "permanent": false
     },
     {
       "source": "/docs/creative/task-reference/list_creatives",
-      "destination": "/dist/docs/3.1.2/creative/task-reference/list_creatives",
+      "destination": "/dist/docs/3.1.19/creative/task-reference/list_creatives",
       "permanent": false
     },
     {
       "source": "/docs/creative/task-reference/sync_creatives",
-      "destination": "/dist/docs/3.1.2/creative/task-reference/sync_creatives",
+      "destination": "/dist/docs/3.1.19/creative/task-reference/sync_creatives",
       "permanent": false
     },
     {
       "source": "/docs/creative/task-reference/get_creative_delivery",
-      "destination": "/dist/docs/3.1.2/creative/task-reference/get_creative_delivery",
+      "destination": "/dist/docs/3.1.19/creative/task-reference/get_creative_delivery",
       "permanent": false
     },
     {
       "source": "/docs/governance/overview",
-      "destination": "/dist/docs/3.1.2/governance/overview",
+      "destination": "/dist/docs/3.1.19/governance/overview",
       "permanent": false
     },
     {
       "source": "/docs/governance/rfc-process",
-      "destination": "/dist/docs/3.1.2/governance/rfc-process",
+      "destination": "/dist/docs/3.1.19/governance/rfc-process",
       "permanent": false
     },
     {
       "source": "/docs/governance/embedded-human-judgment",
-      "destination": "/dist/docs/3.1.2/governance/embedded-human-judgment",
+      "destination": "/dist/docs/3.1.19/governance/embedded-human-judgment",
       "permanent": false
     },
     {
       "source": "/docs/governance/policy-registry",
-      "destination": "/dist/docs/3.1.2/governance/policy-registry",
+      "destination": "/dist/docs/3.1.19/governance/policy-registry",
       "permanent": false
     },
     {
       "source": "/docs/governance/policy-registry-sync",
-      "destination": "/dist/docs/3.1.2/governance/policy-registry-sync",
+      "destination": "/dist/docs/3.1.19/governance/policy-registry-sync",
       "permanent": false
     },
     {
       "source": "/docs/governance/policy-attribution",
-      "destination": "/dist/docs/3.1.2/governance/policy-attribution",
+      "destination": "/dist/docs/3.1.19/governance/policy-attribution",
       "permanent": false
     },
     {
       "source": "/docs/governance/annex-iii-obligations",
-      "destination": "/dist/docs/3.1.2/governance/annex-iii-obligations",
+      "destination": "/dist/docs/3.1.19/governance/annex-iii-obligations",
       "permanent": false
     },
     {
       "source": "/docs/governance/working-group-charter",
-      "destination": "/dist/docs/3.1.2/governance/working-group-charter",
+      "destination": "/dist/docs/3.1.19/governance/working-group-charter",
       "permanent": false
     },
     {
       "source": "/docs/governance/property/index",
-      "destination": "/dist/docs/3.1.2/governance/property/index",
+      "destination": "/dist/docs/3.1.19/governance/property/index",
       "permanent": false
     },
     {
       "source": "/docs/governance/property/adagents",
-      "destination": "/dist/docs/3.1.2/governance/property/adagents",
+      "destination": "/dist/docs/3.1.19/governance/property/adagents",
       "permanent": false
     },
     {
       "source": "/docs/governance/property/managed-networks",
-      "destination": "/dist/docs/3.1.2/governance/property/managed-networks",
+      "destination": "/dist/docs/3.1.19/governance/property/managed-networks",
       "permanent": false
     },
     {
       "source": "/docs/governance/property/authorized-properties",
-      "destination": "/dist/docs/3.1.2/governance/property/authorized-properties",
+      "destination": "/dist/docs/3.1.19/governance/property/authorized-properties",
       "permanent": false
     },
     {
       "source": "/docs/governance/property/specification",
-      "destination": "/dist/docs/3.1.2/governance/property/specification",
+      "destination": "/dist/docs/3.1.19/governance/property/specification",
       "permanent": false
     },
     {
       "source": "/docs/governance/property/tasks/index",
-      "destination": "/dist/docs/3.1.2/governance/property/tasks/index",
+      "destination": "/dist/docs/3.1.19/governance/property/tasks/index",
       "permanent": false
     },
     {
       "source": "/docs/governance/property/tasks/property_lists",
-      "destination": "/dist/docs/3.1.2/governance/property/tasks/property_lists",
+      "destination": "/dist/docs/3.1.19/governance/property/tasks/property_lists",
       "permanent": false
     },
     {
       "source": "/docs/governance/property/tasks/validate_property_delivery",
-      "destination": "/dist/docs/3.1.2/governance/property/tasks/validate_property_delivery",
+      "destination": "/dist/docs/3.1.19/governance/property/tasks/validate_property_delivery",
       "permanent": false
     },
     {
       "source": "/docs/governance/collection/index",
-      "destination": "/dist/docs/3.1.2/governance/collection/index",
+      "destination": "/dist/docs/3.1.19/governance/collection/index",
       "permanent": false
     },
     {
       "source": "/docs/governance/collection/tasks/collection_lists",
-      "destination": "/dist/docs/3.1.2/governance/collection/tasks/collection_lists",
+      "destination": "/dist/docs/3.1.19/governance/collection/tasks/collection_lists",
       "permanent": false
     },
     {
       "source": "/docs/governance/content-standards/index",
-      "destination": "/dist/docs/3.1.2/governance/content-standards/index",
+      "destination": "/dist/docs/3.1.19/governance/content-standards/index",
       "permanent": false
     },
     {
       "source": "/docs/governance/content-standards/artifacts",
-      "destination": "/dist/docs/3.1.2/governance/content-standards/artifacts",
+      "destination": "/dist/docs/3.1.19/governance/content-standards/artifacts",
       "permanent": false
     },
     {
       "source": "/docs/governance/content-standards/implementation-guide",
-      "destination": "/dist/docs/3.1.2/governance/content-standards/implementation-guide",
+      "destination": "/dist/docs/3.1.19/governance/content-standards/implementation-guide",
       "permanent": false
     },
     {
       "source": "/docs/governance/content-standards/tasks/list_content_standards",
-      "destination": "/dist/docs/3.1.2/governance/content-standards/tasks/list_content_standards",
+      "destination": "/dist/docs/3.1.19/governance/content-standards/tasks/list_content_standards",
       "permanent": false
     },
     {
       "source": "/docs/governance/content-standards/tasks/get_content_standards",
-      "destination": "/dist/docs/3.1.2/governance/content-standards/tasks/get_content_standards",
+      "destination": "/dist/docs/3.1.19/governance/content-standards/tasks/get_content_standards",
       "permanent": false
     },
     {
       "source": "/docs/governance/content-standards/tasks/create_content_standards",
-      "destination": "/dist/docs/3.1.2/governance/content-standards/tasks/create_content_standards",
+      "destination": "/dist/docs/3.1.19/governance/content-standards/tasks/create_content_standards",
       "permanent": false
     },
     {
       "source": "/docs/governance/content-standards/tasks/update_content_standards",
-      "destination": "/dist/docs/3.1.2/governance/content-standards/tasks/update_content_standards",
+      "destination": "/dist/docs/3.1.19/governance/content-standards/tasks/update_content_standards",
       "permanent": false
     },
     {
       "source": "/docs/governance/content-standards/tasks/calibrate_content",
-      "destination": "/dist/docs/3.1.2/governance/content-standards/tasks/calibrate_content",
+      "destination": "/dist/docs/3.1.19/governance/content-standards/tasks/calibrate_content",
       "permanent": false
     },
     {
       "source": "/docs/governance/content-standards/tasks/get_media_buy_artifacts",
-      "destination": "/dist/docs/3.1.2/governance/content-standards/tasks/get_media_buy_artifacts",
+      "destination": "/dist/docs/3.1.19/governance/content-standards/tasks/get_media_buy_artifacts",
       "permanent": false
     },
     {
       "source": "/docs/governance/content-standards/tasks/validate_content_delivery",
-      "destination": "/dist/docs/3.1.2/governance/content-standards/tasks/validate_content_delivery",
+      "destination": "/dist/docs/3.1.19/governance/content-standards/tasks/validate_content_delivery",
       "permanent": false
     },
     {
       "source": "/docs/governance/creative/index",
-      "destination": "/dist/docs/3.1.2/governance/creative/index",
+      "destination": "/dist/docs/3.1.19/governance/creative/index",
       "permanent": false
     },
     {
       "source": "/docs/governance/creative/get_creative_features",
-      "destination": "/dist/docs/3.1.2/governance/creative/get_creative_features",
+      "destination": "/dist/docs/3.1.19/governance/creative/get_creative_features",
       "permanent": false
     },
     {
       "source": "/docs/governance/creative/provenance-verification",
-      "destination": "/dist/docs/3.1.2/governance/creative/provenance-verification",
+      "destination": "/dist/docs/3.1.19/governance/creative/provenance-verification",
       "permanent": false
     },
     {
       "source": "/docs/governance/campaign/index",
-      "destination": "/dist/docs/3.1.2/governance/campaign/index",
-      "permanent": false
-    },
-    {
-      "source": "/docs/governance/campaign/responsibilities",
-      "destination": "/dist/docs/3.1.2/governance/campaign/responsibilities",
+      "destination": "/dist/docs/3.1.19/governance/campaign/index",
       "permanent": false
     },
     {
       "source": "/docs/governance/campaign/safety-model",
-      "destination": "/dist/docs/3.1.2/governance/campaign/safety-model",
+      "destination": "/dist/docs/3.1.19/governance/campaign/safety-model",
       "permanent": false
     },
     {
       "source": "/docs/governance/campaign/specification",
-      "destination": "/dist/docs/3.1.2/governance/campaign/specification",
+      "destination": "/dist/docs/3.1.19/governance/campaign/specification",
       "permanent": false
     },
     {
       "source": "/docs/governance/campaign/audit-trail",
-      "destination": "/dist/docs/3.1.2/governance/campaign/audit-trail",
+      "destination": "/dist/docs/3.1.19/governance/campaign/audit-trail",
       "permanent": false
     },
     {
       "source": "/docs/governance/campaign/tasks/index",
-      "destination": "/dist/docs/3.1.2/governance/campaign/tasks/index",
+      "destination": "/dist/docs/3.1.19/governance/campaign/tasks/index",
       "permanent": false
     },
     {
       "source": "/docs/governance/campaign/tasks/sync_plans",
-      "destination": "/dist/docs/3.1.2/governance/campaign/tasks/sync_plans",
+      "destination": "/dist/docs/3.1.19/governance/campaign/tasks/sync_plans",
       "permanent": false
     },
     {
       "source": "/docs/governance/campaign/tasks/report_plan_outcome",
-      "destination": "/dist/docs/3.1.2/governance/campaign/tasks/report_plan_outcome",
+      "destination": "/dist/docs/3.1.19/governance/campaign/tasks/report_plan_outcome",
       "permanent": false
     },
     {
       "source": "/docs/governance/campaign/tasks/check_governance",
-      "destination": "/dist/docs/3.1.2/governance/campaign/tasks/check_governance",
+      "destination": "/dist/docs/3.1.19/governance/campaign/tasks/check_governance",
       "permanent": false
     },
     {
       "source": "/docs/governance/campaign/tasks/get_plan_audit_logs",
-      "destination": "/dist/docs/3.1.2/governance/campaign/tasks/get_plan_audit_logs",
+      "destination": "/dist/docs/3.1.19/governance/campaign/tasks/get_plan_audit_logs",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/overview",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/overview",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/overview",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/monetizing-ai",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/monetizing-ai",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/monetizing-ai",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/product-spectrum",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/product-spectrum",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/product-spectrum",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/networks",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/networks",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/networks",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/workflow",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/workflow",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/workflow",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/measurement",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/measurement",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/measurement",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/si-chat-protocol",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/si-chat-protocol",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/si-chat-protocol",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/implementing-si-agents",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/implementing-si-agents",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/implementing-si-agents",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/implementing-si-hosts",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/implementing-si-hosts",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/implementing-si-hosts",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/specification",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/specification",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/specification",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/tasks/index",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/tasks/index",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/tasks/index",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/tasks/si_get_offering",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/tasks/si_get_offering",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/tasks/si_get_offering",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/tasks/si_initiate_session",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/tasks/si_initiate_session",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/tasks/si_initiate_session",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/tasks/si_send_message",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/tasks/si_send_message",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/tasks/si_send_message",
       "permanent": false
     },
     {
       "source": "/docs/sponsored-intelligence/tasks/si_terminate_session",
-      "destination": "/dist/docs/3.1.2/sponsored-intelligence/tasks/si_terminate_session",
+      "destination": "/dist/docs/3.1.19/sponsored-intelligence/tasks/si_terminate_session",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/index",
-      "destination": "/dist/docs/3.1.2/brand-protocol/index",
+      "destination": "/dist/docs/3.1.19/brand-protocol/index",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/key-concepts",
-      "destination": "/dist/docs/3.1.2/brand-protocol/key-concepts",
+      "destination": "/dist/docs/3.1.19/brand-protocol/key-concepts",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/walkthrough-rights-licensing",
-      "destination": "/dist/docs/3.1.2/brand-protocol/walkthrough-rights-licensing",
+      "destination": "/dist/docs/3.1.19/brand-protocol/walkthrough-rights-licensing",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/for-advertisers",
-      "destination": "/dist/docs/3.1.2/brand-protocol/for-advertisers",
+      "destination": "/dist/docs/3.1.19/brand-protocol/for-advertisers",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/for-rights-holders",
-      "destination": "/dist/docs/3.1.2/brand-protocol/for-rights-holders",
+      "destination": "/dist/docs/3.1.19/brand-protocol/for-rights-holders",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/seller-setup",
-      "destination": "/dist/docs/3.1.2/brand-protocol/seller-setup",
+      "destination": "/dist/docs/3.1.19/brand-protocol/seller-setup",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/brand-json",
-      "destination": "/dist/docs/3.1.2/brand-protocol/brand-json",
+      "destination": "/dist/docs/3.1.19/brand-protocol/brand-json",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/building-a-brand-agent",
-      "destination": "/dist/docs/3.1.2/brand-protocol/building-a-brand-agent",
+      "destination": "/dist/docs/3.1.19/brand-protocol/building-a-brand-agent",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/ui-guidance",
-      "destination": "/dist/docs/3.1.2/brand-protocol/ui-guidance",
+      "destination": "/dist/docs/3.1.19/brand-protocol/ui-guidance",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/tasks/get_brand_identity",
-      "destination": "/dist/docs/3.1.2/brand-protocol/tasks/get_brand_identity",
+      "destination": "/dist/docs/3.1.19/brand-protocol/tasks/get_brand_identity",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/tasks/verify_brand_claim",
-      "destination": "/dist/docs/3.1.2/brand-protocol/tasks/verify_brand_claim",
+      "destination": "/dist/docs/3.1.19/brand-protocol/tasks/verify_brand_claim",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/tasks/verify_brand_claims",
-      "destination": "/dist/docs/3.1.2/brand-protocol/tasks/verify_brand_claims",
+      "destination": "/dist/docs/3.1.19/brand-protocol/tasks/verify_brand_claims",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/tasks/get_rights",
-      "destination": "/dist/docs/3.1.2/brand-protocol/tasks/get_rights",
+      "destination": "/dist/docs/3.1.19/brand-protocol/tasks/get_rights",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/tasks/acquire_rights",
-      "destination": "/dist/docs/3.1.2/brand-protocol/tasks/acquire_rights",
+      "destination": "/dist/docs/3.1.19/brand-protocol/tasks/acquire_rights",
       "permanent": false
     },
     {
       "source": "/docs/brand-protocol/tasks/update_rights",
-      "destination": "/dist/docs/3.1.2/brand-protocol/tasks/update_rights",
+      "destination": "/dist/docs/3.1.19/brand-protocol/tasks/update_rights",
       "permanent": false
     },
     {
       "source": "/docs/signals/overview",
-      "destination": "/dist/docs/3.1.2/signals/overview",
+      "destination": "/dist/docs/3.1.19/signals/overview",
       "permanent": false
     },
     {
       "source": "/docs/signals/key-concepts",
-      "destination": "/dist/docs/3.1.2/signals/key-concepts",
+      "destination": "/dist/docs/3.1.19/signals/key-concepts",
       "permanent": false
     },
     {
       "source": "/docs/signals/ecosystem",
-      "destination": "/dist/docs/3.1.2/signals/ecosystem",
+      "destination": "/dist/docs/3.1.19/signals/ecosystem",
       "permanent": false
     },
     {
       "source": "/docs/signals/data-providers",
-      "destination": "/dist/docs/3.1.2/signals/data-providers",
+      "destination": "/dist/docs/3.1.19/signals/data-providers",
       "permanent": false
     },
     {
       "source": "/docs/signals/specification",
-      "destination": "/dist/docs/3.1.2/signals/specification",
+      "destination": "/dist/docs/3.1.19/signals/specification",
       "permanent": false
     },
     {
       "source": "/docs/signals/tasks/get_signals",
-      "destination": "/dist/docs/3.1.2/signals/tasks/get_signals",
+      "destination": "/dist/docs/3.1.19/signals/tasks/get_signals",
       "permanent": false
     },
     {
       "source": "/docs/signals/tasks/activate_signal",
-      "destination": "/dist/docs/3.1.2/signals/tasks/activate_signal",
+      "destination": "/dist/docs/3.1.19/signals/tasks/activate_signal",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/index",
-      "destination": "/dist/docs/3.1.2/trusted-match/index",
+      "destination": "/dist/docs/3.1.19/trusted-match/index",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/ai-mediation",
-      "destination": "/dist/docs/3.1.2/trusted-match/ai-mediation",
+      "destination": "/dist/docs/3.1.19/trusted-match/ai-mediation",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/buyer-guide",
-      "destination": "/dist/docs/3.1.2/trusted-match/buyer-guide",
+      "destination": "/dist/docs/3.1.19/trusted-match/buyer-guide",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/execution-gap",
-      "destination": "/dist/docs/3.1.2/trusted-match/execution-gap",
+      "destination": "/dist/docs/3.1.19/trusted-match/execution-gap",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/context-and-identity",
-      "destination": "/dist/docs/3.1.2/trusted-match/context-and-identity",
+      "destination": "/dist/docs/3.1.19/trusted-match/context-and-identity",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/specification",
-      "destination": "/dist/docs/3.1.2/trusted-match/specification",
+      "destination": "/dist/docs/3.1.19/trusted-match/specification",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/router-architecture",
-      "destination": "/dist/docs/3.1.2/trusted-match/router-architecture",
+      "destination": "/dist/docs/3.1.19/trusted-match/router-architecture",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/privacy-architecture",
-      "destination": "/dist/docs/3.1.2/trusted-match/privacy-architecture",
+      "destination": "/dist/docs/3.1.19/trusted-match/privacy-architecture",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/data-protection-roles",
-      "destination": "/dist/docs/3.1.2/trusted-match/data-protection-roles",
+      "destination": "/dist/docs/3.1.19/trusted-match/data-protection-roles",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/migration-from-axe",
-      "destination": "/dist/docs/3.1.2/trusted-match/migration-from-axe",
+      "destination": "/dist/docs/3.1.19/trusted-match/migration-from-axe",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/surfaces/web",
-      "destination": "/dist/docs/3.1.2/trusted-match/surfaces/web",
+      "destination": "/dist/docs/3.1.19/trusted-match/surfaces/web",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/surfaces/ctv",
-      "destination": "/dist/docs/3.1.2/trusted-match/surfaces/ctv",
+      "destination": "/dist/docs/3.1.19/trusted-match/surfaces/ctv",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/surfaces/mobile",
-      "destination": "/dist/docs/3.1.2/trusted-match/surfaces/mobile",
+      "destination": "/dist/docs/3.1.19/trusted-match/surfaces/mobile",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/surfaces/retail-media",
-      "destination": "/dist/docs/3.1.2/trusted-match/surfaces/retail-media",
+      "destination": "/dist/docs/3.1.19/trusted-match/surfaces/retail-media",
       "permanent": false
     },
     {
       "source": "/docs/trusted-match/surfaces/ai-assistants",
-      "destination": "/dist/docs/3.1.2/trusted-match/surfaces/ai-assistants",
-      "permanent": false
-    },
-    {
-      "source": "/docs/aao/connect-addie",
-      "destination": "/dist/docs/3.1.2/aao/connect-addie",
-      "permanent": false
-    },
-    {
-      "source": "/docs/aao/aao-admins",
-      "destination": "/dist/docs/3.1.2/aao/aao-admins",
-      "permanent": false
-    },
-    {
-      "source": "/docs/aao/users",
-      "destination": "/dist/docs/3.1.2/aao/users",
-      "permanent": false
-    },
-    {
-      "source": "/docs/aao/org-admins",
-      "destination": "/dist/docs/3.1.2/aao/org-admins",
-      "permanent": false
-    },
-    {
-      "source": "/docs/aao/addie-tools",
-      "destination": "/dist/docs/3.1.2/aao/addie-tools",
-      "permanent": false
-    },
-    {
-      "source": "/docs/aao/directory-api",
-      "destination": "/dist/docs/3.1.2/aao/directory-api",
+      "destination": "/dist/docs/3.1.19/trusted-match/surfaces/ai-assistants",
       "permanent": false
     },
     {
       "source": "/docs/faq",
-      "destination": "/dist/docs/3.1.2/faq",
+      "destination": "/dist/docs/3.1.19/faq",
       "permanent": false
     },
     {
       "source": "/docs/trust",
-      "destination": "/dist/docs/3.1.2/trust",
+      "destination": "/dist/docs/3.1.19/trust",
       "permanent": false
     },
     {
       "source": "/docs/verification/overview",
-      "destination": "/dist/docs/3.1.2/verification/overview",
+      "destination": "/dist/docs/3.1.19/verification/overview",
       "permanent": false
     },
     {
       "source": "/docs/ai-disclosure",
-      "destination": "/dist/docs/3.1.2/ai-disclosure",
+      "destination": "/dist/docs/3.1.19/ai-disclosure",
       "permanent": false
     },
     {
       "source": "/docs/reference/privacy-considerations",
-      "destination": "/dist/docs/3.1.2/reference/privacy-considerations",
+      "destination": "/dist/docs/3.1.19/reference/privacy-considerations",
       "permanent": false
     },
     {
       "source": "/docs/reference/known-limitations",
-      "destination": "/dist/docs/3.1.2/reference/known-limitations",
+      "destination": "/dist/docs/3.1.19/reference/known-limitations",
       "permanent": false
     },
     {
       "source": "/docs/registry/index",
-      "destination": "/dist/docs/3.1.2/registry/index",
+      "destination": "/dist/docs/3.1.19/registry/index",
       "permanent": false
     },
     {
       "source": "/docs/registry/registering-an-agent",
-      "destination": "/dist/docs/3.1.2/registry/registering-an-agent",
+      "destination": "/dist/docs/3.1.19/registry/registering-an-agent",
       "permanent": false
     },
     {
       "source": "/docs/registry/maintaining-your-agent",
-      "destination": "/dist/docs/3.1.2/registry/maintaining-your-agent",
+      "destination": "/dist/docs/3.1.19/registry/maintaining-your-agent",
       "permanent": false
     },
     {
       "source": "/docs/reference/gmsf-reference",
-      "destination": "/dist/docs/3.1.2/reference/gmsf-reference",
+      "destination": "/dist/docs/3.1.19/reference/gmsf-reference",
       "permanent": false
     },
     {
       "source": "/docs/reference/media-channel-taxonomy",
-      "destination": "/dist/docs/3.1.2/reference/media-channel-taxonomy",
+      "destination": "/dist/docs/3.1.19/reference/media-channel-taxonomy",
       "permanent": false
     },
     {
       "source": "/docs/measurement/taxonomy",
-      "destination": "/dist/docs/3.1.2/measurement/taxonomy",
+      "destination": "/dist/docs/3.1.19/measurement/taxonomy",
       "permanent": false
     },
     {
       "source": "/docs/reference/roadmap",
-      "destination": "/dist/docs/3.1.2/reference/roadmap",
+      "destination": "/dist/docs/3.1.19/reference/roadmap",
       "permanent": false
     },
     {
       "source": "/docs/reference/versions",
-      "destination": "/dist/docs/3.1.2/reference/versions",
+      "destination": "/dist/docs/3.1.19/reference/versions",
       "permanent": false
     },
     {
       "source": "/docs/reference/versioning",
-      "destination": "/dist/docs/3.1.2/reference/versioning",
+      "destination": "/dist/docs/3.1.19/reference/versioning",
       "permanent": false
     },
     {
       "source": "/docs/reference/specification-lifecycle",
-      "destination": "/dist/docs/3.1.2/reference/specification-lifecycle",
+      "destination": "/dist/docs/3.1.19/reference/specification-lifecycle",
       "permanent": false
     },
     {
       "source": "/docs/reference/url-canonicalization",
-      "destination": "/dist/docs/3.1.2/reference/url-canonicalization",
+      "destination": "/dist/docs/3.1.19/reference/url-canonicalization",
       "permanent": false
     },
     {
       "source": "/docs/reference/verifying-protocol-tarballs",
-      "destination": "/dist/docs/3.1.2/reference/verifying-protocol-tarballs",
+      "destination": "/dist/docs/3.1.19/reference/verifying-protocol-tarballs",
       "permanent": false
     },
     {
       "source": "/docs/reference/test-vectors/index",
-      "destination": "/dist/docs/3.1.2/reference/test-vectors/index",
+      "destination": "/dist/docs/3.1.19/reference/test-vectors/index",
       "permanent": false
     },
     {
       "source": "/docs/reference/experimental-status",
-      "destination": "/dist/docs/3.1.2/reference/experimental-status",
+      "destination": "/dist/docs/3.1.19/reference/experimental-status",
       "permanent": false
     },
     {
       "source": "/docs/reference/schema-extensions",
-      "destination": "/dist/docs/3.1.2/reference/schema-extensions",
+      "destination": "/dist/docs/3.1.19/reference/schema-extensions",
       "permanent": false
     },
     {
       "source": "/docs/reference/v2-sunset",
-      "destination": "/dist/docs/3.1.2/reference/v2-sunset",
+      "destination": "/dist/docs/3.1.19/reference/v2-sunset",
       "permanent": false
     },
     {
       "source": "/docs/reference/release-notes",
-      "destination": "/dist/docs/3.1.2/reference/release-notes",
+      "destination": "/dist/docs/3.1.19/reference/release-notes",
       "permanent": false
     },
     {
       "source": "/docs/reference/changelog",
-      "destination": "/dist/docs/3.1.2/reference/changelog",
+      "destination": "/dist/docs/3.1.19/reference/changelog",
       "permanent": false
     },
     {
       "source": "/docs/reference/implementor-faq",
-      "destination": "/dist/docs/3.1.2/reference/implementor-faq",
+      "destination": "/dist/docs/3.1.19/reference/implementor-faq",
       "permanent": false
     },
     {
       "source": "/docs/reference/glossary",
-      "destination": "/dist/docs/3.1.2/reference/glossary",
+      "destination": "/dist/docs/3.1.19/reference/glossary",
       "permanent": false
     },
     {
       "source": "/docs/community/working-group",
-      "destination": "/dist/docs/3.1.2/community/working-group",
+      "destination": "/dist/docs/3.1.19/community/working-group",
       "permanent": false
     },
     {
       "source": "/docs/community/joining-slack",
-      "destination": "/dist/docs/3.1.2/community/joining-slack",
+      "destination": "/dist/docs/3.1.19/community/joining-slack",
       "permanent": false
     },
     {
       "source": "/docs/learning/overview",
-      "destination": "/dist/docs/3.1.2/learning/overview",
+      "destination": "/dist/docs/3.1.19/learning/overview",
       "permanent": false
     },
     {
       "source": "/docs/learning/instructional-design",
-      "destination": "/dist/docs/3.1.2/learning/instructional-design",
+      "destination": "/dist/docs/3.1.19/learning/instructional-design",
       "permanent": false
     },
     {
       "source": "/docs/learning/failure-mode-scope",
-      "destination": "/dist/docs/3.1.2/learning/failure-mode-scope",
+      "destination": "/dist/docs/3.1.19/learning/failure-mode-scope",
       "permanent": false
     },
     {
       "source": "/docs/learning/foundations/a1-agentic-advertising",
-      "destination": "/dist/docs/3.1.2/learning/foundations/a1-agentic-advertising",
+      "destination": "/dist/docs/3.1.19/learning/foundations/a1-agentic-advertising",
       "permanent": false
     },
     {
       "source": "/docs/learning/foundations/a2-protocol-architecture",
-      "destination": "/dist/docs/3.1.2/learning/foundations/a2-protocol-architecture",
+      "destination": "/dist/docs/3.1.19/learning/foundations/a2-protocol-architecture",
       "permanent": false
     },
     {
       "source": "/docs/learning/foundations/a2b-testing-your-first-agent",
-      "destination": "/dist/docs/3.1.2/learning/foundations/a2b-testing-your-first-agent",
+      "destination": "/dist/docs/3.1.19/learning/foundations/a2b-testing-your-first-agent",
       "permanent": false
     },
     {
       "source": "/docs/learning/foundations/a3-ecosystem-governance",
-      "destination": "/dist/docs/3.1.2/learning/foundations/a3-ecosystem-governance",
-      "permanent": false
-    },
-    {
-      "source": "/docs/learning/decision-makers/overview",
-      "destination": "/dist/docs/3.1.2/learning/decision-makers/overview",
-      "permanent": false
-    },
-    {
-      "source": "/docs/learning/decision-makers/l1-agentic-advertising",
-      "destination": "/dist/docs/3.1.2/learning/decision-makers/l1-agentic-advertising",
-      "permanent": false
-    },
-    {
-      "source": "/docs/learning/decision-makers/l2-data-brand-governance",
-      "destination": "/dist/docs/3.1.2/learning/decision-makers/l2-data-brand-governance",
-      "permanent": false
-    },
-    {
-      "source": "/docs/learning/decision-makers/l3-deciding-and-leading",
-      "destination": "/dist/docs/3.1.2/learning/decision-makers/l3-deciding-and-leading",
-      "permanent": false
-    },
-    {
-      "source": "/docs/learning/decision-makers/explaining-agentic-advertising",
-      "destination": "/dist/docs/3.1.2/learning/decision-makers/explaining-agentic-advertising",
+      "destination": "/dist/docs/3.1.19/learning/foundations/a3-ecosystem-governance",
       "permanent": false
     },
     {
       "source": "/docs/learning/tracks/publisher",
-      "destination": "/dist/docs/3.1.2/learning/tracks/publisher",
+      "destination": "/dist/docs/3.1.19/learning/tracks/publisher",
       "permanent": false
     },
     {
       "source": "/docs/learning/tracks/buyer",
-      "destination": "/dist/docs/3.1.2/learning/tracks/buyer",
+      "destination": "/dist/docs/3.1.19/learning/tracks/buyer",
       "permanent": false
     },
     {
       "source": "/docs/learning/tracks/platform",
-      "destination": "/dist/docs/3.1.2/learning/tracks/platform",
+      "destination": "/dist/docs/3.1.19/learning/tracks/platform",
       "permanent": false
     },
     {
       "source": "/docs/learning/specialist/media-buy",
-      "destination": "/dist/docs/3.1.2/learning/specialist/media-buy",
+      "destination": "/dist/docs/3.1.19/learning/specialist/media-buy",
       "permanent": false
     },
     {
       "source": "/docs/learning/specialist/creative",
-      "destination": "/dist/docs/3.1.2/learning/specialist/creative",
+      "destination": "/dist/docs/3.1.19/learning/specialist/creative",
       "permanent": false
     },
     {
       "source": "/docs/learning/specialist/signals",
-      "destination": "/dist/docs/3.1.2/learning/specialist/signals",
+      "destination": "/dist/docs/3.1.19/learning/specialist/signals",
       "permanent": false
     },
     {
       "source": "/docs/learning/specialist/governance",
-      "destination": "/dist/docs/3.1.2/learning/specialist/governance",
+      "destination": "/dist/docs/3.1.19/learning/specialist/governance",
       "permanent": false
     },
     {
       "source": "/docs/learning/specialist/sponsored-intelligence",
-      "destination": "/dist/docs/3.1.2/learning/specialist/sponsored-intelligence",
+      "destination": "/dist/docs/3.1.19/learning/specialist/sponsored-intelligence",
       "permanent": false
     },
     {
       "source": "/docs/learning/specialist/security",
-      "destination": "/dist/docs/3.1.2/learning/specialist/security",
-      "permanent": false
-    },
-    {
-      "source": "/docs/learning/specialist/brand",
-      "destination": "/dist/docs/3.1.2/learning/specialist/brand",
-      "permanent": false
-    },
-    {
-      "source": "/docs/learning/supplements/buyer-briefs-and-get-products",
-      "destination": "/dist/docs/3.1.2/learning/supplements/buyer-briefs-and-get-products",
-      "permanent": false
-    },
-    {
-      "source": "/docs/learning/supplements/governance-protocol-by-role",
-      "destination": "/dist/docs/3.1.2/learning/supplements/governance-protocol-by-role",
-      "permanent": false
-    },
-    {
-      "source": "/docs/learning/supplements/creative-agent-workflows",
-      "destination": "/dist/docs/3.1.2/learning/supplements/creative-agent-workflows",
+      "destination": "/dist/docs/3.1.19/learning/specialist/security",
       "permanent": false
     },
     {
       "source": "/docs/learning/policies/nondiscrimination",
-      "destination": "/dist/docs/3.1.2/learning/policies/nondiscrimination",
+      "destination": "/dist/docs/3.1.19/learning/policies/nondiscrimination",
       "permanent": false
     },
     {
       "source": "/docs/learning/policies/learner-records",
-      "destination": "/dist/docs/3.1.2/learning/policies/learner-records",
+      "destination": "/dist/docs/3.1.19/learning/policies/learner-records",
       "permanent": false
     },
     {
       "source": "/docs/learning/policies/recertification",
-      "destination": "/dist/docs/3.1.2/learning/policies/recertification",
+      "destination": "/dist/docs/3.1.19/learning/policies/recertification",
       "permanent": false
     },
     {
       "source": "/docs/learning/policies/complaints",
-      "destination": "/dist/docs/3.1.2/learning/policies/complaints",
+      "destination": "/dist/docs/3.1.19/learning/policies/complaints",
       "permanent": false
     },
     {
       "source": "/docs/learning/policies/conflict-of-interest",
-      "destination": "/dist/docs/3.1.2/learning/policies/conflict-of-interest",
+      "destination": "/dist/docs/3.1.19/learning/policies/conflict-of-interest",
       "permanent": false
     },
     {
       "source": "/docs/learning/policies/intellectual-property",
-      "destination": "/dist/docs/3.1.2/learning/policies/intellectual-property",
+      "destination": "/dist/docs/3.1.19/learning/policies/intellectual-property",
       "permanent": false
     },
     {
       "source": "/docs/learning/policies/personnel-qualifications",
-      "destination": "/dist/docs/3.1.2/learning/policies/personnel-qualifications",
+      "destination": "/dist/docs/3.1.19/learning/policies/personnel-qualifications",
       "permanent": false
     },
     {
       "source": "/docs/learning/policies/refund",
-      "destination": "/dist/docs/3.1.2/learning/policies/refund",
+      "destination": "/dist/docs/3.1.19/learning/policies/refund",
       "permanent": false
     },
     {

--- a/docs/aao/addie-tools.mdx
+++ b/docs/aao/addie-tools.mdx
@@ -20,15 +20,15 @@ Search documentation, code repos, Slack history, curated resources, GitHub issue
 
 ### `search_docs`
 
-Search the AdCP documentation for relevant content. Use this to answer questions about AdCP, the protocol, tools, or how things work.
+Search official AdCP docs, extracted schema facts, and working group documents. Protocol results are isolated by release and always name their version. Pass version when the user names one; omission means stable, never beta. Website and working group results are version-independent. Use one specific query. Verify exact fields and enums with get_schema at the same version, use list_schemas for schema availability, and use get_doc for full content.
 
-*Source: `server/src/addie/mcp/docs-search.ts`*
+*Source: `server/src/addie/mcp/knowledge-search.ts`*
 
 ### `get_doc`
 
-Get the full content of a specific documentation page. Use this after search_docs to read a document in detail.
+Get the full content of a specific documentation page by ID. Canonical IDs returned by search_docs already include the version. For a legacy unversioned ID, pass version; omitted version means stable default.
 
-*Source: `server/src/addie/mcp/docs-search.ts`*
+*Source: `server/src/addie/mcp/knowledge-search.ts`*
 
 ### `search_slack`
 
@@ -300,7 +300,7 @@ Save a brand to the registry as a community brand. Use for manually adding brand
 
 ### `list_brands`
 
-List brands in the registry with optional filters. Can filter by source type and search by name or domain.
+List brands in the registry with optional filters and cached relationship trust state. Can filter by source type and search by name or domain.
 
 *Source: `server/src/addie/mcp/brand-tools.ts`*
 
@@ -1363,7 +1363,7 @@ Mark modules as tested out after a placement assessment confirms the learner alr
 
 ### `start_certification_exam`
 
-Begin an available specialist deep dive module (S1: Media Buy, S2: Creative, S3: Signals, S4: Governance, S6: Security). S5 Sponsored Intelligence is listed in the curriculum but is not assessable until its sandbox labs exist. The learner must hold the Practitioner credential. Returns the capstone format, lab exercises, and assessment criteria. You (Sage) will conduct the combined hands-on lab and adaptive exam — technically assess the learner against the spec.
+Begin an available specialist deep dive module (S1: Media Buy, S2: Creative, S3: Signals, S4: Governance, S5: Sponsored Intelligence, S6: Security). The learner must hold the Practitioner credential. Returns the capstone format, lab exercises, and assessment criteria. You (Sage) will conduct the combined hands-on lab and adaptive exam — technically assess the learner against the spec.
 
 *Source: `server/src/addie/mcp/certification-tools.ts`*
 
@@ -1651,9 +1651,9 @@ on file (set via the dashboard or invite-acceptance flow).
 
 ### `get_billing_portal`
 
-Get a link to the Stripe Customer Portal where the member can view invoices, download receipts, update payment methods, and manage their subscription.
-Use this when a member asks about receipts, invoices, billing history, payment methods, or subscription management.
-The member must be signed in.
+Get a link to the Stripe Customer Portal where an organization owner or admin can view invoices, download receipts, update payment methods, and manage the subscription.
+Use this when an owner or admin asks about receipts, invoices, billing history, payment methods, or subscription management.
+The user must be signed in and have an active owner or admin role in the selected organization.
 
 *Source: `server/src/addie/mcp/billing-tools.ts`*
 

--- a/scripts/build-addie-tool-reference.ts
+++ b/scripts/build-addie-tool-reference.ts
@@ -2,8 +2,8 @@
 /**
  * Build the Addie tool-reference page.
  *
- * Walks `server/src/addie/mcp/*-tools.ts` (plus `knowledge-search.ts`,
- * `docs-search.ts`) for AddieTool definitions, cross-references them against
+ * Walks `server/src/addie/mcp/*-tools.ts` (plus the actively registered
+ * `knowledge-search.ts`) for AddieTool definitions, cross-references them against
  * the curated TOOL_SETS in `server/src/addie/tool-sets.ts`, and writes the
  * combined reference to `docs/aao/addie-tools.mdx`.
  *
@@ -352,10 +352,11 @@ export const ADDIE_TOOL_CATALOG = \`${escaped}\`;
 function main() {
   const checkMode = process.argv.includes('--check');
 
-  // Discover all *-tools.ts files plus the two non-suffix files that also
-  // export tool arrays.
+  // Discover all *-tools.ts files plus the active non-suffix search module.
+  // docs-search.ts is a legacy, unregistered implementation whose duplicate
+  // search_docs/get_doc names must not override the runtime definitions.
   const toolFiles = fs.readdirSync(MCP_DIR)
-    .filter(f => f.endsWith('-tools.ts') || f === 'knowledge-search.ts' || f === 'docs-search.ts')
+    .filter(f => f.endsWith('-tools.ts') || f === 'knowledge-search.ts')
     .map(f => path.join(MCP_DIR, f))
     .sort();
 

--- a/scripts/smoke-docs-index-runtime.mjs
+++ b/scripts/smoke-docs-index-runtime.mjs
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const APP_ROOT = process.env.DOCS_SMOKE_APP_ROOT || '/app';
+const DOCS_CONFIG_PATH = path.join(APP_ROOT, 'docs.json');
+const DOCS_INDEXER_PATH = pathToFileURL(
+  path.join(APP_ROOT, 'dist/addie/mcp/docs-indexer.js'),
+).href;
+
+function collectStrings(value, results = []) {
+  if (typeof value === 'string') {
+    results.push(value);
+  } else if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, results);
+  } else if (value && typeof value === 'object') {
+    for (const item of Object.values(value)) collectStrings(item, results);
+  }
+  return results;
+}
+
+function collectNavigationPages(value, results = []) {
+  if (typeof value === 'string') {
+    results.push(value);
+  } else if (Array.isArray(value)) {
+    for (const item of value) collectNavigationPages(item, results);
+  } else if (value && typeof value === 'object' && Array.isArray(value.pages)) {
+    collectNavigationPages(value.pages, results);
+  }
+  return results;
+}
+
+function findJsonFiles(directory) {
+  const files = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...findJsonFiles(entryPath));
+    } else if (entry.isFile() && entry.name.endsWith('.json')) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+function findIndexedSchema(getDocById, expected) {
+  for (const schemaFile of findJsonFiles(expected.schemasDirectory)) {
+    const schemaPath = path.relative(expected.schemasDirectory, schemaFile)
+      .replaceAll(path.sep, '/')
+      .replace(/\.json$/, '');
+    const indexedSchema = getDocById(
+      `schema:${expected.version}:${schemaPath}`,
+      { version: expected.version },
+    );
+    if (indexedSchema) return indexedSchema;
+  }
+  return null;
+}
+
+assert.ok(fs.existsSync(DOCS_CONFIG_PATH), 'The runtime image must contain /app/docs.json');
+
+const config = JSON.parse(fs.readFileSync(DOCS_CONFIG_PATH, 'utf8'));
+const configuredVersions = config.navigation?.versions;
+assert.ok(
+  Array.isArray(configuredVersions) && configuredVersions.length > 0,
+  'docs.json must configure navigation versions',
+);
+
+const expectedVersions = configuredVersions.map((entry) => {
+  const searchRoutes = collectStrings(entry.groups).filter((value) => value.startsWith('dist/docs/'));
+  const artifacts = new Set(
+    searchRoutes.map((page) => page.match(/^dist\/docs\/([^/]+)\//)?.[1]).filter(Boolean),
+  );
+  assert.equal(
+    artifacts.size,
+    1,
+    `Docs version ${entry.version ?? '<unnamed>'} must select exactly one snapshot`,
+  );
+
+  const artifactVersion = [...artifacts][0];
+  const version = String(entry.version).replace(/\s*\(archived\)\s*$/i, '');
+  const pagePaths = collectNavigationPages(entry.groups)
+    .filter((value) => value.startsWith(`dist/docs/${artifactVersion}/`))
+    .map((page) => page
+    .replace(`dist/docs/${artifactVersion}/`, '')
+    .replace(/\.(md|mdx)$/, ''));
+
+  const docsDirectory = path.join(APP_ROOT, 'dist/docs', artifactVersion);
+  const schemasDirectory = path.join(APP_ROOT, 'dist/schemas', artifactVersion);
+  assert.ok(
+    fs.existsSync(docsDirectory) && fs.statSync(docsDirectory).isDirectory(),
+    `Missing runtime docs snapshot ${artifactVersion}`,
+  );
+
+  for (const pagePath of pagePaths) {
+    assert.ok(
+      fs.existsSync(path.join(docsDirectory, `${pagePath}.mdx`))
+        || fs.existsSync(path.join(docsDirectory, `${pagePath}.md`)),
+      `Runtime snapshot ${artifactVersion} is missing configured page ${pagePath}`,
+    );
+  }
+  assert.ok(
+    fs.existsSync(schemasDirectory) && fs.statSync(schemasDirectory).isDirectory(),
+    `Missing runtime schema snapshot ${artifactVersion}`,
+  );
+
+  return { version, artifactVersion, pagePaths, schemasDirectory };
+});
+
+const {
+  getDocById,
+  getSupportedDocsVersions,
+  initializeDocsIndex,
+  isDocsIndexReady,
+} = await import(DOCS_INDEXER_PATH);
+
+await initializeDocsIndex();
+assert.equal(isDocsIndexReady(), true, 'The compiled docs indexer did not become ready');
+
+const runtimeVersions = getSupportedDocsVersions();
+assert.equal(
+  runtimeVersions.length,
+  expectedVersions.length,
+  'The runtime indexer did not load every docs.json version',
+);
+
+for (const expected of expectedVersions) {
+  const runtimeVersion = runtimeVersions.find((item) => item.version === expected.version);
+  assert.ok(runtimeVersion, `The runtime index is missing docs version ${expected.version}`);
+  assert.equal(runtimeVersion.artifactVersion, expected.artifactVersion);
+
+  const indexedDoc = expected.pagePaths
+    .map((pagePath) => getDocById(`doc:${expected.version}:${pagePath}`, { version: expected.version }))
+    .find(Boolean);
+  assert.ok(indexedDoc, `Snapshot ${expected.artifactVersion} produced no indexed documentation`);
+  assert.equal(indexedDoc.artifactVersion, expected.artifactVersion);
+
+  const indexedSchema = findIndexedSchema(getDocById, expected);
+  assert.ok(indexedSchema, `Snapshot ${expected.artifactVersion} produced no indexed schemas`);
+  assert.equal(indexedSchema.artifactVersion, expected.artifactVersion);
+
+  console.log(
+    `Indexed ${expected.version} from snapshot ${expected.artifactVersion}: `
+      + `${indexedDoc.id}, ${indexedSchema.id}`,
+  );
+}
+
+console.log(`Runtime docs index smoke passed for ${expectedVersions.length} configured versions.`);

--- a/server/src/addie/mcp/docs-indexer.ts
+++ b/server/src/addie/mcp/docs-indexer.ts
@@ -41,6 +41,22 @@ export interface IndexedDoc {
   path: string;
   content: string;
   sourceUrl: string;
+  /** Protocol version this content describes. Undefined means version-independent. */
+  version?: string;
+  /** Frozen release directory backing this result (for example, 3.1.19). */
+  artifactVersion?: string;
+}
+
+export interface DocsVersion {
+  /** Public version selector used by Mintlify and Addie's tools. */
+  version: string;
+  /** Exact frozen dist/docs and dist/schemas snapshot. */
+  artifactVersion: string;
+  displayName: string;
+  isDefault: boolean;
+  isArchived: boolean;
+  /** Logical doc paths present in this version's public navigation. */
+  pagePaths: Set<string>;
 }
 
 /**
@@ -62,6 +78,13 @@ export interface IndexedHeading {
 let docsIndex: IndexedDoc[] = [];
 let headingsIndex: IndexedHeading[] = [];
 let initialized = false;
+let docsVersions: DocsVersion[] = [];
+let errorCodesByDocsVersion = new Map<string, Set<string> | null>();
+let allKnownErrorCodes = new Set<string>();
+
+// These describe the organization and community rather than a protocol release.
+// Keep their live copies searchable alongside every protocol version.
+const VERSION_INDEPENDENT_DOC_PREFIXES = ['aao/', 'community/', 'contributing/'];
 
 /**
  * Generate a URL-safe anchor slug from heading text
@@ -464,7 +487,12 @@ function schemaTitle(schema: JsonObject, relativePath: string): string {
     .replace(/\b\w/g, (character) => character.toUpperCase());
 }
 
-function indexSchemaFiles(schemaRoot: string): IndexedDoc[] {
+function indexSchemaFiles(
+  schemaRoot: string,
+  version: string,
+  artifactVersion: string,
+  unavailableErrorCodePattern: RegExp | null,
+): IndexedDoc[] {
   const indexed: IndexedDoc[] = [];
 
   for (const filePath of findJsonFiles(schemaRoot)) {
@@ -475,16 +503,21 @@ function indexSchemaFiles(schemaRoot: string): IndexedDoc[] {
       const schema = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as unknown;
       if (!isJsonObject(schema)) continue;
 
-      const content = extractSchemaContent(schema);
+      const content = removeUnavailableErrorCodeLines(
+        extractSchemaContent(schema),
+        unavailableErrorCodePattern,
+      );
       if (!content) continue;
 
       indexed.push({
-        id: `schema:${relativePath.replace(/\.json$/, '')}`,
+        id: `schema:${version}:${relativePath.replace(/\.json$/, '')}`,
         title: schemaTitle(schema, relativePath),
         category: 'schema',
         path: relativePath,
         content,
-        sourceUrl: `https://adcontextprotocol.org/schemas/latest/${relativePath}`,
+        sourceUrl: `https://adcontextprotocol.org/schemas/${artifactVersion}/${relativePath}`,
+        version,
+        artifactVersion,
       });
     } catch (error) {
       logger.warn({ error, filePath }, 'Addie Docs: Failed to index schema');
@@ -495,18 +528,127 @@ function indexSchemaFiles(schemaRoot: string): IndexedDoc[] {
 }
 
 /**
- * Build source URL from file path
- * Mintlify serves docs at /docs/ prefix (e.g., /docs/protocols/core-concepts)
+ * Build a source URL for live, version-independent operational docs.
+ * Mintlify's clean /docs routes redirect to the stable frozen snapshot, which
+ * may not contain the live body Addie indexed. Link to the canonical source so
+ * citations always open the exact content returned by search.
  */
 function buildSourceUrl(filePath: string, docsRoot: string): string {
-  const relativePath = path.relative(docsRoot, filePath);
-  // Remove extension and convert to URL path
+  const urlPath = path.relative(docsRoot, filePath).replace(/\\/g, '/');
+
+  return `https://github.com/adcontextprotocol/adcp/blob/main/docs/${urlPath}`;
+}
+
+function buildVersionedSourceUrl(relativePath: string, artifactVersion: string): string {
   const urlPath = relativePath
     .replace(/\.(md|mdx)$/, '')
     .replace(/\/index$/, '')
     .replace(/\\/g, '/');
 
-  return `https://docs.adcontextprotocol.org/docs/${urlPath}`;
+  return `https://docs.adcontextprotocol.org/dist/docs/${artifactVersion}/${urlPath}`;
+}
+
+function findFirstExistingPath(candidates: string[]): string | null {
+  return candidates.find((candidate) => fs.existsSync(candidate)) || null;
+}
+
+function collectNavigationPagePaths(value: unknown, artifactVersions: Set<string>): Set<string> {
+  const paths = new Set<string>();
+
+  const visit = (node: unknown): void => {
+    if (typeof node === 'string') {
+      const match = node.match(/^dist\/docs\/([^/]+)\/(.+)$/);
+      if (match && artifactVersions.has(match[1])) {
+        paths.add(match[2].replace(/\.(md|mdx)$/, ''));
+      }
+      return;
+    }
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+    if (node && typeof node === 'object') {
+      Object.values(node as Record<string, unknown>).forEach(visit);
+    }
+  };
+
+  visit(value);
+  return paths;
+}
+
+function loadDocsVersions(configPath: string): DocsVersion[] {
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+    navigation?: { versions?: Array<Record<string, unknown>> };
+  };
+  const navigationVersions = config.navigation?.versions;
+  if (!Array.isArray(navigationVersions) || navigationVersions.length === 0) {
+    throw new Error(`No navigation.versions found in ${configPath}`);
+  }
+
+  const versions = navigationVersions.map((entry): DocsVersion => {
+    const displayName = String(entry.version || '').trim();
+    const artifactVersions = new Set<string>();
+
+    const findArtifacts = (node: unknown): void => {
+      if (typeof node === 'string') {
+        const match = node.match(/^dist\/docs\/([^/]+)\//);
+        if (match) artifactVersions.add(match[1]);
+      } else if (Array.isArray(node)) {
+        node.forEach(findArtifacts);
+      } else if (node && typeof node === 'object') {
+        Object.values(node as Record<string, unknown>).forEach(findArtifacts);
+      }
+    };
+    findArtifacts(entry.groups);
+
+    if (!displayName || artifactVersions.size !== 1) {
+      throw new Error(
+        `Docs version ${displayName || '<unnamed>'} must reference exactly one dist/docs snapshot; found ${[...artifactVersions].join(', ') || 'none'}`,
+      );
+    }
+
+    const artifactVersion = [...artifactVersions][0];
+    return {
+      version: displayName.replace(/\s*\(archived\)\s*$/i, ''),
+      artifactVersion,
+      displayName,
+      isDefault: entry.default === true,
+      isArchived: /\(archived\)/i.test(displayName),
+      pagePaths: collectNavigationPagePaths(entry.groups, artifactVersions),
+    };
+  });
+
+  if (versions.filter((version) => version.isDefault).length !== 1) {
+    throw new Error('docs.json must declare exactly one default documentation version');
+  }
+
+  return versions;
+}
+
+function versionAliases(version: DocsVersion): string[] {
+  const aliases = [version.version, version.displayName, version.artifactVersion];
+  if (version.isDefault) aliases.push('latest', 'stable', 'current', 'v3');
+  if (version.version.endsWith('-beta')) {
+    aliases.push(version.version.replace(/-beta$/, ''), `${version.version.replace(/-beta$/, '')} beta`);
+  }
+  return aliases.map((alias) => alias.toLowerCase());
+}
+
+/** Resolve a public selector to one frozen docs version. Defaults to stable. */
+export function resolveDocsVersion(requested?: string): DocsVersion | null {
+  if (docsVersions.length === 0) return null;
+  if (!requested) return docsVersions.find((version) => version.isDefault) || null;
+
+  const normalized = requested.trim().toLowerCase();
+  return docsVersions.find((version) => versionAliases(version).includes(normalized)) || null;
+}
+
+export function getSupportedDocsVersions(): DocsVersion[] {
+  return docsVersions.map((version) => ({ ...version, pagePaths: new Set(version.pagePaths) }));
+}
+
+export function formatDocsVersion(version: Pick<DocsVersion, 'displayName' | 'artifactVersion'>): string {
+  return `${version.displayName} (snapshot ${version.artifactVersion})`;
 }
 
 /**
@@ -541,6 +683,46 @@ function findHtmlFiles(dir: string, relativeTo: string = dir): string[] {
  */
 function shouldExcludePage(relativePath: string): boolean {
   return WEBSITE_PAGES_TO_EXCLUDE.some((pattern) => pattern.test(relativePath));
+}
+
+function readVersionErrorCodes(schemaRoot: string): Set<string> | null {
+  const errorCodePath = path.join(schemaRoot, 'enums', 'error-code.json');
+  if (!fs.existsSync(errorCodePath)) return null;
+
+  try {
+    const schema = JSON.parse(fs.readFileSync(errorCodePath, 'utf-8')) as { enum?: unknown[] };
+    return new Set((schema.enum || []).filter((value): value is string => typeof value === 'string'));
+  } catch (error) {
+    logger.warn({ error, errorCodePath }, 'Addie Docs: Failed to read version error-code enum');
+    return null;
+  }
+}
+
+/**
+ * Frozen prose snapshots predate the immutable-release guard and a few contain
+ * error-code rows copied from a newer branch. The closed enum is authoritative;
+ * remove lines naming codes unavailable in the selected release before search.
+ */
+function buildUnavailableErrorCodePattern(
+  allowedCodes: Set<string> | null,
+  allKnownCodes: Set<string>,
+): RegExp | null {
+  if (!allowedCodes) return null;
+  const unavailableCodes = [...allKnownCodes].filter((code) => !allowedCodes.has(code));
+  return unavailableCodes.length > 0
+    ? new RegExp(`\\b(?:${unavailableCodes.join('|')})\\b`)
+    : null;
+}
+
+function removeUnavailableErrorCodeLines(
+  content: string,
+  unavailablePattern: RegExp | null,
+): string {
+  if (!unavailablePattern) return content;
+  return content
+    .split('\n')
+    .filter((line) => !unavailablePattern.test(line))
+    .join('\n');
 }
 
 /**
@@ -601,15 +783,39 @@ function indexWebsitePages(publicRoot: string): IndexedDoc[] {
  * Initialize the docs indexer
  */
 export async function initializeDocsIndex(): Promise<void> {
-  // Find docs directory - try multiple locations
-  const possibleDocsPaths = [
-    // From server/src/addie/mcp/ to docs/
+  const docsRoot = findFirstExistingPath([
     path.resolve(__dirname, '../../../../docs'),
-    // From dist/ to docs/
     path.resolve(__dirname, '../../../docs'),
-    // Absolute path for Docker (mounted volume)
     '/app/docs',
-  ];
+  ]);
+
+  const docsConfigPath = findFirstExistingPath([
+    path.resolve(__dirname, '../../../../docs.json'),
+    path.resolve(__dirname, '../../../docs.json'),
+    '/app/docs.json',
+  ]);
+
+  const versionedDocsRoot = findFirstExistingPath([
+    path.resolve(__dirname, '../../../../dist/docs'),
+    path.resolve(__dirname, '../../docs'),
+    path.resolve(__dirname, '../../../dist/docs'),
+    '/app/dist/docs',
+  ]);
+
+  const versionedSchemasRoot = findFirstExistingPath([
+    path.resolve(__dirname, '../../../../dist/schemas'),
+    path.resolve(__dirname, '../../schemas'),
+    path.resolve(__dirname, '../../../dist/schemas'),
+    '/app/dist/schemas',
+  ]);
+
+  if (!docsConfigPath || !versionedDocsRoot || !versionedSchemasRoot) {
+    throw new Error(
+      'Versioned documentation is required: docs.json, dist/docs, and dist/schemas must be available',
+    );
+  }
+
+  docsVersions = loadDocsVersions(docsConfigPath);
 
   // Find public directory for website pages
   const possiblePublicPaths = [
@@ -621,22 +827,6 @@ export async function initializeDocsIndex(): Promise<void> {
     '/app/server/public',
   ];
 
-  const possibleSchemaPaths = [
-    // From server/src/addie/mcp/ to static schemas
-    path.resolve(__dirname, '../../../../static/schemas/source'),
-    // From dist/addie/mcp/ to static schemas
-    path.resolve(__dirname, '../../../static/schemas/source'),
-    '/app/static/schemas/source',
-  ];
-
-  let docsRoot: string | null = null;
-  for (const p of possibleDocsPaths) {
-    if (fs.existsSync(p)) {
-      docsRoot = p;
-      break;
-    }
-  }
-
   let publicRoot: string | null = null;
   for (const p of possiblePublicPaths) {
     if (fs.existsSync(p)) {
@@ -645,22 +835,27 @@ export async function initializeDocsIndex(): Promise<void> {
     }
   }
 
-  let schemaRoot: string | null = null;
-  for (const p of possibleSchemaPaths) {
-    if (fs.existsSync(p)) {
-      schemaRoot = p;
-      break;
-    }
-  }
-
   const nextDocsIndex: IndexedDoc[] = [];
   const nextHeadingsIndex: IndexedHeading[] = [];
 
-  // Index markdown docs
-  if (docsRoot) {
-    logger.info({ docsRoot }, 'Addie Docs: Indexing documentation');
+  errorCodesByDocsVersion = new Map<string, Set<string> | null>();
+  allKnownErrorCodes = new Set<string>();
+  for (const version of docsVersions) {
+    const schemaRoot = path.join(versionedSchemasRoot, version.artifactVersion);
+    const codes = readVersionErrorCodes(schemaRoot);
+    errorCodesByDocsVersion.set(version.version, codes);
+    codes?.forEach((code) => allKnownErrorCodes.add(code));
+  }
 
-    const markdownFiles = findMarkdownFiles(docsRoot);
+  // Index only explicitly version-independent live docs. Protocol content
+  // comes from the frozen snapshots selected by docs.json below.
+  if (docsRoot) {
+    logger.info({ docsRoot }, 'Addie Docs: Indexing version-independent documentation');
+
+    const markdownFiles = findMarkdownFiles(docsRoot).filter((filePath) => {
+      const relativePath = path.relative(docsRoot, filePath).replace(/\\/g, '/');
+      return VERSION_INDEPENDENT_DOC_PREFIXES.some((prefix) => relativePath.startsWith(prefix));
+    });
 
     for (const filePath of markdownFiles) {
       try {
@@ -697,16 +892,68 @@ export async function initializeDocsIndex(): Promise<void> {
       }
     }
   } else {
-    logger.warn({ paths: possibleDocsPaths }, 'Addie Docs: Could not find docs directory');
+    logger.warn('Addie Docs: Could not find live docs directory; version-independent docs unavailable');
   }
 
-  // Index schema facts separately from prose so callers can retrieve the
-  // complete extracted schema document by its stable schema: ID.
-  if (schemaRoot) {
-    logger.info({ schemaRoot }, 'Addie Docs: Indexing JSON schemas');
-    nextDocsIndex.push(...indexSchemaFiles(schemaRoot));
-  } else {
-    logger.warn({ paths: possibleSchemaPaths }, 'Addie Docs: Could not find schema directory');
+  // Index the exact frozen docs and schemas exposed in Mintlify navigation.
+  for (const version of docsVersions) {
+    const versionDocsRoot = path.join(versionedDocsRoot, version.artifactVersion);
+    const versionSchemaRoot = path.join(versionedSchemasRoot, version.artifactVersion);
+    if (!fs.existsSync(versionDocsRoot) || !fs.existsSync(versionSchemaRoot)) {
+      throw new Error(
+        `Missing Addie search snapshot for ${version.displayName}: ${version.artifactVersion}`,
+      );
+    }
+
+    logger.info(
+      { version: version.version, artifactVersion: version.artifactVersion },
+      'Addie Docs: Indexing frozen protocol documentation',
+    );
+
+    const allowedCodes = errorCodesByDocsVersion.get(version.version) || null;
+    const unavailableErrorCodePattern = buildUnavailableErrorCodePattern(
+      allowedCodes,
+      allKnownErrorCodes,
+    );
+    for (const filePath of findMarkdownFiles(versionDocsRoot)) {
+      const relativePath = path.relative(versionDocsRoot, filePath).replace(/\\/g, '/');
+      const logicalPath = relativePath.replace(/\.(md|mdx)$/, '');
+      if (!version.pagePaths.has(logicalPath)) continue;
+      if (VERSION_INDEPENDENT_DOC_PREFIXES.some((prefix) => relativePath.startsWith(prefix))) continue;
+
+      try {
+        const rawContent = fs.readFileSync(filePath, 'utf-8');
+        const cleanedContent = removeUnavailableErrorCodeLines(
+          cleanContent(rawContent),
+          unavailableErrorCodePattern,
+        );
+        if (cleanedContent.length < 100) continue;
+
+        const title = extractTitle(rawContent, path.basename(filePath));
+        const id = `doc:${version.version}:${logicalPath}`;
+        const sourceUrl = buildVersionedSourceUrl(relativePath, version.artifactVersion);
+        nextDocsIndex.push({
+          id,
+          title,
+          category: extractCategory(filePath, versionDocsRoot),
+          path: relativePath,
+          content: cleanedContent,
+          sourceUrl,
+          version: version.version,
+          artifactVersion: version.artifactVersion,
+        });
+        nextHeadingsIndex.push(...extractHeadings(cleanedContent, id, title, sourceUrl));
+      } catch (error) {
+        logger.warn({ error, filePath }, 'Addie Docs: Failed to index versioned file');
+      }
+    }
+
+    nextDocsIndex.push(...indexSchemaFiles(
+      versionSchemaRoot,
+      version.version,
+      version.artifactVersion,
+      unavailableErrorCodePattern,
+    ));
   }
 
   // Index website HTML pages
@@ -752,7 +999,7 @@ export async function initializeDocsIndex(): Promise<void> {
   const protocolDocCount = docsIndex.length - websiteCount - workingGroupCount - perspectiveCount - schemaCount;
 
   // Warn if protocol docs index seems suspiciously empty (expect 50+ docs)
-  if (docsRoot && protocolDocCount < 10) {
+  if (protocolDocCount < 10) {
     logger.error(
       { protocolDocCount, docsRoot },
       'Addie Docs: Protocol doc count is suspiciously low — search_docs may return incomplete results'
@@ -786,14 +1033,28 @@ export function isDocsIndexReady(): boolean {
  */
 export function searchDocs(
   query: string,
-  options: { category?: string; limit?: number } = {}
+  options: { category?: string; limit?: number; version?: string } = {}
 ): IndexedDoc[] {
   if (!initialized || docsIndex.length === 0) {
     return [];
   }
 
   const limit = options.limit ?? 5;
+  const selectedVersion = resolveDocsVersion(options.version);
+  if (!selectedVersion) return [];
   const queryLower = query.toLowerCase();
+  const allowedErrorCodes = errorCodesByDocsVersion.get(selectedVersion.version);
+  if (allowedErrorCodes) {
+    // Only a literal enum token (for example, `ACCOUNT_REQUIRED`) proves the
+    // caller is asking about that error code. Natural-language wording such
+    // as "is an account required?" must remain searchable.
+    const queryTokens = new Set(queryLower.match(/[a-z0-9_]+/g) || []);
+    const unavailableCodeRequested = [...allKnownErrorCodes].some((code) => {
+      if (allowedErrorCodes.has(code)) return false;
+      return queryTokens.has(code.toLowerCase());
+    });
+    if (unavailableCodeRequested) return [];
+  }
   const queryWords = [...new Set(
     queryLower
       .split(/[^a-z0-9_-]+/)
@@ -816,6 +1077,11 @@ export function searchDocs(
   // Score each document
   const scored = docsIndex
     .filter((doc) => {
+      // Version-independent organization/community material participates in every
+      // search; protocol docs and schemas must match the selected release.
+      if (doc.version && doc.version !== selectedVersion.version) {
+        return false;
+      }
       // Filter by category if specified
       if (options.category && doc.category.toLowerCase() !== options.category.toLowerCase()) {
         return false;
@@ -873,13 +1139,31 @@ export function searchDocs(
  * Accepts the canonical ID (e.g. "doc:media-buy/advanced-topics/targeting")
  * or a bare path without the prefix (e.g. "media-buy/advanced-topics/targeting").
  */
-export function getDocById(id: string): IndexedDoc | null {
-  return docsIndex.find((doc) => doc.id === id)
-    || docsIndex.find((doc) => doc.id === `doc:${id}`)
-    || docsIndex.find((doc) => doc.id === `website:${id}`)
-    || docsIndex.find((doc) => doc.id === `schema:${id.replace(/\.json$/, '')}`)
-    || docsIndex.find((doc) => doc.id === `wg-doc:${id}`)
-    || null;
+export function getDocById(id: string, options: { version?: string } = {}): IndexedDoc | null {
+  const selectedVersion = resolveDocsVersion(options.version);
+  if (!selectedVersion) return null;
+
+  const isAvailable = (doc: IndexedDoc): boolean => (
+    !doc.version || doc.version === selectedVersion.version
+  );
+  const exact = docsIndex.find((doc) => doc.id === id);
+  // A canonical versioned ID is self-scoping. An explicit version argument,
+  // when supplied, still guards against accidental cross-version retrieval.
+  if (exact && (!options.version || isAvailable(exact))) return exact;
+
+  const normalizedPath = id
+    .replace(/^doc:/, '')
+    .replace(/^schema:/, '')
+    .replace(/\.json$/, '');
+  const candidates = [
+    `doc:${selectedVersion.version}:${normalizedPath}`,
+    `schema:${selectedVersion.version}:${normalizedPath}`,
+    `doc:${id}`,
+    `website:${id}`,
+    `wg-doc:${id}`,
+  ];
+
+  return docsIndex.find((doc) => candidates.includes(doc.id) && isAvailable(doc)) || null;
 }
 
 /**
@@ -917,19 +1201,25 @@ export function getHeadingCount(): number {
  */
 export function searchHeadings(
   query: string,
-  options: { docId?: string; limit?: number } = {}
+  options: { docId?: string; limit?: number; version?: string } = {}
 ): IndexedHeading[] {
   if (!initialized || headingsIndex.length === 0) {
     return [];
   }
 
   const limit = options.limit ?? 5;
+  const selectedVersion = resolveDocsVersion(options.version);
+  if (!selectedVersion) return [];
   const queryLower = query.toLowerCase();
   const queryWords = queryLower.split(/\s+/).filter((w) => w.length > 2);
 
   // Score each heading
   const scored = headingsIndex
     .filter((heading) => {
+      const parentDoc = docsIndex.find((doc) => doc.id === heading.doc_id);
+      if (parentDoc?.version && parentDoc.version !== selectedVersion.version) {
+        return false;
+      }
       // Filter by doc if specified
       if (options.docId && heading.doc_id !== options.docId) {
         return false;

--- a/server/src/addie/mcp/knowledge-search.ts
+++ b/server/src/addie/mcp/knowledge-search.ts
@@ -26,7 +26,9 @@ import {
   getDocById,
   getDocCategories,
   getDocCount,
-  type IndexedDoc,
+  getSupportedDocsVersions,
+  resolveDocsVersion,
+  formatDocsVersion,
 } from './docs-indexer.js';
 import {
   initializeExternalRepos,
@@ -47,50 +49,66 @@ import { findChannelWithAccess, getAccessiblePrivateChannelIds } from '../../sla
 const addieDb = new AddieDatabase();
 
 let initialized = false;
+let initializationPromise: Promise<void> | null = null;
 
 /**
  * Initialize knowledge search
  * - Indexes docs from filesystem
  * - Clones/updates and indexes external repos
  */
-export async function initializeKnowledgeSearch(): Promise<void> {
-  logger.info('Addie: Initializing knowledge search');
+export function initializeKnowledgeSearch(): Promise<void> {
+  if (initialized) return Promise.resolve();
+  if (initializationPromise) return initializationPromise;
 
-  // Index docs from filesystem
-  try {
-    await initializeDocsIndex();
-    const docCount = getDocCount();
-    const categories = getDocCategories();
-    logger.info(
-      {
-        docCount,
-        categories: categories.map((c) => `${c.category}(${c.count})`).join(', '),
-      },
-      'Addie: Docs index ready'
-    );
-  } catch (error) {
-    logger.warn({ error }, 'Addie: Failed to index docs');
-  }
+  initializationPromise = (async () => {
+    logger.info('Addie: Initializing knowledge search');
 
-  // Clone/update and index external repos (sales-agent, client libraries, etc.)
-  try {
-    await initializeExternalRepos();
-    const repoStats = getExternalRepoStats();
-    const totalHeadings = getExternalHeadingCount();
-    if (repoStats.length > 0) {
+    // Index docs from filesystem
+    try {
+      await initializeDocsIndex();
+      const docCount = getDocCount();
+      const categories = getDocCategories();
       logger.info(
         {
-          repos: repoStats.map((r) => `${r.id}(${r.docCount} docs, ${r.headingCount} sections)`).join(', '),
-          totalHeadings,
+          docCount,
+          categories: categories.map((c) => `${c.category}(${c.count})`).join(', '),
         },
-        'Addie: External repos index ready'
+        'Addie: Docs index ready'
+      );
+    } catch (error) {
+      logger.warn({ error }, 'Addie: Failed to index docs');
+    }
+
+    // Clone/update and index external repos (sales-agent, client libraries, etc.)
+    try {
+      await initializeExternalRepos();
+      const repoStats = getExternalRepoStats();
+      const totalHeadings = getExternalHeadingCount();
+      if (repoStats.length > 0) {
+        logger.info(
+          {
+            repos: repoStats.map((r) => `${r.id}(${r.docCount} docs, ${r.headingCount} sections)`).join(', '),
+            totalHeadings,
+          },
+          'Addie: External repos index ready'
+        );
+      }
+    } catch (error) {
+      logger.warn({ error }, 'Addie: Failed to index external repos');
+    }
+
+    initialized = isDocsIndexReady() && isExternalReposReady();
+    if (!initialized) {
+      logger.warn(
+        { docsReady: isDocsIndexReady(), externalReposReady: isExternalReposReady() },
+        'Addie: Knowledge search initialization incomplete; a later caller will retry',
       );
     }
-  } catch (error) {
-    logger.warn({ error }, 'Addie: Failed to index external repos');
-  }
+  })().finally(() => {
+    initializationPromise = null;
+  });
 
-  initialized = true;
+  return initializationPromise;
 }
 
 /**
@@ -110,6 +128,8 @@ export interface DocsSearchResult {
   headline: string;
   sourceUrl: string;
   content: string;
+  version?: string;
+  artifactVersion?: string;
 }
 
 /**
@@ -118,14 +138,18 @@ export interface DocsSearchResult {
  */
 export function searchDocsContent(
   query: string,
-  options: { category?: string; limit?: number } = {}
+  options: { category?: string; limit?: number; version?: string } = {}
 ): DocsSearchResult[] {
-  if (!initialized || !isDocsIndexReady()) {
+  if (!isDocsIndexReady()) {
     return [];
   }
 
   const limit = options.limit ?? 5;
-  const results = searchDocs(query, { category: options.category, limit });
+  const results = searchDocs(query, {
+    category: options.category,
+    limit,
+    version: options.version,
+  });
 
   return results.map((doc) => {
     // Create a headline from first 200 chars (skip headings)
@@ -142,6 +166,8 @@ export function searchDocsContent(
       headline: headline + (headline.length >= 200 ? '...' : ''),
       sourceUrl: doc.sourceUrl,
       content: doc.content,
+      version: doc.version,
+      artifactVersion: doc.artifactVersion,
     };
   });
 }
@@ -162,7 +188,7 @@ export const KNOWLEDGE_TOOLS: AddieTool[] = [
   {
     name: 'search_docs',
     description:
-      'Search the official AdCP documentation, extracted JSON schema facts, and working group documents. Includes protocol docs, website content, and documents published by working groups (brand guidelines, positioning, governance docs, etc.). Returns excerpts with source URLs. IMPORTANT: Use ONE well-crafted search with specific keywords rather than multiple searches. For complete request/response fields or enum values, verify with get_schema. To determine whether a schema or protocol feature exists, use list_schemas. For detailed prose or an extracted schema result, use get_doc with the doc ID from results.',
+      'Search official AdCP docs, extracted schema facts, and working group documents. Protocol results are isolated by release and always name their version. Pass version when the user names one; omission means stable, never beta. Website and working group results are version-independent. Use one specific query. Verify exact fields and enums with get_schema at the same version, use list_schemas for schema availability, and use get_doc for full content.',
     usage_hints: 'use for learning, understanding concepts, "how does X work?", "what is X?", "explain X", brand guidelines, working group documents',
     input_schema: {
       type: 'object',
@@ -175,8 +201,24 @@ export const KNOWLEDGE_TOOLS: AddieTool[] = [
           type: 'string',
           description: 'Optional category filter. Protocol docs: media-buy, signals, creative, intro, reference. Working group docs: "working group: <name>" (e.g., "working group: marketing").',
         },
+        version: {
+          type: 'string',
+          description: 'Protocol docs version: 3.1 (stable default), 3.2-beta, 3.0, or 2.5. Also accepts the exact snapshot version returned in results.',
+          enum: [
+            '3.1',
+            '3.1.19',
+            '3.2-beta',
+            '3.2.0-beta.5',
+            '3.0',
+            '3.0.26',
+            '2.5',
+            '2.5.3',
+          ],
+        },
         limit: {
-          type: 'number',
+          type: 'integer',
+          minimum: 1,
+          maximum: 5,
           description: 'Maximum results (default 3, max 5). Use fewer results for simple questions.',
         },
       },
@@ -186,7 +228,7 @@ export const KNOWLEDGE_TOOLS: AddieTool[] = [
   {
     name: 'get_doc',
     description:
-      'Get the full content of a specific documentation page by ID. Use this after search_docs when you need complete details from a document.',
+      'Get the full content of a specific documentation page by ID. Canonical IDs returned by search_docs already include the version. For a legacy unversioned ID, pass version; omitted version means stable default.',
     usage_hints: 'use after search_docs to read complete doc details',
     input_schema: {
       type: 'object',
@@ -194,6 +236,10 @@ export const KNOWLEDGE_TOOLS: AddieTool[] = [
         doc_id: {
           type: 'string',
           description: 'The document ID from search_docs results',
+        },
+        version: {
+          type: 'string',
+          description: 'Optional protocol version for legacy unversioned IDs: 3.1, 3.2-beta, 3.0, or 2.5.',
         },
       },
       required: ['doc_id'],
@@ -531,9 +577,27 @@ export function createKnowledgeToolHandlers(
     const startTime = Date.now();
     const query = input.query as string;
     const category = input.category as string | undefined;
-    const limit = Math.min((input.limit as number) || 3, 5);
+    const requestedVersion = input.version as string | undefined;
+    const requestedLimit = input.limit;
+    const limit = typeof requestedLimit === 'number' && Number.isFinite(requestedLimit)
+      ? Math.min(5, Math.max(1, Math.trunc(requestedLimit)))
+      : 3;
 
-    const results = searchDocsContent(query, { category, limit });
+    if (!isDocsIndexReady()) {
+      return 'Documentation index not ready.';
+    }
+
+    const selectedVersion = resolveDocsVersion(requestedVersion);
+    if (!selectedVersion) {
+      const available = getSupportedDocsVersions().map((version) => version.version).join(', ');
+      return `Unknown documentation version: "${requestedVersion}". Available versions: ${available}.`;
+    }
+
+    const results = searchDocsContent(query, {
+      category,
+      limit,
+      version: selectedVersion.version,
+    });
     const latencyMs = Date.now() - startTime;
 
     // Log search for pattern analysis (async, don't block response)
@@ -553,7 +617,7 @@ export function createKnowledgeToolHandlers(
         { query, category, indexReady: isDocsIndexReady(), docCount: getDocCount() },
         'Addie search_docs: zero results'
       );
-      return `No documentation found for: "${query}"${category ? ` in category: ${category}` : ''}\n\nTry using web_search for external sources or search_slack for community discussions.`;
+      return `No documentation found in AdCP ${formatDocsVersion(selectedVersion)} for: "${query}"${category ? ` in category: ${category}` : ''}\n\nTry another supported protocol version, web_search for external sources, or search_slack for community discussions.`;
     }
 
     // Return smart excerpts that focus on content matching the query
@@ -561,9 +625,14 @@ export function createKnowledgeToolHandlers(
       .map((doc, i) => {
         const excerpt = extractSmartExcerpt(doc.content, query, 500);
 
+        const versionLabel = doc.version && doc.artifactVersion
+          ? `${doc.version} (snapshot ${doc.artifactVersion})`
+          : 'Version-independent';
+
         return `## ${i + 1}. ${doc.title}
 **ID:** ${doc.id}
 **Category:** ${doc.category}
+**Version:** ${versionLabel}
 **Source:** ${doc.sourceUrl}
 
 ${excerpt}
@@ -572,17 +641,23 @@ ${excerpt}
       })
       .join('\n\n---\n\n');
 
-    return `Found ${results.length} docs. Use get_doc with an ID for full content:\n\n${formatted}`;
+    return `Searching AdCP ${formatDocsVersion(selectedVersion)}. Found ${results.length} docs. Use get_doc with an ID for full content:\n\n${formatted}`;
   });
 
   handlers.set('get_doc', async (input) => {
     const docId = input.doc_id as string;
+    const requestedVersion = input.version as string | undefined;
 
-    if (!initialized || !isDocsIndexReady()) {
+    if (!isDocsIndexReady()) {
       return 'Documentation index not ready.';
     }
 
-    const doc = getDocById(docId);
+    if (requestedVersion && !resolveDocsVersion(requestedVersion)) {
+      const available = getSupportedDocsVersions().map((version) => version.version).join(', ');
+      return `Unknown documentation version: "${requestedVersion}". Available versions: ${available}.`;
+    }
+
+    const doc = getDocById(docId, { version: requestedVersion });
     if (!doc) {
       return `Document not found: "${docId}". Use search_docs to find available documents.`;
     }
@@ -594,10 +669,15 @@ ${excerpt}
       content = content.substring(0, maxLength) + '\n\n... [content truncated at 4000 chars]';
     }
 
+    const versionLabel = doc.version && doc.artifactVersion
+      ? `${doc.version} (snapshot ${doc.artifactVersion})`
+      : 'Version-independent';
+
     return `# ${doc.title}
 
 **Source:** ${doc.sourceUrl}
 **Category:** ${doc.category}
+**Version:** ${versionLabel}
 
 ${content}`;
   });

--- a/server/src/addie/mcp/knowledge-search.ts
+++ b/server/src/addie/mcp/knowledge-search.ts
@@ -63,20 +63,24 @@ export function initializeKnowledgeSearch(): Promise<void> {
   initializationPromise = (async () => {
     logger.info('Addie: Initializing knowledge search');
 
-    // Index docs from filesystem
-    try {
-      await initializeDocsIndex();
-      const docCount = getDocCount();
-      const categories = getDocCategories();
-      logger.info(
-        {
-          docCount,
-          categories: categories.map((c) => `${c.category}(${c.count})`).join(', '),
-        },
-        'Addie: Docs index ready'
-      );
-    } catch (error) {
-      logger.warn({ error }, 'Addie: Failed to index docs');
+    // Index docs from filesystem. Preserve a ready index when retrying another
+    // source so a transient external-repo failure does not re-read every
+    // versioned snapshot on each caller.
+    if (!isDocsIndexReady()) {
+      try {
+        await initializeDocsIndex();
+        const docCount = getDocCount();
+        const categories = getDocCategories();
+        logger.info(
+          {
+            docCount,
+            categories: categories.map((c) => `${c.category}(${c.count})`).join(', '),
+          },
+          'Addie: Docs index ready'
+        );
+      } catch (error) {
+        logger.warn({ error }, 'Addie: Failed to index docs');
+      }
     }
 
     // Clone/update and index external repos (sales-agent, client libraries, etc.)

--- a/server/src/addie/mcp/schema-tools.ts
+++ b/server/src/addie/mcp/schema-tools.ts
@@ -20,17 +20,67 @@ import { ToolError } from '../tool-error.js';
 
 const SCHEMA_HOST = 'https://adcontextprotocol.org';
 
-// Schema base URLs for different versions. v3 is current; keep older aliases
-// so Addie can still answer historical questions.
+// Keep schema selection aligned with the frozen releases exposed in docs.json.
+// Legacy aliases remain available for callers that already use them.
+export const DOCS_SCHEMA_RELEASES = Object.freeze({
+  '3.1': '3.1.19',
+  '3.2-beta': '3.2.0-beta.5',
+  '3.0': '3.0.26',
+  '2.5': '2.5.3',
+});
+
 const SCHEMA_BASE_URLS: Record<string, string> = {
+  '3.1': `${SCHEMA_HOST}/schemas/${DOCS_SCHEMA_RELEASES['3.1']}`,
+  '3.2-beta': `${SCHEMA_HOST}/schemas/${DOCS_SCHEMA_RELEASES['3.2-beta']}`,
+  '3.0': `${SCHEMA_HOST}/schemas/${DOCS_SCHEMA_RELEASES['3.0']}`,
+  '2.5': `${SCHEMA_HOST}/schemas/${DOCS_SCHEMA_RELEASES['2.5']}`,
   v2: `${SCHEMA_HOST}/schemas/v2`,
-  v3: `${SCHEMA_HOST}/schemas/v3`,
-  '2.5': `${SCHEMA_HOST}/schemas/v2.5`,
   '2.6': `${SCHEMA_HOST}/schemas/v2.6`,
   '2.6.0': `${SCHEMA_HOST}/schemas/2.6.0`,
 };
 
-const DEFAULT_VERSION = 'v3';
+const DEFAULT_VERSION = '3.1';
+
+// Public documentation selectors resolve to frozen schema snapshots. Keep the
+// legacy v2/2.6 selectors intact, but do not let v3 or "latest" drift away
+// from the stable documentation release.
+const SCHEMA_VERSION_ALIASES: Readonly<Record<string, string>> = Object.freeze({
+  '3.1': '3.1',
+  stable: '3.1',
+  current: '3.1',
+  latest: '3.1',
+  v3: '3.1',
+  [DOCS_SCHEMA_RELEASES['3.1']]: '3.1',
+  '3.2-beta': '3.2-beta',
+  '3.2 beta': '3.2-beta',
+  '3.2': '3.2-beta',
+  [DOCS_SCHEMA_RELEASES['3.2-beta']]: '3.2-beta',
+  '3.0': '3.0',
+  [DOCS_SCHEMA_RELEASES['3.0']]: '3.0',
+  '2.5': '2.5',
+  '2.5 (archived)': '2.5',
+  [DOCS_SCHEMA_RELEASES['2.5']]: '2.5',
+  v2: 'v2',
+  '2.6': '2.6',
+  '2.6.0': '2.6.0',
+});
+
+export const SCHEMA_VERSION_OPTIONS = Object.freeze(Object.keys(SCHEMA_VERSION_ALIASES));
+
+function resolveSchemaVersion(requested?: unknown, fallback = DEFAULT_VERSION): string {
+  const selector = requested === undefined
+    ? fallback
+    : typeof requested === 'string'
+      ? requested.trim().toLowerCase()
+      : '';
+  const canonical = SCHEMA_VERSION_ALIASES[selector];
+  if (!canonical) {
+    throw new ToolError(
+      `Unsupported schema version "${String(requested)}". Supported versions: ${SCHEMA_VERSION_OPTIONS.join(', ')}.`,
+    );
+  }
+  return canonical;
+}
 
 // Cache for fetched schemas (5 minute TTL, max 50 entries)
 const schemaCache = new Map<string, { schema: unknown; fetchedAt: number }>();
@@ -120,7 +170,10 @@ async function fetchRegistry(version: string): Promise<SchemaRegistry> {
     return cached.registry;
   }
 
-  const baseUrl = SCHEMA_BASE_URLS[version] || SCHEMA_BASE_URLS[DEFAULT_VERSION];
+  const baseUrl = SCHEMA_BASE_URLS[version];
+  if (!baseUrl) {
+    throw new ToolError(`Unsupported canonical schema version "${version}".`);
+  }
   const indexUrl = `${baseUrl}/index.json`;
   const index = await fetchSchema(indexUrl);
   const paths = extractRegistryPaths(index);
@@ -264,7 +317,10 @@ async function resolveSchemaPath(
  * Build full schema URL from version and path
  */
 function buildSchemaUrl(version: string, schemaPath: string): string {
-  const baseUrl = SCHEMA_BASE_URLS[version] || SCHEMA_BASE_URLS[DEFAULT_VERSION];
+  const baseUrl = SCHEMA_BASE_URLS[version];
+  if (!baseUrl) {
+    throw new ToolError(`Unsupported canonical schema version "${version}".`);
+  }
   // Remove leading slash and sanitize path
   let cleanPath = schemaPath.startsWith('/') ? schemaPath.slice(1) : schemaPath;
   // Prevent path traversal
@@ -360,8 +416,8 @@ export const SCHEMA_TOOLS: AddieTool[] = [
         version: {
           type: 'string',
           description:
-            'Schema version to use: "v3" (current stable, default), "v2" (legacy), or specific like "2.6.0". Defaults to version in $schema or "v3".',
-          enum: ['v2', 'v3', '2.5', '2.6', '2.6.0'],
+            'Schema version to use. Public docs selectors are 3.1 (stable default), 3.2-beta, 3.0, and 2.5; exact snapshot and legacy aliases are also accepted.',
+          enum: SCHEMA_VERSION_OPTIONS,
         },
       },
       required: ['json'],
@@ -383,8 +439,8 @@ export const SCHEMA_TOOLS: AddieTool[] = [
         },
         version: {
           type: 'string',
-          description: 'Schema version: "v3" (current stable, default), "v2" (legacy), or specific like "2.6.0"',
-          enum: ['v2', 'v3', '2.5', '2.6', '2.6.0'],
+          description: 'Schema version. Match search_docs: 3.1 (stable default), 3.2-beta, 3.0, or 2.5. Exact snapshot and legacy aliases are also accepted.',
+          enum: SCHEMA_VERSION_OPTIONS,
         },
         property: {
           type: 'string',
@@ -405,7 +461,8 @@ export const SCHEMA_TOOLS: AddieTool[] = [
       properties: {
         version: {
           type: 'string',
-          description: 'Optional version to list schemas for',
+          description: 'Optional schema version. Defaults to stable 3.1.',
+          enum: SCHEMA_VERSION_OPTIONS,
         },
       },
     },
@@ -426,12 +483,12 @@ export const SCHEMA_TOOLS: AddieTool[] = [
         from_version: {
           type: 'string',
           description: 'Source version to compare from (default: "v2")',
-          enum: ['v2', 'v3', '2.5', '2.6', '2.6.0'],
+          enum: SCHEMA_VERSION_OPTIONS,
         },
         to_version: {
           type: 'string',
-          description: 'Target version to compare to (default: "v3")',
-          enum: ['v2', 'v3', '2.5', '2.6', '2.6.0'],
+          description: 'Target version to compare to (default: stable 3.1)',
+          enum: SCHEMA_VERSION_OPTIONS,
         },
       },
       required: ['schema_path'],
@@ -492,26 +549,27 @@ export function createSchemaToolHandlers(): Map<
     }
     const jsonObj = json as Record<string, unknown>;
     let schemaPath = input.schema_path as string | undefined;
-    let version = input.version as string | undefined;
+    let requestedVersion = input.version;
 
     // Try to extract version and schema from $schema field. Accepts both
     // major-alias form (`/schemas/v3/...`) and pinned-semver form
-    // (`/schemas/3.0.0/...`). The version must match a key in
-    // SCHEMA_BASE_URLS, which uses `v3` etc. — not bare `3`.
+    // (`/schemas/3.0.0/...`). All selectors are canonicalized below so a
+    // schema URL cannot bypass the frozen release mapping.
     if (jsonObj.$schema && typeof jsonObj.$schema === 'string') {
       const schemaUrl = jsonObj.$schema;
-      const urlMatch = schemaUrl.match(/schemas(?:\.adcontextprotocol\.org)?\/(v\d+(?:\.\d+)?|\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?)\/(.+)$/);
+      const urlMatch = schemaUrl.match(/(?:\/schemas\/|schemas\.adcontextprotocol\.org\/)([^/]+)\/(.+)$/);
       if (urlMatch) {
-        version = version || urlMatch[1];
+        if (requestedVersion === undefined) requestedVersion = urlMatch[1];
         schemaPath = schemaPath || urlMatch[2];
       }
     }
+
+    const version = resolveSchemaVersion(requestedVersion);
 
     if (!schemaPath) {
       return `Cannot determine schema. Please provide schema_path (e.g., "core/format.json") or include a $schema field in the JSON.`;
     }
 
-    version = version || DEFAULT_VERSION;
     const { resolved: resolvedPath, registry } = await resolveSchemaPath(schemaPath, version);
     schemaPath = resolvedPath;
     const schemaUrl = buildSchemaUrl(version, schemaPath);
@@ -540,7 +598,7 @@ ${formatCandidates(schemaPath, registry)}`);
   });
 
   handlers.set('get_schema', async (input) => {
-    const version = (input.version as string) || DEFAULT_VERSION;
+    const version = resolveSchemaVersion(input.version);
     const property = input.property as string | undefined;
 
     const requestedPath = input.schema_path as string;
@@ -610,8 +668,8 @@ ${formatCandidates(requestedPath, registry)}`);
   });
 
   handlers.set('list_schemas', async (input) => {
-    const version = (input.version as string) || DEFAULT_VERSION;
-    const baseUrl = SCHEMA_BASE_URLS[version] || SCHEMA_BASE_URLS[DEFAULT_VERSION];
+    const version = resolveSchemaVersion(input.version);
+    const baseUrl = SCHEMA_BASE_URLS[version];
 
     let registry: SchemaRegistry | null = null;
     try {
@@ -637,7 +695,10 @@ ${formatCandidates(requestedPath, registry)}`);
 ### Schema Versions
 | Version | URL | Notes |
 |---------|-----|-------|
-| v3 | ${SCHEMA_BASE_URLS.v3} | Current stable (3.x) |
+| 3.1 | ${SCHEMA_BASE_URLS['3.1']} | Current stable schema snapshot (${DOCS_SCHEMA_RELEASES['3.1']}) |
+| 3.2-beta | ${SCHEMA_BASE_URLS['3.2-beta']} | Beta docs snapshot (3.2.0-beta.5) |
+| 3.0 | ${SCHEMA_BASE_URLS['3.0']} | Previous 3.x snapshot (3.0.26) |
+| 2.5 | ${SCHEMA_BASE_URLS['2.5']} | Archived snapshot (2.5.3) |
 | v2 | ${SCHEMA_BASE_URLS.v2} | Legacy (2.x) |
 
 ### Key Differences: v2 vs v3
@@ -650,8 +711,8 @@ ${categoryList}
   });
 
   handlers.set('compare_schema_versions', async (input) => {
-    const fromVersion = (input.from_version as string) || 'v2';
-    const toVersion = (input.to_version as string) || 'v3';
+    const fromVersion = resolveSchemaVersion(input.from_version, 'v2');
+    const toVersion = resolveSchemaVersion(input.to_version);
     const requestedPath = input.schema_path as string;
     // Resolve against the "to" version's registry — that's where we most
     // want the path to exist, and the registry also contains legacy schemas.
@@ -739,7 +800,9 @@ ${formatCandidates(requestedPath, registry)}`;
       }
 
       // Add general version changes if available
-      const changeKey = `${fromVersion}-to-${toVersion}`;
+      const changeKey = fromVersion === 'v2' && toVersion.startsWith('3')
+        ? 'v2-to-v3'
+        : `${fromVersion}-to-${toVersion}`;
       if (VERSION_CHANGES[changeKey]) {
         report += `### General ${fromVersion} to ${toVersion} Changes\n`;
         report += VERSION_CHANGES[changeKey].map((change) => `- ${change}`).join('\n') + '\n';

--- a/server/src/addie/mcp/schema-tools.ts
+++ b/server/src/addie/mcp/schema-tools.ts
@@ -82,6 +82,58 @@ function resolveSchemaVersion(requested?: unknown, fallback = DEFAULT_VERSION): 
   return canonical;
 }
 
+const INFERRED_PRERELEASE_RANGES: Readonly<
+  Record<string, Partial<Record<'beta' | 'rc', readonly [number, number]>>>
+> = Object.freeze({
+  '3.0': Object.freeze({ beta: [1, 3] as const, rc: [1, 3] as const }),
+  '3.1': Object.freeze({ beta: [0, 7] as const, rc: [1, 15] as const }),
+  '3.2-beta': Object.freeze({ beta: [0, 5] as const }),
+});
+
+/**
+ * Resolve a version inferred from a document's `$schema` URL.
+ *
+ * Published documents may remain pinned to an older patch snapshot after the
+ * docs move to a newer frozen snapshot. Preserve their release-line meaning
+ * while keeping explicit tool `version` inputs fail-closed.
+ */
+function resolveInferredSchemaVersion(requested: string): string {
+  const selector = requested.trim().toLowerCase();
+  const direct = SCHEMA_VERSION_ALIASES[selector];
+  if (direct) return direct;
+
+  const prereleaseMatch = selector.match(/^(\d+\.\d+)\.0-(beta|rc)\.(\d+)$/);
+  if (prereleaseMatch) {
+    const [, releaseLine, prereleaseKind, prereleaseNumberText] = prereleaseMatch;
+    const canonical = releaseLine === '3.2' ? '3.2-beta' : releaseLine;
+    const range = INFERRED_PRERELEASE_RANGES[canonical]?.[
+      prereleaseKind as 'beta' | 'rc'
+    ];
+    const prereleaseNumber = Number(prereleaseNumberText);
+    if (range && prereleaseNumber >= range[0] && prereleaseNumber <= range[1]) {
+      return canonical;
+    }
+  }
+
+  const patchMatch = selector.match(/^(\d+\.\d+)\.(\d+)$/);
+  if (patchMatch) {
+    const [, releaseLine, patchNumberText] = patchMatch;
+    const frozenVersion = DOCS_SCHEMA_RELEASES[
+      releaseLine as keyof typeof DOCS_SCHEMA_RELEASES
+    ];
+    const frozenMatch = frozenVersion?.match(/^(\d+\.\d+)\.(\d+)$/);
+    if (
+      frozenMatch
+      && frozenMatch[1] === releaseLine
+      && Number(patchNumberText) <= Number(frozenMatch[2])
+    ) {
+      return releaseLine;
+    }
+  }
+
+  return resolveSchemaVersion(requested);
+}
+
 // Cache for fetched schemas (5 minute TTL, max 50 entries)
 const schemaCache = new Map<string, { schema: unknown; fetchedAt: number }>();
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -559,7 +611,9 @@ export function createSchemaToolHandlers(): Map<
       const schemaUrl = jsonObj.$schema;
       const urlMatch = schemaUrl.match(/(?:\/schemas\/|schemas\.adcontextprotocol\.org\/)([^/]+)\/(.+)$/);
       if (urlMatch) {
-        if (requestedVersion === undefined) requestedVersion = urlMatch[1];
+        if (requestedVersion === undefined) {
+          requestedVersion = resolveInferredSchemaVersion(urlMatch[1]);
+        }
         schemaPath = schemaPath || urlMatch[2];
       }
     }

--- a/server/src/addie/rules/behaviors.md
+++ b/server/src/addie/rules/behaviors.md
@@ -177,6 +177,7 @@ Before drafting a GitHub issue about a missing tool, look up the canonical catal
 ## Verify Claims With Tools
 When discussing protocol details, schema structures, or implementation specifics:
 - Any answer containing a field name, enum value, or feature-presence claim must be supported by a successful tool call in this turn. Use `get_schema` for fields and enum values, and `list_schemas` to verify whether a schema or feature exists. Use `search_docs` and `get_doc` for prose guidance and channel-specific behavior.
+- Version scope is part of verification. When the user names a protocol version, pass that version to `search_docs` and use the matching version with schema tools. When they do not name one, `search_docs` intentionally searches the stable default; never present beta-only material as stable. Preserve the version label from every result in your answer.
 - Never state a wire-level claim and then close by offering to verify it; verify it before answering.
 - Use search_repos to check actual code before describing how something works
 - When helping test agents, use validate_adagents, get_agent_status, or evaluate_agent_quality — do not just describe what the user should do. `get_agent_status` reads the registry's cached health + comply verdict (the same data the dashboard renders); `evaluate_agent_quality` runs the comply storyboard suite live.

--- a/server/tests/unit/addie/schema-tools.test.ts
+++ b/server/tests/unit/addie/schema-tools.test.ts
@@ -1,11 +1,54 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import {
+  createSchemaToolHandlers,
+  DOCS_SCHEMA_RELEASES,
   extractRegistryPaths,
   findClosestSchema,
   formatSchemaJson,
+  SCHEMA_TOOLS,
   SCHEMA_MAX_DISPLAY_CHARS,
+  SCHEMA_VERSION_OPTIONS,
   type SchemaRegistry,
 } from '../../../src/addie/mcp/schema-tools.js';
+
+describe('schema version selection', () => {
+  it('accepts every public docs release and defaults its guidance to stable', () => {
+    expect(DOCS_SCHEMA_RELEASES).toEqual({
+      '3.1': '3.1.19',
+      '3.2-beta': '3.2.0-beta.5',
+      '3.0': '3.0.26',
+      '2.5': '2.5.3',
+    });
+    expect(SCHEMA_VERSION_OPTIONS).toEqual(expect.arrayContaining([
+      '3.1',
+      'stable',
+      'current',
+      'latest',
+      'v3',
+      '3.1.19',
+      '3.2-beta',
+      '3.2 beta',
+      '3.2',
+      '3.2.0-beta.5',
+      '3.0',
+      '3.0.26',
+      '2.5',
+      '2.5 (archived)',
+      '2.5.3',
+      'v2',
+      '2.6',
+      '2.6.0',
+    ]));
+
+    for (const toolName of ['validate_json', 'get_schema', 'list_schemas']) {
+      const tool = SCHEMA_TOOLS.find((candidate) => candidate.name === toolName);
+      expect(tool?.input_schema.properties.version.enum).toEqual(SCHEMA_VERSION_OPTIONS);
+    }
+
+    const getSchema = SCHEMA_TOOLS.find((tool) => tool.name === 'get_schema');
+    expect(getSchema?.input_schema.properties.version.description).toContain('3.1 (stable default)');
+  });
+});
 
 // Minimal index.json fixture mirroring the shape served at
 // /schemas/v3/index.json. Covers every ref format we care about.
@@ -36,6 +79,129 @@ const indexFixture = {
     },
   },
 };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('schema handler version resolution', () => {
+  const publicSelectors: Array<{
+    selector?: string;
+    canonical: string;
+    artifact: string;
+  }> = [
+    { canonical: '3.1', artifact: '3.1.19' },
+    { selector: '3.1', canonical: '3.1', artifact: '3.1.19' },
+    { selector: 'stable', canonical: '3.1', artifact: '3.1.19' },
+    { selector: 'current', canonical: '3.1', artifact: '3.1.19' },
+    { selector: 'latest', canonical: '3.1', artifact: '3.1.19' },
+    { selector: 'v3', canonical: '3.1', artifact: '3.1.19' },
+    { selector: '3.1.19', canonical: '3.1', artifact: '3.1.19' },
+    { selector: '3.2-beta', canonical: '3.2-beta', artifact: '3.2.0-beta.5' },
+    { selector: '3.2 beta', canonical: '3.2-beta', artifact: '3.2.0-beta.5' },
+    { selector: '3.2', canonical: '3.2-beta', artifact: '3.2.0-beta.5' },
+    { selector: '3.2.0-beta.5', canonical: '3.2-beta', artifact: '3.2.0-beta.5' },
+    { selector: '3.0', canonical: '3.0', artifact: '3.0.26' },
+    { selector: '3.0.26', canonical: '3.0', artifact: '3.0.26' },
+    { selector: '2.5', canonical: '2.5', artifact: '2.5.3' },
+    { selector: '2.5 (archived)', canonical: '2.5', artifact: '2.5.3' },
+    { selector: '2.5.3', canonical: '2.5', artifact: '2.5.3' },
+  ];
+
+  it('fetches the exact frozen snapshot for the default and every public docs selector', async () => {
+    const fetchMock = vi.fn(async (input: unknown) => {
+      const url = String(input);
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => url.endsWith('/index.json')
+          ? indexFixture
+          : { title: 'Mock schema', type: 'object', properties: {} },
+      } as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const getSchema = createSchemaToolHandlers().get('get_schema');
+    expect(getSchema).toBeDefined();
+
+    for (const [index, { selector, canonical, artifact }] of publicSelectors.entries()) {
+      const schemaPath = `core/version-selector-${index}.json`;
+      const result = await getSchema!({ schema_path: schemaPath, version: selector });
+      const expectedUrl = `https://adcontextprotocol.org/schemas/${artifact}/${schemaPath}`;
+
+      expect(fetchMock.mock.calls.map(([url]) => String(url))).toContain(expectedUrl);
+      expect(result).toContain(`**Schema URL:** ${expectedUrl}`);
+      expect(result).toContain(`**Version:** ${canonical}`);
+    }
+  });
+
+  it('preserves the legacy v2 and 2.6 selectors', async () => {
+    const fetchMock = vi.fn(async (input: unknown) => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => String(input).endsWith('/index.json')
+        ? indexFixture
+        : { title: 'Mock schema', type: 'object', properties: {} },
+    }) as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const getSchema = createSchemaToolHandlers().get('get_schema');
+    expect(getSchema).toBeDefined();
+    const selectors = [
+      ['v2', 'https://adcontextprotocol.org/schemas/v2'],
+      ['2.6', 'https://adcontextprotocol.org/schemas/v2.6'],
+      ['2.6.0', 'https://adcontextprotocol.org/schemas/2.6.0'],
+    ] as const;
+
+    for (const [index, [selector, baseUrl]] of selectors.entries()) {
+      const schemaPath = `core/legacy-version-selector-${index}.json`;
+      await getSchema!({ schema_path: schemaPath, version: selector });
+      expect(fetchMock.mock.calls.map(([url]) => String(url))).toContain(`${baseUrl}/${schemaPath}`);
+    }
+  });
+
+  it('canonicalizes a docs alias extracted from a $schema URL', async () => {
+    const fetchMock = vi.fn(async (input: unknown) => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => String(input).endsWith('/index.json')
+        ? indexFixture
+        : { type: 'object' },
+    }) as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const validateJson = createSchemaToolHandlers().get('validate_json');
+    const schemaPath = 'core/schema-url-alias.json';
+    const result = await validateJson!({
+      json: { $schema: `https://adcontextprotocol.org/schemas/latest/${schemaPath}` },
+    });
+    const expectedUrl = `https://adcontextprotocol.org/schemas/3.1.19/${schemaPath}`;
+
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toContain(expectedUrl);
+    expect(result).toContain(`AdCP 3.1 ${schemaPath} schema`);
+  });
+
+  it('rejects unknown versions in every handler instead of falling back to stable', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const handlers = createSchemaToolHandlers();
+    const calls: Array<[string, Record<string, unknown>]> = [
+      ['validate_json', { json: {}, schema_path: 'core/product.json', version: '4.0' }],
+      ['get_schema', { schema_path: 'core/product.json', version: '4.0' }],
+      ['list_schemas', { version: '4.0' }],
+      ['compare_schema_versions', { schema_path: 'core/product.json', from_version: '4.0' }],
+      ['compare_schema_versions', { schema_path: 'core/product.json', to_version: '4.0' }],
+    ];
+
+    for (const [name, input] of calls) {
+      await expect(handlers.get(name)!(input)).rejects.toThrow('Unsupported schema version "4.0"');
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
 
 function registryFrom(index: unknown): SchemaRegistry {
   const paths = extractRegistryPaths(index);

--- a/server/tests/unit/addie/schema-tools.test.ts
+++ b/server/tests/unit/addie/schema-tools.test.ts
@@ -184,6 +184,61 @@ describe('schema handler version resolution', () => {
     expect(result).toContain(`AdCP 3.1 ${schemaPath} schema`);
   });
 
+  it('maps older pinned $schema snapshots to their frozen release line', async () => {
+    const fetchMock = vi.fn(async (input: unknown) => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => String(input).endsWith('/index.json')
+        ? indexFixture
+        : { type: 'object' },
+    }) as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const validateJson = createSchemaToolHandlers().get('validate_json');
+    const cases = [
+      ['3.1.4', '3.1.19'],
+      ['3.1.0-rc.15', '3.1.19'],
+      ['3.2.0-beta.1', '3.2.0-beta.5'],
+      ['3.0.18', '3.0.26'],
+      ['3.0.0-rc.2', '3.0.26'],
+      ['2.5.1', '2.5.3'],
+    ] as const;
+
+    for (const [index, [pinnedVersion, frozenVersion]] of cases.entries()) {
+      const schemaPath = `core/older-pinned-snapshot-${index}.json`;
+      await validateJson!({
+        json: {
+          $schema: `https://adcontextprotocol.org/schemas/${pinnedVersion}/${schemaPath}`,
+        },
+      });
+
+      expect(fetchMock.mock.calls.map(([url]) => String(url))).toContain(
+        `https://adcontextprotocol.org/schemas/${frozenVersion}/${schemaPath}`,
+      );
+    }
+  });
+
+  it('still rejects unknown and future versions inferred from a $schema URL', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const validateJson = createSchemaToolHandlers().get('validate_json');
+
+    for (const version of [
+      '4.0.1',
+      '3.1.20',
+      '3.2.0-beta.6',
+      '3.2.1-beta.1',
+    ]) {
+      await expect(validateJson!({
+        json: {
+          $schema: `https://adcontextprotocol.org/schemas/${version}/core/product.json`,
+        },
+      })).rejects.toThrow(`Unsupported schema version "${version}"`);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('rejects unknown versions in every handler instead of falling back to stable', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);

--- a/server/tests/unit/docs-indexer.test.ts
+++ b/server/tests/unit/docs-indexer.test.ts
@@ -1,6 +1,4 @@
 import { describe, it, expect, beforeAll, vi } from 'vitest';
-import path from 'path';
-import { fileURLToPath } from 'url';
 
 vi.mock('../../src/db/working-group-db.js', () => ({
   WorkingGroupDatabase: class {
@@ -23,10 +21,14 @@ import {
   getDocCount,
   getHeadingCount,
   getDocById,
+  getSupportedDocsVersions,
+  resolveDocsVersion,
 } from '../../src/addie/mcp/docs-indexer.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import {
+  KNOWLEDGE_TOOLS,
+  createKnowledgeToolHandlers,
+} from '../../src/addie/mcp/knowledge-search.js';
+import { DOCS_SCHEMA_RELEASES } from '../../src/addie/mcp/schema-tools.js';
 
 /**
  * Docs Indexer Tests
@@ -44,7 +46,7 @@ const __dirname = path.dirname(__filename);
 describe('docs-indexer', () => {
   beforeAll(async () => {
     await initializeDocsIndex();
-  });
+  }, 30_000);
 
   it('initializes successfully with docs from the real docs directory', () => {
     expect(isDocsIndexReady()).toBe(true);
@@ -97,15 +99,170 @@ describe('docs-indexer', () => {
 
   describe('get_doc ID resolution', () => {
     it('finds doc by canonical ID with prefix', () => {
-      const doc = getDocById('doc:media-buy/advanced-topics/targeting');
+      const doc = getDocById('doc:3.1:media-buy/advanced-topics/targeting');
       expect(doc).not.toBeNull();
       expect(doc!.title).toBe('Targeting');
+      expect(doc!.version).toBe('3.1');
     });
 
     it('finds doc by bare path without prefix', () => {
       const doc = getDocById('media-buy/advanced-topics/targeting');
       expect(doc).not.toBeNull();
       expect(doc!.title).toBe('Targeting');
+    });
+
+    it('uses an explicit version for legacy unversioned IDs', () => {
+      const doc = getDocById('media-buy/task-reference/get_products', { version: '3.2-beta' });
+      expect(doc?.id).toBe('doc:3.2-beta:media-buy/task-reference/get_products');
+      expect(doc?.sourceUrl).toContain('/dist/docs/3.2.0-beta.5/');
+    });
+
+    it('rejects a canonical versioned ID when the explicit version does not match', () => {
+      expect(getDocById(
+        'doc:3.2-beta:media-buy/task-reference/get_products',
+        { version: '3.1' },
+      )).toBeNull();
+    });
+
+    it('links version-independent live docs to their exact source file', () => {
+      const doc = getDocById('aao/addie-tools');
+      expect(doc?.sourceUrl).toBe(
+        'https://github.com/adcontextprotocol/adcp/blob/main/docs/aao/addie-tools.mdx',
+      );
+    });
+  });
+
+  describe('protocol version isolation', () => {
+    it('loads every public docs version and keeps 3.1 as stable default', () => {
+      const versions = getSupportedDocsVersions();
+      expect(versions.map(({ version, artifactVersion }) => ({ version, artifactVersion }))).toEqual([
+        { version: '3.1', artifactVersion: '3.1.19' },
+        { version: '3.2-beta', artifactVersion: '3.2.0-beta.5' },
+        { version: '3.0', artifactVersion: '3.0.26' },
+        { version: '2.5', artifactVersion: '2.5.3' },
+      ]);
+      expect(resolveDocsVersion()?.version).toBe('3.1');
+      expect(resolveDocsVersion('latest')?.version).toBe('3.1');
+      expect(resolveDocsVersion('3.2')?.version).toBe('3.2-beta');
+      expect(Object.fromEntries(
+        versions.map(({ version, artifactVersion }) => [version, artifactVersion]),
+      )).toEqual(DOCS_SCHEMA_RELEASES);
+    });
+
+    it('returns protocol results only from the requested version', () => {
+      const snapshots = new Map([
+        ['3.1', '3.1.19'],
+        ['3.2-beta', '3.2.0-beta.5'],
+        ['3.0', '3.0.26'],
+        ['2.5', '2.5.3'],
+      ]);
+
+      for (const [version, artifactVersion] of snapshots) {
+        const results = searchDocs('protocol', { version, limit: 20 });
+        const versionedResults = results.filter((doc) => doc.version);
+        expect(versionedResults.length).toBeGreaterThan(0);
+        expect(versionedResults.every((doc) => doc.version === version)).toBe(true);
+        expect(versionedResults.every((doc) => doc.artifactVersion === artifactVersion)).toBe(true);
+        expect(versionedResults.every((doc) => (
+          doc.sourceUrl.startsWith(`https://docs.adcontextprotocol.org/dist/docs/${artifactVersion}/`)
+          || doc.sourceUrl.startsWith(`https://adcontextprotocol.org/schemas/${artifactVersion}/`)
+        ))).toBe(true);
+
+        const intro = getDocById(`doc:${version}:intro`, { version });
+        expect(intro?.artifactVersion).toBe(artifactVersion);
+        expect(intro?.sourceUrl).toBe(
+          `https://docs.adcontextprotocol.org/dist/docs/${artifactVersion}/intro`,
+        );
+      }
+    });
+
+    it('returns headings only from the requested protocol version', () => {
+      const snapshots = new Map([
+        ['3.1', '3.1.19'],
+        ['3.2-beta', '3.2.0-beta.5'],
+        ['3.0', '3.0.26'],
+        ['2.5', '2.5.3'],
+      ]);
+
+      for (const [version, artifactVersion] of snapshots) {
+        const headings = searchHeadings('protocol', { version, limit: 20 });
+        const versionedHeadings = headings.filter((heading) => /^doc:\d/.test(heading.doc_id));
+        expect(versionedHeadings.length).toBeGreaterThan(0);
+        expect(versionedHeadings.every((heading) => (
+          heading.doc_id.startsWith(`doc:${version}:`) &&
+          heading.sourceUrl.startsWith(
+            `https://docs.adcontextprotocol.org/dist/docs/${artifactVersion}/`,
+          )
+        ))).toBe(true);
+      }
+    });
+
+    it('does not leak the 3.2-only ACCOUNT_REQUIRED code into stable versions', () => {
+      for (const version of ['3.1', '3.0', '2.5']) {
+        const results = searchDocs('ACCOUNT_REQUIRED', { version, limit: 20 });
+        expect(results.some((doc) => doc.content.includes('ACCOUNT_REQUIRED'))).toBe(false);
+      }
+
+      const betaResults = searchDocs('ACCOUNT_REQUIRED', { version: '3.2-beta', limit: 20 });
+      expect(betaResults.map((doc) => doc.id)).toContain('schema:3.2-beta:enums/error-code');
+      expect(betaResults.some((doc) => doc.content.includes('ACCOUNT_REQUIRED'))).toBe(true);
+    });
+
+    it('does not index 3.2-only pages from the polluted stable artifact', () => {
+      const betaOnlyPaths = [
+        'media-buy/task-reference/request_proposals',
+        'reference/migration/cross-role-governance-enforcement',
+        'reference/whats-new-in-3-2',
+      ];
+      for (const pagePath of betaOnlyPaths) {
+        expect(getDocById(`doc:3.1:${pagePath}`, { version: '3.1' })).toBeNull();
+        expect(getDocById(`doc:3.2-beta:${pagePath}`, { version: '3.2-beta' })).not.toBeNull();
+      }
+    });
+
+    it('does not interpret natural-language error wording as a literal unavailable code', () => {
+      expect(searchDocs('account required', { version: '3.1', limit: 20 }).length)
+        .toBeGreaterThan(0);
+    });
+
+    it('exposes version selection and labels through Addie tools', async () => {
+      const searchTool = KNOWLEDGE_TOOLS.find((tool) => tool.name === 'search_docs');
+      const getDocTool = KNOWLEDGE_TOOLS.find((tool) => tool.name === 'get_doc');
+      expect(searchTool?.input_schema.properties).toHaveProperty('version');
+      expect(getDocTool?.input_schema.properties).toHaveProperty('version');
+      expect(searchTool?.input_schema.properties.limit).toMatchObject({
+        type: 'integer',
+        minimum: 1,
+        maximum: 5,
+      });
+
+      const handlers = createKnowledgeToolHandlers();
+      const search = handlers.get('search_docs');
+      const getDoc = handlers.get('get_doc');
+      expect(search).toBeDefined();
+      expect(getDoc).toBeDefined();
+
+      const stableResults = await search!({ query: 'ACCOUNT_REQUIRED', version: '3.1' });
+      expect(stableResults).toContain('No documentation found in AdCP 3.1 (snapshot 3.1.19)');
+
+      const results = await search!({ query: 'ACCOUNT_REQUIRED', version: '3.2-beta' });
+      expect(results).toContain('Searching AdCP 3.2-beta (snapshot 3.2.0-beta.5)');
+      expect(results).toContain('**Version:** 3.2-beta (snapshot 3.2.0-beta.5)');
+      expect(results).toContain('ACCOUNT_REQUIRED');
+
+      const detail = await getDoc!({ doc_id: 'schema:3.2-beta:enums/error-code' });
+      expect(detail).toContain('**Version:** 3.2-beta (snapshot 3.2.0-beta.5)');
+      expect(detail).toContain('ACCOUNT_REQUIRED');
+    });
+
+    it('clamps search_docs limits to integer results between one and five', async () => {
+      const search = createKnowledgeToolHandlers().get('search_docs');
+      expect(search).toBeDefined();
+
+      expect(await search!({ query: 'protocol', limit: -10 })).toContain('Found 1 docs');
+      expect(await search!({ query: 'protocol', limit: 2.9 })).toContain('Found 2 docs');
+      expect(await search!({ query: 'protocol', limit: 100 })).toContain('Found 5 docs');
+      expect(await search!({ query: 'protocol', limit: Number.NaN })).toContain('Found 3 docs');
     });
   });
 
@@ -127,10 +284,13 @@ describe('docs-indexer', () => {
     });
 
     it('finds the distinction between refinement and price-negotiation capability', () => {
-      const results = searchDocs('price negotiation refinement capability', { limit: 5 });
-      expect(results.map((doc) => doc.id)).toContain('doc:media-buy/product-discovery/refinement');
+      const results = searchDocs('price negotiation refinement capability', {
+        limit: 20,
+        version: '3.2-beta',
+      });
+      expect(results.map((doc) => doc.id)).toContain('doc:3.2-beta:media-buy/product-discovery/refinement');
 
-      const refinement = getDocById('media-buy/product-discovery/refinement');
+      const refinement = getDocById('media-buy/product-discovery/refinement', { version: '3.2-beta' });
       expect(refinement?.content).toContain('There is no finer-grained price-negotiation capability flag.');
       expect(refinement?.content).toContain('omission communicates no per-ask outcome');
       expect(refinement?.content).toContain("Inspect the returned proposal's pricing and allocations");
@@ -179,12 +339,12 @@ The request includes a structured \`filters\` object.
     it('indexes get_products and product filter schema facts', () => {
       const results = searchDocs('get_products filters geo', { limit: 5 });
       expect(results.some((doc) => [
-        'schema:media-buy/get-products-request',
-        'schema:core/product-filters',
+        'schema:3.1:media-buy/get-products-request',
+        'schema:3.1:core/product-filters',
       ].includes(doc.id))).toBe(true);
 
       const filters = getDocById('core/product-filters.json');
-      expect(filters?.id).toBe('schema:core/product-filters');
+      expect(filters?.id).toBe('schema:3.1:core/product-filters');
       expect(filters?.content).toContain('Field: countries');
       expect(filters?.content).toContain('Field: channels');
     });
@@ -197,18 +357,18 @@ The request includes a structured \`filters\` object.
 
     it('ranks the Trusted Match CTV surface guide for a channel query', () => {
       const results = searchDocs('trusted match ctv', { limit: 3 });
-      expect(results.map((doc) => doc.id)).toContain('doc:trusted-match/surfaces/ctv');
+      expect(results.map((doc) => doc.id)).toContain('doc:3.1:trusted-match/surfaces/ctv');
     });
 
     it('retrieves CTV enum and standard format registry sources', () => {
       const enumResults = searchDocs('ctv_app property type', { limit: 5 });
-      expect(enumResults.map((doc) => doc.id)).toContain('schema:enums/property-type');
+      expect(enumResults.map((doc) => doc.id)).toContain('schema:3.1:enums/property-type');
 
       const formatResults = searchDocs(
         'canonical creative format contracts publisher acceptance product deliverability',
         { limit: 5 },
       );
-      expect(formatResults.map((doc) => doc.id)).toContain('doc:creative/formats');
+      expect(formatResults.map((doc) => doc.id)).toContain('doc:3.1:creative/formats');
     });
   });
 });

--- a/server/tests/unit/knowledge-search-initialization.test.ts
+++ b/server/tests/unit/knowledge-search-initialization.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   docsReady: false,
@@ -46,13 +46,19 @@ vi.mock('../../src/slack/client.js', () => ({
   getAccessiblePrivateChannelIds: vi.fn(async () => []),
 }));
 
-import {
-  initializeKnowledgeSearch,
-  isKnowledgeReady,
-} from '../../src/addie/mcp/knowledge-search.js';
-
 describe('knowledge search initialization', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.docsReady = false;
+    mocks.externalReady = false;
+    mocks.initializeDocsIndex.mockReset();
+    mocks.initializeExternalRepos.mockReset();
+  });
+
   it('deduplicates concurrent calls and retries an incomplete initialization', async () => {
+    const { initializeKnowledgeSearch, isKnowledgeReady } = await import(
+      '../../src/addie/mcp/knowledge-search.js'
+    );
     let releaseDocs!: () => void;
     const docsStarted = new Promise<void>((resolve) => {
       releaseDocs = resolve;
@@ -80,6 +86,28 @@ describe('knowledge search initialization', () => {
 
     await initializeKnowledgeSearch();
     expect(mocks.initializeDocsIndex).toHaveBeenCalledTimes(2);
+    expect(isKnowledgeReady()).toBe(true);
+  });
+
+  it('preserves a ready docs index while retrying external repositories', async () => {
+    const { initializeKnowledgeSearch, isKnowledgeReady } = await import(
+      '../../src/addie/mcp/knowledge-search.js'
+    );
+    mocks.initializeDocsIndex.mockImplementation(async () => {
+      mocks.docsReady = true;
+    });
+    mocks.initializeExternalRepos
+      .mockRejectedValueOnce(new Error('transient external failure'))
+      .mockImplementationOnce(async () => {
+        mocks.externalReady = true;
+      });
+
+    await initializeKnowledgeSearch();
+    expect(isKnowledgeReady()).toBe(false);
+
+    await initializeKnowledgeSearch();
+    expect(mocks.initializeDocsIndex).toHaveBeenCalledTimes(1);
+    expect(mocks.initializeExternalRepos).toHaveBeenCalledTimes(2);
     expect(isKnowledgeReady()).toBe(true);
   });
 });

--- a/server/tests/unit/knowledge-search-initialization.test.ts
+++ b/server/tests/unit/knowledge-search-initialization.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docsReady: false,
+  externalReady: false,
+  initializeDocsIndex: vi.fn(),
+  initializeExternalRepos: vi.fn(),
+}));
+
+vi.mock('../../src/logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('../../src/addie/mcp/docs-indexer.js', () => ({
+  initializeDocsIndex: mocks.initializeDocsIndex,
+  isDocsIndexReady: () => mocks.docsReady,
+  searchDocs: vi.fn(() => []),
+  getDocById: vi.fn(() => null),
+  getDocCategories: vi.fn(() => []),
+  getDocCount: vi.fn(() => 0),
+  getSupportedDocsVersions: vi.fn(() => []),
+  resolveDocsVersion: vi.fn(() => null),
+  formatDocsVersion: vi.fn(() => ''),
+}));
+
+vi.mock('../../src/addie/mcp/external-repos.js', () => ({
+  initializeExternalRepos: mocks.initializeExternalRepos,
+  isExternalReposReady: () => mocks.externalReady,
+  searchExternalDocs: vi.fn(() => []),
+  searchExternalHeadings: vi.fn(() => []),
+  getExternalRepoStats: vi.fn(() => []),
+  getExternalHeadingCount: vi.fn(() => 0),
+  getConfiguredRepos: vi.fn(() => []),
+}));
+
+vi.mock('../../src/db/addie-db.js', () => ({
+  AddieDatabase: class {},
+}));
+
+vi.mock('../../src/addie/services/content-curator.js', () => ({
+  queueWebSearchResult: vi.fn(),
+}));
+
+vi.mock('../../src/slack/client.js', () => ({
+  findChannelWithAccess: vi.fn(),
+  getAccessiblePrivateChannelIds: vi.fn(async () => []),
+}));
+
+import {
+  initializeKnowledgeSearch,
+  isKnowledgeReady,
+} from '../../src/addie/mcp/knowledge-search.js';
+
+describe('knowledge search initialization', () => {
+  it('deduplicates concurrent calls and retries an incomplete initialization', async () => {
+    let releaseDocs!: () => void;
+    const docsStarted = new Promise<void>((resolve) => {
+      releaseDocs = resolve;
+    });
+    mocks.initializeDocsIndex
+      .mockImplementationOnce(async () => {
+        await docsStarted;
+        throw new Error('transient docs failure');
+      })
+      .mockImplementationOnce(async () => {
+        mocks.docsReady = true;
+      });
+    mocks.initializeExternalRepos.mockImplementation(async () => {
+      mocks.externalReady = true;
+    });
+
+    const first = initializeKnowledgeSearch();
+    const second = initializeKnowledgeSearch();
+
+    expect(second).toBe(first);
+    expect(mocks.initializeDocsIndex).toHaveBeenCalledTimes(1);
+    releaseDocs();
+    await Promise.all([first, second]);
+    expect(isKnowledgeReady()).toBe(false);
+
+    await initializeKnowledgeSearch();
+    expect(mocks.initializeDocsIndex).toHaveBeenCalledTimes(2);
+    expect(isKnowledgeReady()).toBe(true);
+  });
+});

--- a/tests/addie/cross-publisher-frequency-docs.test.ts
+++ b/tests/addie/cross-publisher-frequency-docs.test.ts
@@ -5,14 +5,14 @@ import { MODULE_RESOURCES } from '../../server/src/addie/mcp/certification-tools
 describe('TMP coverage in docs and training', () => {
   beforeAll(async () => {
     await initializeDocsIndex();
-  });
+  }, 30_000);
 
   it('surfaces TMP and AdCP/OpenRTB docs in Addie search', () => {
     const results = searchDocs('cross-publisher frequency capping TMP Trusted Match OpenRTB', { limit: 5 });
     const urls = results.map((result) => result.sourceUrl);
 
-    expect(urls).toContain('https://docs.adcontextprotocol.org/docs/trusted-match');
-    expect(urls).toContain('https://docs.adcontextprotocol.org/docs/building/concepts/adcp-vs-openrtb');
+    expect(urls).toContain('https://docs.adcontextprotocol.org/dist/docs/3.1.19/trusted-match');
+    expect(urls).toContain('https://docs.adcontextprotocol.org/dist/docs/3.1.19/building/concepts/adcp-vs-openrtb');
   });
 
   it('includes TMP in all relevant training modules', () => {

--- a/tests/audio-radio-formats.test.cjs
+++ b/tests/audio-radio-formats.test.cjs
@@ -123,7 +123,15 @@ test('audio and radio guidance preserves loudness and normalization semantics', 
   assert.match(radio, /Standardized audio quartile and completion tag events use `audio_daast`/);
 });
 
-test('radio guide is present in live documentation navigation', () => {
+test('radio guide is present in the 3.2 beta documentation navigation', () => {
   const docsConfig = readJson(path.join(ROOT, 'docs.json'));
-  assert.match(JSON.stringify(docsConfig.navigation), /docs\/creative\/channels\/radio/);
+  const betaNavigation = docsConfig.navigation.versions.find(
+    version => version.version === '3.2-beta'
+  );
+
+  assert.ok(betaNavigation, '3.2-beta navigation must exist');
+  assert.match(
+    JSON.stringify(betaNavigation),
+    /dist\/docs\/3\.2\.0-beta\.\d+\/creative\/channels\/radio/
+  );
 });

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -8,6 +8,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const { execFileSync } = require('child_process');
 
 const DOCS_JSON = path.join(__dirname, '../docs.json');
 
@@ -62,6 +63,18 @@ function collectGroups(node) {
   return groups;
 }
 
+/**
+ * Collect directories where Mintlify generates searchable OpenAPI pages.
+ */
+function collectOpenApiDirectories(node) {
+  if (Array.isArray(node)) return node.flatMap(collectOpenApiDirectories);
+  if (!node || typeof node !== 'object') return [];
+
+  const directories = node.openapi?.directory ? [node.openapi.directory] : [];
+  if (node.pages) directories.push(...collectOpenApiDirectories(node.pages));
+  return directories;
+}
+
 function isDirectSlackInvite(value) {
   try {
     const url = new URL(value);
@@ -76,22 +89,16 @@ function containsDirectSlackInvite(content) {
   return urls.some(isDirectSlackInvite);
 }
 
-function isLiveDocsVersionCompatible(liveVersion, packageVersion) {
-  const liveMatch = /^(\d+)\.(\d+)$/.exec(liveVersion);
-  const packageMatch = /^(\d+)\.(\d+)\.\d+(?:-([0-9A-Za-z.-]+))?$/.exec(packageVersion);
-  if (!liveMatch || !packageMatch) return false;
+function snapshotMatchesVersionLabel(label, snapshotVersion) {
+  const labelMatch = /^(\d+\.\d+)(?:-([0-9A-Za-z]+)| \(archived\))?$/.exec(label);
+  const snapshotMatch = /^(\d+\.\d+)\.\d+(?:-([0-9A-Za-z]+)(?:\.|$))?/.exec(snapshotVersion);
+  if (!labelMatch || !snapshotMatch || labelMatch[1] !== snapshotMatch[1]) return false;
 
-  const liveLine = [Number(liveMatch[1]), Number(liveMatch[2])];
-  const packageLine = [Number(packageMatch[1]), Number(packageMatch[2])];
-  if (!packageMatch[3]) {
-    return liveLine[0] === packageLine[0] && liveLine[1] === packageLine[1];
-  }
-
-  // A prerelease package does not make that release line the live docs line.
-  // Keep the latest stable docs active until the release is promoted, while
-  // still rejecting a docs label from a future line.
-  return liveLine[0] < packageLine[0]
-    || (liveLine[0] === packageLine[0] && liveLine[1] <= packageLine[1]);
+  const labelPrerelease = labelMatch[2];
+  const snapshotPrerelease = snapshotMatch[2];
+  return labelPrerelease
+    ? labelPrerelease === snapshotPrerelease
+    : snapshotPrerelease === undefined;
 }
 
 // --- Run tests ---
@@ -115,50 +122,61 @@ const crossVersionDuplicates = [];
 test('default version is first in the versions array', () => {
   if (navigation.versions[0].version !== defaultVersion) {
     throw new Error(
-      `Default version "${defaultVersion}" must be first; Mintlify can omit its ` +
-      `file-backed routes when an archived version precedes it.`
+      `Default version "${defaultVersion}" must be first so Mintlify applies ` +
+      `the correct default routing and search filter.`
     );
   }
 });
 
-test('live docs version matching keeps prerelease packages unreleased', () => {
-  if (!isLiveDocsVersionCompatible('3.1', '3.1.14')) {
-    throw new Error('A stable package must accept its matching live docs line');
-  }
-  if (isLiveDocsVersionCompatible('3.0', '3.1.14')) {
-    throw new Error('A stable package must reject an older live docs line');
-  }
-  if (!isLiveDocsVersionCompatible('3.1', '3.2.0-beta.0')) {
-    throw new Error('A prerelease package must preserve the prior stable live docs line');
-  }
-  if (isLiveDocsVersionCompatible('3.3', '3.2.0-beta.0')) {
-    throw new Error('A prerelease package must reject a future live docs line');
+test('default version carries the Latest tag', () => {
+  const defaultEntry = navigation.versions.find(version => version.default)
+    || navigation.versions[0];
+  if (defaultEntry.tag !== 'Latest') {
+    throw new Error('The default docs version must carry the "Latest" tag');
   }
 });
 
-test('one release-labeled version owns the live docs tree', () => {
-  const liveVersions = navigation.versions.filter(versionEntry =>
-    collectPages(versionEntry.groups).some(page => page.startsWith('docs/'))
-  );
-  const packageVersion = JSON.parse(
-    fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8')
-  ).version;
-
-  if (liveVersions.length !== 1) {
-    throw new Error(`Expected one live docs owner, found ${liveVersions.length}`);
+test('default navigation matches the stable release branch surface', () => {
+  let releaseConfig;
+  try {
+    releaseConfig = JSON.parse(execFileSync(
+      'git',
+      ['show', 'origin/3.1.x:docs.json'],
+      { cwd: rootDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+    ));
+  } catch {
+    if (process.env.REQUIRE_STABLE_DOCS_REF === '1') {
+      throw new Error('origin/3.1.x is required but unavailable');
+    }
+    return;
   }
 
-  const [liveVersion] = liveVersions;
-  if (liveVersion !== navigation.versions[0] || !liveVersion.default) {
-    throw new Error('The live docs owner must be the first and default version');
-  }
-  if (!isLiveDocsVersionCompatible(liveVersion.version, packageVersion)) {
+  const currentDefault = navigation.versions.find(version => version.default)
+    || navigation.versions[0];
+  const releaseDefault = releaseConfig.navigation.versions.find(version => version.default)
+    || releaseConfig.navigation.versions[0];
+  const normalize = page => page
+    .replace(/^dist\/docs\/[^/]+\//, '')
+    .replace(/^docs\//, '');
+  const currentRoutes = [
+    ...collectPages(currentDefault.groups),
+    ...collectOpenApiDirectories(currentDefault.groups),
+  ].map(normalize).sort();
+  const releaseRoutes = [
+    ...collectPages(releaseDefault.groups),
+    ...collectOpenApiDirectories(releaseDefault.groups),
+  ].map(normalize).sort();
+
+  if (JSON.stringify(currentRoutes) !== JSON.stringify(releaseRoutes)) {
+    const releaseSet = new Set(releaseRoutes);
+    const currentSet = new Set(currentRoutes);
+    const unexpected = currentRoutes.filter(route => !releaseSet.has(route));
+    const missing = releaseRoutes.filter(route => !currentSet.has(route));
     throw new Error(
-      `Live docs version "${liveVersion.version}" is incompatible with package release "${packageVersion}"`
+      `Stable navigation drifted from origin/3.1.x.`
+      + `\n      Unexpected: ${unexpected.join(', ') || 'none'}`
+      + `\n      Missing: ${missing.join(', ') || 'none'}`
     );
-  }
-  if (liveVersion.tag !== 'Latest') {
-    throw new Error('The live docs owner must carry the "Latest" tag');
   }
 });
 
@@ -196,6 +214,17 @@ for (const versionEntry of navigation.versions) {
 
   const allPages = collectPages(groups);
   const allGroups = collectGroups(groups);
+  const allSearchRoutes = [...allPages, ...collectOpenApiDirectories(groups)];
+
+  test('uses one canonical route family', () => {
+    const livePages = allSearchRoutes.filter(page => page.startsWith('docs/'));
+    const snapshotPages = allSearchRoutes.filter(page => page.startsWith('dist/docs/'));
+    if (livePages.length > 0 && snapshotPages.length > 0) {
+      throw new Error(
+        `Version "${version}" mixes live and snapshot routes, which splits its search index`
+      );
+    }
+  });
 
   for (const page of allPages) {
     const owner = pageOwners.get(page);
@@ -250,15 +279,42 @@ for (const versionEntry of navigation.versions) {
   });
 
   // Test 5: Versioned (dist/docs/) pages must have consistent version prefix
-  const distPages = allPages.filter(p => p.startsWith('dist/docs/'));
-  if (distPages.length > 0) {
-    test('dist/docs pages share a consistent version prefix', () => {
-      const prefixes = new Set(distPages.map(p => {
+  const distSearchRoutes = allSearchRoutes.filter(p => p.startsWith('dist/docs/'));
+  if (distSearchRoutes.length > 0) {
+    test('indexed routes share a consistent snapshot prefix', () => {
+      const prefixes = new Set(distSearchRoutes.map(p => {
         const parts = p.split('/');
         return `${parts[0]}/${parts[1]}/${parts[2]}`;
       }));
       if (prefixes.size > 1) {
         throw new Error(`Mixed version prefixes: ${[...prefixes].join(', ')}`);
+      }
+    });
+
+    test('snapshot prefix matches the version label', () => {
+      const snapshotVersion = distSearchRoutes[0].split('/')[2];
+      if (!snapshotMatchesVersionLabel(version, snapshotVersion)) {
+        throw new Error(
+          `Version "${version}" cannot use snapshot "${snapshotVersion}"; ` +
+          `Mintlify search filters by the navigation version label`
+        );
+      }
+    });
+
+    test('uses the latest committed snapshot for its release line', () => {
+      const snapshotVersion = distSearchRoutes[0].split('/')[2];
+      const availableSnapshots = fs.readdirSync(path.join(rootDir, 'dist/docs'), {
+        withFileTypes: true,
+      })
+        .filter(entry => entry.isDirectory() && snapshotMatchesVersionLabel(version, entry.name))
+        .map(entry => entry.name)
+        .sort((left, right) => left.localeCompare(right, undefined, { numeric: true }));
+      const latestSnapshot = availableSnapshots.at(-1);
+      if (snapshotVersion !== latestSnapshot) {
+        throw new Error(
+          `Version "${version}" uses stale snapshot "${snapshotVersion}"; ` +
+          `latest committed snapshot is "${latestSnapshot}"`
+        );
       }
     });
   }
@@ -291,12 +347,61 @@ test('page files belong to only one version', () => {
   }
 });
 
-test('live docs route Slack invitations through the joining guide', () => {
-  const liveVersion = navigation.versions.find(version => version.default)
+test('navigable pages are canonical and never redirect', () => {
+  const redirectSources = new Map(
+    docsConfig.redirects.map(redirect => [redirect.source, redirect.destination])
+  );
+  const redirectedPages = [];
+
+  for (const [page, version] of pageOwners) {
+    const destination = redirectSources.get(`/${page}`);
+    if (destination) {
+      redirectedPages.push(`${page} (${version}) -> ${destination}`);
+    }
+  }
+
+  if (redirectedPages.length > 0) {
+    throw new Error(
+      `Mintlify indexes navigation paths before redirects, so redirected pages ` +
+      `disappear from version-filtered search:\n      ${redirectedPages.join('\n      ')}`
+    );
+  }
+});
+
+test('default snapshot pages retain clean-route aliases', () => {
+  const defaultEntry = navigation.versions.find(version => version.default)
+    || navigation.versions[0];
+  const snapshotPages = collectPages(defaultEntry.groups)
+    .filter(page => page.startsWith('dist/docs/'));
+  if (snapshotPages.length === 0) return;
+
+  const redirectsBySource = new Map(
+    docsConfig.redirects.map(redirect => [redirect.source, redirect])
+  );
+  const brokenAliases = [];
+
+  for (const page of snapshotPages) {
+    const cleanPath = `/docs/${page.split('/').slice(3).join('/')}`;
+    const redirect = redirectsBySource.get(cleanPath);
+    if (redirect?.destination !== `/${page}` || redirect.permanent !== false) {
+      brokenAliases.push(`${cleanPath} -> /${page}`);
+    }
+  }
+
+  if (brokenAliases.length > 0) {
+    throw new Error(
+      `Default snapshot pages require temporary clean-route aliases:\n      ` +
+      brokenAliases.join('\n      ')
+    );
+  }
+});
+
+test('docs entry points route Slack invitations through the joining guide', () => {
+  const defaultVersionEntry = navigation.versions.find(version => version.default)
     || navigation.versions[0];
   const directInvitePages = [];
 
-  for (const page of collectPages(liveVersion.groups).filter(page => page.startsWith('docs/'))) {
+  for (const page of collectPages(defaultVersionEntry.groups).filter(page => page.startsWith('docs/'))) {
     if (page === 'docs/community/joining-slack') continue;
     const filePath = fs.existsSync(path.join(rootDir, `${page}.mdx`))
       ? path.join(rootDir, `${page}.mdx`)
@@ -327,7 +432,7 @@ test('live docs route Slack invitations through the joining guide', () => {
     );
   }
 
-  // Mintlify temporarily redirects live routes to immutable 3.1.2 snapshots.
+  // Clean stable routes redirect to the latest immutable 3.1 snapshot.
   // Its global custom-script support lets us repair stale invite anchors at
   // render time without mutating those release artifacts.
   const recoveryScript = fs.readFileSync(
@@ -379,7 +484,7 @@ test('live docs route Slack invitations through the joining guide', () => {
   };
 
   const guideUrl = 'https://docs.adcontextprotocol.org/docs/community/joining-slack';
-  const harness = loadRecoveryHarness('/dist/docs/3.1.2/intro');
+  const harness = loadRecoveryHarness('/dist/docs/3.1.19/intro');
   if (harness.initialAnchor.href !== guideUrl) {
     throw new Error('Snapshot pages must rewrite their direct Slack invite to the recovery guide');
   }
@@ -391,7 +496,7 @@ test('live docs route Slack invitations through the joining guide', () => {
     throw new Error('Slack invite recovery must not rewrite URLs on unrelated hosts');
   }
 
-  harness.navigate('/dist/docs/3.1.2/community/joining-slack');
+  harness.navigate('/dist/docs/3.1.19/community/joining-slack');
   const guideContent = harness.makeElement(harness.directInvite, 'For AAO members only');
   harness.add(guideContent);
   if (guideContent.href !== harness.directInvite) {
@@ -401,96 +506,11 @@ test('live docs route Slack invitations through the joining guide', () => {
     throw new Error('The joining guide must repair legacy organization terminology');
   }
 
-  harness.navigate('/dist/docs/3.1.2/intro');
+  harness.navigate('/dist/docs/3.1.19/intro');
   const introContent = harness.makeElement();
   harness.add(introContent);
   if (introContent.href !== guideUrl) {
     throw new Error('SPA navigation away from the joining guide must resume invite rewriting');
-  }
-});
-
-// Emergency fallback while Mintlify omits file-backed docs/** routes.
-// Remove this invariant with the temporary redirects once live files publish again.
-test('temporary snapshot redirects cover every available live page', () => {
-  const liveVersion = navigation.versions.find(version => version.default)
-    || navigation.versions[0];
-  const livePages = collectPages(liveVersion.groups)
-    .filter(page => page.startsWith('docs/'));
-  const expectedRedirects = new Map();
-  const uncoveredPages = [];
-
-  for (const page of livePages) {
-    const relativePath = page.slice('docs/'.length);
-    const destination = `/dist/docs/3.1.2/${relativePath}`;
-    const filePath = path.join(rootDir, destination.slice(1));
-    if (fs.existsSync(`${filePath}.mdx`) || fs.existsSync(`${filePath}.md`)) {
-      expectedRedirects.set(`/${page}`, destination);
-    } else {
-      uncoveredPages.push(page);
-    }
-  }
-
-  // This file is linked by Addie but intentionally omitted from navigation.
-  expectedRedirects.set(
-    '/docs/aao/aao-admins',
-    '/dist/docs/3.1.2/aao/aao-admins'
-  );
-
-  const expectedUncoveredPages = [
-    'docs/reference/whats-new-in-3-2',
-    'docs/reference/3-2-beta',
-    'docs/reference/migration/3-1-to-3-2',
-    'docs/reference/migration/targeting-aware-discovery',
-    'docs/reference/migration/asset-access',
-    'docs/reference/migration/cross-role-governance-enforcement',
-    'docs/protocol/language-and-localization',
-    'docs/building/by-layer/L3/async-identity-and-convergence',
-    'docs/protocol/sync_agent_notification_configs',
-    'docs/accounts/provisioning-walkthrough',
-    'docs/media-buy/product-discovery/proposal-negotiation',
-    'docs/media-buy/media-buys/indicators',
-    'docs/media-buy/task-reference/list_products',
-    'docs/media-buy/task-reference/request_proposals',
-    'docs/media-buy/task-reference/refine_proposals',
-    'docs/media-buy/task-reference/decline_proposals',
-    'docs/media-buy/task-reference/buy_products',
-    'docs/media-buy/task-reference/accept_proposal',
-    'docs/media-buy/task-reference/control_media_buy',
-    'docs/creative/channels/radio',
-    'docs/governance/creative/policy-backed-rejections',
-    'docs/governance/campaign/tasks/report_plan_adjustment',
-    'docs/brand-protocol/tasks/search_brands',
-  ];
-  if (JSON.stringify(uncoveredPages) !== JSON.stringify(expectedUncoveredPages)) {
-    throw new Error(
-      `Unexpected live pages without a 3.1.2 snapshot: ${uncoveredPages.join(', ')}`
-    );
-  }
-
-  const snapshotRedirects = docsConfig.redirects.filter(redirect =>
-    redirect.destination.startsWith('/dist/docs/3.1.2/')
-  );
-  if (snapshotRedirects.length !== expectedRedirects.size) {
-    throw new Error(
-      `Expected ${expectedRedirects.size} snapshot redirects, found ${snapshotRedirects.length}`
-    );
-  }
-
-  for (const [source, destination] of expectedRedirects) {
-    const matches = docsConfig.redirects.filter(redirect => redirect.source === source);
-    if (matches.length !== 1 || matches[0].destination !== destination) {
-      throw new Error(`${source} must redirect exactly once to ${destination}`);
-    }
-    if (matches[0].permanent !== false) {
-      throw new Error(`${source} snapshot fallback must be temporary`);
-    }
-  }
-
-  const generatedApiRedirect = snapshotRedirects.find(redirect =>
-    redirect.source.startsWith('/docs/registry/api-reference/')
-  );
-  if (generatedApiRedirect) {
-    throw new Error(`Generated API route must not be redirected: ${generatedApiRedirect.source}`);
   }
 });
 


### PR DESCRIPTION
## Summary
- pin Mintlify navigation and Addie indexing to exact release snapshots
- isolate docs and schema results by version while keeping stable 3.1 aligned with the stable release branch
- add production-image and navigation CI guards for every supported docs version

## Testing
- pre-commit suite: 6,476 passed, 30 skipped
- docs navigation validation: 43 passed
- focused Addie and schema behavior tests: 57 passed
- production runtime smoke across 3.1, 3.2-beta, 3.0, and 2.5
- TypeScript typecheck