### PR TITLE
feat(reporting): nielsen_audio demographic system + radio reconciliation guide

### DIFF
--- a/.changeset/add-nielsen-audio-demographic-system.md
+++ b/.changeset/add-nielsen-audio-demographic-system.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add `nielsen_audio` to `demographic-system` (same P/M/W notation as Nielsen TV, measured on the radio panel) and broaden the enum's scope to audio channels. RAJAR remains a `measurement_source`, not a notation system. Documents radio delivery reconciliation in the channel guide: demographic notation, provider identity, and `measurement_windows` maturation as the three declarations, with weekly panel cadence as an optimization-eligibility gate. Implements the WG-ratified #6139 decisions.

--- a/docs/creative/channels/radio.mdx
+++ b/docs/creative/channels/radio.mdx
@@ -135,6 +135,25 @@ The reference declarations contain only the required `audio_main` file slot. Ter
 
 Digital streaming or SSAI inventory is a separate execution context. It may use `audio_hosted` with explicitly declared impression, click, or other supported `pixel_tracker` slots. Standardized audio quartile and completion tag events use `audio_daast`. A terrestrial spot simulcast digitally does not make trackers operational on the terrestrial airing.
 
-Radio delivery measurement, delayed reporting, and reconciliation semantics are tracked separately in [adcp#6167](https://github.com/adcontextprotocol/adcp/issues/6167).
+## Delivery measurement and reconciliation
+
+Radio plans, guarantees, and reconciles on measured audience — panel data (Nielsen Audio in the US, RAJAR in the UK), not served-event counts. Three declarations carry the whole contract:
+
+- **Demographic notation** — `demographic_system` on the CPP pricing option and forecast (e.g. `nielsen_audio` with `demographic: "P25-54"`) says how the audience is written.
+- **Provider identity** — `measurement_source` on forecast and delivery rows (e.g. `nielsen_audio`, `rajar`) says whose data produced the numbers. Notation and provider are separate declarations: RAJAR is a `measurement_source`, not a notation system.
+- **Maturation** — delayed panel publication reuses the existing `measurement_windows` contract (`is_final`, `finalized_at`), the same preliminary→final semantics broadcast uses for C3/C7. There is no separate phase vocabulary.
+
+A buy committed to `grps` against `P25-54` on `nielsen_audio` reconciles when the delivery row carries the same declarations:
+
+```json
+{
+  "grps": 84.2,
+  "measurement_source": "nielsen_audio",
+  "is_final": true,
+  "finalized_at": "2026-10-12T00:00:00Z"
+}
+```
+
+Panel data arrives on the panel's publication cycle — declare `weekly` (or coarser) in `reporting_capabilities.reporting_frequencies`, and buyers treat that cadence as an optimization-eligibility gate: nothing should mid-flight-optimize against numbers that publish weekly. Station affidavits and playout logs prove that scheduled spots aired; the audience currency turns those airings into the audience-size number.
 
 See [Audio](/docs/creative/channels/audio), [Broadcast](/docs/creative/channels/broadcast), and [Creative manifests](/docs/creative/creative-manifests).

--- a/static/schemas/source/enums/demographic-system.json
+++ b/static/schemas/source/enums/demographic-system.json
@@ -2,10 +2,11 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/enums/demographic-system.json",
   "title": "Demographic System",
-  "description": "Audience measurement systems for demographic notation in GRP forecasts and pricing",
+  "description": "Audience measurement systems for demographic notation in GRP forecasts and pricing, across video and audio channels. Specifies how demographics are written, not whose panel produced the numbers — provider identity is measurement_source.",
   "type": "string",
   "enum": [
     "nielsen",
+    "nielsen_audio",
     "barb",
     "agf",
     "oztam",
@@ -14,6 +15,7 @@
   ],
   "enumDescriptions": {
     "nielsen": "Nielsen notation. Prefix: P(ersons), M(en), W(omen), A(dults), C(hildren), T(eens) + age range. Examples: P18-49, M25-54, W35+",
+    "nielsen_audio": "Nielsen Audio (US radio, formerly Arbitron). Same P/M/W/A prefix + age-range notation as Nielsen TV, measured on the PPM/diary radio panel. Examples: P25-54, A18+, W25-54",
     "barb": "BARB (UK). NRS social grade + age bands. Examples: ABC1 Adults, 16-34, Adults",
     "agf": "AGF Videoforschung (Germany). Erwachsene notation + age bands. Examples: E 14-49, E 14+",
     "oztam": "OzTAM (Australia). Age/gender bands, 4+ measurement universe",

--- a/tests/check-platform-agnostic.cjs
+++ b/tests/check-platform-agnostic.cjs
@@ -100,6 +100,11 @@ const ENUM_VALUE_ALLOWLIST = [
   // demographic audience measurement vocabulary (parallel to Nielsen DMA).
   { value: 'nielsen', pathContains: 'enums/demographic-system.json' },
 
+  // enums/demographic-system.json — Nielsen Audio (ex-Arbitron) is the US
+  // radio audience notation, same standing as Nielsen TV notation above
+  // (WG-ratified via adcp#6139).
+  { value: 'nielsen_audio', pathContains: 'enums/demographic-system.json' },
+
   // enums/device-platform.json — Roku OS is a distinct CTV operating system
   // name, same as tvos, fire_os, tizen, webos.
   { value: 'roku_os', pathContains: 'enums/device-platform.json' },


### PR DESCRIPTION
## Summary

Implements the WG-ratified #6139 decisions (radio/broadcast measurement packet, approved — outcome recorded on the issue):

- **`nielsen_audio` enters `demographic-system.json`** — same P/M/W notation scheme as Nielsen TV, measured on the PPM/diary radio panel. Enum + `enumDescriptions` entry, and the enum's description broadened to audio channels with the notation-vs-provider line stated explicitly.
- **RAJAR stays a `measurement_source`, not a notation system** — per the author's own resolution on the #6139 thread (withdrawn from the notation ask; `delivery-forecast.json` already lists `rajar` in `measurement_source` examples).
- **Radio channel guide gains the reconciliation contract** (`radio.mdx`, replacing the bare #6167 pointer): the three declarations — notation (`demographic_system`), provider identity (row-level `measurement_source`), maturation (`measurement_windows` reuse per the #6167 ratification; no `impression_phase`) — with a worked committed-metric ↔ delivery-row example and the weekly-cadence optimization-eligibility gate.

## Dependency note

The delivery-row example references row-level `measurement_source`, which ships in #6241 (the ratified #6139 decision 1 rides there because the OOH block needs the lane immediately). Merge #6241 first, or accept a brief window where the guide references a field that lands days later — schema changes here are independent either way.

Changeset included (minor). Refs #6139, #6167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)