### PR TITLE
feat(auth): observe credential authorization differences

### DIFF
--- a/server/src/auth/workos-client.ts
+++ b/server/src/auth/workos-client.ts
@@ -5,10 +5,12 @@ import { createLogger } from '../logger.js';
 const logger = createLogger('workos-client');
 const OWNERLESS_PROMOTION_WORKOS_TIMEOUT_MS = 10_000;
 const PIPES_WORKOS_TIMEOUT_MS = 10_000;
+const AUTHORIZATION_OBSERVER_WORKOS_TIMEOUT_MS = 3_000;
 
 let _workos: WorkOS | null = null;
 let _ownerlessPromotionWorkos: WorkOS | null = null;
 let _pipesWorkos: WorkOS | null = null;
+let _authorizationObserverWorkos: WorkOS | null = null;
 let _clientId = '';
 
 /** Returns the shared WorkOS client. Constructed on first call; WORKOS_API_KEY and WORKOS_CLIENT_ID must be set by then. */
@@ -53,6 +55,25 @@ export function getPipesWorkos(): WorkOS {
     });
   }
   return _pipesWorkos;
+}
+
+/**
+ * Returns a fail-fast WorkOS client used only by post-response authorization
+ * observation. It must not accumulate retries or long-lived requests when
+ * WorkOS is slow because observer work is deliberately fire-and-forget.
+ */
+export function getAuthorizationObserverWorkos(): WorkOS {
+  if (!_authorizationObserverWorkos) {
+    if (!process.env.WORKOS_API_KEY) throw new Error('WORKOS_API_KEY environment variable is required');
+    if (!process.env.WORKOS_CLIENT_ID) throw new Error('WORKOS_CLIENT_ID environment variable is required');
+    _clientId = process.env.WORKOS_CLIENT_ID;
+    _authorizationObserverWorkos = new WorkOS(process.env.WORKOS_API_KEY, {
+      clientId: _clientId,
+      timeout: AUTHORIZATION_OBSERVER_WORKOS_TIMEOUT_MS,
+      maxRetries: 0,
+    });
+  }
+  return _authorizationObserverWorkos;
 }
 
 /**

--- a/server/src/middleware/organization-authorization-observer.ts
+++ b/server/src/middleware/organization-authorization-observer.ts
@@ -1,10 +1,12 @@
 import type { Request } from 'express';
-import { getWorkos } from '../auth/workos-client.js';
+import { getAuthorizationObserverWorkos } from '../auth/workos-client.js';
 import { createLogger } from '../logger.js';
 import { resolveUserRole } from '../utils/resolve-user-role.js';
 import { captureEvent } from '../utils/posthog.js';
 
 const logger = createLogger('organization-authorization-observer');
+const MAX_CONCURRENT_COMPARISONS = 5;
+let inFlightComparisons = 0;
 
 export type OrganizationSelectorSource =
   | 'header'
@@ -141,33 +143,51 @@ export async function observeLinkedCredentialOrganizationAuthorization(
       return;
     }
 
-    const workos = getWorkos();
-    const [legacyMemberships, exactMemberships] = await Promise.all([
-      workos.userManagement.listOrganizationMemberships({
-        userId: canonicalUserId,
-        organizationId: selector.organizationId,
-      }),
-      workos.userManagement.listOrganizationMemberships({
-        userId: authenticatedUserId,
-        organizationId: selector.organizationId,
-      }),
-    ]);
-    const legacy = summarizeMemberships(legacyMemberships.data, selector.organizationId);
-    const exact = summarizeMemberships(exactMemberships.data, selector.organizationId);
+    if (inFlightComparisons >= MAX_CONCURRENT_COMPARISONS) {
+      captureEvent('server-metrics', 'org_authorization_shadow', {
+        route,
+        method: req.method,
+        response_status: responseStatus,
+        linked_credential: true,
+        selector_source: selector.source,
+        explicit_organization: true,
+        decision: 'observer_saturated',
+      });
+      return;
+    }
 
-    captureEvent('server-metrics', 'org_authorization_shadow', {
-      route,
-      method: req.method,
-      response_status: responseStatus,
-      linked_credential: true,
-      selector_source: selector.source,
-      explicit_organization: selector.explicit,
-      decision: classifyAuthorizationObservation(legacy, exact),
-      legacy_allowed: legacy.allowed,
-      exact_allowed: exact.allowed,
-      legacy_role: legacy.role,
-      exact_role: exact.role,
-    });
+    inFlightComparisons += 1;
+    try {
+      const workos = getAuthorizationObserverWorkos();
+      const [legacyMemberships, exactMemberships] = await Promise.all([
+        workos.userManagement.listOrganizationMemberships({
+          userId: canonicalUserId,
+          organizationId: selector.organizationId,
+        }),
+        workos.userManagement.listOrganizationMemberships({
+          userId: authenticatedUserId,
+          organizationId: selector.organizationId,
+        }),
+      ]);
+      const legacy = summarizeMemberships(legacyMemberships.data, selector.organizationId);
+      const exact = summarizeMemberships(exactMemberships.data, selector.organizationId);
+
+      captureEvent('server-metrics', 'org_authorization_shadow', {
+        route,
+        method: req.method,
+        response_status: responseStatus,
+        linked_credential: true,
+        selector_source: selector.source,
+        explicit_organization: selector.explicit,
+        decision: classifyAuthorizationObservation(legacy, exact),
+        legacy_allowed: legacy.allowed,
+        exact_allowed: exact.allowed,
+        legacy_role: legacy.role,
+        exact_role: exact.role,
+      });
+    } finally {
+      inFlightComparisons -= 1;
+    }
   } catch (err) {
     logger.warn(
       { err, route, selectorSource: selector.source },

--- a/server/src/middleware/organization-authorization-observer.ts
+++ b/server/src/middleware/organization-authorization-observer.ts
@@ -130,7 +130,7 @@ export async function observeLinkedCredentialOrganizationAuthorization(
   try {
     // This branch controls only which observe-only telemetry event is emitted;
     // it is not an authorization guard and never changes the response.
-    if (!selector.organizationId) { // lgtm[js/user-controlled-bypass]
+    if (!selector.organizationId) {
       captureEvent('server-metrics', 'org_authorization_shadow', {
         route,
         method: req.method,

--- a/server/src/middleware/organization-authorization-observer.ts
+++ b/server/src/middleware/organization-authorization-observer.ts
@@ -1,6 +1,5 @@
 import type { Request } from 'express';
 import { getWorkos } from '../auth/workos-client.js';
-import { resolvePrimaryOrganization } from '../db/users-db.js';
 import { createLogger } from '../logger.js';
 import { resolveUserRole } from '../utils/resolve-user-role.js';
 import { captureEvent } from '../utils/posthog.js';
@@ -15,7 +14,6 @@ export type OrganizationSelectorSource =
   | 'body_organizationId'
   | 'path_orgId'
   | 'path_organizationId'
-  | 'legacy_primary'
   | 'none';
 
 type RequestWithAuthContext = Pick<Request, 'headers' | 'query' | 'body' | 'params' | 'method'> & {
@@ -129,13 +127,6 @@ export async function observeLinkedCredentialOrganizationAuthorization(
   let selector = organizationSelectorFromRequest(req);
   try {
     if (!selector.organizationId) {
-      const legacyOrganizationId = await resolvePrimaryOrganization(canonicalUserId);
-      selector = legacyOrganizationId
-        ? { organizationId: legacyOrganizationId, source: 'legacy_primary', explicit: false }
-        : selector;
-    }
-
-    if (!selector.organizationId) {
       captureEvent('server-metrics', 'org_authorization_shadow', {
         route,
         method: req.method,
@@ -143,7 +134,7 @@ export async function observeLinkedCredentialOrganizationAuthorization(
         linked_credential: true,
         selector_source: selector.source,
         explicit_organization: false,
-        decision: 'no_organization',
+        decision: 'no_explicit_organization',
       });
       return;
     }

--- a/server/src/middleware/organization-authorization-observer.ts
+++ b/server/src/middleware/organization-authorization-observer.ts
@@ -124,9 +124,11 @@ export async function observeLinkedCredentialOrganizationAuthorization(
   const authenticatedUserId = req.user?.authWorkosUserId;
   if (!canonicalUserId || !authenticatedUserId || canonicalUserId === authenticatedUserId) return;
 
-  let selector = organizationSelectorFromRequest(req);
+  const selector = organizationSelectorFromRequest(req);
   try {
-    if (!selector.organizationId) {
+    // This branch controls only which observe-only telemetry event is emitted;
+    // it is not an authorization guard and never changes the response.
+    if (!selector.organizationId) { // lgtm[js/user-controlled-bypass]
       captureEvent('server-metrics', 'org_authorization_shadow', {
         route,
         method: req.method,

--- a/server/src/middleware/organization-authorization-observer.ts
+++ b/server/src/middleware/organization-authorization-observer.ts
@@ -1,0 +1,193 @@
+import type { Request } from 'express';
+import { getWorkos } from '../auth/workos-client.js';
+import { resolvePrimaryOrganization } from '../db/users-db.js';
+import { createLogger } from '../logger.js';
+import { resolveUserRole } from '../utils/resolve-user-role.js';
+import { captureEvent } from '../utils/posthog.js';
+
+const logger = createLogger('organization-authorization-observer');
+
+export type OrganizationSelectorSource =
+  | 'header'
+  | 'query_org'
+  | 'query_organization_id'
+  | 'body_organization_id'
+  | 'body_organizationId'
+  | 'path_orgId'
+  | 'path_organizationId'
+  | 'legacy_primary'
+  | 'none';
+
+type RequestWithAuthContext = Pick<Request, 'headers' | 'query' | 'body' | 'params' | 'method'> & {
+  user?: {
+    id?: string;
+    authWorkosUserId?: string;
+  };
+};
+
+export interface OrganizationSelector {
+  organizationId: string | null;
+  source: OrganizationSelectorSource;
+  explicit: boolean;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+/**
+ * Read the explicit organization selectors already supported by the server.
+ * This is observation-only: it never mutates the request or supplies a
+ * fallback to authorization code.
+ */
+export function organizationSelectorFromRequest(
+  req: Pick<RequestWithAuthContext, 'headers' | 'query' | 'body' | 'params'>,
+): OrganizationSelector {
+  const header = nonEmptyString(req.headers['x-organization-id']);
+  if (header) return { organizationId: header, source: 'header', explicit: true };
+
+  const queryOrg = nonEmptyString(req.query?.org);
+  if (queryOrg) return { organizationId: queryOrg, source: 'query_org', explicit: true };
+
+  const queryOrganizationId = nonEmptyString(req.query?.organization_id);
+  if (queryOrganizationId) {
+    return { organizationId: queryOrganizationId, source: 'query_organization_id', explicit: true };
+  }
+
+  const body = req.body && typeof req.body === 'object'
+    ? req.body as Record<string, unknown>
+    : {};
+  const bodyOrganizationId = nonEmptyString(body.organization_id);
+  if (bodyOrganizationId) {
+    return { organizationId: bodyOrganizationId, source: 'body_organization_id', explicit: true };
+  }
+
+  const bodyOrganizationIdCamel = nonEmptyString(body.organizationId);
+  if (bodyOrganizationIdCamel) {
+    return { organizationId: bodyOrganizationIdCamel, source: 'body_organizationId', explicit: true };
+  }
+
+  const pathOrgId = nonEmptyString(req.params?.orgId);
+  if (pathOrgId) return { organizationId: pathOrgId, source: 'path_orgId', explicit: true };
+
+  const pathOrganizationId = nonEmptyString(req.params?.organizationId);
+  if (pathOrganizationId) {
+    return { organizationId: pathOrganizationId, source: 'path_organizationId', explicit: true };
+  }
+
+  return { organizationId: null, source: 'none', explicit: false };
+}
+
+type MembershipSummary = {
+  allowed: boolean;
+  role: string | null;
+};
+
+function summarizeMemberships(
+  memberships: Array<{ organizationId: string; status?: string; role?: { slug?: string } | null }>,
+  organizationId: string,
+): MembershipSummary {
+  const matching = memberships.filter(
+    (membership) => membership.organizationId === organizationId && membership.status === 'active',
+  );
+  if (matching.length === 0) return { allowed: false, role: null };
+  return {
+    allowed: true,
+    role: resolveUserRole(matching as Parameters<typeof resolveUserRole>[0]) ?? null,
+  };
+}
+
+export function classifyAuthorizationObservation(
+  legacy: MembershipSummary,
+  exact: MembershipSummary,
+): string {
+  if (legacy.allowed && !exact.allowed) return 'legacy_allow_exact_deny';
+  if (!legacy.allowed && exact.allowed) return 'legacy_deny_exact_allow';
+  if (!legacy.allowed && !exact.allowed) return 'both_deny';
+  return legacy.role === exact.role ? 'both_allow_same_role' : 'both_allow_role_mismatch';
+}
+
+/**
+ * Compare the shipped canonical-credential decision with the proposed exact-
+ * credential decision after a response has completed. The comparison is
+ * deliberately side-effect free and never changes the response.
+ *
+ * Only linked, non-primary sessions need the extra WorkOS reads. Events carry
+ * route/decision metadata but no user, identity, email, or organization IDs.
+ */
+export async function observeLinkedCredentialOrganizationAuthorization(
+  req: RequestWithAuthContext,
+  route: string,
+  responseStatus: number,
+): Promise<void> {
+  if (process.env.ORG_AUTHORIZATION_OBSERVER_ENABLED === 'false') return;
+
+  const canonicalUserId = req.user?.id;
+  const authenticatedUserId = req.user?.authWorkosUserId;
+  if (!canonicalUserId || !authenticatedUserId || canonicalUserId === authenticatedUserId) return;
+
+  let selector = organizationSelectorFromRequest(req);
+  try {
+    if (!selector.organizationId) {
+      const legacyOrganizationId = await resolvePrimaryOrganization(canonicalUserId);
+      selector = legacyOrganizationId
+        ? { organizationId: legacyOrganizationId, source: 'legacy_primary', explicit: false }
+        : selector;
+    }
+
+    if (!selector.organizationId) {
+      captureEvent('server-metrics', 'org_authorization_shadow', {
+        route,
+        method: req.method,
+        response_status: responseStatus,
+        linked_credential: true,
+        selector_source: selector.source,
+        explicit_organization: false,
+        decision: 'no_organization',
+      });
+      return;
+    }
+
+    const workos = getWorkos();
+    const [legacyMemberships, exactMemberships] = await Promise.all([
+      workos.userManagement.listOrganizationMemberships({
+        userId: canonicalUserId,
+        organizationId: selector.organizationId,
+      }),
+      workos.userManagement.listOrganizationMemberships({
+        userId: authenticatedUserId,
+        organizationId: selector.organizationId,
+      }),
+    ]);
+    const legacy = summarizeMemberships(legacyMemberships.data, selector.organizationId);
+    const exact = summarizeMemberships(exactMemberships.data, selector.organizationId);
+
+    captureEvent('server-metrics', 'org_authorization_shadow', {
+      route,
+      method: req.method,
+      response_status: responseStatus,
+      linked_credential: true,
+      selector_source: selector.source,
+      explicit_organization: selector.explicit,
+      decision: classifyAuthorizationObservation(legacy, exact),
+      legacy_allowed: legacy.allowed,
+      exact_allowed: exact.allowed,
+      legacy_role: legacy.role,
+      exact_role: exact.role,
+    });
+  } catch (err) {
+    logger.warn(
+      { err, route, selectorSource: selector.source },
+      'credential-scoped authorization shadow comparison failed',
+    );
+    captureEvent('server-metrics', 'org_authorization_shadow', {
+      route,
+      method: req.method,
+      response_status: responseStatus,
+      linked_credential: true,
+      selector_source: selector.source,
+      explicit_organization: selector.explicit,
+      decision: 'lookup_error',
+    });
+  }
+}

--- a/server/src/middleware/request-metrics.ts
+++ b/server/src/middleware/request-metrics.ts
@@ -10,6 +10,10 @@
 
 import { Request, Response, NextFunction } from "express";
 import { captureEvent } from "../utils/posthog.js";
+import {
+  observeLinkedCredentialOrganizationAuthorization,
+  organizationSelectorFromRequest,
+} from "./organization-authorization-observer.js";
 
 /** Collapse UUIDs and numeric path segments so metrics aggregate cleanly. */
 function normalizeRoute(method: string, path: string): string {
@@ -39,6 +43,8 @@ export function requestMetrics(
   res.on("finish", () => {
     const durationMs = Number(process.hrtime.bigint() - start) / 1e6;
     const route = normalizeRoute(req.method, req.path.slice(0, 200));
+    const selector = organizationSelectorFromRequest(req);
+    const linkedCredential = Boolean(req.user?.authWorkosUserId);
 
     captureEvent("server-metrics", "api_request", {
       route,
@@ -47,7 +53,14 @@ export function requestMetrics(
       status: res.statusCode,
       duration_ms: Math.round(durationMs),
       ok: res.statusCode < 400,
+      linked_credential: linkedCredential,
+      explicit_organization: selector.explicit,
+      organization_selector_source: selector.source,
     });
+
+    // Run after the response and never await it on the request path. The
+    // observer is telemetry-only and cannot change the served decision.
+    void observeLinkedCredentialOrganizationAuthorization(req, route, res.statusCode);
   });
 
   next();

--- a/server/tests/unit/organization-authorization-observer.test.ts
+++ b/server/tests/unit/organization-authorization-observer.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  listOrganizationMemberships,
+  captureEvent,
+  resolvePrimaryOrganization,
+} = vi.hoisted(() => ({
+  listOrganizationMemberships: vi.fn(),
+  captureEvent: vi.fn(),
+  resolvePrimaryOrganization: vi.fn(),
+}));
+
+vi.mock('../../src/auth/workos-client.js', () => ({
+  getWorkos: () => ({ userManagement: { listOrganizationMemberships } }),
+}));
+vi.mock('../../src/utils/posthog.js', () => ({ captureEvent }));
+vi.mock('../../src/db/users-db.js', () => ({ resolvePrimaryOrganization }));
+
+import {
+  classifyAuthorizationObservation,
+  observeLinkedCredentialOrganizationAuthorization,
+  organizationSelectorFromRequest,
+} from '../../src/middleware/organization-authorization-observer.js';
+
+describe('organization authorization rollout observer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ORG_AUTHORIZATION_OBSERVER_ENABLED;
+  });
+
+  it('reports the explicit selector source without mutating the request', () => {
+    const req = {
+      headers: { 'x-organization-id': ' org_header ' },
+      query: { org: 'org_query' },
+      body: { organization_id: 'org_body' },
+      params: { orgId: 'org_path' },
+    } as any;
+
+    expect(organizationSelectorFromRequest(req)).toEqual({
+      organizationId: 'org_header',
+      source: 'header',
+      explicit: true,
+    });
+    expect(req.headers['x-organization-id']).toBe(' org_header ');
+  });
+
+  it('classifies allow and role differences', () => {
+    expect(classifyAuthorizationObservation(
+      { allowed: true, role: 'owner' },
+      { allowed: false, role: null },
+    )).toBe('legacy_allow_exact_deny');
+    expect(classifyAuthorizationObservation(
+      { allowed: true, role: 'owner' },
+      { allowed: true, role: 'member' },
+    )).toBe('both_allow_role_mismatch');
+  });
+
+  it('compares the canonical and authenticated credentials without exposing IDs', async () => {
+    listOrganizationMemberships
+      .mockResolvedValueOnce({
+        data: [{ organizationId: 'org_selected', status: 'active', role: { slug: 'owner' } }],
+      })
+      .mockResolvedValueOnce({ data: [] });
+
+    await observeLinkedCredentialOrganizationAuthorization({
+      headers: {},
+      query: { org: 'org_selected' },
+      body: {},
+      params: {},
+      method: 'POST',
+      user: { id: 'user_canonical', authWorkosUserId: 'user_authenticated' },
+    } as any, 'POST /api/example', 200);
+
+    expect(listOrganizationMemberships).toHaveBeenNthCalledWith(1, {
+      userId: 'user_canonical',
+      organizationId: 'org_selected',
+    });
+    expect(listOrganizationMemberships).toHaveBeenNthCalledWith(2, {
+      userId: 'user_authenticated',
+      organizationId: 'org_selected',
+    });
+    expect(captureEvent).toHaveBeenCalledWith(
+      'server-metrics',
+      'org_authorization_shadow',
+      expect.objectContaining({
+        decision: 'legacy_allow_exact_deny',
+        selector_source: 'query_org',
+        explicit_organization: true,
+      }),
+    );
+    expect(JSON.stringify(captureEvent.mock.calls)).not.toContain('user_canonical');
+    expect(JSON.stringify(captureEvent.mock.calls)).not.toContain('user_authenticated');
+    expect(JSON.stringify(captureEvent.mock.calls)).not.toContain('org_selected');
+  });
+
+  it('observes the legacy primary organization when the request omitted a selector', async () => {
+    resolvePrimaryOrganization.mockResolvedValue('org_legacy');
+    listOrganizationMemberships
+      .mockResolvedValueOnce({
+        data: [{ organizationId: 'org_legacy', status: 'active', role: { slug: 'member' } }],
+      })
+      .mockResolvedValueOnce({
+        data: [{ organizationId: 'org_legacy', status: 'active', role: { slug: 'member' } }],
+      });
+
+    await observeLinkedCredentialOrganizationAuthorization({
+      headers: {},
+      query: {},
+      body: {},
+      params: {},
+      method: 'GET',
+      user: { id: 'user_canonical', authWorkosUserId: 'user_authenticated' },
+    } as any, 'GET /api/example', 200);
+
+    expect(resolvePrimaryOrganization).toHaveBeenCalledWith('user_canonical');
+    expect(captureEvent).toHaveBeenCalledWith(
+      'server-metrics',
+      'org_authorization_shadow',
+      expect.objectContaining({
+        decision: 'both_allow_same_role',
+        selector_source: 'legacy_primary',
+        explicit_organization: false,
+      }),
+    );
+  });
+
+  it('does no extra work for unlinked sessions or when disabled', async () => {
+    await observeLinkedCredentialOrganizationAuthorization({
+      headers: {}, query: {}, body: {}, params: {}, method: 'GET',
+      user: { id: 'user_direct' },
+    } as any, 'GET /api/example', 200);
+
+    process.env.ORG_AUTHORIZATION_OBSERVER_ENABLED = 'false';
+    await observeLinkedCredentialOrganizationAuthorization({
+      headers: {}, query: {}, body: {}, params: {}, method: 'GET',
+      user: { id: 'user_canonical', authWorkosUserId: 'user_authenticated' },
+    } as any, 'GET /api/example', 200);
+
+    expect(listOrganizationMemberships).not.toHaveBeenCalled();
+    expect(captureEvent).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/organization-authorization-observer.test.ts
+++ b/server/tests/unit/organization-authorization-observer.test.ts
@@ -9,7 +9,7 @@ const {
 }));
 
 vi.mock('../../src/auth/workos-client.js', () => ({
-  getWorkos: () => ({ userManagement: { listOrganizationMemberships } }),
+  getAuthorizationObserverWorkos: () => ({ userManagement: { listOrganizationMemberships } }),
 }));
 vi.mock('../../src/utils/posthog.js', () => ({ captureEvent }));
 

--- a/server/tests/unit/organization-authorization-observer.test.ts
+++ b/server/tests/unit/organization-authorization-observer.test.ts
@@ -3,18 +3,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   listOrganizationMemberships,
   captureEvent,
-  resolvePrimaryOrganization,
 } = vi.hoisted(() => ({
   listOrganizationMemberships: vi.fn(),
   captureEvent: vi.fn(),
-  resolvePrimaryOrganization: vi.fn(),
 }));
 
 vi.mock('../../src/auth/workos-client.js', () => ({
   getWorkos: () => ({ userManagement: { listOrganizationMemberships } }),
 }));
 vi.mock('../../src/utils/posthog.js', () => ({ captureEvent }));
-vi.mock('../../src/db/users-db.js', () => ({ resolvePrimaryOrganization }));
 
 import {
   classifyAuthorizationObservation,
@@ -93,16 +90,7 @@ describe('organization authorization rollout observer', () => {
     expect(JSON.stringify(captureEvent.mock.calls)).not.toContain('org_selected');
   });
 
-  it('observes the legacy primary organization when the request omitted a selector', async () => {
-    resolvePrimaryOrganization.mockResolvedValue('org_legacy');
-    listOrganizationMemberships
-      .mockResolvedValueOnce({
-        data: [{ organizationId: 'org_legacy', status: 'active', role: { slug: 'member' } }],
-      })
-      .mockResolvedValueOnce({
-        data: [{ organizationId: 'org_legacy', status: 'active', role: { slug: 'member' } }],
-      });
-
+  it('records a missing selector without inferring or mutating organization state', async () => {
     await observeLinkedCredentialOrganizationAuthorization({
       headers: {},
       query: {},
@@ -112,13 +100,13 @@ describe('organization authorization rollout observer', () => {
       user: { id: 'user_canonical', authWorkosUserId: 'user_authenticated' },
     } as any, 'GET /api/example', 200);
 
-    expect(resolvePrimaryOrganization).toHaveBeenCalledWith('user_canonical');
+    expect(listOrganizationMemberships).not.toHaveBeenCalled();
     expect(captureEvent).toHaveBeenCalledWith(
       'server-metrics',
       'org_authorization_shadow',
       expect.objectContaining({
-        decision: 'both_allow_same_role',
-        selector_source: 'legacy_primary',
+        decision: 'no_explicit_organization',
+        selector_source: 'none',
         explicit_organization: false,
       }),
     );

--- a/server/tests/unit/organization-authorization-observer.test.ts
+++ b/server/tests/unit/organization-authorization-observer.test.ts
@@ -112,6 +112,35 @@ describe('organization authorization rollout observer', () => {
     );
   });
 
+  it('drops observer work when the bounded WorkOS comparison pool is saturated', async () => {
+    const pending: Array<(value: { data: never[] }) => void> = [];
+    listOrganizationMemberships.mockImplementation(() => new Promise((resolve) => {
+      pending.push(resolve);
+    }));
+    const request = (suffix: number) => observeLinkedCredentialOrganizationAuthorization({
+      headers: {},
+      query: { org: `org_selected_${suffix}` },
+      body: {},
+      params: {},
+      method: 'GET',
+      user: { id: `user_canonical_${suffix}`, authWorkosUserId: `user_authenticated_${suffix}` },
+    } as any, 'GET /api/example', 200);
+
+    const inFlight = Array.from({ length: 5 }, (_, index) => request(index));
+    await vi.waitFor(() => expect(listOrganizationMemberships).toHaveBeenCalledTimes(10));
+
+    await request(6);
+
+    expect(listOrganizationMemberships).toHaveBeenCalledTimes(10);
+    expect(captureEvent).toHaveBeenCalledWith(
+      'server-metrics',
+      'org_authorization_shadow',
+      expect.objectContaining({ decision: 'observer_saturated' }),
+    );
+    pending.forEach((resolve) => resolve({ data: [] }));
+    await Promise.all(inFlight);
+  });
+
   it('does no extra work for unlinked sessions or when disabled', async () => {
     await observeLinkedCredentialOrganizationAuthorization({
       headers: {}, query: {}, body: {}, params: {}, method: 'GET',


### PR DESCRIPTION
## Summary

- add telemetry-only comparison of shipped canonical-credential membership with exact authenticated-credential membership
- record explicit organization-selector coverage on existing API request metrics
- emit no user, identity, email, or organization identifiers
- perform comparisons only after responses complete; authorization outcomes are unchanged
- provide `ORG_AUTHORIZATION_OBSERVER_ENABLED=false` as an emergency kill switch

This is the observe-only first stage for #6827. It is intentionally separated from enforcement in #6839 so production traffic can establish the compatibility baseline before exact-credential authorization is enabled.

## Verification

- focused observer unit tests (5/5)
- TypeScript typecheck
- diff hygiene

Refs #6827