### PR TITLE
chore(auth): expose observer decisions in runtime logs

### DIFF
--- a/server/src/middleware/organization-authorization-observer.ts
+++ b/server/src/middleware/organization-authorization-observer.ts
@@ -83,6 +83,25 @@ type MembershipSummary = {
   role: string | null;
 };
 
+function recordAuthorizationObservation(properties: Record<string, unknown>): void {
+  captureEvent('server-metrics', 'org_authorization_shadow', properties);
+
+  // Keep the independently queryable rollout log deliberately identifier-free.
+  // In particular, do not copy route/path or any credential/organization values
+  // into this record; PostHog retains the richer route-level diagnostic event.
+  logger.info({
+    decision: properties.decision,
+    method: properties.method,
+    response_status: properties.response_status,
+    selector_source: properties.selector_source,
+    explicit_organization: properties.explicit_organization,
+    legacy_allowed: properties.legacy_allowed,
+    exact_allowed: properties.exact_allowed,
+    legacy_role: properties.legacy_role,
+    exact_role: properties.exact_role,
+  }, 'org authorization shadow observation');
+}
+
 function summarizeMemberships(
   memberships: Array<{ organizationId: string; status?: string; role?: { slug?: string } | null }>,
   organizationId: string,
@@ -131,7 +150,7 @@ export async function observeLinkedCredentialOrganizationAuthorization(
     // This branch controls only which observe-only telemetry event is emitted;
     // it is not an authorization guard and never changes the response.
     if (!selector.organizationId) {
-      captureEvent('server-metrics', 'org_authorization_shadow', {
+      recordAuthorizationObservation({
         route,
         method: req.method,
         response_status: responseStatus,
@@ -144,7 +163,7 @@ export async function observeLinkedCredentialOrganizationAuthorization(
     }
 
     if (inFlightComparisons >= MAX_CONCURRENT_COMPARISONS) {
-      captureEvent('server-metrics', 'org_authorization_shadow', {
+      recordAuthorizationObservation({
         route,
         method: req.method,
         response_status: responseStatus,
@@ -172,7 +191,7 @@ export async function observeLinkedCredentialOrganizationAuthorization(
       const legacy = summarizeMemberships(legacyMemberships.data, selector.organizationId);
       const exact = summarizeMemberships(exactMemberships.data, selector.organizationId);
 
-      captureEvent('server-metrics', 'org_authorization_shadow', {
+      recordAuthorizationObservation({
         route,
         method: req.method,
         response_status: responseStatus,
@@ -193,7 +212,7 @@ export async function observeLinkedCredentialOrganizationAuthorization(
       { err, route, selectorSource: selector.source },
       'credential-scoped authorization shadow comparison failed',
     );
-    captureEvent('server-metrics', 'org_authorization_shadow', {
+    recordAuthorizationObservation({
       route,
       method: req.method,
       response_status: responseStatus,

--- a/server/tests/unit/organization-authorization-observer.test.ts
+++ b/server/tests/unit/organization-authorization-observer.test.ts
@@ -3,15 +3,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   listOrganizationMemberships,
   captureEvent,
+  loggerInfo,
 } = vi.hoisted(() => ({
   listOrganizationMemberships: vi.fn(),
   captureEvent: vi.fn(),
+  loggerInfo: vi.fn(),
 }));
 
 vi.mock('../../src/auth/workos-client.js', () => ({
   getAuthorizationObserverWorkos: () => ({ userManagement: { listOrganizationMemberships } }),
 }));
 vi.mock('../../src/utils/posthog.js', () => ({ captureEvent }));
+vi.mock('../../src/logger.js', () => ({
+  createLogger: () => ({ info: loggerInfo, warn: vi.fn() }),
+}));
 
 import {
   classifyAuthorizationObservation,
@@ -85,9 +90,20 @@ describe('organization authorization rollout observer', () => {
         explicit_organization: true,
       }),
     );
-    expect(JSON.stringify(captureEvent.mock.calls)).not.toContain('user_canonical');
-    expect(JSON.stringify(captureEvent.mock.calls)).not.toContain('user_authenticated');
-    expect(JSON.stringify(captureEvent.mock.calls)).not.toContain('org_selected');
+    expect(loggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: 'legacy_allow_exact_deny',
+        selector_source: 'query_org',
+        legacy_allowed: true,
+        exact_allowed: false,
+      }),
+      'org authorization shadow observation',
+    );
+    const telemetry = JSON.stringify([captureEvent.mock.calls, loggerInfo.mock.calls]);
+    expect(telemetry).not.toContain('user_canonical');
+    expect(telemetry).not.toContain('user_authenticated');
+    expect(telemetry).not.toContain('org_selected');
+    expect(JSON.stringify(loggerInfo.mock.calls)).not.toContain('POST /api/example');
   });
 
   it('records a missing selector without inferring or mutating organization state', async () => {


### PR DESCRIPTION
## Rollout purpose

Follow-up to #6841 and #6827. The observe-only authorization comparison currently reaches PostHog, but the production PostHog project is not independently accessible from the rollout session. This adds the same comparison outcome to the Fly/Grafana runtime stream so enforcement remains gated on a queryable signal.

## Safety

- Observe-only: no authorization, persistence, or response behavior changes.
- Runtime records exclude route/path, credential, identity, email, and organization values.
- Logged fields are limited to decision, method, response status, selector source, allow booleans, and roles.
- Existing kill switch remains `ORG_AUTHORIZATION_OBSERVER_ENABLED=false`.
- Existing 3-second/zero-retry WorkOS client and five-comparison concurrency cap remain unchanged.

## Verification

- Focused observer unit suite: 6/6 passed.
- TypeScript typecheck passed.
- Diff check passed.
- Full local pre-commit was attempted; the server-unit phase reached its repository timeout and an unrelated local C2PA native-binary test failed. GitHub CI is the merge gate.