### PR TITLE
docs(radio): correct capability field name to available_reporting_frequencies

### DIFF
--- a/docs/creative/channels/radio.mdx
+++ b/docs/creative/channels/radio.mdx
@@ -154,6 +154,6 @@ A buy committed to `grps` against `P25-54` on `nielsen_audio` reconciles when th
 }
 ```
 
-Panel data arrives on the panel's publication cycle — declare `weekly` (or coarser) in `reporting_capabilities.reporting_frequencies`, and buyers treat that cadence as an optimization-eligibility gate: nothing should mid-flight-optimize against numbers that publish weekly. Station affidavits and playout logs prove that scheduled spots aired; the audience currency turns those airings into the audience-size number.
+Panel data arrives on the panel's publication cycle — declare `weekly` (or coarser) in `reporting_capabilities.available_reporting_frequencies`, and buyers treat that cadence as an optimization-eligibility gate: nothing should mid-flight-optimize against numbers that publish weekly. Station affidavits and playout logs prove that scheduled spots aired; the audience currency turns those airings into the audience-size number.
 
 See [Audio](/docs/creative/channels/audio), [Broadcast](/docs/creative/channels/broadcast), and [Creative manifests](/docs/creative/creative-manifests).


### PR DESCRIPTION
One-line docs fix addressing the unresolved secretariat review thread on #6836 (merged before the thread was resolved — process slip, flagged in the thread reply): the radio guide referenced `reporting_capabilities.reporting_frequencies`, but the wire field is `available_reporting_frequencies` (`core/reporting-capabilities.json`). Guidance was otherwise correct; only the field name changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)