### PR TITLE
feat(reporting): promote cadence optimization-eligibility gate to normative MUST

### DIFF
--- a/.changeset/cadence-gates-optimization-must.md
+++ b/.changeset/cadence-gates-optimization-must.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Promote the reporting-cadence optimization-eligibility rule from guidance to normative: buy-side agents MUST treat a product's declared `available_reporting_frequencies` as an optimization-eligibility gate and MUST NOT make mid-flight optimization decisions against metrics whose declared cadence is `quarterly` or `post_campaign`. Enforcement routes through buyer-artifact grading (sellers have nothing to attest); an anti-drift test pins the normative language to the enum and the governing doc. Ratified with the radio and OOH WG packets (#6138/#6139/#6140).

--- a/docs/media-buy/media-buys/optimization-reporting.mdx
+++ b/docs/media-buy/media-buys/optimization-reporting.mdx
@@ -275,7 +275,7 @@ Publishers declare supported reporting frequencies in the product's `reporting_c
 - **`quarterly`**: Receive notifications once per quarter — matches quarterly measurement-currency publication cycles
 - **`post_campaign`**: A single report after the flight ends — for channels where delivery is only knowable in arrears
 
-A product's declared frequencies are an optimization-eligibility signal: buyers should not mid-flight-optimize against a channel whose data arrives quarterly or post-campaign.
+**Cadence gates optimization eligibility (normative, introduced in 3.2).** Buy-side agents MUST treat a product's declared `available_reporting_frequencies` as an optimization-eligibility gate: a buyer MUST NOT make mid-flight optimization decisions against metrics whose declared cadence is `quarterly` or `post_campaign`. Weekly-cadence channels (OOH and radio audience currencies) support at most week-grain adjustment. This is not advice about statistical power — data on those cadences describes a period that has already closed, so an agent optimizing on it is acting on a model of the channel that is false at decision time. Sellers are not obligated to police buyer behavior; the buyer-side obligation is graded through buyer-artifact testing.
 
 **Cost Consideration:** Hourly webhooks generate 24x more traffic than daily. Large buyer-seller pairs may prefer offline reporting mechanisms (see below) for cost efficiency.
 

--- a/specs/buyer-artifact-testing.md
+++ b/specs/buyer-artifact-testing.md
@@ -635,3 +635,15 @@ Update `server/src/addie/prompts.ts`:
 - Include the testing sequence (comply → RFP → IO)
 - Emphasize that `publisher_response` is the highest-value input for RFP testing
 - Note that `compare_media_kit` is deprecated in favor of these tools
+
+## Cadence-gate check (normative hook)
+
+The reporting-cadence rule in `optimization-reporting.mdx` places a MUST on buyers: no mid-flight optimization decisions against metrics whose declared cadence is `quarterly` or `post_campaign`. Sellers have nothing to attest here — the enforcement surface is buyer-artifact grading.
+
+When a graded buyer artifact records optimization actions (budget reallocation, bid changes, pacing adjustments justified by delivered metrics), the grader checks each cited metric against the product's `reporting_capabilities.available_reporting_frequencies`:
+
+- Cited metric's product declares only `quarterly` and/or `post_campaign` → **fail** (the normative MUST NOT).
+- Cited metric's product declares `weekly` and the optimization grain is finer than weekly → **advisory**.
+- No `available_reporting_frequencies` declared → no finding (the gate needs a declaration to gate on).
+
+Deterministic, no LLM: the check is a join between the artifact's optimization-action records and the product catalog's declared cadences.

--- a/static/schemas/source/enums/reporting-frequency.json
+++ b/static/schemas/source/enums/reporting-frequency.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "/schemas/enums/reporting-frequency.json",
   "title": "Reporting Frequency",
-  "description": "Available frequencies for delivery reports and metrics updates. Weekly and quarterly match audience-currency publication cycles in measured channels (e.g. weekly OOH/radio increments, quarterly circulation updates); post_campaign is a single report after the flight ends. Buyers should treat a product's declared frequencies as an optimization-eligibility signal — mid-flight optimization is not meaningful against data that arrives quarterly or post-campaign.",
+  "description": "Available frequencies for delivery reports and metrics updates. Weekly and quarterly match audience-currency publication cycles in measured channels (e.g. weekly OOH/radio increments, quarterly circulation updates); post_campaign is a single report after the flight ends. Buy-side agents MUST treat a product's declared frequencies as an optimization-eligibility gate: a buyer MUST NOT make mid-flight optimization decisions against metrics whose declared cadence is quarterly or post_campaign — such data describes a period that has closed, and optimizing on it means acting on a model of the channel that is false at decision time.",
   "type": "string",
   "enum": [
     "hourly",

--- a/tests/reporting-cadence-gate.test.ts
+++ b/tests/reporting-cadence-gate.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+
+const ROOT = join(__dirname, "..");
+
+function read(relativePath: string): string {
+  return readFileSync(join(ROOT, relativePath), "utf8");
+}
+
+test("reporting cadence gates optimization eligibility (MUST, 3.2)", () => {
+  const enumSchema = JSON.parse(
+    read("static/schemas/source/enums/reporting-frequency.json")
+  );
+
+  // The measured-channel cadences the gate is defined over.
+  for (const value of ["weekly", "quarterly", "post_campaign"]) {
+    expect(enumSchema.enum).toContain(value);
+  }
+
+  // The normative sentence lives on the enum description — MUST-level, both
+  // halves (gate + prohibition), naming the gated cadences.
+  expect(enumSchema.description).toMatch(/MUST treat/);
+  expect(enumSchema.description).toMatch(/MUST NOT/);
+  expect(enumSchema.description).toMatch(/optimization-eligibility gate/);
+  expect(enumSchema.description).toMatch(/quarterly or post_campaign/);
+
+  // The governing doc carries the same rule against the real wire field, and
+  // routes enforcement to buyer-artifact grading rather than seller conduct.
+  const doc = read("docs/media-buy/media-buys/optimization-reporting.mdx");
+  expect(doc).toMatch(/Cadence gates optimization eligibility/);
+  expect(doc).toMatch(/available_reporting_frequencies/);
+  expect(doc).toMatch(/MUST NOT make mid-flight optimization decisions/);
+  expect(doc).toMatch(/`quarterly` or `post_campaign`/);
+  expect(doc).toMatch(/buyer-artifact testing/);
+
+  // The obligation is the buyer's; the doc must not drift into a field name
+  // that does not exist on the wire.
+  expect(doc).not.toMatch(/reporting_capabilities\.reporting_frequencies/);
+});


### PR DESCRIPTION
## Summary

Promotes the reporting-cadence rule from guidance prose (shipped in #6240) to a normative MUST, per the recommendation carried in — and ratified with — both WG packets (radio #6139, static OOH #6140, umbrella #6138):

> Buy-side agents MUST treat a product's declared `available_reporting_frequencies` as an optimization-eligibility gate: a buyer MUST NOT make mid-flight optimization decisions against metrics whose declared cadence is `quarterly` or `post_campaign`.

## The four pieces

1. **Normative language** on `enums/reporting-frequency.json` and in `optimization-reporting.mdx` (stated against the real wire field, `available_reporting_frequencies`), with the rationale: data on those cadences describes a closed period, so optimizing on it means acting on a model of the channel that is false at decision time.
2. **Enforcement routing**: the obligation is the buyer's — sellers have nothing to attest beyond their existing optional declaration, so no seller-side conformance scenario is added. The deterministic cadence-gate check (artifact optimization-actions ⨝ product declared cadences; fail on quarterly/post_campaign, advisory on sub-weekly grain against weekly) is specified in `specs/buyer-artifact-testing.md`.
3. **Anti-drift pin test** (`tests/reporting-cadence-gate.test.ts`, vitest-discovered by `test:unit` — no packaging changes): locks the enum values, the MUST language on both surfaces, the enforcement-routing sentence, and rejects the field-name drift class that #6856 just fixed.
4. **Changeset** (minor).

## Governance

New MUST on buyer conduct → ballot-class. Both approved packets explicitly carried this promotion as a recommendation, so this PR treats the packet ballots as the ratification and cites them; if the WG prefers an explicit standalone vote, hold merge until then.

Refs #6138, #6139, #6140; follows #6240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)