### PR TITLE
fix(tests): stop cross-file state bleed in the server unit suite

### DIFF
--- a/server/src/middleware/pg-rate-limit-store.ts
+++ b/server/src/middleware/pg-rate-limit-store.ts
@@ -12,11 +12,24 @@ import { createLogger } from '../logger.js';
 
 const logger = createLogger('pg-rate-limit');
 
-// Periodic cleanup of expired rows (runs once, shared across all stores)
-let cleanupStarted = false;
+// Periodic cleanup of expired rows (runs once, shared across all stores).
+//
+// The "once" guard has to live on `globalThis` rather than as a plain
+// module-scope `let`: under vitest, each test file gets a fresh module
+// registry (isolate resets `evaluatedModules`), so a module-scope flag is
+// re-initialized to `false` on every file that imports this module and
+// `startCleanup()` unconditionally arms a *new* `setInterval`. `globalThis`
+// is a real, unreset object for the life of the worker process, so a flag
+// stored there actually enforces "once per process" the way the comment
+// above promises — otherwise every test file that constructs a Postgres
+// rate-limit store leaves one more live interval timer behind (closed
+// over that file's now-stale `query`/`isDatabaseInitialized` bindings)
+// for the remainder of the run.
+const CLEANUP_STARTED_KEY = '__adcp_pg_rate_limit_cleanup_started__';
 function startCleanup(): void {
-  if (cleanupStarted) return;
-  cleanupStarted = true;
+  const g = globalThis as typeof globalThis & { [CLEANUP_STARTED_KEY]?: boolean };
+  if (g[CLEANUP_STARTED_KEY]) return;
+  g[CLEANUP_STARTED_KEY] = true;
   const timer = setInterval(async () => {
     if (!isDatabaseInitialized()) return;
     try {

--- a/server/src/routes/native-auth.ts
+++ b/server/src/routes/native-auth.ts
@@ -222,5 +222,21 @@ export function createNativeAuthRouter(options: NativeAuthRouterOptions): Router
   return router;
 }
 
-const cleanupTimer = setInterval(() => nativeAuthDb.cleanupExpired(), CLEANUP_INTERVAL_MS);
-cleanupTimer.unref();
+// Start the expired-pending/grant sweep once per process. Guarded on
+// `globalThis` rather than a module-scope flag: under vitest, this module
+// is re-evaluated fresh for every test file (isolate resets the module
+// registry between files), so a plain `let`/module-scope guard would reset
+// to unarmed each time and this would register one more `setInterval` per
+// file that imports native-auth.ts — each holding a stale closure over
+// that file's `nativeAuthDb` binding for the remaining life of the worker
+// process. `globalThis` survives the per-file reset, so the guard actually
+// enforces "once per process" here too.
+const CLEANUP_TIMER_STARTED_KEY = '__adcp_native_auth_cleanup_started__';
+const globalWithNativeAuthCleanup = globalThis as typeof globalThis & {
+  [CLEANUP_TIMER_STARTED_KEY]?: boolean;
+};
+if (!globalWithNativeAuthCleanup[CLEANUP_TIMER_STARTED_KEY]) {
+  globalWithNativeAuthCleanup[CLEANUP_TIMER_STARTED_KEY] = true;
+  const cleanupTimer = setInterval(() => nativeAuthDb.cleanupExpired(), CLEANUP_INTERVAL_MS);
+  cleanupTimer.unref();
+}

--- a/server/tests/setup/revenue-tracking-env.ts
+++ b/server/tests/setup/revenue-tracking-env.ts
@@ -1,5 +1,36 @@
 // Test environment setup for vitest
 // Sets up mock environment variables for testing
+//
+// This file re-runs before every test file (vitest resets the module
+// registry per file, and setup files are part of that registry), but
+// `process.env` itself is a real Node object that outlives the reset --
+// with `fileParallelism: false` the whole ~455-file suite shares one
+// forked worker process. Individual test files set ad-hoc vars in
+// `vi.hoisted()` blocks (ADMIN_API_KEY, ADMIN_EMAILS, DEV_USER_EMAIL, ...)
+// to exercise auth boundaries and never restore them. Left alone, those
+// mutations bleed into every file that runs afterward in the same worker,
+// producing a rotating single-test flake (a different downstream file
+// breaks each run, depending on file scheduling order).
+//
+// Snapshot the environment exactly once per worker process, before any
+// test file's mutations happen, and restore it before every file so each
+// file starts from the same pristine baseline regardless of what earlier
+// files left behind.
+const ENV_BASELINE_KEY = '__adcp_server_unit_env_baseline__';
+type GlobalWithEnvBaseline = typeof globalThis & {
+  [ENV_BASELINE_KEY]?: Record<string, string | undefined>;
+};
+const globalWithBaseline = globalThis as GlobalWithEnvBaseline;
+
+if (!globalWithBaseline[ENV_BASELINE_KEY]) {
+  globalWithBaseline[ENV_BASELINE_KEY] = { ...process.env };
+} else {
+  const baseline = globalWithBaseline[ENV_BASELINE_KEY];
+  for (const key of Object.keys(process.env)) {
+    if (!(key in baseline)) delete process.env[key];
+  }
+  Object.assign(process.env, baseline);
+}
 
 process.env.REVENUE_TRACKING_DISABLED = 'true';
 process.env.NODE_ENV = 'test';


### PR DESCRIPTION
## Summary

The server unit suite (~455 files, sequential in one forked worker) has been flaking on a rotating single test that always passes in isolation — this session alone it randomly hit `storyboard-fix-plan-e2e`, `network-health-security`, `api-key-issuance-permissions`, `mcp-route-authorization`, `registry-badge-routes`, and `native-auth-security`. Investigation found vitest's per-file module isolation was already on; two state classes leak *around* it:

1. **`process.env` bleed.** Eight test files set admin-auth vars (`ADMIN_API_KEY`, `ADMIN_EMAILS`, `DEV_USER_*`) in `vi.hoisted()` blocks and never restore them. `middleware/auth.ts` reads `ADMIN_API_KEY` at module scope on each file's fresh import, so a leaked value silently flips auth outcomes (403 vs 404, fail-open vs fail-closed) for whichever unrelated file happens to run next — file scheduling isn't identical run-to-run, hence the rotating victim. Fix: the shared setup file (which re-runs before every test file) snapshots the environment once per worker and restores it before every file — closing the whole class, not just the eight offenders.

2. **Re-arming module-scope timers.** `pg-rate-limit-store.ts`'s `cleanupStarted` flag and `native-auth.ts`'s `cleanupTimer` are module-scope, so they reset on every per-file re-import — every importing file armed one more live `setInterval` holding stale closures for the life of the worker, despite the code's stated arm-once intent. Fix: guards moved to `globalThis` (real process state, like the timers they guard). No production behavior change — in a normal single-import process the guard semantics are identical.

## Verification

- Two consecutive clean full-suite runs on a quiet machine: **457/457 files, 0 failures, ~162s each** (the flaky baseline ran ~310s; part of the delta is machine conditions, part is likely the removed timer accumulation).
- Four additional full runs in a separate worktree during diagnosis: the previously-flaking tests passed in all of them.
- Typecheck clean; the precommit planner correctly classifies all three files as full-suite triggers.

No changeset: test infrastructure plus app-internal timer-guard placement; no protocol surface.

Related: #6853 tracks the separate, deterministic ajv/@modelcontextprotocol-sdk `addKeyword` incompatibility discovered during this investigation (reproduces on some fresh installs, not others — resolution discrepancy noted in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)