### PR TITLE
chore(auth): propagate explicit org from clients

### DIFF
--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1564,11 +1564,12 @@
       const previous = agent.visibility || 'private';
       if (previous === target) return;
       try {
-        const resp = await fetch(`/api/me/member-profile/agents/${index}/visibility`, {
+        const orgQuery = pageState.orgId ? `?org=${encodeURIComponent(pageState.orgId)}` : '';
+        const resp = await fetch(`/api/me/member-profile/agents/${index}/visibility${orgQuery}`, {
           method: 'PATCH',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ visibility: target }),
+          body: JSON.stringify({ visibility: target, organization_id: pageState.orgId || undefined }),
         });
         const data = await resp.json().catch(() => ({}));
         if (!resp.ok) {
@@ -1772,7 +1773,8 @@
       let rows = cachedStoryboardStatuses(agentUrl);
       if (rows.length === 0) {
         try {
-          const res = await fetch('/api/registry/agents/' + encodeURIComponent(agentUrl) + '/storyboard-status', { credentials: 'include' });
+          const orgQuery = pageState.orgId ? '?org=' + encodeURIComponent(pageState.orgId) : '';
+          const res = await fetch('/api/registry/agents/' + encodeURIComponent(agentUrl) + '/storyboard-status' + orgQuery, { credentials: 'include' });
           if (res.ok) {
             const data = await res.json();
             rows = Array.isArray(data.storyboards) ? data.storyboards : [];
@@ -2526,7 +2528,10 @@
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
-          body: JSON.stringify({ opt_out: !checkbox.checked }),
+          body: JSON.stringify({
+            opt_out: !checkbox.checked,
+            organization_id: pageState.orgId || undefined,
+          }),
         });
         if (!res.ok) {
           checkbox.checked = !checkbox.checked;
@@ -3189,7 +3194,10 @@
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'include',
-            body: JSON.stringify({ paused: toggle.checked }),
+            body: JSON.stringify({
+              paused: toggle.checked,
+              organization_id: pageState.orgId || undefined,
+            }),
           });
           if (!res.ok) {
             toggle.checked = !toggle.checked;
@@ -3239,7 +3247,10 @@
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'include',
-            body: JSON.stringify({ interval_hours: parseInt(select.value, 10) }),
+            body: JSON.stringify({
+              interval_hours: parseInt(select.value, 10),
+              organization_id: pageState.orgId || undefined,
+            }),
           });
           if (!res.ok) {
             select.value = previousValue;
@@ -3390,6 +3401,7 @@
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ organization_id: pageState.orgId || undefined }),
         });
         const data = await res.json().catch(() => ({}));
 
@@ -3449,7 +3461,8 @@
       panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 
       try {
-        const res = await fetch(`/api/registry/agents/${encodeURIComponent(agentUrl)}/monitoring/requests?limit=50`, {
+        const orgQuery = pageState.orgId ? `&org=${encodeURIComponent(pageState.orgId)}` : '';
+        const res = await fetch(`/api/registry/agents/${encodeURIComponent(agentUrl)}/monitoring/requests?limit=50${orgQuery}`, {
           credentials: 'include',
         });
         if (!res.ok) throw new Error('Failed to load');

--- a/server/public/onboarding.html
+++ b/server/public/onboarding.html
@@ -936,7 +936,7 @@
               const domain = currentUser.email ? currentUser.email.split('@')[1] : '';
               document.getElementById('loading').style.display = 'none';
               document.getElementById('mainContent').style.display = 'block';
-              showBrandSetup(companyOrg.name, domain);
+              showBrandSetup(companyOrg.name, domain, companyOrg.id);
               return;
             }
           }
@@ -1547,7 +1547,7 @@
         }
 
         // Show brand setup step instead of going directly to dashboard
-        showBrandSetup(orgName, corporateDomain);
+        showBrandSetup(orgName, corporateDomain, data.organization?.id || data.id);
       } catch (error) {
         showError(error.message);
         createBtn.disabled = false;
@@ -1623,9 +1623,11 @@
     // ── Brand setup step ──────────────────────────────────────────────
 
     var createdOrgName = '';
+    var createdOrgId = '';
 
-    function showBrandSetup(orgName, domain) {
+    function showBrandSetup(orgName, domain, orgId) {
       createdOrgName = orgName;
+      createdOrgId = orgId || '';
       document.getElementById('createForm').style.display = 'none';
       document.getElementById('brandSetupSection').style.display = 'block';
       document.getElementById('brandDomain').value = domain || '';
@@ -1676,6 +1678,7 @@
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
+            organization_id: createdOrgId || undefined,
             domain: domain,
             brand_name: createdOrgName,
             logo_url: logoUrl || undefined,

--- a/server/tests/unit/explicit-org-client-compat.test.ts
+++ b/server/tests/unit/explicit-org-client-compat.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const dashboardSource = readFileSync(
+  new URL('../../public/dashboard-agents.html', import.meta.url),
+  'utf8',
+);
+const onboardingSource = readFileSync(
+  new URL('../../public/onboarding.html', import.meta.url),
+  'utf8',
+);
+
+describe('explicit organization client compatibility', () => {
+  it('forwards the selected dashboard organization on private agent requests', () => {
+    expect(dashboardSource).toContain(
+      'body: JSON.stringify({ visibility: target, organization_id: pageState.orgId || undefined })',
+    );
+    expect(dashboardSource).toContain(
+      'organization_id: pageState.orgId || undefined',
+    );
+    expect(dashboardSource).toContain(
+      '/monitoring/requests?limit=50${orgQuery}',
+    );
+    expect(dashboardSource).toContain(
+      '/storyboard-status\' + orgQuery',
+    );
+  });
+
+  it('carries a newly created or selected organization into brand setup', () => {
+    expect(onboardingSource).toContain(
+      'showBrandSetup(companyOrg.name, domain, companyOrg.id)',
+    );
+    expect(onboardingSource).toContain(
+      'showBrandSetup(orgName, corporateDomain, data.organization?.id || data.id)',
+    );
+    expect(onboardingSource).toContain(
+      'organization_id: createdOrgId || undefined',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- forward the dashboard's already-selected organization on private agent reads and mutations
- carry the created/selected organization through onboarding brand setup
- preserve current server behavior when no organization is selected
- add static client contract coverage

This is rollout compatibility preparation for #6827. It does **not** change server authorization decisions or enable enforcement.

## Risk and rollout

The server currently ignores these selectors on legacy paths, so this is additive. It lets observe-only telemetry measure selector coverage before exact-credential authorization is enabled. Missing selectors remain compatible rather than failing closed.

## Validation

- focused Vitest: 36/36 passed
- TypeScript no-emit build passed
- `git diff --check` passed
- repository-wide local pre-commit reached the known local C2PA native-binary failure; clean GitHub CI is the merge gate
