### PR TITLE
feat(auth): add default-off organization roles canary

### DIFF
--- a/server/src/auth/workos-client.ts
+++ b/server/src/auth/workos-client.ts
@@ -6,11 +6,13 @@ const logger = createLogger('workos-client');
 const OWNERLESS_PROMOTION_WORKOS_TIMEOUT_MS = 10_000;
 const PIPES_WORKOS_TIMEOUT_MS = 10_000;
 const AUTHORIZATION_OBSERVER_WORKOS_TIMEOUT_MS = 3_000;
+const AUTHORIZATION_ENFORCEMENT_WORKOS_TIMEOUT_MS = 5_000;
 
 let _workos: WorkOS | null = null;
 let _ownerlessPromotionWorkos: WorkOS | null = null;
 let _pipesWorkos: WorkOS | null = null;
 let _authorizationObserverWorkos: WorkOS | null = null;
+let _authorizationEnforcementWorkos: WorkOS | null = null;
 let _clientId = '';
 
 /** Returns the shared WorkOS client. Constructed on first call; WORKOS_API_KEY and WORKOS_CLIENT_ID must be set by then. */
@@ -74,6 +76,25 @@ export function getAuthorizationObserverWorkos(): WorkOS {
     });
   }
   return _authorizationObserverWorkos;
+}
+
+/**
+ * Returns the fail-fast WorkOS client used by exact-credential enforcement.
+ * A request must surface an unavailable authority source instead of consuming
+ * the SDK default retry budget and appearing to hang.
+ */
+export function getAuthorizationEnforcementWorkos(): WorkOS {
+  if (!_authorizationEnforcementWorkos) {
+    if (!process.env.WORKOS_API_KEY) throw new Error('WORKOS_API_KEY environment variable is required');
+    if (!process.env.WORKOS_CLIENT_ID) throw new Error('WORKOS_CLIENT_ID environment variable is required');
+    _clientId = process.env.WORKOS_CLIENT_ID;
+    _authorizationEnforcementWorkos = new WorkOS(process.env.WORKOS_API_KEY, {
+      clientId: _clientId,
+      timeout: AUTHORIZATION_ENFORCEMENT_WORKOS_TIMEOUT_MS,
+      maxRetries: 0,
+    });
+  }
+  return _authorizationEnforcementWorkos;
 }
 
 /**

--- a/server/src/middleware/organization-authorization-canary.ts
+++ b/server/src/middleware/organization-authorization-canary.ts
@@ -1,0 +1,105 @@
+import type { WorkOS } from "@workos-inc/node";
+import type { OrgAuthorizationPrincipal } from "../auth/organization-principal.js";
+import { createLogger } from "../logger.js";
+import {
+  evaluateUserOrgRoleAuthorization,
+  resolveUserOrgAuthorization,
+  type MembershipRole,
+  type UserOrgAuthorizationMembership,
+  type OrgAuthorizationSource,
+} from "../utils/resolve-user-org-authorization.js";
+
+const logger = createLogger("organization-authorization-canary");
+
+export const ORGANIZATION_AUTHORIZATION_BOUNDARIES = {
+  ORGANIZATION_ROLES_READ: "organization_roles_read",
+} as const;
+
+export type OrganizationAuthorizationBoundary =
+  (typeof ORGANIZATION_AUTHORIZATION_BOUNDARIES)[keyof typeof ORGANIZATION_AUTHORIZATION_BOUNDARIES];
+
+export type OrganizationAuthorizationCanaryDecision =
+  | { enforced: false }
+  | {
+      enforced: true;
+      status: "authorized";
+      membership: UserOrgAuthorizationMembership;
+    }
+  | { enforced: true; status: "forbidden" }
+  | {
+      enforced: true;
+      status: "unavailable";
+      unavailableSources: OrgAuthorizationSource[];
+    };
+
+/**
+ * Enforcement requires both switches. The global switch is the emergency
+ * stop; the fixed boundary allowlist prevents a typo or newly added route from
+ * expanding the canary. Both default off.
+ */
+export function isOrganizationAuthorizationBoundaryEnabled(
+  boundary: OrganizationAuthorizationBoundary
+): boolean {
+  if (process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED !== "true")
+    return false;
+  const enabledBoundaries = new Set(
+    (process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean)
+  );
+  return enabledBoundaries.has(boundary);
+}
+
+/**
+ * Evaluate a default-off route boundary. The WorkOS factory is lazy so the
+ * disabled path performs no new lookup or configuration work. Failure to
+ * construct the client is represented as an unavailable WorkOS source; an
+ * independently sufficient credential grant can still authorize.
+ */
+export async function evaluateOrganizationAuthorizationCanary(input: {
+  boundary: OrganizationAuthorizationBoundary;
+  principal: OrgAuthorizationPrincipal;
+  organizationId: string;
+  getWorkos: () => WorkOS | null;
+  minimumRole?: MembershipRole;
+}): Promise<OrganizationAuthorizationCanaryDecision> {
+  if (!isOrganizationAuthorizationBoundaryEnabled(input.boundary)) {
+    return { enforced: false };
+  }
+
+  let workos: WorkOS | null = null;
+  try {
+    workos = input.getWorkos();
+  } catch (err) {
+    logger.warn(
+      { err, boundary: input.boundary },
+      "Authorization WorkOS client unavailable"
+    );
+  }
+
+  const resolution = await resolveUserOrgAuthorization(
+    workos,
+    input.principal,
+    input.organizationId
+  );
+  const decision = evaluateUserOrgRoleAuthorization(
+    resolution,
+    input.minimumRole
+  );
+  if (decision.status === "authorized") {
+    return {
+      enforced: true,
+      status: "authorized",
+      membership: decision.membership,
+    };
+  }
+  if (decision.status === "unavailable") {
+    return {
+      enforced: true,
+      status: "unavailable",
+      unavailableSources: decision.unavailableSources,
+    };
+  }
+  return { enforced: true, status: "forbidden" };
+}

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -47,6 +47,11 @@ import { emailPrefsDb } from "../db/email-preferences-db.js";
 import { performCreateOrganization } from "../services/organization-bootstrap.js";
 import { collectWorkOSPages } from "../services/workos-pagination.js";
 import { canManageOrganizationBilling } from "../billing/billing-authorization.js";
+import { getAuthorizationEnforcementWorkos } from "../auth/workos-client.js";
+import {
+  evaluateOrganizationAuthorizationCanary,
+  ORGANIZATION_AUTHORIZATION_BOUNDARIES,
+} from "../middleware/organization-authorization-canary.js";
 
 const logger = createLogger("organization-routes");
 
@@ -3489,13 +3494,42 @@ export function createOrganizationsRouter(): Router {
       const user = req.user!;
       const { orgId } = req.params;
 
-      // Verify user is member of this organization
-      const membership = await resolveUserOrgMembership(workos, user.id, orgId);
-      if (!membership) {
-        return res.status(403).json({
-          error: 'Access denied',
-          message: 'You are not a member of this organization',
-        });
+      const canaryDecision = await evaluateOrganizationAuthorizationCanary({
+        boundary: ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_ROLES_READ,
+        principal: user,
+        organizationId: orgId,
+        getWorkos: getAuthorizationEnforcementWorkos,
+      });
+
+      if (canaryDecision.enforced) {
+        logger.info({
+          boundary: ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_ROLES_READ,
+          decision: canaryDecision.status,
+          unavailable_sources: canaryDecision.status === 'unavailable'
+            ? canaryDecision.unavailableSources
+            : undefined,
+        }, 'organization authorization canary decision');
+        if (canaryDecision.status === 'unavailable') {
+          return res.status(503).json({
+            error: 'Authorization temporarily unavailable',
+            message: 'Organization access could not be verified. Please retry.',
+          });
+        }
+        if (canaryDecision.status === 'forbidden') {
+          return res.status(403).json({
+            error: 'Access denied',
+            message: 'You are not a member of this organization',
+          });
+        }
+      } else {
+        // Kill-switch/default path: retain the shipped canonical-user decision.
+        const membership = await resolveUserOrgMembership(workos, user.id, orgId);
+        if (!membership) {
+          return res.status(403).json({
+            error: 'Access denied',
+            message: 'You are not a member of this organization',
+          });
+        }
       }
 
       // Get available roles from WorkOS

--- a/server/tests/unit/organization-authorization-canary.test.ts
+++ b/server/tests/unit/organization-authorization-canary.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  resolveUserOrgAuthorizationMock,
+  evaluateUserOrgRoleAuthorizationMock,
+} = vi.hoisted(() => ({
+  resolveUserOrgAuthorizationMock: vi.fn(),
+  evaluateUserOrgRoleAuthorizationMock: vi.fn(),
+}));
+
+vi.mock("../../src/utils/resolve-user-org-authorization.js", () => ({
+  resolveUserOrgAuthorization: resolveUserOrgAuthorizationMock,
+  evaluateUserOrgRoleAuthorization: evaluateUserOrgRoleAuthorizationMock,
+}));
+
+import {
+  evaluateOrganizationAuthorizationCanary,
+  isOrganizationAuthorizationBoundaryEnabled,
+  ORGANIZATION_AUTHORIZATION_BOUNDARIES,
+} from "../../src/middleware/organization-authorization-canary.js";
+
+const BOUNDARY = ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_ROLES_READ;
+
+describe("organization authorization canary", () => {
+  beforeEach(() => {
+    delete process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED;
+    delete process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES;
+    resolveUserOrgAuthorizationMock.mockReset();
+    evaluateUserOrgRoleAuthorizationMock.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED;
+    delete process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES;
+  });
+
+  it.each([
+    ["both switches absent", undefined, undefined],
+    ["global switch off", "false", BOUNDARY],
+    ["boundary switch absent", "true", undefined],
+    ["different boundary selected", "true", "another_boundary"],
+  ])("does no authority work when %s", async (_label, globalSwitch, boundaries) => {
+    if (globalSwitch !== undefined) {
+      process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = globalSwitch;
+    }
+    if (boundaries !== undefined) {
+      process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = boundaries;
+    }
+    const getWorkos = vi.fn();
+
+    const decision = await evaluateOrganizationAuthorizationCanary({
+      boundary: BOUNDARY,
+      principal: {
+        id: "user_canonical",
+        authWorkosUserId: "user_authenticated",
+      },
+      organizationId: "org_test",
+      getWorkos,
+    });
+
+    expect(decision).toEqual({ enforced: false });
+    expect(getWorkos).not.toHaveBeenCalled();
+    expect(resolveUserOrgAuthorizationMock).not.toHaveBeenCalled();
+  });
+
+  it("requires the global switch and the exact fixed boundary", () => {
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";
+    expect(isOrganizationAuthorizationBoundaryEnabled(BOUNDARY)).toBe(false);
+
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = "another_boundary";
+    expect(isOrganizationAuthorizationBoundaryEnabled(BOUNDARY)).toBe(false);
+
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = `another_boundary, ${BOUNDARY}`;
+    expect(isOrganizationAuthorizationBoundaryEnabled(BOUNDARY)).toBe(true);
+
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "false";
+    expect(isOrganizationAuthorizationBoundaryEnabled(BOUNDARY)).toBe(false);
+  });
+
+  it.each([
+    [
+      {
+        status: "authorized",
+        membership: {
+          organizationId: "org_test",
+          role: "member",
+          source: "workos",
+        },
+      },
+      {
+        enforced: true,
+        status: "authorized",
+        membership: {
+          organizationId: "org_test",
+          role: "member",
+          source: "workos",
+        },
+      },
+    ],
+    [{ status: "forbidden" }, { enforced: true, status: "forbidden" }],
+    [
+      { status: "unavailable", unavailableSources: ["workos"] },
+      { enforced: true, status: "unavailable", unavailableSources: ["workos"] },
+    ],
+  ])(
+    "preserves the typed enforcement decision %#",
+    async (roleDecision, expected) => {
+      process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";
+      process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = BOUNDARY;
+      const resolution = { status: "authorized" };
+      const workos = { userManagement: {} };
+      resolveUserOrgAuthorizationMock.mockResolvedValue(resolution);
+      evaluateUserOrgRoleAuthorizationMock.mockReturnValue(roleDecision);
+
+      const decision = await evaluateOrganizationAuthorizationCanary({
+        boundary: BOUNDARY,
+        principal: {
+          id: "user_canonical",
+          authWorkosUserId: "user_authenticated",
+        },
+        organizationId: "org_test",
+        getWorkos: () => workos as never,
+      });
+
+      expect(decision).toEqual(expected);
+      expect(resolveUserOrgAuthorizationMock).toHaveBeenCalledWith(
+        workos,
+        { id: "user_canonical", authWorkosUserId: "user_authenticated" },
+        "org_test"
+      );
+    }
+  );
+
+  it("represents WorkOS client construction failure as an unavailable source", async () => {
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = BOUNDARY;
+    resolveUserOrgAuthorizationMock.mockResolvedValue({
+      status: "unavailable",
+      unavailableSources: ["workos"],
+    });
+    evaluateUserOrgRoleAuthorizationMock.mockReturnValue({
+      status: "unavailable",
+      unavailableSources: ["workos"],
+    });
+
+    const decision = await evaluateOrganizationAuthorizationCanary({
+      boundary: BOUNDARY,
+      principal: { id: "user_test" },
+      organizationId: "org_test",
+      getWorkos: () => {
+        throw new Error("missing configuration");
+      },
+    });
+
+    expect(resolveUserOrgAuthorizationMock).toHaveBeenCalledWith(
+      null,
+      { id: "user_test" },
+      "org_test"
+    );
+    expect(decision).toEqual({
+      enforced: true,
+      status: "unavailable",
+      unavailableSources: ["workos"],
+    });
+  });
+});

--- a/server/tests/unit/organization-roles-canary-route.test.ts
+++ b/server/tests/unit/organization-roles-canary-route.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+
+const {
+  evaluateCanaryMock,
+  getEnforcementWorkosMock,
+  legacyMembershipMock,
+  listOrganizationRolesMock,
+} = vi.hoisted(() => {
+  process.env.WORKOS_API_KEY ||= "sk_test_organization_roles_canary";
+  process.env.WORKOS_CLIENT_ID ||= "client_test_organization_roles_canary";
+  process.env.WORKOS_COOKIE_PASSWORD ||=
+    "test-cookie-password-32chars-min-len-1234";
+  return {
+    evaluateCanaryMock: vi.fn(),
+    getEnforcementWorkosMock: vi.fn(() => ({ bounded: true })),
+    legacyMembershipMock: vi.fn(),
+    listOrganizationRolesMock: vi.fn(),
+  };
+});
+
+vi.mock("@workos-inc/node", () => ({
+  WorkOS: class {
+    authorization = { listOrganizationRoles: listOrganizationRolesMock };
+  },
+}));
+
+vi.mock("../../src/middleware/auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/middleware/auth.js")>()),
+  requireAuth: (
+    req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction
+  ) => {
+    req.user = {
+      id: "user_canonical",
+      authWorkosUserId: "user_authenticated",
+      email: "linked@example.test",
+      emailVerified: true,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    };
+    next();
+  },
+}));
+
+vi.mock("../../src/auth/workos-client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/auth/workos-client.js")>()),
+  getAuthorizationEnforcementWorkos: getEnforcementWorkosMock,
+}));
+
+vi.mock("../../src/utils/resolve-user-org-membership.js", () => ({
+  resolveUserOrgMembership: legacyMembershipMock,
+}));
+
+vi.mock("../../src/middleware/organization-authorization-canary.js", () => ({
+  ORGANIZATION_AUTHORIZATION_BOUNDARIES: {
+    ORGANIZATION_ROLES_READ: "organization_roles_read",
+  },
+  evaluateOrganizationAuthorizationCanary: evaluateCanaryMock,
+}));
+
+import { createOrganizationsRouter } from "../../src/routes/organizations.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/organizations", createOrganizationsRouter());
+  return app;
+}
+
+describe("GET organization roles authorization canary", () => {
+  beforeEach(() => {
+    evaluateCanaryMock.mockReset().mockResolvedValue({ enforced: false });
+    legacyMembershipMock.mockReset().mockResolvedValue({ role: "member" });
+    listOrganizationRolesMock.mockReset().mockResolvedValue({
+      data: [
+        {
+          id: "role_member",
+          slug: "member",
+          name: "Member",
+          description: "Standard member access",
+          permissions: [],
+        },
+      ],
+    });
+  });
+
+  it("preserves the legacy canonical-user path when the kill switch is off", async () => {
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/roles"
+    );
+
+    expect(response.status).toBe(200);
+    expect(legacyMembershipMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "user_canonical",
+      "org_test"
+    );
+    expect(evaluateCanaryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boundary: "organization_roles_read",
+        principal: expect.objectContaining({
+          id: "user_canonical",
+          authWorkosUserId: "user_authenticated",
+        }),
+        organizationId: "org_test",
+        getWorkos: getEnforcementWorkosMock,
+      })
+    );
+  });
+
+  it("uses the exact canary decision without consulting legacy authority", async () => {
+    evaluateCanaryMock.mockResolvedValue({
+      enforced: true,
+      status: "authorized",
+      membership: {
+        organizationId: "org_test",
+        role: "member",
+        source: "workos",
+      },
+    });
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/roles"
+    );
+
+    expect(response.status).toBe(200);
+    expect(legacyMembershipMock).not.toHaveBeenCalled();
+    expect(listOrganizationRolesMock).toHaveBeenCalledWith("org_test");
+  });
+
+  it("maps exact-credential denial to 403 before reading role data", async () => {
+    evaluateCanaryMock.mockResolvedValue({
+      enforced: true,
+      status: "forbidden",
+    });
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/roles"
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Access denied");
+    expect(legacyMembershipMock).not.toHaveBeenCalled();
+    expect(listOrganizationRolesMock).not.toHaveBeenCalled();
+  });
+
+  it("maps authority-source failure to 503 rather than 403", async () => {
+    evaluateCanaryMock.mockResolvedValue({
+      enforced: true,
+      status: "unavailable",
+      unavailableSources: ["workos"],
+    });
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/roles"
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.body.error).toBe("Authorization temporarily unavailable");
+    expect(legacyMembershipMock).not.toHaveBeenCalled();
+    expect(listOrganizationRolesMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first default-off exact-credential authorization canary for #6827.

- Covers only `GET /api/organizations/:orgId/roles`.
- Requires both a global enforcement switch and the fixed `organization_roles_read` boundary allowlist.
- Keeps the existing canonical-user authorization path byte-for-byte when either switch is off.
- Uses the exact authenticated WorkOS credential plus an active organization-approved credential grant.
- Distinguishes a definitive 403 from an authority-source outage (503).
- Emits identifier-free decision telemetry.

## Rollout controls

The deployed default is off. Enforcement requires both:

```text
ORG_AUTHORIZATION_ENFORCEMENT_ENABLED=true
ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES=organization_roles_read
```

Removing either value restores the legacy decision path on the next rolling restart. No broader boundary is included in this PR.

## Validation

- 13 focused unit/route tests
- TypeScript no-emit build
- `git diff --check`

The authorization foundation and schema landed separately in #6864. This PR will deploy with both switches off and will be observed before the single read boundary is enabled.

Closes no issue; staged rollout for #6827.
