### PR TITLE
test: fix cross-file env leakage, stub DNS in SSRF tests, unsilence with-timeout kills

### DIFF
--- a/scripts/with-timeout.sh
+++ b/scripts/with-timeout.sh
@@ -5,10 +5,12 @@
 # Usage: scripts/with-timeout.sh <seconds> <cmd> [args...]
 #
 # On expiry, SIGTERM is sent first with a 5s grace window before SIGKILL —
-# letting the child attempt a clean shutdown.
+# letting the child attempt a clean shutdown. A timeout prints an explicit
+# marker to stderr: a silently SIGTERMed test suite is indistinguishable from
+# a mystery failure, and the marker is what tells a reader "budget, not bug".
 #
-# Not using `set -e` because the fallback branch handles exit codes explicitly;
-# `-e` would abort before the explicit `exit "$code"` on a non-zero child.
+# Not using `set -e` because exit codes are handled explicitly; `-e` would
+# abort before the explicit `exit "$code"` on a non-zero child.
 set -u -o pipefail
 
 if [ "$#" -lt 2 ]; then
@@ -24,10 +26,31 @@ if ! [[ "$secs" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
+started=$(date +%s)
+
+report_if_timeout() {
+  local code="$1"
+  shift
+  local elapsed=$(( $(date +%s) - started ))
+  # 124 = coreutils timeout default; 143/137 = TERM/KILL with --preserve-status
+  # or the bash fallback. Only report when the budget was actually consumed,
+  # so a child that exits 143 on its own doesn't produce a false marker.
+  if { [ "$code" -eq 124 ] || [ "$code" -eq 143 ] || [ "$code" -eq 137 ]; } \
+    && [ "$elapsed" -ge "$secs" ]; then
+    echo "⏰ TIMEOUT: with-timeout killed the command after ${secs}s (exit $code, elapsed ${elapsed}s): $*" >&2
+  fi
+}
+
 if command -v timeout >/dev/null 2>&1; then
-  exec timeout --preserve-status --kill-after=5 "$secs" "$@"
+  timeout --preserve-status --kill-after=5 "$secs" "$@"
+  code=$?
+  report_if_timeout "$code" "$@"
+  exit "$code"
 elif command -v gtimeout >/dev/null 2>&1; then
-  exec gtimeout --preserve-status --kill-after=5 "$secs" "$@"
+  gtimeout --preserve-status --kill-after=5 "$secs" "$@"
+  code=$?
+  report_if_timeout "$code" "$@"
+  exit "$code"
 fi
 
 "$@" &
@@ -61,4 +84,5 @@ wait "$pid"
 code=$?
 trap - EXIT INT TERM
 cleanup
+report_if_timeout "$code" "$@"
 exit "$code"

--- a/server/src/training-agent/webhook-fetch.ts
+++ b/server/src/training-agent/webhook-fetch.ts
@@ -209,7 +209,7 @@ export async function validateWebhookUrl(
  *
  * The returned function uses userland `undici.fetch` so its dispatcher and
  * request-handler contract stay aligned with the imported undici version. */
-export function createWebhookFetch(options: { allowPrivateIp: boolean }): typeof fetch {
+export function createWebhookFetch(options: { allowPrivateIp: boolean; dnsLookup?: DnsLookup }): typeof fetch {
   if (options.allowPrivateIp && !isWebhookTestOrDevelopment(process.env.NODE_ENV)) {
     throw new Error('Private webhook targets can only be enabled in test or development');
   }
@@ -227,7 +227,7 @@ export function createWebhookFetch(options: { allowPrivateIp: boolean }): typeof
       // Step 2: pre-flight hostname + DNS check. Catches literal private
       // IPs and numeric-encoded bypasses (`http://2852039166/`) before
       // we even open a socket.
-      await assertPublicTarget(url);
+      await assertPublicTarget(url, { dnsLookup: options.dnsLookup });
     }
     // Step 4 (no redirect-follow) and step 3 (connect-time IP recheck via
     // the dispatcher) both apply on the fetch call itself. Manual redirect

--- a/server/tests/unit/api-key-issuance-permissions.test.ts
+++ b/server/tests/unit/api-key-issuance-permissions.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 
@@ -8,10 +8,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.hoisted(() => {
-  process.env.WORKOS_API_KEY = 'sk_test_api_key_issuance';
-  process.env.WORKOS_CLIENT_ID = 'client_test_api_key_issuance';
-  process.env.WORKOS_COOKIE_PASSWORD =
-    'test-cookie-password-at-least-32-characters';
+  vi.stubEnv('WORKOS_API_KEY', 'sk_test_api_key_issuance');
+  vi.stubEnv('WORKOS_CLIENT_ID', 'client_test_api_key_issuance');
+  vi.stubEnv('WORKOS_COOKIE_PASSWORD', 'test-cookie-password-at-least-32-characters');
 });
 
 vi.mock('@workos-inc/node', () => ({
@@ -50,6 +49,10 @@ beforeAll(() => {
 
 afterAll(() => {
   vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 function setMembership(

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 
@@ -9,8 +9,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.hoisted(() => {
-  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'sk_test';
-  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+  vi.stubEnv('WORKOS_API_KEY', process.env.WORKOS_API_KEY ?? 'sk_test');
+  vi.stubEnv('WORKOS_CLIENT_ID', process.env.WORKOS_CLIENT_ID ?? 'client_test');
 });
 
 vi.mock('../../src/services/brandfetch.js', () => ({
@@ -79,6 +79,10 @@ function discoveredBrandWithContext() {
     },
   };
 }
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('GET /api/brands/enrich', () => {
   beforeEach(() => {

--- a/server/tests/unit/registry-measurement-limits.test.ts
+++ b/server/tests/unit/registry-measurement-limits.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 
 vi.hoisted(() => {
-  process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'sk_test';
-  process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+  vi.stubEnv('WORKOS_API_KEY', process.env.WORKOS_API_KEY ?? 'sk_test');
+  vi.stubEnv('WORKOS_CLIENT_ID', process.env.WORKOS_CLIENT_ID ?? 'client_test');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 vi.mock('../../src/db/agent-snapshot-db.js', () => ({

--- a/server/tests/unit/replace-subscription.test.ts
+++ b/server/tests/unit/replace-subscription.test.ts
@@ -5,13 +5,13 @@
  * new price item (and optional coupon). Each safety guard plus the happy
  * path plus the post-Stripe audit-log path are covered.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import type Stripe from 'stripe';
 
-process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
-process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
+vi.stubEnv('WORKOS_API_KEY', process.env.WORKOS_API_KEY ?? 'test');
+vi.stubEnv('WORKOS_CLIENT_ID', process.env.WORKOS_CLIENT_ID ?? 'client_test');
 
 const {
   mockPoolQuery,
@@ -148,6 +148,10 @@ describe('POST /api/admin/accounts/:orgId/replace-subscription', () => {
     vi.clearAllMocks();
     stripeMockState.configured = true;
     mockPoolQuery.mockResolvedValue({ rows: [] });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('returns 503 when Stripe is unconfigured', async () => {

--- a/server/tests/unit/training-agent-webhook-fetch.test.ts
+++ b/server/tests/unit/training-agent-webhook-fetch.test.ts
@@ -56,7 +56,12 @@ describe('createWebhookFetch — SSRF guard', () => {
   });
 
   describe('with allowPrivateIp=false (production)', () => {
-    const fetch = createWebhookFetch({ allowPrivateIp: false });
+    // Stubbed resolver: the guard's DNS behavior is covered by the injected-
+    // lookup tests below; hitting real DNS here made these tests fail on any
+    // machine with a slow or filtered resolver (adcp#6828). 93.184.216.34 is
+    // example.com's public address.
+    const dnsLookup = async () => [{ address: '93.184.216.34', family: 4 }];
+    const fetch = createWebhookFetch({ allowPrivateIp: false, dnsLookup });
 
     it('refuses literal IPv4 loopback', async () => {
       await expect(fetch('http://127.0.0.1/metadata')).rejects.toBeInstanceOf(SsrfRefusedError);

--- a/tests/billing/stripe-client.test.ts
+++ b/tests/billing/stripe-client.test.ts
@@ -1,7 +1,7 @@
 // lint-allow-test-imports-file: this suite legitimately tests
 // `STRIPE_SECRET_KEY`-loaded module init — vi.resetModules() and dynamic
 // imports per test are how the env-var-load behavior is exercised.
-import { describe, test, expect, vi, beforeEach, type MockedClass } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach, type MockedClass } from 'vitest';
 import type Stripe from 'stripe';
 
 // Mock the Stripe module with a constructor that stores the latest mock instance
@@ -19,11 +19,14 @@ describe('stripe-client', () => {
     vi.resetModules();
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   describe('getStripeSubscriptionInfo', () => {
     test('returns null when Stripe is not initialized', async () => {
       // Set environment variable to undefined to disable Stripe
-      const originalEnv = process.env.STRIPE_SECRET_KEY;
-      delete process.env.STRIPE_SECRET_KEY;
+      vi.stubEnv('STRIPE_SECRET_KEY', undefined);
 
       // Re-import module after changing env var
       const { getStripeSubscriptionInfo } = await import('../../server/src/billing/stripe-client.js');
@@ -31,16 +34,11 @@ describe('stripe-client', () => {
       const result = await getStripeSubscriptionInfo('cus_test123');
 
       expect(result).toBeNull();
-
-      // Restore original env var
-      if (originalEnv) {
-        process.env.STRIPE_SECRET_KEY = originalEnv;
-      }
     });
 
     test('returns status "none" for deleted customer', async () => {
       // Set a test Stripe key
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       // Mock Stripe SDK
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
@@ -66,7 +64,7 @@ describe('stripe-client', () => {
     });
 
     test('returns status "none" for customer with no subscriptions', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -89,7 +87,7 @@ describe('stripe-client', () => {
     });
 
     test('returns subscription info for active subscription', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -150,7 +148,7 @@ describe('stripe-client', () => {
     });
 
     test('handles errors gracefully and returns null', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -170,7 +168,7 @@ describe('stripe-client', () => {
 
   describe('createStripeCustomer', () => {
     test('returns null when Stripe is not initialized', async () => {
-      delete process.env.STRIPE_SECRET_KEY;
+      vi.stubEnv('STRIPE_SECRET_KEY', undefined);
 
       const { createStripeCustomer } = await import('../../server/src/billing/stripe-client.js');
 
@@ -183,7 +181,7 @@ describe('stripe-client', () => {
     });
 
     test('creates customer and returns customer ID when no existing customer', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -217,7 +215,7 @@ describe('stripe-client', () => {
     });
 
     test('returns existing customer ID when customer already exists', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -252,7 +250,7 @@ describe('stripe-client', () => {
     });
 
     test('handles errors and returns null', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -273,7 +271,7 @@ describe('stripe-client', () => {
     });
 
     test('searches by workos_organization_id metadata before email', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -307,7 +305,7 @@ describe('stripe-client', () => {
     });
 
     test('falls through to email check when org metadata search returns empty', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -337,7 +335,7 @@ describe('stripe-client', () => {
     });
 
     test('skips email-matched customer that belongs to a different org', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -373,7 +371,7 @@ describe('stripe-client', () => {
     });
 
     test('skips email-matched customer with no org metadata when requesting org is set', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -404,7 +402,7 @@ describe('stripe-client', () => {
 
   describe('createCustomerPortalSession', () => {
     test('returns null when Stripe is not initialized', async () => {
-      delete process.env.STRIPE_SECRET_KEY;
+      vi.stubEnv('STRIPE_SECRET_KEY', undefined);
 
       const { createCustomerPortalSession } = await import('../../server/src/billing/stripe-client.js');
 
@@ -414,7 +412,7 @@ describe('stripe-client', () => {
     });
 
     test('creates portal session and returns URL', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -442,7 +440,7 @@ describe('stripe-client', () => {
 
   describe('createCustomerSession', () => {
     test('returns null when Stripe is not initialized', async () => {
-      delete process.env.STRIPE_SECRET_KEY;
+      vi.stubEnv('STRIPE_SECRET_KEY', undefined);
 
       const { createCustomerSession } = await import('../../server/src/billing/stripe-client.js');
 
@@ -452,7 +450,7 @@ describe('stripe-client', () => {
     });
 
     test('creates customer session and returns client secret', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -480,7 +478,7 @@ describe('stripe-client', () => {
     });
 
     test('re-throws resource_missing so callers can recover from a stale ID', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const notFound = Object.assign(new Error('No such customer'), {
@@ -502,7 +500,7 @@ describe('stripe-client', () => {
     });
 
     test('returns null and swallows other Stripe errors', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -535,7 +533,7 @@ describe('stripe-client', () => {
     };
 
     test('returns null when Stripe is not initialized', async () => {
-      delete process.env.STRIPE_SECRET_KEY;
+      vi.stubEnv('STRIPE_SECRET_KEY', undefined);
 
       const { createAndSendInvoice } = await import('../../server/src/billing/stripe-client.js');
 
@@ -545,7 +543,7 @@ describe('stripe-client', () => {
     });
 
     test('creates subscription with invoice billing and returns invoice details', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -618,7 +616,7 @@ describe('stripe-client', () => {
     });
 
     test('stamps invoice subscriptions with org and user metadata for webhook agreement attribution', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
       const mockDbQuery = vi.fn<any>().mockResolvedValue({ rows: [] });
       vi.doMock('../../server/src/db/client.js', () => ({
         getPool: () => ({ query: mockDbQuery }),
@@ -696,7 +694,7 @@ describe('stripe-client', () => {
     });
 
     test('refuses org-scoped invoice creation without signer metadata', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -722,7 +720,7 @@ describe('stripe-client', () => {
     });
 
     test('stamps metadata when reusing a DB-linked Stripe customer', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
       const mockDbQuery = vi.fn<any>().mockResolvedValue({
         rows: [{ stripe_customer_id: 'cus_linked' }],
       });
@@ -809,7 +807,7 @@ describe('stripe-client', () => {
     });
 
     test('returns null when price has zero amount', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -847,7 +845,7 @@ describe('stripe-client', () => {
     });
 
     test('cancels subscription when invoice has zero amount', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -895,7 +893,7 @@ describe('stripe-client', () => {
     });
 
     test('returns null when lookup key not found', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -918,7 +916,7 @@ describe('stripe-client', () => {
     });
 
     test('uses existing customer when found by email', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -974,7 +972,7 @@ describe('stripe-client', () => {
 
   describe('createCheckoutSession', () => {
     test('includes subscription_data.metadata with org and user IDs for subscription-mode checkout', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockSession = {
@@ -1015,7 +1013,7 @@ describe('stripe-client', () => {
     });
 
     test('does not include subscription_data for one-time payment checkout', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockSession = {
@@ -1054,7 +1052,7 @@ describe('stripe-client', () => {
     });
 
     test('adds autopublish disclosure for membership-tier prices', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -1090,7 +1088,7 @@ describe('stripe-client', () => {
     });
 
     test('adds disclosure for invoice-based membership prices', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -1123,7 +1121,7 @@ describe('stripe-client', () => {
     });
 
     test('omits disclosure for non-membership prices (e.g. event sponsorships)', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -1156,7 +1154,7 @@ describe('stripe-client', () => {
     });
 
     test('omits disclosure when price has no lookup_key', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const mockStripeInstance = {
@@ -1274,7 +1272,7 @@ describe('stripe-client', () => {
 
   describe('getAllOpenInvoices', () => {
     test('does not exceed Stripe 4-level expand cap (data.lines.data.price.product is 5)', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const listMock = vi.fn<any>().mockImplementation(({ expand }: { expand?: string[] }) => {
@@ -1316,7 +1314,7 @@ describe('stripe-client', () => {
     });
 
     test('propagates Stripe errors to the caller (no silent empty-array fallback)', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       // Stripe SDK throws synchronously here to model how the previous swallow
@@ -1336,7 +1334,7 @@ describe('stripe-client', () => {
     });
 
     test('resolves product names via separate stripe.products.retrieve, with caching', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
 
@@ -1394,7 +1392,7 @@ describe('stripe-client', () => {
     // (Rishi @ InMobi, 2026-05-14). Filter them out, but keep real drafts (with
     // line items + amount) and all `open` invoices.
     test('drops empty draft invoices (no line items or zero amount)', async () => {
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const listMock = vi.fn<any>().mockImplementation(({ status }: { status: string }) => {
@@ -1444,7 +1442,7 @@ describe('stripe-client', () => {
       // Locks down the AND semantics of the filter: both conditions must
       // hold. A draft with amount but no lines is still not actionable —
       // there's nothing for Stripe to invoice — and should not surface.
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const listMock = vi.fn<any>().mockImplementation(({ status }: { status: string }) => {
@@ -1479,7 +1477,7 @@ describe('stripe-client', () => {
       // Stripe `open` invoices have already been finalized + sent. Even an
       // edge-case open invoice with a $0 balance (e.g. fully refunded) is
       // legitimate state that the UI needs to render.
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
       const listMock = vi.fn<any>().mockImplementation(({ status }: { status: string }) => {


### PR DESCRIPTION
## Summary

Closes the three root causes behind #6828's rotating pre-commit failures:

1. **Cross-file env leakage (the rotating-victim mechanism).** Five test files mutated `process.env` directly with inline, non-exception-safe restore. Vitest reuses worker threads across test files, so one thrown assertion mid-test left the env poisoned for whichever files ran later in that worker — the victim rotated with scheduling, which is why no failure ever reproduced twice. Converted all five (`stripe-client`, `replace-subscription`, `registry-brand-enrich-route`, `api-key-issuance-permissions`, `registry-measurement-limits`) to `vi.stubEnv` + `afterEach(vi.unstubAllEnvs)`; `vi.hoisted` wrappers preserved where the env read happens at module-import time. 133 tests pass per-file; the four server files pass in one combined invocation.

2. **Real DNS in SSRF-guard tests.** `training-agent-webhook-fetch` resolved example.com against live DNS and failed on any slow or filtered resolver. `createWebhookFetch` now threads the module's existing `dnsLookup` seam (optional param, production default unchanged — same pattern `validateWebhookUrl` already exposes); the production-mode suite injects a stub resolver. The guard's DNS behavior itself remains covered by the injected-lookup tests. 44/44 pass.

3. **Silent timeout kills.** `with-timeout.sh` `exec`'d into coreutils timeout, so an over-budget suite died as a bare SIGTERM — indistinguishable from a mystery failure, and the single most expensive misdirection in the #6828 investigation. Timeouts now print an explicit `⏰ TIMEOUT` marker to stderr, with an elapsed-time guard so a child exiting 143 on its own stays silent.

No behavior changes outside tests and the tooling script; the one production-code touch is an optional parameter with an unchanged default. Non-protocol scope — no changeset.

Fixes #6828

🤖 Generated with [Claude Code](https://claude.com/claude-code)