### PR TITLE
feat(auth): add audited runtime kill switch for #6827 canary

### DIFF
--- a/server/public/admin-settings.html
+++ b/server/public/admin-settings.html
@@ -377,6 +377,34 @@
           </div>
         </div>
 
+        <!-- Exact-credential organization authorization runtime gate -->
+        <div class="setting-section">
+          <h3>Exact-credential organization authorization</h3>
+          <p>
+            Runtime gate for the staged organization-authorization rollout. The Fly environment
+            ceiling must also allow the boundary. Turning this off takes effect across web
+            processes within five seconds and does not require a deploy.
+          </p>
+
+          <div class="current-value not-set" id="currentOrganizationAuthorizationStatus">
+            <span>Loading...</span>
+          </div>
+
+          <div class="setting-row">
+            <div class="field">
+              <label for="organizationAuthorizationEnabled">Roles-read boundary</label>
+              <select id="organizationAuthorizationEnabled">
+                <option value="false">Legacy authorization (off)</option>
+                <option value="true">Exact-credential authorization (on)</option>
+              </select>
+              <small>Currently limited to <code>organization_roles_read</code>. Disable here for rollback within five seconds.</small>
+            </div>
+            <button class="btn btn-primary" id="saveOrganizationAuthorizationBtn" onclick="saveOrganizationAuthorizationEnforcement()" disabled>
+              Save
+            </button>
+          </div>
+        </div>
+
       <!-- Recent changes audit log -->
       <div class="card" id="auditCard">
         <h2>Recent changes</h2>
@@ -425,6 +453,7 @@
         updateCurrentEditorialChannelDisplay();
         updateCurrentAnnouncementChannelDisplay();
         updateTriageDisplay();
+        updateOrganizationAuthorizationDisplay();
 
         document.getElementById('loading').style.display = 'none';
         document.getElementById('content').style.display = 'block';
@@ -1082,6 +1111,77 @@ loadAuditHistory();
         }, 2000);
       } catch (error) {
         console.error('Error saving triage setting:', error);
+        showStatusMessage('Failed to save: ' + error.message, 'error');
+        saveBtn.textContent = 'Save';
+        saveBtn.disabled = false;
+      }
+    }
+
+    function updateOrganizationAuthorizationDisplay() {
+      const setting = currentSettings?.organization_authorization_enforcement ?? {
+        enabled: false,
+        boundaries: [],
+      };
+      const boundaryEnabled = setting.enabled === true &&
+        Array.isArray(setting.boundaries) &&
+        setting.boundaries.includes('organization_roles_read');
+      const environmentStaged = currentSettings?.organization_authorization_environment_ceiling?.boundaries
+        ?.includes('organization_roles_read') === true;
+      const el = document.getElementById('currentOrganizationAuthorizationStatus');
+      const select = document.getElementById('organizationAuthorizationEnabled');
+
+      el.className = boundaryEnabled && environmentStaged ? 'current-value' : 'current-value not-set';
+      if (boundaryEnabled && environmentStaged) {
+        el.innerHTML = '<strong>Status:</strong> Exact-credential roles read active';
+      } else if (boundaryEnabled) {
+        el.innerHTML = '<strong>Status:</strong> Runtime gate armed, but environment ceiling is off';
+      } else {
+        el.innerHTML = `<strong>Status:</strong> Legacy roles read (runtime gate off; environment ceiling ${environmentStaged ? 'staged' : 'off'})`;
+      }
+      select.value = String(boundaryEnabled);
+      document.getElementById('saveOrganizationAuthorizationBtn').disabled = false;
+    }
+
+    async function saveOrganizationAuthorizationEnforcement() {
+      const select = document.getElementById('organizationAuthorizationEnabled');
+      const saveBtn = document.getElementById('saveOrganizationAuthorizationBtn');
+      const enabled = select.value === 'true';
+
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Saving...';
+      try {
+        const response = await fetch('/api/admin/settings/organization-authorization-enforcement', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            enabled,
+            boundaries: ['organization_roles_read'],
+          }),
+        });
+        if (!response.ok) {
+          const data = await response.json();
+          throw new Error(data.message || 'Failed to save');
+        }
+
+        const data = await response.json();
+        currentSettings.organization_authorization_enforcement =
+          data.organization_authorization_enforcement;
+        updateOrganizationAuthorizationDisplay();
+        loadAuditHistory();
+
+        saveBtn.textContent = 'Saved!';
+        saveBtn.classList.add('btn-success');
+        showStatusMessage(
+          `Exact-credential organization authorization ${enabled ? 'enabled' : 'disabled'} at runtime`,
+          'success',
+        );
+        setTimeout(() => {
+          saveBtn.textContent = 'Save';
+          saveBtn.classList.remove('btn-success');
+          saveBtn.disabled = false;
+        }, 2000);
+      } catch (error) {
+        console.error('Error saving organization authorization setting:', error);
         showStatusMessage('Failed to save: ' + error.message, 'error');
         saveBtn.textContent = 'Save';
         saveBtn.disabled = false;

--- a/server/src/auth/organization-authorization-boundaries.ts
+++ b/server/src/auth/organization-authorization-boundaries.ts
@@ -1,0 +1,10 @@
+/** Fixed rollout boundaries shared by persistence, runtime evaluation, and admin controls. */
+export const ORGANIZATION_AUTHORIZATION_BOUNDARIES = {
+  ORGANIZATION_ROLES_READ: 'organization_roles_read',
+} as const;
+
+export type OrganizationAuthorizationBoundary =
+  (typeof ORGANIZATION_AUTHORIZATION_BOUNDARIES)[keyof typeof ORGANIZATION_AUTHORIZATION_BOUNDARIES];
+
+export const ORGANIZATION_AUTHORIZATION_BOUNDARY_VALUES: readonly OrganizationAuthorizationBoundary[] =
+  Object.values(ORGANIZATION_AUTHORIZATION_BOUNDARIES);

--- a/server/src/db/system-settings-db.ts
+++ b/server/src/db/system-settings-db.ts
@@ -3,6 +3,7 @@
  * Manages key-value configuration for application-wide settings
  */
 
+import { ORGANIZATION_AUTHORIZATION_BOUNDARY_VALUES } from '../auth/organization-authorization-boundaries.js';
 import { query } from './client.js';
 
 // ============== Types ==============
@@ -64,6 +65,11 @@ export interface S2CanonicalFormatsDeltaReleaseSetting {
   criteria_deployed_at: string | null;
 }
 
+export interface OrganizationAuthorizationEnforcementSetting {
+  enabled: boolean;
+  boundaries: string[];
+}
+
 // ============== Setting Keys ==============
 
 export const SETTING_KEYS = {
@@ -76,6 +82,7 @@ export const SETTING_KEYS = {
   EDITORIAL_SLACK_CHANNEL: 'editorial_slack_channel',
   ANNOUNCEMENT_SLACK_CHANNEL: 'announcement_slack_channel',
   CERTIFICATION_S2_CANONICAL_FORMATS_DELTA_RELEASE: 'certification_s2_canonical_formats_delta_release',
+  ORGANIZATION_AUTHORIZATION_ENFORCEMENT: 'organization_authorization_enforcement',
 } as const;
 
 // ============== Generic Operations ==============
@@ -143,6 +150,70 @@ export async function getSettingAuditHistory(limit = 50): Promise<SystemSettingA
     [safeLimit]
   );
   return result.rows;
+}
+
+const DEFAULT_ORGANIZATION_AUTHORIZATION_ENFORCEMENT: OrganizationAuthorizationEnforcementSetting = {
+  enabled: false,
+  boundaries: [],
+};
+
+/**
+ * Read the audited runtime gate for exact-credential organization
+ * authorization. Absence is intentionally disabled. Malformed persisted
+ * values throw so an environment-staged enforcement process can fail closed
+ * instead of silently falling back to legacy authorization.
+ */
+export async function getOrganizationAuthorizationEnforcement(): Promise<OrganizationAuthorizationEnforcementSetting> {
+  const setting = await getSetting<unknown>(SETTING_KEYS.ORGANIZATION_AUTHORIZATION_ENFORCEMENT);
+  if (setting === null) {
+    return {
+      ...DEFAULT_ORGANIZATION_AUTHORIZATION_ENFORCEMENT,
+      boundaries: [],
+    };
+  }
+  if (
+    typeof setting !== 'object' ||
+    Array.isArray(setting) ||
+    typeof (setting as { enabled?: unknown }).enabled !== 'boolean' ||
+    !Array.isArray((setting as { boundaries?: unknown }).boundaries) ||
+    !(setting as { boundaries: unknown[] }).boundaries.every((value) => typeof value === 'string')
+  ) {
+    throw new Error('Invalid organization authorization enforcement setting');
+  }
+  const enabled = (setting as { enabled: boolean }).enabled;
+  const boundaries = [...new Set(
+    (setting as { boundaries: string[] }).boundaries.map((value) => value.trim()).filter(Boolean),
+  )];
+  const supportedBoundaries = new Set<string>(ORGANIZATION_AUTHORIZATION_BOUNDARY_VALUES);
+  if (
+    boundaries.some((boundary) => !supportedBoundaries.has(boundary)) ||
+    (enabled && boundaries.length === 0)
+  ) {
+    throw new Error('Invalid organization authorization enforcement setting');
+  }
+  return { enabled, boundaries };
+}
+
+export async function setOrganizationAuthorizationEnforcement(
+  setting: OrganizationAuthorizationEnforcementSetting,
+  updatedBy?: string,
+): Promise<void> {
+  const boundaries = [...new Set(setting.boundaries.map((value) => value.trim()).filter(Boolean))];
+  const supportedBoundaries = new Set<string>(ORGANIZATION_AUTHORIZATION_BOUNDARY_VALUES);
+  if (
+    boundaries.some((boundary) => !supportedBoundaries.has(boundary)) ||
+    (setting.enabled && boundaries.length === 0)
+  ) {
+    throw new Error('Invalid organization authorization enforcement setting');
+  }
+  await setSetting(
+    SETTING_KEYS.ORGANIZATION_AUTHORIZATION_ENFORCEMENT,
+    {
+      enabled: setting.enabled,
+      boundaries,
+    },
+    updatedBy,
+  );
 }
 
 // ============== Billing Channel Operations ==============

--- a/server/src/middleware/organization-authorization-canary.ts
+++ b/server/src/middleware/organization-authorization-canary.ts
@@ -1,5 +1,13 @@
 import type { WorkOS } from "@workos-inc/node";
+import {
+  ORGANIZATION_AUTHORIZATION_BOUNDARIES,
+  type OrganizationAuthorizationBoundary,
+} from "../auth/organization-authorization-boundaries.js";
 import type { OrgAuthorizationPrincipal } from "../auth/organization-principal.js";
+import {
+  getOrganizationAuthorizationEnforcement,
+  type OrganizationAuthorizationEnforcementSetting,
+} from "../db/system-settings-db.js";
 import { createLogger } from "../logger.js";
 import {
   evaluateUserOrgRoleAuthorization,
@@ -10,13 +18,18 @@ import {
 } from "../utils/resolve-user-org-authorization.js";
 
 const logger = createLogger("organization-authorization-canary");
+const RUNTIME_SETTING_CACHE_TTL_MS = 5_000;
 
-export const ORGANIZATION_AUTHORIZATION_BOUNDARIES = {
-  ORGANIZATION_ROLES_READ: "organization_roles_read",
-} as const;
+let runtimeSettingCache:
+  | { setting: OrganizationAuthorizationEnforcementSetting; expiresAt: number }
+  | null = null;
+let runtimeSettingGeneration = 0;
+let runtimeSettingPromise:
+  | { generation: number; promise: Promise<OrganizationAuthorizationEnforcementSetting> }
+  | null = null;
 
-export type OrganizationAuthorizationBoundary =
-  (typeof ORGANIZATION_AUTHORIZATION_BOUNDARIES)[keyof typeof ORGANIZATION_AUTHORIZATION_BOUNDARIES];
+export { ORGANIZATION_AUTHORIZATION_BOUNDARIES };
+export type { OrganizationAuthorizationBoundary };
 
 export type OrganizationAuthorizationCanaryDecision =
   | { enforced: false }
@@ -29,15 +42,15 @@ export type OrganizationAuthorizationCanaryDecision =
   | {
       enforced: true;
       status: "unavailable";
-      unavailableSources: OrgAuthorizationSource[];
+      unavailableSources: Array<OrgAuthorizationSource | "runtime_config">;
     };
 
 /**
- * Enforcement requires both switches. The global switch is the emergency
- * stop; the fixed boundary allowlist prevents a typo or newly added route from
- * expanding the canary. Both default off.
+ * The environment values are a deployment-time ceiling: neither the audited
+ * runtime setting nor a typo can enable a boundary not explicitly staged in
+ * Fly. Both values default off.
  */
-export function isOrganizationAuthorizationBoundaryEnabled(
+export function isOrganizationAuthorizationBoundaryAllowedByEnvironment(
   boundary: OrganizationAuthorizationBoundary
 ): boolean {
   if (process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED !== "true")
@@ -51,6 +64,40 @@ export function isOrganizationAuthorizationBoundaryEnabled(
   return enabledBoundaries.has(boundary);
 }
 
+async function getCachedRuntimeSetting(): Promise<OrganizationAuthorizationEnforcementSetting> {
+  const now = Date.now();
+  if (runtimeSettingCache && runtimeSettingCache.expiresAt > now) {
+    return runtimeSettingCache.setting;
+  }
+  const generation = runtimeSettingGeneration;
+  if (!runtimeSettingPromise || runtimeSettingPromise.generation !== generation) {
+    const promise = getOrganizationAuthorizationEnforcement()
+      .then((setting) => {
+        if (generation === runtimeSettingGeneration) {
+          runtimeSettingCache = {
+            setting,
+            expiresAt: Date.now() + RUNTIME_SETTING_CACHE_TTL_MS,
+          };
+        }
+        return setting;
+      })
+      .finally(() => {
+        if (runtimeSettingPromise?.promise === promise) {
+          runtimeSettingPromise = null;
+        }
+      });
+    runtimeSettingPromise = { generation, promise };
+  }
+  return runtimeSettingPromise.promise;
+}
+
+/** Clear the local process cache after an audited admin update. */
+export function invalidateOrganizationAuthorizationRuntimeSettingCache(): void {
+  runtimeSettingGeneration += 1;
+  runtimeSettingCache = null;
+  runtimeSettingPromise = null;
+}
+
 /**
  * Evaluate a default-off route boundary. The WorkOS factory is lazy so the
  * disabled path performs no new lookup or configuration work. Failure to
@@ -62,9 +109,31 @@ export async function evaluateOrganizationAuthorizationCanary(input: {
   principal: OrgAuthorizationPrincipal;
   organizationId: string;
   getWorkos: () => WorkOS | null;
+  getRuntimeSetting?: () => Promise<OrganizationAuthorizationEnforcementSetting>;
   minimumRole?: MembershipRole;
 }): Promise<OrganizationAuthorizationCanaryDecision> {
-  if (!isOrganizationAuthorizationBoundaryEnabled(input.boundary)) {
+  if (!isOrganizationAuthorizationBoundaryAllowedByEnvironment(input.boundary)) {
+    return { enforced: false };
+  }
+
+  let runtimeSetting: OrganizationAuthorizationEnforcementSetting;
+  try {
+    runtimeSetting = await (input.getRuntimeSetting?.() ?? getCachedRuntimeSetting());
+  } catch (err) {
+    logger.error(
+      { err, boundary: input.boundary },
+      "Organization authorization runtime setting unavailable"
+    );
+    return {
+      enforced: true,
+      status: "unavailable",
+      unavailableSources: ["runtime_config"],
+    };
+  }
+  if (
+    !runtimeSetting.enabled ||
+    !runtimeSetting.boundaries.includes(input.boundary)
+  ) {
     return { enforced: false };
   }
 

--- a/server/src/routes/admin/settings.ts
+++ b/server/src/routes/admin/settings.ts
@@ -7,8 +7,14 @@
  */
 
 import { Router, Request, Response } from 'express';
+import { getOrganizationAuthorizationUserId } from '../../auth/organization-principal.js';
 import { createLogger } from '../../logger.js';
 import { requireGlobalAdmin } from '../../middleware/auth.js';
+import {
+  invalidateOrganizationAuthorizationRuntimeSettingCache,
+  isOrganizationAuthorizationBoundaryAllowedByEnvironment,
+  ORGANIZATION_AUTHORIZATION_BOUNDARIES,
+} from '../../middleware/organization-authorization-canary.js';
 import {
   getAllSettings,
   getBillingChannel,
@@ -30,6 +36,8 @@ import {
   getS2CanonicalFormatsDeltaRelease,
   setS2CanonicalFormatsDeltaRelease,
   getSettingAuditHistory,
+  getOrganizationAuthorizationEnforcement,
+  setOrganizationAuthorizationEnforcement,
 } from '../../db/system-settings-db.js';
 import {
   getSlackChannels,
@@ -108,6 +116,10 @@ export function createAdminSettingsRouter(): Router {
       const editorialChannel = await getEditorialChannel();
       const announcementChannel = await getAnnouncementChannel();
       const s2CanonicalFormatsDeltaRelease = await getS2CanonicalFormatsDeltaRelease();
+      const organizationAuthorizationEnforcement = await getOrganizationAuthorizationEnforcement();
+      const organizationAuthorizationEnvironmentBoundaries = Object.values(
+        ORGANIZATION_AUTHORIZATION_BOUNDARIES,
+      ).filter(isOrganizationAuthorizationBoundaryAllowedByEnvironment);
 
       res.json({
         settings,
@@ -120,6 +132,10 @@ export function createAdminSettingsRouter(): Router {
         editorial_channel: editorialChannel,
         announcement_channel: announcementChannel,
         s2_canonical_formats_delta_release: s2CanonicalFormatsDeltaRelease,
+        organization_authorization_enforcement: organizationAuthorizationEnforcement,
+        organization_authorization_environment_ceiling: {
+          boundaries: organizationAuthorizationEnvironmentBoundaries,
+        },
       });
     } catch (error) {
       logger.error({ err: error }, 'Failed to get system settings');
@@ -529,6 +545,69 @@ export function createAdminSettingsRouter(): Router {
       res.status(500).json({
         error: 'Failed to update release gates',
       });
+    }
+  });
+
+  // PUT /api/admin/settings/organization-authorization-enforcement
+  // Audited runtime gate beneath the deployment-time environment ceiling.
+  // This makes rollback effective across web processes within the five-second
+  // cache window, without another rolling restart.
+  router.put('/organization-authorization-enforcement', ...requireGlobalAdmin, async (req: Request, res: Response) => {
+    try {
+      const enabled = req.body?.enabled;
+      const boundaries = req.body?.boundaries;
+      const allowedBoundaries = new Set<string>(Object.values(ORGANIZATION_AUTHORIZATION_BOUNDARIES));
+
+      if (
+        typeof enabled !== 'boolean' ||
+        !Array.isArray(boundaries) ||
+        !boundaries.every((value) => typeof value === 'string' && allowedBoundaries.has(value)) ||
+        (enabled && boundaries.length === 0)
+      ) {
+        res.status(400).json({
+          error: 'Invalid organization authorization enforcement setting',
+          message: 'enabled must be boolean and boundaries must contain only supported boundary names',
+        });
+        return;
+      }
+
+      const normalizedBoundaries = [...new Set(boundaries)];
+      if (
+        enabled &&
+        normalizedBoundaries.some(
+          (boundary) => !isOrganizationAuthorizationBoundaryAllowedByEnvironment(
+            boundary as (typeof ORGANIZATION_AUTHORIZATION_BOUNDARIES)[keyof typeof ORGANIZATION_AUTHORIZATION_BOUNDARIES],
+          ),
+        )
+      ) {
+        res.status(409).json({
+          error: 'Organization authorization environment ceiling is not staged',
+          message: 'Stage the fixed environment boundary before enabling runtime enforcement',
+        });
+        return;
+      }
+
+      const actorCredentialId = getOrganizationAuthorizationUserId(req.user!);
+      await setOrganizationAuthorizationEnforcement({
+        enabled,
+        boundaries: normalizedBoundaries,
+      }, actorCredentialId);
+      invalidateOrganizationAuthorizationRuntimeSettingCache();
+
+      logger.info(
+        { enabled, boundaries: normalizedBoundaries, actorCredentialId },
+        'Organization authorization runtime enforcement setting updated',
+      );
+      res.json({
+        success: true,
+        organization_authorization_enforcement: {
+          enabled,
+          boundaries: normalizedBoundaries,
+        },
+      });
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to update organization authorization runtime enforcement setting');
+      res.status(500).json({ error: 'Failed to update setting' });
     }
   });
 

--- a/server/tests/unit/admin-organization-authorization-setting.test.ts
+++ b/server/tests/unit/admin-organization-authorization-setting.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+
+const {
+  getSettingMock,
+  setSettingMock,
+  invalidateCacheMock,
+  environmentAllowsBoundaryMock,
+} = vi.hoisted(() => ({
+  getSettingMock: vi.fn(),
+  setSettingMock: vi.fn(),
+  invalidateCacheMock: vi.fn(),
+  environmentAllowsBoundaryMock: vi.fn(),
+}));
+
+vi.mock("../../src/middleware/auth.js", () => {
+  const requireAuth = (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = {
+      id: "user_canonical",
+      authWorkosUserId: "user_authenticated_admin",
+      email: "admin@example.test",
+    } as never;
+    next();
+  };
+  const pass = (_req: express.Request, _res: express.Response, next: express.NextFunction) => next();
+  return { requireGlobalAdmin: [requireAuth, pass, pass] };
+});
+
+vi.mock("../../src/middleware/organization-authorization-canary.js", () => ({
+  ORGANIZATION_AUTHORIZATION_BOUNDARIES: {
+    ORGANIZATION_ROLES_READ: "organization_roles_read",
+  },
+  isOrganizationAuthorizationBoundaryAllowedByEnvironment: environmentAllowsBoundaryMock,
+  invalidateOrganizationAuthorizationRuntimeSettingCache: invalidateCacheMock,
+}));
+
+vi.mock("../../src/db/system-settings-db.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/db/system-settings-db.js")>()),
+  getOrganizationAuthorizationEnforcement: getSettingMock,
+  setOrganizationAuthorizationEnforcement: setSettingMock,
+}));
+
+import { createAdminSettingsRouter } from "../../src/routes/admin/settings.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/admin/settings", createAdminSettingsRouter());
+  return app;
+}
+
+describe("organization authorization runtime admin setting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSettingMock.mockResolvedValue({ enabled: false, boundaries: [] });
+    setSettingMock.mockResolvedValue(undefined);
+    environmentAllowsBoundaryMock.mockReturnValue(true);
+  });
+
+  it.each([
+    [{ enabled: "true", boundaries: ["organization_roles_read"] }],
+    [{ enabled: true, boundaries: [] }],
+    [{ enabled: true, boundaries: ["unknown_boundary"] }],
+    [{ enabled: false, boundaries: "organization_roles_read" }],
+  ])("rejects malformed or unsupported values %#", async (body) => {
+    const response = await request(createApp())
+      .put("/api/admin/settings/organization-authorization-enforcement")
+      .send(body);
+
+    expect(response.status).toBe(400);
+    expect(setSettingMock).not.toHaveBeenCalled();
+    expect(invalidateCacheMock).not.toHaveBeenCalled();
+  });
+
+  it("persists the fixed boundary with exact authenticated-credential audit provenance", async () => {
+    const response = await request(createApp())
+      .put("/api/admin/settings/organization-authorization-enforcement")
+      .send({
+        enabled: true,
+        boundaries: ["organization_roles_read", "organization_roles_read"],
+      });
+
+    expect(response.status).toBe(200);
+    expect(setSettingMock).toHaveBeenCalledWith(
+      { enabled: true, boundaries: ["organization_roles_read"] },
+      "user_authenticated_admin",
+    );
+    expect(invalidateCacheMock).toHaveBeenCalledOnce();
+    expect(response.body.organization_authorization_enforcement).toEqual({
+      enabled: true,
+      boundaries: ["organization_roles_read"],
+    });
+  });
+
+  it("allows an audited runtime rollback without removing the staged boundary", async () => {
+    const response = await request(createApp())
+      .put("/api/admin/settings/organization-authorization-enforcement")
+      .send({ enabled: false, boundaries: ["organization_roles_read"] });
+
+    expect(response.status).toBe(200);
+    expect(setSettingMock).toHaveBeenCalledWith(
+      { enabled: false, boundaries: ["organization_roles_read"] },
+      "user_authenticated_admin",
+    );
+    expect(invalidateCacheMock).toHaveBeenCalledOnce();
+  });
+
+  it("will not arm runtime enforcement before the environment ceiling is staged", async () => {
+    environmentAllowsBoundaryMock.mockReturnValue(false);
+
+    const response = await request(createApp())
+      .put("/api/admin/settings/organization-authorization-enforcement")
+      .send({ enabled: true, boundaries: ["organization_roles_read"] });
+
+    expect(response.status).toBe(409);
+    expect(setSettingMock).not.toHaveBeenCalled();
+    expect(invalidateCacheMock).not.toHaveBeenCalled();
+  });
+
+  it("does not invalidate a cache when persistence fails", async () => {
+    setSettingMock.mockRejectedValueOnce(new Error("database unavailable"));
+
+    const response = await request(createApp())
+      .put("/api/admin/settings/organization-authorization-enforcement")
+      .send({ enabled: false, boundaries: ["organization_roles_read"] });
+
+    expect(response.status).toBe(500);
+    expect(invalidateCacheMock).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/admin-settings-organization-authorization-ui.test.ts
+++ b/server/tests/unit/admin-settings-organization-authorization-ui.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  new URL("../../public/admin-settings.html", import.meta.url),
+  "utf8",
+);
+
+describe("admin organization authorization runtime control", () => {
+  it("loads, renders, and saves the fixed roles-read boundary", () => {
+    expect(source).toContain("updateOrganizationAuthorizationDisplay();");
+    expect(source).toContain("/api/admin/settings/organization-authorization-enforcement");
+    expect(source).toContain("boundaries: ['organization_roles_read']");
+    expect(source).toContain("Disable here for rollback within five seconds.");
+    expect(source).toContain("Runtime gate armed, but environment ceiling is off");
+  });
+});

--- a/server/tests/unit/admin-settings-privacy-gate.test.ts
+++ b/server/tests/unit/admin-settings-privacy-gate.test.ts
@@ -78,6 +78,8 @@ vi.mock('../../src/db/system-settings-db.js', () => ({
   setEditorialChannel: vi.fn(),
   getAnnouncementChannel: (...args: unknown[]) => mockGetAnnouncementChannel(...args),
   setAnnouncementChannel: (...args: unknown[]) => mockSetAnnouncementChannel(...args),
+  getOrganizationAuthorizationEnforcement: vi.fn().mockResolvedValue({ enabled: false, boundaries: [] }),
+  setOrganizationAuthorizationEnforcement: vi.fn(),
 }));
 
 async function buildApp() {

--- a/server/tests/unit/organization-authorization-canary.test.ts
+++ b/server/tests/unit/organization-authorization-canary.test.ts
@@ -3,9 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const {
   resolveUserOrgAuthorizationMock,
   evaluateUserOrgRoleAuthorizationMock,
+  getRuntimeSettingDbMock,
 } = vi.hoisted(() => ({
   resolveUserOrgAuthorizationMock: vi.fn(),
   evaluateUserOrgRoleAuthorizationMock: vi.fn(),
+  getRuntimeSettingDbMock: vi.fn(),
 }));
 
 vi.mock("../../src/utils/resolve-user-org-authorization.js", () => ({
@@ -13,9 +15,14 @@ vi.mock("../../src/utils/resolve-user-org-authorization.js", () => ({
   evaluateUserOrgRoleAuthorization: evaluateUserOrgRoleAuthorizationMock,
 }));
 
+vi.mock("../../src/db/system-settings-db.js", () => ({
+  getOrganizationAuthorizationEnforcement: getRuntimeSettingDbMock,
+}));
+
 import {
   evaluateOrganizationAuthorizationCanary,
-  isOrganizationAuthorizationBoundaryEnabled,
+  invalidateOrganizationAuthorizationRuntimeSettingCache,
+  isOrganizationAuthorizationBoundaryAllowedByEnvironment,
   ORGANIZATION_AUTHORIZATION_BOUNDARIES,
 } from "../../src/middleware/organization-authorization-canary.js";
 
@@ -27,6 +34,8 @@ describe("organization authorization canary", () => {
     delete process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES;
     resolveUserOrgAuthorizationMock.mockReset();
     evaluateUserOrgRoleAuthorizationMock.mockReset();
+    getRuntimeSettingDbMock.mockReset();
+    invalidateOrganizationAuthorizationRuntimeSettingCache();
   });
 
   afterEach(() => {
@@ -47,6 +56,7 @@ describe("organization authorization canary", () => {
       process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = boundaries;
     }
     const getWorkos = vi.fn();
+    const getRuntimeSetting = vi.fn();
 
     const decision = await evaluateOrganizationAuthorizationCanary({
       boundary: BOUNDARY,
@@ -56,25 +66,132 @@ describe("organization authorization canary", () => {
       },
       organizationId: "org_test",
       getWorkos,
+      getRuntimeSetting,
     });
 
     expect(decision).toEqual({ enforced: false });
     expect(getWorkos).not.toHaveBeenCalled();
+    expect(getRuntimeSetting).not.toHaveBeenCalled();
     expect(resolveUserOrgAuthorizationMock).not.toHaveBeenCalled();
   });
 
-  it("requires the global switch and the exact fixed boundary", () => {
+  it("requires the global switch and the exact fixed environment boundary", () => {
     process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";
-    expect(isOrganizationAuthorizationBoundaryEnabled(BOUNDARY)).toBe(false);
+    expect(isOrganizationAuthorizationBoundaryAllowedByEnvironment(BOUNDARY)).toBe(false);
 
     process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = "another_boundary";
-    expect(isOrganizationAuthorizationBoundaryEnabled(BOUNDARY)).toBe(false);
+    expect(isOrganizationAuthorizationBoundaryAllowedByEnvironment(BOUNDARY)).toBe(false);
 
     process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = `another_boundary, ${BOUNDARY}`;
-    expect(isOrganizationAuthorizationBoundaryEnabled(BOUNDARY)).toBe(true);
+    expect(isOrganizationAuthorizationBoundaryAllowedByEnvironment(BOUNDARY)).toBe(true);
 
     process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "false";
-    expect(isOrganizationAuthorizationBoundaryEnabled(BOUNDARY)).toBe(false);
+    expect(isOrganizationAuthorizationBoundaryAllowedByEnvironment(BOUNDARY)).toBe(false);
+  });
+
+  it("keeps legacy authorization when the audited runtime gate is off", async () => {
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = BOUNDARY;
+    const getWorkos = vi.fn();
+    const getRuntimeSetting = vi.fn().mockResolvedValue({
+      enabled: false,
+      boundaries: [BOUNDARY],
+    });
+
+    const decision = await evaluateOrganizationAuthorizationCanary({
+      boundary: BOUNDARY,
+      principal: { id: "user_test" },
+      organizationId: "org_test",
+      getWorkos,
+      getRuntimeSetting,
+    });
+
+    expect(decision).toEqual({ enforced: false });
+    expect(getRuntimeSetting).toHaveBeenCalledOnce();
+    expect(getWorkos).not.toHaveBeenCalled();
+    expect(resolveUserOrgAuthorizationMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the environment is staged but runtime configuration is unavailable", async () => {
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = BOUNDARY;
+    const getWorkos = vi.fn();
+
+    const decision = await evaluateOrganizationAuthorizationCanary({
+      boundary: BOUNDARY,
+      principal: { id: "user_test" },
+      organizationId: "org_test",
+      getWorkos,
+      getRuntimeSetting: vi.fn().mockRejectedValue(new Error("database unavailable")),
+    });
+
+    expect(decision).toEqual({
+      enforced: true,
+      status: "unavailable",
+      unavailableSources: ["runtime_config"],
+    });
+    expect(getWorkos).not.toHaveBeenCalled();
+    expect(resolveUserOrgAuthorizationMock).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the process cache so rollback is visible without a restart", async () => {
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = BOUNDARY;
+    getRuntimeSettingDbMock
+      .mockResolvedValueOnce({ enabled: true, boundaries: [BOUNDARY] })
+      .mockResolvedValueOnce({ enabled: false, boundaries: [BOUNDARY] });
+    resolveUserOrgAuthorizationMock.mockResolvedValue({ status: "authorized" });
+    evaluateUserOrgRoleAuthorizationMock.mockReturnValue({ status: "forbidden" });
+    const input = {
+      boundary: BOUNDARY,
+      principal: { id: "user_test" },
+      organizationId: "org_test",
+      getWorkos: vi.fn(() => ({ userManagement: {} }) as never),
+    };
+
+    expect(await evaluateOrganizationAuthorizationCanary(input)).toEqual({
+      enforced: true,
+      status: "forbidden",
+    });
+    expect(await evaluateOrganizationAuthorizationCanary(input)).toEqual({
+      enforced: true,
+      status: "forbidden",
+    });
+    expect(getRuntimeSettingDbMock).toHaveBeenCalledOnce();
+
+    invalidateOrganizationAuthorizationRuntimeSettingCache();
+    expect(await evaluateOrganizationAuthorizationCanary(input)).toEqual({ enforced: false });
+    expect(getRuntimeSettingDbMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let an in-flight stale read repopulate the cache after rollback", async () => {
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = BOUNDARY;
+    let resolveStaleRead!: (setting: { enabled: boolean; boundaries: string[] }) => void;
+    getRuntimeSettingDbMock
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveStaleRead = resolve;
+      }))
+      .mockResolvedValueOnce({ enabled: false, boundaries: [BOUNDARY] });
+    resolveUserOrgAuthorizationMock.mockResolvedValue({ status: "authorized" });
+    evaluateUserOrgRoleAuthorizationMock.mockReturnValue({ status: "forbidden" });
+    const input = {
+      boundary: BOUNDARY,
+      principal: { id: "user_test" },
+      organizationId: "org_test",
+      getWorkos: vi.fn(() => ({ userManagement: {} }) as never),
+    };
+
+    const staleDecision = evaluateOrganizationAuthorizationCanary(input);
+    await vi.waitFor(() => expect(getRuntimeSettingDbMock).toHaveBeenCalledOnce());
+    invalidateOrganizationAuthorizationRuntimeSettingCache();
+
+    expect(await evaluateOrganizationAuthorizationCanary(input)).toEqual({ enforced: false });
+    resolveStaleRead({ enabled: true, boundaries: [BOUNDARY] });
+    expect(await staleDecision).toEqual({ enforced: true, status: "forbidden" });
+
+    expect(await evaluateOrganizationAuthorizationCanary(input)).toEqual({ enforced: false });
+    expect(getRuntimeSettingDbMock).toHaveBeenCalledTimes(2);
   });
 
   it.each([
@@ -120,6 +237,10 @@ describe("organization authorization canary", () => {
         },
         organizationId: "org_test",
         getWorkos: () => workos as never,
+        getRuntimeSetting: vi.fn().mockResolvedValue({
+          enabled: true,
+          boundaries: [BOUNDARY],
+        }),
       });
 
       expect(decision).toEqual(expected);
@@ -150,6 +271,10 @@ describe("organization authorization canary", () => {
       getWorkos: () => {
         throw new Error("missing configuration");
       },
+      getRuntimeSetting: vi.fn().mockResolvedValue({
+        enabled: true,
+        boundaries: [BOUNDARY],
+      }),
     });
 
     expect(resolveUserOrgAuthorizationMock).toHaveBeenCalledWith(

--- a/server/tests/unit/organization-authorization-setting-db.test.ts
+++ b/server/tests/unit/organization-authorization-setting-db.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const queryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/db/client.js", () => ({ query: queryMock }));
+
+import {
+  getOrganizationAuthorizationEnforcement,
+  setOrganizationAuthorizationEnforcement,
+} from "../../src/db/system-settings-db.js";
+
+describe("organization authorization system setting", () => {
+  beforeEach(() => queryMock.mockReset());
+
+  it("defaults absent configuration off", async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] });
+
+    await expect(getOrganizationAuthorizationEnforcement()).resolves.toEqual({
+      enabled: false,
+      boundaries: [],
+    });
+  });
+
+  it("normalizes persisted boundaries", async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [{ value: { enabled: true, boundaries: [" organization_roles_read ", "organization_roles_read"] } }],
+    });
+
+    await expect(getOrganizationAuthorizationEnforcement()).resolves.toEqual({
+      enabled: true,
+      boundaries: ["organization_roles_read"],
+    });
+  });
+
+  it.each([
+    [true],
+    [{ enabled: "true", boundaries: [] }],
+    [{ enabled: true, boundaries: "organization_roles_read" }],
+    [{ enabled: true, boundaries: [42] }],
+    [{ enabled: true, boundaries: [] }],
+    [{ enabled: true, boundaries: ["unknown_boundary"] }],
+  ])("rejects malformed persisted configuration %#", async (value) => {
+    queryMock.mockResolvedValueOnce({ rows: [{ value }] });
+
+    await expect(getOrganizationAuthorizationEnforcement()).rejects.toThrow(
+      "Invalid organization authorization enforcement setting",
+    );
+  });
+
+  it("writes normalized configuration through the audited setting operation", async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] });
+
+    await setOrganizationAuthorizationEnforcement(
+      {
+        enabled: false,
+        boundaries: [" organization_roles_read ", "organization_roles_read"],
+      },
+      "user_authenticated_admin",
+    );
+
+    expect(queryMock).toHaveBeenCalledOnce();
+    expect(queryMock.mock.calls[0][1]).toEqual([
+      "organization_authorization_enforcement",
+      JSON.stringify({ enabled: false, boundaries: ["organization_roles_read"] }),
+      "user_authenticated_admin",
+    ]);
+  });
+
+  it("will not persist enabled configuration outside the fixed boundary allowlist", async () => {
+    await expect(setOrganizationAuthorizationEnforcement({
+      enabled: true,
+      boundaries: ["unknown_boundary"],
+    })).rejects.toThrow("Invalid organization authorization enforcement setting");
+
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add an audited database-backed runtime gate beneath the existing default-off Fly environment ceiling
- expose the fixed roles-read boundary in admin settings with exact authenticated-credential audit provenance
- cache runtime configuration for five seconds, fail closed when staged configuration is unavailable, and prevent stale in-flight reads from surviving rollback
- refuse to persist unsupported runtime boundaries or arm the gate until the matching environment boundary is staged

## Rollout behavior

This PR is behavior-neutral in production because the Fly enforcement environment values are absent. After this version deploys, the runtime setting will be created disabled. The environment ceiling can then be staged during a rolling release while runtime remains off. Following the day-long clean observation gate, runtime enforcement can be enabled without a restart and disabled across web processes within five seconds.

## Verification

- 6 focused Vitest files: 46 tests passed
- npm run typecheck
- git diff --check

Relates to #6827.