### PR TITLE
fix(addie): harden Sonnet response completion

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -6,6 +6,7 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
+import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream';
 import { createHash, createHmac } from 'node:crypto';
 import { createLogger } from '../logger.js';
 
@@ -76,6 +77,7 @@ export interface InvocationPreparedSnapshot {
 interface PreparedProviderRequest {
   model: string;
   max_tokens: number;
+  output_config?: Anthropic.Beta.BetaOutputConfig;
   system: Anthropic.TextBlockParam[];
   tools: Array<Record<string, unknown>>;
   messages: Anthropic.MessageParam[];
@@ -83,6 +85,18 @@ interface PreparedProviderRequest {
 }
 
 const BLOCKED_TOOL_RESULT = 'Error: Tool execution blocked by policy';
+const DEFAULT_MAX_OUTPUT_TOKENS = 8_192;
+const SONNET_5_MAX_OUTPUT_TOKENS = 16_384;
+
+function addieModelOutputControls(model: string): Pick<PreparedProviderRequest, 'max_tokens' | 'output_config'> {
+  if (/^claude-sonnet-5(?:-|$)/.test(model)) {
+    return {
+      max_tokens: SONNET_5_MAX_OUTPUT_TOKENS,
+      output_config: { effort: 'medium' },
+    };
+  }
+  return { max_tokens: DEFAULT_MAX_OUTPUT_TOKENS };
+}
 
 function isEvaluationExecution(options?: ProcessMessageOptions): boolean {
   return options?.executionMode === 'evaluation' || options?.executionMode === 'replay';
@@ -1078,9 +1092,10 @@ export class AddieClaudeClient {
   ) {
     return {
       model: effectiveModel,
-      // Sonnet 5 uses adaptive thinking by default; leave room for its
-      // thinking summary plus the user-visible answer/tool calls.
-      max_tokens: 8192,
+      // Sonnet 5 defaults to high-effort adaptive thinking, and max_tokens
+      // covers both reasoning and visible output. Medium effort plus a larger
+      // cap keeps tool-heavy chat from spending the whole request on thinking.
+      ...addieModelOutputControls(effectiveModel),
       system: systemBlocks,
       tools,
       messages,
@@ -1252,6 +1267,8 @@ export class AddieClaudeClient {
     }
     let iteration = 0;
     let retriedEmptyPostToolResponse = false;
+    let retriedEmptyInitialResponse = false;
+    let emptyResponseBeforeRecovery: Anthropic.Beta.BetaMessage | null = null;
     let hasExecutedCustomTool = false;
 
     while (iteration < maxIterations) {
@@ -1259,9 +1276,11 @@ export class AddieClaudeClient {
 
       // Use beta API to access web search
       const llmStart = Date.now();
-      let response;
+      let response: Anthropic.Beta.BetaMessage;
+      let reusedEmptyResponse = false;
       const invocationTools = retriedEmptyPostToolResponse ? [] : firstInvocationTools;
       let invocationAttempt = 0;
+      const isEmptyResponseRecovery = emptyResponseBeforeRecovery !== null;
       try {
         const invokeProvider = async (sdkMaxRetries?: number) => {
           invocationAttempt++;
@@ -1285,33 +1304,44 @@ export class AddieClaudeClient {
         // A replay is an exactly-once paid experiment. A timeout can occur
         // after provider acceptance, so neither our outer retry helper nor the
         // Anthropic SDK may submit the request again.
-        response = options?.executionMode === 'replay'
+        response = options?.executionMode === 'replay' || isEmptyResponseRecovery
           ? await invokeProvider(0)
           : await withRetry(
             () => invokeProvider(),
             { maxRetries: 3, initialDelayMs: 1000 },
             'processMessage',
           );
+        if (isEmptyResponseRecovery) emptyResponseBeforeRecovery = null;
       } catch (error) {
-        const stats = this.buildPayloadDebugStats(effectiveModel, systemBlocks, customTools, messages, iteration, requestWebSearchEnabled ? 1 : 0);
-        if (options?.executionMode === 'replay') {
-          // Provider errors may echo request text. Replay logs only categorical
-          // metadata; the signed ledger records the terminal outcome.
-          logger.error(
-            { source: 'processMessage', payload: stats },
-            'Addie: Replay provider invocation failed',
-          );
+        if (isEmptyResponseRecovery && emptyResponseBeforeRecovery) {
+          // The empty end_turn was a valid terminal response. Recovery is
+          // best-effort: if its one extra call fails, retain that terminal and
+          // its already-accounted usage rather than turning fallback into an
+          // exception. Do not log a provider error that may echo input text.
+          logger.warn({ iteration }, 'Addie: Empty-response recovery failed');
+          response = emptyResponseBeforeRecovery;
+          reusedEmptyResponse = true;
         } else {
-          this.logPromptOverflow(error, stats, 'processMessage');
+          const stats = this.buildPayloadDebugStats(effectiveModel, systemBlocks, customTools, messages, iteration, requestWebSearchEnabled ? 1 : 0);
+          if (options?.executionMode === 'replay') {
+            // Provider errors may echo request text. Replay logs only categorical
+            // metadata; the signed ledger records the terminal outcome.
+            logger.error(
+              { source: 'processMessage', payload: stats },
+              'Addie: Replay provider invocation failed',
+            );
+          } else {
+            this.logPromptOverflow(error, stats, 'processMessage');
+          }
+          throw error;
         }
-        throw error;
       }
 
       const llmDuration = Date.now() - llmStart;
       totalLlmMs += llmDuration;
 
       // Track token usage from this iteration
-      if (response.usage) {
+      if (response.usage && !reusedEmptyResponse) {
         totalInputTokens += response.usage.input_tokens;
         totalOutputTokens += response.usage.output_tokens;
         // Cache tokens are optional and may not be present
@@ -1475,11 +1505,36 @@ export class AddieClaudeClient {
           .map(block => block.type === 'text' ? block.text : '')
           .join('\n\n')
           .trim();
+        // A provider-successful but wholly empty first sample has no visible
+        // output or side effect. Production may safely resample it once; eval
+        // and replay preserve the original terminal outcome for integrity.
+        if (
+          operationalExecution
+          && response.stop_reason === 'end_turn'
+          && iteration === 1
+          && !retriedEmptyInitialResponse
+          && !hasExecutedCustomTool
+          && toolExecutions.length === 0
+          && response.content.length === 0
+          && iteration < maxIterations
+        ) {
+          retriedEmptyInitialResponse = true;
+          emptyResponseBeforeRecovery = response;
+          logger.warn({ iteration }, 'Addie: Retrying wholly empty initial response');
+          continue;
+        }
         // Anthropic can occasionally return an empty end_turn immediately
         // after a tool result. Resampling the unchanged post-tool turn once is
         // safe because no assistant response has reached the caller yet.
-        if (!rawText && hasExecutedCustomTool && !retriedEmptyPostToolResponse && iteration < maxIterations) {
+        if (
+          response.stop_reason === 'end_turn'
+          && !rawText
+          && hasExecutedCustomTool
+          && !retriedEmptyPostToolResponse
+          && iteration < maxIterations
+        ) {
           retriedEmptyPostToolResponse = true;
+          emptyResponseBeforeRecovery = response;
           logger.warn({ iteration, toolsUsed }, 'Addie: Retrying empty response after tool use');
           continue;
         }
@@ -2061,6 +2116,8 @@ export class AddieClaudeClient {
     const maxIterations = options?.maxIterations ?? 10;
     let iteration = 0;
     let retriedEmptyPostToolResponse = false;
+    let retriedEmptyInitialResponse = false;
+    let emptyResponseBeforeRecovery: Anthropic.Beta.BetaMessage | null = null;
 
       while (iteration < maxIterations) {
         iteration++;
@@ -2070,6 +2127,7 @@ export class AddieClaudeClient {
         // Collect full response for tool handling
         let currentResponse: Anthropic.Beta.BetaMessage | null = null;
         const textChunks: string[] = [];
+        let reusedEmptyResponse = false;
 
         // Retry loop for streaming API calls (handles overloaded_error).
         // Logical-turn buffering means no model output is exposed and no
@@ -2081,11 +2139,12 @@ export class AddieClaudeClient {
         let receivedDeltaCount = 0;
 
         while (!streamSucceeded && streamRetryCount <= maxStreamRetries) {
+          const isEmptyResponseRecovery: boolean = emptyResponseBeforeRecovery !== null;
           try {
             const invocationTools = retriedEmptyPostToolResponse ? [] : customTools;
             const providerRequest: PreparedProviderRequest = {
               model: effectiveModel,
-              max_tokens: 8192,
+              ...addieModelOutputControls(effectiveModel),
               system: systemBlocks,
               tools: invocationTools as unknown as Array<Record<string, unknown>>,
               messages,
@@ -2096,14 +2155,13 @@ export class AddieClaudeClient {
               iteration,
               streamRetryCount + 1,
             );
-            const stream = this.client.beta.messages.stream(
-              providerRequest as unknown as Parameters<
-                typeof this.client.beta.messages.stream
-              >[0],
+            const anthropicStream: BetaMessageStream = this.client.beta.messages.stream(
+              providerRequest as unknown as Anthropic.Beta.MessageCreateParamsStreaming,
+              isEmptyResponseRecovery ? { maxRetries: 0 } : undefined,
             );
 
             // Process stream events
-            for await (const event of stream) {
+            for await (const event of anthropicStream) {
               if (event.type === 'content_block_delta') {
                 totalReceivedDeltas++;
                 receivedDeltaCount++;
@@ -2113,16 +2171,27 @@ export class AddieClaudeClient {
                 }
               } else if (event.type === 'message_stop') {
                 // Get the final message
-                currentResponse = await stream.finalMessage();
+                currentResponse = await anthropicStream.finalMessage();
               }
             }
 
             if (!currentResponse) {
-              currentResponse = await stream.finalMessage();
+              currentResponse = await anthropicStream.finalMessage();
             }
 
             streamSucceeded = true;
+            if (isEmptyResponseRecovery) emptyResponseBeforeRecovery = null;
           } catch (streamError) {
+            if (isEmptyResponseRecovery && emptyResponseBeforeRecovery) {
+              // See the non-streaming path: recovery is an optional UX
+              // improvement, not a reason to discard the valid first terminal.
+              logger.warn({ iteration }, 'Addie Stream: Empty-response recovery failed');
+              currentResponse = emptyResponseBeforeRecovery;
+              reusedEmptyResponse = true;
+              textChunks.length = 0;
+              receivedDeltaCount = 0;
+              break;
+            }
             streamRetryCount++;
             const stats = this.buildPayloadDebugStats(effectiveModel, systemBlocks, customTools, messages, iteration);
             this.logPromptOverflow(streamError, stats, 'processMessageStream');
@@ -2203,7 +2272,7 @@ export class AddieClaudeClient {
         }
 
         // Track token usage
-        if (currentResponse.usage) {
+        if (currentResponse.usage && !reusedEmptyResponse) {
           totalInputTokens += currentResponse.usage.input_tokens;
           totalOutputTokens += currentResponse.usage.output_tokens;
           if ('cache_creation_input_tokens' in currentResponse.usage) {
@@ -2318,16 +2387,36 @@ export class AddieClaudeClient {
 
         // Done - no tool use
         if (stopAction === 'complete') {
-          const completedIterationText = currentResponse.content
-            .filter((block): block is Anthropic.Beta.BetaTextBlock => block.type === 'text')
-            .map(block => block.text)
-            .join('\n\n')
-            .trim();
+          if (
+            operationalExecution
+            && currentResponse.stop_reason === 'end_turn'
+            && iteration === 1
+            && !retriedEmptyInitialResponse
+            && toolExecutions.length === 0
+            && logicalText.length === 0
+            && iterationText.trim().length === 0
+            && receivedDeltaCount === 0
+            && currentResponse.content.length === 0
+            && iteration < maxIterations
+          ) {
+            retriedEmptyInitialResponse = true;
+            emptyResponseBeforeRecovery = currentResponse;
+            logger.warn({ iteration }, 'Addie Stream: Retrying wholly empty initial response');
+            continue;
+          }
 
           // No deltas were emitted for this iteration, so retrying the same
           // post-tool turn once cannot duplicate text in streaming clients.
-          if (!completedIterationText && toolExecutions.length > 0 && !retriedEmptyPostToolResponse && iteration < maxIterations) {
+          if (
+            currentResponse.stop_reason === 'end_turn'
+            && !iterationText.trim()
+            && receivedDeltaCount === 0
+            && toolExecutions.length > 0
+            && !retriedEmptyPostToolResponse
+            && iteration < maxIterations
+          ) {
             retriedEmptyPostToolResponse = true;
+            emptyResponseBeforeRecovery = currentResponse;
             logger.warn({ iteration, toolsUsed }, 'Addie Stream: Retrying empty response after tool use');
             continue;
           }

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.22';
+export const CODE_VERSION = '2026.08.23';
 
 // Types
 export interface ConfigVersion {

--- a/server/tests/unit/addie-empty-response-fallback.test.ts
+++ b/server/tests/unit/addie-empty-response-fallback.test.ts
@@ -69,6 +69,11 @@ const recoveredEndTurn = {
   usage: { input_tokens: 12, output_tokens: 6 },
 };
 
+const emptyRefusal = {
+  ...emptyEndTurn,
+  stop_reason: 'refusal',
+};
+
 const mixedRecoveryToolUseTurn = {
   ...toolUseTurn,
   content: [
@@ -95,7 +100,25 @@ function makeEmptyStream() {
   };
 }
 
-function makeStream(message: typeof toolUseTurn | typeof emptyEndTurn | typeof recoveredEndTurn | typeof mixedRecoveryToolUseTurn) {
+function makeTextDeltaStreamWithEmptyFinal(text: string) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { type: 'content_block_delta', delta: { type: 'text_delta', text } };
+    },
+    finalMessage: vi.fn().mockResolvedValue(emptyEndTurn),
+  };
+}
+
+function makeThrowingStream(error: Error) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      throw error;
+    },
+    finalMessage: vi.fn(),
+  };
+}
+
+function makeStream(message: typeof toolUseTurn | typeof emptyEndTurn | typeof recoveredEndTurn | typeof mixedRecoveryToolUseTurn | typeof emptyRefusal) {
   return {
     async *[Symbol.asyncIterator]() {
       for (const block of message.content) {
@@ -128,7 +151,9 @@ describe('Addie empty-response fallback (#4430)', () => {
   });
 
   it('returns fallback text and sends monitoring for non-streaming empty responses', async () => {
-    mocks.createMessage.mockResolvedValueOnce(emptyEndTurn);
+    mocks.createMessage
+      .mockResolvedValueOnce(emptyEndTurn)
+      .mockResolvedValueOnce(emptyEndTurn);
 
     const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
     const response = await client.processMessage(
@@ -142,6 +167,9 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
     expect(response.flagged).toBe(true);
     expect(response.flag_reason).toContain('Empty turn');
+    expect(mocks.createMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.createMessage.mock.calls[0][0]).toMatchObject({ max_tokens: 8_192 });
+    expect(mocks.createMessage.mock.calls[0][0]).not.toHaveProperty('output_config');
     expect(mocks.notifySystemError).toHaveBeenCalledWith(expect.objectContaining({
       source: 'addie-empty-response',
       errorMessage: expect.stringContaining('thread-empty'),
@@ -149,7 +177,9 @@ describe('Addie empty-response fallback (#4430)', () => {
   });
 
   it('yields fallback text before done for streaming empty responses', async () => {
-    mocks.streamMessage.mockReturnValueOnce(makeEmptyStream());
+    mocks.streamMessage
+      .mockReturnValueOnce(makeEmptyStream())
+      .mockReturnValueOnce(makeEmptyStream());
 
     const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
     const events: StreamEvent[] = [];
@@ -168,10 +198,265 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(done?.response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
     expect(done?.response.flagged).toBe(true);
     expect(done?.response.flag_reason).toContain('Empty turn');
+    expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
     expect(mocks.notifySystemError).toHaveBeenCalledWith(expect.objectContaining({
       source: 'addie-empty-response',
       errorMessage: expect.stringContaining('processMessageStream'),
     }));
+  });
+
+  it('recovers once from a wholly empty initial non-streaming response', async () => {
+    mocks.createMessage
+      .mockResolvedValueOnce(emptyEndTurn)
+      .mockResolvedValueOnce(recoveredEndTurn);
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+    const response = await client.processMessage(
+      'hello',
+      undefined,
+      undefined,
+      undefined,
+      { uncapped: true, threadId: 'thread-initial-recovered' },
+    );
+
+    expect(response.text).toBe('Issue 42 is open.');
+    expect(response.timing?.iterations).toBe(2);
+    expect(response.usage).toMatchObject({ input_tokens: 22, output_tokens: 6 });
+    expect(mocks.createMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.createMessage.mock.calls[0][0]).toMatchObject({
+      max_tokens: 16_384,
+      output_config: { effort: 'medium' },
+    });
+    expect(mocks.createMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.notifySystemError).not.toHaveBeenCalled();
+  });
+
+  it('recovers once from a wholly empty initial streaming response', async () => {
+    mocks.streamMessage
+      .mockReturnValueOnce(makeEmptyStream())
+      .mockReturnValueOnce(makeStream(recoveredEndTurn));
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+    const events: StreamEvent[] = [];
+    for await (const event of client.processMessageStream(
+      'hello',
+      undefined,
+      undefined,
+      { uncapped: true, threadId: 'thread-stream-initial-recovered' },
+    )) events.push(event);
+
+    const text = events
+      .filter((event): event is Extract<StreamEvent, { type: 'text' }> => event.type === 'text')
+      .map((event) => event.text)
+      .join('');
+    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    expect(text).toBe('Issue 42 is open.');
+    expect(done?.response.timing?.iterations).toBe(2);
+    expect(done?.response.usage).toMatchObject({ input_tokens: 22, output_tokens: 6 });
+    expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.streamMessage.mock.calls[0][0]).toMatchObject({
+      max_tokens: 16_384,
+      output_config: { effort: 'medium' },
+    });
+    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.notifySystemError).not.toHaveBeenCalled();
+  });
+
+  it('does not resample a wholly empty evaluation response', async () => {
+    mocks.createMessage.mockResolvedValueOnce(emptyEndTurn);
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+
+    const response = await client.processMessage(
+      'hello',
+      undefined,
+      undefined,
+      undefined,
+      { uncapped: true, executionMode: 'evaluation' },
+    );
+
+    expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(mocks.createMessage).toHaveBeenCalledOnce();
+    expect(mocks.notifySystemError).not.toHaveBeenCalled();
+  });
+
+  it('never resamples an empty refusal', async () => {
+    mocks.createMessage.mockResolvedValueOnce(emptyRefusal);
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+
+    const response = await client.processMessage(
+      'hello',
+      undefined,
+      undefined,
+      undefined,
+      { uncapped: true },
+    );
+
+    expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(mocks.createMessage).toHaveBeenCalledOnce();
+  });
+
+  it('never resamples an empty streaming refusal', async () => {
+    mocks.streamMessage.mockReturnValueOnce(makeStream(emptyRefusal));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+    const events: StreamEvent[] = [];
+
+    for await (const event of client.processMessageStream(
+      'hello',
+      undefined,
+      undefined,
+      { uncapped: true },
+    )) events.push(event);
+
+    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    expect(done?.response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(mocks.streamMessage).toHaveBeenCalledOnce();
+  });
+
+  it('never resamples an empty refusal after a non-streaming tool call', async () => {
+    mocks.createMessage
+      .mockResolvedValueOnce(toolUseTurn)
+      .mockResolvedValueOnce(emptyRefusal);
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+
+    const response = await client.processMessage(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      undefined,
+      { uncapped: true },
+    );
+
+    expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(getGithubIssue).toHaveBeenCalledOnce();
+    expect(mocks.createMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('never resamples an empty streaming refusal after a tool call', async () => {
+    mocks.streamMessage
+      .mockReturnValueOnce(makeStream(toolUseTurn))
+      .mockReturnValueOnce(makeStream(emptyRefusal));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+    const events: StreamEvent[] = [];
+
+    for await (const event of client.processMessageStream(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      { uncapped: true },
+    )) events.push(event);
+
+    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    expect(done?.response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(getGithubIssue).toHaveBeenCalledOnce();
+    expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to the first empty terminal when non-streaming recovery fails', async () => {
+    mocks.createMessage
+      .mockResolvedValueOnce(emptyEndTurn)
+      .mockRejectedValueOnce(Object.assign(new Error('recovery transport failed'), { status: 529 }));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+
+    const response = await client.processMessage(
+      'hello',
+      undefined,
+      undefined,
+      undefined,
+      { uncapped: true },
+    );
+
+    expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(response.usage).toMatchObject({ input_tokens: 10, output_tokens: 0 });
+    expect(mocks.createMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.createMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.notifySystemError).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to the first empty terminal when streaming recovery fails', async () => {
+    mocks.streamMessage
+      .mockReturnValueOnce(makeEmptyStream())
+      .mockReturnValueOnce(makeThrowingStream(new Error('recovery stream failed')));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+    const events: StreamEvent[] = [];
+
+    for await (const event of client.processMessageStream(
+      'hello',
+      undefined,
+      undefined,
+      { uncapped: true },
+    )) events.push(event);
+
+    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    expect(done?.response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(done?.response.usage).toMatchObject({ input_tokens: 10, output_tokens: 0 });
+    expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.notifySystemError).toHaveBeenCalledOnce();
+  });
+
+  it('does not resample when streaming deltas contain text but the final content is empty', async () => {
+    mocks.streamMessage.mockReturnValueOnce(makeTextDeltaStreamWithEmptyFinal('A complete answer.'));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+    const events: StreamEvent[] = [];
+
+    for await (const event of client.processMessageStream(
+      'hello',
+      undefined,
+      undefined,
+      { uncapped: true },
+    )) events.push(event);
+
+    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    expect(done?.response.text).toBe('A complete answer.');
+    expect(mocks.streamMessage).toHaveBeenCalledOnce();
+    expect(mocks.notifySystemError).not.toHaveBeenCalled();
+  });
+
+  it('allows one tool call after recovering from a wholly empty initial response', async () => {
+    mocks.createMessage
+      .mockResolvedValueOnce(emptyEndTurn)
+      .mockResolvedValueOnce(toolUseTurn)
+      .mockResolvedValueOnce(recoveredEndTurn);
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+
+    const response = await client.processMessage(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      undefined,
+      { uncapped: true },
+    );
+
+    expect(response.text).toBe('Issue 42 is open.');
+    expect(response.timing?.iterations).toBe(3);
+    expect(getGithubIssue).toHaveBeenCalledOnce();
+    expect(mocks.createMessage).toHaveBeenCalledTimes(3);
+    expect(mocks.createMessage.mock.calls[1][0].tools).not.toEqual([]);
+    expect(mocks.createMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.createMessage.mock.calls[2][1]).toBeUndefined();
+  });
+
+  it('restores normal streaming dispatch after initial recovery emits a tool call', async () => {
+    mocks.streamMessage
+      .mockReturnValueOnce(makeEmptyStream())
+      .mockReturnValueOnce(makeStream(toolUseTurn))
+      .mockReturnValueOnce(makeStream(recoveredEndTurn));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+    const events: StreamEvent[] = [];
+
+    for await (const event of client.processMessageStream(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      { uncapped: true },
+    )) events.push(event);
+
+    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    expect(done?.response.text).toBe('Issue 42 is open.');
+    expect(getGithubIssue).toHaveBeenCalledOnce();
+    expect(mocks.streamMessage).toHaveBeenCalledTimes(3);
+    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.streamMessage.mock.calls[2][1]).toBeUndefined();
   });
 
   it('resamples once after a tool returns an empty non-streaming completion', async () => {
@@ -193,6 +478,7 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(response.timing?.iterations).toBe(3);
     expect(getGithubIssue).toHaveBeenCalledOnce();
     expect(mocks.notifySystemError).not.toHaveBeenCalled();
+    expect(mocks.createMessage.mock.calls[2][1]).toEqual({ maxRetries: 0 });
   });
 
   it('does not discard server-managed search results by entering custom-tool recovery', async () => {
@@ -240,6 +526,29 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(done?.response.timing?.iterations).toBe(3);
     expect(getGithubIssue).toHaveBeenCalledOnce();
     expect(mocks.notifySystemError).not.toHaveBeenCalled();
+    expect(mocks.streamMessage.mock.calls[2][1]).toEqual({ maxRetries: 0 });
+  });
+
+  it('falls back without retrying when post-tool recovery transport fails', async () => {
+    mocks.createMessage
+      .mockResolvedValueOnce(toolUseTurn)
+      .mockResolvedValueOnce(emptyEndTurn)
+      .mockRejectedValueOnce(Object.assign(new Error('recovery overloaded'), { status: 529 }));
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const response = await client.processMessage(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      undefined,
+      { uncapped: true },
+    );
+
+    expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(response.usage).toMatchObject({ input_tokens: 20, output_tokens: 5 });
+    expect(getGithubIssue).toHaveBeenCalledOnce();
+    expect(mocks.createMessage).toHaveBeenCalledTimes(3);
+    expect(mocks.createMessage.mock.calls[2][1]).toEqual({ maxRetries: 0 });
   });
 
   it('falls back after the one non-streaming post-tool resample is also empty', async () => {


### PR DESCRIPTION
## Summary

- give Sonnet 5 enough output headroom for adaptive thinking plus visible/tool output, using medium effort and a 16,384-token provider cap
- resample a wholly empty initial `end_turn` once in production, while leaving evaluation/replay outcomes untouched
- keep refusal and stop-sequence terminals fail-closed; make recovery exactly one dispatch with SDK/application retries disabled
- preserve the original terminal and token accounting when recovery fails, and consume recovery state before later tool-loop calls

## Why

Production alerts showed both `max_tokens` truncation late in a tool loop and an empty first-turn completion on Sonnet 5. Sonnet 5 defaults to high-effort adaptive thinking, and reasoning plus visible output share `max_tokens`.

## Validation

- 96 focused response/replay/invocation tests pass
- refusal, retryable recovery failure, empty → tool → normal-dispatch, stream/non-stream regressions included
- TypeScript typecheck and `git diff --check` pass
- independent reliability and replay-policy expert reviews signed off

No protocol surface changed; no changeset is required.