### PR TITLE
fix(server): reuse dedicated database health connection

### DIFF
--- a/server/src/db/client.ts
+++ b/server/src/db/client.ts
@@ -9,6 +9,10 @@ const SLOW_QUERY_THRESHOLD_MS = 500;
 
 let pool: Pool | null = null;
 let poolConfig: DatabaseConfig | null = null;
+let healthClient: Client | null = null;
+let healthClientConnectPromise: Promise<Client> | null = null;
+let healthCheckPromise: Promise<void> | null = null;
+const healthClientClosePromises = new WeakMap<Client, Promise<void>>();
 interface QueryDeadlineContext {
   deadlineMs: number;
   readOnly: boolean;
@@ -87,7 +91,9 @@ const TRANSIENT_CONNECTION_ERRORS = new Set([
 const TRANSIENT_CONNECTION_MESSAGES = [
   "Connection terminated unexpectedly",
   "Connection terminated due to connection timeout",
+  "Client has encountered a connection error and is not queryable",
   "timeout exceeded when trying to connect",
+  "timeout expired",
 ];
 
 export function isTransientConnectionError(err: unknown): boolean {
@@ -250,14 +256,18 @@ export async function getDedicatedClient(): Promise<Client> {
 }
 
 /**
- * Perform a health check using a one-off connection, outside the application
- * pool, so saturated worker traffic does not make a reachable database look
- * down to the load balancer.
+ * Get a reusable connection dedicated to health checks. Keeping this outside
+ * the application pool prevents saturated worker traffic from making a
+ * reachable database look down, while reuse avoids opening a fresh TLS/DB
+ * session for every Fly probe on every machine.
  */
-export async function healthCheck(timeoutMs = 5000): Promise<void> {
+async function getHealthClient(timeoutMs: number): Promise<Client> {
   if (!poolConfig) {
     throw new Error("Database not initialized. Call initializeDatabase() first.");
   }
+
+  if (healthClient) return healthClient;
+  if (healthClientConnectPromise) return healthClientConnectPromise;
 
   const client = new Client({
     connectionString: poolConfig.connectionString,
@@ -270,20 +280,96 @@ export async function healthCheck(timeoutMs = 5000): Promise<void> {
     connectionTimeoutMillis: Math.min(poolConfig.connectionTimeoutMillis ?? timeoutMs, timeoutMs),
   });
 
-  let timeout: NodeJS.Timeout | null = null;
+  client.on('error', (err) => {
+    if (healthClient === client) healthClient = null;
+    logger.warn({ err }, 'Dedicated health check connection failed while idle');
+    void discardHealthClient(client);
+  });
+
+  const connectPromise = (async () => {
+    try {
+      await client.connect();
+      healthClient = client;
+      return client;
+    } catch (error) {
+      await client.end().catch(() => undefined);
+      throw error;
+    }
+  })();
+  healthClientConnectPromise = connectPromise;
+
   try {
-    await client.connect();
-    await Promise.race([
-      client.query('SELECT 1'),
-      new Promise<never>((_, reject) => {
-        timeout = setTimeout(() => reject(new Error('health check query timed out')), timeoutMs);
-      }),
-    ]);
+    return await connectPromise;
   } finally {
-    if (timeout) clearTimeout(timeout);
-    await client.end().catch((err) => {
-      logger.warn({ err }, "Health check connection cleanup failed");
-    });
+    if (healthClientConnectPromise === connectPromise) {
+      healthClientConnectPromise = null;
+    }
+  }
+}
+
+async function discardHealthClient(client: Client): Promise<void> {
+  if (healthClient === client) healthClient = null;
+  const existingClose = healthClientClosePromises.get(client);
+  if (existingClose) return existingClose;
+
+  const closePromise = client.end().catch((err) => {
+    logger.warn({ err }, "Health check connection cleanup failed");
+  });
+  healthClientClosePromises.set(client, closePromise);
+  return closePromise;
+}
+
+/**
+ * Perform a health check on a reusable connection outside the application
+ * pool. Concurrent HTTP probes share one in-flight query. A failed connection
+ * is discarded so the next probe establishes a fresh session.
+ */
+export async function healthCheck(timeoutMs = 5000): Promise<void> {
+  if (healthCheckPromise) return healthCheckPromise;
+
+  const deadlineMs = Date.now() + timeoutMs;
+  const checkOnce = async (): Promise<void> => {
+    const remainingMs = deadlineMs - Date.now();
+    if (remainingMs <= 0) throw new Error('health check query timed out');
+
+    const client = await getHealthClient(remainingMs);
+    let timeout: NodeJS.Timeout | null = null;
+
+    try {
+      await Promise.race([
+        client.query('SELECT 1'),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error('health check query timed out')),
+            Math.max(1, deadlineMs - Date.now()),
+          );
+        }),
+      ]);
+    } catch (error) {
+      await discardHealthClient(client);
+      throw error;
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  };
+
+  const run = async (): Promise<void> => {
+    try {
+      await checkOnce();
+    } catch (error) {
+      if (!isTransientConnectionError(error) || Date.now() >= deadlineMs) throw error;
+      logger.warn({ err: error }, 'Transient health check connection error; retrying once');
+      await checkOnce();
+    }
+  };
+
+  const checkPromise = run();
+  healthCheckPromise = checkPromise;
+
+  try {
+    await checkPromise;
+  } finally {
+    if (healthCheckPromise === checkPromise) healthCheckPromise = null;
   }
 }
 
@@ -292,6 +378,12 @@ export async function healthCheck(timeoutMs = 5000): Promise<void> {
  */
 export async function closeDatabase(): Promise<void> {
   if (pool) {
+    if (healthCheckPromise) await healthCheckPromise.catch(() => undefined);
+    const client = healthClient;
+    healthClient = null;
+    healthClientConnectPromise = null;
+    healthCheckPromise = null;
+    if (client) await discardHealthClient(client);
     await pool.end();
     pool = null;
     poolConfig = null;

--- a/server/tests/integration/health.test.ts
+++ b/server/tests/integration/health.test.ts
@@ -18,7 +18,7 @@ vi.mock("../../src/db/client.js", () => ({
   getPool: vi.fn().mockReturnValue({ query: vi.fn() }),
   isDatabaseInitialized: vi.fn().mockReturnValue(true),
   closeDatabase: vi.fn(),
-  // The /health route exercises a one-off connection via healthCheck().
+  // The /health route exercises the dedicated reusable connection via healthCheck().
   // Stubbing it green keeps the test focused on response shape, not on
   // whether vitest workers can reach Postgres.
   healthCheck: vi.fn().mockResolvedValue(undefined),

--- a/server/tests/unit/db-client-checkout.test.ts
+++ b/server/tests/unit/db-client-checkout.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 describe('db client checkout and health checks', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.doUnmock('pg');
     vi.resetModules();
   });
@@ -14,6 +15,7 @@ describe('db client checkout and health checks', () => {
     const clientConnect = vi.fn().mockResolvedValue(undefined);
     const clientQuery = vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] });
     const clientEnd = vi.fn().mockResolvedValue(undefined);
+    const clientOn = vi.fn();
     const poolInstances: Array<{ query: typeof poolQuery; end: typeof poolEnd; on: typeof poolOn }> = [];
     const clientInstances: Array<{ connect: typeof clientConnect; query: typeof clientQuery; end: typeof clientEnd }> = [];
 
@@ -35,6 +37,7 @@ describe('db client checkout and health checks', () => {
       connect = clientConnect;
       query = clientQuery;
       end = clientEnd;
+      on = clientOn;
 
       constructor() {
         clientInstances.push(this);
@@ -53,6 +56,7 @@ describe('db client checkout and health checks', () => {
       clientConnect,
       clientQuery,
       clientEnd,
+      clientOn,
       poolInstances,
       clientInstances,
     };
@@ -74,7 +78,7 @@ describe('db client checkout and health checks', () => {
     await db.closeDatabase();
   });
 
-  it('runs health checks on a one-off client instead of the application pool', async () => {
+  it('reuses a dedicated health client instead of the application pool', async () => {
     const pg = mockPg();
     pg.poolQuery.mockRejectedValue(new Error('pool should not be used by healthCheck'));
 
@@ -82,15 +86,186 @@ describe('db client checkout and health checks', () => {
     db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
 
     await db.healthCheck(5000);
+    await db.healthCheck(5000);
 
     expect(pg.poolInstances).toHaveLength(1);
     expect(pg.poolQuery).not.toHaveBeenCalled();
     expect(pg.clientInstances).toHaveLength(1);
     expect(pg.clientConnect).toHaveBeenCalledTimes(1);
-    expect(pg.clientQuery).toHaveBeenCalledWith('SELECT 1');
+    expect(pg.clientQuery).toHaveBeenCalledTimes(2);
+    expect(pg.clientQuery).toHaveBeenNthCalledWith(1, 'SELECT 1');
+    expect(pg.clientQuery).toHaveBeenNthCalledWith(2, 'SELECT 1');
+    expect(pg.clientEnd).not.toHaveBeenCalled();
+
+    await db.closeDatabase();
+    expect(pg.clientEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares one in-flight query across concurrent health checks', async () => {
+    const pg = mockPg();
+    let resolveQuery!: (value: { rows: Array<{ '?column?': number }> }) => void;
+    pg.clientQuery.mockReturnValue(new Promise((resolve) => {
+      resolveQuery = resolve;
+    }));
+
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    const first = db.healthCheck(5000);
+    const second = db.healthCheck(5000);
+    await vi.waitFor(() => expect(pg.clientQuery).toHaveBeenCalledTimes(1));
+
+    resolveQuery({ rows: [{ '?column?': 1 }] });
+    await Promise.all([first, second]);
+
+    expect(pg.clientInstances).toHaveLength(1);
+    expect(pg.clientConnect).toHaveBeenCalledTimes(1);
+    expect(pg.clientQuery).toHaveBeenCalledTimes(1);
+
+    await db.closeDatabase();
+  });
+
+  it('discards a failed health connection and reconnects on the next probe', async () => {
+    const pg = mockPg();
+    const failure = new Error('health query failed');
+    pg.clientQuery
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] });
+
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    await expect(db.healthCheck(5000)).rejects.toBe(failure);
+    expect(pg.clientEnd).toHaveBeenCalledTimes(1);
+
+    await expect(db.healthCheck(5000)).resolves.toBeUndefined();
+    expect(pg.clientInstances).toHaveLength(2);
+    expect(pg.clientConnect).toHaveBeenCalledTimes(2);
+    expect(pg.clientQuery).toHaveBeenCalledTimes(2);
+
+    await db.closeDatabase();
+    expect(pg.clientEnd).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a stale health connection once within the original probe deadline', async () => {
+    const pg = mockPg();
+    pg.clientQuery
+      .mockRejectedValueOnce(new Error('Connection terminated unexpectedly'))
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] });
+
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    await expect(db.healthCheck(5000)).resolves.toBeUndefined();
+    expect(pg.clientInstances).toHaveLength(2);
+    expect(pg.clientConnect).toHaveBeenCalledTimes(2);
+    expect(pg.clientQuery).toHaveBeenCalledTimes(2);
     expect(pg.clientEnd).toHaveBeenCalledTimes(1);
 
     await db.closeDatabase();
+    expect(pg.clientEnd).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not grant a stale-connection retry a fresh probe timeout', async () => {
+    vi.useFakeTimers();
+    const pg = mockPg();
+    pg.clientQuery
+      .mockImplementationOnce(() => new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('Connection terminated unexpectedly')), 40);
+      }))
+      .mockReturnValueOnce(new Promise(() => undefined));
+
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    const rejection = expect(db.healthCheck(50)).rejects.toThrow('health check query timed out');
+    await vi.advanceTimersByTimeAsync(50);
+    await rejection;
+
+    expect(pg.clientInstances).toHaveLength(2);
+    expect(pg.clientQuery).toHaveBeenCalledTimes(2);
+    expect(pg.clientEnd).toHaveBeenCalledTimes(2);
+    await db.closeDatabase();
+  });
+
+  it('evicts an idle failed connection without letting its handler clear a replacement', async () => {
+    const pg = mockPg();
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    await db.healthCheck(5000);
+    const firstErrorHandler = pg.clientOn.mock.calls[0][1] as (error: Error) => void;
+    firstErrorHandler(new Error('idle connection closed'));
+
+    await db.healthCheck(5000);
+    expect(pg.clientInstances).toHaveLength(2);
+    firstErrorHandler(new Error('late stale-client error'));
+    await db.healthCheck(5000);
+
+    expect(pg.clientInstances).toHaveLength(2);
+    expect(pg.clientConnect).toHaveBeenCalledTimes(2);
+    expect(pg.clientQuery).toHaveBeenCalledTimes(3);
+    expect(pg.clientEnd).toHaveBeenCalledTimes(1);
+    await db.closeDatabase();
+    expect(pg.clientEnd).toHaveBeenCalledTimes(2);
+  });
+
+  it('times out a hung health query and evicts its connection', async () => {
+    vi.useFakeTimers();
+    const pg = mockPg();
+    pg.clientQuery.mockReturnValue(new Promise(() => undefined));
+
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    const rejection = expect(db.healthCheck(50)).rejects.toThrow('health check query timed out');
+    await vi.advanceTimersByTimeAsync(50);
+    await rejection;
+    expect(pg.clientEnd).toHaveBeenCalledTimes(1);
+
+    await db.closeDatabase();
+  });
+
+  it('recovers on the next probe after a health connection cannot be established', async () => {
+    const pg = mockPg();
+    const failure = new Error('initial connect failed');
+    pg.clientConnect.mockRejectedValueOnce(failure).mockResolvedValueOnce(undefined);
+
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    await expect(db.healthCheck(5000)).rejects.toBe(failure);
+    expect(pg.clientEnd).toHaveBeenCalledTimes(1);
+    await expect(db.healthCheck(5000)).resolves.toBeUndefined();
+
+    expect(pg.clientInstances).toHaveLength(2);
+    expect(pg.clientConnect).toHaveBeenCalledTimes(2);
+    expect(pg.clientQuery).toHaveBeenCalledTimes(1);
+    await db.closeDatabase();
+    expect(pg.clientEnd).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits for an in-flight health check before closing its client and pool', async () => {
+    const pg = mockPg();
+    let resolveQuery!: (value: { rows: Array<{ '?column?': number }> }) => void;
+    pg.clientQuery.mockReturnValue(new Promise((resolve) => {
+      resolveQuery = resolve;
+    }));
+
+    const db = await import('../../src/db/client.js');
+    db.initializeDatabase({ connectionString: 'postgresql://localhost/test' });
+
+    const check = db.healthCheck(5000);
+    await vi.waitFor(() => expect(pg.clientQuery).toHaveBeenCalledTimes(1));
+    const close = db.closeDatabase();
+    await Promise.resolve();
+    expect(pg.clientEnd).not.toHaveBeenCalled();
+    expect(pg.poolEnd).not.toHaveBeenCalled();
+
+    resolveQuery({ rows: [{ '?column?': 1 }] });
+    await Promise.all([check, close]);
+    expect(pg.clientEnd).toHaveBeenCalledTimes(1);
+    expect(pg.poolEnd).toHaveBeenCalledTimes(1);
   });
 
   it('opens dedicated session work outside the application pool', async () => {


### PR DESCRIPTION
## Summary

- reuse one dedicated PostgreSQL connection per process for `/health`
- keep health work isolated from the application pool
- coalesce concurrent probes and replace failed/stale connections
- retry one transient stale-connection failure within the original five-second deadline
- close the dedicated connection during shutdown

## Why

Production observation for #6827 repeatedly found isolated database-health connection timeouts while authorization enforcement was fully disabled. The existing implementation opened and closed a fresh TLS/PostgreSQL session for every Fly probe. With three processes probed every 15 seconds, that is roughly 12 new sessions per minute.

This change preserves the original pool-isolation guarantee while removing connection churn. It does not alter authorization logic, enforcement settings, or response semantics.

## Safety

- failed or idle-error clients are evicted and closed idempotently
- a silently stale connection is retried once on a fresh client without extending the original probe deadline
- concurrent probes share one in-flight query
- shutdown waits for an in-flight check before closing the health client and pool
- production enforcement remains disabled independently of this PR

## Validation

- `npx vitest run --config server/vitest.config.ts server/tests/unit/db-client-checkout.test.ts` — 15/15 passed
- `npx vitest run --config server/vitest.config.ts server/tests/integration/health.test.ts` — 2/2 passed
- `npm run typecheck` — passed
- `git diff --check origin/main...HEAD` equivalent — passed
- two independent expert re-reviews — no remaining blocker

## Rollout

Deploy separately while #6827 remains default-off. Watch public health and production database-health logs through a clean settling window before resuming the authorization canary.

Related: #6827
