### PR TITLE
fix(ci): re-baseline storyboard floors to measured main

### DIFF
--- a/.changeset/recover-storyboard-floors.md
+++ b/.changeset/recover-storyboard-floors.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Re-baseline the storyboard conformance floors to the values measured on main's own CI run after the #6815 coverage rebaseline set them above reality (creative 48 clean/200 steps, creative-builder 48/172, sales 126/553). Every gap below the prior floors is authored known-failing skips with zero step failures; the workflow had been red on main and the mirrored local pre-push gate blocked all compliance-source pushes.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -85,12 +85,12 @@ jobs:
             min_passing_steps: 157
           - surface: current
             tenant: creative
-            min_clean_storyboards: 49
-            min_passing_steps: 209
+            min_clean_storyboards: 48
+            min_passing_steps: 200
           - surface: current
             tenant: creative-builder
-            min_clean_storyboards: 50
-            min_passing_steps: 184
+            min_clean_storyboards: 48
+            min_passing_steps: 172
           - surface: current
             tenant: brand
             min_clean_storyboards: 45
@@ -625,7 +625,7 @@ jobs:
           # three signed-request route profiles; storyboard applicability is
           # reported separately in the aggregate summary.
           MIN_CLEAN: 126
-          MIN_PASSED: 556
+          MIN_PASSED: 553
         run: |
           set -euo pipefail
           echo "Clean storyboards: ${CLEAN} (floor: ${MIN_CLEAN})"

--- a/scripts/run-storyboards-matrix.sh
+++ b/scripts/run-storyboards-matrix.sh
@@ -253,14 +253,17 @@ if [ "${FLOOR_SET}" = "3.0-compat" ]; then
   )
 else
   TENANTS=(
+    # Re-measured on main@32842430342 (post-#6815 coverage rebaseline): every
+    # gap below the prior floors was authored known-failing skips, zero step
+    # failures — see #6876.
     # Ratcheted from the first capability-resolved replay. The runner reports
     # declared-scope applicability and quarantines separately from these
     # clean-result-row and passing-step regression floors.
     "signals:45:80"
-    "sales:126:556"
+    "sales:126:553"
     "governance:47:157"
-    "creative:49:209"
-    "creative-builder:50:184"
+    "creative:48:200"
+    "creative-builder:48:172"
     "brand:45:116"
     "si:42:50"
   )

--- a/tests/run-storyboards-sharding.test.cjs
+++ b/tests/run-storyboards-sharding.test.cjs
@@ -256,8 +256,8 @@ test('current /sales runs fixed orchestrators with isolated children behind one 
   assert.match(workflow, /needs: sales_storyboard_orchestrators/);
   assert.match(workflow, /ORCHESTRATOR_RESULT: \$\{\{ needs\.sales_storyboard_orchestrators\.result \}\}/);
   assert.match(workflow, /MIN_CLEAN: 126/);
-  assert.match(workflow, /MIN_PASSED: 556/);
-  assert.match(matrixRunner, /"sales:126:556"/);
+  assert.match(workflow, /MIN_PASSED: 553/);
+  assert.match(matrixRunner, /"sales:126:553"/);
   assert.match(workflow, /Training agent · current \/sales/);
   assert.match(workflow, /echo "failed=\$\{failed_sum\}"/);
   assert.match(workflow, /echo "not_applicable=\$\{not_applicable_sum\}"/);
@@ -290,10 +290,10 @@ test('current training-agent floors are ratcheted and mirrored by local and CI r
   const matrixRunner = fs.readFileSync(MATRIX_RUNNER, 'utf8');
   const baselines = [
     ['signals', 45, 80],
-    ['sales', 126, 556],
+    ['sales', 126, 553],
     ['governance', 47, 157],
-    ['creative', 49, 209],
-    ['creative-builder', 50, 184],
+    ['creative', 48, 200],
+    ['creative-builder', 48, 172],
     ['brand', 45, 116],
     ['si', 42, 50],
   ];


### PR DESCRIPTION
## Summary

Fixes the storyboard workflow, red on main since this morning's #6815 coverage rebaseline set current-source floors above what main measures. CI's own failing run (32842430342) measures creative **48 clean / 200 steps** (floor was 49/209), creative-builder **48 / 172** (was 50/184), sales **126 / 553** (step floor was 556) — every gap is authored known-failing skips citing packaged-runner blockers, with zero step failures anywhere. This sets both floor mirrors (workflow + `scripts/run-storyboards-matrix.sh`) to those measured values so the ratchet grades regressions from reality again.

Validated end-to-end: the local pre-push matrix ran all seven tenants green with results matching CI's measurements exactly. Closes #6876's floor half; the "local matrix nondeterminism" also reported there turned out to be disk exhaustion on the dev machine (runs degraded 126→117→86 clean as free space fell to 1.9 GB; deterministic and CI-identical after cleanup) — noted on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)