### PR TITLE
feat(addie): persist model execution provenance

### DIFF
--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -114,6 +114,7 @@ import {
   truncateNotificationText,
   planStreamStopFailureFallback,
   resolveStreamTurnCompletion,
+  STREAM_COMPLETION_MISSING_NOTICE,
   STREAM_DELIVERY_UNCERTAIN_NOTICE,
   DEFAULT_STREAM_SOFT_CAP,
 } from './slack-blocks.js';
@@ -1892,6 +1893,11 @@ async function handleUserMessage({
   const certIterations = hasCertificationContext && !routedTools.isAAOAdmin
     ? CERTIFICATION_MAX_ITERATIONS
     : undefined;
+  const dmEffectiveModel = routedTools.requiresPrecision
+    ? ModelConfig.precision
+    : routedTools.requiresDepth
+      ? ModelConfig.depth
+      : AddieModelConfig.chat;
   // Resolve the cost-cap identity + tier (#2790 / #2945 f/u).
   // Prefers a mapped WorkOS user ID (aao_team for AAO admins,
   // member_paid for active subs); falls back to `slack:${userId}` at
@@ -2177,6 +2183,12 @@ async function handleUserMessage({
         tool_executions: [],
         flagged: true,
         flag_reason: `Error: ${error instanceof Error ? error.message : 'Unknown'}`,
+        model_execution: {
+          source: 'local',
+          requested_provider: 'anthropic',
+          requested_model: dmEffectiveModel,
+          reason: 'provider_error',
+        },
       };
       fullText = response.text;
 
@@ -2189,11 +2201,13 @@ async function handleUserMessage({
     }
   }
 
-  const streamCompletion = resolveStreamTurnCompletion(streamWasInterrupted, response, () => {
+  const streamCompletion = resolveStreamTurnCompletion(streamWasInterrupted, response, (): AddieResponse => {
     logger.warn({ fullTextLength: fullText.length, toolsUsedCount: toolsUsed.length },
       'Addie Bolt: Streaming completed without done event - using fallback response');
     return {
-      text: fullText,
+      // Without the terminal `done` receipt, `fullText` is unverified provider
+      // output. Never persist it under a local provenance label.
+      text: STREAM_COMPLETION_MISSING_NOTICE,
       tools_used: toolsUsed,
       tool_executions: toolExecutions.map((t, i) => ({
         ...t,
@@ -2203,6 +2217,12 @@ async function handleUserMessage({
       })),
       flagged: true,
       flag_reason: 'Streaming completed without done event',
+      model_execution: {
+        source: 'local',
+        requested_provider: 'anthropic',
+        requested_model: dmEffectiveModel,
+        reason: 'no_provider_response',
+      },
     };
   });
   if (streamCompletion.kind === 'discard-interrupted') {
@@ -2223,7 +2243,13 @@ async function handleUserMessage({
       input_sanitized: inputValidation.sanitized,
       output_text: '',
       tools_used: toolsUsed,
-      model: AddieModelConfig.chat,
+      model: dmEffectiveModel,
+      model_execution: {
+        source: 'local',
+        requested_provider: 'anthropic',
+        requested_model: dmEffectiveModel,
+        reason: 'stream_interrupted',
+      },
       latency_ms: Date.now() - startTime,
       flagged: true,
       flag_reason: `stream_interrupted:${streamInterruptCategory}`,
@@ -2268,12 +2294,6 @@ async function handleUserMessage({
   // Log assistant response to unified thread
   const assistantFlagged = response.flagged || outputValidation.flagged;
   const flagReason = [response.flag_reason, outputValidation.reason].filter(Boolean).join('; ');
-  const dmEffectiveModel = routedTools.requiresPrecision
-    ? ModelConfig.precision
-    : routedTools.requiresDepth
-      ? ModelConfig.depth
-      : AddieModelConfig.chat;
-
   try {
     await threadService.addMessage({
       thread_id: thread.thread_id,
@@ -2288,6 +2308,7 @@ async function handleUserMessage({
         is_error: exec.is_error,
       })),
       model: dmEffectiveModel,
+      model_execution: response.model_execution,
       latency_ms: Date.now() - startTime,
       tokens_input: response.usage?.input_tokens,
       tokens_output: response.usage?.output_tokens,
@@ -2332,7 +2353,8 @@ async function handleUserMessage({
     input_sanitized: inputValidation.sanitized,
     output_text: outputValidation.sanitized,
     tools_used: response.tools_used,
-    model: AddieModelConfig.chat,
+    model: dmEffectiveModel,
+    model_execution: response.model_execution,
     latency_ms: Date.now() - startTime,
     flagged: userMessageFlagged || assistantFlagged,
     flag_reason: [inputValidation.reason, flagReason].filter(Boolean).join('; ') || undefined,
@@ -2617,6 +2639,7 @@ async function handleAppMention({
     : (routedTools.requiresDepth || mentionIsDepthChannel)
       ? ModelConfig.depth
       : undefined;
+  const mentionEffectiveModel = mentionModelOverride ?? AddieModelConfig.chat;
 
   // Admin users get higher iteration limit for bulk operations.
   // Public home-workspace discussions use a bounded community budget;
@@ -2632,7 +2655,7 @@ async function handleAppMention({
   };
 
   // Process with Claude
-  let response;
+  let response: AddieResponse;
   try {
     response = await claudeClient.processMessage(inputValidation.sanitized, conversationHistory, routedTools.tools, undefined, processOptions);
   } catch (error) {
@@ -2643,6 +2666,12 @@ async function handleAppMention({
       tool_executions: [],
       flagged: true,
       flag_reason: `Error: ${error instanceof Error ? error.message : 'Unknown'}`,
+      model_execution: {
+        source: 'local',
+        requested_provider: 'anthropic',
+        requested_model: mentionEffectiveModel,
+        reason: 'provider_error',
+      },
     };
   }
 
@@ -2663,8 +2692,6 @@ async function handleAppMention({
   // Log assistant response to unified thread
   const assistantFlagged = response.flagged || outputValidation.flagged;
   const flagReason = [response.flag_reason, outputValidation.reason].filter(Boolean).join('; ');
-  const mentionEffectiveModel = mentionModelOverride ?? AddieModelConfig.chat;
-
   try {
     await threadService.addMessage({
       thread_id: thread.thread_id,
@@ -2679,6 +2706,7 @@ async function handleAppMention({
         is_error: exec.is_error,
       })),
       model: mentionEffectiveModel,
+      model_execution: response.model_execution,
       latency_ms: Date.now() - startTime,
       tokens_input: response.usage?.input_tokens,
       tokens_output: response.usage?.output_tokens,
@@ -2723,7 +2751,8 @@ async function handleAppMention({
     input_sanitized: inputValidation.sanitized,
     output_text: outputValidation.sanitized,
     tools_used: response.tools_used,
-    model: AddieModelConfig.chat,
+    model: mentionEffectiveModel,
+    model_execution: response.model_execution,
     latency_ms: Date.now() - startTime,
     flagged: userMessageFlagged || assistantFlagged,
     flag_reason: [inputValidation.reason, flagReason].filter(Boolean).join('; ') || undefined,
@@ -3900,6 +3929,12 @@ async function handleDirectMessage(
     .filter(Boolean)
     .join('\n\n');
 
+  const directMessageEffectiveModel = routedTools.requiresPrecision
+    ? ModelConfig.precision
+    : routedTools.requiresDepth
+      ? ModelConfig.depth
+      : AddieModelConfig.chat;
+
   // Admin users get higher iteration limit for bulk operations. DMs
   // remain user-scoped.
   const processOptions = {
@@ -3917,7 +3952,7 @@ async function handleDirectMessage(
   };
 
   // Process with Claude
-  let response;
+  let response: AddieResponse;
   try {
     response = await claudeClient.processMessage(inputValidation.sanitized, conversationHistory, routedTools.tools, undefined, processOptions);
   } catch (error) {
@@ -3928,6 +3963,12 @@ async function handleDirectMessage(
       tool_executions: [],
       flagged: true,
       flag_reason: `Error: ${error instanceof Error ? error.message : 'Unknown'}`,
+      model_execution: {
+        source: 'local',
+        requested_provider: 'anthropic',
+        requested_model: directMessageEffectiveModel,
+        reason: 'provider_error',
+      },
     };
   }
 
@@ -3957,7 +3998,8 @@ async function handleDirectMessage(
       duration_ms: exec.duration_ms,
       is_error: exec.is_error,
     })),
-    model: AddieModelConfig.chat,
+    model: directMessageEffectiveModel,
+    model_execution: response.model_execution,
     latency_ms: Date.now() - startTime,
     tokens_input: response.usage?.input_tokens,
     tokens_output: response.usage?.output_tokens,
@@ -4028,7 +4070,8 @@ async function handleDirectMessage(
     input_sanitized: inputValidation.sanitized,
     output_text: outputValidation.sanitized,
     tools_used: response.tools_used,
-    model: AddieModelConfig.chat,
+    model: directMessageEffectiveModel,
+    model_execution: response.model_execution,
     latency_ms: Date.now() - startTime,
     delivery_status: delivery.delivered ? 'delivered' : 'failed',
     flagged: userMessageFlagged || assistantFlagged || !delivery.delivered,
@@ -4288,6 +4331,7 @@ async function handleActiveThreadReply({
     : (routedTools.requiresDepth || threadIsDepthChannel)
       ? ModelConfig.depth
       : undefined;
+  const activeThreadEffectiveModel = threadModelOverride ?? AddieModelConfig.chat;
 
   // Admin users get higher iteration limit. Public home-workspace
   // discussions use a bounded community budget; other channels stay user-scoped.
@@ -4302,7 +4346,7 @@ async function handleActiveThreadReply({
   };
 
   // Process with Claude
-  let response;
+  let response: AddieResponse;
   try {
     response = await claudeClient.processMessage(inputValidation.sanitized, conversationHistory, routedTools.tools, undefined, processOptions);
   } catch (error) {
@@ -4313,6 +4357,12 @@ async function handleActiveThreadReply({
       tool_executions: [],
       flagged: true,
       flag_reason: `Error: ${error instanceof Error ? error.message : 'Unknown'}`,
+      model_execution: {
+        source: 'local',
+        requested_provider: 'anthropic',
+        requested_model: activeThreadEffectiveModel,
+        reason: 'provider_error',
+      },
     };
   }
 
@@ -4340,8 +4390,6 @@ async function handleActiveThreadReply({
   // Log assistant response to unified thread
   const assistantFlagged = response.flagged || outputValidation.flagged;
   const flagReason = [response.flag_reason, outputValidation.reason].filter(Boolean).join('; ');
-  const activeThreadEffectiveModel = threadModelOverride ?? AddieModelConfig.chat;
-
   try {
     await threadService.addMessage({
       thread_id: thread.thread_id,
@@ -4356,6 +4404,7 @@ async function handleActiveThreadReply({
         is_error: exec.is_error,
       })),
       model: activeThreadEffectiveModel,
+      model_execution: response.model_execution,
       latency_ms: Date.now() - startTime,
       tokens_input: response.usage?.input_tokens,
       tokens_output: response.usage?.output_tokens,
@@ -4399,7 +4448,8 @@ async function handleActiveThreadReply({
     input_sanitized: inputValidation.sanitized,
     output_text: outputValidation.sanitized,
     tools_used: response.tools_used,
-    model: AddieModelConfig.chat,
+    model: activeThreadEffectiveModel,
+    model_execution: response.model_execution,
     latency_ms: Date.now() - startTime,
     flagged: userMessageFlagged || assistantFlagged,
     flag_reason: [inputValidation.reason, flagReason].filter(Boolean).join('; ') || undefined,
@@ -4950,6 +5000,7 @@ async function handleChannelMessage({
         is_error: exec.is_error,
       })),
       model: invocation.effectiveModel,
+      model_execution: response.model_execution,
       latency_ms: Date.now() - startTime,
       tokens_input: response.usage?.input_tokens,
       tokens_output: response.usage?.output_tokens,
@@ -5721,7 +5772,7 @@ async function handleReactionAdded({
   };
 
   // Process with Claude
-  let response;
+  let response: AddieResponse;
   try {
     response = await claudeClient.processMessage(userInput, conversationHistory, userTools, undefined, processOptions);
   } catch (error) {
@@ -5731,6 +5782,12 @@ async function handleReactionAdded({
       tools_used: [],
       tool_executions: [],
       flagged: false,
+      model_execution: {
+        source: 'local',
+        requested_provider: 'anthropic',
+        requested_model: AddieModelConfig.chat,
+        reason: 'canned_response',
+      },
     };
   }
 
@@ -5761,6 +5818,7 @@ async function handleReactionAdded({
         is_error: exec.is_error,
       })),
       model: AddieModelConfig.chat,
+      model_execution: response.model_execution,
       latency_ms: Date.now() - startTime,
       tokens_input: response.usage?.input_tokens,
       tokens_output: response.usage?.output_tokens,

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -32,6 +32,7 @@ import {
 } from './claude-cost-tracker.js';
 import { EMPTY_RESPONSE_FALLBACK, applyResponsePipeline, stripBannedRituals, hasPersonaCollapse } from './response-postprocess.js';
 import type { AddieInputAttachment } from './chat-attachments.js';
+import type { ModelExecution } from './model-providers/model-provider.js';
 import {
   MAX_OUTPUT_LENGTH,
   formatTruncatedOutput,
@@ -456,13 +457,21 @@ function applyResponsePipelineWithEmptyMonitoring(
   // Fires only when Addie broke character and the deterministic backstop had
   // to scrub a model/provider disclosure — rare by design. A rising rate means
   // the prompt-level identity rule is slipping (e.g. after a model change).
-  if (hasPersonaCollapse(rawText)) {
+  const personaCollapsed = hasPersonaCollapse(rawText);
+  if (personaCollapsed) {
     logger.warn(
       { toolExecutionCount: toolExecutions.length },
       'Addie: persona-collapse disclosure scrubbed from response',
     );
   }
-  return { text: applyResponsePipeline(question, rawText), reason: null };
+  const text = applyResponsePipeline(question, rawText);
+  if (personaCollapsed && text === EMPTY_RESPONSE_FALLBACK) {
+    return {
+      text,
+      reason: 'Empty response after persona-collapse safety rewrite',
+    };
+  }
+  return { text, reason: null };
 }
 
 interface FinalizedAssistantText {
@@ -674,6 +683,8 @@ export interface AddieResponse {
   active_rule_ids?: number[];
   /** Configuration version ID for this interaction */
   config_version_id?: number;
+  /** Provider execution identity or an explicit local-response classification. */
+  model_execution: ModelExecution;
   /** Timing breakdown for each phase of processing */
   timing?: {
     system_prompt_ms: number;
@@ -690,6 +701,30 @@ export interface AddieResponse {
   };
   capacity?: {
     certification_reserve_used: boolean;
+  };
+}
+
+function anthropicModelExecution(model: string, requestedModel: string): ModelExecution {
+  return {
+    source: 'provider',
+    requested_provider: 'anthropic',
+    requested_model: requestedModel,
+    provider: 'anthropic',
+    model,
+    model_resolution: model === requestedModel ? 'exact' : 'provider_canonicalized',
+    fallback_reason: null,
+  };
+}
+
+function localModelExecution(
+  reason: Extract<ModelExecution, { source: 'local' }>['reason'],
+  requestedModel: string,
+): ModelExecution {
+  return {
+    source: 'local',
+    requested_provider: 'anthropic',
+    requested_model: requestedModel,
+    reason,
   };
 }
 
@@ -1154,6 +1189,7 @@ export class AddieClaudeClient {
     options?: ProcessMessageOptions
   ): Promise<AddieResponse> {
     const operationalExecution = !isEvaluationExecution(options);
+    const requestedModel = options?.modelOverride ?? this.model;
 
     // #2950: warn when a caller has neither `costScope` nor explicit
     // `uncapped: true`. Silent default meant a future user-facing
@@ -1197,6 +1233,12 @@ export class AddieClaudeClient {
           tool_executions: [],
           flagged: true,
           flag_reason: 'cost_cap_exceeded',
+          model_execution: {
+            source: 'local',
+            requested_provider: 'anthropic',
+            requested_model: requestedModel,
+            reason: 'cost_cap_exceeded',
+          },
         };
       }
     }
@@ -1487,6 +1529,9 @@ export class AddieClaudeClient {
           flag_reason: `Response truncated: ${response.stop_reason}`,
           active_rule_ids: undefined,
           config_version_id: configVersionId ?? undefined,
+          model_execution: finalized.emptyReason
+            ? localModelExecution('no_provider_response', effectiveModel)
+            : anthropicModelExecution(response.model, effectiveModel),
           timing: {
             system_prompt_ms: systemPromptMs,
             total_llm_ms: totalLlmMs,
@@ -1597,6 +1642,9 @@ export class AddieClaudeClient {
           flag_reason: flagReason ?? undefined,
           active_rule_ids: undefined,
           config_version_id: configVersionId ?? undefined,
+          model_execution: finalized.emptyReason
+            ? localModelExecution('no_provider_response', effectiveModel)
+            : anthropicModelExecution(response.model, effectiveModel),
           timing: {
             system_prompt_ms: systemPromptMs,
             total_llm_ms: totalLlmMs,
@@ -1690,7 +1738,7 @@ export class AddieClaudeClient {
 
         if (toolUseBlocks.length === 0 && serverToolBlocks.length === 0) {
           const textContent = response.content.find((c) => c.type === 'text');
-          const rawText = textContent && textContent.type === 'text' ? textContent.text : "I'm not sure how to help with that.";
+          const rawText = textContent && textContent.type === 'text' ? textContent.text : '';
           const finalized = finalizeAssistantText(userMessage, rawText, toolExecutions);
           const text = finalized.text;
           if (finalized.emptyReason) {
@@ -1720,6 +1768,9 @@ export class AddieClaudeClient {
             flag_reason: finalized.lengthExceeded ? 'Output truncated due to length' : finalized.emptyReason ?? undefined,
             active_rule_ids: undefined,
             config_version_id: configVersionId ?? undefined,
+            model_execution: finalized.emptyReason
+              ? localModelExecution('no_provider_response', effectiveModel)
+              : anthropicModelExecution(response.model, effectiveModel),
             timing: {
               system_prompt_ms: systemPromptMs,
               total_llm_ms: totalLlmMs,
@@ -1919,6 +1970,7 @@ export class AddieClaudeClient {
       flag_reason: 'Max tool iterations reached',
       active_rule_ids: undefined,
       config_version_id: configVersionId ?? undefined,
+      model_execution: localModelExecution('canned_response', effectiveModel),
       timing: {
         system_prompt_ms: systemPromptMs,
         total_llm_ms: totalLlmMs,
@@ -1947,6 +1999,7 @@ export class AddieClaudeClient {
     options?: ProcessMessageOptions
   ): AsyncGenerator<StreamEvent> {
     const operationalExecution = !isEvaluationExecution(options);
+    const requestedModel = options?.modelOverride ?? this.model;
 
     // #2950: matching fail-closed warn on the stream path.
     if (operationalExecution && !options?.costScope && !options?.uncapped) {
@@ -1991,6 +2044,12 @@ export class AddieClaudeClient {
             tool_executions: [],
             flagged: true,
             flag_reason: 'cost_cap_exceeded',
+            model_execution: {
+              source: 'local',
+              requested_provider: 'anthropic',
+              requested_model: requestedModel,
+              reason: 'cost_cap_exceeded',
+            },
           },
         };
         return;
@@ -2118,6 +2177,7 @@ export class AddieClaudeClient {
     let retriedEmptyPostToolResponse = false;
     let retriedEmptyInitialResponse = false;
     let emptyResponseBeforeRecovery: Anthropic.Beta.BetaMessage | null = null;
+    let lastProviderModel: string | undefined;
 
       while (iteration < maxIterations) {
         iteration++;
@@ -2180,6 +2240,7 @@ export class AddieClaudeClient {
             }
 
             streamSucceeded = true;
+            lastProviderModel = currentResponse.model;
             if (isEmptyResponseRecovery) emptyResponseBeforeRecovery = null;
           } catch (streamError) {
             if (isEmptyResponseRecovery && emptyResponseBeforeRecovery) {
@@ -2372,6 +2433,9 @@ export class AddieClaudeClient {
               flag_reason: `Response truncated: ${currentResponse.stop_reason}`,
               active_rule_ids: undefined,
               config_version_id: configVersionId ?? undefined,
+              model_execution: finalized.emptyReason
+                ? localModelExecution('no_provider_response', effectiveModel)
+                : anthropicModelExecution(currentResponse.model, effectiveModel),
               timing: {
                 system_prompt_ms: systemPromptMs,
                 total_llm_ms: totalLlmMs,
@@ -2464,6 +2528,9 @@ export class AddieClaudeClient {
               flag_reason: flagReason ?? undefined,
               active_rule_ids: undefined,
               config_version_id: configVersionId ?? undefined,
+              model_execution: finalized.emptyReason
+                ? localModelExecution('no_provider_response', effectiveModel)
+                : anthropicModelExecution(currentResponse.model, effectiveModel),
               timing: {
                 system_prompt_ms: systemPromptMs,
                 total_llm_ms: totalLlmMs,
@@ -2508,6 +2575,9 @@ export class AddieClaudeClient {
                 flag_reason: finalized.lengthExceeded ? 'Output truncated due to length' : finalized.emptyReason ?? undefined,
                 active_rule_ids: undefined,
                 config_version_id: configVersionId ?? undefined,
+                model_execution: finalized.emptyReason
+                  ? localModelExecution('no_provider_response', effectiveModel)
+                  : anthropicModelExecution(currentResponse.model, effectiveModel),
                 timing: {
                   system_prompt_ms: systemPromptMs,
                   total_llm_ms: totalLlmMs,
@@ -2752,6 +2822,9 @@ export class AddieClaudeClient {
           flag_reason: 'Max tool iterations reached',
           active_rule_ids: undefined,
           config_version_id: configVersionId ?? undefined,
+          model_execution: logicalText && lastProviderModel
+            ? anthropicModelExecution(lastProviderModel, effectiveModel)
+            : localModelExecution('canned_response', effectiveModel),
           timing: {
             system_prompt_ms: systemPromptMs,
             total_llm_ms: totalLlmMs,

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.23';
+export const CODE_VERSION = '2026.08.24';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/direct-message-delivery.ts
+++ b/server/src/addie/direct-message-delivery.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '../logger.js';
 import type { CreateMessageInput } from './thread-service.js';
 import { getSlackApiErrorCode, isPermanentDmDeliveryError } from './slack-api-errors.js';
+import { classifyLocalModelExecution } from './model-providers/model-provider.js';
 
 const logger = createLogger('addie-dm-delivery');
 
@@ -14,7 +15,7 @@ export interface DirectMessageDeliveryInput {
   channelId: string;
   userId: string;
   threadId: string;
-  assistantMessage: CreateMessageInput;
+  assistantMessage: Extract<CreateMessageInput, { role: 'assistant' }>;
   userMessageFlagged: boolean;
   assistantFlagged: boolean;
   flagReason: string;
@@ -75,6 +76,10 @@ export async function deliverAndRecordDirectMessage(
         content_sanitized: undefined,
         flagged: true,
         flag_reason: `Slack delivery failed: ${deliveryLabel}`,
+        model_execution: classifyLocalModelExecution(
+          input.assistantMessage.model_execution,
+          'canned_response',
+        ),
       });
     } catch (error) {
       logger.error({ error, threadId: input.threadId }, 'Addie Bolt: Failed to save undelivered tool audit');

--- a/server/src/addie/email-conversation-handler.ts
+++ b/server/src/addie/email-conversation-handler.ts
@@ -274,6 +274,7 @@ export async function handleEmailConversation(
           }))
         : undefined,
       model: effectiveModel,
+        model_execution: response.model_execution,
       latency_ms: Date.now() - startTime,
       tokens_input: response.usage?.input_tokens,
       tokens_output: response.usage?.output_tokens,

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -8,7 +8,7 @@ import { createLogger } from '../logger.js';
 
 const logger = createLogger('addie-handler');
 import { getChannelInfo, sendChannelMessage } from '../slack/client.js';
-import { AddieClaudeClient, ADMIN_MAX_ITERATIONS, type UserScopedToolsResult } from './claude-client.js';
+import { AddieClaudeClient, ADMIN_MAX_ITERATIONS, type AddieResponse, type UserScopedToolsResult } from './claude-client.js';
 import {
   buildSlackCostOptions,
   SLACK_COST_CHANNEL_INFO_MAX_AGE_MS,
@@ -134,7 +134,7 @@ import type {
   AssistantThreadStartedEvent,
   AppMentionEvent,
   AssistantMessageEvent,
-  AddieInteractionLog,
+  CreateAddieInteractionLog,
   SuggestedPrompt,
 } from './types.js';
 
@@ -650,7 +650,7 @@ export async function handleAssistantMessage(
   );
 
   // If we should deflect, return the deflection response instead of processing
-  let response;
+  let response: AddieResponse;
   if (sensitiveCheck.shouldDeflect && sensitiveCheck.deflectResponse) {
     logger.info({
       userId: event.user,
@@ -665,6 +665,9 @@ export async function handleAssistantMessage(
       tool_executions: [],
       flagged: true,
       flag_reason: `Sensitive topic deflection: ${sensitiveCheck.topicResult.category}`,
+      model_execution: {
+        source: 'local', requested_provider: null, requested_model: null, reason: 'canned_response',
+      },
     };
   } else {
     // Create user-scoped tools (these can only operate on behalf of this user)
@@ -692,6 +695,9 @@ export async function handleAssistantMessage(
         tool_executions: [],
         flagged: true,
         flag_reason: `Error: ${error instanceof Error ? error.message : 'Unknown'}`,
+        model_execution: {
+          source: 'local', requested_provider: 'anthropic', requested_model: AddieModelConfig.chat, reason: 'provider_error',
+        },
       };
     }
   }
@@ -736,7 +742,7 @@ export async function handleAssistantMessage(
     .filter(Boolean)
     .join('; ');
 
-  const log: AddieInteractionLog = {
+  const log: CreateAddieInteractionLog = {
     id: interactionId,
     timestamp: new Date(),
     event_type: 'assistant_thread',
@@ -748,6 +754,7 @@ export async function handleAssistantMessage(
     output_text: outputValidation.sanitized,
     tools_used: response.tools_used,
     model: AddieModelConfig.chat,
+    model_execution: response.model_execution,
     latency_ms: Date.now() - startTime,
     flagged,
     flag_reason: flagReason || undefined,
@@ -824,7 +831,7 @@ export async function handleAppMention(event: AppMentionEvent): Promise<void> {
   );
 
   // If we should deflect, return the deflection response instead of processing
-  let response;
+  let response: AddieResponse;
   if (sensitiveCheck.shouldDeflect && sensitiveCheck.deflectResponse) {
     logger.info({
       userId: event.user,
@@ -840,6 +847,9 @@ export async function handleAppMention(event: AppMentionEvent): Promise<void> {
       tool_executions: [],
       flagged: true,
       flag_reason: `Sensitive topic deflection: ${sensitiveCheck.topicResult.category}`,
+      model_execution: {
+        source: 'local', requested_provider: null, requested_model: null, reason: 'canned_response',
+      },
     };
   } else {
     // Create user-scoped tools (these can only operate on behalf of this user)
@@ -880,6 +890,9 @@ export async function handleAppMention(event: AppMentionEvent): Promise<void> {
         tool_executions: [],
         flagged: true,
         flag_reason: `Error: ${error instanceof Error ? error.message : 'Unknown'}`,
+        model_execution: {
+          source: 'local', requested_provider: 'anthropic', requested_model: AddieModelConfig.chat, reason: 'provider_error',
+        },
       };
     }
   }
@@ -913,7 +926,7 @@ export async function handleAppMention(event: AppMentionEvent): Promise<void> {
     .filter(Boolean)
     .join('; ');
 
-  const log: AddieInteractionLog = {
+  const log: CreateAddieInteractionLog = {
     id: interactionId,
     timestamp: new Date(),
     event_type: 'mention',
@@ -925,6 +938,7 @@ export async function handleAppMention(event: AppMentionEvent): Promise<void> {
     output_text: outputValidation.sanitized,
     tools_used: response.tools_used,
     model: AddieModelConfig.chat,
+    model_execution: response.model_execution,
     latency_ms: Date.now() - startTime,
     flagged,
     flag_reason: flagReason || undefined,

--- a/server/src/addie/jobs/shadow-replay.ts
+++ b/server/src/addie/jobs/shadow-replay.ts
@@ -256,6 +256,12 @@ export async function executeShadowReplay(
         tools_used: [],
         tool_executions: [],
         flagged: false,
+        model_execution: {
+          source: 'local',
+          requested_provider: 'anthropic',
+          requested_model: model,
+          reason: 'no_provider_response',
+        },
       },
       model,
       configVersionId,

--- a/server/src/addie/jobs/task-reminder.ts
+++ b/server/src/addie/jobs/task-reminder.ts
@@ -233,6 +233,9 @@ async function sendReminderDm(slackUserId: string, message: string): Promise<boo
           thread_id: thread.thread_id,
           role: 'assistant',
           content: message,
+          model_execution: {
+            source: 'local', requested_provider: null, requested_model: null, reason: 'canned_response',
+          },
         });
       } catch (err) {
         logger.warn({ err, slackUserId }, 'Failed to save reminder to thread service');

--- a/server/src/addie/model-providers/model-provider.ts
+++ b/server/src/addie/model-providers/model-provider.ts
@@ -7,6 +7,55 @@
  */
 
 export type ModelProviderId = 'anthropic' | 'openai' | 'google';
+export type ModelFallbackReason =
+  | 'primary_unavailable'
+  | 'primary_rate_limited'
+  | 'primary_timeout'
+  | 'primary_capability_unsupported'
+  | 'primary_policy_blocked';
+export type LocalModelResponseReason =
+  | 'cost_cap_exceeded'
+  | 'provider_error'
+  | 'stream_interrupted'
+  | 'no_provider_response'
+  | 'canned_response';
+export type ModelResolution = 'exact' | 'provider_canonicalized' | 'fallback';
+export type RequestedModelSelection =
+  | { requested_provider: ModelProviderId; requested_model: string }
+  | { requested_provider: null; requested_model: null };
+
+export type ModelExecution =
+  | {
+      source: 'provider';
+      requested_provider: ModelProviderId;
+      requested_model: string;
+      provider: ModelProviderId;
+      model: string;
+      model_resolution: ModelResolution;
+      fallback_reason: ModelFallbackReason | null;
+    }
+  | ({ source: 'local'; reason: LocalModelResponseReason } & (
+      | { requested_provider: ModelProviderId; requested_model: string }
+      | { requested_provider: null; requested_model: null }
+    ));
+
+export function classifyLocalModelExecution(
+  selection: RequestedModelSelection,
+  reason: LocalModelResponseReason,
+): Extract<ModelExecution, { source: 'local' }> {
+  if ((selection.requested_provider === null) !== (selection.requested_model === null)) {
+    throw new Error('Requested provider and model must be supplied together');
+  }
+  if (selection.requested_provider === null) {
+    return { source: 'local', requested_provider: null, requested_model: null, reason };
+  }
+  return {
+    source: 'local',
+    requested_provider: selection.requested_provider,
+    requested_model: selection.requested_model,
+    reason,
+  };
+}
 export type ModelReasoningEffort = 'provider_default' | 'none' | 'low' | 'medium' | 'high';
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | JsonValue[] | JsonObject;

--- a/server/src/addie/security.ts
+++ b/server/src/addie/security.ts
@@ -10,7 +10,7 @@
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('addie-security');
-import type { SanitizationResult, AddieInteractionLog } from './types.js';
+import type { SanitizationResult, CreateAddieInteractionLog } from './types.js';
 import { PERSONA_COLLAPSE_PATTERNS } from './response-postprocess.js';
 
 export const MAX_OUTPUT_LENGTH = 10_000;
@@ -598,8 +598,11 @@ export function extractMarkdownImages(text: string): ImageExtractionResult {
 /**
  * Log an interaction for audit purposes
  */
-export function logInteraction(log: AddieInteractionLog): void {
+export function logInteraction(log: CreateAddieInteractionLog): void {
   const emoji = log.flagged ? '⚠️ ' : '';
+  const providerExecution = log.model_execution?.source === 'provider'
+    ? log.model_execution
+    : undefined;
   logger.info(
     {
       interactionId: log.id,
@@ -607,6 +610,13 @@ export function logInteraction(log: AddieInteractionLog): void {
       userId: log.user_id,
       channelId: log.channel_id,
       latencyMs: log.latency_ms,
+      requestedModelProvider: log.model_execution?.requested_provider,
+      modelProvider: providerExecution?.provider,
+      providerModel: providerExecution?.model,
+      providerFallbackReason: providerExecution?.fallback_reason,
+      localResponseReason: log.model_execution?.source === 'local'
+        ? log.model_execution.reason
+        : undefined,
       deliveryStatus: log.delivery_status,
       toolsUsed: log.tools_used,
       flagged: log.flagged,

--- a/server/src/addie/services/relationship-orchestrator.ts
+++ b/server/src/addie/services/relationship-orchestrator.ts
@@ -279,6 +279,9 @@ async function persistSlackThreadMessage(options: {
     thread_id: thread.thread_id,
     role: 'assistant',
     content: options.text,
+    model_execution: {
+      source: 'local', requested_provider: null, requested_model: null, reason: 'canned_response',
+    },
   });
 }
 
@@ -305,6 +308,9 @@ async function persistEmailThreadMessage(options: {
     thread_id: thread.thread_id,
     role: 'assistant',
     content: formatEmailMessageForThread(options.subject, options.text),
+    model_execution: {
+      source: 'local', requested_provider: null, requested_model: null, reason: 'canned_response',
+    },
   });
 }
 

--- a/server/src/addie/slack-blocks.ts
+++ b/server/src/addie/slack-blocks.ts
@@ -87,6 +87,10 @@ export const DEFAULT_STREAM_SOFT_CAP = 9000;
 export const STREAM_DELIVERY_UNCERTAIN_NOTICE =
   "_(I streamed that response, but couldn't finish Slack's delivery metadata. Some of the response may be missing; ask again and I'll retry.)_";
 
+/** Persisted when a stream ends without its terminal provider receipt. */
+export const STREAM_COMPLETION_MISSING_NOTICE =
+  "I'm sorry, that response ended before I could verify it was complete. Please try again.";
+
 export interface StreamAppendDecision {
   /** Pass to `streamer.append({ markdown_text: appendPart })` when non-empty. */
   appendPart: string;

--- a/server/src/addie/thread-service.ts
+++ b/server/src/addie/thread-service.ts
@@ -12,6 +12,7 @@
 import { randomUUID } from 'crypto';
 import { query, getPool } from '../db/client.js';
 import { createLogger } from '../logger.js';
+import type { LocalModelResponseReason, ModelExecution, ModelFallbackReason, ModelProviderId, ModelResolution } from './model-providers/model-provider.js';
 
 const logger = createLogger('addie-thread-service');
 
@@ -112,9 +113,8 @@ export interface Thread {
   updated_at: Date;
 }
 
-export interface CreateMessageInput {
+interface CreateMessageInputBase {
   thread_id: string;
-  role: MessageRole;
   content: string;
   content_sanitized?: string;
   tools_used?: string[];
@@ -168,6 +168,12 @@ export interface CreateMessageInput {
   finalize_client_turn_status?: 'completed' | 'interrupted';
 }
 
+export type CreateMessageInput = CreateMessageInputBase & (
+  /** Atomic requested/actual provider identity for every assistant response. */
+  | { role: 'assistant'; model_execution: ModelExecution }
+  | { role: Exclude<MessageRole, 'assistant'>; model_execution?: never }
+);
+
 export interface ThreadMessage {
   message_id: string;
   thread_id: string;
@@ -178,6 +184,14 @@ export interface ThreadMessage {
   tool_calls: Array<{ name: string; input: unknown; result: unknown; duration_ms?: number; is_error?: boolean }> | null;
   knowledge_ids: number[] | null;
   model: string | null;
+  model_execution_source: 'provider' | 'local' | 'legacy' | null;
+  requested_model_provider: ModelProviderId | null;
+  requested_model: string | null;
+  model_provider: ModelProviderId | null;
+  provider_model: string | null;
+  provider_model_resolution: ModelResolution | null;
+  provider_fallback_reason: ModelFallbackReason | null;
+  local_response_reason: LocalModelResponseReason | null;
   latency_ms: number | null;
   tokens_input: number | null;
   tokens_output: number | null;
@@ -529,14 +543,16 @@ export class ThreadService {
       const result = await client.query<ThreadMessage>(
         `INSERT INTO addie_thread_messages (
           thread_id, role, content, content_sanitized, tools_used, tool_calls,
-          knowledge_ids, model, latency_ms, tokens_input, tokens_output,
+          knowledge_ids, model, model_execution_source, requested_model_provider, requested_model,
+          model_provider, provider_model, provider_model_resolution, provider_fallback_reason, local_response_reason,
+          latency_ms, tokens_input, tokens_output,
           flagged, flag_reason, sequence_number,
           timing_system_prompt_ms, timing_total_llm_ms, timing_total_tool_ms,
           processing_iterations, tokens_cache_creation, tokens_cache_read, active_rule_ids,
           router_decision, config_version_id, email_message_id,
           user_id, user_display_name, message_source,
           client_request_id, delivery_status
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29)
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37)
         RETURNING *`,
         [
           input.thread_id,
@@ -547,6 +563,14 @@ export class ThreadService {
           input.tool_calls ? stripNullBytesFromJson(JSON.stringify(input.tool_calls)) : null,
           input.knowledge_ids ?? null,
           input.model ?? null,
+          input.model_execution?.source ?? null,
+          input.model_execution?.requested_provider ?? null,
+          input.model_execution?.requested_model ?? null,
+          input.model_execution?.source === 'provider' ? input.model_execution.provider : null,
+          input.model_execution?.source === 'provider' ? stripNullBytesString(input.model_execution.model) : null,
+          input.model_execution?.source === 'provider' ? input.model_execution.model_resolution : null,
+          input.model_execution?.source === 'provider' ? input.model_execution.fallback_reason : null,
+          input.model_execution?.source === 'local' ? input.model_execution.reason : null,
           input.latency_ms ?? null,
           input.tokens_input ?? null,
           input.tokens_output ?? null,
@@ -809,6 +833,10 @@ export class ThreadService {
     const result = await query(
       `UPDATE addie_thread_messages
        SET
+         model_execution_source = CASE
+           WHEN role = 'assistant' THEN COALESCE(model_execution_source, 'legacy')
+           ELSE model_execution_source
+         END,
          rating = $2,
          rating_category = $3,
          rating_notes = $4,
@@ -839,7 +867,14 @@ export class ThreadService {
    */
   async flagMessage(messageId: string, reason: string): Promise<void> {
     await query(
-      `UPDATE addie_thread_messages SET flagged = TRUE, flag_reason = $2 WHERE message_id = $1`,
+      `UPDATE addie_thread_messages
+       SET model_execution_source = CASE
+             WHEN role = 'assistant' THEN COALESCE(model_execution_source, 'legacy')
+             ELSE model_execution_source
+           END,
+           flagged = TRUE,
+           flag_reason = $2
+       WHERE message_id = $1`,
       [messageId, reason]
     );
   }
@@ -855,7 +890,13 @@ export class ThreadService {
   ): Promise<void> {
     await query(
       `UPDATE addie_thread_messages
-       SET outcome = $2, user_sentiment = $3, intent_category = $4
+       SET model_execution_source = CASE
+             WHEN role = 'assistant' THEN COALESCE(model_execution_source, 'legacy')
+             ELSE model_execution_source
+           END,
+           outcome = $2,
+           user_sentiment = $3,
+           intent_category = $4
        WHERE message_id = $1`,
       [messageId, outcome, sentiment || null, intentCategory || null]
     );

--- a/server/src/addie/types.ts
+++ b/server/src/addie/types.ts
@@ -2,6 +2,8 @@
  * Types for Addie - AAO's Community Agent
  */
 
+import type { ModelExecution } from './model-providers/model-provider.js';
+
 /**
  * Slack Assistant thread started event
  */
@@ -79,11 +81,17 @@ export interface AddieInteractionLog {
   output_text: string;
   tools_used: string[];
   model: string;
+  model_execution?: ModelExecution;
   latency_ms: number;
   delivery_status?: 'delivered' | 'failed';
   flagged: boolean;
   flag_reason?: string;
 }
+
+/** New audit writes must classify provider-produced versus local output. */
+export type CreateAddieInteractionLog = Omit<AddieInteractionLog, 'model_execution'> & {
+  model_execution: ModelExecution;
+};
 
 /**
  * Content sanitization result

--- a/server/src/db/addie-db.ts
+++ b/server/src/db/addie-db.ts
@@ -1,5 +1,5 @@
 import { query } from './client.js';
-import type { AddieInteractionLog } from '../addie/types.js';
+import type { AddieInteractionLog, CreateAddieInteractionLog } from '../addie/types.js';
 
 /**
  * Database row type for addie_interactions
@@ -17,6 +17,14 @@ interface AddieInteractionRow {
   tools_used: string[];
   knowledge_ids: number[] | null;
   model: string;
+  model_execution_source: 'provider' | 'local' | 'legacy' | null;
+  requested_model_provider: 'anthropic' | 'openai' | 'google' | null;
+  requested_model: string | null;
+  model_provider: 'anthropic' | 'openai' | 'google' | null;
+  provider_model: string | null;
+  provider_model_resolution: 'exact' | 'provider_canonicalized' | 'fallback' | null;
+  provider_fallback_reason: string | null;
+  local_response_reason: string | null;
   latency_ms: number;
   flagged: boolean;
   flag_reason: string | null;
@@ -987,14 +995,15 @@ export class AddieDatabase {
   /**
    * Log an interaction
    */
-  async logInteraction(log: AddieInteractionLog, knowledgeIds?: number[]): Promise<void> {
+  async logInteraction(log: CreateAddieInteractionLog, knowledgeIds?: number[]): Promise<void> {
     await query(
       `INSERT INTO addie_interactions (
         id, event_type, channel_id, thread_ts, user_id,
         input_text, input_sanitized, output_text,
-        tools_used, knowledge_ids, model, latency_ms,
-        flagged, flag_reason
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+        tools_used, knowledge_ids, model, model_execution_source, requested_model_provider, requested_model,
+        model_provider, provider_model, provider_model_resolution, provider_fallback_reason, local_response_reason,
+        latency_ms, flagged, flag_reason
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)`,
       [
         log.id,
         log.event_type,
@@ -1007,6 +1016,14 @@ export class AddieDatabase {
         log.tools_used,
         knowledgeIds || null,
         log.model,
+        log.model_execution?.source || null,
+        log.model_execution?.requested_provider || null,
+        log.model_execution?.requested_model || null,
+        log.model_execution?.source === 'provider' ? log.model_execution.provider : null,
+        log.model_execution?.source === 'provider' ? log.model_execution.model : null,
+        log.model_execution?.source === 'provider' ? log.model_execution.model_resolution : null,
+        log.model_execution?.source === 'provider' ? log.model_execution.fallback_reason : null,
+        log.model_execution?.source === 'local' ? log.model_execution.reason : null,
         log.latency_ms,
         log.flagged,
         log.flag_reason || null,
@@ -1072,6 +1089,32 @@ export class AddieDatabase {
       output_text: row.output_text,
       tools_used: row.tools_used,
       model: row.model,
+      model_execution: row.model_execution_source === 'provider'
+        && row.requested_model_provider && row.requested_model && row.model_provider && row.provider_model
+        ? {
+            source: 'provider',
+            requested_provider: row.requested_model_provider,
+            requested_model: row.requested_model,
+            provider: row.model_provider,
+            model: row.provider_model,
+            model_resolution: row.provider_model_resolution!,
+            fallback_reason: row.provider_fallback_reason as Extract<NonNullable<AddieInteractionLog['model_execution']>, { source: 'provider' }>['fallback_reason'],
+          }
+        : row.model_execution_source === 'local' && row.requested_model_provider && row.requested_model && row.local_response_reason
+          ? {
+              source: 'local',
+              requested_provider: row.requested_model_provider,
+              requested_model: row.requested_model,
+              reason: row.local_response_reason as Extract<NonNullable<AddieInteractionLog['model_execution']>, { source: 'local' }>['reason'],
+            }
+          : row.model_execution_source === 'local' && row.requested_model_provider === null && row.requested_model === null && row.local_response_reason
+            ? {
+                source: 'local',
+                requested_provider: null,
+                requested_model: null,
+                reason: row.local_response_reason as Extract<NonNullable<AddieInteractionLog['model_execution']>, { source: 'local' }>['reason'],
+              }
+            : undefined,
       latency_ms: row.latency_ms,
       flagged: row.flagged,
       flag_reason: row.flag_reason ?? undefined,
@@ -1084,7 +1127,8 @@ export class AddieDatabase {
   async markInteractionReviewed(id: string, reviewedBy: string): Promise<void> {
     await query(
       `UPDATE addie_interactions
-       SET reviewed = TRUE, reviewed_by = $1, reviewed_at = NOW()
+       SET model_execution_source = COALESCE(model_execution_source, 'legacy'),
+           reviewed = TRUE, reviewed_by = $1, reviewed_at = NOW()
        WHERE id = $2`,
       [reviewedBy, id]
     );
@@ -1232,7 +1276,8 @@ export class AddieDatabase {
   ): Promise<void> {
     await query(
       `UPDATE addie_interactions
-       SET rating = $1, rating_by = $2, rating_notes = $3, rated_at = NOW(),
+       SET model_execution_source = COALESCE(model_execution_source, 'legacy'),
+           rating = $1, rating_by = $2, rating_notes = $3, rated_at = NOW(),
            outcome = $4, user_sentiment = $5, intent_category = $6
        WHERE id = $7`,
       [

--- a/server/src/db/migrations/557_addie_response_provider_provenance.sql
+++ b/server/src/db/migrations/557_addie_response_provider_provenance.sql
@@ -1,0 +1,179 @@
+-- Persist the provider identity returned by the model API separately from the
+-- configured/requested model alias already stored in `model`.
+-- Fail and retry deployment rather than waiting indefinitely for either hot
+-- Addie table's brief ACCESS EXCLUSIVE metadata lock.
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE addie_thread_messages
+  ADD COLUMN IF NOT EXISTS model_execution_source VARCHAR(16),
+  ADD COLUMN IF NOT EXISTS requested_model_provider VARCHAR(32),
+  ADD COLUMN IF NOT EXISTS requested_model VARCHAR(256),
+  ADD COLUMN IF NOT EXISTS model_provider VARCHAR(32),
+  ADD COLUMN IF NOT EXISTS provider_model VARCHAR(256),
+  ADD COLUMN IF NOT EXISTS provider_model_resolution VARCHAR(32),
+  ADD COLUMN IF NOT EXISTS provider_fallback_reason VARCHAR(64),
+  ADD COLUMN IF NOT EXISTS local_response_reason VARCHAR(64);
+
+ALTER TABLE addie_thread_messages
+  ADD CONSTRAINT addie_thread_messages_provider_values
+    CHECK (
+      (requested_model_provider IS NULL OR requested_model_provider IN ('anthropic', 'openai', 'google'))
+      AND (model_provider IS NULL OR model_provider IN ('anthropic', 'openai', 'google'))
+    ) NOT VALID,
+  ADD CONSTRAINT addie_thread_messages_execution_source_values
+    CHECK (model_execution_source IN ('provider', 'local', 'legacy')) NOT VALID,
+  ADD CONSTRAINT addie_thread_messages_execution_assistant_only
+    CHECK (model_execution_source IS NULL OR role = 'assistant') NOT VALID,
+  ADD CONSTRAINT addie_thread_messages_provider_model_nonempty
+    CHECK (
+      (requested_model IS NULL OR length(btrim(requested_model)) BETWEEN 1 AND 256)
+      AND (provider_model IS NULL OR length(btrim(provider_model)) BETWEEN 1 AND 256)
+    ) NOT VALID,
+  ADD CONSTRAINT addie_thread_messages_provider_fallback_reason_values
+    CHECK (
+      provider_fallback_reason IS NULL
+      OR provider_fallback_reason IN (
+        'primary_unavailable',
+        'primary_rate_limited',
+        'primary_timeout',
+        'primary_capability_unsupported',
+        'primary_policy_blocked'
+      )
+    ) NOT VALID,
+  ADD CONSTRAINT addie_thread_messages_provider_model_resolution_values
+    CHECK (
+      provider_model_resolution IS NULL
+      OR provider_model_resolution IN ('exact', 'provider_canonicalized', 'fallback')
+    ) NOT VALID,
+  ADD CONSTRAINT addie_thread_messages_local_response_reason_values
+    CHECK (
+      local_response_reason IS NULL
+      OR local_response_reason IN (
+        'cost_cap_exceeded',
+        'provider_error',
+        'stream_interrupted',
+        'no_provider_response',
+        'canned_response'
+      )
+    ) NOT VALID,
+  ADD CONSTRAINT addie_thread_messages_provider_execution_atomic
+    CHECK (
+      (model_execution_source = 'legacy' AND requested_model_provider IS NULL AND requested_model IS NULL AND model_provider IS NULL AND provider_model IS NULL AND provider_model_resolution IS NULL AND provider_fallback_reason IS NULL AND local_response_reason IS NULL)
+      OR (model_execution_source = 'provider' AND requested_model_provider IS NOT NULL AND requested_model IS NOT NULL AND model_provider IS NOT NULL AND provider_model IS NOT NULL AND provider_model_resolution IS NOT NULL AND local_response_reason IS NULL)
+      OR (model_execution_source = 'local' AND ((requested_model_provider IS NULL AND requested_model IS NULL) OR (requested_model_provider IS NOT NULL AND requested_model IS NOT NULL)) AND model_provider IS NULL AND provider_model IS NULL AND provider_model_resolution IS NULL AND provider_fallback_reason IS NULL AND local_response_reason IS NOT NULL)
+    ) NOT VALID,
+  ADD CONSTRAINT addie_thread_messages_provider_fallback_consistent
+    CHECK (
+      model_execution_source IS DISTINCT FROM 'provider'
+      OR (provider_model_resolution = 'exact' AND requested_model_provider = model_provider AND requested_model = provider_model AND provider_fallback_reason IS NULL)
+      OR (provider_model_resolution = 'provider_canonicalized' AND requested_model_provider = model_provider AND requested_model <> provider_model AND provider_fallback_reason IS NULL)
+      OR (provider_model_resolution = 'fallback' AND (requested_model_provider <> model_provider OR requested_model <> provider_model) AND provider_fallback_reason IS NOT NULL)
+    ) NOT VALID;
+
+-- Expand phase: keep the discriminator nullable until every pre-557 app
+-- instance has drained. The application requires it for new assistant writes;
+-- a later contract migration can add the database-level required check.
+
+COMMENT ON COLUMN addie_thread_messages.model IS
+  'Configured/requested model alias retained for compatibility.';
+COMMENT ON COLUMN addie_thread_messages.requested_model_provider IS
+  'Provider selected before execution or fallback.';
+COMMENT ON COLUMN addie_thread_messages.requested_model IS
+  'Model selected before execution or fallback.';
+COMMENT ON COLUMN addie_thread_messages.model_provider IS
+  'Actual provider that produced the assistant response.';
+COMMENT ON COLUMN addie_thread_messages.provider_model IS
+  'Actual model identity returned by the provider API.';
+COMMENT ON COLUMN addie_thread_messages.provider_model_resolution IS
+  'How the actual provider/model relates to the requested selection.';
+COMMENT ON COLUMN addie_thread_messages.provider_fallback_reason IS
+  'Categorical reason actual provider or model differs from the requested selection.';
+COMMENT ON COLUMN addie_thread_messages.local_response_reason IS
+  'Categorical reason the application produced the response without model attribution.';
+
+-- The legacy interaction audit path is still active for two Slack handlers.
+-- Keep its provenance contract aligned until that table is retired.
+ALTER TABLE addie_interactions
+  ADD COLUMN IF NOT EXISTS model_execution_source VARCHAR(16),
+  ADD COLUMN IF NOT EXISTS requested_model_provider VARCHAR(32),
+  ADD COLUMN IF NOT EXISTS requested_model VARCHAR(256),
+  ADD COLUMN IF NOT EXISTS model_provider VARCHAR(32),
+  ADD COLUMN IF NOT EXISTS provider_model VARCHAR(256),
+  ADD COLUMN IF NOT EXISTS provider_model_resolution VARCHAR(32),
+  ADD COLUMN IF NOT EXISTS provider_fallback_reason VARCHAR(64),
+  ADD COLUMN IF NOT EXISTS local_response_reason VARCHAR(64);
+
+ALTER TABLE addie_interactions
+  ADD CONSTRAINT addie_interactions_provider_values
+    CHECK (
+      (requested_model_provider IS NULL OR requested_model_provider IN ('anthropic', 'openai', 'google'))
+      AND (model_provider IS NULL OR model_provider IN ('anthropic', 'openai', 'google'))
+    ) NOT VALID,
+  ADD CONSTRAINT addie_interactions_execution_source_values
+    CHECK (model_execution_source IN ('provider', 'local', 'legacy')) NOT VALID,
+  ADD CONSTRAINT addie_interactions_provider_model_nonempty
+    CHECK (
+      (requested_model IS NULL OR length(btrim(requested_model)) BETWEEN 1 AND 256)
+      AND (provider_model IS NULL OR length(btrim(provider_model)) BETWEEN 1 AND 256)
+    ) NOT VALID,
+  ADD CONSTRAINT addie_interactions_provider_fallback_reason_values
+    CHECK (
+      provider_fallback_reason IS NULL
+      OR provider_fallback_reason IN (
+        'primary_unavailable',
+        'primary_rate_limited',
+        'primary_timeout',
+        'primary_capability_unsupported',
+        'primary_policy_blocked'
+      )
+    ) NOT VALID,
+  ADD CONSTRAINT addie_interactions_provider_model_resolution_values
+    CHECK (
+      provider_model_resolution IS NULL
+      OR provider_model_resolution IN ('exact', 'provider_canonicalized', 'fallback')
+    ) NOT VALID,
+  ADD CONSTRAINT addie_interactions_local_response_reason_values
+    CHECK (
+      local_response_reason IS NULL
+      OR local_response_reason IN (
+        'cost_cap_exceeded',
+        'provider_error',
+        'stream_interrupted',
+        'no_provider_response',
+        'canned_response'
+      )
+    ) NOT VALID,
+  ADD CONSTRAINT addie_interactions_provider_execution_atomic
+    CHECK (
+      (model_execution_source = 'legacy' AND requested_model_provider IS NULL AND requested_model IS NULL AND model_provider IS NULL AND provider_model IS NULL AND provider_model_resolution IS NULL AND provider_fallback_reason IS NULL AND local_response_reason IS NULL)
+      OR (model_execution_source = 'provider' AND requested_model_provider IS NOT NULL AND requested_model IS NOT NULL AND model_provider IS NOT NULL AND provider_model IS NOT NULL AND provider_model_resolution IS NOT NULL AND local_response_reason IS NULL)
+      OR (model_execution_source = 'local' AND ((requested_model_provider IS NULL AND requested_model IS NULL) OR (requested_model_provider IS NOT NULL AND requested_model IS NOT NULL)) AND model_provider IS NULL AND provider_model IS NULL AND provider_model_resolution IS NULL AND provider_fallback_reason IS NULL AND local_response_reason IS NOT NULL)
+    ) NOT VALID,
+  ADD CONSTRAINT addie_interactions_provider_fallback_consistent
+    CHECK (
+      model_execution_source IS DISTINCT FROM 'provider'
+      OR (provider_model_resolution = 'exact' AND requested_model_provider = model_provider AND requested_model = provider_model AND provider_fallback_reason IS NULL)
+      OR (provider_model_resolution = 'provider_canonicalized' AND requested_model_provider = model_provider AND requested_model <> provider_model AND provider_fallback_reason IS NULL)
+      OR (provider_model_resolution = 'fallback' AND (requested_model_provider <> model_provider OR requested_model <> provider_model) AND provider_fallback_reason IS NOT NULL)
+    ) NOT VALID;
+
+-- Keep rolling-deploy writes from pre-557 instances compatible here too.
+
+COMMENT ON COLUMN addie_interactions.requested_model_provider IS
+  'Provider selected before execution or fallback.';
+COMMENT ON COLUMN addie_interactions.requested_model IS
+  'Model selected before execution or fallback.';
+COMMENT ON COLUMN addie_interactions.model_provider IS
+  'Actual provider that produced the interaction output.';
+COMMENT ON COLUMN addie_interactions.provider_model IS
+  'Actual model identity returned by the provider API.';
+COMMENT ON COLUMN addie_interactions.provider_model_resolution IS
+  'How the actual provider/model relates to the requested selection.';
+COMMENT ON COLUMN addie_interactions.provider_fallback_reason IS
+  'Categorical reason actual provider or model differs from the requested selection.';
+COMMENT ON COLUMN addie_interactions.local_response_reason IS
+  'Categorical reason the application produced the response without model attribution.';
+COMMENT ON COLUMN addie_thread_messages.model_execution_source IS
+  'provider for model output, local for application output; NULL denotes pre-migration or rolling-deploy writes.';
+COMMENT ON COLUMN addie_interactions.model_execution_source IS
+  'provider for model output, local for application output; NULL denotes pre-migration or rolling-deploy writes.';

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -17,6 +17,7 @@ import { CachedPostgresStore } from "../middleware/pg-rate-limit-store.js";
 import { optionalAuth } from "../middleware/auth.js";
 import { serveHtmlWithConfig } from "../utils/html-config.js";
 import { AddieClaudeClient, type AddieResponse, type RequestTools } from "../addie/claude-client.js";
+import { classifyLocalModelExecution } from "../addie/model-providers/model-provider.js";
 import { sanitizeSpeakerName } from "../addie/prompts.js";
 import { resolveUserTierFromDb } from "../addie/claude-cost-tracker.js";
 import {
@@ -1150,7 +1151,7 @@ export function createAddieChatRouter(options?: {
         : null;
 
       // Process with Claude
-      let response;
+      let response: AddieResponse;
       try {
         response = await activeChatClient.processMessage(messageToProcess, contextMessages, requestTools, undefined, {
           ...processOptions,
@@ -1182,6 +1183,9 @@ export function createAddieChatRouter(options?: {
           tool_executions: [],
           flagged: true,
           flag_reason: `Error: ${error instanceof Error ? error.message : "Unknown"}`,
+          model_execution: {
+            source: 'local', requested_provider: 'anthropic', requested_model: effectiveModel, reason: 'provider_error',
+          },
         };
       }
 
@@ -1198,6 +1202,10 @@ export function createAddieChatRouter(options?: {
         response.text = normalizedResponse.text;
         response.flagged = true;
         response.flag_reason = response.flag_reason || 'Empty assistant response';
+        response.model_execution = classifyLocalModelExecution(
+          response.model_execution,
+          'no_provider_response',
+        );
       }
 
       // Validate output
@@ -1220,6 +1228,7 @@ export function createAddieChatRouter(options?: {
             }))
           : undefined,
         model: effectiveModel,
+        model_execution: response.model_execution,
         latency_ms: latencyMs,
         tokens_input: response.usage?.input_tokens,
         tokens_output: response.usage?.output_tokens,
@@ -1290,6 +1299,7 @@ export function createAddieChatRouter(options?: {
     let heartbeat: ReturnType<typeof setInterval> | null = null;
     let claimedTurn: { threadId: string; clientRequestId: string; leaseId: string } | null = null;
     let terminalResponse: AddieResponse | undefined;
+    let requestedModelForAttempt = req.user ? AddieModelConfig.chat : AddieModelConfig.anonymousChat;
 
     // Handle client disconnect
     res.on("close", () => {
@@ -1588,6 +1598,7 @@ export function createAddieChatRouter(options?: {
         typeof organization_id === 'string' ? organization_id : null
       );
       const { requestTools, processOptions, effectiveModel } = buildTieredAccess(memberTools, isAuth, hasThreadCertCtx);
+      requestedModelForAttempt = effectiveModel;
       const preTurnCertification = userId && certificationModuleContext.moduleId
         ? await getCertificationModuleExperience(userId, certificationModuleContext.moduleId)
         : null;
@@ -1686,6 +1697,9 @@ export function createAddieChatRouter(options?: {
               is_error: execution.is_error,
             })),
             model: effectiveModel,
+            model_execution: {
+              source: 'local', requested_provider: 'anthropic', requested_model: effectiveModel, reason: 'stream_interrupted',
+            },
             flagged: true,
             flag_reason: `stream_interrupted: ${event.reason}`,
             client_request_id: clientRequestId || undefined,
@@ -1727,6 +1741,9 @@ export function createAddieChatRouter(options?: {
               content: 'Reply interrupted before completion. The learner can safely retry this turn.',
               flagged: true,
               flag_reason: `stream_interrupted: ${event.error}`,
+              model_execution: {
+                source: 'local', requested_provider: 'anthropic', requested_model: effectiveModel, reason: 'stream_interrupted',
+              },
               client_request_id: claimedTurn.clientRequestId,
               delivery_status: 'interrupted',
               client_turn_lease_id: claimedTurn.leaseId,
@@ -1751,6 +1768,9 @@ export function createAddieChatRouter(options?: {
           content: 'Reply interrupted before completion. The learner can safely retry this turn.',
           tools_used: toolsUsed.length > 0 ? toolsUsed : undefined,
           model: effectiveModel,
+          model_execution: {
+            source: 'local', requested_provider: 'anthropic', requested_model: effectiveModel, reason: 'no_provider_response',
+          },
           flagged: true,
           flag_reason: 'stream_interrupted: ended_without_done',
           client_request_id: clientRequestId || undefined,
@@ -1795,6 +1815,10 @@ export function createAddieChatRouter(options?: {
         if (response) {
           response.flagged = true;
           response.flag_reason = response.flag_reason || 'Empty assistant response';
+          response.model_execution = classifyLocalModelExecution(
+            response.model_execution,
+            'no_provider_response',
+          );
         }
       }
       fullText = normalizedStream.text;
@@ -1818,6 +1842,7 @@ export function createAddieChatRouter(options?: {
             }))
           : undefined,
         model: effectiveModel,
+        model_execution: response.model_execution,
         latency_ms: latencyMs,
         tokens_input: response?.usage?.input_tokens,
         tokens_output: response?.usage?.output_tokens,
@@ -2000,6 +2025,12 @@ export function createAddieChatRouter(options?: {
             })),
             flagged: true,
             flag_reason: 'stream_interrupted: route_error',
+            model_execution: {
+              source: 'local',
+              requested_provider: terminalResponse?.model_execution.requested_provider ?? 'anthropic',
+              requested_model: terminalResponse?.model_execution.requested_model ?? requestedModelForAttempt,
+              reason: 'stream_interrupted',
+            },
             client_request_id: claimedTurn.clientRequestId,
             delivery_status: 'interrupted',
             client_turn_lease_id: claimedTurn.leaseId,

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import { serveHtmlWithConfig } from "../utils/html-config.js";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { createLogger } from "../logger.js";
-import { AddieClaudeClient, type RequestTools } from "../addie/claude-client.js";
+import { AddieClaudeClient, type AddieResponse, type RequestTools } from "../addie/claude-client.js";
 import { sanitizeSpeakerName } from "../addie/prompts.js";
 import { resolveUserTierFromDb } from "../addie/claude-cost-tracker.js";
 import {
@@ -731,6 +731,7 @@ export function createTavusRouter() {
     }
 
     let streamError = false;
+    let terminalResponse: AddieResponse | undefined;
     try {
       // Cost cap (#2790 / #2945 f/u): voice sessions carry a
       // thread.user_id resolved from session-init auth. When that
@@ -773,6 +774,8 @@ export function createTavusRouter() {
           logger.error({ error: event.error }, "Tavus: Addie stream error");
           streamError = true;
           break;
+        } else if (event.type === "done") {
+          terminalResponse = event.response;
         }
       }
     } catch (err) {
@@ -781,13 +784,14 @@ export function createTavusRouter() {
     }
 
     // Log the assistant response
-    if (threadId && fullResponse) {
+    if (threadId && terminalResponse && !streamError) {
       const threadService = getThreadService();
       threadService.addMessage({
         thread_id: threadId,
         role: "assistant",
-        content: fullResponse,
+        content: terminalResponse.text,
         model: AddieModelConfig.voice,
+        model_execution: terminalResponse.model_execution,
         latency_ms: Date.now() - startTime,
       }).catch((err) => logger.error({ err }, "Tavus: Failed to log assistant message"));
     }

--- a/server/tests/integration/addie-learning.test.ts
+++ b/server/tests/integration/addie-learning.test.ts
@@ -35,8 +35,8 @@ describe('Addie Learning System Integration Tests', () => {
           id, event_type, channel_id, user_id,
           input_text, input_sanitized, output_text,
           tools_used, model, latency_ms, flagged,
-          active_rules_snapshot
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+          active_rules_snapshot, model_execution_source, local_response_reason
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
         [
           testInteractionId,
           'mention',
@@ -50,6 +50,8 @@ describe('Addie Learning System Integration Tests', () => {
           100,
           false,
           JSON.stringify({ rule_ids: [] }),
+          'local',
+          'canned_response',
         ]
       );
     });

--- a/server/tests/integration/thread-service.test.ts
+++ b/server/tests/integration/thread-service.test.ts
@@ -10,6 +10,7 @@ import {
   type CreateMessageInput,
   type ThreadListFilters,
 } from '../../src/addie/thread-service.js';
+import { AddieDatabase } from '../../src/db/addie-db.js';
 
 // These tests require a running PostgreSQL instance. Lives in integration/
 // so the build-check.yml server-integration job picks them up; the skipIf
@@ -21,6 +22,12 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
   let threadService: ThreadService;
   const TEST_THREAD_EXTERNAL_ID = 'test-channel:test-thread-ts';
   const TEST_WEB_EXTERNAL_ID = 'test-web-conversation-uuid';
+  const TEST_LOCAL_MODEL_EXECUTION = {
+    source: 'local' as const,
+    requested_provider: null,
+    requested_model: null,
+    reason: 'canned_response' as const,
+  };
 
   beforeAll(async () => {
     // Initialize test database
@@ -37,12 +44,14 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
 
   afterAll(async () => {
     // Clean up test data
+    await pool.query("DELETE FROM addie_interactions WHERE id LIKE 'provider-provenance-%'");
     await pool.query(`DELETE FROM addie_threads WHERE external_id LIKE 'test-%'`);
     await closeDatabase();
   });
 
   beforeEach(async () => {
     // Clean up threads before each test
+    await pool.query("DELETE FROM addie_interactions WHERE id LIKE 'provider-provenance-%'");
     await pool.query(`DELETE FROM addie_threads WHERE external_id LIKE 'test-%'`);
   });
 
@@ -176,6 +185,7 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
         thread_id: thread.thread_id,
         role: 'assistant',
         content: 'Second message',
+        model_execution: TEST_LOCAL_MODEL_EXECUTION,
       });
 
       const msg3 = await threadService.addMessage({
@@ -211,12 +221,333 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
           { name: 'search_knowledge', input: { query: 'something' }, result: { found: true } },
         ],
         model: 'claude-sonnet-4-20250514',
+        model_execution: {
+          source: 'provider',
+          requested_provider: 'anthropic',
+          requested_model: 'claude-sonnet-4-20250514',
+          provider: 'openai',
+          model: 'm'.repeat(256),
+          model_resolution: 'fallback',
+          fallback_reason: 'primary_unavailable',
+        },
         latency_ms: 500,
       });
 
       expect(assistantMsg.tools_used).toContain('search_knowledge');
       expect(assistantMsg.model).toBe('claude-sonnet-4-20250514');
+      expect(assistantMsg.model_execution_source).toBe('provider');
+      expect(assistantMsg.requested_model_provider).toBe('anthropic');
+      expect(assistantMsg.requested_model).toBe('claude-sonnet-4-20250514');
+      expect(assistantMsg.model_provider).toBe('openai');
+      expect(assistantMsg.provider_model).toBe('m'.repeat(256));
+      expect(assistantMsg.provider_model_resolution).toBe('fallback');
+      expect(assistantMsg.provider_fallback_reason).toBe('primary_unavailable');
       expect(assistantMsg.latency_ms).toBe(500);
+    });
+
+    it('should distinguish local responses from provider responses', async () => {
+      const thread = await threadService.getOrCreateThread({
+        channel: 'web',
+        external_id: `${TEST_THREAD_EXTERNAL_ID}-local-response`,
+        user_type: 'anonymous',
+      });
+
+      const message = await threadService.addMessage({
+        thread_id: thread.thread_id,
+        role: 'assistant',
+        content: 'Please try again later.',
+        model: 'claude-sonnet-5',
+        model_execution: {
+          source: 'local',
+          requested_provider: 'anthropic',
+          requested_model: 'claude-sonnet-5',
+          reason: 'provider_error',
+        },
+      });
+
+      expect(message.model_execution_source).toBe('local');
+      expect(message.requested_model_provider).toBe('anthropic');
+      expect(message.requested_model).toBe('claude-sonnet-5');
+      expect(message.model_provider).toBeNull();
+      expect(message.provider_model).toBeNull();
+      expect(message.provider_fallback_reason).toBeNull();
+      expect(message.local_response_reason).toBe('provider_error');
+    });
+
+    it('requires explicit resolution metadata for same-provider model fallback', async () => {
+      const thread = await threadService.getOrCreateThread({
+        channel: 'web',
+        external_id: `${TEST_THREAD_EXTERNAL_ID}-same-provider-fallback`,
+        user_type: 'anonymous',
+      });
+
+      const message = await threadService.addMessage({
+        thread_id: thread.thread_id,
+        role: 'assistant',
+        content: 'Fallback completed.',
+        model_execution: {
+          source: 'provider',
+          requested_provider: 'anthropic',
+          requested_model: 'claude-primary',
+          provider: 'anthropic',
+          model: 'claude-fallback',
+          model_resolution: 'fallback',
+          fallback_reason: 'primary_unavailable',
+        },
+      });
+      expect(message.provider_model_resolution).toBe('fallback');
+
+      await expect(pool.query(
+        `INSERT INTO addie_thread_messages (
+           thread_id, role, content, sequence_number, model_execution_source,
+           requested_model_provider, requested_model, model_provider, provider_model,
+           provider_model_resolution
+         ) VALUES (
+           $1, 'assistant', 'invalid fallback', 2, 'provider',
+           'anthropic', 'claude-primary', 'anthropic', 'claude-fallback', 'fallback'
+         )`,
+        [thread.thread_id],
+      )).rejects.toThrow();
+    });
+
+    it('rejects partial provider provenance while allowing rolling-deploy writes', async () => {
+      const thread = await threadService.getOrCreateThread({
+        channel: 'web',
+        external_id: `${TEST_THREAD_EXTERNAL_ID}-partial-provider`,
+        user_type: 'anonymous',
+      });
+
+      await expect(pool.query(
+        `INSERT INTO addie_thread_messages (
+           thread_id, role, content, sequence_number,
+           model_execution_source, requested_model_provider
+         ) VALUES ($1, 'assistant', 'invalid', 1, 'provider', 'anthropic')`,
+        [thread.thread_id],
+      )).rejects.toThrow();
+
+      const rollingDeployWrite = await pool.query<{ model_execution_source: string | null }>(
+        `INSERT INTO addie_thread_messages (
+           thread_id, role, content, sequence_number
+         ) VALUES ($1, 'assistant', 'rolling deploy', 2)
+         RETURNING model_execution_source`,
+        [thread.thread_id],
+      );
+      expect(rollingDeployWrite.rows[0]?.model_execution_source).toBeNull();
+    });
+
+    it('enforces atomic provenance without validating legacy table contents', async () => {
+      const constraintNames = [
+        'addie_thread_messages_provider_values',
+        'addie_thread_messages_execution_source_values',
+        'addie_thread_messages_execution_assistant_only',
+        'addie_thread_messages_provider_model_nonempty',
+        'addie_thread_messages_provider_fallback_reason_values',
+        'addie_thread_messages_provider_model_resolution_values',
+        'addie_thread_messages_local_response_reason_values',
+        'addie_thread_messages_provider_execution_atomic',
+        'addie_thread_messages_provider_fallback_consistent',
+        'addie_interactions_provider_values',
+        'addie_interactions_execution_source_values',
+        'addie_interactions_provider_model_nonempty',
+        'addie_interactions_provider_fallback_reason_values',
+        'addie_interactions_provider_model_resolution_values',
+        'addie_interactions_local_response_reason_values',
+        'addie_interactions_provider_execution_atomic',
+        'addie_interactions_provider_fallback_consistent',
+      ];
+      const result = await pool.query<{ conname: string; convalidated: boolean }>(
+        `SELECT conname, convalidated
+         FROM pg_constraint
+         WHERE conname = ANY($1::text[])
+         ORDER BY conname`,
+        [constraintNames],
+      );
+
+      expect(result.rows).toHaveLength(constraintNames.length);
+      expect(result.rows.every((row) => row.convalidated === false)).toBe(true);
+    });
+
+    it('lazily classifies historical rows when feedback and review paths update them', async () => {
+      const thread = await threadService.getOrCreateThread({
+        channel: 'web',
+        external_id: `${TEST_THREAD_EXTERNAL_ID}-legacy-feedback`,
+        user_type: 'anonymous',
+      });
+
+      const messages = await pool.query<{ message_id: string }>(
+        `INSERT INTO addie_thread_messages (thread_id, role, content, sequence_number)
+         VALUES
+           ($1, 'assistant', 'legacy feedback', 1),
+           ($1, 'assistant', 'legacy flag', 2),
+           ($1, 'assistant', 'legacy outcome', 3)
+         RETURNING message_id`,
+        [thread.thread_id],
+      );
+      const messageIds = messages.rows.map((row) => row.message_id);
+      await pool.query(
+        `INSERT INTO addie_interactions (
+           id, event_type, channel_id, user_id, input_text, input_sanitized,
+           output_text, model, latency_ms
+         ) VALUES
+           ('provider-provenance-legacy-review', 'dm', 'D_TEST', 'legacy-user', 'q', 'q', 'a', 'legacy', 1),
+           ('provider-provenance-legacy-rating', 'dm', 'D_TEST', 'legacy-user', 'q', 'q', 'a', 'legacy', 1)`,
+      );
+
+      await threadService.addMessageFeedback(thread.thread_id, messageIds[0], {
+        rating: 5,
+        rated_by: 'legacy-reviewer',
+        rating_source: 'admin',
+      });
+      await threadService.flagMessage(messageIds[1], 'legacy flag');
+      await threadService.setMessageOutcome(messageIds[2], 'resolved');
+
+      const addieDb = new AddieDatabase();
+      await addieDb.markInteractionReviewed('provider-provenance-legacy-review', 'legacy-reviewer');
+      await addieDb.rateInteraction('provider-provenance-legacy-rating', 4, 'legacy-reviewer');
+
+      const messageSources = await pool.query<{ model_execution_source: string | null }>(
+        `SELECT model_execution_source
+         FROM addie_thread_messages
+         WHERE message_id = ANY($1::uuid[])`,
+        [messageIds],
+      );
+      const interactionSources = await pool.query<{ model_execution_source: string | null }>(
+        `SELECT model_execution_source
+         FROM addie_interactions
+         WHERE id IN ('provider-provenance-legacy-review', 'provider-provenance-legacy-rating')`,
+      );
+
+      expect(messageSources.rows).toHaveLength(3);
+      expect(messageSources.rows.every((row) => row.model_execution_source === 'legacy')).toBe(true);
+      expect(interactionSources.rows).toHaveLength(2);
+      expect(interactionSources.rows.every((row) => row.model_execution_source === 'legacy')).toBe(true);
+    });
+
+    it('round-trips provider and local provenance through the legacy interaction audit', async () => {
+      const addieDb = new AddieDatabase();
+      const userId = 'provider-provenance-user';
+      await pool.query("DELETE FROM addie_interactions WHERE id LIKE 'provider-provenance-%'");
+
+      await addieDb.logInteraction({
+        id: 'provider-provenance-provider',
+        timestamp: new Date(),
+        event_type: 'dm',
+        channel_id: 'D_TEST',
+        user_id: userId,
+        input_text: 'question',
+        input_sanitized: 'question',
+        output_text: 'answer',
+        tools_used: [],
+        model: 'claude-sonnet-5',
+        model_execution: {
+          source: 'provider',
+          requested_provider: 'anthropic',
+          requested_model: 'claude-sonnet-5',
+          provider: 'openai',
+          model: 'p'.repeat(256),
+          model_resolution: 'fallback',
+          fallback_reason: 'primary_unavailable',
+        },
+        latency_ms: 10,
+        flagged: false,
+      });
+      await addieDb.logInteraction({
+        id: 'provider-provenance-local',
+        timestamp: new Date(),
+        event_type: 'dm',
+        channel_id: 'D_TEST',
+        user_id: userId,
+        input_text: 'question',
+        input_sanitized: 'question',
+        output_text: 'try again',
+        tools_used: [],
+        model: 'claude-sonnet-5',
+        model_execution: {
+          source: 'local',
+          requested_provider: 'anthropic',
+          requested_model: 'claude-sonnet-5',
+          reason: 'provider_error',
+        },
+        latency_ms: 5,
+        flagged: true,
+      });
+      await addieDb.logInteraction({
+        id: 'provider-provenance-model-fallback',
+        timestamp: new Date(),
+        event_type: 'dm',
+        channel_id: 'D_TEST',
+        user_id: userId,
+        input_text: 'question',
+        input_sanitized: 'question',
+        output_text: 'fallback answer',
+        tools_used: [],
+        model: 'claude-primary',
+        model_execution: {
+          source: 'provider',
+          requested_provider: 'anthropic',
+          requested_model: 'claude-primary',
+          provider: 'anthropic',
+          model: 'claude-fallback',
+          model_resolution: 'fallback',
+          fallback_reason: 'primary_unavailable',
+        },
+        latency_ms: 7,
+        flagged: false,
+      });
+
+      const interactions = await addieDb.getInteractions({ userId });
+      expect(interactions.find((row) => row.id === 'provider-provenance-provider')?.model_execution).toEqual({
+        source: 'provider',
+        requested_provider: 'anthropic',
+        requested_model: 'claude-sonnet-5',
+        provider: 'openai',
+        model: 'p'.repeat(256),
+        model_resolution: 'fallback',
+        fallback_reason: 'primary_unavailable',
+      });
+      expect(interactions.find((row) => row.id === 'provider-provenance-local')?.model_execution).toEqual({
+        source: 'local',
+        requested_provider: 'anthropic',
+        requested_model: 'claude-sonnet-5',
+        reason: 'provider_error',
+      });
+      expect(interactions.find((row) => row.id === 'provider-provenance-model-fallback')?.model_execution).toEqual({
+        source: 'provider',
+        requested_provider: 'anthropic',
+        requested_model: 'claude-primary',
+        provider: 'anthropic',
+        model: 'claude-fallback',
+        model_resolution: 'fallback',
+        fallback_reason: 'primary_unavailable',
+      });
+
+      await expect(pool.query(
+        `INSERT INTO addie_interactions (
+           id, event_type, channel_id, user_id, input_text, input_sanitized,
+           output_text, model, latency_ms, model_execution_source,
+           requested_model_provider, requested_model, model_provider, provider_model,
+           provider_model_resolution
+         ) VALUES (
+           'provider-provenance-invalid-fallback', 'dm', 'D_TEST', $1, 'q', 'q',
+           'a', 'claude-primary', 1, 'provider',
+           'anthropic', 'claude-primary', 'anthropic', 'claude-fallback', 'fallback'
+         )`,
+        [userId],
+      )).rejects.toThrow();
+
+      await expect(pool.query(
+        `INSERT INTO addie_interactions (
+           id, event_type, channel_id, user_id, input_text, input_sanitized,
+           output_text, model, latency_ms, model_execution_source,
+           requested_model_provider, requested_model, model_provider, provider_model,
+           provider_model_resolution, provider_fallback_reason
+         ) VALUES (
+           'provider-provenance-too-long', 'dm', 'D_TEST', $1, 'q', 'q',
+           'a', 'claude-sonnet-5', 1, 'provider', 'anthropic', 'claude-sonnet-5', 'anthropic', $2,
+           'fallback', 'primary_unavailable'
+         )`,
+        [userId, 'x'.repeat(257)],
+      )).rejects.toThrow();
     });
 
     it('should handle flagged messages', async () => {
@@ -248,7 +579,12 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
       });
 
       await threadService.addMessage({ thread_id: thread.thread_id, role: 'user', content: 'First' });
-      await threadService.addMessage({ thread_id: thread.thread_id, role: 'assistant', content: 'Second' });
+      await threadService.addMessage({
+        thread_id: thread.thread_id,
+        role: 'assistant',
+        content: 'Second',
+        model_execution: TEST_LOCAL_MODEL_EXECUTION,
+      });
       await threadService.addMessage({ thread_id: thread.thread_id, role: 'user', content: 'Third' });
 
       const messages = await threadService.getThreadMessages(thread.thread_id);
@@ -266,11 +602,15 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
         user_type: 'workos',
       });
       for (let index = 1; index <= 5; index += 1) {
-        await threadService.addMessage({
-          thread_id: thread.thread_id,
-          role: index % 2 ? 'user' : 'assistant',
-          content: `page-${index}`,
-        });
+        const input: CreateMessageInput = index % 2
+          ? { thread_id: thread.thread_id, role: 'user', content: `page-${index}` }
+          : {
+              thread_id: thread.thread_id,
+              role: 'assistant',
+              content: `page-${index}`,
+              model_execution: TEST_LOCAL_MODEL_EXECUTION,
+            };
+        await threadService.addMessage(input);
       }
 
       expect((await threadService.getThreadMessages(thread.thread_id, { limit: 2 })).map(m => m.content))
@@ -295,6 +635,7 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
         thread_id: thread.thread_id,
         role: 'assistant',
         content: 'Answer',
+        model_execution: TEST_LOCAL_MODEL_EXECUTION,
       });
 
       await threadService.addMessageFeedback(thread.thread_id, assistantMsg.message_id, {
@@ -330,6 +671,7 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
         thread_id: ownerThread.thread_id,
         role: 'assistant',
         content: 'Private answer',
+        model_execution: TEST_LOCAL_MODEL_EXECUTION,
       });
 
       const updated = await threadService.addMessageFeedback(
@@ -570,7 +912,10 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
       });
 
       await threadService.addMessage({ thread_id: thread.thread_id, role: 'user', content: 'Test' });
-      await threadService.addMessage({ thread_id: thread.thread_id, role: 'assistant', content: 'Response' });
+      await threadService.addMessage({
+        thread_id: thread.thread_id, role: 'assistant', content: 'Response',
+        model_execution: TEST_LOCAL_MODEL_EXECUTION,
+      });
 
       const stats = await threadService.getStats();
 
@@ -633,7 +978,10 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
       });
 
       await threadService.addMessage({ thread_id: thread.thread_id, role: 'user', content: 'Hello' });
-      await threadService.addMessage({ thread_id: thread.thread_id, role: 'assistant', content: 'Hi!' });
+      await threadService.addMessage({
+        thread_id: thread.thread_id, role: 'assistant', content: 'Hi!',
+        model_execution: TEST_LOCAL_MODEL_EXECUTION,
+      });
 
       const threadWithMessages = await threadService.getThreadWithMessages(thread.thread_id);
 
@@ -662,6 +1010,7 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
         thread_id: thread.thread_id,
         role: 'assistant',
         content: 'Answer',
+        model_execution: TEST_LOCAL_MODEL_EXECUTION,
       });
 
       await threadService.setMessageOutcome(
@@ -749,7 +1098,10 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
         user_id: 'U_STATS_1',
       });
       await threadService.addMessage({ thread_id: thread1.thread_id, role: 'user', content: 'Test 1' });
-      await threadService.addMessage({ thread_id: thread1.thread_id, role: 'assistant', content: 'Response 1' });
+      await threadService.addMessage({
+        thread_id: thread1.thread_id, role: 'assistant', content: 'Response 1',
+        model_execution: TEST_LOCAL_MODEL_EXECUTION,
+      });
 
       const thread2 = await threadService.getOrCreateThread({
         channel: 'web',

--- a/server/tests/integration/threads-api.test.ts
+++ b/server/tests/integration/threads-api.test.ts
@@ -78,10 +78,13 @@ describe('Threads API Integration Tests', () => {
 
     // Add messages to the thread
     const msgResult = await pool.query(`
-      INSERT INTO addie_thread_messages (thread_id, role, content, sequence_number)
+      INSERT INTO addie_thread_messages (
+        thread_id, role, content, sequence_number,
+        model_execution_source, local_response_reason
+      )
       VALUES
-        ($1, 'user', 'Hello!', 1),
-        ($1, 'assistant', 'Hi! How can I help?', 2)
+        ($1, 'user', 'Hello!', 1, NULL, NULL),
+        ($1, 'assistant', 'Hi! How can I help?', 2, 'local', 'canned_response')
       RETURNING message_id
     `, [testThreadId]);
     testMessageId = msgResult.rows[1].message_id; // Get the assistant message ID
@@ -383,10 +386,13 @@ describe('Threads API Integration Tests', () => {
       const threadId = threadResult.rows[0].thread_id;
 
       await pool.query(`
-        INSERT INTO addie_thread_messages (thread_id, role, content, sequence_number)
+        INSERT INTO addie_thread_messages (
+          thread_id, role, content, sequence_number,
+          model_execution_source, local_response_reason
+        )
         VALUES
-          ($1, 'user', 'Web question', 1),
-          ($1, 'assistant', 'Web answer', 2)
+          ($1, 'user', 'Web question', 1, NULL, NULL),
+          ($1, 'assistant', 'Web answer', 2, 'local', 'canned_response')
       `, [threadId]);
     });
 

--- a/server/tests/simulation/engine/engine.ts
+++ b/server/tests/simulation/engine/engine.ts
@@ -120,7 +120,7 @@ export class SimulationEngine {
       );
       const threadId = threadResult.rows[0].thread_id;
 
-      for (const msg of profile.messageHistory) {
+      for (const [index, msg] of profile.messageHistory.entries()) {
         const msgTime = new Date(
           this.clock.nowMs() +
           (msg.relativeTime.days ?? 0) * 86400000 +
@@ -128,9 +128,19 @@ export class SimulationEngine {
         );
 
         await this.pool.query(
-          `INSERT INTO addie_thread_messages (thread_id, role, content, created_at)
-           VALUES ($1, $2, $3, $4)`,
-          [threadId, msg.role, msg.content, msgTime]
+          `INSERT INTO addie_thread_messages (
+             thread_id, role, content, created_at, sequence_number,
+             model_execution_source, local_response_reason
+           ) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+          [
+            threadId,
+            msg.role,
+            msg.content,
+            msgTime,
+            index + 1,
+            msg.role === 'assistant' ? 'local' : null,
+            msg.role === 'assistant' ? 'canned_response' : null,
+          ]
         );
       }
     }

--- a/server/tests/unit/addie-empty-response-fallback.test.ts
+++ b/server/tests/unit/addie-empty-response-fallback.test.ts
@@ -44,6 +44,7 @@ import {
 } from '../../src/addie/claude-client.js';
 
 const emptyEndTurn = {
+  model: 'claude-sonnet-4-6-20260801',
   stop_reason: 'end_turn',
   content: [],
   usage: {
@@ -53,6 +54,7 @@ const emptyEndTurn = {
 };
 
 const toolUseTurn = {
+  model: 'claude-sonnet-4-6-20260801',
   stop_reason: 'tool_use',
   content: [{
     type: 'tool_use',
@@ -64,9 +66,25 @@ const toolUseTurn = {
 };
 
 const recoveredEndTurn = {
+  model: 'claude-sonnet-5-20260801',
   stop_reason: 'end_turn',
   content: [{ type: 'text', text: 'Issue 42 is open.' }],
   usage: { input_tokens: 12, output_tokens: 6 },
+};
+
+const personaOnlyEndTurn = {
+  model: 'claude-sonnet-5-20260801',
+  stop_reason: 'end_turn',
+  content: [{
+    type: 'text',
+    text: "I'm Claude, an AI assistant made by Anthropic. As a large language model, I have no real-world identity.",
+  }],
+  usage: { input_tokens: 12, output_tokens: 20 },
+};
+
+const emptyToolUseTurn = {
+  ...emptyEndTurn,
+  stop_reason: 'tool_use',
 };
 
 const emptyRefusal = {
@@ -118,7 +136,7 @@ function makeThrowingStream(error: Error) {
   };
 }
 
-function makeStream(message: typeof toolUseTurn | typeof emptyEndTurn | typeof recoveredEndTurn | typeof mixedRecoveryToolUseTurn | typeof emptyRefusal) {
+function makeStream(message: typeof toolUseTurn | typeof emptyEndTurn | typeof recoveredEndTurn | typeof personaOnlyEndTurn | typeof mixedRecoveryToolUseTurn | typeof emptyRefusal) {
   return {
     async *[Symbol.asyncIterator]() {
       for (const block of message.content) {
@@ -167,6 +185,12 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
     expect(response.flagged).toBe(true);
     expect(response.flag_reason).toContain('Empty turn');
+    expect(response.model_execution).toEqual({
+      source: 'local',
+      requested_provider: 'anthropic',
+      requested_model: 'claude-sonnet-4-6',
+      reason: 'no_provider_response',
+    });
     expect(mocks.createMessage).toHaveBeenCalledTimes(2);
     expect(mocks.createMessage.mock.calls[0][0]).toMatchObject({ max_tokens: 8_192 });
     expect(mocks.createMessage.mock.calls[0][0]).not.toHaveProperty('output_config');
@@ -198,11 +222,116 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(done?.response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
     expect(done?.response.flagged).toBe(true);
     expect(done?.response.flag_reason).toContain('Empty turn');
+    expect(done?.response.model_execution).toEqual({
+      source: 'local',
+      requested_provider: 'anthropic',
+      requested_model: 'claude-sonnet-4-6',
+      reason: 'no_provider_response',
+    });
     expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
     expect(mocks.notifySystemError).toHaveBeenCalledWith(expect.objectContaining({
       source: 'addie-empty-response',
       errorMessage: expect.stringContaining('processMessageStream'),
     }));
+  });
+
+  it('classifies persona-only provider output as a local fallback in both paths', async () => {
+    mocks.createMessage.mockResolvedValueOnce(personaOnlyEndTurn);
+    mocks.streamMessage.mockReturnValueOnce(makeStream(personaOnlyEndTurn));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+
+    const response = await client.processMessage(
+      'who are you?',
+      undefined,
+      undefined,
+      undefined,
+      { uncapped: true, threadId: 'thread-persona-only' },
+    );
+    expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(response.flag_reason).toContain('persona-collapse');
+    expect(response.model_execution).toEqual({
+      source: 'local',
+      requested_provider: 'anthropic',
+      requested_model: 'claude-sonnet-5',
+      reason: 'no_provider_response',
+    });
+
+    const events: StreamEvent[] = [];
+    for await (const event of client.processMessageStream(
+      'who are you?',
+      undefined,
+      undefined,
+      { uncapped: true, threadId: 'thread-stream-persona-only' },
+    )) {
+      events.push(event);
+    }
+    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    expect(done?.response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(done?.response.flag_reason).toContain('persona-collapse');
+    expect(done?.response.model_execution).toEqual({
+      source: 'local',
+      requested_provider: 'anthropic',
+      requested_model: 'claude-sonnet-5',
+      reason: 'no_provider_response',
+    });
+  });
+
+  it('classifies malformed empty tool-use responses as local in both paths', async () => {
+    mocks.createMessage.mockResolvedValueOnce(emptyToolUseTurn);
+    mocks.streamMessage.mockReturnValueOnce(makeStream(emptyToolUseTurn));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+
+    const response = await client.processMessage(
+      'hello', undefined, undefined, undefined, { uncapped: true },
+    );
+    const streamEvents: StreamEvent[] = [];
+    for await (const event of client.processMessageStream(
+      'hello', undefined, undefined, { uncapped: true },
+    )) streamEvents.push(event);
+    const done = streamEvents.find(
+      (event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done',
+    );
+
+    expect(response.model_execution).toEqual({
+      source: 'local', requested_provider: 'anthropic', requested_model: 'claude-sonnet-4-6', reason: 'no_provider_response',
+    });
+    expect(done?.response.model_execution).toEqual({
+      source: 'local', requested_provider: 'anthropic', requested_model: 'claude-sonnet-4-6', reason: 'no_provider_response',
+    });
+  });
+
+  it('classifies the non-streaming max-iteration apology as local', async () => {
+    mocks.createMessage.mockResolvedValueOnce(toolUseTurn);
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const response = await client.processMessage(
+      'hello',
+      undefined,
+      githubIssueTools,
+      undefined,
+      { uncapped: true, maxIterations: 1 },
+    );
+
+    expect(response.flag_reason).toBe('Max tool iterations reached');
+    expect(response.model_execution).toEqual({
+      source: 'local', requested_provider: 'anthropic', requested_model: 'claude-sonnet-4-6', reason: 'canned_response',
+    });
+  });
+
+  it('classifies the streaming max-iteration apology as local', async () => {
+    mocks.streamMessage.mockReturnValueOnce(makeStream(toolUseTurn));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const events: StreamEvent[] = [];
+    for await (const event of client.processMessageStream(
+      'hello', undefined, githubIssueTools, { uncapped: true, maxIterations: 1 },
+    )) events.push(event);
+    const done = events.find(
+      (event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done',
+    );
+
+    expect(done?.response.flag_reason).toBe('Max tool iterations reached');
+    expect(done?.response.model_execution).toEqual({
+      source: 'local', requested_provider: 'anthropic', requested_model: 'claude-sonnet-4-6', reason: 'canned_response',
+    });
   });
 
   it('recovers once from a wholly empty initial non-streaming response', async () => {
@@ -222,6 +351,15 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(response.text).toBe('Issue 42 is open.');
     expect(response.timing?.iterations).toBe(2);
     expect(response.usage).toMatchObject({ input_tokens: 22, output_tokens: 6 });
+    expect(response.model_execution).toEqual({
+      source: 'provider',
+      requested_provider: 'anthropic',
+      requested_model: 'claude-sonnet-5',
+      provider: 'anthropic',
+      model: 'claude-sonnet-5-20260801',
+      model_resolution: 'provider_canonicalized',
+      fallback_reason: null,
+    });
     expect(mocks.createMessage).toHaveBeenCalledTimes(2);
     expect(mocks.createMessage.mock.calls[0][0]).toMatchObject({
       max_tokens: 16_384,

--- a/server/tests/unit/addie-response-truncation.test.ts
+++ b/server/tests/unit/addie-response-truncation.test.ts
@@ -50,6 +50,7 @@ import {
 
 type TruncationStopReason = 'max_tokens' | 'model_context_window_exceeded';
 interface MockMessage {
+  model: string;
   stop_reason: string;
   content: Array<{ type: string; text?: string; [key: string]: unknown }>;
   usage: { input_tokens: number; output_tokens: number };
@@ -64,6 +65,7 @@ function message(
   usage = { input_tokens: 10, output_tokens: 20 },
 ): MockMessage {
   return {
+    model: 'claude-sonnet-4-6-20260801',
     stop_reason: stopReason,
     content: text ? [{ type: 'text', text }] : [],
     usage,
@@ -164,6 +166,15 @@ describe('Addie response truncation (#4431)', () => {
 
     expect(response.text).toBe(expectedTruncation);
     expect(response.flag_reason).toBe(`Response truncated: ${stopReason}`);
+    expect(response.model_execution).toEqual({
+      source: 'provider',
+      requested_provider: 'anthropic',
+      requested_model: 'claude-sonnet-4-6',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6-20260801',
+      model_resolution: 'provider_canonicalized',
+      fallback_reason: null,
+    });
     expect(mocks.createMessage).toHaveBeenCalledOnce();
   });
 
@@ -198,6 +209,15 @@ describe('Addie response truncation (#4431)', () => {
     expect(emittedText).toBe(expectedTruncation);
     expect(done?.response.text).toBe(emittedText);
     expect(done?.response.flag_reason).toBe(`Response truncated: ${stopReason}`);
+    expect(done?.response.model_execution).toEqual({
+      source: 'provider',
+      requested_provider: 'anthropic',
+      requested_model: 'claude-sonnet-4-6',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6-20260801',
+      model_resolution: 'provider_canonicalized',
+      fallback_reason: null,
+    });
     expect(mocks.streamMessage).toHaveBeenCalledOnce();
   });
 

--- a/server/tests/unit/addie/model-provider-anthropic.test.ts
+++ b/server/tests/unit/addie/model-provider-anthropic.test.ts
@@ -13,6 +13,7 @@ import {
   validateNormalizedModelResponse,
 } from '../../../src/addie/model-providers/events.js';
 import {
+  classifyLocalModelExecution,
   UnsupportedModelCapabilityError,
   type ModelProviderCapabilities,
   type ModelRequest,
@@ -20,6 +21,15 @@ import {
   type NormalizedModelEvent,
 } from '../../../src/addie/model-providers/model-provider.js';
 import { AddieClaudeClient } from '../../../src/addie/claude-client.js';
+
+describe('model execution selection integrity', () => {
+  it('rejects a partially populated requested provider/model tuple', () => {
+    expect(() => classifyLocalModelExecution(
+      { requested_provider: 'openai', requested_model: null } as never,
+      'provider_error',
+    )).toThrow('Requested provider and model must be supplied together');
+  });
+});
 
 function request(overrides: Partial<ModelRequest> = {}): ModelRequest {
   return {

--- a/server/tests/unit/addie/shadow-replay.test.ts
+++ b/server/tests/unit/addie/shadow-replay.test.ts
@@ -46,6 +46,15 @@ function response(toolNames: string[]): AddieResponse {
     tools_used: toolNames,
     tool_executions: [],
     flagged: false,
+    model_execution: {
+      source: 'provider',
+      requested_provider: 'anthropic',
+      requested_model: 'claude-example-chat',
+      provider: 'anthropic',
+      model: 'claude-example-chat',
+      model_resolution: 'exact',
+      fallback_reason: null,
+    },
   };
 }
 
@@ -348,6 +357,15 @@ function generatedResponse(overrides: Partial<AddieResponse> = {}): AddieRespons
     tools_used: [],
     tool_executions: [],
     flagged: false,
+    model_execution: {
+      source: 'provider',
+      requested_provider: 'anthropic',
+      requested_model: 'claude-example-chat',
+      provider: 'anthropic',
+      model: 'claude-example-chat',
+      model_resolution: 'exact',
+      fallback_reason: null,
+    },
     usage: { input_tokens: 123, output_tokens: 45 },
     ...overrides,
   };

--- a/server/tests/unit/addie/slack-blocks.test.ts
+++ b/server/tests/unit/addie/slack-blocks.test.ts
@@ -6,6 +6,7 @@ import {
   planStreamStopFailureFallback,
   resolveStreamTurnCompletion,
   summarizeSlackStreamError,
+  STREAM_COMPLETION_MISSING_NOTICE,
   STREAM_DELIVERY_UNCERTAIN_NOTICE,
   SLACK_SECTION_MRKDWN_LIMIT,
   SLACK_SECTION_HARD_LIMIT,
@@ -275,6 +276,26 @@ describe('resolveStreamTurnCompletion', () => {
       kind: 'persist', response: { text: 'fallback' }, source: 'fallback',
     });
     expect(createFallback).toHaveBeenCalledOnce();
+  });
+
+  it('does not persist unverified provider text when the done receipt is missing', () => {
+    const partialProviderText = 'SENTINEL partial provider response';
+    const completion = resolveStreamTurnCompletion(false, undefined, () => ({
+      text: STREAM_COMPLETION_MISSING_NOTICE,
+      model_execution: {
+        source: 'local' as const,
+        requested_provider: 'anthropic' as const,
+        requested_model: 'claude-sonnet-5',
+        reason: 'no_provider_response' as const,
+      },
+    }));
+
+    expect(completion).toMatchObject({
+      kind: 'persist',
+      source: 'fallback',
+      response: { text: STREAM_COMPLETION_MISSING_NOTICE },
+    });
+    expect(JSON.stringify(completion)).not.toContain(partialProviderText);
   });
 
   it('never persists a response after an interruption', () => {

--- a/server/tests/unit/claude-client-cost-gate.test.ts
+++ b/server/tests/unit/claude-client-cost-gate.test.ts
@@ -5,7 +5,7 @@ import {
   __setCostTrackerStore,
   __createInMemoryCostStore,
 } from '../../src/addie/claude-cost-tracker.js';
-import { AddieClaudeClient } from '../../src/addie/claude-client.js';
+import { AddieClaudeClient, type AddieResponse } from '../../src/addie/claude-client.js';
 
 /**
  * End-to-end gate test (#2790). When a user has exhausted their
@@ -63,6 +63,12 @@ describe('claude-client entry-gate behavior (#2790)', () => {
     expect(response.text).toMatch(/conversation limit/);
     // No token usage because no Claude call fired.
     expect(response.usage).toBeUndefined();
+    expect(response.model_execution).toEqual({
+      source: 'local',
+      requested_provider: 'anthropic',
+      requested_model: 'claude-sonnet-4-6',
+      reason: 'cost_cap_exceeded',
+    });
     expect(anthropicCall).not.toHaveBeenCalled();
   });
 
@@ -71,14 +77,14 @@ describe('claude-client entry-gate behavior (#2790)', () => {
     await recordCost('user-y', 'claude-opus-5', { input_tokens: tokensToExceedCap, output_tokens: 0 });
 
     const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
-    const events: Array<{ type: string; response?: { flagged: boolean; flag_reason?: string } }> = [];
+    const events: Array<{ type: string; response?: AddieResponse }> = [];
     for await (const event of client.processMessageStream(
       'hello',
       undefined,
       undefined,
       { costScope: { userId: 'user-y', tier: 'anonymous' } },
     )) {
-      events.push(event as { type: string; response?: { flagged: boolean; flag_reason?: string } });
+      events.push(event as { type: string; response?: AddieResponse });
     }
 
     // A single `done` event carrying the cap-exceeded flag.
@@ -86,6 +92,12 @@ describe('claude-client entry-gate behavior (#2790)', () => {
     expect(events[0].type).toBe('done');
     expect(events[0].response?.flagged).toBe(true);
     expect(events[0].response?.flag_reason).toBe('cost_cap_exceeded');
+    expect(events[0].response?.model_execution).toEqual({
+      source: 'local',
+      requested_provider: 'anthropic',
+      requested_model: 'claude-sonnet-4-6',
+      reason: 'cost_cap_exceeded',
+    });
     expect(anthropicCall).not.toHaveBeenCalled();
   });
 

--- a/server/tests/unit/direct-message-delivery.test.ts
+++ b/server/tests/unit/direct-message-delivery.test.ts
@@ -25,6 +25,15 @@ function makeInput(overrides: { userMessageFlagged?: boolean; assistantFlagged?:
         thread_id: 'thread-1',
         role: 'assistant' as const,
         content: 'Done.',
+        model_execution: {
+          source: 'provider' as const,
+          requested_provider: 'anthropic' as const,
+          requested_model: 'claude-sonnet-5',
+          provider: 'anthropic' as const,
+          model: 'claude-sonnet-5-20260801',
+          model_resolution: 'provider_canonicalized' as const,
+          fallback_reason: null,
+        },
         tools_used: ['update_profile'],
         tool_calls: [{ name: 'update_profile', input: { name: 'Ari' }, result: 'updated' }],
       },
@@ -57,6 +66,12 @@ describe('direct-message delivery orchestration', () => {
     expect(fixture.addMessage).toHaveBeenCalledWith(expect.objectContaining({
       role: 'assistant',
       tool_calls: fixture.input.assistantMessage.tool_calls,
+      model_execution: {
+        source: 'local',
+        requested_provider: 'anthropic',
+        requested_model: 'claude-sonnet-5',
+        reason: 'canned_response',
+      },
       flag_reason: 'Slack delivery failed: restricted_action_read_only_channel',
     }));
     expect(fixture.flagThread).toHaveBeenCalledWith('thread-1', 'Slack delivery failed: restricted_action_read_only_channel');

--- a/server/tests/unit/tavus-session-guidance-route.test.ts
+++ b/server/tests/unit/tavus-session-guidance-route.test.ts
@@ -153,6 +153,24 @@ describe("Tavus session guidance route boundary", () => {
     mocks.getCommitteesLedByUser.mockResolvedValue([]);
     mocks.processMessageStream.mockImplementation(async function* () {
       yield { type: "text", text: "Publishers can use AdCP programmatically." };
+      yield {
+        type: "done",
+        response: {
+          text: "Publishers can use AdCP programmatically.",
+          tools_used: [],
+          tool_executions: [],
+          flagged: false,
+          model_execution: {
+            source: 'provider',
+            requested_provider: 'anthropic',
+            requested_model: 'claude-sonnet-5',
+            provider: 'anthropic',
+            model: 'claude-sonnet-5-20260801',
+            model_resolution: 'provider_canonicalized',
+            fallback_reason: null,
+          },
+        },
+      };
     });
     globalThis.fetch = vi.fn(async (_url, init) => {
       tavusRequestBody = JSON.parse(String(init?.body));
@@ -261,7 +279,51 @@ describe("Tavus session guidance route boundary", () => {
     expect(mocks.addMessage).toHaveBeenCalledWith(
       expect.objectContaining({ role: "user", content: SPOKEN_MESSAGE })
     );
+    expect(mocks.addMessage).toHaveBeenCalledWith(expect.objectContaining({
+      role: 'assistant',
+      content: 'Publishers can use AdCP programmatically.',
+      model_execution: {
+        source: 'provider',
+        requested_provider: 'anthropic',
+        requested_model: 'claude-sonnet-5',
+        provider: 'anthropic',
+        model: 'claude-sonnet-5-20260801',
+        model_resolution: 'provider_canonicalized',
+        fallback_reason: null,
+      },
+    }));
   });
+
+  it.each(['error_event', 'throw'] as const)(
+    'does not persist partial assistant text after %s before terminal done',
+    async (failureMode) => {
+      mocks.addMessage.mockClear();
+      if (failureMode === 'error_event') {
+        mocks.processMessageStream.mockImplementationOnce(async function* () {
+          yield { type: 'text', text: 'partial private response' };
+          yield { type: 'error', error: 'provider failed' };
+        });
+      } else {
+        mocks.processMessageStream.mockImplementationOnce(async function* () {
+          yield { type: 'text', text: 'partial private response' };
+          throw new Error('provider failed');
+        });
+      }
+
+      const response = await request(mountApp())
+        .post('/api/addie/v1/chat/completions')
+        .set('Authorization', 'Bearer test-llm-secret')
+        .send({
+          messages: [
+            { role: 'system', content: `[conductor:thread_id=${THREAD_ID}] server context` },
+            { role: 'user', content: SPOKEN_MESSAGE },
+          ],
+        });
+
+      expect(response.status).toBe(200);
+      expect(mocks.addMessage.mock.calls.filter(([message]) => message.role === 'assistant')).toEqual([]);
+    },
+  );
 
   it("ignores stored guidance and user scope for a non-video thread", async () => {
     storedContext = {


### PR DESCRIPTION
## Summary
- persist requested and actual provider/model provenance for every Addie assistant response
- distinguish exact, provider-canonicalized, fallback, local, and legacy execution paths with fail-closed database constraints
- discard unverifiable partial streaming output and classify local fallbacks explicitly
- update production writers, audit logging, simulations, and integration fixtures for the required provenance contract

## Why
This is the auditability prerequisite for safely evaluating and canarying alternate Addie providers. It prevents fallback or local canned responses from being misattributed to a model and gives us durable requested-vs-actual execution data before any production provider routing changes.

## Validation
- expert review: no remaining actionable findings
- focused unit tests: 175/175
- fresh PostgreSQL integration tests: 75/75
- migrated assistant-history simulation: passed
- full server unit suite: 6,826/6,827; the single order-dependent 404 failure passed in isolation (26/26). A second hook run hit a different order-dependent 404 and passed in isolation (29/29).
- typecheck
- migration validation
- diff check

Progresses #6842
Progresses #6844