### PR TITLE
Add queryable canary authorization telemetry

### DIFF
--- a/server/src/middleware/organization-authorization-canary.ts
+++ b/server/src/middleware/organization-authorization-canary.ts
@@ -16,6 +16,7 @@ import {
   type UserOrgAuthorizationMembership,
   type OrgAuthorizationSource,
 } from "../utils/resolve-user-org-authorization.js";
+import { captureEvent } from "../utils/posthog.js";
 
 const logger = createLogger("organization-authorization-canary");
 const RUNTIME_SETTING_CACHE_TTL_MS = 5_000;
@@ -44,6 +45,26 @@ export type OrganizationAuthorizationCanaryDecision =
       status: "unavailable";
       unavailableSources: Array<OrgAuthorizationSource | "runtime_config">;
     };
+
+/**
+ * Emit one identifier-free record for an enforced canary decision. The
+ * boundary is a fixed server enum and unavailable sources are fixed resolver
+ * labels; never include the principal, membership, or organization ID.
+ */
+export function recordOrganizationAuthorizationCanaryDecision(
+  boundary: OrganizationAuthorizationBoundary,
+  decision: Exclude<OrganizationAuthorizationCanaryDecision, { enforced: false }>
+): void {
+  const properties = {
+    boundary,
+    decision: decision.status,
+    unavailable_sources:
+      decision.status === "unavailable" ? decision.unavailableSources : undefined,
+  };
+
+  captureEvent("server-metrics", "org_authorization_canary", properties);
+  logger.info(properties, "organization authorization canary decision");
+}
 
 /**
  * The environment values are a deployment-time ceiling: neither the audited

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -51,6 +51,7 @@ import { getAuthorizationEnforcementWorkos } from "../auth/workos-client.js";
 import {
   evaluateOrganizationAuthorizationCanary,
   ORGANIZATION_AUTHORIZATION_BOUNDARIES,
+  recordOrganizationAuthorizationCanaryDecision,
 } from "../middleware/organization-authorization-canary.js";
 
 const logger = createLogger("organization-routes");
@@ -3502,13 +3503,10 @@ export function createOrganizationsRouter(): Router {
       });
 
       if (canaryDecision.enforced) {
-        logger.info({
-          boundary: ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_ROLES_READ,
-          decision: canaryDecision.status,
-          unavailable_sources: canaryDecision.status === 'unavailable'
-            ? canaryDecision.unavailableSources
-            : undefined,
-        }, 'organization authorization canary decision');
+        recordOrganizationAuthorizationCanaryDecision(
+          ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_ROLES_READ,
+          canaryDecision,
+        );
         if (canaryDecision.status === 'unavailable') {
           return res.status(503).json({
             error: 'Authorization temporarily unavailable',

--- a/server/tests/unit/organization-authorization-canary.test.ts
+++ b/server/tests/unit/organization-authorization-canary.test.ts
@@ -4,10 +4,12 @@ const {
   resolveUserOrgAuthorizationMock,
   evaluateUserOrgRoleAuthorizationMock,
   getRuntimeSettingDbMock,
+  captureEventMock,
 } = vi.hoisted(() => ({
   resolveUserOrgAuthorizationMock: vi.fn(),
   evaluateUserOrgRoleAuthorizationMock: vi.fn(),
   getRuntimeSettingDbMock: vi.fn(),
+  captureEventMock: vi.fn(),
 }));
 
 vi.mock("../../src/utils/resolve-user-org-authorization.js", () => ({
@@ -19,11 +21,16 @@ vi.mock("../../src/db/system-settings-db.js", () => ({
   getOrganizationAuthorizationEnforcement: getRuntimeSettingDbMock,
 }));
 
+vi.mock("../../src/utils/posthog.js", () => ({
+  captureEvent: captureEventMock,
+}));
+
 import {
   evaluateOrganizationAuthorizationCanary,
   invalidateOrganizationAuthorizationRuntimeSettingCache,
   isOrganizationAuthorizationBoundaryAllowedByEnvironment,
   ORGANIZATION_AUTHORIZATION_BOUNDARIES,
+  recordOrganizationAuthorizationCanaryDecision,
 } from "../../src/middleware/organization-authorization-canary.js";
 
 const BOUNDARY = ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_ROLES_READ;
@@ -35,6 +42,7 @@ describe("organization authorization canary", () => {
     resolveUserOrgAuthorizationMock.mockReset();
     evaluateUserOrgRoleAuthorizationMock.mockReset();
     getRuntimeSettingDbMock.mockReset();
+    captureEventMock.mockReset();
     invalidateOrganizationAuthorizationRuntimeSettingCache();
   });
 
@@ -87,6 +95,46 @@ describe("organization authorization canary", () => {
 
     process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "false";
     expect(isOrganizationAuthorizationBoundaryAllowedByEnvironment(BOUNDARY)).toBe(false);
+  });
+
+  it("records enforced decisions without credential, membership, or organization identifiers", () => {
+    recordOrganizationAuthorizationCanaryDecision(BOUNDARY, {
+      enforced: true,
+      status: "authorized",
+      membership: {
+        organizationId: "org_sensitive",
+        role: "member",
+        source: "workos",
+      },
+    });
+
+    expect(captureEventMock).toHaveBeenCalledWith(
+      "server-metrics",
+      "org_authorization_canary",
+      {
+        boundary: BOUNDARY,
+        decision: "authorized",
+        unavailable_sources: undefined,
+      }
+    );
+    expect(JSON.stringify(captureEventMock.mock.calls)).not.toContain("sensitive");
+
+    captureEventMock.mockClear();
+    recordOrganizationAuthorizationCanaryDecision(BOUNDARY, {
+      enforced: true,
+      status: "unavailable",
+      unavailableSources: ["workos", "runtime_config"],
+    });
+
+    expect(captureEventMock).toHaveBeenCalledWith(
+      "server-metrics",
+      "org_authorization_canary",
+      {
+        boundary: BOUNDARY,
+        decision: "unavailable",
+        unavailable_sources: ["workos", "runtime_config"],
+      }
+    );
   });
 
   it("keeps legacy authorization when the audited runtime gate is off", async () => {

--- a/server/tests/unit/organization-roles-canary-route.test.ts
+++ b/server/tests/unit/organization-roles-canary-route.test.ts
@@ -4,6 +4,7 @@ import request from "supertest";
 
 const {
   evaluateCanaryMock,
+  recordCanaryDecisionMock,
   getEnforcementWorkosMock,
   legacyMembershipMock,
   listOrganizationRolesMock,
@@ -14,6 +15,7 @@ const {
     "test-cookie-password-32chars-min-len-1234";
   return {
     evaluateCanaryMock: vi.fn(),
+    recordCanaryDecisionMock: vi.fn(),
     getEnforcementWorkosMock: vi.fn(() => ({ bounded: true })),
     legacyMembershipMock: vi.fn(),
     listOrganizationRolesMock: vi.fn(),
@@ -59,6 +61,7 @@ vi.mock("../../src/middleware/organization-authorization-canary.js", () => ({
     ORGANIZATION_ROLES_READ: "organization_roles_read",
   },
   evaluateOrganizationAuthorizationCanary: evaluateCanaryMock,
+  recordOrganizationAuthorizationCanaryDecision: recordCanaryDecisionMock,
 }));
 
 import { createOrganizationsRouter } from "../../src/routes/organizations.js";
@@ -73,6 +76,7 @@ function createApp() {
 describe("GET organization roles authorization canary", () => {
   beforeEach(() => {
     evaluateCanaryMock.mockReset().mockResolvedValue({ enforced: false });
+    recordCanaryDecisionMock.mockReset();
     legacyMembershipMock.mockReset().mockResolvedValue({ role: "member" });
     listOrganizationRolesMock.mockReset().mockResolvedValue({
       data: [
@@ -109,6 +113,7 @@ describe("GET organization roles authorization canary", () => {
         getWorkos: getEnforcementWorkosMock,
       })
     );
+    expect(recordCanaryDecisionMock).not.toHaveBeenCalled();
   });
 
   it("uses the exact canary decision without consulting legacy authority", async () => {
@@ -127,6 +132,10 @@ describe("GET organization roles authorization canary", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(recordCanaryDecisionMock).toHaveBeenCalledWith(
+      "organization_roles_read",
+      expect.objectContaining({ enforced: true, status: "authorized" })
+    );
     expect(legacyMembershipMock).not.toHaveBeenCalled();
     expect(listOrganizationRolesMock).toHaveBeenCalledWith("org_test");
   });


### PR DESCRIPTION
## Summary

- emit an identifier-free PostHog event for every enforced organization authorization canary decision
- preserve the existing structured info log without duplication
- keep the default-off path completely inert
- verify that membership and organization identifiers never enter the telemetry payload

## Why

The first #6827 enforcement wave is intentionally limited to the read-only
`organization_roles_read` boundary. The existing decision log is available in
Fly/Grafana, but the rollout also needs an independently queryable signal for
activation and rollback. This uses the same `server-metrics` PostHog convention
as the deployed shadow observer and records only fixed enum values.

This PR does not stage the environment ceiling or enable runtime enforcement.

## Verification

- `npx vitest run --config server/vitest.config.ts server/tests/unit/organization-authorization-canary.test.ts server/tests/unit/organization-roles-canary-route.test.ts` (18/18)
- `npm run typecheck`
- `git diff --check`
- independent review: approved, no blockers

Closes no issue; staged rollout work for #6827.
