### PR TITLE
feat(addie): report provenance data readiness

### DIFF
--- a/server/src/addie/model-execution-readiness.ts
+++ b/server/src/addie/model-execution-readiness.ts
@@ -1,0 +1,304 @@
+import { query as defaultQuery } from '../db/client.js';
+
+export type ModelExecutionReadinessSurface = 'thread_messages' | 'interactions';
+
+export type ModelExecutionReadinessBlockerReason =
+  | 'insufficient_sample_size'
+  | 'unclassified_executions'
+  | 'legacy_executions'
+  | 'invalid_provenance';
+
+export interface ModelExecutionReadinessBlocker {
+  surface: ModelExecutionReadinessSurface;
+  reason: ModelExecutionReadinessBlockerReason;
+}
+
+export interface ModelExecutionReadinessSurfaceSummary {
+  total: number;
+  provider: number;
+  local: number;
+  unclassified: number;
+  legacy: number;
+  invalid: number;
+  fallback: number;
+  canonicalized: number;
+  classification_rate: number;
+  persisted_data_ready: boolean;
+  blockers: ModelExecutionReadinessBlockerReason[];
+}
+
+export interface ModelExecutionReadinessSummary {
+  scope: 'persisted_provenance_data';
+  limitations: [
+    'requires_deployment_drain_confirmation',
+    'does_not_measure_failed_database_writes',
+    'not_a_provider_canary_gate',
+  ];
+  window: {
+    start: string;
+    end: string;
+    hours: number;
+  };
+  minimum_thread_message_samples: number;
+  minimum_interaction_samples: 1;
+  surfaces: Record<ModelExecutionReadinessSurface, ModelExecutionReadinessSurfaceSummary>;
+  persisted_data_ready: boolean;
+  blockers: ModelExecutionReadinessBlocker[];
+}
+
+interface AggregateRow {
+  surface: ModelExecutionReadinessSurface;
+  total: string;
+  provider: string;
+  local: string;
+  unclassified: string;
+  legacy: string;
+  invalid: string;
+  fallback: string;
+  canonicalized: string;
+}
+
+export interface ModelExecutionReadinessOptions {
+  hours?: number;
+  minimumSamples?: number;
+  now?: Date;
+}
+
+type AggregateQuery = (
+  text: string,
+  params: unknown[],
+) => Promise<{ rows: AggregateRow[] }>;
+
+// Keep the canonical message history and the still-active legacy audit sink as
+// separate surfaces: many Slack responses are written to both tables, so
+// combining them would produce a misleading response denominator. A dirty row
+// in either sink still blocks the overall readiness decision.
+const AGGREGATE_SQL = `
+  WITH executions AS (
+    SELECT
+      'thread_messages'::text AS surface,
+      role,
+      role = 'assistant' AS included_in_denominator,
+      model_execution_source,
+      requested_model_provider,
+      requested_model,
+      model_provider,
+      provider_model,
+      provider_model_resolution,
+      provider_fallback_reason,
+      local_response_reason
+    FROM addie_thread_messages
+    WHERE created_at >= $1
+      AND created_at < $2
+      AND (
+        role = 'assistant'
+        OR model_execution_source IS NOT NULL
+        OR requested_model_provider IS NOT NULL OR requested_model IS NOT NULL
+        OR model_provider IS NOT NULL OR provider_model IS NOT NULL
+        OR provider_model_resolution IS NOT NULL OR provider_fallback_reason IS NOT NULL
+        OR local_response_reason IS NOT NULL
+      )
+
+    UNION ALL
+
+    SELECT
+      'interactions'::text AS surface,
+      NULL::text AS role,
+      TRUE AS included_in_denominator,
+      model_execution_source,
+      requested_model_provider,
+      requested_model,
+      model_provider,
+      provider_model,
+      provider_model_resolution,
+      provider_fallback_reason,
+      local_response_reason
+    FROM addie_interactions
+    WHERE created_at >= $1
+      AND created_at < $2
+  ), surfaces(surface) AS (
+    VALUES ('thread_messages'::text), ('interactions'::text)
+  )
+  SELECT
+    surfaces.surface,
+    COUNT(*) FILTER (WHERE included_in_denominator)::text AS total,
+    COUNT(*) FILTER (WHERE included_in_denominator AND model_execution_source = 'provider')::text AS provider,
+    COUNT(*) FILTER (WHERE included_in_denominator AND model_execution_source = 'local')::text AS local,
+    COUNT(*) FILTER (WHERE included_in_denominator AND model_execution_source IS NULL)::text AS unclassified,
+    COUNT(*) FILTER (WHERE included_in_denominator AND model_execution_source = 'legacy')::text AS legacy,
+    COUNT(*) FILTER (WHERE included_in_denominator AND provider_model_resolution = 'fallback')::text AS fallback,
+    COUNT(*) FILTER (WHERE included_in_denominator AND provider_model_resolution = 'provider_canonicalized')::text AS canonicalized,
+    COUNT(*) FILTER (WHERE executions.surface IS NOT NULL AND (
+      (executions.surface = 'thread_messages' AND role IS DISTINCT FROM 'assistant')
+      OR (model_execution_source IS NULL AND (
+        requested_model_provider IS NOT NULL OR requested_model IS NOT NULL
+        OR model_provider IS NOT NULL OR provider_model IS NOT NULL
+        OR provider_model_resolution IS NOT NULL OR provider_fallback_reason IS NOT NULL
+        OR local_response_reason IS NOT NULL
+      ))
+      OR (model_execution_source IS NOT NULL AND model_execution_source NOT IN ('provider', 'local', 'legacy'))
+      OR (requested_model_provider IS NOT NULL AND requested_model_provider NOT IN ('anthropic', 'openai', 'google'))
+      OR (model_provider IS NOT NULL AND model_provider NOT IN ('anthropic', 'openai', 'google'))
+      OR (requested_model IS NOT NULL AND length(btrim(requested_model)) NOT BETWEEN 1 AND 256)
+      OR (provider_model IS NOT NULL AND length(btrim(provider_model)) NOT BETWEEN 1 AND 256)
+      OR (provider_fallback_reason IS NOT NULL AND provider_fallback_reason NOT IN (
+        'primary_unavailable', 'primary_rate_limited', 'primary_timeout',
+        'primary_capability_unsupported', 'primary_policy_blocked'
+      ))
+      OR (local_response_reason IS NOT NULL AND local_response_reason NOT IN (
+        'cost_cap_exceeded', 'provider_error', 'stream_interrupted',
+        'no_provider_response', 'canned_response'
+      ))
+      OR (model_execution_source = 'legacy' AND (
+        requested_model_provider IS NOT NULL OR requested_model IS NOT NULL
+        OR model_provider IS NOT NULL OR provider_model IS NOT NULL
+        OR provider_model_resolution IS NOT NULL OR provider_fallback_reason IS NOT NULL
+        OR local_response_reason IS NOT NULL
+      ))
+      OR (model_execution_source = 'local' AND (
+        ((requested_model_provider IS NULL) <> (requested_model IS NULL))
+        OR model_provider IS NOT NULL OR provider_model IS NOT NULL
+        OR provider_model_resolution IS NOT NULL OR provider_fallback_reason IS NOT NULL
+        OR local_response_reason IS NULL
+      ))
+      OR (model_execution_source = 'provider' AND (
+        requested_model_provider IS NULL OR requested_model IS NULL
+        OR model_provider IS NULL OR provider_model IS NULL
+        OR provider_model_resolution IS NULL OR local_response_reason IS NOT NULL
+        OR (provider_model_resolution = 'exact' AND (
+          requested_model_provider IS DISTINCT FROM model_provider
+          OR requested_model IS DISTINCT FROM provider_model
+          OR provider_fallback_reason IS NOT NULL
+        ))
+        OR (provider_model_resolution = 'provider_canonicalized' AND (
+          requested_model_provider IS DISTINCT FROM model_provider
+          OR requested_model IS NOT DISTINCT FROM provider_model
+          OR provider_fallback_reason IS NOT NULL
+        ))
+        OR (provider_model_resolution = 'fallback' AND (
+          (requested_model_provider IS NOT DISTINCT FROM model_provider
+            AND requested_model IS NOT DISTINCT FROM provider_model)
+          OR provider_fallback_reason IS NULL
+        ))
+        OR provider_model_resolution NOT IN ('exact', 'provider_canonicalized', 'fallback')
+      ))
+    ))::text AS invalid
+  FROM surfaces
+  LEFT JOIN executions USING (surface)
+  GROUP BY surfaces.surface
+  ORDER BY surfaces.surface
+`;
+
+function parseCount(value: string | undefined, field: string): number {
+  if (value === undefined || !/^\d+$/.test(value)) {
+    throw new TypeError(`Invalid aggregate count for ${field}`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new TypeError(`Invalid aggregate count for ${field}`);
+  }
+  return parsed;
+}
+
+function summarizeSurface(
+  row: AggregateRow,
+  minimumSamples: number | null,
+): ModelExecutionReadinessSurfaceSummary {
+  const total = parseCount(row.total, `${row.surface}.total`);
+  const provider = parseCount(row.provider, `${row.surface}.provider`);
+  const local = parseCount(row.local, `${row.surface}.local`);
+  const unclassified = parseCount(row.unclassified, `${row.surface}.unclassified`);
+  const legacy = parseCount(row.legacy, `${row.surface}.legacy`);
+  const invalid = parseCount(row.invalid, `${row.surface}.invalid`);
+  const fallback = parseCount(row.fallback, `${row.surface}.fallback`);
+  const canonicalized = parseCount(row.canonicalized, `${row.surface}.canonicalized`);
+  const blockers: ModelExecutionReadinessBlockerReason[] = [];
+  if (minimumSamples !== null && total < minimumSamples) blockers.push('insufficient_sample_size');
+  if (unclassified > 0) blockers.push('unclassified_executions');
+  if (legacy > 0) blockers.push('legacy_executions');
+  if (invalid > 0) blockers.push('invalid_provenance');
+
+  return {
+    total,
+    provider,
+    local,
+    unclassified,
+    legacy,
+    invalid,
+    fallback,
+    canonicalized,
+    classification_rate: total === 0 ? 0 : (provider + local) / total,
+    persisted_data_ready: blockers.length === 0,
+    blockers,
+  };
+}
+
+export function summarizeModelExecutionReadiness(
+  rows: AggregateRow[],
+  options: Required<Pick<ModelExecutionReadinessOptions, 'hours' | 'minimumSamples' | 'now'>>,
+): ModelExecutionReadinessSummary {
+  const expectedSurfaces: ModelExecutionReadinessSurface[] = ['thread_messages', 'interactions'];
+  if (rows.length !== expectedSurfaces.length
+    || expectedSurfaces.some((surface) => rows.filter((row) => row.surface === surface).length !== 1)
+    || rows.some((row) => !expectedSurfaces.includes(row.surface))) {
+    throw new TypeError('Readiness aggregate must contain exactly one row per surface');
+  }
+  const bySurface = new Map(rows.map((row) => [row.surface, row]));
+  const surfaces = {
+    thread_messages: summarizeSurface(
+      bySurface.get('thread_messages')!,
+      options.minimumSamples,
+    ),
+    interactions: summarizeSurface(
+      bySurface.get('interactions')!,
+      1,
+    ),
+  };
+  const blockers = (Object.entries(surfaces) as Array<[
+    ModelExecutionReadinessSurface,
+    ModelExecutionReadinessSurfaceSummary,
+  ]>).flatMap(([surface, summary]) => summary.blockers.map((reason) => ({ surface, reason })));
+
+  const end = new Date(options.now);
+  const start = new Date(end.getTime() - options.hours * 60 * 60 * 1000);
+  return {
+    scope: 'persisted_provenance_data',
+    limitations: [
+      'requires_deployment_drain_confirmation',
+      'does_not_measure_failed_database_writes',
+      'not_a_provider_canary_gate',
+    ],
+    window: {
+      start: start.toISOString(),
+      end: end.toISOString(),
+      hours: options.hours,
+    },
+    minimum_thread_message_samples: options.minimumSamples,
+    minimum_interaction_samples: 1,
+    surfaces,
+    persisted_data_ready: blockers.length === 0,
+    blockers,
+  };
+}
+
+export async function getModelExecutionReadiness(
+  options: ModelExecutionReadinessOptions = {},
+  query: AggregateQuery = defaultQuery as AggregateQuery,
+): Promise<ModelExecutionReadinessSummary> {
+  const hours = options.hours ?? 24;
+  const minimumSamples = options.minimumSamples ?? 100;
+  const now = options.now ?? new Date();
+  if (!Number.isInteger(hours) || hours < 1 || hours > 168) {
+    throw new RangeError('hours must be an integer from 1 to 168');
+  }
+  if (!Number.isInteger(minimumSamples) || minimumSamples < 1 || minimumSamples > 10_000) {
+    throw new RangeError('minimumSamples must be an integer from 1 to 10000');
+  }
+  if (!Number.isFinite(now.getTime())) {
+    throw new RangeError('now must be a valid date');
+  }
+
+  const start = new Date(now.getTime() - hours * 60 * 60 * 1000);
+  const result = await query(AGGREGATE_SQL, [start, now]);
+  return summarizeModelExecutionReadiness(result.rows, { hours, minimumSamples, now });
+}

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -64,6 +64,7 @@ import {
   getShadowReplayGenerationSummary,
   getShadowReplayJudgmentSummary,
 } from "../addie/jobs/shadow-replay-trace.js";
+import { getModelExecutionReadiness } from '../addie/model-execution-readiness.js';
 
 const logger = createLogger("addie-admin-routes");
 const addieDb = new AddieDatabase();
@@ -614,6 +615,33 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
         "Error fetching shadow replay capture summary",
       );
       res.status(500).json({ error: "Unable to fetch shadow replay capture summary" });
+    }
+  });
+
+  // GET /api/admin/addie/threads/model-execution-provenance-readiness
+  // Privacy-safe persisted-data signal. Deployment drain/error evidence is
+  // still required before a contract migration; provider canaries have their
+  // own target-provider quality and fallback gates.
+  apiRouter.get('/threads/model-execution-provenance-readiness', async (req, res) => {
+    const hours = typeof req.query.hours === 'string' && req.query.hours.trim() !== ''
+      ? Number(req.query.hours)
+      : 24;
+    const minimumSamples = typeof req.query.minimum_thread_message_samples === 'string'
+      && req.query.minimum_thread_message_samples.trim() !== ''
+      ? Number(req.query.minimum_thread_message_samples)
+      : 100;
+    try {
+      const readiness = await getModelExecutionReadiness({ hours, minimumSamples });
+      res.json(readiness);
+    } catch (error) {
+      if (error instanceof RangeError) {
+        return res.status(400).json({ error: error.message });
+      }
+      logger.error(
+        { errorType: error instanceof Error ? error.name : typeof error },
+        'Error fetching model execution readiness',
+      );
+      res.status(500).json({ error: 'Unable to fetch model execution readiness' });
     }
   });
 

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -635,7 +635,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
       res.json(readiness);
     } catch (error) {
       if (error instanceof RangeError) {
-        return res.status(400).json({ error: error.message });
+        return res.status(400).json({ error: 'Invalid readiness query parameters' });
       }
       logger.error(
         { errorType: error instanceof Error ? error.name : typeof error },

--- a/server/tests/integration/thread-service.test.ts
+++ b/server/tests/integration/thread-service.test.ts
@@ -11,6 +11,7 @@ import {
   type ThreadListFilters,
 } from '../../src/addie/thread-service.js';
 import { AddieDatabase } from '../../src/db/addie-db.js';
+import { getModelExecutionReadiness } from '../../src/addie/model-execution-readiness.js';
 
 // These tests require a running PostgreSQL instance. Lives in integration/
 // so the build-check.yml server-integration job picks them up; the skipIf
@@ -44,14 +45,14 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
 
   afterAll(async () => {
     // Clean up test data
-    await pool.query("DELETE FROM addie_interactions WHERE id LIKE 'provider-provenance-%'");
+    await pool.query("DELETE FROM addie_interactions WHERE id LIKE 'provider-provenance-%' OR id LIKE 'readiness-interaction-%'");
     await pool.query(`DELETE FROM addie_threads WHERE external_id LIKE 'test-%'`);
     await closeDatabase();
   });
 
   beforeEach(async () => {
     // Clean up threads before each test
-    await pool.query("DELETE FROM addie_interactions WHERE id LIKE 'provider-provenance-%'");
+    await pool.query("DELETE FROM addie_interactions WHERE id LIKE 'provider-provenance-%' OR id LIKE 'readiness-interaction-%'");
     await pool.query(`DELETE FROM addie_threads WHERE external_id LIKE 'test-%'`);
   });
 
@@ -421,6 +422,64 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
       expect(messageSources.rows.every((row) => row.model_execution_source === 'legacy')).toBe(true);
       expect(interactionSources.rows).toHaveLength(2);
       expect(interactionSources.rows.every((row) => row.model_execution_source === 'legacy')).toBe(true);
+    });
+
+    it('reports a privacy-safe readiness denominator from persisted provenance', async () => {
+      const thread = await threadService.getOrCreateThread({
+        channel: 'web',
+        external_id: `${TEST_THREAD_EXTERNAL_ID}-readiness`,
+        user_type: 'anonymous',
+      });
+      const createdAt = new Date('2100-01-01T11:30:00.000Z');
+      await pool.query(
+        `INSERT INTO addie_thread_messages (
+           thread_id, role, content, sequence_number, created_at,
+           model_execution_source, requested_model_provider, requested_model,
+           model_provider, provider_model, provider_model_resolution,
+           provider_fallback_reason, local_response_reason
+         ) VALUES
+           ($1, 'assistant', 'PRIVATE_PROVIDER_SENTINEL', 1, $2, 'provider', 'anthropic', 'requested', 'anthropic', 'requested', 'exact', NULL, NULL),
+           ($1, 'assistant', 'PRIVATE_LOCAL_SENTINEL', 2, $2, 'local', NULL, NULL, NULL, NULL, NULL, NULL, 'canned_response'),
+           ($1, 'assistant', 'rolling', 3, $2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+           ($1, 'assistant', 'legacy', 4, $2, 'legacy', NULL, NULL, NULL, NULL, NULL, NULL, NULL)`,
+        [thread.thread_id, createdAt],
+      );
+      await pool.query(
+        `INSERT INTO addie_interactions (
+           id, event_type, channel_id, user_id, input_text, input_sanitized,
+           output_text, model, latency_ms, created_at, model_execution_source,
+           requested_model_provider, requested_model, model_provider,
+           provider_model, provider_model_resolution
+         ) VALUES
+           ('readiness-interaction-provider', 'dm', 'D_READY', 'ready-user', 'PRIVATE_INPUT_SENTINEL', 'private', 'PRIVATE_AUDIT_OUTPUT_SENTINEL', 'requested', 1, $1, 'provider', 'anthropic', 'requested', 'anthropic', 'requested', 'exact'),
+           ('readiness-interaction-unclassified', 'dm', 'D_READY', 'ready-user', 'private', 'private', 'private', 'legacy', 1, $1, NULL, NULL, NULL, NULL, NULL, NULL)`,
+        [createdAt],
+      );
+
+      const summary = await getModelExecutionReadiness({
+        hours: 1,
+        minimumSamples: 4,
+        now: new Date('2100-01-01T12:00:00.000Z'),
+      });
+
+      expect(summary.surfaces.thread_messages).toMatchObject({
+        total: 4, provider: 1, local: 1, unclassified: 1, legacy: 1,
+        invalid: 0, classification_rate: 0.5, persisted_data_ready: false,
+      });
+      expect(summary.surfaces.interactions).toMatchObject({
+        total: 2, provider: 1, local: 0, unclassified: 1, legacy: 0,
+        invalid: 0, classification_rate: 0.5, persisted_data_ready: false,
+      });
+      expect(summary.persisted_data_ready).toBe(false);
+      expect(summary.blockers).toEqual([
+        { surface: 'thread_messages', reason: 'unclassified_executions' },
+        { surface: 'thread_messages', reason: 'legacy_executions' },
+        { surface: 'interactions', reason: 'unclassified_executions' },
+      ]);
+      expect(JSON.stringify(summary)).not.toContain('PRIVATE_PROVIDER_SENTINEL');
+      expect(JSON.stringify(summary)).not.toContain('PRIVATE_LOCAL_SENTINEL');
+      expect(JSON.stringify(summary)).not.toContain('PRIVATE_INPUT_SENTINEL');
+      expect(JSON.stringify(summary)).not.toContain('PRIVATE_AUDIT_OUTPUT_SENTINEL');
     });
 
     it('round-trips provider and local provenance through the legacy interaction audit', async () => {

--- a/server/tests/unit/addie-admin-global-auth.test.ts
+++ b/server/tests/unit/addie-admin-global-auth.test.ts
@@ -265,7 +265,7 @@ describe('Addie real global-admin boundary', () => {
       .set('Authorization', 'Bearer static-global-admin-key');
 
     expect(response.status).toBe(400);
-    expect(response.body).toEqual({ error: 'hours must be an integer from 1 to 168' });
+    expect(response.body).toEqual({ error: 'Invalid readiness query parameters' });
     expect(mocks.getModelExecutionReadiness).toHaveBeenCalledWith({
       hours: Number.NaN,
       minimumSamples: 100,

--- a/server/tests/unit/addie-admin-global-auth.test.ts
+++ b/server/tests/unit/addie-admin-global-auth.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   isAdminGroupMember: vi.fn(),
   poolQuery: vi.fn(),
   getWebConversations: vi.fn(),
+  getModelExecutionReadiness: vi.fn(),
   serveHtmlWithConfig: vi.fn(),
 }));
 
@@ -69,6 +70,10 @@ vi.mock('../../src/db/addie-db.js', () => ({
   AddieDatabase: class AddieDatabase {
     getWebConversations = mocks.getWebConversations;
   },
+}));
+
+vi.mock('../../src/addie/model-execution-readiness.js', () => ({
+  getModelExecutionReadiness: mocks.getModelExecutionReadiness,
 }));
 
 vi.mock('../../src/utils/html-config.js', () => ({
@@ -143,6 +148,35 @@ describe('Addie real global-admin boundary', () => {
       }),
     });
     mocks.getWebConversations.mockResolvedValue([]);
+    mocks.getModelExecutionReadiness.mockResolvedValue({
+      scope: 'persisted_provenance_data',
+      limitations: [
+        'requires_deployment_drain_confirmation',
+        'does_not_measure_failed_database_writes',
+        'not_a_provider_canary_gate',
+      ],
+      window: {
+        start: '2026-08-24T00:00:00.000Z',
+        end: '2026-08-25T00:00:00.000Z',
+        hours: 24,
+      },
+      minimum_thread_message_samples: 100,
+      minimum_interaction_samples: 1,
+      surfaces: {
+        thread_messages: {
+          total: 100, provider: 90, local: 10, unclassified: 0, legacy: 0,
+          invalid: 0, fallback: 0, canonicalized: 0, classification_rate: 1,
+          persisted_data_ready: true, blockers: [],
+        },
+        interactions: {
+          total: 5, provider: 5, local: 0, unclassified: 0, legacy: 0,
+          invalid: 0, fallback: 0, canonicalized: 0, classification_rate: 1,
+          persisted_data_ready: true, blockers: [],
+        },
+      },
+      persisted_data_ready: true,
+      blockers: [],
+    });
     mocks.serveHtmlWithConfig.mockImplementation(
       (_req: express.Request, res: express.Response) => {
         res.status(200).send('Addie admin');
@@ -201,6 +235,41 @@ describe('Addie real global-admin boundary', () => {
       'user_sso_admin',
     );
     expect(mocks.getWebConversations).toHaveBeenCalledOnce();
+  });
+
+  it('exposes model execution readiness only through the global-admin boundary', async () => {
+    const denied = await request(app)
+      .get('/api/admin/addie/threads/model-execution-provenance-readiness?hours=48&minimum_thread_message_samples=200')
+      .set('Authorization', 'Bearer sk_tenant_read');
+    expect(denied.status).toBe(403);
+    expect(mocks.getModelExecutionReadiness).not.toHaveBeenCalled();
+
+    const allowed = await request(app)
+      .get('/api/admin/addie/threads/model-execution-provenance-readiness?hours=48&minimum_thread_message_samples=200')
+      .set('Authorization', 'Bearer static-global-admin-key');
+    expect(allowed.status).toBe(200);
+    expect(allowed.body.persisted_data_ready).toBe(true);
+    expect(allowed.body.limitations).toContain('not_a_provider_canary_gate');
+    expect(mocks.getModelExecutionReadiness).toHaveBeenCalledWith({
+      hours: 48,
+      minimumSamples: 200,
+    });
+  });
+
+  it('returns a bounded validation error for malformed readiness windows', async () => {
+    mocks.getModelExecutionReadiness.mockRejectedValueOnce(
+      new RangeError('hours must be an integer from 1 to 168'),
+    );
+    const response = await request(app)
+      .get('/api/admin/addie/threads/model-execution-provenance-readiness?hours=1abc')
+      .set('Authorization', 'Bearer static-global-admin-key');
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'hours must be an integer from 1 to 168' });
+    expect(mocks.getModelExecutionReadiness).toHaveBeenCalledWith({
+      hours: Number.NaN,
+      minimumSamples: 100,
+    });
   });
 });
 

--- a/server/tests/unit/addie/model-execution-readiness.test.ts
+++ b/server/tests/unit/addie/model-execution-readiness.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getModelExecutionReadiness,
+  summarizeModelExecutionReadiness,
+} from '../../../src/addie/model-execution-readiness.js';
+
+const NOW = new Date('2026-08-25T12:00:00.000Z');
+
+function aggregate(surface: 'thread_messages' | 'interactions', overrides: Record<string, string> = {}) {
+  return {
+    surface,
+    total: '100',
+    provider: '90',
+    local: '10',
+    unclassified: '0',
+    legacy: '0',
+    invalid: '0',
+    fallback: '2',
+    canonicalized: '3',
+    ...overrides,
+  };
+}
+
+describe('model execution readiness', () => {
+  it('marks a fully classified representative window ready', () => {
+    const summary = summarizeModelExecutionReadiness([
+      aggregate('thread_messages'),
+      aggregate('interactions', { total: '5', provider: '5', local: '0' }),
+    ], {
+      hours: 24,
+      minimumSamples: 100,
+      now: NOW,
+    });
+
+    expect(summary.persisted_data_ready).toBe(true);
+    expect(summary.blockers).toEqual([]);
+    expect(summary.surfaces.thread_messages.classification_rate).toBe(1);
+    expect(summary.surfaces.interactions.classification_rate).toBe(1);
+    expect(summary.scope).toBe('persisted_provenance_data');
+    expect(summary.limitations).toEqual([
+      'requires_deployment_drain_confirmation',
+      'does_not_measure_failed_database_writes',
+      'not_a_provider_canary_gate',
+    ]);
+    expect(summary.window).toEqual({
+      start: '2026-08-24T12:00:00.000Z',
+      end: '2026-08-25T12:00:00.000Z',
+      hours: 24,
+    });
+  });
+
+  it('keeps every provenance failure in the denominator', () => {
+    const summary = summarizeModelExecutionReadiness([
+      aggregate('thread_messages', {
+        total: '12',
+        provider: '5',
+        local: '2',
+        unclassified: '3',
+        legacy: '2',
+        invalid: '1',
+      }),
+      aggregate('interactions', { total: '1', provider: '1', local: '0' }),
+    ], {
+      hours: 12,
+      minimumSamples: 20,
+      now: NOW,
+    });
+
+    expect(summary.surfaces.thread_messages.classification_rate).toBe(7 / 12);
+    expect(summary.persisted_data_ready).toBe(false);
+    expect(summary.blockers).toEqual([
+      { surface: 'thread_messages', reason: 'insufficient_sample_size' },
+      { surface: 'thread_messages', reason: 'unclassified_executions' },
+      { surface: 'thread_messages', reason: 'legacy_executions' },
+      { surface: 'thread_messages', reason: 'invalid_provenance' },
+    ]);
+  });
+
+  it('blocks when the legacy interaction sink is unclassified without double-counting it', () => {
+    const summary = summarizeModelExecutionReadiness([
+      aggregate('thread_messages'),
+      aggregate('interactions', {
+        total: '7', provider: '4', local: '2', unclassified: '1',
+      }),
+    ], {
+      hours: 24,
+      minimumSamples: 100,
+      now: NOW,
+    });
+
+    expect(summary.surfaces.thread_messages.total).toBe(100);
+    expect(summary.surfaces.interactions.total).toBe(7);
+    expect(summary.persisted_data_ready).toBe(false);
+    expect(summary.blockers).toEqual([
+      { surface: 'interactions', reason: 'unclassified_executions' },
+    ]);
+  });
+
+  it('queries an exact half-open window and returns aggregate counts only', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [
+      aggregate('thread_messages', { total: '3', provider: '2', local: '1' }),
+      aggregate('interactions', { total: '1', provider: '1', local: '0' }),
+    ] });
+    const summary = await getModelExecutionReadiness({
+      hours: 6,
+      minimumSamples: 3,
+      now: NOW,
+    }, query);
+
+    expect(query).toHaveBeenCalledOnce();
+    expect(query.mock.calls[0]?.[1]).toEqual([
+      new Date('2026-08-25T06:00:00.000Z'),
+      NOW,
+    ]);
+    expect(query.mock.calls[0]?.[0]).not.toMatch(/\bcontent\b/);
+    expect(query.mock.calls[0]?.[0]).toContain("role IS DISTINCT FROM 'assistant'");
+    expect(query.mock.calls[0]?.[0]).toMatch(/role = 'assistant'[\s\S]+model_execution_source IS NOT NULL/);
+    expect(query.mock.calls[0]?.[0]).toContain('COUNT(*) FILTER (WHERE included_in_denominator)::text AS total');
+    expect(summary.surfaces.thread_messages).toMatchObject({
+      total: 3, provider: 2, local: 1, persisted_data_ready: true,
+    });
+    expect(summary.persisted_data_ready).toBe(true);
+  });
+
+  it('fails closed on malformed aggregate counts', () => {
+    expect(() => summarizeModelExecutionReadiness([
+      aggregate('thread_messages', { total: '12oops' }),
+      aggregate('interactions'),
+    ], { hours: 24, minimumSamples: 1, now: NOW })).toThrow(
+      'Invalid aggregate count for thread_messages.total',
+    );
+  });
+
+  it('fails closed when a surface aggregate is missing or duplicated', () => {
+    expect(() => summarizeModelExecutionReadiness([
+      aggregate('thread_messages'),
+    ], { hours: 24, minimumSamples: 1, now: NOW })).toThrow(
+      'Readiness aggregate must contain exactly one row per surface',
+    );
+    expect(() => summarizeModelExecutionReadiness([
+      aggregate('thread_messages'),
+      aggregate('thread_messages'),
+    ], { hours: 24, minimumSamples: 1, now: NOW })).toThrow(
+      'Readiness aggregate must contain exactly one row per surface',
+    );
+  });
+
+  it('reports an unobserved interaction sink as inconclusive', () => {
+    const summary = summarizeModelExecutionReadiness([
+      aggregate('thread_messages'),
+      aggregate('interactions', { total: '0', provider: '0', local: '0' }),
+    ], { hours: 24, minimumSamples: 100, now: NOW });
+
+    expect(summary.surfaces.interactions).toMatchObject({
+      total: 0,
+      persisted_data_ready: false,
+      blockers: ['insufficient_sample_size'],
+    });
+    expect(summary.blockers).toContainEqual({
+      surface: 'interactions',
+      reason: 'insufficient_sample_size',
+    });
+  });
+
+  it.each([
+    [{ hours: 0 }, 'hours must be an integer from 1 to 168'],
+    [{ hours: 1.5 }, 'hours must be an integer from 1 to 168'],
+    [{ hours: 169 }, 'hours must be an integer from 1 to 168'],
+    [{ minimumSamples: 0 }, 'minimumSamples must be an integer from 1 to 10000'],
+    [{ minimumSamples: 10_001 }, 'minimumSamples must be an integer from 1 to 10000'],
+    [{ now: new Date('invalid') }, 'now must be a valid date'],
+  ])('rejects invalid options before querying: %j', async (options, message) => {
+    const query = vi.fn();
+    await expect(getModelExecutionReadiness(options, query)).rejects.toThrow(message);
+    expect(query).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add a global-admin-only aggregate report for recent model-execution provenance
- report canonical thread messages and the still-active legacy interaction audit as separate surfaces, so duplicate writes are never blended
- fail closed on unclassified, legacy, invalid, missing-surface, malformed-count, and unobserved interaction data
- explicitly scope the result to persisted data; deployment drain/error evidence is still required before contract migration, and provider canaries retain separate quality/fallback gates

## Safety and privacy

- the query selects only provenance metadata and aggregate counts
- no message, input, output, user, thread, or channel content is returned
- the endpoint is protected by the existing global-admin boundary; tenant admin keys are rejected
- non-assistant rows carrying provenance block readiness without inflating the assistant sample denominator

## Validation

- expert code and evaluation-integrity review: signed off
- typecheck
- focused readiness/admin tests: 21/21
- full server unit suite: 6,850 passed, 30 skipped
- fresh database migrations through 557 plus thread-service integration: 48/48
- migration validation and diff check

## Scope

This is an Addie application observability change and does not modify the published AdCP protocol surface. No changeset is required.

Relates to #6842, #6844, and #6846.
