### PR TITLE
fix(certification): restore LinkedIn credential sharing

### DIFF
--- a/server/public/certification.html
+++ b/server/public/certification.html
@@ -1256,7 +1256,7 @@
 
           var credName = credDef.name;
           var hasCertifier = !!mc.certifier_public_id;
-          var certUrl = hasCertifier ? 'https://credsverse.com/credentials/' + mc.certifier_public_id : '';
+          var certUrl = hasCertifier ? 'https://credsverse.com/credentials/' + encodeURIComponent(String(mc.certifier_public_id)) : '';
           var certPageUrl = window.location.origin + '/certification';
           var shareUrl = certUrl || certPageUrl;
           var badgeImgUrl = mc.certifier_badge_url || '';
@@ -1267,7 +1267,7 @@
             html += '<div class="credential-badge-row">';
             if (badgeImgUrl) {
               var badgeLink = certUrl || certPageUrl;
-              html += '<a href="' + badgeLink + '" target="_blank" rel="noopener" class="credential-badge-link">';
+              html += '<a href="' + esc(badgeLink) + '" target="_blank" rel="noopener" class="credential-badge-link">';
               html += '<img src="' + esc(badgeImgUrl) + '" alt="' + esc(credName) + ' credential badge" class="credential-badge-img" onerror="this.style.display=\'none\'" />';
               html += '</a>';
             }
@@ -1275,7 +1275,7 @@
             html += '<div class="credential-badge-name">' + esc(credName) + '</div>';
             html += '<div class="credential-badge-date">Earned ' + dateStr + '</div>';
             if (hasCertifier) {
-              html += '<a href="' + certUrl + '" target="_blank" rel="noopener" class="credential-badge-verify">View credential, QR code &amp; verification</a>';
+              html += '<a href="' + esc(certUrl) + '" target="_blank" rel="noopener" class="credential-badge-verify">View credential, QR code &amp; verification</a>';
             }
             html += '</div>';
             html += '</div>';
@@ -1283,7 +1283,7 @@
             html += '<div class="credential-badge-info">';
             html += '<div class="credential-badge-name">' + esc(credName) + '</div>';
             html += '<div class="credential-badge-date">Earned ' + dateStr + '</div>';
-            html += '<p class="credential-pending-note">Digital badge is being processed.</p>';
+            html += '<p class="credential-pending-note">External verification is not currently available.</p>';
             html += '</div>';
           }
 
@@ -1445,17 +1445,17 @@
 
         tierMeta.forEach(function(meta, idx) {
           var creds = tiered[idx];
-          var primaryCred = creds[0]; // main credential for this tier
-          var earned = primaryCred ? hasCredential(primaryCred.id) : false;
+          // A tier can contain alternate credentials (for example, the
+          // reasoning-only Level 1 path). Prefer an earned credential for the
+          // card and open the share panel when any credential in the tier is
+          // earned, rather than gating everything on the first definition.
+          var earnedCred = creds.find(function(c) { return hasCredential(c.id); });
+          var primaryCred = earnedCred || creds[0];
+          var earned = !!earnedCred;
           var prog = primaryCred && state.isAuthenticated ? getTierProgress(primaryCred) : null;
 
           var name = primaryCred ? primaryCred.name : meta.fallbackName;
           var req = primaryCred ? primaryCred.description : meta.fallbackReq;
-
-          // For tier 3, check if ANY specialist credential is earned
-          if (meta.level === 3 && creds.length > 1) {
-            earned = creds.some(function(c) { return hasCredential(c.id); });
-          }
 
           html += '<div class="tier-card ' + (earned ? 'tier-card-earned' : '') + '" data-tier="' + meta.level + '">';
           html += '  <div class="tier-card-header">';

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.28';
+export const CODE_VERSION = '2026.08.29';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -608,20 +608,23 @@ function buildShareLinks(
   const lines: string[] = [];
   const year = awardedDate.getFullYear();
   const month = awardedDate.getMonth() + 1;
+  let linkedInUrl = `https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME`
+    + `&name=${encodeURIComponent(credName)}`
+    + `&organizationName=${encodeURIComponent('AgenticAdvertising.org')}`
+    + `&issueYear=${year}&issueMonth=${month}`;
 
   if (certifierPublicId) {
-    const certUrl = `https://credsverse.com/credentials/${certifierPublicId}`;
-    const linkedInUrl = `https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME`
-      + `&name=${encodeURIComponent(credName)}`
-      + `&organizationName=${encodeURIComponent('AgenticAdvertising.org')}`
-      + `&issueYear=${year}&issueMonth=${month}`
-      + `&certId=${encodeURIComponent(certifierPublicId)}`
+    const encodedPublicId = encodeURIComponent(certifierPublicId);
+    const certUrl = `https://credsverse.com/credentials/${encodedPublicId}`;
+    linkedInUrl += `&certId=${encodeURIComponent(certifierPublicId)}`
       + `&certUrl=${encodeURIComponent(certUrl)}`;
 
     lines.push(`- [View and share your credential](${certUrl})`);
-    lines.push(`- [Add to LinkedIn profile](${linkedInUrl})`);
   }
 
+  // LinkedIn's certification form remains available without a third-party
+  // credential URL, even though LinkedIn no longer autofills these fields.
+  lines.push(`- [Add to LinkedIn profile](${linkedInUrl})`);
   lines.push('- [View all credentials](/certification.html)');
   return lines;
 }

--- a/server/tests/unit/certification-dashboard-credential-sharing.test.ts
+++ b/server/tests/unit/certification-dashboard-credential-sharing.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const certificationHtml = readFileSync(
+  join(process.cwd(), 'server/public/certification.html'),
+  'utf8',
+);
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (condition()) return;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error('Certification dashboard did not finish rendering');
+}
+
+describe('certification dashboard credential sharing', () => {
+  it('shows an earned alternate Level 1 credential and its LinkedIn action', async () => {
+    const dom = new JSDOM(certificationHtml, {
+      url: 'https://example.test/certification.html',
+      runScripts: 'dangerously',
+      beforeParse(window) {
+        window.fetch = (async (input: RequestInfo | URL) => {
+          const path = typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.pathname
+              : new URL(input.url).pathname;
+
+          if (path === '/api/config') {
+            return jsonResponse({ user: { id: 'user_test', isMember: false } });
+          }
+          if (path === '/api/certification/tracks') return jsonResponse({ tracks: [] });
+          if (path === '/api/certification/credentials') {
+            return jsonResponse({
+              credentials: [
+                {
+                  id: 'basics',
+                  tier: 1,
+                  name: 'AdCP Basics',
+                  description: 'Foundational credential',
+                  required_modules: ['A1', 'A2'],
+                  sort_order: 1,
+                },
+                {
+                  id: 'decision_makers',
+                  tier: 1,
+                  name: 'AdCP for Decision-Makers',
+                  description: 'Strategic credential',
+                  required_modules: ['L1', 'L2', 'L3'],
+                  sort_order: 8,
+                },
+              ],
+            });
+          }
+          if (path === '/api/me/certification/progress') {
+            return jsonResponse({ progress: [], trackProgress: [], certifications: [] });
+          }
+          if (path === '/api/me/certification/credentials') {
+            return jsonResponse({
+              credentials: [{
+                credential_id: 'decision_makers',
+                awarded_at: '2026-08-26T00:00:00.000Z',
+                certifier_public_id: null,
+                certifier_badge_url: null,
+              }],
+            });
+          }
+          if (path === '/api/me/certification/contributions') {
+            return jsonResponse({ contributions: [] });
+          }
+          if (path === '/api/me/certification/expectation') return jsonResponse({});
+          if (path === '/api/certification/stats') {
+            return jsonResponse({ totalCertified: 0, totalOrgs: 0 });
+          }
+          return jsonResponse({});
+        }) as typeof fetch;
+      },
+    });
+
+    await waitFor(() => dom.window.document.querySelector('.tier-share-panel') !== null);
+
+    const levelOneCard = dom.window.document.querySelector('[data-tier="1"]');
+    expect(levelOneCard?.querySelector('.tier-name')?.textContent).toBe('AdCP for Decision-Makers');
+    expect(levelOneCard?.classList.contains('tier-card-earned')).toBe(true);
+    expect(levelOneCard?.querySelector('.credential-pending-note')?.textContent).toBe(
+      'External verification is not currently available.',
+    );
+
+    const linkedInAction = Array.from(levelOneCard?.querySelectorAll('a') ?? [])
+      .find(link => link.textContent?.trim() === 'Add to LinkedIn profile');
+    expect(linkedInAction?.getAttribute('href')).toContain(
+      'https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME',
+    );
+    expect(linkedInAction?.getAttribute('href')).toContain('name=AdCP%20for%20Decision-Makers');
+
+    dom.window.close();
+  });
+});

--- a/server/tests/unit/certification-deferred-badge-membership.test.ts
+++ b/server/tests/unit/certification-deferred-badge-membership.test.ts
@@ -118,4 +118,33 @@ describe('deferred certification badge membership gate', () => {
     });
     expect(result).toContain('Credential earned: AdCP Practitioner!');
   });
+
+  it('returns a LinkedIn profile link when an earned credential has no external badge configured', async () => {
+    mocks.checkAndAwardCredentials.mockResolvedValue(['decision_makers']);
+    mocks.getCredentials.mockResolvedValue([{
+      id: 'decision_makers',
+      name: 'AdCP for Decision-Makers',
+      tier: 1,
+      certifier_group_id: null,
+    }]);
+    mocks.getUserCredentials.mockResolvedValue([]);
+
+    const handlers = createCertificationToolHandlers({
+      is_member: false,
+      workos_user: {
+        workos_user_id: 'user_decision_maker',
+        email: 'learner@example.test',
+        first_name: 'Test',
+        last_name: 'Learner',
+      },
+    } as any);
+
+    const result = await handlers.get('check_credentials')?.({});
+
+    expect(result).toContain('Credential earned: AdCP for Decision-Makers!');
+    expect(result).toContain('[Add to LinkedIn profile](https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME');
+    expect(result).toContain('&name=AdCP%20for%20Decision-Makers');
+    expect(result).not.toContain('&certId=');
+    expect(mocks.ensureCertifierCredential).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- return a LinkedIn Add-to-Profile form link for earned credentials even when external verification is unavailable
- render earned alternate credentials within a tier on the certification dashboard
- clarify external-verification state and encode external credential IDs

## Testing
- `npm run test:server-unit` (480 files; 6,829 passed, 30 skipped)
- `npm exec -- vitest run --config server/vitest.config.ts tests/unit/certification-deferred-badge-membership.test.ts tests/unit/certification-dashboard-credential-sharing.test.ts tests/unit/certification-credential-issuance.test.ts` (17 passed)
- `npm run typecheck`

## Review
- code reviewer: approved
- security reviewer: approved after external-ID hardening
- certification reviewer: approved after learner-trust copy correction

No protocol changeset: application/Addie/UI-only fix.