### PR TITLE
fix(addie): recover filtered empty responses

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -30,7 +30,12 @@ import {
   formatCapExceededMessage,
   type UserTier,
 } from './claude-cost-tracker.js';
-import { EMPTY_RESPONSE_FALLBACK, applyResponsePipeline, stripBannedRituals, hasPersonaCollapse } from './response-postprocess.js';
+import {
+  EMPTY_RESPONSE_FALLBACK,
+  applyResponsePipeline,
+  stripBannedRituals,
+  hasPersonaCollapse,
+} from './response-postprocess.js';
 import type { AddieInputAttachment } from './chat-attachments.js';
 import type { ModelExecution } from './model-providers/model-provider.js';
 import {
@@ -93,16 +98,19 @@ interface PreparedProviderRequest {
 
 const BLOCKED_TOOL_RESULT = 'Error: Tool execution blocked by policy';
 const DEFAULT_MAX_OUTPUT_TOKENS = 8_192;
-const SONNET_5_MAX_OUTPUT_TOKENS = 16_384;
+const SONNET_5_MAX_OUTPUT_TOKENS = 32_768;
 
-function addieModelOutputControls(model: string): Pick<PreparedProviderRequest, 'max_tokens' | 'output_config'> {
+function addieModelOutputControls(
+  model: string,
+  maxOutputTokens?: number,
+): Pick<PreparedProviderRequest, 'max_tokens' | 'output_config'> {
   if (/^claude-sonnet-5(?:-|$)/.test(model)) {
     return {
-      max_tokens: SONNET_5_MAX_OUTPUT_TOKENS,
+      max_tokens: Math.min(SONNET_5_MAX_OUTPUT_TOKENS, maxOutputTokens ?? SONNET_5_MAX_OUTPUT_TOKENS),
       output_config: { effort: 'medium' },
     };
   }
-  return { max_tokens: DEFAULT_MAX_OUTPUT_TOKENS };
+  return { max_tokens: Math.min(DEFAULT_MAX_OUTPUT_TOKENS, maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS) };
 }
 
 function isEvaluationExecution(options?: ProcessMessageOptions): boolean {
@@ -172,22 +180,23 @@ function classifyStopReason(reason: Anthropic.Beta.BetaStopReason | null): StopA
 /**
  * A successful first turn is safe to resample only when it has no visible
  * answer and every provider block is side-effect-free. Sonnet 5 may return
- * private thinking (or a blank text block) before an otherwise empty
- * `end_turn`; those bytes must neither block recovery nor reach logs. Unknown,
- * tool, server-tool, and result blocks remain fail-closed.
+ * private thinking or allowlisted ritual-only text before an otherwise empty
+ * `end_turn`; those bytes must neither block recovery nor reach logs. Persona
+ * disclosures may contain semantic refusals, so they are not retryable.
+ * Unknown, tool, server-tool, and result blocks remain fail-closed.
  */
 function isSideEffectFreeEmptyEndTurn(
   response: Pick<Anthropic.Beta.BetaMessage, 'stop_reason' | 'content'>,
   visibleText: string,
 ): boolean {
-  if (response.stop_reason !== 'end_turn' || visibleText.trim().length > 0) {
+  const deliverableText = stripBannedRituals(visibleText);
+  if (response.stop_reason !== 'end_turn' || deliverableText.trim().length > 0) {
     return false;
   }
 
   return response.content.every((block) => {
     switch (block.type) {
       case 'text':
-        return block.text.trim().length === 0;
       case 'thinking':
       case 'redacted_thinking':
         return true;
@@ -1166,13 +1175,14 @@ export class AddieClaudeClient {
     systemBlocks: Anthropic.TextBlockParam[],
     tools: Array<Record<string, unknown>>,
     messages: Anthropic.MessageParam[],
+    maxOutputTokens?: number,
   ) {
     return {
       model: effectiveModel,
       // Sonnet 5 defaults to high-effort adaptive thinking, and max_tokens
       // covers both reasoning and visible output. Medium effort plus a larger
       // cap keeps tool-heavy chat from spending the whole request on thinking.
-      ...addieModelOutputControls(effectiveModel),
+      ...addieModelOutputControls(effectiveModel, maxOutputTokens),
       system: systemBlocks,
       tools,
       messages,
@@ -1373,6 +1383,7 @@ export class AddieClaudeClient {
             systemBlocks,
             invocationTools as unknown as Array<Record<string, unknown>>,
             messages,
+            isEmptyResponseRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
           );
           await this.notifyInvocationPrepared(
             options,
@@ -1618,7 +1629,7 @@ export class AddieClaudeClient {
         // safe because no assistant response has reached the caller yet.
         if (
           response.stop_reason === 'end_turn'
-          && !rawText
+          && isSideEffectFreeEmptyEndTurn(response, rawText)
           && hasExecutedCustomTool
           && !retriedEmptyPostToolResponse
           && iteration < maxIterations
@@ -2241,7 +2252,10 @@ export class AddieClaudeClient {
             const invocationTools = retriedEmptyPostToolResponse ? [] : customTools;
             const providerRequest: PreparedProviderRequest = {
               model: effectiveModel,
-              ...addieModelOutputControls(effectiveModel),
+              ...addieModelOutputControls(
+                effectiveModel,
+                isEmptyResponseRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
+              ),
               system: systemBlocks,
               tools: invocationTools as unknown as Array<Record<string, unknown>>,
               messages,
@@ -2507,12 +2521,11 @@ export class AddieClaudeClient {
             continue;
           }
 
-          // No deltas were emitted for this iteration, so retrying the same
-          // post-tool turn once cannot duplicate text in streaming clients.
+          // Logical-turn buffering means no text from this iteration has been
+          // emitted, so retrying ritual-only output cannot duplicate text.
           if (
             currentResponse.stop_reason === 'end_turn'
-            && !iterationText.trim()
-            && receivedDeltaCount === 0
+            && isSideEffectFreeEmptyEndTurn(currentResponse, iterationText)
             && toolExecutions.length > 0
             && !retriedEmptyPostToolResponse
             && iteration < maxIterations

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.28';
+export const CODE_VERSION = '2026.08.29';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "129ba9c62dad14f90bc304208d1975ec801196fdaa4bcdca4d96fa6a352e91cc",
+    "server/src/addie/claude-client.ts": "64574931e0d18000e1f5a99a6bb39744bb1cc1749440d1439411b86486deeb22",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/utils/token-limiter.ts
+++ b/server/src/utils/token-limiter.ts
@@ -64,6 +64,13 @@ export const TOKEN_BUFFERS = {
   safetyMargin: 10000,
 };
 
+/** Match the largest normal chat response budget sent for each model family. */
+export function getResponseTokenReserve(model?: string): number {
+  return /^claude-sonnet-5(?:-|$)/.test(model ?? '')
+    ? 32768
+    : TOKEN_BUFFERS.responseBuffer;
+}
+
 /**
  * Total reserved tokens (not available for conversation history)
  */
@@ -96,6 +103,7 @@ export function estimateToolTokens(toolCount: number): number {
  */
 export function getConversationTokenLimit(model?: string, toolCount?: number): number {
   const limit = MODEL_CONTEXT_LIMITS[model ?? 'default'] ?? MODEL_CONTEXT_LIMITS.default;
+  const responseBuffer = getResponseTokenReserve(model);
 
   // If tool count is provided, use dynamic calculation
   if (toolCount !== undefined) {
@@ -104,13 +112,13 @@ export function getConversationTokenLimit(model?: string, toolCount?: number): n
       TOKEN_BUFFERS.systemPrompt +
       toolTokens +
       TOKEN_BUFFERS.prependedContext +
-      TOKEN_BUFFERS.responseBuffer +
+      responseBuffer +
       TOKEN_BUFFERS.safetyMargin;
     return limit - reserved;
   }
 
   // Fall back to default static buffer
-  return limit - RESERVED_TOKENS;
+  return limit - RESERVED_TOKENS - responseBuffer + TOKEN_BUFFERS.responseBuffer;
 }
 
 /**
@@ -389,7 +397,7 @@ export function checkContextLimit(
   headroom: number;
 } {
   const modelLimit = MODEL_CONTEXT_LIMITS[model ?? 'default'] ?? MODEL_CONTEXT_LIMITS.default;
-  const estimatedTotal = systemPromptTokens + messagesTokens + toolsTokens + TOKEN_BUFFERS.prependedContext + TOKEN_BUFFERS.responseBuffer;
+  const estimatedTotal = systemPromptTokens + messagesTokens + toolsTokens + TOKEN_BUFFERS.prependedContext + getResponseTokenReserve(model);
   const headroom = modelLimit - estimatedTotal;
 
   return {

--- a/server/tests/unit/addie-empty-response-fallback.test.ts
+++ b/server/tests/unit/addie-empty-response-fallback.test.ts
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => ({
   streamMessage: vi.fn(),
   notifySystemError: vi.fn(),
   notifyToolError: vi.fn(),
+  checkCostCap: vi.fn(),
+  recordCost: vi.fn(),
 }));
 
 vi.mock('@anthropic-ai/sdk', () => ({
@@ -35,6 +37,14 @@ vi.mock('../../src/addie/rules/index.js', () => ({
 
 vi.mock('../../src/db/addie-db.js', () => ({
   AddieDatabase: class {},
+}));
+
+vi.mock('../../src/addie/claude-cost-tracker.js', () => ({
+  checkCostCap: mocks.checkCostCap,
+  recordCost: mocks.recordCost,
+  releaseCertificationReserve: vi.fn(),
+  renewCertificationReserve: vi.fn(),
+  formatCapExceededMessage: vi.fn(() => 'cap exceeded'),
 }));
 
 import {
@@ -94,6 +104,13 @@ const blankTextEndTurn = {
   usage: { input_tokens: 10, output_tokens: 1 },
 };
 
+const ritualOnlyEndTurn = {
+  model: 'claude-sonnet-5-20260801',
+  stop_reason: 'end_turn',
+  content: [{ type: 'text', text: 'Great question.' }],
+  usage: { input_tokens: 10, output_tokens: 3 },
+};
+
 const redactedThinkingOnlyEndTurn = {
   model: 'claude-sonnet-5-20260801',
   stop_reason: 'end_turn',
@@ -114,6 +131,16 @@ const personaOnlyEndTurn = {
     text: "I'm Claude, an AI assistant made by Anthropic. As a large language model, I have no real-world identity.",
   }],
   usage: { input_tokens: 12, output_tokens: 20 },
+};
+
+const semanticRefusalEndTurn = {
+  model: 'claude-sonnet-5-20260801',
+  stop_reason: 'end_turn',
+  content: [{
+    type: 'text',
+    text: 'As a large language model, I cannot help with that request.',
+  }],
+  usage: { input_tokens: 12, output_tokens: 14 },
 };
 
 const emptyToolUseTurn = {
@@ -182,7 +209,7 @@ function makeThrowingStream(error: Error) {
   };
 }
 
-function makeStream(message: typeof toolUseTurn | typeof emptyEndTurn | typeof recoveredEndTurn | typeof personaOnlyEndTurn | typeof mixedRecoveryToolUseTurn | typeof emptyRefusal | typeof thinkingOnlyEndTurn | typeof redactedThinkingOnlyEndTurn | typeof blankTextEndTurn) {
+function makeStream(message: typeof toolUseTurn | typeof emptyEndTurn | typeof recoveredEndTurn | typeof personaOnlyEndTurn | typeof semanticRefusalEndTurn | typeof mixedRecoveryToolUseTurn | typeof emptyRefusal | typeof thinkingOnlyEndTurn | typeof redactedThinkingOnlyEndTurn | typeof blankTextEndTurn | typeof ritualOnlyEndTurn) {
   return {
     async *[Symbol.asyncIterator]() {
       for (const block of message.content) {
@@ -211,6 +238,8 @@ describe('Addie empty-response fallback (#4430)', () => {
     mocks.streamMessage.mockReset();
     mocks.notifySystemError.mockReset();
     mocks.notifyToolError.mockReset();
+    mocks.checkCostCap.mockReset().mockResolvedValue({ ok: true });
+    mocks.recordCost.mockReset().mockResolvedValue(undefined);
     getGithubIssue.mockClear();
   });
 
@@ -281,7 +310,7 @@ describe('Addie empty-response fallback (#4430)', () => {
     }));
   });
 
-  it('classifies persona-only provider output as a local fallback in both paths', async () => {
+  it('classifies persona-only provider output as a local fallback without resampling', async () => {
     mocks.createMessage.mockResolvedValueOnce(personaOnlyEndTurn);
     mocks.streamMessage.mockReturnValueOnce(makeStream(personaOnlyEndTurn));
     const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
@@ -301,6 +330,7 @@ describe('Addie empty-response fallback (#4430)', () => {
       requested_model: 'claude-sonnet-5',
       reason: 'no_provider_response',
     });
+    expect(mocks.createMessage).toHaveBeenCalledOnce();
 
     const events: StreamEvent[] = [];
     for await (const event of client.processMessageStream(
@@ -320,6 +350,37 @@ describe('Addie empty-response fallback (#4430)', () => {
       requested_model: 'claude-sonnet-5',
       reason: 'no_provider_response',
     });
+    expect(mocks.streamMessage).toHaveBeenCalledOnce();
+  });
+
+  it('never resamples a semantic refusal returned as end_turn', async () => {
+    mocks.createMessage.mockResolvedValueOnce(semanticRefusalEndTurn);
+    mocks.streamMessage.mockReturnValueOnce(makeStream(semanticRefusalEndTurn));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+
+    const response = await client.processMessage(
+      'perform the blocked action',
+      undefined,
+      githubIssueTools,
+      undefined,
+      { uncapped: true },
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of client.processMessageStream(
+      'perform the blocked action',
+      undefined,
+      githubIssueTools,
+      { uncapped: true },
+    )) events.push(event);
+
+    const done = events.find(
+      (event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done',
+    );
+    expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(done?.response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(mocks.createMessage).toHaveBeenCalledOnce();
+    expect(mocks.streamMessage).toHaveBeenCalledOnce();
+    expect(getGithubIssue).not.toHaveBeenCalled();
   });
 
   it('classifies malformed empty tool-use responses as local in both paths', async () => {
@@ -408,7 +469,11 @@ describe('Addie empty-response fallback (#4430)', () => {
     });
     expect(mocks.createMessage).toHaveBeenCalledTimes(2);
     expect(mocks.createMessage.mock.calls[0][0]).toMatchObject({
-      max_tokens: 16_384,
+      max_tokens: 32_768,
+      output_config: { effort: 'medium' },
+    });
+    expect(mocks.createMessage.mock.calls[1][0]).toMatchObject({
+      max_tokens: 8_192,
       output_config: { effort: 'medium' },
     });
     expect(mocks.createMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
@@ -439,7 +504,11 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(done?.response.usage).toMatchObject({ input_tokens: 22, output_tokens: 6 });
     expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
     expect(mocks.streamMessage.mock.calls[0][0]).toMatchObject({
-      max_tokens: 16_384,
+      max_tokens: 32_768,
+      output_config: { effort: 'medium' },
+    });
+    expect(mocks.streamMessage.mock.calls[1][0]).toMatchObject({
+      max_tokens: 8_192,
       output_config: { effort: 'medium' },
     });
     expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
@@ -450,6 +519,7 @@ describe('Addie empty-response fallback (#4430)', () => {
     ['thinking-only', thinkingOnlyEndTurn],
     ['redacted-thinking-only', redactedThinkingOnlyEndTurn],
     ['blank text', blankTextEndTurn],
+    ['ritual-only text', ritualOnlyEndTurn],
   ])('recovers once from a side-effect-free %s initial non-streaming response', async (_label, initial) => {
     mocks.createMessage
       .mockResolvedValueOnce(initial)
@@ -485,11 +555,56 @@ describe('Addie empty-response fallback (#4430)', () => {
     )) events.push(event);
 
     const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    const emittedText = events
+      .filter((event): event is Extract<StreamEvent, { type: 'text' }> => event.type === 'text')
+      .map((event) => event.text)
+      .join('');
+    expect(emittedText).toBe('Issue 42 is open.');
     expect(done?.response.text).toBe('Issue 42 is open.');
     expect(done?.response.usage).toMatchObject({ input_tokens: 22, output_tokens: 15 });
     expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
     expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
     expect(mocks.notifySystemError).not.toHaveBeenCalled();
+  });
+
+  it('charges aggregate initial-recovery usage once per streaming and non-streaming interaction', async () => {
+    mocks.createMessage
+      .mockResolvedValueOnce(emptyEndTurn)
+      .mockResolvedValueOnce(recoveredEndTurn);
+    mocks.streamMessage
+      .mockReturnValueOnce(makeEmptyStream())
+      .mockReturnValueOnce(makeStream(recoveredEndTurn));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+
+    await client.processMessage(
+      'hello',
+      undefined,
+      undefined,
+      undefined,
+      { costScope: { userId: 'user-nonstream', tier: 'member_paid' } },
+    );
+    for await (const _event of client.processMessageStream(
+      'hello',
+      undefined,
+      undefined,
+      { costScope: { userId: 'user-stream', tier: 'member_paid' } },
+    )) {
+      // Consume the complete response so terminal billing runs.
+    }
+
+    expect(mocks.recordCost).toHaveBeenCalledTimes(2);
+    expect(mocks.recordCost).toHaveBeenNthCalledWith(
+      1,
+      'user-nonstream',
+      'claude-sonnet-5',
+      expect.objectContaining({ input_tokens: 22, output_tokens: 6 }),
+    );
+    expect(mocks.recordCost).toHaveBeenNthCalledWith(
+      2,
+      'user-stream',
+      'claude-sonnet-5',
+      expect.objectContaining({ input_tokens: 22, output_tokens: 6 }),
+    );
   });
 
   it('recovers once when a streaming end_turn contains only whitespace text', async () => {
@@ -510,6 +625,32 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(done?.response.text).toBe('Issue 42 is open.');
     expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
     expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+  });
+
+  it('recovers once when streaming text is entirely removed by postprocessing', async () => {
+    mocks.streamMessage
+      .mockReturnValueOnce(makeStream(ritualOnlyEndTurn))
+      .mockReturnValueOnce(makeStream(recoveredEndTurn));
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+    const events: StreamEvent[] = [];
+    for await (const event of client.processMessageStream(
+      'hello',
+      undefined,
+      undefined,
+      { uncapped: true },
+    )) events.push(event);
+
+    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    const emittedText = events
+      .filter((event): event is Extract<StreamEvent, { type: 'text' }> => event.type === 'text')
+      .map((event) => event.text)
+      .join('');
+    expect(emittedText).toBe('Issue 42 is open.');
+    expect(done?.response.text).toBe('Issue 42 is open.');
+    expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.notifySystemError).not.toHaveBeenCalled();
   });
 
   it('does not resample a wholly empty evaluation response', async () => {
@@ -560,6 +701,26 @@ describe('Addie empty-response fallback (#4430)', () => {
 
     expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
     expect(mocks.createMessage).toHaveBeenCalledOnce();
+    expect(getGithubIssue).not.toHaveBeenCalled();
+  });
+
+  it('does not resample a streaming end_turn containing a tool block', async () => {
+    mocks.streamMessage.mockReturnValueOnce(makeStream(toolBlockEndTurn));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+    const events: StreamEvent[] = [];
+
+    for await (const event of client.processMessageStream(
+      'hello',
+      undefined,
+      githubIssueTools,
+      { uncapped: true },
+    )) events.push(event);
+
+    const done = events.find(
+      (event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done',
+    );
+    expect(done?.response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(mocks.streamMessage).toHaveBeenCalledOnce();
     expect(getGithubIssue).not.toHaveBeenCalled();
   });
 
@@ -741,6 +902,44 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(mocks.streamMessage).toHaveBeenCalledTimes(3);
     expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
     expect(mocks.streamMessage.mock.calls[2][1]).toBeUndefined();
+  });
+
+  it('recovers ritual-only text after tool use in both paths', async () => {
+    mocks.createMessage
+      .mockResolvedValueOnce(toolUseTurn)
+      .mockResolvedValueOnce(ritualOnlyEndTurn)
+      .mockResolvedValueOnce(recoveredEndTurn);
+    mocks.streamMessage
+      .mockReturnValueOnce(makeStream(toolUseTurn))
+      .mockReturnValueOnce(makeStream(ritualOnlyEndTurn))
+      .mockReturnValueOnce(makeStream(recoveredEndTurn));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
+
+    const response = await client.processMessage(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      undefined,
+      { uncapped: true },
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of client.processMessageStream(
+      'check issue 42',
+      undefined,
+      githubIssueTools,
+      { uncapped: true },
+    )) events.push(event);
+    const done = events.find(
+      (event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done',
+    );
+
+    expect(response.text).toBe('Issue 42 is open.');
+    expect(done?.response.text).toBe('Issue 42 is open.');
+    expect(getGithubIssue).toHaveBeenCalledTimes(2);
+    expect(mocks.createMessage).toHaveBeenCalledTimes(3);
+    expect(mocks.streamMessage).toHaveBeenCalledTimes(3);
+    expect(mocks.createMessage.mock.calls[2][0].tools).toEqual([]);
+    expect(mocks.streamMessage.mock.calls[2][0].tools).toEqual([]);
   });
 
   it('resamples once after a tool returns an empty non-streaming completion', async () => {

--- a/tests/utils/token-limiter.test.ts
+++ b/tests/utils/token-limiter.test.ts
@@ -11,6 +11,7 @@ import {
   estimateToolTokens,
   trimConversationHistory,
   getConversationTokenLimit,
+  getResponseTokenReserve,
   checkContextLimit,
   formatTokenCount,
   MODEL_CONTEXT_LIMITS,
@@ -183,7 +184,12 @@ describe('getConversationTokenLimit', () => {
 
   it('should return model-specific limit minus reserved tokens', () => {
     const limit = getConversationTokenLimit('claude-sonnet-5');
-    expect(limit).toBe(MODEL_CONTEXT_LIMITS['claude-sonnet-5'] - RESERVED_TOKENS);
+    expect(limit).toBe(
+      MODEL_CONTEXT_LIMITS['claude-sonnet-5']
+      - RESERVED_TOKENS
+      - getResponseTokenReserve('claude-sonnet-5')
+      + TOKEN_BUFFERS.responseBuffer,
+    );
   });
 
   it('should use default for unknown models', () => {
@@ -198,7 +204,7 @@ describe('getConversationTokenLimit', () => {
     // Expected: model limit - (system prompt + tool tokens + prepended context + response buffer + safety margin)
     const expectedToolTokens = estimateToolTokens(toolCount);
     const expectedReserved = TOKEN_BUFFERS.systemPrompt + expectedToolTokens +
-      TOKEN_BUFFERS.prependedContext + TOKEN_BUFFERS.responseBuffer + TOKEN_BUFFERS.safetyMargin;
+      TOKEN_BUFFERS.prependedContext + getResponseTokenReserve('claude-sonnet-5') + TOKEN_BUFFERS.safetyMargin;
     const expectedLimit = MODEL_CONTEXT_LIMITS['claude-sonnet-5'] - expectedReserved;
 
     expect(limit).toBe(expectedLimit);
@@ -242,6 +248,14 @@ describe('checkContextLimit', () => {
     // Total should include prepended context buffer and response buffer
     expect(result.estimatedTotal).toBe(10000 + 20000 + 5000 + TOKEN_BUFFERS.prependedContext + TOKEN_BUFFERS.responseBuffer);
     expect(result.modelLimit).toBe(MODEL_CONTEXT_LIMITS.default);
+  });
+
+  it('should reserve the full Sonnet 5 response budget', () => {
+    const result = checkContextLimit(10000, 20000, 5000, 'claude-sonnet-5');
+
+    expect(result.estimatedTotal).toBe(
+      10000 + 20000 + 5000 + TOKEN_BUFFERS.prependedContext + 32768,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- give Sonnet 5 adaptive thinking more output headroom while reserving matching context capacity
- retry only side-effect-free blank, thinking-only, or allowlisted ritual-only completions
- cap recovery attempts at 8k output tokens and preserve refusal, tool-use, and server-block boundaries

## Testing
- 85 focused Addie and Claude client tests
- 28 token-limiter tests
- typecheck and changeset scope check
- expert code, security, and test reviews
- isolated full-suite timeout case: 7/7 passing

## Risk
- recovery remains a single production-only resample
- semantic refusals, persona disclosures, unknown blocks, tool calls, and server blocks remain terminal
- no changeset: operational Addie-only change