### PR TITLE
fix(addie): cap non-streaming Sonnet output

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -99,6 +99,10 @@ interface PreparedProviderRequest {
 const BLOCKED_TOOL_RESULT = 'Error: Tool execution blocked by policy';
 const DEFAULT_MAX_OUTPUT_TOKENS = 8_192;
 const SONNET_5_MAX_OUTPUT_TOKENS = 32_768;
+// The Anthropic SDK rejects non-streaming requests whose calculated timeout
+// may exceed ten minutes. Sonnet 5 at 32k crosses that guard; streaming does
+// not, so keep the larger budget there and cap only non-streaming calls.
+const SONNET_5_MAX_NONSTREAMING_OUTPUT_TOKENS = 16_384;
 
 function addieModelOutputControls(
   model: string,
@@ -1177,12 +1181,18 @@ export class AddieClaudeClient {
     messages: Anthropic.MessageParam[],
     maxOutputTokens?: number,
   ) {
+    const safeMaxOutputTokens = /^claude-sonnet-5(?:-|$)/.test(effectiveModel)
+      ? Math.min(
+        SONNET_5_MAX_NONSTREAMING_OUTPUT_TOKENS,
+        maxOutputTokens ?? SONNET_5_MAX_NONSTREAMING_OUTPUT_TOKENS,
+      )
+      : maxOutputTokens;
     return {
       model: effectiveModel,
       // Sonnet 5 defaults to high-effort adaptive thinking, and max_tokens
-      // covers both reasoning and visible output. Medium effort plus a larger
-      // cap keeps tool-heavy chat from spending the whole request on thinking.
-      ...addieModelOutputControls(effectiveModel, maxOutputTokens),
+      // covers both reasoning and visible output. Non-streaming requests must
+      // also remain below the SDK's ten-minute safety threshold.
+      ...addieModelOutputControls(effectiveModel, safeMaxOutputTokens),
       system: systemBlocks,
       tools,
       messages,

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.30';
+export const CODE_VERSION = '2026.08.31';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "64574931e0d18000e1f5a99a6bb39744bb1cc1749440d1439411b86486deeb22",
+    "server/src/addie/claude-client.ts": "a27d617b3917bd4bf3c7a9be1116d50e5f588b1a5338d05952d50ec65b7ba93d",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/tests/unit/addie-empty-response-fallback.test.ts
+++ b/server/tests/unit/addie-empty-response-fallback.test.ts
@@ -469,7 +469,7 @@ describe('Addie empty-response fallback (#4430)', () => {
     });
     expect(mocks.createMessage).toHaveBeenCalledTimes(2);
     expect(mocks.createMessage.mock.calls[0][0]).toMatchObject({
-      max_tokens: 32_768,
+      max_tokens: 16_384,
       output_config: { effort: 'medium' },
     });
     expect(mocks.createMessage.mock.calls[1][0]).toMatchObject({


### PR DESCRIPTION
## Summary

- cap non-streaming Sonnet 5 requests at 16,384 output tokens so the Anthropic SDK does not reject them as potentially exceeding its ten-minute non-streaming limit
- preserve the 32,768-token budget for streaming requests
- bump the Addie code version for behavior tracking

## Production evidence

Three user-facing Addie errors appeared in Slack after the 32,768-token default deployed. The exact error was: `Streaming is required for operations that may take longer than 10 minutes.` The installed SDK accepts 16,384 for non-streaming requests and rejects 32,768 before sending the request.

## Validation

- `npm run typecheck`
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie-empty-response-fallback.test.ts` (39/39)
- `git diff --check`
- independent code review: no findings, merge recommended

No protocol changeset is required; this is Addie application behavior only.