### PR TITLE
fix(deploy): provision Luna router provider secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,18 +114,24 @@ jobs:
             exit 1
           fi
 
-      - name: Stage Luna router shadow HMAC secret
+      - name: Stage Luna router shadow secrets
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           ROUTER_SHADOW_HMAC_KEY: ${{ secrets.ADDIE_ROUTER_LUNA_SHADOW_HMAC_KEY }}
+          ROUTER_SHADOW_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
           if [ "${#ROUTER_SHADOW_HMAC_KEY}" -lt 32 ]; then
             echo "::error::ADDIE_ROUTER_LUNA_SHADOW_HMAC_KEY must be at least 32 characters."
             exit 1
           fi
+          if [ -z "${ROUTER_SHADOW_OPENAI_API_KEY}" ]; then
+            echo "::error::OPENAI_API_KEY must be configured."
+            exit 1
+          fi
           flyctl secrets set --stage \
-            ADDIE_ROUTER_LUNA_SHADOW_HMAC_KEY="${ROUTER_SHADOW_HMAC_KEY}"
+            ADDIE_ROUTER_LUNA_SHADOW_HMAC_KEY="${ROUTER_SHADOW_HMAC_KEY}" \
+            OPENAI_API_KEY="${ROUTER_SHADOW_OPENAI_API_KEY}"
 
       - name: Require Luna router shadow provider secrets
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,6 +114,34 @@ jobs:
             exit 1
           fi
 
+      - name: Stage Luna router shadow HMAC secret
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          ROUTER_SHADOW_HMAC_KEY: ${{ secrets.ADDIE_ROUTER_LUNA_SHADOW_HMAC_KEY }}
+        run: |
+          set -euo pipefail
+          if [ "${#ROUTER_SHADOW_HMAC_KEY}" -lt 32 ]; then
+            echo "::error::ADDIE_ROUTER_LUNA_SHADOW_HMAC_KEY must be at least 32 characters."
+            exit 1
+          fi
+          flyctl secrets set --stage \
+            ADDIE_ROUTER_LUNA_SHADOW_HMAC_KEY="${ROUTER_SHADOW_HMAC_KEY}"
+
+      - name: Require Luna router shadow provider secrets
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          secrets=$(flyctl secrets list --json)
+          for required in OPENAI_API_KEY ADDIE_ROUTER_LUNA_SHADOW_HMAC_KEY; do
+            if ! echo "${secrets}" | jq -e --arg required "${required}" \
+              'if type == "array" then any(.[]; (.Name // .name) == $required) else error("expected Fly secrets JSON array") end' \
+              >/dev/null; then
+              echo "::error::Required Fly secret ${required} is missing."
+              exit 1
+            fi
+          done
+
       # flyctl deploy can fail for two very different reasons:
       #   1. The new image is broken (real failure — must block).
       #   2. Fly's machines API was unreachable during health-check polling

--- a/fly.toml
+++ b/fly.toml
@@ -24,6 +24,16 @@ primary_region = 'iad'
   # Disabled - migrations now run via release_command
   RUN_MIGRATIONS = "false"
   PUBLISHER_CRAWL_QUEUE_ENABLED = "true"
+  # Bounded, evaluation-only Luna router shadow. The runtime additionally
+  # fails closed unless the channel is public and non-shared and the HMAC and
+  # OpenAI provider secrets are present. No shadow output reaches users.
+  ADDIE_ROUTER_LUNA_SHADOW_ENABLED = "true"
+  ADDIE_ROUTER_LUNA_SHADOW_PRODUCTION_DATA_APPROVED = "true"
+  ADDIE_ROUTER_LUNA_SHADOW_CHANNEL_IDS = "C09NUQS93DF"
+  ADDIE_ROUTER_LUNA_SHADOW_SAMPLE_BPS = "10000"
+  ADDIE_ROUTER_LUNA_SHADOW_DAILY_LIMIT = "10"
+  ADDIE_ROUTER_LUNA_SHADOW_DAILY_BUDGET_MICROS = "140000"
+  ADDIE_ROUTER_LUNA_SHADOW_HMAC_KEY_VERSION = "governance-pilot-v1"
   # AdCP 3.2 beta is public; expose the deterministic proposal-negotiation labs.
   ENABLE_ADCP_3_2_PROPOSAL_PROFILES = "true"
   # Use pre-cloned repos from Docker build, skip runtime git fetch.


### PR DESCRIPTION
## Summary
- stage the encrypted OpenAI provider key alongside the router-shadow HMAC before deployment
- fail before touching machines if either repository secret is absent
- retain the existing Fly-side secret verification before rollout

## Context
The bounded router-shadow launch PR merged safely, but its first current-main deployment stopped at the provider-secret gate because Fly did not yet contain `OPENAI_API_KEY`. The HMAC remained staged and no machines were updated. This follow-up completes the encrypted handoff.

## Verification
- pre-commit suite: 1,105 tests passed plus typecheck
- workflow YAML parses successfully
- diff check clean