### PR TITLE
chore(auth): stage read-only authorization ceiling

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -37,6 +37,10 @@ primary_region = 'iad'
   ADDIE_ROUTER_LUNA_SHADOW_HMAC_KEY_VERSION = "governance-pilot-v1"
   # AdCP 3.2 beta is public; expose the deterministic proposal-negotiation labs.
   ENABLE_ADCP_3_2_PROPOSAL_PROFILES = "true"
+  # Deployment-time ceiling for the issue #6827 read-only authorization canary.
+  # The database runtime gate remains independently disabled until explicitly armed.
+  ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true"
+  ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = "organization_roles_read"
   # Use pre-cloned repos from Docker build, skip runtime git fetch.
   # Production image has no git binary — unsetting this degrades gracefully
   # (repos skip indexing) but does not crash.


### PR DESCRIPTION
## Summary

- stage the deployment-time ceiling for the `organization_roles_read` canary
- leave the independent database runtime gate disabled
- keep every write, billing, admin, destructive, and session boundary out of scope

## Rollout safety

This config-only deployment is behavior-neutral until the audited runtime switch is explicitly armed. The default-off observation window has passed with clean health, authorization telemetry, issue feedback, and indexed Slack evidence. After deployment, the runtime gate remains off through a fresh settling interval; rollback remains an immediate runtime write.

## Validation

- `git diff --check`
- production runtime setting verified disabled
- production environment ceiling verified empty before this PR
- current production health and latest tested-SHA deployment verified healthy

Closes no issue; staged rollout for #6827.