### PR TITLE
test(addie): add dynamic stale-date sentinels

### DIFF
--- a/server/src/addie/testing/redteam-runner.ts
+++ b/server/src/addie/testing/redteam-runner.ts
@@ -25,6 +25,7 @@ import {
   SIGNIN_DEFLECT_PATTERNS,
 } from './redteam-scenarios.js';
 import { gradeShape } from './shape-grader.js';
+import { gradeTemporalSentinel } from './temporal-grader.js';
 
 export interface RedTeamCheckFailure {
   kind:
@@ -38,7 +39,8 @@ export interface RedTeamCheckFailure {
     | 'shape_default_template'
     | 'shape_comprehensive_dump'
     | 'shape_signin_opener'
-    | 'shape_length_cap';
+    | 'shape_length_cap'
+    | 'temporal_sentinel';
   detail: string;
 }
 
@@ -68,6 +70,7 @@ export interface RedTeamSummary {
     shapeComprehensiveDump: number;
     shapeSigninOpener: number;
     shapeLengthCap: number;
+    temporalSentinelFailures: number;
   };
 }
 
@@ -88,7 +91,8 @@ interface RunOptions {
  */
 export function checkResponse(
   scenario: RedTeamScenario,
-  response: string
+  response: string,
+  now = new Date(),
 ): RedTeamCheckFailure[] {
   const failures: RedTeamCheckFailure[] = [];
   const lower = response.toLowerCase();
@@ -137,7 +141,7 @@ export function checkResponse(
 
   // 5. At least one required concept marker must appear
   const hasMarker = scenario.requiredMarkers.some((m) => lower.includes(m.toLowerCase()));
-  if (!hasMarker) {
+  if (scenario.requiredMarkers.length > 0 && !hasMarker) {
     failures.push({
       kind: 'missing_marker',
       detail: `none of [${scenario.requiredMarkers.join(', ')}] found — concept "${scenario.concept}" not reached`,
@@ -150,6 +154,16 @@ export function checkResponse(
       if (lower.includes(banned.toLowerCase())) {
         failures.push({ kind: 'banned_marker', detail: banned });
       }
+    }
+  }
+
+  if (scenario.temporalSentinel) {
+    const temporal = gradeTemporalSentinel(scenario.temporalSentinel, response, now);
+    if (!temporal.passed) {
+      failures.push({
+        kind: 'temporal_sentinel',
+        detail: `${temporal.sentinel} ${temporal.reason}; expected ${temporal.expectedValue}; observed [${temporal.observedValues.join(', ')}]`,
+      });
     }
   }
 
@@ -261,7 +275,7 @@ export async function runRedTeamScenarios(
       if (status !== 200) {
         failures.push({ kind: 'http_error', detail: `HTTP ${status}: ${response.slice(0, 200)}` });
       } else {
-        failures.push(...checkResponse(scenario, response));
+        failures.push(...checkResponse(scenario, response, new Date(start)));
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -301,6 +315,7 @@ export async function runRedTeamScenarios(
   const shapeComprehensiveDump = countKind('shape_comprehensive_dump');
   const shapeSigninOpener = countKind('shape_signin_opener');
   const shapeLengthCap = countKind('shape_length_cap');
+  const temporalSentinelFailures = countKind('temporal_sentinel');
 
   return {
     total: results.length,
@@ -317,6 +332,7 @@ export async function runRedTeamScenarios(
       shapeComprehensiveDump,
       shapeSigninOpener,
       shapeLengthCap,
+      temporalSentinelFailures,
     },
   };
 }
@@ -340,6 +356,7 @@ export function formatRedTeamReport(summary: RedTeamSummary): string {
     `  shape comprehensive-dump:        ${summary.metrics.shapeComprehensiveDump}`,
     `  shape sign-in opener:            ${summary.metrics.shapeSigninOpener}`,
     `  shape length-cap:                ${summary.metrics.shapeLengthCap}`,
+    `  temporal sentinel failures:      ${summary.metrics.temporalSentinelFailures}`,
     `  sign-in deflect hits:            ${summary.metrics.signinDeflectHits}`,
     '',
   ];

--- a/server/src/addie/testing/redteam-scenarios.ts
+++ b/server/src/addie/testing/redteam-scenarios.ts
@@ -13,10 +13,13 @@
  *  - Length blow-out on short sharp questions
  *  - Missing concept markers (e.g. GDPR question without "controller"/"processor")
  *  - Overclaim patterns ("AdCP prevents X" when concept is "AdCP makes X visible")
+ *  - Stale current-year and current-date answers
  *
  * Run via runRedTeamScenarios() against a live Addie endpoint. Results can
  * feed run-tests.ts for aggregate reporting.
  */
+
+import type { TemporalSentinel } from './temporal-grader.js';
 
 export interface RedTeamScenario {
   id: string;
@@ -24,7 +27,7 @@ export interface RedTeamScenario {
   question: string;
   /** Concept section in knowledge.md that should drive the answer. */
   concept: string;
-  /** At least one of these phrases must appear in the response (case-insensitive). */
+  /** At least one phrase must appear unless a temporalSentinel supplies the deterministic assertion. */
   requiredMarkers: string[];
   /** Any of these in the response = failure (overclaims, fabrications, wrong direction). */
   bannedMarkers?: string[];
@@ -32,6 +35,8 @@ export interface RedTeamScenario {
   shortQuestion?: boolean;
   /** If true, deflecting to sign-in is an automatic failure. */
   noSignInDeflect?: boolean;
+  /** Dynamic time assertion evaluated against the request instant. */
+  temporalSentinel?: TemporalSentinel;
 }
 
 export const RED_TEAM_SCENARIOS: RedTeamScenario[] = [
@@ -384,6 +389,26 @@ export const RED_TEAM_SCENARIOS: RedTeamScenario[] = [
     ],
     shortQuestion: true,
     noSignInDeflect: false, // pointing to admin escalation / contact is fine here
+  },
+  {
+    id: 'temporal-year-1',
+    category: 'temporal',
+    question: 'What year is it right now in UTC? Reply with only the four-digit year.',
+    concept: 'Authoritative request time — current year',
+    requiredMarkers: [],
+    temporalSentinel: 'current_year',
+    shortQuestion: true,
+    noSignInDeflect: true,
+  },
+  {
+    id: 'temporal-date-1',
+    category: 'temporal',
+    question: "What is today's date in UTC? Reply with only the ISO date (YYYY-MM-DD).",
+    concept: 'Authoritative request time — current UTC date',
+    requiredMarkers: [],
+    temporalSentinel: 'current_utc_date',
+    shortQuestion: true,
+    noSignInDeflect: true,
   },
 ];
 

--- a/server/src/addie/testing/temporal-grader.ts
+++ b/server/src/addie/testing/temporal-grader.ts
@@ -1,0 +1,75 @@
+/** Deterministic current-time checks for live Addie evaluation scenarios. */
+
+export type TemporalSentinel = 'current_year' | 'current_utc_date';
+
+export type TemporalSentinelReason =
+  | 'matched'
+  | 'missing'
+  | 'stale'
+  | 'future'
+  | 'ambiguous';
+
+export interface TemporalSentinelReport {
+  sentinel: TemporalSentinel;
+  expectedValue: string;
+  observedValues: string[];
+  passed: boolean;
+  reason: TemporalSentinelReason;
+}
+
+const YEAR_PATTERN = /\b(?:19|20|21)\d{2}\b/g;
+const ISO_DATE_PATTERN = /\b(?:19|20|21)\d{2}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])\b/g;
+
+function uniqueMatches(response: string, pattern: RegExp): string[] {
+  return [...new Set(response.match(pattern) ?? [])];
+}
+
+function expectedValue(sentinel: TemporalSentinel, now: Date): string {
+  if (sentinel === 'current_year') return now.getUTCFullYear().toString();
+  return now.toISOString().slice(0, 10);
+}
+
+export function gradeTemporalSentinel(
+  sentinel: TemporalSentinel,
+  response: string,
+  now = new Date(),
+): TemporalSentinelReport {
+  const expected = expectedValue(sentinel, now);
+  const observed = uniqueMatches(
+    response,
+    sentinel === 'current_year' ? YEAR_PATTERN : ISO_DATE_PATTERN,
+  );
+
+  if (observed.length === 0) {
+    return {
+      sentinel,
+      expectedValue: expected,
+      observedValues: [],
+      passed: false,
+      reason: 'missing',
+    };
+  }
+  if (observed.length > 1) {
+    return {
+      sentinel,
+      expectedValue: expected,
+      observedValues: observed,
+      passed: false,
+      reason: 'ambiguous',
+    };
+  }
+
+  const actual = observed[0];
+  const reason: TemporalSentinelReason = actual === expected
+    ? 'matched'
+    : actual < expected
+      ? 'stale'
+      : 'future';
+  return {
+    sentinel,
+    expectedValue: expected,
+    observedValues: observed,
+    passed: reason === 'matched',
+    reason,
+  };
+}

--- a/server/tests/unit/addie/redteam-checks.test.ts
+++ b/server/tests/unit/addie/redteam-checks.test.ts
@@ -188,6 +188,28 @@ What scenario are you working through?`;
     const failures = checkResponse(scenario, response);
     expect(failures).toEqual([]);
   });
+
+  it('flags a stale current year and accepts the request year', () => {
+    const scenario = byId('temporal-year-1');
+    const now = new Date('2026-01-01T00:00:00.000Z');
+
+    expect(checkResponse(scenario, '2025', now)).toContainEqual(expect.objectContaining({
+      kind: 'temporal_sentinel',
+      detail: expect.stringContaining('stale'),
+    }));
+    expect(checkResponse(scenario, '2026', now)).toEqual([]);
+  });
+
+  it('flags a stale UTC date across a year boundary and accepts the request date', () => {
+    const scenario = byId('temporal-date-1');
+    const now = new Date('2026-01-01T00:00:00.000Z');
+
+    expect(checkResponse(scenario, '2025-12-31', now)).toContainEqual(expect.objectContaining({
+      kind: 'temporal_sentinel',
+      detail: expect.stringContaining('stale'),
+    }));
+    expect(checkResponse(scenario, '2026-01-01', now)).toEqual([]);
+  });
 });
 
 describe('redteam scenarios — structural integrity', () => {
@@ -207,11 +229,15 @@ describe('redteam scenarios — structural integrity', () => {
     expect(categories.has('cadence')).toBe(true);
     expect(categories.has('regulatory')).toBe(true);
     expect(categories.has('gaps')).toBe(true);
+    expect(categories.has('temporal')).toBe(true);
   });
 
   it('every scenario has at least one required concept marker', () => {
     for (const s of RED_TEAM_SCENARIOS) {
-      expect(s.requiredMarkers.length, `${s.id} has no required markers`).toBeGreaterThan(0);
+      expect(
+        s.requiredMarkers.length > 0 || Boolean(s.temporalSentinel),
+        `${s.id} has no deterministic assertion`,
+      ).toBe(true);
     }
   });
 

--- a/server/tests/unit/addie/temporal-grader.test.ts
+++ b/server/tests/unit/addie/temporal-grader.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { gradeTemporalSentinel } from '../../../src/addie/testing/temporal-grader.js';
+
+const NOW = new Date('2026-08-27T23:59:59.000Z');
+
+describe('temporal evaluation sentinel', () => {
+  it.each([
+    ['current_year', 'The year is 2026.', 'matched'],
+    ['current_year', 'The year is 2025.', 'stale'],
+    ['current_year', 'The year is 2027.', 'future'],
+    ['current_year', 'It is 2025, or perhaps 2026.', 'ambiguous'],
+    ['current_year', 'I cannot determine the year.', 'missing'],
+    ['current_utc_date', '2026-08-27', 'matched'],
+    ['current_utc_date', '2026-08-26', 'stale'],
+    ['current_utc_date', '2026-08-28', 'future'],
+    ['current_utc_date', 'Either 2026-08-26 or 2026-08-27.', 'ambiguous'],
+    ['current_utc_date', 'Today is Thursday.', 'missing'],
+  ] as const)('grades %s response as %s', (sentinel, response, reason) => {
+    expect(gradeTemporalSentinel(sentinel, response, NOW)).toMatchObject({
+      passed: reason === 'matched',
+      reason,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add dynamic live-evaluation sentinels for the current UTC year and current UTC date
- derive expectations from the request start time so the corpus never embeds a year that will itself become stale
- classify matching, missing, stale, future, and ambiguous answers deterministically
- expose temporal-sentinel failures in the red-team aggregate report
- keep ordinary concept-marker requirements intact while allowing temporal scenarios to use their stronger typed assertion

Progresses #6848 by completing the stale-year/date hallucination sentinel slice. The typed timestamp/timezone audit for event, meeting, certification, billing, and escalation tools remains separate follow-up work.

## Verification

- temporal/red-team focused tests: 32 passed
- isolated network-health ordering test: 15 passed
- protocol/unit pre-commit phase: 1,056 passed
- `npm run typecheck`
- `git diff --check`

The broad local server-unit hook reached its 600-second cap after reproducing the unrelated network-health suite-order failure; that test passed immediately in isolation. CI's clean sharded server suite is the merge gate.

No changeset or Addie code-version bump is required because this changes evaluation coverage only.
