### PR TITLE
fix(addie): preserve tool timestamp semantics

### DIFF
--- a/docs/aao/addie-tools.mdx
+++ b/docs/aao/addie-tools.mdx
@@ -678,10 +678,10 @@ If the user is in a channel associated with a working group, you can omit workin
 
 For recurring meetings, use the recurrence parameter with freq, interval, count, and byDay.
 
-Required: title, start_time (ISO format without timezone suffix - use timezone parameter for that)
+Required: title, start_time (RFC 3339 with an explicit offset)
 Optional: working_group_slug (auto-detected from channel), description, agenda, duration_minutes, timezone, topic_slugs, recurrence
 
-IMPORTANT: For start_time, provide the time in the user's timezone WITHOUT a Z suffix. For example, if user says "2pm ET", use "2026-01-15T14:00:00" (not "2026-01-15T14:00:00Z"). The timezone parameter (default: America/New_York) specifies what timezone the start_time is in.
+IMPORTANT: The numeric offset in start_time must agree with timezone at that instant. For example, 2pm New York in January is "2026-01-15T14:00:00-05:00" with timezone "America/New_York". This prevents daylight-saving and server-timezone ambiguity.
 
 Example prompts this handles:
 - "Schedule a technical working group call for next Tuesday at 2pm ET"
@@ -733,7 +733,7 @@ Update an existing meeting's details. Use this when someone wants to change the 
 
 This will update the meeting in the database, Zoom (if configured), and Google Calendar.
 
-IMPORTANT: For start_time, provide the time in the user's timezone WITHOUT a Z suffix (same as schedule_meeting).
+IMPORTANT: start_time must be RFC 3339 with an explicit offset that agrees with the IANA timezone.
 
 *Source: `server/src/addie/mcp/meeting-tools.ts`*
 
@@ -813,7 +813,7 @@ Create a new AAO event. Use this when someone asks to create a meetup, webinar, 
 The event will be created in both Luma (for registration) and the AAO website.
 Returns the Luma URL for sharing and the AAO event page URL.
 
-Required: title, start_time (ISO format), event_type
+Required: title, start_time (RFC 3339 with an explicit offset), event_type
 Optional: description, end_time, timezone, location details, virtual_url, max_attendees
 
 *Source: `server/src/addie/mcp/event-tools.ts`*
@@ -860,7 +860,7 @@ Create a new AAO event. Use this when someone asks to create a meetup, webinar, 
 The event will be created in both Luma (for registration) and the AAO website.
 Returns the Luma URL for sharing and the AAO event page URL.
 
-Required: title, start_time (ISO format), event_type
+Required: title, start_time (RFC 3339 with an explicit offset), event_type
 Optional: description, end_time, timezone, location details, virtual_url, max_attendees
 
 *Source: `server/src/addie/mcp/event-tools.ts`*

--- a/scripts/addie-tool-surface-budget.json
+++ b/scripts/addie-tool-surface-budget.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 4,
   "profile_ids_sha256": "79957b57d370335967ead65eec0cb71fc81c3d469d222169f9319e6c3a3306a8",
-  "profile_contract_sha256": "02201fc984d2e38d0c9c33d9d369c10189fcf30279228bdcfd93af97494f65c2",
+  "profile_contract_sha256": "b6be1f63ecd01e0b96b77329129d899b1f6e95be149933ac2eecc219a3446437",
   "baseline": {
     "id": "2026-08-26-pre-domain-consolidation",
     "metrics": {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.32';
+export const CODE_VERSION = '2026.08.33';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -123,7 +123,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 171088,
+      "wire_schema_bytes": 171087,
       "overridden_tool_count": 7,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -348,7 +348,7 @@
         "list_orphaned_brands"
       ],
       "ordered_tool_names_sha256": "cc78806188aa3b7be55bba733abc1ecbf7b2eea9f83ae6068e5b97ef694eb072",
-      "wire_schema_sha256": "f67e6055817657ece2ed4385cf565849f985c855d2971a23bca3190b457e5bcb"
+      "wire_schema_sha256": "94e13682d6f9475cf161f1a79781df954cee487b8a1ccf1b3e5de11e7f9bda16"
     },
     {
       "id": "legacy_slack:admin_mention:maximum",
@@ -366,7 +366,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 167607,
+      "wire_schema_bytes": 167606,
       "overridden_tool_count": 7,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -586,7 +586,7 @@
         "list_orphaned_brands"
       ],
       "ordered_tool_names_sha256": "1d769dca5f53c7baee0102ce9e49384e23c11d51e1e44d65913124563c08e97c",
-      "wire_schema_sha256": "91550fbb813a4e255679bf6250e720c52f1f62d2566854ab70ea06ee8bac5449"
+      "wire_schema_sha256": "369637808c8599ad2601557930a082d91cb78a23a3a41987c61b9bbcad415c56"
     },
     {
       "id": "legacy_slack:member_dm:maximum",
@@ -604,7 +604,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 119451,
+      "wire_schema_bytes": 119450,
       "overridden_tool_count": 7,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -749,7 +749,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "88484816c567cdded948a50c26649b061d39509263be69448049497bd93edc30",
-      "wire_schema_sha256": "cdfc774c5bf1fa5ee6f72d8f9e899d592e096f0339b970dd41665dc1a6f1a745"
+      "wire_schema_sha256": "18ff1dbb703beddaeba1f4677884efe76eacbd2087a2898a17679971caf3b4d2"
     },
     {
       "id": "legacy_slack:member_mention:maximum",
@@ -767,7 +767,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 115970,
+      "wire_schema_bytes": 115969,
       "overridden_tool_count": 7,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -907,7 +907,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "93d3ff44c928cde4c4b5e99b42fc7711177e21c39c2f1ce6e4c49d966d7fa241",
-      "wire_schema_sha256": "cb367436aa29be11e55e0cbdb6d741b5a241d7515c20f1d9b6bdc0a62df9864e"
+      "wire_schema_sha256": "dc870ed6adf2f460f961d7a78c68d927411ee440f38512055877cb23cb9b4406"
     },
     {
       "id": "mcp_chat:anonymous:exact",
@@ -987,7 +987,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 189984,
+      "wire_schema_bytes": 189983,
       "overridden_tool_count": 36,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -1237,7 +1237,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "0062a413071701796a6fe8f320e99a5eb15786a2060318ed194986d993cd2977",
-      "wire_schema_sha256": "10e60a7b9753168f31cf5ab17c5fe8e4e18050a830084a39d478d18b61e0bbb9"
+      "wire_schema_sha256": "db50e9a036c8be5dd5378202ba71a3f9537f5b6318415188435a0d60862af28e"
     },
     {
       "id": "slack_bolt_reaction:member:maximum",
@@ -1255,7 +1255,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 138347,
+      "wire_schema_bytes": 138346,
       "overridden_tool_count": 36,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -1425,7 +1425,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "61d86f75baf72bec2cb4884059681dee8451ab30d87a39328591a61a1c5f7151",
-      "wire_schema_sha256": "5e919b2572ae51e6e5ff364910ebeeca8b6308bac2def5674a2291f441e3c112"
+      "wire_schema_sha256": "545acc55b3137afd3cf7ac6e544ce1be43715034708d567c5566de63c4a281fb"
     },
     {
       "id": "slack_bolt_reaction:public_channel_admin:maximum",
@@ -1443,7 +1443,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 189511,
+      "wire_schema_bytes": 189510,
       "overridden_tool_count": 31,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -1692,7 +1692,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "91b98cd3c5e703401f7b8ce79683e194a196e64dfe2b9d06a93b1f6d9bbfd027",
-      "wire_schema_sha256": "3c8103ea3606ef539b77986a548d843b94efb29f69bce4812b3b411f1dacdd40"
+      "wire_schema_sha256": "75741d44b1280b123e22e54bc8e5b1a62b8aa9eac6172bde52b43169d97761c4"
     },
     {
       "id": "slack_bolt_reaction:public_channel:maximum",
@@ -1710,7 +1710,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 137874,
+      "wire_schema_bytes": 137873,
       "overridden_tool_count": 31,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -1879,7 +1879,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "d2239cae6f97501a8ae83693ef4fee133822c89a8a38d05300072ada810030f2",
-      "wire_schema_sha256": "0e9beab820752730ae6166fc72424b68e7494d439b2ea204b15451bccc96a360"
+      "wire_schema_sha256": "9288ba7192a5fc0c1f4f61d8c929b8b30ed4762571db4eba43c7a42004f5b989"
     },
     {
       "id": "slack_bolt:admin_dm:adcp_operations",
@@ -1904,7 +1904,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 105705,
+      "wire_schema_bytes": 105948,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -2052,7 +2052,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "bb7e22efc43619d68ab9bd1c6afbc0b8905cc09c92b639681423336ac241f680",
-      "wire_schema_sha256": "569338a56a79e42d9cb8038b2fd134902725687dae0d9c013f74328e2b20ec5e"
+      "wire_schema_sha256": "10684cedc640835ed5bd0ad37a2ac5cc6ab33a53a06b6c7ba54c31b1fe97ffce"
     },
     {
       "id": "slack_bolt:admin_dm:admin",
@@ -2076,7 +2076,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 94855,
+      "wire_schema_bytes": 95098,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -2217,7 +2217,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "a3bd53c648a8d38f57d4d35ca6777d645ec20ecf70b27ed6557f79baea666134",
-      "wire_schema_sha256": "bf6ea3543518c702c98702e102fd75313735e91bd5443ac745c835f1c72411c4"
+      "wire_schema_sha256": "b972744054363d17c4ee7a24589a7787aca3f998decbbf5a63954e41e6e5287d"
     },
     {
       "id": "slack_bolt:admin_dm:agent_conformance",
@@ -2242,7 +2242,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 96283,
+      "wire_schema_bytes": 96526,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -2385,7 +2385,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "8acbd2da935d160d3caaed1136f1a35eb107155fb24f155a91698b4f6f7dbc58",
-      "wire_schema_sha256": "b399af0e5fa3bbcdef4d14aec0778aca4304fb7d942d395801f57e1a8cd6fe1f"
+      "wire_schema_sha256": "598315a18a14ddc55af7639e8debe43d6df77a46599cee701a3c1e5222d27d71"
     },
     {
       "id": "slack_bolt:admin_dm:agent_testing",
@@ -2410,7 +2410,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 106488,
+      "wire_schema_bytes": 106731,
       "overridden_tool_count": 8,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -2560,7 +2560,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "35546a8c91c1de4032f0de007c5cdfcb0bd229d586f093e3bcf7e89e5bd6d8ff",
-      "wire_schema_sha256": "47f3dfc9a48d0ed6c4ee3735abc515131243d5a594482736facff98b8e536e6e"
+      "wire_schema_sha256": "87c7bf527f3b6aa87b9d9e7876644e091877a416bc3d908a31d13ac73eaca5d6"
     },
     {
       "id": "slack_bolt:admin_dm:all_valid_sets_maximum",
@@ -2598,7 +2598,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 166678,
+      "wire_schema_bytes": 166677,
       "overridden_tool_count": 24,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -2819,7 +2819,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "21e72d0f7569878cadecfec8613bf81b0584602116111273f3eeb0b66cb76116"
+      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
     },
     {
       "id": "slack_bolt:admin_dm:billing",
@@ -2844,7 +2844,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 100385,
+      "wire_schema_bytes": 100628,
       "overridden_tool_count": 5,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -2992,7 +2992,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "4d9e83e409081b619dadc361aeff0699a3e2c0094fa103edbb4c49efeb3b212a",
-      "wire_schema_sha256": "c47a46ebe69d28f4b565ea0490ec1307546625aaa1f6e59c1ad16b4fa3ceaaf2"
+      "wire_schema_sha256": "d399889704079c794d759dd5fed64b69f0cfccd0ecb00ac1d505509182a1e7b3"
     },
     {
       "id": "slack_bolt:admin_dm:certification",
@@ -3017,7 +3017,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 103047,
+      "wire_schema_bytes": 103290,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -3167,7 +3167,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "a573e69f3d2e0960f15a68fea4356006c6a01b0079b7c114895ef65610e8e168",
-      "wire_schema_sha256": "b9d5475c859b4911ef76393922a151496fef241ab5c8ec82af4879056a953bdc"
+      "wire_schema_sha256": "f66af732caa0a3171bb881e83806ba72b23e37a5b57f7ecf81a509ca7e47f199"
     },
     {
       "id": "slack_bolt:admin_dm:certification_session",
@@ -3304,7 +3304,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 96109,
+      "wire_schema_bytes": 96352,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -3446,7 +3446,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "db580b3906136a37e517b29fa42813cd7e58bbf7103e2d689e52425edd8173e8",
-      "wire_schema_sha256": "0627681b52a52591948a2f3443e2673a368ecb20c5e5459f9fb0c6fe47ddee8b"
+      "wire_schema_sha256": "0d1f47f0b69486a1c1acbe629ff48a27c010b0eaee70c453773e34834eaa083d"
     },
     {
       "id": "slack_bolt:admin_dm:committee_leadership",
@@ -3471,7 +3471,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 96922,
+      "wire_schema_bytes": 97165,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -3615,7 +3615,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "ac878ea477ba428ac6b2862370d9e94f032f54b17ec78011a087e7a3107911c5",
-      "wire_schema_sha256": "b96797a235c356c3c1c964595ea253351038d46a9b26615c364308e774a34536"
+      "wire_schema_sha256": "ac9f929ccf84babb7136d433c35743f0f0861b8b39541d52453229ce7c83bbef"
     },
     {
       "id": "slack_bolt:admin_dm:content",
@@ -3640,7 +3640,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 97406,
+      "wire_schema_bytes": 97649,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -3785,7 +3785,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "48dcec57f579cecdd874b86f6a7715b2f5da584db1d276686a4b361a89277fae",
-      "wire_schema_sha256": "6fe866cd457300386ee478e489ed9e3fbc5d8d937baff7e5101ccaaf6f537fe2"
+      "wire_schema_sha256": "30dfecbac62435c96dc04508eb861207bd8efe0cccdc0d08421a4ee9fccfa539"
     },
     {
       "id": "slack_bolt:admin_dm:directory",
@@ -3810,7 +3810,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 97151,
+      "wire_schema_bytes": 97394,
       "overridden_tool_count": 12,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -3954,7 +3954,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "5dce99bc859b249992be081e6f2056377f4ef68f96d2550ad9a6dc214174cd9b",
-      "wire_schema_sha256": "0ad598cbc065a11e7eb84b7c640d7338cb8585d14eacd6a8cfbe00c311fe2a2b"
+      "wire_schema_sha256": "c3d2da5634faa852b464b9e467c5162e3787cbdb79e5b4854c8f6cdc166733e3"
     },
     {
       "id": "slack_bolt:admin_dm:events",
@@ -3979,7 +3979,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 97334,
+      "wire_schema_bytes": 97577,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -4124,7 +4124,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "b4b1276069359ae0981d4774f73dec13c2c09a029cfe658a6ab619d3d6cab3e0",
-      "wire_schema_sha256": "f59f3b6dfb3e62453a270a16b1adf9b4c25c9ee7afdc27f5ff5e71ac4cbe7989"
+      "wire_schema_sha256": "78c1b0486423d5455ca51e7a76d872c52341ed0e7e4a65d2482b7c4bb88601a6"
     },
     {
       "id": "slack_bolt:admin_dm:knowledge",
@@ -4149,7 +4149,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 97840,
+      "wire_schema_bytes": 98083,
       "overridden_tool_count": 6,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -4293,7 +4293,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "f94ade7dcd16bf99e60b9947f367fda8dea2900ccb18998c8f8b00464cbfae87",
-      "wire_schema_sha256": "84fcb3e964ed15bbaa9804ffcde93e33cbf180ac4dc3b3811c99cbaac1588d3c"
+      "wire_schema_sha256": "436f689fd93e944f72fd21bf9e326cfb1e0e783d43506a77b637b0ce1ea33a3e"
     },
     {
       "id": "slack_bolt:admin_dm:meetings",
@@ -4318,7 +4318,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 105216,
+      "wire_schema_bytes": 105215,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -4470,7 +4470,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "5d6937d04d27edb1d733350de0ab22b8a7b0cf530f2560ebd321e4c5c9a114ff",
-      "wire_schema_sha256": "a8827e5ba9786f1aa7978a5da5d388608a4ffd892eca12b2aaf03ea7a0fef10c"
+      "wire_schema_sha256": "50f5afbf660a7567f24256308ceb3b2ad12a9e64f916fcec1fc15eea3dc4c648"
     },
     {
       "id": "slack_bolt:admin_dm:member",
@@ -4495,7 +4495,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 108072,
+      "wire_schema_bytes": 108315,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -4654,7 +4654,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "9d786be92871a3293af94f16b9d96a39469bfa9db3fd2e526d46f0e1b632d569",
-      "wire_schema_sha256": "8af91afe2b1245ffd1dbebd254f4e9c3e3e7265ca991f0ae17cfd06b8975276e"
+      "wire_schema_sha256": "b98009910b50ada2f9ab2001402c9ea62d97f349973303176440c100c489deac"
     },
     {
       "id": "slack_bolt:admin_dm:outreach",
@@ -4679,7 +4679,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 94855,
+      "wire_schema_bytes": 95098,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -4820,7 +4820,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "a3bd53c648a8d38f57d4d35ca6777d645ec20ecf70b27ed6557f79baea666134",
-      "wire_schema_sha256": "bf6ea3543518c702c98702e102fd75313735e91bd5443ac745c835f1c72411c4"
+      "wire_schema_sha256": "b972744054363d17c4ee7a24589a7787aca3f998decbbf5a63954e41e6e5287d"
     },
     {
       "id": "slack_bolt:admin_dm:router_unavailable",
@@ -4843,7 +4843,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 97840,
+      "wire_schema_bytes": 98083,
       "overridden_tool_count": 6,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -4987,7 +4987,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "f94ade7dcd16bf99e60b9947f367fda8dea2900ccb18998c8f8b00464cbfae87",
-      "wire_schema_sha256": "84fcb3e964ed15bbaa9804ffcde93e33cbf180ac4dc3b3811c99cbaac1588d3c"
+      "wire_schema_sha256": "436f689fd93e944f72fd21bf9e326cfb1e0e783d43506a77b637b0ce1ea33a3e"
     },
     {
       "id": "slack_bolt:admin_working_group:adcp_operations",
@@ -5012,7 +5012,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 105705,
+      "wire_schema_bytes": 105948,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -5160,7 +5160,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "bb7e22efc43619d68ab9bd1c6afbc0b8905cc09c92b639681423336ac241f680",
-      "wire_schema_sha256": "569338a56a79e42d9cb8038b2fd134902725687dae0d9c013f74328e2b20ec5e"
+      "wire_schema_sha256": "10684cedc640835ed5bd0ad37a2ac5cc6ab33a53a06b6c7ba54c31b1fe97ffce"
     },
     {
       "id": "slack_bolt:admin_working_group:admin",
@@ -5184,7 +5184,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 94855,
+      "wire_schema_bytes": 95098,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -5325,7 +5325,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "a3bd53c648a8d38f57d4d35ca6777d645ec20ecf70b27ed6557f79baea666134",
-      "wire_schema_sha256": "bf6ea3543518c702c98702e102fd75313735e91bd5443ac745c835f1c72411c4"
+      "wire_schema_sha256": "b972744054363d17c4ee7a24589a7787aca3f998decbbf5a63954e41e6e5287d"
     },
     {
       "id": "slack_bolt:admin_working_group:agent_conformance",
@@ -5350,7 +5350,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 96283,
+      "wire_schema_bytes": 96526,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -5493,7 +5493,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "8acbd2da935d160d3caaed1136f1a35eb107155fb24f155a91698b4f6f7dbc58",
-      "wire_schema_sha256": "b399af0e5fa3bbcdef4d14aec0778aca4304fb7d942d395801f57e1a8cd6fe1f"
+      "wire_schema_sha256": "598315a18a14ddc55af7639e8debe43d6df77a46599cee701a3c1e5222d27d71"
     },
     {
       "id": "slack_bolt:admin_working_group:agent_testing",
@@ -5518,7 +5518,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 106488,
+      "wire_schema_bytes": 106731,
       "overridden_tool_count": 8,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -5668,7 +5668,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "35546a8c91c1de4032f0de007c5cdfcb0bd229d586f093e3bcf7e89e5bd6d8ff",
-      "wire_schema_sha256": "47f3dfc9a48d0ed6c4ee3735abc515131243d5a594482736facff98b8e536e6e"
+      "wire_schema_sha256": "87c7bf527f3b6aa87b9d9e7876644e091877a416bc3d908a31d13ac73eaca5d6"
     },
     {
       "id": "slack_bolt:admin_working_group:all_valid_sets_maximum",
@@ -5706,7 +5706,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 166678,
+      "wire_schema_bytes": 166677,
       "overridden_tool_count": 24,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -5927,7 +5927,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "21e72d0f7569878cadecfec8613bf81b0584602116111273f3eeb0b66cb76116"
+      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
     },
     {
       "id": "slack_bolt:admin_working_group:billing",
@@ -5952,7 +5952,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 100385,
+      "wire_schema_bytes": 100628,
       "overridden_tool_count": 5,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -6100,7 +6100,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "4d9e83e409081b619dadc361aeff0699a3e2c0094fa103edbb4c49efeb3b212a",
-      "wire_schema_sha256": "c47a46ebe69d28f4b565ea0490ec1307546625aaa1f6e59c1ad16b4fa3ceaaf2"
+      "wire_schema_sha256": "d399889704079c794d759dd5fed64b69f0cfccd0ecb00ac1d505509182a1e7b3"
     },
     {
       "id": "slack_bolt:admin_working_group:certification",
@@ -6125,7 +6125,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 103047,
+      "wire_schema_bytes": 103290,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -6275,7 +6275,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "a573e69f3d2e0960f15a68fea4356006c6a01b0079b7c114895ef65610e8e168",
-      "wire_schema_sha256": "b9d5475c859b4911ef76393922a151496fef241ab5c8ec82af4879056a953bdc"
+      "wire_schema_sha256": "f66af732caa0a3171bb881e83806ba72b23e37a5b57f7ecf81a509ca7e47f199"
     },
     {
       "id": "slack_bolt:admin_working_group:collaboration",
@@ -6300,7 +6300,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 96109,
+      "wire_schema_bytes": 96352,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -6442,7 +6442,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "db580b3906136a37e517b29fa42813cd7e58bbf7103e2d689e52425edd8173e8",
-      "wire_schema_sha256": "0627681b52a52591948a2f3443e2673a368ecb20c5e5459f9fb0c6fe47ddee8b"
+      "wire_schema_sha256": "0d1f47f0b69486a1c1acbe629ff48a27c010b0eaee70c453773e34834eaa083d"
     },
     {
       "id": "slack_bolt:admin_working_group:committee_leadership",
@@ -6467,7 +6467,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 96922,
+      "wire_schema_bytes": 97165,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -6611,7 +6611,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "ac878ea477ba428ac6b2862370d9e94f032f54b17ec78011a087e7a3107911c5",
-      "wire_schema_sha256": "b96797a235c356c3c1c964595ea253351038d46a9b26615c364308e774a34536"
+      "wire_schema_sha256": "ac9f929ccf84babb7136d433c35743f0f0861b8b39541d52453229ce7c83bbef"
     },
     {
       "id": "slack_bolt:admin_working_group:content",
@@ -6636,7 +6636,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 97406,
+      "wire_schema_bytes": 97649,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -6781,7 +6781,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "48dcec57f579cecdd874b86f6a7715b2f5da584db1d276686a4b361a89277fae",
-      "wire_schema_sha256": "6fe866cd457300386ee478e489ed9e3fbc5d8d937baff7e5101ccaaf6f537fe2"
+      "wire_schema_sha256": "30dfecbac62435c96dc04508eb861207bd8efe0cccdc0d08421a4ee9fccfa539"
     },
     {
       "id": "slack_bolt:admin_working_group:directory",
@@ -6806,7 +6806,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 97151,
+      "wire_schema_bytes": 97394,
       "overridden_tool_count": 12,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -6950,7 +6950,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "5dce99bc859b249992be081e6f2056377f4ef68f96d2550ad9a6dc214174cd9b",
-      "wire_schema_sha256": "0ad598cbc065a11e7eb84b7c640d7338cb8585d14eacd6a8cfbe00c311fe2a2b"
+      "wire_schema_sha256": "c3d2da5634faa852b464b9e467c5162e3787cbdb79e5b4854c8f6cdc166733e3"
     },
     {
       "id": "slack_bolt:admin_working_group:events",
@@ -6975,7 +6975,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 97334,
+      "wire_schema_bytes": 97577,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -7120,7 +7120,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "b4b1276069359ae0981d4774f73dec13c2c09a029cfe658a6ab619d3d6cab3e0",
-      "wire_schema_sha256": "f59f3b6dfb3e62453a270a16b1adf9b4c25c9ee7afdc27f5ff5e71ac4cbe7989"
+      "wire_schema_sha256": "78c1b0486423d5455ca51e7a76d872c52341ed0e7e4a65d2482b7c4bb88601a6"
     },
     {
       "id": "slack_bolt:admin_working_group:knowledge",
@@ -7145,7 +7145,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 97840,
+      "wire_schema_bytes": 98083,
       "overridden_tool_count": 6,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -7289,7 +7289,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "f94ade7dcd16bf99e60b9947f367fda8dea2900ccb18998c8f8b00464cbfae87",
-      "wire_schema_sha256": "84fcb3e964ed15bbaa9804ffcde93e33cbf180ac4dc3b3811c99cbaac1588d3c"
+      "wire_schema_sha256": "436f689fd93e944f72fd21bf9e326cfb1e0e783d43506a77b637b0ce1ea33a3e"
     },
     {
       "id": "slack_bolt:admin_working_group:meetings",
@@ -7314,7 +7314,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 105216,
+      "wire_schema_bytes": 105215,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -7466,7 +7466,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "5d6937d04d27edb1d733350de0ab22b8a7b0cf530f2560ebd321e4c5c9a114ff",
-      "wire_schema_sha256": "a8827e5ba9786f1aa7978a5da5d388608a4ffd892eca12b2aaf03ea7a0fef10c"
+      "wire_schema_sha256": "50f5afbf660a7567f24256308ceb3b2ad12a9e64f916fcec1fc15eea3dc4c648"
     },
     {
       "id": "slack_bolt:admin_working_group:member",
@@ -7491,7 +7491,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 108072,
+      "wire_schema_bytes": 108315,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -7650,7 +7650,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "9d786be92871a3293af94f16b9d96a39469bfa9db3fd2e526d46f0e1b632d569",
-      "wire_schema_sha256": "8af91afe2b1245ffd1dbebd254f4e9c3e3e7265ca991f0ae17cfd06b8975276e"
+      "wire_schema_sha256": "b98009910b50ada2f9ab2001402c9ea62d97f349973303176440c100c489deac"
     },
     {
       "id": "slack_bolt:admin_working_group:outreach",
@@ -7675,7 +7675,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 94855,
+      "wire_schema_bytes": 95098,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -7816,7 +7816,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "a3bd53c648a8d38f57d4d35ca6777d645ec20ecf70b27ed6557f79baea666134",
-      "wire_schema_sha256": "bf6ea3543518c702c98702e102fd75313735e91bd5443ac745c835f1c72411c4"
+      "wire_schema_sha256": "b972744054363d17c4ee7a24589a7787aca3f998decbbf5a63954e41e6e5287d"
     },
     {
       "id": "slack_bolt:admin_working_group:router_unavailable",
@@ -7839,7 +7839,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 97840,
+      "wire_schema_bytes": 98083,
       "overridden_tool_count": 6,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -7983,7 +7983,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "f94ade7dcd16bf99e60b9947f367fda8dea2900ccb18998c8f8b00464cbfae87",
-      "wire_schema_sha256": "84fcb3e964ed15bbaa9804ffcde93e33cbf180ac4dc3b3811c99cbaac1588d3c"
+      "wire_schema_sha256": "436f689fd93e944f72fd21bf9e326cfb1e0e783d43506a77b637b0ce1ea33a3e"
     },
     {
       "id": "slack_bolt:member_dm:adcp_operations",
@@ -8333,7 +8333,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 125095,
+      "wire_schema_bytes": 125094,
       "overridden_tool_count": 21,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -8488,7 +8488,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "e38a1dd17e4d302b4d0b0355f211640cea955db1f0954fb3f02061ea852c70ff",
-      "wire_schema_sha256": "3743e2d77e58a7529681c021fe032b142ef19026c58fed999edec98a60e90896"
+      "wire_schema_sha256": "48544a44ce10f06f8439a1dd589918e09f40c7ca21aa3daf21492809031e17c8"
     },
     {
       "id": "slack_bolt:member_dm:certification",
@@ -8830,7 +8830,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 60309,
+      "wire_schema_bytes": 60552,
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -8914,7 +8914,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "d6eaec50e43a1ffaa4c556086eb77361960f3da0f479f4831374ae979023a7e0",
-      "wire_schema_sha256": "6dd4e48a59c7bfa3913de7ca38a2793b4b891ede846c25d1e2e57d393f882cd9"
+      "wire_schema_sha256": "8c794c37e80ae65126d94278675defe002945c096b3d2a80ffe8823e8f984043"
     },
     {
       "id": "slack_bolt:member_dm:content",
@@ -9348,7 +9348,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 62299,
+      "wire_schema_bytes": 62055,
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -9434,7 +9434,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "ea682614ec6bb2771e5bc2ff172f0843dab6ee5c2a3da45415914855b157ec99",
-      "wire_schema_sha256": "3a862b875dece473057e107ad1d8e033b464a76fde26ce03476d697296b76538"
+      "wire_schema_sha256": "cf6a2f97ba67d713b1c44d3da9245b8cf38a9bdb64f2d5f1b016b618a092077c"
     },
     {
       "id": "slack_bolt:member_dm:member",
@@ -9785,7 +9785,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 94855,
+      "wire_schema_bytes": 95098,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -9926,7 +9926,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "a3bd53c648a8d38f57d4d35ca6777d645ec20ecf70b27ed6557f79baea666134",
-      "wire_schema_sha256": "bf6ea3543518c702c98702e102fd75313735e91bd5443ac745c835f1c72411c4"
+      "wire_schema_sha256": "b972744054363d17c4ee7a24589a7787aca3f998decbbf5a63954e41e6e5287d"
     },
     {
       "id": "slack_bolt:private_channel_admin:agent_conformance",
@@ -10177,7 +10177,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 166678,
+      "wire_schema_bytes": 166677,
       "overridden_tool_count": 24,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -10398,7 +10398,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "21e72d0f7569878cadecfec8613bf81b0584602116111273f3eeb0b66cb76116"
+      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
     },
     {
       "id": "slack_bolt:private_channel_admin:billing",
@@ -10746,7 +10746,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 62603,
+      "wire_schema_bytes": 62846,
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -10832,7 +10832,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "17ceb3bb2ca0d618a48d49adf618fb4087ea50f6ee4c287e8552271784cf77d0",
-      "wire_schema_sha256": "c5b4df552d60e7584a19ff63933ee0828316798d5be989fe4b64d335eba5f406"
+      "wire_schema_sha256": "533a523a325dc8addcdd6ad8ac235bd45fbf81069263de89704c10405473ab33"
     },
     {
       "id": "slack_bolt:private_channel_admin:content",
@@ -11274,7 +11274,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 64593,
+      "wire_schema_bytes": 64349,
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -11362,7 +11362,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "39d1f0dea008ca995883b3ba52243ced633fc05ae25dd1156510caa31b9973ed",
-      "wire_schema_sha256": "e6af3d0f0f18a6d7b0d10445a2bdea8c1c1936a3188c5b71784ea3604f1ed5aa"
+      "wire_schema_sha256": "5630242490ceb5bad5d796dfd0f83bd3589ad5c35f9743ad9dae141196cf6f03"
     },
     {
       "id": "slack_bolt:private_channel_admin:member",
@@ -12042,7 +12042,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 125095,
+      "wire_schema_bytes": 125094,
       "overridden_tool_count": 21,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12197,7 +12197,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "e38a1dd17e4d302b4d0b0355f211640cea955db1f0954fb3f02061ea852c70ff",
-      "wire_schema_sha256": "3743e2d77e58a7529681c021fe032b142ef19026c58fed999edec98a60e90896"
+      "wire_schema_sha256": "48544a44ce10f06f8439a1dd589918e09f40c7ca21aa3daf21492809031e17c8"
     },
     {
       "id": "slack_bolt:private_channel_member:certification",
@@ -12429,7 +12429,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 60309,
+      "wire_schema_bytes": 60552,
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12513,7 +12513,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "d6eaec50e43a1ffaa4c556086eb77361960f3da0f479f4831374ae979023a7e0",
-      "wire_schema_sha256": "6dd4e48a59c7bfa3913de7ca38a2793b4b891ede846c25d1e2e57d393f882cd9"
+      "wire_schema_sha256": "8c794c37e80ae65126d94278675defe002945c096b3d2a80ffe8823e8f984043"
     },
     {
       "id": "slack_bolt:private_channel_member:content",
@@ -12947,7 +12947,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 62299,
+      "wire_schema_bytes": 62055,
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13033,7 +13033,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "ea682614ec6bb2771e5bc2ff172f0843dab6ee5c2a3da45415914855b157ec99",
-      "wire_schema_sha256": "3a862b875dece473057e107ad1d8e033b464a76fde26ce03476d697296b76538"
+      "wire_schema_sha256": "cf6a2f97ba67d713b1c44d3da9245b8cf38a9bdb64f2d5f1b016b618a092077c"
     },
     {
       "id": "slack_bolt:private_channel_member:member",
@@ -13383,7 +13383,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 94382,
+      "wire_schema_bytes": 94625,
       "overridden_tool_count": 2,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13523,7 +13523,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "bb9c44ff1e928c8783c3c983c7df3a13066daee82e00fc70f939d5900bb97cff",
-      "wire_schema_sha256": "d559bfa535d20141fe9980dcb913dc50b7be9134222b702a943d50ed6e79a86c"
+      "wire_schema_sha256": "b1365d95226de802ddb77a89b3e0f66e79cf75c3a5dc2b4d03f0c1256625672d"
     },
     {
       "id": "slack_bolt:public_channel_admin:agent_conformance",
@@ -13772,7 +13772,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 160675,
+      "wire_schema_bytes": 160674,
       "overridden_tool_count": 21,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13985,7 +13985,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "3354f78e8427559cdb0eb347e455edd6032255fb5c3dcd6789e9181647092cb8",
-      "wire_schema_sha256": "ceabe62434908f52432e96f104bd888ceb652b64b2db530fb7bcd7a560ba3b21"
+      "wire_schema_sha256": "2b51e7aec2049c05bdfc8f69c2d853c8374f353975933c4cf82f7c3baa071893"
     },
     {
       "id": "slack_bolt:public_channel_admin:billing",
@@ -14319,7 +14319,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 62130,
+      "wire_schema_bytes": 62373,
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -14404,7 +14404,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "8187bd063db45f9e41e5893b17bba2042032f98729a20b1708a96808353c9677",
-      "wire_schema_sha256": "34537a572558156f488de9a67cb09ec0a8cf2cf2364617c22ecdcc916a1c1830"
+      "wire_schema_sha256": "410932ffbbb47de90b4149f77032cc036fd8f8d12743b4506b281b9f6e78b442"
     },
     {
       "id": "slack_bolt:public_channel_admin:content",
@@ -14842,7 +14842,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 64120,
+      "wire_schema_bytes": 63876,
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -14929,7 +14929,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "b5b490e2beadb82d344dad97457b760396c6df9a36cc471cff2fad180abd4d5b",
-      "wire_schema_sha256": "d945320193901ba9f60428a2fbebae1bb5c8b076467f2785099c855071cab4e0"
+      "wire_schema_sha256": "134703b19f5316bc8d5cfc01960734aba52965b47f778ad17a44b16f7ddaaa11"
     },
     {
       "id": "slack_bolt:public_channel_admin:member",
@@ -15603,7 +15603,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 124622,
+      "wire_schema_bytes": 124621,
       "overridden_tool_count": 21,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -15757,7 +15757,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "d8497806ffdbbbb3ccf8f470ea2b4873c142e0b741cd8c020f2142119f52beb7",
-      "wire_schema_sha256": "ccfdd406a32b203de935cfaba8624d38b2e1997e5728bf233b00327675576f68"
+      "wire_schema_sha256": "1404695b32173be7157747c10d93074ffeb08bfe28b07491e2b82adf30b5c9e9"
     },
     {
       "id": "slack_bolt:public_channel_member:certification",
@@ -15987,7 +15987,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 59836,
+      "wire_schema_bytes": 60079,
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -16070,7 +16070,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "c16319db465ee46af794c7d4ccbfe529b6d638b10bdd3175d90d114699977d5c",
-      "wire_schema_sha256": "d41559a67099451b5e968a2351d93e0d38fbef95711cbd4ad9c25ecea9afda1c"
+      "wire_schema_sha256": "f9665c71a74552924fcdef103dbe9ea2600a86c7ae948fe72aecfc5eb2ec5f91"
     },
     {
       "id": "slack_bolt:public_channel_member:content",
@@ -16500,7 +16500,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 61826,
+      "wire_schema_bytes": 61582,
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -16585,7 +16585,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "1118d061d1c316ff19fd22dd3d35d3563dbdad427c1b9fe4ef27d09b83a62634",
-      "wire_schema_sha256": "7853122f5b9f9b5e7e5e5bc63f36a97906e3d811a952ddf60d381d21a4e54adc"
+      "wire_schema_sha256": "bdabd92d46ae3ac6353ea43576e617ac1678feaae44d3338fb5c80428edc0733"
     },
     {
       "id": "slack_bolt:public_channel_member:member",
@@ -16839,7 +16839,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 166678,
+      "wire_schema_bytes": 166677,
       "overridden_tool_count": 24,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -17060,7 +17060,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "21e72d0f7569878cadecfec8613bf81b0584602116111273f3eeb0b66cb76116"
+      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
     },
     {
       "id": "slack_bolt:system_channel_admin:billing:all_valid_sets_maximum",
@@ -17097,7 +17097,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 166678,
+      "wire_schema_bytes": 166677,
       "overridden_tool_count": 24,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -17318,7 +17318,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "21e72d0f7569878cadecfec8613bf81b0584602116111273f3eeb0b66cb76116"
+      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
     },
     {
       "id": "slack_bolt:system_channel_admin:error:all_valid_sets_maximum",
@@ -17355,7 +17355,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 166678,
+      "wire_schema_bytes": 166677,
       "overridden_tool_count": 24,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -17576,7 +17576,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "21e72d0f7569878cadecfec8613bf81b0584602116111273f3eeb0b66cb76116"
+      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
     },
     {
       "id": "slack_bolt:system_channel_admin:escalation:all_valid_sets_maximum",
@@ -17613,7 +17613,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 166678,
+      "wire_schema_bytes": 166677,
       "overridden_tool_count": 24,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -17834,7 +17834,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "21e72d0f7569878cadecfec8613bf81b0584602116111273f3eeb0b66cb76116"
+      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
     },
     {
       "id": "slack_bolt:system_channel_admin:prospect:all_valid_sets_maximum",
@@ -17871,7 +17871,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 166678,
+      "wire_schema_bytes": 166677,
       "overridden_tool_count": 24,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -18092,7 +18092,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "21e72d0f7569878cadecfec8613bf81b0584602116111273f3eeb0b66cb76116"
+      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
     },
     {
       "id": "tavus_voice:admin:maximum",
@@ -18107,7 +18107,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 162325,
+      "wire_schema_bytes": 162324,
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -18331,7 +18331,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "ee026b5c5493eecf66980d8bc45d13bca576838fd1e56d46a225d8c0a8fc735a",
-      "wire_schema_sha256": "4dfbdc8116a135e5c7be07dacfc2176a8733e019e81154a5278b18caf104f56d"
+      "wire_schema_sha256": "aa0b655e7e72943ce14c8ccd3ea5033780c26238e332df5a63eba20b77785eaf"
     },
     {
       "id": "tavus_voice:baseline:exact",
@@ -18386,7 +18386,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 104901,
+      "wire_schema_bytes": 104657,
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -18525,7 +18525,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "1014ec0f38456600ea98be64558e693f91e59d9f0c9a9802743152bb36a42710",
-      "wire_schema_sha256": "30d1fa2fe46b63451c9fc4829711f8eb86f6cb1ae800bf7ad32961e1f1dd866a"
+      "wire_schema_sha256": "b398a586d2ac3b073ba5fe39929e9cb5c5b6bf666f1029e86026637a295fd063"
     },
     {
       "id": "tavus_voice:member:maximum",
@@ -18721,7 +18721,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 175786,
+      "wire_schema_bytes": 175785,
       "overridden_tool_count": 8,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -18960,7 +18960,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "60c1bf349d4a8bc228804867d449a574dee4951878ba6176c7c9a1eb14821e0c",
-      "wire_schema_sha256": "fffd0ecc5bea66d8dcc8ec40130233a633c3a95d77a4c67d2071ed0d8a1350ba"
+      "wire_schema_sha256": "0b6f9062c1a3e26f4253b2a94f5bc42c576d40a90317c19a74c4c6d86949645f"
     },
     {
       "id": "web_chat:authenticated_member:maximum",
@@ -18978,7 +18978,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 124149,
+      "wire_schema_bytes": 124148,
       "overridden_tool_count": 8,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -19137,7 +19137,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "ba3b0ba34ca3982d006f0b9e069c3d411d4b2ecb543039b6099d6ed9135b8aca",
-      "wire_schema_sha256": "32c89df1ad4de7c14d055d61eff99a1aedc156e99389a2898d72417928de2a64"
+      "wire_schema_sha256": "e3b2d0616ea8df5189d7afc08336dbcb3f514e1c9b76dbb05687cd8eea03a8e7"
     }
   ],
   "baseline": {
@@ -19177,9 +19177,9 @@
       "maximum_slack_member_tools": 1,
       "maximum_slack_admin_tools": -2,
       "maximum_slack_public_tools": -2,
-      "maximum_slack_member_schema_bytes": 933,
-      "maximum_slack_admin_schema_bytes": 558,
-      "maximum_slack_public_schema_bytes": 558,
+      "maximum_slack_member_schema_bytes": 932,
+      "maximum_slack_admin_schema_bytes": 557,
+      "maximum_slack_public_schema_bytes": 557,
       "legacy_slack_member_tools": -83,
       "web_anonymous_tools": 0,
       "web_authenticated_admin_tools": -3
@@ -19366,11 +19366,11 @@
       }
     },
     "profile_ids_sha256": "79957b57d370335967ead65eec0cb71fc81c3d469d222169f9319e6c3a3306a8",
-    "profile_contract_sha256": "02201fc984d2e38d0c9c33d9d369c10189fcf30279228bdcfd93af97494f65c2",
+    "profile_contract_sha256": "b6be1f63ecd01e0b96b77329129d899b1f6e95be149933ac2eecc219a3446437",
     "status": "within_budget"
   },
   "profile_contract": {
     "profile_ids_sha256": "79957b57d370335967ead65eec0cb71fc81c3d469d222169f9319e6c3a3306a8",
-    "profile_contract_sha256": "02201fc984d2e38d0c9c33d9d369c10189fcf30279228bdcfd93af97494f65c2"
+    "profile_contract_sha256": "b6be1f63ecd01e0b96b77329129d899b1f6e95be149933ac2eecc219a3446437"
   }
 }

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -7,6 +7,7 @@
 
 import type { AddieTool } from '../types.js';
 import type { MemberContext } from '../member-context.js';
+import { formatUtcTimestamp } from '../tool-temporal.js';
 
 /** Stripe-defined subscription statuses (safe to interpolate into prompts). */
 const KNOWN_SUBSCRIPTION_STATUSES = new Set([
@@ -631,12 +632,7 @@ function buildShareLinks(
 
 function formatUtcDate(value: string | null): string {
   if (!value) return 'the published deadline';
-  return new Date(value).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    timeZone: 'UTC',
-  });
+  return formatUtcTimestamp(value);
 }
 
 /**
@@ -2227,7 +2223,7 @@ export function createCertificationToolHandlers(
         lines.push('## Earned credentials');
         for (const cred of earnedCreds) {
           const uc = userCredentials.find(u => u.credential_id === cred.id);
-          lines.push(`- **${cred.name}** (Level ${cred.tier}) — earned ${uc ? new Date(uc.awarded_at).toLocaleDateString() : ''}`);
+          lines.push(`- **${cred.name}** (Level ${cred.tier}) — earned ${uc ? formatUtcTimestamp(uc.awarded_at) : ''}`);
         }
         lines.push('');
       }
@@ -2466,7 +2462,7 @@ export function createCertificationToolHandlers(
             }
             const active = await certDb.getActiveAttemptForModule(userId, moduleId);
             if (active) {
-              return `You already have an active ${delta.delta_action_label} delta attempt (started ${new Date(active.started_at).toLocaleDateString()}). Continue the delta assessment.\n\nAttempt ID: ${active.id}\n\n${buildSageResumeSection()}`;
+              return `You already have an active ${delta.delta_action_label} delta attempt (started ${formatUtcTimestamp(active.started_at)}). Continue the delta assessment.\n\nAttempt ID: ${active.id}\n\n${buildSageResumeSection()}`;
             }
           }
           if (deltaStatus.active && deltaStatus.status === 'full_recertification_required') {
@@ -2539,7 +2535,7 @@ export function createCertificationToolHandlers(
         if (options?.trainingModuleContext) {
           options.trainingModuleContext.moduleId = moduleId;
         }
-        return `You already have an active capstone attempt (started ${new Date(active.started_at).toLocaleDateString()}). Continue the capstone.\n\nAttempt ID: ${active.id}\n\n${buildSageResumeSection()}`;
+        return `You already have an active capstone attempt (started ${formatUtcTimestamp(active.started_at)}). Continue the capstone.\n\nAttempt ID: ${active.id}\n\n${buildSageResumeSection()}`;
       }
 
       // Start the module and create an attempt

--- a/server/src/addie/mcp/escalation-tools.ts
+++ b/server/src/addie/mcp/escalation-tools.ts
@@ -431,7 +431,8 @@ export function createEscalationToolHandlers(
         summary: e.summary,
         status: e.status,
         status_label: statusLabel[e.status] || e.status,
-        submitted: new Date(e.created_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }),
+        submitted_at: new Date(e.created_at).toISOString(),
+        submitted_time_zone: 'UTC',
         resolution_notes: e.resolution_notes || undefined,
       }));
 

--- a/server/src/addie/mcp/event-tools.ts
+++ b/server/src/addie/mcp/event-tools.ts
@@ -13,6 +13,11 @@
 import { createLogger } from '../../logger.js';
 import type { AddieTool } from '../types.js';
 import type { MemberContext } from '../member-context.js';
+import {
+  formatZonedTimestamp,
+  isValidIanaTimeZone,
+  parseZonedTimestamp,
+} from '../tool-temporal.js';
 import { isSlackUserAAOAdmin } from './admin-tools.js';
 import { eventsDb } from '../../db/events-db.js';
 import { WorkingGroupDatabase } from '../../db/working-group-db.js';
@@ -397,30 +402,6 @@ function generateSlug(title: string): string {
 }
 
 /**
- * Format date for display
- */
-function formatDate(date: Date): string {
-  return date.toLocaleDateString('en-US', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-}
-
-/**
- * Format time for display
- */
-function formatTime(date: Date, timezone = 'America/New_York'): string {
-  return date.toLocaleTimeString('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    timeZone: timezone,
-    timeZoneName: 'short',
-  });
-}
-
-/**
  * Read-only event tools available to all authenticated users.
  * These let any member check their registrations and browse upcoming events.
  */
@@ -514,7 +495,7 @@ export const EVENT_ADMIN_TOOLS: AddieTool[] = [
 The event will be created in both Luma (for registration) and the AAO website.
 Returns the Luma URL for sharing and the AAO event page URL.
 
-Required: title, start_time (ISO format), event_type
+Required: title, start_time (RFC 3339 with an explicit offset), event_type
 Optional: description, end_time, timezone, location details, virtual_url, max_attendees`,
     input_schema: {
       type: 'object' as const,
@@ -543,15 +524,17 @@ Optional: description, end_time, timezone, location details, virtual_url, max_at
         },
         start_time: {
           type: 'string',
-          description: 'Start time in ISO 8601 format (e.g., "2026-01-15T18:00:00")',
+          format: 'date-time',
+          description: 'RFC 3339 instant with explicit offset matching timezone, e.g. "2026-01-15T18:00:00-05:00".',
         },
         end_time: {
           type: 'string',
-          description: 'End time in ISO 8601 format (optional)',
+          format: 'date-time',
+          description: 'RFC 3339 instant with explicit offset matching timezone.',
         },
         timezone: {
           type: 'string',
-          description: 'Timezone (e.g., "America/New_York", "America/Los_Angeles")',
+          description: 'IANA timezone; defaults to member timezone, then America/New_York.',
         },
         venue_name: {
           type: 'string',
@@ -640,11 +623,13 @@ Optional: description, end_time, timezone, location details, virtual_url, max_at
         },
         start_time: {
           type: 'string',
-          description: 'New start time (ISO 8601)',
+          format: 'date-time',
+          description: 'RFC 3339 instant with explicit offset matching the event timezone.',
         },
         end_time: {
           type: 'string',
-          description: 'New end time (ISO 8601)',
+          format: 'date-time',
+          description: 'RFC 3339 instant with explicit offset matching the event timezone.',
         },
         max_attendees: {
           type: 'number',
@@ -828,18 +813,24 @@ export function createEventToolHandlers(
     const startTimeStr = input.start_time as string;
     const eventType = (input.event_type as EventType) || 'meetup';
     const eventFormat = (input.event_format as EventFormat) || 'in_person';
-    const timezone = (input.timezone as string) || 'America/New_York';
+    const timezone = (input.timezone as string) || memberContext?.timezone || 'America/New_York';
     const publishImmediately = input.publish_immediately !== false;
 
-    // Parse dates
-    const startTime = new Date(startTimeStr);
-    if (isNaN(startTime.getTime())) {
-      return `❌ Invalid start time format. Please use ISO 8601 format (e.g., "2026-01-15T18:00:00")`;
+    const parsedStartTime = parseZonedTimestamp(startTimeStr, timezone);
+    if (!parsedStartTime.ok) {
+      return `❌ Invalid start_time: ${parsedStartTime.error}.`;
     }
+    const startTime = parsedStartTime.date;
 
-    const endTime = input.end_time ? new Date(input.end_time as string) : undefined;
-    if (endTime && isNaN(endTime.getTime())) {
-      return `❌ Invalid end time format. Please use ISO 8601 format.`;
+    const parsedEndTime = input.end_time
+      ? parseZonedTimestamp(input.end_time, timezone)
+      : null;
+    if (parsedEndTime && !parsedEndTime.ok) {
+      return `❌ Invalid end_time: ${parsedEndTime.error}.`;
+    }
+    const endTime = parsedEndTime?.ok ? parsedEndTime.date : undefined;
+    if (endTime && endTime.getTime() <= startTime.getTime()) {
+      return '❌ end_time must be after start_time.';
     }
 
     // Generate slug
@@ -936,7 +927,7 @@ export function createEventToolHandlers(
     const aaoUrl = `${baseUrl}/events/${event.slug}`;
 
     let response = `✅ Created event: **${title}**\n\n`;
-    response += `**When:** ${formatDate(startTime)} at ${formatTime(startTime, timezone)}\n`;
+    response += `**When:** ${formatZonedTimestamp(startTime, timezone)}\n`;
 
     if (eventFormat !== 'virtual' && input.venue_city) {
       response += `**Where:** ${input.venue_name || input.venue_city}\n`;
@@ -1057,7 +1048,7 @@ export function createEventToolHandlers(
       const typeEmoji = eventTypeEmojis[event.event_type] || '📅';
 
       response += `${typeEmoji} **${event.title}**\n`;
-      response += `   ${formatDate(event.start_time)} at ${formatTime(event.start_time, event.timezone)}\n`;
+      response += `   ${formatZonedTimestamp(event.start_time, event.timezone)}\n`;
 
       if (event.venue_city) {
         response += `   📍 ${event.venue_city}`;
@@ -1105,7 +1096,7 @@ export function createEventToolHandlers(
     let response = `## ${event.title}\n\n`;
     response += `**Status:** ${event.status}\n`;
     response += `**Type:** ${event.event_type} (${event.event_format})\n`;
-    response += `**When:** ${formatDate(event.start_time)} at ${formatTime(event.start_time, event.timezone)}\n`;
+    response += `**When:** ${formatZonedTimestamp(event.start_time, event.timezone)}\n`;
 
     if (event.venue_city) {
       response += `**Where:** `;
@@ -1283,13 +1274,25 @@ export function createEventToolHandlers(
       updates.description = input.description;
       changes.push('Description updated');
     }
+    const timezone = event.timezone || 'America/New_York';
     if (input.start_time) {
-      updates.start_time = new Date(input.start_time as string);
-      changes.push(`Start time → ${formatDate(updates.start_time as Date)}`);
+      const parsed = parseZonedTimestamp(input.start_time, timezone);
+      if (!parsed.ok) return `❌ Invalid start_time: ${parsed.error}.`;
+      updates.start_time = parsed.date;
+      updates.timezone = timezone;
+      changes.push(`Start time → ${formatZonedTimestamp(parsed.date, timezone)}`);
     }
     if (input.end_time) {
-      updates.end_time = new Date(input.end_time as string);
-      changes.push('End time updated');
+      const parsed = parseZonedTimestamp(input.end_time, timezone);
+      if (!parsed.ok) return `❌ Invalid end_time: ${parsed.error}.`;
+      updates.end_time = parsed.date;
+      updates.timezone = timezone;
+      changes.push(`End time → ${formatZonedTimestamp(parsed.date, timezone)}`);
+    }
+    const effectiveStart = (updates.start_time as Date | undefined) ?? event.start_time;
+    const effectiveEnd = (updates.end_time as Date | undefined) ?? event.end_time;
+    if (effectiveEnd && effectiveEnd.getTime() <= effectiveStart.getTime()) {
+      return '❌ end_time must be after start_time.';
     }
     if (input.max_attendees !== undefined) {
       updates.max_attendees = input.max_attendees;
@@ -1328,6 +1331,7 @@ export function createEventToolHandlers(
       if (updates.description) lumaUpdates.description = updates.description as string;
       if (updates.start_time) lumaUpdates.start_at = (updates.start_time as Date).toISOString();
       if (updates.end_time) lumaUpdates.end_at = (updates.end_time as Date).toISOString();
+      if (updates.timezone) lumaUpdates.timezone = updates.timezone as string;
       if (updates.virtual_url) lumaUpdates.meeting_url = updates.virtual_url as string;
       if (updates.status) lumaUpdates.visibility = updates.status === 'published' ? 'public' : 'private';
       if (updates.require_rsvp_approval !== undefined) lumaUpdates.require_rsvp_approval = updates.require_rsvp_approval as boolean;
@@ -1597,7 +1601,13 @@ export function createEventToolHandlers(
     response += `• Registration status: ${existing ? existing.registration_status : 'interested'}\n\n`;
 
     if (draftMessage) {
-      const eventDate = formatDate(event.start_time);
+      const eventDate = new Intl.DateTimeFormat('en-US', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        timeZone: event.timezone && isValidIanaTimeZone(event.timezone) ? event.timezone : 'UTC',
+      }).format(event.start_time);
       const location = event.venue_city
         ? `${event.venue_name ? event.venue_name + ', ' : ''}${event.venue_city}`
         : 'Virtual';

--- a/server/src/addie/mcp/meeting-tools.ts
+++ b/server/src/addie/mcp/meeting-tools.ts
@@ -21,6 +21,11 @@ import { WorkingGroupDatabase } from '../../db/working-group-db.js';
 import * as meetingService from '../../services/meeting-service.js';
 import * as zoom from '../../integrations/zoom.js';
 import * as calendar from '../../integrations/google-calendar.js';
+import {
+  formatZonedTimestamp,
+  isValidIanaTimeZone,
+  parseZonedTimestamp,
+} from '../tool-temporal.js';
 
 const logger = createLogger('addie-meeting-tools');
 
@@ -47,92 +52,6 @@ export async function canScheduleMeetings(slackUserId: string): Promise<boolean>
   return false;
 }
 
-/**
- * Format date for display
- */
-function formatDate(date: Date): string {
-  return date.toLocaleDateString('en-US', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-}
-
-/**
- * Format time for display
- */
-function formatTime(date: Date, timezone = 'America/New_York'): string {
-  return date.toLocaleTimeString('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    timeZone: timezone,
-    timeZoneName: 'short',
-  });
-}
-
-/**
- * Get the current time as an ISO string in a specific timezone (for comparison).
- * Returns format like "2026-01-15T09:30:00"
- */
-function getNowInTimezone(timezone: string): string {
-  // 'sv-SE' locale gives us ISO-like format: "2026-01-15 09:30:00"
-  return new Date().toLocaleString('sv-SE', { timeZone: timezone }).replace(' ', 'T');
-}
-
-/**
- * Parse a datetime string (without timezone) as if it were in the specified timezone.
- * Returns a Date object representing the correct UTC moment.
- *
- * For example, "2026-01-15T13:00:00" with timezone "America/New_York" returns
- * a Date representing 18:00 UTC (since 1 PM ET = 6 PM UTC in January).
- */
-function parseDateInTimezone(isoString: string, timezone: string): Date {
-  // Remove any existing timezone suffix
-  const cleanString = isoString.replace(/Z|[+-]\d{2}(:\d{2})?$/, '').substring(0, 19);
-
-  // Parse the components from the string
-  const [datePart, timePart] = cleanString.split('T');
-  const [year, month, day] = datePart.split('-').map(Number);
-  const timeParts = timePart.split(':');
-  const hour = parseInt(timeParts[0], 10);
-  const minute = parseInt(timeParts[1] || '0', 10);
-  const second = parseInt(timeParts[2] || '0', 10);
-
-  // Create a reference date in the target timezone to find the offset
-  // We use a trick: create UTC date, format it in target TZ, compare to find offset
-  const utcGuess = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
-
-  // Format this UTC time in both UTC and target timezone
-  const utcFormatted = utcGuess.toLocaleString('sv-SE', { timeZone: 'UTC' }).replace(' ', 'T');
-  const tzFormatted = utcGuess.toLocaleString('sv-SE', { timeZone: timezone }).replace(' ', 'T');
-
-  // Parse both to find the offset in milliseconds
-  const utcMs = new Date(utcFormatted + 'Z').getTime();
-  const tzMs = new Date(tzFormatted + 'Z').getTime();
-  const offsetMs = tzMs - utcMs;
-
-  // Adjust our UTC guess by the offset to get the correct UTC time
-  return new Date(utcGuess.getTime() - offsetMs);
-}
-
-/**
- * Check if a datetime string (without timezone) represents a future time
- * in the specified timezone.
- */
-function isFutureTimeInTimezone(isoString: string, timezone: string): boolean {
-  // If the string has timezone info, convert to the target timezone for comparison
-  if (/Z|[+-]\d{2}:\d{2}$/.test(isoString)) {
-    const date = new Date(isoString);
-    const dateInTz = date.toLocaleString('sv-SE', { timeZone: timezone }).replace(' ', 'T');
-    return dateInTz > getNowInTimezone(timezone);
-  }
-
-  // No timezone info - treat the string as already being in the target timezone
-  // Just compare strings directly (ISO format is lexicographically sortable)
-  const normalizedInput = isoString.substring(0, 19); // Take just "YYYY-MM-DDTHH:MM:SS"
-  return normalizedInput > getNowInTimezone(timezone);
-}
 
 /**
  * Format recurrence rule for display
@@ -171,38 +90,6 @@ function formatRecurrence(rule: RecurrenceRule): string {
 }
 
 /**
- * Parse natural language date/time
- * Handles formats like "next Tuesday at 3pm ET", "January 15 at 2pm PT"
- */
-function parseDateTime(input: string, defaultTimezone = 'America/New_York'): { date: Date; timezone: string } | null {
-  // This is a simplified parser - in production, use a library like chrono-node
-  const now = new Date();
-
-  // Try ISO format first
-  const isoDate = new Date(input);
-  if (!isNaN(isoDate.getTime())) {
-    return { date: isoDate, timezone: defaultTimezone };
-  }
-
-  // Extract timezone
-  let timezone = defaultTimezone;
-  const tzMatch = input.match(/\b(ET|EST|EDT|PT|PST|PDT|CT|CST|CDT|MT|MST|MDT)\b/i);
-  if (tzMatch) {
-    const tzMap: Record<string, string> = {
-      ET: 'America/New_York', EST: 'America/New_York', EDT: 'America/New_York',
-      PT: 'America/Los_Angeles', PST: 'America/Los_Angeles', PDT: 'America/Los_Angeles',
-      CT: 'America/Chicago', CST: 'America/Chicago', CDT: 'America/Chicago',
-      MT: 'America/Denver', MST: 'America/Denver', MDT: 'America/Denver',
-    };
-    timezone = tzMap[tzMatch[1].toUpperCase()] || defaultTimezone;
-  }
-
-  // Try to parse common formats
-  // For now, require ISO format or defer to Claude's interpretation
-  return null;
-}
-
-/**
  * Meeting tool definitions
  */
 export const MEETING_TOOLS: AddieTool[] = [
@@ -217,10 +104,10 @@ If the user is in a channel associated with a working group, you can omit workin
 
 For recurring meetings, use the recurrence parameter with freq, interval, count, and byDay.
 
-Required: title, start_time (ISO format without timezone suffix - use timezone parameter for that)
+Required: title, start_time (RFC 3339 with an explicit offset)
 Optional: working_group_slug (auto-detected from channel), description, agenda, duration_minutes, timezone, topic_slugs, recurrence
 
-IMPORTANT: For start_time, provide the time in the user's timezone WITHOUT a Z suffix. For example, if user says "2pm ET", use "2026-01-15T14:00:00" (not "2026-01-15T14:00:00Z"). The timezone parameter (default: America/New_York) specifies what timezone the start_time is in.
+IMPORTANT: The numeric offset in start_time must agree with timezone at that instant. For example, 2pm New York in January is "2026-01-15T14:00:00-05:00" with timezone "America/New_York". This prevents daylight-saving and server-timezone ambiguity.
 
 Example prompts this handles:
 - "Schedule a technical working group call for next Tuesday at 2pm ET"
@@ -248,7 +135,8 @@ Example prompts this handles:
         },
         start_time: {
           type: 'string',
-          description: 'Start time in ISO 8601 format WITHOUT timezone suffix. The time should be in the timezone specified by the timezone parameter (default ET). Example: "2026-01-15T14:00:00" for 2pm. Do NOT add "Z" or timezone offsets - the timezone parameter handles that.',
+          format: 'date-time',
+          description: 'RFC 3339 start with explicit offset matching timezone, e.g. "2026-01-15T14:00:00-05:00".',
         },
         duration_minutes: {
           type: 'number',
@@ -256,7 +144,7 @@ Example prompts this handles:
         },
         timezone: {
           type: 'string',
-          description: 'Timezone (default: America/New_York). Examples: America/Los_Angeles, America/Chicago',
+          description: 'IANA timezone for display/recurrence; defaults to member timezone, then America/New_York.',
         },
         topic_slugs: {
           type: 'array',
@@ -410,7 +298,7 @@ Example prompts this handles:
 
 This will update the meeting in the database, Zoom (if configured), and Google Calendar.
 
-IMPORTANT: For start_time, provide the time in the user's timezone WITHOUT a Z suffix (same as schedule_meeting).`,
+IMPORTANT: start_time must be RFC 3339 with an explicit offset that agrees with the IANA timezone.`,
     input_schema: {
       type: 'object' as const,
       properties: {
@@ -432,7 +320,8 @@ IMPORTANT: For start_time, provide the time in the user's timezone WITHOUT a Z s
         },
         start_time: {
           type: 'string',
-          description: 'New start time in ISO 8601 format WITHOUT timezone suffix (e.g., "2026-01-15T14:00:00" for 2pm). Use timezone parameter to specify the timezone.',
+          format: 'date-time',
+          description: 'RFC 3339 start with explicit offset matching timezone, e.g. "2026-01-15T14:00:00-05:00".',
         },
         duration_minutes: {
           type: 'number',
@@ -440,7 +329,7 @@ IMPORTANT: For start_time, provide the time in the user's timezone WITHOUT a Z s
         },
         timezone: {
           type: 'string',
-          description: 'Timezone for start_time (default: America/New_York)',
+          description: 'IANA timezone for start_time. Defaults to the meeting timezone.',
         },
       },
       required: ['meeting_id'],
@@ -589,7 +478,7 @@ export function createMeetingToolHandlers(
 
     const title = input.title as string;
     const startTimeStr = input.start_time as string;
-    const timezone = (input.timezone as string) || 'America/New_York';
+    const timezone = (input.timezone as string) || memberContext?.timezone || 'America/New_York';
     const recurrenceInput = input.recurrence as { freq: string; interval?: number; by_day?: string[]; count?: number } | undefined;
 
     // Find working group
@@ -618,17 +507,14 @@ export function createMeetingToolHandlers(
       }
     }
 
-    // Parse start time in the specified timezone
-    // This ensures "2026-01-15T13:00:00" with timezone "America/New_York"
-    // creates a Date representing 1 PM ET (18:00 UTC), not 1 PM UTC
-    const startTime = parseDateInTimezone(startTimeStr, timezone);
-    if (isNaN(startTime.getTime())) {
-      return `❌ Invalid start time format. Please use ISO 8601 format (e.g., "2026-01-15T14:00:00").`;
+    const parsedStartTime = parseZonedTimestamp(startTimeStr, timezone);
+    if (!parsedStartTime.ok) {
+      return `❌ Invalid start_time: ${parsedStartTime.error}.`;
     }
+    const startTime = parsedStartTime.date;
 
-    // Check if meeting is in the future (comparing in the specified timezone)
-    if (!isFutureTimeInTimezone(startTimeStr, timezone)) {
-      return `❌ Meeting time must be in the future. Current time in ${timezone}: ${formatTime(new Date(), timezone)}`;
+    if (startTime.getTime() <= Date.now()) {
+      return `❌ Meeting time must be in the future. Current instant: ${new Date().toISOString()}.`;
     }
 
     const durationMinutes = (input.duration_minutes as number) || 60;
@@ -726,7 +612,7 @@ export function createMeetingToolHandlers(
         if (seriesResult.meetings.length > 0) {
           response += `**Scheduled ${seriesResult.meetings.length} meeting${seriesResult.meetings.length > 1 ? 's' : ''}:**\n`;
           for (const meeting of seriesResult.meetings.slice(0, 5)) {
-            response += `• ${formatDate(meeting.start_time)} at ${formatTime(meeting.start_time, timezone)}`;
+            response += `• ${formatZonedTimestamp(meeting.start_time, timezone)}`;
             if (meeting.zoom_join_url) {
               response += ` - [Zoom](${meeting.zoom_join_url})`;
             }
@@ -792,7 +678,7 @@ export function createMeetingToolHandlers(
 
       let response = `✅ Scheduled: **${title}**\n\n`;
       response += `**Working Group:** ${workingGroup.name}\n`;
-      response += `**When:** ${formatDate(startTime)} at ${formatTime(startTime, timezone)}\n`;
+      response += `**When:** ${formatZonedTimestamp(startTime, timezone)}\n`;
       response += `**Duration:** ${durationMinutes} minutes\n`;
 
       if (result.meeting.zoom_join_url) {
@@ -879,7 +765,7 @@ export function createMeetingToolHandlers(
     for (const meeting of meetings) {
       response += `📅 **${meeting.title}**\n`;
       response += `   ID: ${meeting.id}\n`;
-      response += `   ${formatDate(meeting.start_time)} at ${formatTime(meeting.start_time, meeting.timezone)}\n`;
+      response += `   ${formatZonedTimestamp(meeting.start_time, meeting.timezone)}\n`;
       if (!groupName) {
         response += `   Group: ${meeting.working_group_name}\n`;
       }
@@ -924,7 +810,7 @@ export function createMeetingToolHandlers(
       }[meeting.rsvp_status] || '📅';
 
       response += `${statusEmoji} **${meeting.title}**\n`;
-      response += `   ${formatDate(meeting.start_time)} at ${formatTime(meeting.start_time, meeting.timezone)}\n`;
+      response += `   ${formatZonedTimestamp(meeting.start_time, meeting.timezone)}\n`;
       response += `   Group: ${meeting.working_group_name}\n`;
       if (meeting.zoom_join_url) {
         response += `   🔗 ${meeting.zoom_join_url}\n`;
@@ -960,7 +846,7 @@ export function createMeetingToolHandlers(
     let response = `## ${meeting.title}\n\n`;
     response += `**Working Group:** ${meeting.working_group_name}\n`;
     response += `**Status:** ${meeting.status}\n`;
-    response += `**When:** ${formatDate(meeting.start_time)} at ${formatTime(meeting.start_time, meeting.timezone)}\n`;
+    response += `**When:** ${formatZonedTimestamp(meeting.start_time, meeting.timezone)}\n`;
 
     if (meeting.description) {
       response += `\n**Description:**\n${meeting.description}\n`;
@@ -1181,9 +1067,13 @@ export function createMeetingToolHandlers(
       : 60;
 
     if (startTimeStr) {
-      const startTime = parseDateInTimezone(startTimeStr, timezone);
-      if (isNaN(startTime.getTime())) {
-        return `❌ Invalid start time format. Please use ISO 8601 format (e.g., "2026-01-15T14:00:00").`;
+      const parsedStartTime = parseZonedTimestamp(startTimeStr, timezone);
+      if (!parsedStartTime.ok) {
+        return `❌ Invalid start_time: ${parsedStartTime.error}.`;
+      }
+      const startTime = parsedStartTime.date;
+      if (startTime.getTime() <= Date.now()) {
+        return `❌ Meeting time must be in the future. Current instant: ${new Date().toISOString()}.`;
       }
       updates.start_time = startTime;
       updates.timezone = timezone;
@@ -1191,11 +1081,18 @@ export function createMeetingToolHandlers(
       const duration = durationMinutes || currentDuration;
       updates.end_time = new Date(startTime.getTime() + duration * 60 * 1000);
 
-      changes.push(`Time → ${formatDate(startTime)} at ${formatTime(startTime, timezone)}`);
+      changes.push(`Time → ${formatZonedTimestamp(startTime, timezone)}`);
     } else if (durationMinutes && meeting.start_time) {
       // Just updating duration, keep existing start time
       updates.end_time = new Date(meeting.start_time.getTime() + durationMinutes * 60 * 1000);
       changes.push(`Duration → ${durationMinutes} minutes`);
+    }
+    if (input.timezone && !startTimeStr) {
+      if (!isValidIanaTimeZone(timezone)) {
+        return `❌ Invalid timezone: "${timezone}" is not a valid IANA timezone.`;
+      }
+      updates.timezone = timezone;
+      changes.push(`Time zone → ${timezone}`);
     }
 
     if (changes.length === 0) {
@@ -1211,10 +1108,10 @@ export function createMeetingToolHandlers(
 
       const errors: string[] = [];
 
-      // Update Zoom meeting if time changed and Zoom meeting exists
-      if (updates.start_time && meeting.zoom_meeting_id && zoom.isZoomConfigured()) {
+      // Keep both the instant and its display timezone aligned in Zoom.
+      if ((updates.start_time || updates.timezone) && meeting.zoom_meeting_id && zoom.isZoomConfigured()) {
         try {
-          const startTime = updates.start_time as Date;
+          const startTime = (updates.start_time as Date | undefined) ?? meeting.start_time;
           await zoom.updateMeeting(meeting.zoom_meeting_id, {
             start_time: startTime.toISOString(),
             duration: durationMinutes || currentDuration,

--- a/server/src/addie/tool-temporal.ts
+++ b/server/src/addie/tool-temporal.ts
@@ -1,0 +1,102 @@
+const RFC3339_DATE_TIME_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$/;
+
+export type ZonedTimestampResult =
+  | { ok: true; date: Date }
+  | { ok: false; error: string };
+
+export function isValidIanaTimeZone(timeZone: string): boolean {
+  if (timeZone !== 'UTC' && !timeZone.includes('/')) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone }).format();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function offsetAtInstant(date: Date, timeZone: string): string | null {
+  try {
+    const value = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      timeZoneName: 'longOffset',
+    }).formatToParts(date).find(part => part.type === 'timeZoneName')?.value;
+    if (value === 'GMT') return '+00:00';
+    return value?.match(/^GMT([+-]\d{2}:\d{2})$/)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse an RFC 3339 instant and verify that its explicit offset agrees with
+ * the supplied IANA timezone at that instant. This rejects ambiguous,
+ * nonexistent, and server-timezone-dependent local timestamps before a tool
+ * performs a mutation.
+ */
+export function parseZonedTimestamp(value: unknown, timeZone: string): ZonedTimestampResult {
+  const match = typeof value === 'string' ? value.match(RFC3339_DATE_TIME_RE) : null;
+  if (!match) {
+    return {
+      ok: false,
+      error: 'must be an RFC 3339 timestamp with an explicit Z or numeric offset (for example, 2026-01-15T14:00:00-05:00)',
+    };
+  }
+  if (!isValidIanaTimeZone(timeZone)) {
+    return {
+      ok: false,
+      error: `timezone must be a valid IANA timezone (received "${timeZone}")`,
+    };
+  }
+
+  const [, year, month, day, hour, minute, second] = match;
+  const calendarCheck = new Date(0);
+  calendarCheck.setUTCFullYear(Number(year), Number(month) - 1, Number(day));
+  calendarCheck.setUTCHours(Number(hour), Number(minute), Number(second), 0);
+  if (
+    calendarCheck.getUTCFullYear() !== Number(year)
+    || calendarCheck.getUTCMonth() !== Number(month) - 1
+    || calendarCheck.getUTCDate() !== Number(day)
+    || calendarCheck.getUTCHours() !== Number(hour)
+    || calendarCheck.getUTCMinutes() !== Number(minute)
+    || calendarCheck.getUTCSeconds() !== Number(second)
+  ) {
+    return { ok: false, error: 'must contain a valid calendar date and time' };
+  }
+
+  const date = new Date(match[0]);
+  if (Number.isNaN(date.getTime())) {
+    return { ok: false, error: 'must be a valid RFC 3339 timestamp' };
+  }
+
+  const suppliedOffset = match[7] === 'Z' ? '+00:00' : match[7];
+  const expectedOffset = offsetAtInstant(date, timeZone);
+  if (!expectedOffset || suppliedOffset !== expectedOffset) {
+    return {
+      ok: false,
+      error: `offset ${suppliedOffset} does not match ${timeZone} at that instant${expectedOffset ? ` (expected ${expectedOffset})` : ''}`,
+    };
+  }
+
+  return { ok: true, date };
+}
+
+/** Format a dated tool record with both human-readable and machine timestamps. */
+export function formatZonedTimestamp(value: Date | string, timeZone?: string | null): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const effectiveTimeZone = timeZone && isValidIanaTimeZone(timeZone) ? timeZone : 'UTC';
+  const display = new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: effectiveTimeZone,
+    timeZoneName: 'short',
+  }).format(date);
+  return `${display} [instant: ${date.toISOString()}; time_zone: ${effectiveTimeZone}]`;
+}
+
+export function formatUtcTimestamp(value: Date | string): string {
+  return formatZonedTimestamp(value, 'UTC');
+}

--- a/server/tests/unit/addie/escalation-temporal-output.test.ts
+++ b/server/tests/unit/addie/escalation-temporal-output.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MemberContext } from '../../../src/addie/member-context.js';
+
+const mocks = vi.hoisted(() => ({
+  listEscalationsForUser: vi.fn(),
+}));
+
+vi.mock('../../../src/db/escalation-db.js', () => ({
+  createEscalation: vi.fn(),
+  markNotificationSent: vi.fn(),
+  listEscalationsForUser: mocks.listEscalationsForUser,
+}));
+
+vi.mock('../../../src/addie/thread-service.js', () => ({
+  getThreadService: vi.fn(),
+}));
+
+vi.mock('../../../src/slack/client.js', () => ({
+  sendChannelMessage: vi.fn(),
+}));
+
+vi.mock('../../../src/db/system-settings-db.js', () => ({
+  getEscalationChannel: vi.fn(),
+}));
+
+import { createEscalationToolHandlers } from '../../../src/addie/mcp/escalation-tools.js';
+
+describe('get_escalation_status temporal output', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns an ISO instant and explicit timezone instead of a locale-only date', async () => {
+    mocks.listEscalationsForUser.mockResolvedValue([{
+      id: 42,
+      summary: 'Access request',
+      status: 'open',
+      created_at: new Date('2026-08-27T06:45:30.000Z'),
+      resolution_notes: null,
+    }]);
+    const memberContext = {
+      workos_user: { workos_user_id: 'user_123' },
+    } as MemberContext;
+    const handler = createEscalationToolHandlers(memberContext).get('get_escalation_status');
+
+    const result = JSON.parse(await handler!({}));
+
+    expect(result.escalations[0]).toEqual(expect.objectContaining({
+      submitted_at: '2026-08-27T06:45:30.000Z',
+      submitted_time_zone: 'UTC',
+    }));
+    expect(result.escalations[0]).not.toHaveProperty('submitted');
+  });
+});

--- a/server/tests/unit/addie/tool-temporal-schemas.test.ts
+++ b/server/tests/unit/addie/tool-temporal-schemas.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { BILLING_TOOLS } from '../../../src/addie/mcp/billing-tools.js';
+import { EVENT_ADMIN_TOOLS } from '../../../src/addie/mcp/event-tools.js';
+import { MEETING_TOOLS } from '../../../src/addie/mcp/meeting-tools.js';
+
+function property(toolName: string, field: string): Record<string, unknown> {
+  const tool = [...EVENT_ADMIN_TOOLS, ...MEETING_TOOLS].find(candidate => candidate.name === toolName);
+  if (!tool) throw new Error(`Missing tool ${toolName}`);
+  return tool.input_schema.properties[field] as Record<string, unknown>;
+}
+
+describe('dated Addie tool schemas', () => {
+  it.each([
+    ['create_event', 'start_time'],
+    ['create_event', 'end_time'],
+    ['update_event', 'start_time'],
+    ['update_event', 'end_time'],
+    ['schedule_meeting', 'start_time'],
+    ['update_meeting', 'start_time'],
+  ])('types %s.%s as an RFC 3339 date-time', (toolName, field) => {
+    const schema = property(toolName, field);
+
+    expect(schema.type).toBe('string');
+    expect(schema.format).toBe('date-time');
+    expect(schema.description).toContain('explicit');
+  });
+
+  it.each([
+    ['create_event', 'timezone'],
+    ['schedule_meeting', 'timezone'],
+    ['update_meeting', 'timezone'],
+  ])('identifies %s.%s as an IANA timezone', (toolName, field) => {
+    expect(property(toolName, field).description).toContain('IANA timezone');
+  });
+
+  it('confirms billing tools expose no dated input records', () => {
+    const datedFields = BILLING_TOOLS.flatMap(tool =>
+      Object.keys(tool.input_schema.properties)
+        .filter(field => /(^date$|_at$|_time$|timestamp|deadline)/.test(field))
+        .map(field => `${tool.name}.${field}`),
+    );
+
+    expect(datedFields).toEqual([]);
+  });
+});

--- a/server/tests/unit/addie/tool-temporal.test.ts
+++ b/server/tests/unit/addie/tool-temporal.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatUtcTimestamp,
+  formatZonedTimestamp,
+  parseZonedTimestamp,
+} from '../../../src/addie/tool-temporal.js';
+
+describe('parseZonedTimestamp', () => {
+  it('accepts an explicit offset that matches the IANA timezone', () => {
+    const result = parseZonedTimestamp('2026-01-15T14:00:00-05:00', 'America/New_York');
+
+    expect(result).toEqual({ ok: true, date: new Date('2026-01-15T19:00:00.000Z') });
+  });
+
+  it('accepts UTC timestamps for UTC', () => {
+    expect(parseZonedTimestamp('2026-01-15T19:00:00Z', 'UTC').ok).toBe(true);
+  });
+
+  it('rejects timestamps without an offset', () => {
+    const result = parseZonedTimestamp('2026-01-15T14:00:00', 'America/New_York');
+
+    expect(result).toEqual(expect.objectContaining({ ok: false }));
+  });
+
+  it('rejects calendar dates that JavaScript would otherwise roll forward', () => {
+    const result = parseZonedTimestamp('2026-02-30T12:00:00Z', 'UTC');
+
+    expect(result).toEqual(expect.objectContaining({ ok: false }));
+  });
+
+  it('rejects an offset that disagrees across a DST boundary', () => {
+    const before = parseZonedTimestamp('2026-03-08T01:30:00-05:00', 'America/New_York');
+    const nonexistent = parseZonedTimestamp('2026-03-08T02:30:00-05:00', 'America/New_York');
+    const after = parseZonedTimestamp('2026-03-08T03:30:00-04:00', 'America/New_York');
+
+    expect(before.ok).toBe(true);
+    expect(nonexistent).toEqual(expect.objectContaining({ ok: false }));
+    expect(after.ok).toBe(true);
+  });
+
+  it('distinguishes both offsets during the repeated fall-back hour', () => {
+    expect(parseZonedTimestamp('2026-11-01T01:30:00-04:00', 'America/New_York').ok).toBe(true);
+    expect(parseZonedTimestamp('2026-11-01T01:30:00-05:00', 'America/New_York').ok).toBe(true);
+  });
+
+  it('rejects invalid IANA timezones', () => {
+    const result = parseZonedTimestamp('2026-01-15T14:00:00-05:00', 'EST');
+
+    expect(result).toEqual(expect.objectContaining({ ok: false }));
+  });
+});
+
+describe('tool timestamp formatting', () => {
+  it('preserves the instant and IANA timezone in dated records', () => {
+    expect(formatZonedTimestamp('2026-01-15T19:00:00.000Z', 'America/New_York')).toContain(
+      '[instant: 2026-01-15T19:00:00.000Z; time_zone: America/New_York]',
+    );
+  });
+
+  it('labels UTC timestamps explicitly', () => {
+    expect(formatUtcTimestamp('2026-01-15T19:00:00.000Z')).toContain(
+      '[instant: 2026-01-15T19:00:00.000Z; time_zone: UTC]',
+    );
+  });
+});

--- a/server/tests/unit/certification-attempt-recovery.test.ts
+++ b/server/tests/unit/certification-attempt-recovery.test.ts
@@ -88,7 +88,8 @@ describe('certification attempt recovery', () => {
     const result = await secondSession.get('get_learner_progress')?.({});
 
     expect(result).toContain('- S3: in progress');
-    expect(result).toContain(`Active attempt: ${ATTEMPT_ID} (started July 19, 2026)`);
+    expect(result).toContain(`Active attempt: ${ATTEMPT_ID}`);
+    expect(result).toContain('[instant: 2026-07-19T14:30:00.000Z; time_zone: UTC]');
     expect(mocks.getUserAttempts).toHaveBeenCalledWith(USER_ID);
   });
 


### PR DESCRIPTION
Closes #6848

## Summary

- require offset-bearing RFC 3339 timestamps whose numeric offset agrees with the supplied IANA timezone before event or meeting mutations
- reject invalid calendar dates and DST-gap timestamps while preserving both fall-back-hour offsets as distinct instants
- include machine-readable instants and explicit timezones in event, meeting, certification, and escalation tool output; confirm billing tools expose no dated inputs
- regenerate the Addie tool reference and inventory without raising any tool-surface budget, and bump `CODE_VERSION` to `2026.08.33`

## Verification

- `npm run precommit:server-unit` (493 files / 7,084 tests passed in the pre-commit verification run)
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie/tool-temporal.test.ts server/tests/unit/addie/tool-temporal-schemas.test.ts server/tests/unit/addie/escalation-temporal-output.test.ts server/tests/unit/certification-attempt-recovery.test.ts` (24 tests)
- `npm run typecheck`
- `npm run test:addie-tools`
- `git diff --check`
- push-time version, changeset-policy, schema-link, and docs-navigation checks

One subsequent duplicate aggregate hook run exposed the existing suite-order-sensitive `rate-limit-retry-after.test.ts` admin probe as a 404. The test passed 13/13 immediately in isolation, and the earlier complete server-unit run was green.

No changeset: application-only Addie behavior; no protocol release surface changed.
