### PR TITLE
fix(addie): contain provider exhaustion

### DIFF
--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -169,6 +169,7 @@ import {
 import { getThreadReplies, getSlackUser, getChannelInfo, getChannelHistory } from '../slack/client.js';
 import { AddieRouter, type RoutingContext, type ExecutionPlan, type ConfidenceTier } from './router.js';
 import { runRouterShadow, selectRouterShadowCohort } from './router-shadow.js';
+import { ProviderHealthController } from './model-providers/provider-health.js';
 import {
   getToolsForSets,
   buildUnavailableSetsHint,
@@ -778,11 +779,15 @@ export async function initializeAddieBolt(): Promise<{ app: InstanceType<typeof 
 
   logger.info('Addie Bolt: Initializing...');
 
+  // Share provider health across routing and response generation so an
+  // account-wide failure gates both paths until a bounded recovery probe.
+  const providerHealth = new ProviderHealthController();
+
   // Initialize Claude client
-  claudeClient = new AddieClaudeClient(anthropicKey, AddieModelConfig.chat);
+  claudeClient = new AddieClaudeClient(anthropicKey, AddieModelConfig.chat, providerHealth);
 
   // Initialize router (uses Haiku for fast classification)
-  addieRouter = new AddieRouter(anthropicKey);
+  addieRouter = new AddieRouter(anthropicKey, undefined, providerHealth);
 
   // Initialize database access
   addieDb = new AddieDatabase();
@@ -2044,14 +2049,27 @@ async function handleUserMessage({
       } else if (terminalDeliveryPlan === 'normal-stop') {
         // Stop the stream with feedback buttons and any inline images.
         try {
-          // Cap-exceeded responses have no streamed text — deliver the cap
-          // message as the terminal text so the user isn't left with silence.
-          if (response?.flag_reason === 'cost_cap_exceeded') {
-            const capGuarded = guardBareJsonEnvelope(response.text, { pathTag: 'dm-streaming-cap-exceeded' });
-            const capValidation = validateOutput(capGuarded.text);
-            const capText = wrapUrlsForSlack(capValidation.sanitized);
-            await streamer.stop({ markdown_text: capText, blocks: [buildFeedbackBlock()] });
+          const providerTerminalText = response?.flag_reason?.startsWith('provider_unavailable:')
+            && response.text.trim()
+            && !fullText.includes(response.text)
+            ? response.text
+            : '';
+          // Local terminal responses normally have no streamed text. If a
+          // provider fails after partial delivery, append the independent
+          // recovery warning before closing the stream as a safety backstop.
+          if (!fullText.trim() && response?.text.trim()) {
+            const terminalGuarded = guardBareJsonEnvelope(response.text, { pathTag: 'dm-streaming-local-terminal' });
+            const terminalValidation = validateOutput(terminalGuarded.text);
+            const terminalText = wrapUrlsForSlack(terminalValidation.sanitized);
+            await streamer.stop({ markdown_text: terminalText, blocks: [buildFeedbackBlock()] });
           } else {
+            if (providerTerminalText) {
+              const terminalGuarded = guardBareJsonEnvelope(providerTerminalText, { pathTag: 'dm-streaming-provider-terminal' });
+              const terminalValidation = validateOutput(terminalGuarded.text);
+              const terminalText = wrapUrlsForSlack(terminalValidation.sanitized);
+              fullText = `${fullText}\n\n${terminalValidation.sanitized}`;
+              await streamer.append({ markdown_text: `\n\n${terminalText}` });
+            }
             // Extract image URLs from streamed text for Slack Block Kit image blocks
             const { images: streamImages } = extractMarkdownImages(fullText);
             const MAX_SLACK_IMAGES = 3;
@@ -2088,9 +2106,10 @@ async function handleUserMessage({
               // Slack rejects section blocks with empty mrkdwn text. If streaming
               // produced nothing (e.g. upstream overload before any deltas), fall
               // back to a plain apology so the user isn't left silent. For
-              // cost_cap_exceeded, deliver the cap message directly.
+              // A local terminal response may have no streamed text; deliver
+              // its recovery message directly.
               if (!slackText.trim()) {
-                const apology = response?.flag_reason === 'cost_cap_exceeded'
+                const apology = response?.text.trim()
                   ? response.text
                   : isRetriesExhaustedError(stopError)
                     ? `${stopError.reason}. Please try again in a moment.`

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -39,6 +39,12 @@ import {
 import type { AddieInputAttachment } from './chat-attachments.js';
 import type { ModelExecution } from './model-providers/model-provider.js';
 import {
+  formatProviderUnavailableMessage,
+  ProviderHealthController,
+  type ProviderAvailability,
+} from './model-providers/provider-health.js';
+import { getProviderRetryAfterSeconds } from './model-providers/provider-errors.js';
+import {
   buildAddieProviderTools,
   buildAddieWireTools,
   mergeAddieToolDefinitions,
@@ -794,6 +800,28 @@ function localModelExecution(
   };
 }
 
+function providerUnavailableResponse(
+  availability: ProviderAvailability,
+  requestedModel: string,
+  toolsUsed: string[] = [],
+  toolExecutions: ToolExecution[] = [],
+  certificationReserveUsed = false,
+): AddieResponse {
+  const baseMessage = formatProviderUnavailableMessage(availability);
+  const text = toolExecutions.some(execution => !execution.is_error)
+    ? `${baseMessage} Some requested actions may already have completed, so review the results above before retrying.`
+    : baseMessage;
+  return {
+    text,
+    tools_used: [...toolsUsed],
+    tool_executions: [...toolExecutions],
+    flagged: true,
+    flag_reason: `provider_unavailable:${availability.category ?? 'unknown'}`,
+    model_execution: localModelExecution('provider_error', requestedModel),
+    capacity: { certification_reserve_used: certificationReserveUsed },
+  };
+}
+
 /**
  * Event types emitted during streaming
  */
@@ -836,12 +864,18 @@ export class AddieClaudeClient {
   private tools: AddieTool[] = [];
   private toolHandlers: Map<string, ToolHandler> = new Map();
   private addieDb: AddieDatabase;
+  private readonly providerHealth: ProviderHealthController;
   private webSearchEnabled: boolean = true; // Enable web search for external questions
 
-  constructor(apiKey: string, model: string = AddieModelConfig.chat) {
+  constructor(
+    apiKey: string,
+    model: string = AddieModelConfig.chat,
+    providerHealth: ProviderHealthController = new ProviderHealthController(),
+  ) {
     this.client = new Anthropic({ apiKey });
     this.model = model;
     this.addieDb = new AddieDatabase();
+    this.providerHealth = providerHealth;
   }
 
   /**
@@ -1305,6 +1339,15 @@ export class AddieClaudeClient {
       }
     }
 
+    // Reserve a half-open probe only after local gates have passed so a
+    // request that never reaches the provider cannot hold the probe lease.
+    if (operationalExecution) {
+      const availability = this.providerHealth.acquire('anthropic', 'chat');
+      if (!availability.allowed) {
+        return providerUnavailableResponse(availability, requestedModel);
+      }
+    }
+
     const toolsUsed: string[] = [];
     const toolExecutions: ToolExecution[] = [];
     let executionSequence = 0;
@@ -1416,6 +1459,7 @@ export class AddieClaudeClient {
             { maxRetries: 3, initialDelayMs: 1000 },
             'processMessage',
           );
+        if (operationalExecution) this.providerHealth.recordSuccess('anthropic', 'chat');
         if (isEmptyResponseRecovery) emptyResponseBeforeRecovery = null;
       } catch (error) {
         if (isEmptyResponseRecovery && emptyResponseBeforeRecovery) {
@@ -1437,6 +1481,17 @@ export class AddieClaudeClient {
             );
           } else {
             this.logPromptOverflow(error, stats, 'processMessage');
+          }
+          if (operationalExecution) {
+            const availability = this.providerHealth.recordFailure('anthropic', 'chat', error);
+            if (!availability.allowed) {
+              return providerUnavailableResponse(
+                availability,
+                requestedModel,
+                toolsUsed,
+                toolExecutions,
+              );
+            }
           }
           throw error;
         }
@@ -2120,11 +2175,25 @@ export class AddieClaudeClient {
         };
         return;
       }
-      if (certificationLeaseId) {
-        certificationLeaseHeartbeat = setInterval(() => {
-          void renewCertificationReserve(options.costScope?.userId, certificationLeaseId);
-        }, 30_000);
+    }
+
+    // As above, cost-capped requests must not consume the one half-open probe.
+    if (operationalExecution) {
+      const availability = this.providerHealth.acquire('anthropic', 'chat');
+      if (!availability.allowed) {
+        await releaseCertificationReserve(options?.costScope?.userId, certificationLeaseId);
+        certificationLeaseId = undefined;
+        yield {
+          type: 'done',
+          response: providerUnavailableResponse(availability, requestedModel),
+        };
+        return;
       }
+    }
+    if (certificationLeaseId) {
+      certificationLeaseHeartbeat = setInterval(() => {
+        void renewCertificationReserve(options?.costScope?.userId, certificationLeaseId);
+      }, 30_000);
     }
 
     const toolsUsed: string[] = [];
@@ -2300,6 +2369,7 @@ export class AddieClaudeClient {
               currentResponse = await anthropicStream.finalMessage();
             }
 
+            if (operationalExecution) this.providerHealth.recordSuccess('anthropic', 'chat');
             streamSucceeded = true;
             lastProviderModel = currentResponse.model;
             if (isEmptyResponseRecovery) emptyResponseBeforeRecovery = null;
@@ -2319,11 +2389,40 @@ export class AddieClaudeClient {
             this.logPromptOverflow(streamError, stats, 'processMessageStream');
 
             const retryable = isRetryableError(streamError);
+            const retryAfterSeconds = getProviderRetryAfterSeconds(streamError);
+            const retryAfterWithinRequestBudget = retryAfterSeconds === undefined
+              || retryAfterSeconds <= 30;
             const canRetry = retryable &&
-                             streamRetryCount <= maxStreamRetries;
+                             streamRetryCount <= maxStreamRetries &&
+                             retryAfterWithinRequestBudget;
 
             if (!canRetry) {
-              const isExhausted = retryable && streamRetryCount > maxStreamRetries;
+              const isExhausted = retryable && (
+                streamRetryCount > maxStreamRetries || !retryAfterWithinRequestBudget
+              );
+              if (operationalExecution) {
+                const availability = this.providerHealth.recordFailure('anthropic', 'chat', streamError);
+                if (!availability.allowed) {
+                  const terminalResponse = providerUnavailableResponse(
+                    availability,
+                    requestedModel,
+                    toolsUsed,
+                    toolExecutions,
+                    certificationReserveUsed,
+                  );
+                  // A terminal provider response is separate from any partial
+                  // prose already emitted. Surface it as a final chunk so every
+                  // consumer retains the recovery and mutation-safety warning.
+                  if (receivedDeltaCount > 0) {
+                    yield { type: 'text', text: `\n\n${terminalResponse.text}` };
+                  }
+                  yield {
+                    type: 'done',
+                    response: terminalResponse,
+                  };
+                  return;
+                }
+              }
               if (isExhausted) {
                 if (receivedDeltaCount > 0) {
                   const errorMsg = streamError instanceof Error ? streamError.message : String(streamError);
@@ -2349,7 +2448,8 @@ export class AddieClaudeClient {
             // Calculate delay with exponential backoff
             const delayMs = Math.min(1000 * Math.pow(2, streamRetryCount - 1), 30000);
             const jitter = delayMs * 0.25 * (Math.random() * 2 - 1);
-            const totalDelay = Math.round(delayMs + jitter);
+            const retryAfterMs = retryAfterSeconds === undefined ? 0 : retryAfterSeconds * 1000;
+            const totalDelay = Math.max(Math.round(delayMs + jitter), retryAfterMs);
 
             // Determine user-friendly reason
             const errorMsg = streamError instanceof Error ? streamError.message : String(streamError);
@@ -2363,6 +2463,7 @@ export class AddieClaudeClient {
                 attempt: streamRetryCount,
                 maxRetries: maxStreamRetries,
                 delayMs: totalDelay,
+                retryAfterSeconds,
                 error: errorMsg,
               },
               'Addie Stream: Retryable error, waiting before retry'

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.33';
+export const CODE_VERSION = '2026.08.34';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,13 +11,13 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "a27d617b3917bd4bf3c7a9be1116d50e5f588b1a5338d05952d50ec65b7ba93d",
+    "server/src/addie/claude-client.ts": "cf0c0042ff4918b8d04539398ca4eaa12d5c48d8481e5324f6553e8030f93d5a",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",
-    "server/src/addie/bolt-app.ts": "1a5cbfad3c49d7439beab4dec628005a2347df18e2d34185e1ef5d383e6674b0",
+    "server/src/addie/bolt-app.ts": "0253ad57463cf6f6001504dbe0fd73bf367ccde8ad48bab3321ac5a19125a2e6",
     "server/src/addie/handler.ts": "eb5eac26ae0949c26ba2ffc4c6fe28045324447b6eeb383ddf7133486097b15e",
-    "server/src/routes/addie-chat.ts": "27427c8ea9180b9bc0e262457ce516e7d66a694639b9cca272943859862c572a",
+    "server/src/routes/addie-chat.ts": "da80a42faf005441f4afbf1d003ccb7067dbd4e87b90dae96c0023511806fc08",
     "server/src/routes/tavus.ts": "640e818f0ecd4da6c72f310b7582f7bc1f2c00fd77dbe0dc521f53459e31003f",
     "server/src/addie/email-conversation-handler.ts": "c094474b506fe9d695122bf451c79930d5e5f3f0dc56d3e77c5c2b3f3b66e9e5",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",

--- a/server/src/addie/model-providers/provider-errors.ts
+++ b/server/src/addie/model-providers/provider-errors.ts
@@ -1,0 +1,134 @@
+import type { ModelProviderId } from './model-provider.js';
+
+export type ProviderFailureCategory =
+  | 'billing_exhausted'
+  | 'rate_limited'
+  | 'overloaded'
+  | 'timeout'
+  | 'unavailable'
+  | 'authentication'
+  | 'invalid_request'
+  | 'unknown';
+
+export interface ProviderFailure {
+  category: ProviderFailureCategory;
+  retryAfterSeconds?: number;
+  status?: number;
+}
+
+const MAX_RETRY_AFTER_SECONDS = 60 * 60;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  return typeof value[key] === 'string' ? value[key] : undefined;
+}
+
+function statusFromError(error: unknown, depth = 0): number | undefined {
+  if (!isRecord(error) || depth > 2) return undefined;
+  for (const key of ['status', 'statusCode']) {
+    const value = error[key];
+    if (typeof value === 'number' && Number.isInteger(value)) return value;
+  }
+  return statusFromError(error.cause, depth + 1);
+}
+
+function messageFromError(error: unknown, depth = 0): string {
+  if (depth > 2) return '';
+  if (error instanceof Error) {
+    return `${error.message}\n${messageFromError(error.cause, depth + 1)}`;
+  }
+  if (!isRecord(error)) return typeof error === 'string' ? error : '';
+  const ownMessage = stringField(error, 'message') ?? '';
+  const body = isRecord(error.error) ? error.error : null;
+  const bodyMessage = body ? stringField(body, 'message') ?? '' : '';
+  return `${ownMessage}\n${bodyMessage}\n${messageFromError(error.cause, depth + 1)}`;
+}
+
+function codeFromError(error: unknown, depth = 0): string[] {
+  if (!isRecord(error) || depth > 2) return [];
+  const body = isRecord(error.error) ? error.error : null;
+  const codes = [
+    stringField(error, 'code'),
+    stringField(error, 'type'),
+    body ? stringField(body, 'code') : undefined,
+    body ? stringField(body, 'type') : undefined,
+    ...codeFromError(error.cause, depth + 1),
+  ];
+  return codes.filter((value): value is string => !!value).map(value => value.toLowerCase());
+}
+
+function headerValue(error: unknown, name: string, depth = 0): string | undefined {
+  if (!isRecord(error) || depth > 2) return undefined;
+  const headers = error.headers;
+  if (isRecord(headers)) {
+    const getter = headers.get;
+    if (typeof getter === 'function') {
+      const value = getter.call(headers, name);
+      if (typeof value === 'string') return value;
+    }
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase() === name && typeof value === 'string') return value;
+    }
+  }
+  return headerValue(error.cause, name, depth + 1);
+}
+
+/** Parse Retry-After once into bounded whole seconds. */
+export function getProviderRetryAfterSeconds(error: unknown, nowMs = Date.now()): number | undefined {
+  const value = headerValue(error, 'retry-after')?.trim();
+  if (!value) return undefined;
+
+  const numeric = Number(value);
+  const seconds = Number.isFinite(numeric)
+    ? Math.ceil(numeric)
+    : Math.ceil((Date.parse(value) - nowMs) / 1000);
+  if (!Number.isFinite(seconds) || seconds < 0) return undefined;
+  return Math.min(MAX_RETRY_AFTER_SECONDS, seconds);
+}
+
+export function classifyProviderFailure(
+  provider: ModelProviderId,
+  error: unknown,
+  nowMs = Date.now(),
+): ProviderFailure {
+  const status = statusFromError(error);
+  const retryAfterSeconds = getProviderRetryAfterSeconds(error, nowMs);
+  const message = messageFromError(error).toLowerCase();
+  const codes = codeFromError(error);
+  const hasCode = (...values: string[]) => values.some(value => codes.includes(value));
+
+  const billingExhausted = provider === 'anthropic'
+    ? /credit balance is too low|plans?\s*&\s*billing/.test(message)
+    : provider === 'openai'
+      ? hasCode('insufficient_quota', 'billing_hard_limit_reached')
+      : false;
+  if (billingExhausted) return { category: 'billing_exhausted', ...(status && { status }) };
+
+  if (status === 429 || hasCode('rate_limit_error', 'rate_limit_exceeded')) {
+    return { category: 'rate_limited', ...(retryAfterSeconds !== undefined && { retryAfterSeconds }), ...(status && { status }) };
+  }
+  if (status === 529 || hasCode('overloaded_error') || /\boverloaded(?:_error)?\b|\bhigh demand\b/.test(message)) {
+    return { category: 'overloaded', ...(retryAfterSeconds !== undefined && { retryAfterSeconds }), ...(status && { status }) };
+  }
+  if (hasCode('timeout', 'request_timeout') || /\b(?:timed? out|timeout)\b/.test(message)) {
+    return { category: 'timeout', ...(retryAfterSeconds !== undefined && { retryAfterSeconds }), ...(status && { status }) };
+  }
+  if (
+    (status !== undefined && status >= 500)
+    || hasCode('api_error', 'connection_error', 'service_unavailable')
+    || /\b(?:connection (?:failed|reset)|service unavailable)\b/.test(message)
+  ) {
+    return { category: 'unavailable', ...(retryAfterSeconds !== undefined && { retryAfterSeconds }), ...(status && { status }) };
+  }
+  if (status === 401 || status === 403 || hasCode('authentication_error', 'permission_error')) {
+    return { category: 'authentication', ...(status && { status }) };
+  }
+  if (status === 400 || hasCode('invalid_request_error')) {
+    return { category: 'invalid_request', ...(status && { status }) };
+  }
+  return { category: 'unknown', ...(status && { status }) };
+}

--- a/server/src/addie/model-providers/provider-health.ts
+++ b/server/src/addie/model-providers/provider-health.ts
@@ -1,0 +1,285 @@
+import { createLogger } from '../../logger.js';
+import { notifySystemError } from '../error-notifier.js';
+import type { ModelProviderId } from './model-provider.js';
+import {
+  classifyProviderFailure,
+  type ProviderFailure,
+  type ProviderFailureCategory,
+} from './provider-errors.js';
+
+const logger = createLogger('addie-provider-health');
+
+export type ProviderService = 'chat' | 'router';
+export type ProviderCircuitStatus = 'healthy' | 'degraded' | 'open' | 'half_open';
+
+export interface ProviderAvailability {
+  allowed: boolean;
+  provider: ModelProviderId;
+  service: ProviderService;
+  status: ProviderCircuitStatus;
+  category?: ProviderFailureCategory;
+  retryAfterSeconds?: number;
+}
+
+interface CircuitState {
+  status: Exclude<ProviderCircuitStatus, 'healthy'>;
+  category: ProviderFailureCategory;
+  consecutiveFailures: number;
+  windowStartedAtMs: number;
+  blockedUntilMs: number;
+  probeLeaseUntilMs: number;
+}
+
+export interface ProviderHealthConfig {
+  failureThreshold: number;
+  failureWindowMs: number;
+  transientCooldownMs: number;
+  billingCooldownMs: number;
+  probeLeaseMs: number;
+}
+
+const DEFAULT_CONFIG: ProviderHealthConfig = {
+  failureThreshold: 3,
+  failureWindowMs: 60_000,
+  transientCooldownMs: 30_000,
+  billingCooldownMs: 5 * 60_000,
+  probeLeaseMs: 30_000,
+};
+
+function circuitKey(provider: ModelProviderId, service: ProviderService): string {
+  return `${provider}:${service}`;
+}
+
+function retryAfterSeconds(state: CircuitState, nowMs: number): number | undefined {
+  const remainingMs = state.status === 'half_open'
+    ? state.probeLeaseUntilMs - nowMs
+    : state.blockedUntilMs - nowMs;
+  return remainingMs > 0 ? Math.max(1, Math.ceil(remainingMs / 1000)) : undefined;
+}
+
+export class ProviderCircuitOpenError extends Error {
+  constructor(readonly availability: ProviderAvailability) {
+    super(`Provider circuit is ${availability.status} for ${availability.provider}:${availability.service}`);
+    this.name = 'ProviderCircuitOpenError';
+  }
+}
+
+export class ProviderHealthController {
+  private readonly serviceStates = new Map<string, CircuitState>();
+  private readonly accountStates = new Map<ModelProviderId, CircuitState>();
+  private readonly config: ProviderHealthConfig;
+  private readonly now: () => number;
+
+  constructor(config: Partial<ProviderHealthConfig> = {}, now: () => number = Date.now) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.now = now;
+  }
+
+  acquire(provider: ModelProviderId, service: ProviderService): ProviderAvailability {
+    const nowMs = this.now();
+    const account = this.acquireState(this.accountStates, provider, provider, service, nowMs);
+    if (account) return account;
+    const serviceState = this.acquireState(
+      this.serviceStates,
+      circuitKey(provider, service),
+      provider,
+      service,
+      nowMs,
+    );
+    return serviceState ?? { allowed: true, provider, service, status: 'healthy' };
+  }
+
+  private acquireState<K>(
+    states: Map<K, CircuitState>,
+    key: K,
+    provider: ModelProviderId,
+    service: ProviderService,
+    nowMs: number,
+  ): ProviderAvailability | null {
+    const state = states.get(key);
+    if (!state) return null;
+    if (state.status === 'degraded') {
+      return { allowed: true, provider, service, status: 'degraded', category: state.category };
+    }
+    if (state.status === 'open' && nowMs < state.blockedUntilMs) {
+      return {
+        allowed: false,
+        provider,
+        service,
+        status: 'open',
+        category: state.category,
+        retryAfterSeconds: retryAfterSeconds(state, nowMs),
+      };
+    }
+    if (state.status === 'half_open' && nowMs < state.probeLeaseUntilMs) {
+      return {
+        allowed: false,
+        provider,
+        service,
+        status: 'half_open',
+        category: state.category,
+        retryAfterSeconds: retryAfterSeconds(state, nowMs),
+      };
+    }
+
+    state.status = 'half_open';
+    state.probeLeaseUntilMs = nowMs + this.config.probeLeaseMs;
+    return { allowed: true, provider, service, status: 'half_open', category: state.category };
+  }
+
+  recordSuccess(provider: ModelProviderId, service: ProviderService): void {
+    const serviceDeleted = this.serviceStates.delete(circuitKey(provider, service));
+    const accountDeleted = this.accountStates.delete(provider);
+    if (serviceDeleted || accountDeleted) {
+      logger.info({ provider, service, event: 'provider_circuit_recovered' }, 'Provider circuit recovered');
+    }
+  }
+
+  recordFailure(provider: ModelProviderId, service: ProviderService, error: unknown): ProviderAvailability {
+    const nowMs = this.now();
+    const failure = classifyProviderFailure(provider, error, nowMs);
+    if (failure.category === 'billing_exhausted') {
+      return this.openCircuit(
+        this.accountStates,
+        provider,
+        provider,
+        service,
+        failure,
+        nowMs,
+        this.config.billingCooldownMs,
+      );
+    }
+
+    const states = this.serviceStates;
+    const key = circuitKey(provider, service);
+    if (failure.category === 'rate_limited' || failure.retryAfterSeconds !== undefined) {
+      return this.openCircuit(
+        states,
+        key,
+        provider,
+        service,
+        failure,
+        nowMs,
+        Math.max(
+          this.config.transientCooldownMs,
+          (failure.retryAfterSeconds ?? 0) * 1000,
+        ),
+      );
+    }
+
+    if (!['overloaded', 'timeout', 'unavailable'].includes(failure.category)) {
+      return { allowed: true, provider, service, status: 'healthy', category: failure.category };
+    }
+
+    const previous = states.get(key);
+    // A failed recovery probe is direct evidence that the provider is still
+    // unhealthy. Reopen immediately instead of letting the original failure
+    // window expire and briefly admitting normal traffic again.
+    if (previous?.status === 'half_open') {
+      return this.openCircuit(
+        states,
+        key,
+        provider,
+        service,
+        failure,
+        nowMs,
+        this.config.transientCooldownMs,
+        previous.consecutiveFailures + 1,
+        nowMs,
+      );
+    }
+    const withinWindow = previous && nowMs - previous.windowStartedAtMs <= this.config.failureWindowMs;
+    const consecutiveFailures = withinWindow ? previous.consecutiveFailures + 1 : 1;
+    if (consecutiveFailures < this.config.failureThreshold) {
+      states.set(key, {
+        status: 'degraded',
+        category: failure.category,
+        consecutiveFailures,
+        windowStartedAtMs: withinWindow ? previous.windowStartedAtMs : nowMs,
+        blockedUntilMs: 0,
+        probeLeaseUntilMs: 0,
+      });
+      logger.warn(
+        { provider, service, category: failure.category, consecutiveFailures, event: 'provider_degraded' },
+        'Provider health degraded',
+      );
+      return { allowed: true, provider, service, status: 'degraded', category: failure.category };
+    }
+
+    return this.openCircuit(
+      states,
+      key,
+      provider,
+      service,
+      { ...failure },
+      nowMs,
+      this.config.transientCooldownMs,
+      consecutiveFailures,
+      withinWindow ? previous.windowStartedAtMs : nowMs,
+    );
+  }
+
+  private openCircuit<K>(
+    states: Map<K, CircuitState>,
+    key: K,
+    provider: ModelProviderId,
+    service: ProviderService,
+    failure: ProviderFailure,
+    nowMs: number,
+    cooldownMs: number,
+    consecutiveFailures = 1,
+    windowStartedAtMs = nowMs,
+  ): ProviderAvailability {
+    const blockedUntilMs = nowMs + cooldownMs;
+    states.set(key, {
+      status: 'open',
+      category: failure.category,
+      consecutiveFailures,
+      windowStartedAtMs,
+      blockedUntilMs,
+      probeLeaseUntilMs: 0,
+    });
+    const retrySeconds = Math.max(1, Math.ceil(cooldownMs / 1000));
+    logger.warn(
+      {
+        provider,
+        service,
+        category: failure.category,
+        retryAfterSeconds: retrySeconds,
+        consecutiveFailures,
+        event: 'provider_circuit_opened',
+      },
+      'Provider circuit opened',
+    );
+    notifySystemError({
+      source: failure.category === 'billing_exhausted'
+        ? `${provider}-billing-exhausted`
+        : `${provider}-${service}-circuit-open`,
+      errorMessage: [
+        `provider=${provider}`,
+        `service=${service}`,
+        `category=${failure.category}`,
+        `retry_after_seconds=${retrySeconds}`,
+        `consecutive_failures=${consecutiveFailures}`,
+      ].join('\n'),
+    });
+    return {
+      allowed: false,
+      provider,
+      service,
+      status: 'open',
+      category: failure.category,
+      retryAfterSeconds: retrySeconds,
+    };
+  }
+}
+
+export function formatProviderUnavailableMessage(availability: ProviderAvailability): string {
+  const prefix = availability.category === 'rate_limited'
+    ? 'The AI service is temporarily rate limited.'
+    : 'The AI service is temporarily unavailable.';
+  if (!availability.retryAfterSeconds) return `${prefix} Please try again shortly.`;
+  const seconds = availability.retryAfterSeconds;
+  if (seconds < 90) return `${prefix} Please try again in about ${seconds} seconds.`;
+  return `${prefix} Please try again in about ${Math.ceil(seconds / 60)} minutes.`;
+}

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -42,6 +42,10 @@ import {
 } from "./model-providers/model-provider.js";
 import { AnthropicRouterProvider } from "./model-providers/anthropic-router-provider.js";
 import {
+  ProviderCircuitOpenError,
+  ProviderHealthController,
+} from "./model-providers/provider-health.js";
+import {
   getToolSetDescriptionsForRouter,
   getValidToolSetNames,
   requiresPrecision as checkPrecision,
@@ -993,11 +997,17 @@ function queueRouterObserver(
  */
 export class AddieRouter {
   private readonly provider: ModelProvider;
+  private readonly providerHealth: ProviderHealthController;
 
-  constructor(apiKey: string, provider?: ModelProvider) {
+  constructor(
+    apiKey: string,
+    provider?: ModelProvider,
+    providerHealth: ProviderHealthController = new ProviderHealthController(),
+  ) {
     this.provider = provider ?? new AnthropicRouterProvider(apiKey, {
       maxRetries: 2,
     });
+    this.providerHealth = providerHealth;
   }
 
   /**
@@ -1015,6 +1025,8 @@ export class AddieRouter {
     let primaryInvocation: PreparedModelInvocation | null = null;
 
     try {
+      const availability = this.providerHealth.acquire(this.provider.id, 'router');
+      if (!availability.allowed) throw new ProviderCircuitOpenError(availability);
       const response = await collectModelResponse(
         this.provider.respond(canonicalRequest, {
           // This callback is deliberately assignment-only. Shadow evidence can
@@ -1025,6 +1037,7 @@ export class AddieRouter {
         }),
         this.provider.id,
       );
+      this.providerHealth.recordSuccess(this.provider.id, 'router');
 
       const text = extractRouterResponseText(response.content);
 
@@ -1115,6 +1128,9 @@ export class AddieRouter {
 
       return plan;
     } catch (error) {
+      if (!(error instanceof ProviderCircuitOpenError)) {
+        this.providerHealth.recordFailure(this.provider.id, 'router', error);
+      }
       const category = classifyRouterError(error);
       logger.error(
         { category },

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -1799,7 +1799,18 @@ export function createAddieChatRouter(options?: {
         return;
       }
 
-      const finalStreamText = fullText.trim() ? fullText : response?.text;
+      const terminalText = response.text.trim();
+      const shouldAppendProviderTerminal = response.flag_reason?.startsWith('provider_unavailable:')
+        && !!fullText.trim()
+        && !!terminalText
+        && !fullText.includes(response.text);
+      const usedTerminalText = !fullText.trim() && !!terminalText;
+      if (usedTerminalText || shouldAppendProviderTerminal) {
+        sendEvent("text", { text: shouldAppendProviderTerminal ? `\n\n${response.text}` : response.text });
+      }
+      const finalStreamText = shouldAppendProviderTerminal
+        ? `${fullText}\n\n${response.text}`
+        : fullText.trim() ? fullText : response.text;
       const normalizedStream = ensureNonEmptyAssistantResponse(finalStreamText);
       if (normalizedStream.usedFallback) {
         logger.warn(

--- a/server/src/utils/anthropic-retry.ts
+++ b/server/src/utils/anthropic-retry.ts
@@ -7,6 +7,10 @@
 
 import { APIError, APIConnectionError } from '@anthropic-ai/sdk';
 import { logger } from '../logger.js';
+import {
+  classifyProviderFailure,
+  getProviderRetryAfterSeconds,
+} from '../addie/model-providers/provider-errors.js';
 
 /**
  * Error thrown when all retry attempts have been exhausted
@@ -18,6 +22,8 @@ export class RetriesExhaustedError extends Error {
   readonly attempts: number;
   /** User-friendly reason for the failure */
   readonly reason: string;
+  /** Provider-supplied recovery delay, normalized to whole seconds. */
+  readonly retryAfterSeconds?: number;
 
   constructor(cause: unknown, attempts: number) {
     const errorMsg = cause instanceof Error ? cause.message : String(cause);
@@ -31,6 +37,7 @@ export class RetriesExhaustedError extends Error {
     this.cause = cause;
     this.attempts = attempts;
     this.reason = reason;
+    this.retryAfterSeconds = getProviderRetryAfterSeconds(cause);
   }
 }
 
@@ -146,6 +153,11 @@ export function isRetryableError(error: unknown): boolean {
     }
   }
 
+  const category = classifyProviderFailure('anthropic', error).category;
+  if (category === 'rate_limited' || category === 'overloaded' || category === 'timeout' || category === 'unavailable') {
+    return true;
+  }
+
   return false;
 }
 
@@ -206,19 +218,35 @@ export async function withRetry<T>(
       }
 
       const delayMs = calculateDelay(attempt, finalConfig);
+      const retryAfterSeconds = getProviderRetryAfterSeconds(error);
+      const providerDelayMs = retryAfterSeconds === undefined ? 0 : retryAfterSeconds * 1000;
+      if (providerDelayMs > finalConfig.maxDelayMs) {
+        logger.warn(
+          {
+            attempt,
+            maxRetries: finalConfig.maxRetries,
+            retryAfterSeconds,
+            operation: operationName,
+          },
+          'Anthropic API: Retry-After exceeds request retry budget; deferring recovery',
+        );
+        throw new RetriesExhaustedError(error, attempt);
+      }
+      const scheduledDelayMs = Math.max(delayMs, providerDelayMs);
 
       logger.warn(
         {
           attempt,
           maxRetries: finalConfig.maxRetries,
-          delayMs: Math.round(delayMs),
+          delayMs: Math.round(scheduledDelayMs),
+          retryAfterSeconds,
           error: error instanceof Error ? error.message : String(error),
           operation: operationName,
         },
         `Anthropic API: Retryable error, waiting before retry ${attempt}/${finalConfig.maxRetries}`
       );
 
-      await sleep(delayMs);
+      await sleep(scheduledDelayMs);
     }
   }
 
@@ -278,19 +306,35 @@ export async function* withStreamRetry<T>(
       }
 
       const delayMs = calculateDelay(attempt, finalConfig);
+      const retryAfterSeconds = getProviderRetryAfterSeconds(error);
+      const providerDelayMs = retryAfterSeconds === undefined ? 0 : retryAfterSeconds * 1000;
+      if (providerDelayMs > finalConfig.maxDelayMs) {
+        logger.warn(
+          {
+            attempt,
+            maxRetries: finalConfig.maxRetries,
+            retryAfterSeconds,
+            operation: operationName,
+          },
+          'Anthropic API Stream: Retry-After exceeds request retry budget; deferring recovery',
+        );
+        throw new RetriesExhaustedError(error, attempt);
+      }
+      const scheduledDelayMs = Math.max(delayMs, providerDelayMs);
 
       logger.warn(
         {
           attempt,
           maxRetries: finalConfig.maxRetries,
-          delayMs: Math.round(delayMs),
+          delayMs: Math.round(scheduledDelayMs),
+          retryAfterSeconds,
           error: error instanceof Error ? error.message : String(error),
           operation: operationName,
         },
         `Anthropic API Stream: Retryable error, waiting before retry ${attempt}/${finalConfig.maxRetries}`
       );
 
-      await sleep(delayMs);
+      await sleep(scheduledDelayMs);
     }
   }
 

--- a/server/tests/unit/addie-chat-object-authorization.test.ts
+++ b/server/tests/unit/addie-chat-object-authorization.test.ts
@@ -557,6 +557,76 @@ describe('Addie chat conversation object authorization', () => {
     expect(mocks.processMessageStream).toHaveBeenCalledOnce();
   });
 
+  it('delivers a done-only provider recovery response once on the streaming path', async () => {
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+    mocks.processMessageStream.mockImplementation(async function* () {
+      yield {
+        type: 'done',
+        response: {
+          ...successfulModelResponse('The AI service is temporarily unavailable. Please try again shortly.'),
+          flagged: true,
+          flag_reason: 'provider_unavailable:overloaded',
+        },
+      };
+    });
+
+    const response = await request(mountChatRouter())
+      .post('/stream')
+      .send({
+        message: 'Stream my conversation',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.text.match(/event: text/g)).toHaveLength(1);
+    expect(response.text).toContain('The AI service is temporarily unavailable. Please try again shortly.');
+    expect(response.text).toContain('event: done');
+  });
+
+  it('appends provider recovery copy after partial streamed text', async () => {
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+    const recoveryText = 'The AI service is temporarily unavailable. Some requested actions may already have completed.';
+    mocks.processMessageStream.mockImplementation(async function* () {
+      yield { type: 'text', text: 'Partial provider response.' };
+      yield {
+        type: 'done',
+        response: {
+          ...successfulModelResponse(recoveryText),
+          flagged: true,
+          flag_reason: 'provider_unavailable:overloaded',
+        },
+      };
+    });
+
+    const response = await request(mountChatRouter())
+      .post('/stream')
+      .send({
+        message: 'Stream my conversation',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.text.match(/event: text/g)).toHaveLength(2);
+    expect(response.text).toContain('Partial provider response.');
+    expect(response.text).toContain(recoveryText);
+    expect(mocks.addMessage).toHaveBeenCalledWith(expect.objectContaining({
+      role: 'assistant',
+      content: expect.stringContaining(recoveryText),
+    }));
+  });
+
   it('replays a completed client request without duplicating messages, tools, or model work', async () => {
     mocks.getThreadByExternalId.mockResolvedValue({
       thread_id: 'thread_attacker',

--- a/server/tests/unit/addie/provider-errors.test.ts
+++ b/server/tests/unit/addie/provider-errors.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyProviderFailure,
+  getProviderRetryAfterSeconds,
+} from '../../../src/addie/model-providers/provider-errors.js';
+
+describe('provider error classification', () => {
+  it('classifies Anthropic credit exhaustion without treating it as a retryable request error', () => {
+    const error = Object.assign(new Error(
+      'Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing.',
+    ), { status: 400 });
+
+    expect(classifyProviderFailure('anthropic', error)).toEqual({
+      category: 'billing_exhausted',
+      status: 400,
+    });
+  });
+
+  it('classifies OpenAI quota exhaustion from its bounded error code', () => {
+    const error = { status: 429, error: { code: 'insufficient_quota' } };
+
+    expect(classifyProviderFailure('openai', error).category).toBe('billing_exhausted');
+  });
+
+  it('keeps ordinary rate limits distinct from billing exhaustion', () => {
+    const error = {
+      status: 429,
+      headers: { 'retry-after': '12.2' },
+      error: { type: 'rate_limit_error' },
+    };
+
+    expect(classifyProviderFailure('anthropic', error, 0)).toEqual({
+      category: 'rate_limited',
+      retryAfterSeconds: 13,
+      status: 429,
+    });
+  });
+
+  it('classifies overload, timeout, and provider unavailability', () => {
+    expect(classifyProviderFailure('anthropic', { status: 529 }).category).toBe('overloaded');
+    expect(classifyProviderFailure('anthropic', new Error('overloaded_error: provider busy')).category).toBe('overloaded');
+    expect(classifyProviderFailure('google', new Error('request timed out')).category).toBe('timeout');
+    expect(classifyProviderFailure('openai', { status: 503 }).category).toBe('unavailable');
+  });
+});
+
+describe('Retry-After parsing', () => {
+  it('parses numeric seconds from Headers-like objects', () => {
+    const error = { headers: new Headers({ 'retry-after': '7' }) };
+    expect(getProviderRetryAfterSeconds(error, 0)).toBe(7);
+  });
+
+  it('parses HTTP dates and unwraps retry errors', () => {
+    const error = {
+      cause: {
+        headers: { 'Retry-After': 'Thu, 01 Jan 1970 00:00:09 GMT' },
+      },
+    };
+    expect(getProviderRetryAfterSeconds(error, 1_000)).toBe(8);
+  });
+
+  it('rejects invalid values and bounds hostile durations', () => {
+    expect(getProviderRetryAfterSeconds({ headers: { 'retry-after': 'later' } }, 0)).toBeUndefined();
+    expect(getProviderRetryAfterSeconds({ headers: { 'retry-after': '999999' } }, 0)).toBe(3600);
+  });
+});

--- a/server/tests/unit/addie/provider-health-runtime.test.ts
+++ b/server/tests/unit/addie/provider-health-runtime.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  ModelProvider,
+  ModelProviderCapabilities,
+  ModelRequest,
+  ModelRespondOptions,
+  NormalizedModelEvent,
+  PreparedModelInvocation,
+} from '../../../src/addie/model-providers/model-provider.js';
+
+const anthropicCall = vi.fn(() => {
+  throw new Error('Anthropic SDK must not be reached while the shared circuit is open');
+});
+
+vi.mock('@anthropic-ai/sdk', () => {
+  class APIError extends Error {}
+  class APIConnectionError extends Error {}
+  return {
+    APIError,
+    APIConnectionError,
+    default: class {
+      beta = { messages: { create: anthropicCall, stream: anthropicCall } };
+      messages = { create: anthropicCall, stream: anthropicCall };
+    },
+  };
+});
+
+import { AddieClaudeClient, type StreamEvent } from '../../../src/addie/claude-client.js';
+import { ProviderHealthController } from '../../../src/addie/model-providers/provider-health.js';
+import { AddieRouter } from '../../../src/addie/router.js';
+
+const capabilities: ModelProviderCapabilities = {
+  streaming: false,
+  structuredOutput: false,
+  reasoning: false,
+  reasoningEfforts: [],
+  customTools: false,
+  providerWebSearch: false,
+  imageInput: false,
+  documentInput: false,
+};
+
+class BillingExhaustedProvider implements ModelProvider {
+  readonly id = 'anthropic' as const;
+  readonly capabilities = capabilities;
+  calls = 0;
+
+  prepare(request: ModelRequest): PreparedModelInvocation {
+    return {
+      provider: this.id,
+      model: request.model,
+      capabilities,
+      providerRequest: {},
+    };
+  }
+
+  async *respond(
+    _request: ModelRequest,
+    _options?: ModelRespondOptions,
+  ): AsyncIterable<NormalizedModelEvent> {
+    this.calls++;
+    throw Object.assign(new Error(
+      'Your credit balance is too low to access the Anthropic API. Go to Plans & Billing.',
+    ), { status: 400 });
+  }
+}
+
+describe('shared Addie provider circuit', () => {
+  beforeEach(() => {
+    anthropicCall.mockClear();
+  });
+
+  it('turns router billing exhaustion into one safe fallback and gates chat dispatch', async () => {
+    const health = new ProviderHealthController();
+    const provider = new BillingExhaustedProvider();
+    const router = new AddieRouter('unused', provider, health);
+
+    const firstRoute = await router.route({ message: 'important question', source: 'dm' });
+    const secondRoute = await router.route({ message: 'another question', source: 'dm' });
+
+    expect(firstRoute).toMatchObject({ action: 'respond', tool_sets: ['knowledge'] });
+    expect(secondRoute).toMatchObject({ action: 'respond', tool_sets: ['knowledge'] });
+    expect(provider.calls).toBe(1);
+
+    const client = new AddieClaudeClient('unused', 'claude-sonnet-4-6', health);
+    const response = await client.processMessage(
+      'hello',
+      undefined,
+      undefined,
+      undefined,
+      { uncapped: true },
+    );
+
+    expect(response).toMatchObject({
+      flagged: true,
+      flag_reason: 'provider_unavailable:billing_exhausted',
+      model_execution: {
+        source: 'local',
+        requested_provider: 'anthropic',
+        requested_model: 'claude-sonnet-4-6',
+        reason: 'provider_error',
+      },
+    });
+    expect(response.text).toBe(
+      'The AI service is temporarily unavailable. Please try again in about 5 minutes.',
+    );
+    expect(response.text).not.toMatch(/billing|credit/i);
+    expect(anthropicCall).not.toHaveBeenCalled();
+  });
+
+  it('emits one done event with the same recovery copy on the stream path', async () => {
+    const health = new ProviderHealthController();
+    health.recordFailure('anthropic', 'chat', Object.assign(new Error(
+      'Your credit balance is too low to access the Anthropic API.',
+    ), { status: 400 }));
+    const client = new AddieClaudeClient('unused', 'claude-sonnet-4-6', health);
+    const events: StreamEvent[] = [];
+
+    for await (const event of client.processMessageStream(
+      'hello',
+      undefined,
+      undefined,
+      { uncapped: true },
+    )) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'done',
+      response: {
+        text: 'The AI service is temporarily unavailable. Please try again in about 5 minutes.',
+        flag_reason: 'provider_unavailable:billing_exhausted',
+      },
+    });
+    expect(anthropicCall).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/addie/provider-health.test.ts
+++ b/server/tests/unit/addie/provider-health.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatProviderUnavailableMessage,
+  ProviderHealthController,
+} from '../../../src/addie/model-providers/provider-health.js';
+
+function transientError(status = 529): Error & { status: number } {
+  return Object.assign(new Error('provider failure'), { status });
+}
+
+describe('ProviderHealthController', () => {
+  it('opens after bounded consecutive transient failures and isolates services', () => {
+    let now = 1_000;
+    const health = new ProviderHealthController({ failureThreshold: 3 }, () => now);
+
+    expect(health.recordFailure('anthropic', 'router', transientError()).status).toBe('degraded');
+    now += 1_000;
+    expect(health.recordFailure('anthropic', 'router', transientError()).status).toBe('degraded');
+    now += 1_000;
+    expect(health.recordFailure('anthropic', 'router', transientError()).status).toBe('open');
+
+    expect(health.acquire('anthropic', 'router').allowed).toBe(false);
+    expect(health.acquire('anthropic', 'chat')).toEqual(expect.objectContaining({
+      allowed: true,
+      status: 'healthy',
+    }));
+  });
+
+  it('opens billing exhaustion across services immediately', () => {
+    const health = new ProviderHealthController({}, () => 10_000);
+    const billingError = Object.assign(new Error(
+      'Your credit balance is too low to access the Anthropic API. Go to Plans & Billing.',
+    ), { status: 400 });
+
+    const failed = health.recordFailure('anthropic', 'router', billingError);
+
+    expect(failed).toEqual(expect.objectContaining({
+      allowed: false,
+      status: 'open',
+      category: 'billing_exhausted',
+      retryAfterSeconds: 300,
+    }));
+    expect(health.acquire('anthropic', 'chat')).toEqual(expect.objectContaining({
+      allowed: false,
+      category: 'billing_exhausted',
+    }));
+  });
+
+  it('uses Retry-After as the minimum rate-limit cooldown', () => {
+    const health = new ProviderHealthController({ transientCooldownMs: 1_000 }, () => 0);
+    const error = { status: 429, headers: { 'retry-after': '45' } };
+
+    expect(health.recordFailure('anthropic', 'chat', error).retryAfterSeconds).toBe(45);
+    expect(health.acquire('anthropic', 'chat').retryAfterSeconds).toBe(45);
+  });
+
+  it('admits only one half-open probe and closes after success', () => {
+    let now = 0;
+    const health = new ProviderHealthController({
+      failureThreshold: 1,
+      transientCooldownMs: 2_000,
+      probeLeaseMs: 500,
+    }, () => now);
+    health.recordFailure('anthropic', 'chat', transientError());
+
+    now = 2_001;
+    expect(health.acquire('anthropic', 'chat')).toEqual(expect.objectContaining({
+      allowed: true,
+      status: 'half_open',
+    }));
+    expect(health.acquire('anthropic', 'chat')).toEqual(expect.objectContaining({
+      allowed: false,
+      status: 'half_open',
+    }));
+
+    health.recordSuccess('anthropic', 'chat');
+    expect(health.acquire('anthropic', 'chat')).toEqual(expect.objectContaining({
+      allowed: true,
+      status: 'healthy',
+    }));
+  });
+
+  it('reopens immediately when a delayed half-open probe fails', () => {
+    let now = 0;
+    const health = new ProviderHealthController({
+      failureThreshold: 1,
+      failureWindowMs: 1_000,
+      transientCooldownMs: 2_000,
+    }, () => now);
+    health.recordFailure('anthropic', 'chat', transientError());
+
+    // Recover well after the original failure window has expired. The probe
+    // itself is the only request that should be admitted.
+    now = 10_000;
+    expect(health.acquire('anthropic', 'chat').status).toBe('half_open');
+    expect(health.recordFailure('anthropic', 'chat', transientError())).toEqual(expect.objectContaining({
+      allowed: false,
+      status: 'open',
+    }));
+    expect(health.acquire('anthropic', 'chat').allowed).toBe(false);
+  });
+
+  it('resets degraded streaks after a successful request', () => {
+    const health = new ProviderHealthController({ failureThreshold: 2 });
+    expect(health.recordFailure('anthropic', 'chat', transientError()).status).toBe('degraded');
+    health.recordSuccess('anthropic', 'chat');
+    expect(health.recordFailure('anthropic', 'chat', transientError()).status).toBe('degraded');
+  });
+});
+
+describe('provider recovery copy', () => {
+  it('keeps billing details private while providing a bounded retry time', () => {
+    const text = formatProviderUnavailableMessage({
+      allowed: false,
+      provider: 'anthropic',
+      service: 'chat',
+      status: 'open',
+      category: 'billing_exhausted',
+      retryAfterSeconds: 300,
+    });
+
+    expect(text).toBe('The AI service is temporarily unavailable. Please try again in about 5 minutes.');
+    expect(text).not.toMatch(/billing|credit/i);
+  });
+});

--- a/server/tests/unit/anthropic-retry.test.ts
+++ b/server/tests/unit/anthropic-retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { isRetryableError, withRetry } from '../../src/utils/anthropic-retry.js';
+import { isRetryableError, RetriesExhaustedError, withRetry } from '../../src/utils/anthropic-retry.js';
 
 describe('isRetryableError', () => {
   it('retries Anthropic stream api_error messages wrapped as JSON', () => {
@@ -47,6 +47,55 @@ describe('isRetryableError', () => {
       jitter: false,
     }, 'billing-test')).rejects.toThrow(/credit balance/i);
 
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors a bounded Retry-After delay before retrying', async () => {
+    vi.useFakeTimers();
+    try {
+      const error = Object.assign(new Error('rate limited'), {
+        status: 429,
+        headers: { 'retry-after': '2' },
+      });
+      const fn = vi.fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue('ok');
+      const promise = withRetry(fn, {
+        maxRetries: 1,
+        initialDelayMs: 10,
+        maxDelayMs: 5_000,
+        jitter: false,
+      }, 'retry-after-test');
+
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(fn).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(promise).resolves.toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('defers long Retry-After recovery instead of tying up the request', async () => {
+    const error = Object.assign(new Error('rate limited'), {
+      status: 429,
+      headers: { 'retry-after': '120' },
+    });
+    const fn = vi.fn().mockRejectedValue(error);
+
+    const rejection = withRetry(fn, {
+      maxRetries: 3,
+      initialDelayMs: 1,
+      maxDelayMs: 30_000,
+      jitter: false,
+    }, 'long-retry-after-test');
+
+    await expect(rejection).rejects.toMatchObject({
+      name: 'RetriesExhaustedError',
+      attempts: 1,
+      retryAfterSeconds: 120,
+    } satisfies Partial<RetriesExhaustedError>);
     expect(fn).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/tests/unit/claude-client-cost-gate.test.ts
+++ b/server/tests/unit/claude-client-cost-gate.test.ts
@@ -6,6 +6,7 @@ import {
   __createInMemoryCostStore,
 } from '../../src/addie/claude-cost-tracker.js';
 import { AddieClaudeClient, type AddieResponse } from '../../src/addie/claude-client.js';
+import { ProviderHealthController } from '../../src/addie/model-providers/provider-health.js';
 
 /**
  * End-to-end gate test (#2790). When a user has exhausted their
@@ -49,7 +50,9 @@ describe('claude-client entry-gate behavior (#2790)', () => {
     const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 5) + 1;
     await recordCost('user-x', 'claude-opus-5', { input_tokens: tokensToExceedCap, output_tokens: 0 });
 
-    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const health = new ProviderHealthController();
+    const acquireSpy = vi.spyOn(health, 'acquire');
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6', health);
     const response = await client.processMessage(
       'hello',
       undefined,
@@ -70,13 +73,16 @@ describe('claude-client entry-gate behavior (#2790)', () => {
       reason: 'cost_cap_exceeded',
     });
     expect(anthropicCall).not.toHaveBeenCalled();
+    expect(acquireSpy).not.toHaveBeenCalled();
   });
 
   it('processMessageStream yields a single cost_cap_exceeded done event when over budget', async () => {
     const tokensToExceedCap = Math.ceil((DAILY_BUDGET_USD.anonymous * 1_000_000) / 5) + 1;
     await recordCost('user-y', 'claude-opus-5', { input_tokens: tokensToExceedCap, output_tokens: 0 });
 
-    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const health = new ProviderHealthController();
+    const acquireSpy = vi.spyOn(health, 'acquire');
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6', health);
     const events: Array<{ type: string; response?: AddieResponse }> = [];
     for await (const event of client.processMessageStream(
       'hello',
@@ -99,6 +105,7 @@ describe('claude-client entry-gate behavior (#2790)', () => {
       reason: 'cost_cap_exceeded',
     });
     expect(anthropicCall).not.toHaveBeenCalled();
+    expect(acquireSpy).not.toHaveBeenCalled();
   });
 
   // A third case — "no costScope → runs uncapped, SDK IS reached" —

--- a/server/tests/unit/claude-client-stream-error.test.ts
+++ b/server/tests/unit/claude-client-stream-error.test.ts
@@ -85,6 +85,7 @@ vi.mock('@anthropic-ai/sdk', () => {
 });
 
 import { AddieClaudeClient, type StreamEvent } from '../../src/addie/claude-client.js';
+import { ProviderHealthController } from '../../src/addie/model-providers/provider-health.js';
 import {
   __setCostTrackerStore,
   __createInMemoryCostStore,
@@ -184,6 +185,29 @@ describe('processMessageStream — mid-stream upstream failure (#4797)', () => {
     expect(streamErrorEvents).toHaveLength(1);
     const evt = streamErrorEvents[0] as Extract<StreamEvent, { type: 'stream_error' }>;
     expect(evt.deltasBeforeError).toBe(1);
+  });
+
+  it('surfaces provider recovery copy when the local circuit opens after buffered deltas', async () => {
+    const health = new ProviderHealthController({ failureThreshold: 1 });
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6', health);
+    const events: StreamEvent[] = [];
+
+    for await (const event of client.processMessageStream(
+      'tell me about Z',
+      undefined,
+      undefined,
+      { costScope: { userId: 'test-user-circuit', tier: 'member_paid' }, maxIterations: 1 },
+    )) {
+      events.push(event);
+    }
+
+    expect(events.filter(event => event.type === 'text')).toEqual([
+      expect.objectContaining({ text: expect.stringContaining('temporarily unavailable') }),
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      type: 'done',
+      response: { flag_reason: 'provider_unavailable:overloaded' },
+    });
   });
 
   it('safely retries after a buffered tool-input delta', async () => {


### PR DESCRIPTION
Closes #6469
Progresses #6842

## Summary

- classify provider failures into bounded categories and parse `Retry-After` into explicit whole seconds
- add a shared provider-health controller with service-scoped transient circuits, account-wide billing exhaustion, and single-probe half-open recovery
- gate Addie's router and chat paths while a circuit is open, using the router's deterministic safe plan and a consistent local recovery response
- preserve completed tool receipts and warn users to review possible completed actions before retrying
- deliver done-only terminal responses consistently in Slack and web streams, and bump Addie's `CODE_VERSION`

## Safety boundaries

- evaluation and replay executions do not read or mutate production circuit state
- this does not switch models or providers, especially after tools may have mutated state; sibling fallback remains separate work in #6470
- circuit logs and alerts contain only bounded provider, service, category, retry, and failure-count fields—not user or provider message content
- user-facing recovery copy does not expose account or billing details

## Verification

- `npm run precommit:server-unit` — 496 files passed; 7,071 tests passed, 30 skipped
- focused provider, retry, cost-gate, and stream regression tests — 7 files passed; 52 tests passed
- `npm run build`
- `npm run typecheck`
- `git diff --check`

No changeset: this is application-only Addie runtime behavior and does not change the published protocol surface.
