### PR TITLE
fix(addie): bound OAuth delivery wait

### DIFF
--- a/server/src/addie/account-link-delivery.ts
+++ b/server/src/addie/account-link-delivery.ts
@@ -1,0 +1,62 @@
+export const ACCOUNT_LINK_DELIVERY_WAIT_MS = 1_500;
+
+export type AccountLinkDeliverySettlement =
+  | { status: 'settled'; delivered: boolean }
+  | { status: 'rejected'; error: unknown };
+
+export type AccountLinkDeliveryWaitResult =
+  | AccountLinkDeliverySettlement
+  | { status: 'timed_out' };
+
+export interface AccountLinkDeliveryWaitOptions {
+  timeoutMs?: number;
+  onLateSettlement?: (
+    settlement: AccountLinkDeliverySettlement,
+  ) => void | Promise<void>;
+}
+
+/**
+ * Keep the OAuth callback independent of Slack's retry budget while retaining
+ * an observer on the delivery promise. The delivery routine owns its eventual
+ * audit write; a late settlement therefore continues after this wait expires
+ * without becoming an unhandled rejection.
+ */
+export async function waitForAccountLinkDelivery(
+  deliver: () => Promise<boolean>,
+  options: AccountLinkDeliveryWaitOptions = {},
+): Promise<AccountLinkDeliveryWaitResult> {
+  const timeoutMs = options.timeoutMs ?? ACCOUNT_LINK_DELIVERY_WAIT_MS;
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+    throw new Error('account_link_delivery_timeout_invalid');
+  }
+
+  let timedOut = false;
+  const observedDelivery: Promise<AccountLinkDeliverySettlement> = (async () => {
+    try {
+      return { status: 'settled', delivered: await deliver() };
+    } catch (error) {
+      return { status: 'rejected', error };
+    }
+  })();
+
+  // Attach the late observer before racing so a rejection is always consumed,
+  // even when Slack finishes after the HTTP response has already redirected.
+  void observedDelivery.then((settlement) => {
+    if (!timedOut || !options.onLateSettlement) return;
+    void Promise.resolve()
+      .then(() => options.onLateSettlement!(settlement))
+      .catch(() => undefined);
+  });
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<{ status: 'timed_out' }>((resolve) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      resolve({ status: 'timed_out' });
+    }, timeoutMs);
+  });
+
+  const result = await Promise.race([observedDelivery, timeout]);
+  if (timer) clearTimeout(timer);
+  return result;
+}

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.35';
+export const CODE_VERSION = '2026.08.36';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -88,6 +88,10 @@ import { createTavusRouter } from "./routes/tavus.js";
 import { createSiChatRoutes } from "./routes/si-chat.js";
 import { sendAccountLinkedMessage, invalidateMemberContextCache, isAddieBoltReady } from "./addie/index.js";
 import {
+  ACCOUNT_LINK_DELIVERY_WAIT_MS,
+  waitForAccountLinkDelivery,
+} from './addie/account-link-delivery.js';
+import {
   consumeAccountLinkCorrelation,
   isAccountLinkCorrelationToken,
   recordProactiveEvent,
@@ -8081,7 +8085,45 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
 
               if (accountNewlyLinked) {
                 const firstName = user.firstName || undefined;
-                await sendAccountLinkedMessage(validatedOrigin, firstName);
+                const deliveryWait = await waitForAccountLinkDelivery(
+                  () => sendAccountLinkedMessage(validatedOrigin, firstName),
+                  {
+                    onLateSettlement: (settlement) => {
+                      logger[settlement.status === 'rejected' ? 'warn' : 'info']({
+                        correlationId: validatedOrigin.correlationId,
+                        threadId: validatedOrigin.threadId,
+                        initiatingUserId: validatedOrigin.initiatingUserId,
+                        reasonCode: settlement.status === 'rejected'
+                          ? 'slack_delivery_late_rejection_observed'
+                          : settlement.delivered
+                            ? 'slack_delivery_late_success_observed'
+                            : 'slack_delivery_late_failure_observed',
+                      }, 'Observed account-link delivery after OAuth wait expired');
+                    },
+                  },
+                );
+                if (deliveryWait.status === 'timed_out') {
+                  logger.warn({
+                    correlationId: validatedOrigin.correlationId,
+                    threadId: validatedOrigin.threadId,
+                    initiatingUserId: validatedOrigin.initiatingUserId,
+                    timeoutMs: ACCOUNT_LINK_DELIVERY_WAIT_MS,
+                    reasonCode: 'slack_delivery_wait_timed_out',
+                  }, 'Continuing OAuth redirect while account-link delivery finishes');
+                } else if (deliveryWait.status === 'rejected') {
+                  // sendAccountLinkedMessage is designed to contain delivery
+                  // failures. Keep auth successful if a future implementation
+                  // unexpectedly rejects instead.
+                  logger.warn({
+                    correlationId: validatedOrigin.correlationId,
+                    threadId: validatedOrigin.threadId,
+                    initiatingUserId: validatedOrigin.initiatingUserId,
+                    errorType: deliveryWait.error instanceof Error
+                      ? deliveryWait.error.name
+                      : typeof deliveryWait.error,
+                    reasonCode: 'slack_delivery_rejection_observed',
+                  }, 'Account-link delivery rejected without failing OAuth');
+                }
               } else {
                 const reasonCode = accountLinked
                   ? 'account_already_linked'

--- a/server/tests/unit/addie/account-link-delivery.test.ts
+++ b/server/tests/unit/addie/account-link-delivery.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { waitForAccountLinkDelivery } from '../../../src/addie/account-link-delivery.js';
+
+describe('account-link delivery wait', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns a successful delivery that settles within the callback budget', async () => {
+    await expect(waitForAccountLinkDelivery(
+      async () => true,
+      { timeoutMs: 100 },
+    )).resolves.toEqual({ status: 'settled', delivered: true });
+  });
+
+  it('returns a delivery failure that settles within the callback budget', async () => {
+    await expect(waitForAccountLinkDelivery(
+      async () => false,
+      { timeoutMs: 100 },
+    )).resolves.toEqual({ status: 'settled', delivered: false });
+  });
+
+  it('contains an unexpected delivery rejection so authentication can continue', async () => {
+    const failure = new Error('synthetic Slack failure');
+    await expect(waitForAccountLinkDelivery(
+      async () => { throw failure; },
+      { timeoutMs: 100 },
+    )).resolves.toEqual({ status: 'rejected', error: failure });
+  });
+
+  it('bounds the callback wait and observes a late success', async () => {
+    vi.useFakeTimers();
+    let finishDelivery!: (delivered: boolean) => void;
+    const delivery = new Promise<boolean>((resolve) => {
+      finishDelivery = resolve;
+    });
+    const onLateSettlement = vi.fn();
+    const waiting = waitForAccountLinkDelivery(
+      () => delivery,
+      { timeoutMs: 25, onLateSettlement },
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(waiting).resolves.toEqual({ status: 'timed_out' });
+
+    finishDelivery(true);
+    await vi.runAllTimersAsync();
+    await vi.waitFor(() => {
+      expect(onLateSettlement).toHaveBeenCalledWith({ status: 'settled', delivered: true });
+    });
+  });
+
+  it('observes a late rejection without surfacing an unhandled promise', async () => {
+    vi.useFakeTimers();
+    let rejectDelivery!: (error: unknown) => void;
+    const delivery = new Promise<boolean>((_resolve, reject) => {
+      rejectDelivery = reject;
+    });
+    const onLateSettlement = vi.fn();
+    const waiting = waitForAccountLinkDelivery(
+      () => delivery,
+      { timeoutMs: 25, onLateSettlement },
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(waiting).resolves.toEqual({ status: 'timed_out' });
+
+    const failure = new Error('late synthetic Slack failure');
+    rejectDelivery(failure);
+    await vi.runAllTimersAsync();
+    await vi.waitFor(() => {
+      expect(onLateSettlement).toHaveBeenCalledWith({ status: 'rejected', error: failure });
+    });
+  });
+});

--- a/server/tests/unit/native-auth-http-wiring.test.ts
+++ b/server/tests/unit/native-auth-http-wiring.test.ts
@@ -362,4 +362,46 @@ describe('native OAuth HTTPServer wiring', () => {
       deliveryStatus: 'skipped',
     }));
   });
+
+  it('completes OAuth when account-link delivery unexpectedly rejects', async () => {
+    mocks.authenticateWithCode.mockResolvedValueOnce({
+      sealedSession: 'SEALED_SESSION_SECRET',
+      user: {
+        id: 'user_1',
+        email: 'person@example.com',
+        firstName: 'Person',
+        lastName: 'Example',
+        emailVerified: true,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    });
+    mocks.listOrganizationMemberships.mockResolvedValueOnce({ data: [] });
+    const origin = {
+      correlationId: 'correlation-origin',
+      surface: 'slack' as const,
+      threadId: 'origin-thread',
+      initiatingUserId: 'U123',
+      externalId: 'D123:111.222',
+    };
+    mocks.consumeAccountLinkCorrelation.mockResolvedValueOnce(origin);
+    vi.spyOn(SlackDatabase.prototype, 'getBySlackUserId').mockResolvedValueOnce({
+      slack_user_id: 'U123',
+      workos_user_id: null,
+    } as never);
+    vi.spyOn(SlackDatabase.prototype, 'mapUser').mockResolvedValueOnce(undefined);
+    mocks.sendAccountLinkedMessage.mockRejectedValueOnce(new Error('synthetic Slack rejection'));
+    server = new HTTPServer();
+
+    const response = await request(appFor(server)).get('/auth/callback').query({
+      code: 'workos-authorization-code',
+      state: JSON.stringify({
+        slack_user_id: 'U123',
+        account_link_correlation: 'a'.repeat(43),
+      }),
+    });
+
+    expect(response.status).toBe(302);
+    expect(mocks.sendAccountLinkedMessage).toHaveBeenCalledWith(origin, 'Person');
+  });
 });


### PR DESCRIPTION
Closes #6919

## Summary
- cap the OAuth callback wait for exact-origin account-link delivery at 1.5 seconds
- keep timed-out delivery observed so late success or failure is handled without unhandled rejections or duplicate audit ownership
- ensure delivery failure never changes the successful OAuth redirect, with identifier-only late-settlement logging
- bump the Addie code version to `2026.08.36`

## Validation
- `npm run precommit` (68 root files / 1,056 tests; 499 server files / 7,098 passed, 30 skipped; typecheck)
- `npm run build`
- `npm run test:addie-tools` (249 tools, 15 sets, inventory current)
- focused OAuth delivery tests (14 tests)

No changeset: application-only Addie reliability change; no protocol release surface.