### PR TITLE
feat(addie): normalize tool result display

### DIFF
--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -1475,7 +1475,7 @@ function filterToolsBySet(
   const filteredToolDefs = userTools.tools.filter(tool => allowedToolNames.has(tool.name));
 
   // Filter handlers to match
-  const filteredHandlers = new Map<string, (input: Record<string, unknown>) => Promise<string>>();
+  const filteredHandlers: RequestTools['handlers'] = new Map();
   for (const [name, handler] of userTools.handlers) {
     if (allowedToolNames.has(name)) {
       filteredHandlers.set(name, handler);

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -54,8 +54,17 @@ import {
   MAX_OUTPUT_LENGTH,
   formatTruncatedOutput,
 } from './security.js';
+import {
+  isToolResultError,
+  normalizeToolError,
+  normalizeToolResult,
+  renderToolExecutionsFallback,
+  type NormalizedToolResult,
+  type ToolHandlerResult,
+  type ToolResultPresentation,
+} from './tool-result-contract.js';
 
-type ToolHandler = (input: Record<string, unknown>) => Promise<string>;
+type ToolHandler = (input: Record<string, unknown>) => Promise<ToolHandlerResult>;
 
 export type AddieExecutionMode = 'production' | 'evaluation' | 'replay';
 
@@ -525,7 +534,15 @@ function applyResponsePipelineWithEmptyMonitoring(
 ): { text: string; reason: string | null } {
   const stripped = stripBannedRituals(rawText);
   const reason = detectEmptyResponse(stripped, toolExecutions);
-  if (reason) return { text: EMPTY_RESPONSE_FALLBACK, reason };
+  if (reason) {
+    const toolFallback = renderToolExecutionsFallback(toolExecutions, (toolName, renderReason) => {
+      logger.warn(
+        { event: 'addie_tool_result_display_degraded', toolName, reason: renderReason },
+        'Addie: Tool result renderer failed; safe text fallback used',
+      );
+    });
+    return { text: toolFallback || EMPTY_RESPONSE_FALLBACK, reason };
+  }
   // Fires only when Addie broke character and the deterministic backstop had
   // to scrub a model/provider disclosure — rare by design. A rising rate means
   // the prompt-level identity rule is slipping (e.g. after a model change).
@@ -742,6 +759,8 @@ export interface ToolExecution {
   duration_ms: number;
   sequence: number;
   blocked_by_policy?: true;
+  /** Shared, user-safe presentation consumed by Slack and web fallbacks. */
+  normalized_result?: ToolResultPresentation;
 }
 
 export interface AddieResponse {
@@ -828,7 +847,13 @@ function providerUnavailableResponse(
 export type StreamEvent =
   | { type: 'text'; text: string }
   | { type: 'tool_start'; tool_name: string; parameters: Record<string, unknown> }
-  | { type: 'tool_end'; tool_name: string; result: string; is_error: boolean }
+  | {
+      type: 'tool_end';
+      tool_name: string;
+      result: string;
+      is_error: boolean;
+      normalized_result?: ToolResultPresentation;
+    }
   | { type: 'retry'; attempt: number; maxRetries: number; delayMs: number; reason: string }
   | {
       // Mid-stream upstream failure after deltas were already received. Anthropic
@@ -1103,6 +1128,48 @@ export class AddieClaudeClient {
     if (!isEvaluationExecution(options)) return result;
     if (kind === 'blocked') return BLOCKED_TOOL_RESULT;
     return kind === 'error' ? 'Error: Tool execution failed' : 'Tool execution completed';
+  }
+
+  private observeNormalizedToolResult(
+    toolName: string,
+    normalized: NormalizedToolResult,
+  ): NormalizedToolResult {
+    if (normalized.display_degradation) {
+      logger.warn(
+        {
+          event: 'addie_tool_result_display_degraded',
+          toolName,
+          reason: normalized.display_degradation,
+        },
+        'Addie: Tool result display payload degraded; text result preserved',
+      );
+    }
+    if (normalized.model_context_truncated || normalized.user_summary_truncated) {
+      logger.warn(
+        {
+          event: 'addie_tool_result_content_bounded',
+          toolName,
+          modelContextTruncated: normalized.model_context_truncated,
+          userSummaryTruncated: normalized.user_summary_truncated,
+        },
+        'Addie: Oversized tool result content bounded',
+      );
+    }
+    return normalized;
+  }
+
+  private recordedToolPresentation(
+    options: ProcessMessageOptions | undefined,
+    normalized: NormalizedToolResult,
+  ): ToolResultPresentation {
+    if (!isEvaluationExecution(options)) return normalized.presentation;
+    return {
+      status: normalized.status,
+      user_summary: isToolResultError(normalized.status)
+        ? 'Tool execution failed'
+        : 'Tool execution completed',
+      source: normalized.presentation.source,
+    };
   }
 
   /**
@@ -1568,15 +1635,22 @@ export class AddieClaudeClient {
             ).join('\n');
             detailedResult = `${resultSummary}\n\nTop results:\n${urls}`;
           }
+          const normalized = this.observeNormalizedToolResult('web_search', normalizeToolResult('web_search', {
+            status: resultCount === 0 ? 'empty' : 'ok',
+            model_context: detailedResult,
+            user_summary: resultSummary,
+          }));
+          const presentation = this.recordedToolPresentation(options, normalized);
 
           toolExecutions.push({
             tool_name: 'web_search',
             parameters: this.recordedToolParameters(options, params),
-            result: this.recordedToolResult(options, detailedResult, 'success'),
-            result_summary: this.recordedToolResult(options, resultSummary, 'success'),
+            result: this.recordedToolResult(options, normalized.model_context, 'success'),
+            result_summary: this.recordedToolResult(options, presentation.user_summary, 'success'),
             is_error: false,
             duration_ms: 0,
             sequence: executionSequence,
+            normalized_result: presentation,
           });
 
           logger.debug(
@@ -1830,15 +1904,22 @@ export class AddieClaudeClient {
               detailedResult = `${resultSummary}\n\nTop results:\n${urls}`;
             }
           }
+          const normalized = this.observeNormalizedToolResult(serverBlock.name, normalizeToolResult(serverBlock.name, {
+            status: resultCount === 0 ? 'empty' : 'ok',
+            model_context: detailedResult,
+            user_summary: resultSummary,
+          }));
+          const presentation = this.recordedToolPresentation(options, normalized);
 
           toolExecutions.push({
             tool_name: serverBlock.name,
             parameters: this.recordedToolParameters(options, params),
-            result: this.recordedToolResult(options, detailedResult, 'success'),
-            result_summary: this.recordedToolResult(options, resultSummary, 'success'),
+            result: this.recordedToolResult(options, normalized.model_context, 'success'),
+            result_summary: this.recordedToolResult(options, presentation.user_summary, 'success'),
             is_error: false,
             duration_ms: 0, // Server-managed, we don't have timing
             sequence: executionSequence,
+            normalized_result: presentation,
           });
 
           logger.debug({
@@ -1931,18 +2012,25 @@ export class AddieClaudeClient {
           const handler = allHandlers.get(toolName);
           if (!handler) {
             const durationMs = Date.now() - startTime;
+            const normalized = this.observeNormalizedToolResult(
+              toolName,
+              normalizeToolError(toolName, new Error(`Unknown tool "${toolName}"`), { expected: false }),
+            );
+            const presentation = this.recordedToolPresentation(options, normalized);
             toolResults.push({
               tool_use_id: toolUseId,
-              content: `Error: Unknown tool "${toolName}"`,
+              content: normalized.model_context,
               is_error: true,
             });
             toolExecutions.push({
               tool_name: toolName,
               parameters: this.recordedToolParameters(options, toolInput),
-              result: this.recordedToolResult(options, `Error: Unknown tool "${toolName}"`, 'error'),
+              result: this.recordedToolResult(options, normalized.model_context, 'error'),
+              result_summary: presentation.user_summary,
               is_error: true,
               duration_ms: durationMs,
               sequence: executionSequence,
+              normalized_result: presentation,
             });
             continue;
           }
@@ -1954,9 +2042,15 @@ export class AddieClaudeClient {
             toolsByName.get(toolName),
           );
           if (!allowed) {
+            const normalized = this.observeNormalizedToolResult(toolName, normalizeToolResult(toolName, {
+              status: 'access_denied',
+              model_context: BLOCKED_TOOL_RESULT,
+              user_summary: 'This tool action was blocked by execution policy.',
+            }));
+            const presentation = this.recordedToolPresentation(options, normalized);
             toolResults.push({
               tool_use_id: toolUseId,
-              content: BLOCKED_TOOL_RESULT,
+              content: normalized.model_context,
               is_error: true,
             });
             toolExecutions.push({
@@ -1968,6 +2062,7 @@ export class AddieClaudeClient {
               duration_ms: 0,
               sequence: executionSequence,
               blocked_by_policy: true,
+              normalized_result: presentation,
             });
             continue;
           }
@@ -1977,11 +2072,17 @@ export class AddieClaudeClient {
             const durationMs = Date.now() - startTime;
 
             // Check if result contains multimodal content (images, PDFs)
-            if (isMultimodalContent(result)) {
+            if (typeof result === 'string' && isMultimodalContent(result)) {
               const multimodal = extractMultimodalContent(result);
               const multimodalBlocks = multimodal ? buildMultimodalContentBlocks(multimodal) : null;
 
               if (multimodalBlocks) {
+                const normalized = this.observeNormalizedToolResult(toolName, normalizeToolResult(toolName, {
+                  status: 'ok',
+                  model_context: multimodalBlocks.summary,
+                  user_summary: multimodalBlocks.summary,
+                }));
+                const presentation = this.recordedToolPresentation(options, normalized);
                 toolResults.push({ tool_use_id: toolUseId, content: multimodalBlocks.content });
                 toolExecutions.push({
                   tool_name: toolName,
@@ -1991,6 +2092,7 @@ export class AddieClaudeClient {
                   is_error: false,
                   duration_ms: durationMs,
                   sequence: executionSequence,
+                  normalized_result: presentation,
                 });
                 logger.info({
                   toolName,
@@ -1999,34 +2101,58 @@ export class AddieClaudeClient {
                 }, 'Addie: Processed multimodal tool result');
               } else {
                 // Failed to parse or validate multimodal content
-                toolResults.push({ tool_use_id: toolUseId, content: 'Error: Failed to process file content' });
+                const normalized = this.observeNormalizedToolResult(
+                  toolName,
+                  normalizeToolError(toolName, new Error('Failed to process file content'), { expected: false }),
+                );
+                const presentation = this.recordedToolPresentation(options, normalized);
+                toolResults.push({ tool_use_id: toolUseId, content: normalized.model_context, is_error: true });
                 toolExecutions.push({
                   tool_name: toolName,
                   parameters: this.recordedToolParameters(options, toolInput),
-                  result: this.recordedToolResult(options, 'Error: Failed to process file content', 'error'),
+                  result: this.recordedToolResult(options, normalized.model_context, 'error'),
+                  result_summary: presentation.user_summary,
                   is_error: true,
                   duration_ms: durationMs,
                   sequence: executionSequence,
+                  normalized_result: presentation,
                 });
               }
             } else {
-              // Regular text result — always a success since tools throw on failure
-              toolResults.push({ tool_use_id: toolUseId, content: result });
+              const normalized = this.observeNormalizedToolResult(
+                toolName,
+                normalizeToolResult(toolName, result),
+              );
+              const presentation = this.recordedToolPresentation(options, normalized);
+              const isError = isToolResultError(normalized.status);
+              const summary = normalized.presentation.source === 'legacy' && typeof result === 'string'
+                ? this.summarizeToolResult(toolName, result)
+                : presentation.user_summary;
+              toolResults.push({
+                tool_use_id: toolUseId,
+                content: normalized.model_context,
+                ...(isError && { is_error: true }),
+              });
               toolExecutions.push({
                 tool_name: toolName,
                 parameters: this.recordedToolParameters(options, toolInput),
-                result: this.recordedToolResult(options, result, 'success'),
-                result_summary: this.recordedToolResult(options, this.summarizeToolResult(toolName, result), 'success'),
-                is_error: false,
+                result: this.recordedToolResult(options, normalized.model_context, isError ? 'error' : 'success'),
+                result_summary: this.recordedToolResult(options, summary, isError ? 'error' : 'success'),
+                is_error: isError,
                 duration_ms: durationMs,
                 sequence: executionSequence,
+                normalized_result: presentation,
               });
             }
           } catch (error) {
             const durationMs = Date.now() - startTime;
             const errorMessage = error instanceof Error ? error.message : 'Unknown error';
             const isExpected = error instanceof ToolError;
-            const errorResult = `Error: ${errorMessage}`;
+            const normalized = this.observeNormalizedToolResult(
+              toolName,
+              normalizeToolError(toolName, error, { expected: isExpected }),
+            );
+            const presentation = this.recordedToolPresentation(options, normalized);
             if (isExpected) {
               logger.warn({ toolName, ...(operationalExecution && { toolInput, error: errorMessage }), durationMs }, 'Addie: Tool returned expected error');
             } else {
@@ -2037,16 +2163,18 @@ export class AddieClaudeClient {
             }
             toolResults.push({
               tool_use_id: toolUseId,
-              content: errorResult,
+              content: normalized.model_context,
               is_error: true,
             });
             toolExecutions.push({
               tool_name: toolName,
               parameters: this.recordedToolParameters(options, toolInput),
-              result: this.recordedToolResult(options, errorResult, 'error'),
+              result: this.recordedToolResult(options, normalized.model_context, 'error'),
+              result_summary: presentation.user_summary,
               is_error: true,
               duration_ms: durationMs,
               sequence: executionSequence,
+              normalized_result: presentation,
             });
           }
         }
@@ -2788,25 +2916,32 @@ export class AddieClaudeClient {
             const handler = allHandlers.get(toolName);
             if (!handler) {
               const durationMs = Date.now() - startTime;
-              const errorResult = `Error: Unknown tool "${toolName}"`;
+              const normalized = this.observeNormalizedToolResult(
+                toolName,
+                normalizeToolError(toolName, new Error(`Unknown tool "${toolName}"`), { expected: false }),
+              );
+              const presentation = this.recordedToolPresentation(options, normalized);
               toolResults.push({
                 tool_use_id: toolUseId,
-                content: errorResult,
+                content: normalized.model_context,
                 is_error: true,
               });
               toolExecutions.push({
                 tool_name: toolName,
                 parameters: this.recordedToolParameters(options, toolInput),
-                result: this.recordedToolResult(options, errorResult, 'error'),
+                result: this.recordedToolResult(options, normalized.model_context, 'error'),
+                result_summary: presentation.user_summary,
                 is_error: true,
                 duration_ms: durationMs,
                 sequence: executionSequence,
+                normalized_result: presentation,
               });
               yield {
                 type: 'tool_end',
                 tool_name: toolName,
-                result: this.recordedToolResult(options, errorResult, 'error'),
+                result: this.recordedToolResult(options, normalized.model_context, 'error'),
                 is_error: true,
+                normalized_result: presentation,
               };
               continue;
             }
@@ -2818,9 +2953,15 @@ export class AddieClaudeClient {
               toolsByName.get(toolName),
             );
             if (!allowed) {
+              const normalized = this.observeNormalizedToolResult(toolName, normalizeToolResult(toolName, {
+                status: 'access_denied',
+                model_context: BLOCKED_TOOL_RESULT,
+                user_summary: 'This tool action was blocked by execution policy.',
+              }));
+              const presentation = this.recordedToolPresentation(options, normalized);
               toolResults.push({
                 tool_use_id: toolUseId,
-                content: BLOCKED_TOOL_RESULT,
+                content: normalized.model_context,
                 is_error: true,
               });
               toolExecutions.push({
@@ -2832,12 +2973,14 @@ export class AddieClaudeClient {
                 duration_ms: 0,
                 sequence: executionSequence,
                 blocked_by_policy: true,
+                normalized_result: presentation,
               });
               yield {
                 type: 'tool_end',
                 tool_name: toolName,
                 result: BLOCKED_TOOL_RESULT,
                 is_error: true,
+                normalized_result: presentation,
               };
               continue;
             }
@@ -2847,11 +2990,17 @@ export class AddieClaudeClient {
               const durationMs = Date.now() - startTime;
 
               // Check if result contains multimodal content (images, PDFs)
-              if (isMultimodalContent(result)) {
+              if (typeof result === 'string' && isMultimodalContent(result)) {
                 const multimodal = extractMultimodalContent(result);
                 const multimodalBlocks = multimodal ? buildMultimodalContentBlocks(multimodal) : null;
 
                 if (multimodalBlocks) {
+                  const normalized = this.observeNormalizedToolResult(toolName, normalizeToolResult(toolName, {
+                    status: 'ok',
+                    model_context: multimodalBlocks.summary,
+                    user_summary: multimodalBlocks.summary,
+                  }));
+                  const presentation = this.recordedToolPresentation(options, normalized);
                   toolResults.push({ tool_use_id: toolUseId, content: multimodalBlocks.content });
                   toolExecutions.push({
                     tool_name: toolName,
@@ -2861,44 +3010,87 @@ export class AddieClaudeClient {
                     is_error: false,
                     duration_ms: durationMs,
                     sequence: executionSequence,
+                    normalized_result: presentation,
                   });
-                  yield { type: 'tool_end', tool_name: toolName, result: this.recordedToolResult(options, multimodalBlocks.summary, 'success'), is_error: false };
+                  yield {
+                    type: 'tool_end',
+                    tool_name: toolName,
+                    result: this.recordedToolResult(options, multimodalBlocks.summary, 'success'),
+                    is_error: false,
+                    normalized_result: presentation,
+                  };
                   logger.info({
                     toolName,
                     multimodalType: multimodal?.type,
                     ...(operationalExecution && { filename: multimodal?.filename }),
                   }, 'Addie Stream: Processed multimodal tool result');
                 } else {
-                  toolResults.push({ tool_use_id: toolUseId, content: 'Error: Failed to process file content' });
+                  const normalized = this.observeNormalizedToolResult(
+                    toolName,
+                    normalizeToolError(toolName, new Error('Failed to process file content'), { expected: false }),
+                  );
+                  const presentation = this.recordedToolPresentation(options, normalized);
+                  toolResults.push({ tool_use_id: toolUseId, content: normalized.model_context, is_error: true });
                   toolExecutions.push({
                     tool_name: toolName,
                     parameters: this.recordedToolParameters(options, toolInput),
-                    result: this.recordedToolResult(options, 'Error: Failed to process file content', 'error'),
+                    result: this.recordedToolResult(options, normalized.model_context, 'error'),
+                    result_summary: presentation.user_summary,
                     is_error: true,
                     duration_ms: durationMs,
                     sequence: executionSequence,
+                    normalized_result: presentation,
                   });
-                  yield { type: 'tool_end', tool_name: toolName, result: this.recordedToolResult(options, 'Error: Failed to process file content', 'error'), is_error: true };
+                  yield {
+                    type: 'tool_end',
+                    tool_name: toolName,
+                    result: this.recordedToolResult(options, normalized.model_context, 'error'),
+                    is_error: true,
+                    normalized_result: presentation,
+                  };
                 }
               } else {
-                // Regular text result — always a success since tools throw on failure
-                toolResults.push({ tool_use_id: toolUseId, content: result });
+                const normalized = this.observeNormalizedToolResult(
+                  toolName,
+                  normalizeToolResult(toolName, result),
+                );
+                const presentation = this.recordedToolPresentation(options, normalized);
+                const isError = isToolResultError(normalized.status);
+                const summary = normalized.presentation.source === 'legacy' && typeof result === 'string'
+                  ? this.summarizeToolResult(toolName, result)
+                  : presentation.user_summary;
+                toolResults.push({
+                  tool_use_id: toolUseId,
+                  content: normalized.model_context,
+                  ...(isError && { is_error: true }),
+                });
                 toolExecutions.push({
                   tool_name: toolName,
                   parameters: this.recordedToolParameters(options, toolInput),
-                  result: this.recordedToolResult(options, result, 'success'),
-                  result_summary: this.recordedToolResult(options, this.summarizeToolResult(toolName, result), 'success'),
-                  is_error: false,
+                  result: this.recordedToolResult(options, normalized.model_context, isError ? 'error' : 'success'),
+                  result_summary: this.recordedToolResult(options, summary, isError ? 'error' : 'success'),
+                  is_error: isError,
                   duration_ms: durationMs,
                   sequence: executionSequence,
+                  normalized_result: presentation,
                 });
-                yield { type: 'tool_end', tool_name: toolName, result: this.recordedToolResult(options, result, 'success'), is_error: false };
+                yield {
+                  type: 'tool_end',
+                  tool_name: toolName,
+                  result: this.recordedToolResult(options, normalized.model_context, isError ? 'error' : 'success'),
+                  is_error: isError,
+                  normalized_result: presentation,
+                };
               }
             } catch (error) {
               const durationMs = Date.now() - startTime;
               const errorMessage = error instanceof Error ? error.message : 'Unknown error';
               const isExpected = error instanceof ToolError;
-              const errorResult = `Error: ${errorMessage}`;
+              const normalized = this.observeNormalizedToolResult(
+                toolName,
+                normalizeToolError(toolName, error, { expected: isExpected }),
+              );
+              const presentation = this.recordedToolPresentation(options, normalized);
               if (isExpected) {
                 logger.warn({ toolName, ...(operationalExecution && { toolInput, error: errorMessage }), durationMs }, 'Addie Stream: Tool returned expected error');
               } else {
@@ -2909,18 +3101,26 @@ export class AddieClaudeClient {
               }
               toolResults.push({
                 tool_use_id: toolUseId,
-                content: errorResult,
+                content: normalized.model_context,
                 is_error: true,
               });
               toolExecutions.push({
                 tool_name: toolName,
                 parameters: this.recordedToolParameters(options, toolInput),
-                result: this.recordedToolResult(options, errorResult, 'error'),
+                result: this.recordedToolResult(options, normalized.model_context, 'error'),
+                result_summary: presentation.user_summary,
                 is_error: true,
                 duration_ms: durationMs,
                 sequence: executionSequence,
+                normalized_result: presentation,
               });
-              yield { type: 'tool_end', tool_name: toolName, result: this.recordedToolResult(options, errorResult, 'error'), is_error: true };
+              yield {
+                type: 'tool_end',
+                tool_name: toolName,
+                result: this.recordedToolResult(options, normalized.model_context, 'error'),
+                is_error: true,
+                normalized_result: presentation,
+              };
             }
           }
 

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.36';
+export const CODE_VERSION = '2026.08.37';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,11 +11,11 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "cf0c0042ff4918b8d04539398ca4eaa12d5c48d8481e5324f6553e8030f93d5a",
+    "server/src/addie/claude-client.ts": "3f403b0d27841b1c16f45dd4c9fdc651b03889a6ee6dac26d4a552c8fec17a14",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",
-    "server/src/addie/bolt-app.ts": "d1083b3b8d61e4266cb067faeba3a2a9bcb4d248e8796af20535e8dd07e5cd56",
+    "server/src/addie/bolt-app.ts": "24575fc310893bec2fc6de47e52b6084acaa7235a83c39fb7c4e21d5ff86e411",
     "server/src/addie/handler.ts": "cf9d66b7b2700cefd2811d2d9c627ea2683c556e6c3afd36ecc99cac12aa5407",
     "server/src/routes/addie-chat.ts": "da80a42faf005441f4afbf1d003ccb7067dbd4e87b90dae96c0023511806fc08",
     "server/src/routes/tavus.ts": "640e818f0ecd4da6c72f310b7582f7bc1f2c00fd77dbe0dc521f53459e31003f",

--- a/server/src/addie/slack-dm-stream.ts
+++ b/server/src/addie/slack-dm-stream.ts
@@ -1,4 +1,5 @@
 import type { AddieResponse, StreamEvent } from './claude-client.js';
+import type { ToolResultPresentation } from './tool-result-contract.js';
 import {
   DEFAULT_STREAM_SOFT_CAP,
   decideStreamAppend,
@@ -11,6 +12,7 @@ export type SlackDmToolExecution = {
   tool_name: string;
   parameters: Record<string, unknown>;
   result: string;
+  normalized_result?: ToolResultPresentation;
 };
 
 export type SlackDmStreamChunk =
@@ -466,6 +468,7 @@ export function reduceSlackDmStreamEvent(
         tool_name: event.tool_name,
         parameters: {},
         result: event.result,
+        ...(event.normalized_result && { normalized_result: event.normalized_result }),
       }],
     };
     if (toolState.delivery.tag !== 'open') return { state: toolState, effects: [] };

--- a/server/src/addie/tool-result-contract.ts
+++ b/server/src/addie/tool-result-contract.ts
@@ -1,0 +1,426 @@
+/**
+ * Addie's application-level tool result contract.
+ *
+ * Tool handlers may keep returning strings while they migrate. Every result is
+ * normalized at the orchestration boundary so provider context, user fallback
+ * text, and optional structured display data cannot accidentally become the
+ * same unbounded blob.
+ */
+
+export const TOOL_RESULT_STATUSES = [
+  'ok',
+  'empty',
+  'access_denied',
+  'invalid_input',
+  'recoverable_error',
+  'error',
+] as const;
+
+export type ToolResultStatus = typeof TOOL_RESULT_STATUSES[number];
+
+export interface ToolResultExposure {
+  /** Short, audience-appropriate explanation. */
+  summary: string;
+  /** Machine-data fields explicitly approved for this audience. */
+  fields?: readonly string[];
+}
+
+export interface StructuredToolResult {
+  status: ToolResultStatus;
+  /** Internal machine data. It is never exposed implicitly. */
+  data?: Readonly<Record<string, unknown>>;
+  model_context: string | ToolResultExposure;
+  user_summary: string | ToolResultExposure;
+  /**
+   * Optional structured presentation. Only registered display types and the
+   * explicitly named data fields survive normalization.
+   */
+  display?: unknown;
+}
+
+export type ToolHandlerResult = string | StructuredToolResult;
+
+export interface ToolDisplayPayload {
+  type: 'fields';
+  data: Readonly<Record<string, unknown>>;
+}
+
+export interface ToolResultPresentation {
+  status: ToolResultStatus;
+  user_summary: string;
+  display?: ToolDisplayPayload;
+  /** Classified and structured results are safe to use as surface fallbacks. */
+  source: 'legacy' | 'classified' | 'structured';
+}
+
+export interface NormalizedToolResult {
+  status: ToolResultStatus;
+  model_context: string;
+  presentation: ToolResultPresentation;
+  display_degradation?:
+    | 'malformed_result'
+    | 'malformed_display'
+    | 'unsupported_display'
+    | 'display_data_unreadable';
+  model_context_truncated: boolean;
+  user_summary_truncated: boolean;
+}
+
+export const MAX_TOOL_MODEL_CONTEXT_LENGTH = 20_000;
+export const MAX_TOOL_USER_SUMMARY_LENGTH = 1_000;
+const MAX_DISPLAY_FIELDS = 20;
+const MAX_DISPLAY_DEPTH = 4;
+const MAX_DISPLAY_COLLECTION_SIZE = 40;
+const UNSAFE_FIELD_NAMES = new Set(['__proto__', 'constructor', 'prototype']);
+
+const STATUS_SET = new Set<string>(TOOL_RESULT_STATUSES);
+const CLASSIFIED_SEARCH_TOOLS = new Set([
+  'search_docs',
+  'get_doc',
+  'search_repos',
+  'search_slack',
+  'get_channel_activity',
+  'search_resources',
+  'get_recent_news',
+  'web_search',
+]);
+
+const STATUS_FALLBACKS: Record<ToolResultStatus, string> = {
+  ok: 'The tool completed successfully.',
+  empty: 'No results were returned.',
+  access_denied: 'You do not have access to that result.',
+  invalid_input: 'The tool could not use the supplied input.',
+  recoverable_error: 'The tool is temporarily unavailable. Please try again.',
+  error: 'The tool could not complete the request.',
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function truncate(value: string, limit: number): { value: string; truncated: boolean } {
+  const trimmed = value.trim();
+  if (trimmed.length <= limit) return { value: trimmed, truncated: false };
+  return {
+    value: `${trimmed.slice(0, Math.max(0, limit - 24)).trimEnd()}\n\n[content truncated]`,
+    truncated: true,
+  };
+}
+
+function safeDisplayValue(
+  value: unknown,
+  depth: number,
+  seen: Set<object>,
+): unknown {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : String(value);
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'undefined' || typeof value === 'function' || typeof value === 'symbol') {
+    return undefined;
+  }
+  if (depth >= MAX_DISPLAY_DEPTH || typeof value !== 'object') return '[nested value omitted]';
+  if (seen.has(value)) return '[circular value omitted]';
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value
+        .slice(0, MAX_DISPLAY_COLLECTION_SIZE)
+        .map((entry) => safeDisplayValue(entry, depth + 1, seen));
+    }
+    const output: Record<string, unknown> = {};
+    for (const key of Object.keys(value).slice(0, MAX_DISPLAY_COLLECTION_SIZE)) {
+      if (UNSAFE_FIELD_NAMES.has(key)) continue;
+      const safeValue = safeDisplayValue((value as Record<string, unknown>)[key], depth + 1, seen);
+      if (safeValue !== undefined) output[key] = safeValue;
+    }
+    return output;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function readAllowlistedFields(
+  data: Readonly<Record<string, unknown>> | undefined,
+  fields: readonly string[] | undefined,
+): { data: Record<string, unknown>; unreadable: boolean } {
+  const selected: Record<string, unknown> = {};
+  if (!data || !fields) return { data: selected, unreadable: false };
+
+  let unreadable = false;
+  for (const field of [...new Set(fields)].slice(0, MAX_DISPLAY_FIELDS)) {
+    if (
+      typeof field !== 'string'
+      || UNSAFE_FIELD_NAMES.has(field)
+      || !Object.prototype.hasOwnProperty.call(data, field)
+    ) continue;
+    try {
+      const value = safeDisplayValue(data[field], 0, new Set());
+      if (value !== undefined) selected[field] = value;
+    } catch {
+      unreadable = true;
+    }
+  }
+  return { data: selected, unreadable };
+}
+
+function formatFields(fields: Readonly<Record<string, unknown>>): string {
+  const entries = Object.entries(fields);
+  if (entries.length === 0) return '';
+  return entries.map(([key, value]) => {
+    let rendered: string;
+    try {
+      rendered = typeof value === 'string' ? value : JSON.stringify(value);
+    } catch {
+      rendered = '[unavailable]';
+    }
+    return `${key}: ${rendered}`;
+  }).join('\n');
+}
+
+function normalizeExposure(
+  exposure: string | ToolResultExposure,
+  data: Readonly<Record<string, unknown>> | undefined,
+  fallback: string,
+  limit: number,
+): { text: string; truncated: boolean; unreadable: boolean } {
+  const summary = typeof exposure === 'string' ? exposure : exposure.summary;
+  const selected = typeof exposure === 'string'
+    ? { data: {}, unreadable: false }
+    : readAllowlistedFields(data, exposure.fields);
+  const details = formatFields(selected.data);
+  const combined = `${typeof summary === 'string' && summary.trim() ? summary.trim() : fallback}${details ? `\n${details}` : ''}`;
+  const bounded = truncate(combined, limit);
+  return { text: bounded.value, truncated: bounded.truncated, unreadable: selected.unreadable };
+}
+
+function firstParagraph(text: string): string {
+  return text.split(/\n\s*\n/, 1)[0]?.trim() || '';
+}
+
+function classifySearchResult(toolName: string, text: string): {
+  status: ToolResultStatus;
+  summary: string;
+} | null {
+  if (!CLASSIFIED_SEARCH_TOOLS.has(toolName)) return null;
+  const lower = text.toLowerCase();
+
+  if (/cannot (?:search|access)|access denied|permission denied/.test(lower)) {
+    return { status: 'access_denied', summary: firstParagraph(text) };
+  }
+  if (/unknown documentation version|invalid (?:repo_id|input|query)/.test(lower)) {
+    return { status: 'invalid_input', summary: firstParagraph(text) };
+  }
+  if (/not (?:ready|yet indexed)|search failed|temporarily unavailable/.test(lower)) {
+    return { status: 'recoverable_error', summary: firstParagraph(text) };
+  }
+  if (/^(?:no |document not found)/i.test(text.trim())) {
+    return { status: 'empty', summary: firstParagraph(text) };
+  }
+
+  const found = text.match(/\bFound (\d+) ([^.\n:]+)/i);
+  if (found) {
+    return { status: 'ok', summary: `Found ${found[1]} ${found[2].trim()}.` };
+  }
+  return { status: 'ok', summary: STATUS_FALLBACKS.ok };
+}
+
+function normalizeLegacy(toolName: string, raw: string): NormalizedToolResult {
+  const boundedModel = truncate(
+    raw.trim() ? raw : 'The tool returned no content.',
+    MAX_TOOL_MODEL_CONTEXT_LENGTH,
+  );
+  if (!raw.trim()) {
+    return {
+      status: 'empty',
+      model_context: boundedModel.value,
+      presentation: {
+        status: 'empty',
+        user_summary: STATUS_FALLBACKS.empty,
+        source: 'classified',
+      },
+      model_context_truncated: boundedModel.truncated,
+      user_summary_truncated: false,
+    };
+  }
+
+  const classified = classifySearchResult(toolName, raw);
+  const status = classified?.status ?? (/^error:/i.test(raw.trim()) ? 'error' : 'ok');
+  const source = classified ? 'classified' : 'legacy';
+  const boundedSummary = truncate(
+    classified?.summary || STATUS_FALLBACKS[status],
+    MAX_TOOL_USER_SUMMARY_LENGTH,
+  );
+  return {
+    status,
+    model_context: boundedModel.value,
+    presentation: {
+      status,
+      user_summary: boundedSummary.value || STATUS_FALLBACKS[status],
+      source,
+    },
+    model_context_truncated: boundedModel.truncated,
+    user_summary_truncated: boundedSummary.truncated,
+  };
+}
+
+function normalizeStructured(raw: StructuredToolResult): NormalizedToolResult {
+  const status = raw.status;
+  const fallback = STATUS_FALLBACKS[status];
+  const model = normalizeExposure(
+    raw.model_context,
+    raw.data,
+    fallback,
+    MAX_TOOL_MODEL_CONTEXT_LENGTH,
+  );
+  const user = normalizeExposure(
+    raw.user_summary,
+    raw.data,
+    fallback,
+    MAX_TOOL_USER_SUMMARY_LENGTH,
+  );
+
+  let display: ToolDisplayPayload | undefined;
+  let displayDegradation: NormalizedToolResult['display_degradation'];
+  if (raw.display !== undefined) {
+    if (!isRecord(raw.display) || typeof raw.display.type !== 'string') {
+      displayDegradation = 'malformed_display';
+    } else if (raw.display.type !== 'fields') {
+      displayDegradation = 'unsupported_display';
+    } else if (!Array.isArray(raw.display.fields)) {
+      displayDegradation = 'malformed_display';
+    } else {
+      const selected = readAllowlistedFields(
+        raw.data,
+        raw.display.fields.filter((field): field is string => typeof field === 'string'),
+      );
+      display = { type: 'fields', data: selected.data };
+      if (selected.unreadable) displayDegradation = 'display_data_unreadable';
+    }
+  }
+
+  if (!displayDegradation && (model.unreadable || user.unreadable)) {
+    displayDegradation = 'display_data_unreadable';
+  }
+
+  return {
+    status,
+    model_context: model.text || fallback,
+    presentation: {
+      status,
+      user_summary: user.text || fallback,
+      ...(display && { display }),
+      source: 'structured',
+    },
+    ...(displayDegradation && { display_degradation: displayDegradation }),
+    model_context_truncated: model.truncated,
+    user_summary_truncated: user.truncated,
+  };
+}
+
+function malformedToolResult(): NormalizedToolResult {
+  const fallback = STATUS_FALLBACKS.error;
+  return {
+    status: 'error',
+    model_context: 'Error: Tool returned a malformed result.',
+    presentation: {
+      status: 'error',
+      user_summary: fallback,
+      source: 'structured',
+    },
+    display_degradation: 'malformed_result',
+    model_context_truncated: false,
+    user_summary_truncated: false,
+  };
+}
+
+export function normalizeToolResult(toolName: string, raw: unknown): NormalizedToolResult {
+  if (typeof raw === 'string') return normalizeLegacy(toolName, raw);
+  try {
+    if (isRecord(raw) && typeof raw.status === 'string' && STATUS_SET.has(raw.status)) {
+      if (
+        (typeof raw.model_context === 'string' || isRecord(raw.model_context))
+        && (typeof raw.user_summary === 'string' || isRecord(raw.user_summary))
+      ) {
+        return normalizeStructured(raw as unknown as StructuredToolResult);
+      }
+    }
+  } catch {
+    return malformedToolResult();
+  }
+  return malformedToolResult();
+}
+
+/**
+ * `recoverable_error` means a retry on a later turn is expected to succeed;
+ * `error` means retrying unchanged input is not expected to help.
+ */
+export function normalizeToolError(
+  toolName: string,
+  error: unknown,
+  options: { expected: boolean },
+): NormalizedToolResult {
+  const message = error instanceof Error ? error.message : 'Unknown error';
+  const lower = message.toLowerCase();
+  let status: ToolResultStatus = 'error';
+  if (/access denied|not authorized|not authenticated|permission/.test(lower)) {
+    status = 'access_denied';
+  } else if (/\b(required|invalid|must be|cannot be empty|unsupported)\b/.test(lower)) {
+    status = 'invalid_input';
+  } else if (options.expected && /try again|temporar|timeout|timed out|unavailable|failed to (?:fetch|load|reach)/.test(lower)) {
+    status = 'recoverable_error';
+  }
+
+  const normalized = normalizeLegacy(toolName, `Error: ${message}`);
+  const summary = truncate(STATUS_FALLBACKS[status], MAX_TOOL_USER_SUMMARY_LENGTH);
+  return {
+    ...normalized,
+    status,
+    presentation: {
+      status,
+      user_summary: summary.value,
+      source: 'classified',
+    },
+    user_summary_truncated: summary.truncated,
+  };
+}
+
+export function isToolResultError(status: ToolResultStatus): boolean {
+  return status === 'access_denied'
+    || status === 'invalid_input'
+    || status === 'recoverable_error'
+    || status === 'error';
+}
+
+export function renderToolResultForUser(
+  presentation: ToolResultPresentation,
+  onDegraded?: (reason: 'renderer_failure') => void,
+): string {
+  try {
+    const summary = presentation.user_summary.trim() || STATUS_FALLBACKS[presentation.status];
+    if (!presentation.display || Object.keys(presentation.display.data).length === 0) return summary;
+    const details = formatFields(presentation.display.data);
+    return truncate(`${summary}${details ? `\n${details}` : ''}`, MAX_TOOL_USER_SUMMARY_LENGTH).value;
+  } catch {
+    onDegraded?.('renderer_failure');
+    return STATUS_FALLBACKS[presentation.status] || STATUS_FALLBACKS.error;
+  }
+}
+
+export function renderToolExecutionsFallback(
+  executions: ReadonlyArray<{ tool_name: string; normalized_result?: ToolResultPresentation }>,
+  onDegraded?: (toolName: string, reason: 'renderer_failure') => void,
+): string | null {
+  const eligible = executions
+    .filter((execution) => execution.normalized_result !== undefined
+      && execution.normalized_result.source !== 'legacy')
+    .slice(-3);
+  if (eligible.length === 0) return null;
+
+  const rendered = eligible.map((execution) => renderToolResultForUser(
+    execution.normalized_result!,
+    (reason) => onDegraded?.(execution.tool_name, reason),
+  )).filter((text) => text.trim().length > 0);
+  if (rendered.length === 0) return STATUS_FALLBACKS.error;
+  if (rendered.length === 1) return rendered[0];
+  return rendered.map((text) => `- ${text}`).join('\n');
+}

--- a/server/src/addie/tool-result-contract.ts
+++ b/server/src/addie/tool-result-contract.ts
@@ -202,7 +202,11 @@ function classifySearchResult(toolName: string, text: string): {
   summary: string;
 } | null {
   if (!CLASSIFIED_SEARCH_TOOLS.has(toolName)) return null;
-  const lower = text.toLowerCase();
+  // Legacy search handlers put their outcome on the first line. Restrict status
+  // detection to that line so matching prose inside a successful document does
+  // not turn the entire tool call into an error receipt.
+  const statusLine = text.trim().split(/\r?\n/, 1)[0] || '';
+  const lower = statusLine.toLowerCase();
 
   if (/cannot (?:search|access)|access denied|permission denied/.test(lower)) {
     return { status: 'access_denied', summary: firstParagraph(text) };
@@ -213,11 +217,11 @@ function classifySearchResult(toolName: string, text: string): {
   if (/not (?:ready|yet indexed)|search failed|temporarily unavailable/.test(lower)) {
     return { status: 'recoverable_error', summary: firstParagraph(text) };
   }
-  if (/^(?:no |document not found)/i.test(text.trim())) {
+  if (/^(?:no |document not found)/i.test(statusLine)) {
     return { status: 'empty', summary: firstParagraph(text) };
   }
 
-  const found = text.match(/\bFound (\d+) ([^.\n:]+)/i);
+  const found = statusLine.match(/\bFound (\d+) ([^.:]+)/i);
   if (found) {
     return { status: 'ok', summary: `Found ${found[1]} ${found[2].trim()}.` };
   }

--- a/server/tests/unit/addie-empty-response-fallback.test.ts
+++ b/server/tests/unit/addie-empty-response-fallback.test.ts
@@ -75,6 +75,16 @@ const toolUseTurn = {
   usage: { input_tokens: 10, output_tokens: 5 },
 };
 
+const searchToolUseTurn = {
+  ...toolUseTurn,
+  content: [{
+    type: 'tool_use',
+    id: 'toolu_search',
+    name: 'search_docs',
+    input: { query: 'missing term' },
+  }],
+};
+
 const recoveredEndTurn = {
   model: 'claude-sonnet-5-20260801',
   stop_reason: 'end_turn',
@@ -209,7 +219,7 @@ function makeThrowingStream(error: Error) {
   };
 }
 
-function makeStream(message: typeof toolUseTurn | typeof emptyEndTurn | typeof recoveredEndTurn | typeof personaOnlyEndTurn | typeof semanticRefusalEndTurn | typeof mixedRecoveryToolUseTurn | typeof emptyRefusal | typeof thinkingOnlyEndTurn | typeof redactedThinkingOnlyEndTurn | typeof blankTextEndTurn | typeof ritualOnlyEndTurn) {
+function makeStream(message: typeof toolUseTurn | typeof searchToolUseTurn | typeof emptyEndTurn | typeof recoveredEndTurn | typeof personaOnlyEndTurn | typeof semanticRefusalEndTurn | typeof mixedRecoveryToolUseTurn | typeof emptyRefusal | typeof thinkingOnlyEndTurn | typeof redactedThinkingOnlyEndTurn | typeof blankTextEndTurn | typeof ritualOnlyEndTurn) {
   return {
     async *[Symbol.asyncIterator]() {
       for (const block of message.content) {
@@ -232,6 +242,17 @@ const githubIssueTools = {
   handlers: new Map([['get_github_issue', getGithubIssue]]),
 };
 
+const emptyDocsResult = 'No documentation found in AdCP 3.2-beta for: "missing term"\n\nTry another query.';
+const searchDocs = vi.fn().mockResolvedValue(emptyDocsResult);
+const searchDocsTools = {
+  tools: [{
+    name: 'search_docs',
+    description: 'Search docs',
+    input_schema: { type: 'object' as const, properties: {} },
+  }],
+  handlers: new Map([['search_docs', searchDocs]]),
+};
+
 describe('Addie empty-response fallback (#4430)', () => {
   beforeEach(() => {
     mocks.createMessage.mockReset();
@@ -241,6 +262,7 @@ describe('Addie empty-response fallback (#4430)', () => {
     mocks.checkCostCap.mockReset().mockResolvedValue({ ok: true });
     mocks.recordCost.mockReset().mockResolvedValue(undefined);
     getGithubIssue.mockClear();
+    searchDocs.mockClear();
   });
 
   it('returns fallback text and sends monitoring for non-streaming empty responses', async () => {
@@ -976,7 +998,11 @@ describe('Addie empty-response fallback (#4430)', () => {
       { uncapped: true, threadId: 'thread-web-search-empty' },
     );
 
-    expect(response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(response.text).toBe('Web search completed (0 results)');
+    expect(response.tool_executions[0]?.normalized_result).toMatchObject({
+      status: 'empty',
+      source: 'structured',
+    });
     expect(mocks.createMessage).toHaveBeenCalledOnce();
     expect(mocks.notifySystemError).toHaveBeenCalledOnce();
   });
@@ -1083,6 +1109,66 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(mocks.streamMessage).toHaveBeenCalledTimes(3);
     expect(mocks.streamMessage.mock.calls[2][0].tools).toEqual([]);
     expect(mocks.notifySystemError).toHaveBeenCalledOnce();
+  });
+
+  it('uses the normalized search summary as the non-streaming web fallback', async () => {
+    mocks.createMessage
+      .mockResolvedValueOnce(searchToolUseTurn)
+      .mockResolvedValueOnce(emptyEndTurn)
+      .mockResolvedValueOnce(emptyEndTurn);
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const response = await client.processMessage(
+      'find missing term',
+      undefined,
+      searchDocsTools,
+      undefined,
+      { uncapped: true, threadId: 'thread-search-fallback' },
+    );
+
+    expect(response.text).toBe('No documentation found in AdCP 3.2-beta for: "missing term"');
+    expect(response.tool_executions[0]).toMatchObject({
+      tool_name: 'search_docs',
+      is_error: false,
+      normalized_result: {
+        status: 'empty',
+        source: 'classified',
+        user_summary: 'No documentation found in AdCP 3.2-beta for: "missing term"',
+      },
+    });
+    expect(searchDocs).toHaveBeenCalledOnce();
+  });
+
+  it('uses the same normalized search summary as the streaming Slack fallback', async () => {
+    mocks.streamMessage
+      .mockReturnValueOnce(makeStream(searchToolUseTurn))
+      .mockReturnValueOnce(makeStream(emptyEndTurn))
+      .mockReturnValueOnce(makeStream(emptyEndTurn));
+
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const events: StreamEvent[] = [];
+    for await (const event of client.processMessageStream(
+      'find missing term',
+      undefined,
+      searchDocsTools,
+      { uncapped: true, threadId: 'thread-stream-search-fallback' },
+    )) events.push(event);
+
+    const text = events
+      .filter((event): event is Extract<StreamEvent, { type: 'text' }> => event.type === 'text')
+      .map((event) => event.text)
+      .join('');
+    const toolEnd = events.find(
+      (event): event is Extract<StreamEvent, { type: 'tool_end' }> => event.type === 'tool_end',
+    );
+    const done = events.find(
+      (event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done',
+    );
+
+    expect(text).toBe('No documentation found in AdCP 3.2-beta for: "missing term"');
+    expect(done?.response.text).toBe(text);
+    expect(toolEnd?.normalized_result).toMatchObject({ status: 'empty', source: 'classified' });
+    expect(searchDocs).toHaveBeenCalledOnce();
   });
 
   it('never repeats a tool emitted by a malformed non-streaming recovery response', async () => {

--- a/server/tests/unit/addie/tool-result-contract.test.ts
+++ b/server/tests/unit/addie/tool-result-contract.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  MAX_TOOL_MODEL_CONTEXT_LENGTH,
+  MAX_TOOL_USER_SUMMARY_LENGTH,
+  TOOL_RESULT_STATUSES,
+  isToolResultError,
+  normalizeToolError,
+  normalizeToolResult,
+  renderToolExecutionsFallback,
+  renderToolResultForUser,
+  type ToolResultPresentation,
+} from '../../../src/addie/tool-result-contract.js';
+
+describe('Addie tool result contract', () => {
+  it.each(TOOL_RESULT_STATUSES)('preserves the %s status', (status) => {
+    const normalized = normalizeToolResult('typed_tool', {
+      status,
+      model_context: `model ${status}`,
+      user_summary: `user ${status}`,
+    });
+
+    expect(normalized.status).toBe(status);
+    expect(normalized.model_context).toBe(`model ${status}`);
+    expect(normalized.presentation).toMatchObject({
+      status,
+      user_summary: `user ${status}`,
+      source: 'structured',
+    });
+    expect(isToolResultError(status)).toBe(
+      ['access_denied', 'invalid_input', 'recoverable_error', 'error'].includes(status),
+    );
+  });
+
+  it('exposes machine fields only through explicit audience allowlists', () => {
+    const normalized = normalizeToolResult('typed_tool', {
+      status: 'ok',
+      data: {
+        title: 'Public title',
+        count: 3,
+        internal_token: 'DO_NOT_EXPOSE',
+      },
+      model_context: { summary: 'Model result', fields: ['title', 'count'] },
+      user_summary: { summary: 'User result', fields: ['title'] },
+      display: { type: 'fields', fields: ['count'] },
+    });
+
+    expect(normalized.model_context).toContain('title: Public title');
+    expect(normalized.model_context).toContain('count: 3');
+    expect(normalized.model_context).not.toContain('DO_NOT_EXPOSE');
+    expect(normalized.presentation.user_summary).toContain('title: Public title');
+    expect(normalized.presentation.user_summary).not.toContain('count: 3');
+    expect(normalized.presentation.user_summary).not.toContain('DO_NOT_EXPOSE');
+    expect(normalized.presentation.display).toEqual({ type: 'fields', data: { count: 3 } });
+  });
+
+  it('bounds oversized model context and user summaries', () => {
+    const normalized = normalizeToolResult('typed_tool', {
+      status: 'ok',
+      model_context: 'm'.repeat(MAX_TOOL_MODEL_CONTEXT_LENGTH + 100),
+      user_summary: 'u'.repeat(MAX_TOOL_USER_SUMMARY_LENGTH + 100),
+    });
+
+    expect(normalized.model_context.length).toBeLessThanOrEqual(MAX_TOOL_MODEL_CONTEXT_LENGTH);
+    expect(normalized.presentation.user_summary.length).toBeLessThanOrEqual(MAX_TOOL_USER_SUMMARY_LENGTH);
+    expect(normalized.model_context_truncated).toBe(true);
+    expect(normalized.user_summary_truncated).toBe(true);
+  });
+
+  it('drops malformed and unsupported display payloads without discarding the result', () => {
+    const malformed = normalizeToolResult('typed_tool', {
+      status: 'ok',
+      model_context: 'model result',
+      user_summary: 'user result',
+      display: { type: 'fields', fields: 'not-an-array' },
+    });
+    const unsupported = normalizeToolResult('typed_tool', {
+      status: 'ok',
+      model_context: 'model result',
+      user_summary: 'user result',
+      display: { type: 'chart', fields: ['count'] },
+    });
+
+    expect(malformed.model_context).toBe('model result');
+    expect(malformed.presentation.user_summary).toBe('user result');
+    expect(malformed.presentation.display).toBeUndefined();
+    expect(malformed.display_degradation).toBe('malformed_display');
+    expect(unsupported.presentation.display).toBeUndefined();
+    expect(unsupported.display_degradation).toBe('unsupported_display');
+  });
+
+  it('turns malformed handler values into a safe non-empty error', () => {
+    const normalized = normalizeToolResult('broken_tool', { surprise: true });
+
+    expect(normalized.status).toBe('error');
+    expect(normalized.model_context).toMatch(/^Error:/);
+    expect(normalized.presentation.user_summary).not.toBe('');
+    expect(normalized.display_degradation).toBe('malformed_result');
+  });
+
+  it('contains malformed structured fields that throw while being read', () => {
+    const modelContext: Record<string, unknown> = { summary: 'safe' };
+    Object.defineProperty(modelContext, 'fields', {
+      enumerable: true,
+      get() {
+        throw new Error('bad getter');
+      },
+    });
+
+    const normalized = normalizeToolResult('broken_tool', {
+      status: 'ok',
+      model_context: modelContext,
+      user_summary: 'safe',
+    });
+
+    expect(normalized.status).toBe('error');
+    expect(normalized.model_context).not.toBe('');
+    expect(normalized.display_degradation).toBe('malformed_result');
+  });
+
+  it('classifies migrated search strings while preserving their model context', () => {
+    const ok = normalizeToolResult('search_docs', 'Searching AdCP 3.2. Found 3 docs.\n\nDetails');
+    const empty = normalizeToolResult('search_docs', 'No documentation found for: "xyz"\n\nTry again.');
+    const denied = normalizeToolResult('search_slack', 'Cannot search #private: Access denied.');
+    const invalid = normalizeToolResult('search_docs', 'Unknown documentation version: "4".');
+    const recoverable = normalizeToolResult('search_docs', 'Documentation index not ready.');
+
+    expect(ok).toMatchObject({
+      status: 'ok',
+      model_context: expect.stringContaining('Details'),
+      presentation: { source: 'classified', user_summary: 'Found 3 docs.' },
+    });
+    expect(empty.status).toBe('empty');
+    expect(denied.status).toBe('access_denied');
+    expect(invalid.status).toBe('invalid_input');
+    expect(recoverable.status).toBe('recoverable_error');
+  });
+
+  it('keeps old-format results compatible but prevents blank legacy output', () => {
+    const legacy = normalizeToolResult('old_tool', 'existing string result');
+    const blank = normalizeToolResult('old_tool', '   ');
+
+    expect(legacy.model_context).toBe('existing string result');
+    expect(legacy.presentation.source).toBe('legacy');
+    expect(blank.status).toBe('empty');
+    expect(blank.model_context).not.toBe('');
+    expect(blank.presentation.user_summary).not.toBe('');
+  });
+
+  it('uses recoverable_error only when a later retry is expected to help', () => {
+    expect(normalizeToolError(
+      'lookup',
+      new Error('Service temporarily unavailable. Please try again.'),
+      { expected: true },
+    ).status).toBe('recoverable_error');
+    expect(normalizeToolError(
+      'lookup',
+      new Error('Record was permanently deleted'),
+      { expected: true },
+    ).status).toBe('error');
+    expect(normalizeToolError(
+      'lookup',
+      new Error('query is required'),
+      { expected: true },
+    ).status).toBe('invalid_input');
+  });
+
+  it('contains renderer failure and reports it separately', () => {
+    const data: Record<string, unknown> = {};
+    Object.defineProperty(data, 'broken', {
+      enumerable: true,
+      get() {
+        throw new Error('renderer exploded');
+      },
+    });
+    const presentation = {
+      status: 'ok',
+      user_summary: 'Safe fallback',
+      source: 'structured',
+      display: { type: 'fields', data },
+    } as ToolResultPresentation;
+    const onDegraded = vi.fn();
+
+    expect(renderToolResultForUser(presentation, onDegraded)).toBe('The tool completed successfully.');
+    expect(onDegraded).toHaveBeenCalledWith('renderer_failure');
+  });
+
+  it('builds a shared non-empty surface fallback only from migrated results', () => {
+    const migrated = normalizeToolResult('search_docs', 'No documentation found for: "xyz"');
+    const legacy = normalizeToolResult('old_tool', 'raw result');
+
+    expect(renderToolExecutionsFallback([
+      { tool_name: 'old_tool', normalized_result: legacy.presentation },
+    ])).toBeNull();
+    expect(renderToolExecutionsFallback([
+      { tool_name: 'old_tool', normalized_result: legacy.presentation },
+      { tool_name: 'search_docs', normalized_result: migrated.presentation },
+    ])).toBe('No documentation found for: "xyz"');
+  });
+});

--- a/server/tests/unit/addie/tool-result-contract.test.ts
+++ b/server/tests/unit/addie/tool-result-contract.test.ts
@@ -135,6 +135,21 @@ describe('Addie tool result contract', () => {
     expect(recoverable.status).toBe('recoverable_error');
   });
 
+  it('does not classify matching prose inside successful search content as an error', () => {
+    const document = normalizeToolResult(
+      'get_doc',
+      '# Search troubleshooting\n\nA permission denied message can indicate a private channel.',
+    );
+    const results = normalizeToolResult(
+      'search_docs',
+      'Searching AdCP 3.2. Found 1 doc.\n\nThe old search failed before this fix.',
+    );
+
+    expect(document.status).toBe('ok');
+    expect(results.status).toBe('ok');
+    expect(results.presentation.user_summary).toBe('Found 1 doc.');
+  });
+
   it('keeps old-format results compatible but prevents blank legacy output', () => {
     const legacy = normalizeToolResult('old_tool', 'existing string result');
     const blank = normalizeToolResult('old_tool', '   ');


### PR DESCRIPTION
## Summary

- add a typed status contract for tool results with explicit model, summary, and display allowlists
- normalize search and web-search result families in both streaming and non-streaming loops
- share safe nonempty fallbacks across Slack and web, with bounded content and separate degradation logging
- preserve redacted replay receipts and legacy handler compatibility

## Validation

- `npm run precommit` (500 server files; 7,116 passed, 30 skipped; root suites and typecheck passed)
- `npm run build`
- `npm run test:addie-tools`

Application-only change; no protocol changeset required.

Closes #6849