### PR TITLE
refactor(addie): centralize custom tool execution

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -17,11 +17,10 @@ import { AddieDatabase } from '../db/addie-db.js';
 import { AddieModelConfig } from '../config/models.js';
 import { getCurrentConfigVersionId } from './config-version.js';
 import { loadRules, loadResponseStyle, invalidateRulesCache } from './rules/index.js';
-import { isMultimodalContent, extractMultimodalContent, isAllowedImageType, type FileReadResult } from './mcp/url-tools.js';
+import { isAllowedImageType } from './mcp/url-tools.js';
 import { withRetry, isRetryableError, RetriesExhaustedError, type RetryConfig } from '../utils/anthropic-retry.js';
 import { formatTokenCount, getConversationTokenLimit, buildDroppedMessagesSummary, type MessageTurn } from '../utils/token-limiter.js';
-import { notifySystemError, notifyToolError } from './error-notifier.js';
-import { ToolError } from './tool-error.js';
+import { notifySystemError } from './error-notifier.js';
 import {
   checkCostCap,
   recordCost,
@@ -37,7 +36,25 @@ import {
   hasPersonaCollapse,
 } from './response-postprocess.js';
 import type { AddieInputAttachment } from './chat-attachments.js';
-import type { ModelExecution } from './model-providers/model-provider.js';
+import type {
+  ModelExecution,
+  ModelToolCallContent,
+  ModelToolResultContent,
+} from './model-providers/model-provider.js';
+import {
+  createAddieToolExecutor,
+  type AddieExecutionMode,
+  type ToolExecution,
+  type ToolExecutionPolicy,
+  type ToolHandler,
+} from './model-providers/tool-orchestration.js';
+export type {
+  AddieExecutionMode,
+  ToolExecution,
+  ToolExecutionPolicy,
+  ToolExecutionPolicyDecision,
+  ToolExecutionPolicyRequest,
+} from './model-providers/tool-orchestration.js';
 import {
   formatProviderUnavailableMessage,
   ProviderHealthController,
@@ -56,37 +73,11 @@ import {
 } from './security.js';
 import {
   isToolResultError,
-  normalizeToolError,
   normalizeToolResult,
   renderToolExecutionsFallback,
   type NormalizedToolResult,
-  type ToolHandlerResult,
   type ToolResultPresentation,
 } from './tool-result-contract.js';
-
-type ToolHandler = (input: Record<string, unknown>) => Promise<ToolHandlerResult>;
-
-export type AddieExecutionMode = 'production' | 'evaluation' | 'replay';
-
-export interface ToolExecutionPolicyRequest {
-  toolName: string;
-  input: Readonly<Record<string, unknown>>;
-  tool?: Readonly<AddieTool>;
-  executionMode: AddieExecutionMode;
-}
-
-export interface ToolExecutionPolicyDecision {
-  allowed: boolean;
-}
-
-/**
- * A policy is fail-closed: only an explicit `{ allowed: true }` dispatches the
- * handler. A rejection, exception, or malformed decision produces a stable
- * blocked receipt instead.
- */
-export type ToolExecutionPolicy = (
-  request: ToolExecutionPolicyRequest,
-) => ToolExecutionPolicyDecision | Promise<ToolExecutionPolicyDecision>;
 
 export interface InvocationPreparedSnapshot {
   execution_mode: AddieExecutionMode;
@@ -111,7 +102,6 @@ interface PreparedProviderRequest {
   betas?: readonly string[];
 }
 
-const BLOCKED_TOOL_RESULT = 'Error: Tool execution blocked by policy';
 const DEFAULT_MAX_OUTPUT_TOKENS = 8_192;
 const SONNET_5_MAX_OUTPUT_TOKENS = 32_768;
 // The Anthropic SDK rejects non-streaming requests whose calculated timeout
@@ -320,62 +310,6 @@ function toAnthropicMessages(turns: MessageTurn[]): Anthropic.MessageParam[] {
   return merged;
 }
 
-/**
- * Build Claude content blocks from multimodal file content.
- * Returns null if the content cannot be converted to valid content blocks.
- */
-function buildMultimodalContentBlocks(
-  multimodal: FileReadResult
-): { content: Anthropic.ToolResultBlockParam['content']; summary: string } | null {
-  if (!multimodal.data) {
-    return null;
-  }
-
-  const contentBlocks: Anthropic.ToolResultBlockParam['content'] = [];
-
-  if (multimodal.type === 'image') {
-    // Validate media type before using
-    if (!isAllowedImageType(multimodal.media_type)) {
-      logger.warn(
-        { mediaType: multimodal.media_type },
-        'Addie: Invalid image media type in multimodal content'
-      );
-      return null;
-    }
-    contentBlocks.push({
-      type: 'image',
-      source: {
-        type: 'base64',
-        media_type: multimodal.media_type,
-        data: multimodal.data,
-      },
-    });
-    contentBlocks.push({
-      type: 'text',
-      text: `[Image: ${multimodal.filename || 'uploaded image'}]`,
-    });
-  } else if (multimodal.type === 'document') {
-    contentBlocks.push({
-      type: 'document',
-      source: {
-        type: 'base64',
-        media_type: 'application/pdf',
-        data: multimodal.data,
-      },
-    });
-    contentBlocks.push({
-      type: 'text',
-      text: `[PDF Document: ${multimodal.filename || 'uploaded document'}]`,
-    });
-  } else {
-    // Unknown multimodal type
-    return null;
-  }
-
-  const summary = `Loaded ${multimodal.type}: ${multimodal.filename || 'file'}`;
-  return { content: contentBlocks, summary };
-}
-
 function buildInputAttachmentBlocks(
   attachments?: AddieInputAttachment[]
 ): Anthropic.ContentBlockParam[] {
@@ -439,6 +373,34 @@ function appendInputAttachments(
       : [];
   currentTurn.content = [...currentContent, ...attachmentBlocks];
   return nextMessages;
+}
+
+/** Adapt the common-loop tool result to Anthropic's continuation wire shape. */
+function toAnthropicToolResultContent(
+  content: ModelToolResultContent['content'],
+): string | Anthropic.ToolResultBlockParam['content'] {
+  if (typeof content === 'string') return content;
+  return content.map((block) => {
+    if (block.type === 'text') return block;
+    if (block.type === 'image') {
+      return {
+        type: 'image' as const,
+        source: {
+          type: 'base64' as const,
+          media_type: block.mediaType,
+          data: block.data,
+        },
+      };
+    }
+    return {
+      type: 'document' as const,
+      source: {
+        type: 'base64' as const,
+        media_type: block.mediaType,
+        data: block.data,
+      },
+    };
+  });
 }
 
 /**
@@ -745,22 +707,6 @@ export interface ProcessMessageOptions {
  */
 export interface RulesOverride {
   systemPrompt: string;
-}
-
-/**
- * Detailed record of a single tool execution
- */
-export interface ToolExecution {
-  tool_name: string;
-  parameters: Record<string, unknown>;
-  result: string;
-  result_summary?: string;
-  is_error: boolean;
-  duration_ms: number;
-  sequence: number;
-  blocked_by_policy?: true;
-  /** Shared, user-safe presentation consumed by Slack and web fallbacks. */
-  normalized_result?: ToolResultPresentation;
 }
 
 export interface AddieResponse {
@@ -1088,31 +1034,6 @@ export class AddieClaudeClient {
     ));
   }
 
-  private async isToolExecutionAllowed(
-    options: ProcessMessageOptions | undefined,
-    toolName: string,
-    toolInput: Record<string, unknown>,
-    tool: AddieTool | undefined,
-  ): Promise<boolean> {
-    if (!options?.toolExecutionPolicy) return !isEvaluationExecution(options);
-
-    try {
-      const decision = await options.toolExecutionPolicy({
-        toolName,
-        input: toolInput,
-        tool,
-        executionMode: options.executionMode ?? 'production',
-      });
-      return decision?.allowed === true;
-    } catch {
-      logger.warn(
-        { toolName, executionMode: options.executionMode ?? 'production' },
-        'Addie: Tool execution policy failed closed',
-      );
-      return false;
-    }
-  }
-
   private recordedToolParameters(
     options: ProcessMessageOptions | undefined,
     toolInput: Record<string, unknown>,
@@ -1123,10 +1044,9 @@ export class AddieClaudeClient {
   private recordedToolResult(
     options: ProcessMessageOptions | undefined,
     result: string,
-    kind: 'success' | 'error' | 'blocked',
+    kind: 'success' | 'error',
   ): string {
     if (!isEvaluationExecution(options)) return result;
-    if (kind === 'blocked') return BLOCKED_TOOL_RESULT;
     return kind === 'error' ? 'Error: Tool execution failed' : 'Tool execution completed';
   }
 
@@ -1450,6 +1370,19 @@ export class AddieClaudeClient {
       firstInvocationTools,
       requestWebSearchEnabled,
     } = prepared;
+    const executeToolCall = createAddieToolExecutor(
+      [...toolsByName.values()],
+      allHandlers,
+      {
+        executionMode: options?.executionMode ?? 'production',
+        policy: options?.toolExecutionPolicy,
+        notificationContext: {
+          slackUserId: options?.slackUserId,
+          userDisplayName: options?.userDisplayName,
+          threadId: options?.threadId,
+        },
+      },
+    );
     systemPromptMs = prepared.systemPromptMs;
 
     if (rulesOverride) {
@@ -1999,8 +1932,6 @@ export class AddieClaudeClient {
           const toolName = block.name;
           hasExecutedCustomTool = true;
           const toolInput = block.input as Record<string, unknown>;
-          const toolUseId = block.id;
-          const startTime = Date.now();
 
           logger.debug(
             { toolName, ...(operationalExecution && { toolInput }) },
@@ -2008,175 +1939,18 @@ export class AddieClaudeClient {
           );
           toolsUsed.push(toolName);
           executionSequence++;
-
-          const handler = allHandlers.get(toolName);
-          if (!handler) {
-            const durationMs = Date.now() - startTime;
-            const normalized = this.observeNormalizedToolResult(
-              toolName,
-              normalizeToolError(toolName, new Error(`Unknown tool "${toolName}"`), { expected: false }),
-            );
-            const presentation = this.recordedToolPresentation(options, normalized);
-            toolResults.push({
-              tool_use_id: toolUseId,
-              content: normalized.model_context,
-              is_error: true,
-            });
-            toolExecutions.push({
-              tool_name: toolName,
-              parameters: this.recordedToolParameters(options, toolInput),
-              result: this.recordedToolResult(options, normalized.model_context, 'error'),
-              result_summary: presentation.user_summary,
-              is_error: true,
-              duration_ms: durationMs,
-              sequence: executionSequence,
-              normalized_result: presentation,
-            });
-            continue;
-          }
-
-          const allowed = await this.isToolExecutionAllowed(
-            options,
-            toolName,
-            toolInput,
-            toolsByName.get(toolName),
-          );
-          if (!allowed) {
-            const normalized = this.observeNormalizedToolResult(toolName, normalizeToolResult(toolName, {
-              status: 'access_denied',
-              model_context: BLOCKED_TOOL_RESULT,
-              user_summary: 'This tool action was blocked by execution policy.',
-            }));
-            const presentation = this.recordedToolPresentation(options, normalized);
-            toolResults.push({
-              tool_use_id: toolUseId,
-              content: normalized.model_context,
-              is_error: true,
-            });
-            toolExecutions.push({
-              tool_name: toolName,
-              parameters: this.recordedToolParameters(options, toolInput),
-              result: BLOCKED_TOOL_RESULT,
-              result_summary: 'Blocked by tool execution policy',
-              is_error: true,
-              duration_ms: 0,
-              sequence: executionSequence,
-              blocked_by_policy: true,
-              normalized_result: presentation,
-            });
-            continue;
-          }
-
-          try {
-            const result = await handler(toolInput);
-            const durationMs = Date.now() - startTime;
-
-            // Check if result contains multimodal content (images, PDFs)
-            if (typeof result === 'string' && isMultimodalContent(result)) {
-              const multimodal = extractMultimodalContent(result);
-              const multimodalBlocks = multimodal ? buildMultimodalContentBlocks(multimodal) : null;
-
-              if (multimodalBlocks) {
-                const normalized = this.observeNormalizedToolResult(toolName, normalizeToolResult(toolName, {
-                  status: 'ok',
-                  model_context: multimodalBlocks.summary,
-                  user_summary: multimodalBlocks.summary,
-                }));
-                const presentation = this.recordedToolPresentation(options, normalized);
-                toolResults.push({ tool_use_id: toolUseId, content: multimodalBlocks.content });
-                toolExecutions.push({
-                  tool_name: toolName,
-                  parameters: this.recordedToolParameters(options, toolInput),
-                  result: this.recordedToolResult(options, multimodalBlocks.summary, 'success'),
-                  result_summary: this.recordedToolResult(options, multimodalBlocks.summary, 'success'),
-                  is_error: false,
-                  duration_ms: durationMs,
-                  sequence: executionSequence,
-                  normalized_result: presentation,
-                });
-                logger.info({
-                  toolName,
-                  multimodalType: multimodal?.type,
-                  ...(operationalExecution && { filename: multimodal?.filename }),
-                }, 'Addie: Processed multimodal tool result');
-              } else {
-                // Failed to parse or validate multimodal content
-                const normalized = this.observeNormalizedToolResult(
-                  toolName,
-                  normalizeToolError(toolName, new Error('Failed to process file content'), { expected: false }),
-                );
-                const presentation = this.recordedToolPresentation(options, normalized);
-                toolResults.push({ tool_use_id: toolUseId, content: normalized.model_context, is_error: true });
-                toolExecutions.push({
-                  tool_name: toolName,
-                  parameters: this.recordedToolParameters(options, toolInput),
-                  result: this.recordedToolResult(options, normalized.model_context, 'error'),
-                  result_summary: presentation.user_summary,
-                  is_error: true,
-                  duration_ms: durationMs,
-                  sequence: executionSequence,
-                  normalized_result: presentation,
-                });
-              }
-            } else {
-              const normalized = this.observeNormalizedToolResult(
-                toolName,
-                normalizeToolResult(toolName, result),
-              );
-              const presentation = this.recordedToolPresentation(options, normalized);
-              const isError = isToolResultError(normalized.status);
-              const summary = normalized.presentation.source === 'legacy' && typeof result === 'string'
-                ? this.summarizeToolResult(toolName, result)
-                : presentation.user_summary;
-              toolResults.push({
-                tool_use_id: toolUseId,
-                content: normalized.model_context,
-                ...(isError && { is_error: true }),
-              });
-              toolExecutions.push({
-                tool_name: toolName,
-                parameters: this.recordedToolParameters(options, toolInput),
-                result: this.recordedToolResult(options, normalized.model_context, isError ? 'error' : 'success'),
-                result_summary: this.recordedToolResult(options, summary, isError ? 'error' : 'success'),
-                is_error: isError,
-                duration_ms: durationMs,
-                sequence: executionSequence,
-                normalized_result: presentation,
-              });
-            }
-          } catch (error) {
-            const durationMs = Date.now() - startTime;
-            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-            const isExpected = error instanceof ToolError;
-            const normalized = this.observeNormalizedToolResult(
-              toolName,
-              normalizeToolError(toolName, error, { expected: isExpected }),
-            );
-            const presentation = this.recordedToolPresentation(options, normalized);
-            if (isExpected) {
-              logger.warn({ toolName, ...(operationalExecution && { toolInput, error: errorMessage }), durationMs }, 'Addie: Tool returned expected error');
-            } else {
-              logger.error({ toolName, ...(operationalExecution && { toolInput, error: errorMessage }), durationMs }, 'Addie: Tool threw unexpected exception');
-              if (operationalExecution) {
-                notifyToolError({ toolName, errorMessage, toolInput, slackUserId: options?.slackUserId, userDisplayName: options?.userDisplayName, threadId: options?.threadId, threw: true });
-              }
-            }
-            toolResults.push({
-              tool_use_id: toolUseId,
-              content: normalized.model_context,
-              is_error: true,
-            });
-            toolExecutions.push({
-              tool_name: toolName,
-              parameters: this.recordedToolParameters(options, toolInput),
-              result: this.recordedToolResult(options, normalized.model_context, 'error'),
-              result_summary: presentation.user_summary,
-              is_error: true,
-              duration_ms: durationMs,
-              sequence: executionSequence,
-              normalized_result: presentation,
-            });
-          }
+          const executed = await executeToolCall({
+            type: 'tool_call',
+            id: block.id,
+            name: toolName,
+            input: toolInput as ModelToolCallContent['input'],
+          }, executionSequence);
+          toolResults.push({
+            tool_use_id: executed.result.toolCallId,
+            content: toAnthropicToolResultContent(executed.result.content),
+            is_error: executed.result.isError,
+          });
+          toolExecutions.push(executed.execution);
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2383,7 +2157,15 @@ export class AddieClaudeClient {
       [...this.toolHandlers, ...(requestTools?.handlers || [])]
         .filter(([name]) => !allowedToolNames || allowedToolNames.has(name)),
     );
-    const toolsByName = new Map(allTools.map((tool) => [tool.name, tool]));
+    const executeToolCall = createAddieToolExecutor(allTools, allHandlers, {
+      executionMode: options?.executionMode ?? 'production',
+      policy: options?.toolExecutionPolicy,
+      notificationContext: {
+        slackUserId: options?.slackUserId,
+        userDisplayName: options?.userDisplayName,
+        threadId: options?.threadId,
+      },
+    });
     const toolCount = allTools.length; // Note: streaming doesn't use web search
 
     // Build proper message turns from thread context
@@ -2896,8 +2678,6 @@ export class AddieClaudeClient {
 
             const toolName = block.name;
             const toolInput = block.input as Record<string, unknown>;
-            const toolUseId = block.id;
-            const startTime = Date.now();
 
             logger.debug(
               { toolName, ...(operationalExecution && { toolInput }) },
@@ -2913,215 +2693,25 @@ export class AddieClaudeClient {
               parameters: this.recordedToolParameters(options, toolInput),
             };
 
-            const handler = allHandlers.get(toolName);
-            if (!handler) {
-              const durationMs = Date.now() - startTime;
-              const normalized = this.observeNormalizedToolResult(
-                toolName,
-                normalizeToolError(toolName, new Error(`Unknown tool "${toolName}"`), { expected: false }),
-              );
-              const presentation = this.recordedToolPresentation(options, normalized);
-              toolResults.push({
-                tool_use_id: toolUseId,
-                content: normalized.model_context,
-                is_error: true,
-              });
-              toolExecutions.push({
-                tool_name: toolName,
-                parameters: this.recordedToolParameters(options, toolInput),
-                result: this.recordedToolResult(options, normalized.model_context, 'error'),
-                result_summary: presentation.user_summary,
-                is_error: true,
-                duration_ms: durationMs,
-                sequence: executionSequence,
-                normalized_result: presentation,
-              });
-              yield {
-                type: 'tool_end',
-                tool_name: toolName,
-                result: this.recordedToolResult(options, normalized.model_context, 'error'),
-                is_error: true,
-                normalized_result: presentation,
-              };
-              continue;
-            }
-
-            const allowed = await this.isToolExecutionAllowed(
-              options,
-              toolName,
-              toolInput,
-              toolsByName.get(toolName),
-            );
-            if (!allowed) {
-              const normalized = this.observeNormalizedToolResult(toolName, normalizeToolResult(toolName, {
-                status: 'access_denied',
-                model_context: BLOCKED_TOOL_RESULT,
-                user_summary: 'This tool action was blocked by execution policy.',
-              }));
-              const presentation = this.recordedToolPresentation(options, normalized);
-              toolResults.push({
-                tool_use_id: toolUseId,
-                content: normalized.model_context,
-                is_error: true,
-              });
-              toolExecutions.push({
-                tool_name: toolName,
-                parameters: this.recordedToolParameters(options, toolInput),
-                result: BLOCKED_TOOL_RESULT,
-                result_summary: 'Blocked by tool execution policy',
-                is_error: true,
-                duration_ms: 0,
-                sequence: executionSequence,
-                blocked_by_policy: true,
-                normalized_result: presentation,
-              });
-              yield {
-                type: 'tool_end',
-                tool_name: toolName,
-                result: BLOCKED_TOOL_RESULT,
-                is_error: true,
-                normalized_result: presentation,
-              };
-              continue;
-            }
-
-            try {
-              const result = await handler(toolInput);
-              const durationMs = Date.now() - startTime;
-
-              // Check if result contains multimodal content (images, PDFs)
-              if (typeof result === 'string' && isMultimodalContent(result)) {
-                const multimodal = extractMultimodalContent(result);
-                const multimodalBlocks = multimodal ? buildMultimodalContentBlocks(multimodal) : null;
-
-                if (multimodalBlocks) {
-                  const normalized = this.observeNormalizedToolResult(toolName, normalizeToolResult(toolName, {
-                    status: 'ok',
-                    model_context: multimodalBlocks.summary,
-                    user_summary: multimodalBlocks.summary,
-                  }));
-                  const presentation = this.recordedToolPresentation(options, normalized);
-                  toolResults.push({ tool_use_id: toolUseId, content: multimodalBlocks.content });
-                  toolExecutions.push({
-                    tool_name: toolName,
-                    parameters: this.recordedToolParameters(options, toolInput),
-                    result: this.recordedToolResult(options, multimodalBlocks.summary, 'success'),
-                    result_summary: this.recordedToolResult(options, multimodalBlocks.summary, 'success'),
-                    is_error: false,
-                    duration_ms: durationMs,
-                    sequence: executionSequence,
-                    normalized_result: presentation,
-                  });
-                  yield {
-                    type: 'tool_end',
-                    tool_name: toolName,
-                    result: this.recordedToolResult(options, multimodalBlocks.summary, 'success'),
-                    is_error: false,
-                    normalized_result: presentation,
-                  };
-                  logger.info({
-                    toolName,
-                    multimodalType: multimodal?.type,
-                    ...(operationalExecution && { filename: multimodal?.filename }),
-                  }, 'Addie Stream: Processed multimodal tool result');
-                } else {
-                  const normalized = this.observeNormalizedToolResult(
-                    toolName,
-                    normalizeToolError(toolName, new Error('Failed to process file content'), { expected: false }),
-                  );
-                  const presentation = this.recordedToolPresentation(options, normalized);
-                  toolResults.push({ tool_use_id: toolUseId, content: normalized.model_context, is_error: true });
-                  toolExecutions.push({
-                    tool_name: toolName,
-                    parameters: this.recordedToolParameters(options, toolInput),
-                    result: this.recordedToolResult(options, normalized.model_context, 'error'),
-                    result_summary: presentation.user_summary,
-                    is_error: true,
-                    duration_ms: durationMs,
-                    sequence: executionSequence,
-                    normalized_result: presentation,
-                  });
-                  yield {
-                    type: 'tool_end',
-                    tool_name: toolName,
-                    result: this.recordedToolResult(options, normalized.model_context, 'error'),
-                    is_error: true,
-                    normalized_result: presentation,
-                  };
-                }
-              } else {
-                const normalized = this.observeNormalizedToolResult(
-                  toolName,
-                  normalizeToolResult(toolName, result),
-                );
-                const presentation = this.recordedToolPresentation(options, normalized);
-                const isError = isToolResultError(normalized.status);
-                const summary = normalized.presentation.source === 'legacy' && typeof result === 'string'
-                  ? this.summarizeToolResult(toolName, result)
-                  : presentation.user_summary;
-                toolResults.push({
-                  tool_use_id: toolUseId,
-                  content: normalized.model_context,
-                  ...(isError && { is_error: true }),
-                });
-                toolExecutions.push({
-                  tool_name: toolName,
-                  parameters: this.recordedToolParameters(options, toolInput),
-                  result: this.recordedToolResult(options, normalized.model_context, isError ? 'error' : 'success'),
-                  result_summary: this.recordedToolResult(options, summary, isError ? 'error' : 'success'),
-                  is_error: isError,
-                  duration_ms: durationMs,
-                  sequence: executionSequence,
-                  normalized_result: presentation,
-                });
-                yield {
-                  type: 'tool_end',
-                  tool_name: toolName,
-                  result: this.recordedToolResult(options, normalized.model_context, isError ? 'error' : 'success'),
-                  is_error: isError,
-                  normalized_result: presentation,
-                };
-              }
-            } catch (error) {
-              const durationMs = Date.now() - startTime;
-              const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-              const isExpected = error instanceof ToolError;
-              const normalized = this.observeNormalizedToolResult(
-                toolName,
-                normalizeToolError(toolName, error, { expected: isExpected }),
-              );
-              const presentation = this.recordedToolPresentation(options, normalized);
-              if (isExpected) {
-                logger.warn({ toolName, ...(operationalExecution && { toolInput, error: errorMessage }), durationMs }, 'Addie Stream: Tool returned expected error');
-              } else {
-                logger.error({ toolName, ...(operationalExecution && { toolInput, error: errorMessage }), durationMs }, 'Addie Stream: Tool threw unexpected exception');
-                if (operationalExecution) {
-                  notifyToolError({ toolName, errorMessage, toolInput, slackUserId: options?.slackUserId, userDisplayName: options?.userDisplayName, threadId: options?.threadId, threw: true });
-                }
-              }
-              toolResults.push({
-                tool_use_id: toolUseId,
-                content: normalized.model_context,
-                is_error: true,
-              });
-              toolExecutions.push({
-                tool_name: toolName,
-                parameters: this.recordedToolParameters(options, toolInput),
-                result: this.recordedToolResult(options, normalized.model_context, 'error'),
-                result_summary: presentation.user_summary,
-                is_error: true,
-                duration_ms: durationMs,
-                sequence: executionSequence,
-                normalized_result: presentation,
-              });
-              yield {
-                type: 'tool_end',
-                tool_name: toolName,
-                result: this.recordedToolResult(options, normalized.model_context, 'error'),
-                is_error: true,
-                normalized_result: presentation,
-              };
-            }
+            const executed = await executeToolCall({
+              type: 'tool_call',
+              id: block.id,
+              name: toolName,
+              input: toolInput as ModelToolCallContent['input'],
+            }, executionSequence);
+            toolResults.push({
+              tool_use_id: executed.result.toolCallId,
+              content: toAnthropicToolResultContent(executed.result.content),
+              is_error: executed.result.isError,
+            });
+            toolExecutions.push(executed.execution);
+            yield {
+              type: 'tool_end',
+              tool_name: toolName,
+              result: executed.execution.result,
+              is_error: executed.execution.is_error,
+              normalized_result: executed.execution.normalized_result,
+            };
           }
 
           // Continue the conversation with tool results
@@ -3214,44 +2804,6 @@ export class AddieClaudeClient {
         await releaseCertificationReserve(options?.costScope?.userId, certificationLeaseId);
       }
     }
-  }
-
-  /**
-   * Create a human-readable summary of tool results
-   */
-  private summarizeToolResult(toolName: string, result: string): string {
-    if (toolName === 'search_docs') {
-      // Parse "Found N documentation pages" from result
-      const match = result.match(/Found (\d+) documentation pages/);
-      if (match) {
-        return `Found ${match[1]} doc page(s)`;
-      }
-      if (result.includes('No documentation found')) {
-        return 'No docs found';
-      }
-    }
-
-    if (toolName === 'search_slack') {
-      // Parse "Found N Slack messages" from result
-      const match = result.match(/Found (\d+) Slack messages/);
-      if (match) {
-        return `Found ${match[1]} Slack message(s)`;
-      }
-      if (result.includes('No Slack discussions found')) {
-        return 'No Slack results';
-      }
-    }
-
-    if (toolName === 'web_search') {
-      // Web search results are already summarized in the tracking code
-      return result;
-    }
-
-    // Default: truncate long results
-    if (result.length > 100) {
-      return result.substring(0, 97) + '...';
-    }
-    return result;
   }
 
   /**

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.37';
+export const CODE_VERSION = '2026.08.38';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "3f403b0d27841b1c16f45dd4c9fdc651b03889a6ee6dac26d4a552c8fec17a14",
+    "server/src/addie/claude-client.ts": "f4dabf3d00d63354bd108928dccdd81b53a62e6ce2f13d1c6af38ff29499e11b",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/addie/model-providers/tool-orchestration.ts
+++ b/server/src/addie/model-providers/tool-orchestration.ts
@@ -1,5 +1,3 @@
-import Ajv, { type ValidateFunction } from 'ajv';
-import addFormats from 'ajv-formats';
 import { createLogger } from '../../logger.js';
 import { notifyToolError } from '../error-notifier.js';
 import {
@@ -24,8 +22,6 @@ import type {
 } from './model-provider.js';
 
 const logger = createLogger('addie-tool-orchestration');
-const toolSchemaAjv = new Ajv({ allErrors: false, strict: false });
-addFormats(toolSchemaAjv);
 const definitionSnapshots = new WeakMap<AddieTool, AddieTool>();
 
 export const BLOCKED_TOOL_RESULT = 'Error: Tool execution blocked by policy';
@@ -81,7 +77,6 @@ export interface AddieToolCallResult {
 interface RegisteredTool {
   definition: AddieTool;
   handler?: ToolHandler;
-  validate?: ValidateFunction;
 }
 
 function isEvaluationExecution(mode: AddieExecutionMode): boolean {
@@ -243,8 +238,9 @@ function failureResult(
 }
 
 /**
- * Compile the request's JSON Schema tools once and return the common,
- * provider-neutral custom-tool execution boundary used by live model loops.
+ * Return the common, provider-neutral custom-tool execution boundary used by
+ * live model loops. Definitions remain canonical JSON Schema at the model
+ * boundary, while handlers retain their established tolerant input coercion.
  */
 export function createAddieToolExecutor(
   tools: readonly AddieTool[],
@@ -254,18 +250,9 @@ export function createAddieToolExecutor(
   const registry = new Map<string, RegisteredTool>();
   for (const sourceDefinition of tools) {
     const definition = snapshotDefinition(sourceDefinition);
-    let validate: ValidateFunction | undefined;
-    try {
-      // Ajv caches by schema object identity, so stable global tool definitions
-      // compile once across requests instead of adding per-message latency.
-      validate = toolSchemaAjv.compile(sourceDefinition.input_schema);
-    } catch (error) {
-      logger.error({ toolName: definition.name, error }, 'Addie: Invalid custom-tool JSON Schema');
-    }
     registry.set(definition.name, {
       definition,
       handler: handlers.get(definition.name),
-      validate,
     });
   }
 
@@ -297,7 +284,12 @@ export function createAddieToolExecutor(
       );
     }
 
-    if (!inputIsObject || !registered.validate || !registered.validate(call.input)) {
+    // Provider adapters guarantee a JSON object for canonical tool calls. Keep
+    // this runtime guard for malformed/synthetic callers, but do not enforce
+    // the advertised JSON Schema here: several long-lived handlers
+    // intentionally coerce recoverable model drift (for example a comma-
+    // separated string where an array of strings was requested).
+    if (!inputIsObject) {
       const normalized = observeNormalizedToolResult(call.name, normalizeToolResult(call.name, {
         status: 'invalid_input',
         model_context: 'Error: Tool input did not match the required JSON Schema',

--- a/server/src/addie/model-providers/tool-orchestration.ts
+++ b/server/src/addie/model-providers/tool-orchestration.ts
@@ -1,0 +1,449 @@
+import Ajv, { type ValidateFunction } from 'ajv';
+import addFormats from 'ajv-formats';
+import { createLogger } from '../../logger.js';
+import { notifyToolError } from '../error-notifier.js';
+import {
+  extractMultimodalContent,
+  isAllowedImageType,
+  isMultimodalContent,
+  type FileReadResult,
+} from '../mcp/url-tools.js';
+import { ToolError } from '../tool-error.js';
+import {
+  isToolResultError,
+  normalizeToolError,
+  normalizeToolResult,
+  type NormalizedToolResult,
+  type ToolHandlerResult,
+  type ToolResultPresentation,
+} from '../tool-result-contract.js';
+import type { AddieTool } from '../types.js';
+import type {
+  ModelToolCallContent,
+  ModelToolResultContent,
+} from './model-provider.js';
+
+const logger = createLogger('addie-tool-orchestration');
+const toolSchemaAjv = new Ajv({ allErrors: false, strict: false });
+addFormats(toolSchemaAjv);
+const definitionSnapshots = new WeakMap<AddieTool, AddieTool>();
+
+export const BLOCKED_TOOL_RESULT = 'Error: Tool execution blocked by policy';
+
+export type ToolHandler = (input: Record<string, unknown>) => Promise<ToolHandlerResult>;
+export type AddieExecutionMode = 'production' | 'evaluation' | 'replay';
+
+export interface ToolExecutionPolicyRequest {
+  toolName: string;
+  input: Readonly<Record<string, unknown>>;
+  tool?: Readonly<AddieTool>;
+  executionMode: AddieExecutionMode;
+}
+
+export interface ToolExecutionPolicyDecision {
+  allowed: boolean;
+}
+
+/** Fail closed: only an explicit `{ allowed: true }` dispatches a handler. */
+export type ToolExecutionPolicy = (
+  request: ToolExecutionPolicyRequest,
+) => ToolExecutionPolicyDecision | Promise<ToolExecutionPolicyDecision>;
+
+export interface ToolExecution {
+  tool_name: string;
+  parameters: Record<string, unknown>;
+  result: string;
+  result_summary?: string;
+  is_error: boolean;
+  duration_ms: number;
+  sequence: number;
+  blocked_by_policy?: true;
+  normalized_result?: ToolResultPresentation;
+}
+
+export interface ToolExecutionNotificationContext {
+  slackUserId?: string;
+  userDisplayName?: string;
+  threadId?: string;
+}
+
+export interface AddieToolExecutorOptions {
+  executionMode: AddieExecutionMode;
+  policy?: ToolExecutionPolicy;
+  notificationContext?: ToolExecutionNotificationContext;
+}
+
+export interface AddieToolCallResult {
+  result: ModelToolResultContent;
+  execution: ToolExecution;
+}
+
+interface RegisteredTool {
+  definition: AddieTool;
+  handler?: ToolHandler;
+  validate?: ValidateFunction;
+}
+
+function isEvaluationExecution(mode: AddieExecutionMode): boolean {
+  return mode === 'evaluation' || mode === 'replay';
+}
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== 'object' || value === null || Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value)) deepFreeze(nested);
+  return Object.freeze(value);
+}
+
+function snapshotDefinition(source: AddieTool): AddieTool {
+  const cached = definitionSnapshots.get(source);
+  if (cached) return cached;
+  const snapshot = deepFreeze(structuredClone(source));
+  definitionSnapshots.set(source, snapshot);
+  return snapshot;
+}
+
+function recordedParameters(
+  mode: AddieExecutionMode,
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  return isEvaluationExecution(mode) ? {} : structuredClone(input);
+}
+
+function recordedResult(
+  mode: AddieExecutionMode,
+  result: string,
+  kind: 'success' | 'error' | 'blocked',
+): string {
+  if (!isEvaluationExecution(mode)) return result;
+  if (kind === 'blocked') return BLOCKED_TOOL_RESULT;
+  return kind === 'error' ? 'Error: Tool execution failed' : 'Tool execution completed';
+}
+
+function recordedPresentation(
+  mode: AddieExecutionMode,
+  normalized: NormalizedToolResult,
+): ToolResultPresentation {
+  if (!isEvaluationExecution(mode)) return normalized.presentation;
+  return {
+    status: normalized.status,
+    user_summary: isToolResultError(normalized.status)
+      ? 'Tool execution failed'
+      : 'Tool execution completed',
+    source: normalized.presentation.source,
+  };
+}
+
+function observeNormalizedToolResult(
+  toolName: string,
+  normalized: NormalizedToolResult,
+): NormalizedToolResult {
+  if (normalized.display_degradation) {
+    logger.warn({
+      event: 'addie_tool_result_display_degraded',
+      toolName,
+      reason: normalized.display_degradation,
+    }, 'Addie: Tool result display payload degraded; text result preserved');
+  }
+  if (normalized.model_context_truncated || normalized.user_summary_truncated) {
+    logger.warn({
+      event: 'addie_tool_result_content_bounded',
+      toolName,
+      modelContextTruncated: normalized.model_context_truncated,
+      userSummaryTruncated: normalized.user_summary_truncated,
+    }, 'Addie: Oversized tool result content bounded');
+  }
+  return normalized;
+}
+
+function summarizeLegacyToolResult(toolName: string, result: string): string {
+  if (toolName === 'search_docs') {
+    const match = result.match(/Found (\d+) documentation pages/);
+    if (match) return `Found ${match[1]} doc page(s)`;
+    if (result.includes('No documentation found')) return 'No docs found';
+  }
+  if (toolName === 'search_slack') {
+    const match = result.match(/Found (\d+) Slack messages/);
+    if (match) return `Found ${match[1]} Slack message(s)`;
+    if (result.includes('No Slack discussions found')) return 'No Slack results';
+  }
+  if (toolName === 'web_search') return result;
+  return result.length > 100 ? `${result.substring(0, 97)}...` : result;
+}
+
+function buildMultimodalContent(
+  multimodal: FileReadResult,
+): { content: ModelToolResultContent['content']; summary: string } | null {
+  if (!multimodal.data) return null;
+
+  if (multimodal.type === 'image') {
+    if (!isAllowedImageType(multimodal.media_type)) {
+      logger.warn(
+        { mediaType: multimodal.media_type },
+        'Addie: Invalid image media type in multimodal content',
+      );
+      return null;
+    }
+    return {
+      content: [
+        { type: 'image', mediaType: multimodal.media_type, data: multimodal.data },
+        { type: 'text', text: `[Image: ${multimodal.filename || 'uploaded image'}]` },
+      ],
+      summary: `Loaded image: ${multimodal.filename || 'file'}`,
+    };
+  }
+
+  if (multimodal.type === 'document') {
+    return {
+      content: [
+        { type: 'document', mediaType: 'application/pdf', data: multimodal.data },
+        { type: 'text', text: `[PDF Document: ${multimodal.filename || 'uploaded document'}]` },
+      ],
+      summary: `Loaded document: ${multimodal.filename || 'file'}`,
+    };
+  }
+  return null;
+}
+
+function failureResult(
+  call: ModelToolCallContent,
+  sequence: number,
+  mode: AddieExecutionMode,
+  normalized: NormalizedToolResult,
+  durationMs: number,
+  blockedByPolicy = false,
+): AddieToolCallResult {
+  const presentation = recordedPresentation(mode, normalized);
+  const resultText = recordedResult(
+    mode,
+    normalized.model_context,
+    blockedByPolicy ? 'blocked' : 'error',
+  );
+  return {
+    result: {
+      type: 'tool_result',
+      toolCallId: call.id,
+      toolName: call.name,
+      content: normalized.model_context,
+      isError: true,
+    },
+    execution: {
+      tool_name: call.name,
+      parameters: recordedParameters(mode, call.input),
+      result: resultText,
+      result_summary: blockedByPolicy
+        ? 'Blocked by tool execution policy'
+        : presentation.user_summary,
+      is_error: true,
+      duration_ms: blockedByPolicy ? 0 : durationMs,
+      sequence,
+      ...(blockedByPolicy && { blocked_by_policy: true as const }),
+      normalized_result: presentation,
+    },
+  };
+}
+
+/**
+ * Compile the request's JSON Schema tools once and return the common,
+ * provider-neutral custom-tool execution boundary used by live model loops.
+ */
+export function createAddieToolExecutor(
+  tools: readonly AddieTool[],
+  handlers: ReadonlyMap<string, ToolHandler>,
+  options: AddieToolExecutorOptions,
+): (call: ModelToolCallContent, sequence: number) => Promise<AddieToolCallResult> {
+  const registry = new Map<string, RegisteredTool>();
+  for (const sourceDefinition of tools) {
+    const definition = snapshotDefinition(sourceDefinition);
+    let validate: ValidateFunction | undefined;
+    try {
+      // Ajv caches by schema object identity, so stable global tool definitions
+      // compile once across requests instead of adding per-message latency.
+      validate = toolSchemaAjv.compile(sourceDefinition.input_schema);
+    } catch (error) {
+      logger.error({ toolName: definition.name, error }, 'Addie: Invalid custom-tool JSON Schema');
+    }
+    registry.set(definition.name, {
+      definition,
+      handler: handlers.get(definition.name),
+      validate,
+    });
+  }
+
+  return async (sourceCall, sequence) => {
+    const clonedInput: unknown = structuredClone(sourceCall.input);
+    const inputIsObject = typeof clonedInput === 'object'
+      && clonedInput !== null
+      && !Array.isArray(clonedInput);
+    const call: ModelToolCallContent = Object.freeze({
+      ...sourceCall,
+      input: deepFreeze(
+        (inputIsObject ? clonedInput : {}) as ModelToolCallContent['input'],
+      ),
+    });
+    const startTime = Date.now();
+    const operationalExecution = options.executionMode === 'production';
+    const registered = registry.get(call.name);
+    if (!registered?.handler) {
+      const normalized = observeNormalizedToolResult(
+        call.name,
+        normalizeToolError(call.name, new Error(`Unknown tool "${call.name}"`), { expected: false }),
+      );
+      return failureResult(
+        call,
+        sequence,
+        options.executionMode,
+        normalized,
+        Date.now() - startTime,
+      );
+    }
+
+    if (!inputIsObject || !registered.validate || !registered.validate(call.input)) {
+      const normalized = observeNormalizedToolResult(call.name, normalizeToolResult(call.name, {
+        status: 'invalid_input',
+        model_context: 'Error: Tool input did not match the required JSON Schema',
+        user_summary: 'The tool received invalid input.',
+      }));
+      return failureResult(
+        call,
+        sequence,
+        options.executionMode,
+        normalized,
+        Date.now() - startTime,
+      );
+    }
+
+    let allowed = !isEvaluationExecution(options.executionMode);
+    if (options.policy) {
+      try {
+        const decision = await options.policy({
+          toolName: call.name,
+          input: call.input,
+          tool: registered.definition,
+          executionMode: options.executionMode,
+        });
+        allowed = decision?.allowed === true;
+      } catch {
+        logger.warn(
+          { toolName: call.name, executionMode: options.executionMode },
+          'Addie: Tool execution policy failed closed',
+        );
+        allowed = false;
+      }
+    }
+    if (!allowed) {
+      const normalized = observeNormalizedToolResult(call.name, normalizeToolResult(call.name, {
+        status: 'access_denied',
+        model_context: BLOCKED_TOOL_RESULT,
+        user_summary: 'This tool action was blocked by execution policy.',
+      }));
+      return failureResult(call, sequence, options.executionMode, normalized, 0, true);
+    }
+
+    try {
+      const handlerResult = await registered.handler(structuredClone(call.input));
+      const durationMs = Date.now() - startTime;
+      if (typeof handlerResult === 'string' && isMultimodalContent(handlerResult)) {
+        const multimodal = extractMultimodalContent(handlerResult);
+        const converted = multimodal ? buildMultimodalContent(multimodal) : null;
+        if (!converted) {
+          const normalized = observeNormalizedToolResult(
+            call.name,
+            normalizeToolError(call.name, new Error('Failed to process file content'), { expected: false }),
+          );
+          return failureResult(call, sequence, options.executionMode, normalized, durationMs);
+        }
+        const normalized = observeNormalizedToolResult(call.name, normalizeToolResult(call.name, {
+          status: 'ok',
+          model_context: converted.summary,
+          user_summary: converted.summary,
+        }));
+        const presentation = recordedPresentation(options.executionMode, normalized);
+        logger.info({
+          toolName: call.name,
+          multimodalType: multimodal?.type,
+          ...(operationalExecution && { filename: multimodal?.filename }),
+        }, 'Addie: Processed multimodal tool result');
+        return {
+          result: {
+            type: 'tool_result',
+            toolCallId: call.id,
+            toolName: call.name,
+            content: converted.content,
+          },
+          execution: {
+            tool_name: call.name,
+            parameters: recordedParameters(options.executionMode, call.input),
+            result: recordedResult(options.executionMode, converted.summary, 'success'),
+            result_summary: recordedResult(options.executionMode, converted.summary, 'success'),
+            is_error: false,
+            duration_ms: durationMs,
+            sequence,
+            normalized_result: presentation,
+          },
+        };
+      }
+
+      const normalized = observeNormalizedToolResult(
+        call.name,
+        normalizeToolResult(call.name, handlerResult),
+      );
+      const presentation = recordedPresentation(options.executionMode, normalized);
+      const isError = isToolResultError(normalized.status);
+      const summary = normalized.presentation.source === 'legacy' && typeof handlerResult === 'string'
+        ? summarizeLegacyToolResult(call.name, handlerResult)
+        : presentation.user_summary;
+      return {
+        result: {
+          type: 'tool_result',
+          toolCallId: call.id,
+          toolName: call.name,
+          content: normalized.model_context,
+          ...(isError && { isError: true }),
+        },
+        execution: {
+          tool_name: call.name,
+          parameters: recordedParameters(options.executionMode, call.input),
+          result: recordedResult(options.executionMode, normalized.model_context, isError ? 'error' : 'success'),
+          result_summary: recordedResult(options.executionMode, summary, isError ? 'error' : 'success'),
+          is_error: isError,
+          duration_ms: durationMs,
+          sequence,
+          normalized_result: presentation,
+        },
+      };
+    } catch (error) {
+      const durationMs = Date.now() - startTime;
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const isExpected = error instanceof ToolError;
+      const normalized = observeNormalizedToolResult(
+        call.name,
+        normalizeToolError(call.name, error, { expected: isExpected }),
+      );
+      if (isExpected) {
+        logger.warn({
+          toolName: call.name,
+          ...(operationalExecution && { toolInput: call.input, error: errorMessage }),
+          durationMs,
+        }, 'Addie: Tool returned expected error');
+      } else {
+        logger.error({
+          toolName: call.name,
+          ...(operationalExecution && { toolInput: call.input, error: errorMessage }),
+          durationMs,
+        }, 'Addie: Tool threw unexpected exception');
+        if (operationalExecution) {
+          notifyToolError({
+            toolName: call.name,
+            errorMessage,
+            toolInput: call.input,
+            slackUserId: options.notificationContext?.slackUserId,
+            userDisplayName: options.notificationContext?.userDisplayName,
+            threadId: options.notificationContext?.threadId,
+            threw: true,
+          });
+        }
+      }
+      return failureResult(call, sequence, options.executionMode, normalized, durationMs);
+    }
+  };
+}

--- a/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
+++ b/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
@@ -60,7 +60,7 @@ describe('createAddieToolExecutor', () => {
     });
   });
 
-  it('rejects malformed provider input before policy or handler dispatch', async () => {
+  it('rejects structurally malformed provider input before policy or handler dispatch', async () => {
     const handler = vi.fn();
     const policy = vi.fn().mockReturnValue({ allowed: true });
     const execute = createAddieToolExecutor([tool], new Map([['lookup', handler]]), {
@@ -68,25 +68,46 @@ describe('createAddieToolExecutor', () => {
       policy,
     });
 
-    const result = await execute(call({ id: 42 }), 1);
+    const result = await execute({
+      type: 'tool_call', id: 'call_2', name: 'lookup', input: null,
+    } as unknown as ModelToolCallContent, 2);
 
     expect(policy).not.toHaveBeenCalled();
     expect(handler).not.toHaveBeenCalled();
     expect(result.result).toMatchObject({ isError: true });
     expect(result.execution).toMatchObject({
-      is_error: true,
-      result: 'Error: Tool input did not match the required JSON Schema',
-      normalized_result: { status: 'invalid_input' },
-    });
-
-    const nullResult = await execute({
-      type: 'tool_call', id: 'call_2', name: 'lookup', input: null,
-    } as unknown as ModelToolCallContent, 2);
-    expect(nullResult.execution).toMatchObject({
       parameters: {},
       is_error: true,
       normalized_result: { status: 'invalid_input' },
     });
+  });
+
+  it('preserves handler-level coercion for recoverable schema drift', async () => {
+    const tolerantTool: AddieTool = {
+      ...tool,
+      input_schema: {
+        type: 'object',
+        properties: { labels: { type: 'array', items: { type: 'string' } } },
+        required: ['labels'],
+      },
+    };
+    const handler = vi.fn(async (input: Record<string, unknown>) => {
+      const labels = typeof input.labels === 'string'
+        ? input.labels.split(',').map((label) => label.trim())
+        : [];
+      return `labels=${labels.join('|')}`;
+    });
+    const execute = createAddieToolExecutor(
+      [tolerantTool],
+      new Map([['lookup', handler]]),
+      { executionMode: 'production', policy: () => ({ allowed: true }) },
+    );
+
+    const result = await execute(call({ labels: 'pricing, targeting' }), 1);
+
+    expect(handler).toHaveBeenCalledWith({ labels: 'pricing, targeting' });
+    expect(result.result).toMatchObject({ content: 'labels=pricing|targeting' });
+    expect(result.execution).toMatchObject({ is_error: false });
   });
 
   it('takes immutable snapshots before the last-moment policy decision', async () => {

--- a/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
+++ b/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ModelToolCallContent } from '../../../src/addie/model-providers/model-provider.js';
+import {
+  BLOCKED_TOOL_RESULT,
+  createAddieToolExecutor,
+} from '../../../src/addie/model-providers/tool-orchestration.js';
+import type { AddieTool } from '../../../src/addie/types.js';
+
+const notifyToolError = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/addie/error-notifier.js', () => ({ notifyToolError }));
+
+const tool: AddieTool = {
+  name: 'lookup',
+  description: 'Look up a value.',
+  replaySafety: 'principal_read',
+  input_schema: {
+    type: 'object',
+    properties: { id: { type: 'string' } },
+    required: ['id'],
+    additionalProperties: false,
+  },
+};
+
+function call(input: Record<string, unknown> = { id: 'abc' }): ModelToolCallContent {
+  return { type: 'tool_call', id: 'call_1', name: 'lookup', input } as ModelToolCallContent;
+}
+
+describe('createAddieToolExecutor', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('executes a validated call and returns a canonical provider-neutral result', async () => {
+    const handler = vi.fn().mockResolvedValue('Found the requested value.');
+    const policy = vi.fn().mockReturnValue({ allowed: true });
+    const execute = createAddieToolExecutor([tool], new Map([['lookup', handler]]), {
+      executionMode: 'production',
+      policy,
+    });
+
+    const result = await execute(call(), 3);
+
+    expect(policy).toHaveBeenCalledWith(expect.objectContaining({
+      toolName: 'lookup',
+      executionMode: 'production',
+      tool: expect.objectContaining({ replaySafety: 'principal_read' }),
+    }));
+    expect(handler).toHaveBeenCalledWith({ id: 'abc' });
+    expect(result.result).toEqual({
+      type: 'tool_result',
+      toolCallId: 'call_1',
+      toolName: 'lookup',
+      content: 'Found the requested value.',
+    });
+    expect(result.execution).toMatchObject({
+      tool_name: 'lookup',
+      parameters: { id: 'abc' },
+      result: 'Found the requested value.',
+      is_error: false,
+      sequence: 3,
+    });
+  });
+
+  it('rejects malformed provider input before policy or handler dispatch', async () => {
+    const handler = vi.fn();
+    const policy = vi.fn().mockReturnValue({ allowed: true });
+    const execute = createAddieToolExecutor([tool], new Map([['lookup', handler]]), {
+      executionMode: 'production',
+      policy,
+    });
+
+    const result = await execute(call({ id: 42 }), 1);
+
+    expect(policy).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.result).toMatchObject({ isError: true });
+    expect(result.execution).toMatchObject({
+      is_error: true,
+      result: 'Error: Tool input did not match the required JSON Schema',
+      normalized_result: { status: 'invalid_input' },
+    });
+
+    const nullResult = await execute({
+      type: 'tool_call', id: 'call_2', name: 'lookup', input: null,
+    } as unknown as ModelToolCallContent, 2);
+    expect(nullResult.execution).toMatchObject({
+      parameters: {},
+      is_error: true,
+      normalized_result: { status: 'invalid_input' },
+    });
+  });
+
+  it('takes immutable snapshots before the last-moment policy decision', async () => {
+    const sourceInput = { id: 'original' };
+    const handler = vi.fn().mockResolvedValue('ok');
+    const policy = vi.fn((request: { input: Record<string, unknown> }) => {
+      expect(() => { request.input.id = 'changed'; }).toThrow();
+      return { allowed: true };
+    });
+    const execute = createAddieToolExecutor([tool], new Map([['lookup', handler]]), {
+      executionMode: 'production',
+      policy,
+    });
+
+    const pending = execute(call(sourceInput), 1);
+    sourceInput.id = 'changed outside';
+    const result = await pending;
+
+    expect(handler).toHaveBeenCalledWith({ id: 'original' });
+    expect(result.execution.parameters).toEqual({ id: 'original' });
+  });
+
+  it('fails closed in replay and redacts blocked inputs', async () => {
+    const handler = vi.fn();
+    const execute = createAddieToolExecutor([tool], new Map([['lookup', handler]]), {
+      executionMode: 'replay',
+    });
+
+    const result = await execute(call({ id: 'secret' }), 1);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.result).toMatchObject({ content: BLOCKED_TOOL_RESULT, isError: true });
+    expect(result.execution).toMatchObject({
+      parameters: {},
+      result: BLOCKED_TOOL_RESULT,
+      blocked_by_policy: true,
+      normalized_result: { status: 'access_denied' },
+    });
+  });
+
+  it('contains handler exceptions and only alerts for production execution', async () => {
+    const handler = vi.fn().mockRejectedValue(new Error('private failure detail'));
+    const execute = createAddieToolExecutor([tool], new Map([['lookup', handler]]), {
+      executionMode: 'production',
+      policy: () => ({ allowed: true }),
+      notificationContext: { threadId: 'thread_1' },
+    });
+
+    const result = await execute(call(), 1);
+
+    expect(result.result).toMatchObject({ isError: true });
+    expect(result.execution.result).toContain('private failure detail');
+    expect(notifyToolError).toHaveBeenCalledWith(expect.objectContaining({
+      toolName: 'lookup',
+      errorMessage: 'private failure detail',
+      threadId: 'thread_1',
+    }));
+  });
+
+  it('expresses multimodal results in canonical model content', async () => {
+    const marker = '__MULTIMODAL_CONTENT__'
+      + JSON.stringify({ type: 'image', data: 'aW1hZ2U=', media_type: 'image/png', filename: 'chart.png' })
+      + '__END_MULTIMODAL__';
+    const execute = createAddieToolExecutor(
+      [tool],
+      new Map([['lookup', vi.fn().mockResolvedValue(marker)]]),
+      { executionMode: 'production', policy: () => ({ allowed: true }) },
+    );
+
+    const result = await execute(call(), 1);
+
+    expect(result.result.content).toEqual([
+      { type: 'image', mediaType: 'image/png', data: 'aW1hZ2U=' },
+      { type: 'text', text: '[Image: chart.png]' },
+    ]);
+    expect(result.execution.result).toBe('Loaded image: chart.png');
+  });
+});


### PR DESCRIPTION
## Summary

- extract custom-tool authorization, JSON Schema validation, dispatch, result normalization, redaction, multimodal conversion, receipts, and error containment into a provider-neutral execution boundary
- route both live Anthropic streaming and non-streaming loops through the same canonical tool-call/tool-result seam while leaving provider dispatch, retry, health, billing, and stream recovery unchanged
- snapshot provider inputs and tool definitions before last-moment policy checks; reject malformed inputs before handlers and preserve evaluation/replay fail-closed behavior
- cache schema validators and immutable definition snapshots across stable tool registrations
- bump Addie code version to `2026.08.38`

This is an incremental production migration toward #6844. It does not enable cross-provider fallback or mutation replay.

## Validation

- `npm run precommit`
  - 501 server test files passed
  - 7,123 tests passed, 30 skipped
  - root unit/lint checks passed
  - TypeScript typecheck passed
- focused orchestration, replay-policy, and truncation parity tests passed

## Release

- No changeset: Addie application/runtime change only.