### PR TITLE
refactor(addie): add canonical anthropic streaming

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.39';
+export const CODE_VERSION = '2026.08.40';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/model-providers/anthropic-provider.ts
+++ b/server/src/addie/model-providers/anthropic-provider.ts
@@ -34,6 +34,10 @@ interface AnthropicResponseLike {
   };
 }
 
+export interface AnthropicMessageStreamTransport extends AsyncIterable<unknown> {
+  finalMessage(): Promise<AnthropicResponseLike>;
+}
+
 export interface AnthropicMessagesTransport {
   beta: {
     messages: {
@@ -41,6 +45,10 @@ export interface AnthropicMessagesTransport {
         request: AnthropicRequest,
         options: { maxRetries: 0 | 2; signal?: AbortSignal },
       ): Promise<AnthropicResponseLike>;
+      stream?(
+        request: AnthropicRequest,
+        options: { maxRetries: 0 | 2; signal?: AbortSignal },
+      ): AnthropicMessageStreamTransport;
     };
   };
 }
@@ -51,7 +59,7 @@ export interface AnthropicModelProviderOptions {
 }
 
 export const ANTHROPIC_PROVIDER_CAPABILITIES: ModelProviderCapabilities = Object.freeze({
-  streaming: false,
+  streaming: true,
   structuredOutput: false,
   reasoning: true,
   reasoningEfforts: Object.freeze(['provider_default', 'medium'] as const),
@@ -60,6 +68,11 @@ export const ANTHROPIC_PROVIDER_CAPABILITIES: ModelProviderCapabilities = Object
   imageInput: true,
   documentInput: true,
 });
+
+interface AnthropicTextDelta {
+  index: number;
+  text: string;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -78,6 +91,7 @@ function deepFreeze<T>(value: T): T {
 
 const MAX_CONTINUATION_BYTES = 2 * 1024 * 1024;
 const MAX_RESPONSE_BLOCKS = 1_000;
+const MAX_STREAM_EVENTS = 100_000;
 const ANTHROPIC_WEB_SEARCH_ERROR_CODES = new Set([
   'invalid_tool_input',
   'unavailable',
@@ -358,6 +372,78 @@ export function normalizeAnthropicResponse(response: AnthropicResponseLike): Mod
   return deepFreeze(normalized);
 }
 
+async function collectAnthropicStream(
+  stream: AnthropicMessageStreamTransport,
+): Promise<{ response: ModelResponse; textDeltas: AnthropicTextDelta[] }> {
+  const textDeltas: AnthropicTextDelta[] = [];
+  let eventCount = 0;
+  let textBytes = 0;
+  for await (const event of stream) {
+    eventCount++;
+    if (eventCount > MAX_STREAM_EVENTS) throw new Error('Anthropic stream event limit exceeded');
+    const record = requireRecord(event, 'stream event');
+    if (record.type !== 'content_block_delta') continue;
+    const delta = requireRecord(record.delta, 'stream delta');
+    if (delta.type !== 'text_delta') continue;
+    if (
+      !Number.isSafeInteger(record.index)
+      || (record.index as number) < 0
+      || typeof delta.text !== 'string'
+    ) throw new Error('Malformed Anthropic text stream delta');
+    textBytes += Buffer.byteLength(delta.text, 'utf8');
+    if (textBytes > MAX_CONTINUATION_BYTES) {
+      throw new Error('Anthropic stream text exceeds size limit');
+    }
+    textDeltas.push({ index: record.index as number, text: delta.text });
+  }
+  const response = normalizeAnthropicResponse(await stream.finalMessage());
+  return { response, textDeltas };
+}
+
+function* normalizedResponseEvents(
+  response: ModelResponse,
+  textDeltas: AnthropicTextDelta[] = [],
+): Generator<NormalizedModelEvent> {
+  const textDeltasByIndex = new Map<number, string[]>();
+  for (const delta of textDeltas) {
+    const chunks = textDeltasByIndex.get(delta.index) ?? [];
+    chunks.push(delta.text);
+    textDeltasByIndex.set(delta.index, chunks);
+  }
+  for (const [index, chunks] of textDeltasByIndex) {
+    const content = response.content[index];
+    if (content?.type !== 'text' || chunks.join('') !== content.text) {
+      throw new Error('Anthropic stream text does not match terminal response');
+    }
+  }
+  yield {
+    type: 'response_start',
+    provider: 'anthropic',
+    model: response.model,
+    id: response.id,
+  };
+  for (let index = 0; index < response.content.length; index++) {
+    const content = response.content[index];
+    if (content.type === 'text') {
+      const streamed = textDeltasByIndex.get(index);
+      if (!streamed || streamed.length === 0) {
+        yield { type: 'text_delta', index, text: content.text };
+      } else {
+        for (const text of streamed) yield { type: 'text_delta', index, text };
+      }
+    } else if (content.type === 'tool_call') {
+      yield { type: 'tool_call', index, call: content };
+    } else if (content.type === 'provider_tool_call') {
+      yield { type: 'provider_tool_call', index, call: content };
+    } else if (content.type === 'provider_tool_result') {
+      yield { type: 'provider_tool_result', index, result: content };
+    } else if (content.type === 'provider_state') {
+      yield { type: 'provider_state', index, state: content as ModelProviderStateContent };
+    }
+  }
+  yield { type: 'response_complete', response };
+}
+
 export function deriveAnthropicProviderToolReceipt(
   call: ModelProviderToolCallContent,
   result: ModelProviderToolResultContent,
@@ -470,33 +556,29 @@ export class AnthropicModelProvider implements ModelProvider {
     request: ModelRequest,
     options?: ModelRespondOptions,
   ): AsyncIterable<NormalizedModelEvent> {
+    validateModelCapabilities('anthropic', this.capabilities, request, {
+      streaming: options?.stream,
+    });
     const prepared = this.prepare(request);
     await options?.beforeDispatch?.(prepared);
+    const transportOptions = {
+      maxRetries: this.transportMaxRetries,
+      ...(options?.signal && { signal: options.signal }),
+    };
+    if (options?.stream) {
+      const messages = this.transport.beta.messages;
+      if (!messages.stream) throw new UnsupportedModelCapabilityError('anthropic', 'streaming');
+      const streamed = await collectAnthropicStream(messages.stream(
+        prepared.providerRequest as AnthropicRequest,
+        transportOptions,
+      ));
+      yield* normalizedResponseEvents(streamed.response, streamed.textDeltas);
+      return;
+    }
     const response = await this.transport.beta.messages.create(
       prepared.providerRequest as AnthropicRequest,
-      { maxRetries: this.transportMaxRetries, ...(options?.signal && { signal: options.signal }) },
+      transportOptions,
     );
-    const normalized = normalizeAnthropicResponse(response);
-    yield {
-      type: 'response_start',
-      provider: 'anthropic',
-      model: normalized.model,
-      id: normalized.id,
-    };
-    for (let index = 0; index < normalized.content.length; index++) {
-      const content = normalized.content[index];
-      if (content.type === 'text') {
-        yield { type: 'text_delta', index, text: content.text };
-      } else if (content.type === 'tool_call') {
-        yield { type: 'tool_call', index, call: content };
-      } else if (content.type === 'provider_tool_call') {
-        yield { type: 'provider_tool_call', index, call: content };
-      } else if (content.type === 'provider_tool_result') {
-        yield { type: 'provider_tool_result', index, result: content };
-      } else if (content.type === 'provider_state') {
-        yield { type: 'provider_state', index, state: content as ModelProviderStateContent };
-      }
-    }
-    yield { type: 'response_complete', response: normalized };
+    yield* normalizedResponseEvents(normalizeAnthropicResponse(response));
   }
 }

--- a/server/src/addie/model-providers/anthropic-router-provider.ts
+++ b/server/src/addie/model-providers/anthropic-router-provider.ts
@@ -201,6 +201,7 @@ export class AnthropicRouterProvider implements ModelProvider {
     request: ModelRequest,
     options: ModelRespondOptions = {},
   ): AsyncIterable<NormalizedModelEvent> {
+    validateModelCapabilities(this.id, this.capabilities, request, { streaming: options.stream });
     const prepared = this.prepare(request);
     await options.beforeDispatch?.(prepared);
     const response = await this.transport.messages.create(

--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -392,6 +392,7 @@ export class GoogleGenerateContentProvider implements ModelProvider {
     request: ModelRequest,
     options: ModelRespondOptions = {},
   ): AsyncIterable<NormalizedModelEvent> {
+    validateModelCapabilities(this.id, this.capabilities, request, { streaming: options.stream });
     const prepared = this.prepare(request);
     if (options.signal?.aborted) throw options.signal.reason;
     await options.beforeDispatch?.(prepared);

--- a/server/src/addie/model-providers/model-provider.ts
+++ b/server/src/addie/model-providers/model-provider.ts
@@ -250,6 +250,8 @@ export interface PreparedModelInvocation {
 
 export interface ModelRespondOptions {
   signal?: AbortSignal;
+  /** Request the provider's streaming transport while retaining normalized events. */
+  stream?: boolean;
   /** Runs immediately before the one SDK dispatch made by this iterator. */
   beforeDispatch?: (prepared: PreparedModelInvocation) => void | Promise<void>;
 }

--- a/server/src/addie/model-providers/openai-responses-provider.ts
+++ b/server/src/addie/model-providers/openai-responses-provider.ts
@@ -192,6 +192,7 @@ export class OpenAIResponsesProvider implements ModelProvider {
     request: ModelRequest,
     options: ModelRespondOptions = {},
   ): AsyncIterable<NormalizedModelEvent> {
+    validateModelCapabilities(this.id, this.capabilities, request, { streaming: options.stream });
     const prepared = this.prepare(request);
     await options.beforeDispatch?.(prepared);
     const response = await this.transport.responses.create(

--- a/server/tests/unit/addie/model-provider-anthropic.test.ts
+++ b/server/tests/unit/addie/model-provider-anthropic.test.ts
@@ -466,6 +466,77 @@ describe('AnthropicModelProvider response normalization', () => {
     expect(create.mock.calls[0]?.[1]).toEqual({ maxRetries: 2 });
   });
 
+  it('uses the streaming transport while preserving normalized chunk boundaries', async () => {
+    const create = vi.fn();
+    const stream = vi.fn(() => ({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'do' },
+        };
+        yield {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'ne' },
+        };
+      },
+      finalMessage: vi.fn(async () => response()),
+    }));
+    const provider = new AnthropicModelProvider(
+      'unused',
+      { beta: { messages: { create, stream } } },
+      { transportMaxRetries: 2 },
+    );
+
+    const events: NormalizedModelEvent[] = [];
+    for await (const event of provider.respond(request(), { stream: true })) events.push(event);
+    const normalized = await collectModelResponse((async function* () { yield* events; })());
+
+    expect(normalized.content).toEqual([{ type: 'text', text: 'done' }]);
+    expect(events.filter((event) => event.type === 'text_delta')).toEqual([
+      { type: 'text_delta', index: 0, text: 'do' },
+      { type: 'text_delta', index: 0, text: 'ne' },
+    ]);
+    expect(create).not.toHaveBeenCalled();
+    expect(stream).toHaveBeenCalledWith(
+      provider.prepare(request()).providerRequest,
+      { maxRetries: 2 },
+    );
+  });
+
+  it('rejects streamed text that disagrees with the terminal response', async () => {
+    const provider = new AnthropicModelProvider('unused', {
+      beta: {
+        messages: {
+          create: vi.fn(),
+          stream: vi.fn(() => ({
+            async *[Symbol.asyncIterator]() {
+              yield {
+                type: 'content_block_delta',
+                index: 0,
+                delta: { type: 'text_delta', text: 'different' },
+              };
+            },
+            finalMessage: vi.fn(async () => response()),
+          })),
+        },
+      },
+    });
+
+    await expect(collectModelResponse(provider.respond(request(), { stream: true })))
+      .rejects.toThrow('Anthropic stream text does not match terminal response');
+  });
+
+  it('fails closed when a transport cannot provide streaming', async () => {
+    const provider = new AnthropicModelProvider('unused', {
+      beta: { messages: { create: vi.fn() } },
+    });
+
+    await expect(collectModelResponse(provider.respond(request(), { stream: true })))
+      .rejects.toBeInstanceOf(UnsupportedModelCapabilityError);
+  });
+
   it('freezes the exact nested envelope before provenance and dispatch', async () => {
     let dispatched: Record<string, unknown> | undefined;
     const provider = new AnthropicModelProvider('unused', {

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -14,7 +14,10 @@ import {
   normalizeGoogleResponse,
   type GoogleGenerateContentTransport,
 } from '../../../src/addie/model-providers/google-generate-content-provider.js';
-import type { ModelRequest } from '../../../src/addie/model-providers/model-provider.js';
+import {
+  UnsupportedModelCapabilityError,
+  type ModelRequest,
+} from '../../../src/addie/model-providers/model-provider.js';
 import {
   executeReadOnlyToolLoop,
   ReadOnlyToolLoopBoundaryError,
@@ -132,6 +135,13 @@ describe('OpenAIResponsesProvider', () => {
     expect(normalized.usage).toEqual({ inputTokens: 10, outputTokens: 5, cacheReadTokens: 2, cacheWriteTokens: 0 });
   });
 
+  it('fails closed when streaming transport is requested', async () => {
+    const provider = new OpenAIResponsesProvider('unused', {} as OpenAIResponsesTransport);
+    await expect(collectModelResponse(
+      provider.respond(request(OPENAI_ROUTER_MODEL), { stream: true }),
+    )).rejects.toBeInstanceOf(UnsupportedModelCapabilityError);
+  });
+
   it('omits unavailable optional cache usage fields', () => {
     const withoutEither = normalizeOpenAIResponse(openAIResponse({
       usage: {
@@ -198,6 +208,16 @@ describe('GoogleGenerateContentProvider', () => {
       apiKey: 'test-key',
       httpOptions: { retryOptions: { attempts: 1 } },
     });
+  });
+
+  it('fails closed when streaming transport is requested', async () => {
+    const provider = new GoogleGenerateContentProvider(
+      'unused',
+      {} as GoogleGenerateContentTransport,
+    );
+    await expect(collectModelResponse(
+      provider.respond(request(GOOGLE_ROUTER_MODEL), { stream: true }),
+    )).rejects.toBeInstanceOf(UnsupportedModelCapabilityError);
   });
 
   it('builds the exact frozen generateContent request', () => {


### PR DESCRIPTION
## Summary

- add an explicit streaming option to the provider-neutral response contract
- implement bounded Anthropic stream normalization while preserving upstream text chunk boundaries
- validate streamed text exactly matches the authoritative terminal response
- fail closed when streaming is requested from providers without streaming support

This does not change production provider selection or the live Addie message loop. A follow-up slice will cut the live loop over while preserving partial-delta interruption telemetry.

## Safety

- cap collected events at 100,000 and text deltas at 2 MB
- retain provider retry configuration and abort propagation
- reject malformed, incomplete, or terminal-inconsistent streams
- preserve the existing buffered logical-turn behavior

## Validation

- focused provider tests: 115 passed
- full precommit, run twice: 501 files; 7,132 passed; 30 skipped
- TypeScript typecheck passed

Progresses #6844 and prepares the streaming cutover needed to preserve #4797 interruption safety.