### PR TITLE
refactor(addie): route live streaming through provider adapter

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -6,7 +6,6 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
-import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream';
 import { createHash, createHmac } from 'node:crypto';
 import { createLogger } from '../logger.js';
 
@@ -203,27 +202,6 @@ function classifyStopReason(reason: Anthropic.Beta.BetaStopReason | null): StopA
  * disclosures may contain semantic refusals, so they are not retryable.
  * Unknown, tool, server-tool, and result blocks remain fail-closed.
  */
-function isSideEffectFreeEmptyEndTurn(
-  response: Pick<Anthropic.Beta.BetaMessage, 'stop_reason' | 'content'>,
-  visibleText: string,
-): boolean {
-  const deliverableText = stripBannedRituals(visibleText);
-  if (response.stop_reason !== 'end_turn' || deliverableText.trim().length > 0) {
-    return false;
-  }
-
-  return response.content.every((block) => {
-    switch (block.type) {
-      case 'text':
-      case 'thinking':
-      case 'redacted_thinking':
-        return true;
-      default:
-        return false;
-    }
-  });
-}
-
 function isSideEffectFreeEmptyModelResponse(
   response: ModelResponse,
   visibleText: string,
@@ -500,34 +478,6 @@ function buildModelToolDefinitions(tools: readonly AddieTool[]): ModelToolDefini
     };
   }
   return definitions;
-}
-
-/** Adapt the common-loop tool result to Anthropic's continuation wire shape. */
-function toAnthropicToolResultContent(
-  content: ModelToolResultContent['content'],
-): string | Anthropic.ToolResultBlockParam['content'] {
-  if (typeof content === 'string') return content;
-  return content.map((block) => {
-    if (block.type === 'text') return block;
-    if (block.type === 'image') {
-      return {
-        type: 'image' as const,
-        source: {
-          type: 'base64' as const,
-          media_type: block.mediaType,
-          data: block.data,
-        },
-      };
-    }
-    return {
-      type: 'document' as const,
-      source: {
-        type: 'base64' as const,
-        media_type: block.mediaType,
-        data: block.data,
-      },
-    };
-  });
 }
 
 /**
@@ -958,8 +908,8 @@ interface PayloadDebugStats {
 
 export class AddieClaudeClient {
   private client: Anthropic;
-  private readonly nonStreamingProvider: AnthropicModelProvider;
-  private readonly exactlyOnceNonStreamingProvider: AnthropicModelProvider;
+  private readonly anthropicProvider: AnthropicModelProvider;
+  private readonly exactlyOnceAnthropicProvider: AnthropicModelProvider;
   private model: string;
   private tools: AddieTool[] = [];
   private toolHandlers: Map<string, ToolHandler> = new Map();
@@ -974,12 +924,12 @@ export class AddieClaudeClient {
   ) {
     this.client = new Anthropic({ apiKey });
     const transport = this.client as unknown as AnthropicMessagesTransport;
-    this.nonStreamingProvider = new AnthropicModelProvider(
+    this.anthropicProvider = new AnthropicModelProvider(
       apiKey,
       transport,
       { transportMaxRetries: 2 },
     );
-    this.exactlyOnceNonStreamingProvider = new AnthropicModelProvider(
+    this.exactlyOnceAnthropicProvider = new AnthropicModelProvider(
       apiKey,
       transport,
       { transportMaxRetries: 0 },
@@ -1343,8 +1293,9 @@ export class AddieClaudeClient {
     messages: ModelMessage[],
     providerWebSearchEnabled: boolean,
     maxOutputTokens?: number,
+    streaming = false,
   ): ModelRequest {
-    const safeMaxOutputTokens = /^claude-sonnet-5(?:-|$)/.test(effectiveModel)
+    const safeMaxOutputTokens = !streaming && /^claude-sonnet-5(?:-|$)/.test(effectiveModel)
       ? Math.min(
         SONNET_5_MAX_NONSTREAMING_OUTPUT_TOKENS,
         maxOutputTokens ?? SONNET_5_MAX_NONSTREAMING_OUTPUT_TOKENS,
@@ -1395,7 +1346,7 @@ export class AddieClaudeClient {
       prepared.modelMessages,
       prepared.requestWebSearchEnabled,
     );
-    const providerRequest = this.nonStreamingProvider.prepare(modelRequest)
+    const providerRequest = this.anthropicProvider.prepare(modelRequest)
       .providerRequest as unknown as PreparedProviderRequest;
     return this.buildInvocationPreparedSnapshot(
       options,
@@ -1592,8 +1543,8 @@ export class AddieClaudeClient {
             isEmptyResponseRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
           );
           const provider = exactlyOnce
-            ? this.exactlyOnceNonStreamingProvider
-            : this.nonStreamingProvider;
+            ? this.exactlyOnceAnthropicProvider
+            : this.anthropicProvider;
           return collectModelResponse(
             provider.respond(modelRequest, {
               beforeDispatch: async (preparedInvocation) => {
@@ -1701,7 +1652,7 @@ export class AddieClaudeClient {
           toolsUsed.push('web_search');
           const correspondingToolUse = earlyServerToolBlocks.find((call) => call.id === result.toolCallId);
           const receipt = correspondingToolUse
-            ? this.nonStreamingProvider.deriveProviderToolReceipt(
+            ? this.anthropicProvider.deriveProviderToolReceipt(
               correspondingToolUse,
               result,
               operationalExecution ? 'production' : 'redacted',
@@ -1953,7 +1904,7 @@ export class AddieClaudeClient {
           // Find corresponding result by matching tool_use_id
           const resultBlock = webSearchResults.find((result) => result.toolCallId === block.id);
           const receipt = resultBlock
-            ? this.nonStreamingProvider.deriveProviderToolReceipt(
+            ? this.anthropicProvider.deriveProviderToolReceipt(
               block,
               resultBlock,
               operationalExecution ? 'production' : 'redacted',
@@ -2303,15 +2254,20 @@ export class AddieClaudeClient {
       toAnthropicMessages(messageTurnsResult.messages),
       options?.inputAttachments,
     );
+    const modelMessages = appendModelInputAttachments(
+      toModelMessages(messageTurnsResult.messages),
+      options?.inputAttachments,
+    );
 
     // Build tool list once — rebuilt every iteration is wasteful since tools don't change.
     // Mark the last tool with cache_control so Anthropic caches all tool definitions.
     const customTools = buildAddieWireTools(allTools) as Anthropic.Tool[];
+    const modelTools = buildModelToolDefinitions(allTools);
     const maxIterations = options?.maxIterations ?? 10;
     let iteration = 0;
     let retriedEmptyPostToolResponse = false;
     let retriedEmptyInitialResponse = false;
-    let emptyResponseBeforeRecovery: Anthropic.Beta.BetaMessage | null = null;
+    let emptyResponseBeforeRecovery: ModelResponse | null = null;
     let lastProviderModel: string | undefined;
 
       while (iteration < maxIterations) {
@@ -2320,8 +2276,7 @@ export class AddieClaudeClient {
         const llmStart = Date.now();
 
         // Collect full response for tool handling
-        let currentResponse: Anthropic.Beta.BetaMessage | null = null;
-        const textChunks: string[] = [];
+        let currentResponse: ModelResponse | null = null;
         let reusedEmptyResponse = false;
 
         // Retry loop for streaming API calls (handles overloaded_error).
@@ -2336,46 +2291,37 @@ export class AddieClaudeClient {
         while (!streamSucceeded && streamRetryCount <= maxStreamRetries) {
           const isEmptyResponseRecovery: boolean = emptyResponseBeforeRecovery !== null;
           try {
-            const invocationTools = retriedEmptyPostToolResponse ? [] : customTools;
-            const providerRequest: PreparedProviderRequest = {
-              model: effectiveModel,
-              ...addieModelOutputControls(
-                effectiveModel,
-                isEmptyResponseRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
-              ),
-              system: systemBlocks,
-              tools: invocationTools as unknown as Array<Record<string, unknown>>,
-              messages,
-            };
-            await this.notifyInvocationPrepared(
-              options,
-              providerRequest,
-              iteration,
-              streamRetryCount + 1,
+            const invocationTools = retriedEmptyPostToolResponse ? [] : modelTools;
+            const modelRequest = this.buildModelRequest(
+              effectiveModel,
+              systemBlocks,
+              invocationTools,
+              modelMessages,
+              false,
+              isEmptyResponseRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
+              true,
             );
-            const anthropicStream: BetaMessageStream = this.client.beta.messages.stream(
-              providerRequest as unknown as Anthropic.Beta.MessageCreateParamsStreaming,
-              isEmptyResponseRecovery ? { maxRetries: 0 } : undefined,
+            const provider = isEmptyResponseRecovery
+              ? this.exactlyOnceAnthropicProvider
+              : this.anthropicProvider;
+            currentResponse = await collectModelResponse(
+              provider.respond(modelRequest, {
+                stream: true,
+                onStreamProgress: () => {
+                  totalReceivedDeltas++;
+                  receivedDeltaCount++;
+                },
+                beforeDispatch: async (preparedInvocation) => {
+                  await this.notifyInvocationPrepared(
+                    options,
+                    preparedInvocation.providerRequest as unknown as PreparedProviderRequest,
+                    iteration,
+                    streamRetryCount + 1,
+                  );
+                },
+              }),
+              'anthropic',
             );
-
-            // Process stream events
-            for await (const event of anthropicStream) {
-              if (event.type === 'content_block_delta') {
-                totalReceivedDeltas++;
-                receivedDeltaCount++;
-                const delta = event.delta;
-                if ('text' in delta && delta.text) {
-                  textChunks.push(delta.text);
-                }
-              } else if (event.type === 'message_stop') {
-                // Get the final message
-                currentResponse = await anthropicStream.finalMessage();
-              }
-            }
-
-            if (!currentResponse) {
-              currentResponse = await anthropicStream.finalMessage();
-            }
 
             if (operationalExecution) this.providerHealth.recordSuccess('anthropic', 'chat');
             streamSucceeded = true;
@@ -2388,7 +2334,6 @@ export class AddieClaudeClient {
               logger.warn({ iteration }, 'Addie Stream: Empty-response recovery failed');
               currentResponse = emptyResponseBeforeRecovery;
               reusedEmptyResponse = true;
-              textChunks.length = 0;
               receivedDeltaCount = 0;
               break;
             }
@@ -2489,7 +2434,6 @@ export class AddieClaudeClient {
             await new Promise(resolve => setTimeout(resolve, totalDelay));
 
             // Discard the failed, never-exposed sample before retrying.
-            textChunks.length = 0;
             receivedDeltaCount = 0;
             currentResponse = null;
           }
@@ -2503,35 +2447,31 @@ export class AddieClaudeClient {
         }
 
         // Track token usage
-        if (currentResponse.usage && !reusedEmptyResponse) {
-          totalInputTokens += currentResponse.usage.input_tokens;
-          totalOutputTokens += currentResponse.usage.output_tokens;
-          if ('cache_creation_input_tokens' in currentResponse.usage) {
-            totalCacheCreationTokens += (currentResponse.usage as { cache_creation_input_tokens?: number }).cache_creation_input_tokens || 0;
-          }
-          if ('cache_read_input_tokens' in currentResponse.usage) {
-            totalCacheReadTokens += (currentResponse.usage as { cache_read_input_tokens?: number }).cache_read_input_tokens || 0;
-          }
+        if (!reusedEmptyResponse) {
+          totalInputTokens += currentResponse.usage.inputTokens;
+          totalOutputTokens += currentResponse.usage.outputTokens;
+          totalCacheCreationTokens += currentResponse.usage.cacheWriteTokens ?? 0;
+          totalCacheReadTokens += currentResponse.usage.cacheReadTokens ?? 0;
         }
 
         logger.debug({
-          stopReason: currentResponse.stop_reason,
+          stopReason: currentResponse.providerFinishReason,
           iteration,
           llmDurationMs: llmDuration,
-          inputTokens: currentResponse.usage?.input_tokens,
-          outputTokens: currentResponse.usage?.output_tokens,
+          inputTokens: currentResponse.usage.inputTokens,
+          outputTokens: currentResponse.usage.outputTokens,
         }, 'Addie Stream: Claude response received');
 
         // The recovery iteration has no tools. If the provider still returns
         // a tool_use block, ignore it rather than executing a mutation twice.
-        if (retriedEmptyPostToolResponse && currentResponse.stop_reason === 'tool_use') {
+        if (retriedEmptyPostToolResponse && currentResponse.finishReason === 'tool_calls') {
           logger.warn({ iteration }, 'Addie Stream: Ignoring tool use from text-only recovery');
           currentResponse = {
             ...currentResponse,
-            stop_reason: 'end_turn',
+            finishReason: 'stop',
+            providerFinishReason: 'end_turn',
             content: [],
           };
-          textChunks.length = 0;
         }
 
         // Build the final usage block + charge the user's cost
@@ -2555,17 +2495,18 @@ export class AddieClaudeClient {
           }
         };
 
-        const stopAction = classifyStopReason(currentResponse.stop_reason);
-        const iterationText = textChunks.join('') || currentResponse.content
-          .filter((block): block is Anthropic.Beta.BetaTextBlock => block.type === 'text')
+        const stopAction = classifyStopReason(
+          currentResponse.providerFinishReason as Anthropic.Beta.BetaStopReason,
+        );
+        const iterationText = currentResponse.content
+          .filter((block) => block.type === 'text')
           .map((block) => block.text)
           .join('\n\n');
         if (stopAction === 'continue') {
           // Resume from the provider response without exposing interim text.
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          messages.push({ role: 'assistant', content: currentResponse.content as any });
+          modelMessages.push({ role: 'assistant', content: currentResponse.content });
           logger.info(
-            { stopReason: currentResponse.stop_reason, iteration },
+            { stopReason: currentResponse.providerFinishReason, iteration },
             'Addie Stream: Continuing resumable Anthropic turn',
           );
           continue;
@@ -2583,14 +2524,13 @@ export class AddieClaudeClient {
             {
               event: 'addie_response_truncated',
               source: 'processMessageStream',
-              stopReason: currentResponse.stop_reason,
+              stopReason: currentResponse.providerFinishReason,
               iteration,
               originalLength: logicalText.length,
               deliveredLength: finalized.text.length,
               localCapExceeded: finalized.lengthExceeded,
-              contentTypes: boundedContentTypes(currentResponse.content),
-              outputTokens: currentResponse.usage?.output_tokens,
-              thinkingTokens: currentResponse.usage?.output_tokens_details?.thinking_tokens,
+              contentTypes: boundedModelContentTypes(currentResponse.content),
+              outputTokens: currentResponse.usage.outputTokens,
             },
             'Addie Stream: Response stopped before completion',
           );
@@ -2603,7 +2543,7 @@ export class AddieClaudeClient {
               tools_used: toolsUsed,
               tool_executions: toolExecutions,
               flagged: true,
-              flag_reason: `Response truncated: ${currentResponse.stop_reason}`,
+              flag_reason: `Response truncated: ${currentResponse.providerFinishReason}`,
               active_rule_ids: undefined,
               config_version_id: configVersionId ?? undefined,
               model_execution: finalized.emptyReason
@@ -2626,12 +2566,12 @@ export class AddieClaudeClient {
         if (stopAction === 'complete') {
           if (
             operationalExecution
-            && currentResponse.stop_reason === 'end_turn'
+            && currentResponse.providerFinishReason === 'end_turn'
             && iteration === 1
             && !retriedEmptyInitialResponse
             && toolExecutions.length === 0
             && logicalText.length === 0
-            && isSideEffectFreeEmptyEndTurn(currentResponse, iterationText)
+            && isSideEffectFreeEmptyModelResponse(currentResponse, iterationText)
             && iteration < maxIterations
           ) {
             retriedEmptyInitialResponse = true;
@@ -2643,8 +2583,8 @@ export class AddieClaudeClient {
           // Logical-turn buffering means no text from this iteration has been
           // emitted, so retrying ritual-only output cannot duplicate text.
           if (
-            currentResponse.stop_reason === 'end_turn'
-            && isSideEffectFreeEmptyEndTurn(currentResponse, iterationText)
+            currentResponse.providerFinishReason === 'end_turn'
+            && isSideEffectFreeEmptyModelResponse(currentResponse, iterationText)
             && toolExecutions.length > 0
             && !retriedEmptyPostToolResponse
             && iteration < maxIterations
@@ -2672,7 +2612,7 @@ export class AddieClaudeClient {
               {
                 event: 'addie_response_truncated',
                 source: 'processMessageStream',
-                stopReason: currentResponse.stop_reason,
+                stopReason: currentResponse.providerFinishReason,
                 iteration,
                 originalLength: logicalText.length,
                 deliveredLength: finalText.length,
@@ -2717,7 +2657,7 @@ export class AddieClaudeClient {
         // Handle tool use
         if (stopAction === 'tool_use') {
           logicalText += iterationText;
-          const toolUseBlocks = currentResponse.content.filter((c: Anthropic.Beta.BetaContentBlock) => c.type === 'tool_use');
+          const toolUseBlocks = currentResponse.content.filter((content) => content.type === 'tool_call');
 
           if (toolUseBlocks.length === 0) {
             // No tools to execute, return current text
@@ -2761,21 +2701,11 @@ export class AddieClaudeClient {
             return;
           }
 
-          // Tool results can contain multimodal content (images, PDFs)
-          type StreamToolResultContent = string | Anthropic.ToolResultBlockParam['content'];
-          interface ToolResult {
-            tool_use_id: string;
-            content: StreamToolResultContent;
-            is_error?: boolean;
-          }
-
-          const toolResults: ToolResult[] = [];
+          const toolResults: ModelToolResultContent[] = [];
 
           for (const block of toolUseBlocks) {
-            if (block.type !== 'tool_use') continue;
-
             const toolName = block.name;
-            const toolInput = block.input as Record<string, unknown>;
+            const toolInput = block.input;
 
             logger.debug(
               { toolName, ...(operationalExecution && { toolInput }) },
@@ -2791,17 +2721,8 @@ export class AddieClaudeClient {
               parameters: this.recordedToolParameters(options, toolInput),
             };
 
-            const executed = await executeToolCall({
-              type: 'tool_call',
-              id: block.id,
-              name: toolName,
-              input: toolInput as ModelToolCallContent['input'],
-            }, executionSequence);
-            toolResults.push({
-              tool_use_id: executed.result.toolCallId,
-              content: toAnthropicToolResultContent(executed.result.content),
-              is_error: executed.result.isError,
-            });
+            const executed = await executeToolCall(block, executionSequence);
+            toolResults.push(executed.result);
             toolExecutions.push(executed.execution);
             yield {
               type: 'tool_end',
@@ -2813,17 +2734,8 @@ export class AddieClaudeClient {
           }
 
           // Continue the conversation with tool results
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          messages.push({ role: 'assistant', content: currentResponse.content as any });
-          messages.push({
-            role: 'user',
-            content: toolResults.map((r) => ({
-              type: 'tool_result' as const,
-              tool_use_id: r.tool_use_id,
-              content: r.content,
-              is_error: r.is_error,
-            })),
-          });
+          modelMessages.push({ role: 'assistant', content: currentResponse.content });
+          modelMessages.push({ role: 'user', content: toolResults });
 
           // Add spacing between tool use and subsequent text to prevent run-on text
           if (logicalText.length > 0 && !logicalText.endsWith('\n')) {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.40';
+export const CODE_VERSION = '2026.08.41';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "a94307da0443c0e9c5844064af66f80f7aee0996cd2109ea36ced753d58ff31d",
+    "server/src/addie/claude-client.ts": "986fc603c90c970ffa3cfd1aeacf4389ba61428a89db8e80313db3ef5d44cd52",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/addie/model-providers/anthropic-provider.ts
+++ b/server/src/addie/model-providers/anthropic-provider.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { setTimeout as delay } from 'node:timers/promises';
 import {
   UnsupportedModelCapabilityError,
   type ModelFinishReason,
@@ -56,6 +57,8 @@ export interface AnthropicMessagesTransport {
 export interface AnthropicModelProviderOptions {
   /** Preserve a caller's established SDK transport retry posture. */
   transportMaxRetries?: 0 | 2;
+  /** Maximum silence between stream events and before the terminal message. */
+  streamIdleTimeoutMs?: number;
 }
 
 export const ANTHROPIC_PROVIDER_CAPABILITIES: ModelProviderCapabilities = Object.freeze({
@@ -92,6 +95,7 @@ function deepFreeze<T>(value: T): T {
 const MAX_CONTINUATION_BYTES = 2 * 1024 * 1024;
 const MAX_RESPONSE_BLOCKS = 1_000;
 const MAX_STREAM_EVENTS = 100_000;
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 60_000;
 const ANTHROPIC_WEB_SEARCH_ERROR_CODES = new Set([
   'invalid_tool_input',
   'unavailable',
@@ -374,30 +378,75 @@ export function normalizeAnthropicResponse(response: AnthropicResponseLike): Mod
 
 async function collectAnthropicStream(
   stream: AnthropicMessageStreamTransport,
+  options: {
+    idleTimeoutMs: number;
+    abort: (reason: Error) => void;
+    onStreamProgress?: ModelRespondOptions['onStreamProgress'];
+  },
 ): Promise<{ response: ModelResponse; textDeltas: AnthropicTextDelta[] }> {
   const textDeltas: AnthropicTextDelta[] = [];
   let eventCount = 0;
   let textBytes = 0;
-  for await (const event of stream) {
-    eventCount++;
-    if (eventCount > MAX_STREAM_EVENTS) throw new Error('Anthropic stream event limit exceeded');
-    const record = requireRecord(event, 'stream event');
-    if (record.type !== 'content_block_delta') continue;
-    const delta = requireRecord(record.delta, 'stream delta');
-    if (delta.type !== 'text_delta') continue;
-    if (
-      !Number.isSafeInteger(record.index)
-      || (record.index as number) < 0
-      || typeof delta.text !== 'string'
-    ) throw new Error('Malformed Anthropic text stream delta');
-    textBytes += Buffer.byteLength(delta.text, 'utf8');
-    if (textBytes > MAX_CONTINUATION_BYTES) {
-      throw new Error('Anthropic stream text exceeds size limit');
+  const iterator = stream[Symbol.asyncIterator]();
+  let completed = false;
+
+  const withIdleTimeout = async <T>(operation: PromiseLike<T>): Promise<T> => {
+    const timeoutController = new AbortController();
+    const timeoutError = new Error('Anthropic stream idle timeout');
+    timeoutError.name = 'TimeoutError';
+    try {
+      try {
+        return await Promise.race([
+          Promise.resolve(operation),
+          delay(options.idleTimeoutMs, undefined, { signal: timeoutController.signal })
+            .then(() => { throw timeoutError; }),
+        ]);
+      } catch (error) {
+        // Settle the race with our stable error before aborting the SDK. Some
+        // transports reject synchronously on abort with a provider-specific
+        // error, which must not replace the authoritative timeout reason.
+        if (error === timeoutError) options.abort(timeoutError);
+        throw error;
+      }
+    } finally {
+      timeoutController.abort();
     }
-    textDeltas.push({ index: record.index as number, text: delta.text });
+  };
+
+  try {
+    while (true) {
+      const next = await withIdleTimeout(iterator.next());
+      if (next.done) {
+        completed = true;
+        break;
+      }
+      eventCount++;
+      if (eventCount > MAX_STREAM_EVENTS) throw new Error('Anthropic stream event limit exceeded');
+      const record = requireRecord(next.value, 'stream event');
+      if (record.type !== 'content_block_delta') continue;
+      options.onStreamProgress?.({ type: 'content_delta' });
+      const delta = requireRecord(record.delta, 'stream delta');
+      if (delta.type !== 'text_delta') continue;
+      if (
+        !Number.isSafeInteger(record.index)
+        || (record.index as number) < 0
+        || typeof delta.text !== 'string'
+      ) throw new Error('Malformed Anthropic text stream delta');
+      textBytes += Buffer.byteLength(delta.text, 'utf8');
+      if (textBytes > MAX_CONTINUATION_BYTES) {
+        throw new Error('Anthropic stream text exceeds size limit');
+      }
+      textDeltas.push({ index: record.index as number, text: delta.text });
+    }
+    const response = normalizeAnthropicResponse(
+      await withIdleTimeout(stream.finalMessage()),
+    );
+    return { response, textDeltas };
+  } finally {
+    if (!completed) {
+      void Promise.resolve(iterator.return?.()).catch(() => undefined);
+    }
   }
-  const response = normalizeAnthropicResponse(await stream.finalMessage());
-  return { response, textDeltas };
 }
 
 function* normalizedResponseEvents(
@@ -498,6 +547,7 @@ export class AnthropicModelProvider implements ModelProvider {
   readonly capabilities = ANTHROPIC_PROVIDER_CAPABILITIES;
   private readonly transport: AnthropicMessagesTransport;
   private readonly transportMaxRetries: 0 | 2;
+  private readonly streamIdleTimeoutMs: number;
 
   constructor(
     apiKey: string,
@@ -506,6 +556,10 @@ export class AnthropicModelProvider implements ModelProvider {
   ) {
     this.transport = transport ?? new Anthropic({ apiKey }) as unknown as AnthropicMessagesTransport;
     this.transportMaxRetries = options.transportMaxRetries ?? 0;
+    this.streamIdleTimeoutMs = options.streamIdleTimeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS;
+    if (!Number.isSafeInteger(this.streamIdleTimeoutMs) || this.streamIdleTimeoutMs <= 0) {
+      throw new RangeError('Anthropic stream idle timeout must be a positive integer');
+    }
   }
 
   prepare(request: ModelRequest): PreparedModelInvocation {
@@ -568,10 +622,23 @@ export class AnthropicModelProvider implements ModelProvider {
     if (options?.stream) {
       const messages = this.transport.beta.messages;
       if (!messages.stream) throw new UnsupportedModelCapabilityError('anthropic', 'streaming');
-      const streamed = await collectAnthropicStream(messages.stream(
-        prepared.providerRequest as AnthropicRequest,
-        transportOptions,
-      ));
+      const streamController = new AbortController();
+      const abortFromCaller = () => streamController.abort(options.signal?.reason);
+      if (options.signal?.aborted) abortFromCaller();
+      else options.signal?.addEventListener('abort', abortFromCaller, { once: true });
+      let streamed: Awaited<ReturnType<typeof collectAnthropicStream>>;
+      try {
+        streamed = await collectAnthropicStream(messages.stream(
+          prepared.providerRequest as AnthropicRequest,
+          { ...transportOptions, signal: streamController.signal },
+        ), {
+          idleTimeoutMs: this.streamIdleTimeoutMs,
+          abort: (reason) => streamController.abort(reason),
+          onStreamProgress: options.onStreamProgress,
+        });
+      } finally {
+        options.signal?.removeEventListener('abort', abortFromCaller);
+      }
       yield* normalizedResponseEvents(streamed.response, streamed.textDeltas);
       return;
     }

--- a/server/src/addie/model-providers/model-provider.ts
+++ b/server/src/addie/model-providers/model-provider.ts
@@ -252,6 +252,11 @@ export interface ModelRespondOptions {
   signal?: AbortSignal;
   /** Request the provider's streaming transport while retaining normalized events. */
   stream?: boolean;
+  /**
+   * Observability-only progress signal emitted before terminal validation.
+   * Callers must not expose buffered content or execute tools from this hook.
+   */
+  onStreamProgress?: (event: { type: 'content_delta' }) => void;
   /** Runs immediately before the one SDK dispatch made by this iterator. */
   beforeDispatch?: (prepared: PreparedModelInvocation) => void | Promise<void>;
 }

--- a/server/tests/unit/addie-empty-response-fallback.test.ts
+++ b/server/tests/unit/addie-empty-response-fallback.test.ts
@@ -20,7 +20,17 @@ vi.mock('@anthropic-ai/sdk', () => ({
           model: String(payload.model),
           ...await mocks.createMessage(payload, options),
         }),
-        stream: mocks.streamMessage,
+        stream: (payload: Record<string, unknown>, options?: unknown) => {
+          const stream = mocks.streamMessage(payload, options);
+          return {
+            [Symbol.asyncIterator]: () => stream[Symbol.asyncIterator](),
+            finalMessage: async () => ({
+              id: 'msg_test_streaming',
+              model: String(payload.model),
+              ...await stream.finalMessage(),
+            }),
+          };
+        },
       },
     };
   },
@@ -198,7 +208,7 @@ function makeEmptyStream() {
 function makeTextDeltaStreamWithEmptyFinal(text: string) {
   return {
     async *[Symbol.asyncIterator]() {
-      yield { type: 'content_block_delta', delta: { type: 'text_delta', text } };
+      yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } };
     },
     finalMessage: vi.fn().mockResolvedValue(emptyEndTurn),
   };
@@ -228,9 +238,10 @@ function makeThrowingStream(error: Error) {
 function makeStream(message: typeof toolUseTurn | typeof searchToolUseTurn | typeof emptyEndTurn | typeof recoveredEndTurn | typeof personaOnlyEndTurn | typeof semanticRefusalEndTurn | typeof mixedRecoveryToolUseTurn | typeof emptyRefusal | typeof thinkingOnlyEndTurn | typeof redactedThinkingOnlyEndTurn | typeof blankTextEndTurn | typeof ritualOnlyEndTurn) {
   return {
     async *[Symbol.asyncIterator]() {
-      for (const block of message.content) {
+      for (let index = 0; index < message.content.length; index++) {
+        const block = message.content[index];
         if (block.type === 'text') {
-          yield { type: 'content_block_delta', delta: { type: 'text_delta', text: block.text } };
+          yield { type: 'content_block_delta', index, delta: { type: 'text_delta', text: block.text } };
         }
       }
     },
@@ -411,7 +422,7 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(getGithubIssue).not.toHaveBeenCalled();
   });
 
-  it('rejects a malformed non-streaming tool turn while streaming retains its local fallback', async () => {
+  it('rejects a malformed tool turn on both response paths', async () => {
     mocks.createMessage.mockResolvedValueOnce(emptyToolUseTurn);
     mocks.streamMessage.mockReturnValueOnce(makeStream(emptyToolUseTurn));
     const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
@@ -423,13 +434,11 @@ describe('Addie empty-response fallback (#4430)', () => {
     for await (const event of client.processMessageStream(
       'hello', undefined, undefined, { uncapped: true },
     )) streamEvents.push(event);
-    const done = streamEvents.find(
-      (event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done',
+    const streamError = streamEvents.find(
+      (event): event is Extract<StreamEvent, { type: 'stream_error' }> => event.type === 'stream_error',
     );
 
-    expect(done?.response.model_execution).toEqual({
-      source: 'local', requested_provider: 'anthropic', requested_model: 'claude-sonnet-4-6', reason: 'no_provider_response',
-    });
+    expect(streamError?.reason).toBe('Tool-call finish has no tool call');
   });
 
   it('classifies the non-streaming max-iteration apology as local', async () => {
@@ -536,7 +545,7 @@ describe('Addie empty-response fallback (#4430)', () => {
       max_tokens: 8_192,
       output_config: { effort: 'medium' },
     });
-    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0, signal: expect.any(AbortSignal) });
     expect(mocks.notifySystemError).not.toHaveBeenCalled();
   });
 
@@ -588,7 +597,7 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(done?.response.text).toBe('Issue 42 is open.');
     expect(done?.response.usage).toMatchObject({ input_tokens: 22, output_tokens: 15 });
     expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
-    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0, signal: expect.any(AbortSignal) });
     expect(mocks.notifySystemError).not.toHaveBeenCalled();
   });
 
@@ -649,7 +658,7 @@ describe('Addie empty-response fallback (#4430)', () => {
     const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
     expect(done?.response.text).toBe('Issue 42 is open.');
     expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
-    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0, signal: expect.any(AbortSignal) });
   });
 
   it('recovers once when streaming text is entirely removed by postprocessing', async () => {
@@ -674,7 +683,7 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(emittedText).toBe('Issue 42 is open.');
     expect(done?.response.text).toBe('Issue 42 is open.');
     expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
-    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0, signal: expect.any(AbortSignal) });
     expect(mocks.notifySystemError).not.toHaveBeenCalled();
   });
 
@@ -728,7 +737,7 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(getGithubIssue).not.toHaveBeenCalled();
   });
 
-  it('does not resample a streaming end_turn containing a tool block', async () => {
+  it('rejects a streaming end_turn containing a tool block', async () => {
     mocks.streamMessage.mockReturnValueOnce(makeStream(toolBlockEndTurn));
     const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
     const events: StreamEvent[] = [];
@@ -740,10 +749,10 @@ describe('Addie empty-response fallback (#4430)', () => {
       { uncapped: true },
     )) events.push(event);
 
-    const done = events.find(
-      (event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done',
+    const streamError = events.find(
+      (event): event is Extract<StreamEvent, { type: 'stream_error' }> => event.type === 'stream_error',
     );
-    expect(done?.response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
+    expect(streamError?.reason).toBe('Client tool call has incompatible finish reason');
     expect(mocks.streamMessage).toHaveBeenCalledOnce();
     expect(getGithubIssue).not.toHaveBeenCalled();
   });
@@ -859,11 +868,11 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(done?.response.text).toBe(ADDIE_EMPTY_RESPONSE_FALLBACK);
     expect(done?.response.usage).toMatchObject({ input_tokens: 10, output_tokens: 0 });
     expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
-    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0, signal: expect.any(AbortSignal) });
     expect(mocks.notifySystemError).toHaveBeenCalledOnce();
   });
 
-  it('does not resample when streaming deltas contain text but the final content is empty', async () => {
+  it('rejects streamed text when the terminal content is empty', async () => {
     mocks.streamMessage.mockReturnValueOnce(makeTextDeltaStreamWithEmptyFinal('A complete answer.'));
     const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-5');
     const events: StreamEvent[] = [];
@@ -875,8 +884,10 @@ describe('Addie empty-response fallback (#4430)', () => {
       { uncapped: true },
     )) events.push(event);
 
-    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
-    expect(done?.response.text).toBe('A complete answer.');
+    const streamError = events.find(
+      (event): event is Extract<StreamEvent, { type: 'stream_error' }> => event.type === 'stream_error',
+    );
+    expect(streamError?.reason).toBe('Anthropic stream text does not match terminal response');
     expect(mocks.streamMessage).toHaveBeenCalledOnce();
     expect(mocks.notifySystemError).not.toHaveBeenCalled();
   });
@@ -924,8 +935,8 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(done?.response.text).toBe('Issue 42 is open.');
     expect(getGithubIssue).toHaveBeenCalledOnce();
     expect(mocks.streamMessage).toHaveBeenCalledTimes(3);
-    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0 });
-    expect(mocks.streamMessage.mock.calls[2][1]).toBeUndefined();
+    expect(mocks.streamMessage.mock.calls[1][1]).toEqual({ maxRetries: 0, signal: expect.any(AbortSignal) });
+    expect(mocks.streamMessage.mock.calls[2][1]).toEqual({ maxRetries: 2, signal: expect.any(AbortSignal) });
   });
 
   it('recovers ritual-only text after tool use in both paths', async () => {
@@ -1037,7 +1048,7 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(done?.response.timing?.iterations).toBe(3);
     expect(getGithubIssue).toHaveBeenCalledOnce();
     expect(mocks.notifySystemError).not.toHaveBeenCalled();
-    expect(mocks.streamMessage.mock.calls[2][1]).toEqual({ maxRetries: 0 });
+    expect(mocks.streamMessage.mock.calls[2][1]).toEqual({ maxRetries: 0, signal: expect.any(AbortSignal) });
   });
 
   it('falls back without retrying when post-tool recovery transport fails', async () => {

--- a/server/tests/unit/addie-response-truncation.test.ts
+++ b/server/tests/unit/addie-response-truncation.test.ts
@@ -18,7 +18,17 @@ vi.mock('@anthropic-ai/sdk', () => ({
           model: String(payload.model),
           ...await mocks.createMessage(payload, options),
         }),
-        stream: mocks.streamMessage,
+        stream: (payload: Record<string, unknown>, options?: unknown) => {
+          const stream = mocks.streamMessage(payload, options);
+          return {
+            [Symbol.asyncIterator]: () => stream[Symbol.asyncIterator](),
+            finalMessage: async () => ({
+              id: 'msg_test_streaming',
+              model: String(payload.model),
+              ...await stream.finalMessage(),
+            }),
+          };
+        },
       },
     };
   },
@@ -88,6 +98,7 @@ function streamFor(finalResponse: MockMessage, chunks: string[]) {
       for (const text of chunks) {
         yield {
           type: 'content_block_delta',
+          index: 0,
           delta: { type: 'text_delta', text },
         };
       }

--- a/server/tests/unit/addie/model-provider-anthropic.test.ts
+++ b/server/tests/unit/addie/model-provider-anthropic.test.ts
@@ -488,9 +488,10 @@ describe('AnthropicModelProvider response normalization', () => {
       { beta: { messages: { create, stream } } },
       { transportMaxRetries: 2 },
     );
+    const onStreamProgress = vi.fn();
 
     const events: NormalizedModelEvent[] = [];
-    for await (const event of provider.respond(request(), { stream: true })) events.push(event);
+    for await (const event of provider.respond(request(), { stream: true, onStreamProgress })) events.push(event);
     const normalized = await collectModelResponse((async function* () { yield* events; })());
 
     expect(normalized.content).toEqual([{ type: 'text', text: 'done' }]);
@@ -499,10 +500,79 @@ describe('AnthropicModelProvider response normalization', () => {
       { type: 'text_delta', index: 0, text: 'ne' },
     ]);
     expect(create).not.toHaveBeenCalled();
+    expect(onStreamProgress).toHaveBeenCalledTimes(2);
+    expect(onStreamProgress).toHaveBeenNthCalledWith(1, { type: 'content_delta' });
     expect(stream).toHaveBeenCalledWith(
       provider.prepare(request()).providerRequest,
-      { maxRetries: 2 },
+      { maxRetries: 2, signal: expect.any(AbortSignal) },
     );
+  });
+
+  it('aborts a stream that stays idle before its first event', async () => {
+    let transportSignal: AbortSignal | undefined;
+    const iteratorReturn = vi.fn(async () => ({ done: true, value: undefined }));
+    const provider = new AnthropicModelProvider(
+      'unused',
+      {
+        beta: {
+          messages: {
+            create: vi.fn(),
+            stream: vi.fn((_payload, options) => {
+              transportSignal = options.signal;
+              return {
+                [Symbol.asyncIterator]() {
+                  return {
+                    next: () => new Promise<IteratorResult<unknown>>(() => undefined),
+                    return: iteratorReturn,
+                  };
+                },
+                finalMessage: vi.fn(),
+              };
+            }),
+          },
+        },
+      },
+      { streamIdleTimeoutMs: 10 },
+    );
+
+    await expect(collectModelResponse(provider.respond(request(), { stream: true })))
+      .rejects.toMatchObject({ name: 'TimeoutError', message: 'Anthropic stream idle timeout' });
+    expect(transportSignal?.aborted).toBe(true);
+    expect(iteratorReturn).toHaveBeenCalledOnce();
+  });
+
+  it('aborts a stream that stays idle waiting for its terminal message', async () => {
+    let transportSignal: AbortSignal | undefined;
+    const finalMessage = vi.fn(() => new Promise<never>(() => undefined));
+    const provider = new AnthropicModelProvider(
+      'unused',
+      {
+        beta: {
+          messages: {
+            create: vi.fn(),
+            stream: vi.fn((_payload, options) => {
+              transportSignal = options.signal;
+              return {
+                async *[Symbol.asyncIterator]() {
+                  yield {
+                    type: 'content_block_delta',
+                    index: 0,
+                    delta: { type: 'text_delta', text: 'partial' },
+                  };
+                },
+                finalMessage,
+              };
+            }),
+          },
+        },
+      },
+      { streamIdleTimeoutMs: 10 },
+    );
+
+    await expect(collectModelResponse(provider.respond(request(), { stream: true })))
+      .rejects.toMatchObject({ name: 'TimeoutError', message: 'Anthropic stream idle timeout' });
+    expect(finalMessage).toHaveBeenCalledOnce();
+    expect(transportSignal?.aborted).toBe(true);
   });
 
   it('rejects streamed text that disagrees with the terminal response', async () => {

--- a/server/tests/unit/claude-client-replay-policy.test.ts
+++ b/server/tests/unit/claude-client-replay-policy.test.ts
@@ -56,7 +56,11 @@ vi.mock('@anthropic-ai/sdk', () => ({
           if (!response) throw new Error('Missing streaming response fixture');
           return {
             async *[Symbol.asyncIterator]() {},
-            finalMessage: vi.fn().mockResolvedValue(response),
+            finalMessage: vi.fn().mockResolvedValue({
+              id: `msg_test_${sdkState.calls.length}`,
+              model: String(payload.model),
+              ...response,
+            }),
           };
         }),
       },

--- a/server/tests/unit/claude-client-stream-error.test.ts
+++ b/server/tests/unit/claude-client-stream-error.test.ts
@@ -30,6 +30,7 @@ function makeKeywordErrorStub() {
     async *[Symbol.asyncIterator]() {
       yield {
         type: 'content_block_delta',
+        index: 0,
         delta: { type: 'text_delta', text: 'Sure, the answer is ' },
       };
       throw new Error("overloaded_error: Anthropic API is overloaded");
@@ -43,6 +44,7 @@ function makeApiErrorStub(MockedAPIError: { new (msg: string): Error & { status?
     async *[Symbol.asyncIterator]() {
       yield {
         type: 'content_block_delta',
+        index: 0,
         delta: { type: 'text_delta', text: 'Sure, the answer is ' },
       };
       const apiErr = new MockedAPIError("Streaming error");
@@ -216,6 +218,8 @@ describe('processMessageStream — mid-stream upstream failure (#4797)', () => {
       streamCalls++;
       if (streamCalls === 2) {
         const recovered = {
+          id: 'msg_recovered',
+          model: 'claude-sonnet-4-6-20260801',
           stop_reason: 'end_turn',
           content: [{ type: 'text', text: 'Recovered response.' }],
           usage: { input_tokens: 4, output_tokens: 3 },
@@ -224,6 +228,7 @@ describe('processMessageStream — mid-stream upstream failure (#4797)', () => {
           async *[Symbol.asyncIterator]() {
             yield {
               type: 'content_block_delta',
+              index: 0,
               delta: { type: 'text_delta', text: 'Recovered response.' },
             };
           },


### PR DESCRIPTION
## Summary

- route Addie’s live Anthropic stream/tool loop through the canonical model-provider adapter
- preserve terminal buffering, retry posture, tool events, and partial-delta accounting while failing closed on malformed or inconsistent terminal responses
- abort streams after 60 seconds without an event or terminal message and surface a stable timeout reason
- refresh the generated Addie tool-surface inventory and bump `CODE_VERSION`

## Validation

- full server unit suite: 7,134 passed, 30 skipped, 0 failed
- focused provider/live-stream suite: 153 passed
- `npm run typecheck`
- `npm run test:addie-tools`
- `git diff --check`

No protocol changeset is required because this is internal Addie runtime behavior.

Progresses #6844 and preserves the interruption-recovery contract from #4797.