### PR TITLE
refactor(addie): share canonical model turn inspection

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -50,6 +50,7 @@ import {
   type AnthropicMessagesTransport,
 } from './model-providers/anthropic-provider.js';
 import { collectModelResponse } from './model-providers/events.js';
+import { inspectModelTurn } from './model-providers/model-turn.js';
 import {
   createAddieToolExecutor,
   type AddieExecutionMode,
@@ -159,39 +160,6 @@ function hashPreparedPayload(
       .digest('hex');
   }
   return createHash('sha256').update(value, 'utf8').digest('hex');
-}
-
-type StopAction = 'complete' | 'truncated' | 'tool_use' | 'continue';
-
-/**
- * Keep every Anthropic stop reason explicit. In particular, truncation is a
- * terminal response (never a reason to sample the same prompt again), while
- * pause_turn/compaction continue with the provider response in history.
- * Do not infer truncation from an alphanumeric final character: headings,
- * URLs, code, and terse list items commonly end that way. The provider's
- * stop_reason is the reliable under-10k completion sentinel.
- */
-function classifyStopReason(reason: Anthropic.Beta.BetaStopReason | null): StopAction {
-  switch (reason) {
-    case 'end_turn':
-    case 'stop_sequence':
-    case 'refusal':
-      return 'complete';
-    case 'max_tokens':
-    case 'model_context_window_exceeded':
-      return 'truncated';
-    case 'tool_use':
-      return 'tool_use';
-    case 'pause_turn':
-    case 'compaction':
-      return 'continue';
-    case null:
-      throw new Error('Anthropic response completed without a stop reason');
-    default: {
-      const exhaustiveReason: never = reason;
-      throw new Error(`Unhandled Anthropic stop reason: ${String(exhaustiveReason)}`);
-    }
-  }
 }
 
 /**
@@ -1639,12 +1607,13 @@ export class AddieClaudeClient {
           content: [],
         };
       }
+      const turn = inspectModelTurn(response);
 
       // Provider-managed web results may accompany either a terminal answer or
       // another tool-call turn. Derive their receipts through the selected
       // adapter so private provider payloads never enter common orchestration.
-      const earlyWebSearchResults = response.content.filter((c) => c.type === 'provider_tool_result');
-      const earlyServerToolBlocks = response.content.filter((c) => c.type === 'provider_tool_call');
+      const earlyWebSearchResults = turn.providerToolResults;
+      const earlyServerToolBlocks = turn.providerToolCalls;
 
       if (earlyWebSearchResults.length > 0) {
         for (const result of earlyWebSearchResults) {
@@ -1697,9 +1666,7 @@ export class AddieClaudeClient {
         }
       }
 
-      const stopAction = classifyStopReason(
-        response.providerFinishReason as Anthropic.Beta.BetaStopReason,
-      );
+      const stopAction = turn.action;
 
       if (stopAction === 'continue') {
         // Anthropic pause_turn and compaction responses are resumable only
@@ -1714,9 +1681,8 @@ export class AddieClaudeClient {
       }
 
       if (stopAction === 'truncated') {
-        const rawText = response.content
-          .map((block) => block.type === 'text' ? block.text : '')
-          .filter(Boolean)
+        const rawText = turn.textBlocks
+          .map((block) => block.text)
           .join('\n\n')
           .trim();
         const finalized = finalizeAssistantText(userMessage, rawText, toolExecutions, true);
@@ -1775,9 +1741,8 @@ export class AddieClaudeClient {
       // Done - no tool use, just text
       if (stopAction === 'complete') {
         // Collect ALL text blocks (web search responses have multiple text blocks)
-        const textBlocks = response.content.filter((c) => c.type === 'text');
-        const rawText = textBlocks
-          .map(block => block.type === 'text' ? block.text : '')
+        const rawText = turn.textBlocks
+          .map((block) => block.text)
           .join('\n\n')
           .trim();
         // A provider-successful but wholly empty first sample has no visible
@@ -1888,13 +1853,13 @@ export class AddieClaudeClient {
       // Handle tool use (both custom tools and server-managed tools like web_search)
       if (stopAction === 'tool_use') {
         // Get custom tool use blocks (these need our handlers)
-        const toolUseBlocks = response.content.filter((c) => c.type === 'tool_call');
+        const toolUseBlocks = turn.toolCalls;
 
         // Get server tool use blocks (web_search - handled by Anthropic)
-        const serverToolBlocks = response.content.filter((c) => c.type === 'provider_tool_call');
+        const serverToolBlocks = turn.providerToolCalls;
 
         // Get web search results (already executed by Anthropic)
-        const webSearchResults = response.content.filter((c) => c.type === 'provider_tool_result');
+        const webSearchResults = turn.providerToolResults;
 
         // Track server-managed tool uses (web search)
         for (const block of serverToolBlocks) {
@@ -1949,8 +1914,7 @@ export class AddieClaudeClient {
         }
 
         if (toolUseBlocks.length === 0 && serverToolBlocks.length === 0) {
-          const textContent = response.content.find((c) => c.type === 'text');
-          const rawText = textContent && textContent.type === 'text' ? textContent.text : '';
+          const rawText = turn.textBlocks[0]?.text ?? '';
           const finalized = finalizeAssistantText(userMessage, rawText, toolExecutions);
           const text = finalized.text;
           if (finalized.emptyReason) {
@@ -2495,11 +2459,9 @@ export class AddieClaudeClient {
           }
         };
 
-        const stopAction = classifyStopReason(
-          currentResponse.providerFinishReason as Anthropic.Beta.BetaStopReason,
-        );
-        const iterationText = currentResponse.content
-          .filter((block) => block.type === 'text')
+        const turn = inspectModelTurn(currentResponse);
+        const stopAction = turn.action;
+        const iterationText = turn.textBlocks
           .map((block) => block.text)
           .join('\n\n');
         if (stopAction === 'continue') {
@@ -2657,7 +2619,7 @@ export class AddieClaudeClient {
         // Handle tool use
         if (stopAction === 'tool_use') {
           logicalText += iterationText;
-          const toolUseBlocks = currentResponse.content.filter((content) => content.type === 'tool_call');
+          const toolUseBlocks = turn.toolCalls;
 
           if (toolUseBlocks.length === 0) {
             // No tools to execute, return current text

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.41';
+export const CODE_VERSION = '2026.08.42';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "986fc603c90c970ffa3cfd1aeacf4389ba61428a89db8e80313db3ef5d44cd52",
+    "server/src/addie/claude-client.ts": "1b0c8246b26962a70fe8aba1a8c3e48ba8ba9e730c468c2bbac9afff83a6c463",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/addie/model-providers/model-turn.ts
+++ b/server/src/addie/model-providers/model-turn.ts
@@ -1,0 +1,57 @@
+import type {
+  ModelProviderToolCallContent,
+  ModelProviderToolResultContent,
+  ModelResponse,
+  ModelTextContent,
+  ModelToolCallContent,
+} from './model-provider.js';
+
+export type ModelTurnAction = 'complete' | 'truncated' | 'tool_use' | 'continue';
+
+export interface InspectedModelTurn {
+  action: ModelTurnAction;
+  textBlocks: ReadonlyArray<ModelTextContent>;
+  toolCalls: ReadonlyArray<ModelToolCallContent>;
+  providerToolCalls: ReadonlyArray<ModelProviderToolCallContent>;
+  providerToolResults: ReadonlyArray<ModelProviderToolResultContent>;
+}
+
+/**
+ * Interpret one already-validated provider response for common orchestration.
+ * Provider-specific finish values remain diagnostic only; decisions use the
+ * canonical finish reason and canonical content variants exclusively.
+ */
+export function inspectModelTurn(response: ModelResponse): InspectedModelTurn {
+  let action: ModelTurnAction;
+  switch (response.finishReason) {
+    case 'stop':
+    case 'refusal':
+      action = 'complete';
+      break;
+    case 'length':
+      action = 'truncated';
+      break;
+    case 'tool_calls':
+      action = 'tool_use';
+      break;
+    case 'continue':
+      action = 'continue';
+      break;
+    default: {
+      const exhaustiveReason: never = response.finishReason;
+      throw new Error(`Unhandled model finish reason: ${String(exhaustiveReason)}`);
+    }
+  }
+
+  return Object.freeze({
+    action,
+    textBlocks: Object.freeze(response.content.filter((content) => content.type === 'text')),
+    toolCalls: Object.freeze(response.content.filter((content) => content.type === 'tool_call')),
+    providerToolCalls: Object.freeze(response.content.filter(
+      (content) => content.type === 'provider_tool_call',
+    )),
+    providerToolResults: Object.freeze(response.content.filter(
+      (content) => content.type === 'provider_tool_result',
+    )),
+  });
+}

--- a/server/src/addie/model-providers/read-only-tool-loop.ts
+++ b/server/src/addie/model-providers/read-only-tool-loop.ts
@@ -1,5 +1,6 @@
 import Ajv, { type ValidateFunction } from 'ajv';
 import { collectModelResponse } from './events.js';
+import { inspectModelTurn } from './model-turn.js';
 import type {
   ModelProvider,
   ModelRequest,
@@ -92,13 +93,6 @@ function addUsage(total: ModelUsage, usage: ModelUsage): ModelUsage {
   };
 }
 
-function responseText(response: ModelResponse): string {
-  return response.content
-    .filter((content) => content.type === 'text')
-    .map((content) => content.text)
-    .join('');
-}
-
 /**
  * Execute a provider-neutral, retry-free tool loop for explicitly classified
  * local reads. This is intentionally narrower than Addie's production loop:
@@ -169,21 +163,22 @@ export async function executeReadOnlyToolLoop(
       beforeDispatch: options.beforeDispatch,
     }), provider.id);
     totalUsage = addUsage(totalUsage, response.usage);
+    const turn = inspectModelTurn(response);
 
-    const calls = response.content.filter((content) => content.type === 'tool_call');
-    const unsupportedContinuation = response.content.some((content) =>
-      content.type === 'provider_tool_call' || content.type === 'provider_tool_result');
+    const calls = turn.toolCalls;
+    const unsupportedContinuation = turn.providerToolCalls.length > 0
+      || turn.providerToolResults.length > 0;
     if (unsupportedContinuation) {
       throw new ReadOnlyToolLoopBoundaryError('provider_continuation_not_allowed');
     }
     if (calls.length === 0) {
-      if (response.finishReason === 'continue') {
+      if (turn.action === 'continue') {
         messages = [...messages, { role: 'assistant', content: response.content }];
         continue;
       }
       return {
         response,
-        text: responseText(response),
+        text: turn.textBlocks.map((content) => content.text).join(''),
         iterations: iteration,
         usage: totalUsage,
         toolExecutions: Object.freeze([...receipts]),

--- a/server/tests/unit/addie/model-provider-turn.test.ts
+++ b/server/tests/unit/addie/model-provider-turn.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  ModelFinishReason,
+  ModelMessageContent,
+  ModelResponse,
+} from '../../../src/addie/model-providers/model-provider.js';
+import { inspectModelTurn } from '../../../src/addie/model-providers/model-turn.js';
+
+function response(
+  finishReason: ModelFinishReason,
+  content: ModelMessageContent[] = [],
+): ModelResponse {
+  return {
+    provider: 'anthropic',
+    model: 'test-model',
+    id: 'test-response',
+    finishReason,
+    providerFinishReason: 'provider-value-must-not-drive-orchestration',
+    usage: { inputTokens: 1, outputTokens: 1 },
+    content,
+  };
+}
+
+const partitionedContent: ModelMessageContent[] = [
+  { type: 'text', text: 'before' },
+  { type: 'tool_call', id: 'tool-1', name: 'search_docs', input: { query: 'test' } },
+  {
+    type: 'provider_tool_call',
+    provider: 'anthropic',
+    id: 'provider-1',
+    name: 'web_search',
+    inputKeys: ['query'],
+  },
+  {
+    type: 'provider_tool_result',
+    provider: 'anthropic',
+    toolCallId: 'provider-1',
+    name: 'web_search',
+    resultCount: 1,
+    isError: false,
+  },
+  { type: 'text', text: 'after' },
+];
+
+describe('inspectModelTurn', () => {
+  it.each([
+    ['stop', 'complete'],
+    ['refusal', 'complete'],
+    ['length', 'truncated'],
+    ['tool_calls', 'tool_use'],
+    ['continue', 'continue'],
+  ] as const)('maps canonical %s without consulting provider diagnostics', (finishReason, action) => {
+    expect(inspectModelTurn(response(finishReason)).action).toBe(action);
+  });
+
+  it('partitions canonical content while retaining text block order', () => {
+    const turn = inspectModelTurn(response('tool_calls', partitionedContent));
+
+    expect(turn.textBlocks.map((block) => block.text)).toEqual(['before', 'after']);
+    expect(turn.toolCalls.map((call) => call.id)).toEqual(['tool-1']);
+    expect(turn.providerToolCalls.map((call) => call.id)).toEqual(['provider-1']);
+    expect(turn.providerToolResults.map((result) => result.toolCallId)).toEqual(['provider-1']);
+    expect(Object.isFrozen(turn)).toBe(true);
+    expect(Object.isFrozen(turn.toolCalls)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- add one provider-neutral model-turn inspector driven only by canonical finish reasons and content variants
- use the same inspected turn in Addie’s non-streaming and streaming production loops
- use the same turn partitioning in the cross-provider read-only replay loop
- remove direct Anthropic stop-reason classification from production orchestration while preserving provider values for diagnostics
- refresh the generated Addie tool inventory and bump `CODE_VERSION`

## Validation

- provider/cross-provider turn suites: 95 passed
- production completion, truncation, fallback, and stream-error suites: 86 passed
- `npm run typecheck`
- `npm run test:addie-tools`
- `git diff --check`

No protocol changeset is required because this is internal Addie runtime behavior.

Progresses #6844.