### PR TITLE
refactor(addie): share canonical usage accumulation

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -44,13 +44,14 @@ import type {
   ModelToolCallContent,
   ModelToolDefinition,
   ModelToolResultContent,
+  ModelUsage,
 } from './model-providers/model-provider.js';
 import {
   AnthropicModelProvider,
   type AnthropicMessagesTransport,
 } from './model-providers/anthropic-provider.js';
 import { collectModelResponse } from './model-providers/events.js';
-import { inspectModelTurn } from './model-providers/model-turn.js';
+import { addModelUsage, inspectModelTurn } from './model-providers/model-turn.js';
 import {
   createAddieToolExecutor,
   type AddieExecutionMode,
@@ -786,6 +787,19 @@ export interface AddieResponse {
   };
 }
 
+function toAddieUsage(usage: ModelUsage): NonNullable<AddieResponse['usage']> {
+  return {
+    input_tokens: usage.inputTokens,
+    output_tokens: usage.outputTokens,
+    ...((usage.cacheWriteTokens ?? 0) > 0 && {
+      cache_creation_input_tokens: usage.cacheWriteTokens,
+    }),
+    ...((usage.cacheReadTokens ?? 0) > 0 && {
+      cache_read_input_tokens: usage.cacheReadTokens,
+    }),
+  };
+}
+
 function anthropicModelExecution(model: string, requestedModel: string): ModelExecution {
   return {
     source: 'provider',
@@ -1416,10 +1430,7 @@ export class AddieClaudeClient {
     let totalToolExecutionMs = 0;
 
     // Token usage tracking (aggregated across iterations)
-    let totalInputTokens = 0;
-    let totalOutputTokens = 0;
-    let totalCacheCreationTokens = 0;
-    let totalCacheReadTokens = 0;
+    let totalUsage: ModelUsage = { inputTokens: 0, outputTokens: 0 };
 
     const prepared = this.prepareFirstNonStreamingInvocation(
       userMessage,
@@ -1580,10 +1591,7 @@ export class AddieClaudeClient {
 
       // Track token usage from this iteration
       if (!reusedEmptyResponse) {
-        totalInputTokens += response.usage.inputTokens;
-        totalOutputTokens += response.usage.outputTokens;
-        totalCacheCreationTokens += response.usage.cacheWriteTokens ?? 0;
-        totalCacheReadTokens += response.usage.cacheReadTokens ?? 0;
+        totalUsage = addModelUsage(totalUsage, response.usage);
       }
 
       logger.debug({
@@ -1691,12 +1699,7 @@ export class AddieClaudeClient {
         }
         const text = finalized.text;
         totalToolExecutionMs = toolExecutions.reduce((sum, execution) => sum + execution.duration_ms, 0);
-        const finalUsage = {
-          input_tokens: totalInputTokens,
-          output_tokens: totalOutputTokens,
-          ...(totalCacheCreationTokens > 0 && { cache_creation_input_tokens: totalCacheCreationTokens }),
-          ...(totalCacheReadTokens > 0 && { cache_read_input_tokens: totalCacheReadTokens }),
-        };
+        const finalUsage = toAddieUsage(totalUsage);
         logger.error(
           {
             event: 'addie_response_truncated',
@@ -1811,12 +1814,7 @@ export class AddieClaudeClient {
           ? 'Output truncated due to length'
           : hallucinationReason ?? finalized.emptyReason;
 
-        const finalUsage = {
-          input_tokens: totalInputTokens,
-          output_tokens: totalOutputTokens,
-          ...(totalCacheCreationTokens > 0 && { cache_creation_input_tokens: totalCacheCreationTokens }),
-          ...(totalCacheReadTokens > 0 && { cache_read_input_tokens: totalCacheReadTokens }),
-        };
+        const finalUsage = toAddieUsage(totalUsage);
         // Record the call against the user's daily budget (#2790).
         // Runs after the response is built so a successful charge
         // counts even if a downstream flag/logging failure occurs.
@@ -1921,12 +1919,7 @@ export class AddieClaudeClient {
             reportEmptyResponseFallback(finalized.emptyReason, toolsUsed, toolExecutions, options, 'processMessage', effectiveModel, iteration);
           }
           totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
-          const terminalUsage = {
-            input_tokens: totalInputTokens,
-            output_tokens: totalOutputTokens,
-            ...(totalCacheCreationTokens > 0 && { cache_creation_input_tokens: totalCacheCreationTokens }),
-            ...(totalCacheReadTokens > 0 && { cache_read_input_tokens: totalCacheReadTokens }),
-          };
+          const terminalUsage = toAddieUsage(totalUsage);
           if (finalized.lengthExceeded) {
             logger.error(
               { event: 'addie_response_truncated', source: 'processMessage', originalLength: rawText.length, deliveredLength: text.length, localCapExceeded: true },
@@ -1982,12 +1975,7 @@ export class AddieClaudeClient {
 
     logger.warn('Addie: Hit max tool iterations');
     totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
-    const maxIterationsUsage = {
-      input_tokens: totalInputTokens,
-      output_tokens: totalOutputTokens,
-      ...(totalCacheCreationTokens > 0 && { cache_creation_input_tokens: totalCacheCreationTokens }),
-      ...(totalCacheReadTokens > 0 && { cache_read_input_tokens: totalCacheReadTokens }),
-    };
+    const maxIterationsUsage = toAddieUsage(totalUsage);
     // Still charge the user for tokens actually consumed on the way
     // to hitting max-iterations — those bytes DID go to Anthropic
     // and DID cost money, regardless of whether the session converged.
@@ -2127,10 +2115,7 @@ export class AddieClaudeClient {
     let totalToolExecutionMs = 0;
 
     // Token usage tracking (aggregated across iterations)
-    let totalInputTokens = 0;
-    let totalOutputTokens = 0;
-    let totalCacheCreationTokens = 0;
-    let totalCacheReadTokens = 0;
+    let totalUsage: ModelUsage = { inputTokens: 0, outputTokens: 0 };
 
     // Get system prompt from rule files (or fallback)
     const promptStart = Date.now();
@@ -2412,10 +2397,7 @@ export class AddieClaudeClient {
 
         // Track token usage
         if (!reusedEmptyResponse) {
-          totalInputTokens += currentResponse.usage.inputTokens;
-          totalOutputTokens += currentResponse.usage.outputTokens;
-          totalCacheCreationTokens += currentResponse.usage.cacheWriteTokens ?? 0;
-          totalCacheReadTokens += currentResponse.usage.cacheReadTokens ?? 0;
+          totalUsage = addModelUsage(totalUsage, currentResponse.usage);
         }
 
         logger.debug({
@@ -2440,15 +2422,8 @@ export class AddieClaudeClient {
 
         // Build the final usage block + charge the user's cost
         // budget (#2790). Both stream terminal paths (end_turn and
-        // no-tool-blocks) share this; kept inline as a local const
-        // rather than hoisted to instance scope because it closes
-        // over the accumulators in this method.
-        const buildStreamUsage = () => ({
-          input_tokens: totalInputTokens,
-          output_tokens: totalOutputTokens,
-          ...(totalCacheCreationTokens > 0 && { cache_creation_input_tokens: totalCacheCreationTokens }),
-          ...(totalCacheReadTokens > 0 && { cache_read_input_tokens: totalCacheReadTokens }),
-        });
+        // no-tool-blocks) serialize the same normalized accumulator.
+        const buildStreamUsage = () => toAddieUsage(totalUsage);
         const chargeStreamCost = async (usage: ReturnType<typeof buildStreamUsage>) => {
           if (operationalExecution && options?.costScope) {
             await recordCost(
@@ -2709,12 +2684,7 @@ export class AddieClaudeClient {
       // Max iterations reached
       logger.warn('Addie Stream: Hit max tool iterations');
       totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
-      const maxIterUsage = {
-        input_tokens: totalInputTokens,
-        output_tokens: totalOutputTokens,
-        ...(totalCacheCreationTokens > 0 && { cache_creation_input_tokens: totalCacheCreationTokens }),
-        ...(totalCacheReadTokens > 0 && { cache_read_input_tokens: totalCacheReadTokens }),
-      };
+      const maxIterUsage = toAddieUsage(totalUsage);
       // Charge the tokens consumed up to the max-iteration wall —
       // the API calls happened regardless of whether we converged.
       if (operationalExecution && options?.costScope) {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.42';
+export const CODE_VERSION = '2026.08.43';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "1b0c8246b26962a70fe8aba1a8c3e48ba8ba9e730c468c2bbac9afff83a6c463",
+    "server/src/addie/claude-client.ts": "e38f2dac327a5221cc22e734a39f4586f2381bcc964836c766267e08557c8b0f",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/addie/model-providers/model-turn.ts
+++ b/server/src/addie/model-providers/model-turn.ts
@@ -4,6 +4,7 @@ import type {
   ModelResponse,
   ModelTextContent,
   ModelToolCallContent,
+  ModelUsage,
 } from './model-provider.js';
 
 export type ModelTurnAction = 'complete' | 'truncated' | 'tool_use' | 'continue';
@@ -14,6 +15,20 @@ export interface InspectedModelTurn {
   toolCalls: ReadonlyArray<ModelToolCallContent>;
   providerToolCalls: ReadonlyArray<ModelProviderToolCallContent>;
   providerToolResults: ReadonlyArray<ModelProviderToolResultContent>;
+}
+
+/** Accumulate normalized usage without inventing absent provider cache metrics. */
+export function addModelUsage(total: ModelUsage, usage: ModelUsage): ModelUsage {
+  return {
+    inputTokens: total.inputTokens + usage.inputTokens,
+    outputTokens: total.outputTokens + usage.outputTokens,
+    ...(total.cacheWriteTokens !== undefined || usage.cacheWriteTokens !== undefined
+      ? { cacheWriteTokens: (total.cacheWriteTokens ?? 0) + (usage.cacheWriteTokens ?? 0) }
+      : {}),
+    ...(total.cacheReadTokens !== undefined || usage.cacheReadTokens !== undefined
+      ? { cacheReadTokens: (total.cacheReadTokens ?? 0) + (usage.cacheReadTokens ?? 0) }
+      : {}),
+  };
 }
 
 /**

--- a/server/src/addie/model-providers/read-only-tool-loop.ts
+++ b/server/src/addie/model-providers/read-only-tool-loop.ts
@@ -1,6 +1,6 @@
 import Ajv, { type ValidateFunction } from 'ajv';
 import { collectModelResponse } from './events.js';
-import { inspectModelTurn } from './model-turn.js';
+import { addModelUsage, inspectModelTurn } from './model-turn.js';
 import type {
   ModelProvider,
   ModelRequest,
@@ -80,19 +80,6 @@ function deepFreeze<T>(value: T): T {
   return Object.freeze(value);
 }
 
-function addUsage(total: ModelUsage, usage: ModelUsage): ModelUsage {
-  return {
-    inputTokens: total.inputTokens + usage.inputTokens,
-    outputTokens: total.outputTokens + usage.outputTokens,
-    ...(total.cacheWriteTokens !== undefined || usage.cacheWriteTokens !== undefined
-      ? { cacheWriteTokens: (total.cacheWriteTokens ?? 0) + (usage.cacheWriteTokens ?? 0) }
-      : {}),
-    ...(total.cacheReadTokens !== undefined || usage.cacheReadTokens !== undefined
-      ? { cacheReadTokens: (total.cacheReadTokens ?? 0) + (usage.cacheReadTokens ?? 0) }
-      : {}),
-  };
-}
-
 /**
  * Execute a provider-neutral, retry-free tool loop for explicitly classified
  * local reads. This is intentionally narrower than Addie's production loop:
@@ -162,7 +149,7 @@ export async function executeReadOnlyToolLoop(
       signal: options.signal,
       beforeDispatch: options.beforeDispatch,
     }), provider.id);
-    totalUsage = addUsage(totalUsage, response.usage);
+    totalUsage = addModelUsage(totalUsage, response.usage);
     const turn = inspectModelTurn(response);
 
     const calls = turn.toolCalls;

--- a/server/tests/unit/addie/model-provider-turn.test.ts
+++ b/server/tests/unit/addie/model-provider-turn.test.ts
@@ -4,7 +4,10 @@ import type {
   ModelMessageContent,
   ModelResponse,
 } from '../../../src/addie/model-providers/model-provider.js';
-import { inspectModelTurn } from '../../../src/addie/model-providers/model-turn.js';
+import {
+  addModelUsage,
+  inspectModelTurn,
+} from '../../../src/addie/model-providers/model-turn.js';
 
 function response(
   finishReason: ModelFinishReason,
@@ -62,5 +65,26 @@ describe('inspectModelTurn', () => {
     expect(turn.providerToolResults.map((result) => result.toolCallId)).toEqual(['provider-1']);
     expect(Object.isFrozen(turn)).toBe(true);
     expect(Object.isFrozen(turn.toolCalls)).toBe(true);
+  });
+});
+
+describe('addModelUsage', () => {
+  it('accumulates token and cache metrics', () => {
+    expect(addModelUsage(
+      { inputTokens: 10, outputTokens: 4, cacheWriteTokens: 3 },
+      { inputTokens: 6, outputTokens: 2, cacheReadTokens: 5 },
+    )).toEqual({
+      inputTokens: 16,
+      outputTokens: 6,
+      cacheWriteTokens: 3,
+      cacheReadTokens: 5,
+    });
+  });
+
+  it('does not invent cache metrics when providers omit them', () => {
+    expect(addModelUsage(
+      { inputTokens: 1, outputTokens: 2 },
+      { inputTokens: 3, outputTokens: 4 },
+    )).toEqual({ inputTokens: 4, outputTokens: 6 });
   });
 });


### PR DESCRIPTION
## Summary
- add one provider-neutral usage accumulator for normalized model responses
- use it across production streaming, production non-streaming, and read-only replay loops
- preserve optional cache-token semantics and the existing Addie response wire shape
- refresh the generated Addie tool inventory and bump `CODE_VERSION`

## Validation
- `npm run typecheck`
- 104 focused Addie provider, replay, streaming, truncation, fallback, and cost tests
- `npm run test:addie-tools`
- pre-push version and changeset gates

No protocol release surface changed, so no changeset is required.

Progresses #6844.