### PR TITLE
refactor(addie): share empty response recovery state

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -51,7 +51,11 @@ import {
   type AnthropicMessagesTransport,
 } from './model-providers/anthropic-provider.js';
 import { collectModelResponse } from './model-providers/events.js';
-import { addModelUsage, inspectModelTurn } from './model-providers/model-turn.js';
+import {
+  addModelUsage,
+  EmptyResponseRecoveryState,
+  inspectModelTurn,
+} from './model-providers/model-turn.js';
 import {
   createAddieToolExecutor,
   type AddieExecutionMode,
@@ -1495,9 +1499,7 @@ export class AddieClaudeClient {
       );
     }
     let iteration = 0;
-    let retriedEmptyPostToolResponse = false;
-    let retriedEmptyInitialResponse = false;
-    let emptyResponseBeforeRecovery: ModelResponse | null = null;
+    const emptyResponseRecovery = new EmptyResponseRecoveryState();
     let hasExecutedCustomTool = false;
 
     while (iteration < maxIterations) {
@@ -1507,9 +1509,9 @@ export class AddieClaudeClient {
       const llmStart = Date.now();
       let response: ModelResponse;
       let reusedEmptyResponse = false;
-      const invocationTools = retriedEmptyPostToolResponse ? [] : modelTools;
+      const invocationTools = emptyResponseRecovery.toolsAllowed ? modelTools : [];
       let invocationAttempt = 0;
-      const isEmptyResponseRecovery = emptyResponseBeforeRecovery !== null;
+      const isEmptyResponseRecovery = emptyResponseRecovery.pending;
       try {
         const invokeProvider = async (exactlyOnce: boolean) => {
           invocationAttempt++;
@@ -1518,7 +1520,7 @@ export class AddieClaudeClient {
             systemBlocks,
             invocationTools,
             modelMessages,
-            !retriedEmptyPostToolResponse && requestWebSearchEnabled,
+            emptyResponseRecovery.toolsAllowed && requestWebSearchEnabled,
             isEmptyResponseRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
           );
           const provider = exactlyOnce
@@ -1549,15 +1551,18 @@ export class AddieClaudeClient {
             'processMessage',
           );
         if (operationalExecution) this.providerHealth.recordSuccess('anthropic', 'chat');
-        if (isEmptyResponseRecovery) emptyResponseBeforeRecovery = null;
+        if (isEmptyResponseRecovery) emptyResponseRecovery.resolve();
       } catch (error) {
-        if (isEmptyResponseRecovery && emptyResponseBeforeRecovery) {
+        const fallbackResponse = isEmptyResponseRecovery
+          ? emptyResponseRecovery.takeFallback()
+          : null;
+        if (fallbackResponse) {
           // The empty end_turn was a valid terminal response. Recovery is
           // best-effort: if its one extra call fails, retain that terminal and
           // its already-accounted usage rather than turning fallback into an
           // exception. Do not log a provider error that may echo input text.
           logger.warn({ iteration }, 'Addie: Empty-response recovery failed');
-          response = emptyResponseBeforeRecovery;
+          response = fallbackResponse;
           reusedEmptyResponse = true;
         } else {
           const stats = this.buildPayloadDebugStats(effectiveModel, systemBlocks, customTools, anthropicMessages, iteration, requestWebSearchEnabled ? 1 : 0);
@@ -1603,10 +1608,10 @@ export class AddieClaudeClient {
         outputTokens: response.usage.outputTokens,
       }, 'Addie: Claude response received');
 
-      // The empty-response recovery call is intentionally text-only. Defend
+      // Post-tool empty-response recovery is intentionally text-only. Defend
       // against a malformed provider response that nevertheless contains a
       // tool request: discard it instead of risking a duplicate mutation.
-      if (retriedEmptyPostToolResponse && response.finishReason === 'tool_calls') {
+      if (emptyResponseRecovery.postToolAttempted && response.finishReason === 'tool_calls') {
         logger.warn({ iteration }, 'Addie: Ignoring tool use from text-only recovery');
         response = {
           ...response,
@@ -1755,14 +1760,13 @@ export class AddieClaudeClient {
           operationalExecution
           && response.providerFinishReason === 'end_turn'
           && iteration === 1
-          && !retriedEmptyInitialResponse
+          && !emptyResponseRecovery.hasAttempted('initial')
           && !hasExecutedCustomTool
           && toolExecutions.length === 0
           && isSideEffectFreeEmptyModelResponse(response, rawText)
           && iteration < maxIterations
         ) {
-          retriedEmptyInitialResponse = true;
-          emptyResponseBeforeRecovery = response;
+          emptyResponseRecovery.schedule('initial', response);
           logger.warn({ iteration }, 'Addie: Retrying wholly empty initial response');
           continue;
         }
@@ -1773,11 +1777,10 @@ export class AddieClaudeClient {
           response.providerFinishReason === 'end_turn'
           && isSideEffectFreeEmptyModelResponse(response, rawText)
           && hasExecutedCustomTool
-          && !retriedEmptyPostToolResponse
+          && !emptyResponseRecovery.hasAttempted('post_tool')
           && iteration < maxIterations
         ) {
-          retriedEmptyPostToolResponse = true;
-          emptyResponseBeforeRecovery = response;
+          emptyResponseRecovery.schedule('post_tool', response);
           logger.warn({ iteration, toolsUsed }, 'Addie: Retrying empty response after tool use');
           continue;
         }
@@ -2214,9 +2217,7 @@ export class AddieClaudeClient {
     const modelTools = buildModelToolDefinitions(allTools);
     const maxIterations = options?.maxIterations ?? 10;
     let iteration = 0;
-    let retriedEmptyPostToolResponse = false;
-    let retriedEmptyInitialResponse = false;
-    let emptyResponseBeforeRecovery: ModelResponse | null = null;
+    const emptyResponseRecovery = new EmptyResponseRecoveryState();
     let lastProviderModel: string | undefined;
 
       while (iteration < maxIterations) {
@@ -2238,9 +2239,9 @@ export class AddieClaudeClient {
         let receivedDeltaCount = 0;
 
         while (!streamSucceeded && streamRetryCount <= maxStreamRetries) {
-          const isEmptyResponseRecovery: boolean = emptyResponseBeforeRecovery !== null;
+          const isEmptyResponseRecovery = emptyResponseRecovery.pending;
           try {
-            const invocationTools = retriedEmptyPostToolResponse ? [] : modelTools;
+            const invocationTools = emptyResponseRecovery.toolsAllowed ? modelTools : [];
             const modelRequest = this.buildModelRequest(
               effectiveModel,
               systemBlocks,
@@ -2275,13 +2276,16 @@ export class AddieClaudeClient {
             if (operationalExecution) this.providerHealth.recordSuccess('anthropic', 'chat');
             streamSucceeded = true;
             lastProviderModel = currentResponse.model;
-            if (isEmptyResponseRecovery) emptyResponseBeforeRecovery = null;
+            if (isEmptyResponseRecovery) emptyResponseRecovery.resolve();
           } catch (streamError) {
-            if (isEmptyResponseRecovery && emptyResponseBeforeRecovery) {
+            const fallbackResponse = isEmptyResponseRecovery
+              ? emptyResponseRecovery.takeFallback()
+              : null;
+            if (fallbackResponse) {
               // See the non-streaming path: recovery is an optional UX
               // improvement, not a reason to discard the valid first terminal.
               logger.warn({ iteration }, 'Addie Stream: Empty-response recovery failed');
-              currentResponse = emptyResponseBeforeRecovery;
+              currentResponse = fallbackResponse;
               reusedEmptyResponse = true;
               receivedDeltaCount = 0;
               break;
@@ -2408,9 +2412,9 @@ export class AddieClaudeClient {
           outputTokens: currentResponse.usage.outputTokens,
         }, 'Addie Stream: Claude response received');
 
-        // The recovery iteration has no tools. If the provider still returns
+        // The post-tool recovery iteration has no tools. If the provider still returns
         // a tool_use block, ignore it rather than executing a mutation twice.
-        if (retriedEmptyPostToolResponse && currentResponse.finishReason === 'tool_calls') {
+        if (emptyResponseRecovery.postToolAttempted && currentResponse.finishReason === 'tool_calls') {
           logger.warn({ iteration }, 'Addie Stream: Ignoring tool use from text-only recovery');
           currentResponse = {
             ...currentResponse,
@@ -2505,14 +2509,13 @@ export class AddieClaudeClient {
             operationalExecution
             && currentResponse.providerFinishReason === 'end_turn'
             && iteration === 1
-            && !retriedEmptyInitialResponse
+            && !emptyResponseRecovery.hasAttempted('initial')
             && toolExecutions.length === 0
             && logicalText.length === 0
             && isSideEffectFreeEmptyModelResponse(currentResponse, iterationText)
             && iteration < maxIterations
           ) {
-            retriedEmptyInitialResponse = true;
-            emptyResponseBeforeRecovery = currentResponse;
+            emptyResponseRecovery.schedule('initial', currentResponse);
             logger.warn({ iteration }, 'Addie Stream: Retrying wholly empty initial response');
             continue;
           }
@@ -2523,11 +2526,10 @@ export class AddieClaudeClient {
             currentResponse.providerFinishReason === 'end_turn'
             && isSideEffectFreeEmptyModelResponse(currentResponse, iterationText)
             && toolExecutions.length > 0
-            && !retriedEmptyPostToolResponse
+            && !emptyResponseRecovery.hasAttempted('post_tool')
             && iteration < maxIterations
           ) {
-            retriedEmptyPostToolResponse = true;
-            emptyResponseBeforeRecovery = currentResponse;
+            emptyResponseRecovery.schedule('post_tool', currentResponse);
             logger.warn({ iteration, toolsUsed }, 'Addie Stream: Retrying empty response after tool use');
             continue;
           }

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.43';
+export const CODE_VERSION = '2026.08.44';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "e38f2dac327a5221cc22e734a39f4586f2381bcc964836c766267e08557c8b0f",
+    "server/src/addie/claude-client.ts": "b3dfba92d066d37359421b9c9bb21202235479e15cf82f45f8b3f7c6a16abb95",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/addie/model-providers/model-turn.ts
+++ b/server/src/addie/model-providers/model-turn.ts
@@ -17,6 +17,57 @@ export interface InspectedModelTurn {
   providerToolResults: ReadonlyArray<ModelProviderToolResultContent>;
 }
 
+export type EmptyResponseRecoveryKind = 'initial' | 'post_tool';
+
+/**
+ * State shared by delivery modes while resampling a side-effect-free empty
+ * terminal. The original response remains authoritative if the optional
+ * recovery call fails. Post-tool recovery is permanently text-only so a
+ * malformed retry cannot repeat a mutation.
+ */
+export class EmptyResponseRecoveryState {
+  private attemptedInitial = false;
+  private attemptedPostTool = false;
+  private fallbackResponse: ModelResponse | null = null;
+
+  get pending(): boolean {
+    return this.fallbackResponse !== null;
+  }
+
+  get toolsAllowed(): boolean {
+    return !this.attemptedPostTool;
+  }
+
+  get postToolAttempted(): boolean {
+    return this.attemptedPostTool;
+  }
+
+  hasAttempted(kind: EmptyResponseRecoveryKind): boolean {
+    return kind === 'initial' ? this.attemptedInitial : this.attemptedPostTool;
+  }
+
+  schedule(kind: EmptyResponseRecoveryKind, response: ModelResponse): boolean {
+    if (this.pending || this.hasAttempted(kind)) return false;
+    if (kind === 'initial') {
+      this.attemptedInitial = true;
+    } else {
+      this.attemptedPostTool = true;
+    }
+    this.fallbackResponse = response;
+    return true;
+  }
+
+  resolve(): void {
+    this.fallbackResponse = null;
+  }
+
+  takeFallback(): ModelResponse | null {
+    const response = this.fallbackResponse;
+    this.fallbackResponse = null;
+    return response;
+  }
+}
+
 /** Accumulate normalized usage without inventing absent provider cache metrics. */
 export function addModelUsage(total: ModelUsage, usage: ModelUsage): ModelUsage {
   return {

--- a/server/tests/unit/addie/model-provider-turn.test.ts
+++ b/server/tests/unit/addie/model-provider-turn.test.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../src/addie/model-providers/model-provider.js';
 import {
   addModelUsage,
+  EmptyResponseRecoveryState,
   inspectModelTurn,
 } from '../../../src/addie/model-providers/model-turn.js';
 
@@ -86,5 +87,44 @@ describe('addModelUsage', () => {
       { inputTokens: 1, outputTokens: 2 },
       { inputTokens: 3, outputTokens: 4 },
     )).toEqual({ inputTokens: 4, outputTokens: 6 });
+  });
+});
+
+describe('EmptyResponseRecoveryState', () => {
+  it('retains the authoritative response until recovery succeeds', () => {
+    const state = new EmptyResponseRecoveryState();
+    const original = response('stop', []);
+
+    expect(state.schedule('initial', original)).toBe(true);
+    expect(state.pending).toBe(true);
+    expect(state.toolsAllowed).toBe(true);
+    expect(state.schedule('post_tool', original)).toBe(false);
+
+    state.resolve();
+    expect(state.pending).toBe(false);
+    expect(state.hasAttempted('initial')).toBe(true);
+    expect(state.schedule('initial', original)).toBe(false);
+  });
+
+  it('returns the original response when recovery fails', () => {
+    const state = new EmptyResponseRecoveryState();
+    const original = response('stop', []);
+
+    state.schedule('initial', original);
+    expect(state.takeFallback()).toBe(original);
+    expect(state.pending).toBe(false);
+  });
+
+  it('makes post-tool recovery permanently text-only', () => {
+    const state = new EmptyResponseRecoveryState();
+    const original = response('stop', []);
+
+    expect(state.schedule('post_tool', original)).toBe(true);
+    expect(state.toolsAllowed).toBe(false);
+    expect(state.postToolAttempted).toBe(true);
+
+    state.resolve();
+    expect(state.toolsAllowed).toBe(false);
+    expect(state.schedule('post_tool', original)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- replace parallel streaming and non-streaming empty-response flags with one provider-neutral recovery-state object
- retain the first safe terminal as the authoritative fallback until the exactly-once recovery call succeeds
- permanently suppress tools after post-tool recovery starts, preventing malformed recovery output from repeating a mutation
- preserve initial-recovery tool behavior, usage accounting, retry policy, and generated tool surface
- bump `CODE_VERSION` and refresh the generated Addie inventory

## Validation
- `npm run typecheck`
- 99 focused Addie recovery, replay, streaming, truncation, and cost tests
- `npm run test:addie-tools`
- pre-push version and changeset gates

No protocol release surface changed, so no changeset is required.

Progresses #6844.