### PR TITLE
refactor(addie): share model loop iteration budget

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -55,6 +55,7 @@ import {
   addModelUsage,
   EmptyResponseRecoveryState,
   inspectModelTurn,
+  ModelLoopBudget,
 } from './model-providers/model-turn.js';
 import {
   createAddieToolExecutor,
@@ -1480,7 +1481,7 @@ export class AddieClaudeClient {
       ? undefined
       : await getCurrentConfigVersionId();
 
-    const maxIterations = options?.maxIterations ?? 10;
+    const loopBudget = new ModelLoopBudget(options?.maxIterations ?? DEFAULT_MAX_ITERATIONS);
 
     // Log if using precision model
     if (options?.modelOverride && options.modelOverride !== this.model) {
@@ -1502,8 +1503,8 @@ export class AddieClaudeClient {
     const emptyResponseRecovery = new EmptyResponseRecoveryState();
     let hasExecutedCustomTool = false;
 
-    while (iteration < maxIterations) {
-      iteration++;
+    while (loopBudget.hasRemaining) {
+      iteration = loopBudget.startNext();
 
       // Use beta API to access web search
       const llmStart = Date.now();
@@ -1764,7 +1765,7 @@ export class AddieClaudeClient {
           && !hasExecutedCustomTool
           && toolExecutions.length === 0
           && isSideEffectFreeEmptyModelResponse(response, rawText)
-          && iteration < maxIterations
+          && loopBudget.hasRemaining
         ) {
           emptyResponseRecovery.schedule('initial', response);
           logger.warn({ iteration }, 'Addie: Retrying wholly empty initial response');
@@ -1778,7 +1779,7 @@ export class AddieClaudeClient {
           && isSideEffectFreeEmptyModelResponse(response, rawText)
           && hasExecutedCustomTool
           && !emptyResponseRecovery.hasAttempted('post_tool')
-          && iteration < maxIterations
+          && loopBudget.hasRemaining
         ) {
           emptyResponseRecovery.schedule('post_tool', response);
           logger.warn({ iteration, toolsUsed }, 'Addie: Retrying empty response after tool use');
@@ -2002,7 +2003,7 @@ export class AddieClaudeClient {
         system_prompt_ms: systemPromptMs,
         total_llm_ms: totalLlmMs,
         total_tool_execution_ms: totalToolExecutionMs,
-        iterations: maxIterations,
+        iterations: loopBudget.limit,
       },
       usage: maxIterationsUsage,
     };
@@ -2215,13 +2216,13 @@ export class AddieClaudeClient {
     // Mark the last tool with cache_control so Anthropic caches all tool definitions.
     const customTools = buildAddieWireTools(allTools) as Anthropic.Tool[];
     const modelTools = buildModelToolDefinitions(allTools);
-    const maxIterations = options?.maxIterations ?? 10;
+    const loopBudget = new ModelLoopBudget(options?.maxIterations ?? DEFAULT_MAX_ITERATIONS);
     let iteration = 0;
     const emptyResponseRecovery = new EmptyResponseRecoveryState();
     let lastProviderModel: string | undefined;
 
-      while (iteration < maxIterations) {
-        iteration++;
+      while (loopBudget.hasRemaining) {
+        iteration = loopBudget.startNext();
 
         const llmStart = Date.now();
 
@@ -2513,7 +2514,7 @@ export class AddieClaudeClient {
             && toolExecutions.length === 0
             && logicalText.length === 0
             && isSideEffectFreeEmptyModelResponse(currentResponse, iterationText)
-            && iteration < maxIterations
+            && loopBudget.hasRemaining
           ) {
             emptyResponseRecovery.schedule('initial', currentResponse);
             logger.warn({ iteration }, 'Addie Stream: Retrying wholly empty initial response');
@@ -2527,7 +2528,7 @@ export class AddieClaudeClient {
             && isSideEffectFreeEmptyModelResponse(currentResponse, iterationText)
             && toolExecutions.length > 0
             && !emptyResponseRecovery.hasAttempted('post_tool')
-            && iteration < maxIterations
+            && loopBudget.hasRemaining
           ) {
             emptyResponseRecovery.schedule('post_tool', currentResponse);
             logger.warn({ iteration, toolsUsed }, 'Addie Stream: Retrying empty response after tool use');
@@ -2725,7 +2726,7 @@ export class AddieClaudeClient {
             system_prompt_ms: systemPromptMs,
             total_llm_ms: totalLlmMs,
             total_tool_execution_ms: totalToolExecutionMs,
-            iterations: maxIterations,
+            iterations: loopBudget.limit,
           },
           usage: maxIterUsage,
           capacity: { certification_reserve_used: certificationReserveUsed },

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.44';
+export const CODE_VERSION = '2026.08.45';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "b3dfba92d066d37359421b9c9bb21202235479e15cf82f45f8b3f7c6a16abb95",
+    "server/src/addie/claude-client.ts": "a220a50bc16548d00af49e55d5bbc8b1544ba30ce1f0e1ae84f10e18f47e64eb",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/addie/model-providers/model-turn.ts
+++ b/server/src/addie/model-providers/model-turn.ts
@@ -68,6 +68,29 @@ export class EmptyResponseRecoveryState {
   }
 }
 
+/** One monotonic iteration wall shared by provider-neutral model loops. */
+export class ModelLoopBudget {
+  private startedIterations = 0;
+
+  constructor(readonly limit: number) {}
+
+  get iteration(): number {
+    return this.startedIterations;
+  }
+
+  get hasRemaining(): boolean {
+    return this.startedIterations < this.limit;
+  }
+
+  startNext(): number {
+    if (!this.hasRemaining) {
+      throw new Error('Model loop iteration budget exhausted');
+    }
+    this.startedIterations++;
+    return this.startedIterations;
+  }
+}
+
 /** Accumulate normalized usage without inventing absent provider cache metrics. */
 export function addModelUsage(total: ModelUsage, usage: ModelUsage): ModelUsage {
   return {

--- a/server/src/addie/model-providers/read-only-tool-loop.ts
+++ b/server/src/addie/model-providers/read-only-tool-loop.ts
@@ -1,6 +1,6 @@
 import Ajv, { type ValidateFunction } from 'ajv';
 import { collectModelResponse } from './events.js';
-import { addModelUsage, inspectModelTurn } from './model-turn.js';
+import { addModelUsage, inspectModelTurn, ModelLoopBudget } from './model-turn.js';
 import type {
   ModelProvider,
   ModelRequest,
@@ -137,8 +137,10 @@ export async function executeReadOnlyToolLoop(
   let totalUsage: ModelUsage = { inputTokens: 0, outputTokens: 0 };
   const receipts: ReadOnlyToolExecutionReceipt[] = [];
   const seenCallIds = new Set<string>();
+  const loopBudget = new ModelLoopBudget(MAX_ITERATIONS);
 
-  for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
+  while (loopBudget.hasRemaining) {
+    const iteration = loopBudget.startNext();
     const request: ModelRequest = {
       ...requestSnapshot,
       messages,

--- a/server/tests/unit/addie/model-provider-turn.test.ts
+++ b/server/tests/unit/addie/model-provider-turn.test.ts
@@ -8,6 +8,7 @@ import {
   addModelUsage,
   EmptyResponseRecoveryState,
   inspectModelTurn,
+  ModelLoopBudget,
 } from '../../../src/addie/model-providers/model-turn.js';
 
 function response(
@@ -126,5 +127,26 @@ describe('EmptyResponseRecoveryState', () => {
     state.resolve();
     expect(state.toolsAllowed).toBe(false);
     expect(state.schedule('post_tool', original)).toBe(false);
+  });
+});
+
+describe('ModelLoopBudget', () => {
+  it('issues monotonic iterations up to the configured wall', () => {
+    const budget = new ModelLoopBudget(2);
+
+    expect(budget.iteration).toBe(0);
+    expect(budget.hasRemaining).toBe(true);
+    expect(budget.startNext()).toBe(1);
+    expect(budget.startNext()).toBe(2);
+    expect(budget.iteration).toBe(2);
+    expect(budget.hasRemaining).toBe(false);
+    expect(() => budget.startNext()).toThrow('Model loop iteration budget exhausted');
+  });
+
+  it('starts exhausted when the configured wall is zero', () => {
+    const budget = new ModelLoopBudget(0);
+
+    expect(budget.hasRemaining).toBe(false);
+    expect(budget.iteration).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- add one provider-neutral monotonic iteration budget
- use it in production streaming, production non-streaming, and cross-provider read-only replay
- derive empty-response recovery eligibility from the same remaining-turn signal
- preserve configured max-iteration reporting and terminal behavior
- bump `CODE_VERSION` and refresh the generated Addie inventory

## Validation
- `npm run typecheck`
- 109 focused Addie provider, recovery, max-iteration, replay, streaming, and cost tests
- `npm run test:addie-tools`
- pre-push version and changeset gates

No protocol release surface changed, so no changeset is required.

Progresses #6844.