### PR TITLE
fix(addie): align schema tools with beta.6 docs

### DIFF
--- a/scripts/addie-tool-surface-budget.json
+++ b/scripts/addie-tool-surface-budget.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 4,
   "profile_ids_sha256": "79957b57d370335967ead65eec0cb71fc81c3d469d222169f9319e6c3a3306a8",
-  "profile_contract_sha256": "b6be1f63ecd01e0b96b77329129d899b1f6e95be149933ac2eecc219a3446437",
+  "profile_contract_sha256": "966f9f5b65a6c351fc79bb8db343a8ba88fabfa98643532e22cdae347f99f0cb",
   "baseline": {
     "id": "2026-08-26-pre-domain-consolidation",
     "metrics": {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -348,7 +348,7 @@
         "list_orphaned_brands"
       ],
       "ordered_tool_names_sha256": "cc78806188aa3b7be55bba733abc1ecbf7b2eea9f83ae6068e5b97ef694eb072",
-      "wire_schema_sha256": "94e13682d6f9475cf161f1a79781df954cee487b8a1ccf1b3e5de11e7f9bda16"
+      "wire_schema_sha256": "d6492f213db9215bba5647013304e62e08b91c0c6887d695f33e977271cfc8fa"
     },
     {
       "id": "legacy_slack:admin_mention:maximum",
@@ -586,7 +586,7 @@
         "list_orphaned_brands"
       ],
       "ordered_tool_names_sha256": "1d769dca5f53c7baee0102ce9e49384e23c11d51e1e44d65913124563c08e97c",
-      "wire_schema_sha256": "369637808c8599ad2601557930a082d91cb78a23a3a41987c61b9bbcad415c56"
+      "wire_schema_sha256": "71a53c3ffef63c1c541fa9d476dbcbcb753cb79523153e76c939cb01e0c09e77"
     },
     {
       "id": "legacy_slack:member_dm:maximum",
@@ -749,7 +749,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "88484816c567cdded948a50c26649b061d39509263be69448049497bd93edc30",
-      "wire_schema_sha256": "18ff1dbb703beddaeba1f4677884efe76eacbd2087a2898a17679971caf3b4d2"
+      "wire_schema_sha256": "5b63459fa11f214676dd73450239b9e7869ae6c52262d25f5504d6de69f3c725"
     },
     {
       "id": "legacy_slack:member_mention:maximum",
@@ -907,7 +907,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "93d3ff44c928cde4c4b5e99b42fc7711177e21c39c2f1ce6e4c49d966d7fa241",
-      "wire_schema_sha256": "dc870ed6adf2f460f961d7a78c68d927411ee440f38512055877cb23cb9b4406"
+      "wire_schema_sha256": "272d45d7f720d1fab1df9fbc4d9073729d07f3f39d5c46a50056ce1dd2680c22"
     },
     {
       "id": "mcp_chat:anonymous:exact",
@@ -1237,7 +1237,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "0062a413071701796a6fe8f320e99a5eb15786a2060318ed194986d993cd2977",
-      "wire_schema_sha256": "db50e9a036c8be5dd5378202ba71a3f9537f5b6318415188435a0d60862af28e"
+      "wire_schema_sha256": "b27a87742909a1f771542d469f480f0bac0928f5ec3c4026033741730f576227"
     },
     {
       "id": "slack_bolt_reaction:member:maximum",
@@ -1425,7 +1425,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "61d86f75baf72bec2cb4884059681dee8451ab30d87a39328591a61a1c5f7151",
-      "wire_schema_sha256": "545acc55b3137afd3cf7ac6e544ce1be43715034708d567c5566de63c4a281fb"
+      "wire_schema_sha256": "22a48c7b10bb5533349652810d7b2450235c288be2b34799e52169984be774e4"
     },
     {
       "id": "slack_bolt_reaction:public_channel_admin:maximum",
@@ -1692,7 +1692,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "91b98cd3c5e703401f7b8ce79683e194a196e64dfe2b9d06a93b1f6d9bbfd027",
-      "wire_schema_sha256": "75741d44b1280b123e22e54bc8e5b1a62b8aa9eac6172bde52b43169d97761c4"
+      "wire_schema_sha256": "373c58366733119c4826e640a590a7d7e48c5d700b5c25a9be1a5127b365dc7e"
     },
     {
       "id": "slack_bolt_reaction:public_channel:maximum",
@@ -1879,7 +1879,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "d2239cae6f97501a8ae83693ef4fee133822c89a8a38d05300072ada810030f2",
-      "wire_schema_sha256": "9288ba7192a5fc0c1f4f61d8c929b8b30ed4762571db4eba43c7a42004f5b989"
+      "wire_schema_sha256": "99e285b13fa1f230c9fae89755a93469d742b4a51b2af398061f661d73289269"
     },
     {
       "id": "slack_bolt:admin_dm:adcp_operations",
@@ -2052,7 +2052,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "bb7e22efc43619d68ab9bd1c6afbc0b8905cc09c92b639681423336ac241f680",
-      "wire_schema_sha256": "10684cedc640835ed5bd0ad37a2ac5cc6ab33a53a06b6c7ba54c31b1fe97ffce"
+      "wire_schema_sha256": "2ba18e2cba0c7cbba985eebdbc44a3fa4764788268f0cfba616ed1a644f24cc1"
     },
     {
       "id": "slack_bolt:admin_dm:admin",
@@ -2217,7 +2217,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "a3bd53c648a8d38f57d4d35ca6777d645ec20ecf70b27ed6557f79baea666134",
-      "wire_schema_sha256": "b972744054363d17c4ee7a24589a7787aca3f998decbbf5a63954e41e6e5287d"
+      "wire_schema_sha256": "669503c8f5676223816b61915962372f55a1a48ba7bfab5a0593850866b94102"
     },
     {
       "id": "slack_bolt:admin_dm:agent_conformance",
@@ -2385,7 +2385,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "8acbd2da935d160d3caaed1136f1a35eb107155fb24f155a91698b4f6f7dbc58",
-      "wire_schema_sha256": "598315a18a14ddc55af7639e8debe43d6df77a46599cee701a3c1e5222d27d71"
+      "wire_schema_sha256": "2b260af1162bff7605f0bf68fea198923a31b707a6aea4689139874970b4a255"
     },
     {
       "id": "slack_bolt:admin_dm:agent_testing",
@@ -2560,7 +2560,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "35546a8c91c1de4032f0de007c5cdfcb0bd229d586f093e3bcf7e89e5bd6d8ff",
-      "wire_schema_sha256": "87c7bf527f3b6aa87b9d9e7876644e091877a416bc3d908a31d13ac73eaca5d6"
+      "wire_schema_sha256": "b47b16d866fcba260835b673a3842558663ca2d1c4a390371d8d87149b4bb3ab"
     },
     {
       "id": "slack_bolt:admin_dm:all_valid_sets_maximum",
@@ -2819,7 +2819,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
+      "wire_schema_sha256": "a81dfdfbd272a7626e0f2cea30dba180f7636c59211db9fa525e88ced44b3c14"
     },
     {
       "id": "slack_bolt:admin_dm:billing",
@@ -2992,7 +2992,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "4d9e83e409081b619dadc361aeff0699a3e2c0094fa103edbb4c49efeb3b212a",
-      "wire_schema_sha256": "d399889704079c794d759dd5fed64b69f0cfccd0ecb00ac1d505509182a1e7b3"
+      "wire_schema_sha256": "9019a48b41758ca57a7158b48559e33446a2414df0aba62d25b7a04f4c1ab431"
     },
     {
       "id": "slack_bolt:admin_dm:certification",
@@ -3167,7 +3167,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "a573e69f3d2e0960f15a68fea4356006c6a01b0079b7c114895ef65610e8e168",
-      "wire_schema_sha256": "f66af732caa0a3171bb881e83806ba72b23e37a5b57f7ecf81a509ca7e47f199"
+      "wire_schema_sha256": "53601652c82d950964ca91eca050588d99dc9795436fc637d0b2ab7aa5e70e53"
     },
     {
       "id": "slack_bolt:admin_dm:certification_session",
@@ -3279,7 +3279,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "7cefa9648ee313d971d9dada8982df4977339c39ed3692d29883e4d9ebe0bb50",
-      "wire_schema_sha256": "31ee505a62ed15986f6740defe8803c912e2f2b0091edf94633a58545820664e"
+      "wire_schema_sha256": "fbc7948e8fb5b3e664f0a46627d0d095ff107fa9af76e33c34319062fe388086"
     },
     {
       "id": "slack_bolt:admin_dm:collaboration",
@@ -3446,7 +3446,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "db580b3906136a37e517b29fa42813cd7e58bbf7103e2d689e52425edd8173e8",
-      "wire_schema_sha256": "0d1f47f0b69486a1c1acbe629ff48a27c010b0eaee70c453773e34834eaa083d"
+      "wire_schema_sha256": "9f33e76a79480ed5f766930d3fa751f9a0f845ef078b5c027f28df693e12bab8"
     },
     {
       "id": "slack_bolt:admin_dm:committee_leadership",
@@ -3615,7 +3615,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "ac878ea477ba428ac6b2862370d9e94f032f54b17ec78011a087e7a3107911c5",
-      "wire_schema_sha256": "ac9f929ccf84babb7136d433c35743f0f0861b8b39541d52453229ce7c83bbef"
+      "wire_schema_sha256": "08f3a187b7c55e060413f8ff217beac949251729d9e6754f8834a53b6c9475c6"
     },
     {
       "id": "slack_bolt:admin_dm:content",
@@ -3785,7 +3785,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "48dcec57f579cecdd874b86f6a7715b2f5da584db1d276686a4b361a89277fae",
-      "wire_schema_sha256": "30dfecbac62435c96dc04508eb861207bd8efe0cccdc0d08421a4ee9fccfa539"
+      "wire_schema_sha256": "dc74f6f82feefe5a7bc6d292a332d915ebceebeb5f678606cf7c2af373a43655"
     },
     {
       "id": "slack_bolt:admin_dm:directory",
@@ -3954,7 +3954,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "5dce99bc859b249992be081e6f2056377f4ef68f96d2550ad9a6dc214174cd9b",
-      "wire_schema_sha256": "c3d2da5634faa852b464b9e467c5162e3787cbdb79e5b4854c8f6cdc166733e3"
+      "wire_schema_sha256": "3342047fe39267ef1ae0ce58948b6b01a212a261b270d0148bd8e447f78c0c54"
     },
     {
       "id": "slack_bolt:admin_dm:events",
@@ -4124,7 +4124,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "b4b1276069359ae0981d4774f73dec13c2c09a029cfe658a6ab619d3d6cab3e0",
-      "wire_schema_sha256": "78c1b0486423d5455ca51e7a76d872c52341ed0e7e4a65d2482b7c4bb88601a6"
+      "wire_schema_sha256": "899b6fca728d1332c4d77df27c7fc3b44efd715e55cdde05a019375ec8a830e4"
     },
     {
       "id": "slack_bolt:admin_dm:knowledge",
@@ -4293,7 +4293,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "f94ade7dcd16bf99e60b9947f367fda8dea2900ccb18998c8f8b00464cbfae87",
-      "wire_schema_sha256": "436f689fd93e944f72fd21bf9e326cfb1e0e783d43506a77b637b0ce1ea33a3e"
+      "wire_schema_sha256": "cd23deaebcb307ebe780af9abd0db45c8680b63124281a2e908090200ebb91be"
     },
     {
       "id": "slack_bolt:admin_dm:meetings",
@@ -4470,7 +4470,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "5d6937d04d27edb1d733350de0ab22b8a7b0cf530f2560ebd321e4c5c9a114ff",
-      "wire_schema_sha256": "50f5afbf660a7567f24256308ceb3b2ad12a9e64f916fcec1fc15eea3dc4c648"
+      "wire_schema_sha256": "414eb9f21b2431ef4d283d3650e4258987e0eed1b9b1dd50656d14560c4d8b9d"
     },
     {
       "id": "slack_bolt:admin_dm:member",
@@ -4654,7 +4654,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "9d786be92871a3293af94f16b9d96a39469bfa9db3fd2e526d46f0e1b632d569",
-      "wire_schema_sha256": "b98009910b50ada2f9ab2001402c9ea62d97f349973303176440c100c489deac"
+      "wire_schema_sha256": "71bd531a1a24d7206e789a7d53bd5f0d5991510da316e765e1349b143fa6b29c"
     },
     {
       "id": "slack_bolt:admin_dm:outreach",
@@ -4820,7 +4820,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "a3bd53c648a8d38f57d4d35ca6777d645ec20ecf70b27ed6557f79baea666134",
-      "wire_schema_sha256": "b972744054363d17c4ee7a24589a7787aca3f998decbbf5a63954e41e6e5287d"
+      "wire_schema_sha256": "669503c8f5676223816b61915962372f55a1a48ba7bfab5a0593850866b94102"
     },
     {
       "id": "slack_bolt:admin_dm:router_unavailable",
@@ -4987,7 +4987,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "f94ade7dcd16bf99e60b9947f367fda8dea2900ccb18998c8f8b00464cbfae87",
-      "wire_schema_sha256": "436f689fd93e944f72fd21bf9e326cfb1e0e783d43506a77b637b0ce1ea33a3e"
+      "wire_schema_sha256": "cd23deaebcb307ebe780af9abd0db45c8680b63124281a2e908090200ebb91be"
     },
     {
       "id": "slack_bolt:admin_working_group:adcp_operations",
@@ -5160,7 +5160,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "bb7e22efc43619d68ab9bd1c6afbc0b8905cc09c92b639681423336ac241f680",
-      "wire_schema_sha256": "10684cedc640835ed5bd0ad37a2ac5cc6ab33a53a06b6c7ba54c31b1fe97ffce"
+      "wire_schema_sha256": "2ba18e2cba0c7cbba985eebdbc44a3fa4764788268f0cfba616ed1a644f24cc1"
     },
     {
       "id": "slack_bolt:admin_working_group:admin",
@@ -5325,7 +5325,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "a3bd53c648a8d38f57d4d35ca6777d645ec20ecf70b27ed6557f79baea666134",
-      "wire_schema_sha256": "b972744054363d17c4ee7a24589a7787aca3f998decbbf5a63954e41e6e5287d"
+      "wire_schema_sha256": "669503c8f5676223816b61915962372f55a1a48ba7bfab5a0593850866b94102"
     },
     {
       "id": "slack_bolt:admin_working_group:agent_conformance",
@@ -5493,7 +5493,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "8acbd2da935d160d3caaed1136f1a35eb107155fb24f155a91698b4f6f7dbc58",
-      "wire_schema_sha256": "598315a18a14ddc55af7639e8debe43d6df77a46599cee701a3c1e5222d27d71"
+      "wire_schema_sha256": "2b260af1162bff7605f0bf68fea198923a31b707a6aea4689139874970b4a255"
     },
     {
       "id": "slack_bolt:admin_working_group:agent_testing",
@@ -5668,7 +5668,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "35546a8c91c1de4032f0de007c5cdfcb0bd229d586f093e3bcf7e89e5bd6d8ff",
-      "wire_schema_sha256": "87c7bf527f3b6aa87b9d9e7876644e091877a416bc3d908a31d13ac73eaca5d6"
+      "wire_schema_sha256": "b47b16d866fcba260835b673a3842558663ca2d1c4a390371d8d87149b4bb3ab"
     },
     {
       "id": "slack_bolt:admin_working_group:all_valid_sets_maximum",
@@ -5927,7 +5927,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
+      "wire_schema_sha256": "a81dfdfbd272a7626e0f2cea30dba180f7636c59211db9fa525e88ced44b3c14"
     },
     {
       "id": "slack_bolt:admin_working_group:billing",
@@ -6100,7 +6100,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "4d9e83e409081b619dadc361aeff0699a3e2c0094fa103edbb4c49efeb3b212a",
-      "wire_schema_sha256": "d399889704079c794d759dd5fed64b69f0cfccd0ecb00ac1d505509182a1e7b3"
+      "wire_schema_sha256": "9019a48b41758ca57a7158b48559e33446a2414df0aba62d25b7a04f4c1ab431"
     },
     {
       "id": "slack_bolt:admin_working_group:certification",
@@ -6275,7 +6275,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "a573e69f3d2e0960f15a68fea4356006c6a01b0079b7c114895ef65610e8e168",
-      "wire_schema_sha256": "f66af732caa0a3171bb881e83806ba72b23e37a5b57f7ecf81a509ca7e47f199"
+      "wire_schema_sha256": "53601652c82d950964ca91eca050588d99dc9795436fc637d0b2ab7aa5e70e53"
     },
     {
       "id": "slack_bolt:admin_working_group:collaboration",
@@ -6442,7 +6442,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "db580b3906136a37e517b29fa42813cd7e58bbf7103e2d689e52425edd8173e8",
-      "wire_schema_sha256": "0d1f47f0b69486a1c1acbe629ff48a27c010b0eaee70c453773e34834eaa083d"
+      "wire_schema_sha256": "9f33e76a79480ed5f766930d3fa751f9a0f845ef078b5c027f28df693e12bab8"
     },
     {
       "id": "slack_bolt:admin_working_group:committee_leadership",
@@ -6611,7 +6611,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "ac878ea477ba428ac6b2862370d9e94f032f54b17ec78011a087e7a3107911c5",
-      "wire_schema_sha256": "ac9f929ccf84babb7136d433c35743f0f0861b8b39541d52453229ce7c83bbef"
+      "wire_schema_sha256": "08f3a187b7c55e060413f8ff217beac949251729d9e6754f8834a53b6c9475c6"
     },
     {
       "id": "slack_bolt:admin_working_group:content",
@@ -6781,7 +6781,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "48dcec57f579cecdd874b86f6a7715b2f5da584db1d276686a4b361a89277fae",
-      "wire_schema_sha256": "30dfecbac62435c96dc04508eb861207bd8efe0cccdc0d08421a4ee9fccfa539"
+      "wire_schema_sha256": "dc74f6f82feefe5a7bc6d292a332d915ebceebeb5f678606cf7c2af373a43655"
     },
     {
       "id": "slack_bolt:admin_working_group:directory",
@@ -6950,7 +6950,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "5dce99bc859b249992be081e6f2056377f4ef68f96d2550ad9a6dc214174cd9b",
-      "wire_schema_sha256": "c3d2da5634faa852b464b9e467c5162e3787cbdb79e5b4854c8f6cdc166733e3"
+      "wire_schema_sha256": "3342047fe39267ef1ae0ce58948b6b01a212a261b270d0148bd8e447f78c0c54"
     },
     {
       "id": "slack_bolt:admin_working_group:events",
@@ -7120,7 +7120,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "b4b1276069359ae0981d4774f73dec13c2c09a029cfe658a6ab619d3d6cab3e0",
-      "wire_schema_sha256": "78c1b0486423d5455ca51e7a76d872c52341ed0e7e4a65d2482b7c4bb88601a6"
+      "wire_schema_sha256": "899b6fca728d1332c4d77df27c7fc3b44efd715e55cdde05a019375ec8a830e4"
     },
     {
       "id": "slack_bolt:admin_working_group:knowledge",
@@ -7289,7 +7289,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "f94ade7dcd16bf99e60b9947f367fda8dea2900ccb18998c8f8b00464cbfae87",
-      "wire_schema_sha256": "436f689fd93e944f72fd21bf9e326cfb1e0e783d43506a77b637b0ce1ea33a3e"
+      "wire_schema_sha256": "cd23deaebcb307ebe780af9abd0db45c8680b63124281a2e908090200ebb91be"
     },
     {
       "id": "slack_bolt:admin_working_group:meetings",
@@ -7466,7 +7466,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "5d6937d04d27edb1d733350de0ab22b8a7b0cf530f2560ebd321e4c5c9a114ff",
-      "wire_schema_sha256": "50f5afbf660a7567f24256308ceb3b2ad12a9e64f916fcec1fc15eea3dc4c648"
+      "wire_schema_sha256": "414eb9f21b2431ef4d283d3650e4258987e0eed1b9b1dd50656d14560c4d8b9d"
     },
     {
       "id": "slack_bolt:admin_working_group:member",
@@ -7650,7 +7650,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "9d786be92871a3293af94f16b9d96a39469bfa9db3fd2e526d46f0e1b632d569",
-      "wire_schema_sha256": "b98009910b50ada2f9ab2001402c9ea62d97f349973303176440c100c489deac"
+      "wire_schema_sha256": "71bd531a1a24d7206e789a7d53bd5f0d5991510da316e765e1349b143fa6b29c"
     },
     {
       "id": "slack_bolt:admin_working_group:outreach",
@@ -7816,7 +7816,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "a3bd53c648a8d38f57d4d35ca6777d645ec20ecf70b27ed6557f79baea666134",
-      "wire_schema_sha256": "b972744054363d17c4ee7a24589a7787aca3f998decbbf5a63954e41e6e5287d"
+      "wire_schema_sha256": "669503c8f5676223816b61915962372f55a1a48ba7bfab5a0593850866b94102"
     },
     {
       "id": "slack_bolt:admin_working_group:router_unavailable",
@@ -7983,7 +7983,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "f94ade7dcd16bf99e60b9947f367fda8dea2900ccb18998c8f8b00464cbfae87",
-      "wire_schema_sha256": "436f689fd93e944f72fd21bf9e326cfb1e0e783d43506a77b637b0ce1ea33a3e"
+      "wire_schema_sha256": "cd23deaebcb307ebe780af9abd0db45c8680b63124281a2e908090200ebb91be"
     },
     {
       "id": "slack_bolt:member_dm:adcp_operations",
@@ -8089,7 +8089,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "afff997d27d10316deaae9b8137ad3f92fedfeda44bb56865a939595281b4104",
-      "wire_schema_sha256": "a3ff4cd2bd97474fb0a28f9b4215bba77aa7f3e5fa2c070bc9d156cfba39d727"
+      "wire_schema_sha256": "8d35b3ffe57fa6adc08477a9461a52cad51813d3148457e4184b1b0a524811df"
     },
     {
       "id": "slack_bolt:member_dm:agent_conformance",
@@ -8190,7 +8190,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "e525ffd5d15f5c28a7ba033be3757dcce3a568fd7a931e82e08eb0402aafc16d",
-      "wire_schema_sha256": "cfb100f382151778afbedf34212dbb6047cf74e0052ac21bec58a800974d3839"
+      "wire_schema_sha256": "4493f19731abe62111ca678665502d608356d3094640016b495c580d82c98eb8"
     },
     {
       "id": "slack_bolt:member_dm:agent_testing",
@@ -8298,7 +8298,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "e04a115904dd0c7df0acbeac327e93a52bec7e508cf8412846f683d634495d20",
-      "wire_schema_sha256": "97132ce3072bc6750e24591efcbbfd0a0532b1258b0edbaf6d72864bb1ed943a"
+      "wire_schema_sha256": "853d0b7ea5dd5e726a556be407d100b6861f9adb05fe82c18afe184d9305cdc4"
     },
     {
       "id": "slack_bolt:member_dm:all_valid_sets_maximum",
@@ -8488,7 +8488,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "e38a1dd17e4d302b4d0b0355f211640cea955db1f0954fb3f02061ea852c70ff",
-      "wire_schema_sha256": "48544a44ce10f06f8439a1dd589918e09f40c7ca21aa3daf21492809031e17c8"
+      "wire_schema_sha256": "4c2cf93ac30d2e984dbfc17ddd59fd323571bde4781138efa23bb92736c13db8"
     },
     {
       "id": "slack_bolt:member_dm:certification",
@@ -8596,7 +8596,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "57a625917270f3e139b4926424cab06adf82d6151a1e615cdab804eeb6367bbb",
-      "wire_schema_sha256": "8a46a1b8382b58b519f3e5e4bf5c4f0f9d0aa7dc28b25ab153082e8712fc0a3f"
+      "wire_schema_sha256": "72dded999d1320cd54ea30b8d322e72cab4322991649e87750d5ca138c97ccfd"
     },
     {
       "id": "slack_bolt:member_dm:certification_session",
@@ -8706,7 +8706,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "3bf55c3f5be1dec9323cd4f4ce7c6cd92cc9451bd58eac89b5ad1b010f49aacb",
-      "wire_schema_sha256": "4f791fc9db6fc34efabd7ce90c81be12ac103918b34d3088b622b592d2e5bda0"
+      "wire_schema_sha256": "ac783cfba5abc9bdbded91033c1d7e8c4b30b229fba5811b5d18b74f0cdd59f8"
     },
     {
       "id": "slack_bolt:member_dm:collaboration",
@@ -8806,7 +8806,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "3122f368b3dd8a24e01bdfd0310baae2025e04db39535033f0c3b4a32f080b12",
-      "wire_schema_sha256": "63109afc62912ad2e67960d8c701e8b7d5ead0460cb7c326d193c741af9ba820"
+      "wire_schema_sha256": "9c64cef72e10753b774770d53224ba03ca7c77971cce88257d34afd3a5799ad6"
     },
     {
       "id": "slack_bolt:member_dm:committee_leadership",
@@ -8914,7 +8914,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "d6eaec50e43a1ffaa4c556086eb77361960f3da0f479f4831374ae979023a7e0",
-      "wire_schema_sha256": "8c794c37e80ae65126d94278675defe002945c096b3d2a80ffe8823e8f984043"
+      "wire_schema_sha256": "253712dfd70509fb81f032f2717f178107a71c073d679ee3ee9289c93e034f5a"
     },
     {
       "id": "slack_bolt:member_dm:content",
@@ -9017,7 +9017,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "247ea18fb5da48aedd4644882b4237076f5a5fc8a0286bfcaa683ed8e7e5e117",
-      "wire_schema_sha256": "5ae498eee36c0c8520dd7b56c2ff091bcd3e541061f0b35c75332c1c0b9c90f5"
+      "wire_schema_sha256": "59a6edb80f3441bd1f12de82790cee71427f002bd47f5e707dc5b950dc4ca7b6"
     },
     {
       "id": "slack_bolt:member_dm:directory",
@@ -9119,7 +9119,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "1cf77118ecb8cd1ec8d12eaeb0fb02a4af055816c22f5b16045690a6dc969441",
-      "wire_schema_sha256": "5062b16e1f895e11c5dcf64bd4ec4bcc386edc43eb9f90f8a74dfa786cf5e5ab"
+      "wire_schema_sha256": "855caf15ef16d78b7bea166a30adc73ac56af6817414d611e05f357d245a7ec0"
     },
     {
       "id": "slack_bolt:member_dm:events",
@@ -9222,7 +9222,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "dc6d363667e2206d81a4a5743e0c336eeef2ae3de377c9a5899561a3128a7a2e",
-      "wire_schema_sha256": "20497b13c5255ba05c121bbd54473bee9e260266c7fd08cf1c58d5ff68e6922e"
+      "wire_schema_sha256": "d23ac45e530338bc8770bc05c452c95f56a181eeca9f12c85dbed1fb6157001e"
     },
     {
       "id": "slack_bolt:member_dm:knowledge",
@@ -9324,7 +9324,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "55bc5e1430d0f14c9b795b0ef5048dcfbd4393a27362a5cfdfda078798c8383d",
-      "wire_schema_sha256": "b5da1fb5a621daa1a881ec6e40bffb451c19093ff00a78fd302c7a7ac2fdcedd"
+      "wire_schema_sha256": "2001cce67e306d329acfb16975d044d816ba6c87a5e96ce7f5677398ac360595"
     },
     {
       "id": "slack_bolt:member_dm:meetings",
@@ -9434,7 +9434,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "ea682614ec6bb2771e5bc2ff172f0843dab6ee5c2a3da45415914855b157ec99",
-      "wire_schema_sha256": "cf6a2f97ba67d713b1c44d3da9245b8cf38a9bdb64f2d5f1b016b618a092077c"
+      "wire_schema_sha256": "5f8f3ae05d06ce09e2368e72f0b33c27c4cb162750d5ba694291c3f59c182dd9"
     },
     {
       "id": "slack_bolt:member_dm:member",
@@ -9553,7 +9553,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "3a2cf9047a7dc9190b843f38c96a9925c6f845cba1182bd6fba04213f02b6b1c",
-      "wire_schema_sha256": "50c5faa9aa7eae96fa245864bf1d7aeea8eaa06ec3eac0cadbc18b7edbc89401"
+      "wire_schema_sha256": "252a9ca6c76c2ff31b1db261bdf075002df814010ad590327691ee3a5cfe7fe7"
     },
     {
       "id": "slack_bolt:member_dm:router_unavailable",
@@ -9653,7 +9653,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "55bc5e1430d0f14c9b795b0ef5048dcfbd4393a27362a5cfdfda078798c8383d",
-      "wire_schema_sha256": "b5da1fb5a621daa1a881ec6e40bffb451c19093ff00a78fd302c7a7ac2fdcedd"
+      "wire_schema_sha256": "2001cce67e306d329acfb16975d044d816ba6c87a5e96ce7f5677398ac360595"
     },
     {
       "id": "slack_bolt:private_channel_admin:adcp_operations",
@@ -9761,7 +9761,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "47e18ebf23b1c558a404775e65dfe79e937817afedb794e33b015ffdb16f0415",
-      "wire_schema_sha256": "e19266458b0817002849af2323067b66b7a22fc1d3e80cf02fb13f5c41bac14b"
+      "wire_schema_sha256": "3f55ae8af6c8851c5b7f3972e455ae473f448151432d746d52f6674a91385da6"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin",
@@ -9926,7 +9926,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "a3bd53c648a8d38f57d4d35ca6777d645ec20ecf70b27ed6557f79baea666134",
-      "wire_schema_sha256": "b972744054363d17c4ee7a24589a7787aca3f998decbbf5a63954e41e6e5287d"
+      "wire_schema_sha256": "669503c8f5676223816b61915962372f55a1a48ba7bfab5a0593850866b94102"
     },
     {
       "id": "slack_bolt:private_channel_admin:agent_conformance",
@@ -10029,7 +10029,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "9c6a3b0ada836a4f8908658de681534705531cb4dcca0de5e2e80bc26083f805",
-      "wire_schema_sha256": "a42338d614c1e2252cd11cc78d6bb31a7d53c2a91327e70b146f953b35eb0434"
+      "wire_schema_sha256": "a4301fcc2d55d42a3edf5c0ee6f7f7db057c3913c61c40e0a0c92354407b427c"
     },
     {
       "id": "slack_bolt:private_channel_admin:agent_testing",
@@ -10139,7 +10139,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "37a636d40b62afac43af06bdfccd7e4998e0f9c30a9d14b54146a1c940243bc8",
-      "wire_schema_sha256": "a76b3df6a29ce02fb6cae4390634f5748251c39cfe68fb721142f80994471b4c"
+      "wire_schema_sha256": "b172f9a989207684936da2d641475aef4c66197ab9f2b3ab8fdb1373da5b5f5f"
     },
     {
       "id": "slack_bolt:private_channel_admin:all_valid_sets_maximum",
@@ -10398,7 +10398,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
+      "wire_schema_sha256": "a81dfdfbd272a7626e0f2cea30dba180f7636c59211db9fa525e88ced44b3c14"
     },
     {
       "id": "slack_bolt:private_channel_admin:billing",
@@ -10510,7 +10510,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "e941a65963d4ba8c1e04c41a00f1219c0145ced9ae80b12c66a4d4413ba7998e",
-      "wire_schema_sha256": "d20e912c31beb94f867329c0c271a7020f964b19dfdf87d068b575cd02c44b92"
+      "wire_schema_sha256": "bb8451b2c8085e60dadf8202a5e18d872657ac63e292a0dcf2159dbec435e0f1"
     },
     {
       "id": "slack_bolt:private_channel_admin:certification",
@@ -10620,7 +10620,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "8a3163e5f1ef62e795e3b5a9f777d9b19030975ac4a0293b19a341454c2a2860",
-      "wire_schema_sha256": "bf9902afd31cc09b571534f5d325f40c5840478ce727bdb823519ff4030baaad"
+      "wire_schema_sha256": "f12f664edf8017c36839be1b2979965496ddf48a9e53a5db7a4636cb922ec8d7"
     },
     {
       "id": "slack_bolt:private_channel_admin:collaboration",
@@ -10722,7 +10722,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "55b96ec233e7baeecfcbdfadce7201eaf5d6dae68c476e3bfad91b4662dafc94",
-      "wire_schema_sha256": "4d079c79eebefd652188e97049fa07b5ece312a8e51066a23cc80cca598a3af8"
+      "wire_schema_sha256": "00cd362e1ab4265a0f5b50f3726a309891f4479ae7caefa39161175fe3ae7959"
     },
     {
       "id": "slack_bolt:private_channel_admin:committee_leadership",
@@ -10832,7 +10832,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "17ceb3bb2ca0d618a48d49adf618fb4087ea50f6ee4c287e8552271784cf77d0",
-      "wire_schema_sha256": "533a523a325dc8addcdd6ad8ac235bd45fbf81069263de89704c10405473ab33"
+      "wire_schema_sha256": "f1334008a89cfd15540081db71ecd68d721b1b75131f3ed3ae83978d2c3f9d02"
     },
     {
       "id": "slack_bolt:private_channel_admin:content",
@@ -10937,7 +10937,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "a16373856b4b90082b688e5da6247192cfa118c8599e4a3ccd38e4587461b935",
-      "wire_schema_sha256": "539afc5e1a3762fb94687a9aeb6d5bb9d0b24fdd43d7fb2540703580e7f1a406"
+      "wire_schema_sha256": "20a93543ae4045bb294ef313923cdc0cdd7cd8cd1f7dce8b4628650b522bf601"
     },
     {
       "id": "slack_bolt:private_channel_admin:directory",
@@ -11041,7 +11041,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "f3a2925494aa24baa41963c5e9ba51d62f8515f0f6d909a330cb83f5434c6466",
-      "wire_schema_sha256": "f7d1f31a0e20bda2aad89a248769ec97021b44858a5a5158e6a60decb22c857f"
+      "wire_schema_sha256": "13c2d5ae0277407ccfb704aaa86fe27bc9ae656ce7667cf386e669cb6c5b45f9"
     },
     {
       "id": "slack_bolt:private_channel_admin:events",
@@ -11146,7 +11146,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "0b8780de97b3730d075498accca78ef175ca85319c27e0aae181a3d377ce9f12",
-      "wire_schema_sha256": "560d5c66b45d435be784cda173a3c916befec3b99b4fcb03f23ec171dc3b12ec"
+      "wire_schema_sha256": "2c6b6750b8319b43f6643c85235494c5dc6ca055d120942220ae8ec104939d79"
     },
     {
       "id": "slack_bolt:private_channel_admin:knowledge",
@@ -11250,7 +11250,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "fb67e298c1e5cfb91fa08cb50a871fbb9bd15dfd25b1fbad8e28325458b3e53d",
-      "wire_schema_sha256": "42cd7bc0465f9e64ffcd5878f594e913f1af4dfc5d78a0abed6ae0413860f653"
+      "wire_schema_sha256": "3f978aa78f15ca4bccf4effbf840c3c459f41387d4ecfdf004b3cdb8dc5d7f03"
     },
     {
       "id": "slack_bolt:private_channel_admin:meetings",
@@ -11362,7 +11362,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "39d1f0dea008ca995883b3ba52243ced633fc05ae25dd1156510caa31b9973ed",
-      "wire_schema_sha256": "5630242490ceb5bad5d796dfd0f83bd3589ad5c35f9743ad9dae141196cf6f03"
+      "wire_schema_sha256": "aa13616523af636b7dc3e0181b17eef42e138c52bff8cba29485f8167f34a5e6"
     },
     {
       "id": "slack_bolt:private_channel_admin:member",
@@ -11483,7 +11483,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "e573274e16766c42c070a338f4445c11803c830a4d2eeed1e8863cfc0c3e9e32",
-      "wire_schema_sha256": "f8681a2d78632d1eccec81b223f49ac8c47c0c9a19b85a705a7ff3e43a89bf5a"
+      "wire_schema_sha256": "0e8fe43689856b8cb860e762f35d6e7f3fcffd89684087f51bc29153a1c4dd4e"
     },
     {
       "id": "slack_bolt:private_channel_admin:outreach",
@@ -11590,7 +11590,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "a76c3ae9bb3dbf4569f0415b7ec5a60ce047e307585ce748116370259cc8aee4",
-      "wire_schema_sha256": "e670e9c5ad8bf44884c55d711227140fa1efe6718c312f1945843016b79ffd9c"
+      "wire_schema_sha256": "1d508f71088b8637560cb3d1869f359f03b6931ed4f15813bfca0cc56e71bd23"
     },
     {
       "id": "slack_bolt:private_channel_admin:router_unavailable",
@@ -11692,7 +11692,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "fb67e298c1e5cfb91fa08cb50a871fbb9bd15dfd25b1fbad8e28325458b3e53d",
-      "wire_schema_sha256": "42cd7bc0465f9e64ffcd5878f594e913f1af4dfc5d78a0abed6ae0413860f653"
+      "wire_schema_sha256": "3f978aa78f15ca4bccf4effbf840c3c459f41387d4ecfdf004b3cdb8dc5d7f03"
     },
     {
       "id": "slack_bolt:private_channel_member:adcp_operations",
@@ -11798,7 +11798,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "afff997d27d10316deaae9b8137ad3f92fedfeda44bb56865a939595281b4104",
-      "wire_schema_sha256": "a3ff4cd2bd97474fb0a28f9b4215bba77aa7f3e5fa2c070bc9d156cfba39d727"
+      "wire_schema_sha256": "8d35b3ffe57fa6adc08477a9461a52cad51813d3148457e4184b1b0a524811df"
     },
     {
       "id": "slack_bolt:private_channel_member:agent_conformance",
@@ -11899,7 +11899,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "e525ffd5d15f5c28a7ba033be3757dcce3a568fd7a931e82e08eb0402aafc16d",
-      "wire_schema_sha256": "cfb100f382151778afbedf34212dbb6047cf74e0052ac21bec58a800974d3839"
+      "wire_schema_sha256": "4493f19731abe62111ca678665502d608356d3094640016b495c580d82c98eb8"
     },
     {
       "id": "slack_bolt:private_channel_member:agent_testing",
@@ -12007,7 +12007,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "e04a115904dd0c7df0acbeac327e93a52bec7e508cf8412846f683d634495d20",
-      "wire_schema_sha256": "97132ce3072bc6750e24591efcbbfd0a0532b1258b0edbaf6d72864bb1ed943a"
+      "wire_schema_sha256": "853d0b7ea5dd5e726a556be407d100b6861f9adb05fe82c18afe184d9305cdc4"
     },
     {
       "id": "slack_bolt:private_channel_member:all_valid_sets_maximum",
@@ -12197,7 +12197,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "e38a1dd17e4d302b4d0b0355f211640cea955db1f0954fb3f02061ea852c70ff",
-      "wire_schema_sha256": "48544a44ce10f06f8439a1dd589918e09f40c7ca21aa3daf21492809031e17c8"
+      "wire_schema_sha256": "4c2cf93ac30d2e984dbfc17ddd59fd323571bde4781138efa23bb92736c13db8"
     },
     {
       "id": "slack_bolt:private_channel_member:certification",
@@ -12305,7 +12305,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "57a625917270f3e139b4926424cab06adf82d6151a1e615cdab804eeb6367bbb",
-      "wire_schema_sha256": "8a46a1b8382b58b519f3e5e4bf5c4f0f9d0aa7dc28b25ab153082e8712fc0a3f"
+      "wire_schema_sha256": "72dded999d1320cd54ea30b8d322e72cab4322991649e87750d5ca138c97ccfd"
     },
     {
       "id": "slack_bolt:private_channel_member:collaboration",
@@ -12405,7 +12405,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "3122f368b3dd8a24e01bdfd0310baae2025e04db39535033f0c3b4a32f080b12",
-      "wire_schema_sha256": "63109afc62912ad2e67960d8c701e8b7d5ead0460cb7c326d193c741af9ba820"
+      "wire_schema_sha256": "9c64cef72e10753b774770d53224ba03ca7c77971cce88257d34afd3a5799ad6"
     },
     {
       "id": "slack_bolt:private_channel_member:committee_leadership",
@@ -12513,7 +12513,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "d6eaec50e43a1ffaa4c556086eb77361960f3da0f479f4831374ae979023a7e0",
-      "wire_schema_sha256": "8c794c37e80ae65126d94278675defe002945c096b3d2a80ffe8823e8f984043"
+      "wire_schema_sha256": "253712dfd70509fb81f032f2717f178107a71c073d679ee3ee9289c93e034f5a"
     },
     {
       "id": "slack_bolt:private_channel_member:content",
@@ -12616,7 +12616,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "247ea18fb5da48aedd4644882b4237076f5a5fc8a0286bfcaa683ed8e7e5e117",
-      "wire_schema_sha256": "5ae498eee36c0c8520dd7b56c2ff091bcd3e541061f0b35c75332c1c0b9c90f5"
+      "wire_schema_sha256": "59a6edb80f3441bd1f12de82790cee71427f002bd47f5e707dc5b950dc4ca7b6"
     },
     {
       "id": "slack_bolt:private_channel_member:directory",
@@ -12718,7 +12718,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "1cf77118ecb8cd1ec8d12eaeb0fb02a4af055816c22f5b16045690a6dc969441",
-      "wire_schema_sha256": "5062b16e1f895e11c5dcf64bd4ec4bcc386edc43eb9f90f8a74dfa786cf5e5ab"
+      "wire_schema_sha256": "855caf15ef16d78b7bea166a30adc73ac56af6817414d611e05f357d245a7ec0"
     },
     {
       "id": "slack_bolt:private_channel_member:events",
@@ -12821,7 +12821,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "dc6d363667e2206d81a4a5743e0c336eeef2ae3de377c9a5899561a3128a7a2e",
-      "wire_schema_sha256": "20497b13c5255ba05c121bbd54473bee9e260266c7fd08cf1c58d5ff68e6922e"
+      "wire_schema_sha256": "d23ac45e530338bc8770bc05c452c95f56a181eeca9f12c85dbed1fb6157001e"
     },
     {
       "id": "slack_bolt:private_channel_member:knowledge",
@@ -12923,7 +12923,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "55bc5e1430d0f14c9b795b0ef5048dcfbd4393a27362a5cfdfda078798c8383d",
-      "wire_schema_sha256": "b5da1fb5a621daa1a881ec6e40bffb451c19093ff00a78fd302c7a7ac2fdcedd"
+      "wire_schema_sha256": "2001cce67e306d329acfb16975d044d816ba6c87a5e96ce7f5677398ac360595"
     },
     {
       "id": "slack_bolt:private_channel_member:meetings",
@@ -13033,7 +13033,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "ea682614ec6bb2771e5bc2ff172f0843dab6ee5c2a3da45415914855b157ec99",
-      "wire_schema_sha256": "cf6a2f97ba67d713b1c44d3da9245b8cf38a9bdb64f2d5f1b016b618a092077c"
+      "wire_schema_sha256": "5f8f3ae05d06ce09e2368e72f0b33c27c4cb162750d5ba694291c3f59c182dd9"
     },
     {
       "id": "slack_bolt:private_channel_member:member",
@@ -13152,7 +13152,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "3a2cf9047a7dc9190b843f38c96a9925c6f845cba1182bd6fba04213f02b6b1c",
-      "wire_schema_sha256": "50c5faa9aa7eae96fa245864bf1d7aeea8eaa06ec3eac0cadbc18b7edbc89401"
+      "wire_schema_sha256": "252a9ca6c76c2ff31b1db261bdf075002df814010ad590327691ee3a5cfe7fe7"
     },
     {
       "id": "slack_bolt:private_channel_member:router_unavailable",
@@ -13252,7 +13252,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "55bc5e1430d0f14c9b795b0ef5048dcfbd4393a27362a5cfdfda078798c8383d",
-      "wire_schema_sha256": "b5da1fb5a621daa1a881ec6e40bffb451c19093ff00a78fd302c7a7ac2fdcedd"
+      "wire_schema_sha256": "2001cce67e306d329acfb16975d044d816ba6c87a5e96ce7f5677398ac360595"
     },
     {
       "id": "slack_bolt:public_channel_admin:adcp_operations",
@@ -13359,7 +13359,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "01c28e511fd27154cb72636f94555ab41a60a83116acb61fc38658251468f5f0",
-      "wire_schema_sha256": "cdf63d38d6dbb9d273cb16d21ddf5606dc15555a8f2a16f3143450b20d3507cb"
+      "wire_schema_sha256": "fd42b51e6bc73bfa01d2324834009286dc521aaacec0485e6f0dc38db8895afc"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin",
@@ -13523,7 +13523,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "bb9c44ff1e928c8783c3c983c7df3a13066daee82e00fc70f939d5900bb97cff",
-      "wire_schema_sha256": "b1365d95226de802ddb77a89b3e0f66e79cf75c3a5dc2b4d03f0c1256625672d"
+      "wire_schema_sha256": "51bb782c0310d2b8b485b9c15f3d60fd85980498e1460ee1556bf56972622381"
     },
     {
       "id": "slack_bolt:public_channel_admin:agent_conformance",
@@ -13625,7 +13625,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "9aa9df9812e3ee1cddad5a178afa9db240ab33171a33f645653695978d228136",
-      "wire_schema_sha256": "bec6410c5d468df0542a9426b665e9cbb570492df7d96c3bee11964690c4db62"
+      "wire_schema_sha256": "18dfc9ca2e3a819e588c3ed1d95ab69a318259bf188d9833271598f51c61ef82"
     },
     {
       "id": "slack_bolt:public_channel_admin:agent_testing",
@@ -13734,7 +13734,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "f59e2aca88d17ad97b9addbf644253466f4992f950e04040b9310447e064702b",
-      "wire_schema_sha256": "13bf4ddfa1cb8bb585345430119a6a197704c638ba27175128943f9ee0567f9b"
+      "wire_schema_sha256": "363b6fe32f431ec4ef7fe041fef36b9728c59cf10268c068d268e4a7ad10e623"
     },
     {
       "id": "slack_bolt:public_channel_admin:all_valid_sets_maximum",
@@ -13985,7 +13985,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "3354f78e8427559cdb0eb347e455edd6032255fb5c3dcd6789e9181647092cb8",
-      "wire_schema_sha256": "2b51e7aec2049c05bdfc8f69c2d853c8374f353975933c4cf82f7c3baa071893"
+      "wire_schema_sha256": "3b62246e053e661dfb932b6ba925cd2b63e23d52fdc5bb2650cedd9333e091b9"
     },
     {
       "id": "slack_bolt:public_channel_admin:billing",
@@ -14085,7 +14085,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "d006d364f68c81d283b55e3882745913cef275c55807ef89b4666bbfb3efcd8e",
-      "wire_schema_sha256": "742bf9c4b84ceea7b602c95fb4a676285ad9b28df43d2e3b98eba4ce2be0244a"
+      "wire_schema_sha256": "80eb7f5bc613557291b731ab63981bc2ae70cef01c6bf96c6feafac3424c9e89"
     },
     {
       "id": "slack_bolt:public_channel_admin:certification",
@@ -14194,7 +14194,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "327e8b28128548ee37a4bd3dd494b5c62a2152ee6ffda7ae790da5c2c6e69993",
-      "wire_schema_sha256": "e6ee774a1886c99743541ba3e4256ad059d7190169fb5d954d4852db9af1687e"
+      "wire_schema_sha256": "c622c9e1512891c5a0225f318215c519100ccff881a10841ac288d44abe2d706"
     },
     {
       "id": "slack_bolt:public_channel_admin:collaboration",
@@ -14295,7 +14295,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "ad59f825c50fd9cee0224155930778ac470c3168831e7d687761d6502f422d5b",
-      "wire_schema_sha256": "378df1cc45998f552b7405d020e5ec92420b2a8118c7e96f83e1a815b99cffcc"
+      "wire_schema_sha256": "7d22dde70013c1e868a08b8a260c4dd67956a56811948f04456bd495e2fcc3bb"
     },
     {
       "id": "slack_bolt:public_channel_admin:committee_leadership",
@@ -14404,7 +14404,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "8187bd063db45f9e41e5893b17bba2042032f98729a20b1708a96808353c9677",
-      "wire_schema_sha256": "410932ffbbb47de90b4149f77032cc036fd8f8d12743b4506b281b9f6e78b442"
+      "wire_schema_sha256": "ca33698acdd0dbfd601078a9e37e2b9eb0d78c0142f666a5e87b64d3d2b777e1"
     },
     {
       "id": "slack_bolt:public_channel_admin:content",
@@ -14508,7 +14508,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "3d10a14f6d48d4008c5926926b835134c5166a9747415b7ff045a1948fb3563a",
-      "wire_schema_sha256": "b2874df6fa4110dd842362765c6034ff2625af8141e7ee5ac2b39115a03bd793"
+      "wire_schema_sha256": "26fb529aee94650bf0ad9f77abc1bc31f864974046b6a95073cead4747202c32"
     },
     {
       "id": "slack_bolt:public_channel_admin:directory",
@@ -14611,7 +14611,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "d3b20a5fea74c90cc232b22d4f0540f5c131b4687ce25d46c72c0f27724f1d45",
-      "wire_schema_sha256": "f0383eb0e00d4f774355270be31d6b67d01ee938649043f4a90276a04d1197b2"
+      "wire_schema_sha256": "7947fcd54e324a2997e33ec920159f8b09daae9416343809c97d95ca5c741bae"
     },
     {
       "id": "slack_bolt:public_channel_admin:events",
@@ -14715,7 +14715,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "8a1da77058259cd9b719e6013012bd090d64111674e645ed1cbf32f61d74abcb",
-      "wire_schema_sha256": "7ee6ad46a880050da1f04588d5f4b7b9aa7736d1326a044d97eeaa3465e3d3cd"
+      "wire_schema_sha256": "acdb03fe310d29293063ba7090457d5d09a9a862e9e05b1958f6626c8503cb3c"
     },
     {
       "id": "slack_bolt:public_channel_admin:knowledge",
@@ -14818,7 +14818,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "d942789acd92f1cab9b53b1be69fb6b9948075bad24c418a1c54ded0d784ea6d",
-      "wire_schema_sha256": "5edae2ea7ea4caf1eddf20d3789298dfafe22570f0e4c0de4bc2297b7752b00e"
+      "wire_schema_sha256": "45ca8878ce315524d583ec3ffed4958339e9c49fc12d2d7588f4996749407f08"
     },
     {
       "id": "slack_bolt:public_channel_admin:meetings",
@@ -14929,7 +14929,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "b5b490e2beadb82d344dad97457b760396c6df9a36cc471cff2fad180abd4d5b",
-      "wire_schema_sha256": "134703b19f5316bc8d5cfc01960734aba52965b47f778ad17a44b16f7ddaaa11"
+      "wire_schema_sha256": "067de5af1e3c1cfe0b2bad60def8024bbd8fe8d7dddeab0d9c129d8c6766f0f7"
     },
     {
       "id": "slack_bolt:public_channel_admin:member",
@@ -15049,7 +15049,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "c2c23fcfca611eab0a7ce304a9df47055b5600dc9e2e2644a2c171f3a4cab524",
-      "wire_schema_sha256": "5b9404e22e24115935cb58c87809672fff562d77a18065ca79e53c39e7a476c0"
+      "wire_schema_sha256": "75cab5c7000e6ee8ea64c0d407bea7de3607b7fd24eefd12b81bd15798c2235a"
     },
     {
       "id": "slack_bolt:public_channel_admin:outreach",
@@ -15155,7 +15155,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "f3da849fded3c28bce166d3ab341ce1237c50e6fb4ba0cd3f809cf62f5ab300f",
-      "wire_schema_sha256": "d0dd8ba07a21e92815735552a8e354db8a59acb94b7723ef68dca69f8b51dd6f"
+      "wire_schema_sha256": "9bcdf3267b3ef380f6d88faeb3535caacc31246e84f676929a0511c65902c69a"
     },
     {
       "id": "slack_bolt:public_channel_admin:router_unavailable",
@@ -15256,7 +15256,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "d942789acd92f1cab9b53b1be69fb6b9948075bad24c418a1c54ded0d784ea6d",
-      "wire_schema_sha256": "5edae2ea7ea4caf1eddf20d3789298dfafe22570f0e4c0de4bc2297b7752b00e"
+      "wire_schema_sha256": "45ca8878ce315524d583ec3ffed4958339e9c49fc12d2d7588f4996749407f08"
     },
     {
       "id": "slack_bolt:public_channel_member:adcp_operations",
@@ -15361,7 +15361,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "39f1054e1f5e4ddd029dab7426187e7ab92e48707a25bb2517ce062af83c4bf4",
-      "wire_schema_sha256": "54a967ed84f65fc648c53c285a14933bbf55e2ee3ab005a096eefe9a2265eeae"
+      "wire_schema_sha256": "adc9f164714db766ca3dab4547cd56bf4ee4c060b0a79dbd11d8611e540b8683"
     },
     {
       "id": "slack_bolt:public_channel_member:agent_conformance",
@@ -15461,7 +15461,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "d8c68a4d3a70e7a73926d740f8335df104fa2d135002153fce5e1ed1249ee6ee",
-      "wire_schema_sha256": "b54b3be53549a2ef2584f3f45425ad229ba5f336c7715a743eb3a6b60a627861"
+      "wire_schema_sha256": "017b3b86fdf2974f8beaed1bbe4734e2a8bbe47119201837de1fbcfaf61b362f"
     },
     {
       "id": "slack_bolt:public_channel_member:agent_testing",
@@ -15568,7 +15568,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "e31bb185d40acac4950b7b2855e5ecec6a6d0d75faea448b4cc381c4fab3f048",
-      "wire_schema_sha256": "99fcfd65aea661459db0779fa044732eae575fb5a5da7c8c6de27905387b73bc"
+      "wire_schema_sha256": "925d766210d5b212fa80006ce183c9d3d041418ed78f60ce32ab14f88df34bff"
     },
     {
       "id": "slack_bolt:public_channel_member:all_valid_sets_maximum",
@@ -15757,7 +15757,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "d8497806ffdbbbb3ccf8f470ea2b4873c142e0b741cd8c020f2142119f52beb7",
-      "wire_schema_sha256": "1404695b32173be7157747c10d93074ffeb08bfe28b07491e2b82adf30b5c9e9"
+      "wire_schema_sha256": "7aadd8aad7d239b263c632d0db8ab478c27c62393f271b92450958bef3180963"
     },
     {
       "id": "slack_bolt:public_channel_member:certification",
@@ -15864,7 +15864,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "16f5c41d40647cf0efa7f1822463c3790694e1b7db7d46a533fa8ab0e4c5094a",
-      "wire_schema_sha256": "5566b6d0608ff91a83720e2fdb3a22dc378d2a704be0c332117ddb9f5ededccc"
+      "wire_schema_sha256": "7beac7a515282cecf83f6834678e074361550dd788ba73c22149fcf2351e28dc"
     },
     {
       "id": "slack_bolt:public_channel_member:collaboration",
@@ -15963,7 +15963,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "609a43b00ced3501f353b277d62d34297d1cca01753dd7c06964f5235cfa6659",
-      "wire_schema_sha256": "8fce7b067d6f92dc7a0041c46977df7d11378352981e4802e2e822ffc828b1a2"
+      "wire_schema_sha256": "946dffb9f5e1038997fe1f342f8624187057ad08218156846e8b4f35ff72da25"
     },
     {
       "id": "slack_bolt:public_channel_member:committee_leadership",
@@ -16070,7 +16070,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "c16319db465ee46af794c7d4ccbfe529b6d638b10bdd3175d90d114699977d5c",
-      "wire_schema_sha256": "f9665c71a74552924fcdef103dbe9ea2600a86c7ae948fe72aecfc5eb2ec5f91"
+      "wire_schema_sha256": "c6995a20bef5d570152ffc3dc7231fbcf0bf307eae5753b5a7d93d391a66d2a7"
     },
     {
       "id": "slack_bolt:public_channel_member:content",
@@ -16172,7 +16172,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "2fc2cb273fb676d21322b3d3272c7fe2b89bae06e3e451e80c86932806b743cc",
-      "wire_schema_sha256": "6e010363c57a8023a3ce9edb36f76da19e03b3769cb466498b8cbfa6d2947ed6"
+      "wire_schema_sha256": "bf67b8039b3e05a2abc8f10764582b82a1d71c5fb50a70229c0d104ecea451b4"
     },
     {
       "id": "slack_bolt:public_channel_member:directory",
@@ -16273,7 +16273,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "ae1c15905731df2e653021500bfc316ece4015b66ff8354c2613e9d5179840da",
-      "wire_schema_sha256": "b0fccb25916f934297a605de0a3ef5f45ee099dc044b9341a85e40d8c742ead7"
+      "wire_schema_sha256": "8e0ddc495c5f71abf81314d594853f24b2869fc2fac67bd15bcb0167eb568acc"
     },
     {
       "id": "slack_bolt:public_channel_member:events",
@@ -16375,7 +16375,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "47fa4cc32b45695509e714d4bceef884cdb0ecc2bcb1c9c3cc4035cd75859e79",
-      "wire_schema_sha256": "c70dffdfbd25d71112d8a2d6b303358537f06691ca5b7d1e20a5f337866619bf"
+      "wire_schema_sha256": "a4ade4983be5c7428f325c53c72281a6396ec3a12970a6431addc9330b3c2c3c"
     },
     {
       "id": "slack_bolt:public_channel_member:knowledge",
@@ -16476,7 +16476,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "766b920233135a10c33ad69bf6e0dcd6fa4aafc5388a48c262147a343c541d92",
-      "wire_schema_sha256": "65978b053197788d4ab4d0b5281932ef21254ec1fdcd340f0f87335c1ee6d07a"
+      "wire_schema_sha256": "3ace9f4834c8fa1ab3804e782013995702932918765072077219d9f98188c1fc"
     },
     {
       "id": "slack_bolt:public_channel_member:meetings",
@@ -16585,7 +16585,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "1118d061d1c316ff19fd22dd3d35d3563dbdad427c1b9fe4ef27d09b83a62634",
-      "wire_schema_sha256": "bdabd92d46ae3ac6353ea43576e617ac1678feaae44d3338fb5c80428edc0733"
+      "wire_schema_sha256": "e47403266c4c725c6723e8dab7513cb9b43b6b0c1d9d2894282e5ebde0d3bb8e"
     },
     {
       "id": "slack_bolt:public_channel_member:member",
@@ -16703,7 +16703,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "2a7bc7f777a5ec8f19fa9164a1ee1e7ae336eb364a0db21569a5ff379a1ff680",
-      "wire_schema_sha256": "783185bb56d3594457f2dfdff18fd1ef0977e3a7971135f79629b9a61cd13a75"
+      "wire_schema_sha256": "301f742ea7fa063b66667c9f65d2b9879ec71e371146ae4856807ff148552878"
     },
     {
       "id": "slack_bolt:public_channel_member:router_unavailable",
@@ -16802,7 +16802,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "766b920233135a10c33ad69bf6e0dcd6fa4aafc5388a48c262147a343c541d92",
-      "wire_schema_sha256": "65978b053197788d4ab4d0b5281932ef21254ec1fdcd340f0f87335c1ee6d07a"
+      "wire_schema_sha256": "3ace9f4834c8fa1ab3804e782013995702932918765072077219d9f98188c1fc"
     },
     {
       "id": "slack_bolt:system_channel_admin:admin:all_valid_sets_maximum",
@@ -17060,7 +17060,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
+      "wire_schema_sha256": "a81dfdfbd272a7626e0f2cea30dba180f7636c59211db9fa525e88ced44b3c14"
     },
     {
       "id": "slack_bolt:system_channel_admin:billing:all_valid_sets_maximum",
@@ -17318,7 +17318,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
+      "wire_schema_sha256": "a81dfdfbd272a7626e0f2cea30dba180f7636c59211db9fa525e88ced44b3c14"
     },
     {
       "id": "slack_bolt:system_channel_admin:error:all_valid_sets_maximum",
@@ -17576,7 +17576,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
+      "wire_schema_sha256": "a81dfdfbd272a7626e0f2cea30dba180f7636c59211db9fa525e88ced44b3c14"
     },
     {
       "id": "slack_bolt:system_channel_admin:escalation:all_valid_sets_maximum",
@@ -17834,7 +17834,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
+      "wire_schema_sha256": "a81dfdfbd272a7626e0f2cea30dba180f7636c59211db9fa525e88ced44b3c14"
     },
     {
       "id": "slack_bolt:system_channel_admin:prospect:all_valid_sets_maximum",
@@ -18092,7 +18092,7 @@
         "complete_certification_exam"
       ],
       "ordered_tool_names_sha256": "6116c004f9f3759786b7c5b39df09c4a5b96f62114865fbc23a21bf14005dc84",
-      "wire_schema_sha256": "4f085fabe61189d08f05cd9286c84b97788121a8444583114f831b515e51e950"
+      "wire_schema_sha256": "a81dfdfbd272a7626e0f2cea30dba180f7636c59211db9fa525e88ced44b3c14"
     },
     {
       "id": "tavus_voice:admin:maximum",
@@ -18331,7 +18331,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "ee026b5c5493eecf66980d8bc45d13bca576838fd1e56d46a225d8c0a8fc735a",
-      "wire_schema_sha256": "aa0b655e7e72943ce14c8ccd3ea5033780c26238e332df5a63eba20b77785eaf"
+      "wire_schema_sha256": "6dc1151c54b4018da1649fcf036ad06c08c43f91104e9660a5ead546018d36cd"
     },
     {
       "id": "tavus_voice:baseline:exact",
@@ -18525,7 +18525,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "1014ec0f38456600ea98be64558e693f91e59d9f0c9a9802743152bb36a42710",
-      "wire_schema_sha256": "b398a586d2ac3b073ba5fe39929e9cb5c5b6bf666f1029e86026637a295fd063"
+      "wire_schema_sha256": "38b8277b537e33d56e9b9c42109a4cf40fe41e9c61a121574643a1c76e8521da"
     },
     {
       "id": "tavus_voice:member:maximum",
@@ -18667,7 +18667,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "777fd9afbfea06766211ff5d208c0e612bbfdc08756213f9ea1501efdf9dd33b",
-      "wire_schema_sha256": "732b2da45d1d117b0672788b07e36ba7bc664ebf34d8d8e675757f1cd3c5d64e"
+      "wire_schema_sha256": "73e1b860fdb29a5462387038275629fdc15b399f43ae2b7cdbb3ac14af896ff3"
     },
     {
       "id": "web_chat:anonymous:maximum",
@@ -18960,7 +18960,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "60c1bf349d4a8bc228804867d449a574dee4951878ba6176c7c9a1eb14821e0c",
-      "wire_schema_sha256": "0b6f9062c1a3e26f4253b2a94f5bc42c576d40a90317c19a74c4c6d86949645f"
+      "wire_schema_sha256": "e42c2a255a926d317960bc44dd017ec0380268d31052caad0e6726cfaa5d158a"
     },
     {
       "id": "web_chat:authenticated_member:maximum",
@@ -19137,7 +19137,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "ba3b0ba34ca3982d006f0b9e069c3d411d4b2ecb543039b6099d6ed9135b8aca",
-      "wire_schema_sha256": "e3b2d0616ea8df5189d7afc08336dbcb3f514e1c9b76dbb05687cd8eea03a8e7"
+      "wire_schema_sha256": "a6305f9fcb2fcc6463538fe528274e768a0a8ea65fa68474015b377a665791a2"
     }
   ],
   "baseline": {
@@ -19366,11 +19366,11 @@
       }
     },
     "profile_ids_sha256": "79957b57d370335967ead65eec0cb71fc81c3d469d222169f9319e6c3a3306a8",
-    "profile_contract_sha256": "b6be1f63ecd01e0b96b77329129d899b1f6e95be149933ac2eecc219a3446437",
+    "profile_contract_sha256": "966f9f5b65a6c351fc79bb8db343a8ba88fabfa98643532e22cdae347f99f0cb",
     "status": "within_budget"
   },
   "profile_contract": {
     "profile_ids_sha256": "79957b57d370335967ead65eec0cb71fc81c3d469d222169f9319e6c3a3306a8",
-    "profile_contract_sha256": "b6be1f63ecd01e0b96b77329129d899b1f6e95be149933ac2eecc219a3446437"
+    "profile_contract_sha256": "966f9f5b65a6c351fc79bb8db343a8ba88fabfa98643532e22cdae347f99f0cb"
   }
 }

--- a/server/src/addie/mcp/schema-tools.ts
+++ b/server/src/addie/mcp/schema-tools.ts
@@ -24,7 +24,7 @@ const SCHEMA_HOST = 'https://adcontextprotocol.org';
 // Legacy aliases remain available for callers that already use them.
 export const DOCS_SCHEMA_RELEASES = Object.freeze({
   '3.1': '3.1.19',
-  '3.2-beta': '3.2.0-beta.5',
+  '3.2-beta': '3.2.0-beta.6',
   '3.0': '3.0.26',
   '2.5': '2.5.3',
 });
@@ -87,7 +87,7 @@ const INFERRED_PRERELEASE_RANGES: Readonly<
 > = Object.freeze({
   '3.0': Object.freeze({ beta: [1, 3] as const, rc: [1, 3] as const }),
   '3.1': Object.freeze({ beta: [0, 7] as const, rc: [1, 15] as const }),
-  '3.2-beta': Object.freeze({ beta: [0, 5] as const }),
+  '3.2-beta': Object.freeze({ beta: [0, 6] as const }),
 });
 
 /**
@@ -750,7 +750,7 @@ ${formatCandidates(requestedPath, registry)}`);
 | Version | URL | Notes |
 |---------|-----|-------|
 | 3.1 | ${SCHEMA_BASE_URLS['3.1']} | Current stable schema snapshot (${DOCS_SCHEMA_RELEASES['3.1']}) |
-| 3.2-beta | ${SCHEMA_BASE_URLS['3.2-beta']} | Beta docs snapshot (3.2.0-beta.5) |
+| 3.2-beta | ${SCHEMA_BASE_URLS['3.2-beta']} | Beta docs snapshot (3.2.0-beta.6) |
 | 3.0 | ${SCHEMA_BASE_URLS['3.0']} | Previous 3.x snapshot (3.0.26) |
 | 2.5 | ${SCHEMA_BASE_URLS['2.5']} | Archived snapshot (2.5.3) |
 | v2 | ${SCHEMA_BASE_URLS.v2} | Legacy (2.x) |

--- a/server/tests/unit/addie/schema-tools.test.ts
+++ b/server/tests/unit/addie/schema-tools.test.ts
@@ -15,7 +15,7 @@ describe('schema version selection', () => {
   it('accepts every public docs release and defaults its guidance to stable', () => {
     expect(DOCS_SCHEMA_RELEASES).toEqual({
       '3.1': '3.1.19',
-      '3.2-beta': '3.2.0-beta.5',
+      '3.2-beta': '3.2.0-beta.6',
       '3.0': '3.0.26',
       '2.5': '2.5.3',
     });
@@ -29,7 +29,7 @@ describe('schema version selection', () => {
       '3.2-beta',
       '3.2 beta',
       '3.2',
-      '3.2.0-beta.5',
+      '3.2.0-beta.6',
       '3.0',
       '3.0.26',
       '2.5',
@@ -97,10 +97,10 @@ describe('schema handler version resolution', () => {
     { selector: 'latest', canonical: '3.1', artifact: '3.1.19' },
     { selector: 'v3', canonical: '3.1', artifact: '3.1.19' },
     { selector: '3.1.19', canonical: '3.1', artifact: '3.1.19' },
-    { selector: '3.2-beta', canonical: '3.2-beta', artifact: '3.2.0-beta.5' },
-    { selector: '3.2 beta', canonical: '3.2-beta', artifact: '3.2.0-beta.5' },
-    { selector: '3.2', canonical: '3.2-beta', artifact: '3.2.0-beta.5' },
-    { selector: '3.2.0-beta.5', canonical: '3.2-beta', artifact: '3.2.0-beta.5' },
+    { selector: '3.2-beta', canonical: '3.2-beta', artifact: '3.2.0-beta.6' },
+    { selector: '3.2 beta', canonical: '3.2-beta', artifact: '3.2.0-beta.6' },
+    { selector: '3.2', canonical: '3.2-beta', artifact: '3.2.0-beta.6' },
+    { selector: '3.2.0-beta.6', canonical: '3.2-beta', artifact: '3.2.0-beta.6' },
     { selector: '3.0', canonical: '3.0', artifact: '3.0.26' },
     { selector: '3.0.26', canonical: '3.0', artifact: '3.0.26' },
     { selector: '2.5', canonical: '2.5', artifact: '2.5.3' },
@@ -199,7 +199,7 @@ describe('schema handler version resolution', () => {
     const cases = [
       ['3.1.4', '3.1.19'],
       ['3.1.0-rc.15', '3.1.19'],
-      ['3.2.0-beta.1', '3.2.0-beta.5'],
+      ['3.2.0-beta.1', '3.2.0-beta.6'],
       ['3.0.18', '3.0.26'],
       ['3.0.0-rc.2', '3.0.26'],
       ['2.5.1', '2.5.3'],
@@ -227,7 +227,7 @@ describe('schema handler version resolution', () => {
     for (const version of [
       '4.0.1',
       '3.1.20',
-      '3.2.0-beta.6',
+      '3.2.0-beta.7',
       '3.2.1-beta.1',
     ]) {
       await expect(validateJson!({

--- a/server/tests/unit/docs-indexer.test.ts
+++ b/server/tests/unit/docs-indexer.test.ts
@@ -117,7 +117,7 @@ describe('docs-indexer', () => {
     it('uses an explicit version for legacy unversioned IDs', () => {
       const doc = getDocById('media-buy/task-reference/get_products', { version: '3.2-beta' });
       expect(doc?.id).toBe('doc:3.2-beta:media-buy/task-reference/get_products');
-      expect(doc?.sourceUrl).toContain('/dist/docs/3.2.0-beta.5/');
+      expect(doc?.sourceUrl).toContain('/dist/docs/3.2.0-beta.6/');
     });
 
     it('rejects a canonical versioned ID when the explicit version does not match', () => {
@@ -140,7 +140,7 @@ describe('docs-indexer', () => {
       const versions = getSupportedDocsVersions();
       expect(versions.map(({ version, artifactVersion }) => ({ version, artifactVersion }))).toEqual([
         { version: '3.1', artifactVersion: '3.1.19' },
-        { version: '3.2-beta', artifactVersion: '3.2.0-beta.5' },
+        { version: '3.2-beta', artifactVersion: '3.2.0-beta.6' },
         { version: '3.0', artifactVersion: '3.0.26' },
         { version: '2.5', artifactVersion: '2.5.3' },
       ]);
@@ -155,7 +155,7 @@ describe('docs-indexer', () => {
     it('returns protocol results only from the requested version', () => {
       const snapshots = new Map([
         ['3.1', '3.1.19'],
-        ['3.2-beta', '3.2.0-beta.5'],
+        ['3.2-beta', '3.2.0-beta.6'],
         ['3.0', '3.0.26'],
         ['2.5', '2.5.3'],
       ]);
@@ -182,7 +182,7 @@ describe('docs-indexer', () => {
     it('returns headings only from the requested protocol version', () => {
       const snapshots = new Map([
         ['3.1', '3.1.19'],
-        ['3.2-beta', '3.2.0-beta.5'],
+        ['3.2-beta', '3.2.0-beta.6'],
         ['3.0', '3.0.26'],
         ['2.5', '2.5.3'],
       ]);
@@ -249,12 +249,12 @@ describe('docs-indexer', () => {
       expect(stableResults).toContain('No documentation found in AdCP 3.1 (snapshot 3.1.19)');
 
       const results = await search!({ query: 'ACCOUNT_REQUIRED', version: '3.2-beta' });
-      expect(results).toContain('Searching AdCP 3.2-beta (snapshot 3.2.0-beta.5)');
-      expect(results).toContain('**Version:** 3.2-beta (snapshot 3.2.0-beta.5)');
+      expect(results).toContain('Searching AdCP 3.2-beta (snapshot 3.2.0-beta.6)');
+      expect(results).toContain('**Version:** 3.2-beta (snapshot 3.2.0-beta.6)');
       expect(results).toContain('ACCOUNT_REQUIRED');
 
       const detail = await getDoc!({ doc_id: 'schema:3.2-beta:enums/error-code' });
-      expect(detail).toContain('**Version:** 3.2-beta (snapshot 3.2.0-beta.5)');
+      expect(detail).toContain('**Version:** 3.2-beta (snapshot 3.2.0-beta.6)');
       expect(detail).toContain('ACCOUNT_REQUIRED');
     });
 


### PR DESCRIPTION
## Summary

- align Addie schema release resolution with the published 3.2.0-beta.6 docs snapshot
- extend supported beta inference through beta.6
- update schema-tool and docs-indexer expectations

## Validation

- focused schema-tools and docs-indexer tests (55 passed)
- full server unit suite (7,147 passed; 30 skipped)
- TypeScript typecheck
- version-sync and push policy checks

No changeset: this is an Addie/docs consistency fix with no protocol release-surface change.