### PR TITLE
fix(tests): avoid Conductor loopback port collisions

### DIFF
--- a/server/tests/setup/revenue-tracking-env.ts
+++ b/server/tests/setup/revenue-tracking-env.ts
@@ -1,5 +1,8 @@
 // Test environment setup for vitest
 // Sets up mock environment variables for testing
+
+import type { Server } from 'node:net';
+import request from 'supertest';
 //
 // This file re-runs before every test file (vitest resets the module
 // registry per file, and setup files are part of that registry), but
@@ -43,3 +46,33 @@ process.env.WORKOS_API_KEY = 'sk_test_mock_key';
 process.env.WORKOS_CLIENT_ID = 'client_mock_id';
 process.env.WORKOS_COOKIE_PASSWORD = 'test-cookie-password-at-least-32-chars-long';
 
+// On macOS, Supertest's `listen(0)` can bind an IPv6 socket while Supertest
+// still builds an IPv4 URL (`127.0.0.1`). Conductor may already own the same
+// numeric port in the separate IPv4 namespace, so the request reaches its
+// JSON 404 handler instead of the Express app. Preserve Supertest's listener
+// lifecycle and select the client loopback address from the actual socket
+// family. Keep the patch Conductor-local; CI and ordinary local runs retain
+// upstream Supertest behavior.
+type SupertestInternal = InstanceType<typeof request.Test>;
+type SupertestPrototype = {
+  __adcpConductorLoopbackPatched?: true;
+  serverAddress(this: SupertestInternal, app: Server, path: string): string;
+};
+
+export function installConductorSupertestLoopback(): void {
+  const testPrototype = request.Test.prototype as unknown as SupertestPrototype;
+  if (testPrototype.__adcpConductorLoopbackPatched) return;
+
+  const originalServerAddress = testPrototype.serverAddress;
+  testPrototype.serverAddress = function serverAddress(app, path) {
+    const url = originalServerAddress.call(this, app, path);
+    const address = app.address();
+    const isIpv6 = address != null
+      && typeof address !== 'string'
+      && (address.family === 'IPv6' || (address.family as string | number) === 6);
+    return isIpv6 ? url.replace('://127.0.0.1:', '://[::1]:') : url;
+  };
+  testPrototype.__adcpConductorLoopbackPatched = true;
+}
+
+if (process.env.CONDUCTOR_IS_LOCAL === '1') installConductorSupertestLoopback();

--- a/server/tests/unit/supertest-conductor-loopback.test.ts
+++ b/server/tests/unit/supertest-conductor-loopback.test.ts
@@ -1,0 +1,70 @@
+import { createServer, type Server } from 'node:http';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { installConductorSupertestLoopback } from '../setup/revenue-tracking-env.js';
+
+type PatchableSupertestPrototype = typeof request.Test.prototype & {
+  __adcpConductorLoopbackPatched?: true;
+};
+const testPrototype = request.Test.prototype as PatchableSupertestPrototype;
+const originalServerAddress = testPrototype.serverAddress;
+const originalPatchMarker = testPrototype.__adcpConductorLoopbackPatched;
+
+installConductorSupertestLoopback();
+
+const openServers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(openServers.splice(0).map(
+    (server) => new Promise<void>((resolve) => server.close(() => resolve())),
+  ));
+});
+
+afterAll(() => {
+  testPrototype.serverAddress = originalServerAddress;
+  if (originalPatchMarker) testPrototype.__adcpConductorLoopbackPatched = originalPatchMarker;
+  else delete testPrototype.__adcpConductorLoopbackPatched;
+});
+
+describe('Conductor Supertest loopback selection', () => {
+  it('routes a fresh app through the family of its ephemeral listener', async () => {
+    const app = express().get('/ok', (_req, res) => res.json({ ok: true }));
+
+    const response = await request(app).get('/ok');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+
+  it('preserves an already-listening IPv4 server', async () => {
+    const server = createServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ family: 'IPv4' }));
+    });
+    openServers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+    const response = await request(server).get('/');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ family: 'IPv4' });
+  });
+
+  it('preserves an already-listening IPv6 server and repeated installation', async () => {
+    const installedServerAddress = testPrototype.serverAddress;
+    installConductorSupertestLoopback();
+    expect(testPrototype.serverAddress).toBe(installedServerAddress);
+    const server = createServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ family: 'IPv6' }));
+    });
+    openServers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, '::1', resolve));
+
+    const response = await request(server).get('/');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ family: 'IPv6' });
+  });
+});


### PR DESCRIPTION
## Summary

- preserve Supertest server lifecycle while matching its request URL to the listener address family
- keep the compatibility shim limited to Conductor-local test runs
- add regression coverage for fresh listeners, existing IPv4/IPv6 servers, idempotence, and prototype restoration

## Root cause

On macOS, Supertest can bind an ephemeral IPv6 listener while constructing an IPv4 loopback URL. If Conductor already owns the same numeric port in the separate IPv4 namespace, the request reaches Conductor’s JSON 404 handler rather than the test app.

## Validation

- full precommit hook: 502 server-unit files, 7,135 passed, 30 skipped
- focused CI-like run: 18/18 passed
- focused Conductor-local run: 3/3 passed
- 100/100 repeated-process loopback regression runs
- typecheck and diff check

Closes #6837