### PR TITLE
fix(docs): keep OpenAPI generation local

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1250,7 +1250,7 @@
               {
                 "group": "Registry API",
                 "openapi": {
-                  "source": "https://agenticadvertising.org/openapi/registry.yaml",
+                  "source": "static/openapi/registry.yaml",
                   "directory": "dist/docs/3.2.0-beta.7/registry/api-reference"
                 },
                 "pages": [
@@ -1881,7 +1881,7 @@
               {
                 "group": "Registry API",
                 "openapi": {
-                  "source": "https://agenticadvertising.org/openapi/registry.yaml",
+                  "source": "static/openapi/registry.yaml",
                   "directory": "dist/docs/3.0.26/registry/api-reference"
                 },
                 "pages": [

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -75,6 +75,18 @@ function collectOpenApiDirectories(node) {
   return directories;
 }
 
+/**
+ * Collect OpenAPI sources so deployments cannot depend on a remote fetch.
+ */
+function collectOpenApiSources(node) {
+  if (Array.isArray(node)) return node.flatMap(collectOpenApiSources);
+  if (!node || typeof node !== 'object') return [];
+
+  const sources = node.openapi?.source ? [node.openapi.source] : [];
+  if (node.pages) sources.push(...collectOpenApiSources(node.pages));
+  return sources;
+}
+
 function isDirectSlackInvite(value) {
   try {
     const url = new URL(value);
@@ -133,6 +145,24 @@ test('default version carries the Latest tag', () => {
     || navigation.versions[0];
   if (defaultEntry.tag !== 'Latest') {
     throw new Error('The default docs version must carry the "Latest" tag');
+  }
+});
+
+test('OpenAPI navigation uses repository-local sources', () => {
+  const sources = collectOpenApiSources(navigation.versions);
+  const remoteSources = sources.filter(source => /^https?:\/\//i.test(source));
+  if (remoteSources.length > 0) {
+    throw new Error(
+      `Remote OpenAPI sources make Mintlify deployment depend on an external fetch: ` +
+      remoteSources.join(', ')
+    );
+  }
+
+  const missingSources = sources.filter(source => !fs.existsSync(
+    path.join(rootDir, source.replace(/^\//, ''))
+  ));
+  if (missingSources.length > 0) {
+    throw new Error(`Missing local OpenAPI sources: ${missingSources.join(', ')}`);
   }
 });
 


### PR DESCRIPTION
## Summary

- use the repository-local OpenAPI registry for all Mintlify version groups
- avoid the external OpenAPI fetch that failed the 3.2.0-beta.7 snapshot deployment
- add a navigation regression test that rejects remote OpenAPI sources

The local and previously referenced remote registries are byte-identical. Release artifacts and published protocol files are unaffected.

## Verification

- `npm run test:docs-nav` (44 passed)
- `npx mint validate`
- `git diff --check`