### PR TITLE
fix(docs): snapshot versioned OpenAPI sources

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -592,7 +592,7 @@
               {
                 "group": "Registry API",
                 "openapi": {
-                  "source": "static/openapi/registry.yaml",
+                  "source": "static/openapi/releases/3.1.19/registry.yaml",
                   "directory": "dist/docs/3.1.19/registry/api-reference"
                 },
                 "pages": [
@@ -1250,7 +1250,7 @@
               {
                 "group": "Registry API",
                 "openapi": {
-                  "source": "static/openapi/registry.yaml",
+                  "source": "static/openapi/releases/3.2.0-beta.7/registry.yaml",
                   "directory": "dist/docs/3.2.0-beta.7/registry/api-reference"
                 },
                 "pages": [
@@ -1881,7 +1881,7 @@
               {
                 "group": "Registry API",
                 "openapi": {
-                  "source": "static/openapi/registry.yaml",
+                  "source": "static/openapi/releases/3.0.26/registry.yaml",
                   "directory": "dist/docs/3.0.26/registry/api-reference"
                 },
                 "pages": [

--- a/static/openapi/releases/3.0.26/registry.yaml
+++ b/static/openapi/releases/3.0.26/registry.yaml
@@ -1,0 +1,6016 @@
+openapi: 3.1.0
+info:
+  title: AgenticAdvertising.org Registry API
+  description: |-
+    REST API for the AgenticAdvertising.org registry. Resolve brands,
+    discover properties, look up agents, and validate authorization in the
+    AdCP ecosystem.
+
+    Most endpoints are public and require no authentication. Endpoints marked
+    with a lock icon accept either an organization API key or a user JWT
+    obtained via the OAuth 2.1 flow — see [Authentication](https://agenticadvertising.org/docs/registry/index#authentication).
+
+    **Base URL:** `https://agenticadvertising.org`
+  version: 1.0.0
+  contact:
+    name: AgenticAdvertising.org
+    url: https://agenticadvertising.org
+servers:
+  - url: https://agenticadvertising.org
+    description: Production
+security: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: |-
+        Bearer token in the `Authorization` header. Two token types are accepted:
+
+        - **Organization API key** (`sk_...`) issued via the dashboard. Org-scoped, long-lived, for server-to-server use.
+        - **User JWT** obtained via the OAuth 2.1 authorization code flow with PKCE. User-scoped, short-lived. Discover the authorization server at `/.well-known/oauth-authorization-server` and the protected-resource metadata at `/.well-known/oauth-protected-resource/api`.
+    oauth2:
+      type: oauth2
+      description: OAuth 2.1 authorization code flow with PKCE. Users authenticate via AuthKit and clients receive a Bearer JWT that authorizes both the MCP endpoint and this REST API. Dynamic client registration is supported at `/register`.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://agenticadvertising.org/authorize
+          tokenUrl: https://agenticadvertising.org/token
+          refreshUrl: https://agenticadvertising.org/token
+          scopes:
+            openid: User identifier
+            profile: User profile information
+            email: User email address
+  schemas:
+    ResolvedBrand:
+      type: object
+      properties:
+        canonical_id:
+          type: string
+          example: acmecorp.com
+        canonical_domain:
+          type: string
+          example: acmecorp.com
+        brand_name:
+          type: string
+          example: Acme Corp
+        names:
+          type: array
+          items:
+            $ref: "#/components/schemas/LocalizedName"
+        keller_type:
+          type: string
+          enum:
+            - master
+            - sub_brand
+            - endorsed
+            - independent
+        parent_brand:
+          type: string
+        house_domain:
+          type: string
+        house_name:
+          type: string
+        brand_agent_url:
+          type: string
+        brand_manifest:
+          type: object
+          additionalProperties: {}
+        source:
+          type: string
+          enum:
+            - brand_json
+            - community
+            - enriched
+      required:
+        - canonical_id
+        - canonical_domain
+        - brand_name
+        - source
+    LocalizedName:
+      type: object
+      additionalProperties:
+        type: string
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+      required:
+        - error
+    BrandRegistryItem:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: acmecorp.com
+        brand_name:
+          type: string
+          example: Acme Corp
+        source:
+          type: string
+          enum:
+            - hosted
+            - brand_json
+            - community
+            - enriched
+        has_manifest:
+          type: boolean
+        verified:
+          type: boolean
+        house_domain:
+          type: string
+        keller_type:
+          type: string
+          enum:
+            - master
+            - sub_brand
+            - endorsed
+            - independent
+      required:
+        - domain
+        - source
+        - has_manifest
+        - verified
+    BrandActivity:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: acmecorp.com
+        total:
+          type: integer
+          example: 3
+        revisions:
+          type: array
+          items:
+            type: object
+            properties:
+              revision_number:
+                type: integer
+                example: 3
+              editor_name:
+                type: string
+                example: Pinnacle Media
+              edit_summary:
+                type: string
+                example: Updated logo and brand colors
+              source:
+                type: string
+                description: Source type of the record at the time of this revision (brand_json, enriched, community)
+              is_rollback:
+                type: boolean
+              rolled_back_to:
+                type: integer
+                description: Revision number that was restored; only present when is_rollback is true
+              created_at:
+                type: string
+                example: 2026-03-01T12:34:56Z
+            required:
+              - revision_number
+              - editor_name
+              - edit_summary
+              - is_rollback
+              - created_at
+      required:
+        - domain
+        - total
+        - revisions
+    PropertyActivity:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: examplepub.com
+        total:
+          type: integer
+          example: 3
+        revisions:
+          type: array
+          items:
+            type: object
+            properties:
+              revision_number:
+                type: integer
+                example: 3
+              editor_name:
+                type: string
+                example: Pinnacle Media
+              edit_summary:
+                type: string
+                example: Updated logo and brand colors
+              source:
+                type: string
+                description: Source type of the record at the time of this revision (brand_json, enriched, community)
+              is_rollback:
+                type: boolean
+              rolled_back_to:
+                type: integer
+                description: Revision number that was restored; only present when is_rollback is true
+              created_at:
+                type: string
+                example: 2026-03-01T12:34:56Z
+            required:
+              - revision_number
+              - editor_name
+              - edit_summary
+              - is_rollback
+              - created_at
+      required:
+        - domain
+        - total
+        - revisions
+    ResolvedProperty:
+      type: object
+      properties:
+        publisher_domain:
+          type: string
+          example: examplepub.com
+        source:
+          type: string
+          enum:
+            - adagents_json
+            - hosted
+            - discovered
+        authorized_agents:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              authorized_for:
+                type: string
+            required:
+              - url
+        properties:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              type:
+                type: string
+              name:
+                type: string
+              identifiers:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PropertyIdentifier"
+              tags:
+                type: array
+                items:
+                  type: string
+        contact:
+          type: object
+          properties:
+            name:
+              type: string
+            email:
+              type: string
+        verified:
+          type: boolean
+      required:
+        - publisher_domain
+        - source
+        - verified
+    PropertyIdentifier:
+      type: object
+      properties:
+        type:
+          type: string
+          example: domain
+        value:
+          type: string
+          example: examplepub.com
+      required:
+        - type
+        - value
+    PropertyRegistryItem:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: examplepub.com
+        source:
+          type: string
+          enum:
+            - adagents_json
+            - hosted
+            - community
+            - discovered
+            - enriched
+        property_count:
+          type: integer
+        agent_count:
+          type: integer
+        verified:
+          type: boolean
+      required:
+        - domain
+        - source
+        - property_count
+        - agent_count
+        - verified
+    ValidationResult:
+      type: object
+      properties:
+        valid:
+          type: boolean
+        domain:
+          type: string
+        url:
+          type: string
+        errors:
+          type: array
+          items:
+            type: string
+        warnings:
+          type: array
+          items:
+            type: string
+        status_code:
+          type: integer
+        raw_data:
+          type: object
+          additionalProperties: {}
+      required:
+        - valid
+    FederatedAgentWithDetails:
+      type: object
+      properties:
+        url:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+          enum:
+            - brand
+            - rights
+            - measurement
+            - governance
+            - creative
+            - sales
+            - buying
+            - signals
+            - unknown
+        protocol:
+          type: string
+          enum:
+            - mcp
+            - a2a
+        description:
+          type: string
+        mcp_endpoint:
+          type: string
+        contact:
+          type: object
+          properties:
+            name:
+              type: string
+            email:
+              type: string
+            website:
+              type: string
+          required:
+            - name
+            - email
+            - website
+        added_date:
+          type: string
+        source:
+          type: string
+          enum:
+            - registered
+            - discovered
+        member:
+          type: object
+          properties:
+            slug:
+              type: string
+            display_name:
+              type: string
+        discovered_from:
+          type: object
+          properties:
+            publisher_domain:
+              type: string
+            authorized_for:
+              type: string
+        health:
+          $ref: "#/components/schemas/AgentHealth"
+        stats:
+          $ref: "#/components/schemas/AgentStats"
+        capabilities:
+          $ref: "#/components/schemas/AgentCapabilities"
+        compliance:
+          $ref: "#/components/schemas/AgentCompliance"
+        publisher_domains:
+          type: array
+          items:
+            type: string
+        property_summary:
+          $ref: "#/components/schemas/PropertySummary"
+      required:
+        - url
+        - name
+        - type
+    AgentHealth:
+      type: object
+      properties:
+        online:
+          type: boolean
+        checked_at:
+          type: string
+        response_time_ms:
+          type: number
+        tools_count:
+          type: integer
+        resources_count:
+          type: integer
+        error:
+          type: string
+      required:
+        - online
+        - checked_at
+    AgentStats:
+      type: object
+      properties:
+        property_count:
+          type: integer
+        publisher_count:
+          type: integer
+        publishers:
+          type: array
+          items:
+            type: string
+        creative_formats:
+          type: integer
+    AgentCapabilities:
+      type: object
+      properties:
+        tools_count:
+          type: integer
+        tools:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              description:
+                type: string
+            required:
+              - name
+              - description
+        standard_operations:
+          type: object
+          properties:
+            can_search_inventory:
+              type: boolean
+            can_get_availability:
+              type: boolean
+            can_reserve_inventory:
+              type: boolean
+            can_get_pricing:
+              type: boolean
+            can_create_order:
+              type: boolean
+            can_list_properties:
+              type: boolean
+          required:
+            - can_search_inventory
+            - can_get_availability
+            - can_reserve_inventory
+            - can_get_pricing
+            - can_create_order
+            - can_list_properties
+        creative_capabilities:
+          type: object
+          properties:
+            formats_supported:
+              type: array
+              items:
+                type: string
+            can_generate:
+              type: boolean
+            can_validate:
+              type: boolean
+            can_preview:
+              type: boolean
+          required:
+            - formats_supported
+            - can_generate
+            - can_validate
+            - can_preview
+      required:
+        - tools_count
+    AgentCompliance:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - passing
+            - degraded
+            - failing
+            - unknown
+        lifecycle_stage:
+          type: string
+          enum:
+            - development
+            - testing
+            - production
+            - deprecated
+        tracks:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            core: pass
+            products: fail
+        streak_days:
+          type: integer
+        last_checked_at:
+          type:
+            - string
+            - "null"
+        headline:
+          type:
+            - string
+            - "null"
+        monitoring_paused:
+          type: boolean
+        check_interval_hours:
+          type: integer
+      required:
+        - status
+        - lifecycle_stage
+        - tracks
+        - streak_days
+        - last_checked_at
+        - headline
+    PropertySummary:
+      type: object
+      properties:
+        total_count:
+          type: integer
+        count_by_type:
+          type: object
+          additionalProperties:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+        publisher_count:
+          type: integer
+      required:
+        - total_count
+        - count_by_type
+        - tags
+        - publisher_count
+    FederatedPublisher:
+      type: object
+      properties:
+        domain:
+          type: string
+        source:
+          type: string
+          enum:
+            - registered
+            - discovered
+        member:
+          type: object
+          properties:
+            slug:
+              type: string
+            display_name:
+              type: string
+        agent_count:
+          type: integer
+        last_validated:
+          type: string
+        discovered_from:
+          type: object
+          properties:
+            agent_url:
+              type: string
+        has_valid_adagents:
+          type: boolean
+        discovered_at:
+          type: string
+      required:
+        - domain
+    DomainLookupResult:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: examplepub.com
+        authorized_agents:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              authorized_for:
+                type: string
+              source:
+                type: string
+                enum:
+                  - registered
+                  - discovered
+              member:
+                type: object
+                properties:
+                  slug:
+                    type: string
+                  display_name:
+                    type: string
+            required:
+              - url
+        sales_agents_claiming:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              source:
+                type: string
+                enum:
+                  - registered
+                  - discovered
+              member:
+                type: object
+                properties:
+                  slug:
+                    type: string
+                  display_name:
+                    type: string
+            required:
+              - url
+      required:
+        - domain
+        - authorized_agents
+        - sales_agents_claiming
+    OperatorLookupResult:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: pubmatic.com
+        member:
+          type:
+            - object
+            - "null"
+          properties:
+            slug:
+              type: string
+            display_name:
+              type: string
+        agents:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              name:
+                type: string
+              type:
+                type: string
+                enum:
+                  - brand
+                  - rights
+                  - measurement
+                  - governance
+                  - creative
+                  - sales
+                  - buying
+                  - signals
+                  - unknown
+              authorized_by:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    publisher_domain:
+                      type: string
+                    authorized_for:
+                      type: string
+                    source:
+                      type: string
+                      enum:
+                        - adagents_json
+                        - agent_claim
+                  required:
+                    - publisher_domain
+                    - source
+            required:
+              - url
+              - name
+              - type
+              - authorized_by
+      required:
+        - domain
+        - member
+        - agents
+    PublisherLookupResult:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: voxmedia.com
+        member:
+          type:
+            - object
+            - "null"
+          properties:
+            slug:
+              type: string
+            display_name:
+              type: string
+        adagents_valid:
+          type:
+            - boolean
+            - "null"
+        properties:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              type:
+                type: string
+              name:
+                type: string
+              identifiers:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PropertyIdentifier"
+              tags:
+                type: array
+                items:
+                  type: string
+        authorized_agents:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              authorized_for:
+                type: string
+              source:
+                type: string
+                enum:
+                  - adagents_json
+                  - agent_claim
+            required:
+              - url
+              - source
+      required:
+        - domain
+        - member
+        - adagents_valid
+        - properties
+        - authorized_agents
+    PublisherPropertySelector:
+      type: object
+      properties:
+        publisher_domain:
+          type: string
+          example: examplepub.com
+        property_types:
+          type: array
+          items:
+            type: string
+        property_ids:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+    PolicySummary:
+      type: object
+      properties:
+        policy_id:
+          type: string
+          example: gdpr_consent
+        version:
+          type: string
+          example: 1.0.0
+        name:
+          type: string
+          example: GDPR Consent Requirements
+        description:
+          type:
+            - string
+            - "null"
+          example: Requirements for valid consent under GDPR
+        category:
+          type: string
+          enum:
+            - regulation
+            - standard
+        enforcement:
+          type: string
+          enum:
+            - must
+            - should
+            - may
+        jurisdictions:
+          type: array
+          items:
+            type: string
+          example:
+            - EU
+            - EEA
+        region_aliases:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          example:
+            EU:
+              - DE
+              - FR
+              - IT
+        policy_categories:
+          type: array
+          items:
+            type: string
+          example:
+            - age_restricted
+            - pharmaceutical_advertising
+        channels:
+          type:
+            - array
+            - "null"
+          items:
+            type: string
+          example:
+            - display
+            - video
+        governance_domains:
+          type: array
+          items:
+            type: string
+          example:
+            - campaign
+            - creative
+        effective_date:
+          type:
+            - string
+            - "null"
+          example: 2025-05-25
+        sunset_date:
+          type:
+            - string
+            - "null"
+        source_url:
+          type:
+            - string
+            - "null"
+          example: https://eur-lex.europa.eu/eli/reg/2016/679/oj
+        source_name:
+          type:
+            - string
+            - "null"
+          example: EUR-Lex
+        source_type:
+          type: string
+          enum:
+            - registry
+            - community
+        review_status:
+          type: string
+          enum:
+            - pending
+            - approved
+        created_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+        updated_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+      required:
+        - policy_id
+        - version
+        - name
+        - description
+        - category
+        - enforcement
+        - jurisdictions
+        - region_aliases
+        - policy_categories
+        - channels
+        - governance_domains
+        - effective_date
+        - sunset_date
+        - source_url
+        - source_name
+        - source_type
+        - review_status
+        - created_at
+        - updated_at
+    Policy:
+      type: object
+      properties:
+        policy_id:
+          type: string
+          example: gdpr_consent
+        version:
+          type: string
+          example: 1.0.0
+        name:
+          type: string
+          example: GDPR Consent Requirements
+        description:
+          type:
+            - string
+            - "null"
+          example: Requirements for valid consent under GDPR
+        category:
+          type: string
+          enum:
+            - regulation
+            - standard
+        enforcement:
+          type: string
+          enum:
+            - must
+            - should
+            - may
+        jurisdictions:
+          type: array
+          items:
+            type: string
+          example:
+            - EU
+            - EEA
+        region_aliases:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          example:
+            EU:
+              - DE
+              - FR
+              - IT
+        policy_categories:
+          type: array
+          items:
+            type: string
+          example:
+            - age_restricted
+            - pharmaceutical_advertising
+        channels:
+          type:
+            - array
+            - "null"
+          items:
+            type: string
+          example:
+            - display
+            - video
+        governance_domains:
+          type: array
+          items:
+            type: string
+          example:
+            - campaign
+            - creative
+        effective_date:
+          type:
+            - string
+            - "null"
+          example: 2025-05-25
+        sunset_date:
+          type:
+            - string
+            - "null"
+        source_url:
+          type:
+            - string
+            - "null"
+          example: https://eur-lex.europa.eu/eli/reg/2016/679/oj
+        source_name:
+          type:
+            - string
+            - "null"
+          example: EUR-Lex
+        policy:
+          type: string
+          example: Data subjects must provide freely given, specific, informed and unambiguous consent...
+        guidance:
+          type:
+            - string
+            - "null"
+        exemplars:
+          type:
+            - object
+            - "null"
+          properties:
+            pass:
+              type: array
+              items:
+                type: object
+                properties:
+                  scenario:
+                    type: string
+                    example: Ad for alcohol shown during children's programming
+                  explanation:
+                    type: string
+                    example: Violates watershed timing rules for alcohol advertising
+                required:
+                  - scenario
+                  - explanation
+            fail:
+              type: array
+              items:
+                type: object
+                properties:
+                  scenario:
+                    type: string
+                    example: Ad for alcohol shown during children's programming
+                  explanation:
+                    type: string
+                    example: Violates watershed timing rules for alcohol advertising
+                required:
+                  - scenario
+                  - explanation
+        ext:
+          type:
+            - object
+            - "null"
+          additionalProperties: {}
+        source_type:
+          type: string
+          enum:
+            - registry
+            - community
+        review_status:
+          type: string
+          enum:
+            - pending
+            - approved
+        created_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+        updated_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+      required:
+        - policy_id
+        - version
+        - name
+        - description
+        - category
+        - enforcement
+        - jurisdictions
+        - region_aliases
+        - policy_categories
+        - channels
+        - governance_domains
+        - effective_date
+        - sunset_date
+        - source_url
+        - source_name
+        - policy
+        - guidance
+        - exemplars
+        - ext
+        - source_type
+        - review_status
+        - created_at
+        - updated_at
+    PolicyHistory:
+      type: object
+      properties:
+        policy_id:
+          type: string
+          example: gdpr_consent
+        total:
+          type: integer
+          example: 3
+        revisions:
+          type: array
+          items:
+            type: object
+            properties:
+              revision_number:
+                type: integer
+                example: 2
+              editor_name:
+                type: string
+                example: Pinnacle Media
+              edit_summary:
+                type: string
+                example: Clarified consent requirements for minors
+              is_rollback:
+                type: boolean
+              rolled_back_to:
+                type: integer
+                description: Revision number that was restored; only present when is_rollback is true
+              created_at:
+                type: string
+                example: 2026-03-01T12:34:56Z
+            required:
+              - revision_number
+              - editor_name
+              - edit_summary
+              - is_rollback
+              - created_at
+      required:
+        - policy_id
+        - total
+        - revisions
+    AgentComplianceDetail:
+      type: object
+      properties:
+        agent_url:
+          type: string
+        status:
+          type: string
+          enum:
+            - passing
+            - degraded
+            - failing
+            - unknown
+            - opted_out
+        lifecycle_stage:
+          type: string
+          enum:
+            - development
+            - testing
+            - production
+            - deprecated
+        compliance_opt_out:
+          type: boolean
+        tracks:
+          type: object
+          additionalProperties:
+            type: string
+        streak_days:
+          type: integer
+        last_checked_at:
+          type:
+            - string
+            - "null"
+        last_passed_at:
+          type:
+            - string
+            - "null"
+        last_failed_at:
+          type:
+            - string
+            - "null"
+        headline:
+          type:
+            - string
+            - "null"
+        status_changed_at:
+          type:
+            - string
+            - "null"
+        storyboards_passing:
+          type: integer
+        storyboards_total:
+          type: integer
+      required:
+        - agent_url
+        - status
+        - lifecycle_stage
+    StoryboardStatus:
+      type: object
+      properties:
+        storyboard_id:
+          type: string
+        title:
+          type: string
+        category:
+          type:
+            - string
+            - "null"
+        track:
+          type:
+            - string
+            - "null"
+        status:
+          type: string
+          enum:
+            - passing
+            - failing
+            - partial
+            - untested
+        steps_passed:
+          type: integer
+        steps_total:
+          type: integer
+        last_tested_at:
+          type:
+            - string
+            - "null"
+        last_passed_at:
+          type:
+            - string
+            - "null"
+      required:
+        - storyboard_id
+        - title
+        - category
+        - track
+        - status
+        - steps_passed
+        - steps_total
+        - last_tested_at
+        - last_passed_at
+    ComplianceRun:
+      type: object
+      properties:
+        id:
+          type: string
+        overall_status:
+          type: string
+        headline:
+          type:
+            - string
+            - "null"
+        tracks_passed:
+          type: integer
+        tracks_failed:
+          type: integer
+        tracks_skipped:
+          type: integer
+        tracks_partial:
+          type: integer
+        tracks_json: {}
+        total_duration_ms:
+          type:
+            - number
+            - "null"
+        triggered_by:
+          type: string
+        tested_at:
+          type: string
+      required:
+        - id
+        - overall_status
+        - headline
+        - tracks_passed
+        - tracks_failed
+        - tracks_skipped
+        - tracks_partial
+        - total_duration_ms
+        - triggered_by
+        - tested_at
+    RegistryMetadata:
+      type: object
+      properties:
+        agent_url:
+          type: string
+        lifecycle_stage:
+          type: string
+          enum:
+            - development
+            - testing
+            - production
+            - deprecated
+        compliance_opt_out:
+          type: boolean
+        monitoring_paused:
+          type: boolean
+        check_interval_hours:
+          type: integer
+        monitoring_paused_at:
+          type:
+            - string
+            - "null"
+        created_at:
+          type: string
+        updated_at:
+          type: string
+      required:
+        - agent_url
+        - lifecycle_stage
+        - compliance_opt_out
+        - monitoring_paused
+        - check_interval_hours
+        - monitoring_paused_at
+        - created_at
+        - updated_at
+    MonitoringSettings:
+      type: object
+      properties:
+        monitoring_paused:
+          type: boolean
+        check_interval_hours:
+          type: integer
+        monitoring_paused_at:
+          type:
+            - string
+            - "null"
+      required:
+        - monitoring_paused
+        - check_interval_hours
+        - monitoring_paused_at
+    OutboundRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        agent_url:
+          type: string
+        request_type:
+          type: string
+        user_agent:
+          type: string
+        response_time_ms:
+          type:
+            - number
+            - "null"
+        success:
+          type: boolean
+        error_message:
+          type:
+            - string
+            - "null"
+        created_at:
+          type: string
+      required:
+        - id
+        - agent_url
+        - request_type
+        - user_agent
+        - response_time_ms
+        - success
+        - error_message
+        - created_at
+    AgentAuthStatus:
+      type: object
+      properties:
+        has_auth:
+          type: boolean
+        agent_context_id:
+          type:
+            - string
+            - "null"
+        auth_type:
+          type:
+            - string
+            - "null"
+          enum:
+            - bearer
+            - basic
+            - oauth
+            - oauth_client_credentials
+            - null
+        has_oauth_token:
+          type: boolean
+        has_valid_oauth:
+          type: boolean
+        oauth_token_expires_at:
+          type:
+            - string
+            - "null"
+        has_oauth_client_credentials:
+          type: boolean
+      required:
+        - has_auth
+        - agent_context_id
+        - auth_type
+        - has_oauth_token
+        - has_valid_oauth
+        - oauth_token_expires_at
+        - has_oauth_client_credentials
+    CredentialSaveValidationError:
+      type: object
+      properties:
+        error:
+          type: string
+        code:
+          type: string
+          enum:
+            - invalid_blob_shape
+            - missing_field
+            - invalid_field_type
+            - field_too_long
+            - invalid_url
+            - invalid_env_reference
+            - invalid_auth_method_value
+          description: Stable rejection tag. UI maps this to operator-friendly prose.
+        field:
+          type: string
+          enum:
+            - oauth_client_credentials
+            - token_endpoint
+            - client_id
+            - client_secret
+            - scope
+            - resource
+            - audience
+            - auth_method
+          description: Field the UI should scroll to + highlight.
+      required:
+        - error
+        - code
+        - field
+    StoryboardSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        category:
+          type: string
+        summary:
+          type: string
+        interaction_model:
+          type: string
+        examples:
+          type: array
+          items:
+            type: string
+        phase_count:
+          type: integer
+        step_count:
+          type: integer
+      required:
+        - id
+        - title
+        - category
+        - summary
+        - interaction_model
+        - examples
+        - phase_count
+        - step_count
+    StoryboardDetail:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        category:
+          type: string
+        summary:
+          type: string
+        agent:
+          type: object
+          properties:
+            interaction_model:
+              type: string
+            examples:
+              type: array
+              items:
+                type: string
+          required:
+            - interaction_model
+        phases:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+              steps:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    title:
+                      type: string
+                    description:
+                      type: string
+                    expected_output:
+                      type: string
+                  required:
+                    - id
+                    - title
+                    - description
+                    - expected_output
+            required:
+              - title
+              - steps
+        prerequisites: {}
+        required_tools:
+          type: array
+          items:
+            type: string
+        track:
+          type: string
+      required:
+        - id
+        - title
+        - category
+        - summary
+        - agent
+        - phases
+    FindCompanyResult:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/CompanySearchResult"
+      required:
+        - results
+    CompanySearchResult:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: coca-cola.com
+        canonical_domain:
+          type: string
+          example: coca-cola.com
+        brand_name:
+          type: string
+          example: The Coca-Cola Company
+        house_domain:
+          type: string
+          example: coca-cola.com
+        keller_type:
+          type: string
+          enum:
+            - master
+            - sub_brand
+            - endorsed
+            - independent
+        parent_brand:
+          type: string
+        brand_agent_url:
+          type: string
+        source:
+          type: string
+          example: community
+      required:
+        - domain
+        - canonical_domain
+        - brand_name
+        - source
+paths:
+  /api:
+    get:
+      operationId: apiDiscovery
+      summary: API discovery
+      description: Returns links to the main API entry points and documentation.
+      tags:
+        - Search
+      responses:
+        "200":
+          description: API discovery information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  version:
+                    type: string
+                  documentation:
+                    type: string
+                  openapi:
+                    type: string
+                  endpoints:
+                    type: object
+                    additionalProperties:
+                      type: string
+                required:
+                  - name
+                  - version
+                  - documentation
+                  - openapi
+                  - endpoints
+  /api/brands/resolve:
+    get:
+      operationId: resolveBrand
+      summary: Resolve brand
+      description: Resolve a domain to its canonical brand identity. Follows brand.json redirects and returns the resolved brand with its house, architecture type, and optional manifest.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+          required: false
+          name: fresh
+          in: query
+      responses:
+        "200":
+          description: Brand resolved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResolvedBrand"
+        "404":
+          description: Brand not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                  file_status:
+                    type: number
+                    description: HTTP status code from brand.json fetch (e.g. 404 vs 200 with invalid data)
+                required:
+                  - error
+                  - domain
+  /api/brands/resolve/bulk:
+    post:
+      operationId: resolveBrandsBulk
+      summary: Bulk resolve brands
+      description: |-
+        Resolve up to 100 domains to their canonical brand identities in a single request.
+
+        **Rate limit:** 20 requests per minute per IP address.
+      tags:
+        - Brand Resolution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domains:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 100
+              required:
+                - domains
+      responses:
+        "200":
+          description: Bulk resolution results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: object
+                    additionalProperties:
+                      allOf:
+                        - $ref: "#/components/schemas/ResolvedBrand"
+                        - type:
+                            - object
+                            - "null"
+                required:
+                  - results
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/brand-json:
+    get:
+      operationId: getBrandJson
+      summary: Get brand.json
+      description: Fetch the raw brand.json file for a domain.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+          required: false
+          name: fresh
+          in: query
+      responses:
+        "200":
+          description: Raw brand.json data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  url:
+                    type: string
+                  variant:
+                    type: string
+                  data:
+                    type: object
+                    additionalProperties: {}
+                  warnings:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - domain
+                  - url
+                  - data
+        "404":
+          description: Brand not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/save:
+    post:
+      operationId: saveBrand
+      summary: Save brand
+      description: Save or update a brand in the registry. Requires authentication. For existing brands, creates a revision-tracked edit. For new brands, creates the brand directly. Cannot edit authoritative brands managed via brand.json.
+      tags:
+        - Brand Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: acmecorp.com
+                brand_name:
+                  type: string
+                  example: Acme Corp
+                brand_manifest:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - domain
+                - brand_name
+      responses:
+        "200":
+          description: Brand saved or updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  message:
+                    type: string
+                  domain:
+                    type: string
+                  id:
+                    type: string
+                  revision_number:
+                    type: integer
+                required:
+                  - success
+                  - message
+                  - domain
+                  - id
+        "400":
+          description: Missing required fields or invalid domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Cannot edit authoritative brand
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/registry:
+    get:
+      operationId: listBrands
+      summary: List brands
+      description: List all brands in the registry with optional search, pagination.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+          required: false
+          name: search
+          in: query
+        - schema:
+            type: integer
+            example: 100
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            example: 0
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Brand list with stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  brands:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/BrandRegistryItem"
+                  stats:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      brand_json:
+                        type: integer
+                      community:
+                        type: integer
+                      enriched:
+                        type: integer
+                    required:
+                      - total
+                      - brand_json
+                      - community
+                      - enriched
+                required:
+                  - brands
+                  - stats
+  /api/brands/history:
+    get:
+      operationId: getBrandHistory
+      summary: Brand activity history
+      description: Returns the edit history for a brand in the registry, newest first. Only brands with community or enriched edits have history; brand.json-sourced brands are authoritative and do not generate revisions.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: integer
+            example: 20
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            example: 0
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Brand activity history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrandActivity"
+        "400":
+          description: domain parameter required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Brand not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                required:
+                  - error
+                  - domain
+  /api/brands/enrich:
+    get:
+      operationId: enrichBrand
+      summary: Enrich brand
+      description: Enrich brand data using Brandfetch. Returns logo, colors, and company information.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Enrichment data from Brandfetch
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+                additionalProperties: {}
+        "503":
+          description: Brandfetch not configured
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/history:
+    get:
+      operationId: getPropertyHistory
+      summary: Property activity history
+      description: Returns the edit history for a property in the registry, newest first.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: integer
+            example: 20
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            example: 0
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Property activity history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PropertyActivity"
+        "400":
+          description: domain parameter required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Property not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                required:
+                  - error
+                  - domain
+  /api/properties/resolve:
+    get:
+      operationId: resolveProperty
+      summary: Resolve property
+      description: Resolve a publisher domain to its property information. Checks hosted properties, discovered properties, then live adagents.json validation.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Property resolved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResolvedProperty"
+        "404":
+          description: Property not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                required:
+                  - error
+                  - domain
+  /api/properties/resolve/bulk:
+    post:
+      operationId: resolvePropertiesBulk
+      summary: Bulk resolve properties
+      description: |-
+        Resolve up to 100 publisher domains at once.
+
+        **Rate limit:** 20 requests per minute per IP address.
+      tags:
+        - Property Resolution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domains:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 100
+              required:
+                - domains
+      responses:
+        "200":
+          description: Bulk resolution results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: object
+                    additionalProperties:
+                      allOf:
+                        - $ref: "#/components/schemas/ResolvedProperty"
+                        - type:
+                            - object
+                            - "null"
+                required:
+                  - results
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/registry:
+    get:
+      operationId: listProperties
+      summary: List properties
+      description: List all properties in the registry with optional search, pagination.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+          required: false
+          name: search
+          in: query
+        - schema:
+            type: integer
+            example: 100
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            example: 0
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Property list with stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  properties:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PropertyRegistryItem"
+                  stats:
+                    type: object
+                    additionalProperties: {}
+                required:
+                  - properties
+                  - stats
+  /api/properties/validate:
+    get:
+      operationId: validateProperty
+      summary: Validate adagents.json
+      description: Validate a domain's adagents.json file and return the validation result.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Validation result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationResult"
+  /api/properties/save:
+    post:
+      operationId: saveProperty
+      summary: Save property
+      description: Save or update a hosted property in the registry. Requires authentication. For existing properties, creates a revision-tracked edit. For new properties, creates the property directly. Cannot edit authoritative properties managed via adagents.json.
+      tags:
+        - Property Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                publisher_domain:
+                  type: string
+                  example: examplepub.com
+                authorized_agents:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      authorized_for:
+                        type: string
+                    required:
+                      - url
+                  example:
+                    - url: https://agent.example.com
+                properties:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                      - type
+                      - name
+                  example:
+                    - type: website
+                      name: Example Publisher
+                contact:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    email:
+                      type: string
+              required:
+                - publisher_domain
+                - authorized_agents
+      responses:
+        "200":
+          description: Property saved or updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  message:
+                    type: string
+                  id:
+                    type: string
+                  revision_number:
+                    type: integer
+                required:
+                  - success
+                  - message
+                  - id
+        "400":
+          description: Missing required fields or invalid domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Cannot edit authoritative property
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/check:
+    post:
+      operationId: checkPropertyList
+      summary: Check property list
+      description: |-
+        Check a list of publisher domains against the AAO registry. Normalizes domains (strips www/m prefixes), removes duplicates, flags known ad tech infrastructure, and identifies domains not yet in the registry.
+
+        Returns four buckets:
+        - **remove**: duplicates or known blocked domains (ad servers, CDNs, trackers, intermediaries)
+        - **modify**: domains that were normalized (e.g. www.example.com → example.com)
+        - **assess**: unknown domains not in registry, not blocked
+        - **ok**: domains found in registry with no changes needed
+
+        Results are stored for 7 days and retrievable via the `report_id`.
+      tags:
+        - Property Resolution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domains:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 10000
+                  example:
+                    - www.nytimes.com
+                    - googlesyndication.com
+                    - wsj.com
+              required:
+                - domains
+      responses:
+        "200":
+          description: Property list check results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      remove:
+                        type: integer
+                      modify:
+                        type: integer
+                      assess:
+                        type: integer
+                      ok:
+                        type: integer
+                    required:
+                      - total
+                      - remove
+                      - modify
+                      - assess
+                      - ok
+                  remove:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        input:
+                          type: string
+                        canonical:
+                          type: string
+                        reason:
+                          type: string
+                          enum:
+                            - duplicate
+                            - blocked
+                        domain_type:
+                          type: string
+                        blocked_reason:
+                          type: string
+                      required:
+                        - input
+                        - canonical
+                        - reason
+                  modify:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        input:
+                          type: string
+                        canonical:
+                          type: string
+                        reason:
+                          type: string
+                      required:
+                        - input
+                        - canonical
+                        - reason
+                  assess:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        domain:
+                          type: string
+                      required:
+                        - domain
+                  ok:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        domain:
+                          type: string
+                        source:
+                          type: string
+                      required:
+                        - domain
+                        - source
+                  report_id:
+                    type: string
+                    description: UUID for retrieving this report later
+                required:
+                  - summary
+                  - remove
+                  - modify
+                  - assess
+                  - ok
+                  - report_id
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/check/{reportId}:
+    get:
+      operationId: getPropertyCheckReport
+      summary: Get property check report
+      description: Retrieve a previously stored property check report by ID. Reports expire after 7 days.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: reportId
+          in: path
+      responses:
+        "200":
+          description: Property check report
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      remove:
+                        type: integer
+                      modify:
+                        type: integer
+                      assess:
+                        type: integer
+                      ok:
+                        type: integer
+                    required:
+                      - total
+                      - remove
+                      - modify
+                      - assess
+                      - ok
+                required:
+                  - summary
+        "404":
+          description: Report not found or expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents:
+    get:
+      operationId: listAgents
+      summary: List agents
+      description: List all registered and discovered agents. Optionally enrich with health checks, capabilities, and property summaries via query parameters.
+      tags:
+        - Agent Discovery
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - brand
+              - rights
+              - measurement
+              - governance
+              - creative
+              - sales
+              - buying
+              - signals
+              - unknown
+          required: false
+          name: type
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+          required: false
+          name: health
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+          required: false
+          name: capabilities
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+          required: false
+          name: properties
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+          required: false
+          name: compliance
+          in: query
+      responses:
+        "200":
+          description: Agent list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agents:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FederatedAgentWithDetails"
+                  count:
+                    type: integer
+                  sources:
+                    type: object
+                    properties:
+                      registered:
+                        type: integer
+                      discovered:
+                        type: integer
+                    required:
+                      - registered
+                      - discovered
+                required:
+                  - agents
+                  - count
+                  - sources
+  /api/registry/publishers:
+    get:
+      operationId: listPublishers
+      summary: List publishers
+      description: List all registered and discovered publishers.
+      tags:
+        - Agent Discovery
+      responses:
+        "200":
+          description: Publisher list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  publishers:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FederatedPublisher"
+                  count:
+                    type: integer
+                  sources:
+                    type: object
+                    properties:
+                      registered:
+                        type: integer
+                      discovered:
+                        type: integer
+                    required:
+                      - registered
+                      - discovered
+                required:
+                  - publishers
+                  - count
+                  - sources
+  /api/registry/stats:
+    get:
+      operationId: getRegistryStats
+      summary: Registry statistics
+      description: Get aggregate statistics about the registry.
+      tags:
+        - Agent Discovery
+      responses:
+        "200":
+          description: Registry statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+                additionalProperties: {}
+  /api/registry/lookup/domain/{domain}:
+    get:
+      operationId: lookupDomain
+      summary: Domain lookup
+      description: Find all agents authorized for a given publisher domain.
+      tags:
+        - Lookups & Authorization
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: path
+      responses:
+        "200":
+          description: Domain lookup result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DomainLookupResult"
+  /api/registry/lookup/property:
+    get:
+      operationId: lookupProperty
+      summary: Property identifier lookup
+      description: Find agents that hold a specific property identifier.
+      tags:
+        - Lookups & Authorization
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: type
+          in: query
+        - schema:
+            type: string
+          required: true
+          name: value
+          in: query
+      responses:
+        "200":
+          description: Matching agents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  value:
+                    type: string
+                  agents:
+                    type: array
+                    items: {}
+                  count:
+                    type: integer
+                required:
+                  - type
+                  - value
+                  - agents
+                  - count
+  /api/registry/lookup/agent/{agentUrl}/domains:
+    get:
+      operationId: getAgentDomains
+      summary: Agent domain lookup
+      description: Get all publisher domains associated with an agent.
+      tags:
+        - Lookups & Authorization
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: agentUrl
+          in: path
+      responses:
+        "200":
+          description: Domains for the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  domains:
+                    type: array
+                    items:
+                      type: string
+                  count:
+                    type: integer
+                required:
+                  - agent_url
+                  - domains
+                  - count
+  /api/registry/operator:
+    get:
+      operationId: lookupOperator
+      summary: Operator lookup
+      description: Given a domain, returns the agents this entity operates and which publishers trust them.
+      tags:
+        - Lookups & Authorization
+      parameters:
+        - schema:
+            type: string
+            example: pubmatic.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Operator lookup result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperatorLookupResult"
+        "400":
+          description: Missing domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/publisher:
+    get:
+      operationId: lookupPublisher
+      summary: Publisher lookup
+      description: Given a domain, returns the inventory this entity publishes and which agents it authorizes.
+      tags:
+        - Lookups & Authorization
+      parameters:
+        - schema:
+            type: string
+            example: voxmedia.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Publisher lookup result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublisherLookupResult"
+        "400":
+          description: Missing domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/validate/product-authorization:
+    post:
+      operationId: validateProductAuthorization
+      summary: Validate product authorization
+      description: Check whether an agent is authorized to sell a product based on its publisher_properties.
+      tags:
+        - Lookups & Authorization
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                agent_url:
+                  type: string
+                publisher_properties:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/PublisherPropertySelector"
+              required:
+                - agent_url
+                - publisher_properties
+      responses:
+        "200":
+          description: Authorization validation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  authorized:
+                    type: boolean
+                  checked_at:
+                    type: string
+                required:
+                  - agent_url
+                  - authorized
+                  - checked_at
+                additionalProperties: {}
+  /api/registry/expand/product-identifiers:
+    post:
+      operationId: expandProductIdentifiers
+      summary: Expand product identifiers
+      description: Expand publisher_properties selectors into concrete property identifiers for caching.
+      tags:
+        - Lookups & Authorization
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                agent_url:
+                  type: string
+                publisher_properties:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/PublisherPropertySelector"
+              required:
+                - agent_url
+                - publisher_properties
+      responses:
+        "200":
+          description: Expanded identifiers
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  properties:
+                    type: array
+                    items: {}
+                  identifiers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        value:
+                          type: string
+                        property_id:
+                          type: string
+                        publisher_domain:
+                          type: string
+                      required:
+                        - type
+                        - value
+                        - property_id
+                        - publisher_domain
+                  property_count:
+                    type: integer
+                  identifier_count:
+                    type: integer
+                  generated_at:
+                    type: string
+                required:
+                  - agent_url
+                  - properties
+                  - identifiers
+                  - property_count
+                  - identifier_count
+                  - generated_at
+  /api/registry/validate/property-authorization:
+    get:
+      operationId: validatePropertyAuthorization
+      summary: Property authorization check
+      description: Quick check if a property identifier is authorized for an agent. Optimized for real-time ad request validation.
+      tags:
+        - Lookups & Authorization
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: agent_url
+          in: query
+        - schema:
+            type: string
+          required: true
+          name: identifier_type
+          in: query
+        - schema:
+            type: string
+          required: true
+          name: identifier_value
+          in: query
+      responses:
+        "200":
+          description: Authorization result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  identifier_type:
+                    type: string
+                  identifier_value:
+                    type: string
+                  authorized:
+                    type: boolean
+                  checked_at:
+                    type: string
+                required:
+                  - agent_url
+                  - identifier_type
+                  - identifier_value
+                  - authorized
+                  - checked_at
+                additionalProperties: {}
+  /api/adagents/validate:
+    post:
+      operationId: validateAdagents
+      summary: Validate adagents.json
+      description: Validate a domain's adagents.json file and optionally validate referenced agent cards.
+      tags:
+        - Validation Tools
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+              required:
+                - domain
+      responses:
+        "200":
+          description: Validation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      domain:
+                        type: string
+                      found:
+                        type: boolean
+                      validation: {}
+                      agent_cards: {}
+                    required:
+                      - domain
+                      - found
+                  timestamp:
+                    type: string
+                required:
+                  - success
+                  - data
+                  - timestamp
+  /api/adagents/create:
+    post:
+      operationId: createAdagents
+      summary: Generate adagents.json
+      description: Generate a valid adagents.json file from a list of authorized agents.
+      tags:
+        - Validation Tools
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                authorized_agents:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      authorized_for:
+                        type: string
+                    required:
+                      - url
+                include_schema:
+                  type: boolean
+                include_timestamp:
+                  type: boolean
+                properties:
+                  type: array
+                  items: {}
+              required:
+                - authorized_agents
+      responses:
+        "200":
+          description: Generated adagents.json
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      success:
+                        type: boolean
+                      adagents_json: {}
+                      validation: {}
+                    required:
+                      - success
+                  timestamp:
+                    type: string
+                required:
+                  - success
+                  - data
+                  - timestamp
+  /api/search:
+    get:
+      operationId: search
+      summary: Search
+      description: Search across brands, publishers, and properties. Returns up to 5 results per category.
+      tags:
+        - Search
+      parameters:
+        - schema:
+            type: string
+            minLength: 2
+          required: true
+          name: q
+          in: query
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  brands:
+                    type: array
+                    items: {}
+                  publishers:
+                    type: array
+                    items: {}
+                  properties:
+                    type: array
+                    items: {}
+                required:
+                  - brands
+                  - publishers
+                  - properties
+  /api/manifest-refs/lookup:
+    get:
+      operationId: lookupManifestRef
+      summary: Manifest reference lookup
+      description: Find the best manifest reference (brand.json URL or agent) for a domain.
+      tags:
+        - Search
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            example: brand.json
+          required: false
+          name: type
+          in: query
+      responses:
+        "200":
+          description: Reference lookup result
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      success:
+                        type: boolean
+                        enum:
+                          - true
+                      found:
+                        type: boolean
+                        enum:
+                          - true
+                      reference:
+                        type: object
+                        properties:
+                          reference_type:
+                            type: string
+                            enum:
+                              - url
+                              - agent
+                          manifest_url:
+                            type:
+                              - string
+                              - "null"
+                          agent_url:
+                            type:
+                              - string
+                              - "null"
+                          agent_id:
+                            type:
+                              - string
+                              - "null"
+                          verification_status:
+                            type: string
+                            enum:
+                              - pending
+                              - valid
+                              - invalid
+                              - unreachable
+                        required:
+                          - reference_type
+                          - manifest_url
+                          - agent_url
+                          - agent_id
+                          - verification_status
+                    required:
+                      - success
+                      - found
+                      - reference
+                  - type: object
+                    properties:
+                      success:
+                        type: boolean
+                        enum:
+                          - false
+                      found:
+                        type: boolean
+                        enum:
+                          - false
+                    required:
+                      - success
+                      - found
+  /api/public/discover-agent:
+    get:
+      operationId: discoverAgent
+      summary: Discover agent
+      description: Probe an agent URL to discover its name, type, supported protocols, and basic statistics.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: url
+          in: query
+      responses:
+        "200":
+          description: Discovered agent info
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  protocols:
+                    type: array
+                    items:
+                      type: string
+                  type:
+                    type: string
+                  stats:
+                    type: object
+                    properties:
+                      format_count:
+                        type: integer
+                      product_count:
+                        type: integer
+                      publisher_count:
+                        type: integer
+                required:
+                  - name
+                  - protocols
+                  - type
+                  - stats
+        "504":
+          description: Connection timeout
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/public/agent-formats:
+    get:
+      operationId: getAgentFormats
+      summary: Get agent formats
+      description: Fetch creative formats from a creative agent.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: url
+          in: query
+      responses:
+        "200":
+          description: Creative formats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  formats:
+                    type: array
+                    items: {}
+                required:
+                  - success
+                  - formats
+  /api/public/agent-products:
+    get:
+      operationId: getAgentProducts
+      summary: Get agent products
+      description: Fetch products from a sales agent.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: url
+          in: query
+      responses:
+        "200":
+          description: Products
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  products:
+                    type: array
+                    items: {}
+                required:
+                  - success
+                  - products
+  /api/public/validate-publisher:
+    get:
+      operationId: validatePublisher
+      summary: Validate publisher
+      description: Validate a publisher domain's adagents.json and return summary statistics.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Publisher validation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  valid:
+                    type: boolean
+                  domain:
+                    type: string
+                  url:
+                    type: string
+                  agent_count:
+                    type: integer
+                  property_count:
+                    type: integer
+                  property_type_counts:
+                    type: object
+                    additionalProperties:
+                      type: integer
+                  tag_count:
+                    type: integer
+                  errors:
+                    type: array
+                    items:
+                      type: string
+                  warnings:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - valid
+                  - domain
+                  - agent_count
+                  - property_count
+                  - property_type_counts
+                  - tag_count
+  /api/policies/registry:
+    get:
+      operationId: listPolicies
+      summary: List policies
+      description: Browse and search the governance policy registry. Returns approved policies with optional filtering by category, enforcement level, jurisdiction, policy category, and governance domain.
+      tags:
+        - Policy Registry
+      parameters:
+        - schema:
+            type: string
+            description: Full-text search on policy name and description
+          required: false
+          description: Full-text search on policy name and description
+          name: search
+          in: query
+        - schema:
+            type: string
+            enum:
+              - regulation
+              - standard
+          required: false
+          name: category
+          in: query
+        - schema:
+            type: string
+            enum:
+              - must
+              - should
+              - may
+          required: false
+          name: enforcement
+          in: query
+        - schema:
+            type: string
+            example: EU
+            description: Filter by jurisdiction (includes region alias matching)
+          required: false
+          description: Filter by jurisdiction (includes region alias matching)
+          name: jurisdiction
+          in: query
+        - schema:
+            type: string
+            example: age_restricted
+          required: false
+          name: policy_category
+          in: query
+        - schema:
+            type: string
+            example: campaign
+            description: Filter by governance domain
+          required: false
+          description: Filter by governance domain
+          name: domain
+          in: query
+        - schema:
+            type: integer
+            description: Results per page (default 20, max 1000)
+          required: false
+          description: Results per page (default 20, max 1000)
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            description: Pagination offset (default 0)
+          required: false
+          description: Pagination offset (default 0)
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Policy listing with facet stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  policies:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PolicySummary"
+                  stats:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      regulation:
+                        type: integer
+                      standard:
+                        type: integer
+                    required:
+                      - total
+                      - regulation
+                      - standard
+                required:
+                  - policies
+                  - stats
+  /api/policies/resolve:
+    get:
+      operationId: resolvePolicy
+      summary: Resolve policy
+      description: Resolve a single policy by ID. Optionally pin to a specific version — returns null if the version does not match.
+      tags:
+        - Policy Registry
+      parameters:
+        - schema:
+            type: string
+            example: gdpr_consent
+          required: true
+          name: policy_id
+          in: query
+        - schema:
+            type: string
+            description: Return null if the current version does not match
+          required: false
+          description: Return null if the current version does not match
+          name: version
+          in: query
+      responses:
+        "200":
+          description: Policy resolved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Policy"
+        "400":
+          description: Missing policy_id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Policy not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  policy_id:
+                    type: string
+                required:
+                  - error
+                  - policy_id
+  /api/policies/resolve/bulk:
+    post:
+      operationId: resolvePoliciesBulk
+      summary: Bulk resolve policies
+      description: |-
+        Resolve up to 100 policies by ID in a single request. Returns a map of policy_id to Policy (or null if not found).
+
+        **Rate limit:** 20 requests per minute per IP address.
+      tags:
+        - Policy Registry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                policy_ids:
+                  type: array
+                  items:
+                    type: string
+                  minItems: 1
+                  maxItems: 100
+                  example:
+                    - gdpr_consent
+                    - coppa_children
+              required:
+                - policy_ids
+      responses:
+        "200":
+          description: Bulk resolution results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: object
+                    additionalProperties:
+                      allOf:
+                        - $ref: "#/components/schemas/Policy"
+                        - type:
+                            - object
+                            - "null"
+                required:
+                  - results
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/policies/history:
+    get:
+      operationId: getPolicyHistory
+      summary: Policy revision history
+      description: Retrieve the edit history for a policy. Each revision records who made the change, a summary, and whether it was a rollback.
+      tags:
+        - Policy Registry
+      parameters:
+        - schema:
+            type: string
+            example: gdpr_consent
+          required: true
+          name: policy_id
+          in: query
+        - schema:
+            type: integer
+            description: Results per page (max 100, default 20)
+          required: false
+          description: Results per page (max 100, default 20)
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            description: Pagination offset (default 0)
+          required: false
+          description: Pagination offset (default 0)
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Revision history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyHistory"
+        "400":
+          description: Missing policy_id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Policy not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  policy_id:
+                    type: string
+                required:
+                  - error
+                  - policy_id
+  /api/policies/save:
+    post:
+      operationId: savePolicy
+      summary: Save policy
+      description: Create or update a community-contributed policy. Requires authentication. Registry-sourced and pending-review policies cannot be edited (returns 409). Updates automatically create a revision record.
+      tags:
+        - Policy Registry
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                policy_id:
+                  type: string
+                  example: my_brand_safety
+                  description: Lowercase alphanumeric with underscores
+                version:
+                  type: string
+                  example: 1.0.0
+                name:
+                  type: string
+                  example: Acme Corp Brand Safety
+                category:
+                  type: string
+                  enum:
+                    - regulation
+                    - standard
+                enforcement:
+                  type: string
+                  enum:
+                    - must
+                    - should
+                    - may
+                policy:
+                  type: string
+                  example: Ads must not appear adjacent to content depicting violence...
+                description:
+                  type: string
+                jurisdictions:
+                  type: array
+                  items:
+                    type: string
+                region_aliases:
+                  type: object
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
+                policy_categories:
+                  type: array
+                  items:
+                    type: string
+                channels:
+                  type: array
+                  items:
+                    type: string
+                effective_date:
+                  type: string
+                sunset_date:
+                  type: string
+                governance_domains:
+                  type: array
+                  items:
+                    type: string
+                source_url:
+                  type: string
+                  description: Must use http:// or https://
+                source_name:
+                  type: string
+                guidance:
+                  type: string
+                exemplars:
+                  type: object
+                  properties:
+                    pass:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          scenario:
+                            type: string
+                          explanation:
+                            type: string
+                        required:
+                          - scenario
+                          - explanation
+                    fail:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          scenario:
+                            type: string
+                          explanation:
+                            type: string
+                        required:
+                          - scenario
+                          - explanation
+                ext:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - policy_id
+                - version
+                - name
+                - category
+                - enforcement
+                - policy
+      responses:
+        "200":
+          description: Policy saved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  message:
+                    type: string
+                  policy_id:
+                    type: string
+                  revision_number:
+                    type:
+                      - integer
+                      - "null"
+                required:
+                  - success
+                  - message
+                  - policy_id
+                  - revision_number
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Cannot edit registry-sourced or pending policy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  policy_id:
+                    type: string
+                required:
+                  - error
+                  - policy_id
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/feed:
+    get:
+      operationId: getRegistryFeed
+      summary: Registry change feed
+      description: |-
+        Poll a cursor-based feed of registry changes. Events are ordered by UUID v7 event_id for monotonic cursor progression. The feed retains events for 90 days.
+
+        Type filtering supports glob patterns: `property.*` matches `property.created`, `property.updated`, etc.
+      tags:
+        - Change Feed
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Resume after this event ID
+          required: false
+          description: Resume after this event ID
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated event type filters with glob support (e.g. property.*)
+            example: property.*,agent.*
+          required: false
+          description: Comma-separated event type filters with glob support (e.g. property.*)
+          name: types
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+            description: Max events per page (default 100, max 10,000)
+          required: false
+          description: Max events per page (default 100, max 10,000)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Feed page
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        event_id:
+                          type: string
+                          format: uuid
+                        event_type:
+                          type: string
+                          example: property.created
+                        entity_type:
+                          type: string
+                          example: property
+                        entity_id:
+                          type: string
+                        payload:
+                          type: object
+                          additionalProperties: {}
+                        actor:
+                          type: string
+                        created_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - event_id
+                        - event_type
+                        - entity_type
+                        - entity_id
+                        - payload
+                        - actor
+                        - created_at
+                  cursor:
+                    type:
+                      - string
+                      - "null"
+                    format: uuid
+                    description: Pass as cursor in the next request to continue polling
+                  has_more:
+                    type: boolean
+                required:
+                  - events
+                  - cursor
+                  - has_more
+        "400":
+          description: Invalid cursor format or type filter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "410":
+          description: Cursor expired (older than 90-day retention window)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum:
+                      - cursor_expired
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/registry/agents/search:
+    get:
+      operationId: searchAgentProfiles
+      summary: Search agent inventory profiles
+      description: Search agents by inventory profile — channels, markets, content categories, property types, and more. Filters use AND across dimensions and OR within a dimension. Results are ranked by relevance score.
+      tags:
+        - Agent Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: Comma-separated channel filter
+            example: ctv,olv
+          required: false
+          description: Comma-separated channel filter
+          name: channels
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated property type filter
+            example: ctv_app,website
+          required: false
+          description: Comma-separated property type filter
+          name: property_types
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated market/country code filter
+            example: US,GB
+          required: false
+          description: Comma-separated market/country code filter
+          name: markets
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated IAB content category filter
+            example: IAB-7,IAB-7-1
+          required: false
+          description: Comma-separated IAB content category filter
+          name: categories
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated tag filter
+            example: premium
+          required: false
+          description: Comma-separated tag filter
+          name: tags
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated delivery type filter
+            example: guaranteed,programmatic
+          required: false
+          description: Comma-separated delivery type filter
+          name: delivery_types
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+            description: Require TMP support
+          required: false
+          description: Require TMP support
+          name: has_tmp
+          in: query
+        - schema:
+            type:
+              - integer
+              - "null"
+            minimum: 0
+            description: Minimum number of properties in inventory
+          required: false
+          description: Minimum number of properties in inventory
+          name: min_properties
+          in: query
+        - schema:
+            type: string
+            description: Pagination cursor from a previous response
+          required: false
+          description: Pagination cursor from a previous response
+          name: cursor
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            description: Max results per page (default 50, max 200)
+          required: false
+          description: Max results per page (default 50, max 200)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Search results ranked by relevance
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        agent_url:
+                          type: string
+                          format: uri
+                        channels:
+                          type: array
+                          items:
+                            type: string
+                        property_types:
+                          type: array
+                          items:
+                            type: string
+                        markets:
+                          type: array
+                          items:
+                            type: string
+                        categories:
+                          type: array
+                          items:
+                            type: string
+                        tags:
+                          type: array
+                          items:
+                            type: string
+                        delivery_types:
+                          type: array
+                          items:
+                            type: string
+                        format_ids:
+                          type: array
+                          items: {}
+                          description: Creative format identifiers supported by this agent
+                        property_count:
+                          type: integer
+                        publisher_count:
+                          type: integer
+                        has_tmp:
+                          type: boolean
+                        category_taxonomy:
+                          type:
+                            - string
+                            - "null"
+                        relevance_score:
+                          type: number
+                        matched_filters:
+                          type: array
+                          items:
+                            type: string
+                        updated_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - agent_url
+                        - channels
+                        - property_types
+                        - markets
+                        - categories
+                        - tags
+                        - delivery_types
+                        - format_ids
+                        - property_count
+                        - publisher_count
+                        - has_tmp
+                        - category_taxonomy
+                        - relevance_score
+                        - matched_filters
+                        - updated_at
+                  cursor:
+                    type:
+                      - string
+                      - "null"
+                  has_more:
+                    type: boolean
+                required:
+                  - results
+                  - cursor
+                  - has_more
+        "400":
+          description: Invalid cursor or parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/crawl-request:
+    post:
+      operationId: requestCrawl
+      summary: Request domain re-crawl
+      description: |-
+        Trigger an immediate re-crawl of a publisher domain after updating adagents.json. The crawl runs asynchronously — returns 202 immediately.
+
+        **Rate limits:** 5 minutes per domain, 30 requests per user per hour.
+      tags:
+        - Agent Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: examplepub.com
+                  description: Publisher domain to re-crawl
+              required:
+                - domain
+      responses:
+        "202":
+          description: Crawl request accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Crawl request accepted
+                  domain:
+                    type: string
+                required:
+                  - message
+                  - domain
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
+  /api/registry/brand-crawl-request:
+    post:
+      operationId: requestBrandCrawl
+      summary: Request brand.json re-crawl
+      description: |-
+        Trigger an immediate re-crawl of a domain's brand.json. The crawl runs asynchronously — returns 202 immediately.
+
+        **Rate limits:** 5 minutes per domain, 30 requests per user per hour (shared with adagents.json crawl requests).
+      tags:
+        - Brand Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: examplebrand.com
+                  description: Domain to re-crawl brand.json for
+              required:
+                - domain
+      responses:
+        "202":
+          description: Brand crawl request accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Brand crawl request accepted
+                  domain:
+                    type: string
+                required:
+                  - message
+                  - domain
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
+  /api/registry/agents/{encodedUrl}/compliance:
+    get:
+      operationId: getAgentCompliance
+      summary: Get agent compliance detail
+      description: |-
+        Returns detailed compliance status for a single agent, including track-level results, storyboard counts, and timestamps.
+
+        If the agent has opted out of compliance monitoring, returns a minimal response with `status: opted_out`.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+            example: https%3A%2F%2Fexample.com%2Fmcp
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Compliance detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentComplianceDetail"
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/storyboard-status:
+    get:
+      operationId: getAgentStoryboardStatus
+      summary: Get agent storyboard status
+      description: |-
+        Returns per-storyboard test results for an agent. Includes title, category, track, pass/fail status, and step counts.
+
+        **Members only** — requires authentication and an active membership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+            example: https%3A%2F%2Fexample.com%2Fmcp
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Storyboard status for the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  storyboards:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/StoryboardStatus"
+                  passing_count:
+                    type: integer
+                  total_count:
+                    type: integer
+                required:
+                  - agent_url
+                  - storyboards
+                  - passing_count
+                  - total_count
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Members only
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  members_only:
+                    type: boolean
+                required:
+                  - error
+                  - members_only
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/storyboard-status:
+    post:
+      operationId: bulkAgentStoryboardStatus
+      summary: Bulk storyboard status
+      description: |-
+        Returns per-storyboard test results for multiple agents in a single request.
+
+        **Members only** — requires authentication and an active membership. Maximum 100 agent URLs per request.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                agent_urls:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 100
+                  description: Agent URLs to fetch storyboard status for
+              required:
+                - agent_urls
+      responses:
+        "200":
+          description: Storyboard status keyed by agent URL
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agents:
+                    type: object
+                    additionalProperties:
+                      anyOf:
+                        - type: array
+                          items:
+                            $ref: "#/components/schemas/StoryboardStatus"
+                        - type: object
+                          properties:
+                            status:
+                              type: string
+                              enum:
+                                - opted_out
+                          required:
+                            - status
+                  invalid_urls:
+                    type: integer
+                    description: Count of invalid URLs that were skipped
+                required:
+                  - agents
+        "400":
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Members only
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  members_only:
+                    type: boolean
+                required:
+                  - error
+                  - members_only
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/compliance/history:
+    get:
+      operationId: getAgentComplianceHistory
+      summary: Get agent compliance history
+      description: |-
+        Returns a list of compliance test runs for an agent, ordered most recent first.
+
+        If the agent has opted out, returns an empty list.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Max results (default 30, max 100)
+          required: false
+          description: Max results (default 30, max 100)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Compliance run history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  runs:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ComplianceRun"
+                  count:
+                    type: integer
+                required:
+                  - agent_url
+                  - runs
+                  - count
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/lifecycle:
+    put:
+      operationId: updateAgentLifecycle
+      summary: Update agent lifecycle stage
+      description: Set the lifecycle stage for an agent. Requires authentication and ownership of the agent.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                lifecycle_stage:
+                  type: string
+                  enum:
+                    - development
+                    - testing
+                    - production
+                    - deprecated
+              required:
+                - lifecycle_stage
+      responses:
+        "200":
+          description: Updated metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegistryMetadata"
+        "400":
+          description: Invalid agent URL or lifecycle stage
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/compliance/opt-out:
+    put:
+      operationId: updateAgentComplianceOptOut
+      summary: Update compliance opt-out
+      description: Opt an agent in or out of public compliance reporting. Requires authentication and ownership of the agent.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                opt_out:
+                  type: boolean
+              required:
+                - opt_out
+      responses:
+        "200":
+          description: Updated metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegistryMetadata"
+        "400":
+          description: Invalid agent URL or opt_out value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/settings:
+    get:
+      operationId: getAgentMonitoringSettings
+      summary: Get monitoring settings
+      description: Returns the monitoring configuration for an agent. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Monitoring settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitoringSettings"
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/pause:
+    put:
+      operationId: updateAgentMonitoringPause
+      summary: Pause or resume monitoring
+      description: Pause or resume automated compliance monitoring for an agent. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                paused:
+                  type: boolean
+              required:
+                - paused
+      responses:
+        "200":
+          description: Updated monitoring settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitoringSettings"
+        "400":
+          description: Invalid agent URL or paused value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/interval:
+    put:
+      operationId: updateAgentMonitoringInterval
+      summary: Update monitoring interval
+      description: Set the check interval for automated compliance monitoring (6–168 hours). Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                interval_hours:
+                  type: integer
+                  minimum: 6
+                  maximum: 168
+              required:
+                - interval_hours
+      responses:
+        "200":
+          description: Updated monitoring settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitoringSettings"
+        "400":
+          description: Invalid agent URL or interval
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/requests:
+    get:
+      operationId: getAgentMonitoringRequests
+      summary: Get outbound request log
+      description: Returns the outbound request log for an agent (compliance checks, health probes, etc.). Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Max results (default 50, max 200)
+          required: false
+          description: Max results (default 50, max 200)
+          name: limit
+          in: query
+        - schema:
+            type: string
+            description: ISO 8601 timestamp to filter from
+          required: false
+          description: ISO 8601 timestamp to filter from
+          name: since
+          in: query
+      responses:
+        "200":
+          description: Outbound request log
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  requests:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/OutboundRequest"
+                  count:
+                    type: integer
+                  total:
+                    type: integer
+                required:
+                  - agent_url
+                  - requests
+                  - count
+                  - total
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/auth-status:
+    get:
+      operationId: getAgentAuthStatus
+      summary: Get agent auth status
+      description: Returns whether an agent has stored authentication credentials and OAuth token status. Requires authentication.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Auth status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentAuthStatus"
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/connect:
+    put:
+      operationId: connectAgent
+      summary: Connect agent credentials
+      description: Store authentication credentials for an agent. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                auth_token:
+                  type: string
+                  maxLength: 4096
+                  description: Bearer or basic auth token
+                auth_type:
+                  type: string
+                  enum:
+                    - bearer
+                    - basic
+                  description: "Auth type (default: bearer)"
+      responses:
+        "200":
+          description: Connection result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+                    enum:
+                      - true
+                  has_auth:
+                    type: boolean
+                  agent_context_id:
+                    type: string
+                required:
+                  - connected
+                  - has_auth
+                  - agent_context_id
+        "400":
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/oauth-client-credentials:
+    put:
+      operationId: saveAgentOAuthClientCredentials
+      summary: Save OAuth 2.0 client-credentials for an agent
+      description: Store a machine-to-machine OAuth 2.0 client-credentials configuration (RFC 6749 §4.4) for this agent. The SDK exchanges at the token endpoint before every call and refreshes on 401. `client_secret` may be a `$ENV:VAR_NAME` reference — the SDK resolves at exchange time, the server stores it as written (encrypted uniformly). Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token_endpoint:
+                  type: string
+                  maxLength: 2048
+                  description: Token endpoint URL (HTTPS required; localhost allowed in dev).
+                client_id:
+                  type: string
+                  maxLength: 2048
+                  description: OAuth client ID. May be a `$ENV:VAR_NAME` reference.
+                client_secret:
+                  type: string
+                  maxLength: 8192
+                  description: OAuth client secret. May be a `$ENV:VAR_NAME` reference. Stored encrypted at rest.
+                scope:
+                  type: string
+                  maxLength: 1024
+                  description: Space-separated OAuth scope values.
+                resource:
+                  type: string
+                  maxLength: 2048
+                  description: RFC 8707 resource indicator.
+                audience:
+                  type: string
+                  maxLength: 2048
+                  description: Audience parameter for audience-validating authorization servers.
+                auth_method:
+                  type: string
+                  enum:
+                    - basic
+                    - body
+                  description: "Client-credentials placement: basic (HTTP Basic header, RFC 6749 §2.3.1 preferred) or body (form fields). SDK default is basic."
+              required:
+                - token_endpoint
+                - client_id
+                - client_secret
+      responses:
+        "200":
+          description: Credentials saved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+                    enum:
+                      - true
+                  has_auth:
+                    type: boolean
+                    enum:
+                      - true
+                  agent_context_id:
+                    type: string
+                  auth_type:
+                    type: string
+                    enum:
+                      - oauth_client_credentials
+                required:
+                  - connected
+                  - has_auth
+                  - agent_context_id
+                  - auth_type
+        "400":
+          description: Invalid parameters — response carries `code` and `field` pointing to the rejection cause.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialSaveValidationError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/oauth-client-credentials/test:
+    post:
+      operationId: testAgentOAuthClientCredentials
+      summary: Dry-run the saved OAuth 2.0 client-credentials config
+      description: Exchange the saved client_credentials at the token endpoint and discard the resulting access token. Returns success + latency on a 2xx exchange, or the SDK's `ClientCredentialsExchangeError` kind (`oauth`, `malformed`, `network`) on failure so operators get same-second feedback instead of waiting for the next compliance heartbeat. Requires authentication and ownership. Requires credentials to already be saved via `PUT /oauth-client-credentials`.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: "Result of the token exchange. `ok: true` on 2xx from the AS; `ok: false` with a typed error otherwise (HTTP response itself is still 200 — the error payload carries the rejection kind so UI can branch on it)."
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      latency_ms:
+                        type: integer
+                    required:
+                      - ok
+                      - latency_ms
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - false
+                      latency_ms:
+                        type: integer
+                      error:
+                        type: object
+                        properties:
+                          kind:
+                            type: string
+                            enum:
+                              - oauth
+                              - malformed
+                              - network
+                            description: "Category of failure: `oauth` = AS returned a typed error (e.g. invalid_client), `malformed` = AS returned an unexpected 2xx payload, `network` = couldn't reach the AS."
+                          message:
+                            type: string
+                          oauth_error:
+                            type: string
+                            description: RFC 6749 `error` field when kind=oauth.
+                          oauth_error_description:
+                            type: string
+                            description: RFC 6749 `error_description` field when kind=oauth.
+                          http_status:
+                            type: integer
+                            description: Status code when the AS returned a non-2xx.
+                        required:
+                          - kind
+                          - message
+                    required:
+                      - ok
+                      - latency_ms
+                      - error
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No saved client-credentials config for this agent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/applicable-storyboards:
+    get:
+      operationId: getApplicableStoryboards
+      summary: Get applicable storyboards for agent
+      description: Probe the agent's get_adcp_capabilities and resolve its declared supported_protocols and specialisms to the compliance bundles that will run. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Bundles the agent will be tested against, driven by its declared capabilities
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  agent_name:
+                    type: string
+                  supported_protocols:
+                    type: array
+                    items:
+                      type: string
+                  specialisms:
+                    type: array
+                    items:
+                      type: string
+                  capabilities_probe_error:
+                    type: string
+                    description: Agent-reported probe error. Untrusted — sanitized and truncated to 500 chars. Present when get_adcp_capabilities was advertised but failed; empty bundle list usually indicates this, not a v2 agent.
+                  bundles:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        kind:
+                          type: string
+                          enum:
+                            - universal
+                            - domain
+                            - specialism
+                        id:
+                          type: string
+                        storyboards:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              title:
+                                type: string
+                              summary:
+                                type: string
+                              step_count:
+                                type: integer
+                            required:
+                              - id
+                              - title
+                              - summary
+                              - step_count
+                      required:
+                        - kind
+                        - id
+                        - storyboards
+                  total_storyboards:
+                    type: integer
+                required:
+                  - agent_url
+                  - agent_name
+                  - supported_protocols
+                  - specialisms
+                  - bundles
+                  - total_storyboards
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "422":
+          description: Agent requires authentication, or declares a specialism not in the local compliance cache
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  needs_auth:
+                    type: boolean
+                  unknown_specialism:
+                    type: boolean
+                  declared_specialisms:
+                    type: array
+                    items:
+                      type: string
+                    description: Specialisms the agent declared, for unknown-specialism errors
+                  known_specialisms:
+                    type: array
+                    items:
+                      type: string
+                    description: Specialism ids present in this server's local compliance cache
+                required:
+                  - error
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  reason:
+                    type: string
+                    enum:
+                      - network
+                      - tls
+                      - timeout
+                      - protocol
+                      - unknown
+                    description: Coarse error classification for UI differentiation
+                required:
+                  - error
+        "504":
+          description: Connection timeout
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/storyboards:
+    get:
+      operationId: listStoryboards
+      summary: List storyboards
+      description: Returns the catalog of compliance storyboards. Optionally filter by category.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: Filter by storyboard category
+          required: false
+          description: Filter by storyboard category
+          name: category
+          in: query
+      responses:
+        "200":
+          description: Storyboard catalog
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  storyboards:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/StoryboardSummary"
+                  count:
+                    type: integer
+                required:
+                  - storyboards
+                  - count
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/storyboards/{id}:
+    get:
+      operationId: getStoryboard
+      summary: Get storyboard detail
+      description: Returns a single storyboard with its full phase and step structure, plus its test kit if available.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: Storyboard ID
+          required: true
+          description: Storyboard ID
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Storyboard detail
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  storyboard:
+                    $ref: "#/components/schemas/StoryboardDetail"
+                  test_kit: {}
+                required:
+                  - storyboard
+        "404":
+          description: Storyboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/find:
+    get:
+      operationId: findBrand
+      summary: Find brands by name
+      description: Search for brands by name or domain. Returns matching results with basic identity info.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            minLength: 2
+            description: Search query (min 2 characters)
+          required: true
+          description: Search query (min 2 characters)
+          name: q
+          in: query
+        - schema:
+            type: string
+            description: Max results (default 10, max 50)
+          required: false
+          description: Max results (default 10, max 50)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FindCompanyResult"
+                required:
+                  - results
+        "400":
+          description: Query too short
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/setup-my-brand:
+    post:
+      operationId: setupMyBrand
+      summary: Set up a hosted brand.json
+      description: Create or update a hosted brand.json for a domain owned by the authenticated user's organization. Returns the hosted URL and a pointer snippet for DNS setup.
+      tags:
+        - Brand Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: acmecorp.com
+                brand_name:
+                  type: string
+                logo_url:
+                  type: string
+                brand_color:
+                  type: string
+              required:
+                - domain
+                - brand_name
+      responses:
+        "200":
+          description: Brand setup result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  has_brand_json:
+                    type: boolean
+                  hosted_brand_json_url:
+                    type: string
+                  pointer_snippet:
+                    type: string
+                    description: JSON string for brand.json pointer
+                required:
+                  - domain
+                  - has_brand_json
+                  - hosted_brand_json_url
+                  - pointer_snippet
+        "400":
+          description: Invalid domain or missing fields
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Domain not owned by user's organization
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/check/bulk:
+    post:
+      operationId: bulkPropertyCheck
+      summary: Bulk property identifier check
+      description: Check up to 10,000 property identifiers (domains, app bundle IDs, CTV store URLs) against the registry catalog. Returns a verdict for each identifier and a summary.
+      tags:
+        - Property Resolution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                identifiers:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 10000
+                  description: Property identifiers to check
+              required:
+                - identifiers
+      responses:
+        "200":
+          description: Check results with report ID
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      ready:
+                        type: integer
+                      known:
+                        type: integer
+                      ad_infra:
+                        type: integer
+                      unknown:
+                        type: integer
+                      skipped:
+                        type: integer
+                    required:
+                      - total
+                      - ready
+                      - known
+                      - ad_infra
+                      - unknown
+                      - skipped
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        input:
+                          type: string
+                        identifier:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                            - type
+                            - value
+                        verdict:
+                          type: string
+                        classification:
+                          type:
+                            - string
+                            - "null"
+                        source:
+                          type:
+                            - string
+                            - "null"
+                        property_rid:
+                          type:
+                            - string
+                            - "null"
+                        action:
+                          type: string
+                      required:
+                        - input
+                        - identifier
+                        - verdict
+                        - classification
+                        - source
+                        - property_rid
+                        - action
+                  report_id:
+                    type: string
+                required:
+                  - summary
+                  - entries
+                  - report_id
+        "400":
+          description: Invalid identifiers
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/check/bulk/{reportId}:
+    get:
+      operationId: getBulkPropertyCheckReport
+      summary: Get bulk check report
+      description: Retrieve a previously generated bulk property check report by ID.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            description: Report UUID
+          required: true
+          description: Report UUID
+          name: reportId
+          in: path
+      responses:
+        "200":
+          description: Report data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      ready:
+                        type: integer
+                      known:
+                        type: integer
+                      ad_infra:
+                        type: integer
+                      unknown:
+                        type: integer
+                      skipped:
+                        type: integer
+                    required:
+                      - total
+                      - ready
+                      - known
+                      - ad_infra
+                      - unknown
+                      - skipped
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        input:
+                          type: string
+                        identifier:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                            - type
+                            - value
+                        verdict:
+                          type: string
+                        classification:
+                          type:
+                            - string
+                            - "null"
+                        source:
+                          type:
+                            - string
+                            - "null"
+                        property_rid:
+                          type:
+                            - string
+                            - "null"
+                        action:
+                          type: string
+                      required:
+                        - input
+                        - identifier
+                        - verdict
+                        - classification
+                        - source
+                        - property_rid
+                        - action
+                required:
+                  - summary
+                  - entries
+        "404":
+          description: Report not found or expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/storyboard/{storyboardId}/step/{stepId}:
+    post:
+      operationId: runStoryboardStep
+      summary: Run a single storyboard step
+      description: Execute a single storyboard step against an agent. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: storyboardId
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: stepId
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                context:
+                  type: object
+                  additionalProperties: {}
+                  description: Optional context object for the step
+                dry_run:
+                  type: boolean
+                  description: "Dry run mode (default: true)"
+      responses:
+        "200":
+          description: Step execution result
+          content:
+            application/json:
+              schema: {}
+        "400":
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Storyboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/storyboards/{storyboardId}/first-step:
+    get:
+      operationId: getStoryboardFirstStep
+      summary: Get first step preview
+      description: Returns a preview of the first step of a storyboard. No agent call needed.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: storyboardId
+          in: path
+      responses:
+        "200":
+          description: First step preview
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  storyboard:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      title:
+                        type: string
+                    required:
+                      - id
+                      - title
+                  step: {}
+                required:
+                  - storyboard
+        "404":
+          description: Storyboard not found or has no steps
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/storyboard/{storyboardId}/run:
+    post:
+      operationId: runStoryboard
+      summary: Run full storyboard evaluation
+      description: Execute all steps of a storyboard against an agent and record the compliance result. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: storyboardId
+          in: path
+      responses:
+        "200":
+          description: Storyboard run result with annotated phases
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  storyboard:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      title:
+                        type: string
+                      category:
+                        type: string
+                      narrative:
+                        type: string
+                    required:
+                      - id
+                      - title
+                      - category
+                  agent:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      profile: {}
+                    required:
+                      - url
+                  phases: {}
+                  summary: {}
+                  observations: {}
+                  total_duration_ms:
+                    type: number
+                  test_kit: {}
+                required:
+                  - storyboard
+                  - agent
+                  - total_duration_ms
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Storyboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/storyboard/{storyboardId}/compare:
+    post:
+      operationId: compareStoryboard
+      summary: Compare storyboard against reference agent
+      description: Run a storyboard against both the target agent and the public reference agent, returning side-by-side results. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: storyboardId
+          in: path
+      responses:
+        "200":
+          description: Side-by-side comparison results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  storyboard:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      title:
+                        type: string
+                      category:
+                        type: string
+                    required:
+                      - id
+                      - title
+                      - category
+                  user_agent:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      profile: {}
+                      summary: {}
+                    required:
+                      - url
+                  reference_agent:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      name:
+                        type: string
+                      profile: {}
+                      summary: {}
+                    required:
+                      - url
+                      - name
+                  phases: {}
+                  total_duration_ms:
+                    type: number
+                required:
+                  - storyboard
+                  - user_agent
+                  - reference_agent
+                  - total_duration_ms
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Storyboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+tags:
+  - name: Brand Resolution
+    description: Resolve advertiser domains to canonical brand identities.
+  - name: Property Resolution
+    description: Resolve publisher domains to their property configurations and authorized agents.
+  - name: Agent Discovery
+    description: Browse the federated agent network, search agent inventory profiles, publisher index, and registry statistics.
+  - name: Change Feed
+    description: Poll cursor-based registry change events for local sync.
+  - name: Lookups & Authorization
+    description: Look up agents by domain or property, and validate ad-serving authorization.
+  - name: Validation Tools
+    description: Validate publisher adagents.json files and generate compliant configurations.
+  - name: Search
+    description: Cross-entity search across brands, publishers, agents, and properties.
+  - name: Agent Probing
+    description: Connect to live agents and inspect their capabilities, formats, and inventory.
+  - name: Brand Discovery
+    description: Discover and crawl brand.json files across domains.
+  - name: Agent Compliance
+    description: Agent compliance status, storyboard test results, and compliance history.
+  - name: Policy Registry
+    description: Browse, resolve, and contribute governance policies for campaign compliance.

--- a/static/openapi/releases/3.1.19/registry.yaml
+++ b/static/openapi/releases/3.1.19/registry.yaml
@@ -1,0 +1,10381 @@
+openapi: 3.1.0
+info:
+  title: AgenticAdvertising.org Registry API
+  description: |-
+    REST API for the AgenticAdvertising.org registry. Resolve brands,
+    discover properties, look up agents, and validate authorization in the
+    AdCP ecosystem.
+
+    Most endpoints are public and require no authentication. Endpoints marked
+    with a lock icon accept either an organization API key or a user JWT
+    obtained via the OAuth 2.1 flow — see [Authentication](https://agenticadvertising.org/docs/registry/index#authentication).
+
+    **Base URL:** `https://agenticadvertising.org`
+  version: 1.0.0
+  contact:
+    name: AgenticAdvertising.org
+    url: https://agenticadvertising.org
+servers:
+  - url: https://agenticadvertising.org
+    description: Production
+security: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: |-
+        Bearer token in the `Authorization` header. Two token types are accepted:
+
+        - **Organization API key** (`sk_...`) issued via the dashboard. Org-scoped, long-lived, for server-to-server use.
+        - **User JWT** obtained via the OAuth 2.1 authorization code flow with PKCE. User-scoped, short-lived. Discover the authorization server at `/.well-known/oauth-authorization-server` and the protected-resource metadata at `/.well-known/oauth-protected-resource/api`.
+    oauth2:
+      type: oauth2
+      description: OAuth 2.1 authorization code flow with PKCE. Users authenticate via AuthKit and clients receive a Bearer JWT that authorizes both the MCP endpoint and this REST API. Dynamic client registration is supported at `/register`.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://agenticadvertising.org/authorize
+          tokenUrl: https://agenticadvertising.org/token
+          refreshUrl: https://agenticadvertising.org/token
+          scopes:
+            openid: User identifier
+            profile: User profile information
+            email: User email address
+  schemas:
+    ResolvedBrand:
+      type: object
+      properties:
+        canonical_id:
+          type: string
+          example: acmecorp.com
+        canonical_domain:
+          type: string
+          example: acmecorp.com
+        brand_name:
+          type: string
+          example: Acme Corp
+        names:
+          type: array
+          items:
+            $ref: "#/components/schemas/LocalizedName"
+        keller_type:
+          type: string
+          enum:
+            - master
+            - sub_brand
+            - endorsed
+            - independent
+        parent_brand:
+          type: string
+        house_domain:
+          type: string
+        house_name:
+          type: string
+        brand_agent_url:
+          type: string
+        brand_manifest:
+          type: object
+          additionalProperties: {}
+        source:
+          type: string
+          enum:
+            - brand_json
+            - community
+            - enriched
+      required:
+        - canonical_id
+        - canonical_domain
+        - brand_name
+        - source
+    LocalizedName:
+      type: object
+      additionalProperties:
+        type: string
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+      required:
+        - error
+    BrandRegistryItem:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: acmecorp.com
+        brand_name:
+          type: string
+          example: Acme Corp
+        source:
+          type: string
+          enum:
+            - hosted
+            - brand_json
+            - community
+            - enriched
+        has_manifest:
+          type: boolean
+        verified:
+          type: boolean
+        house_domain:
+          type: string
+        keller_type:
+          type: string
+          enum:
+            - master
+            - sub_brand
+            - endorsed
+            - independent
+      required:
+        - domain
+        - source
+        - has_manifest
+        - verified
+    BrandActivity:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: acmecorp.com
+        total:
+          type: integer
+          example: 3
+        revisions:
+          type: array
+          items:
+            type: object
+            properties:
+              revision_number:
+                type: integer
+                example: 3
+              editor_name:
+                type: string
+                example: Pinnacle Media
+              edit_summary:
+                type: string
+                example: Updated logo and brand colors
+              source:
+                type: string
+                description: Source type of the record at the time of this revision (brand_json, enriched, community)
+              is_rollback:
+                type: boolean
+              rolled_back_to:
+                type: integer
+                description: Revision number that was restored; only present when is_rollback is true
+              created_at:
+                type: string
+                example: 2026-03-01T12:34:56Z
+            required:
+              - revision_number
+              - editor_name
+              - edit_summary
+              - is_rollback
+              - created_at
+      required:
+        - domain
+        - total
+        - revisions
+    PropertyActivity:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: examplepub.com
+        total:
+          type: integer
+          example: 3
+        revisions:
+          type: array
+          items:
+            type: object
+            properties:
+              revision_number:
+                type: integer
+                example: 3
+              editor_name:
+                type: string
+                example: Pinnacle Media
+              edit_summary:
+                type: string
+                example: Updated logo and brand colors
+              source:
+                type: string
+                description: Source type of the record at the time of this revision (brand_json, enriched, community)
+              is_rollback:
+                type: boolean
+              rolled_back_to:
+                type: integer
+                description: Revision number that was restored; only present when is_rollback is true
+              created_at:
+                type: string
+                example: 2026-03-01T12:34:56Z
+            required:
+              - revision_number
+              - editor_name
+              - edit_summary
+              - is_rollback
+              - created_at
+      required:
+        - domain
+        - total
+        - revisions
+    ResolvedProperty:
+      type: object
+      properties:
+        publisher_domain:
+          type: string
+          example: examplepub.com
+        source:
+          type: string
+          enum:
+            - adagents_json
+            - hosted
+            - discovered
+        authorized_agents:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              authorized_for:
+                type: string
+            required:
+              - url
+        properties:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              type:
+                type: string
+              name:
+                type: string
+              identifiers:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PropertyIdentifier"
+              tags:
+                type: array
+                items:
+                  type: string
+        contact:
+          type: object
+          properties:
+            name:
+              type: string
+            email:
+              type: string
+        verified:
+          type: boolean
+      required:
+        - publisher_domain
+        - source
+        - verified
+    PropertyIdentifier:
+      type: object
+      properties:
+        type:
+          type: string
+          example: domain
+        value:
+          type: string
+          example: examplepub.com
+      required:
+        - type
+        - value
+    PropertyRegistryItem:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: examplepub.com
+        source:
+          type: string
+          enum:
+            - adagents_json
+            - hosted
+            - community
+            - discovered
+            - enriched
+        property_count:
+          type: integer
+        agent_count:
+          type: integer
+        verified:
+          type: boolean
+      required:
+        - domain
+        - source
+        - property_count
+        - agent_count
+        - verified
+    ValidationResult:
+      type: object
+      properties:
+        valid:
+          type: boolean
+        domain:
+          type: string
+        url:
+          type: string
+        errors:
+          type: array
+          items:
+            type: string
+        warnings:
+          type: array
+          items:
+            type: string
+        status_code:
+          type: integer
+        raw_data:
+          type: object
+          additionalProperties: {}
+      required:
+        - valid
+    FederatedAgentWithDetails:
+      type: object
+      properties:
+        url:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+          enum:
+            - brand
+            - rights
+            - measurement
+            - governance
+            - creative
+            - sales
+            - buying
+            - signals
+            - unknown
+        protocol:
+          type: string
+          enum:
+            - mcp
+            - a2a
+        description:
+          type: string
+        mcp_endpoint:
+          type: string
+        contact:
+          type: object
+          properties:
+            name:
+              type: string
+            email:
+              type: string
+            website:
+              type: string
+          required:
+            - name
+            - email
+            - website
+        added_date:
+          type: string
+        member:
+          type: object
+          properties:
+            slug:
+              type: string
+            display_name:
+              type: string
+            membership_tier:
+              type: string
+              description: Raw AAO membership tier enum (e.g. `individual_professional`, `company_leader`). Present only when the profile owner has set their member card to public (`is_public=true`) AND the org has a resolvable tier. Absent for private profiles and for orgs without an active tier-bearing subscription.
+            membership_tier_label:
+              type: string
+              description: Human-readable label for `membership_tier` (e.g. `Professional`, `Partner`, `Leader`). Matches the AAO pricing page. Use this for UI display; the raw enum is for programmatic gating. Presence rules match `membership_tier`.
+            is_founding_member:
+              type: boolean
+              description: True when the profile owner carries the Founding Member badge (joined before the founding-cohort cutoff). Surfaced when the profile owner has set their member card to public (`is_public=true`). Absent for private profiles. Founding Member is orthogonal to tier — founding orgs typically display both (e.g. Scope3 shows `Partner` + `Founding Member`).
+          description: AAO member that owns this agent record. The registry contains only agents that members have explicitly enrolled on their member profile.
+        health:
+          $ref: "#/components/schemas/AgentHealth"
+        stats:
+          $ref: "#/components/schemas/AgentStats"
+        capabilities:
+          $ref: "#/components/schemas/AgentCapabilities"
+        compliance:
+          $ref: "#/components/schemas/AgentCompliance"
+        publisher_domains:
+          type: array
+          items:
+            type: string
+        property_summary:
+          $ref: "#/components/schemas/PropertySummary"
+      required:
+        - url
+        - name
+        - type
+    AgentHealth:
+      type: object
+      properties:
+        online:
+          type: boolean
+        checked_at:
+          type: string
+        response_time_ms:
+          type: number
+        tools_count:
+          type: integer
+        resources_count:
+          type: integer
+        error:
+          type: string
+      required:
+        - online
+        - checked_at
+    AgentStats:
+      type: object
+      properties:
+        property_count:
+          type: integer
+        publisher_count:
+          type: integer
+        publishers:
+          type: array
+          items:
+            type: string
+        creative_formats:
+          type: integer
+    AgentCapabilities:
+      type: object
+      properties:
+        tools_count:
+          type: integer
+        tools:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              description:
+                type: string
+            required:
+              - name
+              - description
+        standard_operations:
+          type: object
+          properties:
+            can_search_inventory:
+              type: boolean
+            can_get_availability:
+              type: boolean
+            can_reserve_inventory:
+              type: boolean
+            can_get_pricing:
+              type: boolean
+            can_create_order:
+              type: boolean
+            can_list_properties:
+              type: boolean
+          required:
+            - can_search_inventory
+            - can_get_availability
+            - can_reserve_inventory
+            - can_get_pricing
+            - can_create_order
+            - can_list_properties
+        creative_capabilities:
+          type: object
+          properties:
+            formats_supported:
+              type: array
+              items:
+                type: string
+            can_generate:
+              type: boolean
+            can_validate:
+              type: boolean
+            can_preview:
+              type: boolean
+          required:
+            - formats_supported
+            - can_generate
+            - can_validate
+            - can_preview
+        signals_capabilities:
+          type: object
+          properties:
+            audience_types:
+              type: array
+              items:
+                type: string
+            can_match:
+              type: boolean
+            can_activate:
+              type: boolean
+            can_get_signals:
+              type: boolean
+          required:
+            - audience_types
+            - can_match
+            - can_activate
+            - can_get_signals
+        measurement_capabilities:
+          type: object
+          properties:
+            metrics:
+              type: array
+              items:
+                type: object
+                properties:
+                  metric_id:
+                    type: string
+                  standard_reference:
+                    type: string
+                  accreditations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        accrediting_body:
+                          type: string
+                        certification_id:
+                          type: string
+                        valid_until:
+                          type: string
+                        evidence_url:
+                          type: string
+                        verified_by_aao:
+                          type: boolean
+                          enum:
+                            - false
+                          description: Always `false` — accreditation claims are vendor-asserted. AAO does not independently verify; renderers should mark these as vendor claims.
+                      required:
+                        - accrediting_body
+                        - verified_by_aao
+                  unit:
+                    type: string
+                  description:
+                    type: string
+                  methodology_url:
+                    type: string
+                  methodology_version:
+                    type: string
+                required:
+                  - metric_id
+          required:
+            - metrics
+          description: Vendor-published per-metric catalog for measurement agents. Populated when the crawler successfully fetched and validated `get_adcp_capabilities.measurement` (AdCP 3.x). Mirrors the protocol shape — see the AdCP `get_adcp_capabilities` reference for field semantics.
+      required:
+        - tools_count
+    AgentCompliance:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - passing
+            - degraded
+            - failing
+            - unknown
+        requested_compliance_target:
+          type:
+            - string
+            - "null"
+          description: Requested compliance target before alias resolution, e.g. 3.0 or 3.1-beta.
+        adcp_version:
+          type:
+            - string
+            - "null"
+          description: Concrete AdCP compliance bundle version used for the latest run, e.g. 3.0.12.
+        lifecycle_stage:
+          type: string
+          enum:
+            - development
+            - testing
+            - production
+            - deprecated
+        tracks:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            core: pass
+            products: fail
+        track_details:
+          type: array
+          items:
+            type: object
+            properties:
+              track:
+                type: string
+              status:
+                type: string
+              scenario_count:
+                type: integer
+              passed_count:
+                type: integer
+              duration_ms:
+                type: number
+              has_coverage_gap_skip:
+                type: boolean
+            required:
+              - track
+              - status
+              - scenario_count
+              - passed_count
+              - duration_ms
+          description: Latest-run per-track summary. Skipped tracks with has_coverage_gap_skip=true represent selected coverage gaps, such as missing_test_controller.
+        streak_days:
+          type: integer
+        last_checked_at:
+          type:
+            - string
+            - "null"
+        headline:
+          type:
+            - string
+            - "null"
+        monitoring_paused:
+          type: boolean
+        check_interval_hours:
+          type: integer
+        verified:
+          type: boolean
+        verified_roles:
+          type: array
+          items:
+            type: string
+            enum:
+              - media-buy
+              - signals
+              - governance
+              - creative
+              - brand
+              - sponsored-intelligence
+              - measurement
+          description: AdCP protocols the agent is AAO Verified for (e.g. media-buy, creative). Matches enums/adcp-protocol.json.
+      required:
+        - status
+        - lifecycle_stage
+        - tracks
+        - streak_days
+        - last_checked_at
+        - headline
+    PropertySummary:
+      type: object
+      properties:
+        total_count:
+          type: integer
+        count_by_type:
+          type: object
+          additionalProperties:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+        publisher_count:
+          type: integer
+      required:
+        - total_count
+        - count_by_type
+        - tags
+        - publisher_count
+    FederatedPublisher:
+      type: object
+      properties:
+        domain:
+          type: string
+        member:
+          type: object
+          properties:
+            slug:
+              type: string
+            display_name:
+              type: string
+            membership_tier:
+              type: string
+              description: Raw AAO membership tier enum (e.g. `individual_professional`, `company_leader`). Present only when the profile owner has set their member card to public (`is_public=true`) AND the org has a resolvable tier. Absent for private profiles and for orgs without an active tier-bearing subscription.
+            membership_tier_label:
+              type: string
+              description: Human-readable label for `membership_tier` (e.g. `Professional`, `Partner`, `Leader`). Matches the AAO pricing page. Use this for UI display; the raw enum is for programmatic gating. Presence rules match `membership_tier`.
+            is_founding_member:
+              type: boolean
+              description: True when the profile owner carries the Founding Member badge (joined before the founding-cohort cutoff). Surfaced when the profile owner has set their member card to public (`is_public=true`). Absent for private profiles. Founding Member is orthogonal to tier — founding orgs typically display both (e.g. Scope3 shows `Partner` + `Founding Member`).
+        agent_count:
+          type: integer
+        last_validated:
+          type: string
+        has_valid_adagents:
+          type: boolean
+      required:
+        - domain
+    DomainLookupResult:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: examplepub.com
+        authorized_agents:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              authorized_for:
+                type: string
+              member:
+                type: object
+                properties:
+                  slug:
+                    type: string
+                  display_name:
+                    type: string
+                  membership_tier:
+                    type: string
+                    description: Raw AAO membership tier enum (e.g. `individual_professional`, `company_leader`). Present only when the profile owner has set their member card to public (`is_public=true`) AND the org has a resolvable tier. Absent for private profiles and for orgs without an active tier-bearing subscription.
+                  membership_tier_label:
+                    type: string
+                    description: Human-readable label for `membership_tier` (e.g. `Professional`, `Partner`, `Leader`). Matches the AAO pricing page. Use this for UI display; the raw enum is for programmatic gating. Presence rules match `membership_tier`.
+                  is_founding_member:
+                    type: boolean
+                    description: True when the profile owner carries the Founding Member badge (joined before the founding-cohort cutoff). Surfaced when the profile owner has set their member card to public (`is_public=true`). Absent for private profiles. Founding Member is orthogonal to tier — founding orgs typically display both (e.g. Scope3 shows `Partner` + `Founding Member`).
+            required:
+              - url
+        sales_agents_claiming:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              member:
+                type: object
+                properties:
+                  slug:
+                    type: string
+                  display_name:
+                    type: string
+                  membership_tier:
+                    type: string
+                    description: Raw AAO membership tier enum (e.g. `individual_professional`, `company_leader`). Present only when the profile owner has set their member card to public (`is_public=true`) AND the org has a resolvable tier. Absent for private profiles and for orgs without an active tier-bearing subscription.
+                  membership_tier_label:
+                    type: string
+                    description: Human-readable label for `membership_tier` (e.g. `Professional`, `Partner`, `Leader`). Matches the AAO pricing page. Use this for UI display; the raw enum is for programmatic gating. Presence rules match `membership_tier`.
+                  is_founding_member:
+                    type: boolean
+                    description: True when the profile owner carries the Founding Member badge (joined before the founding-cohort cutoff). Surfaced when the profile owner has set their member card to public (`is_public=true`). Absent for private profiles. Founding Member is orthogonal to tier — founding orgs typically display both (e.g. Scope3 shows `Partner` + `Founding Member`).
+            required:
+              - url
+      required:
+        - domain
+        - authorized_agents
+        - sales_agents_claiming
+    OperatorLookupResult:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: pubmatic.com
+        member:
+          type:
+            - object
+            - "null"
+          properties:
+            slug:
+              type: string
+            display_name:
+              type: string
+            membership_tier:
+              type: string
+              description: Raw AAO membership tier enum (e.g. `individual_professional`, `company_leader`). Present only when the profile owner has set their member card to public (`is_public=true`) AND the org has a resolvable tier. Absent for private profiles and for orgs without an active tier-bearing subscription.
+            membership_tier_label:
+              type: string
+              description: Human-readable label for `membership_tier` (e.g. `Professional`, `Partner`, `Leader`). Matches the AAO pricing page. Use this for UI display; the raw enum is for programmatic gating. Presence rules match `membership_tier`.
+            is_founding_member:
+              type: boolean
+              description: True when the profile owner carries the Founding Member badge (joined before the founding-cohort cutoff). Surfaced when the profile owner has set their member card to public (`is_public=true`). Absent for private profiles. Founding Member is orthogonal to tier — founding orgs typically display both (e.g. Scope3 shows `Partner` + `Founding Member`).
+        agents:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              name:
+                type: string
+              type:
+                type: string
+                enum:
+                  - brand
+                  - rights
+                  - measurement
+                  - governance
+                  - creative
+                  - sales
+                  - buying
+                  - signals
+                  - unknown
+              authorized_by:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    publisher_domain:
+                      type: string
+                    authorized_for:
+                      type: string
+                    source:
+                      type: string
+                      enum:
+                        - adagents_json
+                        - agent_claim
+                  required:
+                    - publisher_domain
+                    - source
+            required:
+              - url
+              - name
+              - type
+              - authorized_by
+      required:
+        - domain
+        - member
+        - agents
+    PublisherLookupResult:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: voxmedia.com
+        member:
+          type:
+            - object
+            - "null"
+          properties:
+            slug:
+              type: string
+            display_name:
+              type: string
+            membership_tier:
+              type: string
+              description: Raw AAO membership tier enum (e.g. `individual_professional`, `company_leader`). Present only when the profile owner has set their member card to public (`is_public=true`) AND the org has a resolvable tier. Absent for private profiles and for orgs without an active tier-bearing subscription.
+            membership_tier_label:
+              type: string
+              description: Human-readable label for `membership_tier` (e.g. `Professional`, `Partner`, `Leader`). Matches the AAO pricing page. Use this for UI display; the raw enum is for programmatic gating. Presence rules match `membership_tier`.
+            is_founding_member:
+              type: boolean
+              description: True when the profile owner carries the Founding Member badge (joined before the founding-cohort cutoff). Surfaced when the profile owner has set their member card to public (`is_public=true`). Absent for private profiles. Founding Member is orthogonal to tier — founding orgs typically display both (e.g. Scope3 shows `Partner` + `Founding Member`).
+        adagents_valid:
+          type:
+            - boolean
+            - "null"
+        discovery_method:
+          type:
+            - string
+            - "null"
+          enum:
+            - direct
+            - authoritative_location
+            - ads_txt_managerdomain
+            - adagents_authoritative
+            - community_catalog
+            - null
+          description: "How the publisher's adagents.json was discovered on the most recent successful crawl or registry write. `direct`: publisher's own /.well-known/ served the document. `authoritative_location`: publisher's stub redirected to a canonical URL. `ads_txt_managerdomain`: manifest was discovered via ads.txt MANAGERDOMAIN delegation. `adagents_authoritative`: manager file named this publisher through publisher_properties fan-out. `community_catalog`: moderator-approved community catalog. Null until first crawl after migration 470."
+        manager_domain:
+          type:
+            - string
+            - "null"
+          description: The manager domain whose adagents.json was used to authorize this publisher's agents. Non-null only when `discovery_method` is `ads_txt_managerdomain`. Matches the MANAGERDOMAIN value from the publisher's ads.txt.
+        hosting:
+          type: object
+          properties:
+            mode:
+              type: string
+              enum:
+                - self
+                - self_invalid
+                - aao_hosted
+                - self_redirected
+                - none
+              description: Where this publisher's adagents.json lives. `self` = publisher hosts a valid file at their own /.well-known. `self_invalid` = publisher's /.well-known returns a file that fails validation (fixable misconfiguration, not absence). `aao_hosted` = the publisher hosts a stub at their own /.well-known whose `authoritative_location` points at AAO's canonical document. `self_redirected` = the publisher's stub `authoritative_location` resolves to a third-party HTTPS origin (a CDN, partner CMS, or sibling host) — verifiers should audit the TLS chain at `resolved_url`, not at the publisher's own origin. `none` = no adagents.json configured yet.
+            hosted_url:
+              type: string
+              description: Canonical AAO-hosted adagents.json URL. Present iff `mode === 'aao_hosted'`. Publishers reference this URL from their own /.well-known stub via the `authoritative_location` field (see https://docs.adcontextprotocol.org/docs/governance/property/adagents).
+            expected_url:
+              type: string
+              description: Where adagents.json *should* live for this domain — the publisher's own /.well-known path. Always populated, regardless of `mode`.
+            resolved_url:
+              type:
+                - string
+                - "null"
+              description: Where the canonical adagents.json document actually lives after following the publisher's `authoritative_location` stub or any HTTP-layer redirects. Populated when `mode === 'self_redirected'` (the third-party HTTPS origin verifiers should audit) and when `mode === 'aao_hosted'` AND the publisher has actively set up the redirect (`authoritative_location` in the manifest body or a network-layer redirect to AAO's hosted URL). NULL when there's no resolved-URL evidence to report.
+            last_validated:
+              type:
+                - string
+                - "null"
+              description: ISO timestamp of the last successful validation crawl. Lets verifiers sanity-check freshness. NULL when never crawled.
+            last_http_status:
+              type:
+                - integer
+                - "null"
+              minimum: 100
+              maximum: 599
+              description: HTTP status code returned by AAO's most recent fetch attempt of the publisher's `/.well-known/adagents.json`. Verifier-grade chrome — lets a buy-side scraper confirm they see the same response AAO does. NULL until the first crawl records or for transient errors that never produced an HTTP response.
+            last_bytes:
+              type:
+                - integer
+                - "null"
+              minimum: 0
+              description: Response body byte length from the most recent fetch (post-decompression). When `authoritative_location` was followed, measures the canonical document body, not the stub. NULL until the first crawl records.
+            origin_verified_at:
+              type:
+                - string
+                - "null"
+              description: ISO timestamp of the last successful origin verification — AAO fetched the publisher's own /.well-known/adagents.json and confirmed `authoritative_location` points at our hosted URL. When set, the publisher's authorization rows have been promoted to `source='adagents_json'` (origin-attested). NULL when never verified or last attempt failed. Only populated when `mode === 'aao_hosted'`.
+            origin_last_checked_at:
+              type:
+                - string
+                - "null"
+              description: ISO timestamp of the last verification attempt regardless of result. Lets a caller render "checked X minutes ago, not yet verified" vs "never checked." Only populated when `mode === 'aao_hosted'`.
+          required:
+            - mode
+            - expected_url
+        files:
+          type: object
+          properties:
+            adagents_json:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - valid
+                    - community
+                    - invalid
+                    - unknown
+                    - checking
+                  description: What we know about the publisher's adagents.json right now. `valid` = crawler fetched a parsing-and-shape-valid file from the publisher origin. `community` = moderators approved a community adagents.json catalog for this domain. `invalid` = crawler fetched a file that failed validation. `unknown` = never crawled or last result is stale. `checking` = an auto-crawl was kicked off by this request; the page should poll for fresh data shortly.
+                expected_url:
+                  type: string
+                  description: Where adagents.json should live on the publisher's own origin.
+                registry_url:
+                  type: string
+                  description: Registry-served adagents.json URL when the document is community or AgenticAdvertising.org hosted rather than served by the publisher origin.
+              required:
+                - status
+                - expected_url
+            brand_json:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - present
+                    - unknown
+                    - checking
+                  description: What we know about the publisher's brand.json. `present` = a brand record with manifest data exists. `unknown` = no record yet. `checking` = an auto-crawl was kicked off.
+                name:
+                  type: string
+              required:
+                - status
+          required:
+            - adagents_json
+            - brand_json
+          description: Plain-English summary of what AAO has found at the publisher's origin. The publisher page leads with this — `you have a valid adagents.json` is the primary signal, not `mode === self`. Optional in the schema for backwards compatibility; the handler always populates it.
+        properties:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              type:
+                type: string
+              name:
+                type: string
+              identifiers:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PropertyIdentifier"
+              tags:
+                type: array
+                items:
+                  type: string
+                description: Arbitrary string tags on this property. The `relationship:` prefix tag (e.g. `relationship:owned`) is deprecated in favour of the `delegation_type` field and will be removed in a future release.
+              source:
+                type: string
+                enum:
+                  - adagents_json
+                  - community
+                  - discovered
+                  - brand_json
+                description: Where this property came from. `adagents_json` comes from the publisher's own adagents.json, `community` from an approved community adagents.json catalog, `discovered` from crawler or third-party signals, and `brand_json` from the publisher's brand.json when no federated-index data exists yet.
+              delegation_type:
+                type: string
+                enum:
+                  - direct
+                  - delegated
+                  - ad_network
+                description: "Delegation relationship declared in brand.json. Populated only when `source` is `brand_json` — for `adagents_json` and `discovered` sources the authoritative value is on the matching `authorized_agents` entry. Mirrors adagents.json `delegation_type` for bilateral verification: `direct` = publisher treats this as a direct buying path, even if a third party operates the software; `delegated` = a rep firm or manager is authorized to sell on the publisher's behalf (operator-declared, unilateral until corroborated by the publisher's adagents.json); `ad_network` = sold as part of a network/exchange package. `owned` properties have no `delegation_type` — ownership is implicit and has no adagents.json counterpart."
+        brand:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Display name from brand.json or the registered brand row.
+            description:
+              type: string
+              description: Short brand or house description when present in brand.json.
+            logo_url:
+              type: string
+              description: First usable logo URL from brand.json.
+            colors:
+              type: array
+              items:
+                type: string
+              description: Representative hex colors from brand.json, capped for display.
+            industries:
+              type: array
+              items:
+                type: string
+              description: Industry labels from brand.json when present.
+          description: Display-oriented brand identity summary from brand.json. The full raw document remains available from the publisher's /.well-known/brand.json or hosted registry URL.
+        formats:
+          type: array
+          items:
+            type: object
+            properties:
+              format_option_id:
+                type: string
+                description: Stable format option identifier from adagents.json `formats[]`.
+              display_name:
+                type: string
+                description: Human-readable format label for catalog and publisher UI display.
+              format_kind:
+                type: string
+                description: Canonical format discriminator, such as `image`, `video_hosted`, `native_in_feed`, or `custom`.
+              params:
+                type: object
+                additionalProperties: {}
+                description: Canonical format params from the publisher's adagents.json declaration.
+              applies_to_property_ids:
+                type: array
+                items:
+                  type: string
+                description: Property IDs this format applies to; absent means all properties.
+              applies_to_property_tags:
+                type: array
+                items:
+                  type: string
+                description: Property tags this format applies to; absent means all properties.
+              seller_preference:
+                type: string
+                description: Seller preference hint from the format declaration, when present.
+              experimental:
+                type: boolean
+                description: Whether this seller's format declaration is marked experimental.
+            required:
+              - display_name
+              - format_kind
+          description: Display-oriented summary of top-level adagents.json `formats[]`, normalized for publisher pages and agent discovery clients. Each entry preserves `format_kind`, `format_option_id`, and canonical params.
+        authorized_agents:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              authorized_for:
+                type: string
+              source:
+                type: string
+                enum:
+                  - adagents_json
+                  - aao_hosted
+                  - agent_claim
+                description: "How strongly this authorization is attested. `adagents_json`: the publisher's origin actually serves a valid adagents.json (origin-verified). `aao_hosted`: AAO is hosting the canonical document on the publisher's behalf — represents publisher intent but origin has NOT been verified to redirect to AAO. `agent_claim`: the agent claimed it; publisher has not confirmed."
+              properties_authorized:
+                type: integer
+                minimum: 0
+                description: Count of this publisher's properties the agent is authorized to sell. Absent when `rollup_truncated` is set (call `/api/registry/publisher/authorization` for the per-agent count) or when properties are entirely brand.json-hydrated (no adagents.json claim has actually been made about them).
+              properties_total:
+                type: integer
+                minimum: 0
+                description: Total number of properties this publisher exposes through the registry. Same value across all agents in the response. Absent when `properties_authorized` is absent.
+              publisher_wide:
+                type: boolean
+                description: True when the agent has only a publisher-wide authorization row and `properties_authorized` was synthesized as `properties_total`. False when the agent has property-level authorization rows. Absent when the rollup is absent.
+            required:
+              - url
+              - source
+        rollup_truncated:
+          type: object
+          properties:
+            cap:
+              type: integer
+              exclusiveMinimum: 0
+              description: Maximum number of agents for which the rollup is computed in a single response.
+            total_agents:
+              type: integer
+              minimum: 0
+              description: Total authorized-agent count for this publisher (the full population the cap was applied to).
+          required:
+            - cap
+            - total_agents
+          description: Set when the publisher has more authorized agents than the per-agent rollup cap. Above the cap, agents beyond `cap` are returned without `properties_authorized` / `properties_total` / `publisher_wide`; call `/api/registry/publisher/authorization?domain=X&agent=Y` for the per-agent count. Lets a caller decide whether to fan out individual calls or stop reading.
+        auto_crawl_triggered:
+          type: boolean
+          description: Set to `true` when this request triggered a background crawl of the publisher's origin (we hadn't crawled before). The client should refetch in ~3-5s to pick up fresh data. Debounced per-domain so a tight refresh loop won't keep firing crawls.
+      required:
+        - domain
+        - member
+        - adagents_valid
+        - hosting
+        - properties
+        - authorized_agents
+    PublisherPropertySelector:
+      type: object
+      properties:
+        publisher_domain:
+          type: string
+          example: examplepub.com
+        property_types:
+          type: array
+          items:
+            type: string
+        property_ids:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+    CreateAdagentsResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        data:
+          type: object
+          properties:
+            success:
+              type: boolean
+              enum:
+                - true
+            adagents_json:
+              type: string
+              description: Pretty-printed adagents.json document generated by the service.
+            validation:
+              $ref: "#/components/schemas/AdagentsValidationResult"
+          required:
+            - success
+            - adagents_json
+            - validation
+        timestamp:
+          type: string
+          format: date-time
+      required:
+        - success
+        - data
+        - timestamp
+    AdagentsValidationResult:
+      type: object
+      properties:
+        valid:
+          type: boolean
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdagentsValidationIssue"
+        warnings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdagentsValidationWarning"
+        domain:
+          type: string
+        url:
+          type: string
+        status_code:
+          type: integer
+        response_bytes:
+          type: integer
+          minimum: 0
+        resolved_url:
+          type: string
+        raw_data: {}
+        discovery_method:
+          type: string
+          enum:
+            - direct
+            - authoritative_location
+            - ads_txt_managerdomain
+            - adagents_authoritative
+        manager_domain:
+          type: string
+      required:
+        - valid
+        - errors
+        - warnings
+        - domain
+        - url
+        - discovery_method
+    AdagentsValidationIssue:
+      type: object
+      properties:
+        field:
+          type: string
+        message:
+          type: string
+        severity:
+          type: string
+          enum:
+            - error
+      required:
+        - field
+        - message
+        - severity
+    AdagentsValidationWarning:
+      type: object
+      properties:
+        field:
+          type: string
+        message:
+          type: string
+        suggestion:
+          type: string
+      required:
+        - field
+        - message
+    AdagentsAuthorizedAgent:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Agent endpoint URL.
+        authorized_for:
+          type: string
+        authorization_type:
+          type: string
+          enum:
+            - property_ids
+            - property_tags
+            - inline_properties
+            - publisher_properties
+            - signal_ids
+            - signal_tags
+        property_ids:
+          type: array
+          items:
+            type: string
+        property_tags:
+          type: array
+          items:
+            type: string
+        properties:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        publisher_properties:
+          type: array
+          items:
+            type: object
+            properties:
+              publisher_domain:
+                type: string
+              publisher_domains:
+                type: array
+                items:
+                  type: string
+              selection_type:
+                type: string
+                enum:
+                  - all
+                  - by_id
+                  - by_tag
+              property_ids:
+                type: array
+                items:
+                  type: string
+              property_tags:
+                type: array
+                items:
+                  type: string
+            required:
+              - selection_type
+        collections:
+          type: array
+          items:
+            type: object
+            properties:
+              publisher_domain:
+                type: string
+              collection_ids:
+                type: array
+                items:
+                  type: string
+            required:
+              - publisher_domain
+              - collection_ids
+        placement_ids:
+          type: array
+          items:
+            type: string
+        placement_tags:
+          type: array
+          items:
+            type: string
+        delegation_type:
+          type: string
+          enum:
+            - direct
+            - delegated
+            - ad_network
+        exclusive:
+          type: boolean
+        countries:
+          type: array
+          items:
+            type: string
+        effective_from:
+          type: string
+        effective_until:
+          type: string
+        signal_ids:
+          type: array
+          items:
+            type: string
+        signal_tags:
+          type: array
+          items:
+            type: string
+        signing_keys:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+      required:
+        - url
+      additionalProperties: {}
+    CommunityMirrorListResponse:
+      type: object
+      properties:
+        mirrors:
+          type: array
+          items:
+            $ref: "#/components/schemas/CommunityMirrorSummary"
+        total:
+          type: integer
+          minimum: 0
+      required:
+        - mirrors
+        - total
+    CommunityMirrorSummary:
+      type: object
+      properties:
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+        catalog_etag:
+          type:
+            - string
+            - "null"
+        superseded_by:
+          type:
+            - string
+            - "null"
+          pattern: ^https:\/\/
+          description: HTTPS successor document URL, when this mirror has been superseded.
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - platform
+        - catalog_etag
+        - superseded_by
+        - updated_at
+    RateLimitError:
+      type: object
+      properties:
+        error:
+          type: string
+        message:
+          type: string
+        retryAfter:
+          type: integer
+          description: Seconds to wait before retrying.
+      required:
+        - error
+    CommunityMirrorGetResponse:
+      type: object
+      properties:
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+        catalog_etag:
+          type:
+            - string
+            - "null"
+        superseded_by:
+          type:
+            - string
+            - "null"
+          pattern: ^https:\/\/
+          description: HTTPS successor document URL, when this mirror has been superseded.
+        adagents_json:
+          $ref: "#/components/schemas/CommunityMirrorAdagentsJson"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - platform
+        - catalog_etag
+        - superseded_by
+        - adagents_json
+        - created_at
+        - updated_at
+    CommunityMirrorAdagentsJson:
+      type: object
+      properties:
+        $schema:
+          type: string
+          format: uri
+        authorized_agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdagentsAuthorizedAgent"
+          maxItems: 0
+          description: Always empty for community mirrors; these catalogs never assert sales authorization.
+        properties:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        catalog_etag:
+          type: string
+        formats:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        placements:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        placement_tags:
+          type: object
+          additionalProperties: {}
+        collections:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        signals:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        signal_tags:
+          type: object
+          additionalProperties: {}
+        contact: {}
+        superseded_by:
+          type: string
+          pattern: ^https:\/\/
+          description: HTTPS URL for the canonical successor adagents.json document. Clients should re-fetch the successor and update cached mirror references before retiring use of this mirror.
+        last_updated:
+          type: string
+          format: date-time
+      required:
+        - authorized_agents
+      additionalProperties: {}
+    CommunityMirrorPublishResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+        catalog_etag:
+          type:
+            - string
+            - "null"
+        superseded_by:
+          type:
+            - string
+            - "null"
+          pattern: ^https:\/\/
+          description: HTTPS successor document URL, when this mirror has been superseded.
+        publisher_domains:
+          type: array
+          items:
+            type: string
+          description: Publisher domains updated from this community mirror catalog.
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - success
+        - platform
+        - catalog_etag
+        - superseded_by
+        - publisher_domains
+        - updated_at
+    CommunityMirrorPublishError:
+      type: object
+      properties:
+        error:
+          type: string
+        details:
+          type: array
+          items: {}
+          description: Validation details for request-body parse failures or adagents.json conformance errors.
+      required:
+        - error
+    CommunityMirrorPublishRequest:
+      anyOf:
+        - type: object
+          properties:
+            catalog_etag:
+              type: string
+              minLength: 1
+              maxLength: 255
+            formats:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+              minItems: 1
+            properties:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placements:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placement_tags:
+              type: object
+              additionalProperties: {}
+            collections:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signals:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signal_tags:
+              type: object
+              additionalProperties: {}
+            contact: {}
+            superseded_by:
+              type: string
+              pattern: ^https:\/\/
+              description: HTTPS URL for the canonical successor adagents.json document. Set this before deleting a mirror so buyers can migrate cached references.
+          required:
+            - formats
+          additionalProperties: {}
+        - type: object
+          properties:
+            catalog_etag:
+              type: string
+              minLength: 1
+              maxLength: 255
+            formats:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            properties:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+              minItems: 1
+            placements:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placement_tags:
+              type: object
+              additionalProperties: {}
+            collections:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signals:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signal_tags:
+              type: object
+              additionalProperties: {}
+            contact: {}
+            superseded_by:
+              type: string
+              pattern: ^https:\/\/
+              description: HTTPS URL for the canonical successor adagents.json document. Set this before deleting a mirror so buyers can migrate cached references.
+          required:
+            - properties
+          additionalProperties: {}
+        - type: object
+          properties:
+            catalog_etag:
+              type: string
+              minLength: 1
+              maxLength: 255
+            formats:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            properties:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placements:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+              minItems: 1
+            placement_tags:
+              type: object
+              additionalProperties: {}
+            collections:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signals:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signal_tags:
+              type: object
+              additionalProperties: {}
+            contact: {}
+            superseded_by:
+              type: string
+              pattern: ^https:\/\/
+              description: HTTPS URL for the canonical successor adagents.json document. Set this before deleting a mirror so buyers can migrate cached references.
+          required:
+            - placements
+          additionalProperties: {}
+        - type: object
+          properties:
+            catalog_etag:
+              type: string
+              minLength: 1
+              maxLength: 255
+            formats:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            properties:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placements:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placement_tags:
+              type: object
+              additionalProperties: {}
+            collections:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+              minItems: 1
+            signals:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signal_tags:
+              type: object
+              additionalProperties: {}
+            contact: {}
+            superseded_by:
+              type: string
+              pattern: ^https:\/\/
+              description: HTTPS URL for the canonical successor adagents.json document. Set this before deleting a mirror so buyers can migrate cached references.
+          required:
+            - collections
+          additionalProperties: {}
+        - type: object
+          properties:
+            catalog_etag:
+              type: string
+              minLength: 1
+              maxLength: 255
+            formats:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            properties:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placements:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placement_tags:
+              type: object
+              additionalProperties: {}
+            collections:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signals:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+              minItems: 1
+            signal_tags:
+              type: object
+              additionalProperties: {}
+            contact: {}
+            superseded_by:
+              type: string
+              pattern: ^https:\/\/
+              description: HTTPS URL for the canonical successor adagents.json document. Set this before deleting a mirror so buyers can migrate cached references.
+          required:
+            - signals
+          additionalProperties: {}
+      description: Catalog-only adagents.json body for a community mirror. At least one of `formats`, `properties`, `placements`, `collections`, or `signals` must be present and non-empty. The service regenerates `$schema` and `last_updated` before persisting.
+    CommunityMirrorDeleteResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+      required:
+        - success
+        - platform
+    PolicySummary:
+      type: object
+      properties:
+        policy_id:
+          type: string
+          example: gdpr_consent
+        version:
+          type: string
+          example: 1.0.0
+        name:
+          type: string
+          example: GDPR Consent Requirements
+        description:
+          type:
+            - string
+            - "null"
+          example: Requirements for valid consent under GDPR
+        category:
+          type: string
+          enum:
+            - regulation
+            - standard
+        enforcement:
+          type: string
+          enum:
+            - must
+            - should
+            - may
+        jurisdictions:
+          type: array
+          items:
+            type: string
+          example:
+            - EU
+            - EEA
+        region_aliases:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          example:
+            EU:
+              - DE
+              - FR
+              - IT
+        policy_categories:
+          type: array
+          items:
+            type: string
+          example:
+            - age_restricted
+            - pharmaceutical_advertising
+        channels:
+          type:
+            - array
+            - "null"
+          items:
+            type: string
+          example:
+            - display
+            - video
+        governance_domains:
+          type: array
+          items:
+            type: string
+          example:
+            - campaign
+            - creative
+        effective_date:
+          type:
+            - string
+            - "null"
+          example: 2025-05-25
+        sunset_date:
+          type:
+            - string
+            - "null"
+        source_url:
+          type:
+            - string
+            - "null"
+          example: https://eur-lex.europa.eu/eli/reg/2016/679/oj
+        source_name:
+          type:
+            - string
+            - "null"
+          example: EUR-Lex
+        source_type:
+          type: string
+          enum:
+            - registry
+            - community
+        review_status:
+          type: string
+          enum:
+            - pending
+            - approved
+        created_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+        updated_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+      required:
+        - policy_id
+        - version
+        - name
+        - description
+        - category
+        - enforcement
+        - jurisdictions
+        - region_aliases
+        - policy_categories
+        - channels
+        - governance_domains
+        - effective_date
+        - sunset_date
+        - source_url
+        - source_name
+        - source_type
+        - review_status
+        - created_at
+        - updated_at
+    Policy:
+      type: object
+      properties:
+        policy_id:
+          type: string
+          example: gdpr_consent
+        version:
+          type: string
+          example: 1.0.0
+        name:
+          type: string
+          example: GDPR Consent Requirements
+        description:
+          type:
+            - string
+            - "null"
+          example: Requirements for valid consent under GDPR
+        category:
+          type: string
+          enum:
+            - regulation
+            - standard
+        enforcement:
+          type: string
+          enum:
+            - must
+            - should
+            - may
+        jurisdictions:
+          type: array
+          items:
+            type: string
+          example:
+            - EU
+            - EEA
+        region_aliases:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          example:
+            EU:
+              - DE
+              - FR
+              - IT
+        policy_categories:
+          type: array
+          items:
+            type: string
+          example:
+            - age_restricted
+            - pharmaceutical_advertising
+        channels:
+          type:
+            - array
+            - "null"
+          items:
+            type: string
+          example:
+            - display
+            - video
+        governance_domains:
+          type: array
+          items:
+            type: string
+          example:
+            - campaign
+            - creative
+        effective_date:
+          type:
+            - string
+            - "null"
+          example: 2025-05-25
+        sunset_date:
+          type:
+            - string
+            - "null"
+        source_url:
+          type:
+            - string
+            - "null"
+          example: https://eur-lex.europa.eu/eli/reg/2016/679/oj
+        source_name:
+          type:
+            - string
+            - "null"
+          example: EUR-Lex
+        policy:
+          type: string
+          example: Data subjects must provide freely given, specific, informed and unambiguous consent...
+        guidance:
+          type:
+            - string
+            - "null"
+        exemplars:
+          type:
+            - object
+            - "null"
+          properties:
+            pass:
+              type: array
+              items:
+                type: object
+                properties:
+                  scenario:
+                    type: string
+                    example: Ad for alcohol shown during children's programming
+                  explanation:
+                    type: string
+                    example: Violates watershed timing rules for alcohol advertising
+                required:
+                  - scenario
+                  - explanation
+            fail:
+              type: array
+              items:
+                type: object
+                properties:
+                  scenario:
+                    type: string
+                    example: Ad for alcohol shown during children's programming
+                  explanation:
+                    type: string
+                    example: Violates watershed timing rules for alcohol advertising
+                required:
+                  - scenario
+                  - explanation
+        ext:
+          type:
+            - object
+            - "null"
+          additionalProperties: {}
+        source_type:
+          type: string
+          enum:
+            - registry
+            - community
+        review_status:
+          type: string
+          enum:
+            - pending
+            - approved
+        created_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+        updated_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+      required:
+        - policy_id
+        - version
+        - name
+        - description
+        - category
+        - enforcement
+        - jurisdictions
+        - region_aliases
+        - policy_categories
+        - channels
+        - governance_domains
+        - effective_date
+        - sunset_date
+        - source_url
+        - source_name
+        - policy
+        - guidance
+        - exemplars
+        - ext
+        - source_type
+        - review_status
+        - created_at
+        - updated_at
+    PolicyHistory:
+      type: object
+      properties:
+        policy_id:
+          type: string
+          example: gdpr_consent
+        total:
+          type: integer
+          example: 3
+        revisions:
+          type: array
+          items:
+            type: object
+            properties:
+              revision_number:
+                type: integer
+                example: 2
+              editor_name:
+                type: string
+                example: Pinnacle Media
+              edit_summary:
+                type: string
+                example: Clarified consent requirements for minors
+              is_rollback:
+                type: boolean
+              rolled_back_to:
+                type: integer
+                description: Revision number that was restored; only present when is_rollback is true
+              created_at:
+                type: string
+                example: 2026-03-01T12:34:56Z
+            required:
+              - revision_number
+              - editor_name
+              - edit_summary
+              - is_rollback
+              - created_at
+      required:
+        - policy_id
+        - total
+        - revisions
+    AgentComplianceDetail:
+      type: object
+      properties:
+        agent_url:
+          type: string
+        requested_compliance_target:
+          type:
+            - string
+            - "null"
+          description: Requested compliance target before alias resolution, e.g. 3.0 or 3.1-beta. Null for legacy rows before target recording.
+        adcp_version:
+          type:
+            - string
+            - "null"
+          description: Concrete AdCP compliance bundle version used for the latest run, e.g. 3.0.12. Null for legacy rows before version recording.
+        status:
+          type: string
+          enum:
+            - passing
+            - degraded
+            - failing
+            - unknown
+            - opted_out
+        lifecycle_stage:
+          type: string
+          enum:
+            - development
+            - testing
+            - production
+            - deprecated
+        compliance_opt_out:
+          type: boolean
+        tracks:
+          type: object
+          additionalProperties:
+            type: string
+        track_details:
+          type: array
+          items:
+            type: object
+            properties:
+              track:
+                type: string
+              status:
+                type: string
+              scenario_count:
+                type: integer
+              passed_count:
+                type: integer
+              duration_ms:
+                type: number
+              has_coverage_gap_skip:
+                type: boolean
+            required:
+              - track
+              - status
+              - scenario_count
+              - passed_count
+              - duration_ms
+          description: Latest-run per-track summary. Skipped tracks with has_coverage_gap_skip=true represent selected coverage gaps, such as missing_test_controller.
+        streak_days:
+          type: integer
+        last_checked_at:
+          type:
+            - string
+            - "null"
+        last_passed_at:
+          type:
+            - string
+            - "null"
+        last_failed_at:
+          type:
+            - string
+            - "null"
+        headline:
+          type:
+            - string
+            - "null"
+        status_changed_at:
+          type:
+            - string
+            - "null"
+        storyboards_passing:
+          type: integer
+        storyboards_total:
+          type: integer
+        check_interval_hours:
+          type: integer
+          description: How often the heartbeat re-tests this agent, in hours
+        declared_specialisms:
+          type: array
+          items:
+            type: string
+          description: Specialisms the agent declared in get_adcp_capabilities, from the latest run
+        specialism_status:
+          type: object
+          additionalProperties:
+            type: string
+            enum:
+              - passing
+              - failing
+              - untested
+              - unknown
+          description: Per-specialism pass/fail/untested status — keyed on declared specialism, derived from the matching storyboard's status
+        storyboard_statuses:
+          type: array
+          items:
+            type: object
+            properties:
+              storyboard_id:
+                type: string
+              requested_compliance_target:
+                type:
+                  - string
+                  - "null"
+              adcp_version:
+                type:
+                  - string
+                  - "null"
+              title:
+                type: string
+              category:
+                type:
+                  - string
+                  - "null"
+              track:
+                type:
+                  - string
+                  - "null"
+              status:
+                type: string
+                enum:
+                  - passing
+                  - failing
+                  - partial
+                  - untested
+              steps_passed:
+                type: integer
+              steps_total:
+                type: integer
+              failure_count:
+                type: integer
+              skipped_count:
+                type: integer
+              first_failed_step_id:
+                type:
+                  - string
+                  - "null"
+              first_failed_step_title:
+                type:
+                  - string
+                  - "null"
+              first_failed_step_task:
+                type:
+                  - string
+                  - "null"
+              first_failure_message:
+                type:
+                  - string
+                  - "null"
+              last_tested_at:
+                type:
+                  - string
+                  - "null"
+              last_passed_at:
+                type:
+                  - string
+                  - "null"
+            required:
+              - storyboard_id
+              - title
+              - category
+              - track
+              - status
+              - steps_passed
+              - steps_total
+              - failure_count
+              - skipped_count
+              - first_failed_step_id
+              - first_failed_step_title
+              - first_failed_step_task
+              - first_failure_message
+              - last_tested_at
+              - last_passed_at
+          description: Owner-scoped per-storyboard diagnostics used by the dashboard. Empty for non-owners.
+        notices:
+          type: array
+          items: {}
+          description: Run-summary notices from the latest non-dry-run compliance run. Unknown codes/severities are preserved verbatim.
+        observations:
+          type: array
+          items:
+            type: object
+            properties:
+              category:
+                type: string
+              severity:
+                type: string
+              message:
+                type: string
+            required:
+              - category
+              - severity
+              - message
+          description: Public-safe advisory observations from the latest non-dry-run compliance run. Raw evidence is intentionally omitted; this array is not merged across runs, so cleared advisories disappear on the next fresh run.
+        membership_tier:
+          type:
+            - string
+            - "null"
+          description: "Owner-scoped: the agent owner's membership tier. Populated only when the authenticated viewer owns the agent; null otherwise. Field is always present so response shape doesn't reveal ownership."
+        membership_tier_label:
+          type:
+            - string
+            - "null"
+          description: "Owner-scoped: human-readable label for membership_tier (e.g. 'Builder'). Null for non-owners."
+        subscription_status:
+          type:
+            - string
+            - "null"
+          description: "Owner-scoped: the agent owner's subscription status (active, past_due, trialing, etc.). Null for non-owners."
+        is_api_access_tier:
+          type: boolean
+          description: "Owner-scoped: true when the owner's tier and subscription status grant badge eligibility. False for non-owners. Single source of truth — UI should not re-derive."
+        verdict_source:
+          type:
+            - string
+            - "null"
+          enum:
+            - heartbeat
+            - owner_test
+            - manual
+            - webhook
+            - null
+          description: "Owner-scoped: triggered_by value of the most recent non-dry-run compliance check. Null for non-owners and when no run has been recorded. Operators use this as a UX cue ('did this verdict come from my recent test or the system heartbeat?')."
+        verified:
+          type: boolean
+        verified_badges:
+          type: array
+          items:
+            $ref: "#/components/schemas/VerificationBadge"
+      required:
+        - agent_url
+        - status
+        - lifecycle_stage
+    VerificationBadge:
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - media-buy
+            - signals
+            - governance
+            - creative
+            - brand
+            - sponsored-intelligence
+            - measurement
+          description: AdCP protocol this badge covers (enums/adcp-protocol.json).
+        adcp_version:
+          type: string
+          description: AdCP release this badge was issued against, MAJOR.MINOR (e.g. '3.0', '3.1'). Load-bearing for badge identity — pairs with the (agent_url, role, adcp_version) PK.
+        verified_at:
+          type: string
+        verified_specialisms:
+          type: array
+          items:
+            type: string
+            enum:
+              - audience-sync
+              - brand-rights
+              - collection-lists
+              - content-standards
+              - creative-ad-server
+              - creative-generative
+              - creative-template
+              - creative-transformers
+              - governance-aware-seller
+              - governance-delivery-monitor
+              - governance-spend-authority
+              - property-lists
+              - sales-broadcast-tv
+              - sales-catalog-driven
+              - sales-guaranteed
+              - sales-non-guaranteed
+              - sales-proposal-mode
+              - sales-social
+              - signal-marketplace
+              - signal-owned
+              - signed-requests
+              - sponsored-intelligence
+          description: Specialisms demonstrably passed (enums/specialism.json). Preview specialisms are excluded from stable badges.
+        verification_modes:
+          type: array
+          items:
+            type: string
+            enum:
+              - spec
+              - live
+          minItems: 1
+          description: Verification axes earned. 'spec' = AdCP storyboards pass for the declared specialisms. 'live' = AAO has observed real production traffic via canonical campaigns. Always non-empty when a badge is present; an absent badge is conveyed by the parent record being omitted, not by an empty array.
+        verified_protocol_version:
+          type:
+            - string
+            - "null"
+        badge_url:
+          type: string
+          description: Legacy URL — auto-upgrades to the highest active version. For version-pinned embedding, derive `/api/registry/agents/{encoded_url}/badge/{role}/{adcp_version}.svg` where `{encoded_url}` is `encodeURIComponent(agent_url)`.
+      required:
+        - role
+        - adcp_version
+        - verified_at
+        - verified_specialisms
+        - verification_modes
+        - verified_protocol_version
+    AgentVerification:
+      type: object
+      properties:
+        agent_url:
+          type: string
+        verified:
+          type: boolean
+        badges:
+          type: array
+          items:
+            $ref: "#/components/schemas/VerificationBadge"
+        registry_url:
+          type: string
+      required:
+        - agent_url
+        - verified
+        - badges
+    StoryboardStatus:
+      type: object
+      properties:
+        storyboard_id:
+          type: string
+        requested_compliance_target:
+          type:
+            - string
+            - "null"
+          description: Requested compliance target from the run that produced this storyboard verdict, e.g. 3.0 or 3.1-beta.
+        adcp_version:
+          type:
+            - string
+            - "null"
+          description: Concrete AdCP compliance bundle version from the run that produced this storyboard verdict.
+        title:
+          type: string
+        category:
+          type:
+            - string
+            - "null"
+        track:
+          type:
+            - string
+            - "null"
+        status:
+          type: string
+          enum:
+            - passing
+            - failing
+            - partial
+            - untested
+        steps_passed:
+          type: integer
+        steps_total:
+          type: integer
+        failure_count:
+          type: integer
+          description: Root failing or actionable skipped step count. Cascaded prerequisite skips are excluded.
+        skipped_count:
+          type: integer
+          description: Cascaded prerequisite skip count for this storyboard verdict.
+        first_failed_step_id:
+          type:
+            - string
+            - "null"
+          description: First root failing or actionable skipped step id, when captured.
+        first_failed_step_title:
+          type:
+            - string
+            - "null"
+          description: First root failing or actionable skipped step title, when captured.
+        first_failed_step_task:
+          type:
+            - string
+            - "null"
+          description: Task/tool name for the first root failing or actionable skipped step, when captured.
+        first_failure_message:
+          type:
+            - string
+            - "null"
+          description: Runner error/detail text for the first root failing or actionable skipped step, when captured.
+        last_tested_at:
+          type:
+            - string
+            - "null"
+        last_passed_at:
+          type:
+            - string
+            - "null"
+      required:
+        - storyboard_id
+        - title
+        - category
+        - track
+        - status
+        - steps_passed
+        - steps_total
+        - failure_count
+        - skipped_count
+        - first_failed_step_id
+        - first_failed_step_title
+        - first_failed_step_task
+        - first_failure_message
+        - last_tested_at
+        - last_passed_at
+    ComplianceRun:
+      type: object
+      properties:
+        id:
+          type: string
+        requested_compliance_target:
+          type:
+            - string
+            - "null"
+        adcp_version:
+          type:
+            - string
+            - "null"
+        overall_status:
+          type: string
+        headline:
+          type:
+            - string
+            - "null"
+        tracks_passed:
+          type: integer
+        tracks_failed:
+          type: integer
+        tracks_skipped:
+          type: integer
+        tracks_partial:
+          type: integer
+        tracks_json: {}
+        total_duration_ms:
+          type:
+            - number
+            - "null"
+        triggered_by:
+          type: string
+        tested_at:
+          type: string
+      required:
+        - id
+        - overall_status
+        - headline
+        - tracks_passed
+        - tracks_failed
+        - tracks_skipped
+        - tracks_partial
+        - total_duration_ms
+        - triggered_by
+        - tested_at
+    RegistryMetadata:
+      type: object
+      properties:
+        agent_url:
+          type: string
+        lifecycle_stage:
+          type: string
+          enum:
+            - development
+            - testing
+            - production
+            - deprecated
+        compliance_opt_out:
+          type: boolean
+        monitoring_paused:
+          type: boolean
+        check_interval_hours:
+          type: integer
+        monitoring_paused_at:
+          type:
+            - string
+            - "null"
+        created_at:
+          type: string
+        updated_at:
+          type: string
+      required:
+        - agent_url
+        - lifecycle_stage
+        - compliance_opt_out
+        - monitoring_paused
+        - check_interval_hours
+        - monitoring_paused_at
+        - created_at
+        - updated_at
+    MonitoringSettings:
+      type: object
+      properties:
+        monitoring_paused:
+          type: boolean
+        check_interval_hours:
+          type: integer
+        monitoring_paused_at:
+          type:
+            - string
+            - "null"
+      required:
+        - monitoring_paused
+        - check_interval_hours
+        - monitoring_paused_at
+    ComplianceStepDiagnostic:
+      type: object
+      properties:
+        id:
+          anyOf:
+            - type: number
+            - type: string
+        run_id:
+          type: string
+        agent_url:
+          type: string
+        storyboard_id:
+          type: string
+        phase_id:
+          type: string
+        step_id:
+          type: string
+        task:
+          type: string
+        step_passed:
+          type: boolean
+        duration_ms:
+          type:
+            - number
+            - "null"
+        request_url:
+          type:
+            - string
+            - "null"
+        request_jsonb: {}
+        response_status:
+          type:
+            - number
+            - "null"
+        response_headers_jsonb:
+          type:
+            - object
+            - "null"
+          additionalProperties:
+            type: string
+        response_jsonb: {}
+        extraction_path:
+          type:
+            - string
+            - "null"
+        extraction_note:
+          type:
+            - string
+            - "null"
+        error_text:
+          type:
+            - string
+            - "null"
+        adcp_error_jsonb: {}
+        failed_validations_jsonb: {}
+        served_by_agent_url:
+          type:
+            - string
+            - "null"
+        captured_at:
+          type: string
+      required:
+        - id
+        - run_id
+        - agent_url
+        - storyboard_id
+        - phase_id
+        - step_id
+        - task
+        - step_passed
+        - captured_at
+    OutboundRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        agent_url:
+          type: string
+        request_type:
+          type: string
+        user_agent:
+          type: string
+        response_time_ms:
+          type:
+            - number
+            - "null"
+        success:
+          type: boolean
+        error_message:
+          type:
+            - string
+            - "null"
+        created_at:
+          type: string
+      required:
+        - id
+        - agent_url
+        - request_type
+        - user_agent
+        - response_time_ms
+        - success
+        - error_message
+        - created_at
+    AgentAuthStatus:
+      type: object
+      properties:
+        has_auth:
+          type: boolean
+        agent_context_id:
+          type:
+            - string
+            - "null"
+        auth_type:
+          type:
+            - string
+            - "null"
+          enum:
+            - bearer
+            - basic
+            - oauth
+            - oauth_client_credentials
+            - null
+        has_oauth_token:
+          type: boolean
+        has_valid_oauth:
+          type: boolean
+        oauth_token_expires_at:
+          type:
+            - string
+            - "null"
+        has_oauth_client_credentials:
+          type: boolean
+      required:
+        - has_auth
+        - agent_context_id
+        - auth_type
+        - has_oauth_token
+        - has_valid_oauth
+        - oauth_token_expires_at
+        - has_oauth_client_credentials
+    CredentialSaveValidationError:
+      type: object
+      properties:
+        error:
+          type: string
+        code:
+          type: string
+          enum:
+            - invalid_blob_shape
+            - missing_field
+            - invalid_field_type
+            - field_too_long
+            - invalid_url
+            - invalid_env_reference
+            - invalid_auth_method_value
+          description: Stable rejection tag. UI maps this to operator-friendly prose.
+        field:
+          type: string
+          enum:
+            - oauth_client_credentials
+            - token_endpoint
+            - client_id
+            - client_secret
+            - scope
+            - resource
+            - audience
+            - auth_method
+          description: Field the UI should scroll to + highlight.
+      required:
+        - error
+        - code
+        - field
+    StoryboardSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        category:
+          type: string
+        summary:
+          type: string
+        interaction_model:
+          type: string
+        examples:
+          type: array
+          items:
+            type: string
+        phase_count:
+          type: integer
+        step_count:
+          type: integer
+      required:
+        - id
+        - title
+        - category
+        - summary
+        - interaction_model
+        - examples
+        - phase_count
+        - step_count
+    StoryboardDetail:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        category:
+          type: string
+        summary:
+          type: string
+        agent:
+          type: object
+          properties:
+            interaction_model:
+              type: string
+            examples:
+              type: array
+              items:
+                type: string
+          required:
+            - interaction_model
+        phases:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+              steps:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    title:
+                      type: string
+                    description:
+                      type: string
+                    expected_output:
+                      type: string
+                  required:
+                    - id
+                    - title
+                    - description
+                    - expected_output
+            required:
+              - title
+              - steps
+        prerequisites: {}
+        required_tools:
+          type: array
+          items:
+            type: string
+        track:
+          type: string
+      required:
+        - id
+        - title
+        - category
+        - summary
+        - agent
+        - phases
+    FindCompanyResult:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/CompanySearchResult"
+      required:
+        - results
+    CompanySearchResult:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: coca-cola.com
+        canonical_domain:
+          type: string
+          example: coca-cola.com
+        brand_name:
+          type: string
+          example: The Coca-Cola Company
+        house_domain:
+          type: string
+          example: coca-cola.com
+        keller_type:
+          type: string
+          enum:
+            - master
+            - sub_brand
+            - endorsed
+            - independent
+        parent_brand:
+          type: string
+        brand_agent_url:
+          type: string
+        source:
+          type: string
+          example: community
+      required:
+        - domain
+        - canonical_domain
+        - brand_name
+        - source
+    MemberAgentListResponse:
+      type: object
+      properties:
+        agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/MemberAgent"
+      required:
+        - agents
+    MemberAgent:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          example: https://agent.example.com/mcp
+        visibility:
+          $ref: "#/components/schemas/MemberAgentVisibility"
+        type:
+          $ref: "#/components/schemas/MemberAgentType"
+        name:
+          type: string
+        health_check_url:
+          type: string
+          format: uri
+          description: Optional fallback liveness URL used by the health probe when the protocol handshake fails.
+      required:
+        - url
+        - visibility
+        - type
+      description: Agent entry stored on a member profile. `type` is required on read because every write surface declares it and the operator endpoint always emits it; a stored value of `unknown` is the smuggle-protection outcome (snapshot contradicted the declaration without classifying it) and is the only path that surfaces an agent without a real type.
+    MemberAgentVisibility:
+      type: string
+      enum:
+        - private
+        - members_only
+        - public
+      description: Visibility tier on the registry catalog. `private` = profile owner only; `members_only` = AAO API-tier members on operator lookup; `public` = listed in the public catalog and reflected in the org's `brand.json` (requires a paid AAO tier — Professional, Builder, Member, or Leader).
+    MemberAgentType:
+      type: string
+      enum:
+        - brand
+        - rights
+        - measurement
+        - governance
+        - creative
+        - sales
+        - buying
+        - signals
+        - unknown
+      description: Agent type as stored on the registry. Server-side smuggle protection compares the caller's declaration against the capability snapshot (when one exists) and may stamp `unknown` if the snapshot contradicts the declaration without classifying it. `unknown` is reserved for that server-side outcome; clients cannot submit it.
+    MemberAgentResponse:
+      type: object
+      properties:
+        agent:
+          $ref: "#/components/schemas/MemberAgent"
+        warnings:
+          type: array
+          items:
+            $ref: "#/components/schemas/MemberAgentVisibilityWarning"
+        org_auto_created:
+          type: boolean
+          description: "Set to `true` when this `POST` was the caller's first interaction with the registry and the server auto-created the organization (display name derived from the user's email domain for corporate emails, or `<First Last>'s Workspace` for free-email providers). Combined with `profile_auto_created`, this is the one-call storefront experience: a third-party app holding only an OAuth token gets the org, profile, and registered agent in a single request."
+        profile_auto_created:
+          type: boolean
+          description: "Set to `true` when this `POST` was the first agent registration on the caller's organization and the server auto-created a private member profile (display name = organization name, `is_public: false`). Absent on subsequent calls and on update-in-place. Surfaced so storefront-style integrations can show a \"we set up your profile\" hint without needing to detect the prior 404 → bootstrap → retry shape."
+      required:
+        - agent
+    MemberAgentVisibilityWarning:
+      type: object
+      properties:
+        code:
+          type: string
+          enum:
+            - visibility_downgraded
+        agent_url:
+          type: string
+        requested:
+          type: string
+          enum:
+            - public
+        applied:
+          type: string
+          enum:
+            - members_only
+        reason:
+          type: string
+          enum:
+            - tier_required
+        message:
+          type: string
+      required:
+        - code
+        - agent_url
+        - requested
+        - applied
+        - reason
+        - message
+      description: Emitted when the tier gate downgrades a requested visibility.
+    MemberAgentInput:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          example: https://agent.example.com/mcp
+        type:
+          $ref: "#/components/schemas/MemberAgentTypeInput"
+        name:
+          type: string
+        visibility:
+          $ref: "#/components/schemas/MemberAgentVisibility"
+        health_check_url:
+          type: string
+          format: uri
+      required:
+        - url
+        - type
+      description: Request body for `POST /api/me/agents`. `type` is required — the owner declares it; the server never infers.
+    MemberAgentTypeInput:
+      type: string
+      enum:
+        - brand
+        - rights
+        - measurement
+        - governance
+        - creative
+        - sales
+        - buying
+        - signals
+      description: Agent type the caller declares. Required on register; smuggle-protection still cross-checks against the capability snapshot when one exists. The server never infers `type` — the owner declares what kind of agent this is.
+    MemberAgentPatch:
+      type: object
+      properties:
+        name:
+          type: string
+        visibility:
+          $ref: "#/components/schemas/MemberAgentVisibility"
+        type:
+          $ref: "#/components/schemas/MemberAgentTypeInput"
+        health_check_url:
+          type: string
+          format: uri
+      description: Request body for `PATCH /api/me/agents/{url}`. The `url` field cannot be changed via PATCH; re-register at the new URL and DELETE the old entry instead. If `type` is omitted, the existing value is preserved.
+    CreateOrganizationResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        organization:
+          type: object
+          properties:
+            id:
+              type: string
+              example: org_01HXZAB123
+            name:
+              type: string
+              example: Acme Media
+          required:
+            - id
+            - name
+        id:
+          type: string
+          description: "Set on the **prospect-adoption** path: when an org with the user's email domain already exists in a `prospect` state (i.e. the registry pre-recorded it from a brand crawl but no human had claimed it yet), this call adopts that org for the caller instead of creating a new one."
+        name:
+          type: string
+        adopted:
+          type: boolean
+          description: "`true` when the response is the prospect-adoption path. When `true`, no new WorkOS organization was created — the caller is now the owner of an existing prospect record."
+      description: 'Response from `POST /api/organizations`. The body shape varies by path: a fresh creation returns `{ success: true, organization: { id, name } }`; a prospect adoption returns `{ id, name, adopted: true }` directly. Both paths are 2xx; downstream callers should treat any `2xx` as "the org now exists and you are an owner of it" and read whichever id is present.'
+    CreateOrganizationInput:
+      type: object
+      properties:
+        organization_name:
+          type: string
+          minLength: 1
+          maxLength: 200
+          description: Display name for the organization. Used both as the org row name and (when auto-bootstrapping a member profile via the first agent registration) as the profile's `display_name`.
+          example: Acme Media
+        is_personal:
+          type: boolean
+          default: false
+          description: Set to `true` to create a personal workspace instead of a corporate organization. Personal workspaces skip corporate-domain verification, are limited to one per user, and cannot host the `company_*` membership tiers.
+        company_type:
+          $ref: "#/components/schemas/OrganizationCompanyType"
+        revenue_tier:
+          $ref: "#/components/schemas/OrganizationRevenueTier"
+        marketing_opt_in:
+          type: boolean
+          default: false
+          description: Whether the caller opted in to AAO marketing communications. Recorded once per user (not overwritten on subsequent calls). Independent of Terms-of-Service consent, which is recorded server-side from the request context.
+      required:
+        - organization_name
+      description: |-
+        Request body for `POST /api/organizations`.
+
+        Bootstraps a WorkOS organization, mirrors the caller as `owner`, records the caller's ToS / privacy-policy acceptance, and (for non-personal orgs) inserts an email-verified record into `organization_domains` so subsequent registry calls can skip explicit domain-verification.
+
+        Membership tier and corporate domain are *not* caller-supplied: the tier is set by the Stripe webhook on subscription events, and the corporate domain is derived from the authenticated user's email.
+    OrganizationCompanyType:
+      type: string
+      enum:
+        - adtech
+        - agency
+        - brand
+        - publisher
+        - data
+        - ai
+        - other
+      description: Coarse classification of the organization's role in the open ad ecosystem. Drives default verification badges and the member profile's display category.
+    OrganizationRevenueTier:
+      type: string
+      enum:
+        - under_1m
+        - 1m_5m
+        - 5m_50m
+        - 50m_250m
+        - 250m_1b
+        - 1b_plus
+      description: Annual revenue band, USD. Drives membership-tier eligibility for company-tier seats.
+    AdagentsJson:
+      type: object
+      properties:
+        $schema:
+          type: string
+          format: uri
+        authorized_agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdagentsAuthorizedAgent"
+        properties:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        catalog_etag:
+          type: string
+        formats:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        placements:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        placement_tags:
+          type: object
+          additionalProperties: {}
+        collections:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        signals:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        signal_tags:
+          type: object
+          additionalProperties: {}
+        contact: {}
+        superseded_by:
+          type: string
+          format: uri
+          description: HTTPS URL for the canonical successor adagents.json document. Clients should re-fetch the successor and update cached mirror references before retiring use of this mirror.
+        last_updated:
+          type: string
+          format: date-time
+      required:
+        - authorized_agents
+      additionalProperties: {}
+paths:
+  /api:
+    get:
+      operationId: apiDiscovery
+      summary: API discovery
+      description: Returns links to the main API entry points and documentation.
+      tags:
+        - Search
+      responses:
+        "200":
+          description: API discovery information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  version:
+                    type: string
+                  documentation:
+                    type: string
+                  openapi:
+                    type: string
+                  endpoints:
+                    type: object
+                    additionalProperties:
+                      type: string
+                required:
+                  - name
+                  - version
+                  - documentation
+                  - openapi
+                  - endpoints
+  /api/brands/resolve:
+    get:
+      operationId: resolveBrand
+      summary: Resolve brand
+      description: Resolve a domain to its canonical brand identity. Follows brand.json redirects and returns the resolved brand with its house, architecture type, and optional manifest.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+          required: false
+          name: fresh
+          in: query
+      responses:
+        "200":
+          description: Brand resolved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResolvedBrand"
+        "404":
+          description: Brand not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                  file_status:
+                    type: number
+                    description: HTTP status code from brand.json fetch (e.g. 404 vs 200 with invalid data)
+                required:
+                  - error
+                  - domain
+  /api/brands/resolve/bulk:
+    post:
+      operationId: resolveBrandsBulk
+      summary: Bulk resolve brands
+      description: |-
+        Resolve up to 100 domains to their canonical brand identities in a single request.
+
+        **Rate limit:** 20 requests per minute per IP address.
+      tags:
+        - Brand Resolution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domains:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 100
+              required:
+                - domains
+      responses:
+        "200":
+          description: Bulk resolution results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: object
+                    additionalProperties:
+                      allOf:
+                        - $ref: "#/components/schemas/ResolvedBrand"
+                        - type:
+                            - object
+                            - "null"
+                required:
+                  - results
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/brand-json:
+    get:
+      operationId: getBrandJson
+      summary: Get brand.json
+      description: Fetch the raw brand.json file for a domain.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+          required: false
+          name: fresh
+          in: query
+      responses:
+        "200":
+          description: Raw brand.json data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  url:
+                    type: string
+                  variant:
+                    type: string
+                  data:
+                    type: object
+                    additionalProperties: {}
+                  warnings:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - domain
+                  - url
+                  - data
+        "404":
+          description: Brand not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/save:
+    post:
+      operationId: saveBrand
+      summary: Save brand
+      description: Save or update a brand in the registry. Requires authentication. For existing brands, creates a revision-tracked edit. For new brands, creates the brand directly. Cannot edit authoritative brands managed via brand.json.
+      tags:
+        - Brand Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: acmecorp.com
+                brand_name:
+                  type: string
+                  example: Acme Corp
+                brand_manifest:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - domain
+                - brand_name
+      responses:
+        "200":
+          description: Brand saved or updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  message:
+                    type: string
+                  domain:
+                    type: string
+                  id:
+                    type: string
+                  revision_number:
+                    type: integer
+                required:
+                  - success
+                  - message
+                  - domain
+                  - id
+        "400":
+          description: Missing required fields or invalid domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Cannot edit authoritative brand
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/registry:
+    get:
+      operationId: listBrands
+      summary: List brands
+      description: List all brands in the registry with optional search, pagination, and source filter.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+          required: false
+          name: search
+          in: query
+        - schema:
+            type: integer
+            example: 100
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            example: 0
+          required: false
+          name: offset
+          in: query
+        - schema:
+            type: string
+            enum:
+              - hosted
+              - brand_json
+              - enriched
+              - community
+            description: "Filter by source. Values match the per-brand source field in the response: hosted = registered by domain owner via /api/brands; brand_json = crawler-discovered with a live /.well-known/brand.json; enriched = Brandfetch-sourced; community = manually contributed."
+          required: false
+          description: "Filter by source. Values match the per-brand source field in the response: hosted = registered by domain owner via /api/brands; brand_json = crawler-discovered with a live /.well-known/brand.json; enriched = Brandfetch-sourced; community = manually contributed."
+          name: source
+          in: query
+      responses:
+        "200":
+          description: Brand list with stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  brands:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/BrandRegistryItem"
+                  stats:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      hosted:
+                        type: integer
+                      brand_json:
+                        type: integer
+                      community:
+                        type: integer
+                      enriched:
+                        type: integer
+                      houses:
+                        type: integer
+                      sub_brands:
+                        type: integer
+                      with_manifest:
+                        type: integer
+                    required:
+                      - total
+                      - hosted
+                      - brand_json
+                      - community
+                      - enriched
+                      - houses
+                      - sub_brands
+                      - with_manifest
+                required:
+                  - brands
+                  - stats
+        "400":
+          description: Invalid source filter value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/history:
+    get:
+      operationId: getBrandHistory
+      summary: Brand activity history
+      description: Returns the edit history for a brand in the registry, newest first. Only brands with community or enriched edits have history; brand.json-sourced brands are authoritative and do not generate revisions.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: integer
+            example: 20
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            example: 0
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Brand activity history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrandActivity"
+        "400":
+          description: domain parameter required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Brand not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                required:
+                  - error
+                  - domain
+  /api/brands/enrich:
+    get:
+      operationId: enrichBrand
+      summary: Enrich brand
+      description: Enrich brand data using Brandfetch. Returns logo, colors, and company information. Authenticated callers may also receive ephemeral Brand Context API identity/positioning/voice data.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Enrichment data from Brandfetch
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  domain:
+                    type: string
+                  cached:
+                    type: boolean
+                  manifest:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                      description:
+                        type: string
+                      logos:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            url:
+                              type: string
+                            tags:
+                              type: array
+                              items:
+                                type: string
+                          required:
+                            - url
+                            - tags
+                      colors:
+                        type: object
+                        properties:
+                          primary:
+                            type: string
+                          secondary:
+                            type: string
+                          accent:
+                            type: string
+                        additionalProperties: {}
+                      fonts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            role:
+                              type: string
+                          required:
+                            - name
+                            - role
+                          additionalProperties: {}
+                      company:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          industry:
+                            type: string
+                          industries:
+                            type: array
+                            items:
+                              type: string
+                          employees:
+                            type: string
+                          founded:
+                            type: number
+                          location:
+                            type: string
+                        additionalProperties: {}
+                    required:
+                      - name
+                      - url
+                    additionalProperties: {}
+                  company:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      industry:
+                        type: string
+                      industries:
+                        type: array
+                        items:
+                          type: string
+                      employees:
+                        type: string
+                      founded:
+                        type: number
+                      location:
+                        type: string
+                    additionalProperties: {}
+                  source_type:
+                    type: string
+                    enum:
+                      - brand_json
+                      - community
+                      - enriched
+                  context:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                  context_source:
+                    type: string
+                    enum:
+                      - brandfetch
+                  context_scope:
+                    type: string
+                    enum:
+                      - ephemeral
+                  context_error:
+                    type: string
+                required:
+                  - success
+                  - domain
+                  - cached
+        "503":
+          description: Brandfetch not configured
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/history:
+    get:
+      operationId: getPropertyHistory
+      summary: Property activity history
+      description: Returns the edit history for a property in the registry, newest first.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: integer
+            example: 20
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            example: 0
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Property activity history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PropertyActivity"
+        "400":
+          description: domain parameter required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Property not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                required:
+                  - error
+                  - domain
+  /api/properties/resolve:
+    get:
+      operationId: resolveProperty
+      summary: Resolve property
+      description: Resolve a publisher domain to its property information. Checks hosted properties, discovered properties, then live adagents.json validation.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Property resolved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResolvedProperty"
+        "404":
+          description: Property not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                required:
+                  - error
+                  - domain
+  /api/properties/resolve/bulk:
+    post:
+      operationId: resolvePropertiesBulk
+      summary: Bulk resolve properties
+      description: |-
+        Resolve up to 100 publisher domains at once.
+
+        **Rate limit:** 20 requests per minute per IP address.
+      tags:
+        - Property Resolution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domains:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 100
+              required:
+                - domains
+      responses:
+        "200":
+          description: Bulk resolution results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: object
+                    additionalProperties:
+                      allOf:
+                        - $ref: "#/components/schemas/ResolvedProperty"
+                        - type:
+                            - object
+                            - "null"
+                required:
+                  - results
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/registry:
+    get:
+      operationId: listProperties
+      summary: List properties
+      description: List all properties in the registry with optional search, pagination.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+          required: false
+          name: search
+          in: query
+        - schema:
+            type: integer
+            example: 100
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            example: 0
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Property list with stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  properties:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PropertyRegistryItem"
+                  stats:
+                    type: object
+                    additionalProperties: {}
+                required:
+                  - properties
+                  - stats
+  /api/properties/validate:
+    get:
+      operationId: validateProperty
+      summary: Validate adagents.json
+      description: Validate a domain's adagents.json file and return the validation result.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Validation result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationResult"
+  /api/properties/save:
+    post:
+      operationId: saveProperty
+      summary: Save property
+      description: |-
+        Save or update a hosted property in the registry. Requires authentication. For existing properties, creates a revision-tracked edit. For new properties, creates the property directly. Cannot edit authoritative properties managed via adagents.json.
+
+        This is an identity-only write surface: the stored document always carries `authorized_agents: []`. Sales authorization lives solely in the publisher's own origin `adagents.json`; the community registry cannot mint or carry it. Any `authorized_agents` sent in the request body is ignored.
+      tags:
+        - Property Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                publisher_domain:
+                  type: string
+                  example: examplepub.com
+                authorized_agents:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      authorized_for:
+                        type: string
+                    required:
+                      - url
+                  description: Ignored. Community-registry rows never assert sales authorization — the owner's origin adagents.json is the sole authorization source — so any value here is dropped and the stored document carries authorized_agents:[].
+                  example: []
+                properties:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                      - type
+                      - name
+                  example:
+                    - type: website
+                      name: Example Publisher
+                contact:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    email:
+                      type: string
+              required:
+                - publisher_domain
+      responses:
+        "200":
+          description: Property saved or updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  message:
+                    type: string
+                  id:
+                    type: string
+                  revision_number:
+                    type: integer
+                required:
+                  - success
+                  - message
+                  - id
+        "400":
+          description: Missing required fields or invalid domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Cannot edit authoritative property
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/hosted/{domain}/claim:
+    post:
+      operationId: claimHostedPropertyDomain
+      summary: Claim a domain for bind-on-verify
+      description: |-
+        Issue a pending domain claim for the caller's organization and return a claim-specific `authoritative_location` URL (`…/adagents.json?adcp_claim=<token>`). The caller places that single pointer at their own origin `/.well-known/adagents.json`; a subsequent verify-origin reads the token and binds the domain to the caller's org. The token is the per-account artifact that proves WHICH account owns the domain — a plain domain-keyed pointer proves only that the origin endorses AAO hosting, not who the owner is.
+
+        The community write surface stays open; this does not gate writes — it establishes ownership on successful verification. Refused with 409 only when the domain is already verified and locked to a different owner.
+      tags:
+        - Property Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: path
+      responses:
+        "200":
+          description: Claim issued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  domain:
+                    type: string
+                  authoritative_location:
+                    type: string
+                  instructions:
+                    type: string
+                required:
+                  - success
+                  - domain
+                  - authoritative_location
+                  - instructions
+        "400":
+          description: Invalid domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Caller is not a member of any organization
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Domain already verified and locked to another owner
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/hosted/{domain}/verify-origin:
+    post:
+      operationId: verifyHostedPropertyOrigin
+      summary: Verify AAO-hosted publisher origin
+      description: |-
+        Trigger origin verification for an AAO-hosted publisher: fetches the publisher's own `/.well-known/adagents.json` and checks for an `authoritative_location` field pointing at the AAO-hosted URL. On success, promotes `agent_publisher_authorizations` rows from `source='aao_hosted'` to `source='adagents_json'` for the manifest's authorized agents — buyers reading the registry then see them as origin-attested.
+
+        Bind-on-verify: when the pointer carries an `adcp_claim` token (see the claim endpoint), a successful verification binds the domain to that claim's organization and returns `bound_org_id`. Binding is driven by which token the origin pointer carries, never by who triggers verification, so any authenticated caller may trigger it and a squatter cannot bind a domain they don't control. An existing verified owner is never overwritten.
+
+        Failure classification:
+        - `not_found`: publisher origin returned 404 (permanent — demotes if previously verified).
+        - `invalid_json` / `no_authoritative_location` / `authoritative_location_mismatch`: publisher origin returned a parseable response that doesn't satisfy the spec stub pattern (permanent — demotes).
+        - `unresolvable`: DNS NXDOMAIN, private IP, or non-http scheme (permanent — demotes).
+        - `transient`: 5xx / 429 / 3xx / network timeout (leaves persisted state alone, stamps `origin_last_checked_at`).
+      tags:
+        - Property Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: path
+      responses:
+        "200":
+          description: Verification outcome
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  verified:
+                    type: boolean
+                  reason:
+                    type: string
+                    enum:
+                      - authoritative_location_pointer
+                      - not_found
+                      - invalid_json
+                      - no_authoritative_location
+                      - authoritative_location_mismatch
+                      - unresolvable
+                      - transient
+                  checked_at:
+                    type: string
+                  detail:
+                    type: string
+                  bound_org_id:
+                    type: string
+                required:
+                  - verified
+                  - reason
+                  - checked_at
+        "400":
+          description: Invalid domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No hosted property for this domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/check:
+    post:
+      operationId: checkPropertyList
+      summary: Check property list
+      description: |-
+        Check a list of publisher domains against the AAO registry. Normalizes domains (strips www/m prefixes), removes duplicates, flags known ad tech infrastructure, and identifies domains not yet in the registry.
+
+        Returns four buckets:
+        - **remove**: duplicates or known blocked domains (ad servers, CDNs, trackers, intermediaries)
+        - **modify**: domains that were normalized (e.g. www.example.com → example.com)
+        - **assess**: unknown domains not in registry, not blocked
+        - **ok**: domains found in registry with no changes needed
+
+        Results are stored for 7 days and retrievable via the `report_id`.
+      tags:
+        - Property Resolution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domains:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 10000
+                  example:
+                    - www.nytimes.com
+                    - googlesyndication.com
+                    - wsj.com
+              required:
+                - domains
+      responses:
+        "200":
+          description: Property list check results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      remove:
+                        type: integer
+                      modify:
+                        type: integer
+                      assess:
+                        type: integer
+                      ok:
+                        type: integer
+                    required:
+                      - total
+                      - remove
+                      - modify
+                      - assess
+                      - ok
+                  remove:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        input:
+                          type: string
+                        canonical:
+                          type: string
+                        reason:
+                          type: string
+                          enum:
+                            - duplicate
+                            - blocked
+                        domain_type:
+                          type: string
+                        blocked_reason:
+                          type: string
+                      required:
+                        - input
+                        - canonical
+                        - reason
+                  modify:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        input:
+                          type: string
+                        canonical:
+                          type: string
+                        reason:
+                          type: string
+                      required:
+                        - input
+                        - canonical
+                        - reason
+                  assess:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        domain:
+                          type: string
+                      required:
+                        - domain
+                  ok:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        domain:
+                          type: string
+                        source:
+                          type: string
+                      required:
+                        - domain
+                        - source
+                  report_id:
+                    type: string
+                    description: UUID for retrieving this report later
+                required:
+                  - summary
+                  - remove
+                  - modify
+                  - assess
+                  - ok
+                  - report_id
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/check/{reportId}:
+    get:
+      operationId: getPropertyCheckReport
+      summary: Get property check report
+      description: Retrieve a previously stored property check report by ID. Reports expire after 7 days.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: reportId
+          in: path
+      responses:
+        "200":
+          description: Property check report
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      remove:
+                        type: integer
+                      modify:
+                        type: integer
+                      assess:
+                        type: integer
+                      ok:
+                        type: integer
+                    required:
+                      - total
+                      - remove
+                      - modify
+                      - assess
+                      - ok
+                required:
+                  - summary
+        "404":
+          description: Report not found or expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents:
+    get:
+      operationId: listAgents
+      summary: List agents
+      description: List all agents in the registry. Optionally enrich with health checks, capabilities, and property summaries via query parameters. Measurement-vendor filters (`metric_id`, `accreditation`, `q`) imply `type=measurement` when `type` is unset; an explicit `type` other than `measurement` returns 400.
+      tags:
+        - Agent Discovery
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - brand
+              - rights
+              - measurement
+              - governance
+              - creative
+              - sales
+              - buying
+              - signals
+              - unknown
+          required: false
+          name: type
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+          required: false
+          name: health
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+          required: false
+          name: capabilities
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+          required: false
+          name: properties
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+          required: false
+          name: compliance
+          in: query
+        - schema:
+            anyOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+            description: "Measurement-vendor filter: exact match on `measurement.metrics[].metric_id`. Repeatable (each value is OR'd within the param, AND'd with other filters). Implies `type=measurement`."
+            example: attention_units
+          required: false
+          description: "Measurement-vendor filter: exact match on `measurement.metrics[].metric_id`. Repeatable (each value is OR'd within the param, AND'd with other filters). Implies `type=measurement`."
+          name: metric_id
+          in: query
+        - schema:
+            anyOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+            description: "Measurement-vendor filter: exact match on `measurement.metrics[].accreditations[].accrediting_body` (e.g. `MRC`, `JIC`, `ARF`). Repeatable. Implies `type=measurement`. Accreditation claims are vendor-asserted; AAO does not independently verify (`verified_by_aao` is always `false` in the response)."
+            example: MRC
+          required: false
+          description: "Measurement-vendor filter: exact match on `measurement.metrics[].accreditations[].accrediting_body` (e.g. `MRC`, `JIC`, `ARF`). Repeatable. Implies `type=measurement`. Accreditation claims are vendor-asserted; AAO does not independently verify (`verified_by_aao` is always `false` in the response)."
+          name: accreditation
+          in: query
+        - schema:
+            type: string
+            maxLength: 64
+            description: "Measurement-vendor filter: case-insensitive substring match against `measurement.metrics[].metric_id`. v1 scope: metric_id only (description/standard search is a follow-up). Max 64 chars; SQL wildcard characters are escaped. Implies `type=measurement`."
+            example: attention
+          required: false
+          description: "Measurement-vendor filter: case-insensitive substring match against `measurement.metrics[].metric_id`. v1 scope: metric_id only (description/standard search is a follow-up). Max 64 chars; SQL wildcard characters are escaped. Implies `type=measurement`."
+          name: q
+          in: query
+        - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - spec
+                - live
+            description: "Filter to agents whose active badge covers the given verification axis. Repeat the parameter for AND semantics: ?verification_mode=spec&verification_mode=live returns only agents verified on both axes."
+          required: false
+          description: "Filter to agents whose active badge covers the given verification axis. Repeat the parameter for AND semantics: ?verification_mode=spec&verification_mode=live returns only agents verified on both axes."
+          name: verification_mode
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+            description: When true, filter to agents that hold any active verification badge.
+          required: false
+          description: When true, filter to agents that hold any active verification badge.
+          name: verified
+          in: query
+      responses:
+        "200":
+          description: Agent list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agents:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FederatedAgentWithDetails"
+                  count:
+                    type: integer
+                required:
+                  - agents
+                  - count
+        "400":
+          description: Invalid query parameter
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  valid_values:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - error
+  /api/registry/publishers:
+    get:
+      operationId: listPublishers
+      summary: List publishers
+      description: List all registered publishers.
+      tags:
+        - Agent Discovery
+      responses:
+        "200":
+          description: Publisher list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  publishers:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FederatedPublisher"
+                  count:
+                    type: integer
+                required:
+                  - publishers
+                  - count
+  /api/registry/stats:
+    get:
+      operationId: getRegistryStats
+      summary: Registry statistics
+      description: Get aggregate statistics about the registry.
+      tags:
+        - Agent Discovery
+      responses:
+        "200":
+          description: Registry statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+                additionalProperties: {}
+  /api/registry/lookup/domain/{domain}:
+    get:
+      operationId: lookupDomain
+      summary: Domain lookup (deprecated)
+      description: "**Deprecated.** Use `/api/registry/publisher?domain=X` for richer data including hosting state, per-agent rollup, and brand.json fallback. This endpoint will be removed in a future release."
+      deprecated: true
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: path
+      responses:
+        "200":
+          description: Domain lookup result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DomainLookupResult"
+  /api/registry/lookup/property:
+    get:
+      operationId: lookupProperty
+      summary: Property identifier lookup
+      description: Find agents that hold a specific property identifier.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: type
+          in: query
+        - schema:
+            type: string
+          required: true
+          name: value
+          in: query
+      responses:
+        "200":
+          description: Matching agents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  value:
+                    type: string
+                  agents:
+                    type: array
+                    items: {}
+                  count:
+                    type: integer
+                required:
+                  - type
+                  - value
+                  - agents
+                  - count
+  /api/registry/lookup/agent/{agentUrl}/domains:
+    get:
+      operationId: getAgentDomains
+      summary: Agent domain lookup
+      description: Get all publisher domains associated with an agent.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: agentUrl
+          in: path
+      responses:
+        "200":
+          description: Domains for the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  domains:
+                    type: array
+                    items:
+                      type: string
+                  count:
+                    type: integer
+                required:
+                  - agent_url
+                  - domains
+                  - count
+  /api/v1/agents/{encodedUrl}/publishers:
+    get:
+      operationId: getPublishersForAgentLegacyApiPrefix
+      summary: AAO directory inverse-lookup
+      description: |-
+        Given a percent-encoded `agent_url`, returns the publishers whose adagents.json authorizes that agent, with provenance (`discovery_method`, `manager_domain`), per-publisher property counts (`properties_authorized`, `properties_total`, scoped to this publisher only — never network-wide), signing-key pin status, and lifecycle state (`authorized` / `revoked`).
+
+        Spec: [docs/aao/directory-api.mdx](/docs/aao/directory-api) (adcp#4823). This endpoint is the spec-compliant richer-shape replacement for the legacy `/api/registry/lookup/agent/{agentUrl}/domains`, which returns domain strings only.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            description: Percent-encoded agent_url
+          required: true
+          description: Percent-encoded agent_url
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 — return only publishers with last_verified_at ≥ since
+          required: false
+          description: ISO 8601 — return only publishers with last_verified_at ≥ since
+          name: since
+          in: query
+        - schema:
+            type: string
+            description: Opaque pagination cursor returned by a prior response
+          required: false
+          description: Opaque pagination cursor returned by a prior response
+          name: cursor
+          in: query
+        - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - authorized
+                - revoked
+            description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400."
+          required: false
+          description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400."
+          name: status
+          in: query
+        - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - properties
+            description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400."
+          required: false
+          description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400."
+          name: include
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            description: Page size, default 200, max 1000
+          required: false
+          description: Page size, default 200, max 1000
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Publishers authorizing the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  directory_indexed_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                    description: Most recent per-publisher refresh in this page. Null on empty pages (no anchor).
+                  publishers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        publisher_domain:
+                          type: string
+                        discovery_method:
+                          type: string
+                          enum:
+                            - direct
+                            - authoritative_location
+                            - ads_txt_managerdomain
+                            - adagents_authoritative
+                            - community_catalog
+                        manager_domain:
+                          type:
+                            - string
+                            - "null"
+                        properties_authorized:
+                          type: integer
+                          minimum: 0
+                        properties_total:
+                          type: integer
+                          minimum: 0
+                        property_ids:
+                          type: array
+                          items:
+                            type: string
+                          description: Canonical list of property_id strings the agent is authorized for under this publisher. Present iff the request included `?include=properties`. Same population as `properties_authorized` but surfaced as IDs for set-diff comparison.
+                        signing_keys_pinned:
+                          type: boolean
+                        status:
+                          type: string
+                          enum:
+                            - authorized
+                            - revoked
+                        last_verified_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - publisher_domain
+                        - discovery_method
+                        - manager_domain
+                        - properties_authorized
+                        - properties_total
+                        - signing_keys_pinned
+                        - status
+                        - last_verified_at
+                  next_cursor:
+                    type:
+                      - string
+                      - "null"
+                required:
+                  - agent_url
+                  - directory_indexed_at
+                  - publishers
+                  - next_cursor
+        "304":
+          description: Not modified (If-None-Match matched)
+        "400":
+          description: Invalid agent_url, cursor, since, or status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Directory has never indexed any publisher referencing this agent_url. Distinct from 200 + empty.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /v1/agents/{encodedUrl}/publishers:
+    get:
+      operationId: getPublishersForAgent
+      summary: AAO directory inverse-lookup
+      description: |-
+        Given a percent-encoded `agent_url`, returns the publishers whose adagents.json authorizes that agent, with provenance (`discovery_method`, `manager_domain`), per-publisher property counts (`properties_authorized`, `properties_total`, scoped to this publisher only — never network-wide), signing-key pin status, and lifecycle state (`authorized` / `revoked`).
+
+        Spec: [docs/aao/directory-api.mdx](/docs/aao/directory-api) (adcp#4823). This endpoint is the spec-compliant richer-shape replacement for the legacy `/api/registry/lookup/agent/{agentUrl}/domains`, which returns domain strings only.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            description: Percent-encoded agent_url
+          required: true
+          description: Percent-encoded agent_url
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 — return only publishers with last_verified_at ≥ since
+          required: false
+          description: ISO 8601 — return only publishers with last_verified_at ≥ since
+          name: since
+          in: query
+        - schema:
+            type: string
+            description: Opaque pagination cursor returned by a prior response
+          required: false
+          description: Opaque pagination cursor returned by a prior response
+          name: cursor
+          in: query
+        - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - authorized
+                - revoked
+            description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400."
+          required: false
+          description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400."
+          name: status
+          in: query
+        - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - properties
+            description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400."
+          required: false
+          description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400."
+          name: include
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            description: Page size, default 200, max 1000
+          required: false
+          description: Page size, default 200, max 1000
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Publishers authorizing the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  directory_indexed_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                    description: Most recent per-publisher refresh in this page. Null on empty pages (no anchor).
+                  publishers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        publisher_domain:
+                          type: string
+                        discovery_method:
+                          type: string
+                          enum:
+                            - direct
+                            - authoritative_location
+                            - ads_txt_managerdomain
+                            - adagents_authoritative
+                            - community_catalog
+                        manager_domain:
+                          type:
+                            - string
+                            - "null"
+                        properties_authorized:
+                          type: integer
+                          minimum: 0
+                        properties_total:
+                          type: integer
+                          minimum: 0
+                        property_ids:
+                          type: array
+                          items:
+                            type: string
+                          description: Canonical list of property_id strings the agent is authorized for under this publisher. Present iff the request included `?include=properties`. Same population as `properties_authorized` but surfaced as IDs for set-diff comparison.
+                        signing_keys_pinned:
+                          type: boolean
+                        status:
+                          type: string
+                          enum:
+                            - authorized
+                            - revoked
+                        last_verified_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - publisher_domain
+                        - discovery_method
+                        - manager_domain
+                        - properties_authorized
+                        - properties_total
+                        - signing_keys_pinned
+                        - status
+                        - last_verified_at
+                  next_cursor:
+                    type:
+                      - string
+                      - "null"
+                required:
+                  - agent_url
+                  - directory_indexed_at
+                  - publishers
+                  - next_cursor
+        "304":
+          description: Not modified (If-None-Match matched)
+        "400":
+          description: Invalid agent_url, cursor, since, or status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Directory has never indexed any publisher referencing this agent_url. Distinct from 200 + empty.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/operator:
+    get:
+      operationId: lookupOperator
+      summary: Operator lookup
+      description: |-
+        Given a domain, returns the agents this entity operates and which publishers trust them.
+
+        **Response shape is auth-aware.** Anonymous callers see only `public` agents. Authenticated callers on an AAO membership tier with API access also see `members_only` agents. Profile owners (callers whose org owns the queried domain) additionally see `private` agents. This is the primary mechanism by which AAO membership unlocks deeper registry visibility.
+
+        **`scope` bucket filter.** Callers can opt INTO a single visibility bucket (or the full union) regardless of what their auth would otherwise unlock — useful for picker UIs that want exactly one slice (e.g. anonymous-equivalent, members-only catalog, owner's private drafts). `scope` only narrows; it never escalates (e.g. `scope=member` on an explorer or anonymous caller silently returns public only).
+
+        **Member level visibility.** When the profile owner has set their member card to public (`is_public=true`), the `member` object additionally carries `is_founding_member` (boolean) plus `membership_tier` (raw enum) and `membership_tier_label` (e.g. `Professional`, `Partner`, `Leader`) when the org has a resolvable tier. Founding Member is orthogonal to tier — founding orgs typically display both. For private profiles these fields are absent.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            example: pubmatic.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            enum:
+              - public
+              - member
+              - private
+              - all
+            description: |-
+              Visibility bucket filter for returned agents. One value per agent-visibility enum value plus a catch-all. Each bucket is still gated by auth — `scope` can only narrow, never escalate.
+
+              - `public` → only `visibility=public` agents.
+              - `member` → public + members_only (members_only is gated on caller's tier; anonymous or explorer-tier callers silently fall through to public-only rather than 403).
+              - `private` → only `visibility=private`. Private agents are visible only to the profile owner; non-owners get an empty list.
+              - Omitted or `all` → tier-aware full unlock: public + members_only for API-tier members + private for the profile owner.
+
+              Unknown values return 400 — a silent coerce to `all` could leak data the caller explicitly tried to scope away from.
+            example: member
+          required: false
+          description: |-
+            Visibility bucket filter for returned agents. One value per agent-visibility enum value plus a catch-all. Each bucket is still gated by auth — `scope` can only narrow, never escalate.
+
+            - `public` → only `visibility=public` agents.
+            - `member` → public + members_only (members_only is gated on caller's tier; anonymous or explorer-tier callers silently fall through to public-only rather than 403).
+            - `private` → only `visibility=private`. Private agents are visible only to the profile owner; non-owners get an empty list.
+            - Omitted or `all` → tier-aware full unlock: public + members_only for API-tier members + private for the profile owner.
+
+            Unknown values return 400 — a silent coerce to `all` could leak data the caller explicitly tried to scope away from.
+          name: scope
+          in: query
+      responses:
+        "200":
+          description: Operator lookup result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperatorLookupResult"
+        "400":
+          description: Missing or invalid domain, or unknown scope value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/publisher:
+    get:
+      operationId: lookupPublisher
+      summary: Publisher lookup
+      description: |-
+        Given a domain, returns the inventory this entity publishes and which agents it authorizes.
+
+        **This endpoint is unauthenticated and returns the same response shape for every caller.** Compare to `/api/registry/operator`, where AAO membership tier and profile ownership unlock additional agent visibility (`members_only`, `private`). AAO membership does not change the `/publisher` response today.
+
+        **Property source precedence:** publisher-attested adagents.json properties win first. When no publisher-attested adagents properties exist for the domain, brand.json properties supplement and override lower-trust rows, followed by approved community catalogs, then crawler-discovered rows. Each property carries a `source` field (`adagents_json` / `brand_json` / `community` / `discovered`).
+
+        **Per-agent rollup:** each entry in `authorized_agents` may carry `properties_authorized` + `properties_total` + `publisher_wide`. The rollup is suppressed (fields absent) when (a) properties are entirely brand.json-hydrated — no adagents.json claim has been made — or (b) the publisher has more than 50 authorized agents (above-cap entries are returned without rollup; `rollup_truncated` is set with `{ cap, total_agents }`). Use `/api/registry/publisher/authorization?domain=X&agent=Y` for the per-agent count when the index rollup is absent.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            example: voxmedia.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Publisher lookup result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublisherLookupResult"
+        "400":
+          description: Missing domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/publisher/{domain}/adagents/revalidate:
+    post:
+      operationId: revalidatePublisherAdagents
+      summary: Revalidate publisher adagents.json
+      description: |-
+        Admin-only endpoint for support/operator tooling to synchronously fetch a publisher's live `/.well-known/adagents.json`, run the registry validator, persist the refreshed verdict and fetch metadata, and return the validation result. `force=true` is accepted for operator tooling; the current validator always fetches the live origin.
+
+        **Rate limits:** 5 minutes per domain, 30 requests per user per hour.
+      tags:
+        - Authorization Lookups
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            example: publisher.example
+          required: true
+          name: domain
+          in: path
+        - schema:
+            type: string
+            enum:
+              - "1"
+              - "true"
+            description: Accepted for tooling compatibility; live origin validation is always performed.
+          required: false
+          description: Accepted for tooling compatibility; live origin validation is always performed.
+          name: force
+          in: query
+      responses:
+        "200":
+          description: Revalidation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  adagents_valid:
+                    type: boolean
+                  checked_at:
+                    type: string
+                    format: date-time
+                  error:
+                    type: string
+                  issues:
+                    type: object
+                    properties:
+                      errors:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            field:
+                              type: string
+                            message:
+                              type: string
+                            severity:
+                              type: string
+                              enum:
+                                - error
+                          required:
+                            - field
+                            - message
+                            - severity
+                      warnings:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            field:
+                              type: string
+                            message:
+                              type: string
+                            suggestion:
+                              type: string
+                          required:
+                            - field
+                            - message
+                    required:
+                      - errors
+                      - warnings
+                  properties_count:
+                    type: integer
+                    minimum: 0
+                  authorized_agents_count:
+                    type: integer
+                    minimum: 0
+                  status_code:
+                    type: integer
+                    minimum: 100
+                    maximum: 599
+                  response_bytes:
+                    type: integer
+                    minimum: 0
+                  resolved_url:
+                    type: string
+                  discovery_method:
+                    type: string
+                    enum:
+                      - direct
+                      - authoritative_location
+                      - ads_txt_managerdomain
+                      - adagents_authoritative
+                  manager_domain:
+                    type: string
+                required:
+                  - domain
+                  - adagents_valid
+                  - checked_at
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Admin access required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
+  /api/registry/publisher/authorization:
+    get:
+      operationId: lookupPublisherAgentAuthorization
+      summary: Per-agent authorization rollup
+      description: Returns whether a given agent is authorized for a publisher domain and how many of the publisher's properties it can sell. When the agent has property-level authorization rows, the count is the intersection with the publisher's property set; when it only has a publisher-wide row, the count equals the total. Returns 404 when the agent has no authorization (publisher-wide or property-level) for the domain.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            example: voxmedia.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            example: https://sales.pubmatic.com/mcp
+          required: true
+          name: agent
+          in: query
+      responses:
+        "200":
+          description: Authorization rollup
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  publisher_domain:
+                    type: string
+                  agent_url:
+                    type: string
+                  authorized:
+                    type: integer
+                    minimum: 0
+                    description: Count of publisher's properties the agent can sell.
+                  total:
+                    type: integer
+                    minimum: 0
+                    description: Total properties the publisher exposes.
+                  publisher_wide:
+                    type: boolean
+                    description: True when the agent has only a publisher-wide authorization (no property-level rows). In that case `authorized` equals `total`.
+                  source:
+                    type: string
+                    enum:
+                      - adagents_json
+                      - agent_claim
+                  authorized_for:
+                    type: string
+                  unauthorized_properties:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        type:
+                          type: string
+                    description: Properties the agent is NOT authorized for. Empty when publisher_wide is true.
+                required:
+                  - publisher_domain
+                  - agent_url
+                  - authorized
+                  - total
+                  - publisher_wide
+                  - source
+                  - unauthorized_properties
+        "400":
+          description: Missing domain or agent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No authorization record for this agent on this publisher
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/validate/product-authorization:
+    post:
+      operationId: validateProductAuthorization
+      summary: Validate product authorization
+      description: Check whether an agent is authorized to sell a product based on its publisher_properties.
+      tags:
+        - Authorization Lookups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                agent_url:
+                  type: string
+                publisher_properties:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/PublisherPropertySelector"
+              required:
+                - agent_url
+                - publisher_properties
+      responses:
+        "200":
+          description: Authorization validation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  authorized:
+                    type: boolean
+                  checked_at:
+                    type: string
+                required:
+                  - agent_url
+                  - authorized
+                  - checked_at
+                additionalProperties: {}
+  /api/registry/expand/product-identifiers:
+    post:
+      operationId: expandProductIdentifiers
+      summary: Expand product identifiers
+      description: Expand publisher_properties selectors into concrete property identifiers for caching.
+      tags:
+        - Authorization Lookups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                agent_url:
+                  type: string
+                publisher_properties:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/PublisherPropertySelector"
+              required:
+                - agent_url
+                - publisher_properties
+      responses:
+        "200":
+          description: Expanded identifiers
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  properties:
+                    type: array
+                    items: {}
+                  identifiers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        value:
+                          type: string
+                        property_id:
+                          type: string
+                        publisher_domain:
+                          type: string
+                      required:
+                        - type
+                        - value
+                        - property_id
+                        - publisher_domain
+                  property_count:
+                    type: integer
+                  identifier_count:
+                    type: integer
+                  generated_at:
+                    type: string
+                required:
+                  - agent_url
+                  - properties
+                  - identifiers
+                  - property_count
+                  - identifier_count
+                  - generated_at
+  /api/registry/validate/property-authorization:
+    get:
+      operationId: validatePropertyAuthorization
+      summary: Property authorization check
+      description: Quick check if a property identifier is authorized for an agent. Optimized for real-time ad request validation.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: agent_url
+          in: query
+        - schema:
+            type: string
+          required: true
+          name: identifier_type
+          in: query
+        - schema:
+            type: string
+          required: true
+          name: identifier_value
+          in: query
+      responses:
+        "200":
+          description: Authorization result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  identifier_type:
+                    type: string
+                  identifier_value:
+                    type: string
+                  authorized:
+                    type: boolean
+                  checked_at:
+                    type: string
+                required:
+                  - agent_url
+                  - identifier_type
+                  - identifier_value
+                  - authorized
+                  - checked_at
+                additionalProperties: {}
+  /api/adagents/validate:
+    post:
+      operationId: validateAdagents
+      summary: Validate adagents.json
+      description: Validate a domain's adagents.json file and optionally validate referenced agent cards.
+      tags:
+        - Validation Tools
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+              required:
+                - domain
+      responses:
+        "200":
+          description: Validation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      domain:
+                        type: string
+                      found:
+                        type: boolean
+                      validation: {}
+                      agent_cards: {}
+                    required:
+                      - domain
+                      - found
+                  timestamp:
+                    type: string
+                required:
+                  - success
+                  - data
+                  - timestamp
+  /api/adagents/create:
+    post:
+      operationId: createAdagents
+      summary: Generate adagents.json
+      description: Generate a valid adagents.json file from authorized agents and/or catalog content. `authorized_agents` may be empty for a catalog-only community mirror that publishes formats/properties/placements for a platform that has not adopted AdCP.
+      tags:
+        - Validation Tools
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                authorized_agents:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/AdagentsAuthorizedAgent"
+                include_schema:
+                  type: boolean
+                include_timestamp:
+                  type: boolean
+                properties:
+                  type: array
+                  items: {}
+                catalog_etag:
+                  type: string
+                formats:
+                  type: array
+                  items: {}
+                placements:
+                  type: array
+                  items: {}
+                placement_tags:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - authorized_agents
+      responses:
+        "200":
+          description: Generated adagents.json
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateAdagentsResponse"
+  /api/registry/mirrors:
+    get:
+      operationId: listCommunityMirrors
+      summary: List community mirrors
+      description: List persisted catalog-only adagents.json community mirrors. The list projection includes presence and freshness metadata but omits the full `adagents_json` body; fetch a platform-specific mirror for the full document.
+      tags:
+        - Community Mirrors
+      parameters:
+        - schema:
+            type: integer
+            description: Maximum mirrors to return. The service defaults to 100 and clamps values to the 1-500 range.
+          required: false
+          description: Maximum mirrors to return. The service defaults to 100 and clamps values to the 1-500 range.
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            description: Zero-based result offset. Defaults to 0; negative values are clamped to 0.
+          required: false
+          description: Zero-based result offset. Defaults to 0; negative values are clamped to 0.
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Community mirror list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorListResponse"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to list community mirrors
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/mirrors/{platform}:
+    get:
+      operationId: getCommunityMirror
+      summary: Get community mirror
+      description: Fetch one persisted community mirror by platform. A present mirror returns the platform metadata plus the stored catalog-only `adagents_json` document; absent mirrors return 404.
+      tags:
+        - Community Mirrors
+      parameters:
+        - schema:
+            type: string
+            pattern: ^[a-z0-9_-]{1,64}$
+            description: Lowercase platform identifier.
+            example: example_platform
+          required: true
+          description: Lowercase platform identifier.
+          name: platform
+          in: path
+      responses:
+        "200":
+          description: Community mirror
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorGetResponse"
+        "400":
+          description: Invalid platform identifier
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Community mirror not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to read community mirror
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    put:
+      operationId: publishCommunityMirror
+      summary: Publish community mirror
+      description: "Publish or update a catalog-only adagents.json community mirror. Requires a registry moderator or AgenticAdvertising.org admin. The service validates the assembled document against adagents.json, forces `authorized_agents: []`, regenerates `$schema` and `last_updated`, and updates derived publisher-domain catalog rows."
+      tags:
+        - Community Mirrors
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            pattern: ^[a-z0-9_-]{1,64}$
+            description: Lowercase platform identifier.
+            example: example_platform
+          required: true
+          description: Lowercase platform identifier.
+          name: platform
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommunityMirrorPublishRequest"
+      responses:
+        "200":
+          description: Community mirror published
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorPublishResponse"
+        "400":
+          description: Invalid platform, request body, or adagents.json conformance failure
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorPublishError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Only registry moderators or AgenticAdvertising.org admins can manage community mirrors
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to publish community mirror
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      operationId: deleteCommunityMirror
+      summary: Delete community mirror
+      description: Delete a persisted community mirror and retire derived publisher-domain catalog rows. Requires a registry moderator or AgenticAdvertising.org admin. Without `force=true`, the service refuses to delete a mirror that has not first published a `superseded_by` migration URL.
+      tags:
+        - Community Mirrors
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            pattern: ^[a-z0-9_-]{1,64}$
+            description: Lowercase platform identifier.
+            example: example_platform
+          required: true
+          description: Lowercase platform identifier.
+          name: platform
+          in: path
+        - schema:
+            type: string
+            description: Set to `true` to delete a mirror without a `superseded_by` migration URL.
+          required: false
+          description: Set to `true` to delete a mirror without a `superseded_by` migration URL.
+          name: force
+          in: query
+      responses:
+        "200":
+          description: Community mirror deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorDeleteResponse"
+        "400":
+          description: Invalid platform identifier
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Only registry moderators or AgenticAdvertising.org admins can manage community mirrors
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Community mirror not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Mirror has not been superseded and force was not set
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to delete community mirror
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/search:
+    get:
+      operationId: search
+      summary: Search
+      description: Search across brands, publishers, and properties. Returns up to 5 results per category.
+      tags:
+        - Search
+      parameters:
+        - schema:
+            type: string
+            minLength: 2
+          required: true
+          name: q
+          in: query
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  brands:
+                    type: array
+                    items: {}
+                  publishers:
+                    type: array
+                    items: {}
+                  properties:
+                    type: array
+                    items: {}
+                required:
+                  - brands
+                  - publishers
+                  - properties
+  /api/manifest-refs/lookup:
+    get:
+      operationId: lookupManifestRef
+      summary: Manifest reference lookup
+      description: Find the best manifest reference (brand.json URL or agent) for a domain.
+      tags:
+        - Search
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            example: brand.json
+          required: false
+          name: type
+          in: query
+      responses:
+        "200":
+          description: Reference lookup result
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      success:
+                        type: boolean
+                        enum:
+                          - true
+                      found:
+                        type: boolean
+                        enum:
+                          - true
+                      reference:
+                        type: object
+                        properties:
+                          reference_type:
+                            type: string
+                            enum:
+                              - url
+                              - agent
+                          manifest_url:
+                            type:
+                              - string
+                              - "null"
+                          agent_url:
+                            type:
+                              - string
+                              - "null"
+                          agent_id:
+                            type:
+                              - string
+                              - "null"
+                          verification_status:
+                            type: string
+                            enum:
+                              - pending
+                              - valid
+                              - invalid
+                              - unreachable
+                        required:
+                          - reference_type
+                          - manifest_url
+                          - agent_url
+                          - agent_id
+                          - verification_status
+                    required:
+                      - success
+                      - found
+                      - reference
+                  - type: object
+                    properties:
+                      success:
+                        type: boolean
+                        enum:
+                          - false
+                      found:
+                        type: boolean
+                        enum:
+                          - false
+                    required:
+                      - success
+                      - found
+  /api/public/discover-agent:
+    get:
+      operationId: discoverAgent
+      summary: Discover agent
+      description: Probe an agent URL to discover its name, type, supported protocols, and basic statistics.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: url
+          in: query
+      responses:
+        "200":
+          description: Discovered agent info
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  protocols:
+                    type: array
+                    items:
+                      type: string
+                  type:
+                    type: string
+                  tools_count:
+                    type: integer
+                  tools:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        description:
+                          type: string
+                      required:
+                        - name
+                  stats:
+                    type: object
+                    properties:
+                      format_count:
+                        type: integer
+                      product_count:
+                        type: integer
+                      publisher_count:
+                        type: integer
+                required:
+                  - name
+                  - protocols
+                  - type
+                  - tools_count
+                  - tools
+                  - stats
+        "504":
+          description: Connection timeout
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/public/agent-formats:
+    get:
+      operationId: getAgentFormats
+      summary: Get agent formats
+      description: Fetch creative formats from a creative agent.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: url
+          in: query
+      responses:
+        "200":
+          description: Creative formats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  formats:
+                    type: array
+                    items: {}
+                required:
+                  - success
+                  - formats
+  /api/public/agent-products:
+    get:
+      operationId: getAgentProducts
+      summary: Get agent products
+      description: Fetch products from a sales agent.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: url
+          in: query
+      responses:
+        "200":
+          description: Products
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  products:
+                    type: array
+                    items: {}
+                required:
+                  - success
+                  - products
+  /api/public/validate-publisher:
+    get:
+      operationId: validatePublisher
+      summary: Validate publisher
+      description: Validate a publisher domain's adagents.json and return summary statistics.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Publisher validation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  valid:
+                    type: boolean
+                  domain:
+                    type: string
+                  url:
+                    type: string
+                  discovery_method:
+                    type: string
+                    enum:
+                      - direct
+                      - authoritative_location
+                      - ads_txt_managerdomain
+                    description: How the publisher's adagents.json was discovered. `ads_txt_managerdomain` indicates one-hop delegation via ads.txt MANAGERDOMAIN.
+                  manager_domain:
+                    type: string
+                    description: Manager domain that served the manifest. Present only when discovery_method is ads_txt_managerdomain.
+                  agent_count:
+                    type: integer
+                  property_count:
+                    type: integer
+                  property_type_counts:
+                    type: object
+                    additionalProperties:
+                      type: integer
+                  tag_count:
+                    type: integer
+                  errors:
+                    type: array
+                    items:
+                      type: string
+                  warnings:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - valid
+                  - domain
+                  - discovery_method
+                  - agent_count
+                  - property_count
+                  - property_type_counts
+                  - tag_count
+  /api/policies/registry:
+    get:
+      operationId: listPolicies
+      summary: List policies
+      description: Browse and search the governance policy registry. Returns approved policies with optional filtering by category, enforcement level, jurisdiction, policy category, and governance domain.
+      tags:
+        - Policy Registry
+      parameters:
+        - schema:
+            type: string
+            description: Full-text search on policy name and description
+          required: false
+          description: Full-text search on policy name and description
+          name: search
+          in: query
+        - schema:
+            type: string
+            enum:
+              - regulation
+              - standard
+          required: false
+          name: category
+          in: query
+        - schema:
+            type: string
+            enum:
+              - must
+              - should
+              - may
+          required: false
+          name: enforcement
+          in: query
+        - schema:
+            type: string
+            example: EU
+            description: Filter by jurisdiction (includes region alias matching)
+          required: false
+          description: Filter by jurisdiction (includes region alias matching)
+          name: jurisdiction
+          in: query
+        - schema:
+            type: string
+            example: age_restricted
+          required: false
+          name: policy_category
+          in: query
+        - schema:
+            type: string
+            example: campaign
+            description: Filter by governance domain
+          required: false
+          description: Filter by governance domain
+          name: domain
+          in: query
+        - schema:
+            type: integer
+            description: Results per page (default 20, max 1000)
+          required: false
+          description: Results per page (default 20, max 1000)
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            description: Pagination offset (default 0)
+          required: false
+          description: Pagination offset (default 0)
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Policy listing with facet stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  policies:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PolicySummary"
+                  stats:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      regulation:
+                        type: integer
+                      standard:
+                        type: integer
+                    required:
+                      - total
+                      - regulation
+                      - standard
+                required:
+                  - policies
+                  - stats
+  /api/policies/resolve:
+    get:
+      operationId: resolvePolicy
+      summary: Resolve policy
+      description: Resolve a single policy by ID. Optionally pin to a specific version — returns null if the version does not match.
+      tags:
+        - Policy Registry
+      parameters:
+        - schema:
+            type: string
+            example: gdpr_consent
+          required: true
+          name: policy_id
+          in: query
+        - schema:
+            type: string
+            description: Return null if the current version does not match
+          required: false
+          description: Return null if the current version does not match
+          name: version
+          in: query
+      responses:
+        "200":
+          description: Policy resolved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Policy"
+        "400":
+          description: Missing policy_id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Policy not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  policy_id:
+                    type: string
+                required:
+                  - error
+                  - policy_id
+  /api/policies/resolve/bulk:
+    post:
+      operationId: resolvePoliciesBulk
+      summary: Bulk resolve policies
+      description: |-
+        Resolve up to 100 policies by ID in a single request. Returns a map of policy_id to Policy (or null if not found).
+
+        **Rate limit:** 20 requests per minute per IP address.
+      tags:
+        - Policy Registry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                policy_ids:
+                  type: array
+                  items:
+                    type: string
+                  minItems: 1
+                  maxItems: 100
+                  example:
+                    - gdpr_consent
+                    - coppa_children
+              required:
+                - policy_ids
+      responses:
+        "200":
+          description: Bulk resolution results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: object
+                    additionalProperties:
+                      allOf:
+                        - $ref: "#/components/schemas/Policy"
+                        - type:
+                            - object
+                            - "null"
+                required:
+                  - results
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/policies/history:
+    get:
+      operationId: getPolicyHistory
+      summary: Policy revision history
+      description: Retrieve the edit history for a policy. Each revision records who made the change, a summary, and whether it was a rollback.
+      tags:
+        - Policy Registry
+      parameters:
+        - schema:
+            type: string
+            example: gdpr_consent
+          required: true
+          name: policy_id
+          in: query
+        - schema:
+            type: integer
+            description: Results per page (max 100, default 20)
+          required: false
+          description: Results per page (max 100, default 20)
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            description: Pagination offset (default 0)
+          required: false
+          description: Pagination offset (default 0)
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Revision history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyHistory"
+        "400":
+          description: Missing policy_id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Policy not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  policy_id:
+                    type: string
+                required:
+                  - error
+                  - policy_id
+  /api/policies/save:
+    post:
+      operationId: savePolicy
+      summary: Save policy
+      description: Create or update a community-contributed policy. Requires authentication. Registry-sourced and pending-review policies cannot be edited (returns 409). Updates automatically create a revision record.
+      tags:
+        - Policy Registry
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                policy_id:
+                  type: string
+                  example: my_brand_safety
+                  description: Lowercase alphanumeric with underscores
+                version:
+                  type: string
+                  example: 1.0.0
+                name:
+                  type: string
+                  example: Acme Corp Brand Safety
+                category:
+                  type: string
+                  enum:
+                    - regulation
+                    - standard
+                enforcement:
+                  type: string
+                  enum:
+                    - must
+                    - should
+                    - may
+                policy:
+                  type: string
+                  example: Ads must not appear adjacent to content depicting violence...
+                description:
+                  type: string
+                jurisdictions:
+                  type: array
+                  items:
+                    type: string
+                region_aliases:
+                  type: object
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
+                policy_categories:
+                  type: array
+                  items:
+                    type: string
+                channels:
+                  type: array
+                  items:
+                    type: string
+                effective_date:
+                  type: string
+                sunset_date:
+                  type: string
+                governance_domains:
+                  type: array
+                  items:
+                    type: string
+                source_url:
+                  type: string
+                  description: Must use http:// or https://
+                source_name:
+                  type: string
+                guidance:
+                  type: string
+                exemplars:
+                  type: object
+                  properties:
+                    pass:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          scenario:
+                            type: string
+                          explanation:
+                            type: string
+                        required:
+                          - scenario
+                          - explanation
+                    fail:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          scenario:
+                            type: string
+                          explanation:
+                            type: string
+                        required:
+                          - scenario
+                          - explanation
+                ext:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - policy_id
+                - version
+                - name
+                - category
+                - enforcement
+                - policy
+      responses:
+        "200":
+          description: Policy saved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  message:
+                    type: string
+                  policy_id:
+                    type: string
+                  revision_number:
+                    type:
+                      - integer
+                      - "null"
+                required:
+                  - success
+                  - message
+                  - policy_id
+                  - revision_number
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Cannot edit registry-sourced or pending policy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  policy_id:
+                    type: string
+                required:
+                  - error
+                  - policy_id
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/feed:
+    get:
+      operationId: getRegistryFeed
+      summary: Registry change feed
+      description: |-
+        Poll a cursor-based feed of registry changes. Events are ordered by UUID v7 event_id for monotonic cursor progression. The feed retains events for 90 days. The `freshness` object reports when the response was generated, the newest matching event currently visible to the feed, and the resulting feed lag.
+
+        Type filtering supports glob patterns: `property.*` matches `property.created`, `property.updated`, etc.
+      tags:
+        - Change Feed
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Resume after this event ID
+          required: false
+          description: Resume after this event ID
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated event type filters with glob support (e.g. property.*)
+            example: property.*,agent.*
+          required: false
+          description: Comma-separated event type filters with glob support (e.g. property.*)
+          name: types
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+            description: Max events per page (default 100, max 10,000)
+          required: false
+          description: Max events per page (default 100, max 10,000)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Feed page
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        event_id:
+                          type: string
+                          format: uuid
+                        event_type:
+                          type: string
+                          example: property.created
+                        entity_type:
+                          type: string
+                          example: property
+                        entity_id:
+                          type: string
+                        payload:
+                          type: object
+                          additionalProperties: {}
+                        actor:
+                          type: string
+                        created_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - event_id
+                        - event_type
+                        - entity_type
+                        - entity_id
+                        - payload
+                        - actor
+                        - created_at
+                  cursor:
+                    type:
+                      - string
+                      - "null"
+                    format: uuid
+                    description: Pass as cursor in the next request to continue polling
+                  has_more:
+                    type: boolean
+                  freshness:
+                    type: object
+                    properties:
+                      generated_at:
+                        type: string
+                        format: date-time
+                        description: Server timestamp when this feed page was generated.
+                      latest_event_created_at:
+                        type:
+                          - string
+                          - "null"
+                        format: date-time
+                        description: Newest event creation timestamp currently visible in the feed for the requested type filter. Null when no matching event exists inside retention.
+                      lag_seconds:
+                        type:
+                          - integer
+                          - "null"
+                        minimum: 0
+                        description: Seconds between generated_at and latest_event_created_at. Null when no matching event exists.
+                      retention_days:
+                        type: integer
+                        exclusiveMinimum: 0
+                        description: Number of days the registry retains feed cursors and events.
+                    required:
+                      - generated_at
+                      - latest_event_created_at
+                      - lag_seconds
+                      - retention_days
+                required:
+                  - events
+                  - cursor
+                  - has_more
+                  - freshness
+        "400":
+          description: Invalid cursor format or type filter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "410":
+          description: Cursor expired (older than 90-day retention window)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum:
+                      - cursor_expired
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/registry/feed/stream:
+    get:
+      operationId: streamRegistryFeed
+      summary: Registry change feed stream
+      description: "Subscribe to registry feed pages over Server-Sent Events. This is a push-friendly transport for the same cursor contract as `/api/registry/feed`: clients still persist `cursor`, apply only feed events, and recover from `cursor_expired` by re-bootstrapping. The stream emits `feed` events containing a full feed page, `heartbeat` events while caught up, and `error` before closing when the cursor expires or the server cannot query the feed."
+      tags:
+        - Change Feed
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Resume after this event ID
+          required: false
+          description: Resume after this event ID
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated event type filters with glob support (e.g. property.*)
+            example: authorization.*,publisher.adagents_changed
+          required: false
+          description: Comma-separated event type filters with glob support (e.g. property.*)
+          name: types
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+            description: Max events per SSE feed page (default 100, max 10,000)
+          required: false
+          description: Max events per SSE feed page (default 100, max 10,000)
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            minimum: 5
+            maximum: 60
+            description: Server-side interval while caught up (default 15 seconds). Backlog pages are sent without waiting.
+          required: false
+          description: Server-side interval while caught up (default 15 seconds). Backlog pages are sent without waiting.
+          name: poll_interval_seconds
+          in: query
+      responses:
+        "200":
+          description: "SSE stream. `event: feed` data validates as a registry feed page."
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: Server-Sent Events stream. `feed` events carry JSON matching the RegistryFeedPage schema; `heartbeat` events carry `{ generated_at, cursor }`.
+        "400":
+          description: Invalid cursor format, type filter, limit, or poll interval
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "410":
+          description: Initial cursor expired
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum:
+                      - cursor_expired
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/registry/authorizations:
+    get:
+      operationId: getAgentAuthorizations
+      summary: Per-agent authorization pull
+      description: |-
+        Default endpoint for verification consumers (DSPs, sales houses, agencies). Returns the rows where the requested agent appears as `agent_url` — typically ≤ a few hundred. Pair with `/api/registry/feed?entity_type=authorization` to tail subsequent changes via the `X-Sync-Cursor` header.
+
+        **evidence** defaults to `adagents_json` only. `agent_claim` is opt-in (`?evidence=adagents_json,agent_claim`) to prevent buy-side trust misuse — see specs/registry-authorization-model.md.
+      tags:
+        - Change Feed
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: Agent URL to look up. Canonicalized server-side (lowercased, trailing slashes trimmed).
+          required: true
+          description: Agent URL to look up. Canonicalized server-side (lowercased, trailing slashes trimmed).
+          name: agent_url
+          in: query
+        - schema:
+            type: string
+            enum:
+              - raw
+              - effective
+            description: "`effective` (default) applies override layer; `raw` reads base table."
+          required: false
+          description: "`effective` (default) applies override layer; `raw` reads base table."
+          name: include
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated evidence allowlist. Defaults to `adagents_json`.
+            example: adagents_json,agent_claim
+          required: false
+          description: Comma-separated evidence allowlist. Defaults to `adagents_json`.
+          name: evidence
+          in: query
+      responses:
+        "200":
+          description: Authorization rows for the agent.
+          headers:
+            X-Sync-Cursor:
+              description: UUIDv7 cursor for the authorization change feed at snapshot time. Pass to /api/registry/feed?entity_type=authorization&cursor=<value>.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  evidence:
+                    type: array
+                    items:
+                      type: string
+                  include:
+                    type: string
+                    enum:
+                      - raw
+                      - effective
+                  rows:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        agent_url:
+                          type: string
+                        agent_url_canonical:
+                          type: string
+                        property_rid:
+                          type:
+                            - string
+                            - "null"
+                          format: uuid
+                        property_id_slug:
+                          type:
+                            - string
+                            - "null"
+                        publisher_domain:
+                          type:
+                            - string
+                            - "null"
+                        authorized_for:
+                          type:
+                            - string
+                            - "null"
+                        evidence:
+                          type: string
+                        disputed:
+                          type: boolean
+                        created_by:
+                          type:
+                            - string
+                            - "null"
+                        expires_at:
+                          type:
+                            - string
+                            - "null"
+                          format: date-time
+                        created_at:
+                          type: string
+                          format: date-time
+                        updated_at:
+                          type: string
+                          format: date-time
+                        override_applied:
+                          type: boolean
+                        override_reason:
+                          type:
+                            - string
+                            - "null"
+                      required:
+                        - id
+                        - agent_url
+                        - agent_url_canonical
+                        - property_rid
+                        - property_id_slug
+                        - publisher_domain
+                        - authorized_for
+                        - evidence
+                        - disputed
+                        - created_by
+                        - expires_at
+                        - created_at
+                        - updated_at
+                        - override_applied
+                        - override_reason
+                  count:
+                    type: integer
+                required:
+                  - agent_url
+                  - evidence
+                  - include
+                  - rows
+                  - count
+        "400":
+          description: Validation error (missing/empty agent_url, unknown evidence, unknown include)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/authorizations/snapshot:
+    get:
+      operationId: getAgentAuthorizationsSnapshot
+      summary: Bootstrap snapshot for inline verifiers
+      description: |-
+        Streams the full effective authorization set as gzipped NDJSON (one JSON object per line). Consumers persist `X-Sync-Cursor` and tail `/api/registry/feed?entity_type=authorization&cursor=<value>` for deltas.
+
+        **ETag** is the hash of the X-Sync-Cursor — clients can `If-None-Match` to skip a re-pull when nothing has changed. **evidence** defaults to `adagents_json` only; long-run wire size ~150 MB gzipped.
+      tags:
+        - Change Feed
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - raw
+              - effective
+            description: "`effective` (default) applies override layer; `raw` reads base table."
+          required: false
+          description: "`effective` (default) applies override layer; `raw` reads base table."
+          name: include
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated evidence allowlist. Defaults to `adagents_json`.
+            example: adagents_json,agent_claim
+          required: false
+          description: Comma-separated evidence allowlist. Defaults to `adagents_json`.
+          name: evidence
+          in: query
+      responses:
+        "200":
+          description: gzipped NDJSON stream — one authorization row per line.
+          headers:
+            X-Sync-Cursor:
+              description: UUIDv7 cursor for the authorization change feed at snapshot time.
+              schema:
+                type: string
+            ETag:
+              description: Hash of X-Sync-Cursor; clients can If-None-Match.
+              schema:
+                type: string
+            Content-Encoding:
+              description: gzip
+              schema:
+                type: string
+          content:
+            application/x-ndjson:
+              schema:
+                type: string
+                description: Newline-delimited JSON, gzip-compressed.
+        "304":
+          description: Not modified — cursor unchanged from If-None-Match.
+        "400":
+          description: Validation error (unknown evidence, unknown include)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/search:
+    get:
+      operationId: searchAgentProfiles
+      summary: Search agent inventory profiles
+      description: Search agents by inventory profile — channels, markets, content categories, property types, and more. Filters use AND across dimensions and OR within a dimension. Results are ranked by relevance score.
+      tags:
+        - Agent Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: Comma-separated channel filter
+            example: ctv,olv
+          required: false
+          description: Comma-separated channel filter
+          name: channels
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated property type filter
+            example: ctv_app,website
+          required: false
+          description: Comma-separated property type filter
+          name: property_types
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated market/country code filter
+            example: US,GB
+          required: false
+          description: Comma-separated market/country code filter
+          name: markets
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated IAB content category filter
+            example: IAB-7,IAB-7-1
+          required: false
+          description: Comma-separated IAB content category filter
+          name: categories
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated tag filter
+            example: premium
+          required: false
+          description: Comma-separated tag filter
+          name: tags
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated delivery type filter
+            example: guaranteed,programmatic
+          required: false
+          description: Comma-separated delivery type filter
+          name: delivery_types
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+            description: Require TMP support
+          required: false
+          description: Require TMP support
+          name: has_tmp
+          in: query
+        - schema:
+            type:
+              - integer
+              - "null"
+            minimum: 0
+            description: Minimum number of properties in inventory
+          required: false
+          description: Minimum number of properties in inventory
+          name: min_properties
+          in: query
+        - schema:
+            type: string
+            description: Pagination cursor from a previous response
+          required: false
+          description: Pagination cursor from a previous response
+          name: cursor
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            description: Max results per page (default 50, max 200)
+          required: false
+          description: Max results per page (default 50, max 200)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Search results ranked by relevance
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        agent_url:
+                          type: string
+                          format: uri
+                        channels:
+                          type: array
+                          items:
+                            type: string
+                        property_types:
+                          type: array
+                          items:
+                            type: string
+                        markets:
+                          type: array
+                          items:
+                            type: string
+                        categories:
+                          type: array
+                          items:
+                            type: string
+                        tags:
+                          type: array
+                          items:
+                            type: string
+                        delivery_types:
+                          type: array
+                          items:
+                            type: string
+                        format_ids:
+                          type: array
+                          items: {}
+                          description: Creative format identifiers supported by this agent
+                        property_count:
+                          type: integer
+                        publisher_count:
+                          type: integer
+                        has_tmp:
+                          type: boolean
+                        category_taxonomy:
+                          type:
+                            - string
+                            - "null"
+                        relevance_score:
+                          type: number
+                        matched_filters:
+                          type: array
+                          items:
+                            type: string
+                        updated_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - agent_url
+                        - channels
+                        - property_types
+                        - markets
+                        - categories
+                        - tags
+                        - delivery_types
+                        - format_ids
+                        - property_count
+                        - publisher_count
+                        - has_tmp
+                        - category_taxonomy
+                        - relevance_score
+                        - matched_filters
+                        - updated_at
+                  cursor:
+                    type:
+                      - string
+                      - "null"
+                  has_more:
+                    type: boolean
+                required:
+                  - results
+                  - cursor
+                  - has_more
+        "400":
+          description: Invalid cursor or parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/crawl-request:
+    post:
+      operationId: requestCrawl
+      summary: Request domain re-crawl
+      description: |-
+        Trigger an immediate re-crawl of a publisher domain after updating adagents.json. The crawl runs asynchronously — returns 202 immediately.
+
+        **Rate limits:** 5 minutes per domain, 30 requests per user per hour.
+      tags:
+        - Agent Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: examplepub.com
+                  description: Publisher domain to re-crawl
+              required:
+                - domain
+      responses:
+        "202":
+          description: Crawl request accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Crawl request accepted
+                  domain:
+                    type: string
+                required:
+                  - message
+                  - domain
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
+  /api/registry/manager-revalidation-request:
+    post:
+      operationId: requestManagerRevalidation
+      summary: Request manager fan-out re-validation
+      description: |-
+        Trigger re-validation of every publisher delegating to a manager domain via ads.txt `MANAGERDOMAIN`. Use after rotating the manager's `adagents.json` so the change propagates to delegating publishers without waiting for the next routine crawl cycle. Work is queued and drained at a bounded rate (≈50 publishers per 5-minute tick). Returns 202 immediately with the number of publishers enqueued.
+
+        **Rate limits:** 5 minutes per manager domain, 30 requests per user per hour (shared with other crawl-request endpoints).
+      tags:
+        - Agent Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                manager_domain:
+                  type: string
+                  example: raptive.com
+                  description: Manager domain whose delegating publishers should be queued for re-validation. Must already be present as `manager_domain` on at least one publisher row.
+              required:
+                - manager_domain
+      responses:
+        "202":
+          description: Re-validation queue request accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Manager re-validation enqueued
+                  manager_domain:
+                    type: string
+                  publishers_enqueued:
+                    type: integer
+                    description: Number of delegating publisher rows added to or refreshed in the manager_revalidation_queue. Zero if no publisher delegates to this manager.
+                required:
+                  - message
+                  - manager_domain
+                  - publishers_enqueued
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
+  /api/registry/brand-crawl-request:
+    post:
+      operationId: requestBrandCrawl
+      summary: Request brand.json re-crawl
+      description: |-
+        Trigger an immediate re-crawl of a domain's brand.json. The crawl runs asynchronously — returns 202 immediately.
+
+        **Rate limits:** 5 minutes per domain, 30 requests per user per hour (shared with adagents.json crawl requests).
+      tags:
+        - Brand Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: examplebrand.com
+                  description: Domain to re-crawl brand.json for
+              required:
+                - domain
+      responses:
+        "202":
+          description: Brand crawl request accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Brand crawl request accepted
+                  domain:
+                    type: string
+                required:
+                  - message
+                  - domain
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
+  /api/registry/agents/{encodedUrl}/compliance:
+    get:
+      operationId: getAgentCompliance
+      summary: Get agent compliance detail
+      description: |-
+        Returns detailed compliance status for a single agent, including track-level results, storyboard counts, and timestamps.
+
+        If the agent has opted out of compliance monitoring, returns a minimal response with `status: opted_out`.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+            example: https%3A%2F%2Fexample.com%2Fmcp
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Compliance detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentComplianceDetail"
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/.well-known/jwks.json:
+    get:
+      operationId: getJwks
+      summary: AAO public key set
+      description: Returns the JSON Web Key Set (JWKS) containing AAO's public verification keys. Use these to verify AAO Verified badge tokens without calling AAO's API.
+      tags:
+        - Agent Compliance
+      responses:
+        "200":
+          description: JWKS response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  keys:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: {}
+                required:
+                  - keys
+  /api/registry/agents/{encodedUrl}/verification:
+    get:
+      operationId: getAgentVerification
+      summary: Get agent AAO Verified status
+      description: Returns AAO Verified badge status for a single agent. Public and cacheable. Includes role badges, verified storyboards, and a link to the agent's registry listing.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+            example: https%3A%2F%2Fexample.com%2Fmcp
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Verification status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentVerification"
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/badge/{role}.svg:
+    get:
+      operationId: getAgentBadgeSvg
+      summary: Get agent verification badge SVG
+      description: Returns an SVG badge image for the specified agent and role. Shows 'AAO Verified | Sales Agent' (teal) when verified, or 'AAO Verified | Not Verified' (grey) when not. Cacheable, suitable for embedding in websites.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Badge role (sales, buying, creative, governance, signals, measurement)
+          required: true
+          description: Badge role (sales, buying, creative, governance, signals, measurement)
+          name: role
+          in: path
+      responses:
+        "200":
+          description: SVG badge image
+          content:
+            image/svg+xml:
+              schema:
+                type: string
+        "400":
+          description: Invalid agent URL
+        "500":
+          description: Server error
+  /api/registry/agents/{encodedUrl}/badge/{role}/embed:
+    get:
+      operationId: getAgentBadgeEmbed
+      summary: Get embeddable badge code
+      description: Returns HTML and Markdown embed snippets for displaying an AAO Verified badge on websites, social profiles, and documentation. The badge links to the agent's AAO registry listing.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Badge role
+          required: true
+          description: Badge role
+          name: role
+          in: path
+      responses:
+        "200":
+          description: Embed code
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  role:
+                    type: string
+                  badge_svg_url:
+                    type: string
+                  registry_url:
+                    type: string
+                  html:
+                    type: string
+                  markdown:
+                    type: string
+                required:
+                  - agent_url
+                  - role
+                  - badge_svg_url
+                  - registry_url
+                  - html
+                  - markdown
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/badge/{role}/{version}.svg:
+    get:
+      operationId: getAgentBadgeVersionedSvg
+      summary: Get version-pinned agent verification badge SVG
+      description: Returns an SVG badge image scoped to a specific AdCP release (MAJOR.MINOR, e.g. '3.0'). Buyers who want to call out 'verified for 3.0' embed this instead of the legacy `/badge/{role}.svg` (which auto-upgrades to the highest active version). Renders 'Not Verified' when the agent never earned a badge at this version.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Badge role (media-buy, creative, signals, governance, brand, sponsored-intelligence)
+          required: true
+          description: Badge role (media-buy, creative, signals, governance, brand, sponsored-intelligence)
+          name: role
+          in: path
+        - schema:
+            type: string
+            description: AdCP release as MAJOR.MINOR (e.g. '3.0', '3.1')
+          required: true
+          description: AdCP release as MAJOR.MINOR (e.g. '3.0', '3.1')
+          name: version
+          in: path
+      responses:
+        "200":
+          description: SVG badge image
+          content:
+            image/svg+xml:
+              schema:
+                type: string
+        "400":
+          description: Invalid agent URL, role, or version
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+  /api/registry/agents/{encodedUrl}/badge/{role}/{version}/embed:
+    get:
+      operationId: getAgentBadgeVersionedEmbed
+      summary: Get version-pinned embeddable badge code
+      description: Returns HTML and Markdown embed snippets that point at the version-pinned SVG. Alt text includes the version (e.g. 'AAO Verified Media Buy Agent 3.0'). Buyers who want to freeze on a specific AdCP release embed these instead of the legacy `/badge/{role}/embed`.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Badge role
+          required: true
+          description: Badge role
+          name: role
+          in: path
+        - schema:
+            type: string
+            description: AdCP release as MAJOR.MINOR
+          required: true
+          description: AdCP release as MAJOR.MINOR
+          name: version
+          in: path
+      responses:
+        "200":
+          description: Embed code
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  role:
+                    type: string
+                  verified:
+                    type: boolean
+                  adcp_version:
+                    type: string
+                  badge_svg_url:
+                    type: string
+                  registry_url:
+                    type: string
+                  html:
+                    type: string
+                  markdown:
+                    type: string
+                required:
+                  - agent_url
+                  - role
+                  - verified
+                  - badge_svg_url
+                  - registry_url
+                  - html
+                  - markdown
+        "400":
+          description: Invalid agent URL, role, or version
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/storyboard-status:
+    get:
+      operationId: getAgentStoryboardStatus
+      summary: Get agent storyboard status
+      description: |-
+        Returns per-storyboard test results for an agent. Includes title, category, track, pass/fail status, and step counts.
+
+        **Members only** — requires authentication and an active membership. Static admin API key callers may read this for support/debugging.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+            example: https%3A%2F%2Fexample.com%2Fmcp
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Storyboard status for the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  storyboards:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/StoryboardStatus"
+                  passing_count:
+                    type: integer
+                  total_count:
+                    type: integer
+                required:
+                  - agent_url
+                  - storyboards
+                  - passing_count
+                  - total_count
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Members only
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  members_only:
+                    type: boolean
+                required:
+                  - error
+                  - members_only
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/storyboard-status:
+    post:
+      operationId: bulkAgentStoryboardStatus
+      summary: Bulk storyboard status
+      description: |-
+        Returns per-storyboard test results for multiple agents in a single request.
+
+        **Members only** — requires authentication and an active membership. Static admin API key callers may read this for support/debugging. Maximum 100 agent URLs per request.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                agent_urls:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 100
+                  description: Agent URLs to fetch storyboard status for
+              required:
+                - agent_urls
+      responses:
+        "200":
+          description: Storyboard status keyed by agent URL
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agents:
+                    type: object
+                    additionalProperties:
+                      anyOf:
+                        - type: array
+                          items:
+                            $ref: "#/components/schemas/StoryboardStatus"
+                        - type: object
+                          properties:
+                            status:
+                              type: string
+                              enum:
+                                - opted_out
+                          required:
+                            - status
+                  invalid_urls:
+                    type: integer
+                    description: Count of invalid URLs that were skipped
+                required:
+                  - agents
+        "400":
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Members only
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  members_only:
+                    type: boolean
+                required:
+                  - error
+                  - members_only
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/compliance/history:
+    get:
+      operationId: getAgentComplianceHistory
+      summary: Get agent compliance history
+      description: |-
+        Returns a list of compliance test runs for an agent, ordered most recent first.
+
+        If the agent has opted out, returns an empty list.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Max results (default 30, max 100)
+          required: false
+          description: Max results (default 30, max 100)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Compliance run history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  runs:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ComplianceRun"
+                  count:
+                    type: integer
+                required:
+                  - agent_url
+                  - runs
+                  - count
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/lifecycle:
+    put:
+      operationId: updateAgentLifecycle
+      summary: Update agent lifecycle stage
+      description: Set the lifecycle stage for an agent. Requires authentication and ownership of the agent.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                lifecycle_stage:
+                  type: string
+                  enum:
+                    - development
+                    - testing
+                    - production
+                    - deprecated
+              required:
+                - lifecycle_stage
+      responses:
+        "200":
+          description: Updated metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegistryMetadata"
+        "400":
+          description: Invalid agent URL or lifecycle stage
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/compliance/opt-out:
+    put:
+      operationId: updateAgentComplianceOptOut
+      summary: Update compliance opt-out
+      description: Opt an agent in or out of public compliance reporting. Requires authentication and ownership of the agent.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                opt_out:
+                  type: boolean
+              required:
+                - opt_out
+      responses:
+        "200":
+          description: Updated metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegistryMetadata"
+        "400":
+          description: Invalid agent URL or opt_out value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/settings:
+    get:
+      operationId: getAgentMonitoringSettings
+      summary: Get monitoring settings
+      description: Returns the monitoring configuration for an agent. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Monitoring settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitoringSettings"
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/pause:
+    put:
+      operationId: updateAgentMonitoringPause
+      summary: Pause or resume monitoring
+      description: Pause or resume automated compliance monitoring for an agent. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                paused:
+                  type: boolean
+              required:
+                - paused
+      responses:
+        "200":
+          description: Updated monitoring settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitoringSettings"
+        "400":
+          description: Invalid agent URL or paused value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/interval:
+    put:
+      operationId: updateAgentMonitoringInterval
+      summary: Update monitoring interval
+      description: Set the check interval for automated compliance monitoring (6–168 hours). Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                interval_hours:
+                  type: integer
+                  minimum: 6
+                  maximum: 168
+              required:
+                - interval_hours
+      responses:
+        "200":
+          description: Updated monitoring settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitoringSettings"
+        "400":
+          description: Invalid agent URL or interval
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/requeue:
+    post:
+      operationId: requeueAgentForHeartbeat
+      summary: Requeue agent for compliance heartbeat
+      description: Clears the agent's last_checked_at timestamp so it is picked up on the next heartbeat cycle (within ~1 hour). This is queued-async; it does not run the compliance suite synchronously or change the current verdict until the heartbeat completes. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Agent requeued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  requeued:
+                    type: boolean
+                required:
+                  - requeued
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limited
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/compliance/diagnostics:
+    get:
+      operationId: getAgentComplianceStepDiagnostics
+      summary: Get per-step diagnostics for a compliance run
+      description: |-
+        Returns the exact request and response payloads the runner captured for failing storyboard steps on a single compliance run.
+
+        Lets agent owners diff what the runner sent against their own probes without re-running the storyboard. Owner-only, with static admin API key access for support/debugging — payloads echo seller-side account/brand identifiers and may carry sensitive descriptive fields. If `run_id` is omitted, resolves to the latest run for the agent.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Specific compliance run UUID. Defaults to latest.
+          required: false
+          description: Specific compliance run UUID. Defaults to latest.
+          name: run_id
+          in: query
+        - schema:
+            type: string
+            description: Max rows (default 500, max 1000)
+          required: false
+          description: Max rows (default 500, max 1000)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Per-step diagnostics for the requested run
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  run_id:
+                    type:
+                      - string
+                      - "null"
+                  count:
+                    type: integer
+                  diagnostics:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ComplianceStepDiagnostic"
+                required:
+                  - agent_url
+                  - run_id
+                  - count
+                  - diagnostics
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/requests:
+    get:
+      operationId: getAgentMonitoringRequests
+      summary: Get outbound request log
+      description: Returns the outbound request log for an agent (compliance checks, health probes, etc.). Requires authentication and ownership, or the static admin API key for support/debugging.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Max results (default 50, max 200)
+          required: false
+          description: Max results (default 50, max 200)
+          name: limit
+          in: query
+        - schema:
+            type: string
+            description: ISO 8601 timestamp to filter from
+          required: false
+          description: ISO 8601 timestamp to filter from
+          name: since
+          in: query
+      responses:
+        "200":
+          description: Outbound request log
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  requests:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/OutboundRequest"
+                  count:
+                    type: integer
+                  total:
+                    type: integer
+                required:
+                  - agent_url
+                  - requests
+                  - count
+                  - total
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/refresh:
+    post:
+      operationId: refreshAgent
+      summary: Refresh agent snapshot
+      description: |-
+        Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).
+
+        **Compliance re-run:** when the caller owns the agent or is an AAO admin and the capability probe succeeds, the full storyboard suite can run for several minutes on capability-rich agents with a fresh test session, and `agent_storyboard_status` is updated. Owner-triggered runs use `triggered_by: 'owner_test'`; admin-triggered support runs use `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.
+
+        **Auth:** owner of the agent, AAO admin, or static `ADMIN_API_KEY`.
+
+        **Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+            example: https%3A%2F%2Fvastlint.org%2Fmcp
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Snapshot refreshed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  online:
+                    type: boolean
+                  tools_count:
+                    type:
+                      - integer
+                      - "null"
+                  response_time_ms:
+                    type:
+                      - integer
+                      - "null"
+                  inferred_type:
+                    type: string
+                    description: Type inferred from discovered tools (sales, creative, signals, governance, etc.) or 'unknown'
+                  type_promoted:
+                    type: boolean
+                    description: True when registry type was upgraded from unknown to inferred_type
+                  oauth_required:
+                    type: boolean
+                  checked_at:
+                    type: string
+                  error:
+                    type: string
+                  compliance:
+                    type: object
+                    properties:
+                      ran:
+                        type: boolean
+                        description: True if the full storyboard suite ran and agent_storyboard_status was updated. False when ownership couldn't be resolved, the agent reported auth_required, or the compliance call itself failed.
+                      run_id:
+                        type: string
+                        description: Compliance run id written by this refresh. Use with /compliance/diagnostics?run_id=... to inspect failing-step wire evidence.
+                      test_session_id:
+                        type: string
+                        description: Fresh test session id used for the compliance run. Useful when matching seller-side logs to the refresh.
+                      requested_compliance_target:
+                        type: string
+                        description: Requested compliance target before alias resolution, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta. Present when `ran` is true.
+                      adcp_version:
+                        type: string
+                        description: Concrete AdCP compliance bundle version used for the run, e.g. 3.0.12 or 3.1.0-beta.7. Present when `ran` is true.
+                      badge_eligible:
+                        type: boolean
+                        description: True when this run can update public badge state.
+                      badge_eligible_adcp_versions:
+                        type: array
+                        items:
+                          type: string
+                        description: Public badge versions this run can issue, e.g. ['3.0'].
+                      overall_status:
+                        type: string
+                        description: Aggregate verdict from the run (passing / failing / partial / unknown). Only present when `ran` is true.
+                      storyboards_passing:
+                        type: integer
+                        description: Number of storyboards passing on this run.
+                      storyboards_total:
+                        type: integer
+                        description: Number of storyboards evaluated on this run.
+                      observations_count:
+                        type: integer
+                        description: Number of advisory observations emitted by this run.
+                      notices_count:
+                        type: integer
+                        description: Number of run-summary notices emitted by this run.
+                      error:
+                        type: string
+                        description: Reason compliance didn't run when `ran` is false.
+                    required:
+                      - ran
+                    description: Compliance re-run summary. The capability/health portion of the response is independent of this block — a failed compliance run still returns the rest of the snapshot.
+                required:
+                  - online
+                  - tools_count
+                  - response_time_ms
+                  - inferred_type
+                  - type_promoted
+                  - oauth_required
+                  - checked_at
+                  - compliance
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized — must be owner or AAO admin
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Monitoring paused for this agent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
+        "502":
+          description: Probe failed (timeout, DNS, OAuth wall, etc.)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/auth-status:
+    get:
+      operationId: getAgentAuthStatus
+      summary: Get agent auth status
+      description: Returns whether an agent has stored authentication credentials and OAuth token status. Requires authentication.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Auth status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentAuthStatus"
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/connect:
+    put:
+      operationId: connectAgent
+      summary: Connect agent credentials
+      description: Store authentication credentials for an agent. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                auth_token:
+                  type: string
+                  maxLength: 4096
+                  description: Bearer or basic auth token
+                auth_type:
+                  type: string
+                  enum:
+                    - bearer
+                    - basic
+                  description: "Auth type (default: bearer)"
+      responses:
+        "200":
+          description: Connection result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+                    enum:
+                      - true
+                  has_auth:
+                    type: boolean
+                  agent_context_id:
+                    type: string
+                required:
+                  - connected
+                  - has_auth
+                  - agent_context_id
+        "400":
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/oauth-client-credentials:
+    put:
+      operationId: saveAgentOAuthClientCredentials
+      summary: Save OAuth 2.0 client-credentials for an agent
+      description: Store a machine-to-machine OAuth 2.0 client-credentials configuration (RFC 6749 §4.4) for this agent. The SDK exchanges at the token endpoint before every call and refreshes on 401. `client_secret` may be a `$ENV:VAR_NAME` reference — the SDK resolves at exchange time, the server stores it as written (encrypted uniformly). Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token_endpoint:
+                  type: string
+                  maxLength: 2048
+                  description: Token endpoint URL (HTTPS required; localhost allowed in dev).
+                client_id:
+                  type: string
+                  maxLength: 2048
+                  description: OAuth client ID. May be a `$ENV:VAR_NAME` reference.
+                client_secret:
+                  type: string
+                  maxLength: 8192
+                  description: OAuth client secret. May be a `$ENV:VAR_NAME` reference. Stored encrypted at rest.
+                scope:
+                  type: string
+                  maxLength: 1024
+                  description: Space-separated OAuth scope values.
+                resource:
+                  type: string
+                  maxLength: 2048
+                  description: RFC 8707 resource indicator.
+                audience:
+                  type: string
+                  maxLength: 2048
+                  description: Audience parameter for audience-validating authorization servers.
+                auth_method:
+                  type: string
+                  enum:
+                    - basic
+                    - body
+                  description: "Client-credentials placement: basic (HTTP Basic header, RFC 6749 §2.3.1 preferred) or body (form fields). SDK default is basic."
+              required:
+                - token_endpoint
+                - client_id
+                - client_secret
+      responses:
+        "200":
+          description: Credentials saved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+                    enum:
+                      - true
+                  has_auth:
+                    type: boolean
+                    enum:
+                      - true
+                  agent_context_id:
+                    type: string
+                  auth_type:
+                    type: string
+                    enum:
+                      - oauth_client_credentials
+                required:
+                  - connected
+                  - has_auth
+                  - agent_context_id
+                  - auth_type
+        "400":
+          description: Invalid parameters — response carries `code` and `field` pointing to the rejection cause.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialSaveValidationError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/oauth-client-credentials/test:
+    post:
+      operationId: testAgentOAuthClientCredentials
+      summary: Dry-run the saved OAuth 2.0 client-credentials config
+      description: Exchange the saved client_credentials at the token endpoint and discard the resulting access token. Returns success + latency on a 2xx exchange, or the SDK's `ClientCredentialsExchangeError` kind (`oauth`, `malformed`, `network`) on failure so operators get same-second feedback instead of waiting for the next compliance heartbeat. Requires authentication and ownership. Requires credentials to already be saved via `PUT /oauth-client-credentials`.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: "Result of the token exchange. `ok: true` on 2xx from the AS; `ok: false` with a typed error otherwise (HTTP response itself is still 200 — the error payload carries the rejection kind so UI can branch on it)."
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      latency_ms:
+                        type: integer
+                    required:
+                      - ok
+                      - latency_ms
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - false
+                      latency_ms:
+                        type: integer
+                      error:
+                        type: object
+                        properties:
+                          kind:
+                            type: string
+                            enum:
+                              - oauth
+                              - malformed
+                              - network
+                            description: "Category of failure: `oauth` = AS returned a typed error (e.g. invalid_client), `malformed` = AS returned an unexpected 2xx payload, `network` = couldn't reach the AS."
+                          message:
+                            type: string
+                          oauth_error:
+                            type: string
+                            description: RFC 6749 `error` field when kind=oauth.
+                          oauth_error_description:
+                            type: string
+                            description: RFC 6749 `error_description` field when kind=oauth.
+                          http_status:
+                            type: integer
+                            description: Status code when the AS returned a non-2xx.
+                        required:
+                          - kind
+                          - message
+                    required:
+                      - ok
+                      - latency_ms
+                      - error
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No saved client-credentials config for this agent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/applicable-storyboards:
+    get:
+      operationId: getApplicableStoryboards
+      summary: Get applicable storyboards for agent
+      description: Probe the agent's get_adcp_capabilities and resolve its declared supported_protocols and specialisms to the compliance bundles that will run. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Bundles the agent will be tested against, driven by its declared capabilities
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                  adcp_version:
+                    type: string
+                  agent_name:
+                    type: string
+                  supported_protocols:
+                    type: array
+                    items:
+                      type: string
+                  specialisms:
+                    type: array
+                    items:
+                      type: string
+                  capabilities_probe_error:
+                    type: string
+                    description: Agent-reported probe error. Untrusted — sanitized and truncated to 500 chars. Present when get_adcp_capabilities was advertised but failed; empty bundle list usually indicates this, not a v2 agent.
+                  bundles:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        kind:
+                          type: string
+                          enum:
+                            - universal
+                            - domain
+                            - specialism
+                        id:
+                          type: string
+                        storyboards:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              title:
+                                type: string
+                              summary:
+                                type: string
+                              step_count:
+                                type: integer
+                            required:
+                              - id
+                              - title
+                              - summary
+                              - step_count
+                      required:
+                        - kind
+                        - id
+                        - storyboards
+                  total_storyboards:
+                    type: integer
+                required:
+                  - agent_url
+                  - requested_compliance_target
+                  - adcp_version
+                  - agent_name
+                  - supported_protocols
+                  - specialisms
+                  - bundles
+                  - total_storyboards
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "422":
+          description: Agent requires authentication, or declared capabilities cannot be resolved for the selected compliance target
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  error_kind:
+                    type: string
+                    enum:
+                      - specialism_parent_protocol_missing
+                      - unknown_specialism
+                      - unsupported_adcp_version
+                  needs_auth:
+                    type: boolean
+                  unknown_specialism:
+                    type: boolean
+                  specialism_parent_protocol_missing:
+                    type: boolean
+                  specialism:
+                    type: string
+                  parent_protocol:
+                    type: string
+                  compliance_version:
+                    type: string
+                  supported_versions:
+                    type: string
+                  declared_specialisms:
+                    type: array
+                    items:
+                      type: string
+                    description: Specialisms the agent declared, for unknown-specialism errors
+                  declared_protocols:
+                    type: array
+                    items:
+                      type: string
+                    description: Protocols the agent declared, for capability-resolution errors
+                  known_specialisms:
+                    type: array
+                    items:
+                      type: string
+                    description: Specialism ids present in this server's local compliance cache
+                required:
+                  - error
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  reason:
+                    type: string
+                    enum:
+                      - network
+                      - tls
+                      - timeout
+                      - protocol
+                      - unknown
+                    description: Coarse error classification for UI differentiation
+                required:
+                  - error
+        "504":
+          description: Connection timeout
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/storyboards:
+    get:
+      operationId: listStoryboards
+      summary: List storyboards
+      description: Returns the catalog of compliance storyboards. Optionally filter by category.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: Filter by storyboard category
+          required: false
+          description: Filter by storyboard category
+          name: category
+          in: query
+        - schema:
+            type: string
+            description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
+          required: false
+          description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
+          name: compliance_target
+          in: query
+      responses:
+        "200":
+          description: Storyboard catalog
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  adcp_version:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                  storyboards:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/StoryboardSummary"
+                  count:
+                    type: integer
+                required:
+                  - adcp_version
+                  - requested_compliance_target
+                  - storyboards
+                  - count
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/storyboards/{id}:
+    get:
+      operationId: getStoryboard
+      summary: Get storyboard detail
+      description: Returns a single storyboard with its full phase and step structure, plus its test kit if available.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: Storyboard ID
+          required: true
+          description: Storyboard ID
+          name: id
+          in: path
+        - schema:
+            type: string
+            description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
+          required: false
+          description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
+          name: compliance_target
+          in: query
+      responses:
+        "200":
+          description: Storyboard detail
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  adcp_version:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                  storyboard:
+                    $ref: "#/components/schemas/StoryboardDetail"
+                  test_kit: {}
+                required:
+                  - adcp_version
+                  - requested_compliance_target
+                  - storyboard
+        "404":
+          description: Storyboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/find:
+    get:
+      operationId: findBrand
+      summary: Find brands by name
+      description: Search for brands by name or domain. Returns matching results with basic identity info.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            minLength: 2
+            description: Search query (min 2 characters)
+          required: true
+          description: Search query (min 2 characters)
+          name: q
+          in: query
+        - schema:
+            type: string
+            description: Max results (default 10, max 50)
+          required: false
+          description: Max results (default 10, max 50)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FindCompanyResult"
+                required:
+                  - results
+        "400":
+          description: Query too short
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/setup-my-brand:
+    post:
+      operationId: setupMyBrand
+      summary: Set up a hosted brand.json
+      description: Create or update a hosted brand.json for a domain owned by the authenticated user's organization. Returns the hosted URL and a pointer snippet for DNS setup.
+      tags:
+        - Brand Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: acmecorp.com
+                brand_name:
+                  type: string
+                brand_json:
+                  type: object
+                  additionalProperties: {}
+                  description: Optional full brand.json draft to host in the registry
+                logo_url:
+                  type: string
+                brand_color:
+                  type: string
+              required:
+                - domain
+                - brand_name
+      responses:
+        "200":
+          description: Brand setup result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  has_brand_json:
+                    type: boolean
+                  hosted_brand_json_url:
+                    type: string
+                  pointer_snippet:
+                    type: string
+                    description: JSON string for brand.json pointer
+                required:
+                  - domain
+                  - has_brand_json
+                  - hosted_brand_json_url
+                  - pointer_snippet
+        "400":
+          description: Invalid domain or missing fields
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Domain not owned by user's organization
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/check/bulk:
+    post:
+      operationId: bulkPropertyCheck
+      summary: Bulk property identifier check
+      description: Check up to 10,000 property identifiers (domains, app bundle IDs, CTV store URLs) against the registry catalog. Returns a verdict for each identifier and a summary.
+      tags:
+        - Property Resolution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                identifiers:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 10000
+                  description: Property identifiers to check
+              required:
+                - identifiers
+      responses:
+        "200":
+          description: Check results with report ID
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      ready:
+                        type: integer
+                      known:
+                        type: integer
+                      ad_infra:
+                        type: integer
+                      unknown:
+                        type: integer
+                      skipped:
+                        type: integer
+                    required:
+                      - total
+                      - ready
+                      - known
+                      - ad_infra
+                      - unknown
+                      - skipped
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        input:
+                          type: string
+                        identifier:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                            - type
+                            - value
+                        verdict:
+                          type: string
+                        classification:
+                          type:
+                            - string
+                            - "null"
+                        source:
+                          type:
+                            - string
+                            - "null"
+                        property_rid:
+                          type:
+                            - string
+                            - "null"
+                        action:
+                          type: string
+                      required:
+                        - input
+                        - identifier
+                        - verdict
+                        - classification
+                        - source
+                        - property_rid
+                        - action
+                  report_id:
+                    type: string
+                required:
+                  - summary
+                  - entries
+                  - report_id
+        "400":
+          description: Invalid identifiers
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/check/bulk/{reportId}:
+    get:
+      operationId: getBulkPropertyCheckReport
+      summary: Get bulk check report
+      description: Retrieve a previously generated bulk property check report by ID.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            description: Report UUID
+          required: true
+          description: Report UUID
+          name: reportId
+          in: path
+      responses:
+        "200":
+          description: Report data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      ready:
+                        type: integer
+                      known:
+                        type: integer
+                      ad_infra:
+                        type: integer
+                      unknown:
+                        type: integer
+                      skipped:
+                        type: integer
+                    required:
+                      - total
+                      - ready
+                      - known
+                      - ad_infra
+                      - unknown
+                      - skipped
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        input:
+                          type: string
+                        identifier:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                            - type
+                            - value
+                        verdict:
+                          type: string
+                        classification:
+                          type:
+                            - string
+                            - "null"
+                        source:
+                          type:
+                            - string
+                            - "null"
+                        property_rid:
+                          type:
+                            - string
+                            - "null"
+                        action:
+                          type: string
+                      required:
+                        - input
+                        - identifier
+                        - verdict
+                        - classification
+                        - source
+                        - property_rid
+                        - action
+                required:
+                  - summary
+                  - entries
+        "404":
+          description: Report not found or expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/storyboard/{storyboardId}/step/{stepId}:
+    post:
+      operationId: runStoryboardStep
+      summary: Run a single storyboard step
+      description: Execute a single storyboard step against an agent. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: storyboardId
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: stepId
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                context:
+                  type: object
+                  additionalProperties: {}
+                  description: Optional context object for the step
+                dry_run:
+                  type: boolean
+                  description: "Dry run mode (default: true)"
+      responses:
+        "200":
+          description: Step execution result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  adcp_version:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                required:
+                  - adcp_version
+                  - requested_compliance_target
+                additionalProperties: {}
+        "400":
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Storyboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/storyboards/{storyboardId}/first-step:
+    get:
+      operationId: getStoryboardFirstStep
+      summary: Get first step preview
+      description: Returns a preview of the first step of a storyboard. No agent call needed.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: storyboardId
+          in: path
+        - schema:
+            type: string
+            description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
+          required: false
+          description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
+          name: compliance_target
+          in: query
+      responses:
+        "200":
+          description: First step preview
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  adcp_version:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                  storyboard:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      title:
+                        type: string
+                    required:
+                      - id
+                      - title
+                  step: {}
+                required:
+                  - adcp_version
+                  - requested_compliance_target
+                  - storyboard
+        "404":
+          description: Storyboard not found or has no steps
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/storyboard/{storyboardId}/run:
+    post:
+      operationId: runStoryboard
+      summary: Run full storyboard evaluation
+      description: Execute all steps of a storyboard against an agent and record the compliance result. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: storyboardId
+          in: path
+      responses:
+        "200":
+          description: Storyboard run result with annotated phases
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  storyboard:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      title:
+                        type: string
+                      category:
+                        type: string
+                      narrative:
+                        type: string
+                    required:
+                      - id
+                      - title
+                      - category
+                  agent:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      profile: {}
+                    required:
+                      - url
+                  adcp_version:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                  badge_eligible:
+                    type: boolean
+                  badge_eligible_adcp_versions:
+                    type: array
+                    items:
+                      type: string
+                  run_id:
+                    type: string
+                    description: Compliance run id written by this owner-triggered storyboard run.
+                  storyboard_status:
+                    type: object
+                    properties:
+                      storyboard_id:
+                        type: string
+                      status:
+                        type: string
+                        enum:
+                          - passing
+                          - failing
+                          - partial
+                          - untested
+                      steps_passed:
+                        type: integer
+                      steps_total:
+                        type: integer
+                      failure_count:
+                        type: integer
+                      skipped_count:
+                        type: integer
+                      first_failed_step_id:
+                        type:
+                          - string
+                          - "null"
+                      first_failed_step_title:
+                        type:
+                          - string
+                          - "null"
+                      first_failed_step_task:
+                        type:
+                          - string
+                          - "null"
+                      first_failure_message:
+                        type:
+                          - string
+                          - "null"
+                      first_failure_validations:
+                        type: array
+                        items: {}
+                    required:
+                      - storyboard_id
+                      - status
+                      - steps_passed
+                      - steps_total
+                      - failure_count
+                      - skipped_count
+                      - first_failed_step_id
+                      - first_failed_step_title
+                      - first_failed_step_task
+                      - first_failure_message
+                      - first_failure_validations
+                    description: Persisted storyboard verdict for this run, using the same executable-step semantics as agent_storyboard_status.
+                  phases: {}
+                  summary: {}
+                  diagnostics:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        run_id:
+                          type: string
+                        agent_url:
+                          type: string
+                        storyboard_id:
+                          type: string
+                        phase_id:
+                          type: string
+                        step_id:
+                          type: string
+                        task:
+                          type: string
+                        response_status:
+                          type:
+                            - integer
+                            - "null"
+                        error_text:
+                          type:
+                            - string
+                            - "null"
+                        failed_validations_jsonb: {}
+                        adcp_error_jsonb: {}
+                      required:
+                        - run_id
+                        - agent_url
+                        - storyboard_id
+                        - phase_id
+                        - step_id
+                        - task
+                    description: Owner-scoped failing-step validation summary for this run. Full request/response diagnostics remain available via /compliance/diagnostics?run_id=...
+                  observations: {}
+                  total_duration_ms:
+                    type: number
+                  test_kit: {}
+                required:
+                  - storyboard
+                  - agent
+                  - adcp_version
+                  - requested_compliance_target
+                  - badge_eligible
+                  - badge_eligible_adcp_versions
+                  - run_id
+                  - storyboard_status
+                  - diagnostics
+                  - total_duration_ms
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Storyboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/storyboard/{storyboardId}/compare:
+    post:
+      operationId: compareStoryboard
+      summary: Compare storyboard against reference agent
+      description: Run a storyboard against both the target agent and the public reference agent, returning side-by-side results. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: storyboardId
+          in: path
+      responses:
+        "200":
+          description: Side-by-side comparison results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  storyboard:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      title:
+                        type: string
+                      category:
+                        type: string
+                    required:
+                      - id
+                      - title
+                      - category
+                  user_agent:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      profile: {}
+                      summary: {}
+                    required:
+                      - url
+                  reference_agent:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      name:
+                        type: string
+                      profile: {}
+                      summary: {}
+                    required:
+                      - url
+                      - name
+                  adcp_version:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                  badge_eligible:
+                    type: boolean
+                  badge_eligible_adcp_versions:
+                    type: array
+                    items:
+                      type: string
+                  phases: {}
+                  total_duration_ms:
+                    type: number
+                required:
+                  - storyboard
+                  - user_agent
+                  - reference_agent
+                  - adcp_version
+                  - requested_compliance_target
+                  - badge_eligible
+                  - badge_eligible_adcp_versions
+                  - total_duration_ms
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Storyboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/me/agents:
+    get:
+      operationId: listMemberAgents
+      summary: List my registered agents
+      description: List the agents registered on the caller's organization member profile. Returns the same `agents[]` array stored on the profile, in the order members registered them.
+      tags:
+        - Member Agents
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+            example: org_01HXZAB123
+          required: false
+          description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+          name: org
+          in: query
+      responses:
+        "200":
+          description: Registered agents
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberAgentListResponse"
+        "400":
+          description: No organization associated with this account
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "`?org=` was supplied but the caller is not a member of that organization."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No member profile exists yet — create one via `POST /api/me/member-profile`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      operationId: registerMemberAgent
+      summary: Register an agent
+      description: |-
+        Register an agent on the caller's organization member profile.
+
+        Idempotent on `url`: re-posting the same `url` updates the entry in place rather than creating a duplicate. New entries return `201`; updates return `200`.
+
+        **True one-call storefront experience.** A third-party app holding only a user's OAuth token can `POST /api/me/agents` once and have the entire bootstrap chain materialize:
+
+        - If the caller has zero org memberships, the server auto-creates an organization (corporate or personal workspace based on the user's email domain) and the response includes `org_auto_created: true`.
+
+        - If the caller's org has no member profile, the server auto-creates a private profile (display name = organization name, `is_public: false`) and the response includes `profile_auto_created: true`.
+
+        Both auto-bootstraps are best-effort fallbacks. To customize org name / company_type / revenue_tier, or to control profile slug / brand identity / tagline, call `POST /api/organizations` and `POST /api/me/member-profile` explicitly before registering the agent. Tier transitions never happen via this path — go through the billing flow.
+
+        `type` is required and declared by the caller — the server does not infer it. Server-side smuggle protection still cross-checks the declared type against the agent's capability snapshot when one exists; if the snapshot contradicts the declaration without classifying it, the stored value is `unknown` and the dashboard surfaces the conflict for the owner to resolve.
+
+        `visibility: "public"` requires a paid AAO tier (Professional, Builder, Member, or Leader) and a verified primary domain on the organization (set via the Linked Domains UI). Non-API-tier callers (Explorer or no tier) who request `public` will have the entry stored as `members_only` instead, and the response will include a `visibility_downgraded` warning describing the coercion.
+      tags:
+        - Member Agents
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+            example: org_01HXZAB123
+          required: false
+          description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+          name: org
+          in: query
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MemberAgentInput"
+      responses:
+        "200":
+          description: Agent already registered at this `url`; entry updated in place.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberAgentResponse"
+        "201":
+          description: "Agent registered. When this is the first agent on a freshly created organization, the response includes `profile_auto_created: true`."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberAgentResponse"
+        "400":
+          description: Missing or invalid `url`, missing/invalid `type`, or the caller has memberships in other orgs but no primary org set — pass `?org=<id>` to target one explicitly. (Fresh users with no memberships at all hit the org auto-bootstrap path and do not see this error.)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "`?org=` was supplied but the caller is not a member of that organization."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Auto-bootstrap could not run (e.g. the organization has no name yet). Call `POST /api/me/member-profile` to create a profile explicitly, then retry.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/me/agents/{url}:
+    patch:
+      operationId: updateMemberAgent
+      summary: Update an agent
+      description: Update one registered agent identified by its `url`. The `url` field itself cannot be changed via PATCH — supplying a `url` in the body that differs from the path returns `400 url_immutable`; re-register at the new URL and DELETE the old entry to migrate. All other fields accept partial updates.
+      tags:
+        - Member Agents
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: The agent's `url`, URL-encoded (e.g. `https%3A%2F%2Fagent.example.com%2Fmcp`).
+          required: true
+          description: The agent's `url`, URL-encoded (e.g. `https%3A%2F%2Fagent.example.com%2Fmcp`).
+          name: url
+          in: path
+        - schema:
+            type: string
+            description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+            example: org_01HXZAB123
+          required: false
+          description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+          name: org
+          in: query
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MemberAgentPatch"
+      responses:
+        "200":
+          description: Agent updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberAgentResponse"
+        "400":
+          description: No organization associated with this account, or `body.url` differs from the path (`url_immutable`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "`?org=` was supplied but the caller is not a member of that organization."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No member profile, or no agent registered at the given `url`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      operationId: removeMemberAgent
+      summary: Remove an agent
+      description: |-
+        Remove one registered agent identified by its `url`.
+
+        A currently-`public` agent is reflected in the published `brand.json` manifest. To prevent the registry catalog and `brand.json` from silently disagreeing, this endpoint returns `409 unpublish_first` when the agent is `public` — `PATCH /api/me/agents/{url}` with `visibility: "private"` first (or call `DELETE /api/me/member-profile/agents/{index}/publish` to reconcile the manifest), then re-issue the DELETE.
+      tags:
+        - Member Agents
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: The agent's `url`, URL-encoded (e.g. `https%3A%2F%2Fagent.example.com%2Fmcp`).
+          required: true
+          description: The agent's `url`, URL-encoded (e.g. `https%3A%2F%2Fagent.example.com%2Fmcp`).
+          name: url
+          in: path
+        - schema:
+            type: string
+            description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+            example: org_01HXZAB123
+          required: false
+          description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+          name: org
+          in: query
+      responses:
+        "204":
+          description: Agent removed.
+        "400":
+          description: No organization associated with this account
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "`?org=` was supplied but the caller is not a member of that organization."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No member profile, or no agent registered at the given `url`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Agent is currently `public` and reflected in `brand.json`; unpublish first.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/organizations:
+    post:
+      operationId: createOrganization
+      summary: Create or adopt my organization
+      description: |-
+        Bootstrap the caller's organization explicitly. Use this when the caller wants to control the organization name, `company_type`, `revenue_tier`, or `is_personal` flag before any agents are registered.
+
+        **Most storefront-style integrations don't need this call** — `POST /api/me/agents` will auto-create an org for a fresh OAuth user (corporate or personal workspace based on the email domain) and surface `org_auto_created: true` in the response. Reach for `POST /api/organizations` only when the auto-derived defaults aren't acceptable.
+
+        Three outcomes depending on the caller's state:
+
+        - **Fresh create** (most common): a new WorkOS organization is created, the caller is added as `owner`, the corporate domain is recorded as email-verified, and ToS / privacy-policy acceptance is logged from the request context. Returns `{ success: true, organization: { id, name } }`.
+
+        - **Prospect adoption**: an organization with the caller's email domain already exists as a `prospect` (the registry pre-recorded it from a brand crawl but no human had claimed it yet). The caller is promoted to `owner` of the existing record instead of forking a duplicate. Returns `{ id, name, adopted: true }`.
+
+        - **Already-active conflict**: the org exists and is already claimed by another paying member or a previously joined user. Returns `409` with the existing org id so the caller can switch to a join-request flow (`POST /api/organizations/:orgId/join-requests`) instead of trying to register a duplicate.
+
+        Tier transitions happen via the billing flow only — there is no `membership_tier` field on this endpoint. After org creation, send the user to `POST /api/checkout-session` (or the `/dashboard/membership` page) to start a subscription; the Stripe webhook is the sole writer of `organizations.membership_tier`.
+
+        Rate-limited per user: `15` failed attempts per hour; successful calls do not count against the limit so a legitimate registration is never penalized by earlier validation errors.
+      tags:
+        - Onboarding
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateOrganizationInput"
+      responses:
+        "200":
+          description: "Prospect adoption — an existing prospect organization for this domain was claimed by the caller. Body is `{ id, name, adopted: true }`."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateOrganizationResponse"
+        "201":
+          description: "New organization created. Body is `{ success: true, organization: { id, name } }`. The caller is the `owner`; the corporate domain is recorded as email-verified for downstream registry calls."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateOrganizationResponse"
+        "400":
+          description: |-
+            One of:
+            - `organization_name` missing or invalid
+            - `company_type` / `revenue_tier` value not in the documented enum
+            - caller is on a personal-email domain (gmail.com, yahoo.com, …) and is trying to register a corporate org — register `is_personal: true` instead
+            - per-user organization cap reached (10 orgs per user)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: An active organization already exists for this caller's email domain. The body includes `existing_org_id` and `existing_org_name`; the caller should switch to the join-request flow rather than retrying.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded — 15 failed attempts per hour per user. Successful calls do not count against the limit.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+tags:
+  - name: Onboarding
+    description: Explicitly bootstrap a third-party integration into the AAO registry. Most callers don't need this tag — `POST /api/me/agents` auto-creates the org (for fresh users) and the member profile (for first-time agent registration) without a separate round trip. Use `POST /api/organizations` only when you need to override the auto-derived org name / company_type / revenue_tier. Tier transitions happen via the billing flow only; the Stripe webhook is the sole writer of `organizations.membership_tier`.
+  - name: Member Agents
+    description: Register, list, update, and remove agents on the caller's organization member profile. Authenticated programmatic surface for CI / scripts that don't want to round-trip the full member profile.
+  - name: Brand Resolution
+    description: Resolve advertiser domains to canonical brand identities.
+  - name: Property Resolution
+    description: Resolve publisher domains to their property configurations and authorized agents.
+  - name: Agent Discovery
+    description: Browse the federated agent network, search agent inventory profiles, publisher index, and registry statistics.
+  - name: Change Feed
+    description: Poll cursor-based registry change events for local sync.
+  - name: Lookups & Authorization
+    description: Look up agents by domain or property, and validate ad-serving authorization.
+  - name: Validation Tools
+    description: Validate publisher adagents.json files and generate compliant configurations.
+  - name: Community Mirrors
+    description: Publish, fetch, list, and retire catalog-only adagents.json mirrors for platforms that have not adopted AdCP.
+  - name: Search
+    description: Cross-entity search across brands, publishers, agents, and properties.
+  - name: Agent Probing
+    description: Connect to live agents and inspect their capabilities, formats, and inventory.
+  - name: Brand Discovery
+    description: Discover and crawl brand.json files across domains.
+  - name: Agent Compliance
+    description: Agent compliance status, storyboard test results, and compliance history.
+  - name: Policy Registry
+    description: Browse, resolve, and contribute governance policies for campaign compliance.

--- a/static/openapi/releases/3.2.0-beta.7/registry.yaml
+++ b/static/openapi/releases/3.2.0-beta.7/registry.yaml
@@ -1,0 +1,13638 @@
+openapi: 3.1.0
+info:
+  title: AgenticAdvertising.org Registry API
+  description: |-
+    REST API for the AgenticAdvertising.org registry. Resolve brands,
+    discover properties, look up agents, and validate authorization in the
+    AdCP ecosystem.
+
+    Most endpoints are public and require no authentication. Endpoints marked
+    with a lock icon accept either an organization API key or a user JWT
+    obtained via the OAuth 2.1 flow — see [Authentication](https://agenticadvertising.org/docs/registry/index#authentication).
+
+    **Base URL:** `https://agenticadvertising.org`
+  version: 1.0.0
+  contact:
+    name: AgenticAdvertising.org
+    url: https://agenticadvertising.org
+servers:
+  - url: https://agenticadvertising.org
+    description: Production
+security: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: |-
+        Bearer token in the `Authorization` header. Two token types are accepted:
+
+        - **Organization API key** (`sk_...`) issued via the dashboard. Org-scoped, long-lived, for server-to-server use.
+        - **User JWT** obtained via the OAuth 2.1 authorization code flow with PKCE. User-scoped, short-lived. Discover the authorization server at `/.well-known/oauth-authorization-server` and the protected-resource metadata at `/.well-known/oauth-protected-resource/api`.
+    oauth2:
+      type: oauth2
+      description: OAuth 2.1 authorization code flow with PKCE. Users authenticate via AuthKit and clients receive a Bearer JWT that authorizes both the MCP endpoint and this REST API. Dynamic client registration is supported at `/register`.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://agenticadvertising.org/authorize
+          tokenUrl: https://agenticadvertising.org/token
+          refreshUrl: https://agenticadvertising.org/token
+          scopes:
+            openid: User identifier
+            profile: User profile information
+            email: User email address
+  schemas:
+    BrandEventPayload:
+      type: object
+      properties:
+        domain:
+          type: string
+          description: Brand domain; brand.* events are identified by entity_id (the brand) and carry hierarchy context here.
+        chain:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: "On brand.resolved/hierarchy_updated: the resolved brand chain (root → leaf)."
+        ancestor_domains:
+          type: array
+          items:
+            type: string
+        domains:
+          type: array
+          items:
+            type: string
+    ResolvedBrand:
+      type: object
+      properties:
+        canonical_id:
+          type: string
+          example: acmecorp.com
+        canonical_domain:
+          type: string
+          example: acmecorp.com
+        brand_name:
+          type: string
+          example: Acme Corp
+        names:
+          type: array
+          items:
+            $ref: "#/components/schemas/LocalizedName"
+        keller_type:
+          type: string
+          enum:
+            - master
+            - sub_brand
+            - endorsed
+            - independent
+        parent_brand:
+          type: string
+        house_domain:
+          type: string
+        claimed_house_domain:
+          type: string
+          description: House the requested domain claims. This field never extends trust on its own; `relationship_trust` reports whether the reciprocal declaration is current enough to do so.
+        house_name:
+          type: string
+        relationship_trust:
+          type: string
+          enum:
+            - inline
+            - mutual
+            - leaf_only
+            - house_only
+            - standalone
+            - unverifiable
+          description: "How the brand-to-house relationship was established. `inline`: the house's own document defines the brand. `mutual`: both sides publish the relationship — the trust-extending edge. `leaf_only`: the brand claims a house whose reciprocal declaration is missing, not yet active, or too old to extend trust. `house_only`: a house claims the brand, which has not reciprocated. `standalone`: the brand claims no house. `unverifiable`: a claimed house could not be checked."
+        relationship_verified_at:
+          type: string
+          format: date-time
+          description: When both sides of a mutual relationship were last seen agreeing. Present only for `mutual`, and it does not advance while the house side is unreachable, so callers can apply their own edge-aging policy.
+          example: 2026-07-28T12:00:00Z
+        relationship_declared_at:
+          type: string
+          format: date-time
+          description: When the house declared the relationship in `brand_refs[].effective_at`, or the resolver's durable first observation if the publisher omitted that field. Callers can apply a declaration-age ceiling independently of `relationship_verified_at`.
+          example: 2026-01-29T12:00:00Z
+        promoted_from_schema:
+          type: string
+          description: Set when a pre-v3 document was promoted to a canonical v3 document for this response. Identity only — legacy relationship data is preserved opaquely, never promoted to a trust claim.
+        migration_warnings:
+          type: array
+          items:
+            type: object
+            properties:
+              field:
+                type: string
+              message:
+                type: string
+              suggestion:
+                type: string
+            required:
+              - field
+              - message
+          description: Loss or ambiguity encountered while promoting a pre-v3 document. A `house` warning means the legacy house object was preserved only as opaque metadata and did not establish a trusted relationship.
+        brand_agent_url:
+          type: string
+        brand_manifest:
+          type: object
+          additionalProperties: {}
+        source:
+          type: string
+          enum:
+            - hosted
+            - brand_json
+            - community
+            - enriched
+            - stub
+          description: "Provenance of the selected record, not relationship authorization. Deterministic precedence is `hosted` > `brand_json` > `community` > `enriched` > `stub`; normal reads prefer the durable stored winner on a source tie, while `fresh=true` lets a successful live origin read win a tie. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment. `stub`: a minimal organization-derived placeholder awaiting stronger evidence."
+        live_brand_json:
+          type: object
+          properties:
+            valid:
+              type: boolean
+            url:
+              type: string
+            status_code:
+              type: integer
+            errors:
+              type: array
+              items:
+                type: object
+                properties:
+                  field:
+                    type: string
+                  message:
+                    type: string
+                  severity:
+                    type: string
+                    enum:
+                      - error
+                required:
+                  - field
+                  - message
+                  - severity
+            warnings:
+              type: array
+              items:
+                type: object
+                properties:
+                  field:
+                    type: string
+                  message:
+                    type: string
+                  suggestion:
+                    type: string
+                required:
+                  - field
+                  - message
+          required:
+            - valid
+            - url
+            - errors
+            - warnings
+          description: This request's origin-validation diagnostics when `fresh=true` falls back to a stored registry record. Presence means the response is stored evidence, not a successful live-origin read.
+      required:
+        - canonical_id
+        - canonical_domain
+        - brand_name
+        - source
+    LocalizedName:
+      type: object
+      additionalProperties:
+        type: string
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+      required:
+        - error
+    BrandRegistryItem:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: acmecorp.com
+        brand_name:
+          type: string
+          example: Acme Corp
+        source:
+          type: string
+          enum:
+            - hosted
+            - brand_json
+            - community
+            - enriched
+            - stub
+        has_manifest:
+          type: boolean
+        verified:
+          type: boolean
+        house_domain:
+          type: string
+        keller_type:
+          type: string
+          enum:
+            - master
+            - sub_brand
+            - endorsed
+            - independent
+        relationship_trust:
+          type: string
+          enum:
+            - inline
+            - mutual
+            - leaf_only
+            - house_only
+            - standalone
+            - unverifiable
+          description: Trust verdict for the brand-to-house relationship, cached from the last crawler resolution. Absent means not yet computed — absent MUST NOT be interpreted as `standalone`.
+        relationship_verified_at:
+          type: string
+          format: date-time
+          description: When the mutual-assertion edge was last confirmed by both sides. Present only when relationship_trust is `mutual`.
+        claimed_house_domain:
+          type: string
+          description: Unilateral parent claim from the brand's own document. Not trust-extending. Present for `leaf_only` and `unverifiable`.
+      required:
+        - domain
+        - source
+        - has_manifest
+        - verified
+    BrandActivity:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: acmecorp.com
+        total:
+          type: integer
+          example: 3
+        revisions:
+          type: array
+          items:
+            type: object
+            properties:
+              revision_number:
+                type: integer
+                example: 3
+              editor_name:
+                type: string
+                example: Pinnacle Media
+              edit_summary:
+                type: string
+                example: Updated logo and brand colors
+              source:
+                type: string
+                description: Source type of the record at the time of this revision (brand_json, enriched, community)
+              is_rollback:
+                type: boolean
+              rolled_back_to:
+                type: integer
+                description: Revision number that was restored; only present when is_rollback is true
+              created_at:
+                type: string
+                example: 2026-03-01T12:34:56Z
+            required:
+              - revision_number
+              - editor_name
+              - edit_summary
+              - is_rollback
+              - created_at
+      required:
+        - domain
+        - total
+        - revisions
+    PropertyActivity:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: examplepub.com
+        total:
+          type: integer
+          example: 3
+        revisions:
+          type: array
+          items:
+            type: object
+            properties:
+              revision_number:
+                type: integer
+                example: 3
+              editor_name:
+                type: string
+                example: Pinnacle Media
+              edit_summary:
+                type: string
+                example: Updated logo and brand colors
+              source:
+                type: string
+                description: Source type of the record at the time of this revision (brand_json, enriched, community)
+              is_rollback:
+                type: boolean
+              rolled_back_to:
+                type: integer
+                description: Revision number that was restored; only present when is_rollback is true
+              created_at:
+                type: string
+                example: 2026-03-01T12:34:56Z
+            required:
+              - revision_number
+              - editor_name
+              - edit_summary
+              - is_rollback
+              - created_at
+      required:
+        - domain
+        - total
+        - revisions
+    ResolvedProperty:
+      type: object
+      properties:
+        publisher_domain:
+          type: string
+          example: examplepub.com
+        source:
+          type: string
+          enum:
+            - adagents_json
+            - hosted
+            - discovered
+        authorized_agents:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              authorized_for:
+                type: string
+            required:
+              - url
+        properties:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              type:
+                type: string
+              name:
+                type: string
+              identifiers:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PropertyIdentifier"
+              tags:
+                type: array
+                items:
+                  type: string
+        contact:
+          type: object
+          properties:
+            name:
+              type: string
+            email:
+              type: string
+        verified:
+          type: boolean
+      required:
+        - publisher_domain
+        - source
+        - verified
+    PropertyIdentifier:
+      type: object
+      properties:
+        type:
+          type: string
+          example: domain
+        value:
+          type: string
+          example: examplepub.com
+      required:
+        - type
+        - value
+    PropertyRegistryItem:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: examplepub.com
+        source:
+          type: string
+          enum:
+            - adagents_json
+            - hosted
+            - community
+            - discovered
+            - enriched
+        property_count:
+          type: integer
+        agent_count:
+          type: integer
+        verified:
+          type: boolean
+      required:
+        - domain
+        - source
+        - property_count
+        - agent_count
+        - verified
+    ValidationResult:
+      type: object
+      properties:
+        valid:
+          type: boolean
+        domain:
+          type: string
+        url:
+          type: string
+        errors:
+          type: array
+          items:
+            type: string
+        warnings:
+          type: array
+          items:
+            type: string
+        status_code:
+          type: integer
+        raw_data:
+          type: object
+          additionalProperties: {}
+      required:
+        - valid
+    FederatedAgentWithDetails:
+      type: object
+      properties:
+        url:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+          enum:
+            - brand
+            - rights
+            - measurement
+            - governance
+            - creative
+            - sales
+            - buying
+            - signals
+            - unknown
+        protocol:
+          type: string
+          enum:
+            - mcp
+            - a2a
+        description:
+          type: string
+        mcp_endpoint:
+          type: string
+        contact:
+          type: object
+          properties:
+            name:
+              type: string
+            email:
+              type: string
+            website:
+              type: string
+          required:
+            - name
+            - email
+            - website
+        added_date:
+          type: string
+        member:
+          type: object
+          properties:
+            slug:
+              type: string
+            display_name:
+              type: string
+            membership_tier:
+              type: string
+              description: Raw AAO membership tier enum (e.g. `individual_professional`, `company_leader`). Present only when the profile owner has set their member card to public (`is_public=true`) AND the org has a resolvable tier. Absent for private profiles and for orgs without an active tier-bearing subscription.
+            membership_tier_label:
+              type: string
+              description: Human-readable label for `membership_tier` (e.g. `Professional`, `Partner`, `Leader`). Matches the AAO pricing page. Use this for UI display; the raw enum is for programmatic gating. Presence rules match `membership_tier`.
+            is_founding_member:
+              type: boolean
+              description: True when the profile owner carries the Founding Member badge (joined before the founding-cohort cutoff). Surfaced when the profile owner has set their member card to public (`is_public=true`). Absent for private profiles. Founding Member is orthogonal to tier — founding orgs typically display both (e.g. Scope3 shows `Partner` + `Founding Member`).
+          description: AAO member that owns this agent record. The registry contains only agents that members have explicitly enrolled on their member profile.
+        health:
+          $ref: "#/components/schemas/AgentHealth"
+        stats:
+          $ref: "#/components/schemas/AgentStats"
+        capabilities:
+          $ref: "#/components/schemas/AgentCapabilities"
+        compliance:
+          $ref: "#/components/schemas/AgentCompliance"
+        publisher_domains:
+          type: array
+          items:
+            type: string
+        property_summary:
+          $ref: "#/components/schemas/PropertySummary"
+      required:
+        - url
+        - name
+        - type
+    AgentHealth:
+      type: object
+      properties:
+        online:
+          type: boolean
+        checked_at:
+          type: string
+        response_time_ms:
+          type: number
+        tools_count:
+          type: integer
+        resources_count:
+          type: integer
+        error:
+          type: string
+      required:
+        - online
+        - checked_at
+    AgentStats:
+      type: object
+      properties:
+        property_count:
+          type: integer
+        publisher_count:
+          type: integer
+        publishers:
+          type: array
+          items:
+            type: string
+        creative_formats:
+          type: integer
+    AgentCapabilities:
+      type: object
+      properties:
+        tools_count:
+          type: integer
+        tools:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              description:
+                type: string
+            required:
+              - name
+              - description
+        standard_operations:
+          type: object
+          properties:
+            can_search_inventory:
+              type: boolean
+            can_get_availability:
+              type: boolean
+            can_reserve_inventory:
+              type: boolean
+            can_get_pricing:
+              type: boolean
+            can_create_order:
+              type: boolean
+            can_list_properties:
+              type: boolean
+          required:
+            - can_search_inventory
+            - can_get_availability
+            - can_reserve_inventory
+            - can_get_pricing
+            - can_create_order
+            - can_list_properties
+        creative_capabilities:
+          type: object
+          properties:
+            supported_formats:
+              type: array
+              items:
+                type: object
+                properties:
+                  capability_id:
+                    type: string
+                  format:
+                    type: object
+                    properties:
+                      format_kind:
+                        type: string
+                      publisher_domain:
+                        type: string
+                      format_option_id:
+                        type: string
+                      params:
+                        type: object
+                        additionalProperties: {}
+                    required:
+                      - format_kind
+                    additionalProperties: {}
+                  operations:
+                    type: array
+                    items:
+                      type: string
+                      enum:
+                        - build
+                        - validate
+                        - preview
+                    minItems: 1
+                required:
+                  - format
+                  - operations
+                additionalProperties: {}
+            can_generate:
+              type: boolean
+            can_validate:
+              type: boolean
+            can_preview:
+              type: boolean
+          required:
+            - supported_formats
+            - can_generate
+            - can_validate
+            - can_preview
+          additionalProperties: {}
+        signals_capabilities:
+          type: object
+          properties:
+            audience_types:
+              type: array
+              items:
+                type: string
+            can_match:
+              type: boolean
+            can_activate:
+              type: boolean
+            can_get_signals:
+              type: boolean
+          required:
+            - audience_types
+            - can_match
+            - can_activate
+            - can_get_signals
+        measurement_capabilities:
+          type: object
+          properties:
+            metrics:
+              type: array
+              items:
+                type: object
+                properties:
+                  metric_id:
+                    type: string
+                  standard_reference:
+                    type: string
+                  accreditations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        accrediting_body:
+                          type: string
+                        certification_id:
+                          type: string
+                        valid_until:
+                          type: string
+                        evidence_url:
+                          type: string
+                        verified_by_aao:
+                          type: boolean
+                          enum:
+                            - false
+                          description: Always `false` — accreditation claims are vendor-asserted. AAO does not independently verify; renderers should mark these as vendor claims.
+                      required:
+                        - accrediting_body
+                        - verified_by_aao
+                  unit:
+                    type: string
+                  description:
+                    type: string
+                  methodology_url:
+                    type: string
+                  methodology_version:
+                    type: string
+                required:
+                  - metric_id
+          required:
+            - metrics
+          description: Vendor-published per-metric catalog for measurement agents. Populated when the crawler successfully fetched and validated `get_adcp_capabilities.measurement` (AdCP 3.x). Mirrors the protocol shape — see the AdCP `get_adcp_capabilities` reference for field semantics.
+      required:
+        - tools_count
+    AgentCompliance:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - passing
+            - degraded
+            - failing
+            - unknown
+        requested_compliance_target:
+          type:
+            - string
+            - "null"
+          description: Requested compliance target before alias resolution, e.g. 3.0 or 3.1-beta.
+        adcp_version:
+          type:
+            - string
+            - "null"
+          description: Concrete AdCP compliance bundle version used for the latest run, e.g. 3.0.12.
+        lifecycle_stage:
+          type: string
+          enum:
+            - development
+            - testing
+            - production
+            - deprecated
+        tracks:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            core: pass
+            products: fail
+        track_details:
+          type: array
+          items:
+            type: object
+            properties:
+              track:
+                type: string
+              status:
+                type: string
+              scenario_count:
+                type: integer
+              passed_count:
+                type: integer
+              duration_ms:
+                type: number
+              has_coverage_gap_skip:
+                type: boolean
+            required:
+              - track
+              - status
+              - scenario_count
+              - passed_count
+              - duration_ms
+          description: Latest-run per-track summary. Skipped tracks with has_coverage_gap_skip=true represent selected coverage gaps, such as missing_test_controller.
+        streak_days:
+          type: integer
+        last_checked_at:
+          type:
+            - string
+            - "null"
+        headline:
+          type:
+            - string
+            - "null"
+        monitoring_paused:
+          type: boolean
+        check_interval_hours:
+          type: integer
+        verified:
+          type: boolean
+        verified_roles:
+          type: array
+          items:
+            $ref: "#/components/schemas/BadgeRole"
+          description: Canonical badge roles the agent is AgenticAdvertising.org Verified for (e.g. media-buy, creative).
+        verified_role_versions:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          description: "Active AgenticAdvertising.org Verified AdCP releases for each verified role, keyed by canonical badge role and sorted newest-first (e.g. { media-buy: ['3.1', '3.0'] }). Use this when choosing a version-pinned badge URL."
+      required:
+        - status
+        - lifecycle_stage
+        - tracks
+        - streak_days
+        - last_checked_at
+        - headline
+    BadgeRole:
+      type: string
+      enum:
+        - media-buy
+        - creative
+        - signals
+        - governance
+        - brand
+        - sponsored-intelligence
+    PropertySummary:
+      type: object
+      properties:
+        total_count:
+          type: integer
+        count_by_type:
+          type: object
+          additionalProperties:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+        publisher_count:
+          type: integer
+      required:
+        - total_count
+        - count_by_type
+        - tags
+        - publisher_count
+    FederatedPublisher:
+      type: object
+      properties:
+        domain:
+          type: string
+        member:
+          type: object
+          properties:
+            slug:
+              type: string
+            display_name:
+              type: string
+            membership_tier:
+              type: string
+              description: Raw AAO membership tier enum (e.g. `individual_professional`, `company_leader`). Present only when the profile owner has set their member card to public (`is_public=true`) AND the org has a resolvable tier. Absent for private profiles and for orgs without an active tier-bearing subscription.
+            membership_tier_label:
+              type: string
+              description: Human-readable label for `membership_tier` (e.g. `Professional`, `Partner`, `Leader`). Matches the AAO pricing page. Use this for UI display; the raw enum is for programmatic gating. Presence rules match `membership_tier`.
+            is_founding_member:
+              type: boolean
+              description: True when the profile owner carries the Founding Member badge (joined before the founding-cohort cutoff). Surfaced when the profile owner has set their member card to public (`is_public=true`). Absent for private profiles. Founding Member is orthogonal to tier — founding orgs typically display both (e.g. Scope3 shows `Partner` + `Founding Member`).
+        agent_count:
+          type: integer
+        last_validated:
+          type: string
+        has_valid_adagents:
+          type: boolean
+      required:
+        - domain
+    DomainLookupResult:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: examplepub.com
+        authorized_agents:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              authorized_for:
+                type: string
+              member:
+                type: object
+                properties:
+                  slug:
+                    type: string
+                  display_name:
+                    type: string
+                  membership_tier:
+                    type: string
+                    description: Raw AAO membership tier enum (e.g. `individual_professional`, `company_leader`). Present only when the profile owner has set their member card to public (`is_public=true`) AND the org has a resolvable tier. Absent for private profiles and for orgs without an active tier-bearing subscription.
+                  membership_tier_label:
+                    type: string
+                    description: Human-readable label for `membership_tier` (e.g. `Professional`, `Partner`, `Leader`). Matches the AAO pricing page. Use this for UI display; the raw enum is for programmatic gating. Presence rules match `membership_tier`.
+                  is_founding_member:
+                    type: boolean
+                    description: True when the profile owner carries the Founding Member badge (joined before the founding-cohort cutoff). Surfaced when the profile owner has set their member card to public (`is_public=true`). Absent for private profiles. Founding Member is orthogonal to tier — founding orgs typically display both (e.g. Scope3 shows `Partner` + `Founding Member`).
+            required:
+              - url
+        sales_agents_claiming:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              member:
+                type: object
+                properties:
+                  slug:
+                    type: string
+                  display_name:
+                    type: string
+                  membership_tier:
+                    type: string
+                    description: Raw AAO membership tier enum (e.g. `individual_professional`, `company_leader`). Present only when the profile owner has set their member card to public (`is_public=true`) AND the org has a resolvable tier. Absent for private profiles and for orgs without an active tier-bearing subscription.
+                  membership_tier_label:
+                    type: string
+                    description: Human-readable label for `membership_tier` (e.g. `Professional`, `Partner`, `Leader`). Matches the AAO pricing page. Use this for UI display; the raw enum is for programmatic gating. Presence rules match `membership_tier`.
+                  is_founding_member:
+                    type: boolean
+                    description: True when the profile owner carries the Founding Member badge (joined before the founding-cohort cutoff). Surfaced when the profile owner has set their member card to public (`is_public=true`). Absent for private profiles. Founding Member is orthogonal to tier — founding orgs typically display both (e.g. Scope3 shows `Partner` + `Founding Member`).
+            required:
+              - url
+      required:
+        - domain
+        - authorized_agents
+        - sales_agents_claiming
+    OperatorLookupResult:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: pubmatic.com
+        member:
+          type:
+            - object
+            - "null"
+          properties:
+            slug:
+              type: string
+            display_name:
+              type: string
+            membership_tier:
+              type: string
+              description: Raw AAO membership tier enum (e.g. `individual_professional`, `company_leader`). Present only when the profile owner has set their member card to public (`is_public=true`) AND the org has a resolvable tier. Absent for private profiles and for orgs without an active tier-bearing subscription.
+            membership_tier_label:
+              type: string
+              description: Human-readable label for `membership_tier` (e.g. `Professional`, `Partner`, `Leader`). Matches the AAO pricing page. Use this for UI display; the raw enum is for programmatic gating. Presence rules match `membership_tier`.
+            is_founding_member:
+              type: boolean
+              description: True when the profile owner carries the Founding Member badge (joined before the founding-cohort cutoff). Surfaced when the profile owner has set their member card to public (`is_public=true`). Absent for private profiles. Founding Member is orthogonal to tier — founding orgs typically display both (e.g. Scope3 shows `Partner` + `Founding Member`).
+        agents:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              name:
+                type: string
+              type:
+                type: string
+                enum:
+                  - brand
+                  - rights
+                  - measurement
+                  - governance
+                  - creative
+                  - sales
+                  - buying
+                  - signals
+                  - unknown
+              authorized_by:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    publisher_domain:
+                      type: string
+                    authorized_for:
+                      type: string
+                    source:
+                      type: string
+                      enum:
+                        - adagents_json
+                        - agent_claim
+                  required:
+                    - publisher_domain
+                    - source
+            required:
+              - url
+              - name
+              - type
+              - authorized_by
+      required:
+        - domain
+        - member
+        - agents
+    PublisherLookupResult:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: voxmedia.com
+        member:
+          type:
+            - object
+            - "null"
+          properties:
+            slug:
+              type: string
+            display_name:
+              type: string
+            membership_tier:
+              type: string
+              description: Raw AAO membership tier enum (e.g. `individual_professional`, `company_leader`). Present only when the profile owner has set their member card to public (`is_public=true`) AND the org has a resolvable tier. Absent for private profiles and for orgs without an active tier-bearing subscription.
+            membership_tier_label:
+              type: string
+              description: Human-readable label for `membership_tier` (e.g. `Professional`, `Partner`, `Leader`). Matches the AAO pricing page. Use this for UI display; the raw enum is for programmatic gating. Presence rules match `membership_tier`.
+            is_founding_member:
+              type: boolean
+              description: True when the profile owner carries the Founding Member badge (joined before the founding-cohort cutoff). Surfaced when the profile owner has set their member card to public (`is_public=true`). Absent for private profiles. Founding Member is orthogonal to tier — founding orgs typically display both (e.g. Scope3 shows `Partner` + `Founding Member`).
+        adagents_valid:
+          type:
+            - boolean
+            - "null"
+        discovery_method:
+          type:
+            - string
+            - "null"
+          enum:
+            - direct
+            - authoritative_location
+            - ads_txt_managerdomain
+            - adagents_authoritative
+            - community_catalog
+            - null
+          description: "How the publisher's adagents.json was discovered on the most recent successful crawl or registry write. `direct`: publisher's own /.well-known/ served the document. `authoritative_location`: publisher's stub redirected to a canonical URL. `ads_txt_managerdomain`: manifest was discovered via ads.txt MANAGERDOMAIN delegation. `adagents_authoritative`: manager file named this publisher through publisher_properties fan-out. `community_catalog`: moderator-approved community catalog. Null until first crawl after migration 470."
+        manager_domain:
+          type:
+            - string
+            - "null"
+          description: The manager domain whose adagents.json was used to authorize this publisher's agents. Non-null only when `discovery_method` is `ads_txt_managerdomain`. Matches the MANAGERDOMAIN value from the publisher's ads.txt.
+        hosting:
+          type: object
+          properties:
+            mode:
+              type: string
+              enum:
+                - self
+                - self_invalid
+                - aao_hosted
+                - self_redirected
+                - none
+              description: Where this publisher's adagents.json lives. `self` = publisher hosts a valid file at their own /.well-known. `self_invalid` = publisher's /.well-known returns a file that fails validation (fixable misconfiguration, not absence). `aao_hosted` = the publisher hosts a stub at their own /.well-known whose `authoritative_location` points at AAO's canonical document. `self_redirected` = the publisher's stub `authoritative_location` resolves to a third-party HTTPS origin (a CDN, partner CMS, or sibling host) — verifiers should audit the TLS chain at `resolved_url`, not at the publisher's own origin. `none` = no adagents.json configured yet.
+            hosted_url:
+              type: string
+              description: Canonical AAO-hosted adagents.json URL. Present iff `mode === 'aao_hosted'`. Publishers reference this URL from their own /.well-known stub via the `authoritative_location` field (see https://docs.adcontextprotocol.org/docs/governance/property/adagents).
+            expected_url:
+              type: string
+              description: Where adagents.json *should* live for this domain — the publisher's own /.well-known path. Always populated, regardless of `mode`.
+            resolved_url:
+              type:
+                - string
+                - "null"
+              description: Where the canonical adagents.json document actually lives after following the publisher's `authoritative_location` stub or any HTTP-layer redirects. Populated when `mode === 'self_redirected'` (the third-party HTTPS origin verifiers should audit) and when `mode === 'aao_hosted'` AND the publisher has actively set up the redirect (`authoritative_location` in the manifest body or a network-layer redirect to AAO's hosted URL). NULL when there's no resolved-URL evidence to report.
+            last_validated:
+              type:
+                - string
+                - "null"
+              description: ISO timestamp of the last successful validation crawl. Lets verifiers sanity-check freshness. NULL when never crawled.
+            last_http_status:
+              type:
+                - integer
+                - "null"
+              minimum: 100
+              maximum: 599
+              description: HTTP status code returned by AAO's most recent fetch attempt of the publisher's `/.well-known/adagents.json`. Verifier-grade chrome — lets a buy-side scraper confirm they see the same response AAO does. NULL until the first crawl records or for transient errors that never produced an HTTP response.
+            last_bytes:
+              type:
+                - integer
+                - "null"
+              minimum: 0
+              description: Response body byte length from the most recent fetch (post-decompression). When `authoritative_location` was followed, measures the canonical document body, not the stub. NULL until the first crawl records.
+            origin_verified_at:
+              type:
+                - string
+                - "null"
+              description: ISO timestamp of the last successful origin verification — AAO fetched the publisher's own /.well-known/adagents.json and confirmed `authoritative_location` points at our hosted URL. When set, the publisher's authorization rows have been promoted to `source='adagents_json'` (origin-attested). NULL when never verified or last attempt failed. Only populated when `mode === 'aao_hosted'`.
+            origin_last_checked_at:
+              type:
+                - string
+                - "null"
+              description: ISO timestamp of the last verification attempt regardless of result. Lets a caller render "checked X minutes ago, not yet verified" vs "never checked." Only populated when `mode === 'aao_hosted'`.
+          required:
+            - mode
+            - expected_url
+        files:
+          type: object
+          properties:
+            adagents_json:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - valid
+                    - community
+                    - invalid
+                    - unknown
+                    - checking
+                  description: What we know about the publisher's adagents.json right now. `valid` = crawler fetched a parsing-and-shape-valid file from the publisher origin. `community` = moderators approved a community adagents.json catalog for this domain. `invalid` = crawler fetched a file that failed validation. `unknown` = never crawled or last result is stale. `checking` = an auto-crawl was kicked off by this request; the page should poll for fresh data shortly.
+                expected_url:
+                  type: string
+                  description: Where adagents.json should live on the publisher's own origin.
+                registry_url:
+                  type: string
+                  description: Registry-served adagents.json URL when the document is community or AgenticAdvertising.org hosted rather than served by the publisher origin.
+              required:
+                - status
+                - expected_url
+            brand_json:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - present
+                    - unknown
+                    - checking
+                  description: What we know about the publisher's brand.json. `present` = a brand record with manifest data exists. `unknown` = no record yet. `checking` = an auto-crawl was kicked off.
+                name:
+                  type: string
+              required:
+                - status
+          required:
+            - adagents_json
+            - brand_json
+          description: Plain-English summary of what AAO has found at the publisher's origin. The publisher page leads with this — `you have a valid adagents.json` is the primary signal, not `mode === self`. Optional in the schema for backwards compatibility; the handler always populates it.
+        properties:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              type:
+                type: string
+              name:
+                type: string
+              identifiers:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PropertyIdentifier"
+              tags:
+                type: array
+                items:
+                  type: string
+                description: Arbitrary string tags on this property. The `relationship:` prefix tag (e.g. `relationship:owned`) is deprecated in favour of the `delegation_type` field and will be removed in a future release.
+              source:
+                type: string
+                enum:
+                  - adagents_json
+                  - community
+                  - discovered
+                  - brand_json
+                description: Where this property came from. `adagents_json` comes from the publisher's own adagents.json, `community` from an approved community adagents.json catalog, `discovered` from crawler or third-party signals, and `brand_json` from the publisher's brand.json when no federated-index data exists yet.
+              delegation_type:
+                type: string
+                enum:
+                  - direct
+                  - delegated
+                  - ad_network
+                description: "Delegation relationship declared in brand.json. Populated only when `source` is `brand_json` — for `adagents_json` and `discovered` sources the authoritative value is on the matching `authorized_agents` entry. Mirrors adagents.json `delegation_type` for bilateral verification: `direct` = publisher treats this as a direct buying path, even if a third party operates the software; `delegated` = a rep firm or manager is authorized to sell on the publisher's behalf (operator-declared, unilateral until corroborated by the publisher's adagents.json); `ad_network` = sold as part of a network/exchange package. `owned` properties have no `delegation_type` — ownership is implicit and has no adagents.json counterpart."
+        brand:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Display name from brand.json or the registered brand row.
+            description:
+              type: string
+              description: Short brand or house description when present in brand.json.
+            logo_url:
+              type: string
+              description: First usable logo URL from brand.json.
+            colors:
+              type: array
+              items:
+                type: string
+              description: Representative hex colors from brand.json, capped for display.
+            industries:
+              type: array
+              items:
+                type: string
+              description: Industry labels from brand.json when present.
+          description: Display-oriented brand identity summary from brand.json. The full raw document remains available from the publisher's /.well-known/brand.json or hosted registry URL.
+        formats:
+          type: array
+          items:
+            type: object
+            properties:
+              format_option_id:
+                type: string
+                description: Stable format option identifier from adagents.json `formats[]`.
+              display_name:
+                type: string
+                description: Human-readable format label for catalog and publisher UI display.
+              format_kind:
+                type: string
+                description: Canonical format discriminator, such as `image`, `video_hosted`, `native_in_feed`, or `custom`.
+              sample_render_url:
+                type: string
+                pattern: ^https:\/\/
+                description: Optional public HTTPS page where a human can inspect a sample render of this catalog format using publisher- or community-mirror-provided example assets. Informational only; this is not a renderer endpoint, buyer-asset preview, validation result, creative approval, proof of publisher acceptance, or live delivery guarantee.
+              params:
+                type: object
+                additionalProperties: {}
+                description: Canonical format params from the publisher's adagents.json declaration.
+              applies_to_property_ids:
+                type: array
+                items:
+                  type: string
+                description: Property IDs this format applies to; absent means all properties.
+              applies_to_property_tags:
+                type: array
+                items:
+                  type: string
+                description: Property tags this format applies to; absent means all properties.
+              seller_preference:
+                type: string
+                description: Seller preference hint from the format declaration, when present.
+              experimental:
+                type: boolean
+                description: Whether this seller's format declaration is marked experimental.
+            required:
+              - display_name
+              - format_kind
+          description: Lossy display-oriented summary of top-level adagents.json `formats[]`, normalized for publisher pages and eligibility discovery. It preserves `format_kind`, `format_option_id`, params, property scope, preference, and experimental status, but omits `reference_renderer`, `v1_format_ref`, `canonical_formats_only`, `applies_to_channels`, `publisher_domain`, and custom `format_shape`/`format_schema`. Fetch the canonical document at hosting.resolved_url (or hosting.expected_url when self-hosted) for creative validation or reference-renderer discovery.
+        placements:
+          type: array
+          items:
+            type: object
+            properties:
+              placement_id:
+                type: string
+              name:
+                type: string
+              description:
+                type: string
+              property_ids:
+                type: array
+                items:
+                  type: string
+              property_tags:
+                type: array
+                items:
+                  type: string
+              collection_ids:
+                type: array
+                items:
+                  type: string
+              channels:
+                type: array
+                items:
+                  type: string
+              tags:
+                type: array
+                items:
+                  type: string
+              format_options:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    format_option_id:
+                      type: string
+                    format_kind:
+                      type: string
+                      description: Resolved canonical format kind accepted by this placement.
+                    params:
+                      type: object
+                      additionalProperties: {}
+                      description: Resolved canonical narrowing for this placement format.
+                  required:
+                    - format_kind
+                description: Placement format references resolved against the same response's top-level formats plus any inline canonical declarations.
+              source:
+                type: string
+                enum:
+                  - adagents_json
+                  - community
+                description: Publisher-origin placements are adagents_json; moderator-maintained catalog placements are community.
+            required:
+              - placement_id
+              - name
+              - source
+          description: Eligibility-oriented publisher placement summaries. Present only when the request includes `include=placements`; format references are resolved to canonical kind/params so callers can join property → placement → format without a second origin fetch. The lossy summary omits placement `presentation_ref` and `preview_provider`; fetch the resolved raw adagents.json for publisher presentation metadata and preview delegation.
+        authorized_agents:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              authorized_for:
+                type: string
+              source:
+                type: string
+                enum:
+                  - adagents_json
+                  - aao_hosted
+                  - agent_claim
+                description: "How strongly this authorization is attested. `adagents_json`: the publisher's origin actually serves a valid adagents.json (origin-verified). `aao_hosted`: AAO is hosting the canonical document on the publisher's behalf — represents publisher intent but origin has NOT been verified to redirect to AAO. `agent_claim`: the agent claimed it; publisher has not confirmed."
+              properties_authorized:
+                type: integer
+                minimum: 0
+                description: Count of this publisher's properties the agent is authorized to sell. Absent when `rollup_truncated` is set (call `/api/registry/publisher/authorization` for the per-agent count) or when properties are entirely brand.json-hydrated (no adagents.json claim has actually been made about them).
+              properties_total:
+                type: integer
+                minimum: 0
+                description: Total number of properties this publisher exposes through the registry. Same value across all agents in the response. Absent when `properties_authorized` is absent.
+              publisher_wide:
+                type: boolean
+                description: True when the agent has only a publisher-wide authorization row and `properties_authorized` was synthesized as `properties_total`. False when the agent has property-level authorization rows. Absent when the rollup is absent.
+            required:
+              - url
+              - source
+        rollup_truncated:
+          type: object
+          properties:
+            cap:
+              type: integer
+              exclusiveMinimum: 0
+              description: Maximum number of agents for which the rollup is computed in a single response.
+            total_agents:
+              type: integer
+              minimum: 0
+              description: Total authorized-agent count for this publisher (the full population the cap was applied to).
+          required:
+            - cap
+            - total_agents
+          description: Set when the publisher has more authorized agents than the per-agent rollup cap. Above the cap, agents beyond `cap` are returned without `properties_authorized` / `properties_total` / `publisher_wide`; call `/api/registry/publisher/authorization?domain=X&agent=Y` for the per-agent count. Lets a caller decide whether to fan out individual calls or stop reading.
+        auto_crawl_triggered:
+          type: boolean
+          description: Set to `true` when this request triggered a background crawl of the publisher's origin (we hadn't crawled before). The client should refetch in ~3-5s to pick up fresh data. Debounced per-domain so a tight refresh loop won't keep firing crawls.
+      required:
+        - domain
+        - member
+        - adagents_valid
+        - hosting
+        - properties
+        - authorized_agents
+    PublisherPropertySelector:
+      type: object
+      properties:
+        publisher_domain:
+          type: string
+          example: examplepub.com
+        property_types:
+          type: array
+          items:
+            type: string
+        property_ids:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+    CreateAdagentsResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        data:
+          type: object
+          properties:
+            success:
+              type: boolean
+              enum:
+                - true
+            adagents_json:
+              type: string
+              description: Pretty-printed adagents.json document generated by the service.
+            validation:
+              $ref: "#/components/schemas/AdagentsValidationResult"
+          required:
+            - success
+            - adagents_json
+            - validation
+        timestamp:
+          type: string
+          format: date-time
+      required:
+        - success
+        - data
+        - timestamp
+    AdagentsValidationResult:
+      type: object
+      properties:
+        valid:
+          type: boolean
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdagentsValidationIssue"
+        warnings:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdagentsValidationWarning"
+        domain:
+          type: string
+        url:
+          type: string
+        status_code:
+          type: integer
+        response_bytes:
+          type: integer
+          minimum: 0
+        resolved_url:
+          type: string
+        raw_data: {}
+        discovery_method:
+          type: string
+          enum:
+            - direct
+            - authoritative_location
+            - ads_txt_managerdomain
+            - adagents_authoritative
+        manager_domain:
+          type: string
+      required:
+        - valid
+        - errors
+        - warnings
+        - domain
+        - url
+        - discovery_method
+    AdagentsValidationIssue:
+      type: object
+      properties:
+        field:
+          type: string
+        message:
+          type: string
+        severity:
+          type: string
+          enum:
+            - error
+      required:
+        - field
+        - message
+        - severity
+    AdagentsValidationWarning:
+      type: object
+      properties:
+        field:
+          type: string
+        message:
+          type: string
+        suggestion:
+          type: string
+      required:
+        - field
+        - message
+    AdagentsAuthorizedAgent:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Agent endpoint URL.
+        authorized_for:
+          type: string
+        authorization_type:
+          type: string
+          enum:
+            - property_ids
+            - property_tags
+            - inline_properties
+            - publisher_properties
+            - signal_ids
+            - signal_tags
+        property_ids:
+          type: array
+          items:
+            type: string
+        property_tags:
+          type: array
+          items:
+            type: string
+        properties:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        publisher_properties:
+          type: array
+          items:
+            type: object
+            properties:
+              publisher_domain:
+                type: string
+              publisher_domains:
+                type: array
+                items:
+                  type: string
+              selection_type:
+                type: string
+                enum:
+                  - all
+                  - by_id
+                  - by_tag
+              property_ids:
+                type: array
+                items:
+                  type: string
+              property_tags:
+                type: array
+                items:
+                  type: string
+            required:
+              - selection_type
+        collections:
+          type: array
+          items:
+            type: object
+            properties:
+              publisher_domain:
+                type: string
+              collection_ids:
+                type: array
+                items:
+                  type: string
+            required:
+              - publisher_domain
+              - collection_ids
+        placement_ids:
+          type: array
+          items:
+            type: string
+        placement_tags:
+          type: array
+          items:
+            type: string
+        delegation_type:
+          type: string
+          enum:
+            - direct
+            - delegated
+            - ad_network
+        exclusive:
+          type: boolean
+        countries:
+          type: array
+          items:
+            type: string
+        effective_from:
+          type: string
+        effective_until:
+          type: string
+        signal_ids:
+          type: array
+          items:
+            type: string
+        signal_tags:
+          type: array
+          items:
+            type: string
+        signing_keys:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+      required:
+        - url
+      additionalProperties: {}
+    CommunityMirrorProposalListResponse:
+      type: object
+      properties:
+        proposals:
+          type: array
+          items:
+            $ref: "#/components/schemas/CommunityMirrorProposalSummary"
+        total:
+          type: integer
+          minimum: 0
+      required:
+        - proposals
+        - total
+    CommunityMirrorProposalSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Opaque identifier for the proposal.
+          example: 4ec8bc86-6180-4d0e-aa72-9cbf402d3638
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+        catalog_etag:
+          type:
+            - string
+            - "null"
+        superseded_by:
+          type:
+            - string
+            - "null"
+          pattern: ^https:\/\/
+          description: HTTPS URL.
+        proposal_digest:
+          type: string
+          pattern: ^[a-f0-9]{64}$
+          description: SHA-256 digest that reviewers must echo when approving or rejecting this exact revision.
+        base_mirror_digest:
+          type:
+            - string
+            - "null"
+          pattern: ^[a-f0-9]{64}$
+          description: Digest of the public mirror state this proposal was reviewed against, or null when none existed.
+        status:
+          type: string
+          enum:
+            - pending
+            - approved
+            - rejected
+        proposed_at:
+          type: string
+          format: date-time
+        reviewed_at:
+          type:
+            - string
+            - "null"
+          format: date-time
+        published_at:
+          type:
+            - string
+            - "null"
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - platform
+        - catalog_etag
+        - superseded_by
+        - proposal_digest
+        - base_mirror_digest
+        - status
+        - proposed_at
+        - reviewed_at
+        - published_at
+        - updated_at
+    RateLimitError:
+      type: object
+      properties:
+        error:
+          type: string
+        message:
+          type: string
+        retryAfter:
+          type: integer
+          description: Seconds to wait before retrying.
+      required:
+        - error
+    CommunityMirrorProposalGetResponse:
+      type: object
+      properties:
+        proposal:
+          $ref: "#/components/schemas/CommunityMirrorProposal"
+      required:
+        - proposal
+    CommunityMirrorProposal:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Opaque identifier for the proposal.
+          example: 4ec8bc86-6180-4d0e-aa72-9cbf402d3638
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+        adagents_json:
+          $ref: "#/components/schemas/CommunityMirrorAdagentsJson"
+        catalog_etag:
+          type:
+            - string
+            - "null"
+        superseded_by:
+          type:
+            - string
+            - "null"
+          pattern: ^https:\/\/
+          description: HTTPS URL.
+        proposal_digest:
+          type: string
+          pattern: ^[a-f0-9]{64}$
+          description: SHA-256 digest that reviewers must echo when approving or rejecting this exact revision.
+        base_mirror_digest:
+          type:
+            - string
+            - "null"
+          pattern: ^[a-f0-9]{64}$
+          description: Digest of the public mirror state this proposal was reviewed against, or null when none existed.
+        status:
+          type: string
+          enum:
+            - pending
+            - approved
+            - rejected
+        proposed_by_organization_id:
+          type:
+            - string
+            - "null"
+        proposed_by_email:
+          type:
+            - string
+            - "null"
+          format: email
+          description: Contributor email, returned only to registry moderators and AgenticAdvertising.org administrators.
+        proposed_at:
+          type: string
+          format: date-time
+        reviewed_at:
+          type:
+            - string
+            - "null"
+          format: date-time
+        review_notes:
+          type:
+            - string
+            - "null"
+        published_at:
+          type:
+            - string
+            - "null"
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - platform
+        - adagents_json
+        - catalog_etag
+        - superseded_by
+        - proposal_digest
+        - base_mirror_digest
+        - status
+        - proposed_by_organization_id
+        - proposed_at
+        - reviewed_at
+        - review_notes
+        - published_at
+        - created_at
+        - updated_at
+    CommunityMirrorAdagentsJson:
+      type: object
+      properties:
+        $schema:
+          type: string
+          format: uri
+        authorized_agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdagentsAuthorizedAgent"
+          maxItems: 0
+          description: Always empty for community mirrors; these catalogs never assert sales authorization.
+        properties:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        catalog_etag:
+          type: string
+        formats:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        placements:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        placement_tags:
+          type: object
+          additionalProperties: {}
+        collections:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        signals:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        signal_tags:
+          type: object
+          additionalProperties: {}
+        contact: {}
+        superseded_by:
+          type: string
+          pattern: ^https:\/\/
+          description: HTTPS URL for the canonical successor adagents.json document. Clients should re-fetch the successor and update cached mirror references before retiring use of this mirror.
+        last_updated:
+          type: string
+          format: date-time
+      required:
+        - authorized_agents
+      additionalProperties: {}
+    CommunityMirrorProposalApprovalResponse:
+      allOf:
+        - $ref: "#/components/schemas/CommunityMirrorPublishResponse"
+        - type: object
+          properties:
+            proposal_id:
+              type: string
+              format: uuid
+              description: Opaque identifier for the proposal.
+              example: 4ec8bc86-6180-4d0e-aa72-9cbf402d3638
+          required:
+            - proposal_id
+    CommunityMirrorPublishResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+        catalog_etag:
+          type:
+            - string
+            - "null"
+        superseded_by:
+          type:
+            - string
+            - "null"
+          pattern: ^https:\/\/
+          description: HTTPS successor document URL, when this mirror has been superseded.
+        publisher_domains:
+          type: array
+          items:
+            type: string
+          description: Publisher domains updated from this community mirror catalog.
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - success
+        - platform
+        - catalog_etag
+        - superseded_by
+        - publisher_domains
+        - updated_at
+    CommunityMirrorPublishError:
+      type: object
+      properties:
+        error:
+          type: string
+        details:
+          type: array
+          items: {}
+          description: Validation details for request-body parse failures or adagents.json conformance errors.
+      required:
+        - error
+    CommunityMirrorProposalReviewRequest:
+      type: object
+      properties:
+        proposal_digest:
+          type: string
+          pattern: ^[a-f0-9]{64}$
+          description: SHA-256 digest that reviewers must echo when approving or rejecting this exact revision.
+        review_notes:
+          type: string
+          maxLength: 2000
+      required:
+        - proposal_digest
+    CommunityMirrorProposalDecisionResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        proposal:
+          $ref: "#/components/schemas/CommunityMirrorProposal"
+      required:
+        - success
+        - proposal
+    CommunityMirrorProposalRejectRequest:
+      type: object
+      properties:
+        proposal_digest:
+          type: string
+          pattern: ^[a-f0-9]{64}$
+          description: SHA-256 digest that reviewers must echo when approving or rejecting this exact revision.
+        review_notes:
+          type: string
+          minLength: 1
+          maxLength: 2000
+      required:
+        - proposal_digest
+        - review_notes
+    CommunityMirrorListResponse:
+      type: object
+      properties:
+        mirrors:
+          type: array
+          items:
+            $ref: "#/components/schemas/CommunityMirrorSummary"
+        total:
+          type: integer
+          minimum: 0
+      required:
+        - mirrors
+        - total
+    CommunityMirrorSummary:
+      type: object
+      properties:
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+        catalog_etag:
+          type:
+            - string
+            - "null"
+        superseded_by:
+          type:
+            - string
+            - "null"
+          pattern: ^https:\/\/
+          description: HTTPS successor document URL, when this mirror has been superseded.
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - platform
+        - catalog_etag
+        - superseded_by
+        - updated_at
+    CommunityMirrorGetResponse:
+      type: object
+      properties:
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+        catalog_etag:
+          type:
+            - string
+            - "null"
+        superseded_by:
+          type:
+            - string
+            - "null"
+          pattern: ^https:\/\/
+          description: HTTPS successor document URL, when this mirror has been superseded.
+        adagents_json:
+          $ref: "#/components/schemas/CommunityMirrorAdagentsJson"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - platform
+        - catalog_etag
+        - superseded_by
+        - adagents_json
+        - created_at
+        - updated_at
+    CommunityMirrorProposalSubmissionResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        status:
+          type: string
+          enum:
+            - pending
+        proposal_id:
+          type: string
+          format: uuid
+          description: Opaque identifier for the proposal.
+          example: 4ec8bc86-6180-4d0e-aa72-9cbf402d3638
+        proposal_digest:
+          type: string
+          pattern: ^[a-f0-9]{64}$
+          description: SHA-256 digest that reviewers must echo when approving or rejecting this exact revision.
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+        status_url:
+          type: string
+          description: Authenticated API path for fetching proposal status and content.
+        submitted_at:
+          type: string
+          format: date-time
+      required:
+        - success
+        - status
+        - proposal_id
+        - proposal_digest
+        - platform
+        - status_url
+        - submitted_at
+    CommunityMirrorPublishRequest:
+      anyOf:
+        - type: object
+          properties:
+            catalog_etag:
+              type: string
+              minLength: 1
+              maxLength: 255
+            formats:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+              minItems: 1
+            properties:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placements:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placement_tags:
+              type: object
+              additionalProperties: {}
+            collections:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signals:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signal_tags:
+              type: object
+              additionalProperties: {}
+            contact: {}
+            superseded_by:
+              type: string
+              pattern: ^https:\/\/
+              description: HTTPS URL for the canonical successor adagents.json document. Set this before deleting a mirror so buyers can migrate cached references.
+          required:
+            - formats
+          additionalProperties: {}
+        - type: object
+          properties:
+            catalog_etag:
+              type: string
+              minLength: 1
+              maxLength: 255
+            formats:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            properties:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+              minItems: 1
+            placements:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placement_tags:
+              type: object
+              additionalProperties: {}
+            collections:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signals:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signal_tags:
+              type: object
+              additionalProperties: {}
+            contact: {}
+            superseded_by:
+              type: string
+              pattern: ^https:\/\/
+              description: HTTPS URL for the canonical successor adagents.json document. Set this before deleting a mirror so buyers can migrate cached references.
+          required:
+            - properties
+          additionalProperties: {}
+        - type: object
+          properties:
+            catalog_etag:
+              type: string
+              minLength: 1
+              maxLength: 255
+            formats:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            properties:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placements:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+              minItems: 1
+            placement_tags:
+              type: object
+              additionalProperties: {}
+            collections:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signals:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signal_tags:
+              type: object
+              additionalProperties: {}
+            contact: {}
+            superseded_by:
+              type: string
+              pattern: ^https:\/\/
+              description: HTTPS URL for the canonical successor adagents.json document. Set this before deleting a mirror so buyers can migrate cached references.
+          required:
+            - placements
+          additionalProperties: {}
+        - type: object
+          properties:
+            catalog_etag:
+              type: string
+              minLength: 1
+              maxLength: 255
+            formats:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            properties:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placements:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placement_tags:
+              type: object
+              additionalProperties: {}
+            collections:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+              minItems: 1
+            signals:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signal_tags:
+              type: object
+              additionalProperties: {}
+            contact: {}
+            superseded_by:
+              type: string
+              pattern: ^https:\/\/
+              description: HTTPS URL for the canonical successor adagents.json document. Set this before deleting a mirror so buyers can migrate cached references.
+          required:
+            - collections
+          additionalProperties: {}
+        - type: object
+          properties:
+            catalog_etag:
+              type: string
+              minLength: 1
+              maxLength: 255
+            formats:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            properties:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placements:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            placement_tags:
+              type: object
+              additionalProperties: {}
+            collections:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+            signals:
+              type: array
+              items:
+                type: object
+                additionalProperties: {}
+                description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+              minItems: 1
+            signal_tags:
+              type: object
+              additionalProperties: {}
+            contact: {}
+            superseded_by:
+              type: string
+              pattern: ^https:\/\/
+              description: HTTPS URL for the canonical successor adagents.json document. Set this before deleting a mirror so buyers can migrate cached references.
+          required:
+            - signals
+          additionalProperties: {}
+      description: Catalog-only adagents.json body for a community mirror. At least one of `formats`, `properties`, `placements`, `collections`, or `signals` must be present and non-empty. The service regenerates `$schema` and `last_updated` before persisting.
+    CommunityMirrorDeleteResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        platform:
+          type: string
+          pattern: ^[a-z0-9_-]{1,64}$
+          description: Lowercase platform identifier, normalized by the service.
+          example: example_platform
+      required:
+        - success
+        - platform
+    PolicySummary:
+      type: object
+      properties:
+        policy_id:
+          type: string
+          example: gdpr_consent
+        version:
+          type: string
+          example: 1.0.0
+        name:
+          type: string
+          example: GDPR Consent Requirements
+        description:
+          type:
+            - string
+            - "null"
+          example: Requirements for valid consent under GDPR
+        category:
+          type: string
+          enum:
+            - regulation
+            - standard
+        enforcement:
+          type: string
+          enum:
+            - must
+            - should
+            - may
+        jurisdictions:
+          type: array
+          items:
+            type: string
+          example:
+            - EU
+            - EEA
+        region_aliases:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          example:
+            EU:
+              - DE
+              - FR
+              - IT
+        policy_categories:
+          type: array
+          items:
+            type: string
+          example:
+            - age_restricted
+            - pharmaceutical_advertising
+        channels:
+          type:
+            - array
+            - "null"
+          items:
+            type: string
+          example:
+            - display
+            - video
+        governance_domains:
+          type: array
+          items:
+            type: string
+          example:
+            - campaign
+            - creative
+        effective_date:
+          type:
+            - string
+            - "null"
+          example: 2025-05-25
+        sunset_date:
+          type:
+            - string
+            - "null"
+        source_url:
+          type:
+            - string
+            - "null"
+          example: https://eur-lex.europa.eu/eli/reg/2016/679/oj
+        source_name:
+          type:
+            - string
+            - "null"
+          example: EUR-Lex
+        source_type:
+          type: string
+          enum:
+            - registry
+            - community
+        review_status:
+          type: string
+          enum:
+            - pending
+            - approved
+        created_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+        updated_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+      required:
+        - policy_id
+        - version
+        - name
+        - description
+        - category
+        - enforcement
+        - jurisdictions
+        - region_aliases
+        - policy_categories
+        - channels
+        - governance_domains
+        - effective_date
+        - sunset_date
+        - source_url
+        - source_name
+        - source_type
+        - review_status
+        - created_at
+        - updated_at
+    Policy:
+      type: object
+      properties:
+        policy_id:
+          type: string
+          example: gdpr_consent
+        version:
+          type: string
+          example: 1.0.0
+        name:
+          type: string
+          example: GDPR Consent Requirements
+        description:
+          type:
+            - string
+            - "null"
+          example: Requirements for valid consent under GDPR
+        category:
+          type: string
+          enum:
+            - regulation
+            - standard
+        enforcement:
+          type: string
+          enum:
+            - must
+            - should
+            - may
+        jurisdictions:
+          type: array
+          items:
+            type: string
+          example:
+            - EU
+            - EEA
+        region_aliases:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          example:
+            EU:
+              - DE
+              - FR
+              - IT
+        policy_categories:
+          type: array
+          items:
+            type: string
+          example:
+            - age_restricted
+            - pharmaceutical_advertising
+        channels:
+          type:
+            - array
+            - "null"
+          items:
+            type: string
+          example:
+            - display
+            - video
+        governance_domains:
+          type: array
+          items:
+            type: string
+          example:
+            - campaign
+            - creative
+        effective_date:
+          type:
+            - string
+            - "null"
+          example: 2025-05-25
+        sunset_date:
+          type:
+            - string
+            - "null"
+        source_url:
+          type:
+            - string
+            - "null"
+          example: https://eur-lex.europa.eu/eli/reg/2016/679/oj
+        source_name:
+          type:
+            - string
+            - "null"
+          example: EUR-Lex
+        policy:
+          type: string
+          example: Data subjects must provide freely given, specific, informed and unambiguous consent...
+        guidance:
+          type:
+            - string
+            - "null"
+        exemplars:
+          type:
+            - object
+            - "null"
+          properties:
+            pass:
+              type: array
+              items:
+                type: object
+                properties:
+                  scenario:
+                    type: string
+                    example: Ad for alcohol shown during children's programming
+                  explanation:
+                    type: string
+                    example: Violates watershed timing rules for alcohol advertising
+                required:
+                  - scenario
+                  - explanation
+            fail:
+              type: array
+              items:
+                type: object
+                properties:
+                  scenario:
+                    type: string
+                    example: Ad for alcohol shown during children's programming
+                  explanation:
+                    type: string
+                    example: Violates watershed timing rules for alcohol advertising
+                required:
+                  - scenario
+                  - explanation
+        ext:
+          type:
+            - object
+            - "null"
+          additionalProperties: {}
+        source_type:
+          type: string
+          enum:
+            - registry
+            - community
+        review_status:
+          type: string
+          enum:
+            - pending
+            - approved
+        created_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+        updated_at:
+          type: string
+          example: 2026-03-01T12:00:00.000Z
+      required:
+        - policy_id
+        - version
+        - name
+        - description
+        - category
+        - enforcement
+        - jurisdictions
+        - region_aliases
+        - policy_categories
+        - channels
+        - governance_domains
+        - effective_date
+        - sunset_date
+        - source_url
+        - source_name
+        - policy
+        - guidance
+        - exemplars
+        - ext
+        - source_type
+        - review_status
+        - created_at
+        - updated_at
+    PolicyHistory:
+      type: object
+      properties:
+        policy_id:
+          type: string
+          example: gdpr_consent
+        total:
+          type: integer
+          example: 3
+        revisions:
+          type: array
+          items:
+            type: object
+            properties:
+              revision_number:
+                type: integer
+                example: 2
+              editor_name:
+                type: string
+                example: Pinnacle Media
+              edit_summary:
+                type: string
+                example: Clarified consent requirements for minors
+              is_rollback:
+                type: boolean
+              rolled_back_to:
+                type: integer
+                description: Revision number that was restored; only present when is_rollback is true
+              created_at:
+                type: string
+                example: 2026-03-01T12:34:56Z
+            required:
+              - revision_number
+              - editor_name
+              - edit_summary
+              - is_rollback
+              - created_at
+      required:
+        - policy_id
+        - total
+        - revisions
+    RegistryFeedEvent:
+      oneOf:
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - agent.discovered
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AgentEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - agent.removed
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AgentEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - agent.profile_updated
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AgentEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - agent.compliance_changed
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AgentEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - agent.verification_earned
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AgentEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - agent.verification_lost
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AgentEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - property.created
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PropertyEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - property.updated
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PropertyEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - property.merged
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PropertyEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - property.stale
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PropertyEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - property.reactivated
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PropertyEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - collection.created
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/CollectionEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - collection.updated
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/CollectionEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - collection.merged
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/CollectionEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - collection.removed
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/CollectionEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - authorization.granted
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AuthorizationEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - authorization.revoked
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AuthorizationEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - authorization.modified
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/AuthorizationEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - publisher.adagents_changed
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PublisherEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+        - type: object
+          properties:
+            event_id:
+              type: string
+              format: uuid
+            event_type:
+              type: string
+              enum:
+                - publisher.adagents_discovered
+            entity_type:
+              type: string
+            entity_id:
+              type: string
+            payload:
+              $ref: "#/components/schemas/PublisherEventPayload"
+            actor:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+          required:
+            - event_id
+            - event_type
+            - entity_type
+            - entity_id
+            - payload
+            - actor
+            - created_at
+    AgentEventPayload:
+      type: object
+      properties:
+        agent_url:
+          type: string
+          description: Canonical agent URL; the routing key for agent.* events (agents span many publishers).
+        name:
+          type: string
+        type:
+          type: string
+        channels:
+          type: array
+          items:
+            type: string
+        property_types:
+          type: array
+          items:
+            type: string
+        markets:
+          type: array
+          items:
+            type: string
+        categories:
+          type: array
+          items:
+            type: string
+        category_taxonomy:
+          type:
+            - string
+            - "null"
+        tags:
+          type: array
+          items:
+            type: string
+        delivery_types:
+          type: array
+          items:
+            type: string
+        format_ids:
+          type: array
+          items:
+            type: string
+          description: Deprecated 3.x named-format profile projection.
+        format_kinds:
+          type: array
+          items:
+            type: string
+        property_count:
+          type: integer
+        publisher_count:
+          type: integer
+        has_tmp:
+          type: boolean
+        updated_at:
+          type: string
+        changed_fields:
+          type: array
+          items:
+            type: string
+          minItems: 1
+        inventory_profile:
+          type: object
+          additionalProperties: {}
+          description: "On agent.profile_updated: the agent's refreshed inventory profile."
+        compliance_summary:
+          type: object
+          additionalProperties: {}
+        previous_status:
+          type: string
+          description: "On agent.compliance_changed: prior compliance/verification status."
+        current_status:
+          type: string
+          description: "On agent.compliance_changed: new compliance/verification status."
+        headline:
+          type:
+            - string
+            - "null"
+          description: "On agent.compliance_changed: human-readable summary of the compliance transition."
+        tracks:
+          type: object
+          additionalProperties:
+            type: string
+            enum:
+              - pass
+              - fail
+              - partial
+              - skip
+              - silent
+              - warning
+              - unknown
+              - skipped
+          description: "On agent.compliance_changed: map of compliance track id to track status."
+        storyboards_passing:
+          type: integer
+          minimum: 0
+        storyboards_total:
+          type: integer
+          minimum: 0
+        storyboards:
+          type: array
+          items:
+            type: object
+            properties:
+              storyboard_id:
+                type: string
+              status:
+                type: string
+              steps_passed:
+                type: integer
+                minimum: 0
+              steps_total:
+                type: integer
+                minimum: 0
+            required:
+              - storyboard_id
+              - status
+            additionalProperties: {}
+        role:
+          type: string
+          description: "On agent.verification_earned/lost: verified role affected by the badge transition."
+        verified_specialisms:
+          type: array
+          items:
+            type: string
+          description: "On agent.verification_earned: specialisms covered by the earned badge."
+        reason:
+          type: string
+          description: "On agent.verification_lost: reason the badge was revoked."
+        adcp_version:
+          type: string
+          description: "On agent.verification_earned/lost: AdCP version the badge applies to, when known."
+      required:
+        - agent_url
+      additionalProperties: {}
+    PropertyEventPayload:
+      type: object
+      properties:
+        property_rid:
+          type: string
+        publisher_domain:
+          type: string
+          description: Publisher domain that owns the property; the routing key for property.* events.
+        identifiers:
+          type: array
+          items:
+            $ref: "#/components/schemas/PropertyIdentifier"
+        classification:
+          type: string
+        source:
+          type: string
+          enum:
+            - authoritative
+            - enriched
+            - contributed
+        property:
+          type: object
+          additionalProperties: {}
+          description: Optional full post-change property object when available.
+        changed_fields:
+          type: array
+          items:
+            type: string
+          minItems: 1
+        last_resolved_at:
+          type: string
+          description: "On property.stale: last successful resolution timestamp."
+        reactivated_at:
+          type: string
+          description: "On property.reactivated: reactivation timestamp when available."
+        reason:
+          type: string
+          description: "On property.stale: reason the property aged out of active resolution."
+        alias_rid:
+          type: string
+          description: "On property.merged: the RID merged away."
+        canonical_rid:
+          type: string
+          description: "On property.merged: the surviving RID."
+        evidence:
+          type: string
+      additionalProperties: {}
+    CollectionEventPayload:
+      type: object
+      properties:
+        collection_rid:
+          type: string
+        publisher_domain:
+          type: string
+          description: Publisher domain that owns the collection; the routing key for collection.* events.
+        collection_id:
+          type:
+            - string
+            - "null"
+        name:
+          type:
+            - string
+            - "null"
+        kind:
+          type:
+            - string
+            - "null"
+        source:
+          type: string
+        status:
+          type: string
+        identifiers:
+          type: array
+          items:
+            type: object
+            properties:
+              publisher_domain:
+                type: string
+              type:
+                type: string
+              value:
+                type: string
+            required:
+              - publisher_domain
+              - type
+              - value
+          description: Distribution identifiers; the per-identifier publisher_domain (e.g. youtube.com) is the distribution surface, distinct from the owning publisher_domain above.
+        collection:
+          type: object
+          additionalProperties: {}
+        changed_fields:
+          type: array
+          items:
+            type: string
+          minItems: 1
+        alias_rid:
+          type: string
+          description: "On collection.merged: the RID merged away."
+        canonical_rid:
+          type: string
+          description: "On collection.merged: the surviving RID."
+        evidence:
+          type: string
+      additionalProperties: {}
+    AuthorizationEventPayload:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Registry authorization row id when the event is backed by a materialized effective authorization row.
+        agent_url:
+          type: string
+        agent_url_canonical:
+          type: string
+          description: Registry-canonicalized form of agent_url for equality checks.
+        publisher_domain:
+          type: string
+          description: Publisher domain the authorization applies to; the routing key for authorization.* events.
+        authorization_type:
+          type: string
+          description: Present on authorization.granted; authorization.revoked carries only agent_url + publisher_domain.
+        authorized_for:
+          type:
+            - string
+            - "null"
+        property_ids:
+          type: array
+          items:
+            type: string
+        property_tags:
+          type: array
+          items:
+            type: string
+        properties:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+        publisher_properties:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+        property_rid:
+          type:
+            - string
+            - "null"
+          description: Catalog property_rid for materialized per-property authorization rows. Null for publisher-wide rows.
+        property_id_slug:
+          type:
+            - string
+            - "null"
+          description: Publisher-local property id for materialized per-property authorization rows.
+        placement_ids:
+          type: array
+          items:
+            type: string
+        placement_tags:
+          type: array
+          items:
+            type: string
+        collections:
+          type: array
+          items:
+            type: object
+            properties:
+              publisher_domain:
+                type: string
+              collection_ids:
+                type: array
+                items:
+                  type: string
+                minItems: 1
+            required:
+              - publisher_domain
+              - collection_ids
+            additionalProperties: {}
+        countries:
+          type: array
+          items:
+            type: string
+        delegation_type:
+          type: string
+        exclusive:
+          type: boolean
+        effective_from:
+          type: string
+        effective_until:
+          type: string
+        signing_keys:
+          type:
+            - array
+            - "null"
+          items:
+            $ref: "#/components/schemas/SigningKey"
+        evidence:
+          type: string
+        disputed:
+          type: boolean
+        created_by:
+          type:
+            - string
+            - "null"
+        expires_at:
+          type:
+            - string
+            - "null"
+        created_at:
+          type:
+            - string
+            - "null"
+        updated_at:
+          type:
+            - string
+            - "null"
+        override_applied:
+          type: boolean
+        override_reason:
+          type:
+            - string
+            - "null"
+      required:
+        - agent_url
+        - publisher_domain
+      additionalProperties: {}
+    SigningKey:
+      type: object
+      properties:
+        kid:
+          type: string
+          description: Key identifier for selecting the correct signing key.
+        kty:
+          type: string
+          description: JWK key type, such as 'OKP', 'EC', or 'RSA'.
+        alg:
+          type: string
+          description: Expected signing algorithm for this key, such as 'EdDSA' or 'RS256'.
+        use:
+          type: string
+          description: Optional JWK use value. Typically 'sig' for signing keys.
+        crv:
+          type: string
+          description: Curve name for OKP or EC keys, such as 'Ed25519' or 'P-256'.
+        x:
+          type: string
+          description: Base64url-encoded public key x coordinate or public key value for OKP keys.
+        y:
+          type: string
+          description: Base64url-encoded public key y coordinate for EC keys.
+        n:
+          type: string
+          description: Base64url-encoded RSA modulus.
+        e:
+          type: string
+          description: Base64url-encoded RSA public exponent.
+        revoked_at:
+          type: string
+          format: date-time
+          description: Optional revocation timestamp. When present, verifiers MUST reject any signature produced with this key whose signing epoch is at or after this timestamp. The key may continue to appear in the trust anchor during a grace period so caches that have not yet refreshed still find the key and can evaluate the revocation marker.
+      required:
+        - kid
+        - kty
+      additionalProperties: {}
+    PublisherEventPayload:
+      type: object
+      properties:
+        publisher_domain:
+          type: string
+          description: Publisher domain whose adagents.json was discovered/changed; the routing key for publisher.* events.
+        domain:
+          type: string
+          description: Legacy alias for publisher_domain retained for early feed examples.
+        properties_added:
+          type: integer
+          minimum: 0
+        properties_removed:
+          type: integer
+          minimum: 0
+        agents_added:
+          type: array
+          items:
+            type: string
+        agents_removed:
+          type: array
+          items:
+            type: string
+        agent_count:
+          type: integer
+        property_count:
+          type: integer
+        collection_count:
+          type: integer
+        format_count:
+          type: integer
+          minimum: 0
+          description: Number of top-level formats[] declarations after the revision.
+        placement_count:
+          type: integer
+          minimum: 0
+          description: Number of top-level placements[] declarations after the revision.
+        changed_fields:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: Semantic top-level adagents.json fields changed by this revision, including formats or placements. Present on newly emitted 3.2 change events.
+        discovery_method:
+          type: string
+        manager_domain:
+          type:
+            - string
+            - "null"
+        source:
+          type: string
+      additionalProperties: {}
+    AgentComplianceDetail:
+      type: object
+      properties:
+        agent_url:
+          type: string
+        requested_compliance_target:
+          type:
+            - string
+            - "null"
+          description: Requested compliance target before alias resolution, e.g. 3.0 or 3.1-beta. Null for legacy rows before target recording.
+        adcp_version:
+          type:
+            - string
+            - "null"
+          description: Concrete AdCP compliance bundle version used for the latest run, e.g. 3.0.12. Null for legacy rows before version recording.
+        status:
+          type: string
+          enum:
+            - passing
+            - degraded
+            - failing
+            - unknown
+            - opted_out
+        lifecycle_stage:
+          type: string
+          enum:
+            - development
+            - testing
+            - production
+            - deprecated
+        compliance_opt_out:
+          type: boolean
+        badge_requalification_required:
+          type: boolean
+          description: True when monitoring is enabled but badges remain suppressed until a fresh passing full-suite run completes.
+        tracks:
+          type: object
+          additionalProperties:
+            type: string
+        track_details:
+          type: array
+          items:
+            type: object
+            properties:
+              track:
+                type: string
+              status:
+                type: string
+              scenario_count:
+                type: integer
+              passed_count:
+                type: integer
+              duration_ms:
+                type: number
+              has_coverage_gap_skip:
+                type: boolean
+            required:
+              - track
+              - status
+              - scenario_count
+              - passed_count
+              - duration_ms
+          description: Latest-run per-track summary. Skipped tracks with has_coverage_gap_skip=true represent selected coverage gaps, such as missing_test_controller.
+        streak_days:
+          type: integer
+        last_checked_at:
+          type:
+            - string
+            - "null"
+        last_passed_at:
+          type:
+            - string
+            - "null"
+        last_failed_at:
+          type:
+            - string
+            - "null"
+        headline:
+          type:
+            - string
+            - "null"
+        status_changed_at:
+          type:
+            - string
+            - "null"
+        storyboards_passing:
+          type: integer
+        storyboards_total:
+          type: integer
+        check_interval_hours:
+          type: integer
+          description: How often the heartbeat re-tests this agent, in hours
+        declared_specialisms:
+          type: array
+          items:
+            type: string
+          description: Specialisms the agent declared in get_adcp_capabilities, from the latest run
+        specialism_status:
+          type: object
+          additionalProperties:
+            type: string
+            enum:
+              - passing
+              - failing
+              - untested
+              - unknown
+          description: Per-specialism pass/fail/untested status — keyed on declared specialism, derived from the matching storyboard's status
+        storyboard_statuses:
+          type: array
+          items:
+            type: object
+            properties:
+              storyboard_id:
+                type: string
+              requested_compliance_target:
+                type:
+                  - string
+                  - "null"
+              adcp_version:
+                type:
+                  - string
+                  - "null"
+              title:
+                type: string
+              category:
+                type:
+                  - string
+                  - "null"
+              track:
+                type:
+                  - string
+                  - "null"
+              status:
+                type: string
+                enum:
+                  - passing
+                  - failing
+                  - partial
+                  - untested
+              steps_passed:
+                type: integer
+              steps_total:
+                type: integer
+              failure_count:
+                type: integer
+              skipped_count:
+                type: integer
+              first_failed_step_id:
+                type:
+                  - string
+                  - "null"
+              first_failed_step_title:
+                type:
+                  - string
+                  - "null"
+              first_failed_step_task:
+                type:
+                  - string
+                  - "null"
+              first_failure_message:
+                type:
+                  - string
+                  - "null"
+              first_failure_validations:
+                type: array
+                items: {}
+                description: Validation evidence for the first failure. Populated only for owners and empty for other callers.
+              last_tested_at:
+                type:
+                  - string
+                  - "null"
+              last_passed_at:
+                type:
+                  - string
+                  - "null"
+            required:
+              - storyboard_id
+              - title
+              - category
+              - track
+              - status
+              - steps_passed
+              - steps_total
+              - failure_count
+              - skipped_count
+              - first_failed_step_id
+              - first_failed_step_title
+              - first_failed_step_task
+              - first_failure_message
+              - first_failure_validations
+              - last_tested_at
+              - last_passed_at
+          description: Public per-storyboard verdicts and aggregate step counts. First-failure diagnostic fields are populated only for owners; scalar diagnostics are null and validation evidence is empty for other callers.
+        notices:
+          type: array
+          items:
+            $ref: "#/components/schemas/PublicComplianceNotice"
+          maxItems: 50
+          description: Public-safe run-summary notices from the latest non-dry-run compliance run. Unknown code/severity values are preserved verbatim; private fields are omitted.
+        observations:
+          type: array
+          items:
+            type: object
+            properties:
+              category:
+                type: string
+              severity:
+                type: string
+              message:
+                type: string
+            required:
+              - category
+              - severity
+              - message
+          description: Public-safe advisory observations from the latest non-dry-run compliance run. Raw evidence is intentionally omitted; this array is not merged across runs, so cleared advisories disappear on the next fresh run.
+        membership_tier:
+          type:
+            - string
+            - "null"
+          description: "Owner-scoped: the agent owner's membership tier. Populated only when the authenticated viewer owns the agent; null otherwise. Field is always present so response shape doesn't reveal ownership."
+        membership_tier_label:
+          type:
+            - string
+            - "null"
+          description: "Owner-scoped: human-readable label for membership_tier (e.g. 'Builder'). Null for non-owners."
+        subscription_status:
+          type:
+            - string
+            - "null"
+          description: "Owner-scoped: the agent owner's subscription status (active, past_due, trialing, etc.). Null for non-owners."
+        is_api_access_tier:
+          type: boolean
+          description: "Owner-scoped: true when the owner's tier and subscription status grant badge eligibility. False for non-owners. Single source of truth — UI should not re-derive."
+        verdict_source:
+          type:
+            - string
+            - "null"
+          enum:
+            - heartbeat
+            - owner_test
+            - manual
+            - webhook
+            - null
+          description: "Owner-scoped: triggered_by value of the most recent non-dry-run compliance check. Null for non-owners and when no run has been recorded. Operators use this as a UX cue ('did this verdict come from my recent test or the system heartbeat?')."
+        verified:
+          type: boolean
+        verified_badges:
+          type: array
+          items:
+            $ref: "#/components/schemas/VerificationBadge"
+      required:
+        - agent_url
+        - status
+        - lifecycle_stage
+    PublicComplianceNotice:
+      type: object
+      properties:
+        severity:
+          type: string
+          minLength: 1
+          maxLength: 64
+        code:
+          type: string
+          minLength: 1
+          maxLength: 200
+        message:
+          type: string
+          minLength: 1
+          maxLength: 1000
+        effective_version:
+          type: string
+          minLength: 1
+          maxLength: 64
+        requirement:
+          type: string
+          minLength: 1
+          maxLength: 500
+        capability_path:
+          type: string
+          minLength: 1
+          maxLength: 512
+        capability_pointer:
+          type: string
+          minLength: 1
+          maxLength: 1024
+        reference_url:
+          type: string
+          maxLength: 2048
+          format: uri
+      required:
+        - severity
+        - code
+        - message
+      additionalProperties: false
+    VerificationBadge:
+      type: object
+      properties:
+        role:
+          allOf:
+            - $ref: "#/components/schemas/BadgeRole"
+            - description: Canonical role this verification badge covers.
+        adcp_version:
+          type: string
+          description: AdCP release this badge was issued against, MAJOR.MINOR (e.g. '3.0', '3.1'). Load-bearing for badge identity — pairs with the (agent_url, role, adcp_version) PK.
+        verified_at:
+          type: string
+        verified_specialisms:
+          type: array
+          items:
+            type: string
+            enum:
+              - audience-sync
+              - brand-rights
+              - collection-lists
+              - content-standards
+              - creative-ad-server
+              - creative-generative
+              - creative-template
+              - creative-transformers
+              - governance-aware-seller
+              - governance-delivery-monitor
+              - governance-spend-authority
+              - property-lists
+              - sales-broadcast-tv
+              - sales-catalog-driven
+              - sales-guaranteed
+              - sales-non-guaranteed
+              - sales-proposal-mode
+              - sales-social
+              - signal-marketplace
+              - signal-owned
+              - signed-requests
+              - sponsored-intelligence
+          description: Specialisms demonstrably passed (enums/specialism.json). Preview specialisms are excluded from stable badges.
+        verification_modes:
+          type: array
+          items:
+            type: string
+            enum:
+              - spec
+              - live
+          minItems: 1
+          description: Verification axes earned. 'spec' = AdCP storyboards pass for the declared specialisms. 'live' = AAO has observed real production traffic via canonical campaigns. Always non-empty when a badge is present; an absent badge is conveyed by the parent record being omitted, not by an empty array.
+        verified_protocol_version:
+          type:
+            - string
+            - "null"
+        badge_url:
+          type: string
+          description: Legacy URL — auto-upgrades to the highest active version. For version-pinned embedding, derive `/api/registry/agents/{encoded_url}/badge/{role}/{adcp_version}.svg` where `{encoded_url}` is `encodeURIComponent(agent_url)`.
+      required:
+        - role
+        - adcp_version
+        - verified_at
+        - verified_specialisms
+        - verification_modes
+        - verified_protocol_version
+    AgentVerification:
+      type: object
+      properties:
+        agent_url:
+          type: string
+        verified:
+          type: boolean
+        badges:
+          type: array
+          items:
+            $ref: "#/components/schemas/VerificationBadge"
+        registry_url:
+          type: string
+      required:
+        - agent_url
+        - verified
+        - badges
+    StoryboardStatus:
+      type: object
+      properties:
+        storyboard_id:
+          type: string
+        requested_compliance_target:
+          type:
+            - string
+            - "null"
+          description: Requested compliance target from the run that produced this storyboard verdict, e.g. 3.0 or 3.1-beta.
+        adcp_version:
+          type:
+            - string
+            - "null"
+          description: Concrete AdCP compliance bundle version from the run that produced this storyboard verdict.
+        title:
+          type: string
+        category:
+          type:
+            - string
+            - "null"
+        track:
+          type:
+            - string
+            - "null"
+        status:
+          type: string
+          enum:
+            - passing
+            - failing
+            - partial
+            - untested
+        steps_passed:
+          type: integer
+        steps_total:
+          type: integer
+        failure_count:
+          type: integer
+          description: Root failing or actionable skipped step count. Cascaded prerequisite skips are excluded.
+        skipped_count:
+          type: integer
+          description: Cascaded prerequisite skip count for this storyboard verdict.
+        first_failed_step_id:
+          type:
+            - string
+            - "null"
+          description: First root failing or actionable skipped step id, when captured.
+        first_failed_step_title:
+          type:
+            - string
+            - "null"
+          description: First root failing or actionable skipped step title, when captured.
+        first_failed_step_task:
+          type:
+            - string
+            - "null"
+          description: Task/tool name for the first root failing or actionable skipped step, when captured.
+        first_failure_message:
+          type:
+            - string
+            - "null"
+          description: Runner error/detail text for the first root failing or actionable skipped step, when captured.
+        last_tested_at:
+          type:
+            - string
+            - "null"
+        last_passed_at:
+          type:
+            - string
+            - "null"
+      required:
+        - storyboard_id
+        - title
+        - category
+        - track
+        - status
+        - steps_passed
+        - steps_total
+        - failure_count
+        - skipped_count
+        - first_failed_step_id
+        - first_failed_step_title
+        - first_failed_step_task
+        - first_failure_message
+        - last_tested_at
+        - last_passed_at
+    ComplianceRun:
+      type: object
+      properties:
+        id:
+          type: string
+        requested_compliance_target:
+          type:
+            - string
+            - "null"
+        adcp_version:
+          type:
+            - string
+            - "null"
+        overall_status:
+          type: string
+        headline:
+          type:
+            - string
+            - "null"
+        tracks_passed:
+          type: integer
+        tracks_failed:
+          type: integer
+        tracks_skipped:
+          type: integer
+        tracks_partial:
+          type: integer
+        tracks_json: {}
+        total_duration_ms:
+          type:
+            - number
+            - "null"
+        triggered_by:
+          type: string
+        tested_at:
+          type: string
+      required:
+        - id
+        - overall_status
+        - headline
+        - tracks_passed
+        - tracks_failed
+        - tracks_skipped
+        - tracks_partial
+        - total_duration_ms
+        - triggered_by
+        - tested_at
+    RegistryMetadata:
+      type: object
+      properties:
+        agent_url:
+          type: string
+        lifecycle_stage:
+          type: string
+          enum:
+            - development
+            - testing
+            - production
+            - deprecated
+        compliance_opt_out:
+          type: boolean
+        badge_requalification_required:
+          type: boolean
+          description: True after opt-out until a fresh full-suite compliance run completes badge requalification.
+        monitoring_paused:
+          type: boolean
+        check_interval_hours:
+          type: integer
+        monitoring_paused_at:
+          type:
+            - string
+            - "null"
+        created_at:
+          type: string
+        updated_at:
+          type: string
+      required:
+        - agent_url
+        - lifecycle_stage
+        - compliance_opt_out
+        - badge_requalification_required
+        - monitoring_paused
+        - check_interval_hours
+        - monitoring_paused_at
+        - created_at
+        - updated_at
+    MonitoringSettings:
+      type: object
+      properties:
+        monitoring_paused:
+          type: boolean
+        check_interval_hours:
+          type: integer
+        monitoring_paused_at:
+          type:
+            - string
+            - "null"
+      required:
+        - monitoring_paused
+        - check_interval_hours
+        - monitoring_paused_at
+    ComplianceStepDiagnostic:
+      type: object
+      properties:
+        id:
+          anyOf:
+            - type: number
+            - type: string
+        run_id:
+          type: string
+        agent_url:
+          type: string
+        storyboard_id:
+          type: string
+        phase_id:
+          type: string
+        step_id:
+          type: string
+        task:
+          type: string
+        step_passed:
+          type: boolean
+        duration_ms:
+          type:
+            - number
+            - "null"
+        request_url:
+          type:
+            - string
+            - "null"
+        request_jsonb: {}
+        response_status:
+          type:
+            - number
+            - "null"
+        response_headers_jsonb:
+          type:
+            - object
+            - "null"
+          additionalProperties:
+            type: string
+        response_jsonb: {}
+        extraction_path:
+          type:
+            - string
+            - "null"
+        extraction_note:
+          type:
+            - string
+            - "null"
+        error_text:
+          type:
+            - string
+            - "null"
+        adcp_error_jsonb: {}
+        failed_validations_jsonb: {}
+        served_by_agent_url:
+          type:
+            - string
+            - "null"
+        captured_at:
+          type: string
+      required:
+        - id
+        - run_id
+        - agent_url
+        - storyboard_id
+        - phase_id
+        - step_id
+        - task
+        - step_passed
+        - captured_at
+    OutboundRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        agent_url:
+          type: string
+        request_type:
+          type: string
+        user_agent:
+          type: string
+        response_time_ms:
+          type:
+            - number
+            - "null"
+        success:
+          type: boolean
+        error_message:
+          type:
+            - string
+            - "null"
+        created_at:
+          type: string
+      required:
+        - id
+        - agent_url
+        - request_type
+        - user_agent
+        - response_time_ms
+        - success
+        - error_message
+        - created_at
+    AgentAuthStatus:
+      type: object
+      properties:
+        has_auth:
+          type: boolean
+        agent_context_id:
+          type:
+            - string
+            - "null"
+        auth_type:
+          type:
+            - string
+            - "null"
+          enum:
+            - bearer
+            - basic
+            - oauth
+            - oauth_client_credentials
+            - null
+        has_oauth_token:
+          type: boolean
+        has_valid_oauth:
+          type: boolean
+        oauth_token_expires_at:
+          type:
+            - string
+            - "null"
+        has_oauth_client_credentials:
+          type: boolean
+      required:
+        - has_auth
+        - agent_context_id
+        - auth_type
+        - has_oauth_token
+        - has_valid_oauth
+        - oauth_token_expires_at
+        - has_oauth_client_credentials
+    CredentialSaveValidationError:
+      type: object
+      properties:
+        error:
+          type: string
+        code:
+          type: string
+          enum:
+            - invalid_blob_shape
+            - missing_field
+            - invalid_field_type
+            - field_too_long
+            - invalid_url
+            - invalid_env_reference
+            - invalid_auth_method_value
+            - array_too_many
+            - array_too_few
+            - aggregate_too_long
+          description: Stable rejection tag. UI maps this to operator-friendly prose.
+        field:
+          type: string
+          enum:
+            - oauth_client_credentials
+            - token_endpoint
+            - client_id
+            - client_secret
+            - scope
+            - resource
+            - audience
+            - auth_method
+          description: Field the UI should scroll to + highlight.
+      required:
+        - error
+        - code
+        - field
+    StoryboardSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        category:
+          type: string
+        summary:
+          type: string
+        interaction_model:
+          type: string
+        examples:
+          type: array
+          items:
+            type: string
+        phase_count:
+          type: integer
+        step_count:
+          type: integer
+      required:
+        - id
+        - title
+        - category
+        - summary
+        - interaction_model
+        - examples
+        - phase_count
+        - step_count
+    StoryboardDetail:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        category:
+          type: string
+        summary:
+          type: string
+        agent:
+          type: object
+          properties:
+            interaction_model:
+              type: string
+            examples:
+              type: array
+              items:
+                type: string
+          required:
+            - interaction_model
+        phases:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+              steps:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    title:
+                      type: string
+                    description:
+                      type: string
+                    expected_output:
+                      type: string
+                  required:
+                    - id
+                    - title
+                    - description
+                    - expected_output
+            required:
+              - title
+              - steps
+        prerequisites: {}
+        required_tools:
+          type: array
+          items:
+            type: string
+        track:
+          type: string
+      required:
+        - id
+        - title
+        - category
+        - summary
+        - agent
+        - phases
+    FindCompanyResult:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/CompanySearchResult"
+      required:
+        - results
+    CompanySearchResult:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: coca-cola.com
+        canonical_domain:
+          type: string
+          example: coca-cola.com
+        brand_name:
+          type: string
+          example: The Coca-Cola Company
+        house_domain:
+          type: string
+          example: coca-cola.com
+        keller_type:
+          type: string
+          enum:
+            - master
+            - sub_brand
+            - endorsed
+            - independent
+        parent_brand:
+          type: string
+        brand_agent_url:
+          type: string
+        source:
+          type: string
+          example: community
+        relationship_trust:
+          type: string
+          enum:
+            - inline
+            - mutual
+            - leaf_only
+            - house_only
+            - standalone
+            - unverifiable
+          description: Trust verdict for the brand-to-house relationship. Absent means not yet computed — absent MUST NOT be interpreted as `standalone`.
+        relationship_verified_at:
+          type: string
+          format: date-time
+          description: When the mutual-assertion edge was last confirmed by both sides. Present only when relationship_trust is `mutual`.
+        claimed_house_domain:
+          type: string
+          description: Unilateral parent claim from the brand's own document. Not trust-extending. Present for `leaf_only` and `unverifiable`.
+      required:
+        - domain
+        - canonical_domain
+        - brand_name
+        - source
+    MemberAgentListResponse:
+      type: object
+      properties:
+        agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/MemberAgent"
+      required:
+        - agents
+    MemberAgent:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          example: https://agent.example.com/mcp
+        visibility:
+          $ref: "#/components/schemas/MemberAgentVisibility"
+        type:
+          $ref: "#/components/schemas/MemberAgentType"
+        name:
+          type: string
+        health_check_url:
+          type: string
+          format: uri
+          description: Optional fallback liveness URL used by the health probe when the protocol handshake fails.
+      required:
+        - url
+        - visibility
+        - type
+      description: Agent entry stored on a member profile. `type` is required on read because every write surface declares it and the operator endpoint always emits it; a stored value of `unknown` is the smuggle-protection outcome (snapshot contradicted the declaration without classifying it) and is the only path that surfaces an agent without a real type.
+    MemberAgentVisibility:
+      type: string
+      enum:
+        - private
+        - members_only
+        - public
+      description: Visibility tier on the registry catalog. `private` = profile owner only; `members_only` = AAO API-tier members on operator lookup; `public` = listed in the public catalog and reflected in the org's `brand.json` (requires a paid AAO tier — Professional, Builder, Member, or Leader).
+    MemberAgentType:
+      type: string
+      enum:
+        - brand
+        - rights
+        - measurement
+        - governance
+        - creative
+        - sales
+        - buying
+        - signals
+        - unknown
+      description: Agent type as stored on the registry. Server-side smuggle protection compares the caller's declaration against the capability snapshot (when one exists) and may stamp `unknown` if the snapshot contradicts the declaration without classifying it. `unknown` is reserved for that server-side outcome; clients cannot submit it.
+    MemberAgentResponse:
+      type: object
+      properties:
+        agent:
+          $ref: "#/components/schemas/MemberAgent"
+        warnings:
+          type: array
+          items:
+            $ref: "#/components/schemas/MemberAgentVisibilityWarning"
+        org_auto_created:
+          type: boolean
+          description: "Set to `true` when this `POST` was the caller's first interaction with the registry and the server auto-created the organization (display name derived from the user's email domain for corporate emails, or `<First Last>'s Workspace` for free-email providers). Combined with `profile_auto_created`, this is the one-call storefront experience: a third-party app holding only an OAuth token gets the org, profile, and registered agent in a single request."
+        profile_auto_created:
+          type: boolean
+          description: "Set to `true` when this `POST` was the first agent registration on the caller's organization and the server auto-created a private member profile (display name = organization name, `is_public: false`). Absent on subsequent calls and on update-in-place. Surfaced so storefront-style integrations can show a \"we set up your profile\" hint without needing to detect the prior 404 → bootstrap → retry shape."
+      required:
+        - agent
+    MemberAgentVisibilityWarning:
+      type: object
+      properties:
+        code:
+          type: string
+          enum:
+            - visibility_downgraded
+        agent_url:
+          type: string
+        requested:
+          type: string
+          enum:
+            - public
+        applied:
+          type: string
+          enum:
+            - members_only
+        reason:
+          type: string
+          enum:
+            - tier_required
+        message:
+          type: string
+      required:
+        - code
+        - agent_url
+        - requested
+        - applied
+        - reason
+        - message
+      description: Emitted when the tier gate downgrades a requested visibility.
+    MemberAgentInput:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          example: https://agent.example.com/mcp
+        type:
+          $ref: "#/components/schemas/MemberAgentTypeInput"
+        name:
+          type: string
+        visibility:
+          $ref: "#/components/schemas/MemberAgentVisibility"
+        health_check_url:
+          type: string
+          format: uri
+      required:
+        - url
+        - type
+      description: Request body for `POST /api/me/agents`. `type` is required — the owner declares it; the server never infers.
+    MemberAgentTypeInput:
+      type: string
+      enum:
+        - brand
+        - rights
+        - measurement
+        - governance
+        - creative
+        - sales
+        - buying
+        - signals
+      description: Agent type the caller declares. Required on register; smuggle-protection still cross-checks against the capability snapshot when one exists. The server never infers `type` — the owner declares what kind of agent this is.
+    MemberAgentPatch:
+      type: object
+      properties:
+        name:
+          type: string
+        visibility:
+          $ref: "#/components/schemas/MemberAgentVisibility"
+        type:
+          $ref: "#/components/schemas/MemberAgentTypeInput"
+        health_check_url:
+          type: string
+          format: uri
+      description: Request body for `PATCH /api/me/agents/{url}`. The `url` field cannot be changed via PATCH; re-register at the new URL and DELETE the old entry instead. If `type` is omitted, the existing value is preserved.
+    CreateOrganizationResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        organization:
+          type: object
+          properties:
+            id:
+              type: string
+              example: org_01HXZAB123
+            name:
+              type: string
+              example: Acme Media
+          required:
+            - id
+            - name
+        id:
+          type: string
+          description: "Set on the **prospect-adoption** path: when an org with the user's email domain already exists in a `prospect` state (i.e. the registry pre-recorded it from a brand crawl but no human had claimed it yet), this call adopts that org for the caller instead of creating a new one."
+        name:
+          type: string
+        adopted:
+          type: boolean
+          description: "`true` when the response is the prospect-adoption path. When `true`, no new WorkOS organization was created — the caller is now the owner of an existing prospect record."
+      description: 'Response from `POST /api/organizations`. The body shape varies by path: a fresh creation returns `{ success: true, organization: { id, name } }`; a prospect adoption returns `{ id, name, adopted: true }` directly. Both paths are 2xx; downstream callers should treat any `2xx` as "the org now exists and you are an owner of it" and read whichever id is present.'
+    CreateOrganizationInput:
+      type: object
+      properties:
+        organization_name:
+          type: string
+          minLength: 1
+          maxLength: 200
+          description: Display name for the organization. Used both as the org row name and (when auto-bootstrapping a member profile via the first agent registration) as the profile's `display_name`.
+          example: Acme Media
+        is_personal:
+          type: boolean
+          default: false
+          description: Set to `true` to create a personal workspace instead of a corporate organization. Personal workspaces skip corporate-domain verification, are limited to one per user, and cannot host the `company_*` membership tiers.
+        company_type:
+          $ref: "#/components/schemas/OrganizationCompanyType"
+        revenue_tier:
+          $ref: "#/components/schemas/OrganizationRevenueTier"
+        marketing_opt_in:
+          type: boolean
+          default: false
+          description: Whether the caller opted in to AAO marketing communications. Recorded once per user (not overwritten on subsequent calls). Independent of Terms-of-Service consent, which is recorded server-side from the request context.
+      required:
+        - organization_name
+      description: |-
+        Request body for `POST /api/organizations`.
+
+        Bootstraps a WorkOS organization, mirrors the caller as `owner`, records the caller's ToS / privacy-policy acceptance, and (for non-personal orgs) inserts an email-verified record into `organization_domains` so subsequent registry calls can skip explicit domain-verification.
+
+        Membership tier and corporate domain are *not* caller-supplied: the tier is set by the Stripe webhook on subscription events, and the corporate domain is derived from the authenticated user's email.
+    OrganizationCompanyType:
+      type: string
+      enum:
+        - adtech
+        - agency
+        - brand
+        - publisher
+        - data
+        - ai
+        - other
+      description: Coarse classification of the organization's role in the open ad ecosystem. Drives default verification badges and the member profile's display category.
+    OrganizationRevenueTier:
+      type: string
+      enum:
+        - under_1m
+        - 1m_5m
+        - 5m_50m
+        - 50m_250m
+        - 250m_1b
+        - 1b_plus
+      description: Annual revenue band, USD. Drives membership-tier eligibility for company-tier seats.
+    ResolveResponse:
+      type: object
+      properties:
+        resolved:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResolvedEntry"
+        summary:
+          type: object
+          properties:
+            total:
+              type: integer
+            resolved:
+              type: integer
+            created:
+              type: integer
+            excluded:
+              type: integer
+            not_found:
+              type: integer
+          required:
+            - total
+            - resolved
+            - created
+            - excluded
+            - not_found
+        server_timestamp:
+          type: string
+      required:
+        - resolved
+        - summary
+        - server_timestamp
+    ResolvedEntry:
+      type: object
+      properties:
+        identifier:
+          $ref: "#/components/schemas/CatalogIdentifier"
+        property_rid:
+          type:
+            - string
+            - "null"
+          description: Stable catalog handle for joining/dedup and TMP matching. NOT an authorization credential. `null` for excluded (ad_infra / publisher_mask) or unresolved-in-lookup identifiers.
+        classification:
+          type: string
+          example: property
+        status:
+          type: string
+          enum:
+            - existing
+            - created
+            - excluded
+        source:
+          type:
+            - string
+            - "null"
+      required:
+        - identifier
+        - property_rid
+        - classification
+        - status
+        - source
+    CatalogIdentifier:
+      type: object
+      properties:
+        type:
+          type: string
+          example: domain
+        value:
+          type: string
+          example: nytimes.com
+      required:
+        - type
+        - value
+    ResolveRequest:
+      type: object
+      properties:
+        identifiers:
+          type: array
+          items:
+            $ref: "#/components/schemas/CatalogIdentifier"
+          minItems: 1
+          maxItems: 10000
+          description: Identifiers to resolve (and, in resolve mode, contribute). Max 10,000 per call for all callers.
+        provenance:
+          $ref: "#/components/schemas/FactProvenance"
+        mode:
+          type: string
+          enum:
+            - resolve
+            - lookup
+          default: resolve
+          description: "`resolve` (default) contributes the identifiers, auto-creates missing catalog entries, logs demand activity, and returns rids — requires authentication. `lookup` is a pure read: no write, no activity log, no auth."
+      required:
+        - identifiers
+        - provenance
+    FactProvenance:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - agency_allowlist
+            - publisher_declaration
+            - impression_log
+            - ssp_inventory
+            - deal_history
+            - crawl
+            - data_partner
+            - member_assertion
+          description: How the caller knows these identifiers — the trust/audit envelope on the fact. Determines the confidence the catalog assigns. `crawl` is reserved for server-side pipelines; callers use the others.
+        context:
+          type: string
+          example: unilever_q3
+          description: Optional free-text annotation (campaign, dataset).
+      required:
+        - type
+    CatalogDisputeTriageResult:
+      type: object
+      properties:
+        dispute_id:
+          type: string
+        action_taken:
+          type: string
+          enum:
+            - link_suspended
+            - queued_for_review
+            - escalated
+          description: "What filing the dispute did: a medium/weak link is suspended immediately; otherwise the dispute is queued or escalated for review."
+        reason:
+          type: string
+      required:
+        - dispute_id
+        - action_taken
+        - reason
+    CatalogDisputeRequest:
+      type: object
+      properties:
+        dispute_type:
+          type: string
+          enum:
+            - identifier_link
+            - classification
+            - property_data
+            - false_merge
+        subject_type:
+          type: string
+          example: identifier
+          description: What is being disputed — e.g. `identifier` or `property_rid`.
+        subject_value:
+          type: string
+          example: com.example.app
+        claim:
+          type: string
+          minLength: 10
+          maxLength: 2000
+          description: The dispute claim (10–2000 chars).
+        evidence:
+          type: string
+          maxLength: 5000
+          description: Optional supporting evidence (≤5000 chars).
+      required:
+        - dispute_type
+        - subject_type
+        - subject_value
+        - claim
+    CatalogDisputeRecord:
+      type: object
+      properties:
+        id:
+          type: string
+        dispute_type:
+          type: string
+          enum:
+            - identifier_link
+            - classification
+            - property_data
+            - false_merge
+        subject_type:
+          type: string
+        subject_value:
+          type: string
+        claim:
+          type: string
+        evidence:
+          type:
+            - string
+            - "null"
+        status:
+          type: string
+          example: suspended
+          description: Current dispute status.
+        created_at:
+          type: string
+      required:
+        - id
+        - dispute_type
+        - subject_type
+        - subject_value
+        - claim
+        - status
+        - created_at
+      additionalProperties: {}
+    CatalogBrowseResponse:
+      type: object
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/CatalogBrowseEntry"
+        total:
+          type: integer
+        next_cursor:
+          type:
+            - string
+            - "null"
+          description: Opaque cursor for the next page; null when exhausted.
+      required:
+        - entries
+        - total
+        - next_cursor
+    CatalogBrowseEntry:
+      type: object
+      properties:
+        property_rid:
+          type: string
+        property_id:
+          type:
+            - string
+            - "null"
+        classification:
+          type: string
+          example: property
+        source:
+          type: string
+          example: adagents_json
+        status:
+          type: string
+          example: active
+        identifiers:
+          type: array
+          items:
+            $ref: "#/components/schemas/CatalogIdentifier"
+      required:
+        - property_rid
+        - property_id
+        - classification
+        - source
+        - status
+        - identifiers
+    CatalogSyncResponse:
+      type: object
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/CatalogSyncEntry"
+        server_timestamp:
+          type: string
+          description: Watermark to pass as `since` on the next sync (avoids clock skew).
+        next_cursor:
+          type:
+            - string
+            - "null"
+      required:
+        - entries
+        - server_timestamp
+        - next_cursor
+    CatalogSyncEntry:
+      type: object
+      properties:
+        property_rid:
+          type: string
+        property_id:
+          type:
+            - string
+            - "null"
+        classification:
+          type: string
+        source:
+          type: string
+        status:
+          type: string
+        adagents_url:
+          type:
+            - string
+            - "null"
+        created_by:
+          type:
+            - string
+            - "null"
+        created_at:
+          type: string
+        updated_at:
+          type: string
+        source_updated_at:
+          type: string
+      required:
+        - property_rid
+        - property_id
+        - classification
+        - source
+        - status
+        - adagents_url
+        - created_by
+        - created_at
+        - updated_at
+        - source_updated_at
+    AdagentsJson:
+      type: object
+      properties:
+        $schema:
+          type: string
+          format: uri
+        authorized_agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdagentsAuthorizedAgent"
+        properties:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        catalog_etag:
+          type: string
+        formats:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        placements:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        placement_tags:
+          type: object
+          additionalProperties: {}
+        collections:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        signals:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+            description: Protocol-defined catalog object. See the adagents.json JSON Schema for the authoritative nested shape.
+        signal_tags:
+          type: object
+          additionalProperties: {}
+        contact: {}
+        superseded_by:
+          type: string
+          format: uri
+          description: HTTPS URL for the canonical successor adagents.json document. Clients should re-fetch the successor and update cached mirror references before retiring use of this mirror.
+        last_updated:
+          type: string
+          format: date-time
+      required:
+        - authorized_agents
+      additionalProperties: {}
+paths:
+  /api:
+    get:
+      operationId: apiDiscovery
+      summary: API discovery
+      description: Returns links to the main API entry points and documentation.
+      tags:
+        - Search
+      responses:
+        "200":
+          description: API discovery information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  version:
+                    type: string
+                  documentation:
+                    type: string
+                  openapi:
+                    type: string
+                  endpoints:
+                    type: object
+                    additionalProperties:
+                      type: string
+                required:
+                  - name
+                  - version
+                  - documentation
+                  - openapi
+                  - endpoints
+  /api/brands/resolve:
+    get:
+      operationId: resolveBrand
+      summary: Resolve brand
+      description: |-
+        Resolve a domain to its canonical brand identity. Follows brand.json redirects and returns the resolved brand with its house, architecture type, and optional manifest. The domain must be a bare DNS hostname.
+
+        A domain is authoritative for its own identity, so `source` tells you who published the record and `relationship_trust` tells you whether a brand-to-house relationship was confirmed by both sides. Only `mutual` and `inline` are reciprocated; treat everything else as a claim.
+        Record selection is deterministic: `hosted` > `brand_json` > `community` > `enriched`. `source` reports provenance only and must not be used as a substitute for `relationship_trust`.
+        The v3 hierarchy is one level deep. There is no ordered-chain endpoint: third-party verifiers use the reciprocated `house_domain` edge returned here. `claimed_house_domain` is unilateral and never extends trust.
+
+        **Rate limit:** 60 requests per minute per IP address.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+            description: Bypass the resolution cache and refetch from the origin. When a fresh fetch fails and a stored record is returned instead, `live_brand_json` carries that fetch's diagnostics.
+          required: false
+          description: Bypass the resolution cache and refetch from the origin. When a fresh fetch fails and a stored record is returned instead, `live_brand_json` carries that fetch's diagnostics.
+          name: fresh
+          in: query
+      responses:
+        "200":
+          description: Brand resolved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResolvedBrand"
+        "400":
+          description: Invalid or missing domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Brand not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                  file_status:
+                    type: number
+                    description: HTTP status code from brand.json fetch (e.g. 404 vs 200 with invalid data)
+                required:
+                  - error
+                  - domain
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/resolve/bulk:
+    post:
+      operationId: resolveBrandsBulk
+      summary: Bulk resolve brands
+      description: |-
+        Resolve up to 25 domains to their canonical brand identities in a single request. Unresolvable domains map to `null`.
+
+        **Rate limits:** 20 requests and 100 unique domain resolutions per minute per IP address. Request bodies are capped at 16 KB.
+      tags:
+        - Brand Resolution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domains:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 25
+              required:
+                - domains
+      responses:
+        "200":
+          description: Bulk resolution results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: object
+                    additionalProperties:
+                      allOf:
+                        - $ref: "#/components/schemas/ResolvedBrand"
+                        - type:
+                            - object
+                            - "null"
+                required:
+                  - results
+        "400":
+          description: Invalid domain list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: Request body over 16 KB
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Too much resolution work is already queued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/brand-json:
+    get:
+      operationId: getBrandJson
+      summary: Get brand.json
+      description: |-
+        Fetch the raw brand.json file for a bare DNS hostname.
+
+        **Rate limit:** 60 requests per minute per IP address.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+          required: false
+          name: fresh
+          in: query
+      responses:
+        "200":
+          description: Raw brand.json data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  url:
+                    type: string
+                  variant:
+                    type: string
+                  data:
+                    type: object
+                    additionalProperties: {}
+                  warnings:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        field:
+                          type: string
+                        message:
+                          type: string
+                        suggestion:
+                          type: string
+                      required:
+                        - field
+                        - message
+                  promoted_from_schema:
+                    type: string
+                  live_brand_json:
+                    type: object
+                    properties:
+                      valid:
+                        type: boolean
+                      url:
+                        type: string
+                      status_code:
+                        type: integer
+                      errors:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            field:
+                              type: string
+                            message:
+                              type: string
+                            severity:
+                              type: string
+                              enum:
+                                - error
+                          required:
+                            - field
+                            - message
+                            - severity
+                      warnings:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            field:
+                              type: string
+                            message:
+                              type: string
+                            suggestion:
+                              type: string
+                          required:
+                            - field
+                            - message
+                    required:
+                      - valid
+                      - url
+                      - errors
+                      - warnings
+                required:
+                  - domain
+                  - url
+                  - data
+        "400":
+          description: Invalid or missing domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Brand not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/save:
+    post:
+      operationId: saveBrand
+      summary: Save brand
+      description: Save or update a brand in the registry. Requires authentication. For existing brands, creates a revision-tracked edit. For new brands, creates the brand directly. Cannot edit authoritative brands managed via brand.json.
+      tags:
+        - Brand Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: acmecorp.com
+                brand_name:
+                  type: string
+                  example: Acme Corp
+                brand_manifest:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - domain
+                - brand_name
+      responses:
+        "200":
+          description: Brand saved or updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  message:
+                    type: string
+                  domain:
+                    type: string
+                  id:
+                    type: string
+                  revision_number:
+                    type: integer
+                required:
+                  - success
+                  - message
+                  - domain
+                  - id
+        "400":
+          description: Missing required fields or invalid domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Cannot edit authoritative brand
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/registry:
+    get:
+      operationId: listBrands
+      summary: List brands
+      description: List all brands in the registry with optional search, pagination, and source filter.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+          required: false
+          name: search
+          in: query
+        - schema:
+            type: integer
+            example: 100
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            example: 0
+          required: false
+          name: offset
+          in: query
+        - schema:
+            type: string
+            enum:
+              - hosted
+              - brand_json
+              - enriched
+              - community
+              - stub
+            description: "Filter by source. Values match the per-brand source field in the response: hosted = registered by domain owner via /api/brands; brand_json = crawler-discovered with a live /.well-known/brand.json; enriched = Brandfetch-sourced; community = manually contributed; stub = organization-derived placeholder awaiting stronger evidence."
+          required: false
+          description: "Filter by source. Values match the per-brand source field in the response: hosted = registered by domain owner via /api/brands; brand_json = crawler-discovered with a live /.well-known/brand.json; enriched = Brandfetch-sourced; community = manually contributed; stub = organization-derived placeholder awaiting stronger evidence."
+          name: source
+          in: query
+      responses:
+        "200":
+          description: Brand list with stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  brands:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/BrandRegistryItem"
+                  stats:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      hosted:
+                        type: integer
+                      brand_json:
+                        type: integer
+                      community:
+                        type: integer
+                      enriched:
+                        type: integer
+                      stub:
+                        type: integer
+                      houses:
+                        type: integer
+                      sub_brands:
+                        type: integer
+                      with_manifest:
+                        type: integer
+                    required:
+                      - total
+                      - hosted
+                      - brand_json
+                      - community
+                      - enriched
+                      - stub
+                      - houses
+                      - sub_brands
+                      - with_manifest
+                required:
+                  - brands
+                  - stats
+        "400":
+          description: Invalid source filter value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/history:
+    get:
+      operationId: getBrandHistory
+      summary: Brand activity history
+      description: Returns the edit history for a brand in the registry, newest first. Only brands with community or enriched edits have history; brand.json-sourced brands are authoritative and do not generate revisions.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: integer
+            example: 20
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            example: 0
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Brand activity history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrandActivity"
+        "400":
+          description: domain parameter required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Brand not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                required:
+                  - error
+                  - domain
+  /api/brands/enrich:
+    get:
+      operationId: enrichBrand
+      summary: Enrich brand
+      description: Enrich brand data using Brandfetch. Returns logo, colors, and company information. Authenticated callers may also receive ephemeral Brand Context API identity/positioning/voice data.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Enrichment data from Brandfetch
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  domain:
+                    type: string
+                  cached:
+                    type: boolean
+                  manifest:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                      description:
+                        type: string
+                      logos:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            url:
+                              type: string
+                            tags:
+                              type: array
+                              items:
+                                type: string
+                          required:
+                            - url
+                            - tags
+                      colors:
+                        type: object
+                        properties:
+                          primary:
+                            type: string
+                          secondary:
+                            type: string
+                          accent:
+                            type: string
+                        additionalProperties: {}
+                      fonts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            role:
+                              type: string
+                          required:
+                            - name
+                            - role
+                          additionalProperties: {}
+                      company:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          industry:
+                            type: string
+                          industries:
+                            type: array
+                            items:
+                              type: string
+                          employees:
+                            type: string
+                          founded:
+                            type: number
+                          location:
+                            type: string
+                        additionalProperties: {}
+                    required:
+                      - name
+                      - url
+                    additionalProperties: {}
+                  company:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      industry:
+                        type: string
+                      industries:
+                        type: array
+                        items:
+                          type: string
+                      employees:
+                        type: string
+                      founded:
+                        type: number
+                      location:
+                        type: string
+                    additionalProperties: {}
+                  source_type:
+                    type: string
+                    enum:
+                      - brand_json
+                      - community
+                      - enriched
+                  context:
+                    type: object
+                    properties: {}
+                    additionalProperties: {}
+                  context_source:
+                    type: string
+                    enum:
+                      - brandfetch
+                  context_scope:
+                    type: string
+                    enum:
+                      - ephemeral
+                  context_error:
+                    type: string
+                required:
+                  - success
+                  - domain
+                  - cached
+        "503":
+          description: Brandfetch not configured
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/history:
+    get:
+      operationId: getPropertyHistory
+      summary: Property activity history
+      description: Returns the edit history for a property in the registry, newest first.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: integer
+            example: 20
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            example: 0
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Property activity history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PropertyActivity"
+        "400":
+          description: domain parameter required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Property not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                required:
+                  - error
+                  - domain
+  /api/properties/resolve:
+    get:
+      operationId: resolveProperty
+      summary: Resolve property
+      description: Resolve a publisher domain to its property information. Checks hosted properties, discovered properties, then live adagents.json validation.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Property resolved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResolvedProperty"
+        "404":
+          description: Property not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  domain:
+                    type: string
+                required:
+                  - error
+                  - domain
+  /api/properties/resolve/bulk:
+    post:
+      operationId: resolvePropertiesBulk
+      summary: Bulk resolve properties
+      description: |-
+        Resolve up to 100 publisher domains at once.
+
+        **Rate limit:** 20 requests per minute per IP address.
+      tags:
+        - Property Resolution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domains:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 100
+              required:
+                - domains
+      responses:
+        "200":
+          description: Bulk resolution results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: object
+                    additionalProperties:
+                      allOf:
+                        - $ref: "#/components/schemas/ResolvedProperty"
+                        - type:
+                            - object
+                            - "null"
+                required:
+                  - results
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/registry:
+    get:
+      operationId: listProperties
+      summary: List properties
+      description: List all properties in the registry with optional search, pagination.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+          required: false
+          name: search
+          in: query
+        - schema:
+            type: integer
+            example: 100
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            example: 0
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Property list with stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  properties:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PropertyRegistryItem"
+                  stats:
+                    type: object
+                    additionalProperties: {}
+                required:
+                  - properties
+                  - stats
+  /api/properties/validate:
+    get:
+      operationId: validateProperty
+      summary: Validate adagents.json
+      description: Validate a domain's adagents.json file and return the validation result.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Validation result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationResult"
+  /api/properties/save:
+    post:
+      operationId: saveProperty
+      summary: Save property
+      description: |-
+        Save or update a hosted property in the registry. Requires authentication. For existing properties, creates a revision-tracked edit. For new properties, creates the property directly. Cannot edit authoritative properties managed via adagents.json.
+
+        This is an identity-only write surface: the stored document always carries `authorized_agents: []`. Sales authorization lives solely in the publisher's own origin `adagents.json`; the community registry cannot mint or carry it. Any `authorized_agents` sent in the request body is ignored.
+      tags:
+        - Property Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                publisher_domain:
+                  type: string
+                  example: examplepub.com
+                authorized_agents:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      authorized_for:
+                        type: string
+                    required:
+                      - url
+                  description: Ignored. Community-registry rows never assert sales authorization — the owner's origin adagents.json is the sole authorization source — so any value here is dropped and the stored document carries authorized_agents:[].
+                  example: []
+                properties:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                      - type
+                      - name
+                  example:
+                    - type: website
+                      name: Example Publisher
+                contact:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    email:
+                      type: string
+              required:
+                - publisher_domain
+      responses:
+        "200":
+          description: Property saved or updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  message:
+                    type: string
+                  id:
+                    type: string
+                  revision_number:
+                    type: integer
+                required:
+                  - success
+                  - message
+                  - id
+        "400":
+          description: Missing required fields or invalid domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Cannot edit authoritative property
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/hosted/{domain}/claim:
+    post:
+      operationId: claimHostedPropertyDomain
+      summary: Claim a domain for bind-on-verify
+      description: |-
+        Issue a pending domain claim for the caller's organization and return a claim-specific `authoritative_location` URL (`…/adagents.json?adcp_claim=<token>`). The caller places that single pointer at their own origin `/.well-known/adagents.json`; a subsequent verify-origin reads the token and binds the domain to the caller's org. The token is the per-account artifact that proves WHICH account owns the domain — a plain domain-keyed pointer proves only that the origin endorses AAO hosting, not who the owner is.
+
+        The community write surface stays open; this does not gate writes — it establishes ownership on successful verification. Refused with 409 only when the domain is already verified and locked to a different owner.
+      tags:
+        - Property Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: path
+      responses:
+        "200":
+          description: Claim issued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  domain:
+                    type: string
+                  authoritative_location:
+                    type: string
+                  instructions:
+                    type: string
+                required:
+                  - success
+                  - domain
+                  - authoritative_location
+                  - instructions
+        "400":
+          description: Invalid domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Caller is not a member of any organization
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Domain already verified and locked to another owner
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/hosted/{domain}/verify-origin:
+    post:
+      operationId: verifyHostedPropertyOrigin
+      summary: Verify AAO-hosted publisher origin
+      description: |-
+        Trigger origin verification for an AAO-hosted publisher: fetches the publisher's own `/.well-known/adagents.json` and checks for an `authoritative_location` field pointing at the AAO-hosted URL. On success, promotes `agent_publisher_authorizations` rows from `source='aao_hosted'` to `source='adagents_json'` for the manifest's authorized agents — buyers reading the registry then see them as origin-attested.
+
+        Bind-on-verify: when the pointer carries an `adcp_claim` token (see the claim endpoint), a successful verification binds the domain to that claim's organization and returns `bound_org_id`. Binding is driven by which token the origin pointer carries, never by who triggers verification, so any authenticated caller may trigger it and a squatter cannot bind a domain they don't control. An existing verified owner is never overwritten.
+
+        Failure classification:
+        - `not_found`: publisher origin returned 404 (permanent — demotes if previously verified).
+        - `invalid_json` / `no_authoritative_location` / `authoritative_location_mismatch`: publisher origin returned a parseable response that doesn't satisfy the spec stub pattern (permanent — demotes).
+        - `unresolvable`: DNS NXDOMAIN, private IP, or non-http scheme (permanent — demotes).
+        - `transient`: 5xx / 429 / 3xx / network timeout (leaves persisted state alone, stamps `origin_last_checked_at`).
+      tags:
+        - Property Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: path
+      responses:
+        "200":
+          description: Verification outcome
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  verified:
+                    type: boolean
+                  reason:
+                    type: string
+                    enum:
+                      - authoritative_location_pointer
+                      - not_found
+                      - invalid_json
+                      - no_authoritative_location
+                      - authoritative_location_mismatch
+                      - unresolvable
+                      - transient
+                  checked_at:
+                    type: string
+                  detail:
+                    type: string
+                  bound_org_id:
+                    type: string
+                required:
+                  - verified
+                  - reason
+                  - checked_at
+        "400":
+          description: Invalid domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No hosted property for this domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/check:
+    post:
+      operationId: checkPropertyList
+      summary: Check property list
+      description: |-
+        Check a list of publisher domains against the AAO registry. Normalizes domains (strips www/m prefixes), removes duplicates, flags known ad tech infrastructure, and identifies domains not yet in the registry.
+
+        Returns four buckets:
+        - **remove**: duplicates or known blocked domains (ad servers, CDNs, trackers, intermediaries)
+        - **modify**: domains that were normalized (e.g. www.example.com → example.com)
+        - **assess**: unknown domains not in registry, not blocked
+        - **ok**: domains found in registry with no changes needed
+
+        Results are stored for 7 days and retrievable via the `report_id`.
+      tags:
+        - Property Resolution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domains:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 10000
+                  example:
+                    - www.nytimes.com
+                    - googlesyndication.com
+                    - wsj.com
+              required:
+                - domains
+      responses:
+        "200":
+          description: Property list check results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      remove:
+                        type: integer
+                      modify:
+                        type: integer
+                      assess:
+                        type: integer
+                      ok:
+                        type: integer
+                    required:
+                      - total
+                      - remove
+                      - modify
+                      - assess
+                      - ok
+                  remove:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        input:
+                          type: string
+                        canonical:
+                          type: string
+                        reason:
+                          type: string
+                          enum:
+                            - duplicate
+                            - blocked
+                        domain_type:
+                          type: string
+                        blocked_reason:
+                          type: string
+                      required:
+                        - input
+                        - canonical
+                        - reason
+                  modify:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        input:
+                          type: string
+                        canonical:
+                          type: string
+                        reason:
+                          type: string
+                      required:
+                        - input
+                        - canonical
+                        - reason
+                  assess:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        domain:
+                          type: string
+                      required:
+                        - domain
+                  ok:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        domain:
+                          type: string
+                        source:
+                          type: string
+                      required:
+                        - domain
+                        - source
+                  report_id:
+                    type: string
+                    description: UUID for retrieving this report later
+                required:
+                  - summary
+                  - remove
+                  - modify
+                  - assess
+                  - ok
+                  - report_id
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/check/{reportId}:
+    get:
+      operationId: getPropertyCheckReport
+      summary: Get property check report
+      description: Retrieve a previously stored property check report by ID. Reports expire after 7 days.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: reportId
+          in: path
+      responses:
+        "200":
+          description: Property check report
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      remove:
+                        type: integer
+                      modify:
+                        type: integer
+                      assess:
+                        type: integer
+                      ok:
+                        type: integer
+                    required:
+                      - total
+                      - remove
+                      - modify
+                      - assess
+                      - ok
+                required:
+                  - summary
+        "404":
+          description: Report not found or expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents:
+    get:
+      operationId: listAgents
+      summary: List agents
+      description: List all agents in the registry. Optionally enrich with health checks, capabilities, and property summaries via query parameters. Measurement-vendor filters (`metric_id`, `accreditation`, `q`) imply `type=measurement`. Canonical creative-capability filters (`format_kind`, `publisher_domain`, `format_option_id`, `capability_id`, `creative_operation`) match any endpoint exposing that creative surface, including mixed sales/creative agents; add an explicit `type` only to narrow by primary registry classification.
+      tags:
+        - Agent Discovery
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - brand
+              - rights
+              - measurement
+              - governance
+              - creative
+              - sales
+              - buying
+              - signals
+              - unknown
+          required: false
+          name: type
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+          required: false
+          name: health
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+          required: false
+          name: capabilities
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+          required: false
+          name: properties
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+          required: false
+          name: compliance
+          in: query
+        - schema:
+            anyOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+            description: "Measurement-vendor filter: exact match on `measurement.metrics[].metric_id`. Repeatable; multiple values are AND'd (vendor must carry all named metrics). When combined with `accreditation`, a cross-product AND applies — each (metric_id, accreditation) pair must be covered by the same metrics element. Duplicate values are ignored. Maximum 20 unique values; maximum 100 cross-product pairs. Implies `type=measurement`."
+            example: attention_units
+          required: false
+          description: "Measurement-vendor filter: exact match on `measurement.metrics[].metric_id`. Repeatable; multiple values are AND'd (vendor must carry all named metrics). When combined with `accreditation`, a cross-product AND applies — each (metric_id, accreditation) pair must be covered by the same metrics element. Duplicate values are ignored. Maximum 20 unique values; maximum 100 cross-product pairs. Implies `type=measurement`."
+          name: metric_id
+          in: query
+        - schema:
+            anyOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+            description: "Measurement-vendor filter: exact match on `measurement.metrics[].accreditations[].accrediting_body` (e.g. `MRC`, `JIC`, `ARF`). Repeatable; multiple values are AND'd. When combined with `metric_id`, a cross-product AND applies — see `metric_id` description. Duplicate values are ignored. Maximum 20 unique values; maximum 100 cross-product pairs. Implies `type=measurement`. Accreditation claims are vendor-asserted; AAO does not independently verify (`verified_by_aao` is always `false` in the response)."
+            example: MRC
+          required: false
+          description: "Measurement-vendor filter: exact match on `measurement.metrics[].accreditations[].accrediting_body` (e.g. `MRC`, `JIC`, `ARF`). Repeatable; multiple values are AND'd. When combined with `metric_id`, a cross-product AND applies — see `metric_id` description. Duplicate values are ignored. Maximum 20 unique values; maximum 100 cross-product pairs. Implies `type=measurement`. Accreditation claims are vendor-asserted; AAO does not independently verify (`verified_by_aao` is always `false` in the response)."
+          name: accreditation
+          in: query
+        - schema:
+            type: string
+            maxLength: 64
+            description: "Measurement-vendor filter: case-insensitive substring match against `measurement.metrics[].metric_id`. v1 scope: metric_id only (description/standard search is a follow-up). Max 64 chars; SQL wildcard characters are escaped. Implies `type=measurement`."
+            example: attention
+          required: false
+          description: "Measurement-vendor filter: case-insensitive substring match against `measurement.metrics[].metric_id`. v1 scope: metric_id only (description/standard search is a follow-up). Max 64 chars; SQL wildcard characters are escaped. Implies `type=measurement`."
+          name: q
+          in: query
+        - schema:
+            anyOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+            description: "Canonical creative-capability filter: exact match on creative.supported_formats[].format.format_kind. Repeatable with OR semantics. Matches standalone creative agents and mixed-role endpoints."
+            example: video_hosted
+          required: false
+          description: "Canonical creative-capability filter: exact match on creative.supported_formats[].format.format_kind. Repeatable with OR semantics. Matches standalone creative agents and mixed-role endpoints."
+          name: format_kind
+          in: query
+        - schema:
+            type: string
+            description: "Canonical creative-capability filter: exact publisher_domain on the same supported-format entry. Pair with format_option_id to find endpoints claiming an exact publisher format."
+            example: shorts.streamhaus.example
+          required: false
+          description: "Canonical creative-capability filter: exact publisher_domain on the same supported-format entry. Pair with format_option_id to find endpoints claiming an exact publisher format."
+          name: publisher_domain
+          in: query
+        - schema:
+            type: string
+            description: "Canonical creative-capability filter: exact publisher format_option_id on the same supported-format entry."
+            example: spotlight_video
+          required: false
+          description: "Canonical creative-capability filter: exact publisher format_option_id on the same supported-format entry."
+          name: format_option_id
+          in: query
+        - schema:
+            type: string
+            description: "Canonical creative-capability filter: exact endpoint-local creative.supported_formats[].capability_id."
+          required: false
+          description: "Canonical creative-capability filter: exact endpoint-local creative.supported_formats[].capability_id."
+          name: capability_id
+          in: query
+        - schema:
+            anyOf:
+              - type: string
+                enum:
+                  - build
+                  - validate
+                  - preview
+              - type: array
+                items:
+                  type: string
+                  enum:
+                    - build
+                    - validate
+                    - preview
+            description: "Canonical creative-capability filter: required supported operation on the same format entry. Repeatable with OR semantics."
+            example: build
+          required: false
+          description: "Canonical creative-capability filter: required supported operation on the same format entry. Repeatable with OR semantics."
+          name: creative_operation
+          in: query
+        - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - spec
+                - live
+            description: "Filter to agents whose active badge covers the given verification axis. Repeat the parameter for AND semantics: ?verification_mode=spec&verification_mode=live returns only agents verified on both axes."
+          required: false
+          description: "Filter to agents whose active badge covers the given verification axis. Repeat the parameter for AND semantics: ?verification_mode=spec&verification_mode=live returns only agents verified on both axes."
+          name: verification_mode
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+            description: When true, filter to agents that hold any active verification badge.
+          required: false
+          description: When true, filter to agents that hold any active verification badge.
+          name: verified
+          in: query
+      responses:
+        "200":
+          description: Agent list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agents:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FederatedAgentWithDetails"
+                  count:
+                    type: integer
+                required:
+                  - agents
+                  - count
+        "400":
+          description: Invalid query parameter
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  valid_values:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - error
+  /api/registry/publishers:
+    get:
+      operationId: listPublishers
+      summary: List publishers
+      description: List all registered publishers.
+      tags:
+        - Agent Discovery
+      responses:
+        "200":
+          description: Publisher list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  publishers:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FederatedPublisher"
+                  count:
+                    type: integer
+                required:
+                  - publishers
+                  - count
+  /api/registry/stats:
+    get:
+      operationId: getRegistryStats
+      summary: Registry statistics
+      description: Get aggregate statistics about the registry.
+      tags:
+        - Agent Discovery
+      responses:
+        "200":
+          description: Registry statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+                additionalProperties: {}
+  /api/registry/lookup/domain/{domain}:
+    get:
+      operationId: lookupDomain
+      summary: Domain lookup (deprecated)
+      description: "**Deprecated.** Use `/api/registry/publisher?domain=X` for richer data including hosting state, per-agent rollup, and brand.json fallback. This endpoint will be removed in a future release."
+      deprecated: true
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: path
+      responses:
+        "200":
+          description: Domain lookup result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DomainLookupResult"
+  /api/registry/lookup/property:
+    get:
+      operationId: lookupProperty
+      summary: Property identifier lookup
+      description: Find agents that hold a specific property identifier.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: type
+          in: query
+        - schema:
+            type: string
+          required: true
+          name: value
+          in: query
+      responses:
+        "200":
+          description: Matching agents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  value:
+                    type: string
+                  agents:
+                    type: array
+                    items: {}
+                  count:
+                    type: integer
+                required:
+                  - type
+                  - value
+                  - agents
+                  - count
+  /api/registry/lookup/agent/{agentUrl}/domains:
+    get:
+      operationId: getAgentDomains
+      summary: Agent domain lookup
+      description: Get all publisher domains associated with an agent.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: agentUrl
+          in: path
+      responses:
+        "200":
+          description: Domains for the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  domains:
+                    type: array
+                    items:
+                      type: string
+                  count:
+                    type: integer
+                required:
+                  - agent_url
+                  - domains
+                  - count
+  /api/v1/agents/{encodedUrl}/publishers:
+    get:
+      operationId: getPublishersForAgentLegacyApiPrefix
+      summary: AAO directory inverse-lookup
+      description: |-
+        Given a percent-encoded `agent_url`, returns the publishers whose adagents.json authorizes that agent, with provenance (`discovery_method`, `manager_domain`), per-publisher property counts (`properties_authorized`, `properties_total`, scoped to this publisher only — never network-wide), signing-key pin status, and lifecycle state (`authorized` / `revoked`).
+
+        Spec: [docs/aao/directory-api.mdx](/docs/aao/directory-api) (adcp#4823). This endpoint is the spec-compliant richer-shape replacement for the legacy `/api/registry/lookup/agent/{agentUrl}/domains`, which returns domain strings only.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            description: Percent-encoded agent_url
+          required: true
+          description: Percent-encoded agent_url
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 — return only publishers with last_verified_at ≥ since
+          required: false
+          description: ISO 8601 — return only publishers with last_verified_at ≥ since
+          name: since
+          in: query
+        - schema:
+            type: string
+            description: Opaque pagination cursor returned by a prior response
+          required: false
+          description: Opaque pagination cursor returned by a prior response
+          name: cursor
+          in: query
+        - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - authorized
+                - revoked
+            description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400."
+          required: false
+          description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400."
+          name: status
+          in: query
+        - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - properties
+            description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400."
+          required: false
+          description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400."
+          name: include
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            description: Page size, default 200, max 1000
+          required: false
+          description: Page size, default 200, max 1000
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Publishers authorizing the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  directory_indexed_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                    description: Most recent per-publisher refresh in this page. Null on empty pages (no anchor).
+                  publishers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        publisher_domain:
+                          type: string
+                        discovery_method:
+                          type: string
+                          enum:
+                            - direct
+                            - authoritative_location
+                            - ads_txt_managerdomain
+                            - adagents_authoritative
+                            - community_catalog
+                        manager_domain:
+                          type:
+                            - string
+                            - "null"
+                        properties_authorized:
+                          type: integer
+                          minimum: 0
+                        properties_total:
+                          type: integer
+                          minimum: 0
+                        property_ids:
+                          type: array
+                          items:
+                            type: string
+                          description: Canonical list of property_id strings the agent is authorized for under this publisher. Present iff the request included `?include=properties`. Same population as `properties_authorized` but surfaced as IDs for set-diff comparison.
+                        signing_keys_pinned:
+                          type: boolean
+                        status:
+                          type: string
+                          enum:
+                            - authorized
+                            - revoked
+                        last_verified_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - publisher_domain
+                        - discovery_method
+                        - manager_domain
+                        - properties_authorized
+                        - properties_total
+                        - signing_keys_pinned
+                        - status
+                        - last_verified_at
+                  next_cursor:
+                    type:
+                      - string
+                      - "null"
+                required:
+                  - agent_url
+                  - directory_indexed_at
+                  - publishers
+                  - next_cursor
+        "304":
+          description: Not modified (If-None-Match matched)
+        "400":
+          description: Invalid agent_url, cursor, since, or status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Directory has never indexed any publisher referencing this agent_url. Distinct from 200 + empty.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /v1/agents/{encodedUrl}/publishers:
+    get:
+      operationId: getPublishersForAgent
+      summary: AAO directory inverse-lookup
+      description: |-
+        Given a percent-encoded `agent_url`, returns the publishers whose adagents.json authorizes that agent, with provenance (`discovery_method`, `manager_domain`), per-publisher property counts (`properties_authorized`, `properties_total`, scoped to this publisher only — never network-wide), signing-key pin status, and lifecycle state (`authorized` / `revoked`).
+
+        Spec: [docs/aao/directory-api.mdx](/docs/aao/directory-api) (adcp#4823). This endpoint is the spec-compliant richer-shape replacement for the legacy `/api/registry/lookup/agent/{agentUrl}/domains`, which returns domain strings only.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            description: Percent-encoded agent_url
+          required: true
+          description: Percent-encoded agent_url
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            format: date-time
+            description: ISO 8601 — return only publishers with last_verified_at ≥ since
+          required: false
+          description: ISO 8601 — return only publishers with last_verified_at ≥ since
+          name: since
+          in: query
+        - schema:
+            type: string
+            description: Opaque pagination cursor returned by a prior response
+          required: false
+          description: Opaque pagination cursor returned by a prior response
+          name: cursor
+          in: query
+        - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - authorized
+                - revoked
+            description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400."
+          required: false
+          description: "Lifecycle status filter — repeat the key once per value (?status=authorized&status=revoked). Default: authorized. The comma-separated single-value form is rejected with 400."
+          name: status
+          in: query
+        - schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - properties
+            description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400."
+          required: false
+          description: "Opt into expanded per-row fields — repeat the key once per value. v1: `properties` adds `property_ids[]` to each PublisherEntry so consumers can run full set-diff against a federated fetch (count-equality is not set-equality). Unknown values return 400. The comma-separated form is rejected with 400."
+          name: include
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            description: Page size, default 200, max 1000
+          required: false
+          description: Page size, default 200, max 1000
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Publishers authorizing the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  directory_indexed_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                    description: Most recent per-publisher refresh in this page. Null on empty pages (no anchor).
+                  publishers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        publisher_domain:
+                          type: string
+                        discovery_method:
+                          type: string
+                          enum:
+                            - direct
+                            - authoritative_location
+                            - ads_txt_managerdomain
+                            - adagents_authoritative
+                            - community_catalog
+                        manager_domain:
+                          type:
+                            - string
+                            - "null"
+                        properties_authorized:
+                          type: integer
+                          minimum: 0
+                        properties_total:
+                          type: integer
+                          minimum: 0
+                        property_ids:
+                          type: array
+                          items:
+                            type: string
+                          description: Canonical list of property_id strings the agent is authorized for under this publisher. Present iff the request included `?include=properties`. Same population as `properties_authorized` but surfaced as IDs for set-diff comparison.
+                        signing_keys_pinned:
+                          type: boolean
+                        status:
+                          type: string
+                          enum:
+                            - authorized
+                            - revoked
+                        last_verified_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - publisher_domain
+                        - discovery_method
+                        - manager_domain
+                        - properties_authorized
+                        - properties_total
+                        - signing_keys_pinned
+                        - status
+                        - last_verified_at
+                  next_cursor:
+                    type:
+                      - string
+                      - "null"
+                required:
+                  - agent_url
+                  - directory_indexed_at
+                  - publishers
+                  - next_cursor
+        "304":
+          description: Not modified (If-None-Match matched)
+        "400":
+          description: Invalid agent_url, cursor, since, or status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Directory has never indexed any publisher referencing this agent_url. Distinct from 200 + empty.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/operator:
+    get:
+      operationId: lookupOperator
+      summary: Operator lookup
+      description: |-
+        Given a domain, returns the agents this entity operates and which publishers trust them.
+
+        **Response shape is auth-aware.** Anonymous callers see only `public` agents. Authenticated callers on an AAO membership tier with API access also see `members_only` agents. Profile owners (callers whose org owns the queried domain) additionally see `private` agents. This is the primary mechanism by which AAO membership unlocks deeper registry visibility.
+
+        **`scope` bucket filter.** Callers can opt INTO a single visibility bucket (or the full union) regardless of what their auth would otherwise unlock — useful for picker UIs that want exactly one slice (e.g. anonymous-equivalent, members-only catalog, owner's private drafts). `scope` only narrows; it never escalates (e.g. `scope=member` on an explorer or anonymous caller silently returns public only).
+
+        **Member level visibility.** When the profile owner has set their member card to public (`is_public=true`), the `member` object additionally carries `is_founding_member` (boolean) plus `membership_tier` (raw enum) and `membership_tier_label` (e.g. `Professional`, `Partner`, `Leader`) when the org has a resolvable tier. Founding Member is orthogonal to tier — founding orgs typically display both. For private profiles these fields are absent.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            example: pubmatic.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            enum:
+              - public
+              - member
+              - private
+              - all
+            description: |-
+              Visibility bucket filter for returned agents. One value per agent-visibility enum value plus a catch-all. Each bucket is still gated by auth — `scope` can only narrow, never escalate.
+
+              - `public` → only `visibility=public` agents.
+              - `member` → public + members_only (members_only is gated on caller's tier; anonymous or explorer-tier callers silently fall through to public-only rather than 403).
+              - `private` → only `visibility=private`. Private agents are visible only to the profile owner; non-owners get an empty list.
+              - Omitted or `all` → tier-aware full unlock: public + members_only for API-tier members + private for the profile owner.
+
+              Unknown values return 400 — a silent coerce to `all` could leak data the caller explicitly tried to scope away from.
+            example: member
+          required: false
+          description: |-
+            Visibility bucket filter for returned agents. One value per agent-visibility enum value plus a catch-all. Each bucket is still gated by auth — `scope` can only narrow, never escalate.
+
+            - `public` → only `visibility=public` agents.
+            - `member` → public + members_only (members_only is gated on caller's tier; anonymous or explorer-tier callers silently fall through to public-only rather than 403).
+            - `private` → only `visibility=private`. Private agents are visible only to the profile owner; non-owners get an empty list.
+            - Omitted or `all` → tier-aware full unlock: public + members_only for API-tier members + private for the profile owner.
+
+            Unknown values return 400 — a silent coerce to `all` could leak data the caller explicitly tried to scope away from.
+          name: scope
+          in: query
+      responses:
+        "200":
+          description: Operator lookup result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperatorLookupResult"
+        "400":
+          description: Missing or invalid domain, or unknown scope value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/publisher:
+    get:
+      operationId: lookupPublisher
+      summary: Publisher lookup
+      description: |-
+        Given a domain, returns the inventory this entity publishes and which agents it authorizes.
+
+        **This endpoint is unauthenticated and returns the same response shape for every caller.** Compare to `/api/registry/operator`, where AAO membership tier and profile ownership unlock additional agent visibility (`members_only`, `private`). AAO membership does not change the `/publisher` response today.
+
+        **Property source precedence:** publisher-attested adagents.json properties win first. When no publisher-attested adagents properties exist for the domain, brand.json properties supplement and override lower-trust rows, followed by approved community catalogs, then crawler-discovered rows. Each property carries a `source` field (`adagents_json` / `brand_json` / `community` / `discovered`).
+
+        **Per-agent rollup:** each entry in `authorized_agents` may carry `properties_authorized` + `properties_total` + `publisher_wide`. The rollup is suppressed (fields absent) when (a) properties are entirely brand.json-hydrated — no adagents.json claim has been made — or (b) the publisher has more than 50 authorized agents (above-cap entries are returned without rollup; `rollup_truncated` is set with `{ cap, total_agents }`). Use `/api/registry/publisher/authorization?domain=X&agent=Y` for the per-agent count when the index rollup is absent.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            example: voxmedia.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            enum:
+              - placements
+            description: Set to placements to include eligibility-oriented placement summaries with resolved canonical format options.
+          required: false
+          description: Set to placements to include eligibility-oriented placement summaries with resolved canonical format options.
+          name: include
+          in: query
+      responses:
+        "200":
+          description: Publisher lookup result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublisherLookupResult"
+        "400":
+          description: Missing domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Publisher lookup exceeded its bounded read deadline
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - publisher_lookup_timeout
+                  retry_after:
+                    type: integer
+                required:
+                  - error
+                  - code
+                  - retry_after
+  /api/registry/publisher/{domain}/adagents/revalidate:
+    post:
+      operationId: revalidatePublisherAdagents
+      summary: Revalidate publisher adagents.json
+      description: |-
+        Admin-only endpoint for support/operator tooling to synchronously fetch a publisher's live `/.well-known/adagents.json`, run the registry validator, persist the refreshed verdict and fetch metadata, and return the validation result. `force=true` is accepted for operator tooling; the current validator always fetches the live origin.
+
+        **Rate limits:** 5 minutes per domain, 30 requests per user per hour.
+      tags:
+        - Authorization Lookups
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            example: publisher.example
+          required: true
+          name: domain
+          in: path
+        - schema:
+            type: string
+            enum:
+              - "1"
+              - "true"
+            description: Accepted for tooling compatibility; live origin validation is always performed.
+          required: false
+          description: Accepted for tooling compatibility; live origin validation is always performed.
+          name: force
+          in: query
+      responses:
+        "200":
+          description: Revalidation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  adagents_valid:
+                    type: boolean
+                  checked_at:
+                    type: string
+                    format: date-time
+                  error:
+                    type: string
+                  issues:
+                    type: object
+                    properties:
+                      errors:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            field:
+                              type: string
+                            message:
+                              type: string
+                            severity:
+                              type: string
+                              enum:
+                                - error
+                          required:
+                            - field
+                            - message
+                            - severity
+                      warnings:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            field:
+                              type: string
+                            message:
+                              type: string
+                            suggestion:
+                              type: string
+                          required:
+                            - field
+                            - message
+                    required:
+                      - errors
+                      - warnings
+                  properties_count:
+                    type: integer
+                    minimum: 0
+                  authorized_agents_count:
+                    type: integer
+                    minimum: 0
+                  status_code:
+                    type: integer
+                    minimum: 100
+                    maximum: 599
+                  response_bytes:
+                    type: integer
+                    minimum: 0
+                  resolved_url:
+                    type: string
+                  discovery_method:
+                    type: string
+                    enum:
+                      - direct
+                      - authoritative_location
+                      - ads_txt_managerdomain
+                      - adagents_authoritative
+                  manager_domain:
+                    type: string
+                required:
+                  - domain
+                  - adagents_valid
+                  - checked_at
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Admin access required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
+        "503":
+          description: Publisher crawl is temporarily busy
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying
+              required: true
+              description: Seconds to wait before retrying
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - publisher_crawl_busy
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - code
+                  - retry_after
+  /api/registry/brand/{domain}/force-crawl:
+    post:
+      operationId: forceBrandCrawl
+      summary: Force a synchronous brand.json crawl
+      description: |-
+        Admin-only support endpoint that fetches a domain's live `/.well-known/brand.json`, persists valid origin evidence, and returns the before/after state. A verified owner remains labeled `source: hosted` because that field describes identity provenance; `new_source_type: brand_json` and `promoted: true` confirm that live origin evidence was adopted.
+
+        **Rate limits:** 5 minutes per domain, 30 requests per user per hour.
+      tags:
+        - Brand Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            example: brand.example
+          required: true
+          name: domain
+          in: path
+      responses:
+        "200":
+          description: Synchronous crawl result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  previous_source:
+                    type:
+                      - string
+                      - "null"
+                    enum:
+                      - hosted
+                      - brand_json
+                      - community
+                      - enriched
+                      - stub
+                      - null
+                  new_source:
+                    type:
+                      - string
+                      - "null"
+                    enum:
+                      - hosted
+                      - brand_json
+                      - community
+                      - enriched
+                      - stub
+                      - null
+                  previous_source_type:
+                    type:
+                      - string
+                      - "null"
+                    enum:
+                      - brand_json
+                      - community
+                      - enriched
+                      - stub
+                      - null
+                  new_source_type:
+                    type:
+                      - string
+                      - "null"
+                    enum:
+                      - brand_json
+                      - community
+                      - enriched
+                      - stub
+                      - null
+                  promoted:
+                    type: boolean
+                    description: True when the crawl replaced lower-trust stored evidence with live brand.json evidence.
+                  brand_json_found:
+                    type: boolean
+                  live_variant:
+                    type:
+                      - string
+                      - "null"
+                    enum:
+                      - authoritative_location
+                      - house_redirect
+                      - brand_agent
+                      - house_portfolio
+                      - brand_canonical
+                      - null
+                  has_manifest:
+                    type: boolean
+                  checked_at:
+                    type: string
+                    format: date-time
+                required:
+                  - domain
+                  - previous_source
+                  - new_source
+                  - previous_source_type
+                  - new_source_type
+                  - promoted
+                  - brand_json_found
+                  - live_variant
+                  - has_manifest
+                  - checked_at
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Admin access required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                required:
+                  - error
+                  - retry_after
+        "500":
+          description: Crawl failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/publisher/authorization:
+    get:
+      operationId: lookupPublisherAgentAuthorization
+      summary: Per-agent authorization rollup
+      description: Returns whether a given agent is authorized for a publisher domain and how many of the publisher's properties it can sell. When the agent has property-level authorization rows, the count is the intersection with the publisher's property set; when it only has a publisher-wide row, the count equals the total. Returns 404 when the agent has no authorization (publisher-wide or property-level) for the domain.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+            example: voxmedia.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            example: https://sales.pubmatic.com/mcp
+          required: true
+          name: agent
+          in: query
+      responses:
+        "200":
+          description: Authorization rollup
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  publisher_domain:
+                    type: string
+                  agent_url:
+                    type: string
+                  authorized:
+                    type: integer
+                    minimum: 0
+                    description: Count of publisher's properties the agent can sell.
+                  total:
+                    type: integer
+                    minimum: 0
+                    description: Total properties the publisher exposes.
+                  publisher_wide:
+                    type: boolean
+                    description: True when the agent has only a publisher-wide authorization (no property-level rows). In that case `authorized` equals `total`.
+                  source:
+                    type: string
+                    enum:
+                      - adagents_json
+                      - agent_claim
+                  authorized_for:
+                    type: string
+                  unauthorized_properties:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        type:
+                          type: string
+                    description: Properties the agent is NOT authorized for. Empty when publisher_wide is true.
+                required:
+                  - publisher_domain
+                  - agent_url
+                  - authorized
+                  - total
+                  - publisher_wide
+                  - source
+                  - unauthorized_properties
+        "400":
+          description: Missing domain or agent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No authorization record for this agent on this publisher
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Publisher authorization lookup exceeded its bounded read deadline
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - publisher_lookup_timeout
+                  retry_after:
+                    type: integer
+                required:
+                  - error
+                  - code
+                  - retry_after
+  /api/registry/validate/product-authorization:
+    post:
+      operationId: validateProductAuthorization
+      summary: Validate product authorization
+      description: Check whether an agent is authorized to sell a product based on its publisher_properties.
+      tags:
+        - Authorization Lookups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                agent_url:
+                  type: string
+                publisher_properties:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/PublisherPropertySelector"
+              required:
+                - agent_url
+                - publisher_properties
+      responses:
+        "200":
+          description: Authorization validation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  authorized:
+                    type: boolean
+                  checked_at:
+                    type: string
+                required:
+                  - agent_url
+                  - authorized
+                  - checked_at
+                additionalProperties: {}
+  /api/registry/expand/product-identifiers:
+    post:
+      operationId: expandProductIdentifiers
+      summary: Expand product identifiers
+      description: Expand publisher_properties selectors into concrete property identifiers for caching.
+      tags:
+        - Authorization Lookups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                agent_url:
+                  type: string
+                publisher_properties:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/PublisherPropertySelector"
+              required:
+                - agent_url
+                - publisher_properties
+      responses:
+        "200":
+          description: Expanded identifiers
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  properties:
+                    type: array
+                    items: {}
+                  identifiers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        value:
+                          type: string
+                        property_id:
+                          type: string
+                        publisher_domain:
+                          type: string
+                      required:
+                        - type
+                        - value
+                        - property_id
+                        - publisher_domain
+                  property_count:
+                    type: integer
+                  identifier_count:
+                    type: integer
+                  generated_at:
+                    type: string
+                required:
+                  - agent_url
+                  - properties
+                  - identifiers
+                  - property_count
+                  - identifier_count
+                  - generated_at
+  /api/registry/validate/property-authorization:
+    get:
+      operationId: validatePropertyAuthorization
+      summary: Property authorization check
+      description: Quick check if a property identifier is authorized for an agent. Optimized for real-time ad request validation.
+      tags:
+        - Authorization Lookups
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: agent_url
+          in: query
+        - schema:
+            type: string
+          required: true
+          name: identifier_type
+          in: query
+        - schema:
+            type: string
+          required: true
+          name: identifier_value
+          in: query
+      responses:
+        "200":
+          description: Authorization result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  identifier_type:
+                    type: string
+                  identifier_value:
+                    type: string
+                  authorized:
+                    type: boolean
+                  checked_at:
+                    type: string
+                required:
+                  - agent_url
+                  - identifier_type
+                  - identifier_value
+                  - authorized
+                  - checked_at
+                additionalProperties: {}
+  /api/adagents/validate:
+    post:
+      operationId: validateAdagents
+      summary: Validate adagents.json
+      description: Validate a domain's adagents.json file and optionally validate referenced agent cards.
+      tags:
+        - Validation Tools
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+              required:
+                - domain
+      responses:
+        "200":
+          description: Validation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      domain:
+                        type: string
+                      found:
+                        type: boolean
+                      validation: {}
+                      agent_cards: {}
+                    required:
+                      - domain
+                      - found
+                  timestamp:
+                    type: string
+                required:
+                  - success
+                  - data
+                  - timestamp
+  /api/adagents/create:
+    post:
+      operationId: createAdagents
+      summary: Generate adagents.json
+      description: Generate a valid adagents.json file from authorized agents and/or catalog content. `authorized_agents` may be empty for a catalog-only community mirror that publishes formats/properties/placements for a platform that has not adopted AdCP.
+      tags:
+        - Validation Tools
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                authorized_agents:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/AdagentsAuthorizedAgent"
+                include_schema:
+                  type: boolean
+                include_timestamp:
+                  type: boolean
+                properties:
+                  type: array
+                  items: {}
+                catalog_etag:
+                  type: string
+                formats:
+                  type: array
+                  items: {}
+                placements:
+                  type: array
+                  items: {}
+                placement_tags:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - authorized_agents
+      responses:
+        "200":
+          description: Generated adagents.json
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateAdagentsResponse"
+  /api/registry/mirror-proposals:
+    get:
+      operationId: listCommunityMirrorProposals
+      summary: List community mirror proposals
+      description: List the caller's own community-mirror proposals. Registry moderators and AgenticAdvertising.org administrators see the review queue and may filter by status; their default is `pending`.
+      tags:
+        - Community Mirrors
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - pending
+              - approved
+              - rejected
+          required: false
+          name: status
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+            description: Set to `true` for the cross-organization moderator queue; non-moderators receive 403.
+          required: false
+          description: Set to `true` for the cross-organization moderator queue; non-moderators receive 403.
+          name: review_queue
+          in: query
+        - schema:
+            type: integer
+            maximum: 50
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Community mirror proposal list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorProposalListResponse"
+        "400":
+          description: Invalid status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Moderator access required for the review queue
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to list proposals
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/mirror-proposals/{id}:
+    get:
+      operationId: getCommunityMirrorProposal
+      summary: Get community mirror proposal
+      description: Fetch a proposal owned by the caller. Registry moderators and AgenticAdvertising.org administrators may fetch any proposal.
+      tags:
+        - Community Mirrors
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Community mirror proposal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorProposalGetResponse"
+        "400":
+          description: Invalid proposal identifier
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Proposal not found or not visible to the caller
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to read proposal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/mirror-proposals/{id}/approve:
+    post:
+      operationId: approveCommunityMirrorProposal
+      summary: Approve community mirror proposal
+      description: Approve and atomically publish a pending proposal. Requires a registry moderator or AgenticAdvertising.org administrator.
+      tags:
+        - Community Mirrors
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommunityMirrorProposalReviewRequest"
+      responses:
+        "200":
+          description: Proposal approved and mirror published
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorProposalApprovalResponse"
+        "400":
+          description: Invalid identifier, review body, or stale schema conformance
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorPublishError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Reviewer role required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Proposal not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Proposal changed after review, its base mirror is stale, or it was already reviewed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to approve proposal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/mirror-proposals/{id}/reject:
+    post:
+      operationId: rejectCommunityMirrorProposal
+      summary: Reject community mirror proposal
+      description: Reject a pending proposal with reviewer notes. Requires a registry moderator or AgenticAdvertising.org administrator.
+      tags:
+        - Community Mirrors
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommunityMirrorProposalRejectRequest"
+      responses:
+        "200":
+          description: Proposal rejected
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorProposalDecisionResponse"
+        "400":
+          description: Invalid identifier or review body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorPublishError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Reviewer role required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Proposal not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Proposal changed after review or was already reviewed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to reject proposal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/mirrors:
+    get:
+      operationId: listCommunityMirrors
+      summary: List community mirrors
+      description: List persisted catalog-only adagents.json community mirrors. The list projection includes presence and freshness metadata but omits the full `adagents_json` body; fetch a platform-specific mirror for the full document.
+      tags:
+        - Community Mirrors
+      parameters:
+        - schema:
+            type: integer
+            description: Maximum mirrors to return. The service defaults to 100 and clamps values to the 1-500 range.
+          required: false
+          description: Maximum mirrors to return. The service defaults to 100 and clamps values to the 1-500 range.
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            description: Zero-based result offset. Defaults to 0; negative values are clamped to 0.
+          required: false
+          description: Zero-based result offset. Defaults to 0; negative values are clamped to 0.
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Community mirror list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorListResponse"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to list community mirrors
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/mirrors/{platform}:
+    get:
+      operationId: getCommunityMirror
+      summary: Get community mirror
+      description: Fetch one persisted community mirror by platform. A present mirror returns the platform metadata plus the stored catalog-only `adagents_json` document; absent mirrors return 404.
+      tags:
+        - Community Mirrors
+      parameters:
+        - schema:
+            type: string
+            pattern: ^[a-z0-9_-]{1,64}$
+            description: Lowercase platform identifier.
+            example: example_platform
+          required: true
+          description: Lowercase platform identifier.
+          name: platform
+          in: path
+      responses:
+        "200":
+          description: Community mirror
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorGetResponse"
+        "400":
+          description: Invalid platform identifier
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Community mirror not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to read community mirror
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    put:
+      operationId: publishCommunityMirror
+      summary: Publish or propose community mirror
+      description: "Submit a catalog-only adagents.json community mirror. Registry moderators and AgenticAdvertising.org administrators publish immediately; other authenticated organization callers create or refresh a pending proposal and receive HTTP 202. Contributor proposals are limited to 1 MiB and 2,000 catalog items. The service validates the assembled document against adagents.json, forces `authorized_agents: []`, and regenerates `$schema` and `last_updated`."
+      tags:
+        - Community Mirrors
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            pattern: ^[a-z0-9_-]{1,64}$
+            description: Lowercase platform identifier.
+            example: example_platform
+          required: true
+          description: Lowercase platform identifier.
+          name: platform
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommunityMirrorPublishRequest"
+      responses:
+        "200":
+          description: Community mirror published
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorPublishResponse"
+        "202":
+          description: Community mirror proposal accepted for review
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorProposalSubmissionResponse"
+        "400":
+          description: Invalid platform, request body, or adagents.json conformance failure
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorPublishError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Organization context required for community proposals
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: Proposal body or catalog item count exceeds the contributor limit
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to publish community mirror
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      operationId: deleteCommunityMirror
+      summary: Delete community mirror
+      description: Delete a persisted community mirror and retire derived publisher-domain catalog rows. Requires a registry moderator or AgenticAdvertising.org admin. Without `force=true`, the service refuses to delete a mirror that has not first published a `superseded_by` migration URL.
+      tags:
+        - Community Mirrors
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            pattern: ^[a-z0-9_-]{1,64}$
+            description: Lowercase platform identifier.
+            example: example_platform
+          required: true
+          description: Lowercase platform identifier.
+          name: platform
+          in: path
+        - schema:
+            type: string
+            description: Set to `true` to delete a mirror without a `superseded_by` migration URL.
+          required: false
+          description: Set to `true` to delete a mirror without a `superseded_by` migration URL.
+          name: force
+          in: query
+      responses:
+        "200":
+          description: Community mirror deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunityMirrorDeleteResponse"
+        "400":
+          description: Invalid platform identifier
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Only registry moderators or AgenticAdvertising.org admins can manage community mirrors
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Community mirror not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Mirror has not been superseded and force was not set
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Failed to delete community mirror
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/search:
+    get:
+      operationId: search
+      summary: Search
+      description: Search across brands, publishers, and properties. Returns up to 5 results per category.
+      tags:
+        - Search
+      parameters:
+        - schema:
+            type: string
+            minLength: 2
+          required: true
+          name: q
+          in: query
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  brands:
+                    type: array
+                    items: {}
+                  publishers:
+                    type: array
+                    items: {}
+                  properties:
+                    type: array
+                    items: {}
+                required:
+                  - brands
+                  - publishers
+                  - properties
+  /api/manifest-refs/lookup:
+    get:
+      operationId: lookupManifestRef
+      summary: Manifest reference lookup
+      description: Find the best manifest reference (brand.json URL or agent) for a domain.
+      tags:
+        - Search
+      parameters:
+        - schema:
+            type: string
+            example: acmecorp.com
+          required: true
+          name: domain
+          in: query
+        - schema:
+            type: string
+            example: brand.json
+          required: false
+          name: type
+          in: query
+      responses:
+        "200":
+          description: Reference lookup result
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      success:
+                        type: boolean
+                        enum:
+                          - true
+                      found:
+                        type: boolean
+                        enum:
+                          - true
+                      reference:
+                        type: object
+                        properties:
+                          reference_type:
+                            type: string
+                            enum:
+                              - url
+                              - agent
+                          manifest_url:
+                            type:
+                              - string
+                              - "null"
+                          agent_url:
+                            type:
+                              - string
+                              - "null"
+                          agent_id:
+                            type:
+                              - string
+                              - "null"
+                          verification_status:
+                            type: string
+                            enum:
+                              - pending
+                              - valid
+                              - invalid
+                              - unreachable
+                        required:
+                          - reference_type
+                          - manifest_url
+                          - agent_url
+                          - agent_id
+                          - verification_status
+                    required:
+                      - success
+                      - found
+                      - reference
+                  - type: object
+                    properties:
+                      success:
+                        type: boolean
+                        enum:
+                          - false
+                      found:
+                        type: boolean
+                        enum:
+                          - false
+                    required:
+                      - success
+                      - found
+  /api/public/discover-agent:
+    get:
+      operationId: discoverAgent
+      summary: Discover agent
+      description: Probe an agent URL to discover its name, type, supported protocols, and basic statistics.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: url
+          in: query
+      responses:
+        "200":
+          description: Discovered agent info
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  protocols:
+                    type: array
+                    items:
+                      type: string
+                  type:
+                    type: string
+                  tools_count:
+                    type: integer
+                  tools:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        description:
+                          type: string
+                      required:
+                        - name
+                  stats:
+                    type: object
+                    properties:
+                      format_count:
+                        type: integer
+                      product_count:
+                        type: integer
+                      publisher_count:
+                        type: integer
+                required:
+                  - name
+                  - protocols
+                  - type
+                  - tools_count
+                  - tools
+                  - stats
+        "504":
+          description: Connection timeout
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/public/agent-formats:
+    get:
+      operationId: getAgentFormats
+      summary: Get creative-agent format capabilities
+      description: Fetch get_adcp_capabilities creative.supported_formats[] from a creative agent, falling back to the deprecated list_creative_formats catalog for 3.1-compatible agents.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: url
+          in: query
+      responses:
+        "200":
+          description: Canonical creative capabilities
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  formats:
+                    type: array
+                    items: {}
+                required:
+                  - success
+                  - formats
+        "400":
+          description: Missing agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                  retryAfter:
+                    type: integer
+                required:
+                  - error
+                  - message
+        "502":
+          description: Agent discovery failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Connection timeout
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/public/agent-publishers:
+    get:
+      operationId: getAgentPublishers
+      summary: Get agent publisher properties
+      description: Fetch public list_authorized_properties data from a sales agent.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: url
+          in: query
+      responses:
+        "200":
+          description: Publisher properties
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  properties:
+                    type: array
+                    items: {}
+                required:
+                  - success
+                  - properties
+        "400":
+          description: Missing agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                  retryAfter:
+                    type: integer
+                required:
+                  - error
+                  - message
+        "502":
+          description: Agent discovery failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Connection timeout
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/public/agent-products:
+    get:
+      operationId: getAgentProducts
+      summary: Get agent products
+      description: Fetch products from a sales agent.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: url
+          in: query
+      responses:
+        "200":
+          description: Products
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  products:
+                    type: array
+                    items: {}
+                required:
+                  - success
+                  - products
+        "400":
+          description: Missing agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                  retryAfter:
+                    type: integer
+                required:
+                  - error
+                  - message
+        "502":
+          description: Agent discovery failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "504":
+          description: Connection timeout
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/public/validate-publisher:
+    get:
+      operationId: validatePublisher
+      summary: Validate publisher
+      description: Validate a publisher domain's adagents.json and return summary statistics.
+      tags:
+        - Agent Probing
+      parameters:
+        - schema:
+            type: string
+            example: examplepub.com
+          required: true
+          name: domain
+          in: query
+      responses:
+        "200":
+          description: Publisher validation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  valid:
+                    type: boolean
+                  domain:
+                    type: string
+                  url:
+                    type: string
+                  discovery_method:
+                    type: string
+                    enum:
+                      - direct
+                      - authoritative_location
+                      - ads_txt_managerdomain
+                    description: How the publisher's adagents.json was discovered. `ads_txt_managerdomain` indicates one-hop delegation via ads.txt MANAGERDOMAIN.
+                  manager_domain:
+                    type: string
+                    description: Manager domain that served the manifest. Present only when discovery_method is ads_txt_managerdomain.
+                  agent_count:
+                    type: integer
+                  property_count:
+                    type: integer
+                  property_type_counts:
+                    type: object
+                    additionalProperties:
+                      type: integer
+                  tag_count:
+                    type: integer
+                  errors:
+                    type: array
+                    items:
+                      type: string
+                  warnings:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - valid
+                  - domain
+                  - discovery_method
+                  - agent_count
+                  - property_count
+                  - property_type_counts
+                  - tag_count
+  /api/policies/registry:
+    get:
+      operationId: listPolicies
+      summary: List policies
+      description: Browse and search the governance policy registry. Returns approved policies with optional filtering by category, enforcement level, jurisdiction, policy category, and governance domain.
+      tags:
+        - Policy Registry
+      parameters:
+        - schema:
+            type: string
+            description: Full-text search on policy name and description
+          required: false
+          description: Full-text search on policy name and description
+          name: search
+          in: query
+        - schema:
+            type: string
+            enum:
+              - regulation
+              - standard
+          required: false
+          name: category
+          in: query
+        - schema:
+            type: string
+            enum:
+              - must
+              - should
+              - may
+          required: false
+          name: enforcement
+          in: query
+        - schema:
+            type: string
+            example: EU
+            description: Filter by jurisdiction (includes region alias matching)
+          required: false
+          description: Filter by jurisdiction (includes region alias matching)
+          name: jurisdiction
+          in: query
+        - schema:
+            type: string
+            example: age_restricted
+          required: false
+          name: policy_category
+          in: query
+        - schema:
+            type: string
+            example: campaign
+            description: Filter by governance domain
+          required: false
+          description: Filter by governance domain
+          name: domain
+          in: query
+        - schema:
+            type: integer
+            description: Results per page (default 20, max 1000)
+          required: false
+          description: Results per page (default 20, max 1000)
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            description: Pagination offset (default 0)
+          required: false
+          description: Pagination offset (default 0)
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Policy listing with facet stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  policies:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PolicySummary"
+                  stats:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      regulation:
+                        type: integer
+                      standard:
+                        type: integer
+                    required:
+                      - total
+                      - regulation
+                      - standard
+                required:
+                  - policies
+                  - stats
+  /api/policies/resolve:
+    get:
+      operationId: resolvePolicy
+      summary: Resolve policy
+      description: Resolve a single policy by ID. Optionally pin to a specific version — returns null if the version does not match.
+      tags:
+        - Policy Registry
+      parameters:
+        - schema:
+            type: string
+            example: gdpr_consent
+          required: true
+          name: policy_id
+          in: query
+        - schema:
+            type: string
+            description: Return null if the current version does not match
+          required: false
+          description: Return null if the current version does not match
+          name: version
+          in: query
+      responses:
+        "200":
+          description: Policy resolved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Policy"
+        "400":
+          description: Missing policy_id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Policy not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  policy_id:
+                    type: string
+                required:
+                  - error
+                  - policy_id
+  /api/policies/resolve/bulk:
+    post:
+      operationId: resolvePoliciesBulk
+      summary: Bulk resolve policies
+      description: |-
+        Resolve up to 100 policies by ID in a single request. Returns a map of policy_id to Policy (or null if not found).
+
+        **Rate limit:** 20 requests per minute per IP address.
+      tags:
+        - Policy Registry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                policy_ids:
+                  type: array
+                  items:
+                    type: string
+                  minItems: 1
+                  maxItems: 100
+                  example:
+                    - gdpr_consent
+                    - coppa_children
+              required:
+                - policy_ids
+      responses:
+        "200":
+          description: Bulk resolution results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: object
+                    additionalProperties:
+                      allOf:
+                        - $ref: "#/components/schemas/Policy"
+                        - type:
+                            - object
+                            - "null"
+                required:
+                  - results
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/policies/history:
+    get:
+      operationId: getPolicyHistory
+      summary: Policy revision history
+      description: Retrieve the edit history for a policy. Each revision records who made the change, a summary, and whether it was a rollback.
+      tags:
+        - Policy Registry
+      parameters:
+        - schema:
+            type: string
+            example: gdpr_consent
+          required: true
+          name: policy_id
+          in: query
+        - schema:
+            type: integer
+            description: Results per page (max 100, default 20)
+          required: false
+          description: Results per page (max 100, default 20)
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            description: Pagination offset (default 0)
+          required: false
+          description: Pagination offset (default 0)
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Revision history
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyHistory"
+        "400":
+          description: Missing policy_id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Policy not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  policy_id:
+                    type: string
+                required:
+                  - error
+                  - policy_id
+  /api/policies/save:
+    post:
+      operationId: savePolicy
+      summary: Save policy
+      description: Create or update a community-contributed policy. Requires authentication. Registry-sourced and pending-review policies cannot be edited (returns 409). Updates automatically create a revision record.
+      tags:
+        - Policy Registry
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                policy_id:
+                  type: string
+                  example: my_brand_safety
+                  description: Lowercase alphanumeric with underscores
+                version:
+                  type: string
+                  example: 1.0.0
+                name:
+                  type: string
+                  example: Acme Corp Brand Safety
+                category:
+                  type: string
+                  enum:
+                    - regulation
+                    - standard
+                enforcement:
+                  type: string
+                  enum:
+                    - must
+                    - should
+                    - may
+                policy:
+                  type: string
+                  example: Ads must not appear adjacent to content depicting violence...
+                description:
+                  type: string
+                jurisdictions:
+                  type: array
+                  items:
+                    type: string
+                region_aliases:
+                  type: object
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
+                policy_categories:
+                  type: array
+                  items:
+                    type: string
+                channels:
+                  type: array
+                  items:
+                    type: string
+                effective_date:
+                  type: string
+                sunset_date:
+                  type: string
+                governance_domains:
+                  type: array
+                  items:
+                    type: string
+                source_url:
+                  type: string
+                  description: Must use http:// or https://
+                source_name:
+                  type: string
+                guidance:
+                  type: string
+                exemplars:
+                  type: object
+                  properties:
+                    pass:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          scenario:
+                            type: string
+                          explanation:
+                            type: string
+                        required:
+                          - scenario
+                          - explanation
+                    fail:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          scenario:
+                            type: string
+                          explanation:
+                            type: string
+                        required:
+                          - scenario
+                          - explanation
+                ext:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - policy_id
+                - version
+                - name
+                - category
+                - enforcement
+                - policy
+      responses:
+        "200":
+          description: Policy saved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  message:
+                    type: string
+                  policy_id:
+                    type: string
+                  revision_number:
+                    type:
+                      - integer
+                      - "null"
+                required:
+                  - success
+                  - message
+                  - policy_id
+                  - revision_number
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Cannot edit registry-sourced or pending policy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  policy_id:
+                    type: string
+                required:
+                  - error
+                  - policy_id
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/feed:
+    get:
+      operationId: getRegistryFeed
+      summary: Registry change feed
+      description: |-
+        Poll a cursor-based feed of registry changes. Events are ordered by UUID v7 event_id for monotonic cursor progression. The feed retains events for 90 days. The `freshness` object reports when the response was generated, the newest matching event currently visible to the feed, and the resulting feed lag. `publisher.adagents_changed` covers semantic changes in every top-level catalog field, including formats-only and placements-only revisions; new 3.2 events identify them in `payload.changed_fields`.
+
+        Type filtering supports glob patterns: `property.*` matches `property.created`, `property.updated`, etc.
+      tags:
+        - Change Feed
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Resume after this event ID
+          required: false
+          description: Resume after this event ID
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated event type filters with glob support (e.g. property.*)
+            example: property.*,agent.*
+          required: false
+          description: Comma-separated event type filters with glob support (e.g. property.*)
+          name: types
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+            description: Max events per page (default 100, max 10,000)
+          required: false
+          description: Max events per page (default 100, max 10,000)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Feed page
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RegistryFeedEvent"
+                  cursor:
+                    type:
+                      - string
+                      - "null"
+                    format: uuid
+                    description: Pass as cursor in the next request to continue polling
+                  has_more:
+                    type: boolean
+                  freshness:
+                    type: object
+                    properties:
+                      generated_at:
+                        type: string
+                        format: date-time
+                        description: Server timestamp when this feed page was generated.
+                      latest_event_created_at:
+                        type:
+                          - string
+                          - "null"
+                        format: date-time
+                        description: Newest event creation timestamp currently visible in the feed for the requested type filter. Null when no matching event exists inside retention.
+                      lag_seconds:
+                        type:
+                          - integer
+                          - "null"
+                        minimum: 0
+                        description: Seconds between generated_at and latest_event_created_at. Null when no matching event exists.
+                      retention_days:
+                        type: integer
+                        exclusiveMinimum: 0
+                        description: Number of days the registry retains feed cursors and events.
+                    required:
+                      - generated_at
+                      - latest_event_created_at
+                      - lag_seconds
+                      - retention_days
+                required:
+                  - events
+                  - cursor
+                  - has_more
+                  - freshness
+        "400":
+          description: Invalid cursor format or type filter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "410":
+          description: Cursor expired (older than 90-day retention window)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum:
+                      - cursor_expired
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/registry/feed/stream:
+    get:
+      operationId: streamRegistryFeed
+      summary: Registry change feed stream
+      description: "Subscribe to registry feed pages over Server-Sent Events. This is a push-friendly transport for the same cursor contract as `/api/registry/feed`: clients still persist `cursor`, apply only feed events, and recover from `cursor_expired` by re-bootstrapping. The stream emits `feed` events containing a full feed page, `heartbeat` events while caught up, and `error` before closing when the cursor expires or the server cannot query the feed."
+      tags:
+        - Change Feed
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Resume after this event ID
+          required: false
+          description: Resume after this event ID
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated event type filters with glob support (e.g. property.*)
+            example: authorization.*,publisher.adagents_changed
+          required: false
+          description: Comma-separated event type filters with glob support (e.g. property.*)
+          name: types
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+            description: Max events per SSE feed page (default 100, max 10,000)
+          required: false
+          description: Max events per SSE feed page (default 100, max 10,000)
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            minimum: 5
+            maximum: 60
+            description: Server-side interval while caught up (default 15 seconds). Backlog pages are sent without waiting.
+          required: false
+          description: Server-side interval while caught up (default 15 seconds). Backlog pages are sent without waiting.
+          name: poll_interval_seconds
+          in: query
+      responses:
+        "200":
+          description: "SSE stream. `event: feed` data validates as a registry feed page."
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: Server-Sent Events stream. `feed` events carry JSON matching the RegistryFeedPage schema; `heartbeat` events carry `{ generated_at, cursor }`.
+        "400":
+          description: Invalid cursor format, type filter, limit, or poll interval
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "410":
+          description: Initial cursor expired
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum:
+                      - cursor_expired
+                  message:
+                    type: string
+                required:
+                  - error
+                  - message
+  /api/registry/authorizations:
+    get:
+      operationId: getAgentAuthorizations
+      summary: Per-agent authorization pull
+      description: |-
+        Default endpoint for verification consumers (DSPs, sales houses, agencies). Returns the rows where the requested agent appears as `agent_url` — typically ≤ a few hundred. Pair with `/api/registry/feed?entity_type=authorization` to tail subsequent changes via the `X-Sync-Cursor` header.
+
+        **evidence** defaults to `adagents_json` only. `agent_claim` is opt-in (`?evidence=adagents_json,agent_claim`) to prevent buy-side trust misuse — see specs/registry-authorization-model.md.
+      tags:
+        - Change Feed
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: Agent URL to look up. Canonicalized server-side (lowercased, trailing slashes trimmed).
+          required: true
+          description: Agent URL to look up. Canonicalized server-side (lowercased, trailing slashes trimmed).
+          name: agent_url
+          in: query
+        - schema:
+            type: string
+            enum:
+              - raw
+              - effective
+            description: "`effective` (default) applies override layer; `raw` reads base table."
+          required: false
+          description: "`effective` (default) applies override layer; `raw` reads base table."
+          name: include
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated evidence allowlist. Defaults to `adagents_json`.
+            example: adagents_json,agent_claim
+          required: false
+          description: Comma-separated evidence allowlist. Defaults to `adagents_json`.
+          name: evidence
+          in: query
+      responses:
+        "200":
+          description: Authorization rows for the agent.
+          headers:
+            X-Sync-Cursor:
+              description: UUIDv7 cursor for the authorization change feed at snapshot time. Pass to /api/registry/feed?entity_type=authorization&cursor=<value>.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  evidence:
+                    type: array
+                    items:
+                      type: string
+                  include:
+                    type: string
+                    enum:
+                      - raw
+                      - effective
+                  rows:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        agent_url:
+                          type: string
+                        agent_url_canonical:
+                          type: string
+                        property_rid:
+                          type:
+                            - string
+                            - "null"
+                          format: uuid
+                        property_id_slug:
+                          type:
+                            - string
+                            - "null"
+                        publisher_domain:
+                          type:
+                            - string
+                            - "null"
+                        authorized_for:
+                          type:
+                            - string
+                            - "null"
+                        evidence:
+                          type: string
+                        disputed:
+                          type: boolean
+                        created_by:
+                          type:
+                            - string
+                            - "null"
+                        expires_at:
+                          type:
+                            - string
+                            - "null"
+                          format: date-time
+                        created_at:
+                          type: string
+                          format: date-time
+                        updated_at:
+                          type: string
+                          format: date-time
+                        signing_keys:
+                          type:
+                            - array
+                            - "null"
+                          items:
+                            $ref: "#/components/schemas/SigningKey"
+                          description: Publisher-pinned JWK set (authorized_agents[*].signing_keys) from the source adagents.json. Consumers verifying inbound TMP signatures key on kid → JWK. Null when the publisher declared no keys; consumers fall back to the agent-hosted JWKS per spec R-2 (docs/governance/property/adagents.mdx).
+                        override_applied:
+                          type: boolean
+                        override_reason:
+                          type:
+                            - string
+                            - "null"
+                      required:
+                        - id
+                        - agent_url
+                        - agent_url_canonical
+                        - property_rid
+                        - property_id_slug
+                        - publisher_domain
+                        - authorized_for
+                        - evidence
+                        - disputed
+                        - created_by
+                        - expires_at
+                        - created_at
+                        - updated_at
+                        - signing_keys
+                        - override_applied
+                        - override_reason
+                  count:
+                    type: integer
+                required:
+                  - agent_url
+                  - evidence
+                  - include
+                  - rows
+                  - count
+        "400":
+          description: Validation error (missing/empty agent_url, unknown evidence, unknown include)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/authorizations/snapshot:
+    get:
+      operationId: getAgentAuthorizationsSnapshot
+      summary: Bootstrap snapshot for inline verifiers
+      description: |-
+        Streams the full effective authorization set as gzipped NDJSON (one JSON object per line). Consumers persist `X-Sync-Cursor` and tail `/api/registry/feed?entity_type=authorization&cursor=<value>` for deltas.
+
+        **ETag** is the hash of the X-Sync-Cursor — clients can `If-None-Match` to skip a re-pull when nothing has changed. **evidence** defaults to `adagents_json` only; long-run wire size ~150 MB gzipped.
+      tags:
+        - Change Feed
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - raw
+              - effective
+            description: "`effective` (default) applies override layer; `raw` reads base table."
+          required: false
+          description: "`effective` (default) applies override layer; `raw` reads base table."
+          name: include
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated evidence allowlist. Defaults to `adagents_json`.
+            example: adagents_json,agent_claim
+          required: false
+          description: Comma-separated evidence allowlist. Defaults to `adagents_json`.
+          name: evidence
+          in: query
+      responses:
+        "200":
+          description: gzipped NDJSON stream — one authorization row per line.
+          headers:
+            X-Sync-Cursor:
+              description: UUIDv7 cursor for the authorization change feed at snapshot time.
+              schema:
+                type: string
+            ETag:
+              description: Hash of X-Sync-Cursor; clients can If-None-Match.
+              schema:
+                type: string
+            Content-Encoding:
+              description: gzip
+              schema:
+                type: string
+          content:
+            application/x-ndjson:
+              schema:
+                type: string
+                description: Newline-delimited JSON, gzip-compressed.
+        "304":
+          description: Not modified — cursor unchanged from If-None-Match.
+        "400":
+          description: Validation error (unknown evidence, unknown include)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/search:
+    get:
+      operationId: searchAgentProfiles
+      summary: Search agent inventory profiles
+      description: Search agents by inventory profile — channels, markets, content categories, property types, and more. Filters use AND across dimensions and OR within a dimension. Results are ranked by relevance score.
+      tags:
+        - Agent Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: Comma-separated channel filter
+            example: ctv,olv
+          required: false
+          description: Comma-separated channel filter
+          name: channels
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated property type filter
+            example: ctv_app,website
+          required: false
+          description: Comma-separated property type filter
+          name: property_types
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated market/country code filter
+            example: US,GB
+          required: false
+          description: Comma-separated market/country code filter
+          name: markets
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated IAB content category filter
+            example: IAB-7,IAB-7-1
+          required: false
+          description: Comma-separated IAB content category filter
+          name: categories
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated tag filter
+            example: premium
+          required: false
+          description: Comma-separated tag filter
+          name: tags
+          in: query
+        - schema:
+            type: string
+            description: Comma-separated delivery type filter
+            example: guaranteed,programmatic
+          required: false
+          description: Comma-separated delivery type filter
+          name: delivery_types
+          in: query
+        - schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+            description: Require TMP support
+          required: false
+          description: Require TMP support
+          name: has_tmp
+          in: query
+        - schema:
+            type:
+              - integer
+              - "null"
+            minimum: 0
+            description: Minimum number of properties in inventory
+          required: false
+          description: Minimum number of properties in inventory
+          name: min_properties
+          in: query
+        - schema:
+            type: string
+            description: Pagination cursor from a previous response
+          required: false
+          description: Pagination cursor from a previous response
+          name: cursor
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            description: Max results per page (default 50, max 200)
+          required: false
+          description: Max results per page (default 50, max 200)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Search results ranked by relevance
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        agent_url:
+                          type: string
+                          format: uri
+                        channels:
+                          type: array
+                          items:
+                            type: string
+                        property_types:
+                          type: array
+                          items:
+                            type: string
+                        markets:
+                          type: array
+                          items:
+                            type: string
+                        categories:
+                          type: array
+                          items:
+                            type: string
+                        tags:
+                          type: array
+                          items:
+                            type: string
+                        delivery_types:
+                          type: array
+                          items:
+                            type: string
+                        format_kinds:
+                          type: array
+                          items:
+                            type: string
+                          description: Canonical format kinds present in this agent's indexed inventory profile
+                        property_count:
+                          type: integer
+                        publisher_count:
+                          type: integer
+                        has_tmp:
+                          type: boolean
+                        category_taxonomy:
+                          type:
+                            - string
+                            - "null"
+                        relevance_score:
+                          type: number
+                        matched_filters:
+                          type: array
+                          items:
+                            type: string
+                        updated_at:
+                          type: string
+                          format: date-time
+                      required:
+                        - agent_url
+                        - channels
+                        - property_types
+                        - markets
+                        - categories
+                        - tags
+                        - delivery_types
+                        - format_kinds
+                        - property_count
+                        - publisher_count
+                        - has_tmp
+                        - category_taxonomy
+                        - relevance_score
+                        - matched_filters
+                        - updated_at
+                  cursor:
+                    type:
+                      - string
+                      - "null"
+                  has_more:
+                    type: boolean
+                required:
+                  - results
+                  - cursor
+                  - has_more
+        "400":
+          description: Invalid cursor or parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/crawl-request:
+    post:
+      operationId: requestCrawl
+      summary: Request domain re-crawl
+      description: |-
+        Persist a durable re-crawl request for a publisher domain after updating adagents.json. Returns 202 only after the request is committed to the queue. Use the returned `crawl_request_id` with the status endpoint to observe completion.
+
+        **Rate limits:** 5 minutes per domain, 30 requests per user per hour.
+      tags:
+        - Agent Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: examplepub.com
+                  description: Publisher domain to re-crawl
+              required:
+                - domain
+      responses:
+        "202":
+          description: Crawl request accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Crawl request accepted
+                  domain:
+                    type: string
+                  crawl_request_id:
+                    type: string
+                    format: uuid
+                    description: Durable request ID for lifecycle logs and status lookup; acceptance is not completion.
+                required:
+                  - message
+                  - domain
+                  - crawl_request_id
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
+        "503":
+          description: The durable crawl queue is temporarily unavailable; the request was not accepted
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying
+              required: true
+              description: Seconds to wait before retrying
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - crawl_queue_unavailable
+                      - crawl_queue_at_capacity
+                  retry_after:
+                    type: integer
+                required:
+                  - error
+                  - code
+                  - retry_after
+  /api/registry/crawl-request/{crawlRequestId}:
+    get:
+      operationId: getCrawlRequest
+      summary: Get publisher crawl request status
+      description: Return the durable lifecycle for a publisher recrawl. Requesters may read their own requests; registry administrators may read any request.
+      tags:
+        - Agent Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: crawlRequestId
+          in: path
+      responses:
+        "200":
+          description: Durable crawl request lifecycle
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  crawl_request_id:
+                    type: string
+                    format: uuid
+                  domain:
+                    type: string
+                  status:
+                    type: string
+                    enum:
+                      - queued
+                      - running
+                      - deferred
+                      - retrying
+                      - completed
+                      - invalid
+                      - failed
+                  attempts:
+                    type: integer
+                  max_attempts:
+                    type: integer
+                  requested_at:
+                    type: string
+                    format: date-time
+                  started_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                  last_attempted_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                  completed_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                  next_attempt_at:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                  last_error_code:
+                    type:
+                      - string
+                      - "null"
+                required:
+                  - crawl_request_id
+                  - domain
+                  - status
+                  - attempts
+                  - max_attempts
+                  - requested_at
+                  - started_at
+                  - last_attempted_at
+                  - completed_at
+                  - next_attempt_at
+                  - last_error_code
+        "400":
+          description: Invalid crawl request ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Crawl request not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Crawl status is temporarily unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying
+              required: true
+              description: Seconds to wait before retrying
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - crawl_status_unavailable
+                  retry_after:
+                    type: integer
+                required:
+                  - error
+                  - code
+                  - retry_after
+  /api/registry/manager-revalidation-request:
+    post:
+      operationId: requestManagerRevalidation
+      summary: Request manager fan-out re-validation
+      description: |-
+        Trigger re-validation of every publisher delegating to a manager domain via ads.txt `MANAGERDOMAIN`. Use after rotating the manager's `adagents.json` so the change propagates to delegating publishers without waiting for the next routine crawl cycle. Work is queued and drained at a bounded rate (≈50 publishers per 5-minute tick). Returns 202 immediately with the number of publishers enqueued.
+
+        **Rate limits:** 5 minutes per manager domain, 30 requests per user per hour (shared with other crawl-request endpoints).
+      tags:
+        - Agent Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                manager_domain:
+                  type: string
+                  example: raptive.com
+                  description: Manager domain whose delegating publishers should be queued for re-validation. Must already be present as `manager_domain` on at least one publisher row.
+              required:
+                - manager_domain
+      responses:
+        "202":
+          description: Re-validation queue request accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Manager re-validation enqueued
+                  manager_domain:
+                    type: string
+                  publishers_enqueued:
+                    type: integer
+                    description: Number of delegating publisher rows added to or refreshed in the manager_revalidation_queue. Zero if no publisher delegates to this manager.
+                required:
+                  - message
+                  - manager_domain
+                  - publishers_enqueued
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
+  /api/registry/brand-crawl-request:
+    post:
+      operationId: requestBrandCrawl
+      summary: Request brand.json re-crawl
+      description: |-
+        Trigger an immediate re-crawl of a domain's brand.json. The crawl runs asynchronously — returns 202 immediately.
+
+        **Rate limits:** 5 minutes per domain, 30 requests per user per hour (shared with adagents.json crawl requests).
+      tags:
+        - Brand Discovery
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: examplebrand.com
+                  description: Domain to re-crawl brand.json for
+              required:
+                - domain
+      responses:
+        "202":
+          description: Brand crawl request accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Brand crawl request accepted
+                  domain:
+                    type: string
+                required:
+                  - message
+                  - domain
+        "400":
+          description: Invalid domain format, private IP, or unresolvable domain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
+  /api/registry/agents/{encodedUrl}/compliance:
+    get:
+      operationId: getAgentCompliance
+      summary: Get agent compliance detail
+      description: |-
+        Returns detailed compliance status for a single agent, including track-level results, storyboard counts, and timestamps.
+
+        If the agent has opted out of compliance monitoring, returns a minimal response with `status: opted_out`.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+            example: https%3A%2F%2Fexample.com%2Fmcp
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Compliance detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentComplianceDetail"
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/.well-known/jwks.json:
+    get:
+      operationId: getJwks
+      summary: AAO public key set
+      description: Returns the JSON Web Key Set (JWKS) containing AAO's public verification keys. Use these to verify AAO Verified badge tokens without calling AAO's API.
+      tags:
+        - Agent Compliance
+      responses:
+        "200":
+          description: JWKS response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  keys:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: {}
+                required:
+                  - keys
+  /api/registry/agents/{encodedUrl}/verification:
+    get:
+      operationId: getAgentVerification
+      summary: Get agent AgenticAdvertising.org Verified status
+      description: Returns AgenticAdvertising.org Verified badge status for a single agent. Registry visibility controls discovery, not verification, so earned badges remain publicly verifiable for private agents. Compliance opt-out immediately suppresses all badges and returns the same unverified shape as an unknown or never-verified agent.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+            example: https%3A%2F%2Fexample.com%2Fmcp
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Verification status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentVerification"
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Verification status temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/badge/{role}.svg:
+    get:
+      operationId: getAgentBadgeSvg
+      summary: Get agent verification badge SVG
+      description: Returns an SVG badge image for the specified agent and role. Shows the role-specific AgenticAdvertising.org Verified mark (teal) when verified, or 'Not Verified' (grey) when not. Responses use ETags but must be revalidated before reuse so opt-out revocation is reflected immediately. Registry visibility does not affect verification.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            allOf:
+              - $ref: "#/components/schemas/BadgeRole"
+              - description: Canonical badge role
+          required: true
+          description: Canonical badge role
+          name: role
+          in: path
+      responses:
+        "200":
+          description: SVG badge image
+          content:
+            image/svg+xml:
+              schema:
+                type: string
+        "400":
+          description: Invalid agent URL or role
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: object
+                    properties:
+                      error:
+                        type: string
+                      code:
+                        type: string
+                        enum:
+                          - invalid_role
+                      message:
+                        type: string
+                      valid_roles:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BadgeRole"
+                    required:
+                      - error
+                      - code
+                      - message
+                      - valid_roles
+                  - $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+        "503":
+          description: Badge status temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/badge/{role}/embed:
+    get:
+      operationId: getAgentBadgeEmbed
+      summary: Get embeddable badge code
+      description: "Returns HTML and Markdown embed snippets for displaying an AgenticAdvertising.org Verified badge on websites, social profiles, and documentation. Private registry visibility does not suppress verification. Compliance opt-out returns `verified: false` without revealing why the badge is ineligible."
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            allOf:
+              - $ref: "#/components/schemas/BadgeRole"
+              - description: Canonical badge role
+          required: true
+          description: Canonical badge role
+          name: role
+          in: path
+      responses:
+        "200":
+          description: Embed code
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  role:
+                    $ref: "#/components/schemas/BadgeRole"
+                  verified:
+                    type: boolean
+                  adcp_version:
+                    type: string
+                  badge_svg_url:
+                    type: string
+                  registry_url:
+                    type: string
+                  html:
+                    type: string
+                  markdown:
+                    type: string
+                required:
+                  - agent_url
+                  - role
+                  - verified
+                  - badge_svg_url
+                  - registry_url
+                  - html
+                  - markdown
+        "400":
+          description: Invalid agent URL or role
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: object
+                    properties:
+                      error:
+                        type: string
+                      code:
+                        type: string
+                        enum:
+                          - invalid_role
+                      message:
+                        type: string
+                      valid_roles:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BadgeRole"
+                    required:
+                      - error
+                      - code
+                      - message
+                      - valid_roles
+                  - $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Badge status temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/badge/{role}/{version}.svg:
+    get:
+      operationId: getAgentBadgeVersionedSvg
+      summary: Get version-pinned agent verification badge SVG
+      description: Returns an SVG badge image scoped to a specific AdCP release (MAJOR.MINOR, e.g. '3.0'). Buyers who want to call out 'verified for 3.0' embed this instead of the legacy `/badge/{role}.svg` (which auto-upgrades to the highest active version). Renders 'Not Verified' when the agent never earned a badge at this version or opted out of compliance monitoring. Registry visibility does not affect verification.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            allOf:
+              - $ref: "#/components/schemas/BadgeRole"
+              - description: Canonical badge role
+          required: true
+          description: Canonical badge role
+          name: role
+          in: path
+        - schema:
+            type: string
+            description: AdCP release as MAJOR.MINOR (e.g. '3.0', '3.1')
+          required: true
+          description: AdCP release as MAJOR.MINOR (e.g. '3.0', '3.1')
+          name: version
+          in: path
+      responses:
+        "200":
+          description: SVG badge image
+          content:
+            image/svg+xml:
+              schema:
+                type: string
+        "400":
+          description: Invalid agent URL, role, or version
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: object
+                    properties:
+                      error:
+                        type: string
+                      code:
+                        type: string
+                        enum:
+                          - invalid_role
+                      message:
+                        type: string
+                      valid_roles:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BadgeRole"
+                    required:
+                      - error
+                      - code
+                      - message
+                      - valid_roles
+                  - $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+        "503":
+          description: Badge status temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/badge/{role}/{version}/embed:
+    get:
+      operationId: getAgentBadgeVersionedEmbed
+      summary: Get version-pinned embeddable badge code
+      description: "Returns HTML and Markdown embed snippets that point at the version-pinned SVG. Alt text includes the version (e.g. 'AgenticAdvertising.org Verified Media Buy Agent 3.0'). Buyers who want to freeze on a specific AdCP release embed these instead of the legacy `/badge/{role}/embed`. Compliance opt-out returns `verified: false`; registry visibility does not affect verification."
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            allOf:
+              - $ref: "#/components/schemas/BadgeRole"
+              - description: Canonical badge role
+          required: true
+          description: Canonical badge role
+          name: role
+          in: path
+        - schema:
+            type: string
+            description: AdCP release as MAJOR.MINOR
+          required: true
+          description: AdCP release as MAJOR.MINOR
+          name: version
+          in: path
+      responses:
+        "200":
+          description: Embed code
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  role:
+                    $ref: "#/components/schemas/BadgeRole"
+                  verified:
+                    type: boolean
+                  adcp_version:
+                    type: string
+                  badge_svg_url:
+                    type: string
+                  registry_url:
+                    type: string
+                  html:
+                    type: string
+                  markdown:
+                    type: string
+                required:
+                  - agent_url
+                  - role
+                  - verified
+                  - adcp_version
+                  - badge_svg_url
+                  - registry_url
+                  - html
+                  - markdown
+        "400":
+          description: Invalid agent URL, role, or version
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: object
+                    properties:
+                      error:
+                        type: string
+                      code:
+                        type: string
+                        enum:
+                          - invalid_role
+                      message:
+                        type: string
+                      valid_roles:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BadgeRole"
+                    required:
+                      - error
+                      - code
+                      - message
+                      - valid_roles
+                  - $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Badge status temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/storyboard-status:
+    get:
+      operationId: getAgentStoryboardStatus
+      summary: Get agent storyboard status
+      description: |-
+        Returns per-storyboard test results for an agent. Includes title, category, track, pass/fail status, and step counts.
+
+        **Members only** — requires authentication and an active membership. Static admin API key callers may read this for support/debugging.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+            example: https%3A%2F%2Fexample.com%2Fmcp
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Storyboard status for the agent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  storyboards:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/StoryboardStatus"
+                  passing_count:
+                    type: integer
+                  total_count:
+                    type: integer
+                required:
+                  - agent_url
+                  - storyboards
+                  - passing_count
+                  - total_count
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Members only
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  members_only:
+                    type: boolean
+                required:
+                  - error
+                  - members_only
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/storyboard-status:
+    post:
+      operationId: bulkAgentStoryboardStatus
+      summary: Bulk storyboard status
+      description: |-
+        Returns per-storyboard test results for multiple agents in a single request.
+
+        **Members only** — requires authentication and an active membership. Static admin API key callers may read this for support/debugging. Maximum 100 agent URLs per request.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                agent_urls:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 100
+                  description: Agent URLs to fetch storyboard status for
+              required:
+                - agent_urls
+      responses:
+        "200":
+          description: Storyboard status keyed by agent URL
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agents:
+                    type: object
+                    additionalProperties:
+                      anyOf:
+                        - type: array
+                          items:
+                            $ref: "#/components/schemas/StoryboardStatus"
+                        - type: object
+                          properties:
+                            status:
+                              type: string
+                              enum:
+                                - opted_out
+                          required:
+                            - status
+                  invalid_urls:
+                    type: integer
+                    description: Count of invalid URLs that were skipped
+                required:
+                  - agents
+        "400":
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Members only
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  members_only:
+                    type: boolean
+                required:
+                  - error
+                  - members_only
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/compliance/history:
+    get:
+      operationId: getAgentComplianceHistory
+      summary: Get agent compliance history
+      description: |-
+        Returns a list of compliance test runs for an agent, ordered most recent first.
+
+        If the agent has opted out, returns an empty list.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Max results (default 30, max 100)
+          required: false
+          description: Max results (default 30, max 100)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Compliance run history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  runs:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ComplianceRun"
+                  count:
+                    type: integer
+                required:
+                  - agent_url
+                  - runs
+                  - count
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/lifecycle:
+    put:
+      operationId: updateAgentLifecycle
+      summary: Update agent lifecycle stage
+      description: Set the lifecycle stage for an agent. Requires authentication and ownership of the agent.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                lifecycle_stage:
+                  type: string
+                  enum:
+                    - development
+                    - testing
+                    - production
+                    - deprecated
+              required:
+                - lifecycle_stage
+      responses:
+        "200":
+          description: Updated metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegistryMetadata"
+        "400":
+          description: Invalid agent URL or lifecycle stage
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/compliance/opt-out:
+    put:
+      operationId: updateAgentComplianceOptOut
+      summary: Update compliance opt-out
+      description: Opt an agent in or out of public compliance reporting. Opting out immediately revokes every active badge version. Re-enabling monitoring keeps badges suppressed until a fresh passing full-suite run earns them again; partial storyboard reruns cannot restore verification first. Requires authentication and ownership of the agent.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                opt_out:
+                  type: boolean
+              required:
+                - opt_out
+      responses:
+        "200":
+          description: Updated metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegistryMetadata"
+        "400":
+          description: Invalid agent URL or opt_out value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/settings:
+    get:
+      operationId: getAgentMonitoringSettings
+      summary: Get monitoring settings
+      description: Returns the monitoring configuration for an agent. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Monitoring settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitoringSettings"
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/pause:
+    put:
+      operationId: updateAgentMonitoringPause
+      summary: Pause or resume monitoring
+      description: Pause or resume automated compliance monitoring for an agent. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                paused:
+                  type: boolean
+              required:
+                - paused
+      responses:
+        "200":
+          description: Updated monitoring settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitoringSettings"
+        "400":
+          description: Invalid agent URL or paused value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/interval:
+    put:
+      operationId: updateAgentMonitoringInterval
+      summary: Update monitoring interval
+      description: Set the check interval for automated compliance monitoring (6–168 hours). Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                interval_hours:
+                  type: integer
+                  minimum: 6
+                  maximum: 168
+              required:
+                - interval_hours
+      responses:
+        "200":
+          description: Updated monitoring settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitoringSettings"
+        "400":
+          description: Invalid agent URL or interval
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/requeue:
+    post:
+      operationId: requeueAgentForHeartbeat
+      summary: Requeue agent for compliance heartbeat
+      description: Clears the agent's last_checked_at timestamp so it is picked up on the next heartbeat cycle (within ~1 hour). This is queued-async; it does not run the compliance suite synchronously or change the current verdict until the heartbeat completes. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      responses:
+        "200":
+          description: Agent requeued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  requeued:
+                    type: boolean
+                required:
+                  - requeued
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limited
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/compliance/diagnostics:
+    get:
+      operationId: getAgentComplianceStepDiagnostics
+      summary: Get per-step diagnostics for a compliance run
+      description: |-
+        Returns the exact request and response payloads the runner captured for failing storyboard steps on a single compliance run.
+
+        Lets agent owners diff what the runner sent against their own probes without re-running the storyboard. Owner-only, with static admin API key access for support/debugging — payloads echo seller-side account/brand identifiers and may carry sensitive descriptive fields. If `run_id` is omitted, resolves to the latest run for the agent.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Specific compliance run UUID. Defaults to latest.
+          required: false
+          description: Specific compliance run UUID. Defaults to latest.
+          name: run_id
+          in: query
+        - schema:
+            type: string
+            description: Max rows (default 500, max 1000)
+          required: false
+          description: Max rows (default 500, max 1000)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Per-step diagnostics for the requested run
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  run_id:
+                    type:
+                      - string
+                      - "null"
+                  count:
+                    type: integer
+                  diagnostics:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ComplianceStepDiagnostic"
+                required:
+                  - agent_url
+                  - run_id
+                  - count
+                  - diagnostics
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/monitoring/requests:
+    get:
+      operationId: getAgentMonitoringRequests
+      summary: Get outbound request log
+      description: Returns the outbound request log for an agent (compliance checks, health probes, etc.). Requires authentication and ownership, or the static admin API key for support/debugging.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Max results (default 50, max 200)
+          required: false
+          description: Max results (default 50, max 200)
+          name: limit
+          in: query
+        - schema:
+            type: string
+            description: ISO 8601 timestamp to filter from
+          required: false
+          description: ISO 8601 timestamp to filter from
+          name: since
+          in: query
+      responses:
+        "200":
+          description: Outbound request log
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  requests:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/OutboundRequest"
+                  count:
+                    type: integer
+                  total:
+                    type: integer
+                required:
+                  - agent_url
+                  - requests
+                  - count
+                  - total
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/refresh:
+    post:
+      operationId: refreshAgent
+      summary: Refresh agent snapshot
+      description: |-
+        Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).
+
+        **Compliance re-run:** when the caller owns the agent or is an AAO admin and the capability probe succeeds, the full storyboard suite can run for several minutes on capability-rich agents with a fresh test session, and `agent_storyboard_status` is updated. Owner-triggered runs use `triggered_by: 'owner_test'`; admin-triggered support runs use `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.
+
+        **Auth:** owner of the agent, AAO admin, or static `ADMIN_API_KEY`.
+
+        **Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+            example: https%3A%2F%2Fvastlint.org%2Fmcp
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization before its credentials are used.
+      responses:
+        "200":
+          description: Snapshot refreshed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  online:
+                    type: boolean
+                  tools_count:
+                    type:
+                      - integer
+                      - "null"
+                  response_time_ms:
+                    type:
+                      - integer
+                      - "null"
+                  inferred_type:
+                    type: string
+                    description: Type inferred from discovered tools (sales, creative, signals, governance, etc.) or 'unknown'
+                  type_promoted:
+                    type: boolean
+                    description: True when registry type was upgraded from unknown to inferred_type
+                  oauth_required:
+                    type: boolean
+                  checked_at:
+                    type: string
+                  error:
+                    type: string
+                  compliance:
+                    type: object
+                    properties:
+                      ran:
+                        type: boolean
+                        description: True if the full storyboard suite ran and agent_storyboard_status was updated. False when ownership couldn't be resolved, the agent reported auth_required, or the compliance call itself failed.
+                      run_id:
+                        type: string
+                        description: Compliance run id written by this refresh. Use with /compliance/diagnostics?run_id=... to inspect failing-step wire evidence.
+                      test_session_id:
+                        type: string
+                        description: Fresh test session id used for the compliance run. Useful when matching seller-side logs to the refresh.
+                      requested_compliance_target:
+                        type: string
+                        description: Requested compliance target before alias resolution, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta. Present when `ran` is true.
+                      adcp_version:
+                        type: string
+                        description: Concrete AdCP compliance bundle version used for the run, e.g. 3.0.12 or 3.1.0-beta.7. Present when `ran` is true.
+                      badge_eligible:
+                        type: boolean
+                        description: True when this run can update public badge state.
+                      badge_eligible_adcp_versions:
+                        type: array
+                        items:
+                          type: string
+                        description: Public badge versions this run can issue, e.g. ['3.0'].
+                      overall_status:
+                        type: string
+                        description: Aggregate verdict from the run (passing / failing / partial / unknown). Only present when `ran` is true.
+                      storyboards_passing:
+                        type: integer
+                        description: Number of storyboards passing on this run.
+                      storyboards_total:
+                        type: integer
+                        description: Number of storyboards evaluated on this run.
+                      observations_count:
+                        type: integer
+                        description: Number of advisory observations emitted by this run.
+                      notices_count:
+                        type: integer
+                        description: Number of run-summary notices emitted by this run.
+                      error:
+                        type: string
+                        description: Reason compliance didn't run when `ran` is false.
+                    required:
+                      - ran
+                    description: Compliance re-run summary. The capability/health portion of the response is independent of this block — a failed compliance run still returns the rest of the snapshot.
+                required:
+                  - online
+                  - tools_count
+                  - response_time_ms
+                  - inferred_type
+                  - type_promoted
+                  - oauth_required
+                  - checked_at
+                  - compliance
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized — must be owner or AAO admin
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Monitoring paused for this agent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  retry_after:
+                    type: integer
+                    description: Seconds to wait before retrying
+                required:
+                  - error
+                  - retry_after
+        "502":
+          description: Probe failed (timeout, DNS, OAuth wall, etc.)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/auth-status:
+    get:
+      operationId: getAgentAuthStatus
+      summary: Get agent auth status
+      description: Returns whether an agent has stored authentication credentials and OAuth token status. Requires authentication.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Selected organization ID. Required to disambiguate an agent URL registered by multiple organizations.
+          required: false
+          description: Selected organization ID. Required to disambiguate an agent URL registered by multiple organizations.
+          name: org
+          in: query
+      responses:
+        "200":
+          description: Auth status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentAuthStatus"
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/connect:
+    put:
+      operationId: connectAgent
+      summary: Connect agent credentials
+      description: Store authentication credentials for an agent. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                auth_token:
+                  type: string
+                  maxLength: 4096
+                  description: Bearer or basic auth token
+                auth_type:
+                  type: string
+                  enum:
+                    - bearer
+                    - basic
+                  description: "Auth type (default: bearer)"
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization.
+      responses:
+        "200":
+          description: Connection result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+                    enum:
+                      - true
+                  has_auth:
+                    type: boolean
+                  agent_context_id:
+                    type: string
+                required:
+                  - connected
+                  - has_auth
+                  - agent_context_id
+        "400":
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/oauth-client-credentials:
+    put:
+      operationId: saveAgentOAuthClientCredentials
+      summary: Save OAuth 2.0 client-credentials for an agent
+      description: Store a machine-to-machine OAuth 2.0 client-credentials configuration (RFC 6749 §4.4) for this agent. The SDK exchanges at the token endpoint before every call and refreshes on 401. `client_secret` may be a `$ENV:VAR_NAME` reference — the SDK resolves at exchange time, the server stores it as written (encrypted uniformly). Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token_endpoint:
+                  type: string
+                  maxLength: 2048
+                  description: Token endpoint URL (HTTPS required; localhost allowed in dev).
+                client_id:
+                  type: string
+                  maxLength: 2048
+                  description: OAuth client ID. May be a `$ENV:VAR_NAME` reference.
+                client_secret:
+                  type: string
+                  maxLength: 8192
+                  description: OAuth client secret. May be a `$ENV:VAR_NAME` reference. Stored encrypted at rest.
+                scope:
+                  type: string
+                  maxLength: 1024
+                  description: Space-separated OAuth scope values.
+                resource:
+                  anyOf:
+                    - type: string
+                      maxLength: 2048
+                    - type: array
+                      items:
+                        type: string
+                        maxLength: 2048
+                      minItems: 1
+                      maxItems: 8
+                  description: RFC 8707 resource indicator. Accepts a single URI string or an array of 1–8 URI strings for multi-resource authorization servers (Keycloak strict, AWS Cognito multi-RS).
+                audience:
+                  type: string
+                  maxLength: 2048
+                  description: Audience parameter for audience-validating authorization servers.
+                auth_method:
+                  type: string
+                  enum:
+                    - basic
+                    - body
+                  description: "Client-credentials placement: basic (HTTP Basic header, RFC 6749 §2.3.1 preferred) or body (form fields). SDK default is basic."
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization.
+              required:
+                - token_endpoint
+                - client_id
+                - client_secret
+      responses:
+        "200":
+          description: Credentials saved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+                    enum:
+                      - true
+                  has_auth:
+                    type: boolean
+                    enum:
+                      - true
+                  agent_context_id:
+                    type: string
+                  auth_type:
+                    type: string
+                    enum:
+                      - oauth_client_credentials
+                required:
+                  - connected
+                  - has_auth
+                  - agent_context_id
+                  - auth_type
+        "400":
+          description: Invalid parameters — response carries `code` and `field` pointing to the rejection cause.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialSaveValidationError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/oauth-client-credentials/test:
+    post:
+      operationId: testAgentOAuthClientCredentials
+      summary: Dry-run the saved OAuth 2.0 client-credentials config
+      description: Exchange the saved client_credentials at the token endpoint and discard the resulting access token. Returns success + latency on a 2xx exchange, or the SDK's `ClientCredentialsExchangeError` kind (`oauth`, `malformed`, `network`) on failure so operators get same-second feedback instead of waiting for the next compliance heartbeat. Requires authentication and ownership. Requires credentials to already be saved via `PUT /oauth-client-credentials`.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization.
+      responses:
+        "200":
+          description: "Result of the token exchange. `ok: true` on 2xx from the AS; `ok: false` with a typed error otherwise (HTTP response itself is still 200 — the error payload carries the rejection kind so UI can branch on it)."
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      latency_ms:
+                        type: integer
+                    required:
+                      - ok
+                      - latency_ms
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - false
+                      latency_ms:
+                        type: integer
+                      error:
+                        type: object
+                        properties:
+                          kind:
+                            type: string
+                            enum:
+                              - oauth
+                              - malformed
+                              - network
+                            description: "Category of failure: `oauth` = AS returned a typed error (e.g. invalid_client), `malformed` = AS returned an unexpected 2xx payload, `network` = couldn't reach the AS."
+                          message:
+                            type: string
+                          oauth_error:
+                            type: string
+                            description: RFC 6749 `error` field when kind=oauth.
+                          oauth_error_description:
+                            type: string
+                            description: RFC 6749 `error_description` field when kind=oauth.
+                          http_status:
+                            type: integer
+                            description: Status code when the AS returned a non-2xx.
+                        required:
+                          - kind
+                          - message
+                    required:
+                      - ok
+                      - latency_ms
+                      - error
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No saved client-credentials config for this agent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/applicable-storyboards:
+    get:
+      operationId: getApplicableStoryboards
+      summary: Get applicable storyboards for agent
+      description: Probe the agent's get_adcp_capabilities and resolve its declared supported_protocols and specialisms to the compliance bundles that will run. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+            description: Selected organization ID. Required to disambiguate an agent URL registered by multiple organizations.
+          required: false
+          description: Selected organization ID. Required to disambiguate an agent URL registered by multiple organizations.
+          name: org
+          in: query
+      responses:
+        "200":
+          description: Bundles the agent will be tested against, driven by its declared capabilities
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agent_url:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                  adcp_version:
+                    type: string
+                  agent_name:
+                    type: string
+                  supported_protocols:
+                    type: array
+                    items:
+                      type: string
+                  specialisms:
+                    type: array
+                    items:
+                      type: string
+                  capabilities_probe_error:
+                    type: string
+                    description: Agent-reported probe error. Untrusted — sanitized and truncated to 500 chars. Present when get_adcp_capabilities was advertised but failed; empty bundle list usually indicates this, not a v2 agent.
+                  bundles:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        kind:
+                          type: string
+                          enum:
+                            - universal
+                            - domain
+                            - specialism
+                        id:
+                          type: string
+                        storyboards:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              title:
+                                type: string
+                              summary:
+                                type: string
+                              step_count:
+                                type: integer
+                            required:
+                              - id
+                              - title
+                              - summary
+                              - step_count
+                      required:
+                        - kind
+                        - id
+                        - storyboards
+                  total_storyboards:
+                    type: integer
+                required:
+                  - agent_url
+                  - requested_compliance_target
+                  - adcp_version
+                  - agent_name
+                  - supported_protocols
+                  - specialisms
+                  - bundles
+                  - total_storyboards
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "422":
+          description: Agent requires authentication, or declared capabilities cannot be resolved for the selected compliance target
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  error_kind:
+                    type: string
+                    enum:
+                      - specialism_parent_protocol_missing
+                      - unknown_specialism
+                      - unsupported_adcp_version
+                  needs_auth:
+                    type: boolean
+                  unknown_specialism:
+                    type: boolean
+                  specialism_parent_protocol_missing:
+                    type: boolean
+                  specialism:
+                    type: string
+                  parent_protocol:
+                    type: string
+                  compliance_version:
+                    type: string
+                  supported_versions:
+                    type: string
+                  declared_specialisms:
+                    type: array
+                    items:
+                      type: string
+                    description: Specialisms the agent declared, for unknown-specialism errors
+                  declared_protocols:
+                    type: array
+                    items:
+                      type: string
+                    description: Protocols the agent declared, for capability-resolution errors
+                  known_specialisms:
+                    type: array
+                    items:
+                      type: string
+                    description: Specialism ids present in this server's local compliance cache
+                required:
+                  - error
+        "429":
+          description: Capability probe rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  reason:
+                    type: string
+                    enum:
+                      - network
+                      - tls
+                      - timeout
+                      - protocol
+                      - unknown
+                    description: Coarse error classification for UI differentiation
+                required:
+                  - error
+        "504":
+          description: Connection timeout
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/storyboards:
+    get:
+      operationId: listStoryboards
+      summary: List storyboards
+      description: Returns the catalog of compliance storyboards. Optionally filter by category.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: Filter by storyboard category
+          required: false
+          description: Filter by storyboard category
+          name: category
+          in: query
+        - schema:
+            type: string
+            description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
+          required: false
+          description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
+          name: compliance_target
+          in: query
+      responses:
+        "200":
+          description: Storyboard catalog
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  adcp_version:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                  storyboards:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/StoryboardSummary"
+                  count:
+                    type: integer
+                required:
+                  - adcp_version
+                  - requested_compliance_target
+                  - storyboards
+                  - count
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/storyboards/{id}:
+    get:
+      operationId: getStoryboard
+      summary: Get storyboard detail
+      description: Returns a single storyboard with its full phase and step structure, plus its test kit if available.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+            description: Storyboard ID
+          required: true
+          description: Storyboard ID
+          name: id
+          in: path
+        - schema:
+            type: string
+            description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
+          required: false
+          description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
+          name: compliance_target
+          in: query
+      responses:
+        "200":
+          description: Storyboard detail
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  adcp_version:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                  storyboard:
+                    $ref: "#/components/schemas/StoryboardDetail"
+                  test_kit: {}
+                required:
+                  - adcp_version
+                  - requested_compliance_target
+                  - storyboard
+        "404":
+          description: Storyboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/find:
+    get:
+      operationId: findBrand
+      summary: Find brands by name
+      description: Search for brands by name or domain. Returns matching results with basic identity info.
+      tags:
+        - Brand Resolution
+      parameters:
+        - schema:
+            type: string
+            minLength: 2
+            description: Search query (min 2 characters)
+          required: true
+          description: Search query (min 2 characters)
+          name: q
+          in: query
+        - schema:
+            type: string
+            description: Max results (default 10, max 50)
+          required: false
+          description: Max results (default 10, max 50)
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/FindCompanyResult"
+                required:
+                  - results
+        "400":
+          description: Query too short
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/brands/setup-my-brand:
+    post:
+      operationId: setupMyBrand
+      summary: Set up a hosted brand.json
+      description: Create or update a hosted brand.json for a domain owned by the authenticated user's organization. Returns the hosted URL and a pointer snippet for DNS setup.
+      tags:
+        - Brand Resolution
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain:
+                  type: string
+                  example: acmecorp.com
+                brand_name:
+                  type: string
+                brand_json:
+                  type: object
+                  additionalProperties: {}
+                  description: "Optional full brand.json draft to host in the registry. Every recognized logo URL must be an absolute HTTPS URL of at most 2048 characters without userinfo credentials, backslashes, or markup-significant characters. The primary brand color must use #RRGGBB format."
+                logo_url:
+                  type: string
+                  maxLength: 2048
+                  format: uri
+                  description: Absolute HTTPS URL for the brand logo. Userinfo credentials, backslashes, and markup-significant characters are not allowed.
+                  example: https://cdn.example.com/brand/logo.svg
+                brand_color:
+                  type: string
+                  pattern: ^#[0-9a-fA-F]{6}$
+              required:
+                - domain
+                - brand_name
+      responses:
+        "200":
+          description: Brand setup result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  domain:
+                    type: string
+                  has_brand_json:
+                    type: boolean
+                  hosted_brand_json_url:
+                    type: string
+                  pointer_snippet:
+                    type: string
+                    description: JSON string for brand.json pointer
+                required:
+                  - domain
+                  - has_brand_json
+                  - hosted_brand_json_url
+                  - pointer_snippet
+        "400":
+          description: Invalid domain or missing fields
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Domain not owned by user's organization
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/check/bulk:
+    post:
+      operationId: bulkPropertyCheck
+      summary: Bulk property identifier check
+      description: Check up to 10,000 property identifiers (domains, app bundle IDs, CTV store URLs) against the registry catalog. Returns a verdict for each identifier and a summary.
+      tags:
+        - Property Resolution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                identifiers:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 10000
+                  description: Property identifiers to check
+              required:
+                - identifiers
+      responses:
+        "200":
+          description: Check results with report ID
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      ready:
+                        type: integer
+                      known:
+                        type: integer
+                      ad_infra:
+                        type: integer
+                      unknown:
+                        type: integer
+                      skipped:
+                        type: integer
+                    required:
+                      - total
+                      - ready
+                      - known
+                      - ad_infra
+                      - unknown
+                      - skipped
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        input:
+                          type: string
+                        identifier:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                            - type
+                            - value
+                        verdict:
+                          type: string
+                        classification:
+                          type:
+                            - string
+                            - "null"
+                        source:
+                          type:
+                            - string
+                            - "null"
+                        property_rid:
+                          type:
+                            - string
+                            - "null"
+                        action:
+                          type: string
+                      required:
+                        - input
+                        - identifier
+                        - verdict
+                        - classification
+                        - source
+                        - property_rid
+                        - action
+                  report_id:
+                    type: string
+                required:
+                  - summary
+                  - entries
+                  - report_id
+        "400":
+          description: Invalid identifiers
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/properties/check/bulk/{reportId}:
+    get:
+      operationId: getBulkPropertyCheckReport
+      summary: Get bulk check report
+      description: Retrieve a previously generated bulk property check report by ID.
+      tags:
+        - Property Resolution
+      parameters:
+        - schema:
+            type: string
+            description: Report UUID
+          required: true
+          description: Report UUID
+          name: reportId
+          in: path
+      responses:
+        "200":
+          description: Report data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      ready:
+                        type: integer
+                      known:
+                        type: integer
+                      ad_infra:
+                        type: integer
+                      unknown:
+                        type: integer
+                      skipped:
+                        type: integer
+                    required:
+                      - total
+                      - ready
+                      - known
+                      - ad_infra
+                      - unknown
+                      - skipped
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        input:
+                          type: string
+                        identifier:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                            - type
+                            - value
+                        verdict:
+                          type: string
+                        classification:
+                          type:
+                            - string
+                            - "null"
+                        source:
+                          type:
+                            - string
+                            - "null"
+                        property_rid:
+                          type:
+                            - string
+                            - "null"
+                        action:
+                          type: string
+                      required:
+                        - input
+                        - identifier
+                        - verdict
+                        - classification
+                        - source
+                        - property_rid
+                        - action
+                required:
+                  - summary
+                  - entries
+        "404":
+          description: Report not found or expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/storyboard/{storyboardId}/step/{stepId}:
+    post:
+      operationId: runStoryboardStep
+      summary: Run a single storyboard step
+      description: Execute a single storyboard step against an agent. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: storyboardId
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: stepId
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                context:
+                  type: object
+                  additionalProperties: {}
+                  description: Optional context object for the step
+                dry_run:
+                  type: boolean
+                  description: "Dry run mode (default: true)"
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization.
+      responses:
+        "200":
+          description: Step execution result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  adcp_version:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                required:
+                  - adcp_version
+                  - requested_compliance_target
+                additionalProperties: {}
+        "400":
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Storyboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/storyboards/{storyboardId}/first-step:
+    get:
+      operationId: getStoryboardFirstStep
+      summary: Get first step preview
+      description: Returns a preview of the first step of a storyboard. No agent call needed.
+      tags:
+        - Agent Compliance
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: storyboardId
+          in: path
+        - schema:
+            type: string
+            description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
+          required: false
+          description: Compliance target to inspect, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta
+          name: compliance_target
+          in: query
+      responses:
+        "200":
+          description: First step preview
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  adcp_version:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                  storyboard:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      title:
+                        type: string
+                    required:
+                      - id
+                      - title
+                  step: {}
+                required:
+                  - adcp_version
+                  - requested_compliance_target
+                  - storyboard
+        "404":
+          description: Storyboard not found or has no steps
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/storyboard/{storyboardId}/run:
+    post:
+      operationId: runStoryboard
+      summary: Run full storyboard evaluation
+      description: Execute all steps of a storyboard against an agent and record the compliance result. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: storyboardId
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization.
+      responses:
+        "200":
+          description: Storyboard run result with annotated phases
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  storyboard:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      title:
+                        type: string
+                      category:
+                        type: string
+                      narrative:
+                        type: string
+                    required:
+                      - id
+                      - title
+                      - category
+                  agent:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      profile: {}
+                    required:
+                      - url
+                  adcp_version:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                  badge_eligible:
+                    type: boolean
+                  badge_eligible_adcp_versions:
+                    type: array
+                    items:
+                      type: string
+                  run_id:
+                    type: string
+                    description: Compliance run id written by this owner-triggered storyboard run.
+                  storyboard_status:
+                    type: object
+                    properties:
+                      storyboard_id:
+                        type: string
+                      status:
+                        type: string
+                        enum:
+                          - passing
+                          - failing
+                          - partial
+                          - untested
+                      steps_passed:
+                        type: integer
+                      steps_total:
+                        type: integer
+                      failure_count:
+                        type: integer
+                      skipped_count:
+                        type: integer
+                      first_failed_step_id:
+                        type:
+                          - string
+                          - "null"
+                      first_failed_step_title:
+                        type:
+                          - string
+                          - "null"
+                      first_failed_step_task:
+                        type:
+                          - string
+                          - "null"
+                      first_failure_message:
+                        type:
+                          - string
+                          - "null"
+                      first_failure_validations:
+                        type: array
+                        items: {}
+                    required:
+                      - storyboard_id
+                      - status
+                      - steps_passed
+                      - steps_total
+                      - failure_count
+                      - skipped_count
+                      - first_failed_step_id
+                      - first_failed_step_title
+                      - first_failed_step_task
+                      - first_failure_message
+                      - first_failure_validations
+                    description: Persisted storyboard verdict for this run, using the same executable-step semantics as agent_storyboard_status.
+                  phases: {}
+                  summary: {}
+                  diagnostics:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        run_id:
+                          type: string
+                        agent_url:
+                          type: string
+                        storyboard_id:
+                          type: string
+                        phase_id:
+                          type: string
+                        step_id:
+                          type: string
+                        task:
+                          type: string
+                        response_status:
+                          type:
+                            - integer
+                            - "null"
+                        error_text:
+                          type:
+                            - string
+                            - "null"
+                        failed_validations_jsonb: {}
+                        adcp_error_jsonb: {}
+                      required:
+                        - run_id
+                        - agent_url
+                        - storyboard_id
+                        - phase_id
+                        - step_id
+                        - task
+                    description: Owner-scoped failing-step validation summary for this run. Full request/response diagnostics remain available via /compliance/diagnostics?run_id=...
+                  observations: {}
+                  total_duration_ms:
+                    type: number
+                  test_kit: {}
+                required:
+                  - storyboard
+                  - agent
+                  - adcp_version
+                  - requested_compliance_target
+                  - badge_eligible
+                  - badge_eligible_adcp_versions
+                  - run_id
+                  - storyboard_status
+                  - diagnostics
+                  - total_duration_ms
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Storyboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/agents/{encodedUrl}/storyboard/{storyboardId}/compare:
+    post:
+      operationId: compareStoryboard
+      summary: Compare storyboard against reference agent
+      description: Run a storyboard against both the target agent and the public reference agent, returning side-by-side results. Requires authentication and ownership.
+      tags:
+        - Agent Compliance
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: URL-encoded agent URL
+          required: true
+          description: URL-encoded agent URL
+          name: encodedUrl
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: storyboardId
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                organization_id:
+                  type: string
+                  description: Selected organization ID. The caller must own the agent in this organization.
+      responses:
+        "200":
+          description: Side-by-side comparison results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  storyboard:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      title:
+                        type: string
+                      category:
+                        type: string
+                    required:
+                      - id
+                      - title
+                      - category
+                  user_agent:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      profile: {}
+                      summary: {}
+                    required:
+                      - url
+                  reference_agent:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                      name:
+                        type: string
+                      profile: {}
+                      summary: {}
+                    required:
+                      - url
+                      - name
+                  adcp_version:
+                    type: string
+                  requested_compliance_target:
+                    type: string
+                  badge_eligible:
+                    type: boolean
+                  badge_eligible_adcp_versions:
+                    type: array
+                    items:
+                      type: string
+                  phases: {}
+                  total_duration_ms:
+                    type: number
+                required:
+                  - storyboard
+                  - user_agent
+                  - reference_agent
+                  - adcp_version
+                  - requested_compliance_target
+                  - badge_eligible
+                  - badge_eligible_adcp_versions
+                  - total_duration_ms
+        "400":
+          description: Invalid agent URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Storyboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/me/agents:
+    get:
+      operationId: listMemberAgents
+      summary: List my registered agents
+      description: List the agents registered on the caller's organization member profile. Returns the same `agents[]` array stored on the profile, in the order members registered them.
+      tags:
+        - Member Agents
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+            example: org_01HXZAB123
+          required: false
+          description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+          name: org
+          in: query
+      responses:
+        "200":
+          description: Registered agents
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberAgentListResponse"
+        "400":
+          description: No organization associated with this account
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "`?org=` was supplied but the caller is not a member of that organization."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No member profile exists yet — create one via `POST /api/me/member-profile`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      operationId: registerMemberAgent
+      summary: Register an agent
+      description: |-
+        Register an agent on the caller's organization member profile.
+
+        Idempotent on `url`: re-posting the same `url` updates the entry in place rather than creating a duplicate. New entries return `201`; updates return `200`.
+
+        **True one-call storefront experience.** A third-party app holding only a user's OAuth token can `POST /api/me/agents` once and have the entire bootstrap chain materialize:
+
+        - If the caller has zero org memberships, the server auto-creates an organization (corporate or personal workspace based on the user's email domain) and the response includes `org_auto_created: true`.
+
+        - If the caller's org has no member profile, the server auto-creates a private profile (display name = organization name, `is_public: false`) and the response includes `profile_auto_created: true`.
+
+        Both auto-bootstraps are best-effort fallbacks. To customize org name / company_type / revenue_tier, or to control profile slug / brand identity / tagline, call `POST /api/organizations` and `POST /api/me/member-profile` explicitly before registering the agent. Tier transitions never happen via this path — go through the billing flow.
+
+        `type` is required and declared by the caller — the server does not infer it. Server-side smuggle protection still cross-checks the declared type against the agent's capability snapshot when one exists; if the snapshot contradicts the declaration without classifying it, the stored value is `unknown` and the dashboard surfaces the conflict for the owner to resolve.
+
+        `visibility: "public"` requires a paid AAO tier (Professional, Builder, Member, or Leader) and a verified primary domain on the organization (set via the Linked Domains UI). Non-API-tier callers (Explorer or no tier) who request `public` will have the entry stored as `members_only` instead, and the response will include a `visibility_downgraded` warning describing the coercion.
+      tags:
+        - Member Agents
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+            example: org_01HXZAB123
+          required: false
+          description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+          name: org
+          in: query
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MemberAgentInput"
+      responses:
+        "200":
+          description: Agent already registered at this `url`; entry updated in place.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberAgentResponse"
+        "201":
+          description: "Agent registered. When this is the first agent on a freshly created organization, the response includes `profile_auto_created: true`."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberAgentResponse"
+        "400":
+          description: Missing or invalid `url`, missing/invalid `type`, or the caller has memberships in other orgs but no primary org set — pass `?org=<id>` to target one explicitly. (Fresh users with no memberships at all hit the org auto-bootstrap path and do not see this error.)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "`?org=` was supplied but the caller is not a member of that organization."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Auto-bootstrap could not run (e.g. the organization has no name yet). Call `POST /api/me/member-profile` to create a profile explicitly, then retry.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/me/agents/{url}:
+    patch:
+      operationId: updateMemberAgent
+      summary: Update an agent
+      description: Update one registered agent identified by its `url`. The `url` field itself cannot be changed via PATCH — supplying a `url` in the body that differs from the path returns `400 url_immutable`; re-register at the new URL and DELETE the old entry to migrate. All other fields accept partial updates.
+      tags:
+        - Member Agents
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: The agent's `url`, URL-encoded (e.g. `https%3A%2F%2Fagent.example.com%2Fmcp`).
+          required: true
+          description: The agent's `url`, URL-encoded (e.g. `https%3A%2F%2Fagent.example.com%2Fmcp`).
+          name: url
+          in: path
+        - schema:
+            type: string
+            description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+            example: org_01HXZAB123
+          required: false
+          description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+          name: org
+          in: query
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MemberAgentPatch"
+      responses:
+        "200":
+          description: Agent updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberAgentResponse"
+        "400":
+          description: No organization associated with this account, or `body.url` differs from the path (`url_immutable`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "`?org=` was supplied but the caller is not a member of that organization."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No member profile, or no agent registered at the given `url`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      operationId: removeMemberAgent
+      summary: Remove an agent
+      description: |-
+        Remove one registered agent identified by its `url`.
+
+        A currently-`public` agent is reflected in the published `brand.json` manifest. To prevent the registry catalog and `brand.json` from silently disagreeing, this endpoint returns `409 unpublish_first` when the agent is `public` — `PATCH /api/me/agents/{url}` with `visibility: "private"` first (or call `DELETE /api/me/member-profile/agents/{index}/publish` to reconcile the manifest), then re-issue the DELETE.
+      tags:
+        - Member Agents
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      parameters:
+        - schema:
+            type: string
+            description: The agent's `url`, URL-encoded (e.g. `https%3A%2F%2Fagent.example.com%2Fmcp`).
+          required: true
+          description: The agent's `url`, URL-encoded (e.g. `https%3A%2F%2Fagent.example.com%2Fmcp`).
+          name: url
+          in: path
+        - schema:
+            type: string
+            description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+            example: org_01HXZAB123
+          required: false
+          description: WorkOS organization id to act on. Defaults to the caller's primary organization. Use this from a multi-org session (or when shelling with a user JWT) to target a non-primary org. Verification goes through WorkOS membership lookup; non-members get `403`.
+          name: org
+          in: query
+      responses:
+        "204":
+          description: Agent removed.
+        "400":
+          description: No organization associated with this account
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "`?org=` was supplied but the caller is not a member of that organization."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: No member profile, or no agent registered at the given `url`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Agent is currently `public` and reflected in `brand.json`; unpublish first.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/organizations:
+    post:
+      operationId: createOrganization
+      summary: Create or adopt my organization
+      description: |-
+        Bootstrap the caller's organization explicitly. Use this when the caller wants to control the organization name, `company_type`, `revenue_tier`, or `is_personal` flag before any agents are registered.
+
+        **Most storefront-style integrations don't need this call** — `POST /api/me/agents` will auto-create an org for a fresh OAuth user (corporate or personal workspace based on the email domain) and surface `org_auto_created: true` in the response. Reach for `POST /api/organizations` only when the auto-derived defaults aren't acceptable.
+
+        Three outcomes depending on the caller's state:
+
+        - **Fresh create** (most common): a new WorkOS organization is created, the caller is added as `owner`, the corporate domain is recorded as email-verified, and ToS / privacy-policy acceptance is logged from the request context. Returns `{ success: true, organization: { id, name } }`.
+
+        - **Prospect adoption**: an organization with the caller's email domain already exists as a `prospect` (the registry pre-recorded it from a brand crawl but no human had claimed it yet). The caller is promoted to `owner` of the existing record instead of forking a duplicate. Returns `{ id, name, adopted: true }`.
+
+        - **Already-active conflict**: the org exists and is already claimed by another paying member or a previously joined user. Returns `409` with the existing org id so the caller can switch to a join-request flow (`POST /api/organizations/:orgId/join-requests`) instead of trying to register a duplicate.
+
+        Tier transitions happen via the billing flow only — there is no `membership_tier` field on this endpoint. After org creation, send the user to `POST /api/checkout-session` (or the `/dashboard/membership` page) to start a subscription; the Stripe webhook is the sole writer of `organizations.membership_tier`.
+
+        Rate-limited per user: `15` failed attempts per hour; successful calls do not count against the limit so a legitimate registration is never penalized by earlier validation errors.
+      tags:
+        - Onboarding
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateOrganizationInput"
+      responses:
+        "200":
+          description: "Prospect adoption — an existing prospect organization for this domain was claimed by the caller. Body is `{ id, name, adopted: true }`."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateOrganizationResponse"
+        "201":
+          description: "New organization created. Body is `{ success: true, organization: { id, name } }`. The caller is the `owner`; the corporate domain is recorded as email-verified for downstream registry calls."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateOrganizationResponse"
+        "400":
+          description: |-
+            One of:
+            - `organization_name` missing or invalid
+            - `company_type` / `revenue_tier` value not in the documented enum
+            - caller is on a personal-email domain (gmail.com, yahoo.com, …) and is trying to register a corporate org — register `is_personal: true` instead
+            - per-user organization cap reached (10 orgs per user)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: An active organization already exists for this caller's email domain. The body includes `existing_org_id` and `existing_org_name`; the caller should switch to the join-request flow rather than retrying.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: Rate limit exceeded — 15 failed attempts per hour per user. Successful calls do not count against the limit.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/resolve:
+    post:
+      operationId: resolveIdentifiers
+      summary: Resolve identifiers to property_rids (and contribute them)
+      description: The primary fact-contribution path. Takes identifiers plus a provenance envelope and returns stable `property_rid`s. In `resolve` mode (default) it auto-creates missing catalog entries and logs demand activity — so resolving your own identifier list IS the contribution. `property_rid` is a non-authoritative join/match handle, never an authorization credential. Re-resolving is idempotent on the identifier→rid mapping but additive on the activity log.
+      tags:
+        - Property Catalog
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResolveRequest"
+      responses:
+        "200":
+          description: Resolve/lookup result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResolveResponse"
+        "400":
+          description: Invalid request (bad identifiers, unknown provenance type, batch > 10,000)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required for resolve mode
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/catalog/disputes:
+    post:
+      operationId: fileCatalogDispute
+      summary: Dispute a catalog fact
+      description: "Challenge or correct a catalog claim — the community disavow/challenge verb. Adding links is hard; suspending suspicious ones is easy: a disputed medium/weak link is suspended immediately (`action_taken: 'link_suspended'`); stronger claims queue for review. Poll status with getCatalogDispute."
+      tags:
+        - Property Catalog
+      security:
+        - bearerAuth: []
+        - oauth2: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CatalogDisputeRequest"
+      responses:
+        "200":
+          description: Dispute filed and triaged
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CatalogDisputeTriageResult"
+        "400":
+          description: Invalid dispute request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/catalog/disputes/{id}:
+    get:
+      operationId: getCatalogDispute
+      summary: Get a catalog dispute
+      description: Fetch the current state of a filed dispute by id.
+      tags:
+        - Property Catalog
+      parameters:
+        - schema:
+            type: string
+            example: 019539a0-b1c2-7d3e-8f4a-5b6c7d8e9f0a
+          required: true
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Dispute record
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CatalogDisputeRecord"
+        "404":
+          description: Dispute not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/registry/catalog:
+    get:
+      operationId: browseCatalog
+      summary: Browse the property catalog
+      description: Browse the property fact-graph with filters. Cursor-paginated (opaque `cursor` → `next_cursor`). Each entry carries the property's identifiers. `property_rid` is a non-authoritative join/match handle, never an authorization credential.
+      tags:
+        - Property Catalog
+      parameters:
+        - schema:
+            type: string
+            example: property
+          required: false
+          name: classification
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: source
+          in: query
+        - schema:
+            type: string
+            example: active
+          required: false
+          name: status
+          in: query
+        - schema:
+            type: string
+            example: domain
+          required: false
+          name: identifier_type
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: search
+          in: query
+        - schema:
+            type: string
+            description: Minimum lifetime resolve count (integer).
+          required: false
+          description: Minimum lifetime resolve count (integer).
+          name: min_resolves
+          in: query
+        - schema:
+            type: string
+            description: ISO 8601 — only properties with resolve activity since this time.
+          required: false
+          description: ISO 8601 — only properties with resolve activity since this time.
+          name: active_since
+          in: query
+        - schema:
+            type: string
+            description: Page size (integer).
+          required: false
+          description: Page size (integer).
+          name: limit
+          in: query
+        - schema:
+            type: string
+            description: Opaque pagination cursor from a prior `next_cursor`.
+          required: false
+          description: Opaque pagination cursor from a prior `next_cursor`.
+          name: cursor
+          in: query
+      responses:
+        "200":
+          description: Catalog page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CatalogBrowseResponse"
+  /api/registry/catalog/sync:
+    get:
+      operationId: syncCatalog
+      summary: Sync catalog changes since a watermark
+      description: "Delta sync for local mirrors: returns catalog entries created/updated since `since` (a prior `server_timestamp`), capped at 10,000 per page. Pagination is by the returned `server_timestamp` watermark, distinct from browseCatalog's opaque cursor."
+      tags:
+        - Property Catalog
+      parameters:
+        - schema:
+            type: string
+            description: Watermark from a prior response `server_timestamp` (required).
+            example: 2026-03-27T10:00:00Z
+          required: true
+          description: Watermark from a prior response `server_timestamp` (required).
+          name: since
+          in: query
+        - schema:
+            type: string
+            description: Page size, capped at 10,000.
+          required: false
+          description: Page size, capped at 10,000.
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Catalog delta
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CatalogSyncResponse"
+        "400":
+          description: Missing required `since` parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+tags:
+  - name: Onboarding
+    description: Explicitly bootstrap a third-party integration into the AAO registry. Most callers don't need this tag — `POST /api/me/agents` auto-creates the org (for fresh users) and the member profile (for first-time agent registration) without a separate round trip. Use `POST /api/organizations` only when you need to override the auto-derived org name / company_type / revenue_tier. Tier transitions happen via the billing flow only; the Stripe webhook is the sole writer of `organizations.membership_tier`.
+  - name: Member Agents
+    description: Register, list, update, and remove agents on the caller's organization member profile. Authenticated programmatic surface for CI / scripts that don't want to round-trip the full member profile.
+  - name: Brand Resolution
+    description: Resolve advertiser domains to canonical brand identities.
+  - name: Property Resolution
+    description: Resolve publisher domains to their property configurations and authorized agents.
+  - name: Agent Discovery
+    description: Browse the federated agent network, search agent inventory profiles, publisher index, and registry statistics.
+  - name: Change Feed
+    description: Poll cursor-based registry change events for local sync.
+  - name: Lookups & Authorization
+    description: Look up agents by domain or property, and validate ad-serving authorization.
+  - name: Validation Tools
+    description: Validate publisher adagents.json files and generate compliant configurations.
+  - name: Community Mirrors
+    description: Propose, review, publish, fetch, list, and retire catalog-only adagents.json mirrors for platforms that have not adopted AdCP.
+  - name: Search
+    description: Cross-entity search across brands, publishers, agents, and properties.
+  - name: Agent Probing
+    description: Connect to live agents and inspect their capabilities, formats, and inventory.
+  - name: Brand Discovery
+    description: Discover and crawl brand.json files across domains.
+  - name: Agent Compliance
+    description: Agent compliance status, storyboard test results, and compliance history.
+  - name: Policy Registry
+    description: Browse, resolve, and contribute governance policies for campaign compliance.
+  - name: Property Catalog
+    description: "Contribute facts to the property fact-graph: resolve identifiers to stable property_rids (which also contributes them, with provenance) and dispute catalog claims."

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -164,6 +164,23 @@ test('OpenAPI navigation uses repository-local sources', () => {
   if (missingSources.length > 0) {
     throw new Error(`Missing local OpenAPI sources: ${missingSources.join(', ')}`);
   }
+
+  for (const entry of navigation.versions) {
+    const pages = collectPages(entry.groups);
+    const snapshot = pages
+      .map(page => /^dist\/docs\/([^/]+)\//.exec(page)?.[1])
+      .find(Boolean);
+    const entrySources = collectOpenApiSources(entry.groups);
+    const mutableSources = entrySources.filter(
+      source => !snapshot || source !== `static/openapi/releases/${snapshot}/registry.yaml`
+    );
+    if (mutableSources.length > 0) {
+      throw new Error(
+        `Docs version ${entry.version} must use its immutable snapshot OpenAPI source: ` +
+        mutableSources.join(', ')
+      );
+    }
+  }
 });
 
 test('default navigation matches the stable release branch surface', () => {


### PR DESCRIPTION
## Summary

- pin the 3.0, 3.1, and 3.2-beta docs navigation to the OpenAPI registry shipped with each release
- add those immutable registries under dedicated static release-source paths
- add a navigation regression guard requiring version-pinned, repository-local sources

This addresses the production Mintlify full-rebuild failure after `3.2.0-beta.7`: all versions previously shared one mutable source, and the deployer fetched zero OpenAPI inputs before failing generation.

## Verification

- `npm run test:docs-nav` (44 passed)
- `node scripts/check-immutable-release-artifacts.cjs origin/main`
- exact release-tag registry SHA-256 matches for 3.0.26, 3.1.19, and 3.2.0-beta.7
- confidentiality scan clean

`npx mint validate` reaches only the existing archived 2.5 MDX metadata parse errors; it reports no OpenAPI or docs.json configuration error.