### PR TITLE
refactor(addie): add canonical model turn loop state

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -52,10 +52,7 @@ import {
 } from './model-providers/anthropic-provider.js';
 import { collectModelResponse } from './model-providers/events.js';
 import {
-  addModelUsage,
-  EmptyResponseRecoveryState,
-  inspectModelTurn,
-  ModelLoopBudget,
+  ModelTurnLoopState,
 } from './model-providers/model-turn.js';
 import {
   createAddieToolExecutor,
@@ -1434,9 +1431,6 @@ export class AddieClaudeClient {
     let totalLlmMs = 0;
     let totalToolExecutionMs = 0;
 
-    // Token usage tracking (aggregated across iterations)
-    let totalUsage: ModelUsage = { inputTokens: 0, outputTokens: 0 };
-
     const prepared = this.prepareFirstNonStreamingInvocation(
       userMessage,
       threadContext,
@@ -1481,7 +1475,7 @@ export class AddieClaudeClient {
       ? undefined
       : await getCurrentConfigVersionId();
 
-    const loopBudget = new ModelLoopBudget(options?.maxIterations ?? DEFAULT_MAX_ITERATIONS);
+    const modelLoop = new ModelTurnLoopState(options?.maxIterations ?? DEFAULT_MAX_ITERATIONS);
 
     // Log if using precision model
     if (options?.modelOverride && options.modelOverride !== this.model) {
@@ -1500,19 +1494,18 @@ export class AddieClaudeClient {
       );
     }
     let iteration = 0;
-    const emptyResponseRecovery = new EmptyResponseRecoveryState();
     let hasExecutedCustomTool = false;
 
-    while (loopBudget.hasRemaining) {
-      iteration = loopBudget.startNext();
+    while (modelLoop.hasRemaining) {
+      iteration = modelLoop.startNext();
 
       // Use beta API to access web search
       const llmStart = Date.now();
       let response: ModelResponse;
       let reusedEmptyResponse = false;
-      const invocationTools = emptyResponseRecovery.toolsAllowed ? modelTools : [];
+      const invocationTools = modelLoop.emptyResponseRecovery.toolsAllowed ? modelTools : [];
       let invocationAttempt = 0;
-      const isEmptyResponseRecovery = emptyResponseRecovery.pending;
+      const isEmptyResponseRecovery = modelLoop.emptyResponseRecovery.pending;
       try {
         const invokeProvider = async (exactlyOnce: boolean) => {
           invocationAttempt++;
@@ -1521,7 +1514,7 @@ export class AddieClaudeClient {
             systemBlocks,
             invocationTools,
             modelMessages,
-            emptyResponseRecovery.toolsAllowed && requestWebSearchEnabled,
+            modelLoop.emptyResponseRecovery.toolsAllowed && requestWebSearchEnabled,
             isEmptyResponseRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
           );
           const provider = exactlyOnce
@@ -1552,10 +1545,10 @@ export class AddieClaudeClient {
             'processMessage',
           );
         if (operationalExecution) this.providerHealth.recordSuccess('anthropic', 'chat');
-        if (isEmptyResponseRecovery) emptyResponseRecovery.resolve();
+        if (isEmptyResponseRecovery) modelLoop.emptyResponseRecovery.resolve();
       } catch (error) {
         const fallbackResponse = isEmptyResponseRecovery
-          ? emptyResponseRecovery.takeFallback()
+          ? modelLoop.emptyResponseRecovery.takeFallback()
           : null;
         if (fallbackResponse) {
           // The empty end_turn was a valid terminal response. Recovery is
@@ -1595,11 +1588,6 @@ export class AddieClaudeClient {
       const llmDuration = Date.now() - llmStart;
       totalLlmMs += llmDuration;
 
-      // Track token usage from this iteration
-      if (!reusedEmptyResponse) {
-        totalUsage = addModelUsage(totalUsage, response.usage);
-      }
-
       logger.debug({
         stopReason: response.providerFinishReason,
         contentTypes: response.content.map(c => c.type),
@@ -1612,7 +1600,7 @@ export class AddieClaudeClient {
       // Post-tool empty-response recovery is intentionally text-only. Defend
       // against a malformed provider response that nevertheless contains a
       // tool request: discard it instead of risking a duplicate mutation.
-      if (emptyResponseRecovery.postToolAttempted && response.finishReason === 'tool_calls') {
+      if (modelLoop.emptyResponseRecovery.postToolAttempted && response.finishReason === 'tool_calls') {
         logger.warn({ iteration }, 'Addie: Ignoring tool use from text-only recovery');
         response = {
           ...response,
@@ -1621,7 +1609,7 @@ export class AddieClaudeClient {
           content: [],
         };
       }
-      const turn = inspectModelTurn(response);
+      const turn = modelLoop.acceptResponse(response, { countUsage: !reusedEmptyResponse });
 
       // Provider-managed web results may accompany either a terminal answer or
       // another tool-call turn. Derive their receipts through the selected
@@ -1705,7 +1693,7 @@ export class AddieClaudeClient {
         }
         const text = finalized.text;
         totalToolExecutionMs = toolExecutions.reduce((sum, execution) => sum + execution.duration_ms, 0);
-        const finalUsage = toAddieUsage(totalUsage);
+        const finalUsage = toAddieUsage(modelLoop.usage);
         logger.error(
           {
             event: 'addie_response_truncated',
@@ -1761,13 +1749,13 @@ export class AddieClaudeClient {
           operationalExecution
           && response.providerFinishReason === 'end_turn'
           && iteration === 1
-          && !emptyResponseRecovery.hasAttempted('initial')
+          && !modelLoop.emptyResponseRecovery.hasAttempted('initial')
           && !hasExecutedCustomTool
           && toolExecutions.length === 0
           && isSideEffectFreeEmptyModelResponse(response, rawText)
-          && loopBudget.hasRemaining
+          && modelLoop.hasRemaining
         ) {
-          emptyResponseRecovery.schedule('initial', response);
+          modelLoop.emptyResponseRecovery.schedule('initial', response);
           logger.warn({ iteration }, 'Addie: Retrying wholly empty initial response');
           continue;
         }
@@ -1778,10 +1766,10 @@ export class AddieClaudeClient {
           response.providerFinishReason === 'end_turn'
           && isSideEffectFreeEmptyModelResponse(response, rawText)
           && hasExecutedCustomTool
-          && !emptyResponseRecovery.hasAttempted('post_tool')
-          && loopBudget.hasRemaining
+          && !modelLoop.emptyResponseRecovery.hasAttempted('post_tool')
+          && modelLoop.hasRemaining
         ) {
-          emptyResponseRecovery.schedule('post_tool', response);
+          modelLoop.emptyResponseRecovery.schedule('post_tool', response);
           logger.warn({ iteration, toolsUsed }, 'Addie: Retrying empty response after tool use');
           continue;
         }
@@ -1818,7 +1806,7 @@ export class AddieClaudeClient {
           ? 'Output truncated due to length'
           : hallucinationReason ?? finalized.emptyReason;
 
-        const finalUsage = toAddieUsage(totalUsage);
+        const finalUsage = toAddieUsage(modelLoop.usage);
         // Record the call against the user's daily budget (#2790).
         // Runs after the response is built so a successful charge
         // counts even if a downstream flag/logging failure occurs.
@@ -1923,7 +1911,7 @@ export class AddieClaudeClient {
             reportEmptyResponseFallback(finalized.emptyReason, toolsUsed, toolExecutions, options, 'processMessage', effectiveModel, iteration);
           }
           totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
-          const terminalUsage = toAddieUsage(totalUsage);
+          const terminalUsage = toAddieUsage(modelLoop.usage);
           if (finalized.lengthExceeded) {
             logger.error(
               { event: 'addie_response_truncated', source: 'processMessage', originalLength: rawText.length, deliveredLength: text.length, localCapExceeded: true },
@@ -1979,7 +1967,7 @@ export class AddieClaudeClient {
 
     logger.warn('Addie: Hit max tool iterations');
     totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
-    const maxIterationsUsage = toAddieUsage(totalUsage);
+    const maxIterationsUsage = toAddieUsage(modelLoop.usage);
     // Still charge the user for tokens actually consumed on the way
     // to hitting max-iterations — those bytes DID go to Anthropic
     // and DID cost money, regardless of whether the session converged.
@@ -2003,7 +1991,7 @@ export class AddieClaudeClient {
         system_prompt_ms: systemPromptMs,
         total_llm_ms: totalLlmMs,
         total_tool_execution_ms: totalToolExecutionMs,
-        iterations: loopBudget.limit,
+        iterations: modelLoop.limit,
       },
       usage: maxIterationsUsage,
     };
@@ -2118,9 +2106,6 @@ export class AddieClaudeClient {
     let totalLlmMs = 0;
     let totalToolExecutionMs = 0;
 
-    // Token usage tracking (aggregated across iterations)
-    let totalUsage: ModelUsage = { inputTokens: 0, outputTokens: 0 };
-
     // Get system prompt from rule files (or fallback)
     const promptStart = Date.now();
     const { prompt: systemPrompt } = this.getSystemPrompt();
@@ -2216,13 +2201,12 @@ export class AddieClaudeClient {
     // Mark the last tool with cache_control so Anthropic caches all tool definitions.
     const customTools = buildAddieWireTools(allTools) as Anthropic.Tool[];
     const modelTools = buildModelToolDefinitions(allTools);
-    const loopBudget = new ModelLoopBudget(options?.maxIterations ?? DEFAULT_MAX_ITERATIONS);
+    const modelLoop = new ModelTurnLoopState(options?.maxIterations ?? DEFAULT_MAX_ITERATIONS);
     let iteration = 0;
-    const emptyResponseRecovery = new EmptyResponseRecoveryState();
     let lastProviderModel: string | undefined;
 
-      while (loopBudget.hasRemaining) {
-        iteration = loopBudget.startNext();
+      while (modelLoop.hasRemaining) {
+        iteration = modelLoop.startNext();
 
         const llmStart = Date.now();
 
@@ -2240,9 +2224,9 @@ export class AddieClaudeClient {
         let receivedDeltaCount = 0;
 
         while (!streamSucceeded && streamRetryCount <= maxStreamRetries) {
-          const isEmptyResponseRecovery = emptyResponseRecovery.pending;
+          const isEmptyResponseRecovery = modelLoop.emptyResponseRecovery.pending;
           try {
-            const invocationTools = emptyResponseRecovery.toolsAllowed ? modelTools : [];
+            const invocationTools = modelLoop.emptyResponseRecovery.toolsAllowed ? modelTools : [];
             const modelRequest = this.buildModelRequest(
               effectiveModel,
               systemBlocks,
@@ -2277,10 +2261,10 @@ export class AddieClaudeClient {
             if (operationalExecution) this.providerHealth.recordSuccess('anthropic', 'chat');
             streamSucceeded = true;
             lastProviderModel = currentResponse.model;
-            if (isEmptyResponseRecovery) emptyResponseRecovery.resolve();
+            if (isEmptyResponseRecovery) modelLoop.emptyResponseRecovery.resolve();
           } catch (streamError) {
             const fallbackResponse = isEmptyResponseRecovery
-              ? emptyResponseRecovery.takeFallback()
+              ? modelLoop.emptyResponseRecovery.takeFallback()
               : null;
             if (fallbackResponse) {
               // See the non-streaming path: recovery is an optional UX
@@ -2400,11 +2384,6 @@ export class AddieClaudeClient {
           throw new Error('Stream completed without response');
         }
 
-        // Track token usage
-        if (!reusedEmptyResponse) {
-          totalUsage = addModelUsage(totalUsage, currentResponse.usage);
-        }
-
         logger.debug({
           stopReason: currentResponse.providerFinishReason,
           iteration,
@@ -2415,7 +2394,7 @@ export class AddieClaudeClient {
 
         // The post-tool recovery iteration has no tools. If the provider still returns
         // a tool_use block, ignore it rather than executing a mutation twice.
-        if (emptyResponseRecovery.postToolAttempted && currentResponse.finishReason === 'tool_calls') {
+        if (modelLoop.emptyResponseRecovery.postToolAttempted && currentResponse.finishReason === 'tool_calls') {
           logger.warn({ iteration }, 'Addie Stream: Ignoring tool use from text-only recovery');
           currentResponse = {
             ...currentResponse,
@@ -2428,7 +2407,7 @@ export class AddieClaudeClient {
         // Build the final usage block + charge the user's cost
         // budget (#2790). Both stream terminal paths (end_turn and
         // no-tool-blocks) serialize the same normalized accumulator.
-        const buildStreamUsage = () => toAddieUsage(totalUsage);
+        const buildStreamUsage = () => toAddieUsage(modelLoop.usage);
         const chargeStreamCost = async (usage: ReturnType<typeof buildStreamUsage>) => {
           if (operationalExecution && options?.costScope) {
             await recordCost(
@@ -2439,7 +2418,7 @@ export class AddieClaudeClient {
           }
         };
 
-        const turn = inspectModelTurn(currentResponse);
+        const turn = modelLoop.acceptResponse(currentResponse, { countUsage: !reusedEmptyResponse });
         const stopAction = turn.action;
         const iterationText = turn.textBlocks
           .map((block) => block.text)
@@ -2510,13 +2489,13 @@ export class AddieClaudeClient {
             operationalExecution
             && currentResponse.providerFinishReason === 'end_turn'
             && iteration === 1
-            && !emptyResponseRecovery.hasAttempted('initial')
+            && !modelLoop.emptyResponseRecovery.hasAttempted('initial')
             && toolExecutions.length === 0
             && logicalText.length === 0
             && isSideEffectFreeEmptyModelResponse(currentResponse, iterationText)
-            && loopBudget.hasRemaining
+            && modelLoop.hasRemaining
           ) {
-            emptyResponseRecovery.schedule('initial', currentResponse);
+            modelLoop.emptyResponseRecovery.schedule('initial', currentResponse);
             logger.warn({ iteration }, 'Addie Stream: Retrying wholly empty initial response');
             continue;
           }
@@ -2527,10 +2506,10 @@ export class AddieClaudeClient {
             currentResponse.providerFinishReason === 'end_turn'
             && isSideEffectFreeEmptyModelResponse(currentResponse, iterationText)
             && toolExecutions.length > 0
-            && !emptyResponseRecovery.hasAttempted('post_tool')
-            && loopBudget.hasRemaining
+            && !modelLoop.emptyResponseRecovery.hasAttempted('post_tool')
+            && modelLoop.hasRemaining
           ) {
-            emptyResponseRecovery.schedule('post_tool', currentResponse);
+            modelLoop.emptyResponseRecovery.schedule('post_tool', currentResponse);
             logger.warn({ iteration, toolsUsed }, 'Addie Stream: Retrying empty response after tool use');
             continue;
           }
@@ -2687,7 +2666,7 @@ export class AddieClaudeClient {
       // Max iterations reached
       logger.warn('Addie Stream: Hit max tool iterations');
       totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
-      const maxIterUsage = toAddieUsage(totalUsage);
+      const maxIterUsage = toAddieUsage(modelLoop.usage);
       // Charge the tokens consumed up to the max-iteration wall —
       // the API calls happened regardless of whether we converged.
       if (operationalExecution && options?.costScope) {
@@ -2726,7 +2705,7 @@ export class AddieClaudeClient {
             system_prompt_ms: systemPromptMs,
             total_llm_ms: totalLlmMs,
             total_tool_execution_ms: totalToolExecutionMs,
-            iterations: loopBudget.limit,
+            iterations: modelLoop.limit,
           },
           usage: maxIterUsage,
           capacity: { certification_reserve_used: certificationReserveUsed },

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.45';
+export const CODE_VERSION = '2026.08.46';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "a220a50bc16548d00af49e55d5bbc8b1544ba30ce1f0e1ae84f10e18f47e64eb",
+    "server/src/addie/claude-client.ts": "1c3e6c0301623dc14bfad7844a86ac6698dcae555d1fcd5bf305df5358edd10f",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/addie/model-providers/model-turn.ts
+++ b/server/src/addie/model-providers/model-turn.ts
@@ -91,6 +91,63 @@ export class ModelLoopBudget {
   }
 }
 
+/**
+ * Canonical state boundary for a provider-neutral model loop. It owns the
+ * logical turn wall, normalized usage, one-response-per-turn discipline, and
+ * optional empty-terminal recovery state. Delivery adapters still own
+ * transport retries and user-facing events.
+ */
+export class ModelTurnLoopState {
+  readonly emptyResponseRecovery = new EmptyResponseRecoveryState();
+  private readonly budget: ModelLoopBudget;
+  private accumulatedUsage: ModelUsage = { inputTokens: 0, outputTokens: 0 };
+  private awaitingResponse = false;
+
+  constructor(limit: number) {
+    this.budget = new ModelLoopBudget(limit);
+  }
+
+  get limit(): number {
+    return this.budget.limit;
+  }
+
+  get iteration(): number {
+    return this.budget.iteration;
+  }
+
+  get hasRemaining(): boolean {
+    return this.budget.hasRemaining;
+  }
+
+  get usage(): ModelUsage {
+    return { ...this.accumulatedUsage };
+  }
+
+  startNext(): number {
+    if (this.awaitingResponse) {
+      throw new Error('Previous model loop iteration has no response');
+    }
+    const iteration = this.budget.startNext();
+    this.awaitingResponse = true;
+    return iteration;
+  }
+
+  acceptResponse(
+    response: ModelResponse,
+    options: { countUsage?: boolean } = {},
+  ): InspectedModelTurn {
+    if (!this.awaitingResponse) {
+      throw new Error('Model loop response has no active iteration');
+    }
+    const turn = inspectModelTurn(response);
+    if (options.countUsage !== false) {
+      this.accumulatedUsage = addModelUsage(this.accumulatedUsage, response.usage);
+    }
+    this.awaitingResponse = false;
+    return turn;
+  }
+}
+
 /** Accumulate normalized usage without inventing absent provider cache metrics. */
 export function addModelUsage(total: ModelUsage, usage: ModelUsage): ModelUsage {
   return {

--- a/server/src/addie/model-providers/read-only-tool-loop.ts
+++ b/server/src/addie/model-providers/read-only-tool-loop.ts
@@ -1,6 +1,6 @@
 import Ajv, { type ValidateFunction } from 'ajv';
 import { collectModelResponse } from './events.js';
-import { addModelUsage, inspectModelTurn, ModelLoopBudget } from './model-turn.js';
+import { ModelTurnLoopState } from './model-turn.js';
 import type {
   ModelProvider,
   ModelRequest,
@@ -134,13 +134,12 @@ export async function executeReadOnlyToolLoop(
   if (byName.size < 1) throw new ReadOnlyToolLoopBoundaryError('unknown_tool_call');
 
   let messages = [...requestSnapshot.messages];
-  let totalUsage: ModelUsage = { inputTokens: 0, outputTokens: 0 };
   const receipts: ReadOnlyToolExecutionReceipt[] = [];
   const seenCallIds = new Set<string>();
-  const loopBudget = new ModelLoopBudget(MAX_ITERATIONS);
+  const modelLoop = new ModelTurnLoopState(MAX_ITERATIONS);
 
-  while (loopBudget.hasRemaining) {
-    const iteration = loopBudget.startNext();
+  while (modelLoop.hasRemaining) {
+    const iteration = modelLoop.startNext();
     const request: ModelRequest = {
       ...requestSnapshot,
       messages,
@@ -151,8 +150,7 @@ export async function executeReadOnlyToolLoop(
       signal: options.signal,
       beforeDispatch: options.beforeDispatch,
     }), provider.id);
-    totalUsage = addModelUsage(totalUsage, response.usage);
-    const turn = inspectModelTurn(response);
+    const turn = modelLoop.acceptResponse(response);
 
     const calls = turn.toolCalls;
     const unsupportedContinuation = turn.providerToolCalls.length > 0
@@ -169,7 +167,7 @@ export async function executeReadOnlyToolLoop(
         response,
         text: turn.textBlocks.map((content) => content.text).join(''),
         iterations: iteration,
-        usage: totalUsage,
+        usage: modelLoop.usage,
         toolExecutions: Object.freeze([...receipts]),
       };
     }

--- a/server/tests/unit/addie/model-provider-turn.test.ts
+++ b/server/tests/unit/addie/model-provider-turn.test.ts
@@ -9,6 +9,7 @@ import {
   EmptyResponseRecoveryState,
   inspectModelTurn,
   ModelLoopBudget,
+  ModelTurnLoopState,
 } from '../../../src/addie/model-providers/model-turn.js';
 
 function response(
@@ -148,5 +149,44 @@ describe('ModelLoopBudget', () => {
 
     expect(budget.hasRemaining).toBe(false);
     expect(budget.iteration).toBe(0);
+  });
+});
+
+describe('ModelTurnLoopState', () => {
+  it('accepts one canonical response per iteration and accumulates usage', () => {
+    const loop = new ModelTurnLoopState(2);
+    const first = response('stop', [{ type: 'text', text: 'done' }]);
+    first.usage = { inputTokens: 5, outputTokens: 2, cacheReadTokens: 3 };
+
+    expect(loop.startNext()).toBe(1);
+    expect(loop.acceptResponse(first).action).toBe('complete');
+    expect(loop.usage).toEqual({
+      inputTokens: 5,
+      outputTokens: 2,
+      cacheReadTokens: 3,
+    });
+    expect(loop.iteration).toBe(1);
+    expect(loop.hasRemaining).toBe(true);
+  });
+
+  it('does not count a retained fallback response twice', () => {
+    const loop = new ModelTurnLoopState(1);
+    const original = response('stop', []);
+    original.usage = { inputTokens: 7, outputTokens: 1 };
+
+    loop.startNext();
+    loop.acceptResponse(original, { countUsage: false });
+    expect(loop.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
+  });
+
+  it('enforces one response per started iteration', () => {
+    const loop = new ModelTurnLoopState(2);
+    const terminal = response('stop', []);
+
+    expect(() => loop.acceptResponse(terminal)).toThrow('no active iteration');
+    loop.startNext();
+    expect(() => loop.startNext()).toThrow('has no response');
+    loop.acceptResponse(terminal);
+    expect(() => loop.acceptResponse(terminal)).toThrow('no active iteration');
   });
 });


### PR DESCRIPTION
## Summary
- add a canonical provider-neutral state boundary for model turn loops
- require exactly one inspected response for each started logical iteration
- centralize normalized usage, the iteration wall, and empty-response recovery state
- use the boundary in production streaming, production non-streaming, and cross-provider read-only replay
- leave transport retries, stream events, mutation execution, billing, and persistence in their existing owners
- bump `CODE_VERSION` and refresh the generated Addie inventory

## Validation
- `npm run typecheck`
- 112 focused Addie provider, recovery, max-iteration, replay, streaming, and cost tests
- `npm run test:addie-tools`
- pre-push version and changeset gates

No protocol release surface changed, so no changeset is required.

Progresses #6844.