### PR TITLE
refactor(addie): share canonical turn continuation

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -52,6 +52,7 @@ import {
 } from './model-providers/anthropic-provider.js';
 import { collectModelResponse } from './model-providers/events.js';
 import {
+  appendModelTurnContinuation,
   ModelTurnLoopState,
 } from './model-providers/model-turn.js';
 import {
@@ -1674,7 +1675,7 @@ export class AddieClaudeClient {
         // Anthropic pause_turn and compaction responses are resumable only
         // when their content is included in the next request. Repeating the
         // unchanged prompt can loop or repeat server-side work.
-        modelMessages.push({ role: 'assistant', content: response.content });
+        appendModelTurnContinuation(modelMessages, response);
         logger.info(
           { stopReason: response.providerFinishReason, iteration },
           'Addie: Continuing resumable Anthropic turn',
@@ -1899,7 +1900,7 @@ export class AddieClaudeClient {
         // The web search results are already in the response, we just need to continue
         if (toolUseBlocks.length === 0 && serverToolBlocks.length > 0) {
           // Add the response content (including provider continuation state).
-          modelMessages.push({ role: 'assistant', content: response.content });
+          appendModelTurnContinuation(modelMessages, response);
           continue;
         }
 
@@ -1960,8 +1961,7 @@ export class AddieClaudeClient {
           toolExecutions.push(executed.execution);
         }
 
-        modelMessages.push({ role: 'assistant', content: response.content });
-        modelMessages.push({ role: 'user', content: toolResults });
+        appendModelTurnContinuation(modelMessages, response, toolResults);
       }
     }
 
@@ -2425,7 +2425,7 @@ export class AddieClaudeClient {
           .join('\n\n');
         if (stopAction === 'continue') {
           // Resume from the provider response without exposing interim text.
-          modelMessages.push({ role: 'assistant', content: currentResponse.content });
+          appendModelTurnContinuation(modelMessages, currentResponse);
           logger.info(
             { stopReason: currentResponse.providerFinishReason, iteration },
             'Addie Stream: Continuing resumable Anthropic turn',
@@ -2653,8 +2653,7 @@ export class AddieClaudeClient {
           }
 
           // Continue the conversation with tool results
-          modelMessages.push({ role: 'assistant', content: currentResponse.content });
-          modelMessages.push({ role: 'user', content: toolResults });
+          appendModelTurnContinuation(modelMessages, currentResponse, toolResults);
 
           // Add spacing between tool use and subsequent text to prevent run-on text
           if (logicalText.length > 0 && !logicalText.endsWith('\n')) {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.46';
+export const CODE_VERSION = '2026.08.47';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "1c3e6c0301623dc14bfad7844a86ac6698dcae555d1fcd5bf305df5358edd10f",
+    "server/src/addie/claude-client.ts": "58ca556f7f7ed0be74c486fc9efdf29f6ba52be472f0cce126a2b08bdc65289d",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/addie/model-providers/model-turn.ts
+++ b/server/src/addie/model-providers/model-turn.ts
@@ -1,9 +1,11 @@
 import type {
+  ModelMessage,
   ModelProviderToolCallContent,
   ModelProviderToolResultContent,
   ModelResponse,
   ModelTextContent,
   ModelToolCallContent,
+  ModelToolResultContent,
   ModelUsage,
 } from './model-provider.js';
 
@@ -15,6 +17,16 @@ export interface InspectedModelTurn {
   toolCalls: ReadonlyArray<ModelToolCallContent>;
   providerToolCalls: ReadonlyArray<ModelProviderToolCallContent>;
   providerToolResults: ReadonlyArray<ModelProviderToolResultContent>;
+}
+
+/** Append one canonical assistant continuation and any custom-tool results. */
+export function appendModelTurnContinuation(
+  messages: ModelMessage[],
+  response: ModelResponse,
+  toolResults?: ModelToolResultContent[],
+): void {
+  messages.push({ role: 'assistant', content: response.content });
+  if (toolResults) messages.push({ role: 'user', content: toolResults });
 }
 
 export type EmptyResponseRecoveryKind = 'initial' | 'post_tool';

--- a/server/src/addie/model-providers/read-only-tool-loop.ts
+++ b/server/src/addie/model-providers/read-only-tool-loop.ts
@@ -1,6 +1,6 @@
 import Ajv, { type ValidateFunction } from 'ajv';
 import { collectModelResponse } from './events.js';
-import { ModelTurnLoopState } from './model-turn.js';
+import { appendModelTurnContinuation, ModelTurnLoopState } from './model-turn.js';
 import type {
   ModelProvider,
   ModelRequest,
@@ -160,7 +160,7 @@ export async function executeReadOnlyToolLoop(
     }
     if (calls.length === 0) {
       if (turn.action === 'continue') {
-        messages = [...messages, { role: 'assistant', content: response.content }];
+        appendModelTurnContinuation(messages, response);
         continue;
       }
       return {
@@ -241,11 +241,7 @@ export async function executeReadOnlyToolLoop(
         ...(isError && { isError: true }),
       });
     }
-    messages = [
-      ...messages,
-      { role: 'assistant', content: response.content },
-      { role: 'user', content: results },
-    ];
+    appendModelTurnContinuation(messages, response, results);
   }
 
   throw new ReadOnlyToolLoopBoundaryError('iteration_limit_exceeded');

--- a/server/tests/unit/addie/model-provider-turn.test.ts
+++ b/server/tests/unit/addie/model-provider-turn.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type {
   ModelFinishReason,
+  ModelMessage,
   ModelMessageContent,
   ModelResponse,
 } from '../../../src/addie/model-providers/model-provider.js';
 import {
   addModelUsage,
+  appendModelTurnContinuation,
   EmptyResponseRecoveryState,
   inspectModelTurn,
   ModelLoopBudget,
@@ -68,6 +70,40 @@ describe('inspectModelTurn', () => {
     expect(turn.providerToolResults.map((result) => result.toolCallId)).toEqual(['provider-1']);
     expect(Object.isFrozen(turn)).toBe(true);
     expect(Object.isFrozen(turn.toolCalls)).toBe(true);
+  });
+});
+
+describe('appendModelTurnContinuation', () => {
+  it('appends the assistant response and optional tool-result turn', () => {
+    const messages: ModelMessage[] = [];
+    const assistant = response('tool_calls', [{
+      type: 'tool_call',
+      id: 'call-1',
+      name: 'lookup',
+      input: {},
+    }]);
+    const results = [{
+      type: 'tool_result' as const,
+      toolCallId: 'call-1',
+      toolName: 'lookup',
+      content: 'found',
+    }];
+
+    appendModelTurnContinuation(messages, assistant, results);
+
+    expect(messages).toEqual([
+      { role: 'assistant', content: assistant.content },
+      { role: 'user', content: results },
+    ]);
+  });
+
+  it('appends only the assistant turn for provider continuation', () => {
+    const messages: ModelMessage[] = [];
+    const assistant = response('continue', []);
+
+    appendModelTurnContinuation(messages, assistant);
+
+    expect(messages).toEqual([{ role: 'assistant', content: [] }]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add one provider-neutral continuation assembler for canonical model turns
- use it for resumable provider turns and custom-tool result turns
- route production streaming, production non-streaming, and cross-provider read-only replay through the same continuation boundary
- preserve transport retries, mutation execution, message ordering, and provider state
- bump `CODE_VERSION` and refresh the generated Addie inventory

## Validation
- `npm run typecheck`
- 114 focused Addie provider, continuation, recovery, replay, streaming, and cost tests
- `npm run test:addie-tools`
- pre-push version and changeset gates

No protocol release surface changed, so no changeset is required.

Progresses #6844.