### PR TITLE
refactor(addie): share provider turn invocation

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -50,7 +50,6 @@ import {
   AnthropicModelProvider,
   type AnthropicMessagesTransport,
 } from './model-providers/anthropic-provider.js';
-import { collectModelResponse } from './model-providers/events.js';
 import {
   appendModelTurnContinuation,
   ModelTurnLoopState,
@@ -1498,7 +1497,8 @@ export class AddieClaudeClient {
     let hasExecutedCustomTool = false;
 
     while (modelLoop.hasRemaining) {
-      iteration = modelLoop.startNext();
+      const activeTurn = modelLoop.beginNext();
+      iteration = activeTurn.iteration;
 
       // Use beta API to access web search
       const llmStart = Date.now();
@@ -1521,8 +1521,10 @@ export class AddieClaudeClient {
           const provider = exactlyOnce
             ? this.exactlyOnceAnthropicProvider
             : this.anthropicProvider;
-          return collectModelResponse(
-            provider.respond(modelRequest, {
+          return activeTurn.invoke(
+            provider,
+            modelRequest,
+            {
               beforeDispatch: async (preparedInvocation) => {
                 await this.notifyInvocationPrepared(
                   options,
@@ -1531,8 +1533,7 @@ export class AddieClaudeClient {
                   invocationAttempt,
                 );
               },
-            }),
-            'anthropic',
+            },
           );
         };
         // A replay is an exactly-once paid experiment. A timeout can occur
@@ -1610,7 +1611,7 @@ export class AddieClaudeClient {
           content: [],
         };
       }
-      const turn = modelLoop.acceptResponse(response, { countUsage: !reusedEmptyResponse });
+      const turn = activeTurn.acceptResponse(response, { countUsage: !reusedEmptyResponse });
 
       // Provider-managed web results may accompany either a terminal answer or
       // another tool-call turn. Derive their receipts through the selected
@@ -2206,7 +2207,8 @@ export class AddieClaudeClient {
     let lastProviderModel: string | undefined;
 
       while (modelLoop.hasRemaining) {
-        iteration = modelLoop.startNext();
+        const activeTurn = modelLoop.beginNext();
+        iteration = activeTurn.iteration;
 
         const llmStart = Date.now();
 
@@ -2239,8 +2241,10 @@ export class AddieClaudeClient {
             const provider = isEmptyResponseRecovery
               ? this.exactlyOnceAnthropicProvider
               : this.anthropicProvider;
-            currentResponse = await collectModelResponse(
-              provider.respond(modelRequest, {
+            currentResponse = await activeTurn.invoke(
+              provider,
+              modelRequest,
+              {
                 stream: true,
                 onStreamProgress: () => {
                   totalReceivedDeltas++;
@@ -2254,8 +2258,7 @@ export class AddieClaudeClient {
                     streamRetryCount + 1,
                   );
                 },
-              }),
-              'anthropic',
+              },
             );
 
             if (operationalExecution) this.providerHealth.recordSuccess('anthropic', 'chat');
@@ -2418,7 +2421,7 @@ export class AddieClaudeClient {
           }
         };
 
-        const turn = modelLoop.acceptResponse(currentResponse, { countUsage: !reusedEmptyResponse });
+        const turn = activeTurn.acceptResponse(currentResponse, { countUsage: !reusedEmptyResponse });
         const stopAction = turn.action;
         const iterationText = turn.textBlocks
           .map((block) => block.text)

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.47';
+export const CODE_VERSION = '2026.08.48';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "58ca556f7f7ed0be74c486fc9efdf29f6ba52be472f0cce126a2b08bdc65289d",
+    "server/src/addie/claude-client.ts": "fc80ffda42ebeeff81dcebf4c2bb86683bee33fcece8be9ed36ebeca76a26710",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/addie/model-providers/model-turn.ts
+++ b/server/src/addie/model-providers/model-turn.ts
@@ -1,13 +1,17 @@
 import type {
   ModelMessage,
+  ModelProvider,
   ModelProviderToolCallContent,
   ModelProviderToolResultContent,
+  ModelRequest,
   ModelResponse,
+  ModelRespondOptions,
   ModelTextContent,
   ModelToolCallContent,
   ModelToolResultContent,
   ModelUsage,
 } from './model-provider.js';
+import { collectModelResponse } from './events.js';
 
 export type ModelTurnAction = 'complete' | 'truncated' | 'tool_use' | 'continue';
 
@@ -144,6 +148,11 @@ export class ModelTurnLoopState {
     return iteration;
   }
 
+  /** Begin one logical turn whose transport attempts share this state slot. */
+  beginNext(): ActiveModelTurn {
+    return new ActiveModelTurn(this, this.startNext());
+  }
+
   acceptResponse(
     response: ModelResponse,
     options: { countUsage?: boolean } = {},
@@ -156,6 +165,52 @@ export class ModelTurnLoopState {
       this.accumulatedUsage = addModelUsage(this.accumulatedUsage, response.usage);
     }
     this.awaitingResponse = false;
+    return turn;
+  }
+}
+
+/**
+ * One active logical model turn. Sequential transport attempts are allowed so
+ * delivery adapters can retain their retry policy and event timing, but only
+ * one normalized response can be accepted into the common loop.
+ */
+export class ActiveModelTurn {
+  private invocationInFlight = false;
+  private accepted = false;
+
+  constructor(
+    private readonly loop: ModelTurnLoopState,
+    readonly iteration: number,
+  ) {}
+
+  async invoke(
+    provider: ModelProvider,
+    request: ModelRequest,
+    options?: ModelRespondOptions,
+  ): Promise<ModelResponse> {
+    if (this.accepted) throw new Error('Model turn already accepted a response');
+    if (this.invocationInFlight) throw new Error('Model turn provider invocation already in flight');
+    this.invocationInFlight = true;
+    try {
+      return await collectModelResponse(
+        provider.respond(request, options),
+        provider.id,
+      );
+    } finally {
+      this.invocationInFlight = false;
+    }
+  }
+
+  acceptResponse(
+    response: ModelResponse,
+    options: { countUsage?: boolean } = {},
+  ): InspectedModelTurn {
+    if (this.invocationInFlight) {
+      throw new Error('Cannot accept a response while provider invocation is in flight');
+    }
+    if (this.accepted) throw new Error('Model turn already accepted a response');
+    const turn = this.loop.acceptResponse(response, options);
+    this.accepted = true;
     return turn;
   }
 }

--- a/server/src/addie/model-providers/read-only-tool-loop.ts
+++ b/server/src/addie/model-providers/read-only-tool-loop.ts
@@ -1,5 +1,4 @@
 import Ajv, { type ValidateFunction } from 'ajv';
-import { collectModelResponse } from './events.js';
 import { appendModelTurnContinuation, ModelTurnLoopState } from './model-turn.js';
 import type {
   ModelProvider,
@@ -139,18 +138,19 @@ export async function executeReadOnlyToolLoop(
   const modelLoop = new ModelTurnLoopState(MAX_ITERATIONS);
 
   while (modelLoop.hasRemaining) {
-    const iteration = modelLoop.startNext();
+    const activeTurn = modelLoop.beginNext();
+    const iteration = activeTurn.iteration;
     const request: ModelRequest = {
       ...requestSnapshot,
       messages,
       tools: snapshotTools.map((tool) => tool.definition),
       providerTools: [],
     };
-    const response = await collectModelResponse(provider.respond(request, {
+    const response = await activeTurn.invoke(provider, request, {
       signal: options.signal,
       beforeDispatch: options.beforeDispatch,
-    }), provider.id);
-    const turn = modelLoop.acceptResponse(response);
+    });
+    const turn = activeTurn.acceptResponse(response);
 
     const calls = turn.toolCalls;
     const unsupportedContinuation = turn.providerToolCalls.length > 0

--- a/server/tests/unit/addie/model-provider-turn.test.ts
+++ b/server/tests/unit/addie/model-provider-turn.test.ts
@@ -3,6 +3,8 @@ import type {
   ModelFinishReason,
   ModelMessage,
   ModelMessageContent,
+  ModelProvider,
+  ModelRequest,
   ModelResponse,
 } from '../../../src/addie/model-providers/model-provider.js';
 import {
@@ -26,6 +28,34 @@ function response(
     providerFinishReason: 'provider-value-must-not-drive-orchestration',
     usage: { inputTokens: 1, outputTokens: 1 },
     content,
+  };
+}
+
+const request: ModelRequest = {
+  model: 'test-model',
+  system: [],
+  messages: [],
+  tools: [],
+  maxOutputTokens: 100,
+};
+
+function providerFor(
+  respond: ModelProvider['respond'],
+): ModelProvider {
+  return {
+    id: 'anthropic',
+    capabilities: {
+      streaming: true,
+      structuredOutput: true,
+      reasoning: true,
+      reasoningEfforts: ['provider_default'],
+      customTools: true,
+      providerWebSearch: true,
+      imageInput: true,
+      documentInput: true,
+    },
+    prepare: () => { throw new Error('not used'); },
+    respond,
   };
 }
 
@@ -224,5 +254,45 @@ describe('ModelTurnLoopState', () => {
     expect(() => loop.startNext()).toThrow('has no response');
     loop.acceptResponse(terminal);
     expect(() => loop.acceptResponse(terminal)).toThrow('no active iteration');
+  });
+
+  it('invokes and accepts a provider response through one active turn', async () => {
+    const loop = new ModelTurnLoopState(1);
+    const terminal = response('stop', [{ type: 'text', text: 'done' }]);
+    const provider = providerFor(async function* (_request, options) {
+      expect(options?.stream).toBe(true);
+      yield { type: 'response_start', provider: 'anthropic', model: 'test-model' };
+      yield { type: 'text_delta', index: 0, text: 'done' };
+      yield { type: 'response_complete', response: terminal };
+    });
+
+    const activeTurn = loop.beginNext();
+    const invoked = await activeTurn.invoke(provider, request, { stream: true });
+    const inspected = activeTurn.acceptResponse(invoked);
+
+    expect(activeTurn.iteration).toBe(1);
+    expect(inspected.action).toBe('complete');
+    expect(loop.usage).toEqual({ inputTokens: 1, outputTokens: 1 });
+  });
+
+  it('allows sequential transport retries but accepts only one response', async () => {
+    const loop = new ModelTurnLoopState(1);
+    const terminal = response('stop');
+    let attempts = 0;
+    const provider = providerFor(async function* () {
+      attempts++;
+      if (attempts === 1) throw new Error('temporary failure');
+      yield { type: 'response_start', provider: 'anthropic', model: 'test-model' };
+      yield { type: 'response_complete', response: terminal };
+    });
+    const activeTurn = loop.beginNext();
+
+    await expect(activeTurn.invoke(provider, request)).rejects.toThrow('temporary failure');
+    const invoked = await activeTurn.invoke(provider, request);
+    activeTurn.acceptResponse(invoked);
+
+    expect(attempts).toBe(2);
+    await expect(activeTurn.invoke(provider, request)).rejects.toThrow('already accepted');
+    expect(() => activeTurn.acceptResponse(terminal)).toThrow('already accepted');
   });
 });


### PR DESCRIPTION
## Summary
- add an active canonical turn handle that owns normalized provider invocation and response acceptance
- allow sequential transport attempts within one logical turn while enforcing a single accepted response
- route production streaming, production non-streaming, and read-only replay through the same invocation boundary
- preserve provider selection, exactly-once replay/recovery, streaming retry events, mutation execution, and message ordering
- bump `CODE_VERSION` and refresh the generated Addie inventory

## Validation
- `npm run typecheck`
- 49 focused canonical-turn, read-only replay, cost-gate, replay-policy, and streaming-error tests
- 1,056 root unit tests and source-policy lints passed in the pre-commit gate
- `npm run test:addie-tools`
- pre-push version and changeset gates

The full local server-unit phase exceeded its 600-second commit-hook wall under shared-machine load; its only reported failures were unrelated storyboard subprocess timeouts. The focused runtime suites are green, and the PR CI matrix will run the full shards on dedicated runners.

No protocol release surface changed, so no changeset is required.

Progresses #6844.