### PR TITLE
refactor(addie): centralize recovery mutation safety

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -1599,19 +1599,11 @@ export class AddieClaudeClient {
         outputTokens: response.usage.outputTokens,
       }, 'Addie: Claude response received');
 
-      // Post-tool empty-response recovery is intentionally text-only. Defend
-      // against a malformed provider response that nevertheless contains a
-      // tool request: discard it instead of risking a duplicate mutation.
-      if (modelLoop.emptyResponseRecovery.postToolAttempted && response.finishReason === 'tool_calls') {
-        logger.warn({ iteration }, 'Addie: Ignoring tool use from text-only recovery');
-        response = {
-          ...response,
-          finishReason: 'stop',
-          providerFinishReason: 'end_turn',
-          content: [],
-        };
-      }
       const turn = activeTurn.acceptResponse(response, { countUsage: !reusedEmptyResponse });
+      response = turn.response;
+      if (turn.discardedRecoveryToolCalls) {
+        logger.warn({ iteration }, 'Addie: Ignoring tool use from text-only recovery');
+      }
 
       // Provider-managed web results may accompany either a terminal answer or
       // another tool-call turn. Derive their receipts through the selected
@@ -2395,16 +2387,10 @@ export class AddieClaudeClient {
           outputTokens: currentResponse.usage.outputTokens,
         }, 'Addie Stream: Claude response received');
 
-        // The post-tool recovery iteration has no tools. If the provider still returns
-        // a tool_use block, ignore it rather than executing a mutation twice.
-        if (modelLoop.emptyResponseRecovery.postToolAttempted && currentResponse.finishReason === 'tool_calls') {
+        const turn = activeTurn.acceptResponse(currentResponse, { countUsage: !reusedEmptyResponse });
+        currentResponse = turn.response;
+        if (turn.discardedRecoveryToolCalls) {
           logger.warn({ iteration }, 'Addie Stream: Ignoring tool use from text-only recovery');
-          currentResponse = {
-            ...currentResponse,
-            finishReason: 'stop',
-            providerFinishReason: 'end_turn',
-            content: [],
-          };
         }
 
         // Build the final usage block + charge the user's cost
@@ -2421,7 +2407,6 @@ export class AddieClaudeClient {
           }
         };
 
-        const turn = activeTurn.acceptResponse(currentResponse, { countUsage: !reusedEmptyResponse });
         const stopAction = turn.action;
         const iterationText = turn.textBlocks
           .map((block) => block.text)

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.48';
+export const CODE_VERSION = '2026.08.49';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "fc80ffda42ebeeff81dcebf4c2bb86683bee33fcece8be9ed36ebeca76a26710",
+    "server/src/addie/claude-client.ts": "b59dd5b79dc579d5e1830c08b3d0b48b83d26d8fe92ba96ee56932bc4f7a0b00",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/addie/model-providers/model-turn.ts
+++ b/server/src/addie/model-providers/model-turn.ts
@@ -23,6 +23,11 @@ export interface InspectedModelTurn {
   providerToolResults: ReadonlyArray<ModelProviderToolResultContent>;
 }
 
+export interface AcceptedModelTurn extends InspectedModelTurn {
+  response: ModelResponse;
+  discardedRecoveryToolCalls: boolean;
+}
+
 /** Append one canonical assistant continuation and any custom-tool results. */
 export function appendModelTurnContinuation(
   messages: ModelMessage[],
@@ -156,16 +161,32 @@ export class ModelTurnLoopState {
   acceptResponse(
     response: ModelResponse,
     options: { countUsage?: boolean } = {},
-  ): InspectedModelTurn {
+  ): AcceptedModelTurn {
     if (!this.awaitingResponse) {
       throw new Error('Model loop response has no active iteration');
     }
-    const turn = inspectModelTurn(response);
+    // Post-tool recovery is permanently text-only. A malformed provider
+    // response must not be able to request the same mutation a second time.
+    const discardedRecoveryToolCalls = this.emptyResponseRecovery.postToolAttempted
+      && response.finishReason === 'tool_calls';
+    const acceptedResponse: ModelResponse = discardedRecoveryToolCalls
+      ? {
+          ...response,
+          finishReason: 'stop',
+          providerFinishReason: 'end_turn',
+          content: [],
+        }
+      : response;
+    const turn = inspectModelTurn(acceptedResponse);
     if (options.countUsage !== false) {
-      this.accumulatedUsage = addModelUsage(this.accumulatedUsage, response.usage);
+      this.accumulatedUsage = addModelUsage(this.accumulatedUsage, acceptedResponse.usage);
     }
     this.awaitingResponse = false;
-    return turn;
+    return Object.freeze({
+      ...turn,
+      response: acceptedResponse,
+      discardedRecoveryToolCalls,
+    });
   }
 }
 
@@ -204,7 +225,7 @@ export class ActiveModelTurn {
   acceptResponse(
     response: ModelResponse,
     options: { countUsage?: boolean } = {},
-  ): InspectedModelTurn {
+  ): AcceptedModelTurn {
     if (this.invocationInFlight) {
       throw new Error('Cannot accept a response while provider invocation is in flight');
     }

--- a/server/tests/unit/addie/model-provider-turn.test.ts
+++ b/server/tests/unit/addie/model-provider-turn.test.ts
@@ -245,6 +245,31 @@ describe('ModelTurnLoopState', () => {
     expect(loop.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
   });
 
+  it('discards tool calls returned by a post-tool text-only recovery', () => {
+    const loop = new ModelTurnLoopState(1);
+    const original = response('stop');
+    const repeatedMutation = response('tool_calls', [{
+      type: 'tool_call',
+      id: 'repeat-1',
+      name: 'mutate_again',
+      input: {},
+    }]);
+
+    loop.emptyResponseRecovery.schedule('post_tool', original);
+    const activeTurn = loop.beginNext();
+    const accepted = activeTurn.acceptResponse(repeatedMutation);
+
+    expect(accepted.action).toBe('complete');
+    expect(accepted.toolCalls).toEqual([]);
+    expect(accepted.discardedRecoveryToolCalls).toBe(true);
+    expect(accepted.response).toMatchObject({
+      finishReason: 'stop',
+      providerFinishReason: 'end_turn',
+      content: [],
+    });
+    expect(loop.usage).toEqual({ inputTokens: 1, outputTokens: 1 });
+  });
+
   it('enforces one response per started iteration', () => {
     const loop = new ModelTurnLoopState(2);
     const terminal = response('stop', []);


### PR DESCRIPTION
## Summary
- make canonical turn acceptance enforce post-tool recovery as text-only
- return the authoritative accepted response and a bounded discard signal with the inspected turn
- remove duplicate malformed repeat-tool handling from streaming and non-streaming delivery paths
- retain path-specific warning logs while preventing a recovery sample from repeating mutations
- bump `CODE_VERSION` and refresh the generated Addie inventory

## Validation
- `npm run typecheck`
- 50 focused canonical-turn, read-only replay, cost-gate, replay-policy, and streaming-error tests
- `npm run test:addie-tools`
- pre-push version and changeset gates

No protocol release surface changed, so no changeset is required.

Progresses #6844.