### PR TITLE
refactor(addie): centralize model turn decisions

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -1664,14 +1664,14 @@ export class AddieClaudeClient {
 
       const stopAction = turn.action;
 
-      if (stopAction === 'continue') {
+      if (stopAction === 'continue' || stopAction === 'continue_provider_tools') {
         // Anthropic pause_turn and compaction responses are resumable only
         // when their content is included in the next request. Repeating the
         // unchanged prompt can loop or repeat server-side work.
         appendModelTurnContinuation(modelMessages, response);
         logger.info(
           { stopReason: response.providerFinishReason, iteration },
-          'Addie: Continuing resumable Anthropic turn',
+          'Addie: Continuing resumable provider turn',
         );
         continue;
       }
@@ -1835,7 +1835,7 @@ export class AddieClaudeClient {
       }
 
       // Handle tool use (both custom tools and server-managed tools like web_search)
-      if (stopAction === 'tool_use') {
+      if (stopAction === 'execute_tools') {
         // Get custom tool use blocks (these need our handlers)
         const toolUseBlocks = turn.toolCalls;
 
@@ -1887,53 +1887,6 @@ export class AddieClaudeClient {
             ...(operationalExecution && { inputKeys: block.inputKeys }),
             resultCount: resultBlock?.resultCount ?? 0,
           }, 'Addie: Server tool executed (web_search)');
-        }
-
-        // If only server tools were used (no custom tools), continue the loop
-        // The web search results are already in the response, we just need to continue
-        if (toolUseBlocks.length === 0 && serverToolBlocks.length > 0) {
-          // Add the response content (including provider continuation state).
-          appendModelTurnContinuation(modelMessages, response);
-          continue;
-        }
-
-        if (toolUseBlocks.length === 0 && serverToolBlocks.length === 0) {
-          const rawText = turn.textBlocks[0]?.text ?? '';
-          const finalized = finalizeAssistantText(userMessage, rawText, toolExecutions);
-          const text = finalized.text;
-          if (finalized.emptyReason) {
-            reportEmptyResponseFallback(finalized.emptyReason, toolsUsed, toolExecutions, options, 'processMessage', effectiveModel, iteration);
-          }
-          totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
-          const terminalUsage = toAddieUsage(modelLoop.usage);
-          if (finalized.lengthExceeded) {
-            logger.error(
-              { event: 'addie_response_truncated', source: 'processMessage', originalLength: rawText.length, deliveredLength: text.length, localCapExceeded: true },
-              'Addie: Normally completed response exceeded output cap',
-            );
-          }
-          if (operationalExecution && options?.costScope) {
-            await recordCost(options.costScope.userId, options.modelOverride ?? AddieModelConfig.chat, terminalUsage);
-          }
-          return {
-            text,
-            tools_used: toolsUsed,
-            tool_executions: toolExecutions,
-            flagged: finalized.lengthExceeded || !!finalized.emptyReason,
-            flag_reason: finalized.lengthExceeded ? 'Output truncated due to length' : finalized.emptyReason ?? undefined,
-            active_rule_ids: undefined,
-            config_version_id: configVersionId ?? undefined,
-            model_execution: finalized.emptyReason
-              ? localModelExecution('no_provider_response', effectiveModel)
-              : anthropicModelExecution(response.model, effectiveModel),
-            timing: {
-              system_prompt_ms: systemPromptMs,
-              total_llm_ms: totalLlmMs,
-              total_tool_execution_ms: totalToolExecutionMs,
-              iterations: iteration,
-            },
-            usage: terminalUsage,
-          };
         }
 
         const toolResults: ModelToolResultContent[] = [];
@@ -2411,12 +2364,12 @@ export class AddieClaudeClient {
         const iterationText = turn.textBlocks
           .map((block) => block.text)
           .join('\n\n');
-        if (stopAction === 'continue') {
+        if (stopAction === 'continue' || stopAction === 'continue_provider_tools') {
           // Resume from the provider response without exposing interim text.
           appendModelTurnContinuation(modelMessages, currentResponse);
           logger.info(
             { stopReason: currentResponse.providerFinishReason, iteration },
-            'Addie Stream: Continuing resumable Anthropic turn',
+            'Addie Stream: Continuing resumable provider turn',
           );
           continue;
         }
@@ -2562,51 +2515,9 @@ export class AddieClaudeClient {
         }
 
         // Handle tool use
-        if (stopAction === 'tool_use') {
+        if (stopAction === 'execute_tools') {
           logicalText += iterationText;
           const toolUseBlocks = turn.toolCalls;
-
-          if (toolUseBlocks.length === 0) {
-            // No tools to execute, return current text
-            totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
-            const streamUsage = buildStreamUsage();
-            const finalized = finalizeAssistantText(userMessage, logicalText, toolExecutions);
-            if (finalized.emptyReason) {
-              reportEmptyResponseFallback(finalized.emptyReason, toolsUsed, toolExecutions, options, 'processMessageStream', effectiveModel, iteration);
-            }
-            if (finalized.lengthExceeded) {
-              logger.error(
-                { event: 'addie_response_truncated', source: 'processMessageStream', originalLength: logicalText.length, deliveredLength: finalized.text.length, localCapExceeded: true },
-                'Addie Stream: Normally completed response exceeded output cap',
-              );
-            }
-            await chargeStreamCost(streamUsage);
-            yield { type: 'text', text: finalized.text };
-            yield {
-              type: 'done',
-              response: {
-                text: finalized.text,
-                tools_used: toolsUsed,
-                tool_executions: toolExecutions,
-                flagged: finalized.lengthExceeded || !!finalized.emptyReason,
-                flag_reason: finalized.lengthExceeded ? 'Output truncated due to length' : finalized.emptyReason ?? undefined,
-                active_rule_ids: undefined,
-                config_version_id: configVersionId ?? undefined,
-                model_execution: finalized.emptyReason
-                  ? localModelExecution('no_provider_response', effectiveModel)
-                  : anthropicModelExecution(currentResponse.model, effectiveModel),
-                timing: {
-                  system_prompt_ms: systemPromptMs,
-                  total_llm_ms: totalLlmMs,
-                  total_tool_execution_ms: totalToolExecutionMs,
-                  iterations: iteration,
-                },
-                usage: streamUsage,
-                capacity: { certification_reserve_used: certificationReserveUsed },
-              },
-            };
-            return;
-          }
 
           const toolResults: ModelToolResultContent[] = [];
 

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.49';
+export const CODE_VERSION = '2026.08.50';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "b59dd5b79dc579d5e1830c08b3d0b48b83d26d8fe92ba96ee56932bc4f7a0b00",
+    "server/src/addie/claude-client.ts": "8e24e412b1892d4ef1e6905c8cd3ad7423e1e5e93b6644ae42ddf837bf6e2498",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/addie/model-providers/model-turn.ts
+++ b/server/src/addie/model-providers/model-turn.ts
@@ -13,7 +13,12 @@ import type {
 } from './model-provider.js';
 import { collectModelResponse } from './events.js';
 
-export type ModelTurnAction = 'complete' | 'truncated' | 'tool_use' | 'continue';
+export type ModelTurnAction =
+  | 'complete'
+  | 'truncated'
+  | 'execute_tools'
+  | 'continue'
+  | 'continue_provider_tools';
 
 export interface InspectedModelTurn {
   action: ModelTurnAction;
@@ -256,6 +261,14 @@ export function addModelUsage(total: ModelUsage, usage: ModelUsage): ModelUsage 
  * canonical finish reason and canonical content variants exclusively.
  */
 export function inspectModelTurn(response: ModelResponse): InspectedModelTurn {
+  const textBlocks = Object.freeze(response.content.filter((content) => content.type === 'text'));
+  const toolCalls = Object.freeze(response.content.filter((content) => content.type === 'tool_call'));
+  const providerToolCalls = Object.freeze(response.content.filter(
+    (content) => content.type === 'provider_tool_call',
+  ));
+  const providerToolResults = Object.freeze(response.content.filter(
+    (content) => content.type === 'provider_tool_result',
+  ));
   let action: ModelTurnAction;
   switch (response.finishReason) {
     case 'stop':
@@ -266,7 +279,15 @@ export function inspectModelTurn(response: ModelResponse): InspectedModelTurn {
       action = 'truncated';
       break;
     case 'tool_calls':
-      action = 'tool_use';
+      // A provider-managed tool is continuation state, not an application
+      // mutation. When custom and provider-managed calls coexist, the custom
+      // calls must execute before the next model turn. A malformed tool-call
+      // finish with no canonical calls remains terminal and side-effect free.
+      action = toolCalls.length > 0
+        ? 'execute_tools'
+        : providerToolCalls.length > 0
+          ? 'continue_provider_tools'
+          : 'complete';
       break;
     case 'continue':
       action = 'continue';
@@ -279,13 +300,9 @@ export function inspectModelTurn(response: ModelResponse): InspectedModelTurn {
 
   return Object.freeze({
     action,
-    textBlocks: Object.freeze(response.content.filter((content) => content.type === 'text')),
-    toolCalls: Object.freeze(response.content.filter((content) => content.type === 'tool_call')),
-    providerToolCalls: Object.freeze(response.content.filter(
-      (content) => content.type === 'provider_tool_call',
-    )),
-    providerToolResults: Object.freeze(response.content.filter(
-      (content) => content.type === 'provider_tool_result',
-    )),
+    textBlocks,
+    toolCalls,
+    providerToolCalls,
+    providerToolResults,
   });
 }

--- a/server/src/addie/model-providers/read-only-tool-loop.ts
+++ b/server/src/addie/model-providers/read-only-tool-loop.ts
@@ -152,17 +152,16 @@ export async function executeReadOnlyToolLoop(
     });
     const turn = activeTurn.acceptResponse(response);
 
-    const calls = turn.toolCalls;
     const unsupportedContinuation = turn.providerToolCalls.length > 0
       || turn.providerToolResults.length > 0;
     if (unsupportedContinuation) {
       throw new ReadOnlyToolLoopBoundaryError('provider_continuation_not_allowed');
     }
-    if (calls.length === 0) {
-      if (turn.action === 'continue') {
-        appendModelTurnContinuation(messages, response);
-        continue;
-      }
+    if (turn.action === 'continue') {
+      appendModelTurnContinuation(messages, response);
+      continue;
+    }
+    if (turn.action !== 'execute_tools') {
       return {
         response,
         text: turn.textBlocks.map((content) => content.text).join(''),
@@ -171,6 +170,7 @@ export async function executeReadOnlyToolLoop(
         toolExecutions: Object.freeze([...receipts]),
       };
     }
+    const calls = turn.toolCalls;
 
     if (receipts.length + calls.length > MAX_TOOL_CALLS) {
       throw new ReadOnlyToolLoopBoundaryError('tool_call_limit_exceeded');

--- a/server/tests/unit/addie-response-truncation.test.ts
+++ b/server/tests/unit/addie-response-truncation.test.ts
@@ -92,6 +92,27 @@ function message(
   };
 }
 
+function providerToolTurn(): MockMessage {
+  return {
+    model: 'claude-sonnet-4-6-20260801',
+    stop_reason: 'tool_use',
+    content: [
+      {
+        type: 'server_tool_use',
+        id: 'server_web_4431',
+        name: 'web_search',
+        input: { query: 'AdCP' },
+      },
+      {
+        type: 'web_search_tool_result',
+        tool_use_id: 'server_web_4431',
+        content: [{ type: 'web_search_result', title: 'AdCP', url: 'https://adcontextprotocol.org' }],
+      },
+    ],
+    usage: { input_tokens: 4, output_tokens: 5 },
+  };
+}
+
 function streamFor(finalResponse: MockMessage, chunks: string[]) {
   return {
     async *[Symbol.asyncIterator]() {
@@ -474,6 +495,33 @@ describe('Addie response truncation (#4431)', () => {
     expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
     expect(mocks.streamMessage.mock.calls[1][0].messages).toEqual(expect.arrayContaining([
       expect.objectContaining({ role: 'assistant', content: [{ type: 'text', text: 'Interim server status.' }] }),
+    ]));
+  });
+
+  it('continues a streaming provider-managed tool turn before delivering the terminal answer', async () => {
+    mocks.streamMessage
+      .mockReturnValueOnce(streamFor(providerToolTurn(), []))
+      .mockReturnValueOnce(streamFor(message('end_turn', 'Search complete.'), ['Search complete.']));
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const events: StreamEvent[] = [];
+
+    for await (const event of client.processMessageStream(
+      'Search for AdCP',
+      undefined,
+      undefined,
+      { uncapped: true },
+    )) events.push(event);
+
+    const textEvents = events.filter((event): event is Extract<StreamEvent, { type: 'text' }> => event.type === 'text');
+    const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
+    expect(textEvents).toEqual([{ type: 'text', text: 'Search complete.' }]);
+    expect(done?.response.text).toBe('Search complete.');
+    expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.streamMessage.mock.calls[1][0].messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        role: 'assistant',
+        content: expect.arrayContaining([expect.objectContaining({ type: 'server_tool_use' })]),
+      }),
     ]));
   });
 

--- a/server/tests/unit/addie/model-provider-turn.test.ts
+++ b/server/tests/unit/addie/model-provider-turn.test.ts
@@ -85,7 +85,6 @@ describe('inspectModelTurn', () => {
     ['stop', 'complete'],
     ['refusal', 'complete'],
     ['length', 'truncated'],
-    ['tool_calls', 'tool_use'],
     ['continue', 'continue'],
   ] as const)('maps canonical %s without consulting provider diagnostics', (finishReason, action) => {
     expect(inspectModelTurn(response(finishReason)).action).toBe(action);
@@ -94,12 +93,27 @@ describe('inspectModelTurn', () => {
   it('partitions canonical content while retaining text block order', () => {
     const turn = inspectModelTurn(response('tool_calls', partitionedContent));
 
+    expect(turn.action).toBe('execute_tools');
     expect(turn.textBlocks.map((block) => block.text)).toEqual(['before', 'after']);
     expect(turn.toolCalls.map((call) => call.id)).toEqual(['tool-1']);
     expect(turn.providerToolCalls.map((call) => call.id)).toEqual(['provider-1']);
     expect(turn.providerToolResults.map((result) => result.toolCallId)).toEqual(['provider-1']);
     expect(Object.isFrozen(turn)).toBe(true);
     expect(Object.isFrozen(turn.toolCalls)).toBe(true);
+  });
+
+  it('continues provider-managed tools without treating them as application mutations', () => {
+    const providerOnly = partitionedContent.filter((content) => (
+      content.type === 'provider_tool_call' || content.type === 'provider_tool_result'
+    ));
+
+    expect(inspectModelTurn(response('tool_calls', providerOnly)).action)
+      .toBe('continue_provider_tools');
+  });
+
+  it('completes a malformed tool-call finish with no canonical calls', () => {
+    expect(inspectModelTurn(response('tool_calls', [{ type: 'text', text: 'done' }])).action)
+      .toBe('complete');
   });
 });
 


### PR DESCRIPTION
## Summary

- classify canonical model turns once as terminal, truncated, resumable, provider-tool continuation, or custom-tool execution
- use that shared decision in non-streaming, streaming, and read-only replay loops
- continue provider-managed tool turns consistently in streaming delivery and remove unreachable adapter-specific no-tool branches
- bump Addie code version and refresh the generated tool-surface inventory

## Safety

- decisions use normalized finish reasons and canonical content only
- provider-managed tools remain continuation state and never become application mutations
- mixed turns still execute custom tools before continuing
- malformed tool-call finishes with no canonical calls remain terminal and side-effect free
- streaming billing and event emission remain in the delivery adapter

## Verification

- `npx tsc --project server/tsconfig.json --noEmit`
- 115 focused runtime tests across model-turn, truncation, empty-response, and read-only provider suites
- `npm run test:addie-tools`
- pre-commit: 1,056 root unit tests and 7,160 server unit tests passed (30 skipped)

Part of #6844.