### PR TITLE
refactor(addie): centralize provider tool receipts

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -56,6 +56,7 @@ import {
 } from './model-providers/model-turn.js';
 import {
   createAddieToolExecutor,
+  recordProviderToolResults,
   type AddieExecutionMode,
   type ToolExecution,
   type ToolExecutionPolicy,
@@ -84,10 +85,7 @@ import {
   formatTruncatedOutput,
 } from './security.js';
 import {
-  isToolResultError,
-  normalizeToolResult,
   renderToolExecutionsFallback,
-  type NormalizedToolResult,
   type ToolResultPresentation,
 } from './tool-result-contract.js';
 
@@ -1115,57 +1113,6 @@ export class AddieClaudeClient {
     return isEvaluationExecution(options) ? {} : toolInput;
   }
 
-  private recordedToolResult(
-    options: ProcessMessageOptions | undefined,
-    result: string,
-    kind: 'success' | 'error',
-  ): string {
-    if (!isEvaluationExecution(options)) return result;
-    return kind === 'error' ? 'Error: Tool execution failed' : 'Tool execution completed';
-  }
-
-  private observeNormalizedToolResult(
-    toolName: string,
-    normalized: NormalizedToolResult,
-  ): NormalizedToolResult {
-    if (normalized.display_degradation) {
-      logger.warn(
-        {
-          event: 'addie_tool_result_display_degraded',
-          toolName,
-          reason: normalized.display_degradation,
-        },
-        'Addie: Tool result display payload degraded; text result preserved',
-      );
-    }
-    if (normalized.model_context_truncated || normalized.user_summary_truncated) {
-      logger.warn(
-        {
-          event: 'addie_tool_result_content_bounded',
-          toolName,
-          modelContextTruncated: normalized.model_context_truncated,
-          userSummaryTruncated: normalized.user_summary_truncated,
-        },
-        'Addie: Oversized tool result content bounded',
-      );
-    }
-    return normalized;
-  }
-
-  private recordedToolPresentation(
-    options: ProcessMessageOptions | undefined,
-    normalized: NormalizedToolResult,
-  ): ToolResultPresentation {
-    if (!isEvaluationExecution(options)) return normalized.presentation;
-    return {
-      status: normalized.status,
-      user_summary: isToolResultError(normalized.status)
-        ? 'Tool execution failed'
-        : 'Tool execution completed',
-      source: normalized.presentation.source,
-    };
-  }
-
   /**
    * Invalidate the cached system prompt (forces re-read of rule files)
    */
@@ -1605,61 +1552,29 @@ export class AddieClaudeClient {
         logger.warn({ iteration }, 'Addie: Ignoring tool use from text-only recovery');
       }
 
-      // Provider-managed web results may accompany either a terminal answer or
-      // another tool-call turn. Derive their receipts through the selected
-      // adapter so private provider payloads never enter common orchestration.
-      const earlyWebSearchResults = turn.providerToolResults;
-      const earlyServerToolBlocks = turn.providerToolCalls;
-
-      if (earlyWebSearchResults.length > 0) {
-        for (const result of earlyWebSearchResults) {
-          executionSequence++;
-          toolsUsed.push('web_search');
-          const correspondingToolUse = earlyServerToolBlocks.find((call) => call.id === result.toolCallId);
-          const receipt = correspondingToolUse
-            ? this.anthropicProvider.deriveProviderToolReceipt(
-              correspondingToolUse,
-              result,
-              operationalExecution ? 'production' : 'redacted',
-            )
-            : {
-              parameters: {},
-              resultSummary: result.isError
-                ? 'Web search failed'
-                : `Web search completed (${result.resultCount} results)`,
-              resultDetails: result.isError
-                ? 'Web search failed'
-                : `Web search completed (${result.resultCount} results)`,
-              isError: result.isError,
-            };
-          const normalized = this.observeNormalizedToolResult('web_search', normalizeToolResult('web_search', {
-            status: receipt.isError ? 'error' : result.resultCount === 0 ? 'empty' : 'ok',
-            model_context: receipt.resultDetails,
-            user_summary: receipt.resultSummary,
-          }));
-          const presentation = this.recordedToolPresentation(options, normalized);
-
-          toolExecutions.push({
-            tool_name: 'web_search',
-            parameters: this.recordedToolParameters(options, receipt.parameters),
-            result: this.recordedToolResult(options, normalized.model_context, receipt.isError ? 'error' : 'success'),
-            result_summary: this.recordedToolResult(options, presentation.user_summary, receipt.isError ? 'error' : 'success'),
-            is_error: receipt.isError,
-            duration_ms: 0,
-            sequence: executionSequence,
-            normalized_result: presentation,
-          });
-
-          logger.debug(
-            {
-              resultCount: result.resultCount,
-              ...(operationalExecution && {
-                query: (receipt.parameters as Record<string, unknown>).query,
-              }),
-            },
-            'Addie: Web search completed',
-          );
-        }
+      // Provider results may accompany a terminal, provider-continuation, or
+      // mixed custom-tool turn. Record them once at the normalized boundary.
+      const providerToolExecutions = recordProviderToolResults(
+        this.anthropicProvider,
+        turn.providerToolCalls,
+        turn.providerToolResults,
+        {
+          executionMode: options?.executionMode ?? 'production',
+          startingSequence: executionSequence,
+        },
+      );
+      for (const recorded of providerToolExecutions) {
+        executionSequence = recorded.execution.sequence;
+        toolsUsed.push(recorded.execution.tool_name);
+        toolExecutions.push(recorded.execution);
+        logger.debug(
+          {
+            toolName: recorded.execution.tool_name,
+            resultCount: recorded.result.resultCount,
+            parameterKeys: Object.keys(recorded.receipt.parameters).sort(),
+          },
+          'Addie: Provider tool completed',
+        );
       }
 
       const stopAction = turn.action;
@@ -1834,60 +1749,10 @@ export class AddieClaudeClient {
         };
       }
 
-      // Handle tool use (both custom tools and server-managed tools like web_search)
+      // Handle custom tool use. Provider-managed results were recorded above.
       if (stopAction === 'execute_tools') {
         // Get custom tool use blocks (these need our handlers)
         const toolUseBlocks = turn.toolCalls;
-
-        // Get server tool use blocks (web_search - handled by Anthropic)
-        const serverToolBlocks = turn.providerToolCalls;
-
-        // Get web search results (already executed by Anthropic)
-        const webSearchResults = turn.providerToolResults;
-
-        // Track server-managed tool uses (web search)
-        for (const block of serverToolBlocks) {
-          executionSequence++;
-          toolsUsed.push(block.name);
-
-          // Find corresponding result by matching tool_use_id
-          const resultBlock = webSearchResults.find((result) => result.toolCallId === block.id);
-          const receipt = resultBlock
-            ? this.anthropicProvider.deriveProviderToolReceipt(
-              block,
-              resultBlock,
-              operationalExecution ? 'production' : 'redacted',
-            )
-            : {
-              parameters: {},
-              resultSummary: 'Web search completed',
-              resultDetails: 'Web search completed',
-              isError: false,
-            };
-          const normalized = this.observeNormalizedToolResult(block.name, normalizeToolResult(block.name, {
-            status: receipt.isError ? 'error' : (resultBlock?.resultCount ?? 0) === 0 ? 'empty' : 'ok',
-            model_context: receipt.resultDetails,
-            user_summary: receipt.resultSummary,
-          }));
-          const presentation = this.recordedToolPresentation(options, normalized);
-
-          toolExecutions.push({
-            tool_name: block.name,
-            parameters: this.recordedToolParameters(options, receipt.parameters),
-            result: this.recordedToolResult(options, normalized.model_context, receipt.isError ? 'error' : 'success'),
-            result_summary: this.recordedToolResult(options, presentation.user_summary, receipt.isError ? 'error' : 'success'),
-            is_error: receipt.isError,
-            duration_ms: 0, // Server-managed, we don't have timing
-            sequence: executionSequence,
-            normalized_result: presentation,
-          });
-
-          logger.debug({
-            toolName: block.name,
-            ...(operationalExecution && { inputKeys: block.inputKeys }),
-            resultCount: resultBlock?.resultCount ?? 0,
-          }, 'Addie: Server tool executed (web_search)');
-        }
 
         const toolResults: ModelToolResultContent[] = [];
 
@@ -2344,6 +2209,41 @@ export class AddieClaudeClient {
         currentResponse = turn.response;
         if (turn.discardedRecoveryToolCalls) {
           logger.warn({ iteration }, 'Addie Stream: Ignoring tool use from text-only recovery');
+        }
+
+        const providerToolExecutions = recordProviderToolResults(
+          this.anthropicProvider,
+          turn.providerToolCalls,
+          turn.providerToolResults,
+          {
+            executionMode: options?.executionMode ?? 'production',
+            startingSequence: executionSequence,
+          },
+        );
+        for (const recorded of providerToolExecutions) {
+          executionSequence = recorded.execution.sequence;
+          toolsUsed.push(recorded.execution.tool_name);
+          toolExecutions.push(recorded.execution);
+          yield {
+            type: 'tool_start',
+            tool_name: recorded.execution.tool_name,
+            parameters: recorded.execution.parameters,
+          };
+          yield {
+            type: 'tool_end',
+            tool_name: recorded.execution.tool_name,
+            result: recorded.execution.result,
+            is_error: recorded.execution.is_error,
+            normalized_result: recorded.execution.normalized_result,
+          };
+          logger.debug(
+            {
+              toolName: recorded.execution.tool_name,
+              resultCount: recorded.result.resultCount,
+              parameterKeys: Object.keys(recorded.receipt.parameters).sort(),
+            },
+            'Addie Stream: Provider tool completed',
+          );
         }
 
         // Build the final usage block + charge the user's cost

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.50';
+export const CODE_VERSION = '2026.08.51';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -11,7 +11,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "8e24e412b1892d4ef1e6905c8cd3ad7423e1e5e93b6644ae42ddf837bf6e2498",
+    "server/src/addie/claude-client.ts": "6085900b5fe63fc6c6612861fb6bba19f3c57f0b09632eff470188f0ac05d095",
     "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "54a62e0d89023ff9c67321639da80e67559f181eccdecf80dbdc57cc42af5b05",

--- a/server/src/addie/model-providers/tool-orchestration.ts
+++ b/server/src/addie/model-providers/tool-orchestration.ts
@@ -17,6 +17,10 @@ import {
 } from '../tool-result-contract.js';
 import type { AddieTool } from '../types.js';
 import type {
+  ModelProvider,
+  ModelProviderToolCallContent,
+  ModelProviderToolReceipt,
+  ModelProviderToolResultContent,
   ModelToolCallContent,
   ModelToolResultContent,
 } from './model-provider.js';
@@ -71,6 +75,12 @@ export interface AddieToolExecutorOptions {
 
 export interface AddieToolCallResult {
   result: ModelToolResultContent;
+  execution: ToolExecution;
+}
+
+export interface AddieProviderToolExecution {
+  result: ModelProviderToolResultContent;
+  receipt: ModelProviderToolReceipt;
   execution: ToolExecution;
 }
 
@@ -148,6 +158,81 @@ function observeNormalizedToolResult(
     }, 'Addie: Oversized tool result content bounded');
   }
   return normalized;
+}
+
+function fallbackProviderToolReceipt(
+  result: ModelProviderToolResultContent,
+): ModelProviderToolReceipt {
+  const displayName = result.name === 'web_search'
+    ? 'Web search'
+    : result.name.replaceAll('_', ' ');
+  const resultSummary = result.isError
+    ? `${displayName} failed`
+    : `${displayName} completed (${result.resultCount} results)`;
+  return {
+    toolCallId: result.toolCallId,
+    toolName: result.name,
+    parameters: {},
+    resultSummary,
+    resultDetails: resultSummary,
+    isError: result.isError,
+  };
+}
+
+/**
+ * Convert completed provider-managed tool results into the same execution
+ * ledger used by custom tools. Results, rather than call blocks, are the
+ * authoritative execution boundary: a mixed provider/custom turn therefore
+ * records each provider action exactly once, while an unfinished provider
+ * call is not reported as completed.
+ */
+export function recordProviderToolResults(
+  provider: Pick<ModelProvider, 'id' | 'deriveProviderToolReceipt'>,
+  calls: readonly ModelProviderToolCallContent[],
+  results: readonly ModelProviderToolResultContent[],
+  options: {
+    executionMode: AddieExecutionMode;
+    startingSequence: number;
+  },
+): AddieProviderToolExecution[] {
+  return results.map((result, index) => {
+    if (result.provider !== provider.id) {
+      throw new Error('Provider tool result does not match selected provider');
+    }
+    const call = calls.find((candidate) => (
+      candidate.provider === provider.id
+      && candidate.id === result.toolCallId
+      && candidate.name === result.name
+    ));
+    const receipt = call && provider.deriveProviderToolReceipt
+      ? provider.deriveProviderToolReceipt(
+          call,
+          result,
+          isEvaluationExecution(options.executionMode) ? 'redacted' : 'production',
+        )
+      : fallbackProviderToolReceipt(result);
+    const normalized = observeNormalizedToolResult(result.name, normalizeToolResult(result.name, {
+      status: receipt.isError ? 'error' : result.resultCount === 0 ? 'empty' : 'ok',
+      model_context: receipt.resultDetails,
+      user_summary: receipt.resultSummary,
+    }));
+    const presentation = recordedPresentation(options.executionMode, normalized);
+    const kind = receipt.isError ? 'error' : 'success';
+    return {
+      result,
+      receipt,
+      execution: {
+        tool_name: receipt.toolName,
+        parameters: recordedParameters(options.executionMode, receipt.parameters),
+        result: recordedResult(options.executionMode, normalized.model_context, kind),
+        result_summary: recordedResult(options.executionMode, presentation.user_summary, kind),
+        is_error: receipt.isError,
+        duration_ms: 0,
+        sequence: options.startingSequence + index + 1,
+        normalized_result: presentation,
+      },
+    };
+  });
 }
 
 function summarizeLegacyToolResult(toolName: string, result: string): string {

--- a/server/tests/unit/addie-response-truncation.test.ts
+++ b/server/tests/unit/addie-response-truncation.test.ts
@@ -113,6 +113,33 @@ function providerToolTurn(): MockMessage {
   };
 }
 
+function mixedProviderAndCustomToolTurn(): MockMessage {
+  return {
+    model: 'claude-sonnet-4-6-20260801',
+    stop_reason: 'tool_use',
+    content: [
+      {
+        type: 'server_tool_use',
+        id: 'server_web_4431',
+        name: 'web_search',
+        input: { query: 'AdCP' },
+      },
+      {
+        type: 'web_search_tool_result',
+        tool_use_id: 'server_web_4431',
+        content: [{ type: 'web_search_result', title: 'AdCP', url: 'https://adcontextprotocol.org' }],
+      },
+      {
+        type: 'tool_use',
+        id: 'custom_lookup_4431',
+        name: 'lookup',
+        input: {},
+      },
+    ],
+    usage: { input_tokens: 4, output_tokens: 5 },
+  };
+}
+
 function streamFor(finalResponse: MockMessage, chunks: string[]) {
   return {
     async *[Symbol.asyncIterator]() {
@@ -513,9 +540,16 @@ describe('Addie response truncation (#4431)', () => {
     )) events.push(event);
 
     const textEvents = events.filter((event): event is Extract<StreamEvent, { type: 'text' }> => event.type === 'text');
+    const toolEvents = events.filter((event) => event.type === 'tool_start' || event.type === 'tool_end');
     const done = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done');
     expect(textEvents).toEqual([{ type: 'text', text: 'Search complete.' }]);
+    expect(toolEvents).toEqual([
+      { type: 'tool_start', tool_name: 'web_search', parameters: { query: 'AdCP' } },
+      expect.objectContaining({ type: 'tool_end', tool_name: 'web_search', is_error: false }),
+    ]);
     expect(done?.response.text).toBe('Search complete.');
+    expect(done?.response.tools_used).toEqual(['web_search']);
+    expect(done?.response.tool_executions).toHaveLength(1);
     expect(mocks.streamMessage).toHaveBeenCalledTimes(2);
     expect(mocks.streamMessage.mock.calls[1][0].messages).toEqual(expect.arrayContaining([
       expect.objectContaining({
@@ -523,6 +557,36 @@ describe('Addie response truncation (#4431)', () => {
         content: expect.arrayContaining([expect.objectContaining({ type: 'server_tool_use' })]),
       }),
     ]));
+  });
+
+  it('records a provider result exactly once on a mixed custom-tool turn', async () => {
+    mocks.createMessage
+      .mockResolvedValueOnce(mixedProviderAndCustomToolTurn())
+      .mockResolvedValueOnce(message('end_turn', 'Both lookups completed.'));
+    const lookup = vi.fn().mockResolvedValue('Custom lookup completed.');
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+
+    const response = await client.processMessage(
+      'Run both lookups',
+      undefined,
+      {
+        tools: [{ name: 'lookup', description: 'Lookup', input_schema: { type: 'object', properties: {} } }],
+        handlers: new Map([['lookup', lookup]]),
+      },
+      undefined,
+      { uncapped: true },
+    );
+
+    expect(lookup).toHaveBeenCalledOnce();
+    expect(response.tools_used).toEqual(['web_search', 'lookup']);
+    expect(response.tool_executions).toHaveLength(2);
+    expect(response.tool_executions.map((execution) => ({
+      tool: execution.tool_name,
+      sequence: execution.sequence,
+    }))).toEqual([
+      { tool: 'web_search', sequence: 1 },
+      { tool: 'lookup', sequence: 2 },
+    ]);
   });
 
   it('charges accumulated truncation usage exactly once', async () => {

--- a/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
+++ b/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
@@ -1,8 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ModelToolCallContent } from '../../../src/addie/model-providers/model-provider.js';
+import type {
+  ModelProvider,
+  ModelProviderToolCallContent,
+  ModelProviderToolResultContent,
+  ModelToolCallContent,
+} from '../../../src/addie/model-providers/model-provider.js';
 import {
   BLOCKED_TOOL_RESULT,
   createAddieToolExecutor,
+  recordProviderToolResults,
 } from '../../../src/addie/model-providers/tool-orchestration.js';
 import type { AddieTool } from '../../../src/addie/types.js';
 
@@ -184,5 +190,110 @@ describe('createAddieToolExecutor', () => {
       { type: 'text', text: '[Image: chart.png]' },
     ]);
     expect(result.execution.result).toBe('Loaded image: chart.png');
+  });
+});
+
+describe('recordProviderToolResults', () => {
+  const providerCall: ModelProviderToolCallContent = {
+    type: 'provider_tool_call',
+    provider: 'anthropic',
+    id: 'server_1',
+    name: 'web_search',
+    inputKeys: ['query'],
+  };
+  const providerResult: ModelProviderToolResultContent = {
+    type: 'provider_tool_result',
+    provider: 'anthropic',
+    toolCallId: 'server_1',
+    name: 'web_search',
+    resultCount: 2,
+    isError: false,
+  };
+
+  it('records one adapter-derived execution per completed provider result', () => {
+    const deriveProviderToolReceipt = vi.fn(() => ({
+      toolCallId: 'server_1',
+      toolName: 'web_search',
+      parameters: { query: 'AdCP' },
+      resultSummary: 'Web search completed (2 results)',
+      resultDetails: 'Web search completed (2 results)\n\nTop results:\nAdCP: https://example.com',
+      isError: false,
+    }));
+    const provider: Pick<ModelProvider, 'id' | 'deriveProviderToolReceipt'> = {
+      id: 'anthropic',
+      deriveProviderToolReceipt,
+    };
+
+    const recorded = recordProviderToolResults(
+      provider,
+      [providerCall, { ...providerCall, id: 'unfinished' }],
+      [providerResult],
+      { executionMode: 'production', startingSequence: 4 },
+    );
+
+    expect(deriveProviderToolReceipt).toHaveBeenCalledOnce();
+    expect(deriveProviderToolReceipt).toHaveBeenCalledWith(
+      providerCall,
+      providerResult,
+      'production',
+    );
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]?.execution).toMatchObject({
+      tool_name: 'web_search',
+      parameters: { query: 'AdCP' },
+      is_error: false,
+      sequence: 5,
+      normalized_result: { status: 'ok' },
+    });
+  });
+
+  it('redacts evaluation receipts and safely records unmatched results', () => {
+    const deriveProviderToolReceipt = vi.fn(() => ({
+      toolCallId: 'server_1',
+      toolName: 'web_search',
+      parameters: { query: 'private query' },
+      resultSummary: 'private summary',
+      resultDetails: 'private details',
+      isError: false,
+    }));
+
+    const redacted = recordProviderToolResults(
+      { id: 'anthropic', deriveProviderToolReceipt },
+      [providerCall],
+      [providerResult],
+      { executionMode: 'replay', startingSequence: 0 },
+    );
+    const unmatched = recordProviderToolResults(
+      { id: 'anthropic' },
+      [],
+      [{ ...providerResult, toolCallId: 'missing', resultCount: 0 }],
+      { executionMode: 'production', startingSequence: 7 },
+    );
+
+    expect(deriveProviderToolReceipt).toHaveBeenCalledWith(
+      providerCall,
+      providerResult,
+      'redacted',
+    );
+    expect(redacted[0]?.execution).toMatchObject({
+      parameters: {},
+      result: 'Tool execution completed',
+      result_summary: 'Tool execution completed',
+    });
+    expect(unmatched[0]?.execution).toMatchObject({
+      parameters: {},
+      result: 'Web search completed (0 results)',
+      sequence: 8,
+      normalized_result: { status: 'empty' },
+    });
+  });
+
+  it('rejects results from a provider other than the selected adapter', () => {
+    expect(() => recordProviderToolResults(
+      { id: 'openai' },
+      [],
+      [providerResult],
+      { executionMode: 'production', startingSequence: 0 },
+    )).toThrow('Provider tool result does not match selected provider');
   });
 });


### PR DESCRIPTION
## Summary

- record provider-managed tool results through a shared provider-neutral receipt path in both streaming and non-streaming flows
- record each completed provider result exactly once, reject cross-provider results, and avoid treating unfinished calls as completed
- preserve replay redaction, bounded fallbacks, ledger sequencing, streaming tool events, and terminal-answer continuation
- remove the mixed provider/custom turn double-recording path
- bump the Addie code version and refresh the generated tool inventory

## Verification

- npm run precommit
  - root: 68 files, 1,056 tests passed
  - server: 503 files, 7,164 tests passed, 30 skipped
  - typecheck passed
- focused provider suite: 123 tests passed
- Addie tool inventory check passed
- git diff --check passed

Part of #6844