### PR TITLE
fix(email): use verified sender domain

### DIFF
--- a/server/src/addie/email-conversation-handler.ts
+++ b/server/src/addie/email-conversation-handler.ts
@@ -251,7 +251,7 @@ export async function handleEmailConversation(
       textContent: outputValidation.sanitized,
       fromEmail: input.addieAddress.includes('+')
         ? input.addieAddress
-        : 'addie@agenticadvertising.org',
+        : 'addie@updates.agenticadvertising.org',
     });
 
     if (!replyResult.success) {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -21,7 +21,7 @@
     "server/src/addie/handler.ts": "cf9d66b7b2700cefd2811d2d9c627ea2683c556e6c3afd36ecc99cac12aa5407",
     "server/src/routes/addie-chat.ts": "da80a42faf005441f4afbf1d003ccb7067dbd4e87b90dae96c0023511806fc08",
     "server/src/routes/tavus.ts": "640e818f0ecd4da6c72f310b7582f7bc1f2c00fd77dbe0dc521f53459e31003f",
-    "server/src/addie/email-conversation-handler.ts": "c094474b506fe9d695122bf451c79930d5e5f3f0dc56d3e77c5c2b3f3b66e9e5",
+    "server/src/addie/email-conversation-handler.ts": "091feb8569d9d254351c2c37b11747e34d3e5f6777bc362e5de750c05568a4a5",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",
     "server/src/addie/jobs/shadow-replay-cohort.ts": "316d0764cd65e4c631d6efef7d090fd46a6a8fff22d4c917a40b44a7a69eee1f",
     "server/src/addie/tool-sets.ts": "a6a375c9c4e360d3628a465acaf9892f844e17346433f1523ee9cd4573525838"

--- a/server/src/notifications/email.ts
+++ b/server/src/notifications/email.ts
@@ -19,7 +19,8 @@ if (!RESEND_API_KEY) {
 }
 
 const FROM_EMAIL = 'AgenticAdvertising.org <hello@updates.agenticadvertising.org>';
-const FROM_EMAIL_ADDIE = 'Addie from AgenticAdvertising.org <addie@updates.agenticadvertising.org>';
+const ADDIE_EMAIL_ADDRESS = 'addie@updates.agenticadvertising.org';
+const FROM_EMAIL_ADDIE = `Addie from AgenticAdvertising.org <${ADDIE_EMAIL_ADDRESS}>`;
 const BASE_URL = process.env.BASE_URL || 'https://agenticadvertising.org';
 
 /**
@@ -819,7 +820,7 @@ export async function sendEmailReply(data: {
   htmlContent: string;
   textContent: string;
   fromName?: string; // Name to show (defaults to "Addie from AgenticAdvertising.org")
-  fromEmail?: string; // Email address to send from (defaults to addie@agenticadvertising.org)
+  fromEmail?: string; // Email address to send from (defaults to the verified Addie sender)
   excludeAddresses?: string[]; // Addresses to exclude from recipients (e.g., the Addie address itself)
 }): Promise<{ success: boolean; messageId?: string; error?: string }> {
   if (!resend) {
@@ -828,17 +829,21 @@ export async function sendEmailReply(data: {
   }
 
   const fromName = data.fromName || 'Addie from AgenticAdvertising.org';
-  // Validate fromEmail is from our domain to prevent spoofing
-  const ALLOWED_FROM_DOMAINS = ['agenticadvertising.org', 'updates.agenticadvertising.org'];
+  // Only send from the Resend-verified subdomain. Preserve legacy plus-address
+  // local parts so replies continue using the inbound conversation alias.
   const fromEmail = (() => {
     if (data.fromEmail) {
-      const domain = data.fromEmail.split('@')[1]?.toLowerCase();
-      if (domain && ALLOWED_FROM_DOMAINS.includes(domain)) {
+      const [localPart, domain, ...extraParts] = data.fromEmail.split('@');
+      const normalizedDomain = domain?.toLowerCase();
+      if (localPart && extraParts.length === 0 && normalizedDomain === 'updates.agenticadvertising.org') {
         return data.fromEmail;
+      }
+      if (localPart && extraParts.length === 0 && normalizedDomain === 'agenticadvertising.org') {
+        return `${localPart}@updates.agenticadvertising.org`;
       }
       logger.warn({ requestedFromEmail: data.fromEmail }, 'Rejected invalid fromEmail domain');
     }
-    return 'addie@agenticadvertising.org';
+    return ADDIE_EMAIL_ADDRESS;
   })();
   const from = `${fromName} <${fromEmail}>`;
 
@@ -1036,7 +1041,7 @@ export async function sendIntroductionEmail(data: {
 
   try {
     const { data: sendData, error } = await resend.emails.send({
-      from: 'Addie from AgenticAdvertising.org <addie@agenticadvertising.org>',
+      from: FROM_EMAIL_ADDIE,
       to: data.memberEmail,
       replyTo: data.requesterEmail,
       subject,

--- a/server/tests/unit/email-notification.test.ts
+++ b/server/tests/unit/email-notification.test.ts
@@ -475,6 +475,73 @@ describe('Email Notifications', () => {
     });
   });
 
+  describe('sendIntroductionEmail', () => {
+    it('sends from the verified updates subdomain', async () => {
+      const { sendIntroductionEmail } = await import('../../src/notifications/email.js');
+
+      const result = await sendIntroductionEmail({
+        memberEmail: 'member@example.com',
+        memberName: 'Taylor Member',
+        memberSlug: 'example-member',
+        requesterName: 'Riley Requester',
+        requesterEmail: 'riley@example.com',
+        requesterMessage: 'I would like to connect.',
+      });
+
+      expect(result).toEqual({ success: true, messageId: 'test-email-id' });
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: 'Addie from AgenticAdvertising.org <addie@updates.agenticadvertising.org>',
+          to: 'member@example.com',
+          replyTo: 'riley@example.com',
+        })
+      );
+    });
+  });
+
+  describe('sendEmailReply', () => {
+    const threadContext = {
+      messageId: '<message-123@example.com>',
+      subject: 'Sender domain regression',
+      from: 'Requester <requester@example.com>',
+      to: ['addie@agenticadvertising.org'],
+    };
+
+    it('defaults to the verified updates subdomain', async () => {
+      const { sendEmailReply } = await import('../../src/notifications/email.js');
+
+      const result = await sendEmailReply({
+        threadContext,
+        htmlContent: '<p>Reply</p>',
+        textContent: 'Reply',
+      });
+
+      expect(result).toEqual({ success: true, messageId: 'test-email-id' });
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: 'Addie from AgenticAdvertising.org <addie@updates.agenticadvertising.org>',
+        })
+      );
+    });
+
+    it('moves legacy plus-address senders onto the verified subdomain', async () => {
+      const { sendEmailReply } = await import('../../src/notifications/email.js');
+
+      await sendEmailReply({
+        threadContext,
+        htmlContent: '<p>Reply</p>',
+        textContent: 'Reply',
+        fromEmail: 'addie+prospect@agenticadvertising.org',
+      });
+
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: 'Addie from AgenticAdvertising.org <addie+prospect@updates.agenticadvertising.org>',
+        })
+      );
+    });
+  });
+
   describe('hasSignupEmailBeenSent', () => {
     it('should return true if member signup email was sent', async () => {
       mockHasEmailBeenSent.mockImplementation(({ email_type }) => {


### PR DESCRIPTION
## Summary
- send introduction emails from the verified updates subdomain
- normalize conversational reply senders onto the verified subdomain while preserving plus-address aliases
- add regression coverage for introduction and reply sender selection
- refresh the generated Addie tool-surface inventory

## Validation
- three expert reviews: no blockers; ready to push
- email notification tests: 28 passed
- email conversation flow tests: 26 passed
- TypeScript typecheck passed
- full production build passed
- general precommit unit suite: 1,056 passed
- full server-unit precommit phase reached its configured 600-second local timeout without reporting a test failure; GitHub CI is the merge gate