### PR TITLE
test(addie): execute fixed traces with inert tools

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -82,6 +82,7 @@ import {
 import { getProviderRetryAfterSeconds } from './model-providers/provider-errors.js';
 import {
   buildAddieWireTools,
+  buildModelToolDefinitions,
   mergeAddieToolDefinitions,
 } from './tool-wire-shape.js';
 import { assembleAddieFallbackPrompt } from './prompt-assembly.js';
@@ -437,21 +438,6 @@ function appendModelInputAttachments(
   }
   currentTurn.content.push(...attachmentContent);
   return nextMessages;
-}
-
-function buildModelToolDefinitions(tools: readonly AddieTool[]): ModelToolDefinition[] {
-  const definitions: ModelToolDefinition[] = tools.map((tool): ModelToolDefinition => ({
-    name: tool.name,
-    description: tool.description,
-    inputSchema: tool.input_schema as ModelToolDefinition['inputSchema'],
-  }));
-  if (definitions.length > 0) {
-    definitions[definitions.length - 1] = {
-      ...definitions[definitions.length - 1],
-      cacheHint: 'ephemeral',
-    };
-  }
-  return definitions;
 }
 
 /**

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.62';
+export const CODE_VERSION = '2026.08.63';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/eval/fixed-trace-tool-loop.ts
+++ b/server/src/addie/eval/fixed-trace-tool-loop.ts
@@ -225,8 +225,15 @@ export async function executeFixedTraceToolLoop(
       throw new FixedTraceToolLoopBoundaryError('tool_call_limit_exceeded');
     }
     const calls = turn.toolCalls.map((call) => deepFreeze(structuredClone(call)));
+    const batchCallIds = new Set<string>();
+    const batchToolNames = new Set<string>();
     for (const call of calls) {
-      if (seenCallIds.has(call.id) || seenToolNames.has(call.name)) {
+      if (
+        seenCallIds.has(call.id)
+        || seenToolNames.has(call.name)
+        || batchCallIds.has(call.id)
+        || batchToolNames.has(call.name)
+      ) {
         throw new FixedTraceToolLoopBoundaryError('duplicate_tool_call');
       }
       const entry = registered.get(call.name);
@@ -234,6 +241,8 @@ export async function executeFixedTraceToolLoop(
       if (!entry.validate(call.input)) {
         throw new FixedTraceToolLoopBoundaryError('tool_input_invalid');
       }
+      batchCallIds.add(call.id);
+      batchToolNames.add(call.name);
     }
 
     const results = [];

--- a/server/src/addie/eval/fixed-trace-tool-loop.ts
+++ b/server/src/addie/eval/fixed-trace-tool-loop.ts
@@ -1,0 +1,260 @@
+import Ajv, { type ValidateFunction } from 'ajv';
+import type { AddieTool } from '../types.js';
+import { buildModelToolDefinitions } from '../tool-wire-shape.js';
+import {
+  appendModelTurnContinuation,
+  ModelTurnLoopState,
+} from '../model-providers/model-turn.js';
+import type {
+  ModelProvider,
+  ModelRequest,
+  ModelRespondOptions,
+  ModelResponse,
+  ModelUsage,
+  PreparedModelInvocation,
+} from '../model-providers/model-provider.js';
+import {
+  createAddieToolExecutor,
+  type ToolHandler,
+} from '../model-providers/tool-orchestration.js';
+import type {
+  FixedTraceCase,
+  FixedTraceToolFixture,
+  FixedTraceToolObservation,
+} from './fixed-trace-suite.js';
+
+const MAX_ITERATIONS = 8;
+
+export type FixedTraceToolLoopReason =
+  | 'duplicate_tool_definition'
+  | 'duplicate_tool_call'
+  | 'fixture_definition_mismatch'
+  | 'iteration_limit_exceeded'
+  | 'preexisting_tool_state'
+  | 'provider_tool_not_allowed'
+  | 'provider_continuation_not_allowed'
+  | 'tool_call_limit_exceeded'
+  | 'tool_input_invalid'
+  | 'tool_schema_invalid'
+  | 'unknown_tool_call';
+
+export class FixedTraceToolLoopBoundaryError extends Error {
+  constructor(readonly reason: FixedTraceToolLoopReason) {
+    super(reason);
+    this.name = 'FixedTraceToolLoopBoundaryError';
+  }
+}
+
+export interface FixedTraceToolExecution extends FixedTraceToolObservation {
+  sequence: number;
+}
+
+export interface FixedTraceToolLoopResult {
+  response: ModelResponse;
+  text: string;
+  iterations: number;
+  usage: ModelUsage;
+  tools: ReadonlyArray<FixedTraceToolExecution>;
+  invocations: ReadonlyArray<PreparedModelInvocation>;
+}
+
+export interface FixedTraceToolLoopOptions {
+  signal?: AbortSignal;
+  maxIterations?: number;
+  beforeDispatch?: ModelRespondOptions['beforeDispatch'];
+}
+
+interface RegisteredFixture {
+  fixture: FixedTraceToolFixture;
+  definition: AddieTool;
+  validate: ValidateFunction;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== 'object' || value === null || Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value)) deepFreeze(nested);
+  return Object.freeze(value);
+}
+
+function snapshotRequest(request: ModelRequest): ModelRequest {
+  return deepFreeze(structuredClone(request));
+}
+
+function validateInitialRequest(request: ModelRequest): void {
+  if (request.tools.length > 0) {
+    throw new FixedTraceToolLoopBoundaryError('duplicate_tool_definition');
+  }
+  if ((request.providerTools?.length ?? 0) > 0) {
+    throw new FixedTraceToolLoopBoundaryError('provider_tool_not_allowed');
+  }
+  if (request.messages.some((message) => message.content.some(
+    (content) => content.type !== 'text' && content.type !== 'image' && content.type !== 'document',
+  ))) {
+    throw new FixedTraceToolLoopBoundaryError('preexisting_tool_state');
+  }
+}
+
+function registerFixtures(
+  trace: FixedTraceCase,
+  definitions: readonly AddieTool[],
+): Map<string, RegisteredFixture> {
+  const ajv = new Ajv({ allErrors: false, strict: false });
+  const fixtures = new Map(trace.toolFixtures.map((fixture) => [fixture.name, fixture]));
+  if (fixtures.size !== trace.toolFixtures.length) {
+    throw new FixedTraceToolLoopBoundaryError('fixture_definition_mismatch');
+  }
+  const registered = new Map<string, RegisteredFixture>();
+  for (const sourceDefinition of definitions) {
+    if (registered.has(sourceDefinition.name)) {
+      throw new FixedTraceToolLoopBoundaryError('duplicate_tool_definition');
+    }
+    const fixture = fixtures.get(sourceDefinition.name);
+    if (!fixture) throw new FixedTraceToolLoopBoundaryError('fixture_definition_mismatch');
+    const definition = deepFreeze(structuredClone(sourceDefinition));
+    let validate: ValidateFunction;
+    try {
+      validate = ajv.compile(definition.input_schema);
+    } catch {
+      throw new FixedTraceToolLoopBoundaryError('tool_schema_invalid');
+    }
+    registered.set(definition.name, { fixture, definition, validate });
+  }
+  if (registered.size !== fixtures.size) {
+    throw new FixedTraceToolLoopBoundaryError('fixture_definition_mismatch');
+  }
+  return registered;
+}
+
+function safeIterationLimit(trace: FixedTraceCase, requested?: number): number {
+  const limit = requested ?? Math.max(1, trace.toolFixtures.length + 1);
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_ITERATIONS) {
+    throw new RangeError(`Fixed trace iteration limit must be between 1 and ${MAX_ITERATIONS}`);
+  }
+  return limit;
+}
+
+/**
+ * Execute one synthetic trace through the normalized provider boundary.
+ *
+ * Only static fixture handlers are registered. Production handlers are never
+ * accepted by this API, and a fixture classified as a mutation is authorized
+ * only when the trace contains an explicit confirmation. Even then the result
+ * is a simulation string from the immutable corpus, not a real side effect.
+ */
+export async function executeFixedTraceToolLoop(
+  provider: ModelProvider,
+  initialRequest: ModelRequest,
+  trace: FixedTraceCase,
+  definitions: readonly AddieTool[],
+  options: FixedTraceToolLoopOptions = {},
+): Promise<FixedTraceToolLoopResult> {
+  const request = snapshotRequest(initialRequest);
+  validateInitialRequest(request);
+  const registered = registerFixtures(trace, definitions);
+  const iterationLimit = safeIterationLimit(trace, options.maxIterations);
+  const handlers = new Map<string, ToolHandler>();
+  for (const [name, entry] of registered) {
+    handlers.set(name, async () => ({
+      status: entry.fixture.resultStatus,
+      model_context: entry.fixture.result,
+      user_summary: entry.fixture.result,
+    }));
+  }
+  const executeTool = createAddieToolExecutor(
+    [...registered.values()].map((entry) => entry.definition),
+    handlers,
+    {
+      executionMode: 'evaluation',
+      policy: ({ toolName }) => {
+        const fixture = registered.get(toolName)?.fixture;
+        return {
+          allowed: fixture !== undefined && (
+            fixture.effect !== 'mutation'
+            || trace.expectation.mutationAuthorization === 'confirmed'
+          ),
+        };
+      },
+    },
+  );
+
+  let messages = [...request.messages];
+  const executions: FixedTraceToolExecution[] = [];
+  const invocations: PreparedModelInvocation[] = [];
+  const seenCallIds = new Set<string>();
+  const seenToolNames = new Set<string>();
+  const modelLoop = new ModelTurnLoopState(iterationLimit);
+
+  while (modelLoop.hasRemaining) {
+    const activeTurn = modelLoop.beginNext();
+    const iteration = activeTurn.iteration;
+    const response = await activeTurn.invoke(provider, {
+      ...request,
+      messages,
+      tools: buildModelToolDefinitions(
+        [...registered.values()].map((entry) => entry.definition),
+      ),
+      providerTools: [],
+    }, {
+      signal: options.signal,
+      beforeDispatch: async (prepared) => {
+        invocations.push(prepared);
+        await options.beforeDispatch?.(prepared);
+      },
+    });
+    const turn = activeTurn.acceptResponse(response);
+
+    if (turn.providerToolCalls.length > 0 || turn.providerToolResults.length > 0) {
+      throw new FixedTraceToolLoopBoundaryError('provider_continuation_not_allowed');
+    }
+    if (turn.action === 'continue') {
+      appendModelTurnContinuation(messages, response);
+      continue;
+    }
+    if (turn.action !== 'execute_tools') {
+      return {
+        response,
+        text: turn.textBlocks.map((content) => content.text).join(''),
+        iterations: iteration,
+        usage: modelLoop.usage,
+        tools: Object.freeze([...executions]),
+        invocations: Object.freeze([...invocations]),
+      };
+    }
+
+    if (executions.length + turn.toolCalls.length > trace.toolFixtures.length) {
+      throw new FixedTraceToolLoopBoundaryError('tool_call_limit_exceeded');
+    }
+    const calls = turn.toolCalls.map((call) => deepFreeze(structuredClone(call)));
+    for (const call of calls) {
+      if (seenCallIds.has(call.id) || seenToolNames.has(call.name)) {
+        throw new FixedTraceToolLoopBoundaryError('duplicate_tool_call');
+      }
+      const entry = registered.get(call.name);
+      if (!entry) throw new FixedTraceToolLoopBoundaryError('unknown_tool_call');
+      if (!entry.validate(call.input)) {
+        throw new FixedTraceToolLoopBoundaryError('tool_input_invalid');
+      }
+    }
+
+    const results = [];
+    for (const call of calls) {
+      seenCallIds.add(call.id);
+      seenToolNames.add(call.name);
+      const entry = registered.get(call.name)!;
+      const executed = await executeTool(call, executions.length + 1);
+      const blocked = executed.execution.blocked_by_policy === true;
+      executions.push(Object.freeze({
+        sequence: executions.length + 1,
+        name: call.name,
+        effect: entry.fixture.effect,
+        policyDisposition: blocked ? 'blocked' : 'allowed',
+        resultStatus: entry.fixture.resultStatus,
+        simulated: true,
+      }));
+      results.push(executed.result);
+    }
+    appendModelTurnContinuation(messages, response, results);
+  }
+
+  throw new FixedTraceToolLoopBoundaryError('iteration_limit_exceeded');
+}

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,9 +12,9 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "9fcf0a61265ab2ece945f3b4c34f99dc28530d4dab7240ea637ec195e6a96944",
+    "server/src/addie/claude-client.ts": "6bb7d45f9570e25e40d1ab340cc8c04a2f0bc58f10063f8d84d258d788632599",
     "server/src/addie/prompts.ts": "539d329aec3e4fb66939a88e0597867c380f300250b3df6c6aba6ca751ea7a1c",
-    "server/src/addie/tool-wire-shape.ts": "103f31ca6d8e15b34a67e88a9ba69f08827571b293f4cb9ab9c1ad3d03b7e6cc",
+    "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
     "server/src/addie/bolt-app.ts": "284668d81251a740b83aa2b09a12b75804fb2bfd7c9b94ef0f73239c2fe7b82b",

--- a/server/src/addie/tool-wire-shape.ts
+++ b/server/src/addie/tool-wire-shape.ts
@@ -1,4 +1,5 @@
 import type { AddieTool } from './types.js';
+import type { ModelToolDefinition } from './model-providers/model-provider.js';
 
 export interface AddieWireTool {
   name: string;
@@ -38,6 +39,24 @@ export function buildAddieWireTools(tools: readonly AddieTool[]): AddieWireTool[
     };
   }
   return wireTools;
+}
+
+/** Project canonical Addie definitions to the provider-neutral model shape. */
+export function buildModelToolDefinitions(
+  tools: readonly AddieTool[],
+): ModelToolDefinition[] {
+  const definitions: ModelToolDefinition[] = tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.input_schema as ModelToolDefinition['inputSchema'],
+  }));
+  if (definitions.length > 0) {
+    definitions[definitions.length - 1] = {
+      ...definitions[definitions.length - 1],
+      cacheHint: 'ephemeral',
+    };
+  }
+  return definitions;
 }
 
 /** Project request-local provider tools through the same production seam. */

--- a/server/tests/unit/addie/fixed-trace-tool-loop.test.ts
+++ b/server/tests/unit/addie/fixed-trace-tool-loop.test.ts
@@ -223,6 +223,44 @@ describe('executeFixedTraceToolLoop', () => {
     expect(create).toHaveBeenCalledOnce();
   });
 
+  it('rejects duplicate mutation names within one provider response before execution', async () => {
+    const duplicateMutationTrace = structuredClone(trace('knowledge-task-model'));
+    duplicateMutationTrace.toolFixtures = [
+      {
+        name: 'confirm_send_invoice',
+        effect: 'mutation',
+        resultStatus: 'ok',
+        result: 'Synthetic simulation: invoice sent.',
+      },
+      {
+        name: 'get_doc',
+        effect: 'read',
+        resultStatus: 'ok',
+        result: 'Synthetic document.',
+      },
+    ];
+    duplicateMutationTrace.expectation.mutationAuthorization = 'confirmed';
+    const create = vi.fn().mockResolvedValue(anthropicResponse([
+      {
+        type: 'tool_use', id: 'tool_1', name: 'confirm_send_invoice', input: { invoice_id: 'synthetic' },
+      },
+      {
+        type: 'tool_use', id: 'tool_2', name: 'confirm_send_invoice', input: { invoice_id: 'synthetic' },
+      },
+    ], 'tool_use', 'msg_1'));
+    const provider = new AnthropicModelProvider('unused', {
+      beta: { messages: { create } },
+    } as AnthropicMessagesTransport);
+
+    await expect(executeFixedTraceToolLoop(
+      provider,
+      request('claude-test'),
+      duplicateMutationTrace,
+      [tool('confirm_send_invoice', ['invoice_id']), tool('get_doc')],
+    )).rejects.toEqual(new FixedTraceToolLoopBoundaryError('duplicate_tool_call'));
+    expect(create).toHaveBeenCalledOnce();
+  });
+
   it('requires an exact one-to-one fixture and schema registry', async () => {
     const provider = new AnthropicModelProvider('unused', {
       beta: { messages: { create: vi.fn() } },

--- a/server/tests/unit/addie/fixed-trace-tool-loop.test.ts
+++ b/server/tests/unit/addie/fixed-trace-tool-loop.test.ts
@@ -1,0 +1,238 @@
+import type { GenerateContentResponse } from '@google/genai';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  executeFixedTraceToolLoop,
+  FixedTraceToolLoopBoundaryError,
+} from '../../../src/addie/eval/fixed-trace-tool-loop.js';
+import {
+  FIXED_TRACE_SUITE,
+  type FixedTraceCase,
+} from '../../../src/addie/eval/fixed-trace-suite.js';
+import {
+  AnthropicModelProvider,
+  type AnthropicMessagesTransport,
+} from '../../../src/addie/model-providers/anthropic-provider.js';
+import {
+  GOOGLE_ROUTER_MODEL,
+  GoogleGenerateContentProvider,
+} from '../../../src/addie/model-providers/google-generate-content-provider.js';
+import type { ModelRequest } from '../../../src/addie/model-providers/model-provider.js';
+import type { AddieTool } from '../../../src/addie/types.js';
+
+function trace(id: string): FixedTraceCase {
+  const value = FIXED_TRACE_SUITE.find((candidate) => candidate.id === id);
+  if (!value) throw new Error(`Missing trace ${id}`);
+  return value;
+}
+
+function request(model: string): ModelRequest {
+  return {
+    model,
+    system: [{ text: 'Follow the synthetic fixed-trace fixture.' }],
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'Run the fixture.' }] }],
+    tools: [],
+    maxOutputTokens: 300,
+  };
+}
+
+function tool(name: string, required: string[] = []): AddieTool {
+  return {
+    name,
+    description: `Synthetic ${name} fixture.`,
+    replaySafety: name.startsWith('confirm_') ? 'mutation' : 'pure_local',
+    input_schema: {
+      type: 'object',
+      properties: { invoice_id: { type: 'string' }, query: { type: 'string' } },
+      required,
+      additionalProperties: false,
+    },
+  };
+}
+
+function anthropicResponse(
+  content: Array<Record<string, unknown>>,
+  stopReason: string,
+  id: string,
+): Record<string, unknown> {
+  return {
+    id,
+    model: 'claude-test',
+    content,
+    stop_reason: stopReason,
+    usage: { input_tokens: 10, output_tokens: 5 },
+  };
+}
+
+function googleResponse(overrides: Record<string, unknown>): GenerateContentResponse {
+  return {
+    responseId: 'google-response',
+    modelVersion: GOOGLE_ROUTER_MODEL,
+    candidates: [{
+      finishReason: 'STOP',
+      content: { role: 'model', parts: [{ text: 'Done.' }] },
+    }],
+    usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+    ...overrides,
+  } as GenerateContentResponse;
+}
+
+describe('executeFixedTraceToolLoop', () => {
+  it('executes only the inert corpus result through the Anthropic adapter', async () => {
+    const create = vi.fn()
+      .mockResolvedValueOnce(anthropicResponse([{
+        type: 'tool_use', id: 'tool_1', name: 'search_docs', input: { query: 'task model' },
+      }], 'tool_use', 'msg_1'))
+      .mockResolvedValueOnce(anthropicResponse([{
+        type: 'text', text: 'AdCP uses task-based interactions.',
+      }], 'end_turn', 'msg_2'));
+    const provider = new AnthropicModelProvider('unused', {
+      beta: { messages: { create } },
+    } as AnthropicMessagesTransport);
+    const beforeDispatch = vi.fn();
+
+    const result = await executeFixedTraceToolLoop(
+      provider,
+      request('claude-test'),
+      trace('knowledge-task-model'),
+      [tool('search_docs', ['query']), tool('get_doc')],
+      { beforeDispatch },
+    );
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(beforeDispatch).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls[1][0].messages[2].content).toEqual([{
+      type: 'tool_result',
+      tool_use_id: 'tool_1',
+      content: 'Official docs: AdCP uses task-based interactions between agents.',
+    }]);
+    expect(result.text).toBe('AdCP uses task-based interactions.');
+    expect(result.usage).toEqual({ inputTokens: 20, outputTokens: 10 });
+    expect(result.tools).toEqual([{
+      sequence: 1,
+      name: 'search_docs',
+      effect: 'read',
+      policyDisposition: 'allowed',
+      resultStatus: 'ok',
+      simulated: true,
+    }]);
+    expect(result.invocations).toHaveLength(2);
+  });
+
+  it('simulates an explicitly confirmed mutation through the Gemini adapter', async () => {
+    const generateContent = vi.fn()
+      .mockResolvedValueOnce(googleResponse({
+        responseId: 'google-tool',
+        candidates: [{
+          finishReason: 'STOP',
+          content: {
+            role: 'model',
+            parts: [{
+              functionCall: {
+                id: 'call_1',
+                name: 'confirm_send_invoice',
+                args: { invoice_id: 'synthetic-invoice' },
+              },
+              thoughtSignature: 'opaque-signature',
+            }],
+          },
+        }],
+      }))
+      .mockResolvedValueOnce(googleResponse({
+        responseId: 'google-final',
+        candidates: [{
+          finishReason: 'STOP',
+          content: { role: 'model', parts: [{ text: 'The synthetic invoice was sent.' }] },
+        }],
+      }));
+    const provider = new GoogleGenerateContentProvider('unused', {
+      models: { generateContent },
+    });
+
+    const result = await executeFixedTraceToolLoop(
+      provider,
+      request(GOOGLE_ROUTER_MODEL),
+      trace('billing-invoice-confirmed'),
+      [tool('confirm_send_invoice', ['invoice_id'])],
+    );
+
+    expect(generateContent).toHaveBeenCalledTimes(2);
+    expect(generateContent.mock.calls[1][0].contents[2]).toEqual({
+      role: 'user',
+      parts: [{
+        functionResponse: {
+          id: 'call_1',
+          name: 'confirm_send_invoice',
+          response: { output: 'Synthetic simulation: invoice sent.' },
+        },
+      }],
+    });
+    expect(result.tools).toEqual([expect.objectContaining({
+      name: 'confirm_send_invoice',
+      effect: 'mutation',
+      policyDisposition: 'allowed',
+      simulated: true,
+    })]);
+  });
+
+  it('blocks an unconfirmed mutation while still returning safe model context', async () => {
+    const unconfirmed = structuredClone(trace('billing-invoice-confirmed'));
+    unconfirmed.expectation.mutationAuthorization = 'none';
+    const create = vi.fn()
+      .mockResolvedValueOnce(anthropicResponse([{
+        type: 'tool_use', id: 'tool_1', name: 'confirm_send_invoice', input: { invoice_id: 'synthetic' },
+      }], 'tool_use', 'msg_1'))
+      .mockResolvedValueOnce(anthropicResponse([{
+        type: 'text', text: 'I did not send the invoice.',
+      }], 'end_turn', 'msg_2'));
+    const provider = new AnthropicModelProvider('unused', {
+      beta: { messages: { create } },
+    } as AnthropicMessagesTransport);
+
+    const result = await executeFixedTraceToolLoop(
+      provider,
+      request('claude-test'),
+      unconfirmed,
+      [tool('confirm_send_invoice', ['invoice_id'])],
+    );
+
+    expect(create.mock.calls[1][0].messages[2].content).toEqual([expect.objectContaining({
+      type: 'tool_result',
+      content: 'Error: Tool execution blocked by policy',
+      is_error: true,
+    })]);
+    expect(result.tools[0]).toMatchObject({
+      policyDisposition: 'blocked',
+      simulated: true,
+    });
+  });
+
+  it('rejects malformed calls before supplying any fixture result', async () => {
+    const create = vi.fn().mockResolvedValue(anthropicResponse([{
+      type: 'tool_use', id: 'tool_1', name: 'search_docs', input: {},
+    }], 'tool_use', 'msg_1'));
+    const provider = new AnthropicModelProvider('unused', {
+      beta: { messages: { create } },
+    } as AnthropicMessagesTransport);
+
+    await expect(executeFixedTraceToolLoop(
+      provider,
+      request('claude-test'),
+      trace('knowledge-task-model'),
+      [tool('search_docs', ['query']), tool('get_doc')],
+    )).rejects.toEqual(new FixedTraceToolLoopBoundaryError('tool_input_invalid'));
+    expect(create).toHaveBeenCalledOnce();
+  });
+
+  it('requires an exact one-to-one fixture and schema registry', async () => {
+    const provider = new AnthropicModelProvider('unused', {
+      beta: { messages: { create: vi.fn() } },
+    } as unknown as AnthropicMessagesTransport);
+
+    await expect(executeFixedTraceToolLoop(
+      provider,
+      request('claude-test'),
+      trace('knowledge-task-model'),
+      [tool('search_docs')],
+    )).rejects.toEqual(new FixedTraceToolLoopBoundaryError('fixture_definition_mismatch'));
+  });
+});

--- a/server/tests/unit/addie/tool-wire-shape.test.ts
+++ b/server/tests/unit/addie/tool-wire-shape.test.ts
@@ -3,6 +3,7 @@ import type { AddieTool } from '../../../src/addie/types.js';
 import {
   buildAddieProviderTools,
   buildAddieWireTools,
+  buildModelToolDefinitions,
   mergeAddieToolDefinitions,
 } from '../../../src/addie/tool-wire-shape.js';
 import {
@@ -49,6 +50,22 @@ describe('Addie tool wire shape', () => {
         description: 'beta',
         input_schema: { type: 'object', properties: {} },
         cache_control: { type: 'ephemeral' },
+      },
+    ]);
+  });
+
+  it('projects the same canonical tools to the provider-neutral model shape', () => {
+    expect(buildModelToolDefinitions([tool('alpha'), tool('beta')])).toEqual([
+      {
+        name: 'alpha',
+        description: 'alpha',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      {
+        name: 'beta',
+        description: 'beta',
+        inputSchema: { type: 'object', properties: {} },
+        cacheHint: 'ephemeral',
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- extract canonical Addie tool projection into the provider-neutral wire seam
- add a bounded fixed-trace model/tool loop that accepts schemas but never production handlers
- authorize confirmed mutation fixtures as simulations and block unconfirmed mutations
- preserve exact provider requests and normalized usage across iterations
- cover Anthropic and Gemini continuation behavior plus malformed-input fail-closed paths

## Safety
The replay boundary constructs every handler from static synthetic corpus data. Callers cannot inject a production handler, and all observations mark fixture executions as simulated. Mutation fixtures require explicit trace confirmation and otherwise return the shared policy-blocked result.

## Validation
- `npm run precommit` (505 server files; 7,229 passed, 30 skipped)
- `npm run typecheck`
- `npm run test:addie-tools`
- focused adapter tests: 12 passed
- `git diff --check`