### PR TITLE
feat(addie): support OpenAI custom tools

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.65';
+export const CODE_VERSION = '2026.08.66';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.64';
+export const CODE_VERSION = '2026.08.65';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.66';
+export const CODE_VERSION = '2026.08.67';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/model-providers/openai-responses-provider.ts
+++ b/server/src/addie/model-providers/openai-responses-provider.ts
@@ -90,6 +90,15 @@ function parseToolInput(value: string, name: string): JsonObject {
   return parsed as JsonObject;
 }
 
+function toolResultOutput(content: Extract<ModelMessageContent, { type: 'tool_result' }>): string {
+  const output = typeof content.content === 'string'
+    ? content.content
+    : textOnly(content.content, `tool result ${content.toolCallId}`);
+  return content.isError
+    ? `[Tool execution error]\n${output || 'No error details provided.'}`
+    : output;
+}
+
 function toOpenAIInput(messages: readonly ModelMessage[]): ResponseInputItem[] {
   const input: ResponseInputItem[] = [];
   for (const message of messages) {
@@ -117,9 +126,7 @@ function toOpenAIInput(messages: readonly ModelMessage[]): ResponseInputItem[] {
         input.push({
           type: 'function_call_output',
           call_id: content.toolCallId,
-          output: typeof content.content === 'string'
-            ? content.content
-            : textOnly(content.content, `tool result ${content.toolCallId}`),
+          output: toolResultOutput(content),
         });
       } else {
         throw new Error(`OpenAI adapter does not support ${content.type} in a ${message.role} message`);

--- a/server/src/addie/model-providers/openai-responses-provider.ts
+++ b/server/src/addie/model-providers/openai-responses-provider.ts
@@ -1,7 +1,14 @@
 import OpenAI from 'openai';
-import type { Response, ResponseCreateParamsNonStreaming } from 'openai/resources/responses/responses';
 import type {
+  FunctionTool,
+  Response,
+  ResponseCreateParamsNonStreaming,
+  ResponseInputItem,
+} from 'openai/resources/responses/responses';
+import type {
+  JsonObject,
   ModelFinishReason,
+  ModelMessage,
   ModelMessageContent,
   ModelProvider,
   ModelProviderCapabilities,
@@ -12,7 +19,7 @@ import type {
   PreparedModelInvocation,
 } from './model-provider.js';
 import { UnexpectedModelIdentityError } from './model-provider.js';
-import { validateModelCapabilities } from './capabilities.js';
+import { assertPlainJson, validateModelCapabilities } from './capabilities.js';
 import { validateNormalizedModelResponse } from './events.js';
 
 export const OPENAI_ROUTER_MODEL = 'gpt-5.6-luna';
@@ -31,7 +38,7 @@ export const OPENAI_RESPONSES_CAPABILITIES: ModelProviderCapabilities = Object.f
   structuredOutput: true,
   reasoning: true,
   reasoningEfforts: Object.freeze(['provider_default', 'none', 'low', 'medium', 'high'] as const),
-  customTools: false,
+  customTools: true,
   providerWebSearch: false,
   imageInput: false,
   documentInput: false,
@@ -56,6 +63,74 @@ function textOnly(content: ModelMessageContent[], label: string): string {
   return content.map((block) => block.type === 'text' ? block.text : '').join('');
 }
 
+function toOpenAITool(tool: ModelRequest['tools'][number]): FunctionTool {
+  return {
+    type: 'function',
+    name: tool.name,
+    description: tool.description,
+    parameters: structuredClone(tool.inputSchema) as Record<string, unknown>,
+    // Addie's canonical schemas intentionally allow optional properties that
+    // do not satisfy OpenAI's strict-schema subset. Runtime validation and the
+    // common tool executor remain authoritative.
+    strict: false,
+  };
+}
+
+function parseToolInput(value: string, name: string): JsonObject {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(`Malformed OpenAI function arguments for ${name}`);
+  }
+  assertPlainJson(parsed, `OpenAI function arguments for ${name}`);
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`Malformed OpenAI function arguments for ${name}`);
+  }
+  return parsed as JsonObject;
+}
+
+function toOpenAIInput(messages: readonly ModelMessage[]): ResponseInputItem[] {
+  const input: ResponseInputItem[] = [];
+  for (const message of messages) {
+    if (message.content.length === 0) throw new Error('OpenAI adapter requires non-empty messages');
+    let pendingText: string[] = [];
+    const flushText = () => {
+      if (pendingText.length === 0) return;
+      input.push({ type: 'message', role: message.role, content: pendingText.join('') });
+      pendingText = [];
+    };
+    for (const content of message.content) {
+      if (content.type === 'text') {
+        pendingText.push(content.text);
+        continue;
+      }
+      flushText();
+      if (content.type === 'tool_call' && message.role === 'assistant') {
+        input.push({
+          type: 'function_call',
+          call_id: content.id,
+          name: content.name,
+          arguments: JSON.stringify(content.input),
+        });
+      } else if (content.type === 'tool_result' && message.role === 'user') {
+        input.push({
+          type: 'function_call_output',
+          call_id: content.toolCallId,
+          output: typeof content.content === 'string'
+            ? content.content
+            : textOnly(content.content, `tool result ${content.toolCallId}`),
+          ...(content.toolName && { name: content.toolName }),
+        });
+      } else {
+        throw new Error(`OpenAI adapter does not support ${content.type} in a ${message.role} message`);
+      }
+    }
+    flushText();
+  }
+  return input;
+}
+
 function toOpenAIRequest(request: ModelRequest): ResponseCreateParamsNonStreaming {
   validateModelCapabilities('openai', OPENAI_RESPONSES_CAPABILITIES, request);
   if (request.model !== OPENAI_ROUTER_MODEL) {
@@ -64,26 +139,22 @@ function toOpenAIRequest(request: ModelRequest): ResponseCreateParamsNonStreamin
   if (request.system.some((block) => block.cacheHint !== undefined)) {
     throw new Error('OpenAI router adapter does not support cache hints');
   }
-  if (request.tools.length > 0 || (request.providerTools?.length ?? 0) > 0) {
-    throw new Error('OpenAI router adapter is tool-free');
+  if ((request.providerTools?.length ?? 0) > 0) {
+    throw new Error('OpenAI adapter does not support provider tools');
   }
 
   const effort = request.reasoning?.effort;
   return {
     model: request.model,
     instructions: request.system.map((block) => block.text).join('\n\n'),
-    input: request.messages.map((message) => ({
-      type: 'message' as const,
-      role: message.role,
-      content: textOnly(message.content, 'messages'),
-    })),
+    input: toOpenAIInput(request.messages),
     max_output_tokens: request.maxOutputTokens,
     store: false,
     background: false,
     stream: false,
     truncation: 'disabled',
     parallel_tool_calls: false,
-    tools: [],
+    tools: request.tools.map(toOpenAITool),
     text: request.outputSchema
       ? {
           format: {
@@ -123,25 +194,49 @@ export function normalizeOpenAIResponse(response: Response): ModelResponse {
   let refused = finishReason === 'refusal';
   for (const item of response.output) {
     if (item.type === 'reasoning') continue;
-    if (item.type !== 'message' || item.role !== 'assistant') {
-      throw new Error(`Unexpected OpenAI output item: ${item.type}`);
-    }
-    if (item.status !== 'completed' && response.status === 'completed') {
-      throw new Error('Incomplete OpenAI message output');
-    }
-    for (const part of item.content) {
-      if (part.type === 'output_text') {
-        content.push({ type: 'text', text: part.text });
-      } else if (part.type === 'refusal') {
-        refused = true;
-      } else {
-        const exhaustive: never = part;
-        throw new Error(`Unexpected OpenAI message part: ${String(exhaustive)}`);
+    if (item.type === 'function_call') {
+      if (
+        typeof item.call_id !== 'string'
+        || !item.call_id.trim()
+        || item.call_id.length > 256
+        || typeof item.name !== 'string'
+        || !item.name.trim()
+        || item.name.length > 128
+        || typeof item.arguments !== 'string'
+        || Buffer.byteLength(item.arguments, 'utf8') > 1024 * 1024
+        || (item.status !== undefined && item.status !== 'completed')
+        || item.namespace !== undefined
+        || (item.caller !== undefined && item.caller !== null && item.caller.type !== 'direct')
+      ) throw new Error('Malformed OpenAI function call');
+      content.push({
+        type: 'tool_call',
+        id: item.call_id,
+        name: item.name,
+        input: parseToolInput(item.arguments, item.name),
+      });
+    } else if (item.type === 'message' && item.role === 'assistant') {
+      if (item.status !== 'completed' && response.status === 'completed') {
+        throw new Error('Incomplete OpenAI message output');
       }
-    }
+      for (const part of item.content) {
+        if (part.type === 'output_text') {
+          content.push({ type: 'text', text: part.text });
+        } else if (part.type === 'refusal') {
+          refused = true;
+        } else {
+          const exhaustive: never = part;
+          throw new Error(`Unexpected OpenAI message part: ${String(exhaustive)}`);
+        }
+      }
+    } else throw new Error(`Unexpected OpenAI output item: ${item.type}`);
   }
 
+  const hasFunctionCall = content.some((item) => item.type === 'tool_call');
+  if (hasFunctionCall && finishReason !== 'stop') {
+    throw new Error('OpenAI response ended before function calls were terminal');
+  }
   if (refused) finishReason = 'refusal';
+  else if (hasFunctionCall) finishReason = 'tool_calls';
 
   if (finishReason === 'stop' && content.length < 1) throw new Error('Empty OpenAI response output');
   const normalized = deepFreeze({
@@ -205,8 +300,9 @@ export class OpenAIResponsesProvider implements ModelProvider {
     }
     yield { type: 'response_start', provider: this.id, model: normalized.model, id: normalized.id };
     for (const [index, item] of normalized.content.entries()) {
-      if (item.type !== 'text') throw new Error('OpenAI router adapter emitted non-text content');
-      yield { type: 'text_delta', index, text: item.text };
+      if (item.type === 'text') yield { type: 'text_delta', index, text: item.text };
+      else if (item.type === 'tool_call') yield { type: 'tool_call', index, call: item };
+      else throw new Error('OpenAI adapter emitted unsupported content');
     }
     yield { type: 'response_complete', response: normalized };
   }

--- a/server/src/addie/model-providers/openai-responses-provider.ts
+++ b/server/src/addie/model-providers/openai-responses-provider.ts
@@ -120,7 +120,6 @@ function toOpenAIInput(messages: readonly ModelMessage[]): ResponseInputItem[] {
           output: typeof content.content === 'string'
             ? content.content
             : textOnly(content.content, `tool result ${content.toolCallId}`),
-          ...(content.toolName && { name: content.toolName }),
         });
       } else {
         throw new Error(`OpenAI adapter does not support ${content.type} in a ${message.role} message`);

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -171,7 +171,7 @@ describe('OpenAIResponsesProvider', () => {
       input: [
         { type: 'message', role: 'user', content: 'Find the task model.' },
         { type: 'function_call', call_id: 'call_1', name: 'search_docs', arguments: '{"query":"task model"}' },
-        { type: 'function_call_output', call_id: 'call_1', name: 'search_docs', output: 'The protocol is task based.' },
+        { type: 'function_call_output', call_id: 'call_1', output: 'The protocol is task based.' },
       ],
       tools: [{
         type: 'function',
@@ -281,7 +281,6 @@ describe('OpenAIResponsesProvider', () => {
         {
           type: 'function_call_output',
           call_id: 'call_1',
-          name: 'search_docs',
           output: expect.stringContaining('Official docs: AdCP uses task-based interactions'),
         },
       ]),

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -189,6 +189,27 @@ describe('OpenAIResponsesProvider', () => {
     });
   });
 
+  it('marks failed tool results explicitly in Responses continuation output', () => {
+    const provider = new OpenAIResponsesProvider('unused', {} as OpenAIResponsesTransport);
+    const prepared = provider.prepare(request(OPENAI_ROUTER_MODEL, {
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'Find the task model.' }] },
+        { role: 'assistant', content: [{
+          type: 'tool_call', id: 'call_1', name: 'search_docs', input: { query: 'task model' },
+        }] },
+        { role: 'user', content: [{
+          type: 'tool_result', toolCallId: 'call_1', toolName: 'search_docs', content: '', isError: true,
+        }] },
+      ],
+    }));
+
+    expect(prepared.providerRequest.input).toEqual([
+      { type: 'message', role: 'user', content: 'Find the task model.' },
+      { type: 'function_call', call_id: 'call_1', name: 'search_docs', arguments: '{"query":"task model"}' },
+      { type: 'function_call_output', call_id: 'call_1', output: '[Tool execution error]\nNo error details provided.' },
+    ]);
+  });
+
   it('normalizes and emits function calls through the shared event boundary', async () => {
     const create = vi.fn().mockResolvedValue(openAIResponse({
       output: [{

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -23,6 +23,8 @@ import {
   ReadOnlyToolLoopBoundaryError,
 } from '../../../src/addie/model-providers/read-only-tool-loop.js';
 import { createOfficialDocsReadOnlyToolBoundary } from '../../../src/addie/jobs/official-docs-read-only-tools.js';
+import { executeFixedTraceToolLoop } from '../../../src/addie/eval/fixed-trace-tool-loop.js';
+import { FIXED_TRACE_SUITE } from '../../../src/addie/eval/fixed-trace-suite.js';
 
 const { googleGenAIConstructor } = vi.hoisted(() => ({
   googleGenAIConstructor: vi.fn(function FakeGoogleGenAI() {
@@ -135,6 +137,157 @@ describe('OpenAIResponsesProvider', () => {
     expect(normalized.usage).toEqual({ inputTokens: 10, outputTokens: 5, cacheReadTokens: 2, cacheWriteTokens: 0 });
   });
 
+  it('projects custom tools and stateless function-call continuation exactly', () => {
+    const provider = new OpenAIResponsesProvider('unused', {} as OpenAIResponsesTransport);
+    const prepared = provider.prepare(request(OPENAI_ROUTER_MODEL, {
+      tools: [{
+        name: 'search_docs',
+        description: 'Search official docs.',
+        inputSchema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+          additionalProperties: false,
+        },
+      }],
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'Find the task model.' }] },
+        { role: 'assistant', content: [{
+          type: 'tool_call',
+          id: 'call_1',
+          name: 'search_docs',
+          input: { query: 'task model' },
+        }] },
+        { role: 'user', content: [{
+          type: 'tool_result',
+          toolCallId: 'call_1',
+          toolName: 'search_docs',
+          content: 'The protocol is task based.',
+        }] },
+      ],
+    }));
+
+    expect(prepared.providerRequest).toMatchObject({
+      input: [
+        { type: 'message', role: 'user', content: 'Find the task model.' },
+        { type: 'function_call', call_id: 'call_1', name: 'search_docs', arguments: '{"query":"task model"}' },
+        { type: 'function_call_output', call_id: 'call_1', name: 'search_docs', output: 'The protocol is task based.' },
+      ],
+      tools: [{
+        type: 'function',
+        name: 'search_docs',
+        description: 'Search official docs.',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+          additionalProperties: false,
+        },
+        strict: false,
+      }],
+      parallel_tool_calls: false,
+    });
+  });
+
+  it('normalizes and emits function calls through the shared event boundary', async () => {
+    const create = vi.fn().mockResolvedValue(openAIResponse({
+      output: [{
+        id: 'fc_1',
+        type: 'function_call',
+        call_id: 'call_1',
+        name: 'search_docs',
+        arguments: '{"query":"task model"}',
+        status: 'completed',
+      }],
+    }));
+    const provider = new OpenAIResponsesProvider('unused', { responses: { create } });
+    const normalized = await collectModelResponse(provider.respond(request(OPENAI_ROUTER_MODEL, {
+      tools: [{ name: 'search_docs', description: 'Search.', inputSchema: { type: 'object' } }],
+    })), 'openai');
+
+    expect(normalized).toMatchObject({
+      finishReason: 'tool_calls',
+      content: [{
+        type: 'tool_call',
+        id: 'call_1',
+        name: 'search_docs',
+        input: { query: 'task model' },
+      }],
+    });
+  });
+
+  it('round-trips function results through the normalized fixed-trace loop', async () => {
+    const create = vi.fn()
+      .mockResolvedValueOnce(openAIResponse({
+        id: 'resp_tool',
+        output: [{
+          id: 'fc_1',
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'search_docs',
+          arguments: '{"query":"task model"}',
+          status: 'completed',
+        }],
+      }))
+      .mockResolvedValueOnce(openAIResponse({
+        id: 'resp_final',
+        output: [{
+          id: 'msg_final',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'The protocol uses task-based interactions.', annotations: [] }],
+        }],
+      }));
+    const provider = new OpenAIResponsesProvider('unused', { responses: { create } });
+    const trace = FIXED_TRACE_SUITE.find((candidate) => candidate.id === 'knowledge-task-model')!;
+    const definitions = trace.toolFixtures.map((fixture) => ({
+      name: fixture.name,
+      description: `Synthetic ${fixture.name}.`,
+      replaySafety: 'pure_local' as const,
+      input_schema: fixture.name === 'search_docs'
+        ? {
+            type: 'object' as const,
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+          }
+        : {
+            type: 'object' as const,
+            properties: { doc_id: { type: 'string' } },
+            required: ['doc_id'],
+            additionalProperties: false,
+          },
+    }));
+
+    const result = await executeFixedTraceToolLoop(
+      provider,
+      request(OPENAI_ROUTER_MODEL),
+      trace,
+      definitions,
+      { maxIterations: 3 },
+    );
+
+    expect(result).toMatchObject({
+      iterations: 2,
+      text: 'The protocol uses task-based interactions.',
+      usage: { inputTokens: 20, outputTokens: 10, cacheReadTokens: 4, cacheWriteTokens: 0 },
+      tools: [{ name: 'search_docs', simulated: true, policyDisposition: 'allowed' }],
+    });
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls[1][0]).toMatchObject({
+      input: expect.arrayContaining([
+        { type: 'function_call', call_id: 'call_1', name: 'search_docs', arguments: '{"query":"task model"}' },
+        {
+          type: 'function_call_output',
+          call_id: 'call_1',
+          name: 'search_docs',
+          output: expect.stringContaining('Official docs: AdCP uses task-based interactions'),
+        },
+      ]),
+    });
+  });
+
   it('fails closed when streaming transport is requested', async () => {
     const provider = new OpenAIResponsesProvider('unused', {} as OpenAIResponsesTransport);
     await expect(collectModelResponse(
@@ -175,17 +328,39 @@ describe('OpenAIResponsesProvider', () => {
     expect(withoutRead.usage).toEqual({ inputTokens: 10, outputTokens: 5, cacheWriteTokens: 3 });
   });
 
-  it('fails closed on unsupported models, tools, cache hints, and non-text input', () => {
+  it('fails closed on unsupported models, provider tools, cache hints, and unsupported input', () => {
     const provider = new OpenAIResponsesProvider('unused', {} as OpenAIResponsesTransport);
     expect(() => provider.prepare(request('gpt-other'))).toThrow('Unsupported OpenAI router model');
-    expect(() => provider.prepare(request(OPENAI_ROUTER_MODEL, { tools: [{ name: 'x', description: 'x', inputSchema: {} }] }))).toThrow();
+    expect(() => provider.prepare(request(OPENAI_ROUTER_MODEL, { providerTools: [{ type: 'web_search' }] }))).toThrow('providerWebSearch');
     expect(() => provider.prepare(request(OPENAI_ROUTER_MODEL, { system: [{ text: 'x', cacheHint: 'ephemeral' }] }))).toThrow('cache hints');
     expect(() => provider.prepare(request(OPENAI_ROUTER_MODEL, { messages: [{ role: 'user', content: [{ type: 'image', mediaType: 'image/png', data: 'x' }] }] }))).toThrow();
+    expect(() => provider.prepare(request(OPENAI_ROUTER_MODEL, { messages: [{ role: 'user', content: [{ type: 'tool_call', id: 'x', name: 'x', input: {} }] }] }))).toThrow('does not support tool_call');
+    expect(() => provider.prepare(request(OPENAI_ROUTER_MODEL, { messages: [{ role: 'user', content: [] }] }))).toThrow('non-empty');
   });
 
   it('rejects incomplete, unexpected, and malformed responses', () => {
     expect(() => normalizeOpenAIResponse(openAIResponse({ status: 'queued' }))).toThrow('Nonterminal');
-    expect(() => normalizeOpenAIResponse(openAIResponse({ output: [{ type: 'function_call' }] }))).toThrow('Unexpected');
+    expect(() => normalizeOpenAIResponse(openAIResponse({ output: [{ type: 'function_call' }] }))).toThrow('Malformed');
+    expect(() => normalizeOpenAIResponse(openAIResponse({
+      output: [{
+        type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'search_docs',
+        arguments: 'not-json', status: 'completed',
+      }],
+    }))).toThrow('arguments');
+    expect(() => normalizeOpenAIResponse(openAIResponse({
+      output: [{
+        type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'search_docs',
+        arguments: '[]', status: 'completed',
+      }],
+    }))).toThrow('arguments');
+    expect(() => normalizeOpenAIResponse(openAIResponse({
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      output: [{
+        type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'search_docs',
+        arguments: '{}', status: 'completed',
+      }],
+    }))).toThrow('before function calls were terminal');
     expect(() => normalizeOpenAIResponse(openAIResponse({ usage: undefined }))).toThrow('usage');
     expect(normalizeOpenAIResponse(openAIResponse({
       status: 'incomplete',


### PR DESCRIPTION
## Summary
- project canonical Addie tool schemas into OpenAI Responses function tools
- normalize OpenAI function calls into the shared provider-neutral tool boundary
- round-trip stateless function-call results across model iterations
- reject malformed, truncated, namespaced, or unsupported continuation state before tool execution

## Safety
Parallel function calls remain disabled. Canonical runtime validation and the common Addie tool executor stay authoritative, and incomplete model responses can never dispatch a tool.

## Validation
- `npm run precommit` (507 server files; 7,259 passed, 30 skipped)
- provider-boundary tests: 158 passed
- `npm run test:addie-tools`
- `npm run typecheck`
- isolated unrelated flaky SI authorization test: 20 passed

Part of #6846