### PR TITLE
test(addie): run fixed traces across providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "docs:example-coverage": "node scripts/docs-example-coverage.cjs",
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs",
     "eval:addie-router-providers": "tsx --import dotenv/config server/tests/manual/provider-router-eval.ts",
+    "eval:addie-fixed-traces": "tsx --import dotenv/config server/tests/manual/fixed-trace-provider-eval.ts",
     "eval:addie-google-read-only-tools": "tsx --import dotenv/config server/tests/manual/provider-read-only-tool-loop.ts"
   },
   "dependencies": {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.67';
+export const CODE_VERSION = '2026.08.68';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -1,0 +1,245 @@
+import type {
+  ModelProvider,
+  ModelRequest,
+  ModelRespondOptions,
+  ModelUsage,
+  NormalizedModelEvent,
+  PreparedModelInvocation,
+} from '../model-providers/model-provider.js';
+
+export interface FixedTraceBudgetPricing {
+  inputUsdPerMillionTokens: number;
+  outputUsdPerMillionTokens: number;
+  source: string;
+}
+
+export type FixedTraceBudgetRejectionReason =
+  | 'budget_exposure_unknown'
+  | 'soft_limit_exceeded';
+
+export class FixedTraceBudgetAdmissionError extends Error {
+  readonly terminalStatus = 'not_dispatched_budget' as const;
+
+  constructor(
+    readonly reason: FixedTraceBudgetRejectionReason,
+    readonly prepared: PreparedModelInvocation,
+  ) {
+    super(reason);
+    this.name = 'FixedTraceBudgetAdmissionError';
+  }
+}
+
+export interface FixedTraceBudgetSnapshot {
+  policy: 'soft_admission_target';
+  softMaxUsd: number;
+  accountedSpendUsd: number;
+  reservedUsd: number;
+  remainingUsd: number | null;
+  dispatchedCalls: number;
+  completedCalls: number;
+  budgetRejectedCalls: number;
+  admissionClosed: boolean;
+  exposureUnknown: boolean;
+}
+
+interface Reservation {
+  readonly usd: number;
+  active: boolean;
+}
+
+function validatePricing(pricing: FixedTraceBudgetPricing): void {
+  if (
+    !Number.isFinite(pricing.inputUsdPerMillionTokens)
+    || pricing.inputUsdPerMillionTokens < 0
+    || !Number.isFinite(pricing.outputUsdPerMillionTokens)
+    || pricing.outputUsdPerMillionTokens < 0
+    || !pricing.source.trim()
+  ) throw new Error('Fixed trace budget pricing is invalid');
+}
+
+function requestBytes(prepared: PreparedModelInvocation): number {
+  return Buffer.byteLength(JSON.stringify(prepared.providerRequest), 'utf8');
+}
+
+function costUsd(
+  inputTokens: number,
+  outputTokens: number,
+  pricing: FixedTraceBudgetPricing,
+): number {
+  if (
+    !Number.isSafeInteger(inputTokens)
+    || inputTokens < 0
+    || !Number.isSafeInteger(outputTokens)
+    || outputTokens < 0
+  ) throw new Error('Fixed trace budget usage is invalid');
+  return (
+    inputTokens * pricing.inputUsdPerMillionTokens
+    + outputTokens * pricing.outputUsdPerMillionTokens
+  ) / 1_000_000;
+}
+
+/**
+ * Shared, serial admission state for a live fixed-trace run.
+ *
+ * Input bytes are used as a conservative token upper bound and the full output
+ * allowance is reserved before dispatch. A dispatched call without terminal
+ * usage makes total exposure unknowable, so every later call is refused.
+ */
+export class FixedTraceBudget {
+  private accountedSpendUsd = 0;
+  private reservedUsd = 0;
+  private dispatchedCalls = 0;
+  private completedCalls = 0;
+  private budgetRejectedCalls = 0;
+  private admissionClosed = false;
+  private exposureUnknown = false;
+
+  constructor(readonly softMaxUsd: number) {
+    if (!Number.isFinite(softMaxUsd) || softMaxUsd <= 0) {
+      throw new RangeError('Fixed trace soft budget must be positive');
+    }
+  }
+
+  reserve(
+    prepared: PreparedModelInvocation,
+    maxOutputTokens: number,
+    pricing: FixedTraceBudgetPricing,
+  ): Reservation {
+    validatePricing(pricing);
+    if (!Number.isSafeInteger(maxOutputTokens) || maxOutputTokens < 1) {
+      throw new RangeError('Fixed trace output reserve must be a positive integer');
+    }
+    if (this.exposureUnknown) {
+      this.budgetRejectedCalls++;
+      throw new FixedTraceBudgetAdmissionError('budget_exposure_unknown', prepared);
+    }
+    if (this.admissionClosed) {
+      this.budgetRejectedCalls++;
+      throw new FixedTraceBudgetAdmissionError('soft_limit_exceeded', prepared);
+    }
+    const usd = costUsd(requestBytes(prepared), maxOutputTokens, pricing);
+    if (this.accountedSpendUsd + this.reservedUsd + usd > this.softMaxUsd) {
+      this.admissionClosed = true;
+      this.budgetRejectedCalls++;
+      throw new FixedTraceBudgetAdmissionError('soft_limit_exceeded', prepared);
+    }
+    this.reservedUsd += usd;
+    return { usd, active: true };
+  }
+
+  markDispatched(reservation: Reservation): void {
+    this.requireActive(reservation);
+    this.dispatchedCalls++;
+  }
+
+  complete(
+    reservation: Reservation,
+    usage: ModelUsage,
+    pricing: FixedTraceBudgetPricing,
+  ): void {
+    const actualUsd = costUsd(usage.inputTokens, usage.outputTokens, pricing);
+    this.release(reservation);
+    this.accountedSpendUsd += actualUsd;
+    this.completedCalls++;
+  }
+
+  cancel(reservation: Reservation): void {
+    this.release(reservation);
+  }
+
+  markExposureUnknown(reservation: Reservation): void {
+    this.release(reservation);
+    this.exposureUnknown = true;
+  }
+
+  snapshot(): FixedTraceBudgetSnapshot {
+    return Object.freeze({
+      policy: 'soft_admission_target',
+      softMaxUsd: this.softMaxUsd,
+      accountedSpendUsd: this.accountedSpendUsd,
+      reservedUsd: this.reservedUsd,
+      remainingUsd: this.exposureUnknown
+        ? null
+        : Math.max(0, this.softMaxUsd - this.accountedSpendUsd - this.reservedUsd),
+      dispatchedCalls: this.dispatchedCalls,
+      completedCalls: this.completedCalls,
+      budgetRejectedCalls: this.budgetRejectedCalls,
+      admissionClosed: this.admissionClosed,
+      exposureUnknown: this.exposureUnknown,
+    });
+  }
+
+  private requireActive(reservation: Reservation): void {
+    if (!reservation.active) throw new Error('Fixed trace budget reservation is inactive');
+  }
+
+  private release(reservation: Reservation): void {
+    this.requireActive(reservation);
+    reservation.active = false;
+    this.reservedUsd = Math.max(0, this.reservedUsd - reservation.usd);
+  }
+}
+
+/** Model-provider decorator that applies a shared budget at the dispatch edge. */
+export class BudgetedFixedTraceProvider implements ModelProvider {
+  readonly id: ModelProvider['id'];
+  readonly capabilities: ModelProvider['capabilities'];
+  readonly deriveProviderToolReceipt?: ModelProvider['deriveProviderToolReceipt'];
+
+  constructor(
+    private readonly delegate: ModelProvider,
+    private readonly budget: FixedTraceBudget,
+    private readonly pricing: FixedTraceBudgetPricing,
+  ) {
+    validatePricing(pricing);
+    this.id = delegate.id;
+    this.capabilities = delegate.capabilities;
+    if (delegate.deriveProviderToolReceipt) {
+      this.deriveProviderToolReceipt = delegate.deriveProviderToolReceipt.bind(delegate);
+    }
+  }
+
+  prepare(request: ModelRequest): PreparedModelInvocation {
+    return this.delegate.prepare(request);
+  }
+
+  async *respond(
+    request: ModelRequest,
+    options: ModelRespondOptions = {},
+  ): AsyncIterable<NormalizedModelEvent> {
+    let reservation: Reservation | null = null;
+    let dispatchStarted = false;
+    let settled = false;
+    try {
+      for await (const event of this.delegate.respond(request, {
+        ...options,
+        beforeDispatch: async (prepared) => {
+          reservation = this.budget.reserve(prepared, request.maxOutputTokens, this.pricing);
+          try {
+            await options.beforeDispatch?.(prepared);
+          } catch (error) {
+            this.budget.cancel(reservation);
+            reservation = null;
+            throw error;
+          }
+          this.budget.markDispatched(reservation);
+          dispatchStarted = true;
+        },
+      })) {
+        if (event.type === 'response_complete') {
+          if (!reservation || !dispatchStarted) {
+            throw new Error('Fixed trace provider completed without dispatch admission');
+          }
+          this.budget.complete(reservation, event.response.usage, this.pricing);
+          settled = true;
+        }
+        yield event;
+      }
+    } finally {
+      if (reservation && !settled) {
+        if (dispatchStarted) this.budget.markExposureUnknown(reservation);
+        else this.budget.cancel(reservation);
+      }
+    }
+  }
+}

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -28,6 +28,7 @@ import {
   executeFixedTraceToolLoop,
   FixedTraceToolLoopBoundaryError,
 } from './fixed-trace-tool-loop.js';
+import { FixedTraceBudgetAdmissionError } from './fixed-trace-budget.js';
 import {
   FIXED_TRACE_SUITE,
   FIXED_TRACE_SUITE_VERSION,
@@ -133,6 +134,10 @@ function estimateCostUsd(usage: ModelUsage, pricing: FixedTracePricing): number 
     usage.inputTokens * pricing.inputUsdPerMillionTokens
     + usage.outputTokens * pricing.outputUsdPerMillionTokens
   ) / 1_000_000;
+}
+
+function reasoningRequest(effort: ModelReasoningEffort): Pick<ModelRequest, 'reasoning'> | Record<string, never> {
+  return effort === 'provider_default' ? {} : { reasoning: { effort } };
 }
 
 function modelResolution(
@@ -306,7 +311,7 @@ export function buildFixedTraceGenerationRequest(
     ],
     messages: messagesForTrace(trace),
     tools: [],
-    reasoning: { effort: config.reasoningEffort },
+    ...reasoningRequest(config.reasoningEffort),
     maxOutputTokens: config.maxOutputTokens,
     requestMetadata: {
       purpose: 'fixed_trace_generation',
@@ -369,7 +374,7 @@ async function executeRouter(
       isThread: (trace.request.threadContext?.length ?? 0) > 0,
       threadMessages: trace.request.threadContext?.map((entry) => `${entry.user}: ${entry.text}`),
     }, config.model),
-    reasoning: { effort: config.reasoningEffort },
+    ...reasoningRequest(config.reasoningEffort),
     maxOutputTokens: config.maxOutputTokens,
     requestMetadata: { purpose: 'fixed_trace_router', trace_id: trace.id },
   };
@@ -407,14 +412,20 @@ async function executeRouter(
     } catch {
       return { request, response, plan: null, output, status: 'malformed', metadata };
     }
-  } catch {
+  } catch (error) {
+    if (error instanceof FixedTraceBudgetAdmissionError) invocations.push(error.prepared);
     const state = { invocations, dispatched, latencyMs: Date.now() - startedAt };
+    const status = error instanceof FixedTraceBudgetAdmissionError
+      ? 'not_dispatched_budget'
+      : timedOut && dispatched
+        ? 'timeout_after_dispatch'
+        : 'provider_error';
     return {
       request,
       response: null,
       plan: null,
-      output: fallbackOutput(timedOut && dispatched ? 'timeout_after_dispatch' : 'provider_error'),
-      status: timedOut && dispatched ? 'timeout_after_dispatch' : 'provider_error',
+      output: fallbackOutput(status),
+      status,
       metadata: localStageMetadata(request, config, state),
     };
   } finally {
@@ -545,7 +556,10 @@ export async function runFixedTraceCase(
       tools: result.tools.map(({ sequence: _sequence, ...tool }) => tool),
     };
   } catch (error) {
-    const terminalStatus = error instanceof FixedTraceToolLoopBoundaryError
+    if (error instanceof FixedTraceBudgetAdmissionError) invocations.push(error.prepared);
+    const terminalStatus = error instanceof FixedTraceBudgetAdmissionError
+      ? 'not_dispatched_budget'
+      : error instanceof FixedTraceToolLoopBoundaryError
       ? 'malformed'
       : timedOut && dispatched
         ? 'timeout_after_dispatch'

--- a/server/tests/manual/fixed-trace-provider-eval.ts
+++ b/server/tests/manual/fixed-trace-provider-eval.ts
@@ -1,0 +1,363 @@
+/**
+ * Live synthetic fixed-trace replay across normalized providers.
+ *
+ * Production handlers and production messages are never loaded into the
+ * executor: every tool result comes from the immutable fixed-trace fixtures.
+ * The required shared soft budget admits each exact prepared request before
+ * dispatch and halts after unknown spend exposure.
+ *
+ * Example:
+ * DOTENV_CONFIG_PATH=.env.local npm run eval:addie-fixed-traces -- \
+ *   --soft-max-usd=1 --output=.context/evals/fixed-traces.json
+ */
+import { createHash, randomUUID } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { ModelConfig } from '../../src/config/models.js';
+import { CODE_VERSION, computeRouterRulesHash } from '../../src/addie/config-version.js';
+import {
+  BudgetedFixedTraceProvider,
+  FixedTraceBudget,
+  type FixedTraceBudgetPricing,
+} from '../../src/addie/eval/fixed-trace-budget.js';
+import {
+  fixedTraceToolSchemaSha256,
+  runFixedTraceCase,
+  type FixedTraceProviderStageConfig,
+  type FixedTraceRunnerConfig,
+} from '../../src/addie/eval/fixed-trace-runner.js';
+import {
+  FIXED_TRACE_SUITE,
+  FIXED_TRACE_SUITE_VERSION,
+  fixedTraceSuiteSha256,
+  summarizeFixedTraceRun,
+} from '../../src/addie/eval/fixed-trace-suite.js';
+import { AnthropicRouterProvider } from '../../src/addie/model-providers/anthropic-router-provider.js';
+import { AnthropicModelProvider } from '../../src/addie/model-providers/anthropic-provider.js';
+import type {
+  ModelProvider,
+  ModelProviderId,
+  ModelReasoningEffort,
+} from '../../src/addie/model-providers/model-provider.js';
+import {
+  OpenAIResponsesProvider,
+  OPENAI_ROUTER_MODEL,
+} from '../../src/addie/model-providers/openai-responses-provider.js';
+import {
+  GoogleGenerateContentProvider,
+  GOOGLE_ROUTER_MODEL,
+} from '../../src/addie/model-providers/google-generate-content-provider.js';
+import { loadResponseStyle, loadRules } from '../../src/addie/rules/index.js';
+import { ADMIN_TOOLS } from '../../src/addie/mcp/admin-tools.js';
+import { BILLING_TOOLS } from '../../src/addie/mcp/billing-tools.js';
+import { KNOWLEDGE_TOOLS } from '../../src/addie/mcp/knowledge-search.js';
+import { MEMBER_TOOLS } from '../../src/addie/mcp/member-tools.js';
+import type { AddieTool } from '../../src/addie/types.js';
+
+type ProviderName = ModelProviderId;
+
+interface ProviderPlan {
+  name: ProviderName;
+  router: Omit<FixedTraceProviderStageConfig, 'provider'> & { provider: ModelProvider };
+  generation: Omit<FixedTraceProviderStageConfig, 'provider'> & { provider: ModelProvider };
+}
+
+const TOOL_NAMES = new Set([
+  'search_docs',
+  'get_doc',
+  'get_my_profile',
+  'find_duplicate_orgs',
+  'send_invoice',
+  'confirm_send_invoice',
+]);
+
+const PRICING = {
+  anthropicRouter: {
+    inputUsdPerMillionTokens: 1,
+    outputUsdPerMillionTokens: 5,
+    source: 'Repository Anthropic pricing table: Claude Haiku 4.5, refreshed August 2026.',
+  },
+  anthropicGeneration: {
+    inputUsdPerMillionTokens: 3,
+    outputUsdPerMillionTokens: 15,
+    source: 'Repository Anthropic pricing table: Claude Sonnet 5 standard, refreshed August 2026.',
+  },
+  openai: {
+    inputUsdPerMillionTokens: 0.2,
+    outputUsdPerMillionTokens: 1.2,
+    source: 'OpenAI gpt-5.6-luna standard, checked 2026-08-25.',
+  },
+  google: {
+    inputUsdPerMillionTokens: 0.75,
+    outputUsdPerMillionTokens: 3.75,
+    source: 'Google Gemini 3.7 Flash introductory standard, checked 2026-08-25.',
+  },
+} satisfies Record<string, FixedTraceBudgetPricing>;
+
+function argument(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  return process.argv.find((value) => value.startsWith(prefix))?.slice(prefix.length);
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function sourceBundle(): { sha256: string; files: string[] } {
+  const trackedFiles = execFileSync('git', [
+    'ls-files', '-z', 'package.json', 'package-lock.json', 'server/src/addie',
+    'server/src/config/models.ts', 'server/tests/manual/fixed-trace-provider-eval.ts',
+  ], { encoding: 'utf8' }).split('\0').filter(Boolean).sort();
+  const files = [...new Set([
+    ...trackedFiles,
+    'server/src/addie/eval/fixed-trace-budget.ts',
+    'server/src/addie/eval/fixed-trace-runner.ts',
+    'server/tests/manual/fixed-trace-provider-eval.ts',
+  ])].sort();
+  const hash = createHash('sha256');
+  for (const file of files) {
+    hash.update(file, 'utf8').update('\0').update(readFileSync(file)).update('\0');
+  }
+  return { sha256: hash.digest('hex'), files };
+}
+
+function canonicalToolDefinitions(): AddieTool[] {
+  const definitions = [
+    ...KNOWLEDGE_TOOLS,
+    ...MEMBER_TOOLS,
+    ...ADMIN_TOOLS,
+    ...BILLING_TOOLS,
+  ].filter((tool) => TOOL_NAMES.has(tool.name));
+  const byName = new Map<string, AddieTool>();
+  for (const definition of definitions) {
+    if (byName.has(definition.name)) throw new Error(`Duplicate fixed-trace tool: ${definition.name}`);
+    byName.set(definition.name, definition);
+  }
+  const missing = [...TOOL_NAMES].filter((name) => !byName.has(name));
+  if (missing.length > 0) throw new Error(`Missing fixed-trace tools: ${missing.join(', ')}`);
+  return [...TOOL_NAMES].map((name) => byName.get(name)!);
+}
+
+function stage(
+  provider: ModelProvider,
+  model: string,
+  reasoningEffort: ModelReasoningEffort,
+  maxOutputTokens: number,
+  maxIterations: number,
+  pricing: FixedTraceBudgetPricing,
+): FixedTraceProviderStageConfig {
+  return {
+    provider,
+    model,
+    reasoningEffort,
+    maxOutputTokens,
+    timeoutMs: 120_000,
+    maxIterations,
+    samplingMode: 'provider_no_sampling_control',
+    temperature: null,
+    pricing,
+  };
+}
+
+function providerPlans(
+  names: readonly ProviderName[],
+  budget: FixedTraceBudget,
+): ProviderPlan[] {
+  const plans: ProviderPlan[] = [];
+  if (names.includes('anthropic')) {
+    if (!process.env.ANTHROPIC_API_KEY) throw new Error('ANTHROPIC_API_KEY is required');
+    if (ModelConfig.fast !== 'claude-haiku-4-5') throw new Error('Fixed traces pin Anthropic routing to claude-haiku-4-5');
+    if (ModelConfig.primary !== 'claude-sonnet-5') throw new Error('Fixed traces pin Anthropic generation to claude-sonnet-5');
+    const router = new AnthropicRouterProvider(process.env.ANTHROPIC_API_KEY, { maxRetries: 0 });
+    const generation = new AnthropicModelProvider(
+      process.env.ANTHROPIC_API_KEY,
+      undefined,
+      { transportMaxRetries: 0 },
+    );
+    plans.push({
+      name: 'anthropic',
+      router: stage(
+        new BudgetedFixedTraceProvider(router, budget, PRICING.anthropicRouter),
+        ModelConfig.fast,
+        'provider_default',
+        300,
+        1,
+        PRICING.anthropicRouter,
+      ),
+      generation: stage(
+        new BudgetedFixedTraceProvider(generation, budget, PRICING.anthropicGeneration),
+        ModelConfig.primary,
+        'provider_default',
+        900,
+        4,
+        PRICING.anthropicGeneration,
+      ),
+    });
+  }
+  if (names.includes('openai')) {
+    if (!process.env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is required');
+    const provider = new OpenAIResponsesProvider(process.env.OPENAI_API_KEY);
+    plans.push({
+      name: 'openai',
+      router: stage(
+        new BudgetedFixedTraceProvider(provider, budget, PRICING.openai),
+        OPENAI_ROUTER_MODEL,
+        'none',
+        300,
+        1,
+        PRICING.openai,
+      ),
+      generation: stage(
+        new BudgetedFixedTraceProvider(provider, budget, PRICING.openai),
+        OPENAI_ROUTER_MODEL,
+        'none',
+        900,
+        4,
+        PRICING.openai,
+      ),
+    });
+  }
+  if (names.includes('google')) {
+    if (!process.env.GEMINI_API_KEY) throw new Error('GEMINI_API_KEY is required');
+    const provider = new GoogleGenerateContentProvider(process.env.GEMINI_API_KEY);
+    plans.push({
+      name: 'google',
+      router: stage(
+        new BudgetedFixedTraceProvider(provider, budget, PRICING.google),
+        GOOGLE_ROUTER_MODEL,
+        'low',
+        1_200,
+        1,
+        PRICING.google,
+      ),
+      generation: stage(
+        new BudgetedFixedTraceProvider(provider, budget, PRICING.google),
+        GOOGLE_ROUTER_MODEL,
+        'low',
+        1_200,
+        4,
+        PRICING.google,
+      ),
+    });
+  }
+  return plans;
+}
+
+const providerNames = (argument('providers') ?? 'anthropic,openai,google').split(',') as ProviderName[];
+if (providerNames.some((name) => !['anthropic', 'openai', 'google'].includes(name))) {
+  throw new Error('Unknown --providers value');
+}
+if (new Set(providerNames).size !== providerNames.length || providerNames.length === 0) {
+  throw new Error('--providers must contain one or more unique providers');
+}
+const softMaxUsd = Number(argument('soft-max-usd'));
+if (!Number.isFinite(softMaxUsd) || softMaxUsd <= 0) {
+  throw new Error('--soft-max-usd is required and must be positive');
+}
+const outputArgument = argument('output');
+if (!outputArgument?.trim()) throw new Error('--output is required');
+const outputPath = resolve(outputArgument);
+
+const gitCommit = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+const gitDirty = execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' }).trim().length > 0;
+const sources = sourceBundle();
+const promptConfigVersion = sha256(JSON.stringify({
+  codeVersion: CODE_VERSION,
+  routerRulesHash: computeRouterRulesHash(),
+  rules: loadRules(),
+  responseStyle: loadResponseStyle(),
+}));
+const toolDefinitions = canonicalToolDefinitions();
+const toolSchemaSha256 = fixedTraceToolSchemaSha256(toolDefinitions);
+const budget = new FixedTraceBudget(softMaxUsd);
+const plans = providerPlans(providerNames, budget);
+const runStartedAt = new Date().toISOString();
+const runRootId = `fixed-trace-${runStartedAt}-${randomUUID()}`;
+const runs = [];
+
+for (const plan of plans) {
+  const baseConfig: FixedTraceRunnerConfig = {
+    runId: `${runRootId}-${plan.name}`,
+    sourceBundleSha256: sources.sha256,
+    gitCommit,
+    gitDirty,
+    promptConfigVersion,
+    toolDefinitions,
+    router: plan.router,
+    generation: plan.generation,
+  };
+  const observations = [];
+  for (const trace of FIXED_TRACE_SUITE) {
+    const traceConfig = trace.category === 'truncation'
+      ? {
+          ...baseConfig,
+          generation: { ...baseConfig.generation, maxOutputTokens: 32 },
+        }
+      : baseConfig;
+    observations.push(await runFixedTraceCase(trace, traceConfig, toolSchemaSha256));
+  }
+  const evaluated = summarizeFixedTraceRun(observations);
+  runs.push({
+    provider: plan.name,
+    requestedConfig: {
+      router: {
+        provider: plan.router.provider.id,
+        model: plan.router.model,
+        reasoningEffort: plan.router.reasoningEffort,
+        maxOutputTokens: plan.router.maxOutputTokens,
+        timeoutMs: plan.router.timeoutMs,
+        maxIterations: plan.router.maxIterations,
+        pricing: plan.router.pricing,
+      },
+      generation: {
+        provider: plan.generation.provider.id,
+        model: plan.generation.model,
+        reasoningEffort: plan.generation.reasoningEffort,
+        maxOutputTokens: plan.generation.maxOutputTokens,
+        truncationMaxOutputTokens: 32,
+        timeoutMs: plan.generation.timeoutMs,
+        maxIterations: plan.generation.maxIterations,
+        pricing: plan.generation.pricing,
+      },
+    },
+    ...evaluated,
+    observations,
+  });
+}
+
+const budgetState = budget.snapshot();
+const artifact = {
+  artifactVersion: 'fixed_trace_provider_eval_v1',
+  runRootId,
+  runStartedAt,
+  runCompletedAt: new Date().toISOString(),
+  traceSuiteVersion: FIXED_TRACE_SUITE_VERSION,
+  traceSuiteSha256: fixedTraceSuiteSha256(),
+  traceCount: FIXED_TRACE_SUITE.length,
+  sourceBundleSha256: sources.sha256,
+  sourceBundleFiles: sources.files,
+  gitCommit,
+  gitDirty,
+  addieCodeVersion: CODE_VERSION,
+  promptConfigVersion,
+  toolSchemaSha256,
+  requestedProviders: providerNames,
+  budget: budgetState,
+  budgetNote: 'Soft admission target: exact prepared-request bytes and the full output allowance are reserved before each dispatch. Remote work may continue after a client timeout; any dispatched call without terminal usage marks exposure unknown and blocks every later dispatch.',
+  complete: runs.every((run) => run.summary.complete),
+  comparisonEligible: runs.every((run) => run.summary.comparisonEligible)
+    && !budgetState.exposureUnknown
+    && !budgetState.admissionClosed,
+  runs,
+};
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, `${JSON.stringify(artifact, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
+console.log(JSON.stringify({
+  outputPath,
+  runRootId,
+  providers: providerNames,
+  comparisonEligible: artifact.comparisonEligible,
+  budget: budgetState,
+}, null, 2));

--- a/server/tests/unit/addie/fixed-trace-budget.test.ts
+++ b/server/tests/unit/addie/fixed-trace-budget.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  BudgetedFixedTraceProvider,
+  FixedTraceBudget,
+  FixedTraceBudgetAdmissionError,
+} from '../../../src/addie/eval/fixed-trace-budget.js';
+import { collectModelResponse } from '../../../src/addie/model-providers/events.js';
+import type {
+  ModelProvider,
+  ModelProviderCapabilities,
+  ModelRequest,
+  ModelRespondOptions,
+  ModelResponse,
+  NormalizedModelEvent,
+  PreparedModelInvocation,
+} from '../../../src/addie/model-providers/model-provider.js';
+
+const CAPABILITIES: ModelProviderCapabilities = {
+  streaming: false,
+  structuredOutput: false,
+  reasoning: false,
+  reasoningEfforts: [],
+  customTools: false,
+  providerWebSearch: false,
+  imageInput: false,
+  documentInput: false,
+};
+
+const REQUEST: ModelRequest = {
+  model: 'budget-model',
+  system: [],
+  messages: [{ role: 'user', content: [{ type: 'text', text: 'Synthetic request.' }] }],
+  tools: [],
+  maxOutputTokens: 100,
+};
+
+const RESPONSE: ModelResponse = {
+  provider: 'openai',
+  model: 'budget-model',
+  id: 'response-1',
+  content: [{ type: 'text', text: 'Synthetic response.' }],
+  finishReason: 'stop',
+  providerFinishReason: 'completed',
+  usage: { inputTokens: 10, outputTokens: 5 },
+};
+
+const PRICING = {
+  inputUsdPerMillionTokens: 1,
+  outputUsdPerMillionTokens: 5,
+  source: 'Synthetic budget pricing.',
+};
+
+class BudgetScriptedProvider implements ModelProvider {
+  readonly id = 'openai' as const;
+  readonly capabilities = CAPABILITIES;
+  readonly dispatches = vi.fn();
+
+  constructor(private readonly script: Array<ModelResponse | Error>) {}
+
+  prepare(request: ModelRequest): PreparedModelInvocation {
+    return {
+      provider: this.id,
+      model: request.model,
+      capabilities: this.capabilities,
+      providerRequest: { model: request.model, input: request.messages },
+    };
+  }
+
+  async *respond(
+    request: ModelRequest,
+    options: ModelRespondOptions = {},
+  ): AsyncIterable<NormalizedModelEvent> {
+    await options.beforeDispatch?.(this.prepare(request));
+    this.dispatches();
+    const next = this.script.shift();
+    if (!next) throw new Error('Script exhausted');
+    if (next instanceof Error) throw next;
+    yield { type: 'response_start', provider: this.id, model: next.model, id: next.id };
+    yield { type: 'text_delta', index: 0, text: 'Synthetic response.' };
+    yield { type: 'response_complete', response: next };
+  }
+}
+
+describe('fixed trace provider budget', () => {
+  it('rejects over-budget work before provider dispatch', async () => {
+    const delegate = new BudgetScriptedProvider([RESPONSE]);
+    const budget = new FixedTraceBudget(0.000001);
+    const provider = new BudgetedFixedTraceProvider(delegate, budget, PRICING);
+
+    await expect(collectModelResponse(provider.respond(REQUEST))).rejects.toMatchObject({
+      name: 'FixedTraceBudgetAdmissionError',
+      reason: 'soft_limit_exceeded',
+      terminalStatus: 'not_dispatched_budget',
+    });
+    expect(delegate.dispatches).not.toHaveBeenCalled();
+    expect(budget.snapshot()).toMatchObject({
+      accountedSpendUsd: 0,
+      dispatchedCalls: 0,
+      completedCalls: 0,
+      budgetRejectedCalls: 1,
+      admissionClosed: true,
+      exposureUnknown: false,
+    });
+  });
+
+  it('releases the reserve and accounts terminal usage', async () => {
+    const delegate = new BudgetScriptedProvider([RESPONSE]);
+    const budget = new FixedTraceBudget(1);
+    const provider = new BudgetedFixedTraceProvider(delegate, budget, PRICING);
+
+    await expect(collectModelResponse(provider.respond(REQUEST))).resolves.toEqual(RESPONSE);
+    expect(budget.snapshot()).toMatchObject({
+      accountedSpendUsd: 0.000035,
+      reservedUsd: 0,
+      dispatchedCalls: 1,
+      completedCalls: 1,
+      budgetRejectedCalls: 0,
+      exposureUnknown: false,
+    });
+  });
+
+  it('halts later calls after a dispatched response has unknown usage', async () => {
+    const delegate = new BudgetScriptedProvider([new Error('transport failed'), RESPONSE]);
+    const budget = new FixedTraceBudget(1);
+    const provider = new BudgetedFixedTraceProvider(delegate, budget, PRICING);
+
+    await expect(collectModelResponse(provider.respond(REQUEST))).rejects.toThrow('transport failed');
+    expect(budget.snapshot()).toMatchObject({
+      dispatchedCalls: 1,
+      completedCalls: 0,
+      exposureUnknown: true,
+    });
+    await expect(collectModelResponse(provider.respond(REQUEST))).rejects.toBeInstanceOf(
+      FixedTraceBudgetAdmissionError,
+    );
+    expect(delegate.dispatches).toHaveBeenCalledTimes(1);
+    expect(budget.snapshot().budgetRejectedCalls).toBe(1);
+  });
+
+  it('treats malformed terminal usage as unknown exposure', async () => {
+    const delegate = new BudgetScriptedProvider([{
+      ...RESPONSE,
+      usage: { inputTokens: -1, outputTokens: 5 },
+    }]);
+    const budget = new FixedTraceBudget(1);
+    const provider = new BudgetedFixedTraceProvider(delegate, budget, PRICING);
+
+    await expect(collectModelResponse(provider.respond(REQUEST))).rejects.toThrow(
+      'Fixed trace budget usage is invalid',
+    );
+    expect(budget.snapshot()).toMatchObject({
+      reservedUsd: 0,
+      remainingUsd: null,
+      dispatchedCalls: 1,
+      completedCalls: 0,
+      exposureUnknown: true,
+    });
+  });
+
+  it('does not mark exposure unknown when the caller hook blocks dispatch', async () => {
+    const delegate = new BudgetScriptedProvider([RESPONSE]);
+    const budget = new FixedTraceBudget(1);
+    const provider = new BudgetedFixedTraceProvider(delegate, budget, PRICING);
+
+    await expect(collectModelResponse(provider.respond(REQUEST, {
+      beforeDispatch: () => { throw new Error('local policy rejected'); },
+    }))).rejects.toThrow('local policy rejected');
+    expect(delegate.dispatches).not.toHaveBeenCalled();
+    expect(budget.snapshot()).toMatchObject({
+      reservedUsd: 0,
+      dispatchedCalls: 0,
+      exposureUnknown: false,
+    });
+  });
+});

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -7,6 +7,10 @@ import {
   type FixedTraceRunnerConfig,
 } from '../../../src/addie/eval/fixed-trace-runner.js';
 import {
+  BudgetedFixedTraceProvider,
+  FixedTraceBudget,
+} from '../../../src/addie/eval/fixed-trace-budget.js';
+import {
   FIXED_TRACE_SUITE,
   gradeFixedTrace,
   type FixedTraceCase,
@@ -37,7 +41,7 @@ const CAPABILITIES: ModelProviderCapabilities = {
 
 class ScriptedProvider implements ModelProvider {
   readonly id = 'anthropic' as const;
-  readonly capabilities = CAPABILITIES;
+  readonly capabilities: ModelProviderCapabilities;
   readonly prepare = vi.fn((request: ModelRequest): PreparedModelInvocation => ({
     provider: this.id,
     model: request.model,
@@ -47,7 +51,12 @@ class ScriptedProvider implements ModelProvider {
   }));
   readonly respondCalls: ModelRequest[] = [];
 
-  constructor(private readonly script: Array<ModelResponse | Error>) {}
+  constructor(
+    private readonly script: Array<ModelResponse | Error>,
+    capabilities: ModelProviderCapabilities = CAPABILITIES,
+  ) {
+    this.capabilities = capabilities;
+  }
 
   async *respond(
     request: ModelRequest,
@@ -236,6 +245,54 @@ describe('fixed trace artifact runner', () => {
     });
     expect(generation.respondCalls).toHaveLength(0);
     expect(gradeFixedTrace(selectedTrace, observation).deterministicPass).toBe(true);
+  });
+
+  it('omits provider-default reasoning from adapters without reasoning support', async () => {
+    const router = new ScriptedProvider([routeResponse('ignore')], {
+      ...CAPABILITIES,
+      reasoning: false,
+      reasoningEfforts: [],
+    });
+    const generation = new ScriptedProvider([]);
+    const selectedTrace = trace('surface-channel-chatter');
+    const runConfig = config(router, generation);
+    runConfig.router.reasoningEffort = 'provider_default';
+
+    await runFixedTraceCase(selectedTrace, runConfig);
+
+    expect(router.respondCalls[0].reasoning).toBeUndefined();
+  });
+
+  it('records budget admission refusal as not dispatched', async () => {
+    const delegate = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const budget = new FixedTraceBudget(0.000001);
+    const router = new BudgetedFixedTraceProvider(delegate, budget, {
+      inputUsdPerMillionTokens: 1,
+      outputUsdPerMillionTokens: 5,
+      source: 'Synthetic test pricing.',
+    });
+    const generation = new ScriptedProvider([]);
+
+    const observation = await runFixedTraceCase(
+      trace('knowledge-task-model'),
+      config(router, generation),
+    );
+
+    expect(observation).toMatchObject({
+      terminalStage: 'router',
+      terminalStatus: 'not_dispatched_budget',
+      output: '',
+      flagged: true,
+      metadata: {
+        router: {
+          source: 'local',
+          dispatched: false,
+          estimatedCostUsd: 0,
+        },
+      },
+    });
+    expect(delegate.respondCalls).toHaveLength(0);
+    expect(gradeFixedTrace(trace('knowledge-task-model'), observation).metadataPass).toBe(true);
   });
 
   it('attributes malformed router output to the router and preserves its cost', async () => {


### PR DESCRIPTION
## Summary
- add a live fixed-trace CLI for the normalized Anthropic, OpenAI, and Google provider adapters
- enforce one shared pre-dispatch soft budget and fail closed when remote cost exposure becomes unknown
- replay only inert synthetic fixture tools; production tool handlers are never invoked
- persist complete provider/model/config, request, source, prompt, tool, cost, latency, output, and grade provenance
- omit provider-default reasoning from prepared requests for adapters that do not support reasoning configuration

## Safety
- `--soft-max-usd` and an exclusive output path are required
- retries are disabled and the shared budget spans router and generation calls across every selected provider
- a timeout, dispatch error, missing terminal response, or malformed usage closes later admissions
- no paid live provider calls were made while developing this PR; the bounded comparison run follows the merged gates

## Validation
- focused fixed-trace tests: 13 passed
- `npm run typecheck`
- `npm run test:addie-tools`: 249 tools across 23 sets
- no-dispatch CLI smoke: 11 observations, 0 dispatches, 100% metadata pass rate
- staged `npm run precommit`: 508 files passed; 7,267 tests passed; 30 skipped

Part of #6846