### PR TITLE
fix(addie): upgrade SDK to beta 15

### DIFF
--- a/.agents/sdk-shim-ledger.json
+++ b/.agents/sdk-shim-ledger.json
@@ -58,5 +58,22 @@
       "node_modules/@adcp/sdk/dist/lib/negotiation/verification.js",
       "node_modules/@adcp/sdk/dist/lib/negotiation/verification.mjs"
     ]
+  },
+  {
+    "id": "beta15-macro-url-zod-workaround",
+    "title": "SDK beta.15 macro-bearing URL Zod workaround",
+    "kind": "sdk_generated_validator_bypass",
+    "status": "temporary",
+    "owner": "compliance",
+    "upstream": "adcontextprotocol/adcp-client#2738",
+    "problem": "SDK 14 beta.15 generates macro-bearing URL schemas as an impossible intersection of object-only unions with strings, rejecting valid DAAST and pixel-tracker assets.",
+    "localBehavior": "The current storyboard runner resolves the staged SDK JSON Schema bundle and passes it through the public schemaRoot option instead of using the broken generated Zod snapshot.",
+    "removalCondition": "Remove when a published SDK generates valid string-based macro-bearing URL validators and the current creative storyboard lane passes without an explicit staged schemaRoot.",
+    "paths": [
+      "server/tests/manual/run-storyboards.ts"
+    ],
+    "terms": [
+      "'dist', 'lib', 'schemas-data'"
+    ]
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.2.0-beta.9",
       "dependencies": {
-        "@adcp/sdk": "14.0.0-beta.13",
+        "@adcp/sdk": "14.0.0-beta.15",
         "@anthropic-ai/sdk": "^0.120.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.9.1",
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "14.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-14.0.0-beta.13.tgz",
-      "integrity": "sha512-LU/4VrL1BQDoWrMVxDPg0yUU+7yyepTQlX+5BSS2EwERYGMOzS/P1tYIUU3wNptilDFfz6BIyJ/KnWa1WLV2cQ==",
+      "version": "14.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-14.0.0-beta.15.tgz",
+      "integrity": "sha512-jD00OQON5eSt4KXZscuTFlqsxMlUmBHv/g98chj/WpLrSL8Yux/JMqVeMYmcGDG4+4CZTadRWN4i1qt+ZFTrQQ==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -163,7 +163,7 @@
         "adcp": "bin/adcp.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
         "@a2a-js/sdk": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "eval:addie-google-read-only-tools": "tsx --import dotenv/config server/tests/manual/provider-read-only-tool-loop.ts"
   },
   "dependencies": {
-    "@adcp/sdk": "14.0.0-beta.13",
+    "@adcp/sdk": "14.0.0-beta.15",
     "@anthropic-ai/sdk": "^0.120.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.9.1",

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -3024,7 +3024,7 @@ Tell ${codingTool}: "Build a buyer agent using @adcp/sdk that connects to the pu
 
 The SDK handles protocol details — the learner focuses on orchestration logic.
 
-Use the exact 3.2 beta.6 wire pin with @adcp/sdk@14.0.0-beta.12 for the targeting-aware discovery portion. Decompose one messy request into brief plus criteria.offer_filters, criteria.targeting_overlay, and criteria.required_overlay_support; verify that unsupported future-selection requirements filter products; review any targeting_resolution.modifications before purchase; and verify effective package targeting on readback. Treat the get_products compatibility facade's equivalent fields as compatibility evidence, not as proof that the compact tasks work.
+Use the exact 3.2 beta.6 wire pin with @adcp/sdk@14.0.0-beta.15 for the targeting-aware discovery portion. Decompose one messy request into brief plus criteria.offer_filters, criteria.targeting_overlay, and criteria.required_overlay_support; verify that unsupported future-selection requirements filter products; review any targeting_resolution.modifications before purchase; and verify effective package targeting on readback. Treat the get_products compatibility facade's equivalent fields as compatibility evidence, not as proof that the compact tasks work.
 
 Reference: ${SDKS_URL}
 
@@ -3039,7 +3039,7 @@ Validate in two parts.
 
 1. Run the compatibility buying workflow against the public test agent and share the output. Use the \`adcp\` CLI:
 \`\`\`
-npx @adcp/sdk@14.0.0-beta.12 test-mcp get_products '{"adcp_version":"3.2-beta.6","buying_mode":"brief","brief":"<your campaign brief>"}'
+npx @adcp/sdk@14.0.0-beta.15 test-mcp get_products '{"adcp_version":"3.2-beta.8","buying_mode":"brief","brief":"<your campaign brief>"}'
 \`\`\`
 
 Replace \`<your campaign brief>\` with your actual brief. Then run the full buying flow: get_products (select a canonical \`format_options[]\` entry) → create_media_buy → get_adcp_capabilities on the chosen creative endpoint → sync_creatives with \`format_kind\` and optional \`format_option_ref\`.

--- a/server/src/training-agent/FRAMEWORK_MIGRATION.md
+++ b/server/src/training-agent/FRAMEWORK_MIGRATION.md
@@ -60,7 +60,7 @@ working during the 3.x compatibility window.
   proposal negotiation is a 3.2 feature.
 - Capability projection removes lifecycle and proposal-refinement metadata for
   pre-3.2 callers.
-- The current wire bundle is `3.2-beta.6`; `3.2-beta.0` remains only as the
+- The current wire bundle is `3.2-beta.8`; `3.2-beta.0` remains only as the
   historical feature-introduction boundary for rejected discovery responses.
 
 ## Invariants for future changes

--- a/server/src/training-agent/comply-test-controller.ts
+++ b/server/src/training-agent/comply-test-controller.ts
@@ -35,7 +35,11 @@ import type {
   ComplyBudgetSimulation,
   SeededProductAvailability,
 } from './types.js';
-import { supportsAccountChangeFeed, supportsGetProductsRejected } from './types.js';
+import {
+  supportsAccountChangeFeed,
+  supportsGetProductsRejected,
+  TRAINING_AGENT_CURRENT_ADCP_VERSION,
+} from './types.js';
 import {
   findSessionsMatching,
   findSessionMatching,
@@ -1585,7 +1589,7 @@ function localScenariosFor(ctx: TrainingContext): string[] {
   const scenarios = ctx.storyboardCompat?.version === '3.0'
     ? LOCAL_SCENARIOS.filter(s => s !== 'force_creative_purge' && s !== 'force_wholesale_feed_webhook' && s !== 'seed_rights_grant' && s !== 'query_provenance_audit_observations' && s !== 'query_account_governance_binding')
     : [...LOCAL_SCENARIOS];
-  return supportsAccountChangeFeed(ctx.servedAdcpVersion ?? '3.2-beta.6')
+  return supportsAccountChangeFeed(ctx.servedAdcpVersion ?? TRAINING_AGENT_CURRENT_ADCP_VERSION)
     ? scenarios
     : scenarios.filter(s => s !== 'expire_account_change_cursor');
 }
@@ -1909,7 +1913,7 @@ export async function handleComplyTestController(args: ToolArgs, ctx: TrainingCo
     return handleForceTaskCompletion(completionScope, rawArgs);
   }
   if (scenario === 'expire_account_change_cursor') {
-    if (!supportsAccountChangeFeed(ctx.servedAdcpVersion ?? '3.2-beta.6')) {
+    if (!supportsAccountChangeFeed(ctx.servedAdcpVersion ?? TRAINING_AGENT_CURRENT_ADCP_VERSION)) {
       return {
         success: false,
         error: 'UNKNOWN_SCENARIO',

--- a/server/src/training-agent/product-factory.ts
+++ b/server/src/training-agent/product-factory.ts
@@ -39,7 +39,7 @@ type CanonicalFormatProjection = {
   params: ProductFormatDeclaration['params'];
 };
 type TrainingProduct = Omit<Product,
-  'product_card' | 'product_card_detailed' | 'collections' | 'installments'
+  'product_card' | 'product_card_detailed' | 'collections' | 'installments' | 'audience_activation'
 > & {
   product_card?: Product['product_card'] | ProductCardManifest;
   product_card_detailed?: Product['product_card_detailed'] | ProductCardManifest;

--- a/server/src/training-agent/schema-compat.ts
+++ b/server/src/training-agent/schema-compat.ts
@@ -1,0 +1,40 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { SELLER_GOVERNANCE_DISCOVERY_ADCP_VERSION } from './types.js';
+
+const RETAINED_SCHEMA_BUNDLE = '3.2.0-beta.6';
+
+let registration: Promise<void> | undefined;
+
+function retainedSchemaRoot(): string {
+  // TypeScript executes from server/src during local development and from
+  // dist/server/src after compilation. The committed release bundle lives in
+  // dist/schemas in both cases, so check the corresponding module-relative
+  // location for each layout.
+  const candidates = [
+    fileURLToPath(new URL(`../../../schemas/${RETAINED_SCHEMA_BUNDLE}/`, import.meta.url)),
+    fileURLToPath(new URL(`../../../dist/schemas/${RETAINED_SCHEMA_BUNDLE}/`, import.meta.url)),
+  ];
+  const root = candidates.find(candidate => existsSync(candidate));
+  if (!root) {
+    throw new Error(
+      `Training-agent schema bundle ${RETAINED_SCHEMA_BUNDLE} is missing; checked ${candidates.join(', ')}`,
+    );
+  }
+  return root;
+}
+
+/**
+ * Register the training agent's retained beta.6 checkpoint with SDK builds
+ * that only package their own latest prerelease schema.
+ *
+ * This is deliberately lazy: @adcp/sdk/testing owns the public external-root
+ * API, but the rest of that entry point is unnecessary unless the training
+ * agent is actually used.
+ */
+export function ensureTrainingAgentSchemaBundle(): Promise<void> {
+  registration ??= import('@adcp/sdk/testing').then(({ registerExternalSchemaRoot }) => {
+    registerExternalSchemaRoot(SELLER_GOVERNANCE_DISCOVERY_ADCP_VERSION, retainedSchemaRoot());
+  });
+  return registration;
+}

--- a/server/src/training-agent/seller-managed-control-jobs.ts
+++ b/server/src/training-agent/seller-managed-control-jobs.ts
@@ -3,6 +3,7 @@ import {
   AdcpError,
   type AdcpStructuredError,
   type IdempotencyStore,
+  type ScopedTaskRef,
   type TaskRegistry,
   type TaskRegistryScope,
 } from '@adcp/sdk/server';
@@ -613,38 +614,73 @@ export interface SellerManagedReplayTaskRegistry extends TaskRegistry {
  * replayed; every other collision retains the SDK's fail-closed behavior. */
 export function withSellerManagedTaskReplay(registry: TaskRegistry): SellerManagedReplayTaskRegistry {
   const authorizedOwners = new Map<string, string>();
+  const taskRefs = new Map<string, ScopedTaskRef>();
+
+  const aliasedScope = (taskId: string, scope: TaskRegistryScope): TaskRegistryScope => {
+    const taskRef = taskRefs.get(taskId);
+    return taskRef?.accountId === scope.accountId
+      && authorizedOwners.get(taskId) === scope.ownerScope
+      ? taskRef
+      : scope;
+  };
+
   return {
     ...registry,
+    get registryId() {
+      return registry.registryId;
+    },
     async authorizeSellerManagedReplay(opts) {
-      const existing = await registry._getTaskUnsafe(opts.taskId);
+      let taskRef = taskRefs.get(opts.taskId);
+      let existing = taskRef
+        ? await registry.getTask(opts.taskId, taskRef)
+        : null;
+      if (!existing) {
+        const reboundRef: ScopedTaskRef = {
+          taskId: opts.taskId,
+          accountId: opts.accountId,
+          ownerScope: opts.ownerScope,
+          ...(registry.registryId && { registryId: registry.registryId }),
+        };
+        existing = await registry.getTask(opts.taskId, reboundRef);
+        if (existing) taskRef = reboundRef;
+      }
       if (existing && (existing.tool !== 'control_media_buy' || existing.accountId !== opts.accountId)) {
+        throw new Error(`Seller-managed task replay scope mismatch: ${opts.taskId}`);
+      }
+      if (!existing || !taskRef) {
         throw new Error(`Seller-managed task replay scope mismatch: ${opts.taskId}`);
       }
       // Production ownership is atomically rebound in the durable store. The
       // projection is also required for the SDK in-memory registry used by
       // tests and local development, which intentionally exposes no mutation
       // method for task metadata.
+      taskRefs.set(opts.taskId, taskRef);
       authorizedOwners.set(opts.taskId, opts.ownerScope);
     },
     async create(opts) {
       if (opts.overrideTaskId?.startsWith('smc_')) {
-        const existing = await registry._getTaskUnsafe(opts.overrideTaskId);
-        if (existing) {
+        const taskRef = taskRefs.get(opts.overrideTaskId);
+        const existing = taskRef
+          ? await registry.getTask(opts.overrideTaskId, taskRef)
+          : null;
+        if (existing && taskRef) {
           const ownerScope = opts.ownerScope ?? `account:${opts.accountId}`;
           const authorizedOwner = authorizedOwners.get(opts.overrideTaskId);
           if (existing.tool !== opts.tool || existing.accountId !== opts.accountId
             || (existing.ownerScope !== ownerScope && authorizedOwner !== ownerScope)) {
             throw new Error(`Seller-managed task replay scope mismatch: ${opts.overrideTaskId}`);
           }
-          return { taskId: existing.taskId };
+          return { ...taskRef, ownerScope };
         }
       }
-      return await registry.create(opts);
+      const taskRef = await registry.create(opts);
+      if (taskRef.taskId.startsWith('smc_')) taskRefs.set(taskRef.taskId, taskRef);
+      return taskRef;
     },
     async getTask<TResult = unknown>(taskId: string, scope: TaskRegistryScope) {
       const authorizedOwner = authorizedOwners.get(taskId);
       const existing = authorizedOwner === scope.ownerScope
-        ? await registry._getTaskUnsafe<TResult>(taskId)
+        ? await registry.getTask<TResult>(taskId, aliasedScope(taskId, scope))
         : await registry.getTask<TResult>(taskId, scope);
       const ownerScope = authorizedOwners.get(taskId);
       return existing && ownerScope === scope.ownerScope && existing.accountId === scope.accountId
@@ -657,10 +693,33 @@ export function withSellerManagedTaskReplay(registry: TaskRegistry): SellerManag
         const tasks = [...listed.tasks];
         for (const [taskId, ownerScope] of authorizedOwners) {
           if (ownerScope !== opts.ownerScope || tasks.some(task => task.taskId === taskId)) continue;
-          const task = await registry._getTaskUnsafe(taskId);
+          const taskRef = taskRefs.get(taskId);
+          const task = taskRef ? await registry.getTask(taskId, taskRef) : null;
           if (task?.accountId === opts.accountId) tasks.push({ ...task, ownerScope });
         }
         return { tasks };
+      },
+    }),
+    async complete(taskId, scope, result) {
+      return await registry.complete(taskId, aliasedScope(taskId, scope), result);
+    },
+    async fail(taskId, scope, error, result) {
+      return await registry.fail(taskId, aliasedScope(taskId, scope), error, result);
+    },
+    async updateProgress(taskId, scope, progress) {
+      return await registry.updateProgress(taskId, aliasedScope(taskId, scope), progress);
+    },
+    _registerBackground(taskId, scope, completion) {
+      registry._registerBackground(taskId, aliasedScope(taskId, scope), completion);
+    },
+    async awaitTask(taskId, scope) {
+      await registry.awaitTask(taskId, aliasedScope(taskId, scope));
+    },
+    ...(registry.clear && {
+      async clear() {
+        authorizedOwners.clear();
+        taskRefs.clear();
+        await registry.clear!();
       },
     }),
   };

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -88,7 +88,7 @@ import type {
   ProposalPurchase,
   RefineProposalsRequest,
 } from '@adcp/sdk';
-import { CreativeAssetSchema, CreativeManifestSchema, GetProductsRequestSchema } from '@adcp/sdk/schemas';
+import { CreativeAssetSchema, GetProductsRequestSchema } from '@adcp/sdk/schemas';
 import { verifyGovernedServiceAuthorization } from './governance-verify.js';
 import { getCanonicalBase } from './canonical-base.js';
 import { validateProtocolSchema } from '../services/protocol-schema-validator.js';
@@ -10973,24 +10973,24 @@ function jsonPointerPath(pointer: string): Array<string | number> {
 }
 
 async function validateManifestSchema(manifest: NonNullable<ValidateInputArgs['manifest']>): Promise<ValidateInputViolation[]> {
-  if (manifest.format_kind === 'seller_rendered_stateful_display'
-    || manifest.format_kind === 'coordinated_placements'
-    || manifest.component_assets !== undefined) {
-    const result = await validateProtocolSchema('/schemas/core/creative-manifest.json', manifest);
-    return result.errors.map(issue => ({
-      rule: 'schema',
-      field: schemaIssueField(jsonPointerPath(issue.instancePath)),
-      expected: issue.message ?? 'valid creative manifest',
-      predicted: issue.keyword,
-    }));
-  }
-  const parsed = CreativeManifestSchema.safeParse(manifest);
-  if (parsed.success) return [];
-  return parsed.error.issues.map(issue => ({
+  // The protocol JSON Schema is authoritative. SDK 14 beta.15's generated
+  // Zod snapshot accidentally intersects macro-bearing URL strings with
+  // object-only branches, which rejects valid DAAST and tracker assets.
+  // WHATWG URL parsing accepts the Unicode full-stop variants as DNS label
+  // separators, while AJV's URI format check does not. Normalize only the
+  // schema-validation copy so the later URL safety checks still inspect the
+  // caller's original value.
+  const schemaValue = JSON.parse(JSON.stringify(manifest, (_key, value: unknown) => (
+    typeof value === 'string' && value.includes('://')
+      ? value.replace(/[。．｡]/g, '.')
+      : value
+  ))) as typeof manifest;
+  const result = await validateProtocolSchema('/schemas/core/creative-manifest.json', schemaValue);
+  return result.errors.map(issue => ({
     rule: 'schema',
-    field: schemaIssueField(issue.path.filter((part): part is string | number => typeof part === 'string' || typeof part === 'number')),
-    expected: issue.message,
-    predicted: issue.code,
+    field: schemaIssueField(jsonPointerPath(issue.instancePath)),
+    expected: issue.message ?? 'valid creative manifest',
+    predicted: issue.keyword,
   }));
 }
 

--- a/server/src/training-agent/tenants/registry.ts
+++ b/server/src/training-agent/tenants/registry.ts
@@ -56,6 +56,7 @@ import { getCanonicalBase } from '../canonical-base.js';
 import { creativeProjectionAdapters } from '../task-handlers.js';
 import { sharedTrainingTaskStore } from '../mcp-task-store.js';
 import { taskRegistryNamespaceForTenant } from '../task-registry-scope.js';
+import { ensureTrainingAgentSchemaBundle } from '../schema-compat.js';
 
 export { getCanonicalBase } from '../canonical-base.js';
 
@@ -278,6 +279,7 @@ export function createRegistryHolder(options: {
       if (registry) return registry;
       if (pendingInit) return pendingInit;
       const promise = (async () => {
+        await ensureTrainingAgentSchemaBundle();
         const t0 = Date.now();
         logger.info('Tenant registry init starting');
         const hostBase = buildHostBaseUrl();

--- a/server/src/training-agent/tenants/router.ts
+++ b/server/src/training-agent/tenants/router.ts
@@ -806,7 +806,7 @@ function projectTenantCapabilities(
     }
     if (tenantId === 'sales' && storyboardCompat?.version !== '3.0') {
       structured.adcp.capability_changes = {
-        capabilities_version: 'training-agent-3.2-beta.6',
+        capabilities_version: 'training-agent-3.2-beta.8',
         last_modified: '2026-08-24T00:00:00.000Z',
         cache_ttl_seconds: 300,
         notifications: {

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -763,7 +763,7 @@ describe('tenant routing smoke', () => {
       );
 
       const capabilitiesResponse = await callTenantTool(url, 3, 'get_adcp_capabilities', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         adcp_major_version: 3,
       }) as {
         result?: { structuredContent?: {
@@ -781,7 +781,7 @@ describe('tenant routing smoke', () => {
           };
         } };
       };
-      expect(capabilitiesResponse.result?.structuredContent?.adcp_version).toBe('3.2-beta.6');
+      expect(capabilitiesResponse.result?.structuredContent?.adcp_version).toBe('3.2-beta.8');
       expect(capabilitiesResponse.result?.structuredContent?.adcp?.supported_versions).toContain('3.2-beta.6');
       const mediaBuy = capabilitiesResponse.result?.structuredContent?.media_buy;
       expect(mediaBuy?.supports_proposals).toBe(true);
@@ -837,7 +837,7 @@ describe('tenant routing smoke', () => {
       }
 
       const requested = await callTenantTool(url, 4, 'request_proposals', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-request-0001',
         account: {
@@ -851,12 +851,12 @@ describe('tenant routing smoke', () => {
           proposals?: Array<{ proposal_id?: string }>;
         } };
       };
-      expect(requested.result?.structuredContent?.adcp_version).toBe('3.2-beta.6');
+      expect(requested.result?.structuredContent?.adcp_version).toBe('3.2-beta.8');
       const sourceProposalId = requested.result?.structuredContent?.proposals?.[0]?.proposal_id;
       expect(sourceProposalId, JSON.stringify(requested)).toBeTruthy();
 
       const partial = await callTenantTool(url, 5, 'refine_proposals', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-refine-three-0001',
         account: {
@@ -877,14 +877,14 @@ describe('tenant routing smoke', () => {
         } };
       };
       const counteroffer = partial.result?.structuredContent;
-      expect(counteroffer?.adcp_version).toBe('3.2-beta.6');
+      expect(counteroffer?.adcp_version).toBe('3.2-beta.8');
       expect(counteroffer?.adcp_error).toBeUndefined();
       expect(counteroffer?.results?.[0]?.outcome, JSON.stringify(counteroffer)).toBe('partial');
       expect(counteroffer?.results?.[0]?.reason_code).toBe('alternatives_unavailable');
       expect(counteroffer?.results?.[0]?.proposals).toHaveLength(2);
 
       const refined = await callTenantTool(url, 6, 'refine_proposals', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-refine-two-0001',
         account: {
@@ -905,7 +905,7 @@ describe('tenant routing smoke', () => {
         } };
       };
       const refinement = refined.result?.structuredContent;
-      expect(refinement?.adcp_version).toBe('3.2-beta.6');
+      expect(refinement?.adcp_version).toBe('3.2-beta.8');
       expect(refinement?.adcp_error).toBeUndefined();
       expect(refinement?.results?.[0]?.outcome).toBe('revised');
       expect(refinement?.results?.[0]?.proposals).toHaveLength(2);
@@ -913,7 +913,7 @@ describe('tenant routing smoke', () => {
       const revisedProposalId = refinement?.results?.[0]?.proposals?.[0]?.proposal_id;
       expect(revisedProposalId).toEqual(expect.any(String));
       const finalized = await callTenantTool(url, 7, 'refine_proposals', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-finalize-0001',
         refinements: [{ proposal_id: revisedProposalId, action: 'finalize' }],
@@ -2057,9 +2057,9 @@ describe('tenant routing smoke', () => {
         ?.filter(format => format.operations?.includes('preview'))
         .map(format => format.capability_id) ?? [];
       const previewRouteIds = creative?.preview?.routes?.map(route => route.capability_id) ?? [];
-      expect(body.result?.structuredContent?.adcp_version).toBe('3.2-beta.6');
+      expect(body.result?.structuredContent?.adcp_version).toBe('3.2-beta.8');
       expect(body.result?.structuredContent?.adcp?.major_versions).toContain(3);
-      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', '3.2-beta.6']);
+      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', '3.2-beta.6', '3.2-beta.8']);
       expect(mediaBuy?.features?.inline_creative_management).toBe(true);
       expect(mediaBuy?.supported_optimization_metrics).toContain('clicks');
       expect(mediaBuy?.vendor_metric_optimization?.supported_targets).toContain('threshold_rate');
@@ -3451,7 +3451,7 @@ describe('tenant routing smoke', () => {
         field: 'adcp_version',
         details: {
           adcp_version: '4.0',
-          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', '3.2-beta.6'],
+          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', '3.2-beta.6', '3.2-beta.8'],
         },
       });
       expect(unsupportedBody.result?.structuredContent?.context?.correlation_id).toBe('tenant-local-version-unsupported');
@@ -3875,7 +3875,7 @@ describe('tenant routing smoke', () => {
       };
       const payload = {
         idempotency_key: 'tenant-products-idempotency-0001',
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         buying_mode: 'wholesale',
         account,
       };
@@ -3993,7 +3993,7 @@ describe('tenant routing smoke', () => {
         brand: account.brand,
       }) as { result?: { structuredContent?: { adcp_version?: string; products?: Array<{ product_id?: string }>; replayed?: boolean } } };
       expect(aliasReplay.result?.structuredContent).not.toHaveProperty('adcp_error');
-      expect(aliasReplay.result?.structuredContent?.adcp_version).toBe('3.2-beta.6');
+      expect(aliasReplay.result?.structuredContent?.adcp_version).toBe('3.2-beta.8');
       expect(aliasReplay.result?.structuredContent?.products?.map(product => product.product_id))
         .toEqual(first.result?.structuredContent?.products?.map(product => product.product_id));
       expect(aliasReplay.result?.structuredContent?.replayed).toBeUndefined();
@@ -4196,7 +4196,7 @@ describe('tenant routing smoke', () => {
         sandbox: true,
       };
       const directive = await callTenantTool(url, 91, 'comply_test_controller', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         account,
         scenario: 'force_get_products_arm',
         params: {
@@ -4208,7 +4208,7 @@ describe('tenant routing smoke', () => {
       expect(directive.result?.structuredContent?.success).toBe(true);
 
       const rejected = await callTenantTool(url, 92, 'get_products', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         adcp_major_version: 3,
         idempotency_key: 'tenant-products-rejected-0001',
         buying_mode: 'brief',

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -28,13 +28,16 @@ export const GET_PRODUCTS_REJECTED_ADCP_VERSION = '3.2-beta.2' as const;
  */
 export const SELLER_GOVERNANCE_DISCOVERY_ADCP_VERSION = '3.2-beta.6' as const;
 
+/** Current prerelease schema bundle shipped by the server SDK. */
+export const TRAINING_AGENT_CURRENT_ADCP_VERSION = '3.2-beta.8' as const;
+
 /** Release checkpoints the reference training agent can serve. */
 export const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = [
   '3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6',
   '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14',
   '3.1-rc.15', '3.1', SELLER_GOVERNANCE_DISCOVERY_ADCP_VERSION,
+  TRAINING_AGENT_CURRENT_ADCP_VERSION,
 ] as const;
-export const TRAINING_AGENT_CURRENT_ADCP_VERSION = SELLER_GOVERNANCE_DISCOVERY_ADCP_VERSION;
 export const TRAINING_AGENT_DEFAULT_ADCP_VERSION = '3.0' as const;
 
 export const PROPOSAL_NEGOTIATION_PROFILES = [

--- a/server/tests/integration/training-agent-3-0-compat-tools.test.ts
+++ b/server/tests/integration/training-agent-3-0-compat-tools.test.ts
@@ -21,7 +21,7 @@ const { stopSessionCleanup } = await import('../../src/training-agent/state.js')
 
 const COMPAT_CTX = { mode: 'open' as const, storyboardCompat: { version: '3.0' as const } };
 const AUTH = 'Bearer compat-tools-token';
-const CURRENT_ADCP_VERSION = '3.2-beta.6';
+const CURRENT_ADCP_VERSION = '3.2-beta.8';
 
 async function simulateListTools(server: ReturnType<typeof createTrainingAgentServer>): Promise<string[]> {
   const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -41,6 +41,7 @@ import {
   type LoadedTestKit,
 } from '../../src/compliance/storyboard-runner-options.js';
 import { formatFailureDetailSnippet, formatStepFailureDetail } from './storyboard-report-format.js';
+import { TRAINING_AGENT_CURRENT_ADCP_VERSION } from '../../src/training-agent/types.js';
 
 // Set auth env BEFORE loading the training-agent router. The router captures
 // PUBLIC_TEST_AGENT_TOKEN / TRAINING_AGENT_TOKEN into its authenticator at
@@ -102,12 +103,20 @@ if (shardIndex !== undefined && shardCount !== undefined && (shardIndex < 0 || s
 const shard = shardIndex === undefined || shardCount === undefined
   ? undefined
   : { index: shardIndex, count: shardCount };
+const installedSdkVersion = readFileSync(
+  join(process.cwd(), 'node_modules', '@adcp', 'sdk', 'ADCP_VERSION'),
+  'utf8',
+).trim();
+const installedSdkSchemaRoot = join(
+  process.cwd(),
+  'node_modules', '@adcp', 'sdk', 'dist', 'lib', 'schemas-data', installedSdkVersion,
+);
 const complianceOptions = process.env.ADCP_COMPLIANCE_DIR
   ? {
       complianceDir: process.env.ADCP_COMPLIANCE_DIR,
       ...(process.env.ADCP_SCHEMA_ROOT && { schemaRoot: process.env.ADCP_SCHEMA_ROOT }),
     }
-  : undefined;
+  : { schemaRoot: installedSdkSchemaRoot };
 const releasedComplianceVersion = process.env.ADCP_COMPLIANCE_DIR
   ? loadComplianceIndex(complianceOptions).adcp_version
   : undefined;
@@ -121,7 +130,7 @@ const isThreeZeroCompatRun = releasedComplianceVersion !== undefined && /^3\.0\.
 const wireAdcpVersion = isThreeZeroCompatRun
   ? '3.0'
   : releasedComplianceVersion === undefined
-    ? '3.2-beta.6'
+    ? TRAINING_AGENT_CURRENT_ADCP_VERSION
     : undefined;
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/server/tests/unit/certification-module-methodology.test.ts
+++ b/server/tests/unit/certification-module-methodology.test.ts
@@ -80,7 +80,7 @@ describe('selectModuleMethodology', () => {
     for (const phase of ['build', 'validate']) {
       const instructions = await getInstructions({ module_id: 'C4', phase });
 
-      expect(instructions).toContain('@adcp/sdk@14.0.0-beta.12');
+      expect(instructions).toContain('@adcp/sdk@14.0.0-beta.15');
       expect(instructions).toContain('beta.6');
       expect(instructions).not.toContain('beta.5');
       expect(instructions).not.toContain('@adcp/sdk@14.0.0-beta.7');

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -250,7 +250,7 @@ describe('comply_test_controller', () => {
 
     it('advertises force_get_products_arm for the 3.2 beta release', async () => {
       const { result } = await simulateCallTool(server, 'comply_test_controller', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         adcp_major_version: 3,
         scenario: 'list_scenarios',
         account: ACCOUNT,
@@ -1006,7 +1006,7 @@ describe('comply_test_controller', () => {
       expect(seeded.success).toBe(true);
 
       const { result: active32 } = await simulateCallTool(server, 'get_media_buys', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         account: ACCOUNT,
         brand: BRAND,
         media_buy_ids: ['proposal_bound_change_rights'],
@@ -1070,7 +1070,7 @@ describe('comply_test_controller', () => {
       expect(released31Errors, released31Errors.join('; ')).toEqual([]);
 
       const sellerManaged = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         account: ACCOUNT,
         media_buy_id: 'proposal_bound_change_rights',
         revision: activeBuy32.revision,
@@ -1086,7 +1086,7 @@ describe('comply_test_controller', () => {
       });
 
       const unevaluatedCondition = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         account: ACCOUNT,
         media_buy_id: 'proposal_bound_change_rights',
         revision: activeBuy32.revision,
@@ -1102,7 +1102,7 @@ describe('comply_test_controller', () => {
       });
 
       const packageCeiling = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         account: ACCOUNT,
         media_buy_id: 'proposal_bound_change_rights',
         revision: activeBuy32.revision,
@@ -1122,7 +1122,7 @@ describe('comply_test_controller', () => {
       });
 
       const { result: paused } = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         account: ACCOUNT,
         media_buy_id: 'proposal_bound_change_rights',
         revision: activeBuy32.revision,
@@ -1141,7 +1141,7 @@ describe('comply_test_controller', () => {
       });
 
       const { result: pausedRead } = await simulateCallTool(server, 'get_media_buys', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         account: ACCOUNT,
         media_buy_ids: ['proposal_bound_change_rights'],
       });
@@ -1222,7 +1222,7 @@ describe('comply_test_controller', () => {
       });
 
       const { result: before } = await simulateCallTool(server, 'get_media_buys', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         account: ACCOUNT,
         media_buy_ids: ['bounded_self_serve_budget'],
       });
@@ -1235,7 +1235,7 @@ describe('comply_test_controller', () => {
       }]);
 
       const { result: increased, isError: increaseError } = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         account: ACCOUNT,
         media_buy_id: 'bounded_self_serve_budget',
         revision: buy.revision,
@@ -1248,7 +1248,7 @@ describe('comply_test_controller', () => {
       });
 
       const requote = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         account: ACCOUNT,
         media_buy_id: 'bounded_self_serve_budget',
         revision: increased.revision,
@@ -1273,7 +1273,7 @@ describe('comply_test_controller', () => {
       ];
       for (const { field, value } of untypedCommercialUpdates) {
         const rejected = await simulateCallTool(server, 'update_media_buy', {
-          adcp_version: '3.2-beta.6',
+          adcp_version: '3.2-beta.8',
           account: ACCOUNT,
           brand: BRAND,
           media_buy_id: 'bounded_self_serve_budget',
@@ -1346,7 +1346,7 @@ describe('comply_test_controller', () => {
       });
 
       const { result } = await simulateCallTool(server, 'get_media_buys', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         account: ACCOUNT,
         media_buy_ids: ['paused_without_resume_term'],
       });
@@ -1441,7 +1441,7 @@ describe('comply_test_controller', () => {
         });
 
         const attempt = await simulateCallTool(server, testCase.tool, {
-          adcp_version: testCase.tool === 'control_media_buy' ? '3.2-beta.6' : '3.1',
+          adcp_version: testCase.tool === 'control_media_buy' ? '3.2-beta.8' : '3.1',
           account: ACCOUNT,
           media_buy_id: testCase.id,
           revision: 1,
@@ -1765,7 +1765,7 @@ describe('comply_test_controller', () => {
       });
 
       const rejectedCompactControl = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.6',
+        adcp_version: '3.2-beta.8',
         account: ACCOUNT,
         media_buy_id: 'created_from_allowed_actions',
         revision: updated.revision,

--- a/server/tests/unit/seller-managed-control-jobs.test.ts
+++ b/server/tests/unit/seller-managed-control-jobs.test.ts
@@ -67,7 +67,11 @@ describe('seller-managed control durable jobs', () => {
     await expect(registry.create({
       tool: 'control_media_buy', accountId: INPUT.accountId,
       ownerScope: INPUT.ownerScope, overrideTaskId: INPUT.taskId,
-    })).resolves.toEqual({ taskId: INPUT.taskId });
+    })).resolves.toMatchObject({
+      taskId: INPUT.taskId,
+      accountId: INPUT.accountId,
+      ownerScope: INPUT.ownerScope,
+    });
     await registry.authorizeSellerManagedReplay({
       taskId: INPUT.taskId,
       accountId: INPUT.accountId,
@@ -76,12 +80,31 @@ describe('seller-managed control durable jobs', () => {
     await expect(registry.create({
       tool: 'control_media_buy', accountId: INPUT.accountId,
       ownerScope: 'session:new-connection', overrideTaskId: INPUT.taskId,
-    })).resolves.toEqual({ taskId: INPUT.taskId });
+    })).resolves.toMatchObject({
+      taskId: INPUT.taskId,
+      accountId: INPUT.accountId,
+      ownerScope: 'session:new-connection',
+    });
     expect(await registry.getTask(INPUT.taskId, {
       accountId: INPUT.accountId,
       ownerScope: 'session:new-connection',
     })).toMatchObject({
       ownerScope: 'session:new-connection',
+    });
+    await registry.updateProgress(INPUT.taskId, {
+      accountId: INPUT.accountId,
+      ownerScope: 'session:new-connection',
+    }, { message: 'reconnected' });
+    await registry.complete(INPUT.taskId, {
+      accountId: INPUT.accountId,
+      ownerScope: 'session:new-connection',
+    }, { status: 'completed' });
+    expect(await registry.getTask(INPUT.taskId, {
+      accountId: INPUT.accountId,
+      ownerScope: 'session:new-connection',
+    })).toMatchObject({
+      status: 'completed',
+      result: { status: 'completed' },
     });
     expect(await registry.list?.({
       accountId: INPUT.accountId,
@@ -110,7 +133,11 @@ describe('seller-managed control durable jobs', () => {
     await expect(registry.create({
       tool: 'control_media_buy', accountId: INPUT.accountId,
       ownerScope: 'session:replacement', overrideTaskId: INPUT.taskId,
-    })).resolves.toEqual({ taskId: INPUT.taskId });
+    })).resolves.toMatchObject({
+      taskId: INPUT.taskId,
+      accountId: INPUT.accountId,
+      ownerScope: 'session:replacement',
+    });
     expect(await registry.getTask(INPUT.taskId, {
       accountId: INPUT.accountId,
       ownerScope: 'session:replacement',

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -69,6 +69,8 @@ import { getAgentUrl } from '../../src/training-agent/config.js';
 import { computeDeliveryStatementDigest } from '../../src/training-agent/governance-payload-hash.js';
 import {
   supportsSellerGovernanceDiscovery,
+  TRAINING_AGENT_CURRENT_ADCP_VERSION,
+  TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS,
   type TrainingContext,
 } from '../../src/training-agent/types.js';
 import {
@@ -114,7 +116,7 @@ const VALID_PRICING_MODELS = [
 ] as const;
 
 const TEST_AGENT_URL = 'http://localhost:3000/api/training-agent';
-const CURRENT_ADCP_VERSION = '3.2-beta.6';
+const CURRENT_ADCP_VERSION = TRAINING_AGENT_CURRENT_ADCP_VERSION;
 
 const DEFAULT_CTX: TrainingContext = { mode: 'open', authenticatedAgentUrl: 'https://buyer.example' };
 
@@ -2667,6 +2669,27 @@ describe('validate_input handler', () => {
 
     expect(result.results).toEqual([
       { target: { kind: 'canonical', id: 'image' }, result_kind: 'validated_pass' },
+    ]);
+  });
+
+  it('accepts protocol-valid macro-bearing URL assets under SDK beta.15', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const { result } = await simulateCallTool(server, 'validate_input', {
+      manifest: {
+        format_kind: 'audio_daast',
+        assets: {
+          daast_tag: {
+            asset_type: 'daast',
+            delivery_type: 'url',
+            url: 'https://daast.acme.example/tag.xml',
+          },
+        },
+      },
+      targets: [{ kind: 'canonical', id: 'audio_daast' }],
+    });
+
+    expect(result.results).toEqual([
+      { target: { kind: 'canonical', id: 'audio_daast' }, result_kind: 'validated_pass' },
     ]);
   });
 
@@ -16117,7 +16140,7 @@ describe('get_adcp_capabilities handler', () => {
 
     expect(result.adcp).toMatchObject({
       major_versions: [3],
-      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', CURRENT_ADCP_VERSION],
+      supported_versions: [...TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS],
       idempotency: { supported: true, replay_ttl_seconds: 86400 },
     });
     expect(result.adcp_version).toBe('3.0');
@@ -17241,7 +17264,7 @@ describe('MCP Tasks protocol', () => {
         code: -32602,
         data: {
           adcp_version: '99.0',
-          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', CURRENT_ADCP_VERSION],
+          supported_versions: [...TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS],
           supported_majors: [3],
           context: { correlation_id: 'task-version-unsupported' },
           adcp_error: {
@@ -21546,7 +21569,7 @@ describe('AdCP protocol compliance', () => {
     expect(parsed.adcp_version).toBe('3.0');
     expect(parsed.adcp).toMatchObject({
       major_versions: [3],
-      supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', CURRENT_ADCP_VERSION],
+      supported_versions: [...TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS],
     });
   });
 
@@ -21611,7 +21634,7 @@ describe('AdCP protocol compliance', () => {
       details: {
         adcp_version: '4.0',
         adcp_major_version: 4,
-        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', CURRENT_ADCP_VERSION],
+        supported_versions: [...TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS],
         supported_majors: [3],
       },
     });
@@ -21632,7 +21655,7 @@ describe('AdCP protocol compliance', () => {
       field: 'adcp_version',
       details: {
         adcp_version: '3.1-beta',
-        supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', CURRENT_ADCP_VERSION],
+        supported_versions: [...TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS],
         supported_majors: [3],
       },
     });

--- a/tests/run-storyboards-schema-root-options.test.cjs
+++ b/tests/run-storyboards-schema-root-options.test.cjs
@@ -74,7 +74,10 @@ test('released storyboard runs forward schemaRoot with adcpVersion', () => {
 
 test('storyboard runs pin the intended wire surface without changing schema selection', () => {
   const source = fs.readFileSync(RUNNER_FILE, 'utf8');
-  assert.match(source, /const wireAdcpVersion = isThreeZeroCompatRun[\s\S]*\? '3\.0'[\s\S]*releasedComplianceVersion === undefined[\s\S]*\? '3\.2-beta\.6'[\s\S]*: undefined/);
+  assert.match(source, /import \{ TRAINING_AGENT_CURRENT_ADCP_VERSION \} from/);
+  assert.match(source, /const installedSdkSchemaRoot = join\([\s\S]*schemas-data[\s\S]*installedSdkVersion/);
+  assert.match(source, /: \{ schemaRoot: installedSdkSchemaRoot \}/);
+  assert.match(source, /const wireAdcpVersion = isThreeZeroCompatRun[\s\S]*\? '3\.0'[\s\S]*releasedComplianceVersion === undefined[\s\S]*\? TRAINING_AGENT_CURRENT_ADCP_VERSION[\s\S]*: undefined/);
   assert.equal(
     (source.match(/\.\.\.\(wireAdcpVersion && \{ wireAdcpVersion \}\)/g) ?? []).length,
     3,

--- a/tests/sdk-runtime-compat.test.cjs
+++ b/tests/sdk-runtime-compat.test.cjs
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 const { pathToFileURL } = require('node:url');
@@ -9,6 +10,41 @@ async function loadInstalledSingleAgentClients() {
     (await import('@adcp/sdk')).SingleAgentClient,
   ];
 }
+
+function currentTrainingAgentAdcpVersion() {
+  const source = fs.readFileSync(path.resolve(
+    __dirname,
+    '..',
+    'server/src/training-agent/types.ts',
+  ), 'utf8');
+  const match = source.match(/TRAINING_AGENT_CURRENT_ADCP_VERSION\s*=\s*'([^']+)'/);
+  assert.ok(match, 'training-agent current AdCP version must remain an explicit release pin');
+  return match[1];
+}
+
+test('installed SDK bundles the training-agent current AdCP version', async () => {
+  const currentVersion = currentTrainingAgentAdcpVersion();
+  for (const sdk of [require('@adcp/sdk'), await import('@adcp/sdk')]) {
+    assert.doesNotThrow(() => sdk.resolveAdcpVersion(currentVersion));
+    assert.ok(
+      sdk.listBundledAdcpVersions().includes(sdk.resolveAdcpVersion(currentVersion)),
+      `${currentVersion} must resolve to an installed SDK schema bundle`,
+    );
+  }
+});
+
+test('training agent registers its retained beta.6 release bundle', async () => {
+  const retainedVersion = '3.2-beta.6';
+  const schemaRoot = path.resolve(__dirname, '..', 'dist/schemas/3.2.0-beta.6');
+  const cjsTesting = require('@adcp/sdk/testing');
+  const esmTesting = await import('@adcp/sdk/testing');
+  cjsTesting.registerExternalSchemaRoot(retainedVersion, schemaRoot);
+  esmTesting.registerExternalSchemaRoot(retainedVersion, schemaRoot);
+
+  assert.doesNotThrow(() => require('@adcp/sdk').resolveAdcpVersion(retainedVersion));
+  const esmSdk = await import('@adcp/sdk');
+  assert.doesNotThrow(() => esmSdk.resolveAdcpVersion(retainedVersion));
+});
 
 async function runScopedCapabilityCase(SingleAgentClient, supportedVersion, methodName) {
   const client = new SingleAgentClient({

--- a/tests/targeting-aware-discovery.test.cjs
+++ b/tests/targeting-aware-discovery.test.cjs
@@ -1269,7 +1269,7 @@ test("buyer teaching surfaces explain structured-first targeting", () => {
   }
   assert.match(skill, /fewer tokens/);
   assert.match(addieKnowledge, /No targeting-resolution echo confirms only/);
-  assert.match(certificationTools, /exact 3\.2 beta\.6 wire pin with @adcp\/sdk@14\.0\.0-beta\.12/);
+  assert.match(certificationTools, /exact 3\.2 beta\.6 wire pin with @adcp\/sdk@14\.0\.0-beta\.15/);
   assert.match(certificationTools, /3\.2 targeting-aware objectives live/);
   assert.doesNotMatch(certificationTools, /issues\/6199/);
   assert.match(


### PR DESCRIPTION
## Summary

- upgrade `@adcp/sdk` from `14.0.0-beta.13` to `14.0.0-beta.15`, which includes adcontextprotocol/adcp-client#2731
- align the training-agent runtime with the beta-8 schema bundle shipped by beta 15 while retaining beta 6 as the seller-governance feature boundary
- adapt seller-managed task replay to the SDK public `ScopedTaskRef` API and add a bundle-compatibility regression guard
- update the operator-facing SDK command example to the installed beta/version

## Verification

- `npm run typecheck`
- focused Addie/task tests: 78 passed
- SDK shim/runtime compatibility tests: 7 passed
- training controller tests: 96 passed
- beta-15 tenant routing regressions: 4 passed
- signals storyboard discovery: 46 clean / 86 steps (floor: 45 / 80)
- issue-shaped HTTP fixture: saved bearer reached MCP; no false OAuth observation and no protected-resource metadata probe

Fixes #6903