### PR TITLE
fix(compliance): replace invalid channel value "video" with "olv" in fixture products

### DIFF
--- a/.changeset/fix-channel-enum-video-to-olv.md
+++ b/.changeset/fix-channel-enum-video-to-olv.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix invalid channel value "video" in compliance fixture products. The Channel enum has never included "video"; the correct value is "olv" (online video). Affects 19 occurrences across 17 compliance source files.

--- a/static/compliance/source/protocols/governance/index.yaml
+++ b/static/compliance/source/protocols/governance/index.yaml
@@ -60,7 +60,7 @@ fixtures:
             duration_ms_exact: 30000
     - product_id: "outdoor_video_q2"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_15s"
           format_kind: "video_hosted"

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -110,7 +110,7 @@ fixtures:
   products:
     - product_id: "sports_preroll_q2"
       delivery_type: "non_guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_30s"
           format_kind: "video_hosted"

--- a/static/compliance/source/protocols/media-buy/scenarios/acceptance_policy_discovery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/acceptance_policy_discovery.yaml
@@ -52,7 +52,7 @@ fixtures:
       name: "Acceptance policy video"
       description: "Sandbox video inventory with a product-specific acceptance profile"
       delivery_type: "non_guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       acceptance_policy_profile_ids:
         - "google_political_advertising_acceptance"
       format_options:

--- a/static/compliance/source/protocols/media-buy/scenarios/billing_finality_delivery.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/billing_finality_delivery.yaml
@@ -51,7 +51,7 @@ fixtures:
   products:
     - product_id: "billing_finality_video_q3"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_15s"
           format_kind: "video_hosted"

--- a/static/compliance/source/protocols/media-buy/scenarios/completed_views_buy_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/completed_views_buy_flow.yaml
@@ -90,7 +90,7 @@ fixtures:
   products:
     - product_id: "cpcv_video_q2"
       delivery_type: "non_guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_30s"
           format_kind: "video_hosted"

--- a/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async.yaml
@@ -89,7 +89,7 @@ fixtures:
   products:
     - product_id: "async_signed_io_q2"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_30s"
           format_kind: "video_hosted"

--- a/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async_lifecycle.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/create_media_buy_async_lifecycle.yaml
@@ -61,7 +61,7 @@ fixtures:
   products:
     - product_id: "async_lifecycle_video_q3"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_30s"
           format_kind: "video_hosted"

--- a/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/delivery_reporting.yaml
@@ -52,7 +52,7 @@ fixtures:
             height: 250
     - product_id: "outdoor_video_q2"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_15s"
           format_kind: "video_hosted"
@@ -60,7 +60,7 @@ fixtures:
             duration_ms_exact: 15000
     - product_id: "video_viewability_q2"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_15s"
           format_kind: "video_hosted"

--- a/static/compliance/source/protocols/media-buy/scenarios/demographic_targeting.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/demographic_targeting.yaml
@@ -72,7 +72,7 @@ fixtures:
           unknown_handling: "selectable"
     - product_id: "demographic_bucket_video"
       delivery_type: "non_guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_ids:
         - id: "video_30s"
       demographic_targeting:

--- a/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/governance_approved.yaml
@@ -73,7 +73,7 @@ fixtures:
             height: 250
     - product_id: "outdoor_video_q2"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_15s"
           format_kind: "video_hosted"

--- a/static/compliance/source/protocols/media-buy/scenarios/outcome_target.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/outcome_target.yaml
@@ -60,7 +60,7 @@ fixtures:
       name: "Outcome Target Planning Video"
       description: "Compliance fixture: fixed-price video inventory for reverse-forecast planning."
       delivery_type: "non_guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "outcome_target_video_30s"
           format_kind: "video_hosted"

--- a/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/reach_buy_flow.yaml
@@ -91,7 +91,7 @@ fixtures:
   products:
     - product_id: "reach_ctv_q2"
       delivery_type: "non_guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_30s"
           format_kind: "video_hosted"

--- a/static/compliance/source/protocols/media-buy/scenarios/typed_proposal_negotiation.yaml
+++ b/static/compliance/source/protocols/media-buy/scenarios/typed_proposal_negotiation.yaml
@@ -65,7 +65,7 @@ fixtures:
   products:
     - product_id: "premium_video_q4"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_30s"
           format_kind: "video_hosted"

--- a/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
+++ b/static/compliance/source/specialisms/creative-generative/generative-seller.yaml
@@ -84,7 +84,7 @@ fixtures:
             height: 250
     - product_id: "outdoor_video_q2"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_15s"
           format_kind: "video_hosted"

--- a/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
+++ b/static/compliance/source/specialisms/governance-delivery-monitor/index.yaml
@@ -64,7 +64,7 @@ fixtures:
             height: 250
     - product_id: "outdoor_video_q2"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_15s"
           format_kind: "video_hosted"

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -115,7 +115,7 @@ fixtures:
             height: 250
     - product_id: "video_outdoor_non_guaranteed"
       delivery_type: "non_guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_30s"
           format_kind: "video_hosted"
@@ -124,7 +124,7 @@ fixtures:
     # Guaranteed products used by the main storyboard phases (hardcoded in sample_requests).
     - product_id: "sports_preroll_q2_guaranteed"
       delivery_type: "guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_30s"
           format_kind: "video_hosted"

--- a/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-non-guaranteed/index.yaml
@@ -87,7 +87,7 @@ fixtures:
             height: 250
     - product_id: "outdoor_video_auction"
       delivery_type: "non_guaranteed"
-      channels: ["video"]
+      channels: ["olv"]
       format_options:
         - format_option_id: "video_30s"
           format_kind: "video_hosted"


### PR DESCRIPTION
## Summary

- Replace all `channels: ["video"]` with `channels: ["olv"]` across 17 compliance source fixture files (19 occurrences)
- `"video"` has never been a valid value in the Channel enum — verified against every published schema version from 3.1.1 through 3.2.0-beta.9
- Only `channels:` array references were changed; `asset_type: "video"` references (valid) are untouched

## Affected files

**Protocols:**
- `protocols/governance/index.yaml`
- `protocols/media-buy/index.yaml`
- `protocols/media-buy/scenarios/` — 11 scenario files (delivery_reporting, billing_finality_delivery, reach_buy_flow, demographic_targeting, acceptance_policy_discovery, create_media_buy_async, create_media_buy_async_lifecycle, governance_approved, outcome_target, typed_proposal_negotiation, completed_views_buy_flow)

**Specialisms:**
- `specialisms/governance-delivery-monitor/index.yaml`
- `specialisms/creative-generative/generative-seller.yaml`
- `specialisms/sales-guaranteed/index.yaml` (2 occurrences)
- `specialisms/sales-non-guaranteed/index.yaml`

## Test plan

- [x] Schema build passes (`build-schemas.cjs`)
- [x] Compliance symbol linking passes (`build-compliance.cjs`)
- [x] Zero remaining `channels: ["video"]` references in source
- [x] All 206 compliance YAML files parse cleanly

Fixes #6981