### PR TITLE
fix(test): isolate mockCurrentUser in announcement-admin-route tests

### DIFF
--- a/tests/addie/admin-tools.test.ts
+++ b/tests/addie/admin-tools.test.ts
@@ -1189,8 +1189,9 @@ describe("community mirror review handlers", () => {
 
   beforeEach(() => {
     vi.unstubAllGlobals();
-    process.env.ADMIN_API_KEY = "test-admin-key";
-    process.env.BASE_URL = "https://registry.example";
+    vi.unstubAllEnvs();
+    vi.stubEnv('ADMIN_API_KEY', 'test-admin-key');
+    vi.stubEnv('BASE_URL', 'https://registry.example');
   });
 
   it("lists the moderator queue through the protected registry API", async () => {

--- a/tests/announcement/announcement-admin-route.test.ts
+++ b/tests/announcement/announcement-admin-route.test.ts
@@ -23,7 +23,7 @@ const {
   mockMarkLinkedInPosted,
   mockRefreshReviewCardForOrg,
   mockLoadDraftAndState,
-  mockCurrentUser,
+  mockGetCurrentUser,
 } = vi.hoisted(() => {
   process.env.WORKOS_API_KEY = process.env.WORKOS_API_KEY ?? 'test';
   process.env.WORKOS_CLIENT_ID = process.env.WORKOS_CLIENT_ID ?? 'client_test';
@@ -31,7 +31,7 @@ const {
     mockMarkLinkedInPosted: vi.fn<any>(),
     mockRefreshReviewCardForOrg: vi.fn<any>(),
     mockLoadDraftAndState: vi.fn<any>(),
-    mockCurrentUser: { id: 'user_wk_admin01', email: 'admin@example.com', is_admin: true },
+    mockGetCurrentUser: vi.fn(() => ({ id: 'user_wk_admin01', email: 'admin@example.com', is_admin: true })),
   };
 });
 
@@ -43,13 +43,13 @@ vi.mock('../../server/src/addie/jobs/announcement-handlers.js', () => ({
 
 vi.mock('../../server/src/middleware/auth.js', () => ({
   requireAuth: (req: any, _res: any, next: any) => {
-    req.user = mockCurrentUser;
+    req.user = mockGetCurrentUser();
     next();
   },
   requireAdmin: (_req: any, _res: any, next: any) => next(),
   requireGlobalAdmin: [
     (req: any, _res: any, next: any) => {
-      req.user = mockCurrentUser;
+      req.user = mockGetCurrentUser();
       next();
     },
     (_req: any, _res: any, next: any) => next(),
@@ -85,7 +85,8 @@ beforeEach(() => {
   mockMarkLinkedInPosted.mockReset();
   mockRefreshReviewCardForOrg.mockReset();
   mockLoadDraftAndState.mockReset();
-  mockCurrentUser.id = 'user_wk_admin01';
+  mockGetCurrentUser.mockReset();
+  mockGetCurrentUser.mockReturnValue({ id: 'user_wk_admin01', email: 'admin@example.com', is_admin: true });
   mockRefreshReviewCardForOrg.mockResolvedValue(undefined);
 });
 
@@ -101,7 +102,7 @@ describe('POST /api/admin/accounts/:orgId/announcement/linkedin', () => {
   });
 
   it('403 when the caller is the static ADMIN_API_KEY', async () => {
-    mockCurrentUser.id = 'admin_api_key';
+    mockGetCurrentUser.mockReturnValue({ id: 'admin_api_key', email: 'admin@example.com', is_admin: true });
     const app = buildApp();
     const res = await request(app)
       .post(`/api/admin/accounts/${ORG_ID}/announcement/linkedin`)

--- a/tests/announcement/announcement-channel-resolver.test.ts
+++ b/tests/announcement/announcement-channel-resolver.test.ts
@@ -10,7 +10,7 @@
  * the DB value set, so the env fallback was dropped. Setting the env
  * var in a test here must NOT affect the resolver's return value.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { mockGetEditorialChannel } = vi.hoisted(() => ({
   mockGetEditorialChannel: vi.fn<any>(),
@@ -41,16 +41,9 @@ vi.mock('../../server/src/services/announcement-visual.js', () => ({
 
 import { resolveEditorialChannel } from '../../server/src/addie/jobs/announcement-trigger.js';
 
-const ORIGINAL_ENV = process.env.SLACK_EDITORIAL_REVIEW_CHANNEL;
-
 beforeEach(() => {
   mockGetEditorialChannel.mockReset();
-  delete process.env.SLACK_EDITORIAL_REVIEW_CHANNEL;
-});
-
-afterEach(() => {
-  if (ORIGINAL_ENV === undefined) delete process.env.SLACK_EDITORIAL_REVIEW_CHANNEL;
-  else process.env.SLACK_EDITORIAL_REVIEW_CHANNEL = ORIGINAL_ENV;
+  vi.unstubAllEnvs();
 });
 
 describe('resolveEditorialChannel', () => {
@@ -69,7 +62,7 @@ describe('resolveEditorialChannel', () => {
       channel_id: 'C0FROMDB01',
       channel_name: 'admin-editorial-review',
     });
-    process.env.SLACK_EDITORIAL_REVIEW_CHANNEL = 'C0STALEENVCHANNEL';
+    vi.stubEnv('SLACK_EDITORIAL_REVIEW_CHANNEL', 'C0STALEENVCHANNEL');
 
     expect(await resolveEditorialChannel()).toBe('C0FROMDB01');
   });
@@ -78,7 +71,7 @@ describe('resolveEditorialChannel', () => {
     mockGetEditorialChannel.mockResolvedValueOnce({ channel_id: null, channel_name: null });
     // Previously this would fall back to the env var. After #3000 rollout
     // completed, a stale env var would otherwise mask a misconfigured DB.
-    process.env.SLACK_EDITORIAL_REVIEW_CHANNEL = 'C0STALEENVCHANNEL';
+    vi.stubEnv('SLACK_EDITORIAL_REVIEW_CHANNEL', 'C0STALEENVCHANNEL');
 
     expect(await resolveEditorialChannel()).toBeNull();
   });
@@ -108,7 +101,7 @@ describe('resolveEditorialChannel', () => {
     mockGetEditorialChannel.mockRejectedValueOnce(new Error('db connection reset'));
     // Even with env set, a DB failure no longer silently activates a
     // fallback — the job skips and logs instead.
-    process.env.SLACK_EDITORIAL_REVIEW_CHANNEL = 'C0STALEENVCHANNEL';
+    vi.stubEnv('SLACK_EDITORIAL_REVIEW_CHANNEL', 'C0STALEENVCHANNEL');
 
     expect(await resolveEditorialChannel()).toBeNull();
   });

--- a/tests/billing/webhook-security.test.ts
+++ b/tests/billing/webhook-security.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 import type Stripe from 'stripe';
 import type { MockedClass } from 'vitest';
 
@@ -9,6 +9,10 @@ vi.mock('stripe', () => {
 });
 
 describe('Webhook Security', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   describe('Stripe webhook signature verification', () => {
     test('webhook endpoint requires raw body for signature verification', () => {
       // This test documents that the webhook endpoint MUST receive
@@ -24,8 +28,8 @@ describe('Webhook Security', () => {
     });
 
     test('rejects webhook with invalid signature', async () => {
-      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test';
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_WEBHOOK_SECRET', 'whsec_test');
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
 
@@ -53,8 +57,8 @@ describe('Webhook Security', () => {
     });
 
     test('accepts webhook with valid signature', async () => {
-      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test';
-      process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+      vi.stubEnv('STRIPE_WEBHOOK_SECRET', 'whsec_test');
+      vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_mock');
 
       const StripeMock = (await import('stripe')).default as unknown as MockedClass<typeof Stripe>;
 
@@ -98,16 +102,10 @@ describe('Webhook Security', () => {
       // Document that STRIPE_WEBHOOK_SECRET is required
       // Without it, webhooks cannot be verified and should be rejected
 
-      const originalEnv = process.env.STRIPE_WEBHOOK_SECRET;
-      delete process.env.STRIPE_WEBHOOK_SECRET;
+      vi.stubEnv('STRIPE_WEBHOOK_SECRET', undefined as unknown as string);
 
       // The webhook endpoint should check for this and return 500
       expect(process.env.STRIPE_WEBHOOK_SECRET).toBeUndefined();
-
-      // Restore
-      if (originalEnv) {
-        process.env.STRIPE_WEBHOOK_SECRET = originalEnv;
-      }
     });
   });
 


### PR DESCRIPTION
## Summary

Eliminate thread-safety issues in test files that run under the root vitest config (`pool: 'threads'`) by isolating shared mutable state. This addresses root cause (3) from the #6740 triage and hardens all other `process.env` mutation sites found in the `tests/` tree against cross-thread bleed.

Root causes (1) and (2) were fixed in #6800.

## Changes

**`tests/announcement/announcement-admin-route.test.ts`** — shared mutable mock object
- Replace `mockCurrentUser` shared object with `mockGetCurrentUser` vi.fn() factory
- Auth middleware mocks call `mockGetCurrentUser()` per invocation instead of sharing a reference
- 403 test uses `mockReturnValue()` instead of property mutation

**`tests/announcement/announcement-channel-resolver.test.ts`** — env var leak
- Replace manual `process.env` delete/restore with `vi.stubEnv` + `vi.unstubAllEnvs`
- Remove `afterEach` and `ORIGINAL_ENV` manual save/restore pattern
- `SLACK_EDITORIAL_REVIEW_CHANNEL` mutations no longer leak to concurrent workers

**`tests/addie/admin-tools.test.ts`** — env var leak
- Replace unconditional `process.env.ADMIN_API_KEY` / `process.env.BASE_URL` assignments with `vi.stubEnv`
- Add `vi.unstubAllEnvs()` in `beforeEach` for automatic restoration

**`tests/billing/webhook-security.test.ts`** — env var leak
- Replace direct `process.env.STRIPE_WEBHOOK_SECRET` / `STRIPE_SECRET_KEY` assignments with `vi.stubEnv`
- Replace manual delete/restore in "webhook secret must be configured" test
- Add `vi.unstubAllEnvs()` in `beforeEach` for automatic restoration

## Verification

- `npx vitest run tests/announcement/` — 175/175 passed
- `npx vitest run tests/addie/admin-tools.test.ts` — 30/30 passed
- `npx vitest run tests/billing/webhook-security.test.ts` — 7/7 passed
- Full parallel run (12 files, 212 tests) — all passed under threads pool
- Swept all `tests/` files for remaining non-idempotent `process.env` mutations — zero remaining

Refs #6740