### PR TITLE
feat(release): validate schema PR bundles in both SDKs

### DIFF
--- a/.changeset/validate-schema-pr-bundles.md
+++ b/.changeset/validate-schema-pr-bundles.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Build deterministic, retained commit-addressed schema PR bundles and validate them against both official SDK generators before protocol changes merge.

--- a/.github/workflows/cleanup-schema-pr-bundles.yml
+++ b/.github/workflows/cleanup-schema-pr-bundles.yml
@@ -1,0 +1,150 @@
+name: Clean up schema PR bundles
+
+on:
+  schedule:
+    - cron: '23 4 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: List expired objects without deleting them
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cleanup-schema-pr-bundles
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete expired preview bundles
+    if: github.repository == 'adcontextprotocol/adcp'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      BUCKET: ${{ vars.ADCP_ARTIFACT_R2_BUCKET || 'adcp-artifacts' }}
+      RETENTION_DAYS: ${{ vars.SCHEMA_PR_BUNDLE_RETENTION_DAYS || '90' }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID || secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY || secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+    steps:
+      - name: Delete expired commit-addressed previews
+        run: |
+          set -euo pipefail
+          if [[ ! "${RETENTION_DAYS}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::SCHEMA_PR_BUNDLE_RETENTION_DAYS must be a positive integer"
+            exit 1
+          fi
+          if [[ -z "${R2_ACCOUNT_ID:-}" || -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+            echo "::error::Missing R2 cleanup credentials"
+            exit 1
+          fi
+
+          endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          cutoff_epoch="$(date -u -d "${RETENTION_DAYS} days ago" +%s)"
+          cleanup_dir="$(mktemp -d)"
+          trap 'rm -rf "${cleanup_dir}"' EXIT
+
+          page=0
+          continuation_args=()
+          while true; do
+            page_file="${cleanup_dir}/page-${page}.json"
+            aws s3api list-objects-v2 \
+              --bucket "${BUCKET}" \
+              --prefix 'protocol/pr/' \
+              --max-keys 1000 \
+              --no-paginate \
+              --endpoint-url "${endpoint}" \
+              --region auto \
+              --no-cli-pager \
+              "${continuation_args[@]}" > "${page_file}"
+
+            next_token="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("NextContinuationToken", ""))' "${page_file}")"
+            if [[ -z "${next_token}" ]]; then
+              break
+            fi
+            continuation_args=(--continuation-token "${next_token}")
+            page=$((page + 1))
+          done
+
+          python3 - "${cleanup_dir}" "${cutoff_epoch}" <<'PY'
+          import datetime
+          import glob
+          import json
+          import pathlib
+          import re
+          import sys
+
+          cleanup_dir = pathlib.Path(sys.argv[1])
+          cutoff = datetime.datetime.fromtimestamp(int(sys.argv[2]), datetime.timezone.utc)
+          key_pattern = re.compile(
+              r"^protocol/pr/[0-9a-f]{40}/latest\.tgz(?:\.sha256|\.provenance\.json)?$"
+          )
+          objects_by_commit = {}
+
+          for page_path in sorted(glob.glob(str(cleanup_dir / "page-*.json"))):
+              with open(page_path, encoding="utf-8") as page_file:
+                  page = json.load(page_file)
+              for item in page.get("Contents", []):
+                  key = item["Key"]
+                  if not key_pattern.fullmatch(key):
+                      print(f"Skipping unrecognized preview key: {key}", file=sys.stderr)
+                      continue
+                  modified = datetime.datetime.fromisoformat(
+                      item["LastModified"].replace("Z", "+00:00")
+                  )
+                  commit = key.split("/")[2]
+                  objects_by_commit.setdefault(commit, []).append((key, modified))
+
+          stale_keys = []
+          for objects in objects_by_commit.values():
+              if max(modified for _, modified in objects) < cutoff:
+                  stale_keys.extend(key for key, _ in objects)
+          stale_keys.sort()
+
+          (cleanup_dir / "stale-keys.txt").write_text(
+              "".join(f"{key}\n" for key in stale_keys), encoding="utf-8"
+          )
+          for batch_number, start in enumerate(range(0, len(stale_keys), 1000)):
+              payload = {
+                  "Objects": [{"Key": key} for key in stale_keys[start:start + 1000]],
+                  "Quiet": True,
+              }
+              (cleanup_dir / f"delete-{batch_number}.json").write_text(
+                  json.dumps(payload), encoding="utf-8"
+              )
+          print(len(stale_keys))
+          PY
+
+          stale_count="$(wc -l < "${cleanup_dir}/stale-keys.txt" | tr -d ' ')"
+          if [[ "${stale_count}" == '0' ]]; then
+            echo "No schema PR bundle objects exceeded ${RETENTION_DAYS} days."
+          elif [[ "${DRY_RUN}" == 'true' ]]; then
+            echo "Dry run: ${stale_count} object(s) would be deleted:"
+            cat "${cleanup_dir}/stale-keys.txt"
+          else
+            shopt -s nullglob
+            for payload in "${cleanup_dir}"/delete-*.json; do
+              result="${payload%.json}-result.json"
+              aws s3api delete-objects \
+                --bucket "${BUCKET}" \
+                --delete "file://${payload}" \
+                --endpoint-url "${endpoint}" \
+                --region auto \
+                --no-cli-pager > "${result}"
+              python3 -c 'import json, sys; errors=json.load(open(sys.argv[1])).get("Errors", []); errors and sys.exit(f"R2 deletion errors: {errors}")' "${result}"
+            done
+            echo "Deleted ${stale_count} schema PR bundle object(s) older than ${RETENTION_DAYS} days."
+          fi
+
+          {
+            echo '### Schema PR bundle retention'
+            echo
+            echo "- Retention: ${RETENTION_DAYS} days"
+            echo "- Expired objects: ${stale_count}"
+            echo "- Dry run: ${DRY_RUN}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/publish-schema-pr-bundle.yml
+++ b/.github/workflows/publish-schema-pr-bundle.yml
@@ -1,0 +1,98 @@
+name: Publish schema PR bundle
+
+on:
+  workflow_run:
+    workflows: ['Validate schema PR bundle']
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  publish:
+    name: Publish immutable PR bundle
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: schema-pr-bundle-${{ github.event.workflow_run.head_sha }}
+          path: bundle
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload immutable artifact tuple to R2
+        env:
+          BUCKET: ${{ vars.ADCP_ARTIFACT_R2_BUCKET || 'adcp-artifacts' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID || secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY || secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          set -euo pipefail
+          if [[ -z "${R2_ACCOUNT_ID:-}" || -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+            echo "::error::Missing R2 publication credentials"
+            exit 1
+          fi
+          (
+            cd bundle
+            shasum -a 256 -c latest.tgz.sha256
+          )
+          node -e "const fs=require('node:fs'); const p=require('./bundle/latest.tgz.provenance.json'); const digest=fs.readFileSync('./bundle/latest.tgz.sha256','utf8').trim().split(/\s+/)[0]; if (p.source_repository !== 'adcontextprotocol/adcp') throw new Error('Unexpected protocol provenance repository'); if (p.source_commit !== process.env.PR_HEAD_SHA) throw new Error('Protocol provenance does not match PR head'); if (p.bundle_sha256 !== digest) throw new Error('Protocol provenance digest does not match checksum')"
+
+          endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          prefix="protocol/pr/${PR_HEAD_SHA}"
+
+          upload_immutable() {
+            local source="$1"
+            local key="$2"
+            local content_type="$3"
+            local existing
+            local head_error
+            existing="$(mktemp)"
+            head_error="$(mktemp)"
+
+            if aws s3api head-object --bucket "${BUCKET}" --key "${key}" --endpoint-url "${endpoint}" --region auto --no-cli-pager >/dev/null 2>"${head_error}"; then
+              aws s3 cp "s3://${BUCKET}/${key}" "${existing}" --endpoint-url "${endpoint}" --region auto --no-progress --only-show-errors
+              if ! cmp -s "${source}" "${existing}"; then
+                echo "::error::R2 object ${key} exists with different bytes; refusing overwrite"
+                exit 1
+              fi
+              echo "Verified existing immutable object ${key}"
+              return
+            fi
+
+            if ! grep -Eq '(404|Not Found)' "${head_error}"; then
+              cat "${head_error}" >&2
+              echo "::error::Could not safely determine whether R2 object ${key} exists"
+              exit 1
+            fi
+
+            aws s3 cp "${source}" "s3://${BUCKET}/${key}" \
+              --endpoint-url "${endpoint}" \
+              --region auto \
+              --no-progress \
+              --only-show-errors \
+              --no-guess-mime-type \
+              --cache-control 'public, max-age=86400' \
+              --content-type "${content_type}"
+          }
+
+          upload_immutable bundle/latest.tgz "${prefix}/latest.tgz" 'application/gzip'
+          upload_immutable bundle/latest.tgz.sha256 "${prefix}/latest.tgz.sha256" 'text/plain; charset=utf-8'
+          upload_immutable bundle/latest.tgz.provenance.json "${prefix}/latest.tgz.provenance.json" 'application/json; charset=utf-8'
+
+          {
+            echo '### Immutable PR bundle'
+            echo
+            echo "- Bundle: https://adcontextprotocol.org/${prefix}/latest.tgz"
+            echo "- Checksum: https://adcontextprotocol.org/${prefix}/latest.tgz.sha256"
+            echo "- Provenance: https://adcontextprotocol.org/${prefix}/latest.tgz.provenance.json"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/validate-schema-bundle.yml
+++ b/.github/workflows/validate-schema-bundle.yml
@@ -3,6 +3,8 @@ name: Validate schema PR bundle
 on:
   pull_request:
     branches: [main]
+    # Preview artifacts are only for changes to canonical schema sources.
+    # Compliance, OpenAPI, and build-tool changes remain covered by normal CI.
     paths:
       - 'static/schemas/source/**'
 

--- a/.github/workflows/validate-schema-bundle.yml
+++ b/.github/workflows/validate-schema-bundle.yml
@@ -5,19 +5,6 @@ on:
     branches: [main]
     paths:
       - 'static/schemas/source/**'
-      - 'static/compliance/source/**'
-      - 'static/openapi/registry.yaml'
-      - 'skills/**'
-      - 'CHANGELOG.md'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'scripts/build-schemas.cjs'
-      - 'scripts/build-compliance.cjs'
-      - 'scripts/build-protocol-tarball.cjs'
-      - 'scripts/build-schema-pr-bundle.sh'
-      - 'scripts/lint-compliance-packaged-refs.cjs'
-      - 'scripts/mcp-schema-projection.cjs'
-      - '.github/workflows/validate-schema-bundle.yml'
 
 concurrency:
   group: schema-pr-bundle-${{ github.event.pull_request.number }}

--- a/.github/workflows/validate-schema-bundle.yml
+++ b/.github/workflows/validate-schema-bundle.yml
@@ -1,0 +1,234 @@
+name: Validate schema PR bundle
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'static/schemas/source/**'
+      - 'static/compliance/source/**'
+      - 'static/openapi/registry.yaml'
+      - 'skills/**'
+      - 'CHANGELOG.md'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/build-schemas.cjs'
+      - 'scripts/build-compliance.cjs'
+      - 'scripts/build-protocol-tarball.cjs'
+      - 'scripts/build-schema-pr-bundle.sh'
+      - 'scripts/lint-compliance-packaged-refs.cjs'
+      - 'scripts/mcp-schema-projection.cjs'
+      - '.github/workflows/validate-schema-bundle.yml'
+
+concurrency:
+  group: schema-pr-bundle-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+jobs:
+  build-bundle:
+    name: Build deterministic PR bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build schemas, compliance, and protocol bundle
+        env:
+          ADCP_PROTOCOL_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: scripts/build-schema-pr-bundle.sh
+
+      - name: Verify provenance and reproducibility
+        run: |
+          set -euo pipefail
+          source_date_epoch="$(git show -s --format=%ct HEAD)"
+          export SOURCE_DATE_EPOCH="${source_date_epoch}"
+          export ADCP_PROTOCOL_COMMIT_SHA="${PR_HEAD_SHA}"
+
+          (
+            cd dist/protocol
+            shasum -a 256 -c latest.tgz.sha256
+          )
+
+          bundle_version="$(node -p "require('./dist/protocol/latest.tgz.provenance.json').published_version")"
+          tar -xOf dist/protocol/latest.tgz "adcp-${bundle_version}/manifest.json" > "${RUNNER_TEMP}/bundle-manifest.json"
+          node <<'NODE'
+          const fs = require('node:fs');
+          const manifest = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + '/bundle-manifest.json', 'utf8'));
+          const provenance = JSON.parse(fs.readFileSync('dist/protocol/latest.tgz.provenance.json', 'utf8'));
+          if (manifest.source?.repository !== 'adcontextprotocol/adcp') {
+            throw new Error(`Unexpected bundle source repository ${manifest.source?.repository}`);
+          }
+          if (manifest.source?.commit_sha !== process.env.PR_HEAD_SHA) {
+            throw new Error(`Bundle manifest commit ${manifest.source?.commit_sha} does not match PR head ${process.env.PR_HEAD_SHA}`);
+          }
+          if (provenance.source_repository !== 'adcontextprotocol/adcp') {
+            throw new Error(`Unexpected provenance source repository ${provenance.source_repository}`);
+          }
+          if (provenance.source_commit !== process.env.PR_HEAD_SHA) {
+            throw new Error(`Provenance commit ${provenance.source_commit} does not match PR head ${process.env.PR_HEAD_SHA}`);
+          }
+          const checksum = fs.readFileSync('dist/protocol/latest.tgz.sha256', 'utf8').trim().split(/\s+/)[0];
+          if (provenance.bundle_sha256 !== checksum) {
+            throw new Error(`Provenance digest ${provenance.bundle_sha256} does not match checksum ${checksum}`);
+          }
+          NODE
+
+          cp dist/protocol/latest.tgz "${RUNNER_TEMP}/first.tgz"
+          cp dist/protocol/latest.tgz.sha256 "${RUNNER_TEMP}/first.tgz.sha256"
+          cp dist/protocol/latest.tgz.provenance.json "${RUNNER_TEMP}/first.tgz.provenance.json"
+          scripts/build-schema-pr-bundle.sh
+          cmp "${RUNNER_TEMP}/first.tgz" dist/protocol/latest.tgz
+          cmp "${RUNNER_TEMP}/first.tgz.sha256" dist/protocol/latest.tgz.sha256
+          cmp "${RUNNER_TEMP}/first.tgz.provenance.json" dist/protocol/latest.tgz.provenance.json
+
+      - name: Upload protocol PR bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: schema-pr-bundle-${{ github.event.pull_request.head.sha }}
+          path: |
+            dist/protocol/latest.tgz
+            dist/protocol/latest.tgz.sha256
+            dist/protocol/latest.tgz.provenance.json
+          if-no-files-found: error
+          retention-days: 14
+
+  typescript-sdk:
+    name: Generate TypeScript SDK
+    needs: build-bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: schema-pr-bundle-${{ github.event.pull_request.head.sha }}
+          path: bundle
+
+      - uses: actions/checkout@v7.0.1
+        with:
+          repository: adcontextprotocol/adcp-client
+          path: sdk
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: sdk/package-lock.json
+
+      - run: npm ci
+        working-directory: sdk
+
+      - name: Generate and build from the PR bundle
+        run: |
+          set -euo pipefail
+          (cd bundle && shasum -a 256 -c latest.tgz.sha256)
+          node -e "const fs=require('node:fs'); const p=require('./bundle/latest.tgz.provenance.json'); const digest=fs.readFileSync('./bundle/latest.tgz.sha256','utf8').trim().split(/\s+/)[0]; if (p.source_repository !== 'adcontextprotocol/adcp') throw new Error('Unexpected protocol provenance repository'); if (p.source_commit !== process.env.PR_HEAD_SHA) throw new Error('Protocol provenance does not match PR head'); if (p.bundle_sha256 !== digest) throw new Error('Protocol provenance digest does not match checksum')"
+          bundle_version="$(node -p "require('./bundle/latest.tgz.provenance.json').published_version")"
+          mkdir -p "${RUNNER_TEMP}/protocol-host/protocol"
+          cp bundle/latest.tgz "${RUNNER_TEMP}/protocol-host/protocol/${bundle_version}.tgz"
+          cp bundle/latest.tgz.sha256 "${RUNNER_TEMP}/protocol-host/protocol/${bundle_version}.tgz.sha256"
+          printf '%s\n' "${bundle_version}" > sdk/ADCP_VERSION
+
+          python3 -m http.server 8765 --directory "${RUNNER_TEMP}/protocol-host" > "${RUNNER_TEMP}/protocol-http.log" 2>&1 &
+          server_pid=$!
+          trap 'kill "${server_pid}" 2>/dev/null || true' EXIT
+          curl --fail --silent --show-error --retry 10 --retry-connrefused --retry-delay 1 \
+            "http://127.0.0.1:8765/protocol/${bundle_version}.tgz" >/dev/null
+
+          export ADCP_BASE_URL=http://127.0.0.1:8765
+          export ADCP_GITHUB_FALLBACK=0
+          npm --prefix sdk run sync-schemas
+          npm --prefix sdk run generate-types
+          npm --prefix sdk run validate-schemas
+
+          # build:lib also ensures historical compatibility caches. The primary
+          # cache above remains the PR bundle; older pinned bundles come from
+          # the normal public host.
+          unset ADCP_BASE_URL ADCP_GITHUB_FALLBACK
+          npm --prefix sdk run build:lib
+
+          bundle_digest="$(node -p "require('./bundle/latest.tgz.provenance.json').bundle_sha256")"
+          {
+            echo '### TypeScript SDK validation'
+            echo
+            echo "- SDK commit: \`$(git -C sdk rev-parse HEAD)\`"
+            echo "- Protocol commit: \`${PR_HEAD_SHA}\`"
+            echo "- Bundle SHA-256: \`${bundle_digest}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  python-sdk:
+    name: Generate Python SDK
+    needs: build-bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: schema-pr-bundle-${{ github.event.pull_request.head.sha }}
+          path: bundle
+
+      - uses: actions/checkout@v7.0.1
+        with:
+          repository: adcontextprotocol/adcp-client-python
+          path: sdk
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v7.0.0
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: sdk/pyproject.toml
+
+      - name: Install SDK development dependencies
+        run: python -m pip install -e '.[dev]'
+        working-directory: sdk
+
+      - name: Generate and test from the PR bundle
+        run: |
+          set -euo pipefail
+          (cd bundle && shasum -a 256 -c latest.tgz.sha256)
+          node -e "const fs=require('node:fs'); const p=require('./bundle/latest.tgz.provenance.json'); const digest=fs.readFileSync('./bundle/latest.tgz.sha256','utf8').trim().split(/\s+/)[0]; if (p.source_repository !== 'adcontextprotocol/adcp') throw new Error('Unexpected protocol provenance repository'); if (p.source_commit !== process.env.PR_HEAD_SHA) throw new Error('Protocol provenance does not match PR head'); if (p.bundle_sha256 !== digest) throw new Error('Protocol provenance digest does not match checksum')"
+          bundle_version="$(node -p "require('./bundle/latest.tgz.provenance.json').published_version")"
+          printf '%s\n' "${bundle_version}" > sdk/src/adcp/ADCP_VERSION
+          mkdir -p "${RUNNER_TEMP}/protocol-host/protocol"
+          cp bundle/latest.tgz "${RUNNER_TEMP}/protocol-host/protocol/${bundle_version}.tgz"
+          cp bundle/latest.tgz.sha256 "${RUNNER_TEMP}/protocol-host/protocol/${bundle_version}.tgz.sha256"
+
+          python3 -m http.server 8765 --directory "${RUNNER_TEMP}/protocol-host" > "${RUNNER_TEMP}/protocol-http.log" 2>&1 &
+          server_pid=$!
+          trap 'kill "${server_pid}" 2>/dev/null || true' EXIT
+          curl --fail --silent --show-error --retry 10 --retry-connrefused --retry-delay 1 \
+            "http://127.0.0.1:8765/protocol/${bundle_version}.tgz" >/dev/null
+
+          ADCP_BASE_URL=http://127.0.0.1:8765 \
+            ADCP_SKIP_SIGNATURE=1 \
+            make -C sdk regenerate-schemas PYTHON=python
+          make -C sdk validate-generated PYTHON=python
+          (
+            cd sdk
+            python -m pytest tests/test_code_generation.py tests/test_schemas_version_pin.py -q
+          )
+
+          bundle_digest="$(node -p "require('./bundle/latest.tgz.provenance.json').bundle_sha256")"
+          {
+            echo '### Python SDK validation'
+            echo
+            echo "- SDK commit: \`$(git -C sdk rev-parse HEAD)\`"
+            echo "- Protocol commit: \`${PR_HEAD_SHA}\`"
+            echo "- Bundle SHA-256: \`${bundle_digest}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ server/node_modules
 /dist/compliance/v*
 /dist/protocol/latest.tgz
 /dist/protocol/latest.tgz.sha256
+/dist/protocol/latest.tgz.provenance.json
 /dist/protocol/latest.tgz.sig
 /dist/protocol/latest.tgz.crt
 

--- a/docs/accounts/tasks/list_account_changes.mdx
+++ b/docs/accounts/tasks/list_account_changes.mdx
@@ -35,7 +35,7 @@ For the complete coverage matrix and rationale, see the
 
 ## Request
 
-**Request schema:** [`account/list-account-changes-request.json`](https://adcontextprotocol.org/schemas/latest/account/list-account-changes-request.json)
+**Request schema:** [`account/list-account-changes-request.json`](https://adcontextprotocol.org/schemas/v3/account/list-account-changes-request.json)
 
 | Field | Required | Description |
 | --- | --- | --- |
@@ -58,7 +58,7 @@ Acquire a high-water checkpoint before reading several snapshots:
 
 ## Response
 
-**Response schema:** [`account/list-account-changes-response.json`](https://adcontextprotocol.org/schemas/latest/account/list-account-changes-response.json)
+**Response schema:** [`account/list-account-changes-response.json`](https://adcontextprotocol.org/schemas/v3/account/list-account-changes-response.json)
 
 | Field | Description |
 | --- | --- |

--- a/docs/building/schemas-and-sdks.mdx
+++ b/docs/building/schemas-and-sdks.mdx
@@ -45,6 +45,39 @@ Publishers declare their agent endpoints and authorization scopes in `adagents.j
 
 For the full authorization type reference and worked examples, see [Authorization Patterns](/docs/governance/property/adagents#authorization-patterns) in the governance docs.
 
+## Validate an unreleased schema in both SDKs
+
+Schema-changing pull requests build a deterministic protocol bundle and run both the TypeScript and Python generators against it. The check records three machine-readable values in `latest.tgz.provenance.json`: the protocol commit, the bundle SHA-256, and the published-version label. A passing SDK job therefore identifies the exact protocol input it consumed.
+
+For same-repository pull requests, the workflow also publishes an immutable tuple keyed by the full head commit:
+
+```text
+https://adcontextprotocol.org/protocol/pr/<commit-sha>/latest.tgz
+https://adcontextprotocol.org/protocol/pr/<commit-sha>/latest.tgz.sha256
+https://adcontextprotocol.org/protocol/pr/<commit-sha>/latest.tgz.provenance.json
+```
+
+These bundles are unsigned development artifacts. Verify the checksum and provenance before using one, and never use a PR bundle in production.
+
+Preview bundles are retained for 90 days by default and removed by a daily cleanup job. Maintainers can change the window with the `SCHEMA_PR_BUNDLE_RETENTION_DAYS` repository variable. Rerun the protocol validation workflow to recreate an expired bundle for a still-current commit.
+
+To reproduce the artifact locally after committing the protocol inputs, run:
+
+```bash
+scripts/build-schema-pr-bundle.sh
+```
+
+The script derives both the source commit and deterministic timestamp from `HEAD`, refuses uncommitted bundle inputs, and writes the same three files under `dist/protocol/`.
+
+When creating a dependent SDK pull request:
+
+1. Copy the three artifact URLs from the protocol workflow summary.
+2. Regenerate with the SDK repository's supported local-bundle input and commit its provenance metadata with the generated output.
+3. Put the full protocol commit and bundle SHA-256 in the dependent pull request body.
+4. After every protocol force-push or rebase, use the new head-SHA URL, regenerate, and confirm the old commit no longer appears in generated metadata or the pull request description.
+
+The workflow's TypeScript and Python jobs are the executable reference for the current generator commands. Scoped generation is intentionally separate: this check validates the complete bundle so generator failures cannot be hidden by a file filter.
+
 ## Where to go next
 
 <CardGroup cols={2}>

--- a/docs/building/schemas-and-sdks.mdx
+++ b/docs/building/schemas-and-sdks.mdx
@@ -76,7 +76,7 @@ When creating a dependent SDK pull request:
 3. Put the full protocol commit and bundle SHA-256 in the dependent pull request body.
 4. After every protocol force-push or rebase, use the new head-SHA URL, regenerate, and confirm the old commit no longer appears in generated metadata or the pull request description.
 
-The workflow's TypeScript and Python jobs are the executable reference for the current generator commands. Scoped generation is intentionally separate: this check validates the complete bundle so generator failures cannot be hidden by a file filter.
+The preview workflow is intentionally triggered only by changes under `static/schemas/source/**`. Once triggered, its TypeScript and Python jobs validate the complete bundle rather than only the changed schema files. Changes limited to compliance sources, the OpenAPI registry, or build tooling remain covered by their normal CI checks but do not publish a schema preview bundle.
 
 ## Where to go next
 

--- a/scripts/build-compliance.cjs
+++ b/scripts/build-compliance.cjs
@@ -41,6 +41,20 @@ const SPECIALISM_ENUM = path.join(__dirname, '../static/schemas/source/enums/spe
 const PROTOCOL_ENUM = path.join(__dirname, '../static/schemas/source/enums/adcp-protocol.json');
 const SCHEMAS_DIR = path.join(__dirname, '../static/schemas/source');
 
+function resolveBuildTimestamp(env = process.env, now = new Date()) {
+  if (env.SOURCE_DATE_EPOCH === undefined) return now.toISOString();
+  if (!/^\d+$/.test(env.SOURCE_DATE_EPOCH)) {
+    throw new Error('SOURCE_DATE_EPOCH must be an integer number of seconds since the Unix epoch');
+  }
+  const date = new Date(Number(env.SOURCE_DATE_EPOCH) * 1000);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('SOURCE_DATE_EPOCH is outside the supported date range');
+  }
+  return date.toISOString();
+}
+
+const BUILD_TIMESTAMP = resolveBuildTimestamp();
+
 const args = process.argv.slice(2);
 const isRelease = args.includes('--release');
 const isCheck = args.includes('--check');
@@ -537,7 +551,7 @@ function generateIndex(version, sourceDir) {
   return {
     published_version: version,
     adcp_version: version,
-    generated_at: new Date().toISOString(),
+    generated_at: BUILD_TIMESTAMP,
     universal,
     protocols: protocolEntries,
     domains: domainAliasEntries,

--- a/scripts/build-protocol-tarball.cjs
+++ b/scripts/build-protocol-tarball.cjs
@@ -49,6 +49,36 @@ const PACKAGE_JSON = path.join(ROOT, 'package.json');
 const args = process.argv.slice(2);
 const isRelease = args.includes('--release');
 
+const SOURCE_REPOSITORY = 'adcontextprotocol/adcp';
+
+function resolveBuildMetadata(env = process.env, now = new Date()) {
+  let generatedAt = now.toISOString();
+  let archiveMtime;
+
+  if (env.SOURCE_DATE_EPOCH !== undefined) {
+    if (!/^\d+$/.test(env.SOURCE_DATE_EPOCH)) {
+      throw new Error('SOURCE_DATE_EPOCH must be an integer number of seconds since the Unix epoch');
+    }
+    archiveMtime = new Date(Number(env.SOURCE_DATE_EPOCH) * 1000);
+    if (Number.isNaN(archiveMtime.getTime())) {
+      throw new Error('SOURCE_DATE_EPOCH is outside the supported date range');
+    }
+    generatedAt = archiveMtime.toISOString();
+  }
+
+  const sourceCommit = env.ADCP_PROTOCOL_COMMIT_SHA;
+  if (sourceCommit !== undefined && !/^[0-9a-f]{40}$/.test(sourceCommit)) {
+    throw new Error('ADCP_PROTOCOL_COMMIT_SHA must be a lowercase 40-character Git commit SHA');
+  }
+
+  return {
+    generatedAt,
+    archiveMtime,
+    sourceCommit,
+    sourceRepository: SOURCE_REPOSITORY
+  };
+}
+
 function getVersion() {
   return JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8')).version;
 }
@@ -81,6 +111,40 @@ function walk(dir, base = dir) {
     else out.push(path.relative(base, full));
   }
   return out;
+}
+
+function archiveEntries(stagingRoot, rootDirName) {
+  const entries = [];
+
+  function visit(relativePath) {
+    entries.push(relativePath);
+    const absolutePath = path.join(stagingRoot, relativePath);
+    if (!fs.statSync(absolutePath).isDirectory()) return;
+
+    for (const name of fs.readdirSync(absolutePath).sort()) {
+      visit(path.join(relativePath, name));
+    }
+  }
+
+  visit(rootDirName);
+  return entries;
+}
+
+function pinGeneratedAt(filePath, generatedAt) {
+  if (!fs.existsSync(filePath)) return;
+  const document = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  if (typeof document.generated_at !== 'string') return;
+  document.generated_at = generatedAt;
+  fs.writeFileSync(filePath, JSON.stringify(document, null, 2) + '\n');
+}
+
+function pinPublishedVersion(filePath, publishedVersion) {
+  if (!fs.existsSync(filePath)) return;
+  const document = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  if ('published_version' in document) document.published_version = publishedVersion;
+  if ('adcp_version' in document) document.adcp_version = publishedVersion;
+  if (typeof document.baseUrl === 'string') document.baseUrl = `/schemas/${publishedVersion}`;
+  fs.writeFileSync(filePath, JSON.stringify(document, null, 2) + '\n');
 }
 
 function writeBundleReadme(bundleDir, version, isDev) {
@@ -160,21 +224,55 @@ ship with a major bump.
   fs.writeFileSync(path.join(bundleDir, 'README.md'), readme);
 }
 
-async function buildTarball(label, stagingRoot, rootDirName, outFile) {
+async function buildTarball(label, stagingRoot, rootDirName, outFile, metadata) {
   await tar.create(
     {
       gzip: { level: 9 },
       file: outFile,
       cwd: stagingRoot,
-      portable: true
+      portable: true,
+      noDirRecurse: true,
+      ...(metadata.archiveMtime ? { mtime: metadata.archiveMtime } : {})
     },
-    [rootDirName]
+    archiveEntries(stagingRoot, rootDirName)
   );
   const size = fs.statSync(outFile).size;
   console.log(`   ✓ ${label}: ${outFile.replace(ROOT + '/', '')} (${(size / 1024).toFixed(1)} KB)`);
 }
 
-function stageBundle(bundleParent, version, schemasSource, rootDirName, isDev = false) {
+function writeIntegritySidecars(tarballPath, metadata, publishedVersion) {
+  const digest = sha256(tarballPath);
+  const tarballName = path.basename(tarballPath);
+  const provenancePath = `${tarballPath}.provenance.json`;
+  fs.writeFileSync(`${tarballPath}.sha256`, `${digest}  ${tarballName}\n`);
+
+  if (metadata.sourceCommit) {
+    fs.writeFileSync(
+      provenancePath,
+      JSON.stringify({
+        schema_version: 1,
+        source_repository: metadata.sourceRepository,
+        source_commit: metadata.sourceCommit,
+        source_date: metadata.generatedAt,
+        published_version: publishedVersion,
+        bundle_file: tarballName,
+        bundle_sha256: digest
+      }, null, 2) + '\n'
+    );
+  } else {
+    fs.rmSync(provenancePath, { force: true });
+  }
+}
+
+function stageBundle(
+  bundleParent,
+  version,
+  schemasSource,
+  rootDirName,
+  metadata,
+  isDev = false,
+  publishedVersion = version
+) {
   if (fs.existsSync(bundleParent)) fs.rmSync(bundleParent, { recursive: true, force: true });
   ensureDir(bundleParent);
   const bundleDir = path.join(bundleParent, rootDirName);
@@ -182,6 +280,10 @@ function stageBundle(bundleParent, version, schemasSource, rootDirName, isDev = 
 
   const schemasDst = path.join(bundleDir, 'schemas');
   copyTree(schemasSource, schemasDst);
+  pinGeneratedAt(path.join(schemasDst, 'manifest.json'), metadata.generatedAt);
+  if (publishedVersion !== version) {
+    pinPublishedVersion(path.join(schemasDst, 'index.json'), publishedVersion);
+  }
 
   const complianceSource = path.join(DIST_COMPLIANCE, version);
   if (!fs.existsSync(complianceSource)) {
@@ -189,6 +291,10 @@ function stageBundle(bundleParent, version, schemasSource, rootDirName, isDev = 
   }
   const complianceDst = path.join(bundleDir, 'compliance');
   copyTree(complianceSource, complianceDst);
+  pinGeneratedAt(path.join(complianceDst, 'index.json'), metadata.generatedAt);
+  if (publishedVersion !== version) {
+    pinPublishedVersion(path.join(complianceDst, 'index.json'), publishedVersion);
+  }
   assertCompliancePackagedRefs(complianceDst, 'Compliance packaged-reference lint failed for staged protocol bundle');
 
   if (fs.existsSync(OPENAPI_FILE)) {
@@ -224,9 +330,15 @@ function stageBundle(bundleParent, version, schemasSource, rootDirName, isDev = 
   // (ComplianceIndex.adcp_version). Both carry full semver; distinct from the
   // wire field in core/version-envelope.json (release-precision).
   const manifest = {
-    published_version: version,
-    adcp_version: version,
-    generated_at: new Date().toISOString(),
+    published_version: publishedVersion,
+    adcp_version: publishedVersion,
+    generated_at: metadata.generatedAt,
+    ...(metadata.sourceCommit ? {
+      source: {
+        repository: metadata.sourceRepository,
+        commit_sha: metadata.sourceCommit
+      }
+    } : {}),
     root_dir: rootDirName,
     contents: {
       schemas: fs.existsSync(schemasDst),
@@ -247,6 +359,7 @@ function stageBundle(bundleParent, version, schemasSource, rootDirName, isDev = 
 
 async function main() {
   const version = getVersion();
+  const metadata = resolveBuildMetadata();
 
   console.log(isRelease
     ? `🚀 RELEASE BUILD: Creating protocol tarball for AdCP v${version}`
@@ -274,19 +387,19 @@ async function main() {
     console.log(`📋 Staging bundle for ${version}`);
     const versionStage = path.join(stagingRoot, version);
     const versionRoot = `adcp-${version}`;
-    const manifest = stageBundle(versionStage, version, versionSchemas, versionRoot);
+    const manifest = stageBundle(versionStage, version, versionSchemas, versionRoot, metadata);
     console.log(`   ✓ manifest: ${manifest.file_count} files, root: ${manifest.root_dir}`);
 
     const versionTar = path.join(OUT_DIR, `${version}.tgz`);
-    await buildTarball(`version tarball`, versionStage, versionRoot, versionTar);
-    fs.writeFileSync(versionTar + '.sha256', `${sha256(versionTar)}  ${version}.tgz\n`);
+    await buildTarball(`version tarball`, versionStage, versionRoot, versionTar, metadata);
+    writeIntegritySidecars(versionTar, metadata, version);
 
     console.log(`📋 Staging latest bundle (mirrors release)`);
     const latestStage = path.join(stagingRoot, 'latest');
-    stageBundle(latestStage, version, versionSchemas, versionRoot, true);
+    stageBundle(latestStage, version, versionSchemas, versionRoot, metadata, true);
     const latestTar = path.join(OUT_DIR, `latest.tgz`);
-    await buildTarball(`latest tarball`, latestStage, versionRoot, latestTar);
-    fs.writeFileSync(latestTar + '.sha256', `${sha256(latestTar)}  latest.tgz\n`);
+    await buildTarball(`latest tarball`, latestStage, versionRoot, latestTar, metadata);
+    writeIntegritySidecars(latestTar, metadata, version);
 
     console.log(`📝 Staging dist/protocol/${version}.tgz for git commit`);
     try {
@@ -302,12 +415,15 @@ async function main() {
   } else {
     console.log(`📋 Staging latest bundle`);
     const latestStage = path.join(stagingRoot, 'latest');
-    const latestRoot = `adcp-latest`;
-    const manifest = stageBundle(latestStage, 'latest', latestSchemas, latestRoot, true);
+    // PR bundles retain release-compatible internal naming so current SDK
+    // sync commands can consume them under the package semver. The external
+    // object remains commit-addressed and is never presented as a release.
+    const latestRoot = metadata.sourceCommit ? `adcp-${version}` : `adcp-latest`;
+    const manifest = stageBundle(latestStage, 'latest', latestSchemas, latestRoot, metadata, true, version);
     console.log(`   ✓ manifest: ${manifest.file_count} files, root: ${manifest.root_dir}`);
     const latestTar = path.join(OUT_DIR, `latest.tgz`);
-    await buildTarball(`latest tarball`, latestStage, latestRoot, latestTar);
-    fs.writeFileSync(latestTar + '.sha256', `${sha256(latestTar)}  latest.tgz\n`);
+    await buildTarball(`latest tarball`, latestStage, latestRoot, latestTar, metadata);
+    writeIntegritySidecars(latestTar, metadata, version);
   }
 
   fs.rmSync(stagingRoot, { recursive: true, force: true });
@@ -323,7 +439,18 @@ async function main() {
   console.log(`   /protocol/latest.tgz         - Development bundle`);
 }
 
-main().catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  archiveEntries,
+  buildTarball,
+  pinGeneratedAt,
+  pinPublishedVersion,
+  resolveBuildMetadata,
+  writeIntegritySidecars
+};

--- a/scripts/build-protocol-tarball.cjs
+++ b/scripts/build-protocol-tarball.cjs
@@ -130,21 +130,42 @@ function archiveEntries(stagingRoot, rootDirName) {
   return entries;
 }
 
+function updateJsonFile(filePath, update) {
+  let fd;
+  try {
+    fd = fs.openSync(filePath, 'r+');
+  } catch (error) {
+    if (error.code === 'ENOENT') return;
+    throw error;
+  }
+
+  try {
+    const document = JSON.parse(fs.readFileSync(fd, 'utf8'));
+    if (!update(document)) return;
+
+    const output = JSON.stringify(document, null, 2) + '\n';
+    fs.ftruncateSync(fd, 0);
+    fs.writeSync(fd, output, 0, 'utf8');
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
 function pinGeneratedAt(filePath, generatedAt) {
-  if (!fs.existsSync(filePath)) return;
-  const document = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  if (typeof document.generated_at !== 'string') return;
-  document.generated_at = generatedAt;
-  fs.writeFileSync(filePath, JSON.stringify(document, null, 2) + '\n');
+  updateJsonFile(filePath, document => {
+    if (typeof document.generated_at !== 'string') return false;
+    document.generated_at = generatedAt;
+    return true;
+  });
 }
 
 function pinPublishedVersion(filePath, publishedVersion) {
-  if (!fs.existsSync(filePath)) return;
-  const document = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  if ('published_version' in document) document.published_version = publishedVersion;
-  if ('adcp_version' in document) document.adcp_version = publishedVersion;
-  if (typeof document.baseUrl === 'string') document.baseUrl = `/schemas/${publishedVersion}`;
-  fs.writeFileSync(filePath, JSON.stringify(document, null, 2) + '\n');
+  updateJsonFile(filePath, document => {
+    if ('published_version' in document) document.published_version = publishedVersion;
+    if ('adcp_version' in document) document.adcp_version = publishedVersion;
+    if (typeof document.baseUrl === 'string') document.baseUrl = `/schemas/${publishedVersion}`;
+    return true;
+  });
 }
 
 function writeBundleReadme(bundleDir, version, isDev) {

--- a/scripts/build-schema-pr-bundle.sh
+++ b/scripts/build-schema-pr-bundle.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+source_commit="${ADCP_PROTOCOL_COMMIT_SHA:-$(git rev-parse HEAD)}"
+head_commit="$(git rev-parse HEAD)"
+if [[ "${source_commit}" != "${head_commit}" ]]; then
+  echo "error: ADCP_PROTOCOL_COMMIT_SHA ${source_commit} does not match checked-out HEAD ${head_commit}" >&2
+  exit 1
+fi
+
+dirty_inputs="$(git status --porcelain --untracked-files=all)"
+if [[ -n "${dirty_inputs}" ]]; then
+  echo "error: protocol bundle inputs must be committed before building provenance:" >&2
+  echo "${dirty_inputs}" >&2
+  exit 1
+fi
+
+source_date_epoch="$(git show -s --format=%ct HEAD)"
+export SOURCE_DATE_EPOCH="${source_date_epoch}"
+export ADCP_PROTOCOL_COMMIT_SHA="${source_commit}"
+
+npm run build:schemas
+npm run build:compliance
+npm run build:protocol-tarball
+
+(
+  cd dist/protocol
+  shasum -a 256 -c latest.tgz.sha256
+)
+
+node <<'NODE'
+const provenance = require('./dist/protocol/latest.tgz.provenance.json');
+if (provenance.source_commit !== process.env.ADCP_PROTOCOL_COMMIT_SHA) {
+  throw new Error(`Bundle provenance ${provenance.source_commit} does not match ${process.env.ADCP_PROTOCOL_COMMIT_SHA}`);
+}
+console.log(`Protocol commit: ${provenance.source_commit}`);
+console.log(`Bundle SHA-256: ${provenance.bundle_sha256}`);
+NODE
+
+echo "Bundle: ${repo_root}/dist/protocol/latest.tgz"
+echo "Checksum: ${repo_root}/dist/protocol/latest.tgz.sha256"
+echo "Provenance: ${repo_root}/dist/protocol/latest.tgz.provenance.json"

--- a/scripts/build-schemas.cjs
+++ b/scripts/build-schemas.cjs
@@ -44,6 +44,21 @@ const PACKAGE_JSON = path.join(__dirname, '../package.json');
 const SKILLS_DIR = path.join(__dirname, '../skills');
 const SCHEMA_ORIGIN = 'https://adcontextprotocol.org';
 
+function resolveBuildTimestamp(env = process.env, now = new Date()) {
+  if (env.SOURCE_DATE_EPOCH === undefined) return now.toISOString();
+  if (!/^\d+$/.test(env.SOURCE_DATE_EPOCH)) {
+    throw new Error('SOURCE_DATE_EPOCH must be an integer number of seconds since the Unix epoch');
+  }
+  const date = new Date(Number(env.SOURCE_DATE_EPOCH) * 1000);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('SOURCE_DATE_EPOCH is outside the supported date range');
+  }
+  return date.toISOString();
+}
+
+const BUILD_TIMESTAMP = resolveBuildTimestamp();
+const BUILD_DATE = BUILD_TIMESTAMP.slice(0, 10);
+
 // Active MCP role catalogs intentionally use explicit tool sets. Protocol
 // tags alone are not sufficient: creative construction is historically tagged
 // media-buy, while a seller-hosted media-buy role also needs account, task,
@@ -798,7 +813,7 @@ function generateExtensionRegistry(extensions, targetVersion) {
     title: 'AdCP Extension Registry',
     description: 'Auto-generated registry of formal AdCP extensions. Extensions provide typed schemas for vendor-specific or domain-specific data within the ext field. Agents declare which extensions they support in their agent card.',
     _generated: true,
-    _generatedAt: new Date().toISOString(),
+    _generatedAt: BUILD_TIMESTAMP,
     extensions: {}
   };
 
@@ -1335,7 +1350,7 @@ function buildManifest(sourceDir, urlVersion, semverVersion, repoRoot) {
   return {
     $schema: `/schemas/${urlVersion}/manifest.schema.json`,
     adcp_version: semverVersion,
-    generated_at: new Date().toISOString(),
+    generated_at: BUILD_TIMESTAMP,
     tools: toolsObj,
     task_result_resolution: buildTaskResultResolution(sourceDir, toolsObj),
     error_code_policy: {
@@ -1401,7 +1416,7 @@ function copyAndTransformSchemas(sourceDir, targetDir, version) {
         // in core/version-envelope.json, which uses release-precision.
         schema.published_version = version;
         schema.adcp_version = version;
-        schema.lastUpdated = new Date().toISOString().split('T')[0];
+        schema.lastUpdated = BUILD_DATE;
         schema.baseUrl = `/schemas/${version}`;
         schema.protocol_layers = [
           {
@@ -2203,7 +2218,7 @@ async function generateBundledSchemas(sourceDir, bundledDir, version) {
 
       // Add metadata indicating this is bundled
       dereferenced._bundled = {
-        generatedAt: new Date().toISOString(),
+        generatedAt: BUILD_TIMESTAMP,
         note: 'This is a bundled schema with all $ref resolved inline. For the modular version with references, use the parent directory.'
       };
 

--- a/tests/release-workflow-immutability.test.cjs
+++ b/tests/release-workflow-immutability.test.cjs
@@ -18,6 +18,10 @@ const releaseDocsWorkflow = fs.readFileSync(
   path.join(repoRoot, '.github/workflows/release-docs.yml'),
   'utf8'
 );
+const schemaPrWorkflowConfig = YAML.parse(fs.readFileSync(
+  path.join(repoRoot, '.github/workflows/validate-schema-bundle.yml'),
+  'utf8'
+));
 const workflowConfig = YAML.parse(workflow);
 const eolReleaseBranches = ['2.5-maintenance', '2.6.x'];
 const activeWorkflowPaths = [
@@ -60,6 +64,12 @@ const changesetsActionImplementation = fs.readFileSync(
   'utf8'
 );
 const changesetsActionContract = YAML.parse(changesetsActionContractSource);
+
+assert.deepStrictEqual(
+  schemaPrWorkflowConfig.on.pull_request.paths,
+  ['static/schemas/source/**'],
+  'Schema PR bundle validation must run only for canonical schema source changes.'
+);
 
 assert.strictEqual(
   crypto.createHash('sha256').update(changesetsActionContractSource).digest('hex'),

--- a/tests/sign-protocol-tarball.test.cjs
+++ b/tests/sign-protocol-tarball.test.cjs
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -7,6 +8,17 @@ const { describe, it } = require('node:test');
 
 const ROOT = path.resolve(__dirname, '..');
 const SCRIPT = path.join(ROOT, 'scripts/sign-protocol-tarball.sh');
+const {
+  buildTarball,
+  pinGeneratedAt,
+  pinPublishedVersion,
+  resolveBuildMetadata,
+  writeIntegritySidecars,
+} = require('../scripts/build-protocol-tarball.cjs');
+
+function digest(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
 
 function makeWorkspace(version = '1.2.3') {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sign-protocol-tarball-'));
@@ -149,5 +161,100 @@ describe('sign-protocol-tarball.sh', () => {
     assert.match(output, /Skipping 1\.2\.2\.tgz \(signature sidecars already exist\)/);
     assert.equal(fs.readFileSync(`${oldTarball}.sig`, 'utf8'), 'old-signature');
     assert.equal(fs.readFileSync(`${oldTarball}.crt`, 'utf8'), 'old-certificate');
+  });
+});
+
+describe('build-protocol-tarball.cjs', () => {
+  it('uses SOURCE_DATE_EPOCH and protocol commit for stable metadata', () => {
+    const metadata = resolveBuildMetadata({
+      SOURCE_DATE_EPOCH: '1787979011',
+      ADCP_PROTOCOL_COMMIT_SHA: 'e0567393bb3ae3d955532b99949ba1dfc3b4a40f',
+    });
+
+    assert.equal(metadata.generatedAt, '2026-08-29T04:50:11.000Z');
+    assert.equal(metadata.archiveMtime.toISOString(), metadata.generatedAt);
+    assert.equal(metadata.sourceRepository, 'adcontextprotocol/adcp');
+    assert.equal(metadata.sourceCommit, 'e0567393bb3ae3d955532b99949ba1dfc3b4a40f');
+  });
+
+  it('fails closed on invalid reproducible-build inputs', () => {
+    assert.throws(
+      () => resolveBuildMetadata({ SOURCE_DATE_EPOCH: 'yesterday' }),
+      /SOURCE_DATE_EPOCH must be an integer/,
+    );
+    assert.throws(
+      () => resolveBuildMetadata({ ADCP_PROTOCOL_COMMIT_SHA: 'e0567393bb' }),
+      /40-character Git commit SHA/,
+    );
+  });
+
+  it('creates reproducible tarball and provenance bytes', async (t) => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-protocol-tarball-'));
+    t.after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+    const staging = path.join(tmp, 'staging');
+    const bundleRoot = path.join(staging, 'adcp-latest');
+    fs.mkdirSync(path.join(bundleRoot, 'schemas'), { recursive: true });
+    fs.writeFileSync(path.join(bundleRoot, 'README.md'), 'bundle\n');
+    fs.writeFileSync(path.join(bundleRoot, 'schemas', 'index.json'), '{"adcp_version":"latest"}\n');
+
+    const metadata = resolveBuildMetadata({
+      SOURCE_DATE_EPOCH: '1787979011',
+      ADCP_PROTOCOL_COMMIT_SHA: 'e0567393bb3ae3d955532b99949ba1dfc3b4a40f',
+    });
+    const first = path.join(tmp, 'first.tgz');
+    const second = path.join(tmp, 'second.tgz');
+
+    await buildTarball('first', staging, 'adcp-latest', first, metadata);
+    fs.utimesSync(path.join(bundleRoot, 'README.md'), new Date(), new Date());
+    await buildTarball('second', staging, 'adcp-latest', second, metadata);
+
+    assert.equal(digest(first), digest(second));
+
+    writeIntegritySidecars(first, metadata, '3.2.0-beta.9');
+    const provenance = JSON.parse(fs.readFileSync(`${first}.provenance.json`, 'utf8'));
+    assert.equal(provenance.source_commit, metadata.sourceCommit);
+    assert.equal(provenance.bundle_sha256, digest(first));
+    assert.equal(fs.readFileSync(`${first}.sha256`, 'utf8'), `${digest(first)}  first.tgz\n`);
+
+    writeIntegritySidecars(first, resolveBuildMetadata({}, new Date(0)), '3.2.0-beta.9');
+    assert.equal(fs.existsSync(`${first}.provenance.json`), false);
+  });
+
+  it('pins generated timestamps without changing unrelated metadata', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-protocol-manifest-'));
+    const manifestPath = path.join(tmp, 'manifest.json');
+    try {
+      fs.writeFileSync(manifestPath, JSON.stringify({ generated_at: 'now', value: 42 }));
+      pinGeneratedAt(manifestPath, '2026-08-29T04:50:11.000Z');
+      assert.deepEqual(JSON.parse(fs.readFileSync(manifestPath, 'utf8')), {
+        generated_at: '2026-08-29T04:50:11.000Z',
+        value: 42,
+      });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the package semver expected by SDK sync in PR bundle indexes', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-protocol-index-'));
+    const indexPath = path.join(tmp, 'index.json');
+    try {
+      fs.writeFileSync(indexPath, JSON.stringify({
+        published_version: 'latest',
+        adcp_version: 'latest',
+        baseUrl: '/schemas/latest',
+        schemas: {},
+      }));
+      pinPublishedVersion(indexPath, '3.2.0-beta.9');
+      assert.deepEqual(JSON.parse(fs.readFileSync(indexPath, 'utf8')), {
+        published_version: '3.2.0-beta.9',
+        adcp_version: '3.2.0-beta.9',
+        baseUrl: '/schemas/3.2.0-beta.9',
+        schemas: {},
+      });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- build deterministic, commit-addressed protocol bundles with checksum and provenance metadata
- run bundle validation and publication only for PRs that change canonical schema sources under `static/schemas/source/**`
- validate each schema PR bundle against the current TypeScript and Python SDK generators before publishing it to an immutable R2 URL
- automatically delete commit preview bundles after 90 days, with a configurable repository retention value and a safe dry-run mode
- document how downstream SDK PRs can pin and test the exact protocol PR artifact

## Testing

- reproducibility: two independent schema/compliance builds produced byte-identical bundles
- TypeScript SDK: exact local bundle sync, generation, validation, and library build
- Python SDK: exact local bundle regeneration, validation, and 49 focused tests
- `node --test tests/sign-protocol-tarball.test.cjs` (11 tests)
- `actionlint` for all three workflows
- `shellcheck scripts/build-schema-pr-bundle.sh`
- `npm run typecheck`
- schema-link lint and docs navigation validation (45 tests)
- pre-commit core/unit gates passed; full server-unit gate hit its 600-second cap after one unrelated flaky test, which passed in isolation
- pre-push storyboard matrix could not discover raw capabilities for any tenant; static storyboard checks passed and the shared discovery failure occurred before scenario selection

Closes #6984
