### PR TITLE
fix(integrity): scan past_due subs and surface unconfigured escalation channel

### DIFF
--- a/server/src/addie/jobs/integrity-invariants.ts
+++ b/server/src/addie/jobs/integrity-invariants.ts
@@ -144,7 +144,7 @@ async function ensureStripeReflectionEscalation(
         { escalationId: escalation.id, organizationId: violation.subject_id },
         'Stripe reflection escalation persisted but no escalation channel is configured',
       );
-      return { ensured: true, notified: false, error: false };
+      return { ensured: true, notified: false, error: true };
     }
 
     const sent = await sendChannelMessage(

--- a/server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts
+++ b/server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts
@@ -88,7 +88,7 @@ function isReflected(org: OrgRow): boolean {
 export const stripeSubReflectedInOrgRowInvariant: Invariant = {
   name: 'stripe-sub-reflected-in-org-row',
   description:
-    'Every membership subscription that is active or trialing in Stripe is fully reflected in the org row for its linked customer — entitled status PLUS populated stripe_subscription_id and tier-resolving product fields. Catches missed webhooks (Lina-class) and partial-truth rows where status was set manually but Stripe data never synced (Adzymic-class).',
+    'Every membership subscription that is active, trialing, or past_due in Stripe is fully reflected in the org row for its linked customer — entitled status PLUS populated stripe_subscription_id and tier-resolving product fields. Catches missed webhooks (Lina-class) and partial-truth rows where status was set manually but Stripe data never synced (Adzymic-class).',
   severity: 'critical',
   async check(ctx: InvariantContext): Promise<InvariantResult> {
     const { pool, stripe, logger } = ctx;
@@ -112,7 +112,7 @@ export const stripeSubReflectedInOrgRowInvariant: Invariant = {
     // through to the Stripe Dashboard by id to know who to link.
     const memberSubs: Stripe.Subscription[] = [];
     const productCache = new Map<string, Stripe.Product | Stripe.DeletedProduct>();
-    for (const status of ['active', 'trialing'] as const) {
+    for (const status of ['active', 'trialing', 'past_due'] as const) {
       for await (const sub of stripe.subscriptions.list({
         status,
         limit: 100,

--- a/server/tests/unit/integrity-invariants-job.test.ts
+++ b/server/tests/unit/integrity-invariants-job.test.ts
@@ -228,7 +228,7 @@ describe('runIntegrityInvariantsJob', () => {
     expect(result).toEqual(expect.objectContaining({
       durableEscalations: 1,
       escalationNotifications: 0,
-      escalationErrors: 0,
+      escalationErrors: 1,
     }));
     expect(mocks.createEscalation).toHaveBeenCalledOnce();
     expect(mocks.releaseEscalationNotificationClaim).toHaveBeenCalledWith(42);

--- a/server/tests/unit/integrity/invariants.test.ts
+++ b/server/tests/unit/integrity/invariants.test.ts
@@ -514,15 +514,19 @@ describe('stripe-sub-reflected-in-org-row', () => {
 
   /**
    * `for await ... of stripe.subscriptions.list(...)` consumes the auto-paginating
-   * iterator. Mock returns an async-iterable. First call ⇒ active subs, second ⇒ trialing.
+   * iterator. Mock returns an async-iterable. First call ⇒ active subs,
+   * second ⇒ trialing, third ⇒ past_due.
    */
-  function mockSubsListWith(activeSubs: unknown[], trialingSubs: unknown[] = []): void {
+  function mockSubsListWith(activeSubs: unknown[], trialingSubs: unknown[] = [], pastDueSubs: unknown[] = []): void {
     mockStripeSubsList
       .mockImplementationOnce(() => ({
         async *[Symbol.asyncIterator]() { for (const s of activeSubs) yield s; },
       }))
       .mockImplementationOnce(() => ({
         async *[Symbol.asyncIterator]() { for (const s of trialingSubs) yield s; },
+      }))
+      .mockImplementationOnce(() => ({
+        async *[Symbol.asyncIterator]() { for (const s of pastDueSubs) yield s; },
       }));
   }
 
@@ -1012,13 +1016,16 @@ describe('stripe-sub-reflected-in-org-row partial-truth', () => {
     };
   }
 
-  function mockSubsListWith(activeSubs: unknown[], trialingSubs: unknown[] = []): void {
+  function mockSubsListWith(activeSubs: unknown[], trialingSubs: unknown[] = [], pastDueSubs: unknown[] = []): void {
     mockStripeSubsList
       .mockImplementationOnce(() => ({
         async *[Symbol.asyncIterator]() { for (const s of activeSubs) yield s; },
       }))
       .mockImplementationOnce(() => ({
         async *[Symbol.asyncIterator]() { for (const s of trialingSubs) yield s; },
+      }))
+      .mockImplementationOnce(() => ({
+        async *[Symbol.asyncIterator]() { for (const s of pastDueSubs) yield s; },
       }));
   }
 


### PR DESCRIPTION
## Summary

Two bugs in the integrity invariants framework that reduce detection coverage for the Stripe→DB sync failures tracked in #6930 and #6686:

1. **Missing `past_due` in scan loop** — `stripe-sub-reflected-in-org-row` scanned only `active` and `trialing` subscriptions from Stripe, but `ENTITLED_STATUSES` (and `TIER_PRESERVING_STATUSES`) include `past_due`. A member in dunning with a broken DB row was invisible to the 6-hour integrity scan.

2. **Silent escalation swallow** — when no Slack escalation channel is configured, the job returned `error: false`, so the result reported zero errors despite no admin being notified. Changed to `error: true` so the job result accurately reflects that notification failed.

## Changes

- `server/src/audit/integrity/invariants/stripe-sub-reflected-in-org-row.ts` — add `past_due` to the `subscriptions.list` scan loop; update invariant description
- `server/src/addie/jobs/integrity-invariants.ts` — return `error: true` when escalation channel is unconfigured
- `server/tests/unit/integrity/invariants.test.ts` — update both `mockSubsListWith` helpers to supply the third status iteration
- `server/tests/unit/integrity-invariants-job.test.ts` — update assertion from `escalationErrors: 0` to `1`

## Verification

- `npx vitest run server/tests/unit/integrity/invariants.test.ts` — 54/54 passed
- `npx vitest run server/tests/unit/integrity-invariants-job.test.ts` — 13/13 passed

Refs #6930