### PR TITLE
feat(addie): add provider-neutral tool choice

### DIFF
--- a/server/src/addie/model-providers/anthropic-provider.ts
+++ b/server/src/addie/model-providers/anthropic-provider.ts
@@ -592,6 +592,11 @@ export class AnthropicModelProvider implements ModelProvider {
         ...(block.cacheHint === 'ephemeral' && { cache_control: { type: 'ephemeral' } }),
       })),
       tools,
+      ...(request.toolChoice && {
+        tool_choice: request.toolChoice.type === 'tool'
+          ? { type: 'tool', name: request.toolChoice.name }
+          : { type: request.toolChoice.type === 'required' ? 'any' : 'auto' },
+      }),
       messages: toAnthropicMessages(request.messages),
       betas: ['web-search-2025-03-05'],
     } satisfies AnthropicRequest));

--- a/server/src/addie/model-providers/capabilities.ts
+++ b/server/src/addie/model-providers/capabilities.ts
@@ -70,6 +70,19 @@ export function validateModelCapabilities(
       throw new Error('Custom tool name collides with provider tool: web_search');
     }
   }
+  if (request.toolChoice) {
+    if (request.tools.length === 0 && (request.providerTools?.length ?? 0) === 0) {
+      throw new Error('Model tool choice requires at least one tool');
+    }
+    if (request.toolChoice.type === 'tool') {
+      if (!request.toolChoice.name.trim()) {
+        throw new Error('Named model tool choice requires a name');
+      }
+      if (!toolNames.has(request.toolChoice.name)) {
+        throw new Error(`Named model tool choice is unavailable: ${request.toolChoice.name}`);
+      }
+    }
+  }
 
   const requireCapability = (
     required: boolean,

--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -201,8 +201,12 @@ function toGoogleRequest(request: ModelRequest): GenerateContentParameters {
         }],
         toolConfig: {
           functionCallingConfig: {
-            mode: FunctionCallingConfigMode.VALIDATED,
-            allowedFunctionNames: request.tools.map((tool) => tool.name),
+            mode: request.toolChoice?.type === 'required' || request.toolChoice?.type === 'tool'
+              ? FunctionCallingConfigMode.ANY
+              : FunctionCallingConfigMode.VALIDATED,
+            allowedFunctionNames: request.toolChoice?.type === 'tool'
+              ? [request.toolChoice.name]
+              : request.tools.map((tool) => tool.name),
           },
         },
       }),

--- a/server/src/addie/model-providers/model-provider.ts
+++ b/server/src/addie/model-providers/model-provider.ts
@@ -185,12 +185,19 @@ export interface ModelOutputSchema {
   strict?: boolean;
 }
 
+/** Canonical custom/provider-tool selection policy translated only by adapters. */
+export type ModelToolChoice =
+  | { type: 'auto' }
+  | { type: 'required' }
+  | { type: 'tool'; name: string };
+
 export interface ModelRequest {
   model: string;
   system: ModelSystemBlock[];
   messages: ModelMessage[];
   tools: ModelToolDefinition[];
   providerTools?: ModelProviderTool[];
+  toolChoice?: ModelToolChoice;
   outputSchema?: ModelOutputSchema;
   reasoning?: { effort: ModelReasoningEffort };
   maxOutputTokens: number;

--- a/server/src/addie/model-providers/openai-responses-provider.ts
+++ b/server/src/addie/model-providers/openai-responses-provider.ts
@@ -161,6 +161,11 @@ function toOpenAIRequest(request: ModelRequest): ResponseCreateParamsNonStreamin
     truncation: 'disabled',
     parallel_tool_calls: false,
     tools: request.tools.map(toOpenAITool),
+    ...(request.toolChoice && {
+      tool_choice: request.toolChoice.type === 'tool'
+        ? { type: 'function' as const, name: request.toolChoice.name }
+        : request.toolChoice.type,
+    }),
     text: request.outputSchema
       ? {
           format: {

--- a/server/tests/unit/addie/model-provider-anthropic.test.ts
+++ b/server/tests/unit/addie/model-provider-anthropic.test.ts
@@ -63,6 +63,20 @@ function sha256(value: unknown): string {
 }
 
 describe('AnthropicModelProvider request translation', () => {
+  it.each([
+    [{ type: 'auto' as const }, { type: 'auto' }],
+    [{ type: 'required' as const }, { type: 'any' }],
+    [{ type: 'tool' as const, name: 'search_docs' }, { type: 'tool', name: 'search_docs' }],
+  ])('translates canonical %o tool choice', (toolChoice, expected) => {
+    const provider = new AnthropicModelProvider('unused', {} as AnthropicMessagesTransport);
+    const prepared = provider.prepare(request({
+      tools: [{ name: 'search_docs', description: 'Search.', inputSchema: { type: 'object' } }],
+      toolChoice,
+    }));
+
+    expect(prepared.providerRequest).toMatchObject({ tool_choice: expected });
+  });
+
   it('builds the exact Anthropic envelope from canonical messages and tools', () => {
     const provider = new AnthropicModelProvider('unused', {} as AnthropicMessagesTransport);
     const serverContinuation = normalizeAnthropicResponse(response({
@@ -901,6 +915,16 @@ describe('provider-neutral capability and event guards', () => {
       tools: [{ name: 'web_search', description: 'collision', inputSchema: {} }],
       providerTools: [{ type: 'web_search' }],
     }))).toThrow('collides with provider tool');
+  });
+
+  it('rejects unavailable or tool-free canonical tool choices', () => {
+    const provider = new AnthropicModelProvider('unused', {} as AnthropicMessagesTransport);
+    expect(() => provider.prepare(request({ toolChoice: { type: 'required' } })))
+      .toThrow('requires at least one tool');
+    expect(() => provider.prepare(request({
+      tools: [{ name: 'search_docs', description: 'Search.', inputSchema: {} }],
+      toolChoice: { type: 'tool', name: 'get_doc' },
+    }))).toThrow('unavailable: get_doc');
   });
 
   it('rejects non-JSON schemas and tool inputs before translation', () => {

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -88,6 +88,20 @@ function googleResponse(overrides: Record<string, unknown> = {}): GenerateConten
 }
 
 describe('OpenAIResponsesProvider', () => {
+  it.each([
+    [{ type: 'auto' as const }, 'auto'],
+    [{ type: 'required' as const }, 'required'],
+    [{ type: 'tool' as const, name: 'search_docs' }, { type: 'function', name: 'search_docs' }],
+  ])('translates canonical %o tool choice', (toolChoice, expected) => {
+    const provider = new OpenAIResponsesProvider('unused', {} as OpenAIResponsesTransport);
+    const prepared = provider.prepare(request(OPENAI_ROUTER_MODEL, {
+      tools: [{ name: 'search_docs', description: 'Search.', inputSchema: { type: 'object' } }],
+      toolChoice,
+    }));
+
+    expect(prepared.providerRequest).toMatchObject({ tool_choice: expected });
+  });
+
   it('builds a frozen, store-free structured-output request', () => {
     const provider = new OpenAIResponsesProvider('unused', {} as OpenAIResponsesTransport);
     const prepared = provider.prepare(request(OPENAI_ROUTER_MODEL, {
@@ -396,6 +410,25 @@ describe('OpenAIResponsesProvider', () => {
 });
 
 describe('GoogleGenerateContentProvider', () => {
+  it.each([
+    [{ type: 'auto' as const }, 'VALIDATED', ['search_docs', 'get_doc']],
+    [{ type: 'required' as const }, 'ANY', ['search_docs', 'get_doc']],
+    [{ type: 'tool' as const, name: 'search_docs' }, 'ANY', ['search_docs']],
+  ])('translates canonical %o tool choice', (toolChoice, mode, allowedFunctionNames) => {
+    const provider = new GoogleGenerateContentProvider('unused', {} as GoogleGenerateContentTransport);
+    const prepared = provider.prepare(request(GOOGLE_ROUTER_MODEL, {
+      tools: [
+        { name: 'search_docs', description: 'Search.', inputSchema: { type: 'object' } },
+        { name: 'get_doc', description: 'Read.', inputSchema: { type: 'object' } },
+      ],
+      toolChoice,
+    }));
+
+    expect(prepared.providerRequest).toMatchObject({
+      config: { toolConfig: { functionCallingConfig: { mode, allowedFunctionNames } } },
+    });
+  });
+
   it('disables SDK retries in the default transport', () => {
     googleGenAIConstructor.mockClear();
     new GoogleGenerateContentProvider('test-key');


### PR DESCRIPTION
## Summary

- add a canonical auto, required, or named custom-tool choice to the provider-neutral model request
- fail closed when a tool choice has no available tool or names a tool outside the request surface
- translate the same contract to Anthropic tool_choice, OpenAI Responses tool_choice, and Google function-calling modes and allowlists

## Safety and scope

This is a dormant orchestration capability. Existing requests omit toolChoice and retain their exact provider envelopes, so this PR does not force retrieval or change production model behavior. A later policy slice can apply required or named choices only where routing has enough evidence to do so safely.

## Validation

- provider/turn/orchestration focused suite: 7 files, 170 tests passed
- full pre-commit server suite: 514 files, 7,347 tests passed, 30 skipped
- root and ancillary pre-commit gates passed
- TypeScript passed
- git diff check passed

No Addie CODE_VERSION bump is needed because no active runtime request sets the new optional control.