### PR TITLE
fix(addie): require official docs retrieval

### DIFF
--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -3566,6 +3566,7 @@ export async function buildChannelResponseInvocation(input: {
         ? {
             disableServerTools: true,
             allowedToolNames: OFFICIAL_DOCS_ALLOWED_TOOLS,
+            initialToolChoice: { type: 'tool', name: 'search_docs' },
             maxIterations: 4,
           }
         : {}),

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -46,6 +46,7 @@ import type {
   ModelMessageContent,
   ModelRequest,
   ModelResponse,
+  ModelToolChoice,
   ModelToolCallContent,
   ModelToolDefinition,
   ModelToolResultContent,
@@ -679,6 +680,8 @@ export interface ProcessMessageOptions {
   allowedToolNames?: readonly string[];
   /** Router-selected capability sets used to scope prompt guidance/catalog. */
   selectedToolSetNames?: readonly string[];
+  /** Optional first-turn tool requirement chosen by trusted orchestration. */
+  initialToolChoice?: ModelToolChoice;
   /** Dedicated key for HMACing private invocation payloads in evaluation provenance. */
   invocationHashKey?: string;
   /** Caller-owned HMAC domain separator. Must be supplied with invocationHashKey. */
@@ -1247,6 +1250,7 @@ export class AddieClaudeClient {
     providerWebSearchEnabled: boolean,
     maxOutputTokens?: number,
     streaming = false,
+    toolChoice?: ModelToolChoice,
   ): ModelRequest {
     const safeMaxOutputTokens = !streaming && /^claude-sonnet-5(?:-|$)/.test(effectiveModel)
       ? Math.min(
@@ -1265,6 +1269,7 @@ export class AddieClaudeClient {
       })),
       messages,
       tools,
+      ...(toolChoice && { toolChoice }),
       ...(providerWebSearchEnabled && { providerTools: [{ type: 'web_search' as const }] }),
       ...(controls.output_config?.effort === 'medium' && {
         reasoning: { effort: 'medium' as const },
@@ -1298,6 +1303,9 @@ export class AddieClaudeClient {
       prepared.modelTools,
       prepared.modelMessages,
       prepared.requestWebSearchEnabled,
+      undefined,
+      false,
+      options?.initialToolChoice,
     );
     const providerRequest = this.anthropicProvider.prepare(modelRequest)
       .providerRequest as unknown as PreparedProviderRequest;
@@ -1486,6 +1494,10 @@ export class AddieClaudeClient {
             modelMessages,
             modelLoop.emptyResponseRecovery.toolsAllowed && requestWebSearchEnabled,
             isEmptyResponseRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
+            false,
+            iteration === 1 && invocationTools.length > 0
+              ? options?.initialToolChoice
+              : undefined,
           );
           const provider = exactlyOnce
             ? this.exactlyOnceAnthropicProvider
@@ -2075,6 +2087,9 @@ export class AddieClaudeClient {
               false,
               isEmptyResponseRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
               true,
+              iteration === 1 && invocationTools.length > 0
+                ? options?.initialToolChoice
+                : undefined,
             );
             const provider = isEmptyResponseRecovery
               ? this.exactlyOnceAnthropicProvider

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.77';
+export const CODE_VERSION = '2026.08.78';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,12 +12,12 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "6bb7d45f9570e25e40d1ab340cc8c04a2f0bc58f10063f8d84d258d788632599",
+    "server/src/addie/claude-client.ts": "f3f65a34e5e434dbd89b6e093412e360aef71ef7cf09d0a67482cb77906deb8f",
     "server/src/addie/prompts.ts": "539d329aec3e4fb66939a88e0597867c380f300250b3df6c6aba6ca751ea7a1c",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
-    "server/src/addie/bolt-app.ts": "284668d81251a740b83aa2b09a12b75804fb2bfd7c9b94ef0f73239c2fe7b82b",
+    "server/src/addie/bolt-app.ts": "d359a0482e792017b6d2355e9de5d0fc835138e0c22ae7304807469dfab64e6f",
     "server/src/addie/handler.ts": "cf9d66b7b2700cefd2811d2d9c627ea2683c556e6c3afd36ecc99cac12aa5407",
     "server/src/routes/addie-chat.ts": "da80a42faf005441f4afbf1d003ccb7067dbd4e87b90dae96c0023511806fc08",
     "server/src/routes/tavus.ts": "640e818f0ecd4da6c72f310b7582f7bc1f2c00fd77dbe0dc521f53459e31003f",

--- a/server/tests/unit/addie/shadow-replay-trace.test.ts
+++ b/server/tests/unit/addie/shadow-replay-trace.test.ts
@@ -80,6 +80,7 @@ function captureInput(identity = createShadowReplayCaptureIdentity({
       requestContext: 'request-context-sentinel',
       disableServerTools: true,
       allowedToolNames: [...OFFICIAL_DOCS_ALLOWED_TOOLS],
+      initialToolChoice: { type: 'tool', name: 'search_docs' },
     },
     effectiveModel: 'claude-test',
     selectedToolSets: ['knowledge'],

--- a/server/tests/unit/addie/shadow-replay.test.ts
+++ b/server/tests/unit/addie/shadow-replay.test.ts
@@ -309,6 +309,7 @@ function officialDocsInvocation(): ChannelResponseInvocation {
       requestContext: 'Synthetic public fixture context.',
       disableServerTools: true,
       allowedToolNames: OFFICIAL_DOCS_ALLOWED_TOOLS,
+      initialToolChoice: { type: 'tool', name: 'search_docs' },
       maxIterations: 4,
     },
     effectiveModel: 'claude-example-chat',
@@ -470,6 +471,7 @@ describe('verified official docs replay generation', () => {
           executionMode: 'replay',
           disableServerTools: true,
           allowedToolNames: OFFICIAL_DOCS_ALLOWED_TOOLS,
+          initialToolChoice: { type: 'tool', name: 'search_docs' },
           maxIterations: 4,
         });
         expect(requestTools.tools).toEqual([]);

--- a/server/tests/unit/claude-client-replay-policy.test.ts
+++ b/server/tests/unit/claude-client-replay-policy.test.ts
@@ -465,6 +465,7 @@ describe('AddieClaudeClient replay execution policy', () => {
       uncapped: true as const,
       disableServerTools: true,
       allowedToolNames: ['search_docs', 'get_doc'] as const,
+      initialToolChoice: { type: 'tool' as const, name: 'search_docs' },
       invocationHashKey: 'exact-provider-boundary-key',
       invocationHashDomain: 'official-docs-test:v1',
     };
@@ -475,15 +476,21 @@ describe('AddieClaudeClient replay execution policy', () => {
     expect(client.hasRegisteredTools(options.allowedToolNames)).toBe(true);
     expect(prepared.tool_schemas.map(({ name }) => name)).toEqual(['search_docs', 'get_doc']);
 
-    sdkState.nonStreamingResponses.push(textResponse());
+    sdkState.nonStreamingResponses.push(
+      toolUseResponse([{ id: 'tool-1', name: 'search_docs', input: { value: 'current question' } }]),
+      textResponse(),
+    );
     const actual: InvocationPreparedSnapshot[] = [];
     await client.processMessage(
       'current question', undefined, scopedTools, { systemPrompt: 'system' },
       { ...options, onInvocationPrepared: (snapshot) => actual.push(snapshot) },
     );
-    expect(actual).toEqual([prepared]);
+    expect(actual).toHaveLength(2);
+    expect(actual[0]).toEqual(prepared);
     expect((sdkState.calls[0].tools as Array<{ name: string }>).map(({ name }) => name))
       .toEqual(['search_docs', 'get_doc']);
+    expect(sdkState.calls[0].tool_choice).toEqual({ type: 'tool', name: 'search_docs' });
+    expect(sdkState.calls[1]).not.toHaveProperty('tool_choice');
     expect(prepared.message_payloads).toHaveLength(1);
     expect(prepared.provider_request_sha256).toBe(invocationHmac(
       options.invocationHashKey,


### PR DESCRIPTION
## Summary

- require `search_docs` on only the first model turn of the existing signed official-docs capability profile
- include the trusted initial tool choice in prepared invocation provenance so preview, live execution, and replay hash the same provider request
- return later turns to automatic tool selection and leave normal chat, router fallback, mixed-domain, and mutation-capable routes unchanged
- bump Addie `CODE_VERSION` to `2026.08.78` and regenerate the 249-tool / 23-set runtime inventory

## Safety boundary

The policy is scoped to the existing official-docs profile, which disables server tools and allows only `search_docs` and `get_doc`. Invalid or unavailable named choices fail closed in the provider adapter. The choice is omitted after iteration one and whenever no tools are available.

## Validation

- focused Addie/replay/provider tests: 129 passed
- full precommit server suite: 514 files, 7,347 passed, 30 skipped
- `npm run typecheck`
- `npm run test:addie-tools`
- generated tool reference and runtime inventory verification
- `git diff --check`

No paid fixed-production-trace replay was run for this change: the general fixed corpus intentionally remains unforced so its tool-selection metric stays honest. This change is confined to the separately signed official-docs capture/replay boundary and is covered by exact provider-request parity tests.