### PR TITLE
chore: retire shipped SDK compatibility shims

### DIFF
--- a/.agents/sdk-shim-ledger.json
+++ b/.agents/sdk-shim-ledger.json
@@ -24,13 +24,12 @@
     "owner": "compliance",
     "upstream": "adcontextprotocol/adcp-client#2105",
     "problem": "The SDK package ships a snapshot of compliance bundles, schema bundles, and generated validators. Current PR storyboard runs need to grade current repo source before a new protocol bundle exists.",
-    "localBehavior": "Build current compliance/schema bundles, copy them into the SDK cache, and patch generated validators for same-PR controller enums and request/response schema additions. The patch regression suite also loads the installed generated response validator to prove the additive account response remains consumable by the pinned 3.1 SDK.",
+    "localBehavior": "Build current compliance/schema bundles, copy them into the SDK cache, and patch generated validators for same-PR controller enums and request/response schema additions.",
     "releaseFollowUp": "This overlay is validation-only and does not publish generated types. After the protocol release, regenerate and publish @adcp/sdk, then explicitly upgrade pinned downstream consumers including agentic-api.",
     "removalCondition": "Remove when the storyboard matrix passes current compliance and schema roots through public SDK options instead of overlaying the SDK cache.",
     "paths": [
       "scripts/overlay-compliance-cache.sh",
-      "scripts/run-storyboards-matrix.sh",
-      "tests/sdk-runtime-compat.test.cjs"
+      "scripts/run-storyboards-matrix.sh"
     ],
     "terms": [
       "node_modules/@adcp/sdk/compliance/cache",

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -366,11 +366,11 @@ export function badgeEligibleVersionsForTargetSelection(
 // stale local cache), not platform errors — callers should log at warn and
 // return actionable coaching, not alarm on them as system failures.
 //
-// Until @adcp/sdk exports typed errors (tracked upstream at
-// adcontextprotocol/adcp-client#734), we classify by message regex. The
-// patterns match the exact strings thrown at
-// node_modules/@adcp/sdk/dist/lib/testing/storyboard/compliance.js:337
-// and :347. Swap to `instanceof` checks once the SDK emits coded errors.
+// SDK 14 beta.15 exports CapabilityResolutionError (#734), so current errors
+// are classified by class + code and use its structured specialism/protocol
+// fields. Anchored message patterns remain only as a compatibility fallback
+// for serialized/older-SDK errors and for unsupported-version detail, whose
+// structured fields are tracked in adcontextprotocol/adcp-client#2754.
 //
 // Security notes:
 //   - The captured groups echo agent-declared content. Regex is anchored at
@@ -479,13 +479,43 @@ export function classifyCapabilityResolutionError(
   const msg = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
   if (!msg) return undefined;
 
-  if (err instanceof CapabilityResolutionError && err.code === 'unsupported_adcp_version') {
-    const match = msg.match(UNSUPPORTED_ADCP_VERSION_RE);
-    return {
-      kind: 'unsupported_adcp_version',
-      complianceVersion: match ? sanitizeClassifiedValue(match[1], 80) : undefined,
-      supportedVersions: match ? parseSupportedVersionList(match[2]) : [],
-    };
+  if (err instanceof CapabilityResolutionError) {
+    if (err.code === 'unsupported_adcp_version') {
+      const match = msg.match(UNSUPPORTED_ADCP_VERSION_RE);
+      return {
+        kind: 'unsupported_adcp_version',
+        complianceVersion: match ? sanitizeClassifiedValue(match[1], 80) : undefined,
+        supportedVersions: match ? parseSupportedVersionList(match[2]) : [],
+      };
+    }
+
+    if (err.code === 'unknown_specialism') {
+      return {
+        kind: 'unknown_specialism',
+        specialism: err.specialism ? sanitizeClassifiedValue(err.specialism) : undefined,
+      };
+    }
+
+    if (err.code === 'specialism_parent_protocol_missing') {
+      const specialism = err.specialism ? sanitizeClassifiedValue(err.specialism) : undefined;
+      const parentProtocol = err.parentProtocol ? sanitizeClassifiedValue(err.parentProtocol) : undefined;
+      if (!parentProtocol) return { kind: 'unknown_specialism', specialism };
+      const nearMiss = nearMissProtocolDeclaration(parentProtocol, declaredProtocols);
+      if (nearMiss) {
+        return {
+          kind: 'unrecognized_supported_protocol',
+          specialism,
+          parentProtocol,
+          declaredProtocol: nearMiss.declaredProtocol,
+          expectedProtocol: nearMiss.expectedProtocol,
+        };
+      }
+      return {
+        kind: 'specialism_parent_protocol_missing',
+        specialism,
+        parentProtocol,
+      };
+    }
   }
 
   const unsupportedVersionMatch = msg.match(UNSUPPORTED_ADCP_VERSION_RE);

--- a/server/src/capabilities.ts
+++ b/server/src/capabilities.ts
@@ -596,9 +596,10 @@ export class CapabilityDiscovery {
         agent_uri: url,
         protocol: "mcp",
         ...agentConfigAuthFields(auth),
-      // TODO(adcp-client#1799): maxResponseBytes is currently dormant on
-      // getAgentInfo/listTools — the SDK doesn't yet wrap that path in
-      // withResponseSizeLimit. Re-verify when upstream lands.
+      // SDK 14 beta.15 applies maxResponseBytes to getAgentInfo/listTools,
+      // but MCP endpoint discovery and SSE responses remain outside that
+      // limit. Treat this as a guardrail, not a hostile-peer hard cap
+      // (adcp-client#1799).
       }], withSdkSafeTransport({
         userAgent: AAO_UA_DISCOVERY,
         transport: { maxResponseBytes: 4 * 1024 * 1024 },
@@ -642,7 +643,7 @@ export class CapabilityDiscovery {
         agent_uri: url,
         protocol: "a2a",
         ...agentConfigAuthFields(auth),
-      // TODO(adcp-client#1799): cap dormant on A2AClient.fromCardUrl until upstream wraps it.
+      // The discovery cap also covers A2AClient.fromCardUrl in SDK 14 beta.15.
       }], withSdkSafeTransport({
         userAgent: AAO_UA_DISCOVERY,
         transport: { maxResponseBytes: 4 * 1024 * 1024 },

--- a/server/src/services/hosted-compliance-version.ts
+++ b/server/src/services/hosted-compliance-version.ts
@@ -16,13 +16,11 @@ export const HOSTED_COMPLIANCE_TARGET_PREFERENCE = [
   '3.1-beta',
   DEFAULT_HOSTED_COMPLIANCE_LINE,
 ] as const;
-// Budget for a full-suite comply() assessment. @adcp/sdk 9.0.0-beta.28 applies
-// this value as the wall-clock budget for the *entire* pre-flight assessment
-// (not per-call), and a capability-rich agent legitimately runs ~117s — the SDK
-// default (120s) grades such agents "unreachable" with 0 steps. 600s clears
-// that ceiling. Revisit when the SDK restores per-call timeout semantics
-// (adcontextprotocol/adcp-client#2221): a per-call ceiling this large would let
-// a single hung call hold a connection for 10 minutes.
+// Soft scheduling budget for a full-suite comply() assessment. SDK 14 beta.15
+// stops starting new storyboards when this expires and preserves completed
+// results as a timed-out partial run (adcontextprotocol/adcp-client#2221).
+// 600s gives capability-rich agents enough time to finish the hosted suite;
+// per-request network ceilings are configured separately on the transport.
 export const HOSTED_FULL_COMPLIANCE_TIMEOUT_MS = 600_000;
 
 // Interactive full-suite runs (evaluate_agent_quality via Addie) need a higher
@@ -30,7 +28,6 @@ export const HOSTED_FULL_COMPLIANCE_TIMEOUT_MS = 600_000;
 // for target discovery and network jitter.  The background callers (heartbeat,
 // registry refresh) keep the shared 600s constant so heartbeat lock TTLs and
 // hung-call risk stay bounded.
-// TODO(adcontextprotocol/adcp-client#2221): collapse when upstream per-call timeout is restored
 export const HOSTED_INTERACTIVE_COMPLIANCE_TIMEOUT_MS = 1_200_000;
 
 export interface HostedComplianceTarget {

--- a/server/src/training-agent/state.ts
+++ b/server/src/training-agent/state.ts
@@ -307,11 +307,12 @@ function createSession(): SessionState {
  * Conformance storyboards reference these IDs by hardcoded value — e.g. the
  * `creative_ad_server` storyboard calls `list_creatives` with no filter and
  * asserts `creatives[0].pricing_options`, then calls `build_creative` /
- * `report_usage` against `campaign_hero_video`. The storyboard declares
- * `controller_seeding: true` to have the runner auto-fire `seed_creative`,
- * but the SDK side of that wiring (adcp-client#778) is still open.
+ * `report_usage` against `campaign_hero_video`. SDK 14 beta.15 auto-fires
+ * `seed_creative` for storyboards that declare `controller_seeding: true`.
  *
- * Session handlers consult this map as a read-through fallback:
+ * Session handlers retain this map as a read-through fallback for direct
+ * tool smoke tests and harnesses that intentionally opt out of controller
+ * seeding:
  *  - `list_creatives` merges compliance fixtures in when the session has
  *    none synced (so storyboards that never sync still see them); filtered
  *    queries skip the fallback — an explicit `creative_ids` filter means

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -17130,10 +17130,9 @@ export async function handleGetAdcpCapabilities(args: ToolArgs, ctx: TrainingCon
       // union across catalog products (product-factory.ts assigns these
       // by channel mix). Gate scenarios — clicks_buy_flow / reach_buy_flow
       // / completed_views_buy_flow — read this field and grade
-      // not_applicable when missing. adcp-client#1818 will auto-derive
-      // from product-level metric_optimization.supported_metrics once
-      // the SDK ships the seller-level field; until then this is a
-      // manual declaration.
+      // not_applicable when missing. adcontextprotocol/adcp-client#1818
+      // derives the union when an adopter supplies a static productCatalog;
+      // this dynamic reference handler declares the same honest union.
       supported_optimization_metrics: ['clicks', 'views', 'completed_views', 'engagements', 'reach'],
       execution: {
         targeting: {

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -244,10 +244,10 @@ export const TRAINING_SALES_CAPABILITIES = {
     supported_hashed_identifiers: ['hashed_email' as const],
     supported_action_sources: ['website' as const, 'app' as const],
   },
-  // Seller-level rollup of metric-optimization capabilities. Honest union
-  // across catalog products (product-factory.ts assigns these by channel mix).
-  // The tenant router projects these fields onto get_adcp_capabilities until
-  // the SDK exposes them directly (adcp-client#1818).
+  // Seller-level rollup of metric-optimization capabilities. The SDK can
+  // derive this from an adopter-supplied static productCatalog (#1818); this
+  // training platform resolves products dynamically, so it declares the
+  // honest union explicitly and the tenant router preserves that declaration.
   supported_optimization_metrics: ['clicks' as const, 'views' as const, 'completed_views' as const, 'engagements' as const, 'reach' as const],
   vendor_metric_optimization: {
     supported_targets: ['threshold_rate' as const],
@@ -566,7 +566,9 @@ function throwGetProductsExecutionError(message: string): never {
 /** The DecisioningPlatform contract is canonical even when the outer SDK
  * negotiates a legacy wire. Keep legacy selector echo metadata in our state,
  * but let the SDK reconstruct the 3.0 response from stable canonical refs.
- * Remove this adapter when adcontextprotocol/adcp-client#2497 ships. */
+ * adcontextprotocol/adcp-client#2497 added a raw lifecycle-handler escape
+ * hatch; remove this adapter only after create/update/get media-buy legacy
+ * handlers use that seam. */
 function canonicalMediaBuyPlatformResult<T>(result: T): T {
   const withoutLegacyPackageSelector = (value: unknown): unknown => {
     if (!value || typeof value !== 'object' || Array.isArray(value)) return value;

--- a/server/tests/integration/training-agent-tool-dispatch-smoke.test.ts
+++ b/server/tests/integration/training-agent-tool-dispatch-smoke.test.ts
@@ -111,25 +111,11 @@ describe('tool dispatch smoke', () => {
     await new Promise<void>(resolve => server.close(() => resolve()));
   });
 
-  // SDK bug allowlist — adcontextprotocol/adcp-client#1688.
-  // The SDK auto-advertises these tools on /creative-builder via specialism
-  // membership, but CreativeBuilderPlatform (stateless build/transform) has
-  // no method slots for them — they live on CreativeAdServerPlatform.
-  // Calls correctly return UNSUPPORTED_FEATURE today. Remove this allowlist
-  // entry once the SDK narrows tool advertisement to interface method
-  // presence; the test will then catch any future regression naturally.
-  const SDK_AUTO_ADVERTISED_UNIMPLEMENTED = new Set<string>([
-    'creative-builder/list_creatives',
-    'creative-builder/get_creative_delivery',
-  ]);
-
   it.each(TEST_CASES)('%s / %s handler is wired (no NOT_IMPLEMENTED)', async (tenantId, toolName) => {
     const body = await callTool(baseUrl, tenantId, toolName);
 
     const structured = body.result?.structuredContent;
     const errorCode = (structured?.adcp_error as Record<string, unknown> | undefined)?.code;
-    const knownSdkBug = SDK_AUTO_ADVERTISED_UNIMPLEMENTED.has(`${tenantId}/${toolName}`);
-
     // Domain errors (INVALID_REQUEST, MEDIA_BUY_NOT_FOUND, …) are expected
     // and count as passing — those mean the handler ran. Only NOT_IMPLEMENTED
     // and UNSUPPORTED_FEATURE indicate the dispatch path is unwired.
@@ -138,20 +124,18 @@ describe('tool dispatch smoke', () => {
       `${tenantId}/${toolName}: handler returned NOT_IMPLEMENTED — add the method to the v6 platform class`,
     ).not.toBe('NOT_IMPLEMENTED');
 
-    if (!knownSdkBug) {
-      expect(
-        errorCode,
-        `${tenantId}/${toolName}: handler returned UNSUPPORTED_FEATURE — wire the method in the platform class`,
-      ).not.toBe('UNSUPPORTED_FEATURE');
+    expect(
+      errorCode,
+      `${tenantId}/${toolName}: handler returned UNSUPPORTED_FEATURE — wire the method in the platform class`,
+    ).not.toBe('UNSUPPORTED_FEATURE');
 
-      // SDK-level UNSUPPORTED_FEATURE surfaces as a text string, not an
-      // adcp_error envelope. Check the raw content text as a belt-and-suspenders
-      // guard so the test catches both the AdcpError and SDK-wrapper forms.
-      const textContent = body.result?.content?.[0]?.text ?? '';
-      expect(
-        textContent,
-        `${tenantId}/${toolName}: SDK returned UNSUPPORTED_FEATURE — method missing from platform class`,
-      ).not.toMatch(/UNSUPPORTED_FEATURE/);
-    }
+    // SDK-level UNSUPPORTED_FEATURE surfaces as a text string, not an
+    // adcp_error envelope. Check the raw content text as a belt-and-suspenders
+    // guard so the test catches both the AdcpError and SDK-wrapper forms.
+    const textContent = body.result?.content?.[0]?.text ?? '';
+    expect(
+      textContent,
+      `${tenantId}/${toolName}: SDK returned UNSUPPORTED_FEATURE — method missing from platform class`,
+    ).not.toMatch(/UNSUPPORTED_FEATURE/);
   }, 15000);
 });

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -232,7 +232,7 @@ const CURRENT_SOURCE_KNOWN_FAILING_STORYBOARDS: ReadonlyMap<string, string> = ne
 const CURRENT_SOURCE_TENANT_KNOWN_FAILING_STORYBOARDS: ReadonlyMap<string, string> = new Map([
   [
     'sales/media_buy_seller/create_media_buy_async_lifecycle',
-    'The packaged framework writes the submitted handoff to a task registry partition that get_task_status cannot read back under the storyboard account. The create_media_buy submitted arm remains graded separately. Remove when framework task reads preserve the handoff account partition.',
+    'SDK 14 beta.15 still writes the submitted handoff to a task registry partition that get_task_status cannot read back under the storyboard account (adcontextprotocol/adcp-client#2703). The create_media_buy submitted arm remains graded separately. Remove when framework task reads preserve the handoff account partition.',
   ],
   [
     'sales/creative/creative_lifecycle_webhooks',
@@ -279,24 +279,16 @@ const CURRENT_SOURCE_TENANT_KNOWN_FAILING_STORYBOARDS: ReadonlyMap<string, strin
     'The localization storyboard begins capability steps before enforcing its required list_creatives tool. The stateless creative-builder tenant intentionally does not serve a creative library, so this scenario must be not applicable. Remove when required_tools gating happens before execution.',
   ],
   [
-    'creative-builder/creative_transformers',
-    'The packaged response validator treats JSON-valued transformer parameter defaults and option values as object-only, rejecting valid string and number values permitted by transformer-param.json. Remove when list-transformers-response validation preserves the JSON value union.',
-  ],
-  [
-    'creative-builder/creative_transformers/governance_denied',
-    'The packaged response validator treats JSON-valued transformer parameter defaults as object-only, so discovery fails before the governance-denial assertion can use the selected transformer. Remove when list-transformers-response validation preserves the JSON value union.',
-  ],
-  [
     'brand/security_baseline',
     'The packaged SDK auth-probe allowlist has no read-only empty-input brand task. Remove when the SDK accepts list_accounts (or a brand read) as a security_baseline probe.',
   ],
   [
     'brand/brand/signed_response_envelope_vectors',
-    'This opt-in storyboard is advertised only by agents that declare the signed-response-envelope runner contract. The training agent does not declare it, but capability resolution currently schedules the storyboard anyway. Remove when scenario-contract gating marks it not applicable.',
+    'SDK 14 beta.15 enforces requires_contract for probe and replay pseudo-steps but not ordinary comply_test_controller steps, so this opt-in storyboard executes without signed_responses_runner and fails UNKNOWN_SCENARIO. Remove when adcontextprotocol/adcp-client#2755 ships.',
   ],
   [
     'brand/brand/single_side_trust_extension',
-    'This opt-in storyboard is advertised only by agents that declare the single-side trust-extension runner contract. The training agent does not declare it, but capability resolution currently schedules the storyboard anyway. Remove when scenario-contract gating marks it not applicable.',
+    'Same SDK 14 beta.15 requires_contract gap as signed_response_envelope_vectors: ordinary comply_test_controller steps execute without single_side_trust_runner. Remove when adcontextprotocol/adcp-client#2755 ships.',
   ],
   [
     'si/security_baseline',
@@ -324,14 +316,6 @@ const KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new Map([
   [
     'governance_delivery_monitor/check_governance_drift',
     'The packaged runner injects an intent tool/payload/plan_id tuple into this authored delivery check, producing a mixed intent+execution request that the governance agent correctly rejects. Initial approval coverage remains active. Remove when the governance invariant preserves execution-shaped check_governance requests.',
-  ],
-  [
-    'creative_transformers/build_variants',
-    'The beta.12 packaged storyboard response validator still rejects the BuildCreativeVariantSuccess creatives[]/variants[] arm emitted by the training agent, so the runner cannot promote the produced build_variant_id into later storyboard context. The previously cited adcp-client#2105 tracked a different schema-bundle API and is closed; remove this skip when the build_variants response schema-grades under the packaged SDK.',
-  ],
-  [
-    'creative_transformers/refine_variant',
-    'Same beta.12 blocker as creative_transformers/build_variants: refinement depends on the skipped parent build_variant_id and returns the same BuildCreativeVariantSuccess creatives[]/variants[] response shape. Remove when the packaged storyboard runner accepts that variant arm.',
   ],
   [
     'media_buy_seller/canonical_formats/reject_conflicting_dual_emission',

--- a/server/tests/unit/capability-resolution-error-classifier.test.ts
+++ b/server/tests/unit/capability-resolution-error-classifier.test.ts
@@ -1,12 +1,9 @@
 /**
  * Unit tests for classifyCapabilityResolutionError and presentCapabilityResolutionError.
  *
- * These tests pin the regex classifier to the exact error strings thrown by
- * `@adcp/sdk`'s `resolveStoryboardsForCapabilities`. If upstream changes
- * the wording (adcontextprotocol/adcp-client#734 tracks moving to typed
- * errors), these tests will fail and force us to update the classifier
- * rather than silently letting config-errors escalate back to generic
- * "system error" paths.
+ * Current SDK errors are classified by CapabilityResolutionError code and
+ * structured fields. The message-shaped cases below preserve compatibility
+ * with serialized results and older SDK releases.
  *
  * Security-relevant invariants (exercised below):
  *   - Regex is anchored at start of message so attacker-crafted strings
@@ -20,12 +17,70 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { CapabilityResolutionError } from '@adcp/sdk/testing';
 import {
   classifyCapabilityResolutionError,
   presentCapabilityResolutionError,
 } from '../../src/addie/services/compliance-testing.js';
 
 describe('classifyCapabilityResolutionError', () => {
+  it('classifies typed parent-protocol errors without depending on message wording', () => {
+    const err = new CapabilityResolutionError({
+      code: 'specialism_parent_protocol_missing',
+      message: 'wording may change',
+      specialism: 'sales-guaranteed',
+      parentProtocol: 'media_buy',
+    });
+    expect(classifyCapabilityResolutionError(err)).toEqual({
+      kind: 'specialism_parent_protocol_missing',
+      specialism: 'sales-guaranteed',
+      parentProtocol: 'media_buy',
+    });
+  });
+
+  it('classifies typed unknown-specialism errors without depending on message wording', () => {
+    const err = new CapabilityResolutionError({
+      code: 'unknown_specialism',
+      message: 'wording may change',
+      specialism: 'made-up-thing',
+    });
+    expect(classifyCapabilityResolutionError(err)).toEqual({
+      kind: 'unknown_specialism',
+      specialism: 'made-up-thing',
+    });
+  });
+
+  it('classifies typed unsupported-version errors while structured fields are pending upstream', () => {
+    const err = new CapabilityResolutionError({
+      code: 'unsupported_adcp_version',
+      message:
+        'Compliance cache version 3.1.0-beta.5 is not supported by this seller. ' +
+        'Seller advertises adcp.supported_versions [3.0, 3.1]. ' +
+        'Install or select a compatible compliance cache instead of relying on major_versions alone.',
+    });
+    expect(classifyCapabilityResolutionError(err)).toEqual({
+      kind: 'unsupported_adcp_version',
+      complianceVersion: '3.1.0-beta.5',
+      supportedVersions: ['3.0', '3.1'],
+    });
+  });
+
+  it('classifies typed protocol spelling near-misses using declared capabilities', () => {
+    const err = new CapabilityResolutionError({
+      code: 'specialism_parent_protocol_missing',
+      message: 'wording may change',
+      specialism: 'sales-guaranteed',
+      parentProtocol: 'media_buy',
+    });
+    expect(classifyCapabilityResolutionError(err, ['media-buy'])).toEqual({
+      kind: 'unrecognized_supported_protocol',
+      specialism: 'sales-guaranteed',
+      parentProtocol: 'media_buy',
+      declaredProtocol: 'media-buy',
+      expectedProtocol: 'media_buy',
+    });
+  });
+
   it('classifies the parent-protocol-missing message with extracted fields', () => {
     const err = new Error(
       'Agent declared specialism "measurement-verification" (parent protocol: governance) ' +

--- a/tests/lint-sdk-shims.test.cjs
+++ b/tests/lint-sdk-shims.test.cjs
@@ -43,7 +43,6 @@ test('scanner finds the expected high-risk SDK reach-ins', () => {
   const findings = collectFindings();
   assert.ok(findings.some((f) => f.file === 'scripts/stage-sdk-schema-bundle.sh' && f.term.includes('schemas-data')));
   assert.ok(findings.some((f) => f.file === 'scripts/overlay-compliance-cache.sh' && f.term.includes('schemas.generated.js')));
-  assert.ok(findings.some((f) => f.file === 'tests/sdk-runtime-compat.test.cjs' && f.term.includes('schemas.generated.js')));
 });
 
 test('matchingPrivateTerm ignores comment-only lines but catches private SDK code', () => {

--- a/tests/sdk-runtime-compat.test.cjs
+++ b/tests/sdk-runtime-compat.test.cjs
@@ -2,7 +2,6 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
-const { pathToFileURL } = require('node:url');
 
 async function loadInstalledSingleAgentClients() {
   return [
@@ -23,11 +22,7 @@ function trainingAgentAdcpVersion(constantName) {
 }
 
 function installedSdkAdcpVersion() {
-  return fs.readFileSync(path.resolve(
-    __dirname,
-    '..',
-    'node_modules/@adcp/sdk/ADCP_VERSION',
-  ), 'utf8').trim();
+  return require('@adcp/sdk').ADCP_VERSION;
 }
 
 function canonicalAdcpVersion(version) {
@@ -149,12 +144,7 @@ test('installed SDK uses request-local scoped capabilities for get_products adap
 });
 
 test('installed 3.1 SDK accepts the additive flat advertiser natural-key response', async () => {
-  const schemasPath = path.resolve(
-    __dirname,
-    '..',
-    'node_modules/@adcp/sdk/dist/lib/types/schemas.generated.js',
-  );
-  const { SyncAccountsResponseSchema } = await import(pathToFileURL(schemasPath).href);
+  const { SyncAccountsResponseSchema } = await import('@adcp/sdk/schemas');
   const parsed = SyncAccountsResponseSchema.safeParse({
     status: 'completed',
     accounts: [{


### PR DESCRIPTION
## Summary
- replace private SDK schema/version reach-ins with beta.15 public exports
- classify current capability-resolution failures by typed SDK code and fields, retaining a bounded legacy fallback
- remove creative-transformer quarantines and dispatch allowlists now covered by beta.15
- refresh retained shim/TODO comments so their remaining removal conditions are accurate

## Upstream follow-ups
- adcontextprotocol/adcp-client#2752 — add a safe brand/account auth probe
- adcontextprotocol/adcp-client#2753 — preserve bundle/specialism verdicts
- adcontextprotocol/adcp-client#2754 — expose structured unsupported-version details
- adcontextprotocol/adcp-client#2755 — enforce requires_contract for ordinary steps
- adcontextprotocol/adcp-client#2703 — preserve async task registry account partition

## Verification
- full pre-commit hook
- typecheck
- SDK shim/runtime compatibility: 8/8
- targeted capability classifier + tool dispatch: 116/116
- current-source storyboard matrix: all seven tenants green; creative-builder 55/55 applicable clean
- released 3.0.26 compatibility matrix: all seven tenants green

No protocol release-surface changes; no changeset required.
