### PR TITLE
refactor(addie): centralize tool turn sequencing

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -62,6 +62,7 @@ import {
 } from './model-providers/model-turn.js';
 import {
   createAddieToolExecutor,
+  executeAddieToolCalls,
   recordProviderToolResults,
   type AddieExecutionMode,
   type ToolExecution,
@@ -1793,25 +1794,28 @@ export class AddieClaudeClient {
 
       // Handle custom tool use. Provider-managed results were recorded above.
       if (stopAction === 'execute_tools') {
-        // Get custom tool use blocks (these need our handlers)
-        const toolUseBlocks = turn.toolCalls;
-
         const toolResults: ModelToolResultContent[] = [];
 
-        for (const block of toolUseBlocks) {
-          const toolName = block.name;
-          hasExecutedCustomTool = true;
-          const toolInput = block.input;
-
-          logger.debug(
-            { toolName, ...(operationalExecution && { toolInput }) },
-            'Addie: Calling tool',
-          );
-          toolsUsed.push(toolName);
-          executionSequence++;
-          const executed = await executeToolCall(block, executionSequence);
-          toolResults.push(executed.result);
-          toolExecutions.push(executed.execution);
+        for await (const event of executeAddieToolCalls(
+          turn.toolCalls,
+          executeToolCall,
+          executionSequence,
+        )) {
+          executionSequence = event.sequence;
+          if (event.type === 'start') {
+            hasExecutedCustomTool = true;
+            logger.debug(
+              {
+                toolName: event.call.name,
+                ...(operationalExecution && { toolInput: event.call.input }),
+              },
+              'Addie: Calling tool',
+            );
+            toolsUsed.push(event.call.name);
+          } else {
+            toolResults.push(event.executed.result);
+            toolExecutions.push(event.executed.execution);
+          }
         }
 
         appendModelTurnContinuation(modelMessages, response, toolResults);
@@ -2468,38 +2472,39 @@ export class AddieClaudeClient {
         // Handle tool use
         if (stopAction === 'execute_tools') {
           logicalText += iterationText;
-          const toolUseBlocks = turn.toolCalls;
-
           const toolResults: ModelToolResultContent[] = [];
 
-          for (const block of toolUseBlocks) {
-            const toolName = block.name;
-            const toolInput = block.input;
-
-            logger.debug(
-              { toolName, ...(operationalExecution && { toolInput }) },
-              'Addie Stream: Calling tool',
-            );
-            toolsUsed.push(toolName);
-            executionSequence++;
-
-            // Emit tool start event
-            yield {
-              type: 'tool_start',
-              tool_name: toolName,
-              parameters: this.recordedToolParameters(options, toolInput),
-            };
-
-            const executed = await executeToolCall(block, executionSequence);
-            toolResults.push(executed.result);
-            toolExecutions.push(executed.execution);
-            yield {
-              type: 'tool_end',
-              tool_name: toolName,
-              result: executed.execution.result,
-              is_error: executed.execution.is_error,
-              normalized_result: executed.execution.normalized_result,
-            };
+          for await (const event of executeAddieToolCalls(
+            turn.toolCalls,
+            executeToolCall,
+            executionSequence,
+          )) {
+            executionSequence = event.sequence;
+            if (event.type === 'start') {
+              logger.debug(
+                {
+                  toolName: event.call.name,
+                  ...(operationalExecution && { toolInput: event.call.input }),
+                },
+                'Addie Stream: Calling tool',
+              );
+              toolsUsed.push(event.call.name);
+              yield {
+                type: 'tool_start',
+                tool_name: event.call.name,
+                parameters: this.recordedToolParameters(options, event.call.input),
+              };
+            } else {
+              toolResults.push(event.executed.result);
+              toolExecutions.push(event.executed.execution);
+              yield {
+                type: 'tool_end',
+                tool_name: event.call.name,
+                result: event.executed.execution.result,
+                is_error: event.executed.execution.is_error,
+                normalized_result: event.executed.execution.normalized_result,
+              };
+            }
           }
 
           // Continue the conversation with tool results

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.78';
+export const CODE_VERSION = '2026.08.79';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/eval/fixed-trace-tool-loop.ts
+++ b/server/src/addie/eval/fixed-trace-tool-loop.ts
@@ -15,6 +15,7 @@ import type {
 } from '../model-providers/model-provider.js';
 import {
   createAddieToolExecutor,
+  executeAddieToolCalls,
   type ToolHandler,
 } from '../model-providers/tool-orchestration.js';
 import type {
@@ -236,23 +237,25 @@ export async function executeFixedTraceToolLoop(
     }
 
     const results = [];
-    for (const call of calls) {
-      seenCallIds.add(call.id);
-      seenToolNames.add(call.name);
-      const entry = registered.get(call.name)!;
-      const executed = await executeTool(call, executions.length + 1);
-      const blocked = executed.execution.blocked_by_policy === true;
-      executions.push(Object.freeze({
-        sequence: executions.length + 1,
-        name: call.name,
-        description: entry.definition.description,
-        input: deepFreeze(structuredClone(call.input)),
-        effect: entry.fixture.effect,
-        policyDisposition: blocked ? 'blocked' : 'allowed',
-        resultStatus: entry.fixture.resultStatus,
-        simulated: true,
-      }));
-      results.push(executed.result);
+    for await (const event of executeAddieToolCalls(calls, executeTool, executions.length)) {
+      if (event.type === 'start') {
+        seenCallIds.add(event.call.id);
+        seenToolNames.add(event.call.name);
+      } else {
+        const entry = registered.get(event.call.name)!;
+        const blocked = event.executed.execution.blocked_by_policy === true;
+        executions.push(Object.freeze({
+          sequence: event.sequence,
+          name: event.call.name,
+          description: entry.definition.description,
+          input: deepFreeze(structuredClone(event.call.input)),
+          effect: entry.fixture.effect,
+          policyDisposition: blocked ? 'blocked' : 'allowed',
+          resultStatus: entry.fixture.resultStatus,
+          simulated: true,
+        }));
+        results.push(event.executed.result);
+      }
     }
     appendModelTurnContinuation(messages, response, results);
   }

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,7 +12,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "f3f65a34e5e434dbd89b6e093412e360aef71ef7cf09d0a67482cb77906deb8f",
+    "server/src/addie/claude-client.ts": "496991afea5c6ad2271c89fd09c8ba350b6aff662819c7a00d295da940d17a8b",
     "server/src/addie/prompts.ts": "539d329aec3e4fb66939a88e0597867c380f300250b3df6c6aba6ca751ea7a1c",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/src/addie/model-providers/tool-orchestration.ts
+++ b/server/src/addie/model-providers/tool-orchestration.ts
@@ -79,6 +79,24 @@ export interface AddieToolCallResult {
   execution: ToolExecution;
 }
 
+export type AddieToolExecutor = (
+  call: ModelToolCallContent,
+  sequence: number,
+) => Promise<AddieToolCallResult>;
+
+export type AddieToolExecutionEvent =
+  | {
+      type: 'start';
+      call: ModelToolCallContent;
+      sequence: number;
+    }
+  | {
+      type: 'end';
+      call: ModelToolCallContent;
+      sequence: number;
+      executed: AddieToolCallResult;
+    };
+
 export interface AddieProviderToolExecution {
   result: ModelProviderToolResultContent;
   receipt: ModelProviderToolReceipt;
@@ -341,7 +359,7 @@ export function createAddieToolExecutor(
   tools: readonly AddieTool[],
   handlers: ReadonlyMap<string, ToolHandler>,
   options: AddieToolExecutorOptions,
-): (call: ModelToolCallContent, sequence: number) => Promise<AddieToolCallResult> {
+): AddieToolExecutor {
   const registry = new Map<string, RegisteredTool>();
   for (const sourceDefinition of tools) {
     const definition = snapshotDefinition(sourceDefinition);
@@ -542,4 +560,23 @@ export function createAddieToolExecutor(
       return failureResult(call, sequence, options.executionMode, normalized, durationMs);
     }
   };
+}
+
+/**
+ * Execute one canonical custom-tool turn sequentially. The shared sequence is
+ * advanced before dispatch so delivery modes can emit a start event without
+ * taking ownership of mutation ordering or ledger numbering.
+ */
+export async function* executeAddieToolCalls(
+  calls: readonly ModelToolCallContent[],
+  execute: AddieToolExecutor,
+  startingSequence: number,
+): AsyncGenerator<AddieToolExecutionEvent> {
+  let sequence = startingSequence;
+  for (const call of calls) {
+    sequence++;
+    yield Object.freeze({ type: 'start', call, sequence });
+    const executed = await execute(call, sequence);
+    yield Object.freeze({ type: 'end', call, sequence, executed });
+  }
 }

--- a/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
+++ b/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
@@ -8,6 +8,7 @@ import type {
 import {
   BLOCKED_TOOL_RESULT,
   createAddieToolExecutor,
+  executeAddieToolCalls,
   recordProviderToolResults,
 } from '../../../src/addie/model-providers/tool-orchestration.js';
 import type { AddieTool } from '../../../src/addie/types.js';
@@ -210,6 +211,48 @@ describe('createAddieToolExecutor', () => {
       { type: 'text', text: '[Image: chart.png]' },
     ]);
     expect(result.execution.result).toBe('Loaded image: chart.png');
+  });
+});
+
+describe('executeAddieToolCalls', () => {
+  it('owns sequential dispatch and ledger numbering for one custom-tool turn', async () => {
+    const first = call({ id: 'first' });
+    const second = { ...call({ id: 'second' }), id: 'call_2' };
+    const executionOrder: string[] = [];
+    const execute = vi.fn(async (toolCall: ModelToolCallContent, sequence: number) => {
+      executionOrder.push(toolCall.id);
+      return {
+        result: {
+          type: 'tool_result' as const,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          content: `result ${sequence}`,
+        },
+        execution: {
+          tool_name: toolCall.name,
+          parameters: toolCall.input,
+          result: `result ${sequence}`,
+          is_error: false,
+          duration_ms: 0,
+          sequence,
+        },
+      };
+    });
+
+    const events = [];
+    for await (const event of executeAddieToolCalls([first, second], execute, 4)) {
+      events.push(event);
+    }
+
+    expect(executionOrder).toEqual(['call_1', 'call_2']);
+    expect(execute).toHaveBeenNthCalledWith(1, first, 5);
+    expect(execute).toHaveBeenNthCalledWith(2, second, 6);
+    expect(events.map(({ type, sequence }) => [type, sequence])).toEqual([
+      ['start', 5],
+      ['end', 5],
+      ['start', 6],
+      ['end', 6],
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

- add one canonical async lifecycle for sequential custom-tool turns
- use it from production non-streaming, production streaming, and fixed-trace evaluation loops
- keep delivery-specific logging and stream events at the delivery boundary while centralizing mutation order and ledger numbering
- bump Addie `CODE_VERSION` to `2026.08.79` and regenerate the runtime inventory

## Safety

The shared lifecycle advances each sequence before dispatch, emits start/end states in order, and never parallelizes tool calls. Existing authorization, confirmation, executor error containment, replay redaction, provider-result recording, message continuation, and streaming cancellation semantics remain unchanged. No provider selection or canary behavior changes.

## Validation

- focused live/eval tool-loop, replay, retry, truncation, empty-response, and provider-health suites
- final full precommit: 1,056 root tests; 514 server files with 7,348 passed and 30 skipped; TypeScript passed
- `npm run test:addie-tools`: 249 tools / 23 sets, inventory current and within budget, portability passed
- `git diff --check`

No paid provider replay was run because this is a behavior-preserving orchestration extraction; provider requests, tool schemas, tool results, and fixed-trace expectations are unchanged.