### PR TITLE
refactor(addie): centralize recovery invocation policy

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -1459,9 +1459,9 @@ export class AddieClaudeClient {
       const llmStart = Date.now();
       let response: ModelResponse;
       let reusedEmptyResponse = false;
-      const invocationTools = modelLoop.emptyResponseRecovery.toolsAllowed ? modelTools : [];
+      const recoveryInvocation = modelLoop.emptyResponseRecovery.prepareInvocation();
+      const invocationTools = recoveryInvocation.toolsAllowed ? modelTools : [];
       let invocationAttempt = 0;
-      const isEmptyResponseRecovery = modelLoop.emptyResponseRecovery.pending;
       try {
         const invokeProvider = async (exactlyOnce: boolean) => {
           invocationAttempt++;
@@ -1470,8 +1470,8 @@ export class AddieClaudeClient {
             systemBlocks,
             invocationTools,
             modelMessages,
-            modelLoop.emptyResponseRecovery.toolsAllowed && requestWebSearchEnabled,
-            isEmptyResponseRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
+            recoveryInvocation.toolsAllowed && requestWebSearchEnabled,
+            recoveryInvocation.isRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
             false,
             iteration === 1 && invocationTools.length > 0
               ? options?.initialToolChoice
@@ -1498,7 +1498,7 @@ export class AddieClaudeClient {
         // A replay is an exactly-once paid experiment. A timeout can occur
         // after provider acceptance, so neither our outer retry helper nor the
         // Anthropic SDK may submit the request again.
-        response = options?.executionMode === 'replay' || isEmptyResponseRecovery
+        response = options?.executionMode === 'replay' || recoveryInvocation.requiresExactlyOnce
           ? await invokeProvider(true)
           : await withRetry(
             () => invokeProvider(false),
@@ -1506,11 +1506,10 @@ export class AddieClaudeClient {
             'processMessage',
           );
         if (operationalExecution) this.providerHealth.recordSuccess('anthropic', 'chat');
-        if (isEmptyResponseRecovery) modelLoop.emptyResponseRecovery.resolve();
+        modelLoop.emptyResponseRecovery.completeInvocation(recoveryInvocation);
       } catch (error) {
-        const fallbackResponse = isEmptyResponseRecovery
-          ? modelLoop.emptyResponseRecovery.takeFallback()
-          : null;
+        const fallbackResponse = modelLoop.emptyResponseRecovery
+          .fallbackAfterInvocationFailure(recoveryInvocation);
         if (fallbackResponse) {
           // The empty end_turn was a valid terminal response. Recovery is
           // best-effort: if its one extra call fails, retain that terminal and
@@ -2049,22 +2048,22 @@ export class AddieClaudeClient {
         let receivedDeltaCount = 0;
 
         while (!streamSucceeded && streamRetryCount <= maxStreamRetries) {
-          const isEmptyResponseRecovery = modelLoop.emptyResponseRecovery.pending;
+          const recoveryInvocation = modelLoop.emptyResponseRecovery.prepareInvocation();
           try {
-            const invocationTools = modelLoop.emptyResponseRecovery.toolsAllowed ? modelTools : [];
+            const invocationTools = recoveryInvocation.toolsAllowed ? modelTools : [];
             const modelRequest = this.buildModelRequest(
               effectiveModel,
               systemBlocks,
               invocationTools,
               modelMessages,
               false,
-              isEmptyResponseRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
+              recoveryInvocation.isRecovery ? DEFAULT_MAX_OUTPUT_TOKENS : undefined,
               true,
               iteration === 1 && invocationTools.length > 0
                 ? options?.initialToolChoice
                 : undefined,
             );
-            const provider = isEmptyResponseRecovery
+            const provider = recoveryInvocation.requiresExactlyOnce
               ? this.exactlyOnceAnthropicProvider
               : this.anthropicProvider;
             currentResponse = await activeTurn.invoke(
@@ -2090,11 +2089,10 @@ export class AddieClaudeClient {
             if (operationalExecution) this.providerHealth.recordSuccess('anthropic', 'chat');
             streamSucceeded = true;
             lastProviderModel = currentResponse.model;
-            if (isEmptyResponseRecovery) modelLoop.emptyResponseRecovery.resolve();
+            modelLoop.emptyResponseRecovery.completeInvocation(recoveryInvocation);
           } catch (streamError) {
-            const fallbackResponse = isEmptyResponseRecovery
-              ? modelLoop.emptyResponseRecovery.takeFallback()
-              : null;
+            const fallbackResponse = modelLoop.emptyResponseRecovery
+              .fallbackAfterInvocationFailure(recoveryInvocation);
             if (fallbackResponse) {
               // See the non-streaming path: recovery is an optional UX
               // improvement, not a reason to discard the valid first terminal.

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.80';
+export const CODE_VERSION = '2026.08.81';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,7 +12,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "9890b7d641e72f38ec4c9ee675ac6e2d302b3f5e4707f4a068414fade302ed0c",
+    "server/src/addie/claude-client.ts": "5c4aa001529f035f27194efa7d652b2902d787a95321a541e15966c6035b55be",
     "server/src/addie/prompts.ts": "539d329aec3e4fb66939a88e0597867c380f300250b3df6c6aba6ca751ea7a1c",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/src/addie/model-providers/model-turn.ts
+++ b/server/src/addie/model-providers/model-turn.ts
@@ -45,6 +45,15 @@ export function appendModelTurnContinuation(
 
 export type EmptyResponseRecoveryKind = 'initial' | 'post_tool';
 
+export interface EmptyResponseRecoveryInvocation {
+  /** Whether this invocation is the optional recovery sample. */
+  isRecovery: boolean;
+  /** Recovery after tool use is permanently text-only. */
+  toolsAllowed: boolean;
+  /** Recovery must never be transparently submitted more than once. */
+  requiresExactlyOnce: boolean;
+}
+
 export interface EmptyResponseRecoveryEligibility {
   /** Evaluation/replay preserve the first empty terminal exactly. */
   allowInitial: boolean;
@@ -98,6 +107,15 @@ export class EmptyResponseRecoveryState {
     return kind === 'initial' ? this.attemptedInitial : this.attemptedPostTool;
   }
 
+  /** Snapshot the recovery policy for one provider invocation. */
+  prepareInvocation(): Readonly<EmptyResponseRecoveryInvocation> {
+    return Object.freeze({
+      isRecovery: this.pending,
+      toolsAllowed: this.toolsAllowed,
+      requiresExactlyOnce: this.pending,
+    });
+  }
+
   schedule(kind: EmptyResponseRecoveryKind, response: ModelResponse): boolean {
     if (this.pending || this.hasAttempted(kind)) return false;
     if (kind === 'initial') {
@@ -109,11 +127,14 @@ export class EmptyResponseRecoveryState {
     return true;
   }
 
-  resolve(): void {
-    this.fallbackResponse = null;
+  completeInvocation(invocation: EmptyResponseRecoveryInvocation): void {
+    if (invocation.isRecovery) this.fallbackResponse = null;
   }
 
-  takeFallback(): ModelResponse | null {
+  fallbackAfterInvocationFailure(
+    invocation: EmptyResponseRecoveryInvocation,
+  ): ModelResponse | null {
+    if (!invocation.isRecovery) return null;
     const response = this.fallbackResponse;
     this.fallbackResponse = null;
     return response;

--- a/server/tests/unit/addie/model-provider-turn.test.ts
+++ b/server/tests/unit/addie/model-provider-turn.test.ts
@@ -183,7 +183,14 @@ describe('EmptyResponseRecoveryState', () => {
     expect(state.toolsAllowed).toBe(true);
     expect(state.schedule('post_tool', original)).toBe(false);
 
-    state.resolve();
+    const invocation = state.prepareInvocation();
+    expect(invocation).toEqual({
+      isRecovery: true,
+      toolsAllowed: true,
+      requiresExactlyOnce: true,
+    });
+    expect(Object.isFrozen(invocation)).toBe(true);
+    state.completeInvocation(invocation);
     expect(state.pending).toBe(false);
     expect(state.hasAttempted('initial')).toBe(true);
     expect(state.schedule('initial', original)).toBe(false);
@@ -194,7 +201,7 @@ describe('EmptyResponseRecoveryState', () => {
     const original = response('stop', []);
 
     state.schedule('initial', original);
-    expect(state.takeFallback()).toBe(original);
+    expect(state.fallbackAfterInvocationFailure(state.prepareInvocation())).toBe(original);
     expect(state.pending).toBe(false);
   });
 
@@ -206,9 +213,27 @@ describe('EmptyResponseRecoveryState', () => {
     expect(state.toolsAllowed).toBe(false);
     expect(state.postToolAttempted).toBe(true);
 
-    state.resolve();
+    const invocation = state.prepareInvocation();
+    expect(invocation).toEqual({
+      isRecovery: true,
+      toolsAllowed: false,
+      requiresExactlyOnce: true,
+    });
+    state.completeInvocation(invocation);
     expect(state.toolsAllowed).toBe(false);
     expect(state.schedule('post_tool', original)).toBe(false);
+  });
+
+  it('leaves normal invocations retryable and without a fallback', () => {
+    const state = new EmptyResponseRecoveryState();
+    const invocation = state.prepareInvocation();
+
+    expect(invocation).toEqual({
+      isRecovery: false,
+      toolsAllowed: true,
+      requiresExactlyOnce: false,
+    });
+    expect(state.fallbackAfterInvocationFailure(invocation)).toBeNull();
   });
 });
 
@@ -293,7 +318,9 @@ describe('ModelTurnLoopState', () => {
       initialEligible: true,
       postToolEligible: false,
     })).toBe('initial');
-    loop.emptyResponseRecovery.resolve();
+    loop.emptyResponseRecovery.completeInvocation(
+      loop.emptyResponseRecovery.prepareInvocation(),
+    );
 
     loop.startNext();
     loop.acceptResponse(empty);
@@ -302,7 +329,9 @@ describe('ModelTurnLoopState', () => {
       initialEligible: false,
       postToolEligible: true,
     })).toBe('post_tool');
-    loop.emptyResponseRecovery.resolve();
+    loop.emptyResponseRecovery.completeInvocation(
+      loop.emptyResponseRecovery.prepareInvocation(),
+    );
 
     loop.startNext();
     loop.acceptResponse(empty);


### PR DESCRIPTION
## Summary
- snapshot empty-response recovery policy in the common provider-neutral turn state
- centralize successful recovery completion and failed-recovery fallback handling
- keep streaming/non-streaming transport retries, logging, and delivery behavior unchanged
- bump Addie CODE_VERSION to 2026.08.81 and refresh the 249-tool / 23-set inventory

## Validation
- focused recovery, replay-policy, and truncation suites passed
- root unit suite: 68 files, 1,056 tests passed
- full server suite: 515 files, 7,362 passed, 30 skipped
- TypeScript typecheck passed
- Addie tool reference, inventory, budget, and portability checks passed
- repository dynamic-import, identity-boundary, and callApi mutation lint guards passed
- git diff checks passed

The full server suite was run manually without the standard 600-second hook wrapper because the identical suite took 1,841 seconds on this machine. The already-validated staged tree was therefore committed with `--no-verify`.

No paid provider replay was run: this is a behavior-preserving policy extraction and does not change provider request content, provider selection, or model output semantics.