### PR TITLE
refactor(addie): bind tool dispatch to ledger

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -63,7 +63,6 @@ import {
 import {
   AddieToolExecutionLedger,
   createAddieToolExecutor,
-  executeAddieToolCalls,
   type AddieExecutionMode,
   type ToolExecution,
   type ToolExecutionPolicy,
@@ -1758,12 +1757,11 @@ export class AddieClaudeClient {
       if (stopAction === 'execute_tools') {
         const toolResults: ModelToolResultContent[] = [];
 
-        for await (const event of executeAddieToolCalls(
+        for await (const event of executionLedger.executeCustomCalls(
           turn.toolCalls,
           executeToolCall,
-          executionLedger.sequence,
+          toolResults,
         )) {
-          executionLedger.recordCustomEvent(event, toolResults);
           if (event.type === 'start') {
             hasExecutedCustomTool = true;
             logger.debug(
@@ -2417,12 +2415,11 @@ export class AddieClaudeClient {
           logicalText += iterationText;
           const toolResults: ModelToolResultContent[] = [];
 
-          for await (const event of executeAddieToolCalls(
+          for await (const event of executionLedger.executeCustomCalls(
             turn.toolCalls,
             executeToolCall,
-            executionLedger.sequence,
+            toolResults,
           )) {
-            executionLedger.recordCustomEvent(event, toolResults);
             if (event.type === 'start') {
               logger.debug(
                 {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.82';
+export const CODE_VERSION = '2026.08.83';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,7 +12,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "4c20e3c1c26692682bda159ae469fd97b20e99dd19ab4727829ad7cd39697a40",
+    "server/src/addie/claude-client.ts": "2ce2b3cd6aa8554573bf9eee1202dd0beead8a4fe2fd80654cbae03605f0cbd3",
     "server/src/addie/prompts.ts": "539d329aec3e4fb66939a88e0597867c380f300250b3df6c6aba6ca751ea7a1c",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/src/addie/model-providers/tool-orchestration.ts
+++ b/server/src/addie/model-providers/tool-orchestration.ts
@@ -150,7 +150,18 @@ export class AddieToolExecutionLedger {
     return recorded;
   }
 
-  recordCustomEvent(
+  async *executeCustomCalls(
+    calls: readonly ModelToolCallContent[],
+    execute: AddieToolExecutor,
+    turnResults: ModelToolResultContent[],
+  ): AsyncGenerator<AddieToolExecutionEvent> {
+    for await (const event of executeAddieToolCalls(calls, execute, this.currentSequence)) {
+      this.recordCustomEvent(event, turnResults);
+      yield event;
+    }
+  }
+
+  private recordCustomEvent(
     event: AddieToolExecutionEvent,
     turnResults: ModelToolResultContent[],
   ): void {

--- a/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
+++ b/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
@@ -406,12 +406,14 @@ describe('AddieToolExecutionLedger', () => {
       },
     }));
 
-    for await (const event of executeAddieToolCalls([call()], execute, ledger.sequence)) {
-      ledger.recordCustomEvent(event, customResults);
+    const events = [];
+    for await (const event of ledger.executeCustomCalls([call()], execute, customResults)) {
+      events.push(event.type);
     }
 
     expect(providerExecutions[0]?.execution.sequence).toBe(1);
     expect(execute).toHaveBeenCalledWith(expect.objectContaining({ id: 'call_1' }), 2);
+    expect(events).toEqual(['start', 'end']);
     expect(ledger.sequence).toBe(2);
     expect(ledger.toolsUsed).toEqual(['web_search', 'lookup']);
     expect(ledger.executions.map(({ sequence }) => sequence)).toEqual([1, 2]);
@@ -420,28 +422,32 @@ describe('AddieToolExecutionLedger', () => {
     ]);
   });
 
-  it('rejects a custom completion without its matching start event', () => {
+  it('rejects a custom completion whose execution sequence does not match', async () => {
     const ledger = new AddieToolExecutionLedger();
-    expect(() => ledger.recordCustomEvent({
-      type: 'end',
-      call: call(),
-      sequence: 1,
-      executed: {
-        result: {
-          type: 'tool_result',
-          toolCallId: 'call_1',
-          toolName: 'lookup',
-          content: 'result',
-        },
-        execution: {
-          tool_name: 'lookup',
-          parameters: {},
-          result: 'result',
-          is_error: false,
-          duration_ms: 0,
-          sequence: 1,
-        },
+    const execute = vi.fn(async (toolCall: ModelToolCallContent, sequence: number) => ({
+      result: {
+        type: 'tool_result' as const,
+        toolCallId: toolCall.id,
+        toolName: toolCall.name,
+        content: 'result',
       },
-    }, [])).toThrow('Custom-tool completion does not match its start event');
+      execution: {
+        tool_name: toolCall.name,
+        parameters: toolCall.input,
+        result: 'result',
+        is_error: false,
+        duration_ms: 0,
+        sequence: sequence + 1,
+      },
+    }));
+    const consume = async () => {
+      for await (const _event of ledger.executeCustomCalls([call()], execute, [])) {
+        // Consume the full turn so the mismatched completion is validated.
+      }
+    };
+
+    await expect(consume()).rejects.toThrow(
+      'Custom-tool completion does not match its start event',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- bind provider-neutral custom-tool dispatch and ledger recording into one operation
- remove the public two-step dispatch/record sequence from streaming and non-streaming delivery adapters
- keep delivery-specific logs and stream events unchanged while ensuring every dispatched completion is ledgered before exposure
- fail closed when an executor reports a completion sequence that does not match its start event
- bump Addie CODE_VERSION to 2026.08.83 and refresh the 249-tool / 23-set inventory

## Validation
- focused provider/replay/recovery/truncation suites: 6 files, 192 tests passed
- root unit suite: 68 files, 1,056 tests passed
- full server suite: 515 files, 7,364 passed, 30 skipped
- normal staged-tree pre-commit hook passed, including the same full server suite and typecheck
- Addie tool reference, inventory, budget, and portability checks passed
- repository dynamic-import, identity-boundary, and callApi mutation lint guards passed
- git diff checks passed

No paid provider replay was run: this is a behavior-preserving orchestration encapsulation and does not change provider request content, tool dispatch order, provider selection, or model output semantics.