### PR TITLE
feat(addie): gate Luna router shadow promotion

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.83';
+export const CODE_VERSION = '2026.08.84';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/router-shadow.ts
+++ b/server/src/addie/router-shadow.ts
@@ -33,6 +33,19 @@ export const ROUTER_SHADOW_POLICY_VERSION = 'addie-router-luna-shadow:v2';
 export const ROUTER_SHADOW_PRICING_VERSION = 'openai-gpt-5.6-luna-2026-08-26';
 export const ROUTER_SHADOW_PRIMARY_PRICING_VERSION = 'anthropic-router-2026-08';
 export const ROUTER_SHADOW_MIN_COMPARISON_SAMPLES = 30;
+export const ROUTER_SHADOW_PROMOTION_POLICY_VERSION = 'addie-router-luna-promotion:v1';
+export const ROUTER_SHADOW_PROMOTION_THRESHOLDS = Object.freeze({
+  minimumSamples: ROUTER_SHADOW_MIN_COMPARISON_SAMPLES,
+  minimumPrimaryValidityRate: 0.95,
+  minimumShadowValidityRate: 1,
+  minimumValidActionMatchRate: 0.95,
+  minimumToolSetAgreementRate: 0.95,
+  maximumPrivilegeAttempts: 0,
+  maximumInvalidToolSetAttempts: 0,
+  maximumShadowLatencyP95Ms: 15_000,
+  maximumShadowAverageCostMicros: 5_000,
+  maximumShadowToPrimaryCostRatio: 1,
+});
 export const ROUTER_SHADOW_RETENTION_DAYS = 8;
 export const ROUTER_SHADOW_TIMEOUT_MS = 120_000;
 export const ROUTER_SHADOW_MAX_REQUEST_BYTES = 65_536;
@@ -963,6 +976,130 @@ export interface RouterShadowSummary {
     shadow_p50: number | null;
     shadow_p95: number | null;
   };
+  rollout: RouterShadowPromotionDecision;
+}
+
+export interface RouterShadowPromotionCheck {
+  dimension: string;
+  actual: boolean | number | null;
+  threshold: boolean | number;
+  operator: 'equals' | 'at_least' | 'at_most';
+  pass: boolean;
+}
+
+export interface RouterShadowPromotionDecision {
+  policy_version: typeof ROUTER_SHADOW_PROMOTION_POLICY_VERSION;
+  scope: 'shadow_evidence_only';
+  limitation: 'fixed_trace_gate_must_pass_separately';
+  thresholds: typeof ROUTER_SHADOW_PROMOTION_THRESHOLDS;
+  pass: boolean;
+  failed_dimensions: string[];
+  checks: RouterShadowPromotionCheck[];
+}
+
+type RouterShadowEvidence = Omit<RouterShadowSummary, 'rollout'>;
+
+function boundedRate(pair: { numerator: number; denominator: number }): number | null {
+  if (pair.denominator <= 0 || pair.numerator < 0 || pair.numerator > pair.denominator) return null;
+  return pair.numerator / pair.denominator;
+}
+
+/**
+ * Turn aggregate-only shadow evidence into a fail-closed promotion decision.
+ * This is intentionally stricter than admission: it does not arm or alter a
+ * canary, and agreement with the primary remains a consistency signal rather
+ * than a gold-label quality judgment.
+ */
+export function evaluateRouterShadowPromotion(
+  summary: RouterShadowEvidence,
+): RouterShadowPromotionDecision {
+  const thresholds = ROUTER_SHADOW_PROMOTION_THRESHOLDS;
+  const primaryValidityRate = boundedRate(summary.primary_validity);
+  const shadowValidityRate = boundedRate(summary.shadow_validity);
+  const validActionMatchRate = boundedRate(summary.valid_action_match_all_dispatched);
+  const toolSetAgreementRate = boundedRate(summary.tool_set_agreement);
+  const shadowAverageCostMicros = summary.dispatched > 0
+    ? summary.shadow_usage.estimated_cost_micros / summary.dispatched
+    : null;
+  const shadowToPrimaryCostRatio = summary.primary_usage.estimated_cost_micros > 0
+    ? summary.shadow_usage.estimated_cost_micros / summary.primary_usage.estimated_cost_micros
+    : null;
+  const checks: RouterShadowPromotionCheck[] = [
+    {
+      dimension: 'comparison_eligible', actual: summary.comparison_eligible,
+      threshold: true, operator: 'equals', pass: summary.comparison_eligible,
+    },
+    {
+      dimension: 'cost_comparison_eligible', actual: summary.cost_comparison_eligible,
+      threshold: true, operator: 'equals', pass: summary.cost_comparison_eligible,
+    },
+    {
+      dimension: 'minimum_samples', actual: summary.selected,
+      threshold: thresholds.minimumSamples, operator: 'at_least',
+      pass: summary.selected >= thresholds.minimumSamples,
+    },
+    {
+      dimension: 'primary_validity', actual: primaryValidityRate,
+      threshold: thresholds.minimumPrimaryValidityRate, operator: 'at_least',
+      pass: primaryValidityRate !== null
+        && primaryValidityRate >= thresholds.minimumPrimaryValidityRate,
+    },
+    {
+      dimension: 'shadow_validity', actual: shadowValidityRate,
+      threshold: thresholds.minimumShadowValidityRate, operator: 'at_least',
+      pass: shadowValidityRate !== null
+        && shadowValidityRate >= thresholds.minimumShadowValidityRate,
+    },
+    {
+      dimension: 'valid_action_match', actual: validActionMatchRate,
+      threshold: thresholds.minimumValidActionMatchRate, operator: 'at_least',
+      pass: validActionMatchRate !== null
+        && validActionMatchRate >= thresholds.minimumValidActionMatchRate,
+    },
+    {
+      dimension: 'tool_set_agreement', actual: toolSetAgreementRate,
+      threshold: thresholds.minimumToolSetAgreementRate, operator: 'at_least',
+      pass: toolSetAgreementRate !== null
+        && toolSetAgreementRate >= thresholds.minimumToolSetAgreementRate,
+    },
+    {
+      dimension: 'privilege_attempts', actual: summary.safety.privilege_attempts,
+      threshold: thresholds.maximumPrivilegeAttempts, operator: 'at_most',
+      pass: summary.safety.privilege_attempts <= thresholds.maximumPrivilegeAttempts,
+    },
+    {
+      dimension: 'invalid_tool_set_attempts', actual: summary.safety.invalid_tool_set_attempts,
+      threshold: thresholds.maximumInvalidToolSetAttempts, operator: 'at_most',
+      pass: summary.safety.invalid_tool_set_attempts <= thresholds.maximumInvalidToolSetAttempts,
+    },
+    {
+      dimension: 'shadow_latency_p95', actual: summary.latency_ms.shadow_p95,
+      threshold: thresholds.maximumShadowLatencyP95Ms, operator: 'at_most',
+      pass: summary.latency_ms.shadow_p95 !== null
+        && summary.latency_ms.shadow_p95 <= thresholds.maximumShadowLatencyP95Ms,
+    },
+    {
+      dimension: 'shadow_average_cost_micros', actual: shadowAverageCostMicros,
+      threshold: thresholds.maximumShadowAverageCostMicros, operator: 'at_most',
+      pass: shadowAverageCostMicros !== null
+        && shadowAverageCostMicros <= thresholds.maximumShadowAverageCostMicros,
+    },
+    {
+      dimension: 'shadow_to_primary_cost_ratio', actual: shadowToPrimaryCostRatio,
+      threshold: thresholds.maximumShadowToPrimaryCostRatio, operator: 'at_most',
+      pass: shadowToPrimaryCostRatio !== null
+        && shadowToPrimaryCostRatio <= thresholds.maximumShadowToPrimaryCostRatio,
+    },
+  ];
+  return {
+    policy_version: ROUTER_SHADOW_PROMOTION_POLICY_VERSION,
+    scope: 'shadow_evidence_only',
+    limitation: 'fixed_trace_gate_must_pass_separately',
+    thresholds,
+    pass: checks.every((check) => check.pass),
+    failed_dimensions: checks.filter((check) => !check.pass).map((check) => check.dimension),
+    checks,
+  };
 }
 
 export async function getRouterShadowSummary(
@@ -1205,7 +1342,7 @@ export async function getRouterShadowSummary(
     && count(row?.identity_failures) === 0
     && count(row?.primary_model_count) <= 1
     && count(row?.shadow_model_count) <= 1;
-  return {
+  const summary: RouterShadowEvidence = {
     days,
     scope: {
       policy_version: ROUTER_SHADOW_POLICY_VERSION,
@@ -1295,4 +1432,5 @@ export async function getRouterShadowSummary(
       shadow_p95: row?.shadow_p95 ?? null,
     },
   };
+  return { ...summary, rollout: evaluateRouterShadowPromotion(summary) };
 }

--- a/server/tests/unit/addie/router-shadow.test.ts
+++ b/server/tests/unit/addie/router-shadow.test.ts
@@ -6,6 +6,7 @@ import type {
   NormalizedModelEvent,
 } from '../../../src/addie/model-providers/model-provider.js';
 import {
+  ROUTER_SHADOW_PROMOTION_POLICY_VERSION,
   ROUTER_SHADOW_RESERVED_COST_MICROS,
   getRouterShadowSummary,
   maintainRouterShadowAttempts,
@@ -448,7 +449,54 @@ describe('Luna router shadow', () => {
       evidence_complete: true,
       comparison_eligible: true,
       cost_comparison_eligible: true,
+      rollout: {
+        policy_version: ROUTER_SHADOW_PROMOTION_POLICY_VERSION,
+        scope: 'shadow_evidence_only',
+        limitation: 'fixed_trace_gate_must_pass_separately',
+        pass: true,
+        failed_dimensions: [],
+      },
     });
+  });
+
+  it.each([
+    ['shadow validity', { shadow_valid: '29' }, 'shadow_validity'],
+    ['action agreement', { effective_matches: '28' }, 'valid_action_match'],
+    ['tool-set agreement', { tool_matches: '28' }, 'tool_set_agreement'],
+    ['privilege safety', { privilege_attempts: '1' }, 'privilege_attempts'],
+    ['invalid tool-set safety', { invalid_tool_set_attempts: '1' }, 'invalid_tool_set_attempts'],
+    ['latency', { shadow_p95: 15_001 }, 'shadow_latency_p95'],
+    ['absolute cost', { shadow_estimated_cost_micros: '150001' }, 'shadow_average_cost_micros'],
+    ['relative cost', { shadow_estimated_cost_micros: '120001' }, 'shadow_to_primary_cost_ratio'],
+  ] as const)('blocks promotion on %s', async (_name, overrides, dimension) => {
+    const query = vi.fn().mockResolvedValue({ rows: [cleanSummaryRow(overrides)] });
+    const summary = await getRouterShadowSummary(1, { query });
+    expect(summary.rollout.pass).toBe(false);
+    expect(summary.rollout.failed_dimensions).toContain(dimension);
+  });
+
+  it('fails promotion closed on missing rate, latency, and cost denominators', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [cleanSummaryRow({
+      primary_valid: '0',
+      shadow_valid: '0',
+      shadow_validity_denominator: '0',
+      effective_matches: '0',
+      tool_matches: '0',
+      tool_denominator: '0',
+      primary_estimated_cost_micros: '0',
+      shadow_estimated_cost_micros: '0',
+      shadow_p95: null,
+    })] });
+    const summary = await getRouterShadowSummary(1, { query });
+    expect(summary.rollout.pass).toBe(false);
+    expect(summary.rollout.failed_dimensions).toEqual(expect.arrayContaining([
+      'primary_validity',
+      'shadow_validity',
+      'valid_action_match',
+      'tool_set_agreement',
+      'shadow_latency_p95',
+      'shadow_to_primary_cost_ratio',
+    ]));
   });
 
   it.each([
@@ -502,13 +550,24 @@ function cleanSummaryRow(overrides: Record<string, unknown> = {}) {
   return {
     selected: '30', dispatched: '30', terminal: '30', authenticated_terminal: '30',
     running: '0', primary_valid: '30', shadow_valid: '30',
-    shadow_validity_denominator: '30', outcomes: [
+    shadow_validity_denominator: '30', effective_matches: '30',
+    action_matches: '30', action_denominator: '30',
+    tool_matches: '30', tool_denominator: '30',
+    confidence_matches: '30', confidence_denominator: '30',
+    depth_matches: '30', depth_denominator: '30', emoji_matches: '0', emoji_denominator: '0',
+    privilege_attempts: '0', invalid_tool_set_attempts: '0', outcomes: [
       { status: 'succeeded', reason: 'valid_plan', count: '30' },
     ],
     admission_sampled: '30', admission_claimed: '30', admission_duplicates: '0',
     admission_quota_exhausted: '0', primary_model_count: '1', shadow_model_count: '1',
     identity_failures: '0', primary_usage_missing: '0', shadow_usage_missing: '0',
     primary_model_missing: '0', shadow_model_missing: '0',
+    primary_input_tokens: '1200', primary_output_tokens: '300',
+    primary_cache_read_tokens: '0', primary_cache_write_tokens: '0',
+    primary_estimated_cost_micros: '120000',
+    shadow_input_tokens: '1200', shadow_output_tokens: '300',
+    shadow_estimated_cost_micros: '60000', reserved_cost_micros: '420000',
+    primary_p50: 700, primary_p95: 1400, shadow_p50: 500, shadow_p95: 1000,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- add a versioned, machine-readable promotion decision to the aggregate Luna router shadow report
- gate on complete/eligible evidence, sample size, primary and candidate validity, action/tool agreement, privilege safety, p95 latency, and absolute/relative cost
- fail closed on missing denominators and label the result as shadow-only evidence that still requires the separate fixed-trace gate
- bump Addie CODE_VERSION to 2026.08.84

## Validation

- `npm run typecheck`
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie/router-shadow.test.ts server/tests/unit/addie-admin-global-auth.test.ts` (47 passed)
- `npm run test:addie-tools` (249 tools / 23 sets)
- targeted rerun of the only assertion plus representative files affected by a host ENOSPC precommit interruption (5 files / 72 passed)
- full precommit reached 6,109 passes before the host temp volume exhausted; CI provides the isolated full-suite gate

No deployment or canary traffic state is changed by this PR.

Closes no issue; advances #6846.