### PR TITLE
refactor(addie): prepare router provider fallback

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.84';
+export const CODE_VERSION = '2026.08.85';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -34,6 +34,7 @@ import type {
   ModelMessageContent,
   ModelProvider,
   ModelRequest,
+  ModelResponse,
   PreparedModelInvocation,
 } from "./model-providers/model-provider.js";
 import {
@@ -718,6 +719,7 @@ Respond with ONLY the JSON object, no other text.`;
 export function buildRouterModelRequest(
   ctx: RoutingContext,
   model = ModelConfig.fast,
+  reasoning?: ModelRequest['reasoning'],
 ): ModelRequest {
   return {
     model,
@@ -728,6 +730,7 @@ export function buildRouterModelRequest(
     }],
     tools: [],
     maxOutputTokens: 300,
+    ...(reasoning && { reasoning }),
   };
 }
 
@@ -748,10 +751,17 @@ export function extractRouterResponseText(
 }
 
 function classifyRouterError(error: unknown):
+  | "invalid_json"
+  | "schema_invalid"
+  | "refusal"
+  | "truncated"
+  | "incomplete"
   | "unexpected_model_identity"
   | "invalid_provider_event_stream"
   | "unsupported_provider_capability"
   | "provider_error" {
+  if (error instanceof RouterPlanParseError) return error.category;
+  if (error instanceof RouterTerminalResponseError) return error.category;
   if (error instanceof UnexpectedModelIdentityError) {
     return "unexpected_model_identity";
   }
@@ -762,6 +772,13 @@ function classifyRouterError(error: unknown):
     return "unsupported_provider_capability";
   }
   return "provider_error";
+}
+
+class RouterTerminalResponseError extends Error {
+  constructor(readonly category: 'refusal' | 'truncated' | 'incomplete') {
+    super(`Router response was not terminal: ${category}`);
+    this.name = 'RouterTerminalResponseError';
+  }
 }
 
 /**
@@ -978,6 +995,24 @@ export function parseRouterResponse(response: string): ParsedPlan {
   }
 }
 
+function strictPlanToParsedPlan(plan: StrictRouterPlan): ParsedPlan {
+  if (plan.action === 'ignore') return { action: 'ignore', reason: plan.reason };
+  if (plan.action === 'react') {
+    if (!plan.emoji) throw new RouterPlanParseError('schema_invalid', 'React response has no emoji');
+    return { action: 'react', emoji: plan.emoji, reason: plan.reason };
+  }
+  if (!plan.tool_sets || !plan.confidence || typeof plan.requires_depth !== 'boolean') {
+    throw new RouterPlanParseError('schema_invalid', 'Respond response is incomplete');
+  }
+  return {
+    action: 'respond',
+    tool_sets: plan.tool_sets,
+    confidence: plan.confidence,
+    requires_depth: plan.requires_depth,
+    reason: plan.reason,
+  };
+}
+
 export interface RouterModelObservation {
   canonicalRequest: ModelRequest;
   primaryInvocation: PreparedModelInvocation | null;
@@ -1004,6 +1039,15 @@ export interface RouterRouteOptions {
    * It cannot change or delay the production decision.
    */
   observer?: (observation: RouterModelObservation) => void | Promise<void>;
+  /** Used by a higher-level canary boundary so it can invoke the fallback provider. */
+  failureMode?: 'safe_fallback' | 'throw';
+}
+
+export interface AddieRouterProviderOptions {
+  model?: string;
+  reasoning?: ModelRequest['reasoning'];
+  /** Reject malformed, incomplete, or unauthorized plans instead of normalizing them. */
+  strictOutput?: boolean;
 }
 
 function queueRouterObserver(
@@ -1030,16 +1074,23 @@ function queueRouterObserver(
 export class AddieRouter {
   private readonly provider: ModelProvider;
   private readonly providerHealth: ProviderHealthController;
+  private readonly model: string;
+  private readonly reasoning?: ModelRequest['reasoning'];
+  private readonly strictOutput: boolean;
 
   constructor(
     apiKey: string,
     provider?: ModelProvider,
     providerHealth: ProviderHealthController = new ProviderHealthController(),
+    options: AddieRouterProviderOptions = {},
   ) {
     this.provider = provider ?? new AnthropicRouterProvider(apiKey, {
       maxRetries: 2,
     });
     this.providerHealth = providerHealth;
+    this.model = options.model ?? ModelConfig.fast;
+    this.reasoning = options.reasoning;
+    this.strictOutput = options.strictOutput ?? false;
   }
 
   /**
@@ -1053,8 +1104,12 @@ export class AddieRouter {
     options: RouterRouteOptions = {},
   ): Promise<ExecutionPlan> {
     const startTime = Date.now();
-    const canonicalRequest = deepFreezeRouterValue(buildRouterModelRequest(ctx));
+    const canonicalRequest = deepFreezeRouterValue(
+      buildRouterModelRequest(ctx, this.model, this.reasoning),
+    );
     let primaryInvocation: PreparedModelInvocation | null = null;
+    let primaryResponse: ModelResponse | null = null;
+    let rawResponseText: string | null = null;
 
     try {
       const availability = this.providerHealth.acquire(this.provider.id, 'router');
@@ -1069,11 +1124,24 @@ export class AddieRouter {
         }),
         this.provider.id,
       );
-      this.providerHealth.recordSuccess(this.provider.id, 'router');
-
+      primaryResponse = response;
       const text = extractRouterResponseText(response.content);
+      rawResponseText = text;
 
-      const parsedPlan = parseRouterResponse(text);
+      if (this.strictOutput && response.finishReason !== 'stop') {
+        throw new RouterTerminalResponseError(
+          response.finishReason === 'length'
+            ? 'truncated'
+            : response.finishReason === 'refusal'
+              ? 'refusal'
+              : 'incomplete',
+        );
+      }
+
+      const parsedPlan = this.strictOutput
+        ? strictPlanToParsedPlan(parseStrictRouterPlan(text, ctx.isAAOAdmin ?? false))
+        : parseRouterResponse(text);
+      this.providerHealth.recordSuccess(this.provider.id, 'router');
       const latencyMs = Date.now() - startTime;
 
       // Filter tool sets to only valid/permitted sets for this user
@@ -1107,7 +1175,7 @@ export class AddieRouter {
         latency_ms: latencyMs,
         tokens_input: response.usage.inputTokens,
         tokens_output: response.usage.outputTokens,
-        model: ModelConfig.fast,
+        model: this.model,
         requires_precision: requiresPrecisionMode,
         requires_depth: requiresDepthMode,
       };
@@ -1131,7 +1199,7 @@ export class AddieRouter {
 
       // Track for performance metrics (fire-and-forget, errors handled internally)
       void trackApiCall({
-        model: ModelConfig.fast,
+        model: this.model,
         purpose: ApiPurpose.ROUTER,
         tokens_input: response.usage.inputTokens,
         tokens_output: response.usage.outputTokens,
@@ -1148,7 +1216,7 @@ export class AddieRouter {
         finishReason: response.finishReason,
         primaryErrorCategory: null,
         requestedProvider: this.provider.id,
-        requestedModel: ModelConfig.fast,
+        requestedModel: this.model,
         returnedProvider: response.provider,
         returnedModel: response.model,
         inputTokens: response.usage.inputTokens,
@@ -1182,20 +1250,21 @@ export class AddieRouter {
         primaryInvocation,
         isAdmin: ctx.isAAOAdmin ?? false,
         productionPlan: fallbackPlan,
-        rawResponseText: null,
-        responseContent: [],
-        finishReason: null,
+        rawResponseText,
+        responseContent: primaryResponse?.content ?? [],
+        finishReason: primaryResponse?.finishReason ?? null,
         primaryErrorCategory: category,
         requestedProvider: this.provider.id,
-        requestedModel: ModelConfig.fast,
-        returnedProvider: null,
-        returnedModel: null,
-        inputTokens: null,
-        outputTokens: null,
-        cacheReadTokens: null,
-        cacheWriteTokens: null,
+        requestedModel: this.model,
+        returnedProvider: primaryResponse?.provider ?? null,
+        returnedModel: primaryResponse?.model ?? null,
+        inputTokens: primaryResponse?.usage.inputTokens ?? null,
+        outputTokens: primaryResponse?.usage.outputTokens ?? null,
+        cacheReadTokens: primaryResponse?.usage.cacheReadTokens ?? null,
+        cacheWriteTokens: primaryResponse?.usage.cacheWriteTokens ?? null,
         latencyMs: Date.now() - startTime,
       });
+      if (options.failureMode === 'throw') throw error;
       return fallbackPlan;
     }
   }

--- a/server/tests/unit/addie-router.test.ts
+++ b/server/tests/unit/addie-router.test.ts
@@ -54,16 +54,21 @@ const ROUTER_CAPABILITIES = Object.freeze({
 
 function fakeRouterProvider(
   content: ModelMessageContent[],
-  options: { finishReason?: ModelResponse['finishReason']; error?: Error } = {},
+  options: {
+    finishReason?: ModelResponse['finishReason'];
+    error?: Error;
+    providerId?: ModelProvider['id'];
+  } = {},
 ): ModelProvider & { requests: ModelRequest[] } {
   const requests: ModelRequest[] = [];
+  const providerId = options.providerId ?? 'anthropic';
   return {
-    id: 'anthropic',
+    id: providerId,
     capabilities: ROUTER_CAPABILITIES,
     requests,
     prepare(request: ModelRequest): PreparedModelInvocation {
       return {
-        provider: 'anthropic',
+        provider: providerId,
         model: request.model,
         capabilities: ROUTER_CAPABILITIES,
         providerRequest: {},
@@ -73,7 +78,7 @@ function fakeRouterProvider(
       requests.push(request);
       if (options.error) throw options.error;
       const response: ModelResponse = {
-        provider: 'anthropic',
+        provider: providerId,
         model: request.model,
         id: 'router-response',
         content,
@@ -83,7 +88,7 @@ function fakeRouterProvider(
       };
       yield {
         type: 'response_start',
-        provider: 'anthropic',
+        provider: providerId,
         model: request.model,
         id: response.id,
       };
@@ -717,6 +722,84 @@ describe('AddieRouter.route', () => {
       tokens_input: 12,
       tokens_output: 7,
       model: ModelConfig.fast,
+    });
+  });
+
+  it('uses provider-specific model settings with strict output validation', async () => {
+    const provider = fakeRouterProvider([{
+      type: 'text',
+      text: '{"action":"respond","tool_sets":["knowledge"],"confidence":"high","requires_depth":false,"reason":"documented"}',
+    }], { providerId: 'openai' });
+    const context: RoutingContext = {
+      message: 'How does AdCP work?',
+      source: 'channel',
+      isAAOAdmin: false,
+    };
+    const subject = new AddieRouter('unused', provider, undefined, {
+      model: 'gpt-5.6-luna',
+      reasoning: { effort: 'none' },
+      strictOutput: true,
+    });
+
+    const plan = await subject.route(context, { failureMode: 'throw' });
+
+    expect(provider.requests).toEqual([
+      buildRouterModelRequest(context, 'gpt-5.6-luna', { effort: 'none' }),
+    ]);
+    expect(plan).toMatchObject({
+      action: 'respond',
+      tool_sets: ['knowledge'],
+      model: 'gpt-5.6-luna',
+    });
+  });
+
+  it.each([
+    ['malformed JSON', [{ type: 'text', text: 'not-json' }], 'stop'],
+    ['unauthorized tool set', [{
+      type: 'text',
+      text: '{"action":"respond","tool_sets":["admin"],"confidence":"high","requires_depth":false,"reason":"unsafe"}',
+    }], 'stop'],
+    ['truncated response', [{
+      type: 'text',
+      text: '{"action":"ignore","reason":"partial"}',
+    }], 'length'],
+  ] as const)('throws on strict %s so a caller can invoke fallback', async (
+    _name,
+    content,
+    finishReason,
+  ) => {
+    const provider = fakeRouterProvider([...content], { finishReason });
+    const subject = new AddieRouter('unused', provider, undefined, { strictOutput: true });
+    await expect(subject.route({
+      message: 'important question',
+      source: 'channel',
+      isAAOAdmin: false,
+    }, { failureMode: 'throw' })).rejects.toThrow();
+  });
+
+  it('observes strict candidate failure metadata before the caller falls back', async () => {
+    const provider = fakeRouterProvider([{ type: 'text', text: 'not-json' }], {
+      providerId: 'openai',
+    });
+    const observer = vi.fn();
+    const subject = new AddieRouter('unused', provider, undefined, {
+      model: 'gpt-5.6-luna',
+      strictOutput: true,
+    });
+
+    await expect(subject.route({ message: 'route me', source: 'channel' }, {
+      failureMode: 'throw',
+      observer,
+    })).rejects.toThrow('Router response is not JSON');
+    await vi.waitFor(() => expect(observer).toHaveBeenCalledOnce());
+    expect(observer.mock.calls[0][0]).toMatchObject({
+      requestedProvider: 'openai',
+      requestedModel: 'gpt-5.6-luna',
+      returnedProvider: 'openai',
+      returnedModel: 'gpt-5.6-luna',
+      inputTokens: 12,
+      outputTokens: 7,
+      primaryErrorCategory: 'invalid_json',
     });
   });
 


### PR DESCRIPTION
## Summary

- parameterize the common Addie router with an exact provider model and portable reasoning settings
- add strict candidate-output validation for malformed, unauthorized, refused, incomplete, and truncated routes
- allow a higher-level canary boundary to request an exception and invoke its fallback provider
- preserve returned-provider/model, terminal reason, token usage, content, and raw text in failure observations
- keep the existing Anthropic compatibility parser and safe local fallback as the default
- bump Addie CODE_VERSION to 2026.08.85

## Validation

- `npm run typecheck`
- focused router/provider/shadow/health suite: 4 files, 149 passed, 27 expected skipped
- `npm run test:addie-tools` (249 tools / 23 sets)

The prior PR's isolated full CI suite passed immediately before this branch was cut. This branch will receive the same full CI/security/Ladon gate. No provider selection or production traffic state changes in this PR.

Advances #6844 and #6846.