### PR TITLE
feat(addie): support abortable router requests

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.85';
+export const CODE_VERSION = '2026.08.86';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -1041,6 +1041,8 @@ export interface RouterRouteOptions {
   observer?: (observation: RouterModelObservation) => void | Promise<void>;
   /** Used by a higher-level canary boundary so it can invoke the fallback provider. */
   failureMode?: 'safe_fallback' | 'throw';
+  /** Cancels the provider request without changing the default fallback behavior. */
+  signal?: AbortSignal;
 }
 
 export interface AddieRouterProviderOptions {
@@ -1121,6 +1123,7 @@ export class AddieRouter {
           beforeDispatch: (prepared) => {
             primaryInvocation = prepared;
           },
+          signal: options.signal,
         }),
         this.provider.id,
       );

--- a/server/tests/unit/addie-router.test.ts
+++ b/server/tests/unit/addie-router.test.ts
@@ -11,6 +11,7 @@ import type {
   ModelMessageContent,
   ModelProvider,
   ModelRequest,
+  ModelRespondOptions,
   ModelResponse,
   NormalizedModelEvent,
   PreparedModelInvocation,
@@ -59,13 +60,15 @@ function fakeRouterProvider(
     error?: Error;
     providerId?: ModelProvider['id'];
   } = {},
-): ModelProvider & { requests: ModelRequest[] } {
+): ModelProvider & { requests: ModelRequest[]; signals: Array<AbortSignal | undefined> } {
   const requests: ModelRequest[] = [];
+  const signals: Array<AbortSignal | undefined> = [];
   const providerId = options.providerId ?? 'anthropic';
   return {
     id: providerId,
     capabilities: ROUTER_CAPABILITIES,
     requests,
+    signals,
     prepare(request: ModelRequest): PreparedModelInvocation {
       return {
         provider: providerId,
@@ -74,8 +77,15 @@ function fakeRouterProvider(
         providerRequest: {},
       };
     },
-    async *respond(request: ModelRequest): AsyncIterable<NormalizedModelEvent> {
+    async *respond(
+      request: ModelRequest,
+      respondOptions?: ModelRespondOptions,
+    ): AsyncIterable<NormalizedModelEvent> {
       requests.push(request);
+      signals.push(respondOptions?.signal);
+      if (respondOptions?.signal?.aborted) {
+        throw respondOptions.signal.reason ?? new Error('aborted');
+      }
       if (options.error) throw options.error;
       const response: ModelResponse = {
         provider: providerId,
@@ -751,6 +761,23 @@ describe('AddieRouter.route', () => {
       tool_sets: ['knowledge'],
       model: 'gpt-5.6-luna',
     });
+  });
+
+  it('forwards an abort signal so a canary boundary can enforce its deadline', async () => {
+    const provider = fakeRouterProvider([{
+      type: 'text',
+      text: '{"action":"ignore","reason":"not needed"}',
+    }]);
+    const subject = new AddieRouter('unused', provider, undefined, { strictOutput: true });
+    const controller = new AbortController();
+    const deadlineError = new Error('router_canary_timeout');
+    controller.abort(deadlineError);
+
+    await expect(subject.route({ message: 'route me', source: 'channel' }, {
+      failureMode: 'throw',
+      signal: controller.signal,
+    })).rejects.toBe(deadlineError);
+    expect(provider.signals).toEqual([controller.signal]);
   });
 
   it.each([


### PR DESCRIPTION
## Summary
- forward caller abort signals through the provider-neutral router boundary
- preserve the existing safe fallback default and strict throw-for-fallback behavior
- cover pre-aborted requests and exact signal forwarding

## Why
A bounded Luna primary canary needs a hard, caller-owned deadline before it can safely fall back to Anthropic. This is the minimal prerequisite and does not change provider selection or production traffic.

## Validation
- npm run typecheck
- npx vitest run server/tests/unit/addie-router.test.ts --reporter=dot
- git diff --check

## Rollout
No rollout or provider-selection change. CODE_VERSION is 2026.08.86.