### PR TITLE
feat(addie): add Luna router canary ledger

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.86';
+export const CODE_VERSION = '2026.08.87';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/router-canary.ts
+++ b/server/src/addie/router-canary.ts
@@ -1,0 +1,523 @@
+import { createHmac } from 'node:crypto';
+import type { QueryResultRow } from 'pg';
+import { query as defaultQuery } from '../db/client.js';
+import { FIXED_TRACE_ROLLOUT_POLICY_VERSION } from './eval/fixed-trace-rollout.js';
+import { OPENAI_ROUTER_MODEL } from './model-providers/openai-responses-provider.js';
+import { ROUTER_SHADOW_PROMOTION_POLICY_VERSION } from './router-shadow.js';
+
+export const ROUTER_CANARY_POLICY_VERSION = 'addie-router-luna-canary:v1';
+export const ROUTER_CANARY_PRICING_VERSION = 'openai-gpt-5.6-luna-2026-08-26';
+export const ROUTER_CANARY_MAX_CHANNELS = 4;
+export const ROUTER_CANARY_MAX_DEADLINE_MS = 15_000;
+export const ROUTER_CANARY_STALE_INFLIGHT_MS = 15 * 60 * 1000;
+export const ROUTER_CANARY_ROLLBACK_POLICY = Object.freeze({
+  minimumCompleted: 5,
+  maximumFailureRate: 0.2,
+  maximumAverageLatencyMs: 10_000,
+  maximumAverageCostMicros: 5_000,
+});
+
+const LUNA_INPUT_MICROS_PER_TOKEN = 0.2;
+const LUNA_OUTPUT_MICROS_PER_TOKEN = 1.2;
+export const ROUTER_CANARY_MAX_REQUEST_BYTES = 65_536;
+const MAX_OUTPUT_TOKENS = 300;
+export const ROUTER_CANARY_RESERVED_COST_MICROS = Math.ceil(
+  ROUTER_CANARY_MAX_REQUEST_BYTES * LUNA_INPUT_MICROS_PER_TOKEN
+  + MAX_OUTPUT_TOKENS * LUNA_OUTPUT_MICROS_PER_TOKEN,
+);
+
+type QueryFn = <T extends QueryResultRow = QueryResultRow>(
+  text: string,
+  params?: unknown[],
+) => Promise<{ rows: T[]; rowCount?: number | null }>;
+
+type RouterCanaryEnvironment = Record<string, string | undefined>;
+
+export type RouterCanarySelectionReason =
+  | 'selected'
+  | 'disabled'
+  | 'production_data_not_approved'
+  | 'evidence_not_approved'
+  | 'invalid_configuration'
+  | 'private_channel'
+  | 'shared_channel'
+  | 'channel_not_allowlisted'
+  | 'sample_excluded';
+
+export type RouterCanaryAdmissionReason =
+  | RouterCanarySelectionReason
+  | 'daily_limit_reached'
+  | 'rolled_back'
+  | 'ledger_unavailable';
+
+export interface RouterCanaryCohortInput {
+  channelId: string;
+  opportunityId: string;
+  channelIsPublic: boolean;
+  channelIsShared: boolean;
+}
+
+export interface RouterCanarySelection {
+  selected: boolean;
+  reason: RouterCanarySelectionReason;
+}
+
+interface RouterCanaryConfig {
+  hmacKeyVersion: string;
+  sampleBps: number;
+  dailyLimit: number;
+  dailyBudgetMicros: number;
+  deadlineMs: number;
+}
+
+export interface RouterCanaryAdmission {
+  status: 'admitted';
+  admissionDate: string;
+  deadlineMs: number;
+  policyVersion: typeof ROUTER_CANARY_POLICY_VERSION;
+  pricingVersion: typeof ROUTER_CANARY_PRICING_VERSION;
+  hashKeyVersion: string;
+  requestedModel: typeof OPENAI_ROUTER_MODEL;
+}
+
+export type AdmitRouterCanaryResult =
+  | RouterCanaryAdmission
+  | { status: 'not_admitted'; reason: RouterCanaryAdmissionReason };
+
+export type RouterCanaryFailureReason =
+  | 'timeout'
+  | 'invalid_output'
+  | 'unexpected_model_identity'
+  | 'invalid_provider_event_stream'
+  | 'unsupported_provider_capability'
+  | 'provider_error';
+
+export interface RouterCanaryOutcome {
+  status: 'candidate_succeeded' | 'fallback_succeeded' | 'fallback_safe_default';
+  failureReason?: RouterCanaryFailureReason;
+  candidateLatencyMs: number;
+  candidateCostMicros: number;
+  fallbackLatencyMs?: number;
+}
+
+export interface RouterCanaryRecordResult {
+  recorded: boolean;
+  rolledBack: boolean;
+  rollbackReason: string | null;
+}
+
+function parseBoundedInteger(
+  value: string | undefined,
+  minimum: number,
+  maximum: number,
+): number | null {
+  if (!value || !/^\d+$/.test(value.trim())) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= minimum && parsed <= maximum
+    ? parsed
+    : null;
+}
+
+function digest(key: string, value: string): string {
+  return createHmac('sha256', key)
+    .update(`${ROUTER_CANARY_POLICY_VERSION}\0sample\0`, 'utf8')
+    .update(value, 'utf8')
+    .digest('hex');
+}
+
+function resolveRouterCanaryCohort(
+  input: RouterCanaryCohortInput,
+  env: RouterCanaryEnvironment = process.env,
+): RouterCanarySelection & { config?: RouterCanaryConfig } {
+  if (env.ADDIE_ROUTER_LUNA_CANARY_ENABLED !== 'true') {
+    return { selected: false, reason: 'disabled' };
+  }
+  if (env.ADDIE_ROUTER_LUNA_CANARY_PRODUCTION_DATA_APPROVED !== 'true') {
+    return { selected: false, reason: 'production_data_not_approved' };
+  }
+  if (
+    env.ADDIE_ROUTER_LUNA_CANARY_FIXED_TRACE_POLICY_VERSION
+      !== FIXED_TRACE_ROLLOUT_POLICY_VERSION
+    || env.ADDIE_ROUTER_LUNA_CANARY_SHADOW_PROMOTION_POLICY_VERSION
+      !== ROUTER_SHADOW_PROMOTION_POLICY_VERSION
+  ) {
+    return { selected: false, reason: 'evidence_not_approved' };
+  }
+  if (!input.channelIsPublic) return { selected: false, reason: 'private_channel' };
+  if (input.channelIsShared) return { selected: false, reason: 'shared_channel' };
+
+  const channels = (env.ADDIE_ROUTER_LUNA_CANARY_CHANNEL_IDS ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const hmacKey = env.ADDIE_ROUTER_LUNA_CANARY_HMAC_KEY?.trim();
+  const hmacKeyVersion = env.ADDIE_ROUTER_LUNA_CANARY_HMAC_KEY_VERSION?.trim();
+  const sampleBps = parseBoundedInteger(
+    env.ADDIE_ROUTER_LUNA_CANARY_SAMPLE_BPS,
+    1,
+    10_000,
+  );
+  const configuredDailyLimit = parseBoundedInteger(
+    env.ADDIE_ROUTER_LUNA_CANARY_DAILY_LIMIT,
+    1,
+    100,
+  );
+  const dailyBudgetMicros = parseBoundedInteger(
+    env.ADDIE_ROUTER_LUNA_CANARY_DAILY_BUDGET_MICROS,
+    ROUTER_CANARY_RESERVED_COST_MICROS,
+    10_000_000,
+  );
+  const deadlineMs = parseBoundedInteger(
+    env.ADDIE_ROUTER_LUNA_CANARY_DEADLINE_MS,
+    1_000,
+    ROUTER_CANARY_MAX_DEADLINE_MS,
+  );
+  const channelsValid = channels.length >= 1
+    && channels.length <= ROUTER_CANARY_MAX_CHANNELS
+    && new Set(channels).size === channels.length
+    && channels.every((channel) => /^C[A-Z0-9]{8,}$/.test(channel));
+  if (
+    !channelsValid
+    || !hmacKey
+    || hmacKey.length < 32
+    || !hmacKeyVersion
+    || !/^[A-Za-z0-9._:-]{1,64}$/.test(hmacKeyVersion)
+    || !env.OPENAI_API_KEY?.trim()
+    || sampleBps === null
+    || configuredDailyLimit === null
+    || dailyBudgetMicros === null
+    || deadlineMs === null
+    || !input.channelId
+    || !input.opportunityId
+  ) {
+    return { selected: false, reason: 'invalid_configuration' };
+  }
+  if (!channels.includes(input.channelId)) {
+    return { selected: false, reason: 'channel_not_allowlisted' };
+  }
+  const bucket = Number.parseInt(
+    digest(hmacKey, `${input.channelId}\0${input.opportunityId}`).slice(0, 8),
+    16,
+  ) % 10_000;
+  if (bucket >= sampleBps) return { selected: false, reason: 'sample_excluded' };
+
+  const budgetSlots = Math.floor(dailyBudgetMicros / ROUTER_CANARY_RESERVED_COST_MICROS);
+  const dailyLimit = Math.min(configuredDailyLimit, budgetSlots);
+  if (dailyLimit < 1) return { selected: false, reason: 'invalid_configuration' };
+  return {
+    selected: true,
+    reason: 'selected',
+    config: {
+      hmacKeyVersion,
+      sampleBps,
+      dailyLimit,
+      dailyBudgetMicros,
+      deadlineMs,
+    },
+  };
+}
+
+/** Pure, fail-closed selection. Configuration secrets never leave this module. */
+export function selectRouterCanaryCohort(
+  input: RouterCanaryCohortInput,
+  env: RouterCanaryEnvironment = process.env,
+): RouterCanarySelection {
+  const { selected, reason } = resolveRouterCanaryCohort(input, env);
+  return { selected, reason };
+}
+
+interface AdmissionRow {
+  admitted: boolean;
+  reason: 'admitted' | 'daily_limit_reached' | 'rolled_back' | 'invalid_configuration';
+  admission_date: string;
+}
+
+/**
+ * Atomically claims a bounded paid-call slot. No production identifier or
+ * per-opportunity hash is passed to or persisted by the ledger.
+ */
+export async function admitRouterCanary(
+  input: RouterCanaryCohortInput,
+  dependencies: {
+    env?: RouterCanaryEnvironment;
+    query?: QueryFn;
+    now?: Date;
+  } = {},
+): Promise<AdmitRouterCanaryResult> {
+  const selection = resolveRouterCanaryCohort(input, dependencies.env);
+  if (!selection.selected || !selection.config) {
+    return { status: 'not_admitted', reason: selection.reason };
+  }
+  const config = selection.config;
+  const runQuery = dependencies.query ?? defaultQuery as QueryFn;
+  const now = dependencies.now ?? new Date();
+  try {
+    await runQuery(
+      `INSERT INTO addie_router_canary_state (
+         policy_version, pricing_version, hash_key_version, requested_model,
+         sample_bps, daily_limit, daily_budget_micros, reserved_cost_micros,
+         deadline_ms, created_at, updated_at
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10)
+       ON CONFLICT DO NOTHING`,
+      [
+        ROUTER_CANARY_POLICY_VERSION,
+        ROUTER_CANARY_PRICING_VERSION,
+        config.hmacKeyVersion,
+        OPENAI_ROUTER_MODEL,
+        config.sampleBps,
+        config.dailyLimit,
+        config.dailyBudgetMicros,
+        ROUTER_CANARY_RESERVED_COST_MICROS,
+        config.deadlineMs,
+        now,
+      ],
+    );
+    await runQuery(
+      `INSERT INTO addie_router_canary_daily_metrics (
+         metric_date, policy_version, pricing_version, hash_key_version,
+         requested_model, created_at, updated_at
+       ) VALUES (($1::timestamptz AT TIME ZONE 'UTC')::date, $2, $3, $4, $5, $1, $1)
+       ON CONFLICT DO NOTHING`,
+      [
+        now,
+        ROUTER_CANARY_POLICY_VERSION,
+        ROUTER_CANARY_PRICING_VERSION,
+        config.hmacKeyVersion,
+        OPENAI_ROUTER_MODEL,
+      ],
+    );
+    const result = await runQuery<AdmissionRow>(
+      `WITH current AS (
+         SELECT metrics.metric_date, metrics.admitted_count, state.daily_limit,
+                state.rolled_back_at, state.inflight_count, state.last_admitted_at,
+                state.sample_bps, state.daily_budget_micros,
+                state.reserved_cost_micros, state.deadline_ms
+         FROM addie_router_canary_daily_metrics metrics
+         JOIN addie_router_canary_state state USING (
+           policy_version, pricing_version, hash_key_version, requested_model
+         )
+         WHERE metrics.metric_date = ($1::timestamptz AT TIME ZONE 'UTC')::date
+           AND metrics.policy_version = $2 AND metrics.pricing_version = $3
+           AND metrics.hash_key_version = $4 AND metrics.requested_model = $5
+         FOR UPDATE OF metrics, state
+       ), decision AS (
+         SELECT *,
+           rolled_back_at IS NULL
+             AND NOT (
+               inflight_count > 0
+               AND last_admitted_at < $1::timestamptz - ($10::integer * INTERVAL '1 millisecond')
+             )
+             AND admitted_count < daily_limit
+             AND sample_bps = $6 AND daily_limit = $7
+             AND daily_budget_micros = $8 AND reserved_cost_micros = $9
+             AND deadline_ms = $11 AS admitted,
+           CASE
+             WHEN sample_bps <> $6 OR daily_limit <> $7
+               OR daily_budget_micros <> $8 OR reserved_cost_micros <> $9
+               OR deadline_ms <> $11 THEN 'invalid_configuration'
+             WHEN rolled_back_at IS NOT NULL OR (
+               inflight_count > 0
+               AND last_admitted_at < $1::timestamptz - ($10::integer * INTERVAL '1 millisecond')
+             ) THEN 'rolled_back'
+             WHEN admitted_count >= daily_limit THEN 'daily_limit_reached'
+             ELSE 'admitted'
+           END AS reason
+         FROM current
+       ), state_update AS (
+         UPDATE addie_router_canary_state state
+         SET inflight_count = state.inflight_count + CASE WHEN decision.admitted THEN 1 ELSE 0 END,
+             last_admitted_at = CASE WHEN decision.admitted THEN $1::timestamptz ELSE state.last_admitted_at END,
+             rolled_back_at = CASE
+               WHEN decision.reason = 'rolled_back' AND state.rolled_back_at IS NULL
+                 THEN $1::timestamptz
+               ELSE state.rolled_back_at
+             END,
+             rollback_reason = CASE
+               WHEN decision.reason = 'rolled_back' AND state.rolled_back_at IS NULL
+                 THEN 'stale_inflight'
+               ELSE state.rollback_reason
+             END,
+             updated_at = $1::timestamptz
+         FROM decision
+         WHERE state.policy_version = $2 AND state.pricing_version = $3
+           AND state.hash_key_version = $4 AND state.requested_model = $5
+       ), metrics_update AS (
+         UPDATE addie_router_canary_daily_metrics metrics
+         SET sampled_count = metrics.sampled_count + 1,
+             admitted_count = metrics.admitted_count + CASE WHEN decision.admitted THEN 1 ELSE 0 END,
+             quota_rejected_count = metrics.quota_rejected_count
+               + CASE WHEN decision.reason = 'daily_limit_reached' THEN 1 ELSE 0 END,
+             rollback_rejected_count = metrics.rollback_rejected_count
+               + CASE WHEN decision.reason = 'rolled_back' THEN 1 ELSE 0 END,
+             invalid_config_count = metrics.invalid_config_count
+               + CASE WHEN decision.reason = 'invalid_configuration' THEN 1 ELSE 0 END,
+             updated_at = $1::timestamptz
+         FROM decision
+         WHERE metrics.metric_date = decision.metric_date
+           AND metrics.policy_version = $2 AND metrics.pricing_version = $3
+           AND metrics.hash_key_version = $4 AND metrics.requested_model = $5
+         RETURNING decision.admitted, decision.reason, metrics.metric_date::text AS admission_date
+       )
+       SELECT admitted, reason, admission_date FROM metrics_update`,
+      [
+        now,
+        ROUTER_CANARY_POLICY_VERSION,
+        ROUTER_CANARY_PRICING_VERSION,
+        config.hmacKeyVersion,
+        OPENAI_ROUTER_MODEL,
+        config.sampleBps,
+        config.dailyLimit,
+        config.dailyBudgetMicros,
+        ROUTER_CANARY_RESERVED_COST_MICROS,
+        ROUTER_CANARY_STALE_INFLIGHT_MS,
+        config.deadlineMs,
+      ],
+    );
+    const row = result.rows[0];
+    if (!row) return { status: 'not_admitted', reason: 'ledger_unavailable' };
+    if (!row.admitted) {
+      return {
+        status: 'not_admitted',
+        reason: row.reason === 'rolled_back'
+          ? 'rolled_back'
+          : row.reason === 'daily_limit_reached'
+            ? 'daily_limit_reached'
+            : 'invalid_configuration',
+      };
+    }
+    return {
+      status: 'admitted',
+      admissionDate: row.admission_date,
+      deadlineMs: config.deadlineMs,
+      policyVersion: ROUTER_CANARY_POLICY_VERSION,
+      pricingVersion: ROUTER_CANARY_PRICING_VERSION,
+      hashKeyVersion: config.hmacKeyVersion,
+      requestedModel: OPENAI_ROUTER_MODEL,
+    };
+  } catch {
+    return { status: 'not_admitted', reason: 'ledger_unavailable' };
+  }
+}
+
+function validMetric(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+/** Records one aggregate terminal outcome and atomically latches rollback. */
+export async function recordRouterCanaryOutcome(
+  admission: RouterCanaryAdmission,
+  outcome: RouterCanaryOutcome,
+  dependencies: { query?: QueryFn; now?: Date } = {},
+): Promise<RouterCanaryRecordResult> {
+  if (
+    !validMetric(outcome.candidateLatencyMs)
+    || !validMetric(outcome.candidateCostMicros)
+    || (outcome.fallbackLatencyMs !== undefined && !validMetric(outcome.fallbackLatencyMs))
+    || (outcome.status === 'candidate_succeeded' && outcome.failureReason !== undefined)
+    || (outcome.status !== 'candidate_succeeded' && outcome.failureReason === undefined)
+  ) {
+    throw new Error('Invalid router canary outcome');
+  }
+  const runQuery = dependencies.query ?? defaultQuery as QueryFn;
+  const now = dependencies.now ?? new Date();
+  const failureReason = outcome.failureReason ?? null;
+  const result = await runQuery<{
+    rolled_back: boolean;
+    rollback_reason: string | null;
+  }>(
+    `WITH current AS (
+       SELECT metrics.*, state.inflight_count, state.rolled_back_at
+       FROM addie_router_canary_daily_metrics metrics
+       JOIN addie_router_canary_state state USING (
+         policy_version, pricing_version, hash_key_version, requested_model
+       )
+       WHERE metrics.metric_date = $1::date
+         AND metrics.policy_version = $2 AND metrics.pricing_version = $3
+         AND metrics.hash_key_version = $4 AND metrics.requested_model = $5
+       FOR UPDATE OF metrics, state
+     ), updated_metrics AS (
+       UPDATE addie_router_canary_daily_metrics metrics
+       SET completed_count = metrics.completed_count + 1,
+           candidate_success_count = metrics.candidate_success_count
+             + CASE WHEN $6 = 'candidate_succeeded' THEN 1 ELSE 0 END,
+           candidate_failure_count = metrics.candidate_failure_count
+             + CASE WHEN $6 <> 'candidate_succeeded' THEN 1 ELSE 0 END,
+           fallback_success_count = metrics.fallback_success_count
+             + CASE WHEN $6 = 'fallback_succeeded' THEN 1 ELSE 0 END,
+           fallback_safe_default_count = metrics.fallback_safe_default_count
+             + CASE WHEN $6 = 'fallback_safe_default' THEN 1 ELSE 0 END,
+           timeout_count = metrics.timeout_count + CASE WHEN $7 = 'timeout' THEN 1 ELSE 0 END,
+           invalid_output_count = metrics.invalid_output_count
+             + CASE WHEN $7 = 'invalid_output' THEN 1 ELSE 0 END,
+           identity_error_count = metrics.identity_error_count + CASE
+             WHEN $7 IN ('unexpected_model_identity', 'invalid_provider_event_stream',
+                         'unsupported_provider_capability') THEN 1 ELSE 0 END,
+           provider_error_count = metrics.provider_error_count
+             + CASE WHEN $7 = 'provider_error' THEN 1 ELSE 0 END,
+           candidate_latency_ms_sum = metrics.candidate_latency_ms_sum + $8,
+           candidate_latency_ms_max = GREATEST(metrics.candidate_latency_ms_max, $8),
+           candidate_cost_micros_sum = metrics.candidate_cost_micros_sum + $9,
+           fallback_latency_ms_sum = metrics.fallback_latency_ms_sum + COALESCE($10, 0),
+           updated_at = $11::timestamptz
+       FROM current
+       WHERE metrics.metric_date = current.metric_date
+         AND metrics.policy_version = $2 AND metrics.pricing_version = $3
+         AND metrics.hash_key_version = $4 AND metrics.requested_model = $5
+         AND current.inflight_count > 0
+         AND current.completed_count < current.admitted_count
+       RETURNING metrics.*
+     ), decision AS (
+       SELECT *, CASE
+         WHEN $6 = 'fallback_safe_default' THEN 'fallback_safe_default'
+         WHEN $7 IN ('unexpected_model_identity', 'invalid_provider_event_stream',
+                     'unsupported_provider_capability') THEN 'provider_identity_or_capability'
+         WHEN completed_count >= $12
+           AND candidate_failure_count::numeric / completed_count > $13 THEN 'failure_rate'
+         WHEN completed_count >= $12
+           AND candidate_latency_ms_sum / completed_count > $14 THEN 'average_latency'
+         WHEN completed_count >= $12
+           AND candidate_cost_micros_sum / completed_count > $15 THEN 'average_cost'
+         ELSE NULL
+       END AS new_rollback_reason
+       FROM updated_metrics
+     ), updated_state AS (
+       UPDATE addie_router_canary_state state
+       SET inflight_count = state.inflight_count - 1,
+           rolled_back_at = CASE
+             WHEN state.rolled_back_at IS NULL AND decision.new_rollback_reason IS NOT NULL
+               THEN $11::timestamptz
+             ELSE state.rolled_back_at
+           END,
+           rollback_reason = COALESCE(state.rollback_reason, decision.new_rollback_reason),
+           updated_at = $11::timestamptz
+       FROM decision
+       WHERE state.policy_version = $2 AND state.pricing_version = $3
+         AND state.hash_key_version = $4 AND state.requested_model = $5
+       RETURNING state.rolled_back_at IS NOT NULL AS rolled_back, state.rollback_reason
+     )
+     SELECT rolled_back, rollback_reason FROM updated_state`,
+    [
+      admission.admissionDate,
+      admission.policyVersion,
+      admission.pricingVersion,
+      admission.hashKeyVersion,
+      admission.requestedModel,
+      outcome.status,
+      failureReason,
+      outcome.candidateLatencyMs,
+      outcome.candidateCostMicros,
+      outcome.fallbackLatencyMs ?? null,
+      now,
+      ROUTER_CANARY_ROLLBACK_POLICY.minimumCompleted,
+      ROUTER_CANARY_ROLLBACK_POLICY.maximumFailureRate,
+      ROUTER_CANARY_ROLLBACK_POLICY.maximumAverageLatencyMs,
+      ROUTER_CANARY_ROLLBACK_POLICY.maximumAverageCostMicros,
+    ],
+  );
+  const row = result.rows[0];
+  return {
+    recorded: Boolean(row),
+    rolledBack: row?.rolled_back ?? false,
+    rollbackReason: row?.rollback_reason ?? null,
+  };
+}

--- a/server/src/addie/router-canary.ts
+++ b/server/src/addie/router-canary.ts
@@ -1,9 +1,12 @@
 import { createHmac } from 'node:crypto';
 import type { QueryResultRow } from 'pg';
 import { query as defaultQuery } from '../db/client.js';
+import { createLogger } from '../logger.js';
 import { FIXED_TRACE_ROLLOUT_POLICY_VERSION } from './eval/fixed-trace-rollout.js';
 import { OPENAI_ROUTER_MODEL } from './model-providers/openai-responses-provider.js';
 import { ROUTER_SHADOW_PROMOTION_POLICY_VERSION } from './router-shadow.js';
+
+const logger = createLogger('addie-router-canary');
 
 export const ROUTER_CANARY_POLICY_VERSION = 'addie-router-luna-canary:v1';
 export const ROUTER_CANARY_PRICING_VERSION = 'openai-gpt-5.6-luna-2026-08-26';
@@ -395,6 +398,9 @@ export async function admitRouterCanary(
       requestedModel: OPENAI_ROUTER_MODEL,
     };
   } catch {
+    // Do not attach the database error or cohort input: either could contain
+    // details outside this aggregate-only observability boundary.
+    logger.error('Router canary admission ledger unavailable');
     return { status: 'not_admitted', reason: 'ledger_unavailable' };
   }
 }

--- a/server/src/db/migrations/566_addie_router_canary_ledger.sql
+++ b/server/src/db/migrations/566_addie_router_canary_ledger.sql
@@ -1,0 +1,88 @@
+-- Aggregate-only, default-off Luna router canary accounting.
+-- These tables intentionally contain no channel, user, thread, message,
+-- prompt, response, reason text, or per-opportunity hash columns.
+CREATE TABLE addie_router_canary_state (
+  policy_version VARCHAR(64) NOT NULL,
+  pricing_version VARCHAR(64) NOT NULL,
+  hash_key_version VARCHAR(64) NOT NULL,
+  requested_model VARCHAR(64) NOT NULL,
+  sample_bps INTEGER NOT NULL CHECK (sample_bps BETWEEN 1 AND 10000),
+  daily_limit SMALLINT NOT NULL CHECK (daily_limit BETWEEN 1 AND 100),
+  daily_budget_micros INTEGER NOT NULL CHECK (daily_budget_micros > 0),
+  reserved_cost_micros INTEGER NOT NULL CHECK (reserved_cost_micros > 0),
+  deadline_ms INTEGER NOT NULL CHECK (deadline_ms BETWEEN 1000 AND 15000),
+  inflight_count SMALLINT NOT NULL DEFAULT 0 CHECK (inflight_count BETWEEN 0 AND 100),
+  last_admitted_at TIMESTAMPTZ,
+  rolled_back_at TIMESTAMPTZ,
+  rollback_reason VARCHAR(64) CHECK (
+    rollback_reason IS NULL OR rollback_reason IN (
+      'stale_inflight', 'fallback_safe_default',
+      'provider_identity_or_capability', 'failure_rate',
+      'average_latency', 'average_cost'
+    )
+  ),
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (policy_version, pricing_version, hash_key_version, requested_model),
+  CHECK (length(btrim(policy_version)) BETWEEN 1 AND 64),
+  CHECK (length(btrim(pricing_version)) BETWEEN 1 AND 64),
+  CHECK (length(btrim(hash_key_version)) BETWEEN 1 AND 64),
+  CHECK (length(btrim(requested_model)) BETWEEN 1 AND 64),
+  CHECK (daily_limit * reserved_cost_micros <= daily_budget_micros),
+  CHECK ((rolled_back_at IS NULL) = (rollback_reason IS NULL)),
+  CHECK (last_admitted_at IS NOT NULL OR inflight_count = 0)
+);
+
+CREATE TABLE addie_router_canary_daily_metrics (
+  metric_date DATE NOT NULL,
+  policy_version VARCHAR(64) NOT NULL,
+  pricing_version VARCHAR(64) NOT NULL,
+  hash_key_version VARCHAR(64) NOT NULL,
+  requested_model VARCHAR(64) NOT NULL,
+  sampled_count INTEGER NOT NULL DEFAULT 0 CHECK (sampled_count >= 0),
+  admitted_count INTEGER NOT NULL DEFAULT 0 CHECK (admitted_count BETWEEN 0 AND 100),
+  completed_count INTEGER NOT NULL DEFAULT 0 CHECK (completed_count BETWEEN 0 AND 100),
+  quota_rejected_count INTEGER NOT NULL DEFAULT 0 CHECK (quota_rejected_count >= 0),
+  rollback_rejected_count INTEGER NOT NULL DEFAULT 0 CHECK (rollback_rejected_count >= 0),
+  invalid_config_count INTEGER NOT NULL DEFAULT 0 CHECK (invalid_config_count >= 0),
+  candidate_success_count INTEGER NOT NULL DEFAULT 0 CHECK (candidate_success_count >= 0),
+  candidate_failure_count INTEGER NOT NULL DEFAULT 0 CHECK (candidate_failure_count >= 0),
+  fallback_success_count INTEGER NOT NULL DEFAULT 0 CHECK (fallback_success_count >= 0),
+  fallback_safe_default_count INTEGER NOT NULL DEFAULT 0 CHECK (fallback_safe_default_count >= 0),
+  timeout_count INTEGER NOT NULL DEFAULT 0 CHECK (timeout_count >= 0),
+  invalid_output_count INTEGER NOT NULL DEFAULT 0 CHECK (invalid_output_count >= 0),
+  identity_error_count INTEGER NOT NULL DEFAULT 0 CHECK (identity_error_count >= 0),
+  provider_error_count INTEGER NOT NULL DEFAULT 0 CHECK (provider_error_count >= 0),
+  candidate_latency_ms_sum BIGINT NOT NULL DEFAULT 0 CHECK (candidate_latency_ms_sum >= 0),
+  candidate_latency_ms_max INTEGER NOT NULL DEFAULT 0 CHECK (candidate_latency_ms_max >= 0),
+  candidate_cost_micros_sum BIGINT NOT NULL DEFAULT 0 CHECK (candidate_cost_micros_sum >= 0),
+  fallback_latency_ms_sum BIGINT NOT NULL DEFAULT 0 CHECK (fallback_latency_ms_sum >= 0),
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (
+    metric_date, policy_version, pricing_version, hash_key_version, requested_model
+  ),
+  FOREIGN KEY (policy_version, pricing_version, hash_key_version, requested_model)
+    REFERENCES addie_router_canary_state (
+      policy_version, pricing_version, hash_key_version, requested_model
+    ),
+  CHECK (length(btrim(policy_version)) BETWEEN 1 AND 64),
+  CHECK (length(btrim(pricing_version)) BETWEEN 1 AND 64),
+  CHECK (length(btrim(hash_key_version)) BETWEEN 1 AND 64),
+  CHECK (length(btrim(requested_model)) BETWEEN 1 AND 64),
+  CHECK (completed_count <= admitted_count),
+  CHECK (candidate_success_count + candidate_failure_count = completed_count),
+  CHECK (fallback_success_count + fallback_safe_default_count = candidate_failure_count),
+  CHECK (timeout_count + invalid_output_count + identity_error_count + provider_error_count
+    = candidate_failure_count),
+  CHECK (sampled_count >= admitted_count + quota_rejected_count
+    + rollback_rejected_count + invalid_config_count)
+);
+
+CREATE INDEX idx_addie_router_canary_metrics_date
+  ON addie_router_canary_daily_metrics (metric_date);
+
+COMMENT ON TABLE addie_router_canary_state IS
+  'Aggregate-only configuration and latched rollback state for the bounded Luna router canary';
+COMMENT ON TABLE addie_router_canary_daily_metrics IS
+  'Aggregate-only Luna router canary outcomes; contains no production identity, text, or per-opportunity hash';

--- a/server/tests/integration/router-canary-migration.test.ts
+++ b/server/tests/integration/router-canary-migration.test.ts
@@ -1,0 +1,159 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Pool } from 'pg';
+import {
+  ROUTER_CANARY_RESERVED_COST_MICROS,
+  admitRouterCanary,
+  recordRouterCanaryOutcome,
+} from '../../src/addie/router-canary.js';
+import { FIXED_TRACE_ROLLOUT_POLICY_VERSION } from '../../src/addie/eval/fixed-trace-rollout.js';
+import { ROUTER_SHADOW_PROMOTION_POLICY_VERSION } from '../../src/addie/router-shadow.js';
+import { closeDatabase, initializeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+
+const CHANNEL_ID = 'C0123456789';
+const KEY_VERSION = 'router-canary-integration-v1';
+
+function environment(overrides: Record<string, string | undefined> = {}) {
+  return {
+    ADDIE_ROUTER_LUNA_CANARY_ENABLED: 'true',
+    ADDIE_ROUTER_LUNA_CANARY_PRODUCTION_DATA_APPROVED: 'true',
+    ADDIE_ROUTER_LUNA_CANARY_FIXED_TRACE_POLICY_VERSION:
+      FIXED_TRACE_ROLLOUT_POLICY_VERSION,
+    ADDIE_ROUTER_LUNA_CANARY_SHADOW_PROMOTION_POLICY_VERSION:
+      ROUTER_SHADOW_PROMOTION_POLICY_VERSION,
+    ADDIE_ROUTER_LUNA_CANARY_CHANNEL_IDS: CHANNEL_ID,
+    ADDIE_ROUTER_LUNA_CANARY_SAMPLE_BPS: '10000',
+    ADDIE_ROUTER_LUNA_CANARY_DAILY_LIMIT: '10',
+    ADDIE_ROUTER_LUNA_CANARY_DAILY_BUDGET_MICROS: String(
+      ROUTER_CANARY_RESERVED_COST_MICROS * 10,
+    ),
+    ADDIE_ROUTER_LUNA_CANARY_DEADLINE_MS: '10000',
+    ADDIE_ROUTER_LUNA_CANARY_HMAC_KEY: 'integration-canary-key'.padEnd(32, 'x'),
+    ADDIE_ROUTER_LUNA_CANARY_HMAC_KEY_VERSION: KEY_VERSION,
+    OPENAI_API_KEY: 'unused',
+    ...overrides,
+  };
+}
+
+function cohort(opportunityId: string) {
+  return {
+    channelId: CHANNEL_ID,
+    opportunityId,
+    channelIsPublic: true,
+    channelIsShared: false,
+  };
+}
+
+describe('migration 566: Luna router canary ledger', () => {
+  let pool: Pool;
+  let migrationReady = false;
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL
+        || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+    migrationReady = true;
+  }, 60_000);
+
+  beforeEach(async () => {
+    await pool.query(
+      'DELETE FROM addie_router_canary_daily_metrics WHERE hash_key_version = $1',
+      [KEY_VERSION],
+    );
+    await pool.query(
+      'DELETE FROM addie_router_canary_state WHERE hash_key_version = $1',
+      [KEY_VERSION],
+    );
+  });
+
+  afterAll(async () => {
+    if (pool && migrationReady) {
+      await pool.query(
+        'DELETE FROM addie_router_canary_daily_metrics WHERE hash_key_version = $1',
+        [KEY_VERSION],
+      );
+      await pool.query(
+        'DELETE FROM addie_router_canary_state WHERE hash_key_version = $1',
+        [KEY_VERSION],
+      );
+    }
+    await closeDatabase();
+  });
+
+  it('contains only aggregate rollout state and metrics columns', async () => {
+    const columns = await pool.query<{ table_name: string; column_name: string }>(
+      `SELECT table_name, column_name FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name IN ('addie_router_canary_state', 'addie_router_canary_daily_metrics')`,
+    );
+    const names = columns.rows.map(({ column_name }) => column_name);
+    expect(names).toEqual(expect.arrayContaining([
+      'sampled_count', 'admitted_count', 'completed_count', 'rolled_back_at',
+    ]));
+    expect(names).not.toEqual(expect.arrayContaining([
+      'channel_id', 'thread_id', 'message_id', 'user_id', 'opportunity_id',
+      'source_binding_hmac', 'prompt', 'response',
+    ]));
+  });
+
+  it('atomically enforces the daily admission cap without source persistence', async () => {
+    const limited = environment({
+      ADDIE_ROUTER_LUNA_CANARY_DAILY_LIMIT: '1',
+      ADDIE_ROUTER_LUNA_CANARY_DAILY_BUDGET_MICROS: String(
+        ROUTER_CANARY_RESERVED_COST_MICROS,
+      ),
+    });
+    const results = await Promise.all([
+      admitRouterCanary(cohort('1.000001'), { env: limited }),
+      admitRouterCanary(cohort('1.000002'), { env: limited }),
+    ]);
+    expect(results.map((result) => result.status).sort()).toEqual([
+      'admitted', 'not_admitted',
+    ]);
+    expect(results.find((result) => result.status === 'not_admitted')).toEqual({
+      status: 'not_admitted', reason: 'daily_limit_reached',
+    });
+  });
+
+  it('latches rollback after the bounded failure-rate threshold', async () => {
+    for (let index = 0; index < 5; index++) {
+      const admitted = await admitRouterCanary(cohort(`2.00000${index}`), {
+        env: environment(),
+      });
+      expect(admitted.status).toBe('admitted');
+      if (admitted.status !== 'admitted') throw new Error('expected admission');
+      const failed = index >= 3;
+      const recorded = await recordRouterCanaryOutcome(admitted, failed ? {
+        status: 'fallback_succeeded',
+        failureReason: 'provider_error',
+        candidateLatencyMs: 100,
+        candidateCostMicros: 100,
+        fallbackLatencyMs: 100,
+      } : {
+        status: 'candidate_succeeded',
+        candidateLatencyMs: 100,
+        candidateCostMicros: 100,
+      });
+      expect(recorded.recorded).toBe(true);
+      expect(recorded.rolledBack).toBe(index === 4);
+    }
+
+    await expect(admitRouterCanary(cohort('2.000006'), {
+      env: environment(),
+    })).resolves.toEqual({ status: 'not_admitted', reason: 'rolled_back' });
+    const state = await pool.query<{
+      inflight_count: number;
+      rollback_reason: string;
+    }>(
+      `SELECT inflight_count, rollback_reason
+       FROM addie_router_canary_state WHERE hash_key_version = $1`,
+      [KEY_VERSION],
+    );
+    expect(state.rows[0]).toEqual({
+      inflight_count: 0,
+      rollback_reason: 'failure_rate',
+    });
+  });
+});

--- a/server/tests/unit/addie/router-canary.test.ts
+++ b/server/tests/unit/addie/router-canary.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FIXED_TRACE_ROLLOUT_POLICY_VERSION } from '../../../src/addie/eval/fixed-trace-rollout.js';
+import {
+  ROUTER_CANARY_POLICY_VERSION,
+  ROUTER_CANARY_PRICING_VERSION,
+  ROUTER_CANARY_RESERVED_COST_MICROS,
+  admitRouterCanary,
+  recordRouterCanaryOutcome,
+  selectRouterCanaryCohort,
+  type RouterCanaryAdmission,
+} from '../../../src/addie/router-canary.js';
+import { ROUTER_SHADOW_PROMOTION_POLICY_VERSION } from '../../../src/addie/router-shadow.js';
+
+const CHANNEL_ID = 'C0123456789';
+const OPPORTUNITY_ID = '1724688000.000001';
+const HMAC_KEY = 'canary-test-key'.padEnd(32, 'x');
+
+function environment(overrides: Record<string, string | undefined> = {}) {
+  return {
+    ADDIE_ROUTER_LUNA_CANARY_ENABLED: 'true',
+    ADDIE_ROUTER_LUNA_CANARY_PRODUCTION_DATA_APPROVED: 'true',
+    ADDIE_ROUTER_LUNA_CANARY_FIXED_TRACE_POLICY_VERSION:
+      FIXED_TRACE_ROLLOUT_POLICY_VERSION,
+    ADDIE_ROUTER_LUNA_CANARY_SHADOW_PROMOTION_POLICY_VERSION:
+      ROUTER_SHADOW_PROMOTION_POLICY_VERSION,
+    ADDIE_ROUTER_LUNA_CANARY_CHANNEL_IDS: CHANNEL_ID,
+    ADDIE_ROUTER_LUNA_CANARY_SAMPLE_BPS: '10000',
+    ADDIE_ROUTER_LUNA_CANARY_DAILY_LIMIT: '1',
+    ADDIE_ROUTER_LUNA_CANARY_DAILY_BUDGET_MICROS: String(
+      ROUTER_CANARY_RESERVED_COST_MICROS,
+    ),
+    ADDIE_ROUTER_LUNA_CANARY_DEADLINE_MS: '10000',
+    ADDIE_ROUTER_LUNA_CANARY_HMAC_KEY: HMAC_KEY,
+    ADDIE_ROUTER_LUNA_CANARY_HMAC_KEY_VERSION: 'test-v1',
+    OPENAI_API_KEY: 'private-openai-key',
+    ...overrides,
+  };
+}
+
+const cohort = {
+  channelId: CHANNEL_ID,
+  opportunityId: OPPORTUNITY_ID,
+  channelIsPublic: true,
+  channelIsShared: false,
+};
+
+function admission(): RouterCanaryAdmission {
+  return {
+    status: 'admitted',
+    admissionDate: '2026-08-29',
+    deadlineMs: 10_000,
+    policyVersion: ROUTER_CANARY_POLICY_VERSION,
+    pricingVersion: ROUTER_CANARY_PRICING_VERSION,
+    hashKeyVersion: 'test-v1',
+    requestedModel: 'gpt-5.6-luna',
+  };
+}
+
+describe('Luna router canary ledger', () => {
+  it.each([
+    [{ ADDIE_ROUTER_LUNA_CANARY_ENABLED: 'false' }, 'disabled'],
+    [{ ADDIE_ROUTER_LUNA_CANARY_PRODUCTION_DATA_APPROVED: 'false' }, 'production_data_not_approved'],
+    [{ ADDIE_ROUTER_LUNA_CANARY_FIXED_TRACE_POLICY_VERSION: 'stale' }, 'evidence_not_approved'],
+    [{ ADDIE_ROUTER_LUNA_CANARY_SHADOW_PROMOTION_POLICY_VERSION: 'stale' }, 'evidence_not_approved'],
+    [{ ADDIE_ROUTER_LUNA_CANARY_HMAC_KEY: 'short' }, 'invalid_configuration'],
+    [{ ADDIE_ROUTER_LUNA_CANARY_DEADLINE_MS: '15001' }, 'invalid_configuration'],
+    [{ ADDIE_ROUTER_LUNA_CANARY_CHANNEL_IDS: 'COTHER00000' }, 'channel_not_allowlisted'],
+    [{ OPENAI_API_KEY: undefined }, 'invalid_configuration'],
+  ])('fails closed for %s', (override, reason) => {
+    expect(selectRouterCanaryCohort(cohort, environment(override))).toEqual({
+      selected: false,
+      reason,
+    });
+  });
+
+  it('rejects private and shared channels before sampling', () => {
+    expect(selectRouterCanaryCohort({
+      ...cohort,
+      channelIsPublic: false,
+    }, environment()).reason).toBe('private_channel');
+    expect(selectRouterCanaryCohort({
+      ...cohort,
+      channelIsShared: true,
+    }, environment()).reason).toBe('shared_channel');
+  });
+
+  it('samples deterministically without exposing configuration secrets', () => {
+    const sparse = environment({ ADDIE_ROUTER_LUNA_CANARY_SAMPLE_BPS: '5000' });
+    const first = selectRouterCanaryCohort(cohort, sparse);
+    expect(selectRouterCanaryCohort(cohort, sparse)).toEqual(first);
+    expect(['selected', 'sample_excluded']).toContain(first.reason);
+    expect(first).not.toHaveProperty('config');
+  });
+
+  it('admits atomically without passing production identity or secrets to SQL', async () => {
+    const runQuery = vi.fn(async (sql: string) => {
+      if (sql.includes('SELECT admitted, reason, admission_date')) {
+        return {
+          rows: [{ admitted: true, reason: 'admitted', admission_date: '2026-08-29' }],
+          rowCount: 1,
+        };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+    const result = await admitRouterCanary(cohort, {
+      env: environment(),
+      query: runQuery,
+      now: new Date('2026-08-29T12:00:00.000Z'),
+    });
+
+    expect(result).toEqual(admission());
+    const persistedValues = runQuery.mock.calls.flatMap(([, params]) => params ?? []);
+    expect(persistedValues).not.toContain(CHANNEL_ID);
+    expect(persistedValues).not.toContain(OPPORTUNITY_ID);
+    expect(persistedValues).not.toContain(HMAC_KEY);
+    expect(persistedValues).not.toContain('private-openai-key');
+  });
+
+  it.each([
+    [{ admitted: false, reason: 'daily_limit_reached', admission_date: '2026-08-29' }, 'daily_limit_reached'],
+    [{ admitted: false, reason: 'rolled_back', admission_date: '2026-08-29' }, 'rolled_back'],
+    [{ admitted: false, reason: 'invalid_configuration', admission_date: '2026-08-29' }, 'invalid_configuration'],
+  ] as const)('reports a rejected database admission as %s', async (row, reason) => {
+    const runQuery = vi.fn(async (sql: string) => ({
+      rows: sql.includes('SELECT admitted, reason, admission_date') ? [row] : [],
+      rowCount: 1,
+    }));
+    await expect(admitRouterCanary(cohort, {
+      env: environment(), query: runQuery,
+    })).resolves.toEqual({ status: 'not_admitted', reason });
+  });
+
+  it('falls back without dispatch when the ledger is unavailable', async () => {
+    await expect(admitRouterCanary(cohort, {
+      env: environment(),
+      query: vi.fn().mockRejectedValue(new Error('database unavailable')),
+    })).resolves.toEqual({ status: 'not_admitted', reason: 'ledger_unavailable' });
+  });
+
+  it('records one aggregate outcome and returns the latched rollback state', async () => {
+    const runQuery = vi.fn().mockResolvedValue({
+      rows: [{ rolled_back: true, rollback_reason: 'failure_rate' }],
+      rowCount: 1,
+    });
+    await expect(recordRouterCanaryOutcome(admission(), {
+      status: 'fallback_succeeded',
+      failureReason: 'timeout',
+      candidateLatencyMs: 10_000,
+      candidateCostMicros: 200,
+      fallbackLatencyMs: 500,
+    }, {
+      query: runQuery,
+      now: new Date('2026-08-29T12:00:10.000Z'),
+    })).resolves.toEqual({
+      recorded: true,
+      rolledBack: true,
+      rollbackReason: 'failure_rate',
+    });
+    const params = runQuery.mock.calls[0][1];
+    expect(params).toEqual(expect.arrayContaining([
+      'fallback_succeeded', 'timeout', 10_000, 200, 500,
+    ]));
+    expect(params).not.toEqual(expect.arrayContaining([CHANNEL_ID, OPPORTUNITY_ID, HMAC_KEY]));
+  });
+
+  it('rejects internally inconsistent terminal outcomes', async () => {
+    await expect(recordRouterCanaryOutcome(admission(), {
+      status: 'candidate_succeeded',
+      failureReason: 'provider_error',
+      candidateLatencyMs: 1,
+      candidateCostMicros: 1,
+    })).rejects.toThrow('Invalid router canary outcome');
+  });
+});


### PR DESCRIPTION
## Summary
- add fail-closed deterministic canary cohort selection with exact fixed-trace and shadow-promotion policy pins
- add aggregate-only database admission, daily budget, in-flight recovery, and latched rollback state
- auto-rollback on fallback safe-default, identity/capability failures, or bounded failure/latency/cost thresholds
- add unit and migration/concurrency coverage

## Privacy and safety boundaries
- persists no channel, user, thread, message, prompt, response, reason text, source hash, or per-opportunity record
- never passes production IDs, HMAC keys, or provider keys to SQL
- database unavailability, configuration drift, exhausted quota, stale in-flight work, or a latched rollback all fail closed
- no runtime caller exists yet, and fly.toml has no canary settings, so this PR changes no production traffic

## Validation
- npm run typecheck
- 55 focused canary + shadow unit tests passed
- migration DDL and admission/outcome/rollback smoke passed against a fresh schema; temporary local tables were removed
- the normal shared local test database could not run runMigrations because it contains an unrelated stale migration-533 filename collision; isolated CI remains authoritative
- git diff --check

## Version
CODE_VERSION 2026.08.87.