### PR TITLE
feat(addie): add bounded Luna router runtime

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.87';
+export const CODE_VERSION = '2026.08.88';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/router-canary-runtime.ts
+++ b/server/src/addie/router-canary-runtime.ts
@@ -1,0 +1,247 @@
+import { createLogger } from '../logger.js';
+import { OPENAI_ROUTER_MODEL } from './model-providers/openai-responses-provider.js';
+import {
+  ROUTER_CANARY_MAX_REQUEST_BYTES,
+  admitRouterCanary,
+  recordRouterCanaryOutcome,
+  type AdmitRouterCanaryResult,
+  type RouterCanaryAdmission,
+  type RouterCanaryCohortInput,
+  type RouterCanaryFailureReason,
+  type RouterCanaryOutcome,
+} from './router-canary.js';
+import {
+  buildRouterModelRequest,
+  type AddieRouter,
+  type ExecutionPlan,
+  type RouterModelObservation,
+  type RoutingContext,
+} from './router.js';
+
+const logger = createLogger('addie-router-canary-runtime');
+const LUNA_INPUT_MICROS_PER_TOKEN = 0.2;
+const LUNA_OUTPUT_MICROS_PER_TOKEN = 1.2;
+
+type RouterRoute = AddieRouter['route'];
+
+export interface RouterCanaryRuntimeInput extends RouterCanaryCohortInput {
+  routingContext: RoutingContext;
+}
+
+export type RouterCanaryRuntimeReason =
+  | 'candidate_succeeded'
+  | 'candidate_failed'
+  | 'request_too_large'
+  | 'outcome_not_recorded'
+  | Exclude<AdmitRouterCanaryResult, RouterCanaryAdmission>['reason'];
+
+export interface RouterCanaryRuntimeResult {
+  plan: ExecutionPlan;
+  provider: 'luna' | 'anthropic_fallback';
+  reason: RouterCanaryRuntimeReason;
+}
+
+export interface RouterCanaryRuntimeDependencies {
+  candidateRoute: RouterRoute;
+  fallbackRoute: RouterRoute;
+  admit?: typeof admitRouterCanary;
+  record?: typeof recordRouterCanaryOutcome;
+  env?: Record<string, string | undefined>;
+  now?: () => Date;
+  scheduleTimeout?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  clearScheduledTimeout?: (timeout: ReturnType<typeof setTimeout>) => void;
+  yieldForObserver?: () => Promise<void>;
+}
+
+function safeKnowledgePlan(): ExecutionPlan {
+  return {
+    action: 'respond',
+    tool_sets: ['knowledge'],
+    confidence: 'high',
+    reason: 'Router provider fallback failed - defaulting to knowledge tools',
+    decision_method: 'llm',
+  };
+}
+
+function estimateCostMicros(observation: RouterModelObservation | null): number {
+  if (!observation || observation.inputTokens === null || observation.outputTokens === null) {
+    return 0;
+  }
+  return Math.ceil(
+    observation.inputTokens * LUNA_INPUT_MICROS_PER_TOKEN
+    + observation.outputTokens * LUNA_OUTPUT_MICROS_PER_TOKEN,
+  );
+}
+
+function classifyCandidateFailure(
+  observation: RouterModelObservation | null,
+  timedOut: boolean,
+): RouterCanaryFailureReason {
+  if (timedOut) return 'timeout';
+  switch (observation?.primaryErrorCategory) {
+    case 'invalid_json':
+    case 'schema_invalid':
+    case 'refusal':
+    case 'truncated':
+    case 'incomplete':
+      return 'invalid_output';
+    case 'unexpected_model_identity':
+    case 'invalid_provider_event_stream':
+    case 'unsupported_provider_capability':
+      return observation.primaryErrorCategory;
+    default:
+      return 'provider_error';
+  }
+}
+
+async function defaultYieldForObserver(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function fallback(
+  input: RouterCanaryRuntimeInput,
+  dependencies: RouterCanaryRuntimeDependencies,
+  reason: RouterCanaryRuntimeReason,
+  terminal?: {
+    admission: RouterCanaryAdmission;
+    failureReason: RouterCanaryFailureReason;
+    candidateLatencyMs: number;
+    candidateCostMicros: number;
+  },
+): Promise<RouterCanaryRuntimeResult> {
+  const fallbackCapture: { current: RouterModelObservation | null } = { current: null };
+  const startedAt = (dependencies.now ?? (() => new Date()))().getTime();
+  let plan: ExecutionPlan;
+  try {
+    plan = await dependencies.fallbackRoute(input.routingContext, {
+      observer: (observation) => {
+        fallbackCapture.current = observation;
+      },
+    });
+    await (dependencies.yieldForObserver ?? defaultYieldForObserver)();
+  } catch {
+    logger.error('Router canary Anthropic fallback threw unexpectedly');
+    plan = safeKnowledgePlan();
+  }
+
+  if (terminal) {
+    const fallbackLatencyMs = fallbackCapture.current?.latencyMs
+      ?? Math.max(0, (dependencies.now ?? (() => new Date()))().getTime() - startedAt);
+    const outcome: RouterCanaryOutcome = {
+      status: fallbackCapture.current?.primaryErrorCategory === null
+        ? 'fallback_succeeded'
+        : 'fallback_safe_default',
+      failureReason: terminal.failureReason,
+      candidateLatencyMs: terminal.candidateLatencyMs,
+      candidateCostMicros: terminal.candidateCostMicros,
+      fallbackLatencyMs,
+    };
+    try {
+      const recorded = await (dependencies.record ?? recordRouterCanaryOutcome)(
+        terminal.admission,
+        outcome,
+      );
+      if (!recorded.recorded) logger.error('Router canary terminal outcome was not recorded');
+    } catch {
+      logger.error('Router canary terminal outcome ledger unavailable');
+    }
+  }
+
+  return { plan, provider: 'anthropic_fallback', reason };
+}
+
+/**
+ * Runs one admitted Luna route within a hard deadline. Every candidate error,
+ * missing observation, or ledger failure returns through the Anthropic router.
+ */
+export async function routeWithRouterCanary(
+  input: RouterCanaryRuntimeInput,
+  dependencies: RouterCanaryRuntimeDependencies,
+): Promise<RouterCanaryRuntimeResult> {
+  const request = buildRouterModelRequest(
+    input.routingContext,
+    OPENAI_ROUTER_MODEL,
+    { effort: 'none' },
+  );
+  if (Buffer.byteLength(JSON.stringify(request), 'utf8') > ROUTER_CANARY_MAX_REQUEST_BYTES) {
+    return fallback(input, dependencies, 'request_too_large');
+  }
+
+  const admission = await (dependencies.admit ?? admitRouterCanary)(input, {
+    env: dependencies.env,
+    now: (dependencies.now ?? (() => new Date()))(),
+  });
+  if (admission.status !== 'admitted') {
+    return fallback(input, dependencies, admission.reason);
+  }
+
+  const controller = new AbortController();
+  let timedOut = false;
+  const candidateCapture: { current: RouterModelObservation | null } = { current: null };
+  const startedAt = (dependencies.now ?? (() => new Date()))().getTime();
+  const schedule = dependencies.scheduleTimeout ?? setTimeout;
+  const clear = dependencies.clearScheduledTimeout ?? clearTimeout;
+  const timeout = schedule(() => {
+    timedOut = true;
+    controller.abort(new Error('router_canary_timeout'));
+  }, admission.deadlineMs);
+  let timeoutCleared = false;
+  const clearCandidateTimeout = () => {
+    if (timeoutCleared) return;
+    timeoutCleared = true;
+    clear(timeout);
+  };
+
+  try {
+    const plan = await dependencies.candidateRoute(input.routingContext, {
+      failureMode: 'throw',
+      signal: controller.signal,
+      observer: (observation) => {
+        candidateCapture.current = observation;
+      },
+    });
+    clearCandidateTimeout();
+    await (dependencies.yieldForObserver ?? defaultYieldForObserver)();
+    if (!candidateCapture.current || candidateCapture.current.primaryErrorCategory !== null) {
+      return fallback(input, dependencies, 'candidate_failed', {
+        admission,
+        failureReason: classifyCandidateFailure(candidateCapture.current, timedOut),
+        candidateLatencyMs: Math.max(
+          0,
+          (dependencies.now ?? (() => new Date()))().getTime() - startedAt,
+        ),
+        candidateCostMicros: estimateCostMicros(candidateCapture.current),
+      });
+    }
+    let recorded;
+    try {
+      recorded = await (dependencies.record ?? recordRouterCanaryOutcome)(admission, {
+        status: 'candidate_succeeded',
+        candidateLatencyMs: candidateCapture.current.latencyMs,
+        candidateCostMicros: estimateCostMicros(candidateCapture.current),
+      });
+    } catch {
+      logger.error('Router canary success outcome ledger unavailable');
+      return fallback(input, dependencies, 'outcome_not_recorded');
+    }
+    if (!recorded.recorded) {
+      logger.error('Router canary success outcome was not recorded');
+      return fallback(input, dependencies, 'outcome_not_recorded');
+    }
+    return { plan, provider: 'luna', reason: 'candidate_succeeded' };
+  } catch {
+    clearCandidateTimeout();
+    await (dependencies.yieldForObserver ?? defaultYieldForObserver)();
+    return fallback(input, dependencies, 'candidate_failed', {
+      admission,
+      failureReason: classifyCandidateFailure(candidateCapture.current, timedOut),
+      candidateLatencyMs: candidateCapture.current?.latencyMs ?? Math.max(
+        0,
+        (dependencies.now ?? (() => new Date()))().getTime() - startedAt,
+      ),
+      candidateCostMicros: estimateCostMicros(candidateCapture.current),
+    });
+  } finally {
+    clearCandidateTimeout();
+  }
+}

--- a/server/tests/unit/addie/router-canary-runtime.test.ts
+++ b/server/tests/unit/addie/router-canary-runtime.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  RouterCanaryAdmission,
+  RouterCanaryOutcome,
+} from '../../../src/addie/router-canary.js';
+import { ROUTER_CANARY_MAX_REQUEST_BYTES } from '../../../src/addie/router-canary.js';
+import { routeWithRouterCanary } from '../../../src/addie/router-canary-runtime.js';
+import type {
+  AddieRouter,
+  ExecutionPlan,
+  RouterModelObservation,
+  RouterRouteOptions,
+  RoutingContext,
+} from '../../../src/addie/router.js';
+
+type RouterRoute = AddieRouter['route'];
+
+const context: RoutingContext = {
+  message: 'How does AdCP work?',
+  source: 'channel',
+  isAAOAdmin: false,
+};
+const cohort = {
+  channelId: 'C0123456789',
+  opportunityId: '1724688000.000001',
+  channelIsPublic: true,
+  channelIsShared: false,
+  routingContext: context,
+};
+const candidatePlan: ExecutionPlan = {
+  action: 'respond',
+  tool_sets: ['knowledge'],
+  confidence: 'high',
+  reason: 'candidate',
+  decision_method: 'llm',
+  latency_ms: 50,
+  tokens_input: 100,
+  tokens_output: 20,
+  model: 'gpt-5.6-luna',
+};
+const fallbackPlan: ExecutionPlan = {
+  action: 'ignore',
+  reason: 'fallback',
+  decision_method: 'llm',
+  latency_ms: 75,
+  tokens_input: 120,
+  tokens_output: 25,
+  model: 'claude-haiku-4-5',
+};
+
+function admission(): RouterCanaryAdmission {
+  return {
+    status: 'admitted',
+    admissionDate: '2026-08-29',
+    deadlineMs: 10_000,
+    policyVersion: 'addie-router-luna-canary:v1',
+    pricingVersion: 'openai-gpt-5.6-luna-2026-08-26',
+    hashKeyVersion: 'test-v1',
+    requestedModel: 'gpt-5.6-luna',
+  };
+}
+
+function observation(
+  provider: 'openai' | 'anthropic',
+  error: RouterModelObservation['primaryErrorCategory'] = null,
+): RouterModelObservation {
+  const model = provider === 'openai' ? 'gpt-5.6-luna' : 'claude-haiku-4-5';
+  return {
+    canonicalRequest: {
+      model,
+      system: [{ text: 'router' }],
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'question' }] }],
+      tools: [],
+      maxOutputTokens: 300,
+    },
+    primaryInvocation: null,
+    isAdmin: false,
+    productionPlan: provider === 'openai' ? candidatePlan : fallbackPlan,
+    rawResponseText: error ? null : '{"action":"ignore","reason":"done"}',
+    responseContent: [],
+    finishReason: error ? null : 'stop',
+    primaryErrorCategory: error,
+    requestedProvider: provider,
+    requestedModel: model,
+    returnedProvider: error ? null : provider,
+    returnedModel: error ? null : model,
+    inputTokens: error ? null : 100,
+    outputTokens: error ? null : 20,
+    cacheReadTokens: null,
+    cacheWriteTokens: null,
+    latencyMs: provider === 'openai' ? 50 : 75,
+  };
+}
+
+function routeReturning(
+  plan: ExecutionPlan,
+  seenObservation: RouterModelObservation,
+): RouterRoute {
+  return async (_routingContext: RoutingContext, options: RouterRouteOptions = {}) => {
+    options.observer?.(seenObservation);
+    return plan;
+  };
+}
+
+function baseDependencies(overrides: Partial<Parameters<typeof routeWithRouterCanary>[1]> = {}) {
+  return {
+    candidateRoute: vi.fn(routeReturning(candidatePlan, observation('openai'))),
+    fallbackRoute: vi.fn(routeReturning(fallbackPlan, observation('anthropic'))),
+    admit: vi.fn().mockResolvedValue(admission()),
+    record: vi.fn().mockResolvedValue({
+      recorded: true, rolledBack: false, rollbackReason: null,
+    }),
+    yieldForObserver: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('Luna router canary runtime', () => {
+  it('uses an admitted strict candidate and records its bounded outcome', async () => {
+    const candidateRoute = vi.fn(routeReturning(candidatePlan, observation('openai')));
+    const record = vi.fn().mockResolvedValue({
+      recorded: true, rolledBack: false, rollbackReason: null,
+    });
+    const dependencies = baseDependencies({ candidateRoute, record });
+
+    await expect(routeWithRouterCanary(cohort, dependencies)).resolves.toEqual({
+      plan: candidatePlan,
+      provider: 'luna',
+      reason: 'candidate_succeeded',
+    });
+    const routeOptions = candidateRoute.mock.calls[0][1];
+    expect(routeOptions.failureMode).toBe('throw');
+    expect(routeOptions.signal).toBeInstanceOf(AbortSignal);
+    expect(record).toHaveBeenCalledWith(admission(), {
+      status: 'candidate_succeeded',
+      candidateLatencyMs: 50,
+      candidateCostMicros: 44,
+    });
+  });
+
+  it('uses Anthropic without calling the candidate when admission is closed', async () => {
+    const candidateRoute = vi.fn(routeReturning(candidatePlan, observation('openai')));
+    const fallbackRoute = vi.fn(routeReturning(fallbackPlan, observation('anthropic')));
+    const dependencies = baseDependencies({
+      candidateRoute,
+      fallbackRoute,
+      admit: vi.fn().mockResolvedValue({
+        status: 'not_admitted', reason: 'rolled_back',
+      }),
+    });
+
+    await expect(routeWithRouterCanary(cohort, dependencies)).resolves.toEqual({
+      plan: fallbackPlan,
+      provider: 'anthropic_fallback',
+      reason: 'rolled_back',
+    });
+    expect(candidateRoute).not.toHaveBeenCalled();
+    expect(fallbackRoute).toHaveBeenCalledOnce();
+    expect(dependencies.record).not.toHaveBeenCalled();
+  });
+
+  it('falls back and accounts for strict candidate output failure', async () => {
+    const failedObservation = observation('openai', 'schema_invalid');
+    const candidateRoute: RouterRoute = async (_ctx, options = {}) => {
+      options.observer?.(failedObservation);
+      throw new Error('invalid output');
+    };
+    const record = vi.fn().mockResolvedValue({
+      recorded: true, rolledBack: false, rollbackReason: null,
+    });
+
+    await expect(routeWithRouterCanary(cohort, baseDependencies({
+      candidateRoute,
+      record,
+    }))).resolves.toMatchObject({
+      plan: fallbackPlan,
+      provider: 'anthropic_fallback',
+      reason: 'candidate_failed',
+    });
+    expect(record.mock.calls[0][1]).toMatchObject({
+      status: 'fallback_succeeded',
+      failureReason: 'invalid_output',
+      candidateLatencyMs: 50,
+      candidateCostMicros: 0,
+      fallbackLatencyMs: 75,
+    } satisfies RouterCanaryOutcome);
+  });
+
+  it('records a fallback safe-default so the ledger can roll back immediately', async () => {
+    const candidateRoute: RouterRoute = async () => {
+      throw new Error('provider failed');
+    };
+    const fallbackRoute = routeReturning(
+      fallbackPlan,
+      observation('anthropic', 'provider_error'),
+    );
+    const record = vi.fn().mockResolvedValue({
+      recorded: true, rolledBack: true, rollbackReason: 'fallback_safe_default',
+    });
+
+    await routeWithRouterCanary(cohort, baseDependencies({
+      candidateRoute,
+      fallbackRoute,
+      record,
+    }));
+
+    expect(record.mock.calls[0][1]).toMatchObject({
+      status: 'fallback_safe_default',
+      failureReason: 'provider_error',
+    });
+  });
+
+  it('aborts a slow candidate at the admitted deadline and falls back', async () => {
+    let observedSignal: AbortSignal | undefined;
+    const candidateRoute: RouterRoute = async (_ctx, options = {}) => {
+      observedSignal = options.signal;
+      await new Promise<never>((_resolve, reject) => {
+        options.signal?.addEventListener('abort', () => reject(options.signal?.reason), {
+          once: true,
+        });
+      });
+    };
+    const record = vi.fn().mockResolvedValue({
+      recorded: true, rolledBack: false, rollbackReason: null,
+    });
+    const scheduleTimeout = (callback: () => void) => setTimeout(callback, 0);
+
+    const result = await routeWithRouterCanary(cohort, baseDependencies({
+      candidateRoute,
+      record,
+      scheduleTimeout,
+    }));
+
+    expect(observedSignal?.aborted).toBe(true);
+    expect(result).toMatchObject({
+      plan: fallbackPlan,
+      provider: 'anthropic_fallback',
+      reason: 'candidate_failed',
+    });
+    expect(record.mock.calls[0][1]).toMatchObject({ failureReason: 'timeout' });
+  });
+
+  it('does not use a candidate decision when success accounting fails', async () => {
+    const fallbackRoute = vi.fn(routeReturning(fallbackPlan, observation('anthropic')));
+    const result = await routeWithRouterCanary(cohort, baseDependencies({
+      fallbackRoute,
+      record: vi.fn().mockResolvedValue({
+        recorded: false, rolledBack: false, rollbackReason: null,
+      }),
+    }));
+    expect(result).toEqual({
+      plan: fallbackPlan,
+      provider: 'anthropic_fallback',
+      reason: 'outcome_not_recorded',
+    });
+    expect(fallbackRoute).toHaveBeenCalledOnce();
+  });
+
+  it('rejects oversized requests before admission or candidate dispatch', async () => {
+    const dependencies = baseDependencies();
+    const oversized = {
+      ...cohort,
+      routingContext: {
+        ...context,
+        message: 'x'.repeat(ROUTER_CANARY_MAX_REQUEST_BYTES + 1),
+      },
+    };
+    await expect(routeWithRouterCanary(oversized, dependencies)).resolves.toMatchObject({
+      plan: fallbackPlan,
+      provider: 'anthropic_fallback',
+      reason: 'request_too_large',
+    });
+    expect(dependencies.admit).not.toHaveBeenCalled();
+    expect(dependencies.candidateRoute).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add the higher-level Luna-primary/Anthropic-fallback runtime boundary
- require successful aggregate admission before candidate dispatch
- enforce the admitted hard deadline with AbortSignal and reject oversized requests before admission
- require strict candidate success plus durable terminal accounting before using a Luna decision
- classify and record candidate failures, Anthropic fallback success, and Anthropic safe-default outcomes

## Safety behavior
- any closed gate, admission failure, timeout, malformed/refused/truncated candidate, identity/capability drift, missing observation, or outcome-ledger failure routes through Anthropic
- unexpected Anthropic fallback throws still return the existing safe knowledge plan
- logs contain categorical operational messages only, without production context or error objects
- there is still no production caller and no fly.toml canary configuration, so provider selection remains unchanged

## Validation
- npm run typecheck
- focused canary runtime, ledger, and router suites: 3 files, 116 passed / 27 expected skipped
- git diff --check

## Version
CODE_VERSION 2026.08.88.