### PR TITLE
feat(addie): wire dormant Luna router canary

### DIFF
--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -173,7 +173,10 @@ import {
 } from './thread-utils.js';
 import { getThreadReplies, getSlackUser, getChannelInfo, getChannelHistory } from '../slack/client.js';
 import { AddieRouter, type RoutingContext, type ExecutionPlan, type ConfidenceTier } from './router.js';
-import { routeWithRouterCanary } from './router-canary-runtime.js';
+import {
+  loadRouterCanaryMetadata,
+  routeWithRouterCanary,
+} from './router-canary-runtime.js';
 import { selectRouterCanaryCohort } from './router-canary.js';
 import { runRouterShadow, selectRouterShadowCohort } from './router-shadow.js';
 import { ProviderHealthController } from './model-providers/provider-health.js';
@@ -4802,8 +4805,9 @@ async function handleChannelMessage({
       });
       const routerPlanPromise = canaryCandidate?.selected && addieLunaRouter
         ? (async () => {
-            const currentChannel = await getChannelInfo(channelId, { forceRefresh: true })
-              .catch(() => null);
+            const currentChannel = await loadRouterCanaryMetadata(
+              () => getChannelInfo(channelId, { forceRefresh: true }),
+            );
             const result = await routeWithRouterCanary({
               channelId,
               opportunityId: event.ts,

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -173,8 +173,14 @@ import {
 } from './thread-utils.js';
 import { getThreadReplies, getSlackUser, getChannelInfo, getChannelHistory } from '../slack/client.js';
 import { AddieRouter, type RoutingContext, type ExecutionPlan, type ConfidenceTier } from './router.js';
+import { routeWithRouterCanary } from './router-canary-runtime.js';
+import { selectRouterCanaryCohort } from './router-canary.js';
 import { runRouterShadow, selectRouterShadowCohort } from './router-shadow.js';
 import { ProviderHealthController } from './model-providers/provider-health.js';
+import {
+  OPENAI_ROUTER_MODEL,
+  OpenAIResponsesProvider,
+} from './model-providers/openai-responses-provider.js';
 import {
   getToolsForSets,
   buildUnavailableSetsHint,
@@ -763,6 +769,7 @@ async function buildCurrentChannelCostOptions(
 
 let addieDb: AddieDatabase | null = null;
 let addieRouter: AddieRouter | null = null;
+let addieLunaRouter: AddieRouter | null = null;
 let threadContextStore: DatabaseThreadContextStore | null = null;
 let initialized = false;
 
@@ -774,6 +781,7 @@ export async function initializeAddieBolt(): Promise<{ app: InstanceType<typeof 
   const botToken = process.env.ADDIE_BOT_TOKEN || process.env.SLACK_BOT_TOKEN;
   const signingSecret = process.env.ADDIE_SIGNING_SECRET || process.env.SLACK_SIGNING_SECRET;
   const anthropicKey = process.env.ADDIE_ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY;
+  const openAiKey = process.env.OPENAI_API_KEY?.trim();
 
   if (!botToken || !signingSecret) {
     logger.warn('Addie Bolt: Missing ADDIE_BOT_TOKEN or ADDIE_SIGNING_SECRET, Addie will be disabled');
@@ -796,6 +804,21 @@ export async function initializeAddieBolt(): Promise<{ app: InstanceType<typeof 
 
   // Initialize router (uses Haiku for fast classification)
   addieRouter = new AddieRouter(anthropicKey, undefined, providerHealth);
+
+  // Construct the strict candidate independently. Selection remains default-off
+  // and fail-closed in router-canary.ts; merely having an API key changes no traffic.
+  addieLunaRouter = openAiKey
+    ? new AddieRouter(
+        openAiKey,
+        new OpenAIResponsesProvider(openAiKey),
+        providerHealth,
+        {
+          model: OPENAI_ROUTER_MODEL,
+          reasoning: { effort: 'none' },
+          strictOutput: true,
+        },
+      )
+    : null;
 
   // Initialize database access
   addieDb = new AddieDatabase();
@@ -4759,6 +4782,15 @@ async function handleChannelMessage({
 
     // If no quick match, use the full router AND retrieve SI agents in parallel
     if (!plan) {
+      const canaryCandidate = addieLunaRouter && selectRouterCanaryCohort({
+        channelId,
+        opportunityId: event.ts,
+        // This only avoids a metadata fetch when the independent feature,
+        // evidence, config, allowlist, and sample gates are already closed.
+        // Paid-call admission rechecks live Slack metadata below.
+        channelIsPublic: true,
+        channelIsShared: false,
+      });
       const shadowCandidate = selectRouterShadowCohort({
         channelId,
         opportunityId: event.ts,
@@ -4768,25 +4800,45 @@ async function handleChannelMessage({
         channelIsPublic: true,
         channelIsShared: false,
       });
+      const routerPlanPromise = canaryCandidate?.selected && addieLunaRouter
+        ? (async () => {
+            const currentChannel = await getChannelInfo(channelId, { forceRefresh: true })
+              .catch(() => null);
+            const result = await routeWithRouterCanary({
+              channelId,
+              opportunityId: event.ts,
+              channelIsPublic: currentChannel?.is_private === false,
+              channelIsShared: currentChannel === null
+                || currentChannel.is_shared
+                || currentChannel.is_org_shared
+                || currentChannel.is_pending_ext_shared === true,
+              routingContext: routingCtx,
+            }, {
+              candidateRoute: addieLunaRouter.route.bind(addieLunaRouter),
+              fallbackRoute: addieRouter.route.bind(addieRouter),
+            });
+            return result.plan;
+          })()
+        : addieRouter.route(routingCtx, {
+            ...(shadowCandidate.selected && {
+              observer: async (observation) => {
+                const currentChannel = await getChannelInfo(channelId, { forceRefresh: true })
+                  .catch(() => null);
+                await runRouterShadow({
+                  channelId,
+                  opportunityId: event.ts,
+                  channelIsPublic: currentChannel?.is_private === false,
+                  channelIsShared: currentChannel === null
+                    || currentChannel.is_shared
+                    || currentChannel.is_org_shared
+                    || currentChannel.is_pending_ext_shared === true,
+                  observation,
+                });
+              },
+            }),
+          });
       const [routerPlan, siResult] = await Promise.all([
-        addieRouter.route(routingCtx, {
-          ...(shadowCandidate.selected && {
-            observer: async (observation) => {
-              const currentChannel = await getChannelInfo(channelId, { forceRefresh: true })
-                .catch(() => null);
-              await runRouterShadow({
-                channelId,
-                opportunityId: event.ts,
-                channelIsPublic: currentChannel?.is_private === false,
-                channelIsShared: currentChannel === null
-                  || currentChannel.is_shared
-                  || currentChannel.is_org_shared
-                  || currentChannel.is_pending_ext_shared === true,
-                observation,
-              });
-            },
-          }),
-        }),
+        routerPlanPromise,
         siRetriever.retrieve(messageText),
       ]);
       plan = routerPlan;

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.88';
+export const CODE_VERSION = '2026.08.89';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -17,7 +17,7 @@
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
-    "server/src/addie/bolt-app.ts": "d359a0482e792017b6d2355e9de5d0fc835138e0c22ae7304807469dfab64e6f",
+    "server/src/addie/bolt-app.ts": "6381501e1b8587f22efdf013fe04dfbc1654861ed1da6bf978299e4b086189b1",
     "server/src/addie/handler.ts": "cf9d66b7b2700cefd2811d2d9c627ea2683c556e6c3afd36ecc99cac12aa5407",
     "server/src/routes/addie-chat.ts": "da80a42faf005441f4afbf1d003ccb7067dbd4e87b90dae96c0023511806fc08",
     "server/src/routes/tavus.ts": "640e818f0ecd4da6c72f310b7582f7bc1f2c00fd77dbe0dc521f53459e31003f",

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -17,7 +17,7 @@
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
-    "server/src/addie/bolt-app.ts": "6381501e1b8587f22efdf013fe04dfbc1654861ed1da6bf978299e4b086189b1",
+    "server/src/addie/bolt-app.ts": "095d208903672fdbdab649d2d5fb58a4dc7d5a466f4d5666f5d3b7a0993ba640",
     "server/src/addie/handler.ts": "cf9d66b7b2700cefd2811d2d9c627ea2683c556e6c3afd36ecc99cac12aa5407",
     "server/src/routes/addie-chat.ts": "da80a42faf005441f4afbf1d003ccb7067dbd4e87b90dae96c0023511806fc08",
     "server/src/routes/tavus.ts": "640e818f0ecd4da6c72f310b7582f7bc1f2c00fd77dbe0dc521f53459e31003f",

--- a/server/src/addie/router-canary-runtime.ts
+++ b/server/src/addie/router-canary-runtime.ts
@@ -21,6 +21,7 @@ import {
 const logger = createLogger('addie-router-canary-runtime');
 const LUNA_INPUT_MICROS_PER_TOKEN = 0.2;
 const LUNA_OUTPUT_MICROS_PER_TOKEN = 1.2;
+export const ROUTER_CANARY_METADATA_TIMEOUT_MS = 750;
 
 type RouterRoute = AddieRouter['route'];
 
@@ -51,6 +52,35 @@ export interface RouterCanaryRuntimeDependencies {
   scheduleTimeout?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
   clearScheduledTimeout?: (timeout: ReturnType<typeof setTimeout>) => void;
   yieldForObserver?: () => Promise<void>;
+}
+
+/** Fail closed before the minimum candidate deadline if live metadata hangs. */
+export async function loadRouterCanaryMetadata<T>(
+  loader: () => Promise<T | null>,
+  dependencies: {
+    timeoutMs?: number;
+    scheduleTimeout?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+    clearScheduledTimeout?: (timeout: ReturnType<typeof setTimeout>) => void;
+  } = {},
+): Promise<T | null> {
+  const timeoutMs = dependencies.timeoutMs ?? ROUTER_CANARY_METADATA_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 999) {
+    throw new Error('Invalid router canary metadata timeout');
+  }
+  const schedule = dependencies.scheduleTimeout ?? setTimeout;
+  const clear = dependencies.clearScheduledTimeout ?? clearTimeout;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutResult = new Promise<null>((resolve) => {
+    timeout = schedule(() => resolve(null), timeoutMs);
+  });
+  try {
+    return await Promise.race([
+      Promise.resolve().then(loader).catch(() => null),
+      timeoutResult,
+    ]);
+  } finally {
+    if (timeout !== undefined) clear(timeout);
+  }
 }
 
 function safeKnowledgePlan(): ExecutionPlan {

--- a/server/tests/unit/addie/router-canary-runtime.test.ts
+++ b/server/tests/unit/addie/router-canary-runtime.test.ts
@@ -4,7 +4,10 @@ import type {
   RouterCanaryOutcome,
 } from '../../../src/addie/router-canary.js';
 import { ROUTER_CANARY_MAX_REQUEST_BYTES } from '../../../src/addie/router-canary.js';
-import { routeWithRouterCanary } from '../../../src/addie/router-canary-runtime.js';
+import {
+  loadRouterCanaryMetadata,
+  routeWithRouterCanary,
+} from '../../../src/addie/router-canary-runtime.js';
 import type {
   AddieRouter,
   ExecutionPlan,
@@ -116,6 +119,30 @@ function baseDependencies(overrides: Partial<Parameters<typeof routeWithRouterCa
 }
 
 describe('Luna router canary runtime', () => {
+  it('fails closed when live channel metadata outlasts its sub-deadline', async () => {
+    const clearScheduledTimeout = vi.fn();
+    const result = await loadRouterCanaryMetadata(
+      () => new Promise<never>(() => undefined),
+      {
+        timeoutMs: 10,
+        scheduleTimeout: (callback) => setTimeout(callback, 0),
+        clearScheduledTimeout,
+      },
+    );
+    expect(result).toBeNull();
+    expect(clearScheduledTimeout).toHaveBeenCalledOnce();
+  });
+
+  it('returns live metadata and clears its pending timeout', async () => {
+    const clearScheduledTimeout = vi.fn();
+    const metadata = { is_private: false };
+    await expect(loadRouterCanaryMetadata(() => Promise.resolve(metadata), {
+      timeoutMs: 10,
+      clearScheduledTimeout,
+    })).resolves.toBe(metadata);
+    expect(clearScheduledTimeout).toHaveBeenCalledOnce();
+  });
+
   it('uses an admitted strict candidate and records its bounded outcome', async () => {
     const candidateRoute = vi.fn(routeReturning(candidatePlan, observation('openai')));
     const record = vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- construct a strict Luna router adapter only when OPENAI_API_KEY is present
- route sampled cold-channel opportunities through the bounded canary runtime
- re-fetch live Slack channel metadata before paid-call admission
- preserve the existing Anthropic router plus detached Luna-shadow observer for every non-canary path
- keep SI retrieval parallel with either routing path

## Rollout state
The canary remains disabled because fly.toml contains none of the required ADDIE_ROUTER_LUNA_CANARY settings. Enabling requires all fail-closed gates: explicit enablement, production-data approval, exact fixed-trace and shadow-promotion policy pins, bounded allowlist/sample/count/cost/deadline values, HMAC key/version, and OPENAI_API_KEY. No deployment or environment mutation is part of this PR.

## Safety behavior
- missing or stale channel metadata fails the public/non-shared eligibility recheck
- canary selection never replaces quick-match routing
- candidate selection suppresses the detached shadow duplicate; all closed canary gates retain the current shadow path
- Luna and Anthropic share provider-health accounting by provider ID

## Validation
- npm run typecheck
- focused router/canary/shadow suites: 4 files, 154 passed / 27 expected skipped
- verified fly.toml contains no canary configuration
- git diff --check

## Version
CODE_VERSION 2026.08.89.