### PR TITLE
feat(addie): expose aggregate canary status

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.89';
+export const CODE_VERSION = '2026.08.90';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/router-canary.ts
+++ b/server/src/addie/router-canary.ts
@@ -12,6 +12,7 @@ export const ROUTER_CANARY_POLICY_VERSION = 'addie-router-luna-canary:v1';
 export const ROUTER_CANARY_PRICING_VERSION = 'openai-gpt-5.6-luna-2026-08-26';
 export const ROUTER_CANARY_MAX_CHANNELS = 4;
 export const ROUTER_CANARY_MAX_DEADLINE_MS = 15_000;
+export const ROUTER_CANARY_SUMMARY_MAX_DAYS = 90;
 export const ROUTER_CANARY_STALE_INFLIGHT_MS = 15 * 60 * 1000;
 export const ROUTER_CANARY_ROLLBACK_POLICY = Object.freeze({
   minimumCompleted: 5,
@@ -525,5 +526,230 @@ export async function recordRouterCanaryOutcome(
     recorded: Boolean(row),
     rolledBack: row?.rolled_back ?? false,
     rollbackReason: row?.rollback_reason ?? null,
+  };
+}
+
+interface RouterCanarySummaryRow {
+  hash_key_version: string;
+  sample_bps: number;
+  daily_limit: number;
+  daily_budget_micros: number;
+  reserved_cost_micros: number;
+  deadline_ms: number;
+  inflight_count: number;
+  rolled_back_at: Date | null;
+  rollback_reason: string | null;
+  sampled_count: string;
+  admitted_count: string;
+  completed_count: string;
+  quota_rejected_count: string;
+  rollback_rejected_count: string;
+  invalid_config_count: string;
+  candidate_success_count: string;
+  candidate_failure_count: string;
+  fallback_success_count: string;
+  fallback_safe_default_count: string;
+  timeout_count: string;
+  invalid_output_count: string;
+  identity_error_count: string;
+  provider_error_count: string;
+  candidate_latency_ms_sum: string;
+  candidate_latency_ms_max: number;
+  candidate_cost_micros_sum: string;
+  fallback_latency_ms_sum: string;
+}
+
+function count(value: string | undefined): number {
+  const parsed = Number.parseInt(value ?? '0', 10);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+export interface RouterCanarySummary {
+  days: number;
+  scope: {
+    policy_version: typeof ROUTER_CANARY_POLICY_VERSION;
+    pricing_version: typeof ROUTER_CANARY_PRICING_VERSION;
+    requested_provider: 'openai';
+    requested_model: typeof OPENAI_ROUTER_MODEL;
+    population: 'allowlisted_public_channel_full_model_router_only';
+  };
+  rollback_thresholds: typeof ROUTER_CANARY_ROLLBACK_POLICY;
+  cohorts: Array<{
+    hash_key_version: string;
+    config: {
+      sample_bps: number;
+      daily_limit: number;
+      daily_budget_micros: number;
+      reserved_cost_micros: number;
+      deadline_ms: number;
+    };
+    state: {
+      inflight: number;
+      rolled_back: boolean;
+      rolled_back_at: string | null;
+      rollback_reason: string | null;
+    };
+    admission: {
+      sampled: number;
+      admitted: number;
+      quota_rejected: number;
+      rollback_rejected: number;
+      invalid_configuration: number;
+    };
+    outcomes: {
+      completed: number;
+      candidate_succeeded: number;
+      candidate_failed: number;
+      fallback_succeeded: number;
+      fallback_safe_default: number;
+      timeout: number;
+      invalid_output: number;
+      identity_or_capability_error: number;
+      provider_error: number;
+    };
+    rates: {
+      completion: number | null;
+      candidate_success: number | null;
+      fallback_safe_default: number | null;
+    };
+    candidate: {
+      latency_ms_average: number | null;
+      latency_ms_max: number | null;
+      estimated_cost_micros: number;
+      estimated_cost_micros_average: number | null;
+    };
+    fallback: { latency_ms_average: number | null };
+  }>;
+}
+
+/** Aggregate-only operator visibility for the dormant or active canary. */
+export async function getRouterCanarySummary(
+  days = 7,
+  dependencies: { query?: QueryFn } = {},
+): Promise<RouterCanarySummary> {
+  if (!Number.isInteger(days) || days < 1 || days > ROUTER_CANARY_SUMMARY_MAX_DAYS) {
+    throw new RangeError('Invalid router canary summary window');
+  }
+  const runQuery = dependencies.query ?? defaultQuery as QueryFn;
+  const result = await runQuery<RouterCanarySummaryRow>(
+    `SELECT state.hash_key_version, state.sample_bps, state.daily_limit,
+            state.daily_budget_micros, state.reserved_cost_micros,
+            state.deadline_ms, state.inflight_count, state.rolled_back_at,
+            state.rollback_reason,
+            COALESCE(SUM(metrics.sampled_count), 0)::text AS sampled_count,
+            COALESCE(SUM(metrics.admitted_count), 0)::text AS admitted_count,
+            COALESCE(SUM(metrics.completed_count), 0)::text AS completed_count,
+            COALESCE(SUM(metrics.quota_rejected_count), 0)::text AS quota_rejected_count,
+            COALESCE(SUM(metrics.rollback_rejected_count), 0)::text AS rollback_rejected_count,
+            COALESCE(SUM(metrics.invalid_config_count), 0)::text AS invalid_config_count,
+            COALESCE(SUM(metrics.candidate_success_count), 0)::text AS candidate_success_count,
+            COALESCE(SUM(metrics.candidate_failure_count), 0)::text AS candidate_failure_count,
+            COALESCE(SUM(metrics.fallback_success_count), 0)::text AS fallback_success_count,
+            COALESCE(SUM(metrics.fallback_safe_default_count), 0)::text
+              AS fallback_safe_default_count,
+            COALESCE(SUM(metrics.timeout_count), 0)::text AS timeout_count,
+            COALESCE(SUM(metrics.invalid_output_count), 0)::text AS invalid_output_count,
+            COALESCE(SUM(metrics.identity_error_count), 0)::text AS identity_error_count,
+            COALESCE(SUM(metrics.provider_error_count), 0)::text AS provider_error_count,
+            COALESCE(SUM(metrics.candidate_latency_ms_sum), 0)::text
+              AS candidate_latency_ms_sum,
+            COALESCE(MAX(metrics.candidate_latency_ms_max), 0)::integer
+              AS candidate_latency_ms_max,
+            COALESCE(SUM(metrics.candidate_cost_micros_sum), 0)::text
+              AS candidate_cost_micros_sum,
+            COALESCE(SUM(metrics.fallback_latency_ms_sum), 0)::text
+              AS fallback_latency_ms_sum
+     FROM addie_router_canary_state state
+     LEFT JOIN addie_router_canary_daily_metrics metrics
+       ON metrics.policy_version = state.policy_version
+      AND metrics.pricing_version = state.pricing_version
+      AND metrics.hash_key_version = state.hash_key_version
+      AND metrics.requested_model = state.requested_model
+      AND metrics.metric_date >= (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::date
+        - ($1::integer - 1)
+     WHERE state.policy_version = $2 AND state.pricing_version = $3
+       AND state.requested_model = $4
+     GROUP BY state.policy_version, state.pricing_version, state.requested_model,
+              state.hash_key_version, state.sample_bps, state.daily_limit,
+              state.daily_budget_micros, state.reserved_cost_micros,
+              state.deadline_ms, state.inflight_count, state.rolled_back_at,
+              state.rollback_reason, state.created_at
+     ORDER BY state.created_at DESC`,
+    [
+      days,
+      ROUTER_CANARY_POLICY_VERSION,
+      ROUTER_CANARY_PRICING_VERSION,
+      OPENAI_ROUTER_MODEL,
+    ],
+  );
+  return {
+    days,
+    scope: {
+      policy_version: ROUTER_CANARY_POLICY_VERSION,
+      pricing_version: ROUTER_CANARY_PRICING_VERSION,
+      requested_provider: 'openai',
+      requested_model: OPENAI_ROUTER_MODEL,
+      population: 'allowlisted_public_channel_full_model_router_only',
+    },
+    rollback_thresholds: ROUTER_CANARY_ROLLBACK_POLICY,
+    cohorts: result.rows.map((row) => {
+      const admitted = count(row.admitted_count);
+      const completed = count(row.completed_count);
+      const candidateSucceeded = count(row.candidate_success_count);
+      const fallbackSafeDefault = count(row.fallback_safe_default_count);
+      const candidateLatency = count(row.candidate_latency_ms_sum);
+      const candidateCost = count(row.candidate_cost_micros_sum);
+      const fallbackLatency = count(row.fallback_latency_ms_sum);
+      return {
+        hash_key_version: row.hash_key_version,
+        config: {
+          sample_bps: row.sample_bps,
+          daily_limit: row.daily_limit,
+          daily_budget_micros: row.daily_budget_micros,
+          reserved_cost_micros: row.reserved_cost_micros,
+          deadline_ms: row.deadline_ms,
+        },
+        state: {
+          inflight: row.inflight_count,
+          rolled_back: row.rolled_back_at !== null,
+          rolled_back_at: row.rolled_back_at?.toISOString() ?? null,
+          rollback_reason: row.rollback_reason,
+        },
+        admission: {
+          sampled: count(row.sampled_count),
+          admitted,
+          quota_rejected: count(row.quota_rejected_count),
+          rollback_rejected: count(row.rollback_rejected_count),
+          invalid_configuration: count(row.invalid_config_count),
+        },
+        outcomes: {
+          completed,
+          candidate_succeeded: candidateSucceeded,
+          candidate_failed: count(row.candidate_failure_count),
+          fallback_succeeded: count(row.fallback_success_count),
+          fallback_safe_default: fallbackSafeDefault,
+          timeout: count(row.timeout_count),
+          invalid_output: count(row.invalid_output_count),
+          identity_or_capability_error: count(row.identity_error_count),
+          provider_error: count(row.provider_error_count),
+        },
+        rates: {
+          completion: admitted > 0 ? completed / admitted : null,
+          candidate_success: completed > 0 ? candidateSucceeded / completed : null,
+          fallback_safe_default: completed > 0 ? fallbackSafeDefault / completed : null,
+        },
+        candidate: {
+          latency_ms_average: completed > 0 ? candidateLatency / completed : null,
+          latency_ms_max: completed > 0 ? row.candidate_latency_ms_max : null,
+          estimated_cost_micros: candidateCost,
+          estimated_cost_micros_average: completed > 0 ? candidateCost / completed : null,
+        },
+        fallback: {
+          latency_ms_average: count(row.candidate_failure_count) > 0
+            ? fallbackLatency / count(row.candidate_failure_count)
+            : null,
+        },
+      };
+    }),
   };
 }

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -69,6 +69,10 @@ import {
   ROUTER_SHADOW_RETENTION_DAYS,
   getRouterShadowSummary,
 } from '../addie/router-shadow.js';
+import {
+  ROUTER_CANARY_SUMMARY_MAX_DAYS,
+  getRouterCanarySummary,
+} from '../addie/router-canary.js';
 
 const logger = createLogger("addie-admin-routes");
 const addieDb = new AddieDatabase();
@@ -642,6 +646,28 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
         'Error fetching router shadow summary',
       );
       res.status(500).json({ error: 'Unable to fetch router shadow summary' });
+    }
+  });
+
+  // GET /api/admin/addie/threads/router-canary-summary
+  // Aggregate-only admission, fallback, latency, cost, and rollback evidence.
+  apiRouter.get('/threads/router-canary-summary', async (req, res) => {
+    const days = typeof req.query.days === 'string' && req.query.days.trim() !== ''
+      ? Number(req.query.days)
+      : 7;
+    if (!Number.isInteger(days) || days < 1 || days > ROUTER_CANARY_SUMMARY_MAX_DAYS) {
+      return res.status(400).json({
+        error: `days must be an integer from 1 to ${ROUTER_CANARY_SUMMARY_MAX_DAYS}`,
+      });
+    }
+    try {
+      res.json(await getRouterCanarySummary(days));
+    } catch (error) {
+      logger.error(
+        { errorType: error instanceof Error ? error.name : typeof error },
+        'Error fetching router canary summary',
+      );
+      res.status(500).json({ error: 'Unable to fetch router canary summary' });
     }
   });
 

--- a/server/tests/unit/addie/router-canary.test.ts
+++ b/server/tests/unit/addie/router-canary.test.ts
@@ -5,6 +5,7 @@ import {
   ROUTER_CANARY_PRICING_VERSION,
   ROUTER_CANARY_RESERVED_COST_MICROS,
   admitRouterCanary,
+  getRouterCanarySummary,
   recordRouterCanaryOutcome,
   selectRouterCanaryCohort,
   type RouterCanaryAdmission,
@@ -170,5 +171,84 @@ describe('Luna router canary ledger', () => {
       candidateLatencyMs: 1,
       candidateCostMicros: 1,
     })).rejects.toThrow('Invalid router canary outcome');
+  });
+
+  it('returns aggregate-only canary status, rates, and latched rollback state', async () => {
+    const runQuery = vi.fn().mockResolvedValue({
+      rows: [{
+        hash_key_version: 'test-v1',
+        sample_bps: 100,
+        daily_limit: 10,
+        daily_budget_micros: ROUTER_CANARY_RESERVED_COST_MICROS * 10,
+        reserved_cost_micros: ROUTER_CANARY_RESERVED_COST_MICROS,
+        deadline_ms: 10_000,
+        inflight_count: 0,
+        rolled_back_at: new Date('2026-08-29T12:00:00.000Z'),
+        rollback_reason: 'failure_rate',
+        sampled_count: '12',
+        admitted_count: '10',
+        completed_count: '10',
+        quota_rejected_count: '1',
+        rollback_rejected_count: '1',
+        invalid_config_count: '0',
+        candidate_success_count: '8',
+        candidate_failure_count: '2',
+        fallback_success_count: '2',
+        fallback_safe_default_count: '0',
+        timeout_count: '1',
+        invalid_output_count: '1',
+        identity_error_count: '0',
+        provider_error_count: '0',
+        candidate_latency_ms_sum: '5000',
+        candidate_latency_ms_max: 900,
+        candidate_cost_micros_sum: '3000',
+        fallback_latency_ms_sum: '400',
+      }],
+      rowCount: 1,
+    });
+
+    const summary = await getRouterCanarySummary(7, { query: runQuery });
+
+    expect(summary).toMatchObject({
+      days: 7,
+      cohorts: [{
+        hash_key_version: 'test-v1',
+        state: {
+          rolled_back: true,
+          rolled_back_at: '2026-08-29T12:00:00.000Z',
+          rollback_reason: 'failure_rate',
+        },
+        admission: { sampled: 12, admitted: 10 },
+        outcomes: {
+          completed: 10,
+          candidate_succeeded: 8,
+          candidate_failed: 2,
+        },
+        rates: {
+          completion: 1,
+          candidate_success: 0.8,
+          fallback_safe_default: 0,
+        },
+        candidate: {
+          latency_ms_average: 500,
+          latency_ms_max: 900,
+          estimated_cost_micros: 3000,
+          estimated_cost_micros_average: 300,
+        },
+        fallback: { latency_ms_average: 200 },
+      }],
+    });
+    expect(runQuery.mock.calls[0][1]).toEqual([
+      7,
+      ROUTER_CANARY_POLICY_VERSION,
+      ROUTER_CANARY_PRICING_VERSION,
+      'gpt-5.6-luna',
+    ]);
+  });
+
+  it.each([0, 91, 1.5])('rejects invalid summary window %s', async (days) => {
+    await expect(getRouterCanarySummary(days, {
+      query: vi.fn(),
+    })).rejects.toThrow('Invalid router canary summary window');
   });
 });


### PR DESCRIPTION
## Summary
- add an admin-only aggregate Luna canary status endpoint with a bounded 1–90 day window
- report cohort configuration, admission funnel, terminal outcomes, success/fallback rates, aggregate latency/cost, and latched rollback state
- pin the summary scope to the current canary policy, pricing version, provider, and model

## Privacy boundary
The query reads only the aggregate canary state and daily metrics tables. It returns no channel, user, thread, message, prompt, response, reason text, source hash, or per-opportunity record.

## Endpoint
GET /api/admin/addie/threads/router-canary-summary?days=7

## Validation
- npm run typecheck
- focused canary ledger/runtime suites: 30 passed
- summary query passed against a real local Postgres schema seeded through the production admission/outcome functions; temporary tables were removed
- npm run test:addie-tools (249 tools / 23 sets; budget and portability green)
- git diff --check

## Rollout
Observability only. The canary remains disabled; no fly.toml or production environment changes. CODE_VERSION 2026.08.90.