### PR TITLE
fix(addie): align fixed traces with docs retrieval

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.98';
+export const CODE_VERSION = '2026.08.99';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -292,6 +292,9 @@ export function buildFixedTraceGenerationRequest(
 ): ModelRequest {
   const availableToolNames = definitions.map((definition) => definition.name);
   const selectedToolSets = route.action === 'respond' ? route.tool_sets ?? [] : [];
+  const exactKnowledgeRoute = selectedToolSets.length === 1
+    && selectedToolSets[0] === 'knowledge';
+  const hasOfficialDocsToolBoundary = availableToolNames.includes('search_docs');
   return {
     model: config.model,
     system: [
@@ -311,6 +314,9 @@ export function buildFixedTraceGenerationRequest(
     ],
     messages: messagesForTrace(trace),
     tools: [],
+    ...(exactKnowledgeRoute && hasOfficialDocsToolBoundary
+      ? { toolChoice: { type: 'tool' as const, name: 'search_docs' } }
+      : {}),
     ...reasoningRequest(config.reasoningEffort),
     maxOutputTokens: config.maxOutputTokens,
     requestMetadata: {

--- a/server/src/addie/eval/fixed-trace-tool-loop.ts
+++ b/server/src/addie/eval/fixed-trace-tool-loop.ts
@@ -141,6 +141,7 @@ export async function executeFixedTraceToolLoop(
 ): Promise<FixedTraceToolLoopResult> {
   const request = snapshotRequest(initialRequest);
   validateInitialRequest(request);
+  const { toolChoice: initialToolChoice, ...requestWithoutToolChoice } = request;
   const registered = registerFixtures(trace, definitions);
   const iterationLimit = safeIterationLimit(trace, options.maxIterations);
   const handlers = new Map<string, ToolHandler>();
@@ -179,12 +180,16 @@ export async function executeFixedTraceToolLoop(
     const activeTurn = modelLoop.beginNext();
     const iteration = activeTurn.iteration;
     const response = await activeTurn.invoke(provider, {
-      ...request,
+      ...requestWithoutToolChoice,
       messages,
       tools: buildModelToolDefinitions(
         [...registered.values()].map((entry) => entry.definition),
       ),
       providerTools: [],
+      // Production's official-docs profile forces search_docs only on the
+      // first turn. Requiring it again after the fixture result would create
+      // a duplicate call and make replay diverge from the live loop.
+      ...(iteration === 1 && initialToolChoice ? { toolChoice: initialToolChoice } : {}),
     }, {
       signal: options.signal,
       beforeDispatch: async (prepared) => {

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -637,7 +637,7 @@ ${
     ? 'These guidelines apply ONLY when you have already decided to "respond" (not for channel messages where the default is "ignore").\n'
     : ""
 }IMPORTANT: Select tool SETS based on the user's INTENT:
-- Questions about AdCP concepts, protocol behavior, or documented requirements → ["knowledge"]. A requirement that mentions an identifier or asset is still conceptual unless the user explicitly asks to inspect a schema field or structure
+- Questions about AdCP concepts, protocol behavior, or documented requirements → ["knowledge"]. A requirement that mentions an identifier or asset is still conceptual unless the user explicitly asks to inspect a schema field or structure. "What do the official docs say about package identifiers?" → exactly ["knowledge"]
 - Explicit AdCP schema fields, structure, or versioned schema documentation → ["knowledge", "schema_reference"]. This includes "Which AdCP field..." and "Where is the 3.2 schema documentation?" Validating JSON or comparing schema versions → ["schema_reference"]. If schema work is part of validating an implementation, select exactly ["schema_reference", "agent_validation"] and add ["knowledge"] only when separate protocol documentation beyond the schema is requested. Example: "Inspect the schema fields and then validate my implementation against them" → ["schema_reference", "agent_validation"]
 - Explicit requests to search or recap Slack history/channel activity, community discussions, curated resources, recent industry news, supplied web pages, or Slack files → ["community_research"]. Do not add it merely because community opinion could supplement an authoritative answer
 - Questions about the current member's profile, company listing, logo, account, or brand-domain claim → ["member_profile"]
@@ -672,6 +672,7 @@ ${isAAOAdmin ? `- Adding/removing committee or working group leaders, managing g
 - Community-wide engagement ranking, most engaged members overall, top contributors, who to invite to events, lifecycle stage analytics → ["admin_workflows"]` : ''}
 - Multiple intents? Include multiple sets: ["knowledge", "agent_validation"]
 - Open or unsettled multi-stakeholder governance questions → ["knowledge", "community_research"] to distinguish documented rules from current discussion
+- Current date or time from the trusted request context → respond with []. Never ignore a direct date/time question
 - General questions needing no tools → []
 
 **directory note**: The directory lists MEMBER ORGANIZATIONS (companies), not individual people. If a user asks for "a contact in [role/department]" without specifying what service or capability they need, route to "respond" with ["directory"] — the handler can ask follow-up questions with full context.

--- a/server/src/addie/testing/provider-router-eval.ts
+++ b/server/src/addie/testing/provider-router-eval.ts
@@ -114,6 +114,8 @@ const channel = (message: string, channelName = 'general'): RoutingContext => ({
 
 export const SYNTHETIC_ROUTER_CORPUS: ReadonlyArray<RouterEvalCase> = Object.freeze([
   { id: 'protocol-schema', context: dm('Which field carries the media buy identifier in AdCP 3.2?'), expected: { action: 'respond', toolSets: ['knowledge', 'schema_reference'], confidence: 'high', requiresDepth: false } },
+  { id: 'protocol-identifier-concept', context: dm('What do the official docs say about package identifiers?'), expected: { action: 'respond', toolSets: ['knowledge'], confidence: 'high', requiresDepth: false } },
+  { id: 'current-utc-date', context: dm('What is the current UTC date?'), expected: { action: 'respond', toolSets: [], confidence: 'high', requiresDepth: false } },
   { id: 'schema-validation', context: dm('Validate this JSON against the AdCP media-buy schema and compare it with version 3.1.'), expected: { action: 'respond', toolSets: ['schema_reference'], confidence: 'high', requiresDepth: false } },
   { id: 'community-research', context: dm('Search recent Slack discussions and industry resources about community meetup formats.'), expected: { action: 'respond', toolSets: ['community_research'], confidence: 'high', requiresDepth: false } },
   { id: 'github-roadmap', context: dm('Search the protocol roadmap and open RFC issues for measurement work.'), expected: { action: 'respond', toolSets: ['github', 'knowledge'], confidence: 'high', requiresDepth: true } },

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  buildFixedTraceGenerationRequest,
   fixedTraceToolSchemaSha256,
   runFixedTraceCase,
   type FixedTraceProviderStageConfig,
@@ -227,10 +228,38 @@ describe('fixed trace artifact runner', () => {
     });
     expect(observation.metadata.generation.providerRequestSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(generation.respondCalls).toHaveLength(2);
+    expect(generation.respondCalls[0].toolChoice).toEqual({ type: 'tool', name: 'search_docs' });
+    expect(generation.respondCalls[1].toolChoice).toBeUndefined();
     expect(gradeFixedTrace(selectedTrace, observation)).toMatchObject({
       deterministicPass: true,
       metadataPass: true,
     });
+  });
+
+  it('forces official-doc retrieval only when the exact knowledge route exposes search_docs', () => {
+    const selectedTrace = trace('knowledge-task-model');
+    const exactKnowledge = buildFixedTraceGenerationRequest(
+      selectedTrace,
+      { action: 'respond', tool_sets: ['knowledge'], confidence: 'high', requires_depth: false, reason: 'docs' },
+      [tool('search_docs'), tool('get_doc')],
+      stage(new ScriptedProvider([]), 3),
+    );
+    const mixedRoute = buildFixedTraceGenerationRequest(
+      selectedTrace,
+      { action: 'respond', tool_sets: ['knowledge', 'schema_reference'], confidence: 'high', requires_depth: false, reason: 'schema' },
+      [tool('search_docs'), tool('get_doc')],
+      stage(new ScriptedProvider([]), 3),
+    );
+    const noBoundary = buildFixedTraceGenerationRequest(
+      selectedTrace,
+      { action: 'respond', tool_sets: ['knowledge'], confidence: 'high', requires_depth: false, reason: 'docs' },
+      [tool('get_doc')],
+      stage(new ScriptedProvider([]), 3),
+    );
+
+    expect(exactKnowledge.toolChoice).toEqual({ type: 'tool', name: 'search_docs' });
+    expect(mixedRoute.toolChoice).toBeUndefined();
+    expect(noBoundary.toolChoice).toBeUndefined();
   });
 
   it('stops at the surface decision without dispatching generation', async () => {

--- a/server/tests/unit/addie/provider-router-eval.test.ts
+++ b/server/tests/unit/addie/provider-router-eval.test.ts
@@ -141,8 +141,8 @@ describe('strict router eval', () => {
   });
 
   it('uses a frozen synthetic corpus covering every tool set', () => {
-    expect(SYNTHETIC_ROUTER_CORPUS).toHaveLength(61);
-    expect(new Set(SYNTHETIC_ROUTER_CORPUS.map((testCase) => testCase.id)).size).toBe(61);
+    expect(SYNTHETIC_ROUTER_CORPUS).toHaveLength(63);
+    expect(new Set(SYNTHETIC_ROUTER_CORPUS.map((testCase) => testCase.id)).size).toBe(63);
     const expectedSets = new Set(SYNTHETIC_ROUTER_CORPUS.flatMap((testCase) => testCase.expected.toolSets ?? []));
     expect(expectedSets).toEqual(new Set([
       'knowledge', 'member_profile', 'community_groups', 'directory', 'brand_registry', 'agent_validation', 'property_catalog', 'agent_conformance',
@@ -154,7 +154,7 @@ describe('strict router eval', () => {
       'outreach', 'collaboration', 'certification',
     ]));
     const productionRouter = new AddieRouter('unused');
-    expect(MODEL_ROUTER_CORPUS).toHaveLength(60);
+    expect(MODEL_ROUTER_CORPUS).toHaveLength(62);
     for (const testCase of MODEL_ROUTER_CORPUS) {
       expect(productionRouter.quickMatch(testCase.context), testCase.id).toBeNull();
     }
@@ -190,6 +190,8 @@ describe('strict router eval', () => {
     expect(nonAdmin).toContain('Exact bare acknowledgments');
     expect(nonAdmin).toContain('Do not respond merely to disclaim expertise or recommend a professional');
     expect(nonAdmin).toContain('A requirement that mentions an identifier or asset is still conceptual');
+    expect(nonAdmin).toContain('official docs say about package identifiers');
+    expect(nonAdmin).toContain('Never ignore a direct date/time question');
     expect(nonAdmin).toContain('a basic schema/JSON validation, a basic implementation validation, or a property-catalog audit');
     expect(nonAdmin).toContain('select exactly ["agent_validation", "property_catalog"]');
     expect(nonAdmin).toContain('Community introductions, announcements, and positive social updates');
@@ -200,6 +202,14 @@ describe('strict router eval', () => {
     const channelCase = SYNTHETIC_ROUTER_CORPUS.find((item) => item.id === 'channel-protocol')!;
     const mentionCase = SYNTHETIC_ROUTER_CORPUS.find((item) => item.id === 'mention-protocol')!;
     expect(mentionCase.expected.toolSets).toEqual(channelCase.expected.toolSets);
+  });
+
+  it('keeps conceptual identifiers out of schema tools and answers trusted clock questions directly', () => {
+    const identifierCase = SYNTHETIC_ROUTER_CORPUS.find((item) => item.id === 'protocol-identifier-concept')!;
+    const dateCase = SYNTHETIC_ROUTER_CORPUS.find((item) => item.id === 'current-utc-date')!;
+
+    expect(identifierCase.expected).toMatchObject({ action: 'respond', toolSets: ['knowledge'] });
+    expect(dateCase.expected).toMatchObject({ action: 'respond', toolSets: [] });
   });
 
   it('accepts exact plans and rejects fallback-shaped, unauthorized, or extra-field output', () => {


### PR DESCRIPTION
## Summary

- mirror production's exact-knowledge `search_docs` requirement in fixed-trace replay
- apply named tool choice only to the first turn so post-result generation cannot be forced into a duplicate call
- add router guidance and synthetic regression cases for trusted UTC clock questions and conceptual package identifiers
- bump Addie `CODE_VERSION` to `2026.08.99`

## Why

The exact-main cross-provider matrix showed Luna skipping retrieval on `knowledge-task-model`, even though production's official-docs profile forces `search_docs`. That made the replay stricter than neither production nor its own required-tool expectation. The same matrix found two Anthropic router misses: ignoring a direct UTC-date question and broadening a conceptual identifier question into schema tools.

This change repairs replay/production parity without weakening any score threshold or enabling a canary.

## Verification

- `npm run test:addie-tools`
- focused Addie unit tests: 35 passed
- root precommit: 68 files / 1,056 tests passed
- staged server suite, twice: 518 files / 7,441 passed / 30 skipped
- `npm run typecheck`
- exact clean-head Luna router matrix: 186/186 valid; action/confidence/emoji 100%; zero privilege leaks or invalid sets; both new cases exact in all three passes; tool exact 95.33%, depth 99.33%, stability 93.55%; $0.127336
- exact clean-head OpenAI fixed traces: `knowledge-task-model` now calls `search_docs`; answer/tool-selection/mutation-safety/metadata 100%. Overall rollout remains failed/non-eligible because of one billing-route mismatch and one invalid independent-judge output; no rerun-to-green and no canary change.

Tracks #6846.
