### PR TITLE
perf(addie): narrow knowledge route context

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.103';
+export const CODE_VERSION = '2026.08.104';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -651,7 +651,7 @@ ${
 - Committee documents and news-source proposals → ["content"]
 - Submitting or reviewing articles/perspectives, reading a Google Doc for publication, or generating, regenerating, or checking the cover illustration for a member's post → ["publishing"]
 - Reading a specific GitHub issue/PR, drafting a bug or feature request, or creating a confirmed issue → ["github"]. Protocol roadmap/RFC research → ["github", "knowledge"]. Do not add community research unless explicitly requested
-- Searching for an existing explanatory diagram/image, or substantive concept explanations that materially benefit from a visual → ["illustrations"]. Never use this set for an article/perspective cover; those always use ["publishing"]
+- Searching for an existing explanatory diagram/image, or a request that explicitly asks for a visual, figure, or diagram → ["illustrations"]. A text-only overview or detailed concept explanation is exactly ["knowledge"] even when a visual might be useful. Never use this set for an article/perspective cover; those always use ["publishing"]
 - Questions about tracked working-group documents → ["knowledge", "community_groups"]. Questions about the current member's company listing or brand profile → ["member_profile"]
 - Membership pricing or the current member's own payment link, invoice creation, or billing portal → ["member_billing"]
 ${isAAOAdmin

--- a/server/src/addie/rules/index.ts
+++ b/server/src/addie/rules/index.ts
@@ -72,8 +72,11 @@ const BEHAVIOR_SECTION_TOOL_SETS: Readonly<Record<string, readonly string[] | nu
 };
 
 const KNOWLEDGE_RULE_TOOL_SETS = new Set(['knowledge', 'schema_reference']);
+// Ordinary protocol questions use the authoritative docs boundary and do not
+// need the volatile roadmap snapshot or expert-persona catalog. Explicit
+// roadmap/RFC requests route with `github`; community research has its own
+// domain, so those requests still receive the ecosystem context.
 const ECOSYSTEM_CONTEXT_TOOL_SETS = new Set([
-  'knowledge',
   'community_research',
   'github',
   'content',
@@ -113,8 +116,10 @@ export interface LoadRulesOptions {
  * Assembly order:
  * 1. identity.md and applicable behaviors.md sections
  * 2. knowledge.md for knowledge/schema routes
- * 3. `.agents/current-context.md` — active AdCP roadmap snapshot (weekly refresh, treated as data-only)
- * 4. Expert-panel reference built from `.claude/agents/*.md` frontmatter
+ * 3. For ecosystem/research routes, `.agents/current-context.md` — active
+ *    AdCP roadmap snapshot (weekly refresh, treated as data-only)
+ * 4. For those same routes, the expert-panel reference built from
+ *    `.claude/agents/*.md` frontmatter
  * 5. urls.md for action routes, then constraints.md for every route
  *
  * response-style.md is loaded separately. Files are read once and cached.

--- a/server/src/addie/testing/provider-router-eval.ts
+++ b/server/src/addie/testing/provider-router-eval.ts
@@ -115,6 +115,7 @@ const channel = (message: string, channelName = 'general'): RoutingContext => ({
 export const SYNTHETIC_ROUTER_CORPUS: ReadonlyArray<RouterEvalCase> = Object.freeze([
   { id: 'protocol-schema', context: dm('Which field carries the media buy identifier in AdCP 3.2?'), expected: { action: 'respond', toolSets: ['knowledge', 'schema_reference'], confidence: 'high', requiresDepth: false } },
   { id: 'protocol-identifier-concept', context: dm('What do the official docs say about package identifiers?'), expected: { action: 'respond', toolSets: ['knowledge'], confidence: 'high', requiresDepth: false } },
+  { id: 'protocol-text-overview', context: dm('Give a detailed overview of the protocol.'), expected: { action: 'respond', toolSets: ['knowledge'], confidence: 'high', requiresDepth: true } },
   { id: 'current-utc-date', context: dm('What is the current UTC date?'), expected: { action: 'respond', toolSets: [], confidence: 'high', requiresDepth: false } },
   { id: 'schema-validation', context: dm('Validate this JSON against the AdCP media-buy schema and compare it with version 3.1.'), expected: { action: 'respond', toolSets: ['schema_reference'], confidence: 'high', requiresDepth: false } },
   { id: 'community-research', context: dm('Search recent Slack discussions and industry resources about community meetup formats.'), expected: { action: 'respond', toolSets: ['community_research'], confidence: 'high', requiresDepth: false } },

--- a/server/tests/unit/addie/provider-router-eval.test.ts
+++ b/server/tests/unit/addie/provider-router-eval.test.ts
@@ -141,8 +141,8 @@ describe('strict router eval', () => {
   });
 
   it('uses a frozen synthetic corpus covering every tool set', () => {
-    expect(SYNTHETIC_ROUTER_CORPUS).toHaveLength(63);
-    expect(new Set(SYNTHETIC_ROUTER_CORPUS.map((testCase) => testCase.id)).size).toBe(63);
+    expect(SYNTHETIC_ROUTER_CORPUS).toHaveLength(64);
+    expect(new Set(SYNTHETIC_ROUTER_CORPUS.map((testCase) => testCase.id)).size).toBe(64);
     const expectedSets = new Set(SYNTHETIC_ROUTER_CORPUS.flatMap((testCase) => testCase.expected.toolSets ?? []));
     expect(expectedSets).toEqual(new Set([
       'knowledge', 'member_profile', 'community_groups', 'directory', 'brand_registry', 'agent_validation', 'property_catalog', 'agent_conformance',
@@ -154,7 +154,7 @@ describe('strict router eval', () => {
       'outreach', 'collaboration', 'certification',
     ]));
     const productionRouter = new AddieRouter('unused');
-    expect(MODEL_ROUTER_CORPUS).toHaveLength(62);
+    expect(MODEL_ROUTER_CORPUS).toHaveLength(63);
     for (const testCase of MODEL_ROUTER_CORPUS) {
       expect(productionRouter.quickMatch(testCase.context), testCase.id).toBeNull();
     }

--- a/server/tests/unit/rules-loader.test.ts
+++ b/server/tests/unit/rules-loader.test.ts
@@ -193,9 +193,12 @@ describe('Rules Loader', () => {
     expect(knowledgeRules).toContain('# Knowledge');
     expect(knowledgeRules).toContain('## Knowledge Search First');
     expect(knowledgeRules).not.toContain('## Verify Claims With Tools');
-    expect(knowledgeRules).toContain('# Current AdCP Context');
-    expect(knowledgeRules).toContain('# Expert Panel');
+    expect(knowledgeRules).not.toContain('# Current AdCP Context');
+    expect(knowledgeRules).not.toContain('# Expert Panel');
     expect(knowledgeRules).not.toContain('# Canonical URL Reference');
+    const roadmapRules = loadScopedRules(['knowledge', 'github']);
+    expect(roadmapRules).toContain('# Current AdCP Context');
+    expect(roadmapRules).toContain('# Expert Panel');
     expect(billingRules).toContain('## Individual Practitioner Suitability');
     expect(billingRules).not.toContain('# Knowledge');
     expect(billingRules).not.toContain('# Current AdCP Context');
@@ -207,6 +210,15 @@ describe('Rules Loader', () => {
     const billingRules = loadRules({ selectedToolSetNames: ['member_billing'] });
 
     expect(billingRules.length).toBeLessThan(completeRules.length * 0.6);
+  });
+
+  it('keeps volatile ecosystem context off ordinary knowledge routes', () => {
+    const knowledgeRules = loadScopedRules(['knowledge']);
+    const roadmapRules = loadScopedRules(['knowledge', 'github']);
+
+    expect(knowledgeRules.length).toBeLessThan(roadmapRules.length);
+    expect(knowledgeRules).not.toContain('<addie_reference>');
+    expect(roadmapRules).toContain('<addie_reference>');
   });
 });
 


### PR DESCRIPTION
## Summary

- keep volatile roadmap and expert-panel context off ordinary knowledge routes while preserving it for explicit research and roadmap domains
- require explicit visual intent before the router adds the illustrations domain
- add the previously missed text-only protocol overview to the fixed synthetic router corpus
- bump Addie CODE_VERSION to 2026.08.104

## Validation

- focused provider, fixed-trace, router, tool, and rules tests: 464 passed
- root unit suite: 1,056 passed
- full server unit suite: 7,457 passed, 30 skipped
- Addie tool inventory generation/check/portability passed
- TypeScript typecheck passed

## Evaluation evidence

Exact head: 0524578886c290276a25b9431a23a8c3c7d7739d (clean)

- ordinary knowledge-route prompt: 150,095 to 121,349 characters (-19.2%); explicit knowledge + GitHub roadmap routes retain the full context
- Luna router: 189/189 observed and comparison-eligible; new text-only overview case passed 3/3; action/confidence/depth/emoji 100%; exact tool sets 143/153 (93.46%); $0.121491 accounted; no unknown exposure
- Gemini fixed traces: deterministic, answer, routing, tool selection, mutation safety, and metadata all 100%; candidate cost $0.285645 (previous eligible run $0.366114); combined cost $0.332647; candidate p95 20.648s
- rollout remains failed: judge consensus 85.71% and disagreement 14.29% on one terse task-model answer

No stochastic rerun was used to seek a green sample. Both model canaries remain disabled.

No protocol changeset is required because this is Addie application and evaluation work.