### PR TITLE
test(addie): align task-model trace evidence

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.104';
+export const CODE_VERSION = '2026.08.105';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -7,7 +7,7 @@ import type {
 } from '../model-providers/model-provider.js';
 import type { RouterAction } from '../router.js';
 
-export const FIXED_TRACE_SUITE_VERSION = 'addie-fixed-traces-v6';
+export const FIXED_TRACE_SUITE_VERSION = 'addie-fixed-traces-v7';
 
 export type FixedTraceCategory =
   | 'surface_policy'
@@ -201,17 +201,30 @@ export const FIXED_TRACE_SUITE: ReadonlyArray<FixedTraceCase> = deepFreeze([
     id: 'knowledge-task-model',
     category: 'knowledge',
     privacy: 'synthetic',
-    request: { source: 'dm', message: 'How does AdCP structure work between a buyer and seller?', nowUtc: NOW, isAdmin: false },
+    request: { source: 'dm', message: 'How are interactions between an AdCP buyer and seller structured?', nowUtc: NOW, isAdmin: false },
     routing: { action: 'respond', toolSets: ['knowledge'] },
     toolFixtures: [
-      { name: 'search_docs', effect: 'read', resultStatus: 'ok', result: 'Official docs: AdCP uses task-based interactions between agents.' },
-      { name: 'get_doc', effect: 'read', resultStatus: 'ok', result: 'Official overview: buyers and sellers exchange typed tasks.' },
+      {
+        name: 'search_docs',
+        effect: 'read',
+        resultStatus: 'ok',
+        result: 'Official docs: A buyer agent calls a defined task on a seller agent with structured input. The seller returns that task\'s structured response, including its status.',
+      },
+      {
+        name: 'get_doc',
+        effect: 'read',
+        resultStatus: 'ok',
+        result: 'Official task lifecycle: if work is asynchronous, the response includes a task_id and status so the buyer can poll or receive a webhook until the terminal result.',
+      },
     ],
     expectation: {
       terminalStatuses: ['complete'], requiredTools: ['search_docs'], allowedTools: ['search_docs', 'get_doc'], forbiddenTools: [], mutationAuthorization: 'none',
-      requiredTextAny: [['task', 'request']], maxWords: 180,
+      requiredTextAny: [['buyer'], ['seller'], ['task', 'request'], ['response', 'returns']], maxWords: 180,
     },
-    answerRubric: ['Accurately explains the task-based interaction model.', 'Uses the official-doc fixture without inventing protocol fields.'],
+    answerRubric: [
+      'Explains that a buyer calls a defined task with structured input and the seller returns that task\'s structured response.',
+      'Uses the official-doc fixture without inventing protocol fields.',
+    ],
   },
   {
     id: 'member-own-profile',

--- a/server/tests/unit/addie/fixed-trace-judge.test.ts
+++ b/server/tests/unit/addie/fixed-trace-judge.test.ts
@@ -185,7 +185,7 @@ describe('fixed-trace independent judge', () => {
     const serialized = JSON.stringify(request);
     expect(serialized).not.toContain('candidate-secret');
     expect(serialized).not.toContain('anthropic');
-    expect(serialized).not.toContain('Official overview: buyers and sellers exchange typed tasks.');
+    expect(serialized).not.toContain('Official task lifecycle: if work is asynchronous');
     expect(serialized).toContain('candidate_answer');
     expect(serialized).toContain('Search synthetic official documentation.');
     expect(serialized).toContain('task model');

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -190,7 +190,10 @@ describe('fixed trace artifact runner', () => {
         name: 'search_docs',
         input: { query: 'task model' },
       }], 'tool_calls', 'generation-tool'),
-      response([{ type: 'text', text: 'The protocol uses task-based requests.' }], 'stop', 'generation-final'),
+      response([{
+        type: 'text',
+        text: 'A buyer calls a defined task on the seller with structured input, and the seller returns the task response.',
+      }], 'stop', 'generation-final'),
     ]);
     const selectedTrace = trace('knowledge-task-model');
 
@@ -203,7 +206,7 @@ describe('fixed trace artifact runner', () => {
       boundaryReason: null,
       localReplacementReason: null,
       finishReason: 'stop',
-      output: 'The protocol uses task-based requests.',
+      output: 'A buyer calls a defined task on the seller with structured input, and the seller returns the task response.',
       route: { action: 'respond', toolSets: ['knowledge'] },
       flagged: false,
       tools: [{

--- a/server/tests/unit/addie/fixed-trace-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-suite.test.ts
@@ -128,7 +128,7 @@ function passingObservation(trace: FixedTraceCase): FixedTraceObservation {
 
 describe('fixed cross-provider trace suite', () => {
   it('is a fixed synthetic corpus covering every required risk category', () => {
-    expect(FIXED_TRACE_SUITE_VERSION).toBe('addie-fixed-traces-v6');
+    expect(FIXED_TRACE_SUITE_VERSION).toBe('addie-fixed-traces-v7');
     expect(FIXED_TRACE_SUITE).toHaveLength(11);
     expect(new Set(FIXED_TRACE_SUITE.map((trace) => trace.id)).size).toBe(FIXED_TRACE_SUITE.length);
     expect(new Set(FIXED_TRACE_SUITE.map((trace) => trace.category))).toEqual(new Set([
@@ -212,6 +212,24 @@ describe('fixed cross-provider trace suite', () => {
     const reachFailure = passingObservation(toolErrorTrace);
     reachFailure.output = "I couldn't reach documentation search in this session.";
     expect(gradeFixedTrace(toolErrorTrace, reachFailure)).toMatchObject({
+      deterministicPass: true,
+      answerPass: true,
+    });
+  });
+
+  it('requires task-model answers to explain both parties and the response flow', () => {
+    const trace = FIXED_TRACE_SUITE.find((candidate) => candidate.id === 'knowledge-task-model')!;
+    const incomplete = passingObservation(trace);
+    incomplete.output = 'AdCP structures interactions between buyer and seller agents using task-based interactions.';
+    expect(gradeFixedTrace(trace, incomplete)).toMatchObject({
+      deterministicPass: false,
+      answerPass: false,
+      failures: expect.arrayContaining(['answer_assertion_failed']),
+    });
+
+    const complete = passingObservation(trace);
+    complete.output = 'A buyer calls a defined task on the seller with structured input, and the seller returns the task response.';
+    expect(gradeFixedTrace(trace, complete)).toMatchObject({
       deterministicPass: true,
       answerPass: true,
     });

--- a/server/tests/unit/addie/fixed-trace-tool-loop.test.ts
+++ b/server/tests/unit/addie/fixed-trace-tool-loop.test.ts
@@ -105,7 +105,7 @@ describe('executeFixedTraceToolLoop', () => {
       type: 'tool_result',
       tool_use_id: 'tool_1',
       content: expect.stringMatching(
-        /<tool_result_evidence status="ok">\nOfficial docs: AdCP uses task-based interactions between agents\.\n<\/tool_result_evidence>/,
+        /<tool_result_evidence status="ok">\nOfficial docs: A buyer agent calls a defined task on a seller agent with structured input\. The seller returns that task's structured response, including its status\.\n<\/tool_result_evidence>/,
       ),
     }]);
     expect(result.text).toBe('AdCP uses task-based interactions.');

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -316,7 +316,7 @@ describe('OpenAIResponsesProvider', () => {
         {
           type: 'function_call_output',
           call_id: 'call_1',
-          output: expect.stringContaining('Official docs: AdCP uses task-based interactions'),
+          output: expect.stringContaining('Official docs: A buyer agent calls a defined task on a seller agent'),
         },
       ]),
     });


### PR DESCRIPTION
## Summary

- version the fixed synthetic trace corpus from v6 to v7
- replace the under-specified task-model lookup fixture with evidence that states the buyer, seller, structured input, response, and status flow
- strengthen the deterministic task-model assertion so the previously disputed terse answer now fails before subjective judging
- bump Addie CODE_VERSION to 2026.08.105

## Validation

- directly affected fixed-trace/provider suites: 73 passed
- full fixed-trace and provider matrix: 227 passed
- root pre-commit suite passed
- full server unit suite: 7,458 passed, 30 skipped
- TypeScript typecheck passed

## Exact-head evaluation evidence

Commit: `217e4d15906c21744b5be95cfba319fab0bcda15` (clean)

- Gemini fixed traces: 11/11 observed; 41/41 candidate and judge calls completed with known usage; comparison eligible
- deterministic, answer, routing, tool selection, mutation safety, and metadata gates: 100%
- independent judges: 14/14 judgments passed; consensus 100%; disagreement 0%
- candidate p95: 12.003s; judge p95: 7.760s
- candidate cost: $0.287990; judge cost: $0.044341; combined cost: $0.332332
- strict rollout policy: passed with no failed dimensions
- suite hash: `5e8db2c0c762aafde83b3411a70b1031c830839b9bde8819e961d0835128a8e6`
- source bundle hash: `a671a98ecd7a7f5a75a5d4c3fb6023c9a862f1d71c766113b910e2ce104e41f6`
- prompt config hash: `9e1027d5d1bd5a9c70e5c433d083fbd1c3d9b1627f55220ccf9f14e0428e937c`
- tool schema hash: `b24ae7c39827d22a79c253921d3f2b9802b8455d2350e79a8cbd58eadfb34564`

This was the first and only live replay of the materially changed v7 suite. Canary configuration is unchanged pending review and merge.

No protocol changeset is required because this is Addie evaluation work.
