### PR TITLE
feat(addie): isolate provider shadow execution

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -112,7 +112,7 @@ export interface InvocationPreparedSnapshot {
   tool_schemas: Array<{ index: number; name: string; sha256: string }>;
   message_payloads: Array<{ index: number; sha256: string }>;
   message_count: number;
-  /** HMAC/SHA-256 of the exact object handed to the Anthropic SDK. */
+  /** HMAC/SHA-256 of the exact object handed to the selected provider SDK. */
   provider_request_sha256: string;
 }
 
@@ -146,8 +146,14 @@ function addieModelOutputControls(
   return { max_tokens: Math.min(DEFAULT_MAX_OUTPUT_TOKENS, maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS) };
 }
 
-function isEvaluationExecution(options?: ProcessMessageOptions): boolean {
-  return options?.executionMode === 'evaluation' || options?.executionMode === 'replay';
+function isIsolatedExecution(options?: ProcessMessageOptions): boolean {
+  return options?.executionMode === 'evaluation'
+    || options?.executionMode === 'replay'
+    || options?.executionMode === 'shadow';
+}
+
+function isExactlyOnceExecution(options?: ProcessMessageOptions): boolean {
+  return options?.executionMode === 'replay' || options?.executionMode === 'shadow';
 }
 
 function hashPreparedPayload(
@@ -163,7 +169,7 @@ function hashPreparedPayload(
   // inputs are present. A partial configuration must never silently fall back
   // to an unkeyed digest. Production callers that do not request HMAC hashing
   // retain the historical SHA-256 behavior.
-  if (hasKey || hasDomain || executionMode === 'evaluation' || executionMode === 'replay') {
+  if (hasKey || hasDomain || executionMode !== 'production') {
     if (!hasKey || !hasDomain) return 'unavailable';
     return createHmac('sha256', key)
       .update('addie-invocation\0', 'utf8')
@@ -595,7 +601,7 @@ function reportEmptyResponseFallback(
   model: string,
   iteration: number,
 ): void {
-  if (isEvaluationExecution(options)) return;
+  if (isIsolatedExecution(options)) return;
 
   const successful = toolExecutions.filter(t => !t.is_error).length;
   const errored = toolExecutions.length - successful;
@@ -668,7 +674,7 @@ export interface UserScopedToolsResult {
  * Options for message processing
  */
 export interface ProcessMessageOptions {
-  /** Request-local execution mode. Evaluation/replay suppress operational side effects. */
+  /** Request-local execution mode. Evaluation, replay, and shadow suppress operational side effects. */
   executionMode?: AddieExecutionMode;
   /** Exclude provider-managed tools such as web search for this request only. */
   disableServerTools?: boolean;
@@ -689,7 +695,7 @@ export interface ProcessMessageOptions {
   /** Fail-closed hook evaluated immediately before each custom handler dispatch. */
   toolExecutionPolicy?: ToolExecutionPolicy;
   /**
-   * Called immediately before an Anthropic invocation with hashes of the exact,
+   * Called immediately before a provider invocation with hashes of the exact,
    * ordered system and tool payloads. Transcript content is intentionally absent.
    */
   onInvocationPrepared?: (
@@ -1144,7 +1150,7 @@ export class AddieClaudeClient {
     options: ProcessMessageOptions | undefined,
     toolInput: Record<string, unknown>,
   ): Record<string, unknown> {
-    return isEvaluationExecution(options) ? {} : toolInput;
+    return isIsolatedExecution(options) ? {} : toolInput;
   }
 
   /**
@@ -1176,7 +1182,7 @@ export class AddieClaudeClient {
     options?: ProcessMessageOptions,
   ) {
     const requestWebSearchEnabled = this.webSearchEnabled
-      && !isEvaluationExecution(options)
+      && !isIsolatedExecution(options)
       && options?.disableServerTools !== true;
     const effectiveModel = options?.modelOverride ?? this.model;
     const allowedToolNames = options?.allowedToolNames
@@ -1339,7 +1345,7 @@ export class AddieClaudeClient {
     rulesOverride?: RulesOverride,
     options?: ProcessMessageOptions
   ): Promise<AddieResponse> {
-    const operationalExecution = !isEvaluationExecution(options);
+    const operationalExecution = !isIsolatedExecution(options);
     const requestedModel = options?.modelOverride ?? this.model;
 
     // #2950: warn when a caller has neither `costScope` nor explicit
@@ -1522,10 +1528,10 @@ export class AddieClaudeClient {
             },
           );
         };
-        // A replay is an exactly-once paid experiment. A timeout can occur
-        // after provider acceptance, so neither our outer retry helper nor the
-        // Anthropic SDK may submit the request again.
-        response = options?.executionMode === 'replay' || recoveryInvocation.requiresExactlyOnce
+        // Replay and shadow are exactly-once paid experiments. A timeout can
+        // occur after provider acceptance, so neither our outer retry helper
+        // nor the provider SDK may submit the request again.
+        response = isExactlyOnceExecution(options) || recoveryInvocation.requiresExactlyOnce
           ? await invokeProvider(true)
           : await withRetry(
             () => invokeProvider(false),
@@ -1555,12 +1561,12 @@ export class AddieClaudeClient {
             requestWebSearchEnabled ? 1 : 0,
             options?.requestContext?.trim() ? options.requestContext.length : 0,
           );
-          if (options?.executionMode === 'replay') {
-            // Provider errors may echo request text. Replay logs only categorical
-            // metadata; the signed ledger records the terminal outcome.
+          if (isIsolatedExecution(options)) {
+            // Provider errors may echo request text. Isolated executions log
+            // only categorical metadata; the caller's ledger records the outcome.
             logger.error(
               { source: 'processMessage', payload: stats },
-              'Addie: Replay provider invocation failed',
+              'Addie: Isolated provider invocation failed',
             );
           } else {
             this.logPromptOverflow(error, stats, 'processMessage');
@@ -1859,7 +1865,7 @@ export class AddieClaudeClient {
     requestTools?: RequestTools,
     options?: ProcessMessageOptions
   ): AsyncGenerator<StreamEvent> {
-    const operationalExecution = !isEvaluationExecution(options);
+    const operationalExecution = !isIsolatedExecution(options);
     const requestedModel = options?.modelOverride ?? this.model;
 
     // #2950: matching fail-closed warn on the stream path.
@@ -2062,7 +2068,7 @@ export class AddieClaudeClient {
         // Logical-turn buffering means no model output is exposed and no
         // custom tool executes until a complete response is assembled, so a
         // failed sample is safe to discard and retry even after deltas arrive.
-        const maxStreamRetries = 3;
+        const maxStreamRetries = isExactlyOnceExecution(options) ? 0 : 3;
         let streamRetryCount = 0;
         let streamSucceeded = false;
         let receivedDeltaCount = 0;
@@ -2083,7 +2089,7 @@ export class AddieClaudeClient {
                 ? options?.initialToolChoice
                 : undefined,
             );
-            const provider = recoveryInvocation.requiresExactlyOnce
+            const provider = isExactlyOnceExecution(options) || recoveryInvocation.requiresExactlyOnce
               ? this.exactlyOnceAnthropicProvider
               : this.anthropicProvider;
             currentResponse = await activeTurn.invoke(
@@ -2132,7 +2138,16 @@ export class AddieClaudeClient {
               0,
               options?.requestContext?.trim() ? options.requestContext.length : 0,
             );
-            this.logPromptOverflow(streamError, stats, 'processMessageStream');
+            if (isIsolatedExecution(options)) {
+              // Provider errors may echo request text. Isolated executions log
+              // only categorical metadata; the caller's ledger records the outcome.
+              logger.error(
+                { source: 'processMessageStream', payload: stats },
+                'Addie Stream: Isolated provider invocation failed',
+              );
+            } else {
+              this.logPromptOverflow(streamError, stats, 'processMessageStream');
+            }
 
             const retryable = isRetryableError(streamError);
             const retryAfterSeconds = getProviderRetryAfterSeconds(streamError);
@@ -2541,7 +2556,14 @@ export class AddieClaudeClient {
         },
       };
     } catch (error) {
-      logger.error({ error }, 'Addie Stream: Error during streaming');
+      if (isIsolatedExecution(options)) {
+        logger.error(
+          { source: 'processMessageStream' },
+          'Addie Stream: Isolated execution terminated',
+        );
+      } else {
+        logger.error({ error }, 'Addie Stream: Error during streaming');
+      }
       if (!streamErrorEmitted) {
         yield {
           type: 'stream_error',

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.105';
+export const CODE_VERSION = '2026.08.106';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,7 +12,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "7ba262b6bf4fd51f72961e34ef0ba3362eb6eb48a2742967c4f4dce9aff39e0f",
+    "server/src/addie/claude-client.ts": "3481879616a66796c6cf79d9e6a626d619e19da42694252cbdd2a4037349d833",
     "server/src/addie/prompts.ts": "c2e52c173b6bbf76e9202b8be709a84320ce935e08d169cd6ec76b19978ce143",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/src/addie/model-providers/tool-orchestration.ts
+++ b/server/src/addie/model-providers/tool-orchestration.ts
@@ -32,7 +32,7 @@ const definitionSnapshots = new WeakMap<AddieTool, AddieTool>();
 export const BLOCKED_TOOL_RESULT = 'Error: Tool execution blocked by policy';
 
 export type ToolHandler = (input: Record<string, unknown>) => Promise<ToolHandlerResult>;
-export type AddieExecutionMode = 'production' | 'evaluation' | 'replay';
+export type AddieExecutionMode = 'production' | 'evaluation' | 'replay' | 'shadow';
 
 export interface ToolExecutionPolicyRequest {
   toolName: string;
@@ -195,8 +195,8 @@ interface RegisteredTool {
   handler?: ToolHandler;
 }
 
-function isEvaluationExecution(mode: AddieExecutionMode): boolean {
-  return mode === 'evaluation' || mode === 'replay';
+function isIsolatedExecution(mode: AddieExecutionMode): boolean {
+  return mode === 'evaluation' || mode === 'replay' || mode === 'shadow';
 }
 
 function deepFreeze<T>(value: T): T {
@@ -217,7 +217,7 @@ function recordedParameters(
   mode: AddieExecutionMode,
   input: Record<string, unknown>,
 ): Record<string, unknown> {
-  return isEvaluationExecution(mode) ? {} : structuredClone(input);
+  return isIsolatedExecution(mode) ? {} : structuredClone(input);
 }
 
 function recordedResult(
@@ -225,7 +225,7 @@ function recordedResult(
   result: string,
   kind: 'success' | 'error' | 'blocked',
 ): string {
-  if (!isEvaluationExecution(mode)) return result;
+  if (!isIsolatedExecution(mode)) return result;
   if (kind === 'blocked') return BLOCKED_TOOL_RESULT;
   return kind === 'error' ? 'Error: Tool execution failed' : 'Tool execution completed';
 }
@@ -234,7 +234,7 @@ function recordedPresentation(
   mode: AddieExecutionMode,
   normalized: NormalizedToolResult,
 ): ToolResultPresentation {
-  if (!isEvaluationExecution(mode)) return normalized.presentation;
+  if (!isIsolatedExecution(mode)) return normalized.presentation;
   return {
     status: normalized.status,
     user_summary: isToolResultError(normalized.status)
@@ -314,7 +314,7 @@ export function recordProviderToolResults(
       ? provider.deriveProviderToolReceipt(
           call,
           result,
-          isEvaluationExecution(options.executionMode) ? 'redacted' : 'production',
+          isIsolatedExecution(options.executionMode) ? 'redacted' : 'production',
         )
       : fallbackProviderToolReceipt(result);
     const normalized = observeNormalizedToolResult(result.name, normalizeToolResult(result.name, {
@@ -504,7 +504,7 @@ export function createAddieToolExecutor(
       );
     }
 
-    let allowed = !isEvaluationExecution(options.executionMode);
+    let allowed = !isIsolatedExecution(options.executionMode);
     if (options.policy) {
       try {
         const decision = await options.policy({

--- a/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
+++ b/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
@@ -159,10 +159,10 @@ describe('createAddieToolExecutor', () => {
     expect(result.execution.parameters).toEqual({ id: 'original' });
   });
 
-  it('fails closed in replay and redacts blocked inputs', async () => {
+  it.each(['replay', 'shadow'] as const)('fails closed in %s and redacts blocked inputs', async (executionMode) => {
     const handler = vi.fn();
     const execute = createAddieToolExecutor([tool], new Map([['lookup', handler]]), {
-      executionMode: 'replay',
+      executionMode,
     });
 
     const result = await execute(call({ id: 'secret' }), 1);
@@ -312,7 +312,7 @@ describe('recordProviderToolResults', () => {
     });
   });
 
-  it('redacts evaluation receipts and safely records unmatched results', () => {
+  it.each(['replay', 'shadow'] as const)('redacts %s receipts and safely records unmatched results', (executionMode) => {
     const deriveProviderToolReceipt = vi.fn(() => ({
       toolCallId: 'server_1',
       toolName: 'web_search',
@@ -326,7 +326,7 @@ describe('recordProviderToolResults', () => {
       { id: 'anthropic', deriveProviderToolReceipt },
       [providerCall],
       [providerResult],
-      { executionMode: 'replay', startingSequence: 0 },
+      { executionMode, startingSequence: 0 },
     );
     const unmatched = recordProviderToolResults(
       { id: 'anthropic' },

--- a/server/tests/unit/claude-client-replay-policy.test.ts
+++ b/server/tests/unit/claude-client-replay-policy.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const sdkState = vi.hoisted(() => ({
   nonStreamingResponses: [] as unknown[],
-  streamingResponses: [] as Array<Record<string, unknown>>,
+  streamingResponses: [] as Array<Record<string, unknown> | Error>,
   calls: [] as Array<Record<string, unknown>>,
   requestOptions: [] as unknown[],
 }));
@@ -50,17 +50,20 @@ vi.mock('@anthropic-ai/sdk', () => ({
             ...response as Record<string, unknown>,
           };
         }),
-        stream: vi.fn((payload: Record<string, unknown>) => {
+        stream: vi.fn((payload: Record<string, unknown>, options?: unknown) => {
           sdkState.calls.push(payload);
+          sdkState.requestOptions.push(options);
           const response = sdkState.streamingResponses.shift();
           if (!response) throw new Error('Missing streaming response fixture');
           return {
             async *[Symbol.asyncIterator]() {},
-            finalMessage: vi.fn().mockResolvedValue({
-              id: `msg_test_${sdkState.calls.length}`,
-              model: String(payload.model),
-              ...response,
-            }),
+            finalMessage: response instanceof Error
+              ? vi.fn().mockRejectedValue(response)
+              : vi.fn().mockResolvedValue({
+                id: `msg_test_${sdkState.calls.length}`,
+                model: String(payload.model),
+                ...response,
+              }),
           };
         }),
       },
@@ -136,77 +139,80 @@ beforeEach(() => {
   notifySystemError.mockReset();
 });
 
-describe('AddieClaudeClient replay execution policy', () => {
-  it('blocks mutation and unclassified handlers while executing a pure local read once', async () => {
-    const mutation = vi.fn().mockResolvedValue('mutated');
-    const mixed = vi.fn().mockResolvedValue('mixed');
-    const safeRead = vi.fn().mockResolvedValue('private raw read result');
-    const tools = requestTools(
-      [tool('mutate_record', 'mutation'), tool('mixed_tool'), tool('read_docs', 'pure_local')],
-      [
-        ['mutate_record', mutation],
-        ['mixed_tool', mixed],
-        ['read_docs', safeRead],
-      ],
-    );
-    sdkState.nonStreamingResponses.push(
-      toolUseResponse([
-        { id: 'tool-1', name: 'mutate_record', input: { value: 'secret mutation' } },
-        { id: 'tool-2', name: 'mixed_tool', input: { value: 'secret mixed' } },
-        { id: 'tool-3', name: 'read_docs', input: { value: 'secret query' } },
-      ]),
-      textResponse(),
-    );
+describe('AddieClaudeClient isolated execution policy', () => {
+  it.each(['replay', 'shadow'] as const)(
+    'blocks mutation and unclassified handlers in %s while executing a pure local read once',
+    async (executionMode) => {
+      const mutation = vi.fn().mockResolvedValue('mutated');
+      const mixed = vi.fn().mockResolvedValue('mixed');
+      const safeRead = vi.fn().mockResolvedValue('private raw read result');
+      const tools = requestTools(
+        [tool('mutate_record', 'mutation'), tool('mixed_tool'), tool('read_docs', 'pure_local')],
+        [
+          ['mutate_record', mutation],
+          ['mixed_tool', mixed],
+          ['read_docs', safeRead],
+        ],
+      );
+      sdkState.nonStreamingResponses.push(
+        toolUseResponse([
+          { id: 'tool-1', name: 'mutate_record', input: { value: 'secret mutation' } },
+          { id: 'tool-2', name: 'mixed_tool', input: { value: 'secret mixed' } },
+          { id: 'tool-3', name: 'read_docs', input: { value: 'secret query' } },
+        ]),
+        textResponse(),
+      );
 
-    const client = new AddieClaudeClient('unused');
-    const response = await client.processMessage(
-      'evaluate this',
-      undefined,
-      tools,
-      { systemPrompt: 'evaluation system' },
-      {
-        executionMode: 'replay',
-        disableServerTools: true,
-        toolExecutionPolicy: ({ toolName, tool: definition }) => {
-          if (toolName === 'mixed_tool') throw new Error('policy lookup failed');
-          return { allowed: definition?.replaySafety === 'pure_local' };
+      const client = new AddieClaudeClient('unused');
+      const response = await client.processMessage(
+        'evaluate this',
+        undefined,
+        tools,
+        { systemPrompt: 'evaluation system' },
+        {
+          executionMode,
+          disableServerTools: true,
+          toolExecutionPolicy: ({ toolName, tool: definition }) => {
+            if (toolName === 'mixed_tool') throw new Error('policy lookup failed');
+            return { allowed: definition?.replaySafety === 'pure_local' };
+          },
         },
-      },
-    );
+      );
 
-    expect(mutation).not.toHaveBeenCalled();
-    expect(mixed).not.toHaveBeenCalled();
-    expect(safeRead).toHaveBeenCalledOnce();
-    expect(safeRead).toHaveBeenCalledWith({ value: 'secret query' });
-    expect(response.tool_executions).toHaveLength(3);
-    expect(response.tool_executions.slice(0, 2)).toEqual([
-      expect.objectContaining({
-        tool_name: 'mutate_record',
+      expect(mutation).not.toHaveBeenCalled();
+      expect(mixed).not.toHaveBeenCalled();
+      expect(safeRead).toHaveBeenCalledOnce();
+      expect(safeRead).toHaveBeenCalledWith({ value: 'secret query' });
+      expect(response.tool_executions).toHaveLength(3);
+      expect(response.tool_executions.slice(0, 2)).toEqual([
+        expect.objectContaining({
+          tool_name: 'mutate_record',
+          parameters: {},
+          result: 'Error: Tool execution blocked by policy',
+          duration_ms: 0,
+          blocked_by_policy: true,
+          is_error: true,
+        }),
+        expect.objectContaining({
+          tool_name: 'mixed_tool',
+          parameters: {},
+          result: 'Error: Tool execution blocked by policy',
+          duration_ms: 0,
+          blocked_by_policy: true,
+          is_error: true,
+        }),
+      ]);
+      expect(response.tool_executions[2]).toMatchObject({
+        tool_name: 'read_docs',
         parameters: {},
-        result: 'Error: Tool execution blocked by policy',
-        duration_ms: 0,
-        blocked_by_policy: true,
-        is_error: true,
-      }),
-      expect.objectContaining({
-        tool_name: 'mixed_tool',
-        parameters: {},
-        result: 'Error: Tool execution blocked by policy',
-        duration_ms: 0,
-        blocked_by_policy: true,
-        is_error: true,
-      }),
-    ]);
-    expect(response.tool_executions[2]).toMatchObject({
-      tool_name: 'read_docs',
-      parameters: {},
-      result: 'Tool execution completed',
-      result_summary: 'Tool execution completed',
-      is_error: false,
-    });
-    expect(JSON.stringify(response.tool_executions)).not.toContain('secret');
-    expect(JSON.stringify(response.tool_executions)).not.toContain('private raw read result');
-  });
+        result: 'Tool execution completed',
+        result_summary: 'Tool execution completed',
+        is_error: false,
+      });
+      expect(JSON.stringify(response.tool_executions)).not.toContain('secret');
+      expect(JSON.stringify(response.tool_executions)).not.toContain('private raw read result');
+    },
+  );
 
   it('applies the same fail-closed policy and redaction to streaming dispatch', async () => {
     const mixed = vi.fn().mockResolvedValue('must not run');
@@ -290,7 +296,7 @@ describe('AddieClaudeClient replay execution policy', () => {
     });
   });
 
-  it('suppresses evaluation notifications while preserving production behavior', async () => {
+  it('suppresses isolated-execution notifications while preserving production behavior', async () => {
     const handler = vi.fn().mockRejectedValue(new Error('sensitive failure'));
     const tools = requestTools([tool('failing_read', 'pure_local')], [['failing_read', handler]]);
     const client = new AddieClaudeClient('unused');
@@ -319,6 +325,23 @@ describe('AddieClaudeClient replay execution policy', () => {
       { executionMode: 'evaluation', disableServerTools: true },
     );
     expect(notifySystemError).not.toHaveBeenCalled();
+
+    sdkState.nonStreamingResponses.push(
+      toolUseResponse([{ id: 'shadow-fail', name: 'failing_read', input: { value: 'shadow secret' } }]),
+      textResponse(),
+    );
+    const shadow = await client.processMessage(
+      'shadow', undefined, tools, { systemPrompt: 'system' },
+      {
+        executionMode: 'shadow',
+        toolExecutionPolicy: () => ({ allowed: true }),
+      },
+    );
+    expect(notifyToolError).not.toHaveBeenCalled();
+    expect(shadow.tool_executions[0]).toMatchObject({
+      parameters: {},
+      result: 'Error: Tool execution failed',
+    });
 
     sdkState.nonStreamingResponses.push(
       toolUseResponse([{ id: 'prod-fail', name: 'failing_read', input: { value: 'production input' } }]),
@@ -425,30 +448,69 @@ describe('AddieClaudeClient replay execution policy', () => {
     expect(sdkState.calls).toHaveLength(1);
   });
 
-  it('submits replay exactly once and logs no provider-echoed private text', async () => {
-    const privateSentinel = 'private-provider-error-sentinel';
-    const error = Object.assign(new Error(`temporary 500 ${privateSentinel}`), { status: 500 });
-    sdkState.nonStreamingResponses.push(error);
-    const client = new AddieClaudeClient('unused', 'test-model');
+  it.each(['replay', 'shadow'] as const)(
+    'submits %s exactly once and logs no provider-echoed private text',
+    async (executionMode) => {
+      const privateSentinel = 'private-provider-error-sentinel';
+      const error = Object.assign(new Error(`temporary 500 ${privateSentinel}`), { status: 500 });
+      sdkState.nonStreamingResponses.push(error);
+      const client = new AddieClaudeClient('unused', 'test-model');
 
-    await expect(client.processMessage(
-      'private question',
-      undefined,
-      undefined,
-      { systemPrompt: 'private system' },
-      {
-        executionMode: 'replay',
-        disableServerTools: true,
-        uncapped: true,
-        invocationHashKey: 'no-retry-key',
-        invocationHashDomain: 'no-retry-domain',
-      },
-    )).rejects.toThrow(privateSentinel);
+      await expect(client.processMessage(
+        'private question',
+        undefined,
+        undefined,
+        { systemPrompt: 'private system' },
+        {
+          executionMode,
+          disableServerTools: true,
+          uncapped: true,
+          invocationHashKey: 'no-retry-key',
+          invocationHashDomain: 'no-retry-domain',
+        },
+      )).rejects.toThrow(privateSentinel);
 
-    expect(sdkState.calls).toHaveLength(1);
-    expect(sdkState.requestOptions).toEqual([{ maxRetries: 0 }]);
-    expect(JSON.stringify(loggerState.entries)).not.toContain(privateSentinel);
-  });
+      expect(sdkState.calls).toHaveLength(1);
+      expect(sdkState.requestOptions).toEqual([{ maxRetries: 0 }]);
+      expect(JSON.stringify(loggerState.entries)).not.toContain(privateSentinel);
+    },
+  );
+
+  it.each(['replay', 'shadow'] as const)(
+    'streams %s exactly once and logs no provider-echoed private text',
+    async (executionMode) => {
+      const privateSentinel = 'private-stream-provider-error-sentinel';
+      const error = Object.assign(new Error(`temporary 500 ${privateSentinel}`), { status: 500 });
+      sdkState.streamingResponses.push(error);
+      const client = new AddieClaudeClient('unused', 'test-model');
+      const events: StreamEvent[] = [];
+
+      for await (const event of client.processMessageStream(
+        'private streaming question',
+        undefined,
+        undefined,
+        {
+          executionMode,
+          disableServerTools: true,
+          uncapped: true,
+          invocationHashKey: 'no-stream-retry-key',
+          invocationHashDomain: 'no-stream-retry-domain',
+        },
+      )) {
+        events.push(event);
+      }
+
+      expect(sdkState.calls).toHaveLength(1);
+      expect(sdkState.requestOptions).toEqual([
+        expect.objectContaining({ maxRetries: 0, signal: expect.any(AbortSignal) }),
+      ]);
+      expect(events.some((event) => event.type === 'retry')).toBe(false);
+      expect(events).toEqual([
+        expect.objectContaining({ type: 'stream_error' }),
+      ]);
+      expect(JSON.stringify(loggerState.entries)).not.toContain(privateSentinel);
+    },
+  );
 
   it('enforces an exact request-local tool boundary in both preparation and provider calls', async () => {
     const client = new AddieClaudeClient('unused', 'test-model');
@@ -546,9 +608,10 @@ describe('AddieClaudeClient replay execution policy', () => {
       );
 
     const missing = prepare({ executionMode: 'replay' });
+    const shadowMissing = prepare({ executionMode: 'shadow' });
     const keyOnly = prepare({ executionMode: 'replay', invocationHashKey: 'key-a' });
     const domainOnly = prepare({ executionMode: 'replay', invocationHashDomain: 'domain-a' });
-    for (const snapshot of [missing, keyOnly, domainOnly]) {
+    for (const snapshot of [missing, shadowMissing, keyOnly, domainOnly]) {
       expect(snapshot.system_blocks.every(({ sha256 }) => sha256 === 'unavailable')).toBe(true);
       expect(snapshot.tool_schemas.every(({ sha256 }) => sha256 === 'unavailable')).toBe(true);
     }
@@ -577,7 +640,11 @@ describe('AddieClaudeClient replay execution policy', () => {
   });
 
   it('preserves production custom schemas while intrinsically omitting provider tools', async () => {
-    sdkState.nonStreamingResponses.push(textResponse('production'), textResponse('replay'));
+    sdkState.nonStreamingResponses.push(
+      textResponse('production'),
+      textResponse('replay'),
+      textResponse('shadow'),
+    );
     const client = new AddieClaudeClient('unused');
     client.registerTool(tool('read_docs', 'pure_local'), vi.fn().mockResolvedValue('docs'));
 
@@ -592,14 +659,25 @@ describe('AddieClaudeClient replay execution policy', () => {
         }),
       },
     );
+    await client.processMessage(
+      'shadow', undefined, undefined, { systemPrompt: 'system' }, {
+        executionMode: 'shadow',
+        toolExecutionPolicy: ({ tool: definition }) => ({
+          allowed: definition?.replaySafety === 'pure_local',
+        }),
+      },
+    );
 
     const productionTools = sdkState.calls[0].tools as Array<Record<string, unknown>>;
     const replayTools = sdkState.calls[1].tools as Array<Record<string, unknown>>;
+    const shadowTools = sdkState.calls[2].tools as Array<Record<string, unknown>>;
     expect(productionTools.find((entry) => entry.name === 'read_docs')).toEqual(
       replayTools.find((entry) => entry.name === 'read_docs'),
     );
     expect(productionTools.some((entry) => entry.name === 'web_search')).toBe(true);
     expect(replayTools.some((entry) => entry.name === 'web_search')).toBe(false);
+    expect(shadowTools).toEqual(replayTools);
+    expect(shadowTools.some((entry) => entry.name === 'web_search')).toBe(false);
   });
 
   it('keeps the large cacheable prompt block stable across routed domains', () => {


### PR DESCRIPTION
## Summary

- add a distinct `shadow` execution mode to the shared Addie tool/runtime boundary
- make shadow execution fail closed for tool dispatch, redact recorded inputs/results, suppress operational side effects, and disable provider-managed web search
- submit replay and shadow provider calls exactly once, with SDK retries disabled and provider-echoed error text excluded from logs
- bump the Addie code version to `2026.08.106`

## Rollout safety

This PR only establishes request-local shadow semantics. It does not add provider selection, inject a Gemini runtime, route production traffic, or enable a user-visible canary. Shadow execution remains dormant until separately wired behind rollout controls.

## Validation

- affected matrix: 10 files, 95 tests passed
- Addie tool generation, inventory, and portability checks
- full pre-commit server suite: 519 files, 7,464 passed, 30 skipped
- root unit suite: 68 files, 1,056 passed
- TypeScript typecheck
- `git diff --check`
