### PR TITLE
feat(addie): inject isolated response providers

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -50,6 +50,8 @@ import type {
   ModelExecution,
   ModelMessage,
   ModelMessageContent,
+  ModelProvider,
+  ModelProviderId,
   ModelRequest,
   ModelResponse,
   ModelToolChoice,
@@ -57,6 +59,7 @@ import type {
   ModelToolDefinition,
   ModelToolResultContent,
   ModelUsage,
+  PreparedModelInvocation,
 } from './model-providers/model-provider.js';
 import {
   AnthropicModelProvider,
@@ -802,25 +805,30 @@ function toAddieUsage(usage: ModelUsage): NonNullable<AddieResponse['usage']> {
   };
 }
 
-function anthropicModelExecution(model: string, requestedModel: string): ModelExecution {
+function providerModelExecution(
+  response: Pick<ModelResponse, 'provider' | 'model'>,
+  requestedProvider: ModelProviderId,
+  requestedModel: string,
+): ModelExecution {
   return {
     source: 'provider',
-    requested_provider: 'anthropic',
+    requested_provider: requestedProvider,
     requested_model: requestedModel,
-    provider: 'anthropic',
-    model,
-    model_resolution: model === requestedModel ? 'exact' : 'provider_canonicalized',
+    provider: response.provider,
+    model: response.model,
+    model_resolution: response.model === requestedModel ? 'exact' : 'provider_canonicalized',
     fallback_reason: null,
   };
 }
 
 function localModelExecution(
   reason: Extract<ModelExecution, { source: 'local' }>['reason'],
+  requestedProvider: ModelProviderId,
   requestedModel: string,
 ): ModelExecution {
   return {
     source: 'local',
-    requested_provider: 'anthropic',
+    requested_provider: requestedProvider,
     requested_model: requestedModel,
     reason,
   };
@@ -828,6 +836,7 @@ function localModelExecution(
 
 function providerUnavailableResponse(
   availability: ProviderAvailability,
+  requestedProvider: ModelProviderId,
   requestedModel: string,
   toolsUsed: readonly string[] = [],
   toolExecutions: readonly ToolExecution[] = [],
@@ -843,7 +852,7 @@ function providerUnavailableResponse(
     tool_executions: [...toolExecutions],
     flagged: true,
     flag_reason: `provider_unavailable:${availability.category ?? 'unknown'}`,
-    model_execution: localModelExecution('provider_error', requestedModel),
+    model_execution: localModelExecution('provider_error', requestedProvider, requestedModel),
     capacity: { certification_reserve_used: certificationReserveUsed },
   };
 }
@@ -890,10 +899,20 @@ interface PayloadDebugStats {
   largest_message?: { index: number; role: string; chars: number };
 }
 
+/**
+ * Injectable provider seam for isolated full-response evaluation. Alternate
+ * providers remain barred from production delivery until provider-specific
+ * accounting and rollout gates are in place.
+ */
+export interface AddieModelProviderBinding {
+  provider: ModelProvider;
+  /** Provider instance whose transport performs exactly one SDK submission. */
+  exactlyOnceProvider?: ModelProvider;
+}
+
 export class AddieClaudeClient {
-  private client: Anthropic;
-  private readonly anthropicProvider: AnthropicModelProvider;
-  private readonly exactlyOnceAnthropicProvider: AnthropicModelProvider;
+  private readonly modelProvider: ModelProvider;
+  private readonly exactlyOnceModelProvider: ModelProvider;
   private model: string;
   private tools: AddieTool[] = [];
   private toolHandlers: Map<string, ToolHandler> = new Map();
@@ -905,19 +924,29 @@ export class AddieClaudeClient {
     apiKey: string,
     model: string = AddieModelConfig.chat,
     providerHealth: ProviderHealthController = new ProviderHealthController(),
+    providerBinding?: AddieModelProviderBinding,
   ) {
-    this.client = new Anthropic({ apiKey });
-    const transport = this.client as unknown as AnthropicMessagesTransport;
-    this.anthropicProvider = new AnthropicModelProvider(
-      apiKey,
-      transport,
-      { transportMaxRetries: 2 },
-    );
-    this.exactlyOnceAnthropicProvider = new AnthropicModelProvider(
-      apiKey,
-      transport,
-      { transportMaxRetries: 0 },
-    );
+    if (providerBinding) {
+      this.modelProvider = providerBinding.provider;
+      this.exactlyOnceModelProvider = providerBinding.exactlyOnceProvider
+        ?? providerBinding.provider;
+    } else {
+      const client = new Anthropic({ apiKey });
+      const transport = client as unknown as AnthropicMessagesTransport;
+      this.modelProvider = new AnthropicModelProvider(
+        apiKey,
+        transport,
+        { transportMaxRetries: 2 },
+      );
+      this.exactlyOnceModelProvider = new AnthropicModelProvider(
+        apiKey,
+        transport,
+        { transportMaxRetries: 0 },
+      );
+    }
+    if (this.exactlyOnceModelProvider.id !== this.modelProvider.id) {
+      throw new Error('Normal and exactly-once Addie providers must use the same provider');
+    }
     this.model = model;
     this.addieDb = new AddieDatabase();
     this.providerHealth = providerHealth;
@@ -1097,7 +1126,8 @@ export class AddieClaudeClient {
 
   private buildInvocationPreparedSnapshot(
     options: ProcessMessageOptions | undefined,
-    providerRequest: PreparedProviderRequest,
+    modelRequest: ModelRequest,
+    preparedInvocation: PreparedModelInvocation,
     iteration: number,
     attempt: number,
   ): InvocationPreparedSnapshot {
@@ -1108,39 +1138,63 @@ export class AddieClaudeClient {
       options?.invocationHashKey,
       options?.invocationHashDomain,
     );
+    const providerRequest = preparedInvocation.providerRequest;
+    // Preserve the existing Anthropic envelope hashes byte-for-byte. Other
+    // adapters expose different SDK shapes, so their component hashes use the
+    // canonical ordered request while the full request hash always covers the
+    // exact provider SDK payload.
+    const anthropicRequest = preparedInvocation.provider === 'anthropic'
+      ? providerRequest as unknown as PreparedProviderRequest
+      : null;
+    const systemBlocks: readonly unknown[] = anthropicRequest?.system ?? modelRequest.system;
+    const toolPayloads: Array<{ name: string; payload: unknown }> = anthropicRequest
+      ? anthropicRequest.tools.map((tool, index) => ({
+          name: typeof tool.name === 'string' ? tool.name : `tool_${index}`,
+          payload: tool,
+        }))
+      : [
+          ...modelRequest.tools.map((tool) => ({ name: tool.name, payload: tool })),
+          ...(modelRequest.providerTools ?? []).map((tool) => ({
+            name: `provider:${tool.type}`,
+            payload: tool,
+          })),
+        ];
+    const messagePayloads: readonly unknown[] = anthropicRequest?.messages ?? modelRequest.messages;
     return {
       execution_mode: executionMode,
-      model: providerRequest.model,
+      model: preparedInvocation.model,
       iteration,
       attempt,
-      system_blocks: providerRequest.system.map((block, index) => ({
+      system_blocks: systemBlocks.map((block, index) => ({
         index,
         sha256: hash(block),
       })),
-      tool_schemas: providerRequest.tools.map((tool, index) => ({
+      tool_schemas: toolPayloads.map(({ name, payload }, index) => ({
         index,
-        name: typeof tool.name === 'string' ? tool.name : `tool_${index}`,
-        sha256: hash(tool),
+        name,
+        sha256: hash(payload),
       })),
-      message_payloads: providerRequest.messages.map((message, index) => ({
+      message_payloads: messagePayloads.map((message, index) => ({
         index,
         sha256: hash(message),
       })),
-      message_count: providerRequest.messages.length,
+      message_count: messagePayloads.length,
       provider_request_sha256: hash(providerRequest),
     };
   }
 
   private async notifyInvocationPrepared(
     options: ProcessMessageOptions | undefined,
-    providerRequest: PreparedProviderRequest,
+    modelRequest: ModelRequest,
+    preparedInvocation: PreparedModelInvocation,
     iteration: number,
     attempt: number,
   ): Promise<void> {
     if (!options?.onInvocationPrepared) return;
     await options.onInvocationPrepared(this.buildInvocationPreparedSnapshot(
       options,
-      providerRequest,
+      modelRequest,
+      preparedInvocation,
       iteration,
       attempt,
     ));
@@ -1274,7 +1328,9 @@ export class AddieClaudeClient {
       model: effectiveModel,
       system: systemBlocks.map((block) => ({
         text: block.text,
-        ...('cache_control' in block && block.cache_control?.type === 'ephemeral'
+        ...(this.modelProvider.id === 'anthropic'
+          && 'cache_control' in block
+          && block.cache_control?.type === 'ephemeral'
           ? { cacheHint: 'ephemeral' as const }
           : {}),
       })),
@@ -1318,11 +1374,11 @@ export class AddieClaudeClient {
       false,
       options?.initialToolChoice,
     );
-    const providerRequest = this.anthropicProvider.prepare(modelRequest)
-      .providerRequest as unknown as PreparedProviderRequest;
+    const preparedInvocation = this.modelProvider.prepare(modelRequest);
     return this.buildInvocationPreparedSnapshot(
       options,
-      providerRequest,
+      modelRequest,
+      preparedInvocation,
       1,
       1,
     );
@@ -1347,6 +1403,9 @@ export class AddieClaudeClient {
   ): Promise<AddieResponse> {
     const operationalExecution = !isIsolatedExecution(options);
     const requestedModel = options?.modelOverride ?? this.model;
+    if (operationalExecution && this.modelProvider.id !== 'anthropic') {
+      throw new Error('Alternate Addie model providers are restricted to isolated execution');
+    }
 
     // #2950: warn when a caller has neither `costScope` nor explicit
     // `uncapped: true`. Silent default meant a future user-facing
@@ -1390,12 +1449,11 @@ export class AddieClaudeClient {
           tool_executions: [],
           flagged: true,
           flag_reason: 'cost_cap_exceeded',
-          model_execution: {
-            source: 'local',
-            requested_provider: 'anthropic',
-            requested_model: requestedModel,
-            reason: 'cost_cap_exceeded',
-          },
+          model_execution: localModelExecution(
+            'cost_cap_exceeded',
+            this.modelProvider.id,
+            requestedModel,
+          ),
         };
       }
     }
@@ -1403,9 +1461,13 @@ export class AddieClaudeClient {
     // Reserve a half-open probe only after local gates have passed so a
     // request that never reaches the provider cannot hold the probe lease.
     if (operationalExecution) {
-      const availability = this.providerHealth.acquire('anthropic', 'chat');
+      const availability = this.providerHealth.acquire(this.modelProvider.id, 'chat');
       if (!availability.allowed) {
-        return providerUnavailableResponse(availability, requestedModel);
+        return providerUnavailableResponse(
+          availability,
+          this.modelProvider.id,
+          requestedModel,
+        );
       }
     }
 
@@ -1511,8 +1573,8 @@ export class AddieClaudeClient {
               : undefined,
           );
           const provider = exactlyOnce
-            ? this.exactlyOnceAnthropicProvider
-            : this.anthropicProvider;
+            ? this.exactlyOnceModelProvider
+            : this.modelProvider;
           return activeTurn.invoke(
             provider,
             modelRequest,
@@ -1520,7 +1582,8 @@ export class AddieClaudeClient {
               beforeDispatch: async (preparedInvocation) => {
                 await this.notifyInvocationPrepared(
                   options,
-                  preparedInvocation.providerRequest as unknown as PreparedProviderRequest,
+                  modelRequest,
+                  preparedInvocation,
                   iteration,
                   invocationAttempt,
                 );
@@ -1538,7 +1601,7 @@ export class AddieClaudeClient {
             { maxRetries: 3, initialDelayMs: 1000 },
             'processMessage',
           );
-        if (operationalExecution) this.providerHealth.recordSuccess('anthropic', 'chat');
+        if (operationalExecution) this.providerHealth.recordSuccess(this.modelProvider.id, 'chat');
         modelLoop.emptyResponseRecovery.completeInvocation(recoveryInvocation);
       } catch (error) {
         const fallbackResponse = modelLoop.emptyResponseRecovery
@@ -1572,10 +1635,15 @@ export class AddieClaudeClient {
             this.logPromptOverflow(error, stats, 'processMessage');
           }
           if (operationalExecution) {
-            const availability = this.providerHealth.recordFailure('anthropic', 'chat', error);
+            const availability = this.providerHealth.recordFailure(
+              this.modelProvider.id,
+              'chat',
+              error,
+            );
             if (!availability.allowed) {
               return providerUnavailableResponse(
                 availability,
+                this.modelProvider.id,
                 requestedModel,
                 toolsUsed,
                 toolExecutions,
@@ -1596,7 +1664,7 @@ export class AddieClaudeClient {
         llmDurationMs: llmDuration,
         inputTokens: response.usage.inputTokens,
         outputTokens: response.usage.outputTokens,
-      }, 'Addie: Claude response received');
+      }, 'Addie: Model response received');
 
       const turn = activeTurn.acceptResponse(response, { countUsage: !reusedEmptyResponse });
       response = turn.response;
@@ -1607,7 +1675,7 @@ export class AddieClaudeClient {
       // Provider results may accompany a terminal, provider-continuation, or
       // mixed custom-tool turn. Record them once at the normalized boundary.
       const providerToolExecutions = executionLedger.recordProviderResults(
-        this.anthropicProvider,
+        this.modelProvider,
         turn.providerToolCalls,
         turn.providerToolResults,
         options?.executionMode ?? 'production',
@@ -1660,7 +1728,7 @@ export class AddieClaudeClient {
             contentTypes: boundedModelContentTypes(response.content),
             outputTokens: response.usage.outputTokens,
           },
-          'Addie: Anthropic stopped before response completion',
+          'Addie: Model provider stopped before response completion',
         );
         if (operationalExecution && options?.costScope) {
           await recordCost(
@@ -1678,10 +1746,10 @@ export class AddieClaudeClient {
           active_rule_ids: undefined,
           config_version_id: configVersionId ?? undefined,
           model_execution: finalized.emptyReason
-            ? localModelExecution('no_provider_response', effectiveModel)
+            ? localModelExecution('no_provider_response', this.modelProvider.id, effectiveModel)
             : finalized.localReplacementReason
-              ? localModelExecution('canned_response', effectiveModel)
-            : anthropicModelExecution(response.model, effectiveModel),
+              ? localModelExecution('canned_response', this.modelProvider.id, effectiveModel)
+            : providerModelExecution(response, this.modelProvider.id, effectiveModel),
           timing: {
             system_prompt_ms: systemPromptMs,
             total_llm_ms: totalLlmMs,
@@ -1777,10 +1845,10 @@ export class AddieClaudeClient {
           active_rule_ids: undefined,
           config_version_id: configVersionId ?? undefined,
           model_execution: finalized.emptyReason
-            ? localModelExecution('no_provider_response', effectiveModel)
+            ? localModelExecution('no_provider_response', this.modelProvider.id, effectiveModel)
             : finalized.localReplacementReason
-              ? localModelExecution('canned_response', effectiveModel)
-            : anthropicModelExecution(response.model, effectiveModel),
+              ? localModelExecution('canned_response', this.modelProvider.id, effectiveModel)
+            : providerModelExecution(response, this.modelProvider.id, effectiveModel),
           timing: {
             system_prompt_ms: systemPromptMs,
             total_llm_ms: totalLlmMs,
@@ -1819,9 +1887,8 @@ export class AddieClaudeClient {
     logger.warn('Addie: Hit max tool iterations');
     totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
     const maxIterationsUsage = toAddieUsage(modelLoop.usage);
-    // Still charge the user for tokens actually consumed on the way
-    // to hitting max-iterations — those bytes DID go to Anthropic
-    // and DID cost money, regardless of whether the session converged.
+    // Still charge the user for tokens actually consumed on the way to
+    // hitting max-iterations. Production delivery is Anthropic-only here.
     if (operationalExecution && options?.costScope) {
       await recordCost(
         options.costScope.userId,
@@ -1837,7 +1904,7 @@ export class AddieClaudeClient {
       flag_reason: 'Max tool iterations reached',
       active_rule_ids: undefined,
       config_version_id: configVersionId ?? undefined,
-      model_execution: localModelExecution('canned_response', effectiveModel),
+      model_execution: localModelExecution('canned_response', this.modelProvider.id, effectiveModel),
       timing: {
         system_prompt_ms: systemPromptMs,
         total_llm_ms: totalLlmMs,
@@ -1867,6 +1934,9 @@ export class AddieClaudeClient {
   ): AsyncGenerator<StreamEvent> {
     const operationalExecution = !isIsolatedExecution(options);
     const requestedModel = options?.modelOverride ?? this.model;
+    if (operationalExecution && this.modelProvider.id !== 'anthropic') {
+      throw new Error('Alternate Addie model providers are restricted to isolated execution');
+    }
 
     // #2950: matching fail-closed warn on the stream path.
     if (operationalExecution && !options?.costScope && !options?.uncapped) {
@@ -1911,12 +1981,11 @@ export class AddieClaudeClient {
             tool_executions: [],
             flagged: true,
             flag_reason: 'cost_cap_exceeded',
-            model_execution: {
-              source: 'local',
-              requested_provider: 'anthropic',
-              requested_model: requestedModel,
-              reason: 'cost_cap_exceeded',
-            },
+            model_execution: localModelExecution(
+              'cost_cap_exceeded',
+              this.modelProvider.id,
+              requestedModel,
+            ),
           },
         };
         return;
@@ -1925,13 +1994,17 @@ export class AddieClaudeClient {
 
     // As above, cost-capped requests must not consume the one half-open probe.
     if (operationalExecution) {
-      const availability = this.providerHealth.acquire('anthropic', 'chat');
+      const availability = this.providerHealth.acquire(this.modelProvider.id, 'chat');
       if (!availability.allowed) {
         await releaseCertificationReserve(options?.costScope?.userId, certificationLeaseId);
         certificationLeaseId = undefined;
         yield {
           type: 'done',
-          response: providerUnavailableResponse(availability, requestedModel),
+          response: providerUnavailableResponse(
+            availability,
+            this.modelProvider.id,
+            requestedModel,
+          ),
         };
         return;
       }
@@ -2090,8 +2163,8 @@ export class AddieClaudeClient {
                 : undefined,
             );
             const provider = isExactlyOnceExecution(options) || recoveryInvocation.requiresExactlyOnce
-              ? this.exactlyOnceAnthropicProvider
-              : this.anthropicProvider;
+              ? this.exactlyOnceModelProvider
+              : this.modelProvider;
             currentResponse = await activeTurn.invoke(
               provider,
               modelRequest,
@@ -2104,7 +2177,8 @@ export class AddieClaudeClient {
                 beforeDispatch: async (preparedInvocation) => {
                   await this.notifyInvocationPrepared(
                     options,
-                    preparedInvocation.providerRequest as unknown as PreparedProviderRequest,
+                    modelRequest,
+                    preparedInvocation,
                     iteration,
                     streamRetryCount + 1,
                   );
@@ -2112,7 +2186,7 @@ export class AddieClaudeClient {
               },
             );
 
-            if (operationalExecution) this.providerHealth.recordSuccess('anthropic', 'chat');
+            if (operationalExecution) this.providerHealth.recordSuccess(this.modelProvider.id, 'chat');
             streamSucceeded = true;
             lastProviderModel = currentResponse.model;
             modelLoop.emptyResponseRecovery.completeInvocation(recoveryInvocation);
@@ -2162,10 +2236,15 @@ export class AddieClaudeClient {
                 streamRetryCount > maxStreamRetries || !retryAfterWithinRequestBudget
               );
               if (operationalExecution) {
-                const availability = this.providerHealth.recordFailure('anthropic', 'chat', streamError);
+                const availability = this.providerHealth.recordFailure(
+                  this.modelProvider.id,
+                  'chat',
+                  streamError,
+                );
                 if (!availability.allowed) {
                   const terminalResponse = providerUnavailableResponse(
                     availability,
+                    this.modelProvider.id,
                     requestedModel,
                     toolsUsed,
                     toolExecutions,
@@ -2260,7 +2339,7 @@ export class AddieClaudeClient {
           llmDurationMs: llmDuration,
           inputTokens: currentResponse.usage.inputTokens,
           outputTokens: currentResponse.usage.outputTokens,
-        }, 'Addie Stream: Claude response received');
+        }, 'Addie Stream: Model response received');
 
         const turn = activeTurn.acceptResponse(currentResponse, { countUsage: !reusedEmptyResponse });
         currentResponse = turn.response;
@@ -2269,7 +2348,7 @@ export class AddieClaudeClient {
         }
 
         const providerToolExecutions = executionLedger.recordProviderResults(
-          this.anthropicProvider,
+          this.modelProvider,
           turn.providerToolCalls,
           turn.providerToolResults,
           options?.executionMode ?? 'production',
@@ -2360,10 +2439,10 @@ export class AddieClaudeClient {
               active_rule_ids: undefined,
               config_version_id: configVersionId ?? undefined,
               model_execution: finalized.emptyReason
-                ? localModelExecution('no_provider_response', effectiveModel)
+                ? localModelExecution('no_provider_response', this.modelProvider.id, effectiveModel)
                 : finalized.localReplacementReason
-                  ? localModelExecution('canned_response', effectiveModel)
-                : anthropicModelExecution(currentResponse.model, effectiveModel),
+                  ? localModelExecution('canned_response', this.modelProvider.id, effectiveModel)
+                : providerModelExecution(currentResponse, this.modelProvider.id, effectiveModel),
               timing: {
                 system_prompt_ms: systemPromptMs,
                 total_llm_ms: totalLlmMs,
@@ -2444,10 +2523,10 @@ export class AddieClaudeClient {
               active_rule_ids: undefined,
               config_version_id: configVersionId ?? undefined,
               model_execution: finalized.emptyReason
-                ? localModelExecution('no_provider_response', effectiveModel)
+                ? localModelExecution('no_provider_response', this.modelProvider.id, effectiveModel)
                 : finalized.localReplacementReason
-                  ? localModelExecution('canned_response', effectiveModel)
-                : anthropicModelExecution(currentResponse.model, effectiveModel),
+                  ? localModelExecution('canned_response', this.modelProvider.id, effectiveModel)
+                : providerModelExecution(currentResponse, this.modelProvider.id, effectiveModel),
               timing: {
                 system_prompt_ms: systemPromptMs,
                 total_llm_ms: totalLlmMs,
@@ -2541,10 +2620,14 @@ export class AddieClaudeClient {
           active_rule_ids: undefined,
           config_version_id: configVersionId ?? undefined,
           model_execution: finalizedMaxIter.localReplacementReason
-            ? localModelExecution('canned_response', effectiveModel)
+            ? localModelExecution('canned_response', this.modelProvider.id, effectiveModel)
             : logicalText && lastProviderModel
-            ? anthropicModelExecution(lastProviderModel, effectiveModel)
-            : localModelExecution('canned_response', effectiveModel),
+            ? providerModelExecution(
+                { provider: this.modelProvider.id, model: lastProviderModel },
+                this.modelProvider.id,
+                effectiveModel,
+              )
+            : localModelExecution('canned_response', this.modelProvider.id, effectiveModel),
           timing: {
             system_prompt_ms: systemPromptMs,
             total_llm_ms: totalLlmMs,

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.106';
+export const CODE_VERSION = '2026.08.107';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,7 +12,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "3481879616a66796c6cf79d9e6a626d619e19da42694252cbdd2a4037349d833",
+    "server/src/addie/claude-client.ts": "d3af804bac0c4f6328ac7ebcd337c88c3a7f7a391964e639b2b526b7f3b2f6a2",
     "server/src/addie/prompts.ts": "c2e52c173b6bbf76e9202b8be709a84320ce935e08d169cd6ec76b19978ce143",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/tests/unit/claude-client-replay-policy.test.ts
+++ b/server/tests/unit/claude-client-replay-policy.test.ts
@@ -78,6 +78,14 @@ import {
   type StreamEvent,
 } from '../../src/addie/claude-client.js';
 import type { AddieTool } from '../../src/addie/types.js';
+import type {
+  ModelProvider,
+  ModelProviderId,
+  ModelRequest,
+  ModelRespondOptions,
+  NormalizedModelEvent,
+  PreparedModelInvocation,
+} from '../../src/addie/model-providers/model-provider.js';
 
 const usage = { input_tokens: 3, output_tokens: 2 };
 
@@ -127,6 +135,59 @@ function invocationHmac(key: string, domain: string, value: string): string {
     .update('\0', 'utf8')
     .update(value, 'utf8')
     .digest('hex');
+}
+
+function fakeProvider(
+  id: ModelProviderId,
+  responseText: string,
+): ModelProvider & {
+  prepare: ReturnType<typeof vi.fn<(request: ModelRequest) => PreparedModelInvocation>>;
+  respond: ReturnType<typeof vi.fn<(
+    request: ModelRequest,
+    options?: ModelRespondOptions,
+  ) => AsyncIterable<NormalizedModelEvent>>>;
+} {
+  const capabilities = {
+    streaming: false,
+    structuredOutput: true,
+    reasoning: true,
+    reasoningEfforts: ['provider_default', 'none', 'low', 'medium', 'high'] as const,
+    customTools: true,
+    providerWebSearch: false,
+    imageInput: false,
+    documentInput: false,
+  };
+  const prepare = vi.fn((request: ModelRequest): PreparedModelInvocation => ({
+    provider: id,
+    model: request.model,
+    capabilities,
+    providerRequest: structuredClone({
+      model: request.model,
+      system: request.system,
+      messages: request.messages,
+      tools: request.tools,
+      maxOutputTokens: request.maxOutputTokens,
+    }),
+  }));
+  const respond = vi.fn((request: ModelRequest, options?: ModelRespondOptions) => (async function* () {
+    const prepared = prepare(request);
+    await options?.beforeDispatch?.(prepared);
+    yield { type: 'response_start', provider: id, model: request.model, id: `${id}-response` };
+    yield { type: 'text_delta', index: 0, text: responseText };
+    yield {
+      type: 'response_complete',
+      response: {
+        provider: id,
+        model: request.model,
+        id: `${id}-response`,
+        content: [{ type: 'text', text: responseText }],
+        finishReason: 'stop',
+        providerFinishReason: 'stop',
+        usage: { inputTokens: 7, outputTokens: 3 },
+      },
+    };
+  })());
+  return { id, capabilities, prepare, respond };
 }
 
 beforeEach(() => {
@@ -678,6 +739,105 @@ describe('AddieClaudeClient isolated execution policy', () => {
     expect(replayTools.some((entry) => entry.name === 'web_search')).toBe(false);
     expect(shadowTools).toEqual(replayTools);
     expect(shadowTools.some((entry) => entry.name === 'web_search')).toBe(false);
+  });
+
+  it('runs an injected alternate provider exactly once for a full shadow response', async () => {
+    const normalProvider = fakeProvider('google', 'normal response must not run');
+    const exactlyOnceProvider = fakeProvider('google', 'shadow candidate');
+    const client = new AddieClaudeClient(
+      'unused',
+      'gemini-test',
+      undefined,
+      { provider: normalProvider, exactlyOnceProvider },
+    );
+    const prepared = client.prepareMessageInvocation(
+      'private question',
+      undefined,
+      undefined,
+      { systemPrompt: 'private system' },
+      {
+        executionMode: 'shadow',
+        disableServerTools: true,
+        invocationHashKey: 'alternate-provider-key',
+        invocationHashDomain: 'alternate-provider-shadow:v1',
+      },
+    );
+    const snapshots: InvocationPreparedSnapshot[] = [];
+
+    const response = await client.processMessage(
+      'private question',
+      undefined,
+      undefined,
+      { systemPrompt: 'private system' },
+      {
+        executionMode: 'shadow',
+        disableServerTools: true,
+        invocationHashKey: 'alternate-provider-key',
+        invocationHashDomain: 'alternate-provider-shadow:v1',
+        onInvocationPrepared: (snapshot) => snapshots.push(snapshot),
+      },
+    );
+
+    expect(normalProvider.respond).not.toHaveBeenCalled();
+    expect(exactlyOnceProvider.respond).toHaveBeenCalledOnce();
+    expect(sdkState.calls).toHaveLength(0);
+    expect(snapshots).toEqual([prepared]);
+    expect(response).toMatchObject({
+      text: 'Shadow candidate',
+      model_execution: {
+        source: 'provider',
+        requested_provider: 'google',
+        requested_model: 'gemini-test',
+        provider: 'google',
+        model: 'gemini-test',
+        model_resolution: 'exact',
+        fallback_reason: null,
+      },
+      usage: { input_tokens: 7, output_tokens: 3 },
+    });
+    const dispatchedRequest = exactlyOnceProvider.prepare.mock.calls[0][0];
+    expect(dispatchedRequest.system.every((block) => block.cacheHint === undefined)).toBe(true);
+    expect(dispatchedRequest.providerTools).toBeUndefined();
+  });
+
+  it('keeps alternate providers dormant for production delivery', async () => {
+    const provider = fakeProvider('openai', 'must not run');
+    const client = new AddieClaudeClient(
+      'unused',
+      'gpt-test',
+      undefined,
+      { provider },
+    );
+
+    await expect(client.processMessage(
+      'production question',
+      undefined,
+      undefined,
+      { systemPrompt: 'system' },
+      { uncapped: true },
+    )).rejects.toThrow('restricted to isolated execution');
+    const stream = client.processMessageStream(
+      'production stream',
+      undefined,
+      undefined,
+      { uncapped: true },
+    );
+    await expect(stream.next()).rejects.toThrow('restricted to isolated execution');
+
+    expect(provider.prepare).not.toHaveBeenCalled();
+    expect(provider.respond).not.toHaveBeenCalled();
+  });
+
+  it('rejects a binding whose exactly-once provider could cross provider state', () => {
+    expect(() => new AddieClaudeClient(
+      'unused',
+      'test-model',
+      undefined,
+      {
+        provider: fakeProvider('openai', 'unused'),
+        exactlyOnceProvider: fakeProvider('google', 'unused'),
+      },
+    )).toThrow('must use the same provider');
   });
 
   it('keeps the large cacheable prompt block stable across routed domains', () => {


### PR DESCRIPTION
## Summary

- inject a normalized model-provider binding into the Addie response loop while preserving Anthropic as the default
- permit alternate providers only for isolated evaluation, replay, and shadow execution; production and operational delivery fail closed before provider preparation or dispatch
- preserve existing Anthropic invocation hashes while hashing each adapter's exact prepared request and recording provider-neutral execution, health, and tool provenance
- use a same-provider exactly-once transport for isolated execution and reject mismatched provider bindings

## Safety and rollout

- no production call site or runtime selector is added
- no router or full-response canary is enabled
- no cross-provider fallback is introduced
- no paid provider calls were made
- Addie `CODE_VERSION` and generated tool-surface inventory are updated

## Verification

- focused provider/runtime matrix: 6 files, 150 tests passed
- `npm run build:addie-tools`
- `npm run test:addie-tools`
- `npm run precommit`: 519 server files / 7,467 tests passed, plus root unit/lint gates and typecheck
- staged diff and confidentiality scans passed

Advances #6844 and #6846.