### PR TITLE
feat(addie): bind isolated replay targets

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -1228,6 +1228,22 @@ export class AddieClaudeClient {
     return toolNames.every((name) => definitions.has(name) && this.toolHandlers.has(name));
   }
 
+  /**
+   * Copy the registered tool surface into a provider-isolated client. This is
+   * deliberately not a production selector: alternate providers remain
+   * blocked by the operational guards in both message entry points.
+   */
+  forkForIsolatedProvider(
+    model: string,
+    providerBinding: AddieModelProviderBinding,
+  ): AddieClaudeClient {
+    const fork = new AddieClaudeClient('', model, undefined, providerBinding);
+    fork.tools = [...this.tools];
+    fork.toolHandlers = new Map(this.toolHandlers);
+    fork.webSearchEnabled = false;
+    return fork;
+  }
+
   private prepareFirstNonStreamingInvocation(
     userMessage: string,
     threadContext?: Array<{ user: string; text: string }>,

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.107';
+export const CODE_VERSION = '2026.08.108';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,7 +12,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "d3af804bac0c4f6328ac7ebcd337c88c3a7f7a391964e639b2b526b7f3b2f6a2",
+    "server/src/addie/claude-client.ts": "a0f5a8c0fce2e621344db0237aee98f6b4266cb262cfadb6d06c43cd32918460",
     "server/src/addie/prompts.ts": "c2e52c173b6bbf76e9202b8be709a84320ce935e08d169cd6ec76b19978ce143",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/src/addie/jobs/shadow-replay.ts
+++ b/server/src/addie/jobs/shadow-replay.ts
@@ -4,6 +4,7 @@ import type { MemberContext } from '../member-context.js';
 import type { SIRetrievalResult } from '../services/si-retriever.js';
 import type { ThreadContext } from '../thread-service.js';
 import type { AddieTool } from '../types.js';
+import type { ModelProviderId } from '../model-providers/model-provider.js';
 import { getCurrentConfigVersionId } from '../config-version.js';
 import {
   buildChannelResponseInvocation,
@@ -86,11 +87,25 @@ export interface VerifiedOfficialDocsReplayInput {
   invocation: ChannelResponseInvocation;
   /** Fingerprint already checked by the signed hydrated-context parity gate. */
   docsCorpusFingerprint: string;
+  /**
+   * Optional alternate-provider target prepared from this same verified
+   * invocation. No production call site supplies one yet.
+   */
+  target?: VerifiedOfficialDocsReplayTarget;
+}
+
+export interface VerifiedOfficialDocsReplayTarget {
+  provider: ModelProviderId;
+  model: string;
+  firstInvocation: InvocationPreparedSnapshot;
 }
 
 export interface VerifiedOfficialDocsReplayResult extends ShadowReplayGenerationCompletion {
   traceId: string;
+  provider: ModelProviderId;
   model: string;
+  returnedProvider: ModelProviderId | null;
+  returnedModel: string | null;
   executionPolicyVersion: typeof OFFICIAL_DOCS_REPLAY_EXECUTION_POLICY_VERSION;
   completeFidelity: boolean;
   judgment?: ShadowReplayJudgeEvidence;
@@ -417,6 +432,53 @@ function sameOrderedSnapshotItems(
   });
 }
 
+function sourceReplayTarget(trace: ResolvedShadowReplayTrace): VerifiedOfficialDocsReplayTarget {
+  return {
+    provider: 'anthropic',
+    model: trace.expected.effective_model,
+    firstInvocation: {
+      execution_mode: 'replay',
+      model: trace.expected.effective_model,
+      iteration: 1,
+      attempt: 1,
+      system_blocks: trace.expected.system_block_hmacs,
+      tool_schemas: trace.expected.tool_schema_hmacs,
+      message_payloads: trace.expected.message_payload_hmacs,
+      message_count: trace.expected.message_count,
+      provider_request_sha256: trace.expected.provider_request_hmac ?? '',
+    },
+  };
+}
+
+function assertTargetFirstInvocation(target: VerifiedOfficialDocsReplayTarget): void {
+  const snapshot = target.firstInvocation;
+  if (!target.model.trim() || target.model.length > 160) {
+    throw new OfficialDocsReplayBoundaryError('target_model_invalid');
+  }
+  if (snapshot.execution_mode !== 'replay'
+    || snapshot.model !== target.model
+    || snapshot.iteration !== 1
+    || snapshot.attempt !== 1
+    || !/^[0-9a-f]{64}$/.test(snapshot.provider_request_sha256)) {
+    throw new OfficialDocsReplayBoundaryError('target_invocation_invalid');
+  }
+}
+
+function sameFirstInvocation(
+  expected: InvocationPreparedSnapshot,
+  actual: InvocationPreparedSnapshot,
+): boolean {
+  return expected.execution_mode === actual.execution_mode
+    && expected.model === actual.model
+    && expected.iteration === actual.iteration
+    && expected.attempt === actual.attempt
+    && expected.message_count === actual.message_count
+    && expected.provider_request_sha256 === actual.provider_request_sha256
+    && sameOrderedSnapshotItems(expected.system_blocks, actual.system_blocks)
+    && sameOrderedSnapshotItems(expected.tool_schemas, actual.tool_schemas)
+    && sameOrderedSnapshotItems(expected.message_payloads, actual.message_payloads);
+}
+
 function evidenceHmac(
   trace: ResolvedShadowReplayTrace,
   purpose: string,
@@ -460,19 +522,19 @@ function assertOfficialDocsReplayPreflight(input: VerifiedOfficialDocsReplayInpu
 }
 
 function assertLaterInvocationBoundary(
-  trace: ResolvedShadowReplayTrace,
+  target: VerifiedOfficialDocsReplayTarget,
   snapshot: InvocationPreparedSnapshot,
 ): void {
   if (snapshot.execution_mode !== 'replay') {
     throw new OfficialDocsReplayBoundaryError('execution_mode_drift');
   }
-  if (snapshot.model !== trace.expected.effective_model) {
+  if (snapshot.model !== target.model) {
     throw new OfficialDocsReplayBoundaryError('model_drift');
   }
-  if (!sameOrderedSnapshotItems(trace.expected.system_block_hmacs, snapshot.system_blocks)) {
+  if (!sameOrderedSnapshotItems(target.firstInvocation.system_blocks, snapshot.system_blocks)) {
     throw new OfficialDocsReplayBoundaryError('system_blocks_drift');
   }
-  if (!sameOrderedSnapshotItems(trace.expected.tool_schema_hmacs, snapshot.tool_schemas)
+  if (!sameOrderedSnapshotItems(target.firstInvocation.tool_schemas, snapshot.tool_schemas)
     || !exactAllowedNames(snapshot.tool_schemas.map(({ name }) => name))) {
     throw new OfficialDocsReplayBoundaryError('tool_schemas_drift');
   }
@@ -525,6 +587,8 @@ export async function executeVerifiedOfficialDocsReplay(
   dependencies: VerifiedOfficialDocsReplayDependencies = {},
 ): Promise<VerifiedOfficialDocsReplayResult> {
   assertOfficialDocsReplayPreflight(input);
+  const target = input.target ?? sourceReplayTarget(input.trace);
+  assertTargetFirstInvocation(target);
   const client = dependencies.client ?? getChannelClaudeClient();
   if (!client) throw new OfficialDocsReplayBoundaryError('channel_client_not_initialized');
   if (!dependencies.renewLease) {
@@ -614,6 +678,7 @@ export async function executeVerifiedOfficialDocsReplay(
         invocationHashKey: input.trace.identity.hashKey,
         invocationHashDomain: input.trace.identity.hashDomain,
         uncapped: true,
+        modelOverride: target.model,
         onInvocationPrepared: async (snapshot) => {
           if (invocations.length >= MAX_OFFICIAL_DOCS_REPLAY_INVOCATIONS) {
             throw new OfficialDocsReplayBoundaryError('invocation_limit_exceeded');
@@ -623,14 +688,20 @@ export async function executeVerifiedOfficialDocsReplay(
             throw new OfficialDocsReplayBoundaryError('provider_retry_not_allowed');
           }
           if (snapshot.iteration === 1) {
-            const first = verifyShadowReplayFirstInvocation(input.trace, snapshot);
-            if (!first.verified) {
-              throw new OfficialDocsReplayBoundaryError(
-                first.reasons[0] ?? 'first_invocation_drift',
-              );
+            if (input.target) {
+              if (!sameFirstInvocation(target.firstInvocation, snapshot)) {
+                throw new OfficialDocsReplayBoundaryError('target_invocation_drift');
+              }
+            } else {
+              const first = verifyShadowReplayFirstInvocation(input.trace, snapshot);
+              if (!first.verified) {
+                throw new OfficialDocsReplayBoundaryError(
+                  first.reasons[0] ?? 'first_invocation_drift',
+                );
+              }
             }
           } else {
-            assertLaterInvocationBoundary(input.trace, snapshot);
+            assertLaterInvocationBoundary(target, snapshot);
           }
           const previousRequestHmac = providerRequestHmacByIteration.get(snapshot.iteration);
           if (previousRequestHmac && previousRequestHmac !== snapshot.provider_request_sha256) {
@@ -712,7 +783,10 @@ export async function executeVerifiedOfficialDocsReplay(
     }
     throw new OfficialDocsReplayExecutionError({
       traceId: input.trace.traceId,
-      model: input.invocation.effectiveModel,
+      provider: target.provider,
+      model: target.model,
+      returnedProvider: null,
+      returnedModel: null,
       executionPolicyVersion: OFFICIAL_DOCS_REPLAY_EXECUTION_POLICY_VERSION,
       completeFidelity: false,
       status: error instanceof OfficialDocsReplayBoundaryError ? 'blocked' : 'error',
@@ -773,6 +847,12 @@ export async function executeVerifiedOfficialDocsReplay(
   }
   if (invocations.length === 0) blockedCapabilities.add('missing_invocation_snapshot');
   if (response.flagged) blockedCapabilities.add('flagged_response');
+  const execution = response.model_execution;
+  if (execution.source !== 'provider'
+    || execution.requested_provider !== target.provider
+    || execution.requested_model !== target.model) {
+    blockedCapabilities.add('provider_identity_drift');
+  }
 
   const guarded = guardBareJsonEnvelope(response.text, { pathTag: 'verified-docs-replay' });
   const validated = validateOutput(guarded.text);
@@ -793,7 +873,10 @@ export async function executeVerifiedOfficialDocsReplay(
 
   const completion: VerifiedOfficialDocsReplayResult = {
     traceId: input.trace.traceId,
-    model: input.invocation.effectiveModel,
+    provider: target.provider,
+    model: target.model,
+    returnedProvider: execution.source === 'provider' ? execution.provider : null,
+    returnedModel: execution.source === 'provider' ? execution.model : null,
     executionPolicyVersion: OFFICIAL_DOCS_REPLAY_EXECUTION_POLICY_VERSION,
     completeFidelity,
     status: completeFidelity ? 'succeeded' : 'blocked',
@@ -813,7 +896,7 @@ export async function executeVerifiedOfficialDocsReplay(
       text: validated.sanitized,
       outputHmac,
       outputBytes,
-      generatorModel: input.invocation.effectiveModel,
+      generatorModel: target.model,
     }));
     return { ...completion, judgment };
   } catch {

--- a/server/tests/unit/addie/shadow-replay.test.ts
+++ b/server/tests/unit/addie/shadow-replay.test.ts
@@ -531,6 +531,114 @@ describe('verified official docs replay generation', () => {
     expect(JSON.stringify(result)).not.toContain(PRIVATE_SENTINEL);
   });
 
+  it('binds an alternate target to its exact prepared request without changing source parity', async () => {
+    const targetSnapshot = officialDocsSnapshot({
+      model: 'gemini-3.7-flash',
+      provider_request_sha256: 'f'.repeat(64),
+    });
+    const fakeClient = {
+      processMessage: vi.fn(async (
+        _question: string,
+        _history: unknown,
+        _requestTools: RequestTools,
+        _rules: unknown,
+        options: ProcessMessageOptions,
+      ) => {
+        expect(options.modelOverride).toBe('gemini-3.7-flash');
+        await options.onInvocationPrepared?.(targetSnapshot);
+        return generatedResponse({
+          model_execution: {
+            source: 'provider',
+            requested_provider: 'google',
+            requested_model: 'gemini-3.7-flash',
+            provider: 'google',
+            model: 'gemini-3.7-flash-20260801',
+            model_resolution: 'provider_canonicalized',
+            fallback_reason: null,
+          },
+        });
+      }),
+    };
+
+    const result = await executeVerifiedOfficialDocsReplay({
+      trace: officialDocsTrace(),
+      invocation: officialDocsInvocation(),
+      docsCorpusFingerprint: 'docs-fingerprint',
+      target: {
+        provider: 'google',
+        model: 'gemini-3.7-flash',
+        firstInvocation: targetSnapshot,
+      },
+    }, {
+      client: fakeClient as never,
+      getDocsFingerprint: () => 'docs-fingerprint',
+      renewLease: async () => true,
+      createKnowledgeHandlers: () => new Map([
+        ['search_docs', vi.fn()],
+        ['get_doc', vi.fn()],
+      ]),
+    });
+
+    expect(result).toMatchObject({
+      status: 'succeeded',
+      provider: 'google',
+      model: 'gemini-3.7-flash',
+      returnedProvider: 'google',
+      returnedModel: 'gemini-3.7-flash-20260801',
+      invocations: [{ provider_request_hmac: 'f'.repeat(64) }],
+    });
+    expect(result.invocations[0].provider_request_hmac).not.toBe(PROVIDER_HMAC);
+  });
+
+  it('blocks alternate dispatch when its prepared request drifts from preflight', async () => {
+    const expected = officialDocsSnapshot({
+      model: 'gemini-3.7-flash',
+      provider_request_sha256: 'f'.repeat(64),
+    });
+    const fakeClient = {
+      processMessage: vi.fn(async (
+        _question: string,
+        _history: unknown,
+        _requestTools: RequestTools,
+        _rules: unknown,
+        options: ProcessMessageOptions,
+      ) => {
+        await options.onInvocationPrepared?.({
+          ...expected,
+          provider_request_sha256: '9'.repeat(64),
+        });
+        return generatedResponse();
+      }),
+    };
+
+    await expect(executeVerifiedOfficialDocsReplay({
+      trace: officialDocsTrace(),
+      invocation: officialDocsInvocation(),
+      docsCorpusFingerprint: 'docs-fingerprint',
+      target: {
+        provider: 'google',
+        model: 'gemini-3.7-flash',
+        firstInvocation: expected,
+      },
+    }, {
+      client: fakeClient as never,
+      getDocsFingerprint: () => 'docs-fingerprint',
+      renewLease: async () => true,
+      createKnowledgeHandlers: () => new Map([
+        ['search_docs', vi.fn()],
+        ['get_doc', vi.fn()],
+      ]),
+    })).rejects.toMatchObject({
+      name: 'OfficialDocsReplayExecutionError',
+      completion: {
+        status: 'blocked',
+        reason: 'target_invocation_drift',
+        provider: 'google',
+        model: 'gemini-3.7-flash',
+      },
+    });
+  });
+
   it('blocks output rejected by the production security validator', async () => {
     const secret = `sk-${'a'.repeat(32)}`;
     const fakeClient = {

--- a/server/tests/unit/claude-client-replay-policy.test.ts
+++ b/server/tests/unit/claude-client-replay-policy.test.ts
@@ -840,6 +840,20 @@ describe('AddieClaudeClient isolated execution policy', () => {
     )).toThrow('must use the same provider');
   });
 
+  it('forks the registered tool surface into a server-tool-free isolated client', () => {
+    const source = new AddieClaudeClient('unused', 'source-model');
+    source.registerTool(tool('search_docs', 'pure_local'), vi.fn());
+    source.setWebSearchEnabled(true);
+    const provider = fakeProvider('google', 'candidate');
+
+    const fork = source.forkForIsolatedProvider('gemini-test', { provider });
+
+    expect(fork).not.toBe(source);
+    expect(fork.hasRegisteredTools(['search_docs'])).toBe(true);
+    expect(fork.isWebSearchEnabled()).toBe(false);
+    expect(source.isWebSearchEnabled()).toBe(true);
+  });
+
   it('keeps the large cacheable prompt block stable across routed domains', () => {
     const client = new AddieClaudeClient('unused', 'test-model');
     client.registerTool(tool('query_prospects', 'pure_local'), vi.fn().mockResolvedValue('prospects'));


### PR DESCRIPTION
## Summary

- let the verified official-docs replay executor bind an optional alternate provider/model to an exact preflight invocation snapshot
- preserve the existing signed Anthropic source-parity checks and diagnostic reasons when no alternate target is supplied
- require the actual first dispatch to match the candidate preflight snapshot, keep later invocations on the candidate model/tool boundary, and exclude provider-identity drift from successful evidence
- add a provider-isolated Addie client fork that copies registered definitions/handlers but forces provider-managed server tools off
- return requested and actual provider/model identity in the in-memory verified replay result

## Dormant boundary

- no scheduler or production call site supplies an alternate target
- no environment selector or activation flag is added
- no replay claim or database schema is changed
- no canary or production provider traffic is enabled
- no paid provider calls were made

This isolates execution semantics for review before a separate admission-and-ledger PR wires Google shadow selection.

## Verification

- focused replay/provider matrix: 6 files, 142 tests passed
- `npm run build:addie-tools`
- `npm run test:addie-tools`
- `npm run precommit`: 519 server files / 7,470 tests passed, plus root unit/lint gates and typecheck
- staged diff and confidentiality scans passed

Advances #6844 and #6846.