### PR TITLE
feat(addie): bind replay generation provenance

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.108';
+export const CODE_VERSION = '2026.08.109';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/jobs/shadow-replay-trace.ts
+++ b/server/src/addie/jobs/shadow-replay-trace.ts
@@ -3,7 +3,9 @@ import type { QueryResult, QueryResultRow } from 'pg';
 import { getClient, query } from '../../db/client.js';
 import { isUuid } from '../../utils/uuid.js';
 import type { InvocationPreparedSnapshot } from '../claude-client.js';
+import { CODE_VERSION } from '../config-version.js';
 import type { MemberContext } from '../member-context.js';
+import type { ModelProviderId } from '../model-providers/model-provider.js';
 import type { SIRetrievalResult } from '../services/si-retriever.js';
 import type { ThreadContext } from '../thread-service.js';
 import type { ChannelRespondPlan, ChannelResponseInvocation } from '../bolt-app.js';
@@ -158,6 +160,14 @@ export interface ShadowReplayGenerationCompletion {
   blockedCapabilities: string[];
   inputTokens: number;
   outputTokens: number;
+  returnedProvider?: ModelProviderId | null;
+  returnedModel?: string | null;
+}
+
+export interface ShadowReplayGenerationTarget {
+  provider: ModelProviderId;
+  model: string;
+  firstProviderRequestHmac: string;
 }
 
 export type ShadowReplayGenerationClaimDecision =
@@ -167,6 +177,11 @@ export type ShadowReplayGenerationClaimDecision =
   | 'trace_unavailable';
 
 export interface ShadowReplayGenerationSummaryRow extends QueryResultRow {
+  requested_provider: ModelProviderId;
+  requested_model: string;
+  addie_code_version: string;
+  returned_provider: ModelProviderId | null;
+  returned_model: string | null;
   status: string;
   reason: string;
   count: number;
@@ -1234,6 +1249,7 @@ const DETERMINISTIC_FAILURE_LABELS = new Set([
 function validateGenerationCompletion(
   trace: ResolvedShadowReplayTrace,
   outcome: ShadowReplayGenerationCompletion,
+  target: ShadowReplayGenerationTarget,
 ): void {
   if (!CATEGORICAL_REASON.test(outcome.reason)) {
     throw new Error('shadow_replay_generation_reason_invalid');
@@ -1269,10 +1285,9 @@ function validateGenerationCompletion(
   if (firstInvocation && (
     firstInvocation.iteration !== 1
     || firstInvocation.attempt !== 1
-    || !trace.expected.provider_request_hmac
     || !equalDigest(
       firstInvocation.provider_request_hmac,
-      trace.expected.provider_request_hmac,
+      target.firstProviderRequestHmac,
     )
   )) {
     throw new Error('shadow_replay_generation_first_invocation_mismatch');
@@ -1314,6 +1329,39 @@ function validateGenerationCompletion(
   )) {
     throw new Error('shadow_replay_generation_success_inconsistent');
   }
+  const returnedProvider = outcome.returnedProvider ?? null;
+  const returnedModel = outcome.returnedModel ?? null;
+  if ((returnedProvider === null) !== (returnedModel === null)
+    || (returnedProvider !== null && (
+      !isBoundedModel(returnedModel!)
+      || providerForModel(returnedModel!) !== returnedProvider
+    ))) {
+    throw new Error('shadow_replay_generation_returned_model_invalid');
+  }
+}
+
+function isBoundedModel(model: string): boolean {
+  return model.length > 0
+    && model.length <= 160
+    && !/[\u0000-\u001f\u007f]/.test(model);
+}
+
+function resolveGenerationTarget(
+  trace: ResolvedShadowReplayTrace,
+  target?: ShadowReplayGenerationTarget,
+): ShadowReplayGenerationTarget | null {
+  const resolved = target ?? {
+    provider: providerForModel(trace.expected.effective_model),
+    model: trace.expected.effective_model,
+    firstProviderRequestHmac: trace.expected.provider_request_hmac ?? '',
+  };
+  if (!['anthropic', 'openai', 'google'].includes(resolved.provider)
+    || !isBoundedModel(resolved.model)
+    || providerForModel(resolved.model) !== resolved.provider
+    || !HMAC.test(resolved.firstProviderRequestHmac)) {
+    return null;
+  }
+  return resolved as ShadowReplayGenerationTarget;
 }
 
 function validateJudgmentCompletion(
@@ -1321,6 +1369,7 @@ function validateJudgmentCompletion(
   outcome: ShadowReplayGenerationCompletion,
   judgment: ShadowReplayJudgmentCompletion,
   persistedAt: Date,
+  generatorModel: string,
 ): void {
   if (outcome.status !== 'succeeded' || !outcome.outputHmac) {
     throw new Error('shadow_replay_judgment_generation_incomplete');
@@ -1417,7 +1466,7 @@ function validateJudgmentCompletion(
       || judgment.judgeModel.length > 160
       || /[\u0000-\u001f\u007f]/.test(judgment.judgeModel)
       || judgment.judgeProvider !== providerForModel(judgment.judgeModel)
-      || judgment.selfJudged !== (judgment.judgeModel === trace.expected.effective_model)
+      || judgment.selfJudged !== (judgment.judgeModel === generatorModel)
       || !judgment.judgePromptVersion
       || !BOUNDED_VERSION.test(judgment.judgePromptVersion)
       || !judgment.judgePromptHmac
@@ -1486,13 +1535,19 @@ function validateJudgmentCompletion(
 export async function claimShadowReplayGeneration(
   trace: ResolvedShadowReplayTrace,
   dailyLimit: number,
-  dependencies: { query?: QueryFn; now?: Date } = {},
+  dependencies: {
+    query?: QueryFn;
+    now?: Date;
+    target?: ShadowReplayGenerationTarget;
+  } = {},
 ): Promise<ShadowReplayGenerationClaimDecision> {
   const runQuery = dependencies.query ?? query as QueryFn;
   const now = dependencies.now ?? new Date();
   if (!Number.isSafeInteger(dailyLimit) || dailyLimit < 1 || dailyLimit > 100) {
     return 'trace_unavailable';
   }
+  const target = resolveGenerationTarget(trace, dependencies.target);
+  if (!target) return 'trace_unavailable';
   const boundedLimit = dailyLimit;
   const result = await runQuery<{ decision: ShadowReplayGenerationClaimDecision }>(
     `WITH eligible AS MATERIALIZED (
@@ -1511,13 +1566,14 @@ export async function claimShadowReplayGeneration(
          AND trace.provider_request_hmac IS NOT NULL
      ), inserted AS (
        INSERT INTO addie_shadow_replay_generations (
-         trace_id, execution_policy_version, model,
+         trace_id, execution_policy_version, requested_provider, model,
+         addie_code_version,
          quota_date, quota_slot, first_provider_request_hmac,
          started_at, heartbeat_at, retained_until
        )
-       SELECT eligible.trace_id, $8, $7,
+       SELECT eligible.trace_id, $8, $11, $12, $14,
               ($9::timestamptz AT TIME ZONE 'UTC')::date, slot,
-              eligible.provider_request_hmac, $9, $9, eligible.retained_until
+              $13, $9, $9, eligible.retained_until
        FROM eligible
        CROSS JOIN LATERAL generate_series(1, $10::integer) AS slot
        ORDER BY slot
@@ -1550,6 +1606,10 @@ export async function claimShadowReplayGeneration(
       SHADOW_REPLAY_POLICY_VERSION,
       now,
       boundedLimit,
+      target.provider,
+      target.model,
+      target.firstProviderRequestHmac,
+      CODE_VERSION,
     ],
   );
   const decision = result.rows[0]?.decision ?? 'trace_unavailable';
@@ -1608,13 +1668,18 @@ export async function completeShadowReplayGeneration(
     judgment?: ShadowReplayJudgmentCompletion | null;
     query?: QueryFn;
     now?: Date;
+    target?: ShadowReplayGenerationTarget;
   } = {},
 ): Promise<boolean> {
-  validateGenerationCompletion(trace, outcome);
+  const target = resolveGenerationTarget(trace, dependencies.target);
+  if (!target) throw new Error('shadow_replay_generation_target_invalid');
+  validateGenerationCompletion(trace, outcome, target);
   const runQuery = dependencies.query ?? query as QueryFn;
   const completedAt = dependencies.now ?? new Date();
   const judgment = dependencies.judgment ?? null;
-  if (judgment) validateJudgmentCompletion(trace, outcome, judgment, completedAt);
+  if (judgment) {
+    validateJudgmentCompletion(trace, outcome, judgment, completedAt, target.model);
+  }
   const captureStatus = outcome.status === 'succeeded'
     ? 'verified'
     : outcome.status === 'blocked'
@@ -1646,9 +1711,14 @@ export async function completeShadowReplayGeneration(
            blocked_capabilities = $9::jsonb,
            input_tokens = $10,
            output_tokens = $11,
+           returned_provider = $46,
+           returned_model = $47,
            completed_at = $12
        WHERE generation.trace_id = $1
          AND generation.status = 'running'
+         AND generation.requested_provider = $43
+         AND generation.model = $44
+         AND generation.first_provider_request_hmac = $45
          AND EXISTS (
            SELECT 1 FROM addie_shadow_replay_traces trace
            WHERE trace.trace_id = generation.trace_id
@@ -1742,6 +1812,11 @@ export async function completeShadowReplayGeneration(
       judgment?.startedAt ?? null,
       judgment?.completedAt ?? null,
       trace.expected.retained_until,
+      target.provider,
+      target.model,
+      target.firstProviderRequestHmac,
+      outcome.returnedProvider ?? null,
+      outcome.returnedModel ?? null,
     ],
   );
   return result.rows[0]?.completed === true;
@@ -1834,7 +1909,12 @@ export async function getShadowReplayGenerationSummary(
   const runQuery = dependencies.query ?? query as QueryFn;
   const boundedDays = Math.max(1, Math.min(7, Math.trunc(days)));
   const result = await runQuery<ShadowReplayGenerationSummaryRow>(
-    `SELECT generation.status,
+    `SELECT generation.requested_provider,
+            generation.model AS requested_model,
+            generation.addie_code_version,
+            generation.returned_provider,
+            generation.returned_model,
+            generation.status,
             generation.reason,
             COUNT(*)::integer AS count,
             COALESCE(SUM(generation.input_tokens), 0)::integer AS input_tokens,
@@ -1843,8 +1923,11 @@ export async function getShadowReplayGenerationSummary(
      JOIN addie_shadow_replay_traces trace ON trace.trace_id = generation.trace_id
      WHERE generation.started_at >= NOW() - ($2::integer * INTERVAL '1 day')
        AND trace.capture_version = $1
-     GROUP BY generation.status, generation.reason
-     ORDER BY generation.status, generation.reason`,
+     GROUP BY generation.requested_provider, generation.model,
+              generation.addie_code_version, generation.returned_provider,
+              generation.returned_model, generation.status, generation.reason
+     ORDER BY generation.requested_provider, generation.model,
+              generation.status, generation.reason`,
     [SHADOW_REPLAY_TRACE_CAPTURE_VERSION, boundedDays],
   );
   return result.rows;

--- a/server/src/db/migrations/567_shadow_replay_generation_provenance.sql
+++ b/server/src/db/migrations/567_shadow_replay_generation_provenance.sql
@@ -1,0 +1,40 @@
+-- Bind every replay generation to immutable requested/returned model metadata.
+-- Existing rows predate exact code-version capture and are labelled explicitly.
+
+ALTER TABLE addie_shadow_replay_generations
+  ADD COLUMN requested_provider VARCHAR(16) NOT NULL DEFAULT 'unknown',
+  ADD COLUMN addie_code_version VARCHAR(64) NOT NULL DEFAULT 'legacy-unrecorded',
+  ADD COLUMN returned_provider VARCHAR(16),
+  ADD COLUMN returned_model VARCHAR(160);
+
+UPDATE addie_shadow_replay_generations
+SET requested_provider = CASE
+      WHEN model LIKE 'claude-%' THEN 'anthropic'
+      WHEN model ~ '^(gpt-|o[0-9])' THEN 'openai'
+      WHEN model LIKE 'gemini-%' THEN 'google'
+      ELSE 'unknown'
+    END,
+    addie_code_version = 'legacy-unrecorded';
+
+ALTER TABLE addie_shadow_replay_generations
+  ADD CONSTRAINT shadow_replay_generation_requested_provider_valid
+    CHECK (requested_provider IN ('anthropic', 'openai', 'google', 'unknown')),
+  ADD CONSTRAINT shadow_replay_generation_code_version_valid
+    CHECK (addie_code_version ~ '^[a-zA-Z0-9._:-]{1,64}$'),
+  ADD CONSTRAINT shadow_replay_generation_returned_provider_valid
+    CHECK (returned_provider IS NULL OR returned_provider IN ('anthropic', 'openai', 'google')),
+  ADD CONSTRAINT shadow_replay_generation_returned_model_valid
+    CHECK (returned_model IS NULL OR length(returned_model) > 0),
+  ADD CONSTRAINT shadow_replay_generation_returned_model_all_or_none
+    CHECK ((returned_provider IS NULL) = (returned_model IS NULL));
+
+COMMENT ON COLUMN addie_shadow_replay_generations.requested_provider IS
+  'Provider atomically claimed before the first replay SDK dispatch';
+COMMENT ON COLUMN addie_shadow_replay_generations.model IS
+  'Exact model atomically claimed before the first replay SDK dispatch';
+COMMENT ON COLUMN addie_shadow_replay_generations.addie_code_version IS
+  'Addie code/config version active when the replay generation was claimed';
+COMMENT ON COLUMN addie_shadow_replay_generations.returned_provider IS
+  'Provider identity returned by the SDK, null when no provider response exists';
+COMMENT ON COLUMN addie_shadow_replay_generations.returned_model IS
+  'Canonicalized model identity returned by the SDK, null with returned_provider';

--- a/server/tests/integration/shadow-replay-trace-migration.test.ts
+++ b/server/tests/integration/shadow-replay-trace-migration.test.ts
@@ -5,6 +5,7 @@ import type { Pool } from 'pg';
 import { closeDatabase, initializeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
 import { claimShadowReplayGeneration } from '../../src/addie/jobs/shadow-replay-trace.js';
+import { CODE_VERSION } from '../../src/addie/config-version.js';
 
 const EXTERNAL_ID = 'shadow-replay-migration-test:1000.0001';
 const CORRECTED_EXTERNAL_ID = 'shadow-replay-migration-test:1000.0002';
@@ -24,7 +25,7 @@ const MIGRATION_556_SQL = readFileSync(
   'utf8',
 );
 
-describe('migrations 552, 554, 555, and 556: shadow replay traces', () => {
+describe('migrations 552 through 567: shadow replay traces', () => {
   let pool: Pool;
 
   beforeAll(async () => {
@@ -218,7 +219,11 @@ describe('migrations 552, 554, 555, and 556: shadow replay traces', () => {
         'execution_policy_version',
         'status',
         'reason',
+        'requested_provider',
         'model',
+        'addie_code_version',
+        'returned_provider',
+        'returned_model',
         'quota_date',
         'quota_slot',
         'first_provider_request_hmac',
@@ -246,6 +251,12 @@ describe('migrations 552, 554, 555, and 556: shadow replay traces', () => {
       definition.includes('jsonb_array_length(tool_executions) <= 8'))).toBe(true);
     expect(generationConstraints.rows.some(({ definition }) =>
       definition.includes('UNIQUE (quota_date, quota_slot)'))).toBe(true);
+    expect(generationConstraints.rows.some(({ definition }) =>
+      definition.includes("requested_provider")
+      && definition.includes("'unknown'"))).toBe(true);
+    expect(generationConstraints.rows.some(({ definition }) =>
+      definition.includes('(returned_provider IS NULL)')
+      && definition.includes('(returned_model IS NULL)'))).toBe(true);
 
     const judgmentColumns = await pool.query<{ column_name: string }>(
       `SELECT column_name
@@ -497,14 +508,21 @@ describe('migrations 552, 554, 555, and 556: shadow replay traces', () => {
         provider_request_hmac: '3'.repeat(64),
       },
     } as never;
+    const target = {
+      provider: 'google' as const,
+      model: 'gemini-3.7-flash',
+      firstProviderRequestHmac: '9'.repeat(64),
+    };
     const sameTraceDecisions = await Promise.all([
       claimShadowReplayGeneration(sameTraceAuthorization, 1, {
         query: sameTraceQuery as never,
         now,
+        target,
       }),
       claimShadowReplayGeneration(sameTraceAuthorization, 1, {
         query: sameTraceQuery as never,
         now,
+        target,
       }),
     ]);
     expect(sameTraceDecisions.sort()).toEqual(['already_claimed', 'claimed']);
@@ -513,5 +531,23 @@ describe('migrations 552, 554, 555, and 556: shadow replay traces', () => {
       [sameTrace.traceId],
     );
     expect(traceStatus.rows[0].capture_status).toBe('pending');
+    const generation = await pool.query<{
+      requested_provider: string;
+      model: string;
+      addie_code_version: string;
+      first_provider_request_hmac: string;
+    }>(
+      `SELECT requested_provider, model, addie_code_version,
+              first_provider_request_hmac
+       FROM addie_shadow_replay_generations
+       WHERE trace_id = $1`,
+      [sameTrace.traceId],
+    );
+    expect(generation.rows[0]).toEqual({
+      requested_provider: target.provider,
+      model: target.model,
+      addie_code_version: CODE_VERSION,
+      first_provider_request_hmac: target.firstProviderRequestHmac,
+    });
   });
 });

--- a/server/tests/unit/addie/shadow-replay-trace.test.ts
+++ b/server/tests/unit/addie/shadow-replay-trace.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { InvocationPreparedSnapshot } from '../../../src/addie/claude-client.js';
+import { CODE_VERSION } from '../../../src/addie/config-version.js';
 import {
   beginShadowReplayCaptureAttempt,
   claimShadowReplayGeneration,
@@ -605,7 +606,36 @@ describe('shadow replay trace authorization', () => {
     expect(runQuery.mock.calls[0][0]).toContain('parity_marked AS');
     expect(runQuery.mock.calls[0][0]).toContain('SET capture_parity_verified = TRUE');
     expect(runQuery.mock.calls[0][1][9]).toBe(100);
+    expect(runQuery.mock.calls[0][1].slice(10, 14)).toEqual([
+      'anthropic',
+      trace.expected.effective_model,
+      trace.expected.provider_request_hmac,
+      CODE_VERSION,
+    ]);
     expect(JSON.stringify(runQuery.mock.calls)).not.toContain(QUESTION);
+  });
+
+  it('atomically claims an explicit alternate-provider target', async () => {
+    const { trace } = await authorizedTrace();
+    const target = {
+      provider: 'google' as const,
+      model: 'gemini-3.7-flash',
+      firstProviderRequestHmac: '9'.repeat(64),
+    };
+    const runQuery = vi.fn(async () => ({ rows: [{ decision: 'claimed' }], rowCount: 1 }));
+    await expect(claimShadowReplayGeneration(trace, 1, {
+      query: runQuery as never,
+      now: NOW,
+      target,
+    })).resolves.toBe('claimed');
+    expect(runQuery.mock.calls[0][0]).toContain('requested_provider, model');
+    expect(runQuery.mock.calls[0][0]).toContain('addie_code_version');
+    expect(runQuery.mock.calls[0][1].slice(10, 14)).toEqual([
+      target.provider,
+      target.model,
+      target.firstProviderRequestHmac,
+      CODE_VERSION,
+    ]);
   });
 
   it('fails closed before SQL when the generation quota is not bounded', async () => {
@@ -618,6 +648,21 @@ describe('shadow replay trace authorization', () => {
     await expect(claimShadowReplayGeneration(trace, 101, {
       query: runQuery as never,
       now: NOW,
+    })).resolves.toBe('trace_unavailable');
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
+  it('fails closed before SQL for an inconsistent provider target', async () => {
+    const { trace } = await authorizedTrace();
+    const runQuery = vi.fn();
+    await expect(claimShadowReplayGeneration(trace, 1, {
+      query: runQuery as never,
+      now: NOW,
+      target: {
+        provider: 'openai',
+        model: 'gemini-3.7-flash',
+        firstProviderRequestHmac: '9'.repeat(64),
+      },
     })).resolves.toBe('trace_unavailable');
     expect(runQuery).not.toHaveBeenCalled();
   });
@@ -650,6 +695,11 @@ describe('shadow replay trace authorization', () => {
   it('atomically completes a hash-only generation and its trace outcome', async () => {
     const { trace } = await authorizedTrace();
     const runQuery = vi.fn(async () => ({ rows: [{ completed: true }], rowCount: 1 }));
+    const target = {
+      provider: 'google' as const,
+      model: 'gemini-3.7-flash',
+      firstProviderRequestHmac: '9'.repeat(64),
+    };
     const outcome = {
       status: 'succeeded' as const,
       reason: 'generation_succeeded',
@@ -658,7 +708,7 @@ describe('shadow replay trace authorization', () => {
       invocations: [{
         iteration: 1,
         attempt: 1,
-        provider_request_hmac: trace.expected.provider_request_hmac!,
+        provider_request_hmac: target.firstProviderRequestHmac,
       }],
       toolExecutions: [{
         sequence: 1,
@@ -671,10 +721,13 @@ describe('shadow replay trace authorization', () => {
       blockedCapabilities: [],
       inputTokens: 20,
       outputTokens: 10,
+      returnedProvider: 'google' as const,
+      returnedModel: 'gemini-3.7-flash-20260801',
     };
     await expect(completeShadowReplayGeneration(trace, outcome, {
       query: runQuery as never,
       now: NOW,
+      target,
     })).resolves.toBe(true);
     expect(runQuery.mock.calls[0][0]).toContain("generation.status = 'running'");
     expect(runQuery.mock.calls[0][0]).toContain("trace.capture_status = 'pending'");
@@ -683,6 +736,13 @@ describe('shadow replay trace authorization', () => {
       shadow_eval_capture_parity_verified: true,
       shadow_eval_replay_generation_status: 'succeeded',
     });
+    expect(runQuery.mock.calls[0][1].slice(42, 47)).toEqual([
+      target.provider,
+      target.model,
+      target.firstProviderRequestHmac,
+      outcome.returnedProvider,
+      outcome.returnedModel,
+    ]);
     expect(JSON.stringify(runQuery.mock.calls)).not.toContain(QUESTION);
   });
 
@@ -938,6 +998,27 @@ describe('shadow replay trace authorization', () => {
     expect(runQuery).not.toHaveBeenCalled();
   });
 
+  it('rejects incomplete returned provider metadata before persistence', async () => {
+    const { trace } = await authorizedTrace();
+    const runQuery = vi.fn();
+    await expect(completeShadowReplayGeneration(trace, {
+      status: 'blocked',
+      reason: 'provider_identity_drift',
+      outputHmac: null,
+      outputBytes: 0,
+      invocations: [],
+      toolExecutions: [],
+      blockedCapabilities: ['provider_identity_drift'],
+      inputTokens: 0,
+      outputTokens: 0,
+      returnedProvider: 'google',
+      returnedModel: null,
+    }, { query: runQuery as never })).rejects.toThrow(
+      'shadow_replay_generation_returned_model_invalid',
+    );
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
   it('persists a pre-provider boundary outcome with no invocation evidence', async () => {
     const { trace } = await authorizedTrace();
     const runQuery = vi.fn(async () => ({ rows: [{ completed: true }], rowCount: 1 }));
@@ -1047,6 +1128,11 @@ describe('shadow replay trace authorization', () => {
 
   it('reports only categorical generation outcomes and token totals', async () => {
     const rows = [{
+      requested_provider: 'google',
+      requested_model: 'gemini-3.7-flash',
+      addie_code_version: '2026.08.109',
+      returned_provider: 'google',
+      returned_model: 'gemini-3.7-flash-20260801',
       status: 'succeeded',
       reason: 'replay_generation_succeeded',
       count: 2,
@@ -1057,6 +1143,8 @@ describe('shadow replay trace authorization', () => {
     await expect(getShadowReplayGenerationSummary(999, { query: runQuery as never }))
       .resolves.toEqual(rows);
     expect(runQuery.mock.calls[0][1]).toEqual([3, 7]);
+    expect(runQuery.mock.calls[0][0]).toContain('generation.requested_provider');
+    expect(runQuery.mock.calls[0][0]).toContain('generation.addie_code_version');
     expect(runQuery.mock.calls[0][0]).not.toContain('question_hmac');
   });
 


### PR DESCRIPTION
## Summary

- atomically bind every shadow replay generation claim to requested provider, model, first-request digest, execution policy, and Addie code version
- persist the provider and canonical model identity actually returned by the SDK
- make completion fail closed unless it matches the exact claimed provider/model/request tuple
- expose provider/model/config dimensions in the categorical generation summary
- retain rolling-deploy compatibility through explicit legacy defaults for older workers

This is a dormant persistence seam. It does not add a scheduler selector, enable a canary, change production routing, or make a model call.

## Verification

- focused trace/judge unit suite: 49 tests passed
- expanded shadow replay suite: 132 tests passed
- staged precommit: 519 files, 7,473 tests passed, 30 skipped
- TypeScript typecheck passed
- Addie tool inventory build/check passed
- migrations 555 and 567 applied successfully in a transaction-only PostgreSQL schema and rolled back
- full integration migration test could not start locally because the shared test database contains a pre-existing migration-533 filename mismatch; CI's clean database remains authoritative

No changeset: Addie runtime/database implementation only; no protocol release surface changed.

Related: #6844, #6846
