### PR TITLE
feat(addie): gate Google shadow responses

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.109';
+export const CODE_VERSION = '2026.08.110';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/jobs/shadow-evaluator.ts
+++ b/server/src/addie/jobs/shadow-evaluator.ts
@@ -36,6 +36,7 @@ import {
   recoverStaleShadowReplayGenerations,
   renewShadowReplayGenerationLease,
   resolveShadowReplayTrace,
+  type ShadowReplayGenerationTarget,
   verifyShadowReplayTraceContext,
 } from './shadow-replay-trace.js';
 import {
@@ -48,6 +49,8 @@ import {
   OfficialDocsReplayBoundaryError,
   OfficialDocsReplayExecutionError,
   OfficialDocsReplayOutputConsumerError,
+  prepareVerifiedOfficialDocsReplayTarget,
+  type VerifiedOfficialDocsReplayTarget,
 } from './shadow-replay.js';
 import {
   createShadowReplayInternalErrorEvidence,
@@ -62,6 +65,10 @@ import {
   resolveShadowJudgeModel,
   type ShadowEvalType,
 } from './shadow-eval-metadata.js';
+import {
+  createGoogleShadowReplayProvider,
+  selectShadowReplayTarget,
+} from './shadow-replay-target.js';
 
 const logger = createLogger('shadow-evaluator');
 
@@ -422,6 +429,9 @@ export async function runShadowEvaluatorJob(
     getChannel?: typeof buildChannelContext;
     buildInvocation?: typeof buildChannelResponseInvocation;
     selectReplayActivation?: typeof selectOfficialDocsReplayActivation;
+    selectReplayTarget?: typeof selectShadowReplayTarget;
+    createGoogleProvider?: typeof createGoogleShadowReplayProvider;
+    prepareReplayTarget?: typeof prepareVerifiedOfficialDocsReplayTarget;
     selectJudgeActivation?: typeof selectOfficialDocsJudgeActivation;
     claimGeneration?: typeof claimShadowReplayGeneration;
     executeReplay?: typeof executeVerifiedOfficialDocsReplay;
@@ -577,6 +587,54 @@ export async function runShadowEvaluatorJob(
         continue;
       }
 
+      const targetSelection = (
+        dependencies.selectReplayTarget ?? selectShadowReplayTarget
+      )();
+      if (targetSelection.mode === 'blocked') {
+        await finishCapture(capture, 'verified', `replay_${targetSelection.reason}`, {
+          parityVerified: true,
+        });
+        result.skipped++;
+        continue;
+      }
+
+      let replayClient = client;
+      let replayTarget: VerifiedOfficialDocsReplayTarget | undefined;
+      let generationTarget: ShadowReplayGenerationTarget | undefined;
+      if (targetSelection.mode === 'alternate') {
+        const provider = (
+          dependencies.createGoogleProvider ?? createGoogleShadowReplayProvider
+        )();
+        if (!provider || provider.id !== targetSelection.provider) {
+          await finishCapture(capture, 'verified', 'replay_google_provider_unavailable', {
+            parityVerified: true,
+          });
+          result.skipped++;
+          continue;
+        }
+        try {
+          replayClient = client.forkForIsolatedProvider(targetSelection.model, { provider });
+          replayTarget = (
+            dependencies.prepareReplayTarget ?? prepareVerifiedOfficialDocsReplayTarget
+          )({
+            trace: authorization.trace,
+            invocation,
+            docsCorpusFingerprint,
+          }, targetSelection, replayClient);
+          generationTarget = {
+            provider: replayTarget.provider,
+            model: replayTarget.model,
+            firstProviderRequestHmac: replayTarget.firstInvocation.provider_request_sha256,
+          };
+        } catch {
+          await finishCapture(capture, 'verified', 'replay_google_target_unavailable', {
+            parityVerified: true,
+          });
+          result.skipped++;
+          continue;
+        }
+      }
+
       const judgeActivation = (
         dependencies.selectJudgeActivation ?? selectOfficialDocsJudgeActivation
       )({
@@ -602,9 +660,12 @@ export async function runShadowEvaluatorJob(
             continue;
           }
           try {
+            const excludedJudgeModels = replayTarget
+              ? [invocation.effectiveModel, replayTarget.model]
+              : [invocation.effectiveModel];
             judgeModel = (
               dependencies.resolveJudgeModel ?? resolveShadowJudgeModel
-            )([invocation.effectiveModel]);
+            )([...new Set(excludedJudgeModels)]);
           } catch {
             await finishCapture(capture, 'skipped', 'judge_model_unavailable', {
               parityVerified: true,
@@ -612,7 +673,7 @@ export async function runShadowEvaluatorJob(
             result.skipped++;
             continue;
           }
-          if (judgeModel === invocation.effectiveModel) {
+          if (judgeModel === invocation.effectiveModel || judgeModel === replayTarget?.model) {
             await finishCapture(capture, 'skipped', 'judge_model_not_independent', {
               parityVerified: true,
             });
@@ -630,9 +691,12 @@ export async function runShadowEvaluatorJob(
         }
       }
 
-      const claim = await (
-        dependencies.claimGeneration ?? claimShadowReplayGeneration
-      )(authorization.trace, activation.dailyLimit);
+      const claimGeneration = dependencies.claimGeneration ?? claimShadowReplayGeneration;
+      const claim = generationTarget
+        ? await claimGeneration(authorization.trace, activation.dailyLimit, {
+          target: generationTarget,
+        })
+        : await claimGeneration(authorization.trace, activation.dailyLimit);
       if (claim === 'already_claimed') {
         // Another worker owns this exact trace. It alone may complete the
         // generation ledger; this worker must not call either model.
@@ -667,15 +731,17 @@ export async function runShadowEvaluatorJob(
           client: judgeClient ?? undefined,
           renewLease,
         });
-        const generation = await (
-          dependencies.executeReplay ?? executeVerifiedOfficialDocsReplay
-        )({
+        const executeReplay = dependencies.executeReplay ?? executeVerifiedOfficialDocsReplay;
+        const replayInput = {
           trace: authorization.trace,
           invocation,
           docsCorpusFingerprint,
-        }, {
+          ...(replayTarget ? { target: replayTarget } : {}),
+        };
+        const generation = await executeReplay(replayInput, {
           renewLease,
           outputConsumer,
+          ...(replayTarget ? { client: replayClient } : {}),
         });
         const completeGeneration = dependencies.completeGeneration
           ?? completeShadowReplayGeneration;
@@ -685,13 +751,20 @@ export async function runShadowEvaluatorJob(
             generation.outputHmac!,
           )
           : generation.judgment;
+        const targetDependency = generationTarget ? { target: generationTarget } : {};
         const completed = judgment
           ? await completeGeneration(
             authorization.trace,
             generation,
-            { judgment },
+            { judgment, ...targetDependency },
           )
-          : await completeGeneration(authorization.trace, generation);
+          : generationTarget
+            ? await completeGeneration(
+              authorization.trace,
+              generation,
+              targetDependency,
+            )
+            : await completeGeneration(authorization.trace, generation);
         if (!completed) {
           logger.warn('Shadow evaluator: Claimed replay generation was not completed');
           result.errors++;
@@ -737,9 +810,20 @@ export async function runShadowEvaluatorJob(
               safeGeneration.outputHmac,
             )
             : null;
+          const targetDependency = generationTarget ? { target: generationTarget } : {};
           completed = judgment
-            ? await completeGeneration(authorization.trace, terminal, { judgment })
-            : await completeGeneration(authorization.trace, terminal);
+            ? await completeGeneration(
+              authorization.trace,
+              terminal,
+              { judgment, ...targetDependency },
+            )
+            : generationTarget
+              ? await completeGeneration(
+                authorization.trace,
+                terminal,
+                targetDependency,
+              )
+              : await completeGeneration(authorization.trace, terminal);
         } catch {
           // Keep the one-attempt row running. Stale recovery will close it;
           // never fall through to mutable capture completion after a claim.

--- a/server/src/addie/jobs/shadow-replay-judge.ts
+++ b/server/src/addie/jobs/shadow-replay-judge.ts
@@ -402,7 +402,7 @@ export async function executeIndependentShadowReplayJudge(
     ...baseWithoutRequest,
     judgeProvider: 'anthropic',
     judgeModel: input.judgeModel,
-    selfJudged: input.judgeModel === input.trace.expected.effective_model,
+    selfJudged: input.judgeModel === input.generatorModel,
     judgePromptVersion: SHADOW_REPLAY_JUDGE_PROMPT_VERSION,
     judgeRequestHmac: requestHmac,
     judgePromptHmac: promptHmac,

--- a/server/src/addie/jobs/shadow-replay-target.ts
+++ b/server/src/addie/jobs/shadow-replay-target.ts
@@ -1,0 +1,62 @@
+import {
+  GOOGLE_ROUTER_MODEL,
+  GoogleGenerateContentProvider,
+} from '../model-providers/google-generate-content-provider.js';
+
+interface ShadowReplayTargetEnvironment {
+  SHADOW_EVAL_FULL_RESPONSE_GOOGLE_ENABLED?: string;
+  SHADOW_EVAL_FULL_RESPONSE_GOOGLE_PRODUCTION_DATA_APPROVED?: string;
+  SHADOW_EVAL_FULL_RESPONSE_GOOGLE_MODEL?: string;
+  GEMINI_API_KEY?: string;
+}
+
+export type ShadowReplayTargetSelection =
+  | { mode: 'source'; reason: 'google_disabled' }
+  | {
+      mode: 'blocked';
+      reason:
+        | 'google_production_data_not_approved'
+        | 'google_model_invalid'
+        | 'google_credentials_unavailable';
+    }
+  | {
+      mode: 'alternate';
+      reason: 'google_enabled';
+      provider: 'google';
+      model: typeof GOOGLE_ROUTER_MODEL;
+    };
+
+/**
+ * Alternate full-response replay is independently default-off. A partially
+ * enabled target blocks rather than falling back to the source provider and
+ * contaminating the requested-provider cohort.
+ */
+export function selectShadowReplayTarget(
+  env: ShadowReplayTargetEnvironment = process.env,
+): ShadowReplayTargetSelection {
+  if (env.SHADOW_EVAL_FULL_RESPONSE_GOOGLE_ENABLED !== 'true') {
+    return { mode: 'source', reason: 'google_disabled' };
+  }
+  if (env.SHADOW_EVAL_FULL_RESPONSE_GOOGLE_PRODUCTION_DATA_APPROVED !== 'true') {
+    return { mode: 'blocked', reason: 'google_production_data_not_approved' };
+  }
+  if (env.SHADOW_EVAL_FULL_RESPONSE_GOOGLE_MODEL?.trim() !== GOOGLE_ROUTER_MODEL) {
+    return { mode: 'blocked', reason: 'google_model_invalid' };
+  }
+  if (!env.GEMINI_API_KEY?.trim()) {
+    return { mode: 'blocked', reason: 'google_credentials_unavailable' };
+  }
+  return {
+    mode: 'alternate',
+    reason: 'google_enabled',
+    provider: 'google',
+    model: GOOGLE_ROUTER_MODEL,
+  };
+}
+
+export function createGoogleShadowReplayProvider(
+  env: ShadowReplayTargetEnvironment = process.env,
+): GoogleGenerateContentProvider | null {
+  const apiKey = env.GEMINI_API_KEY?.trim();
+  return apiKey ? new GoogleGenerateContentProvider(apiKey) : null;
+}

--- a/server/src/addie/jobs/shadow-replay.ts
+++ b/server/src/addie/jobs/shadow-replay.ts
@@ -89,7 +89,7 @@ export interface VerifiedOfficialDocsReplayInput {
   docsCorpusFingerprint: string;
   /**
    * Optional alternate-provider target prepared from this same verified
-   * invocation. No production call site supplies one yet.
+   * invocation. Only the default-off shadow target admission may supply it.
    */
   target?: VerifiedOfficialDocsReplayTarget;
 }
@@ -148,6 +148,37 @@ export class OfficialDocsReplayOutputConsumerError extends Error {
     super('replay_output_consumer_failed');
     this.name = 'OfficialDocsReplayOutputConsumerError';
   }
+}
+
+/** Prepare the exact alternate-provider request that will later be dispatched. */
+export function prepareVerifiedOfficialDocsReplayTarget(
+  input: Omit<VerifiedOfficialDocsReplayInput, 'target'>,
+  target: Pick<VerifiedOfficialDocsReplayTarget, 'provider' | 'model'>,
+  client: NonNullable<ReturnType<typeof getChannelClaudeClient>>,
+): VerifiedOfficialDocsReplayTarget {
+  assertOfficialDocsReplayPreflight(input);
+  const prepared = {
+    ...target,
+    firstInvocation: client.prepareMessageInvocation(
+      input.trace.question,
+      undefined,
+      input.invocation.requestTools,
+      undefined,
+      {
+        ...input.invocation.processOptions,
+        executionMode: 'replay',
+        disableServerTools: true,
+        allowedToolNames: OFFICIAL_DOCS_ALLOWED_TOOLS,
+        maxIterations: 4,
+        invocationHashKey: input.trace.identity.hashKey,
+        invocationHashDomain: input.trace.identity.hashDomain,
+        uncapped: true,
+        modelOverride: target.model,
+      },
+    ),
+  };
+  assertTargetFirstInvocation(prepared);
+  return prepared;
 }
 
 function canonicalJson(value: unknown): string {

--- a/server/tests/unit/addie/shadow-evaluator-capture.test.ts
+++ b/server/tests/unit/addie/shadow-evaluator-capture.test.ts
@@ -76,6 +76,13 @@ function baseDependencies() {
   const getMember = vi.fn().mockResolvedValue({ slackUserId: 'U_TEST' });
   const getChannel = vi.fn().mockResolvedValue({ viewing_channel_is_private: false });
   const resolveTrace = vi.fn().mockResolvedValue(authorizedTrace());
+  const forkForIsolatedProvider = vi.fn();
+  const sourceClient = {
+    prepareMessageInvocation,
+    isWebSearchEnabled: () => true,
+    processMessage: providerCall,
+    forkForIsolatedProvider,
+  };
   return {
     providerCall,
     judgeCall,
@@ -83,17 +90,15 @@ function baseDependencies() {
     getMember,
     getChannel,
     resolveTrace,
+    sourceClient,
+    forkForIsolatedProvider,
     dependencies: {
       purgeTraces: vi.fn().mockResolvedValue(0),
       recoverGenerations: vi.fn().mockResolvedValue(0),
       listPending: vi.fn().mockResolvedValue([capture]),
       resolveTrace,
       completeCapture,
-      getClient: vi.fn().mockReturnValue({
-        prepareMessageInvocation,
-        isWebSearchEnabled: () => true,
-        processMessage: providerCall,
-      }),
+      getClient: vi.fn().mockReturnValue(sourceClient),
       getDocsFingerprint: vi.fn().mockReturnValue('docs-fingerprint'),
       getConfigVersionId: vi.fn().mockResolvedValue(42),
       getMember,
@@ -114,6 +119,12 @@ function baseDependencies() {
         reason: 'generation_disabled',
         dailyLimit: 0,
       }),
+      selectReplayTarget: vi.fn().mockReturnValue({
+        mode: 'source',
+        reason: 'google_disabled',
+      }),
+      createGoogleProvider: vi.fn(),
+      prepareReplayTarget: vi.fn(),
       selectJudgeActivation: vi.fn().mockReturnValue({
         enabled: false,
         reason: 'judge_disabled',
@@ -164,6 +175,135 @@ describe('shadow evaluator capture-only orchestration', () => {
       expect.objectContaining({ status: 'skipped', reason: 'config_version_drift' }),
     );
     expect(fixture.getMember).not.toHaveBeenCalled();
+    expect(fixture.providerCall).not.toHaveBeenCalled();
+  });
+
+  it('blocks a partially configured alternate target before claim', async () => {
+    const fixture = baseDependencies();
+    fixture.dependencies.selectReplayActivation = vi.fn().mockReturnValue({
+      enabled: true,
+      reason: 'enabled',
+      dailyLimit: 5,
+    });
+    fixture.dependencies.selectReplayTarget = vi.fn().mockReturnValue({
+      mode: 'blocked',
+      reason: 'google_model_invalid',
+    });
+
+    const result = await runShadowEvaluatorJob({ limit: 5 }, fixture.dependencies as never);
+
+    expect(result).toMatchObject({ skipped: 1, errors: 0 });
+    expect(fixture.completeCapture).toHaveBeenCalledWith(
+      capture.trace_id,
+      capture.thread_id,
+      expect.objectContaining({
+        status: 'verified',
+        reason: 'replay_google_model_invalid',
+        parityVerified: true,
+      }),
+    );
+    expect(fixture.dependencies.claimGeneration).not.toHaveBeenCalled();
+    expect(fixture.forkForIsolatedProvider).not.toHaveBeenCalled();
+  });
+
+  it('binds one prepared Google target through claim, execution, and completion', async () => {
+    const fixture = baseDependencies();
+    fixture.dependencies.selectReplayActivation = vi.fn().mockReturnValue({
+      enabled: true,
+      reason: 'enabled',
+      dailyLimit: 5,
+    });
+    const selection = {
+      mode: 'alternate' as const,
+      reason: 'google_enabled' as const,
+      provider: 'google' as const,
+      model: 'gemini-3.7-flash' as const,
+    };
+    const provider = { id: 'google' as const };
+    const candidateClient = { processMessage: vi.fn() };
+    const target = {
+      provider: selection.provider,
+      model: selection.model,
+      firstInvocation: {
+        execution_mode: 'replay' as const,
+        model: selection.model,
+        iteration: 1,
+        attempt: 1,
+        system_blocks: [],
+        tool_schemas: [],
+        message_payloads: [],
+        message_count: 1,
+        provider_request_sha256: '9'.repeat(64),
+      },
+    };
+    const generationTarget = {
+      provider: selection.provider,
+      model: selection.model,
+      firstProviderRequestHmac: target.firstInvocation.provider_request_sha256,
+    };
+    fixture.dependencies.selectReplayTarget = vi.fn().mockReturnValue(selection);
+    fixture.dependencies.createGoogleProvider = vi.fn().mockReturnValue(provider);
+    fixture.forkForIsolatedProvider.mockReturnValue(candidateClient);
+    fixture.dependencies.prepareReplayTarget = vi.fn().mockReturnValue(target);
+    fixture.dependencies.selectJudgeActivation = vi.fn().mockReturnValue({
+      enabled: true,
+      reason: 'enabled',
+      dailyLimit: 5,
+    });
+    fixture.dependencies.hydrateHumanEvidence = vi.fn().mockResolvedValue({
+      slackMessageTs: '1000.3',
+      userId: 'U_HUMAN',
+      content: 'A substantive human answer used only in memory.',
+    });
+    fixture.dependencies.resolveJudgeModel = vi.fn().mockReturnValue('claude-judge');
+    fixture.dependencies.getJudgeClient = vi.fn().mockReturnValue({ messages: {} });
+    fixture.dependencies.claimGeneration = vi.fn().mockResolvedValue('claimed');
+    const generation = {
+      traceId: capture.trace_id,
+      provider: selection.provider,
+      model: selection.model,
+      returnedProvider: 'google' as const,
+      returnedModel: 'gemini-3.7-flash-20260801',
+      executionPolicyVersion: OFFICIAL_DOCS_REPLAY_EXECUTION_POLICY_VERSION,
+      completeFidelity: false,
+      status: 'blocked' as const,
+      reason: 'generation_blocked',
+      outputHmac: 'b'.repeat(64),
+      outputBytes: 42,
+      invocations: [{
+        iteration: 1,
+        attempt: 1,
+        provider_request_hmac: target.firstInvocation.provider_request_sha256,
+      }],
+      toolExecutions: [],
+      blockedCapabilities: ['generation_blocked'],
+      inputTokens: 20,
+      outputTokens: 10,
+    };
+    fixture.dependencies.executeReplay = vi.fn().mockResolvedValue(generation);
+
+    const result = await runShadowEvaluatorJob({ limit: 5 }, fixture.dependencies as never);
+
+    expect(result).toMatchObject({ skipped: 1, errors: 0 });
+    expect(fixture.forkForIsolatedProvider).toHaveBeenCalledWith(selection.model, { provider });
+    expect(fixture.dependencies.claimGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({ traceId: capture.trace_id }),
+      5,
+      { target: generationTarget },
+    );
+    expect(fixture.dependencies.resolveJudgeModel).toHaveBeenCalledWith([
+      'claude-test',
+      selection.model,
+    ]);
+    expect(fixture.dependencies.executeReplay).toHaveBeenCalledWith(
+      expect.objectContaining({ target }),
+      expect.objectContaining({ client: candidateClient }),
+    );
+    expect(fixture.dependencies.completeGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({ traceId: capture.trace_id }),
+      generation,
+      { target: generationTarget },
+    );
     expect(fixture.providerCall).not.toHaveBeenCalled();
   });
 

--- a/server/tests/unit/addie/shadow-replay-target.test.ts
+++ b/server/tests/unit/addie/shadow-replay-target.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createGoogleShadowReplayProvider,
+  selectShadowReplayTarget,
+} from '../../../src/addie/jobs/shadow-replay-target.js';
+import { GOOGLE_ROUTER_MODEL } from '../../../src/addie/model-providers/google-generate-content-provider.js';
+
+const enabled = {
+  SHADOW_EVAL_FULL_RESPONSE_GOOGLE_ENABLED: 'true',
+  SHADOW_EVAL_FULL_RESPONSE_GOOGLE_PRODUCTION_DATA_APPROVED: 'true',
+  SHADOW_EVAL_FULL_RESPONSE_GOOGLE_MODEL: GOOGLE_ROUTER_MODEL,
+  GEMINI_API_KEY: 'test-key',
+};
+
+describe('shadow replay target admission', () => {
+  it('preserves source replay when Google is disabled', () => {
+    expect(selectShadowReplayTarget({})).toEqual({
+      mode: 'source',
+      reason: 'google_disabled',
+    });
+  });
+
+  it('blocks partially configured production-data admission', () => {
+    expect(selectShadowReplayTarget({
+      ...enabled,
+      SHADOW_EVAL_FULL_RESPONSE_GOOGLE_PRODUCTION_DATA_APPROVED: 'false',
+    })).toEqual({ mode: 'blocked', reason: 'google_production_data_not_approved' });
+    expect(selectShadowReplayTarget({
+      ...enabled,
+      SHADOW_EVAL_FULL_RESPONSE_GOOGLE_MODEL: 'gemini-other',
+    })).toEqual({ mode: 'blocked', reason: 'google_model_invalid' });
+    expect(selectShadowReplayTarget({
+      ...enabled,
+      GEMINI_API_KEY: ' ',
+    })).toEqual({ mode: 'blocked', reason: 'google_credentials_unavailable' });
+  });
+
+  it('selects only the exact supported Google target', () => {
+    expect(selectShadowReplayTarget(enabled)).toEqual({
+      mode: 'alternate',
+      reason: 'google_enabled',
+      provider: 'google',
+      model: GOOGLE_ROUTER_MODEL,
+    });
+    expect(createGoogleShadowReplayProvider(enabled)?.id).toBe('google');
+    expect(createGoogleShadowReplayProvider({})).toBeNull();
+  });
+});

--- a/server/tests/unit/addie/shadow-replay.test.ts
+++ b/server/tests/unit/addie/shadow-replay.test.ts
@@ -13,6 +13,7 @@ import {
   executeShadowReplay,
   executeVerifiedOfficialDocsReplay,
   hashReplayValue,
+  prepareVerifiedOfficialDocsReplayTarget,
 } from '../../../src/addie/jobs/shadow-replay.js';
 import { OFFICIAL_DOCS_ALLOWED_TOOLS } from '../../../src/addie/jobs/shadow-replay-cohort.js';
 import type { ResolvedShadowReplayTrace } from '../../../src/addie/jobs/shadow-replay-trace.js';
@@ -588,6 +589,45 @@ describe('verified official docs replay generation', () => {
       invocations: [{ provider_request_hmac: 'f'.repeat(64) }],
     });
     expect(result.invocations[0].provider_request_hmac).not.toBe(PROVIDER_HMAC);
+  });
+
+  it('prepares the exact replay-mode alternate request without dispatching', () => {
+    const firstInvocation = officialDocsSnapshot({
+      execution_mode: 'replay',
+      model: 'gemini-3.7-flash',
+      provider_request_sha256: 'f'.repeat(64),
+    });
+    const prepareMessageInvocation = vi.fn().mockReturnValue(firstInvocation);
+    const input = {
+      trace: officialDocsTrace(),
+      invocation: officialDocsInvocation(),
+      docsCorpusFingerprint: 'docs-fingerprint',
+    };
+
+    expect(prepareVerifiedOfficialDocsReplayTarget(input, {
+      provider: 'google',
+      model: 'gemini-3.7-flash',
+    }, { prepareMessageInvocation } as never)).toEqual({
+      provider: 'google',
+      model: 'gemini-3.7-flash',
+      firstInvocation,
+    });
+    expect(prepareMessageInvocation).toHaveBeenCalledWith(
+      input.trace.question,
+      undefined,
+      input.invocation.requestTools,
+      undefined,
+      expect.objectContaining({
+        executionMode: 'replay',
+        disableServerTools: true,
+        allowedToolNames: OFFICIAL_DOCS_ALLOWED_TOOLS,
+        maxIterations: 4,
+        invocationHashKey: input.trace.identity.hashKey,
+        invocationHashDomain: input.trace.identity.hashDomain,
+        uncapped: true,
+        modelOverride: 'gemini-3.7-flash',
+      }),
+    );
   });
 
   it('blocks alternate dispatch when its prepared request drifts from preflight', async () => {


### PR DESCRIPTION
## Summary

- add an independently default-off Google full-response shadow target requiring an enable flag, a separate production-data approval flag, the exact supported model, and a configured credential
- block partially configured target admission categorically instead of silently falling back to the source provider
- prepare the exact Gemini request before claim, then bind the same provider/model/request digest through the immutable ledger, isolated client, execution, and completion
- keep source replay behavior unchanged when the Google target is disabled
- exclude both the source and candidate models from independent judge selection and bind self-judge provenance to the actual generator

This does not change user-visible delivery or production routing. No rollout flag or canary is enabled by this PR.

## Verification

- focused provider/replay matrix: 7 files, 137 tests passed
- staged precommit and commit hook: 520 files, 7,479 tests passed, 30 skipped
- TypeScript typecheck passed
- Addie tool inventory build/check passed
- provider transports were mocked; no paid model call occurred

No changeset: Addie runtime implementation only; no protocol release surface changed.

Related: #6844, #6846
