### PR TITLE
feat(addie): split shadow evidence by provider

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.110';
+export const CODE_VERSION = '2026.08.111';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/jobs/shadow-replay-trace.ts
+++ b/server/src/addie/jobs/shadow-replay-trace.ts
@@ -177,9 +177,14 @@ export type ShadowReplayGenerationClaimDecision =
   | 'trace_unavailable';
 
 export interface ShadowReplayGenerationSummaryRow extends QueryResultRow {
+  capture_version: number;
+  capture_policy_version: string;
+  source_config_version_id: number;
+  source_model: string;
   requested_provider: ModelProviderId;
   requested_model: string;
   addie_code_version: string;
+  execution_policy_version: string;
   returned_provider: ModelProviderId | null;
   returned_model: string | null;
   status: string;
@@ -223,8 +228,30 @@ export interface ShadowReplayJudgmentCompletion {
 }
 
 export interface ShadowReplayJudgmentSummaryRow extends QueryResultRow {
+  capture_version: number;
+  capture_policy_version: string;
+  source_config_version_id: number;
+  source_model: string;
+  has_human_evidence: boolean;
+  requested_provider: ModelProviderId;
+  requested_model: string;
+  addie_code_version: string;
+  execution_policy_version: string;
+  returned_provider: ModelProviderId | null;
+  returned_model: string | null;
+  judgment_policy_version: string;
+  judge_provider: ShadowReplayJudgeProvider | null;
+  judge_model: string | null;
+  self_judged: boolean | null;
+  judge_prompt_version: string | null;
   status: string;
   reason: string;
+  evaluation_valid: boolean;
+  evaluation_skipped: boolean;
+  knowledge_gap: boolean | null;
+  gap_severity: ShadowReplayGapSeverity | null;
+  shadow_quality: ShadowReplayQuality | null;
+  deterministic_failure_labels: string[];
   count: number;
   input_tokens: number;
   output_tokens: number;
@@ -1909,9 +1936,14 @@ export async function getShadowReplayGenerationSummary(
   const runQuery = dependencies.query ?? query as QueryFn;
   const boundedDays = Math.max(1, Math.min(7, Math.trunc(days)));
   const result = await runQuery<ShadowReplayGenerationSummaryRow>(
-    `SELECT generation.requested_provider,
+    `SELECT trace.capture_version,
+            trace.policy_version AS capture_policy_version,
+            trace.source_config_version_id,
+            trace.effective_model AS source_model,
+            generation.requested_provider,
             generation.model AS requested_model,
             generation.addie_code_version,
+            generation.execution_policy_version,
             generation.returned_provider,
             generation.returned_model,
             generation.status,
@@ -1923,8 +1955,11 @@ export async function getShadowReplayGenerationSummary(
      JOIN addie_shadow_replay_traces trace ON trace.trace_id = generation.trace_id
      WHERE generation.started_at >= NOW() - ($2::integer * INTERVAL '1 day')
        AND trace.capture_version = $1
-     GROUP BY generation.requested_provider, generation.model,
-              generation.addie_code_version, generation.returned_provider,
+     GROUP BY trace.capture_version, trace.policy_version,
+              trace.source_config_version_id, trace.effective_model,
+              generation.requested_provider, generation.model,
+              generation.addie_code_version, generation.execution_policy_version,
+              generation.returned_provider,
               generation.returned_model, generation.status, generation.reason
      ORDER BY generation.requested_provider, generation.model,
               generation.status, generation.reason`,
@@ -1940,17 +1975,55 @@ export async function getShadowReplayJudgmentSummary(
   const runQuery = dependencies.query ?? query as QueryFn;
   const boundedDays = Math.max(1, Math.min(7, Math.trunc(days)));
   const result = await runQuery<ShadowReplayJudgmentSummaryRow>(
-    `SELECT judgment.status,
+    `SELECT trace.capture_version,
+            trace.policy_version AS capture_policy_version,
+            trace.source_config_version_id,
+            trace.effective_model AS source_model,
+            judgment.human_evidence_content_hmac IS NOT NULL AS has_human_evidence,
+            generation.requested_provider,
+            generation.model AS requested_model,
+            generation.addie_code_version,
+            generation.execution_policy_version,
+            generation.returned_provider,
+            generation.returned_model,
+            judgment.judgment_policy_version,
+            judgment.judge_provider,
+            judgment.judge_model,
+            judgment.self_judged,
+            judgment.judge_prompt_version,
+            judgment.status,
             judgment.reason,
+            judgment.evaluation_valid,
+            judgment.evaluation_skipped,
+            judgment.knowledge_gap,
+            judgment.gap_severity,
+            judgment.shadow_quality,
+            judgment.deterministic_failure_labels,
             COUNT(*)::integer AS count,
             COALESCE(SUM(judgment.input_tokens), 0)::integer AS input_tokens,
             COALESCE(SUM(judgment.output_tokens), 0)::integer AS output_tokens
      FROM addie_shadow_replay_judgments judgment
-     JOIN addie_shadow_replay_traces trace ON trace.trace_id = judgment.trace_id
+     JOIN addie_shadow_replay_generations generation
+       ON generation.trace_id = judgment.trace_id
+     JOIN addie_shadow_replay_traces trace ON trace.trace_id = generation.trace_id
      WHERE judgment.completed_at >= NOW() - ($2::integer * INTERVAL '1 day')
        AND trace.capture_version = $1
-     GROUP BY judgment.status, judgment.reason
-     ORDER BY judgment.status, judgment.reason`,
+     GROUP BY trace.capture_version, trace.policy_version,
+              trace.source_config_version_id, trace.effective_model,
+              (judgment.human_evidence_content_hmac IS NOT NULL),
+              generation.requested_provider, generation.model,
+              generation.addie_code_version, generation.execution_policy_version,
+              generation.returned_provider, generation.returned_model,
+              judgment.judgment_policy_version, judgment.judge_provider,
+              judgment.judge_model, judgment.self_judged,
+              judgment.judge_prompt_version, judgment.status,
+              judgment.reason, judgment.evaluation_valid,
+              judgment.evaluation_skipped, judgment.knowledge_gap,
+              judgment.gap_severity, judgment.shadow_quality,
+              judgment.deterministic_failure_labels
+     ORDER BY generation.requested_provider, generation.model,
+              judgment.judge_provider, judgment.judge_model,
+              judgment.status, judgment.reason`,
     [SHADOW_REPLAY_TRACE_CAPTURE_VERSION, boundedDays],
   );
   return result.rows;

--- a/server/tests/manual/shadow-eval-prod-summary.ts
+++ b/server/tests/manual/shadow-eval-prod-summary.ts
@@ -88,6 +88,16 @@ interface CaptureSummary {
     input_tokens: number;
     output_tokens: number;
     outcomes: Array<{
+      capture_version: number;
+      capture_policy_version: string;
+      source_config_version_id: number;
+      source_model: string;
+      requested_provider: string;
+      requested_model: string;
+      addie_code_version: string;
+      execution_policy_version: string;
+      returned_provider: string | null;
+      returned_model: string | null;
       status: string;
       reason: string;
       count: number;
@@ -100,8 +110,30 @@ interface CaptureSummary {
     input_tokens: number;
     output_tokens: number;
     outcomes: Array<{
+      capture_version: number;
+      capture_policy_version: string;
+      source_config_version_id: number;
+      source_model: string;
+      has_human_evidence: boolean;
+      requested_provider: string;
+      requested_model: string;
+      addie_code_version: string;
+      execution_policy_version: string;
+      returned_provider: string | null;
+      returned_model: string | null;
+      judgment_policy_version: string;
+      judge_provider: string | null;
+      judge_model: string | null;
+      self_judged: boolean | null;
+      judge_prompt_version: string | null;
       status: string;
       reason: string;
+      evaluation_valid: boolean;
+      evaluation_skipped: boolean;
+      knowledge_gap: boolean | null;
+      gap_severity: string | null;
+      shadow_quality: string | null;
+      deterministic_failure_labels: string[];
       count: number;
       input_tokens: number;
       output_tokens: number;
@@ -348,8 +380,16 @@ async function main() {
         + `${captureSummary.generations.output_tokens} output tokens)`,
       );
       for (const outcome of captureSummary.generations.outcomes) {
+        const returned = outcome.returned_provider && outcome.returned_model
+          ? `${outcome.returned_provider}/${outcome.returned_model}`
+          : 'none';
         console.log(
-          `  ${`${outcome.status}:${outcome.reason}`.padEnd(52)} ${outcome.count} `
+          `  candidate=${outcome.requested_provider}/${outcome.requested_model} `
+          + `source=${outcome.source_model}@config:${outcome.source_config_version_id} `
+          + `returned=${returned} code=${outcome.addie_code_version} `
+          + `capture=v${outcome.capture_version}/${outcome.capture_policy_version} `
+          + `execution=${outcome.execution_policy_version} `
+          + `${outcome.status}:${outcome.reason} ${outcome.count} `
           + `(${outcome.input_tokens} input / ${outcome.output_tokens} output tokens)`,
         );
       }
@@ -361,8 +401,26 @@ async function main() {
         + `${captureSummary.judgments.output_tokens} output tokens)`,
       );
       for (const outcome of captureSummary.judgments.outcomes) {
+        const returned = outcome.returned_provider && outcome.returned_model
+          ? `${outcome.returned_provider}/${outcome.returned_model}`
+          : 'none';
+        const judge = outcome.judge_provider && outcome.judge_model
+          ? `${outcome.judge_provider}/${outcome.judge_model}`
+          : 'none';
         console.log(
-          `  ${`${outcome.status}:${outcome.reason}`.padEnd(52)} ${outcome.count} `
+          `  candidate=${outcome.requested_provider}/${outcome.requested_model} `
+          + `source=${outcome.source_model}@config:${outcome.source_config_version_id} `
+          + `returned=${returned} code=${outcome.addie_code_version} `
+          + `capture=v${outcome.capture_version}/${outcome.capture_policy_version} `
+          + `execution=${outcome.execution_policy_version} `
+          + `human_evidence=${String(outcome.has_human_evidence)} `
+          + `judge=${judge} self_judged=${String(outcome.self_judged)} `
+          + `judgment=${outcome.judgment_policy_version}/`
+          + `${outcome.judge_prompt_version ?? 'none'} `
+          + `quality=${outcome.shadow_quality ?? 'none'} `
+          + `gap=${outcome.gap_severity ?? 'none'} `
+          + `shape_failures=${outcome.deterministic_failure_labels.join(',') || 'none'} `
+          + `${outcome.status}:${outcome.reason} ${outcome.count} `
           + `(${outcome.input_tokens} input / ${outcome.output_tokens} output tokens)`,
         );
       }

--- a/server/tests/unit/addie/shadow-replay-trace.test.ts
+++ b/server/tests/unit/addie/shadow-replay-trace.test.ts
@@ -1128,9 +1128,14 @@ describe('shadow replay trace authorization', () => {
 
   it('reports only categorical generation outcomes and token totals', async () => {
     const rows = [{
+      capture_version: 3,
+      capture_policy_version: 'official-docs-capture:v3',
+      source_config_version_id: 42,
+      source_model: 'claude-sonnet-5',
       requested_provider: 'google',
       requested_model: 'gemini-3.7-flash',
       addie_code_version: '2026.08.109',
+      execution_policy_version: 'official-docs-read-only:v1',
       returned_provider: 'google',
       returned_model: 'gemini-3.7-flash-20260801',
       status: 'succeeded',
@@ -1145,13 +1150,37 @@ describe('shadow replay trace authorization', () => {
     expect(runQuery.mock.calls[0][1]).toEqual([3, 7]);
     expect(runQuery.mock.calls[0][0]).toContain('generation.requested_provider');
     expect(runQuery.mock.calls[0][0]).toContain('generation.addie_code_version');
+    expect(runQuery.mock.calls[0][0]).toContain('generation.execution_policy_version');
+    expect(runQuery.mock.calls[0][0]).toContain('trace.source_config_version_id');
     expect(runQuery.mock.calls[0][0]).not.toContain('question_hmac');
   });
 
   it('reports categorical judgment totals and a no-payload opportunity funnel', async () => {
     const judgments = [{
+      capture_version: 3,
+      capture_policy_version: 'official-docs-capture:v3',
+      source_config_version_id: 42,
+      source_model: 'claude-sonnet-5',
+      has_human_evidence: true,
+      requested_provider: 'google',
+      requested_model: 'gemini-3.7-flash',
+      addie_code_version: '2026.08.111',
+      execution_policy_version: 'official-docs-read-only:v1',
+      returned_provider: 'google',
+      returned_model: 'gemini-3.7-flash-20260801',
+      judgment_policy_version: 'official-docs-judgment:v1',
+      judge_provider: 'anthropic',
+      judge_model: 'claude-sonnet-5',
+      self_judged: false,
+      judge_prompt_version: 'shadow-replay-judge:v1',
       status: 'judged',
       reason: 'judgment_completed',
+      evaluation_valid: true,
+      evaluation_skipped: false,
+      knowledge_gap: false,
+      gap_severity: 'none',
+      shadow_quality: 'equivalent',
+      deterministic_failure_labels: [],
       count: 2,
       input_tokens: 80,
       output_tokens: 20,
@@ -1160,6 +1189,11 @@ describe('shadow replay trace authorization', () => {
     await expect(getShadowReplayJudgmentSummary(999, { query: judgmentQuery as never }))
       .resolves.toEqual(judgments);
     expect(judgmentQuery.mock.calls[0][1]).toEqual([3, 7]);
+    expect(judgmentQuery.mock.calls[0][0]).toContain('generation.requested_provider');
+    expect(judgmentQuery.mock.calls[0][0]).toContain('judgment.judge_provider');
+    expect(judgmentQuery.mock.calls[0][0]).toContain('judgment.shadow_quality');
+    expect(judgmentQuery.mock.calls[0][0]).toContain('has_human_evidence');
+    expect(judgmentQuery.mock.calls[0][0]).not.toMatch(/question_hmac|source_output_hmac/);
 
     const funnel = {
       opportunities: 5,


### PR DESCRIPTION
## Summary

- split shadow generation summaries by exact capture, source, requested candidate, returned provider/model, Addie code, and execution-policy provenance
- split judgment summaries by the same candidate provenance plus judgment policy, independent judge identity, judge prompt version, self-judgment status, and categorical quality outcomes
- keep the production summary aggregate-only: no prompts, answers, trace IDs, or raw HMACs are returned
- bump the Addie code version to `2026.08.111`

Before this change, judgment rows could collapse results from different candidate providers/models and omitted the judge/config identity needed to interpret rollout evidence.

## Verification

- focused shadow matrix: 5 files, 73 tests passed
- full staged precommit: root 68 files / 1,056 tests; server 520 files / 7,479 passed / 30 skipped
- `npm run typecheck`
- `npm run build:addie-tools`
- `npm run test:addie-tools`
- `git diff --check`
- confidentiality scan

No changeset: Addie application-only change. No canary or environment setting changed, and no paid model call was made.
