### PR TITLE
feat(addie): record shadow latency and cost

### DIFF
--- a/server/src/addie/claude-pricing.ts
+++ b/server/src/addie/claude-pricing.ts
@@ -24,6 +24,8 @@ interface ModelRates {
   cacheReadUsd: number;
 }
 
+export const CLAUDE_PRICING_VERSION = 'anthropic-standard-2026-08' as const;
+
 const PRICING_PER_MILLION_TOKENS: Record<string, ModelRates> = {
   // Claude Fable — highest-cost generally available tier
   'claude-fable-5': { inputUsd: 10, outputUsd: 50, cacheCreationUsd: 12.5, cacheReadUsd: 1 },
@@ -92,7 +94,10 @@ export function costUsdMicros(model: string, usage: ClaudeUsage): number {
   return Math.ceil(total);
 }
 
-/** Test-only helper to assert a model has known pricing. */
-export function __hasKnownPricing(model: string): boolean {
+/** Return whether cost calculations can use an exact reviewed rate. */
+export function hasKnownClaudePricing(model: string): boolean {
   return Object.prototype.hasOwnProperty.call(PRICING_PER_MILLION_TOKENS, model);
 }
+
+/** Backwards-compatible test helper. */
+export const __hasKnownPricing = hasKnownClaudePricing;

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.111';
+export const CODE_VERSION = '2026.08.112';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/jobs/shadow-evaluator.ts
+++ b/server/src/addie/jobs/shadow-evaluator.ts
@@ -798,6 +798,10 @@ export async function runShadowEvaluatorJob(
           blockedCapabilities: boundaryReason ? [boundaryReason] : [],
           inputTokens: 0,
           outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          usageAvailable: false,
+          latencyMs: null,
           });
         let completed = false;
         try {

--- a/server/src/addie/jobs/shadow-replay-pricing.ts
+++ b/server/src/addie/jobs/shadow-replay-pricing.ts
@@ -1,0 +1,71 @@
+import {
+  CLAUDE_PRICING_VERSION,
+  costUsdMicros,
+  hasKnownClaudePricing,
+} from '../claude-pricing.js';
+import type { ModelProviderId } from '../model-providers/model-provider.js';
+import { GOOGLE_ROUTER_MODEL } from '../model-providers/google-generate-content-provider.js';
+
+export const GOOGLE_SHADOW_REPLAY_PRICING_VERSION =
+  'google-gemini-3.7-flash-through-2026-12-31' as const;
+
+export interface ShadowReplayUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+export interface ShadowReplayPricing {
+  provider: ModelProviderId;
+  model: string;
+  version: string;
+  validBefore: Date | null;
+  estimateCostMicros: (usage: ShadowReplayUsage) => number;
+}
+
+/** Resolve only exact, reviewed rates. Unknown models are not safe to spend on. */
+export function resolveShadowReplayPricing(
+  provider: ModelProviderId,
+  model: string,
+): ShadowReplayPricing | null {
+  if (provider === 'anthropic' && hasKnownClaudePricing(model)) {
+    return {
+      provider,
+      model,
+      version: `${CLAUDE_PRICING_VERSION}:${model}`,
+      validBefore: null,
+      estimateCostMicros: (usage) => costUsdMicros(model, {
+        input_tokens: usage.inputTokens,
+        output_tokens: usage.outputTokens,
+        cache_read_input_tokens: usage.cacheReadTokens,
+        cache_creation_input_tokens: usage.cacheWriteTokens,
+      }),
+    };
+  }
+  if (provider === 'google' && model === GOOGLE_ROUTER_MODEL) {
+    return {
+      provider,
+      model,
+      version: GOOGLE_SHADOW_REPLAY_PRICING_VERSION,
+      validBefore: new Date('2027-01-01T00:00:00.000Z'),
+      // Official standard pricing checked 2026-08-30: $0.75/M input,
+      // $0.075/M cached input, and $3.75/M output (including thought tokens).
+      // A malformed cache count is conservatively charged in addition to the
+      // full input count instead of allowing a negative uncached denominator.
+      estimateCostMicros: (usage) => {
+        const cacheWithinInput = usage.cacheReadTokens <= usage.inputTokens;
+        const uncachedInput = cacheWithinInput
+          ? usage.inputTokens - usage.cacheReadTokens
+          : usage.inputTokens;
+        return Math.ceil(
+          uncachedInput * 0.75
+          + usage.cacheReadTokens * 0.075
+          + usage.cacheWriteTokens * 0.75
+          + usage.outputTokens * 3.75,
+        );
+      },
+    };
+  }
+  return null;
+}

--- a/server/src/addie/jobs/shadow-replay-trace.ts
+++ b/server/src/addie/jobs/shadow-replay-trace.ts
@@ -17,6 +17,7 @@ import {
   canonicalOfficialDocsPlan,
   isOfficialDocsProfile,
 } from './shadow-replay-cohort.js';
+import { resolveShadowReplayPricing } from './shadow-replay-pricing.js';
 
 export const SHADOW_REPLAY_TRACE_CAPTURE_VERSION = 3 as const;
 export const SHADOW_REPLAY_TRACE_HASH_DOMAIN = 'addie-shadow-replay-trace:v3' as const;
@@ -160,6 +161,10 @@ export interface ShadowReplayGenerationCompletion {
   blockedCapabilities: string[];
   inputTokens: number;
   outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  usageAvailable: boolean;
+  latencyMs: number | null;
   returnedProvider?: ModelProviderId | null;
   returnedModel?: string | null;
 }
@@ -185,6 +190,7 @@ export interface ShadowReplayGenerationSummaryRow extends QueryResultRow {
   requested_model: string;
   addie_code_version: string;
   execution_policy_version: string;
+  pricing_version: string;
   returned_provider: ModelProviderId | null;
   returned_model: string | null;
   status: string;
@@ -192,6 +198,13 @@ export interface ShadowReplayGenerationSummaryRow extends QueryResultRow {
   count: number;
   input_tokens: number;
   output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  usage_complete_count: number;
+  latency_count: number;
+  estimated_cost_micros: string;
+  latency_p50_ms: number | null;
+  latency_p95_ms: number | null;
 }
 
 export type ShadowReplayJudgmentStatus = 'judged' | 'deterministic_failure' | 'skipped' | 'error';
@@ -1293,8 +1306,35 @@ function validateGenerationCompletion(
     throw new Error('shadow_replay_generation_output_bytes_invalid');
   }
   if (!Number.isInteger(outcome.inputTokens) || outcome.inputTokens < 0
-    || !Number.isInteger(outcome.outputTokens) || outcome.outputTokens < 0) {
+    || !Number.isInteger(outcome.outputTokens) || outcome.outputTokens < 0
+    || !Number.isInteger(outcome.cacheReadTokens) || outcome.cacheReadTokens < 0
+    || !Number.isInteger(outcome.cacheWriteTokens) || outcome.cacheWriteTokens < 0
+    || [
+      outcome.inputTokens,
+      outcome.outputTokens,
+      outcome.cacheReadTokens,
+      outcome.cacheWriteTokens,
+    ].some((value) => value > 2_147_483_647)) {
     throw new Error('shadow_replay_generation_usage_invalid');
+  }
+  if (typeof outcome.usageAvailable !== 'boolean'
+    || (!outcome.usageAvailable && (
+      outcome.inputTokens !== 0
+      || outcome.outputTokens !== 0
+      || outcome.cacheReadTokens !== 0
+      || outcome.cacheWriteTokens !== 0
+    ))) {
+    throw new Error('shadow_replay_generation_usage_completeness_invalid');
+  }
+  if (outcome.latencyMs !== null && (
+    !Number.isSafeInteger(outcome.latencyMs)
+    || outcome.latencyMs < 0
+    || outcome.latencyMs > 900_000
+  )) {
+    throw new Error('shadow_replay_generation_latency_invalid');
+  }
+  if (outcome.usageAvailable && outcome.latencyMs === null) {
+    throw new Error('shadow_replay_generation_latency_required');
   }
   if (outcome.invocations.length > 4
     || (outcome.status === 'succeeded' && outcome.invocations.length === 0)) {
@@ -1353,6 +1393,8 @@ function validateGenerationCompletion(
     outcome.blockedCapabilities.length > 0
     || outcome.toolExecutions.some(({ disposition }) => disposition !== 'live_read')
     || outcome.reason !== 'generation_succeeded'
+    || !outcome.usageAvailable
+    || outcome.latencyMs === null
   )) {
     throw new Error('shadow_replay_generation_success_inconsistent');
   }
@@ -1575,6 +1617,10 @@ export async function claimShadowReplayGeneration(
   }
   const target = resolveGenerationTarget(trace, dependencies.target);
   if (!target) return 'trace_unavailable';
+  const pricing = resolveShadowReplayPricing(target.provider, target.model);
+  if (!pricing || (pricing.validBefore && now >= pricing.validBefore)) {
+    return 'trace_unavailable';
+  }
   const boundedLimit = dailyLimit;
   const result = await runQuery<{ decision: ShadowReplayGenerationClaimDecision }>(
     `WITH eligible AS MATERIALIZED (
@@ -1594,11 +1640,11 @@ export async function claimShadowReplayGeneration(
      ), inserted AS (
        INSERT INTO addie_shadow_replay_generations (
          trace_id, execution_policy_version, requested_provider, model,
-         addie_code_version,
+         addie_code_version, pricing_version,
          quota_date, quota_slot, first_provider_request_hmac,
          started_at, heartbeat_at, retained_until
        )
-       SELECT eligible.trace_id, $8, $11, $12, $14,
+       SELECT eligible.trace_id, $8, $11, $12, $14, $15,
               ($9::timestamptz AT TIME ZONE 'UTC')::date, slot,
               $13, $9, $9, eligible.retained_until
        FROM eligible
@@ -1637,6 +1683,7 @@ export async function claimShadowReplayGeneration(
       target.model,
       target.firstProviderRequestHmac,
       CODE_VERSION,
+      pricing.version,
     ],
   );
   const decision = result.rows[0]?.decision ?? 'trace_unavailable';
@@ -1700,6 +1747,8 @@ export async function completeShadowReplayGeneration(
 ): Promise<boolean> {
   const target = resolveGenerationTarget(trace, dependencies.target);
   if (!target) throw new Error('shadow_replay_generation_target_invalid');
+  const pricing = resolveShadowReplayPricing(target.provider, target.model);
+  if (!pricing) throw new Error('shadow_replay_generation_pricing_unavailable');
   validateGenerationCompletion(trace, outcome, target);
   const runQuery = dependencies.query ?? query as QueryFn;
   const completedAt = dependencies.now ?? new Date();
@@ -1712,6 +1761,14 @@ export async function completeShadowReplayGeneration(
     : outcome.status === 'blocked'
       ? 'skipped'
       : 'error';
+  const estimatedCostMicros = outcome.usageAvailable
+    ? pricing.estimateCostMicros({
+      inputTokens: outcome.inputTokens,
+      outputTokens: outcome.outputTokens,
+      cacheReadTokens: outcome.cacheReadTokens,
+      cacheWriteTokens: outcome.cacheWriteTokens,
+    })
+    : null;
   const context = {
     shadow_eval_status: outcome.status === 'error' ? 'error' : 'skipped',
     shadow_eval_type: 'suppressed_opportunity',
@@ -1738,6 +1795,11 @@ export async function completeShadowReplayGeneration(
            blocked_capabilities = $9::jsonb,
            input_tokens = $10,
            output_tokens = $11,
+           cache_read_tokens = $48,
+           cache_write_tokens = $49,
+           usage_complete = $50,
+           latency_ms = $51,
+           estimated_cost_micros = $52,
            returned_provider = $46,
            returned_model = $47,
            completed_at = $12
@@ -1746,6 +1808,7 @@ export async function completeShadowReplayGeneration(
          AND generation.requested_provider = $43
          AND generation.model = $44
          AND generation.first_provider_request_hmac = $45
+         AND generation.pricing_version = $53
          AND EXISTS (
            SELECT 1 FROM addie_shadow_replay_traces trace
            WHERE trace.trace_id = generation.trace_id
@@ -1844,6 +1907,12 @@ export async function completeShadowReplayGeneration(
       target.firstProviderRequestHmac,
       outcome.returnedProvider ?? null,
       outcome.returnedModel ?? null,
+      outcome.cacheReadTokens,
+      outcome.cacheWriteTokens,
+      outcome.usageAvailable,
+      outcome.latencyMs,
+      estimatedCostMicros,
+      pricing.version,
     ],
   );
   return result.rows[0]?.completed === true;
@@ -1944,13 +2013,27 @@ export async function getShadowReplayGenerationSummary(
             generation.model AS requested_model,
             generation.addie_code_version,
             generation.execution_policy_version,
+            generation.pricing_version,
             generation.returned_provider,
             generation.returned_model,
             generation.status,
             generation.reason,
             COUNT(*)::integer AS count,
             COALESCE(SUM(generation.input_tokens), 0)::integer AS input_tokens,
-            COALESCE(SUM(generation.output_tokens), 0)::integer AS output_tokens
+            COALESCE(SUM(generation.output_tokens), 0)::integer AS output_tokens,
+            COALESCE(SUM(generation.cache_read_tokens), 0)::integer AS cache_read_tokens,
+            COALESCE(SUM(generation.cache_write_tokens), 0)::integer AS cache_write_tokens,
+            COUNT(*) FILTER (WHERE generation.usage_complete)::integer
+              AS usage_complete_count,
+            COUNT(generation.latency_ms)::integer AS latency_count,
+            COALESCE(SUM(generation.estimated_cost_micros), 0)::text
+              AS estimated_cost_micros,
+            percentile_disc(0.5) WITHIN GROUP (ORDER BY generation.latency_ms)
+              FILTER (WHERE generation.latency_ms IS NOT NULL)::double precision
+              AS latency_p50_ms,
+            percentile_disc(0.95) WITHIN GROUP (ORDER BY generation.latency_ms)
+              FILTER (WHERE generation.latency_ms IS NOT NULL)::double precision
+              AS latency_p95_ms
      FROM addie_shadow_replay_generations generation
      JOIN addie_shadow_replay_traces trace ON trace.trace_id = generation.trace_id
      WHERE generation.started_at >= NOW() - ($2::integer * INTERVAL '1 day')
@@ -1959,6 +2042,7 @@ export async function getShadowReplayGenerationSummary(
               trace.source_config_version_id, trace.effective_model,
               generation.requested_provider, generation.model,
               generation.addie_code_version, generation.execution_policy_version,
+              generation.pricing_version,
               generation.returned_provider,
               generation.returned_model, generation.status, generation.reason
      ORDER BY generation.requested_provider, generation.model,

--- a/server/src/addie/jobs/shadow-replay.ts
+++ b/server/src/addie/jobs/shadow-replay.ts
@@ -124,6 +124,7 @@ export interface VerifiedOfficialDocsReplayDependencies {
   getDocsFingerprint?: typeof getDocsCorpusFingerprint;
   createKnowledgeHandlers?: typeof createKnowledgeToolHandlers;
   renewLease?: () => Promise<boolean>;
+  monotonicNow?: () => number;
   outputConsumer?: (
     output: TrustedOfficialDocsReplayOutput,
   ) => Promise<ShadowReplayJudgeEvidence>;
@@ -607,6 +608,26 @@ function boundedUsage(value: number | undefined): number {
     : 0;
 }
 
+function hasCompleteUsage(
+  usage: AddieResponse['usage'],
+): usage is NonNullable<AddieResponse['usage']> {
+  if (!usage) return false;
+  const values = [
+    usage.input_tokens,
+    usage.output_tokens,
+    usage.cache_read_input_tokens ?? 0,
+    usage.cache_creation_input_tokens ?? 0,
+  ];
+  return values.every((value) => Number.isSafeInteger(value) && value >= 0);
+}
+
+function generationLatencyMs(startedAt: number, completedAt: number): number | null {
+  const duration = completedAt - startedAt;
+  return Number.isFinite(duration) && duration >= 0 && duration <= 900_000
+    ? Math.ceil(duration)
+    : null;
+}
+
 /**
  * Generate one non-user-visible answer from an already authorized and parity-
  * checked official-docs invocation. Raw questions, tool payloads/results, and
@@ -691,6 +712,8 @@ export async function executeVerifiedOfficialDocsReplay(
     });
   }
 
+  const monotonicNow = dependencies.monotonicNow ?? (() => performance.now());
+  const generationStartedAt = monotonicNow();
   let response: AddieResponse;
   try {
     response = await client.processMessage(
@@ -799,6 +822,7 @@ export async function executeVerifiedOfficialDocsReplay(
       },
     );
   } catch (error) {
+    const latencyMs = generationLatencyMs(generationStartedAt, monotonicNow());
     const reason = error instanceof OfficialDocsReplayBoundaryError
       ? error.reason
       : 'provider_execution_failed';
@@ -831,6 +855,10 @@ export async function executeVerifiedOfficialDocsReplay(
         : ['provider_execution_failed', 'usage_unavailable'],
       inputTokens: 0,
       outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      usageAvailable: false,
+      latencyMs,
     });
   }
 
@@ -892,6 +920,10 @@ export async function executeVerifiedOfficialDocsReplay(
   if (getFingerprint() !== input.docsCorpusFingerprint) {
     blockedCapabilities.add('docs_corpus_drift');
   }
+  const latencyMs = generationLatencyMs(generationStartedAt, monotonicNow());
+  const usageAvailable = hasCompleteUsage(response.usage);
+  if (!usageAvailable) blockedCapabilities.add('usage_unavailable');
+  if (latencyMs === null) blockedCapabilities.add('latency_unavailable');
 
   // The model output is never returned or persisted. Only evidence over the
   // exact bytes produced by the client leaves this scope.
@@ -901,6 +933,7 @@ export async function executeVerifiedOfficialDocsReplay(
   const completeFidelity = blocked.length === 0
     && invocations.length > 0
     && toolExecutions.every(({ disposition }) => disposition === 'live_read');
+  const usage = usageAvailable ? response.usage : undefined;
 
   const completion: VerifiedOfficialDocsReplayResult = {
     traceId: input.trace.traceId,
@@ -917,8 +950,12 @@ export async function executeVerifiedOfficialDocsReplay(
     invocations,
     toolExecutions,
     blockedCapabilities: blocked,
-    inputTokens: boundedUsage(response.usage?.input_tokens),
-    outputTokens: boundedUsage(response.usage?.output_tokens),
+    inputTokens: boundedUsage(usage?.input_tokens),
+    outputTokens: boundedUsage(usage?.output_tokens),
+    cacheReadTokens: boundedUsage(usage?.cache_read_input_tokens),
+    cacheWriteTokens: boundedUsage(usage?.cache_creation_input_tokens),
+    usageAvailable,
+    latencyMs,
   };
   if (!completeFidelity || !dependencies.outputConsumer) return completion;
 

--- a/server/src/db/migrations/568_shadow_replay_generation_cost.sql
+++ b/server/src/db/migrations/568_shadow_replay_generation_cost.sql
@@ -1,0 +1,43 @@
+-- Record complete, reproducible latency and cost evidence for each newly
+-- completed full-response shadow generation. Existing rows remain explicitly
+-- unpriced because their cache usage and generation-only latency were not kept.
+
+ALTER TABLE addie_shadow_replay_generations
+  ADD COLUMN pricing_version VARCHAR(64) NOT NULL DEFAULT 'legacy-unrecorded',
+  ADD COLUMN usage_complete BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN cache_read_tokens INTEGER NOT NULL DEFAULT 0
+    CHECK (cache_read_tokens >= 0),
+  ADD COLUMN cache_write_tokens INTEGER NOT NULL DEFAULT 0
+    CHECK (cache_write_tokens >= 0),
+  ADD COLUMN latency_ms INTEGER CHECK (latency_ms BETWEEN 0 AND 900000),
+  ADD COLUMN estimated_cost_micros BIGINT
+    CHECK (estimated_cost_micros IS NULL OR estimated_cost_micros >= 0),
+  ADD CONSTRAINT shadow_replay_generation_pricing_version_valid
+    CHECK (pricing_version ~ '^[a-zA-Z0-9._:-]{1,64}$'),
+  ADD CONSTRAINT shadow_replay_generation_cost_completeness CHECK (
+    (usage_complete AND latency_ms IS NOT NULL AND estimated_cost_micros IS NOT NULL)
+    OR
+    (NOT usage_complete AND estimated_cost_micros IS NULL)
+  ),
+  ADD CONSTRAINT shadow_replay_generation_new_usage_consistency CHECK (
+    pricing_version = 'legacy-unrecorded'
+    OR usage_complete
+    OR (
+      input_tokens = 0 AND output_tokens = 0
+      AND cache_read_tokens = 0 AND cache_write_tokens = 0
+    )
+  ),
+  ADD CONSTRAINT shadow_replay_generation_new_success_evidence CHECK (
+    pricing_version = 'legacy-unrecorded'
+    OR status <> 'succeeded'
+    OR usage_complete
+  );
+
+COMMENT ON COLUMN addie_shadow_replay_generations.pricing_version IS
+  'Immutable reviewed price-table version selected before the provider call';
+COMMENT ON COLUMN addie_shadow_replay_generations.usage_complete IS
+  'True only when normalized terminal usage was returned; false is not equivalent to zero usage';
+COMMENT ON COLUMN addie_shadow_replay_generations.latency_ms IS
+  'Generation-only monotonic wall time, excluding any later independent judgment';
+COMMENT ON COLUMN addie_shadow_replay_generations.estimated_cost_micros IS
+  'Cost computed from complete token/cache usage and the persisted pricing version';

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -601,6 +601,26 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
             (sum, outcome) => sum + outcome.output_tokens,
             0,
           ),
+          cache_read_tokens: generationOutcomes.reduce(
+            (sum, outcome) => sum + outcome.cache_read_tokens,
+            0,
+          ),
+          cache_write_tokens: generationOutcomes.reduce(
+            (sum, outcome) => sum + outcome.cache_write_tokens,
+            0,
+          ),
+          usage_complete: generationOutcomes.reduce(
+            (sum, outcome) => sum + outcome.usage_complete_count,
+            0,
+          ),
+          latency_complete: generationOutcomes.reduce(
+            (sum, outcome) => sum + outcome.latency_count,
+            0,
+          ),
+          estimated_cost_micros: generationOutcomes.reduce(
+            (sum, outcome) => sum + BigInt(outcome.estimated_cost_micros),
+            0n,
+          ).toString(),
           outcomes: generationOutcomes,
         },
         judgments: {

--- a/server/tests/integration/shadow-replay-trace-migration.test.ts
+++ b/server/tests/integration/shadow-replay-trace-migration.test.ts
@@ -25,7 +25,7 @@ const MIGRATION_556_SQL = readFileSync(
   'utf8',
 );
 
-describe('migrations 552 through 567: shadow replay traces', () => {
+describe('migrations 552 through 568: shadow replay traces', () => {
   let pool: Pool;
 
   beforeAll(async () => {
@@ -234,14 +234,20 @@ describe('migrations 552 through 567: shadow replay traces', () => {
         'blocked_capabilities',
         'input_tokens',
         'output_tokens',
+        'pricing_version',
+        'usage_complete',
+        'cache_read_tokens',
+        'cache_write_tokens',
+        'latency_ms',
+        'estimated_cost_micros',
         'started_at',
         'heartbeat_at',
         'completed_at',
         'retained_until',
       ]),
     );
-    const generationConstraints = await pool.query<{ definition: string }>(
-      `SELECT pg_get_constraintdef(oid) AS definition
+    const generationConstraints = await pool.query<{ constraint_name: string; definition: string }>(
+      `SELECT conname AS constraint_name, pg_get_constraintdef(oid) AS definition
        FROM pg_constraint
        WHERE conrelid = 'addie_shadow_replay_generations'::regclass`,
     );
@@ -257,6 +263,16 @@ describe('migrations 552 through 567: shadow replay traces', () => {
     expect(generationConstraints.rows.some(({ definition }) =>
       definition.includes('(returned_provider IS NULL)')
       && definition.includes('(returned_model IS NULL)'))).toBe(true);
+    expect(generationConstraints.rows.some(({ definition }) =>
+      definition.includes('usage_complete')
+      && definition.includes('estimated_cost_micros IS NOT NULL'))).toBe(true);
+    expect(generationConstraints.rows.some(({ constraint_name, definition }) =>
+      constraint_name === 'shadow_replay_generation_new_success_evidence'
+      && definition.includes('pricing_version')
+      && definition.includes('legacy-unrecorded')
+      && definition.includes('status')
+      && definition.includes('succeeded')
+      && definition.includes('usage_complete'))).toBe(true);
 
     const judgmentColumns = await pool.query<{ column_name: string }>(
       `SELECT column_name
@@ -439,7 +455,7 @@ describe('migrations 552 through 567: shadow replay traces', () => {
            message_payload_hmacs, provider_request_hmac
          ) VALUES (
            gen_random_uuid(), 3, $1, $2, $3, $4, 'test-v1', 'read-only-v1',
-           $5, 'claude-example-chat', FALSE, FALSE, 1, $6, $6, $6, $6, $6,
+           $5, 'claude-sonnet-5', FALSE, FALSE, 1, $6, $6, $6, $6, $6,
            $6, $6, $6, '[]'::jsonb, '[]'::jsonb, $6,
            NOW() + INTERVAL '1 hour', NOW() + INTERVAL '7 days',
            'official_docs_v1', 'official-docs-policy:v1',
@@ -474,7 +490,7 @@ describe('migrations 552 through 567: shadow replay traces', () => {
       claimShadowReplayGeneration({
         ...trace,
         expected: {
-          effective_model: 'claude-example-chat',
+          effective_model: 'claude-sonnet-5',
           provider_request_hmac: String(index + 3).repeat(64),
         },
       } as never, 1, { query: concurrentQuery as never, now })));
@@ -504,7 +520,7 @@ describe('migrations 552 through 567: shadow replay traces', () => {
     const sameTraceAuthorization = {
       ...sameTrace,
       expected: {
-        effective_model: 'claude-example-chat',
+        effective_model: 'claude-sonnet-5',
         provider_request_hmac: '3'.repeat(64),
       },
     } as never;
@@ -535,9 +551,10 @@ describe('migrations 552 through 567: shadow replay traces', () => {
       requested_provider: string;
       model: string;
       addie_code_version: string;
+      pricing_version: string;
       first_provider_request_hmac: string;
     }>(
-      `SELECT requested_provider, model, addie_code_version,
+      `SELECT requested_provider, model, addie_code_version, pricing_version,
               first_provider_request_hmac
        FROM addie_shadow_replay_generations
        WHERE trace_id = $1`,
@@ -547,6 +564,7 @@ describe('migrations 552 through 567: shadow replay traces', () => {
       requested_provider: target.provider,
       model: target.model,
       addie_code_version: CODE_VERSION,
+      pricing_version: 'google-gemini-3.7-flash-through-2026-12-31',
       first_provider_request_hmac: target.firstProviderRequestHmac,
     });
   });

--- a/server/tests/manual/shadow-eval-prod-summary.ts
+++ b/server/tests/manual/shadow-eval-prod-summary.ts
@@ -87,6 +87,11 @@ interface CaptureSummary {
     total: number;
     input_tokens: number;
     output_tokens: number;
+    cache_read_tokens: number;
+    cache_write_tokens: number;
+    usage_complete: number;
+    latency_complete: number;
+    estimated_cost_micros: string;
     outcomes: Array<{
       capture_version: number;
       capture_policy_version: string;
@@ -96,6 +101,7 @@ interface CaptureSummary {
       requested_model: string;
       addie_code_version: string;
       execution_policy_version: string;
+      pricing_version: string;
       returned_provider: string | null;
       returned_model: string | null;
       status: string;
@@ -103,6 +109,13 @@ interface CaptureSummary {
       count: number;
       input_tokens: number;
       output_tokens: number;
+      cache_read_tokens: number;
+      cache_write_tokens: number;
+      usage_complete_count: number;
+      latency_count: number;
+      estimated_cost_micros: string;
+      latency_p50_ms: number | null;
+      latency_p95_ms: number | null;
     }>;
   };
   judgments?: {
@@ -377,7 +390,13 @@ async function main() {
       console.log(
         `Generation-only replays: ${captureSummary.generations.total} `
         + `(${captureSummary.generations.input_tokens} input / `
-        + `${captureSummary.generations.output_tokens} output tokens)`,
+        + `${captureSummary.generations.output_tokens} output / `
+        + `${captureSummary.generations.cache_read_tokens} cache-read / `
+        + `${captureSummary.generations.cache_write_tokens} cache-write tokens; `
+        + `${captureSummary.generations.usage_complete}/${captureSummary.generations.total} `
+        + `complete usage; ${captureSummary.generations.latency_complete}/`
+        + `${captureSummary.generations.total} timed; `
+        + `${captureSummary.generations.estimated_cost_micros} cost micros)`,
       );
       for (const outcome of captureSummary.generations.outcomes) {
         const returned = outcome.returned_provider && outcome.returned_model
@@ -388,9 +407,16 @@ async function main() {
           + `source=${outcome.source_model}@config:${outcome.source_config_version_id} `
           + `returned=${returned} code=${outcome.addie_code_version} `
           + `capture=v${outcome.capture_version}/${outcome.capture_policy_version} `
-          + `execution=${outcome.execution_policy_version} `
+          + `execution=${outcome.execution_policy_version} pricing=${outcome.pricing_version} `
           + `${outcome.status}:${outcome.reason} ${outcome.count} `
-          + `(${outcome.input_tokens} input / ${outcome.output_tokens} output tokens)`,
+          + `usage=${outcome.usage_complete_count}/${outcome.count} `
+          + `timed=${outcome.latency_count}/${outcome.count} `
+          + `latency_p50/p95=${outcome.latency_p50_ms ?? 'none'}/`
+          + `${outcome.latency_p95_ms ?? 'none'}ms `
+          + `cost=${outcome.estimated_cost_micros}µUSD `
+          + `(${outcome.input_tokens} input / ${outcome.output_tokens} output / `
+          + `${outcome.cache_read_tokens} cache-read / `
+          + `${outcome.cache_write_tokens} cache-write tokens)`,
         );
       }
     }

--- a/server/tests/unit/addie/shadow-evaluator-capture.test.ts
+++ b/server/tests/unit/addie/shadow-evaluator-capture.test.ts
@@ -684,6 +684,10 @@ describe('shadow evaluator capture-only orchestration', () => {
         blockedCapabilities: [],
         inputTokens: 0,
         outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        usageAvailable: false,
+        latencyMs: null,
       },
     );
     expect(fixture.completeCapture).not.toHaveBeenCalled();

--- a/server/tests/unit/addie/shadow-replay-judge.test.ts
+++ b/server/tests/unit/addie/shadow-replay-judge.test.ts
@@ -53,7 +53,7 @@ function trace(withHuman = true): ResolvedShadowReplayTrace {
       contentHmac: traceDigest('human-response-content', HUMAN_TEXT),
     } : null,
     expected: {
-      effective_model: 'claude-sonnet-fixture',
+      effective_model: 'claude-sonnet-5',
       provider_request_hmac: 'b'.repeat(64),
       tool_schema_hmacs: [],
       retained_until: new Date(Date.now() + 60_000),
@@ -102,6 +102,10 @@ async function expectJudgmentPersists(
     blockedCapabilities: [],
     inputTokens: 100,
     outputTokens: 20,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    usageAvailable: true,
+    latencyMs: 25,
   }, {
     judgment,
     query: query as never,
@@ -177,7 +181,7 @@ describe('shadow replay independent judge', () => {
       text: longOutput,
       outputHmac: 'a'.repeat(64),
       outputBytes: Buffer.byteLength(longOutput),
-      generatorModel: 'claude-sonnet-fixture',
+      generatorModel: 'claude-sonnet-5',
     });
 
     expect(result.status).toBe('deterministic_failure');
@@ -202,7 +206,7 @@ describe('shadow replay independent judge', () => {
       text: output,
       outputHmac: 'a'.repeat(64),
       outputBytes: Buffer.byteLength(output),
-      generatorModel: 'claude-sonnet-fixture',
+      generatorModel: 'claude-sonnet-5',
     });
 
     expect(result).toMatchObject({
@@ -234,7 +238,7 @@ describe('shadow replay independent judge', () => {
       humanEvidence: humanEvidence(),
       guardedOutput: 'The task lifecycle is request, delivery, and completion.',
       outputHmac: 'a'.repeat(64),
-      generatorModel: 'claude-sonnet-fixture',
+      generatorModel: 'claude-sonnet-5',
       judgeModel: 'claude-opus-fixture',
       judgeEnabled: true,
     }, {
@@ -311,7 +315,7 @@ describe('shadow replay independent judge', () => {
       humanEvidence: humanEvidence(),
       guardedOutput: 'A concise response.',
       outputHmac: 'a'.repeat(64),
-      generatorModel: 'claude-sonnet-fixture',
+      generatorModel: 'claude-sonnet-5',
       judgeModel: 'claude-opus-fixture',
     } as unknown as Parameters<typeof executeIndependentShadowReplayJudge>[0];
 
@@ -337,7 +341,7 @@ describe('shadow replay independent judge', () => {
       humanEvidence: humanEvidence(),
       guardedOutput: 'A concise response.',
       outputHmac: 'a'.repeat(64),
-      generatorModel: 'claude-sonnet-fixture',
+      generatorModel: 'claude-sonnet-5',
       judgeModel: 'claude-opus-fixture',
       judgeEnabled: true,
     }, {
@@ -391,7 +395,7 @@ describe('shadow replay independent judge', () => {
       humanEvidence: humanEvidence(),
       guardedOutput: 'A concise response.',
       outputHmac: 'a'.repeat(64),
-      generatorModel: 'claude-sonnet-fixture',
+      generatorModel: 'claude-sonnet-5',
       judgeModel: 'claude-opus-fixture',
       judgeEnabled: true,
     }, {
@@ -415,7 +419,7 @@ describe('shadow replay independent judge', () => {
       text: 'A concise response.',
       outputHmac: 'a'.repeat(64),
       outputBytes: 19,
-      generatorModel: 'claude-sonnet-fixture',
+      generatorModel: 'claude-sonnet-5',
     };
 
     await expect(consumer(output)).resolves.toMatchObject({
@@ -441,7 +445,7 @@ describe('shadow replay independent judge', () => {
       text: 'A concise response.',
       outputHmac: 'a'.repeat(64),
       outputBytes: 19,
-      generatorModel: 'claude-sonnet-fixture',
+      generatorModel: 'claude-sonnet-5',
     });
 
     expect(result).toMatchObject({

--- a/server/tests/unit/addie/shadow-replay-pricing.test.ts
+++ b/server/tests/unit/addie/shadow-replay-pricing.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GOOGLE_SHADOW_REPLAY_PRICING_VERSION,
+  resolveShadowReplayPricing,
+} from '../../../src/addie/jobs/shadow-replay-pricing.js';
+
+describe('shadow replay pricing', () => {
+  it('prices exact Anthropic usage including cache reads and writes', () => {
+    const pricing = resolveShadowReplayPricing('anthropic', 'claude-sonnet-5');
+    expect(pricing?.version).toBe('anthropic-standard-2026-08:claude-sonnet-5');
+    expect(pricing?.estimateCostMicros({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 1_000,
+      cacheWriteTokens: 200,
+    })).toBe(1_650);
+  });
+
+  it('prices only the exact reviewed Google model', () => {
+    const pricing = resolveShadowReplayPricing('google', 'gemini-3.7-flash');
+    expect(pricing?.version).toBe(GOOGLE_SHADOW_REPLAY_PRICING_VERSION);
+    expect(pricing?.validBefore?.toISOString()).toBe('2027-01-01T00:00:00.000Z');
+    expect(pricing?.estimateCostMicros({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 20,
+      cacheWriteTokens: 0,
+    })).toBe(137);
+    expect(resolveShadowReplayPricing('google', 'gemini-unreviewed')).toBeNull();
+  });
+
+  it('fails closed for unsupported provider/model price tables', () => {
+    expect(resolveShadowReplayPricing('anthropic', 'claude-unreviewed')).toBeNull();
+    expect(resolveShadowReplayPricing('openai', 'gpt-unreviewed')).toBeNull();
+  });
+});

--- a/server/tests/unit/addie/shadow-replay-trace.test.ts
+++ b/server/tests/unit/addie/shadow-replay-trace.test.ts
@@ -34,11 +34,23 @@ const TRACE_KEY_VERSION = 'test-v1';
 const NOW = new Date('2026-08-25T08:00:00.000Z');
 const QUESTION = 'private.person@example.test secret-question-sentinel';
 const HUMAN_RESPONSE = 'A private exact human answer with enough substantive bytes.';
+const COMPLETE_GENERATION_USAGE = {
+  cacheReadTokens: 4,
+  cacheWriteTokens: 2,
+  usageAvailable: true,
+  latencyMs: 250,
+} as const;
+const UNAVAILABLE_GENERATION_USAGE = {
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  usageAvailable: false,
+  latencyMs: null,
+} as const;
 
 function snapshot(): InvocationPreparedSnapshot {
   return {
     execution_mode: 'production',
-    model: 'claude-test',
+    model: 'claude-sonnet-5',
     iteration: 1,
     attempt: 1,
     system_blocks: [{ index: 0, sha256: 'a'.repeat(64) }],
@@ -83,7 +95,7 @@ function captureInput(identity = createShadowReplayCaptureIdentity({
       allowedToolNames: [...OFFICIAL_DOCS_ALLOWED_TOOLS],
       initialToolChoice: { type: 'tool', name: 'search_docs' },
     },
-    effectiveModel: 'claude-test',
+    effectiveModel: 'claude-sonnet-5',
     selectedToolSets: ['knowledge'],
     isAdmin: false,
   };
@@ -606,11 +618,12 @@ describe('shadow replay trace authorization', () => {
     expect(runQuery.mock.calls[0][0]).toContain('parity_marked AS');
     expect(runQuery.mock.calls[0][0]).toContain('SET capture_parity_verified = TRUE');
     expect(runQuery.mock.calls[0][1][9]).toBe(100);
-    expect(runQuery.mock.calls[0][1].slice(10, 14)).toEqual([
+    expect(runQuery.mock.calls[0][1].slice(10, 15)).toEqual([
       'anthropic',
       trace.expected.effective_model,
       trace.expected.provider_request_hmac,
       CODE_VERSION,
+      'anthropic-standard-2026-08:claude-sonnet-5',
     ]);
     expect(JSON.stringify(runQuery.mock.calls)).not.toContain(QUESTION);
   });
@@ -630,12 +643,39 @@ describe('shadow replay trace authorization', () => {
     })).resolves.toBe('claimed');
     expect(runQuery.mock.calls[0][0]).toContain('requested_provider, model');
     expect(runQuery.mock.calls[0][0]).toContain('addie_code_version');
-    expect(runQuery.mock.calls[0][1].slice(10, 14)).toEqual([
+    expect(runQuery.mock.calls[0][1].slice(10, 15)).toEqual([
       target.provider,
       target.model,
       target.firstProviderRequestHmac,
       CODE_VERSION,
+      'google-gemini-3.7-flash-through-2026-12-31',
     ]);
+  });
+
+  it('does not claim a paid generation without an exact price table', async () => {
+    const { trace } = await authorizedTrace();
+    trace.expected.effective_model = 'claude-unreviewed';
+    const runQuery = vi.fn();
+    await expect(claimShadowReplayGeneration(trace, 1, {
+      query: runQuery as never,
+      now: NOW,
+    })).resolves.toBe('trace_unavailable');
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
+  it('does not claim Google generation after its introductory rate expires', async () => {
+    const { trace } = await authorizedTrace();
+    const runQuery = vi.fn();
+    await expect(claimShadowReplayGeneration(trace, 1, {
+      query: runQuery as never,
+      now: new Date('2027-01-01T00:00:00.000Z'),
+      target: {
+        provider: 'google',
+        model: 'gemini-3.7-flash',
+        firstProviderRequestHmac: '9'.repeat(64),
+      },
+    })).resolves.toBe('trace_unavailable');
+    expect(runQuery).not.toHaveBeenCalled();
   });
 
   it('fails closed before SQL when the generation quota is not bounded', async () => {
@@ -721,6 +761,7 @@ describe('shadow replay trace authorization', () => {
       blockedCapabilities: [],
       inputTokens: 20,
       outputTokens: 10,
+      ...COMPLETE_GENERATION_USAGE,
       returnedProvider: 'google' as const,
       returnedModel: 'gemini-3.7-flash-20260801',
     };
@@ -742,6 +783,14 @@ describe('shadow replay trace authorization', () => {
       target.firstProviderRequestHmac,
       outcome.returnedProvider,
       outcome.returnedModel,
+    ]);
+    expect(runQuery.mock.calls[0][1].slice(47, 53)).toEqual([
+      COMPLETE_GENERATION_USAGE.cacheReadTokens,
+      COMPLETE_GENERATION_USAGE.cacheWriteTokens,
+      true,
+      COMPLETE_GENERATION_USAGE.latencyMs,
+      52,
+      'google-gemini-3.7-flash-through-2026-12-31',
     ]);
     expect(JSON.stringify(runQuery.mock.calls)).not.toContain(QUESTION);
   });
@@ -771,6 +820,7 @@ describe('shadow replay trace authorization', () => {
       blockedCapabilities: [],
       inputTokens: 20,
       outputTokens: 10,
+      ...COMPLETE_GENERATION_USAGE,
     }, {
       query: runQuery as never,
       now: NOW,
@@ -836,6 +886,7 @@ describe('shadow replay trace authorization', () => {
       blockedCapabilities: [],
       inputTokens: 1,
       outputTokens: 1,
+      ...COMPLETE_GENERATION_USAGE,
     }, {
       query: runQuery as never,
       now: NOW,
@@ -882,6 +933,7 @@ describe('shadow replay trace authorization', () => {
       blockedCapabilities: [],
       inputTokens: 1,
       outputTokens: 1,
+      ...COMPLETE_GENERATION_USAGE,
     }, {
       query: runQuery as never,
       now: NOW,
@@ -940,6 +992,7 @@ describe('shadow replay trace authorization', () => {
       blockedCapabilities: [],
       inputTokens: 1,
       outputTokens: 1,
+      ...COMPLETE_GENERATION_USAGE,
     }, {
       query: runQuery as never,
       now: NOW,
@@ -992,6 +1045,7 @@ describe('shadow replay trace authorization', () => {
       blockedCapabilities: ['private:value'],
       inputTokens: 0,
       outputTokens: 0,
+      ...UNAVAILABLE_GENERATION_USAGE,
     }, { query: runQuery as never })).rejects.toThrow(
       'shadow_replay_generation_blocked_capability_invalid',
     );
@@ -1011,6 +1065,7 @@ describe('shadow replay trace authorization', () => {
       blockedCapabilities: ['provider_identity_drift'],
       inputTokens: 0,
       outputTokens: 0,
+      ...UNAVAILABLE_GENERATION_USAGE,
       returnedProvider: 'google',
       returnedModel: null,
     }, { query: runQuery as never })).rejects.toThrow(
@@ -1032,8 +1087,41 @@ describe('shadow replay trace authorization', () => {
       blockedCapabilities: ['provider_request_drift'],
       inputTokens: 0,
       outputTokens: 0,
+      ...UNAVAILABLE_GENERATION_USAGE,
     }, { query: runQuery as never, now: NOW })).resolves.toBe(true);
     expect(JSON.parse(runQuery.mock.calls[0][1][6] as string)).toEqual([]);
+  });
+
+  it('persists unavailable provider usage as null cost rather than zero cost', async () => {
+    const { trace } = await authorizedTrace();
+    const runQuery = vi.fn(async () => ({ rows: [{ completed: true }], rowCount: 1 }));
+    await expect(completeShadowReplayGeneration(trace, {
+      status: 'error',
+      reason: 'provider_execution_failed',
+      outputHmac: null,
+      outputBytes: 0,
+      invocations: [{
+        iteration: 1,
+        attempt: 1,
+        provider_request_hmac: trace.expected.provider_request_hmac!,
+      }],
+      toolExecutions: [],
+      blockedCapabilities: ['provider_execution_failed', 'usage_unavailable'],
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      usageAvailable: false,
+      latencyMs: 500,
+    }, { query: runQuery as never, now: NOW })).resolves.toBe(true);
+    expect(runQuery.mock.calls[0][1].slice(47, 53)).toEqual([
+      0,
+      0,
+      false,
+      500,
+      null,
+      'anthropic-standard-2026-08:claude-sonnet-5',
+    ]);
   });
 
   it('rejects a success row whose signed first request or policy outcome is inconsistent', async () => {
@@ -1048,6 +1136,7 @@ describe('shadow replay trace authorization', () => {
       blockedCapabilities: [],
       inputTokens: 1,
       outputTokens: 1,
+      ...COMPLETE_GENERATION_USAGE,
     };
     await expect(completeShadowReplayGeneration(trace, {
       ...base,
@@ -1101,6 +1190,7 @@ describe('shadow replay trace authorization', () => {
       blockedCapabilities: ['unapproved_tool'],
       inputTokens: 1,
       outputTokens: 1,
+      ...COMPLETE_GENERATION_USAGE,
     }, { query: runQuery as never })).rejects.toThrow(
       'shadow_replay_generation_tool_binding_invalid',
     );
@@ -1136,6 +1226,7 @@ describe('shadow replay trace authorization', () => {
       requested_model: 'gemini-3.7-flash',
       addie_code_version: '2026.08.109',
       execution_policy_version: 'official-docs-read-only:v1',
+      pricing_version: 'google-gemini-3.7-flash-through-2026-12-31',
       returned_provider: 'google',
       returned_model: 'gemini-3.7-flash-20260801',
       status: 'succeeded',
@@ -1143,6 +1234,13 @@ describe('shadow replay trace authorization', () => {
       count: 2,
       input_tokens: 100,
       output_tokens: 40,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      usage_complete_count: 2,
+      latency_count: 2,
+      estimated_cost_micros: '225',
+      latency_p50_ms: 900,
+      latency_p95_ms: 1_100,
     }];
     const runQuery = vi.fn(async () => ({ rows, rowCount: 1 }));
     await expect(getShadowReplayGenerationSummary(999, { query: runQuery as never }))
@@ -1151,6 +1249,11 @@ describe('shadow replay trace authorization', () => {
     expect(runQuery.mock.calls[0][0]).toContain('generation.requested_provider');
     expect(runQuery.mock.calls[0][0]).toContain('generation.addie_code_version');
     expect(runQuery.mock.calls[0][0]).toContain('generation.execution_policy_version');
+    expect(runQuery.mock.calls[0][0]).toContain('generation.pricing_version');
+    expect(runQuery.mock.calls[0][0]).toContain('generation.usage_complete');
+    expect(runQuery.mock.calls[0][0]).toContain('generation.estimated_cost_micros');
+    expect(runQuery.mock.calls[0][0]).toContain('COUNT(generation.latency_ms)');
+    expect(runQuery.mock.calls[0][0]).toContain('percentile_disc(0.95)');
     expect(runQuery.mock.calls[0][0]).toContain('trace.source_config_version_id');
     expect(runQuery.mock.calls[0][0]).not.toContain('question_hmac');
   });

--- a/server/tests/unit/addie/shadow-replay.test.ts
+++ b/server/tests/unit/addie/shadow-replay.test.ts
@@ -488,6 +488,12 @@ describe('verified official docs replay generation', () => {
         if (decision?.allowed) await requestTools.handlers.get('search_docs')?.(input);
         return generatedResponse({
           tools_used: ['search_docs'],
+          usage: {
+            input_tokens: 123,
+            output_tokens: 45,
+            cache_read_input_tokens: 67,
+            cache_creation_input_tokens: 8,
+          },
           tool_executions: [{
             tool_name: 'search_docs',
             parameters: {},
@@ -508,6 +514,7 @@ describe('verified official docs replay generation', () => {
       client: fakeClient as never,
       getDocsFingerprint: () => 'docs-fingerprint',
       renewLease: async () => true,
+      monotonicNow: vi.fn().mockReturnValueOnce(100).mockReturnValueOnce(350),
       createKnowledgeHandlers: createHandlers as never,
     });
 
@@ -520,6 +527,10 @@ describe('verified official docs replay generation', () => {
       outputBytes: expect.any(Number),
       inputTokens: 123,
       outputTokens: 45,
+      cacheReadTokens: 67,
+      cacheWriteTokens: 8,
+      usageAvailable: true,
+      latencyMs: 250,
     });
     expect(result.outputHmac).toMatch(/^[0-9a-f]{64}$/);
     expect(result.toolExecutions).toMatchObject([{
@@ -715,6 +726,44 @@ describe('verified official docs replay generation', () => {
     });
     expect(outputConsumer).not.toHaveBeenCalled();
     expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it('marks missing terminal usage incomplete instead of treating it as zero', async () => {
+    const fakeClient = {
+      processMessage: vi.fn(async (
+        _question: string,
+        _history: unknown,
+        _requestTools: RequestTools,
+        _rules: unknown,
+        options: ProcessMessageOptions,
+      ) => {
+        await options.onInvocationPrepared?.(officialDocsSnapshot());
+        return generatedResponse({ usage: undefined });
+      }),
+    };
+    const result = await executeVerifiedOfficialDocsReplay({
+      trace: officialDocsTrace(),
+      invocation: officialDocsInvocation(),
+      docsCorpusFingerprint: 'docs-fingerprint',
+    }, {
+      client: fakeClient as never,
+      getDocsFingerprint: () => 'docs-fingerprint',
+      renewLease: async () => true,
+      monotonicNow: vi.fn().mockReturnValueOnce(100).mockReturnValueOnce(200),
+      createKnowledgeHandlers: () => new Map([
+        ['search_docs', vi.fn()],
+        ['get_doc', vi.fn()],
+      ]),
+    });
+    expect(result).toMatchObject({
+      status: 'blocked',
+      reason: 'usage_unavailable',
+      usageAvailable: false,
+      inputTokens: 0,
+      outputTokens: 0,
+      latencyMs: 100,
+      blockedCapabilities: ['usage_unavailable'],
+    });
   });
 
   it('contains consumer failures behind a safe post-generation completion', async () => {


### PR DESCRIPTION
## Summary

- pin an exact reviewed price-table version when each production shadow generation is claimed, and fail closed before dispatch for unknown models or expired prices
- persist complete token/cache usage, monotonic generation-only latency, and estimated cost without storing response payloads
- expose exact-cohort usage/timing denominators, p50/p95 latency, cache tokens, and aggregate cost for promotion decisions
- add migration 568 and bump the Addie code version to `2026.08.112`

## Safety

- successful generations require complete usage and latency evidence
- missing or malformed usage is represented as unavailable, never as a zero-token success
- Google Gemini 3.7 Flash introductory pricing expires explicitly at 2027-01-01 UTC; no generation is admitted against a stale rate table
- timing covers only the provider generation loop and excludes independent judging
- legacy rows remain explicitly marked `legacy-unrecorded`
- no canary configuration, environment state, or paid provider call changed

## Verification

- `npm run precommit` (521 server test files; 7,486 passed, 30 skipped; typecheck passed)
- `npm run test:migrations`
- `npm run build:addie-tools`
- `npm run test:addie-tools`
- focused shadow replay/pricing/evaluator tests (102 passed)
- migration 568 applied transactionally to a temporary PostgreSQL table and rolled back
- `git diff --cached --check`
- confidential-name scan clean

The local long-lived integration database has unrelated stale migration-533 metadata, so the fresh-database CI integration job is the authority for the full migration chain.
