### PR TITLE
feat(addie): record shadow judge latency and cost

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.112';
+export const CODE_VERSION = '2026.08.113';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.113';
+export const CODE_VERSION = '2026.08.114';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/jobs/shadow-replay-judge.ts
+++ b/server/src/addie/jobs/shadow-replay-judge.ts
@@ -8,6 +8,7 @@ import {
   type ResolvedShadowReplayTrace,
   type ShadowReplayJudgmentCompletion,
 } from './shadow-replay-trace.js';
+import { resolveShadowReplayPricing } from './shadow-replay-pricing.js';
 import type { TrustedOfficialDocsReplayOutput } from './shadow-replay.js';
 
 export const SHADOW_REPLAY_JUDGE_PROMPT_VERSION =
@@ -66,6 +67,7 @@ export interface ExecuteShadowReplayJudgeDependencies {
   client?: JudgeClient;
   renewLease?: () => Promise<boolean>;
   now?: () => Date;
+  monotonicNow?: () => number;
 }
 
 export interface CreateShadowReplayOutputConsumerInput {
@@ -235,10 +237,42 @@ function parseStrictVerdict(text: string): ParsedJudgeVerdict | null {
   }
 }
 
-function boundedUsage(value: number | undefined): number {
-  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
-    ? value
-    : 0;
+function normalizeJudgeUsage(usage: unknown): {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  usageAvailable: boolean;
+} {
+  const candidate = usage && typeof usage === 'object'
+    ? usage as Record<string, unknown>
+    : {};
+  const validRequired = (value: unknown) => Number.isSafeInteger(value) && Number(value) >= 0;
+  const validOptional = (value: unknown) => value === undefined || validRequired(value);
+  const complete = validRequired(candidate.input_tokens)
+    && validRequired(candidate.output_tokens)
+    && validOptional(candidate.cache_read_input_tokens)
+    && validOptional(candidate.cache_creation_input_tokens);
+  return complete ? {
+    inputTokens: candidate.input_tokens as number,
+    outputTokens: candidate.output_tokens as number,
+    cacheReadTokens: (candidate.cache_read_input_tokens as number | undefined) ?? 0,
+    cacheWriteTokens: (candidate.cache_creation_input_tokens as number | undefined) ?? 0,
+    usageAvailable: true,
+  } : {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    usageAvailable: false,
+  };
+}
+
+function judgeLatencyMs(startedAt: number, completedAt: number): number | null {
+  const duration = completedAt - startedAt;
+  return Number.isFinite(duration) && duration >= 0 && duration <= 900_000
+    ? Math.ceil(duration)
+    : null;
 }
 
 function shapeEvidence(question: string, output: string): ShadowReplayDeterministicShapeEvidence {
@@ -260,7 +294,8 @@ type EvidenceBase = Omit<
   ShadowReplayJudgeEvidence,
   'status' | 'reason' | 'evaluationValid' | 'evaluationSkipped'
   | 'knowledgeGap' | 'gapSeverity' | 'shadowQuality' | 'judgeResponseHmac'
-  | 'inputTokens' | 'outputTokens' | 'completedAt'
+  | 'inputTokens' | 'outputTokens' | 'cacheReadTokens' | 'cacheWriteTokens'
+  | 'usageAvailable' | 'pricingVersion' | 'latencyMs' | 'completedAt'
 >;
 
 function terminalEvidence(
@@ -274,6 +309,11 @@ function terminalEvidence(
     responseHmac?: string | null;
     inputTokens?: number;
     outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+    usageAvailable?: boolean;
+    pricingVersion?: string;
+    latencyMs?: number | null;
     verdict?: ParsedJudgeVerdict;
   },
 ): ShadowReplayJudgeEvidence {
@@ -289,6 +329,11 @@ function terminalEvidence(
     judgeResponseHmac: input.responseHmac ?? null,
     inputTokens: input.inputTokens ?? 0,
     outputTokens: input.outputTokens ?? 0,
+    cacheReadTokens: input.cacheReadTokens ?? 0,
+    cacheWriteTokens: input.cacheWriteTokens ?? 0,
+    usageAvailable: input.usageAvailable ?? false,
+    pricingVersion: input.pricingVersion ?? 'not-applicable',
+    latencyMs: input.latencyMs ?? null,
     completedAt,
   };
 }
@@ -371,6 +416,14 @@ export async function executeIndependentShadowReplayJudge(
       evaluationSkipped: true,
     });
   }
+  const pricing = resolveShadowReplayPricing('anthropic', input.judgeModel);
+  if (!pricing || (pricing.validBefore && startedAt >= pricing.validBefore)) {
+    return terminalEvidence(baseWithoutRequest, now(), {
+      status: 'skipped',
+      reason: 'judge_pricing_unavailable',
+      evaluationSkipped: true,
+    });
+  }
   if (byteLength(input.trace.question) > MAX_SHADOW_REPLAY_JUDGE_QUESTION_BYTES
     || byteLength(input.humanEvidence.content) > MAX_SHADOW_REPLAY_JUDGE_HUMAN_BYTES
     || byteLength(input.guardedOutput) > MAX_SHADOW_REPLAY_JUDGE_OUTPUT_BYTES) {
@@ -426,6 +479,8 @@ export async function executeIndependentShadowReplayJudge(
   }
 
   let response: Anthropic.Message;
+  const monotonicNow = dependencies.monotonicNow ?? (() => performance.now());
+  const providerStartedAt = monotonicNow();
   try {
     response = await dependencies.client.messages.create(
       providerRequest,
@@ -435,26 +490,28 @@ export async function executeIndependentShadowReplayJudge(
       },
     );
   } catch {
+    const latencyMs = judgeLatencyMs(providerStartedAt, monotonicNow());
     return terminalEvidence(base, now(), {
       status: 'error',
       reason: 'judge_provider_error',
+      pricingVersion: pricing.version,
+      latencyMs,
     });
   }
+  const latencyMs = judgeLatencyMs(providerStartedAt, monotonicNow());
 
   const responseHmac = judgeHmac(input.trace, 'provider-response', {
     content: response.content,
     stop_reason: response.stop_reason,
   });
-  const usage = {
-    inputTokens: boundedUsage(response.usage?.input_tokens),
-    outputTokens: boundedUsage(response.usage?.output_tokens),
-  };
+  const usage = normalizeJudgeUsage(response.usage);
+  const pricedUsage = { ...usage, pricingVersion: pricing.version, latencyMs };
   if (response.stop_reason === 'max_tokens') {
     return terminalEvidence(base, now(), {
       status: 'error',
       reason: 'judge_output_truncated',
       responseHmac,
-      ...usage,
+      ...pricedUsage,
     });
   }
   if (
@@ -466,7 +523,7 @@ export async function executeIndependentShadowReplayJudge(
       status: 'error',
       reason: 'judge_output_invalid',
       responseHmac,
-      ...usage,
+      ...pricedUsage,
     });
   }
   const text = response.content[0].text;
@@ -476,7 +533,15 @@ export async function executeIndependentShadowReplayJudge(
       status: 'error',
       reason: 'judge_output_invalid',
       responseHmac,
-      ...usage,
+      ...pricedUsage,
+    });
+  }
+  if (!usage.usageAvailable) {
+    return terminalEvidence(base, now(), {
+      status: 'error',
+      reason: 'judge_usage_unavailable',
+      responseHmac,
+      ...pricedUsage,
     });
   }
   return terminalEvidence(base, now(), {
@@ -484,7 +549,7 @@ export async function executeIndependentShadowReplayJudge(
     reason: 'judgment_succeeded',
     evaluationValid: true,
     responseHmac,
-    ...usage,
+    ...pricedUsage,
     verdict,
   });
 }
@@ -560,6 +625,11 @@ export function createShadowReplayInternalErrorEvidence(
     humanEvidenceContentHmac: trace.humanEvidence?.contentHmac ?? null,
     inputTokens: 0,
     outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    usageAvailable: false,
+    pricingVersion: 'not-applicable',
+    latencyMs: null,
     startedAt,
     completedAt: now(),
     deterministicShape: {

--- a/server/src/addie/jobs/shadow-replay-judge.ts
+++ b/server/src/addie/jobs/shadow-replay-judge.ts
@@ -248,7 +248,7 @@ function normalizeJudgeUsage(usage: unknown): {
     ? usage as Record<string, unknown>
     : {};
   const validRequired = (value: unknown) => Number.isSafeInteger(value) && Number(value) >= 0;
-  const validOptional = (value: unknown) => value === undefined || validRequired(value);
+  const validOptional = (value: unknown) => value == null || validRequired(value);
   const complete = validRequired(candidate.input_tokens)
     && validRequired(candidate.output_tokens)
     && validOptional(candidate.cache_read_input_tokens)

--- a/server/src/addie/jobs/shadow-replay-trace.ts
+++ b/server/src/addie/jobs/shadow-replay-trace.ts
@@ -236,6 +236,11 @@ export interface ShadowReplayJudgmentCompletion {
   humanEvidenceContentHmac: string | null;
   inputTokens: number;
   outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  usageAvailable: boolean;
+  pricingVersion: string;
+  latencyMs: number | null;
   startedAt: Date;
   completedAt: Date;
 }
@@ -257,6 +262,7 @@ export interface ShadowReplayJudgmentSummaryRow extends QueryResultRow {
   judge_model: string | null;
   self_judged: boolean | null;
   judge_prompt_version: string | null;
+  pricing_version: string;
   status: string;
   reason: string;
   evaluation_valid: boolean;
@@ -268,6 +274,13 @@ export interface ShadowReplayJudgmentSummaryRow extends QueryResultRow {
   count: number;
   input_tokens: number;
   output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  usage_complete_count: number;
+  latency_count: number;
+  estimated_cost_micros: string;
+  latency_p50_ms: number | null;
+  latency_p95_ms: number | null;
 }
 
 export interface ShadowReplayFunnelSummary extends QueryResultRow {
@@ -1452,10 +1465,33 @@ function validateJudgmentCompletion(
   if (
     !Number.isSafeInteger(judgment.inputTokens) || judgment.inputTokens < 0
     || !Number.isSafeInteger(judgment.outputTokens) || judgment.outputTokens < 0
+    || !Number.isSafeInteger(judgment.cacheReadTokens) || judgment.cacheReadTokens < 0
+    || !Number.isSafeInteger(judgment.cacheWriteTokens) || judgment.cacheWriteTokens < 0
     || judgment.inputTokens > 2_147_483_647
     || judgment.outputTokens > 2_147_483_647
+    || judgment.cacheReadTokens > 2_147_483_647
+    || judgment.cacheWriteTokens > 2_147_483_647
   ) {
     throw new Error('shadow_replay_judgment_usage_invalid');
+  }
+  if (typeof judgment.usageAvailable !== 'boolean'
+    || (!judgment.usageAvailable && (
+      judgment.inputTokens !== 0
+      || judgment.outputTokens !== 0
+      || judgment.cacheReadTokens !== 0
+      || judgment.cacheWriteTokens !== 0
+    ))) {
+    throw new Error('shadow_replay_judgment_usage_completeness_invalid');
+  }
+  if (!BOUNDED_VERSION.test(judgment.pricingVersion)) {
+    throw new Error('shadow_replay_judgment_pricing_version_invalid');
+  }
+  if (judgment.latencyMs !== null && (
+    !Number.isSafeInteger(judgment.latencyMs)
+    || judgment.latencyMs < 0
+    || judgment.latencyMs > 900_000
+  )) {
+    throw new Error('shadow_replay_judgment_latency_invalid');
   }
   if (
     !Number.isSafeInteger(judgment.shapeWordCount)
@@ -1515,6 +1551,13 @@ function validateJudgmentCompletion(
   ) {
     throw new Error('shadow_replay_judgment_provenance_incomplete');
   }
+  if ((!judgeExecuted && (
+    judgment.pricingVersion !== 'not-applicable'
+    || judgment.usageAvailable
+    || judgment.latencyMs !== null
+  )) || (judgeExecuted && judgment.pricingVersion === 'not-applicable')) {
+    throw new Error('shadow_replay_judgment_cost_provenance_invalid');
+  }
   if (
     !judgment.sourceOutputHmac
     || !equalDigest(judgment.sourceOutputHmac, outcome.outputHmac)
@@ -1567,6 +1610,8 @@ function validateJudgmentCompletion(
         judgment.shadowQuality,
       )
       || judgment.deterministicFailureLabels.length !== 0
+      || !judgment.usageAvailable
+      || judgment.latencyMs === null
       || (judgment.knowledgeGap && judgment.gapSeverity === 'none')
       || (!judgment.knowledgeGap && judgment.gapSeverity !== 'none')
     ) {
@@ -1769,6 +1814,24 @@ export async function completeShadowReplayGeneration(
       cacheWriteTokens: outcome.cacheWriteTokens,
     })
     : null;
+  let judgmentEstimatedCostMicros: number | null = null;
+  if (judgment?.judgeModel) {
+    const judgmentPricing = resolveShadowReplayPricing(
+      providerForModel(judgment.judgeModel) as ModelProviderId,
+      judgment.judgeModel,
+    );
+    if (!judgmentPricing || judgmentPricing.version !== judgment.pricingVersion) {
+      throw new Error('shadow_replay_judgment_pricing_unavailable');
+    }
+    judgmentEstimatedCostMicros = judgment.usageAvailable
+      ? judgmentPricing.estimateCostMicros({
+        inputTokens: judgment.inputTokens,
+        outputTokens: judgment.outputTokens,
+        cacheReadTokens: judgment.cacheReadTokens,
+        cacheWriteTokens: judgment.cacheWriteTokens,
+      })
+      : null;
+  }
   const context = {
     shadow_eval_status: outcome.status === 'error' ? 'error' : 'skipped',
     shadow_eval_type: 'suppressed_opportunity',
@@ -1837,14 +1900,17 @@ export async function completeShadowReplayGeneration(
          judge_prompt_version, judge_prompt_hmac,
          judge_request_hmac, judge_response_hmac,
          question_hmac, source_output_hmac, human_evidence_content_hmac,
-         input_tokens, output_tokens, started_at, completed_at, retained_until
+         input_tokens, output_tokens, started_at, completed_at, retained_until,
+         pricing_version, usage_complete, cache_read_tokens, cache_write_tokens,
+         latency_ms, estimated_cost_micros
        )
        SELECT
          trace_completed.trace_id, $16, $17, $18,
          $19, $20, $21, $22, $23, $24::text[],
          $25, $26, $27,
          $28, $29, $30, $31, $32, $33, $34,
-         $35, $36, $37, $38, $39, $40, $41, $42
+         $35, $36, $37, $38, $39, $40, $41, $42,
+         $54, $55, $56, $57, $58, $59
        FROM trace_completed
        WHERE $15::boolean
        RETURNING trace_id
@@ -1913,6 +1979,12 @@ export async function completeShadowReplayGeneration(
       outcome.latencyMs,
       estimatedCostMicros,
       pricing.version,
+      judgment?.pricingVersion ?? null,
+      judgment?.usageAvailable ?? null,
+      judgment?.cacheReadTokens ?? null,
+      judgment?.cacheWriteTokens ?? null,
+      judgment?.latencyMs ?? null,
+      judgmentEstimatedCostMicros,
     ],
   );
   return result.rows[0]?.completed === true;
@@ -2075,6 +2147,7 @@ export async function getShadowReplayJudgmentSummary(
             judgment.judge_model,
             judgment.self_judged,
             judgment.judge_prompt_version,
+            judgment.pricing_version,
             judgment.status,
             judgment.reason,
             judgment.evaluation_valid,
@@ -2085,7 +2158,17 @@ export async function getShadowReplayJudgmentSummary(
             judgment.deterministic_failure_labels,
             COUNT(*)::integer AS count,
             COALESCE(SUM(judgment.input_tokens), 0)::integer AS input_tokens,
-            COALESCE(SUM(judgment.output_tokens), 0)::integer AS output_tokens
+            COALESCE(SUM(judgment.output_tokens), 0)::integer AS output_tokens,
+            COALESCE(SUM(judgment.cache_read_tokens), 0)::integer AS cache_read_tokens,
+            COALESCE(SUM(judgment.cache_write_tokens), 0)::integer AS cache_write_tokens,
+            COUNT(*) FILTER (WHERE judgment.usage_complete)::integer AS usage_complete_count,
+            COUNT(judgment.latency_ms)::integer AS latency_count,
+            COALESCE(SUM(judgment.estimated_cost_micros), 0)::text
+              AS estimated_cost_micros,
+            PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY judgment.latency_ms)::double precision
+              AS latency_p50_ms,
+            PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY judgment.latency_ms)::double precision
+              AS latency_p95_ms
      FROM addie_shadow_replay_judgments judgment
      JOIN addie_shadow_replay_generations generation
        ON generation.trace_id = judgment.trace_id
@@ -2100,7 +2183,7 @@ export async function getShadowReplayJudgmentSummary(
               generation.returned_provider, generation.returned_model,
               judgment.judgment_policy_version, judgment.judge_provider,
               judgment.judge_model, judgment.self_judged,
-              judgment.judge_prompt_version, judgment.status,
+              judgment.judge_prompt_version, judgment.pricing_version, judgment.status,
               judgment.reason, judgment.evaluation_valid,
               judgment.evaluation_skipped, judgment.knowledge_gap,
               judgment.gap_severity, judgment.shadow_quality,

--- a/server/src/db/migrations/569_shadow_replay_judgment_cost.sql
+++ b/server/src/db/migrations/569_shadow_replay_judgment_cost.sql
@@ -1,0 +1,57 @@
+-- Give independent-judge promotion evidence the same reproducible pricing,
+-- usage-completeness, cache, and monotonic-latency contract as generation.
+-- Existing rows remain explicitly unpriced.
+
+ALTER TABLE addie_shadow_replay_judgments
+  ADD COLUMN pricing_version VARCHAR(64) NOT NULL DEFAULT 'legacy-unrecorded',
+  ADD COLUMN usage_complete BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN cache_read_tokens INTEGER NOT NULL DEFAULT 0
+    CHECK (cache_read_tokens >= 0),
+  ADD COLUMN cache_write_tokens INTEGER NOT NULL DEFAULT 0
+    CHECK (cache_write_tokens >= 0),
+  ADD COLUMN latency_ms INTEGER CHECK (latency_ms BETWEEN 0 AND 900000),
+  ADD COLUMN estimated_cost_micros BIGINT
+    CHECK (estimated_cost_micros IS NULL OR estimated_cost_micros >= 0),
+  ADD CONSTRAINT shadow_replay_judgment_pricing_version_valid
+    CHECK (pricing_version ~ '^[a-zA-Z0-9._:-]{1,64}$'),
+  ADD CONSTRAINT shadow_replay_judgment_cost_completeness CHECK (
+    (usage_complete AND estimated_cost_micros IS NOT NULL)
+    OR
+    (NOT usage_complete AND estimated_cost_micros IS NULL)
+  ),
+  ADD CONSTRAINT shadow_replay_judgment_new_usage_consistency CHECK (
+    pricing_version = 'legacy-unrecorded'
+    OR usage_complete
+    OR (
+      input_tokens = 0 AND output_tokens = 0
+      AND cache_read_tokens = 0 AND cache_write_tokens = 0
+    )
+  ),
+  ADD CONSTRAINT shadow_replay_judgment_new_execution_consistency CHECK (
+    pricing_version = 'legacy-unrecorded'
+    OR (
+      judge_model IS NULL
+      AND pricing_version = 'not-applicable'
+      AND NOT usage_complete
+      AND latency_ms IS NULL
+      AND estimated_cost_micros IS NULL
+    )
+    OR (
+      judge_model IS NOT NULL
+      AND pricing_version <> 'not-applicable'
+    )
+  ),
+  ADD CONSTRAINT shadow_replay_judgment_new_success_evidence CHECK (
+    pricing_version = 'legacy-unrecorded'
+    OR status <> 'judged'
+    OR (usage_complete AND latency_ms IS NOT NULL)
+  );
+
+COMMENT ON COLUMN addie_shadow_replay_judgments.pricing_version IS
+  'Reviewed price-table version used for the judge call, or not-applicable when no call ran';
+COMMENT ON COLUMN addie_shadow_replay_judgments.usage_complete IS
+  'True only when normalized terminal judge usage was returned; false is not zero usage';
+COMMENT ON COLUMN addie_shadow_replay_judgments.latency_ms IS
+  'Monotonic provider-call time only, excluding deterministic grading and persistence';
+COMMENT ON COLUMN addie_shadow_replay_judgments.estimated_cost_micros IS
+  'Judge cost computed from complete token/cache usage and the persisted pricing version';

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -633,6 +633,26 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
             (sum, outcome) => sum + outcome.output_tokens,
             0,
           ),
+          cache_read_tokens: judgmentOutcomes.reduce(
+            (sum, outcome) => sum + outcome.cache_read_tokens,
+            0,
+          ),
+          cache_write_tokens: judgmentOutcomes.reduce(
+            (sum, outcome) => sum + outcome.cache_write_tokens,
+            0,
+          ),
+          usage_complete: judgmentOutcomes.reduce(
+            (sum, outcome) => sum + outcome.usage_complete_count,
+            0,
+          ),
+          latency_complete: judgmentOutcomes.reduce(
+            (sum, outcome) => sum + outcome.latency_count,
+            0,
+          ),
+          estimated_cost_micros: judgmentOutcomes.reduce(
+            (sum, outcome) => sum + BigInt(outcome.estimated_cost_micros),
+            0n,
+          ).toString(),
           outcomes: judgmentOutcomes,
         },
         funnel,

--- a/server/tests/integration/shadow-replay-trace-migration.test.ts
+++ b/server/tests/integration/shadow-replay-trace-migration.test.ts
@@ -25,7 +25,7 @@ const MIGRATION_556_SQL = readFileSync(
   'utf8',
 );
 
-describe('migrations 552 through 568: shadow replay traces', () => {
+describe('migrations 552 through 569: shadow replay traces', () => {
   let pool: Pool;
 
   beforeAll(async () => {
@@ -307,6 +307,12 @@ describe('migrations 552 through 568: shadow replay traces', () => {
         'human_evidence_content_hmac',
         'input_tokens',
         'output_tokens',
+        'pricing_version',
+        'usage_complete',
+        'cache_read_tokens',
+        'cache_write_tokens',
+        'latency_ms',
+        'estimated_cost_micros',
         'started_at',
         'completed_at',
         'retained_until',
@@ -315,8 +321,8 @@ describe('migrations 552 through 568: shadow replay traces', () => {
     expect(judgmentColumns.rows.map(({ column_name }) => column_name)).not.toEqual(
       expect.arrayContaining(['question', 'human_response', 'generated_output']),
     );
-    const judgmentConstraints = await pool.query<{ definition: string }>(
-      `SELECT pg_get_constraintdef(oid) AS definition
+    const judgmentConstraints = await pool.query<{ constraint_name: string; definition: string }>(
+      `SELECT conname AS constraint_name, pg_get_constraintdef(oid) AS definition
        FROM pg_constraint
        WHERE conrelid = 'addie_shadow_replay_judgments'::regclass`,
     );
@@ -324,6 +330,14 @@ describe('migrations 552 through 568: shadow replay traces', () => {
       definition.includes('self_judged = false'))).toBe(true);
     expect(judgmentConstraints.rows.some(({ definition }) =>
       definition.includes('array_to_string(deterministic_failure_labels'))).toBe(true);
+    expect(judgmentConstraints.rows.some(({ constraint_name, definition }) =>
+      constraint_name === 'shadow_replay_judgment_new_success_evidence'
+      && definition.includes('pricing_version')
+      && definition.includes('legacy-unrecorded')
+      && definition.includes('status')
+      && definition.includes('judged')
+      && definition.includes('usage_complete')
+      && definition.includes('latency_ms'))).toBe(true);
   });
 
   it('categorically closes existing pending v2 traces instead of upgrading them', async () => {

--- a/server/tests/manual/shadow-eval-prod-summary.ts
+++ b/server/tests/manual/shadow-eval-prod-summary.ts
@@ -122,6 +122,11 @@ interface CaptureSummary {
     total: number;
     input_tokens: number;
     output_tokens: number;
+    cache_read_tokens: number;
+    cache_write_tokens: number;
+    usage_complete: number;
+    latency_complete: number;
+    estimated_cost_micros: string;
     outcomes: Array<{
       capture_version: number;
       capture_policy_version: string;
@@ -139,6 +144,7 @@ interface CaptureSummary {
       judge_model: string | null;
       self_judged: boolean | null;
       judge_prompt_version: string | null;
+      pricing_version: string;
       status: string;
       reason: string;
       evaluation_valid: boolean;
@@ -150,6 +156,13 @@ interface CaptureSummary {
       count: number;
       input_tokens: number;
       output_tokens: number;
+      cache_read_tokens: number;
+      cache_write_tokens: number;
+      usage_complete_count: number;
+      latency_count: number;
+      estimated_cost_micros: string;
+      latency_p50_ms: number | null;
+      latency_p95_ms: number | null;
     }>;
   };
   funnel?: {
@@ -424,7 +437,13 @@ async function main() {
       console.log(
         `Judgment outcomes: ${captureSummary.judgments.total} `
         + `(${captureSummary.judgments.input_tokens} input / `
-        + `${captureSummary.judgments.output_tokens} output tokens)`,
+        + `${captureSummary.judgments.output_tokens} output / `
+        + `${captureSummary.judgments.cache_read_tokens} cache-read / `
+        + `${captureSummary.judgments.cache_write_tokens} cache-write tokens; `
+        + `${captureSummary.judgments.usage_complete}/${captureSummary.judgments.total} `
+        + `complete usage; ${captureSummary.judgments.latency_complete}/`
+        + `${captureSummary.judgments.total} timed; `
+        + `${captureSummary.judgments.estimated_cost_micros} cost micros)`,
       );
       for (const outcome of captureSummary.judgments.outcomes) {
         const returned = outcome.returned_provider && outcome.returned_model
@@ -443,11 +462,19 @@ async function main() {
           + `judge=${judge} self_judged=${String(outcome.self_judged)} `
           + `judgment=${outcome.judgment_policy_version}/`
           + `${outcome.judge_prompt_version ?? 'none'} `
+          + `pricing=${outcome.pricing_version} `
           + `quality=${outcome.shadow_quality ?? 'none'} `
           + `gap=${outcome.gap_severity ?? 'none'} `
           + `shape_failures=${outcome.deterministic_failure_labels.join(',') || 'none'} `
           + `${outcome.status}:${outcome.reason} ${outcome.count} `
-          + `(${outcome.input_tokens} input / ${outcome.output_tokens} output tokens)`,
+          + `usage=${outcome.usage_complete_count}/${outcome.count} `
+          + `timed=${outcome.latency_count}/${outcome.count} `
+          + `latency_p50/p95=${outcome.latency_p50_ms ?? 'none'}/`
+          + `${outcome.latency_p95_ms ?? 'none'}ms `
+          + `cost=${outcome.estimated_cost_micros}µUSD `
+          + `(${outcome.input_tokens} input / ${outcome.output_tokens} output / `
+          + `${outcome.cache_read_tokens} cache-read / `
+          + `${outcome.cache_write_tokens} cache-write tokens)`,
         );
       }
     }

--- a/server/tests/unit/addie/shadow-replay-judge.test.ts
+++ b/server/tests/unit/addie/shadow-replay-judge.test.ts
@@ -455,6 +455,46 @@ describe('shadow replay independent judge', () => {
     });
   });
 
+  it('normalizes nullable cache usage counters to zero', async () => {
+    const response = {
+      ...judgeResponse(JSON.stringify({
+        knowledge_gap: false,
+        gap_severity: 'none',
+        shadow_quality: 'equivalent',
+      })),
+      usage: {
+        input_tokens: 23,
+        output_tokens: 11,
+        cache_read_input_tokens: null,
+        cache_creation_input_tokens: null,
+      },
+    };
+    const result = await executeIndependentShadowReplayJudge({
+      trace: trace(),
+      humanEvidence: humanEvidence(),
+      guardedOutput: 'A concise response.',
+      outputHmac: 'a'.repeat(64),
+      generatorModel: 'claude-sonnet-5',
+      judgeModel: 'claude-opus-4-6',
+      judgeEnabled: true,
+    }, {
+      client: { messages: { create: vi.fn(async () => response) } } as never,
+      renewLease: async () => true,
+      monotonicNow: vi.fn().mockReturnValueOnce(10).mockReturnValueOnce(20),
+    });
+
+    expect(result).toMatchObject({
+      status: 'judged',
+      reason: 'judgment_succeeded',
+      usageAvailable: true,
+      inputTokens: 23,
+      outputTokens: 11,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      latencyMs: 10,
+    });
+  });
+
   it.each([
     {
       name: 'array-valued enums',

--- a/server/tests/unit/addie/shadow-replay-judge.test.ts
+++ b/server/tests/unit/addie/shadow-replay-judge.test.ts
@@ -74,11 +74,16 @@ function judgeResponse(text: string, stopReason = 'end_turn') {
     id: 'msg_fixture',
     type: 'message',
     role: 'assistant',
-    model: 'claude-opus-fixture',
+    model: 'claude-opus-4-6',
     content: [{ type: 'text', text }],
     stop_reason: stopReason,
     stop_sequence: null,
-    usage: { input_tokens: 23, output_tokens: 11 },
+    usage: {
+      input_tokens: 23,
+      output_tokens: 11,
+      cache_read_input_tokens: 5,
+      cache_creation_input_tokens: 2,
+    },
   };
 }
 
@@ -170,7 +175,7 @@ describe('shadow replay independent judge', () => {
       trace: resolvedTrace,
       humanEvidence: null,
       judgeEnabled: true,
-      judgeModel: 'claude-opus-fixture',
+      judgeModel: 'claude-opus-4-6',
     }, {
       client: { messages: { create } } as never,
       renewLease: vi.fn(async () => true),
@@ -201,7 +206,7 @@ describe('shadow replay independent judge', () => {
       trace: resolvedTrace,
       humanEvidence: null,
       judgeEnabled: true,
-      judgeModel: 'claude-opus-fixture',
+      judgeModel: 'claude-opus-4-6',
     }, {})({
       text: output,
       outputHmac: 'a'.repeat(64),
@@ -239,18 +244,19 @@ describe('shadow replay independent judge', () => {
       guardedOutput: 'The task lifecycle is request, delivery, and completion.',
       outputHmac: 'a'.repeat(64),
       generatorModel: 'claude-sonnet-5',
-      judgeModel: 'claude-opus-fixture',
+      judgeModel: 'claude-opus-4-6',
       judgeEnabled: true,
     }, {
       client: { messages: { create } } as never,
       renewLease,
+      monotonicNow: vi.fn().mockReturnValueOnce(100).mockReturnValueOnce(350),
     });
 
     expect(order).toEqual(['lease', 'provider']);
     expect(create).toHaveBeenCalledTimes(1);
     const [request, options] = create.mock.calls[0];
     expect(request).toMatchObject({
-      model: 'claude-opus-fixture',
+      model: 'claude-opus-4-6',
       max_tokens: MAX_SHADOW_REPLAY_JUDGE_TOKENS,
     });
     expect(request.messages[0].content).toContain('knowledge_gap=true only');
@@ -269,10 +275,15 @@ describe('shadow replay independent judge', () => {
       gapSeverity: 'none',
       shadowQuality: 'equivalent',
       judgeProvider: 'anthropic',
-      judgeModel: 'claude-opus-fixture',
+      judgeModel: 'claude-opus-4-6',
       selfJudged: false,
       inputTokens: 23,
       outputTokens: 11,
+      cacheReadTokens: 5,
+      cacheWriteTokens: 2,
+      usageAvailable: true,
+      pricingVersion: 'anthropic-standard-2026-08:claude-opus-4-6',
+      latencyMs: 250,
     });
     expect(result.judgePromptHmac).toMatch(/^[0-9a-f]{64}$/);
     expect(result.judgeRequestHmac).toMatch(/^[0-9a-f]{64}$/);
@@ -307,6 +318,33 @@ describe('shadow replay independent judge', () => {
     expect(create).not.toHaveBeenCalled();
   });
 
+  it('rejects an unpriced judge model before lease renewal or provider dispatch', async () => {
+    const create = vi.fn();
+    const renewLease = vi.fn();
+    const result = await executeIndependentShadowReplayJudge({
+      trace: trace(),
+      humanEvidence: humanEvidence(),
+      guardedOutput: 'A concise response.',
+      outputHmac: 'a'.repeat(64),
+      generatorModel: 'claude-sonnet-5',
+      judgeModel: 'claude-unpriced-fixture',
+      judgeEnabled: true,
+    }, {
+      client: { messages: { create } } as never,
+      renewLease,
+    });
+
+    expect(result).toMatchObject({
+      status: 'skipped',
+      reason: 'judge_pricing_unavailable',
+      pricingVersion: 'not-applicable',
+      usageAvailable: false,
+      latencyMs: null,
+    });
+    expect(renewLease).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it('fails closed when low-level judge activation is omitted at runtime', async () => {
     const create = vi.fn();
     const renewLease = vi.fn();
@@ -316,7 +354,7 @@ describe('shadow replay independent judge', () => {
       guardedOutput: 'A concise response.',
       outputHmac: 'a'.repeat(64),
       generatorModel: 'claude-sonnet-5',
-      judgeModel: 'claude-opus-fixture',
+      judgeModel: 'claude-opus-4-6',
     } as unknown as Parameters<typeof executeIndependentShadowReplayJudge>[0];
 
     const result = await executeIndependentShadowReplayJudge(input, {
@@ -342,7 +380,7 @@ describe('shadow replay independent judge', () => {
       guardedOutput: 'A concise response.',
       outputHmac: 'a'.repeat(64),
       generatorModel: 'claude-sonnet-5',
-      judgeModel: 'claude-opus-fixture',
+      judgeModel: 'claude-opus-4-6',
       judgeEnabled: true,
     }, {
       client: { messages: { create } } as never,
@@ -352,6 +390,69 @@ describe('shadow replay independent judge', () => {
     expect(result).toMatchObject({ status: 'error', reason: 'judge_output_invalid' });
     expect(result.judgeResponseHmac).toMatch(/^[0-9a-f]{64}$/);
     expect(JSON.stringify(result)).not.toContain(PRIVATE_SENTINEL);
+  });
+
+  it('retains provider-call timing but not invented usage when the judge fails', async () => {
+    const result = await executeIndependentShadowReplayJudge({
+      trace: trace(),
+      humanEvidence: humanEvidence(),
+      guardedOutput: 'A concise response.',
+      outputHmac: 'a'.repeat(64),
+      generatorModel: 'claude-sonnet-5',
+      judgeModel: 'claude-opus-4-6',
+      judgeEnabled: true,
+    }, {
+      client: { messages: { create: vi.fn(async () => { throw new Error('provider down'); }) } } as never,
+      renewLease: async () => true,
+      monotonicNow: vi.fn().mockReturnValueOnce(50).mockReturnValueOnce(125),
+    });
+
+    expect(result).toMatchObject({
+      status: 'error',
+      reason: 'judge_provider_error',
+      pricingVersion: 'anthropic-standard-2026-08:claude-opus-4-6',
+      usageAvailable: false,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      latencyMs: 75,
+    });
+  });
+
+  it('records malformed terminal usage as unavailable instead of zero-token success', async () => {
+    const response = {
+      ...judgeResponse(JSON.stringify({
+        knowledge_gap: false,
+        gap_severity: 'none',
+        shadow_quality: 'equivalent',
+      })),
+      usage: { input_tokens: Number.NaN, output_tokens: 11 },
+    };
+    const result = await executeIndependentShadowReplayJudge({
+      trace: trace(),
+      humanEvidence: humanEvidence(),
+      guardedOutput: 'A concise response.',
+      outputHmac: 'a'.repeat(64),
+      generatorModel: 'claude-sonnet-5',
+      judgeModel: 'claude-opus-4-6',
+      judgeEnabled: true,
+    }, {
+      client: { messages: { create: vi.fn(async () => response) } } as never,
+      renewLease: async () => true,
+      monotonicNow: vi.fn().mockReturnValueOnce(10).mockReturnValueOnce(20),
+    });
+
+    expect(result).toMatchObject({
+      status: 'error',
+      reason: 'judge_usage_unavailable',
+      usageAvailable: false,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      latencyMs: 10,
+    });
   });
 
   it.each([
@@ -396,7 +497,7 @@ describe('shadow replay independent judge', () => {
       guardedOutput: 'A concise response.',
       outputHmac: 'a'.repeat(64),
       generatorModel: 'claude-sonnet-5',
-      judgeModel: 'claude-opus-fixture',
+      judgeModel: 'claude-opus-4-6',
       judgeEnabled: true,
     }, {
       client: { messages: { create: vi.fn(async () => response) } } as never,
@@ -413,7 +514,7 @@ describe('shadow replay independent judge', () => {
       trace: trace(false),
       humanEvidence: null,
       judgeEnabled: false,
-      judgeModel: 'claude-opus-fixture',
+      judgeModel: 'claude-opus-4-6',
     }, {});
     const output = {
       text: 'A concise response.',
@@ -435,7 +536,7 @@ describe('shadow replay independent judge', () => {
       trace: resolvedTrace,
       humanEvidence: humanEvidence(),
       judgeEnabled: true,
-      judgeModel: 'claude-opus-fixture',
+      judgeModel: 'claude-opus-4-6',
     }, {
       client: { messages: { create: vi.fn() } } as never,
       renewLease: async () => { throw new Error(PRIVATE_SENTINEL); },

--- a/server/tests/unit/addie/shadow-replay-trace.test.ts
+++ b/server/tests/unit/addie/shadow-replay-trace.test.ts
@@ -46,6 +46,20 @@ const UNAVAILABLE_GENERATION_USAGE = {
   usageAvailable: false,
   latencyMs: null,
 } as const;
+const COMPLETE_JUDGMENT_USAGE = {
+  cacheReadTokens: 6,
+  cacheWriteTokens: 3,
+  usageAvailable: true,
+  pricingVersion: 'anthropic-standard-2026-08:claude-opus-4-6',
+  latencyMs: 125,
+} as const;
+const NO_JUDGE_USAGE = {
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  usageAvailable: false,
+  pricingVersion: 'not-applicable',
+  latencyMs: null,
+} as const;
 
 function snapshot(): InvocationPreparedSnapshot {
   return {
@@ -836,8 +850,8 @@ describe('shadow replay trace authorization', () => {
         shapeWordCount: 24,
         shapeExpectedMaxWords: 100,
         shapeRatioToExpected: 0.24,
-        judgeProvider: 'openai',
-        judgeModel: 'gpt-test',
+        judgeProvider: 'anthropic',
+        judgeModel: 'claude-opus-4-6',
         selfJudged: false,
         judgePromptVersion: 'official-docs-judge:v1',
         judgePromptHmac: '4'.repeat(64),
@@ -847,6 +861,7 @@ describe('shadow replay trace authorization', () => {
         humanEvidenceContentHmac: trace.humanEvidence!.contentHmac,
         inputTokens: 30,
         outputTokens: 12,
+        ...COMPLETE_JUDGMENT_USAGE,
         startedAt: new Date(NOW.getTime() - 1_000),
         completedAt: NOW,
       },
@@ -858,6 +873,14 @@ describe('shadow replay trace authorization', () => {
       shadow_eval_judgment_status: 'judged',
       shadow_eval_judgment_reason: 'judgment_completed',
     });
+    expect(runQuery.mock.calls[0][1].slice(53, 59)).toEqual([
+      COMPLETE_JUDGMENT_USAGE.pricingVersion,
+      true,
+      COMPLETE_JUDGMENT_USAGE.cacheReadTokens,
+      COMPLETE_JUDGMENT_USAGE.cacheWriteTokens,
+      COMPLETE_JUDGMENT_USAGE.latencyMs,
+      472,
+    ]);
     expect(JSON.stringify(runQuery.mock.calls)).not.toContain(QUESTION);
     expect(JSON.stringify(runQuery.mock.calls)).not.toContain(HUMAN_RESPONSE);
   });
@@ -902,8 +925,8 @@ describe('shadow replay trace authorization', () => {
         shapeWordCount: 20,
         shapeExpectedMaxWords: 100,
         shapeRatioToExpected: 0.2,
-        judgeProvider: 'openai',
-        judgeModel: 'gpt-test',
+        judgeProvider: 'anthropic',
+        judgeModel: 'claude-opus-4-6',
         selfJudged: false,
         judgePromptVersion: 'official-docs-judge:v1',
         judgePromptHmac: '4'.repeat(64),
@@ -913,6 +936,7 @@ describe('shadow replay trace authorization', () => {
         humanEvidenceContentHmac: trace.humanEvidence!.contentHmac,
         inputTokens: 1,
         outputTokens: 1,
+        ...COMPLETE_JUDGMENT_USAGE,
         startedAt: new Date(NOW.getTime() - 1_000),
         completedAt: NOW,
       },
@@ -960,6 +984,11 @@ describe('shadow replay trace authorization', () => {
         humanEvidenceContentHmac: trace.humanEvidence!.contentHmac,
         inputTokens: 1,
         outputTokens: 1,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        usageAvailable: true,
+        pricingVersion: 'anthropic-standard-2026-08:claude-sonnet-5',
+        latencyMs: 125,
         startedAt: new Date(NOW.getTime() - 1_000),
         completedAt: NOW,
       },
@@ -1019,6 +1048,7 @@ describe('shadow replay trace authorization', () => {
         humanEvidenceContentHmac: trace.humanEvidence!.contentHmac,
         inputTokens: 0,
         outputTokens: 0,
+        ...NO_JUDGE_USAGE,
         startedAt: new Date(NOW.getTime() - 1_000),
         completedAt: NOW,
       },
@@ -1276,6 +1306,7 @@ describe('shadow replay trace authorization', () => {
       judge_model: 'claude-sonnet-5',
       self_judged: false,
       judge_prompt_version: 'shadow-replay-judge:v1',
+      pricing_version: 'anthropic-standard-2026-08:claude-sonnet-5',
       status: 'judged',
       reason: 'judgment_completed',
       evaluation_valid: true,
@@ -1287,6 +1318,13 @@ describe('shadow replay trace authorization', () => {
       count: 2,
       input_tokens: 80,
       output_tokens: 20,
+      cache_read_tokens: 10,
+      cache_write_tokens: 4,
+      usage_complete_count: 2,
+      latency_count: 2,
+      estimated_cost_micros: '600',
+      latency_p50_ms: 300,
+      latency_p95_ms: 450,
     }];
     const judgmentQuery = vi.fn(async () => ({ rows: judgments, rowCount: 1 }));
     await expect(getShadowReplayJudgmentSummary(999, { query: judgmentQuery as never }))
@@ -1295,6 +1333,11 @@ describe('shadow replay trace authorization', () => {
     expect(judgmentQuery.mock.calls[0][0]).toContain('generation.requested_provider');
     expect(judgmentQuery.mock.calls[0][0]).toContain('judgment.judge_provider');
     expect(judgmentQuery.mock.calls[0][0]).toContain('judgment.shadow_quality');
+    expect(judgmentQuery.mock.calls[0][0]).toContain('judgment.pricing_version');
+    expect(judgmentQuery.mock.calls[0][0]).toContain('judgment.usage_complete');
+    expect(judgmentQuery.mock.calls[0][0]).toContain('judgment.estimated_cost_micros');
+    expect(judgmentQuery.mock.calls[0][0]).toContain('COUNT(judgment.latency_ms)');
+    expect(judgmentQuery.mock.calls[0][0]).toContain('PERCENTILE_CONT(0.95)');
     expect(judgmentQuery.mock.calls[0][0]).toContain('has_human_evidence');
     expect(judgmentQuery.mock.calls[0][0]).not.toMatch(/question_hmac|source_output_hmac/);
 


### PR DESCRIPTION
## Summary

- pin the independent shadow judge to an exact, known pricing cohort before provider dispatch and fail closed when pricing is unavailable
- record provider-only monotonic judge latency plus complete input, output, cache-read, and cache-write usage without inventing zero usage
- persist and expose aggregate judge price, completeness denominators, p50/p95 latency, and estimated cost without retaining response payloads
- add migration 569 with rolling-deploy compatibility and advance Addie `CODE_VERSION` to `2026.08.113`

## Safety properties

- unknown judge models are skipped before lease acquisition or provider dispatch
- provider errors retain measured latency but cannot claim complete usage or cost
- successful judgments require complete usage and latency evidence
- persistence re-resolves pricing and rejects price-version drift
- no canary, environment, or production configuration changes
- no paid or stochastic replay calls
- no changeset: this is Addie runtime/evaluation infrastructure, not a protocol release surface

## Verification

- initial implementation head: `npm run precommit` and the commit hook each passed 521 files / 7,489 tests plus type-check
- review follow-up head: nullable-cache regression test — 1 file, 19 passed; type-check passed
- two follow-up full local attempts reached the 600-second watchdog without an assertion failure while unrelated workspaces were running long Vitest jobs; the fresh exact-head CI matrix is the authoritative full gate
- focused shadow replay/evaluator suite — 5 files, 95 passed
- `npm run test:migrations` — 3 passed
- migration 569 applied to a minimal temporary PostgreSQL schema and verified all six new judgment columns before rollback
- `npm run build:addie-tools`
- `npm run test:addie-tools`
- `git diff --check`
- confidential-name scan

## Rollout

Canaries remain disabled. This PR only makes independent-judge evaluation evidence reproducible and queryable for later fixed-trace provider gates.
