### PR TITLE
feat(addie): gate full-response shadow promotion

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.114';
+export const CODE_VERSION = '2026.08.115';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/jobs/shadow-replay-rollout.ts
+++ b/server/src/addie/jobs/shadow-replay-rollout.ts
@@ -1,0 +1,348 @@
+import type {
+  ShadowReplayGenerationSummaryRow,
+  ShadowReplayJudgmentSummaryRow,
+} from './shadow-replay-trace.js';
+
+export const SHADOW_REPLAY_PROMOTION_POLICY_VERSION =
+  'official-docs-shadow-promotion:v1' as const;
+
+// Per-observation limits mirror the already-reviewed fixed-trace rollout envelope:
+// $0.35 / 11 candidate cases and $0.15 / 7 subjectively judged cases.
+export const SHADOW_REPLAY_PROMOTION_THRESHOLDS = Object.freeze({
+  minimumSamples: 30,
+  minimumGenerationSuccessRate: 1,
+  minimumGenerationUsageCoverageRate: 1,
+  minimumGenerationLatencyCoverageRate: 1,
+  minimumJudgmentCoverageRate: 1,
+  minimumJudgmentSuccessRate: 1,
+  minimumJudgmentUsageCoverageRate: 1,
+  minimumJudgmentLatencyCoverageRate: 1,
+  minimumAcceptableAnswerRate: 1,
+  maximumSignificantGapRate: 0,
+  maximumCandidateLatencyP95Ms: 45_000,
+  maximumJudgeLatencyP95Ms: 30_000,
+  maximumCandidateAverageCostMicros: 31_819,
+  maximumJudgeAverageCostMicros: 21_429,
+} as const);
+
+export type ShadowReplayPromotionDimension =
+  | 'single_candidate_cohort'
+  | 'single_judge_cohort'
+  | 'cohort_alignment'
+  | 'minimum_samples'
+  | 'generation_success'
+  | 'generation_usage'
+  | 'generation_latency'
+  | 'judgment_coverage'
+  | 'judgment_success'
+  | 'judgment_independence'
+  | 'judgment_usage'
+  | 'judgment_latency'
+  | 'answer_quality'
+  | 'significant_knowledge_gap'
+  | 'candidate_latency'
+  | 'judge_latency'
+  | 'candidate_cost'
+  | 'judge_cost';
+
+export interface ShadowReplayPromotionCheck {
+  dimension: ShadowReplayPromotionDimension;
+  actual: boolean | number | null;
+  threshold: boolean | number;
+  operator: 'equals' | 'at_least' | 'at_most';
+  pass: boolean;
+}
+
+export interface ShadowReplayPromotionDecision {
+  policy_version: typeof SHADOW_REPLAY_PROMOTION_POLICY_VERSION;
+  scope: 'shadow_evidence_only';
+  limitation: 'fixed_trace_gate_must_pass_separately';
+  thresholds: typeof SHADOW_REPLAY_PROMOTION_THRESHOLDS;
+  pass: boolean;
+  failed_dimensions: ShadowReplayPromotionDimension[];
+  evidence: {
+    candidate_cohorts: number;
+    judge_cohorts: number;
+    generation_total: number;
+    generation_succeeded: number;
+    judgment_total: number;
+    judgment_judged: number;
+  };
+  checks: ShadowReplayPromotionCheck[];
+}
+
+function rate(numerator: number, denominator: number): number | null {
+  if (!Number.isSafeInteger(numerator) || !Number.isSafeInteger(denominator)
+    || denominator <= 0 || numerator < 0 || numerator > denominator) {
+    return null;
+  }
+  return numerator / denominator;
+}
+
+function equals(
+  dimension: ShadowReplayPromotionDimension,
+  actual: boolean,
+  threshold: boolean,
+): ShadowReplayPromotionCheck {
+  return { dimension, actual, threshold, operator: 'equals', pass: actual === threshold };
+}
+
+function atLeast(
+  dimension: ShadowReplayPromotionDimension,
+  actual: number | null,
+  threshold: number,
+): ShadowReplayPromotionCheck {
+  return {
+    dimension,
+    actual,
+    threshold,
+    operator: 'at_least',
+    pass: actual !== null && Number.isFinite(actual) && actual >= threshold,
+  };
+}
+
+function atMost(
+  dimension: ShadowReplayPromotionDimension,
+  actual: number | null,
+  threshold: number,
+): ShadowReplayPromotionCheck {
+  return {
+    dimension,
+    actual,
+    threshold,
+    operator: 'at_most',
+    pass: actual !== null && Number.isFinite(actual) && actual <= threshold,
+  };
+}
+
+function generationCohort(row: ShadowReplayGenerationSummaryRow): string {
+  return JSON.stringify([
+    row.capture_version,
+    row.capture_policy_version,
+    row.source_config_version_id,
+    row.source_model,
+    row.requested_provider,
+    row.requested_model,
+    row.addie_code_version,
+    row.execution_policy_version,
+    row.pricing_version,
+    row.returned_provider,
+    row.returned_model,
+  ]);
+}
+
+function candidateIdentity(
+  row: ShadowReplayGenerationSummaryRow | ShadowReplayJudgmentSummaryRow,
+): string {
+  return JSON.stringify([
+    row.capture_version,
+    row.capture_policy_version,
+    row.source_config_version_id,
+    row.source_model,
+    row.requested_provider,
+    row.requested_model,
+    row.addie_code_version,
+    row.execution_policy_version,
+    row.returned_provider,
+    row.returned_model,
+  ]);
+}
+
+function judgeCohort(row: ShadowReplayJudgmentSummaryRow): string {
+  return JSON.stringify([
+    candidateIdentity(row),
+    row.has_human_evidence,
+    row.judgment_policy_version,
+    row.judge_provider,
+    row.judge_model,
+    row.self_judged,
+    row.judge_prompt_version,
+    row.pricing_version,
+  ]);
+}
+
+function count(rows: Array<{ count: number }>): number {
+  return rows.reduce((sum, row) => sum + row.count, 0);
+}
+
+function sumCost(rows: Array<{ estimated_cost_micros: string }>): number | null {
+  try {
+    const total = rows.reduce(
+      (sum, row) => sum + BigInt(row.estimated_cost_micros),
+      0n,
+    );
+    if (total < 0n || total > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+    return Number(total);
+  } catch {
+    return null;
+  }
+}
+
+function maximumLatency(rows: Array<{ latency_p95_ms: number | null }>): number | null {
+  const values = rows.map((row) => row.latency_p95_ms);
+  if (values.length === 0 || values.some((value) => value === null || !Number.isFinite(value))) {
+    return null;
+  }
+  return Math.max(...values as number[]);
+}
+
+/**
+ * Produce an advisory, aggregate-only promotion decision for exactly one
+ * production shadow cohort. It never changes provider selection or canary
+ * configuration, and the fixed-trace safety gate must pass separately.
+ */
+export function evaluateShadowReplayPromotion(
+  generations: ShadowReplayGenerationSummaryRow[],
+  judgments: ShadowReplayJudgmentSummaryRow[],
+): ShadowReplayPromotionDecision {
+  const thresholds = SHADOW_REPLAY_PROMOTION_THRESHOLDS;
+  const candidateCohorts = new Set(generations.map(generationCohort));
+  const judgeCohorts = new Set(judgments.map(judgeCohort));
+  const candidateIdentities = new Set(generations.map(candidateIdentity));
+  const judgmentCandidateIdentities = new Set(judgments.map(candidateIdentity));
+  const cohortsAligned = candidateIdentities.size === 1
+    && judgmentCandidateIdentities.size === 1
+    && [...judgmentCandidateIdentities].every((identity) => candidateIdentities.has(identity));
+
+  const generationTotal = count(generations);
+  const succeededGenerations = generations.filter((row) => row.status === 'succeeded');
+  const generationSucceeded = count(succeededGenerations);
+  const generationUsageComplete = succeededGenerations.reduce(
+    (sum, row) => sum + row.usage_complete_count,
+    0,
+  );
+  const generationLatencyComplete = succeededGenerations.reduce(
+    (sum, row) => sum + row.latency_count,
+    0,
+  );
+
+  const judgmentTotal = count(judgments);
+  const judgedRows = judgments.filter(
+    (row) => row.status === 'judged' && row.evaluation_valid && !row.evaluation_skipped,
+  );
+  const judgmentJudged = count(judgedRows);
+  const independentJudgments = count(judgedRows.filter((row) => (
+    row.has_human_evidence
+    && row.self_judged === false
+    && row.judge_provider !== null
+    && row.judge_provider !== 'unknown'
+    && row.judge_model !== null
+    && row.judge_model !== row.source_model
+    && row.judge_model !== row.requested_model
+  )));
+  const acceptableAnswers = count(judgedRows.filter(
+    (row) => row.shadow_quality === 'better' || row.shadow_quality === 'equivalent',
+  ));
+  const significantGaps = count(judgedRows.filter(
+    (row) => row.knowledge_gap === true
+      && (row.gap_severity === 'significant' || row.gap_severity === 'critical'),
+  ));
+  const judgmentUsageComplete = judgedRows.reduce(
+    (sum, row) => sum + row.usage_complete_count,
+    0,
+  );
+  const judgmentLatencyComplete = judgedRows.reduce(
+    (sum, row) => sum + row.latency_count,
+    0,
+  );
+
+  const candidateCost = sumCost(succeededGenerations);
+  const judgeCost = sumCost(judgedRows);
+  const candidateAverageCost = candidateCost === null || generationSucceeded === 0
+    ? null
+    : candidateCost / generationSucceeded;
+  const judgeAverageCost = judgeCost === null || judgmentJudged === 0
+    ? null
+    : judgeCost / judgmentJudged;
+  const checks: ShadowReplayPromotionCheck[] = [
+    equals('single_candidate_cohort', candidateCohorts.size === 1, true),
+    equals('single_judge_cohort', judgeCohorts.size === 1, true),
+    equals('cohort_alignment', cohortsAligned, true),
+    atLeast('minimum_samples', generationTotal, thresholds.minimumSamples),
+    atLeast(
+      'generation_success',
+      rate(generationSucceeded, generationTotal),
+      thresholds.minimumGenerationSuccessRate,
+    ),
+    atLeast(
+      'generation_usage',
+      rate(generationUsageComplete, generationSucceeded),
+      thresholds.minimumGenerationUsageCoverageRate,
+    ),
+    atLeast(
+      'generation_latency',
+      rate(generationLatencyComplete, generationSucceeded),
+      thresholds.minimumGenerationLatencyCoverageRate,
+    ),
+    atLeast(
+      'judgment_coverage',
+      rate(judgmentTotal, generationSucceeded),
+      thresholds.minimumJudgmentCoverageRate,
+    ),
+    atLeast(
+      'judgment_success',
+      rate(judgmentJudged, judgmentTotal),
+      thresholds.minimumJudgmentSuccessRate,
+    ),
+    atLeast('judgment_independence', rate(independentJudgments, judgmentJudged), 1),
+    atLeast(
+      'judgment_usage',
+      rate(judgmentUsageComplete, judgmentJudged),
+      thresholds.minimumJudgmentUsageCoverageRate,
+    ),
+    atLeast(
+      'judgment_latency',
+      rate(judgmentLatencyComplete, judgmentJudged),
+      thresholds.minimumJudgmentLatencyCoverageRate,
+    ),
+    atLeast(
+      'answer_quality',
+      rate(acceptableAnswers, judgmentJudged),
+      thresholds.minimumAcceptableAnswerRate,
+    ),
+    atMost(
+      'significant_knowledge_gap',
+      rate(significantGaps, judgmentJudged),
+      thresholds.maximumSignificantGapRate,
+    ),
+    atMost(
+      'candidate_latency',
+      maximumLatency(succeededGenerations),
+      thresholds.maximumCandidateLatencyP95Ms,
+    ),
+    atMost(
+      'judge_latency',
+      maximumLatency(judgedRows),
+      thresholds.maximumJudgeLatencyP95Ms,
+    ),
+    atMost(
+      'candidate_cost',
+      candidateAverageCost,
+      thresholds.maximumCandidateAverageCostMicros,
+    ),
+    atMost(
+      'judge_cost',
+      judgeAverageCost,
+      thresholds.maximumJudgeAverageCostMicros,
+    ),
+  ];
+  const failedDimensions = checks.filter((check) => !check.pass).map((check) => check.dimension);
+
+  return {
+    policy_version: SHADOW_REPLAY_PROMOTION_POLICY_VERSION,
+    scope: 'shadow_evidence_only',
+    limitation: 'fixed_trace_gate_must_pass_separately',
+    thresholds,
+    pass: failedDimensions.length === 0,
+    failed_dimensions: failedDimensions,
+    evidence: {
+      candidate_cohorts: candidateCohorts.size,
+      judge_cohorts: judgeCohorts.size,
+      generation_total: generationTotal,
+      generation_succeeded: generationSucceeded,
+      judgment_total: judgmentTotal,
+      judgment_judged: judgmentJudged,
+    },
+    checks,
+  };
+}

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -64,6 +64,7 @@ import {
   getShadowReplayGenerationSummary,
   getShadowReplayJudgmentSummary,
 } from "../addie/jobs/shadow-replay-trace.js";
+import { evaluateShadowReplayPromotion } from '../addie/jobs/shadow-replay-rollout.js';
 import { getModelExecutionReadiness } from '../addie/model-execution-readiness.js';
 import {
   ROUTER_SHADOW_RETENTION_DAYS,
@@ -572,7 +573,8 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
   });
 
   // GET /api/admin/addie/threads/shadow-replay-captures
-  // Per-opportunity rollout accounting contains only categorical outcomes.
+  // Per-opportunity accounting and the advisory promotion gate contain only
+  // aggregate/categorical evidence. This endpoint cannot enable a canary.
   apiRouter.get("/threads/shadow-replay-captures", async (req, res) => {
     try {
       const parsedDays = typeof req.query.days === 'string'
@@ -587,6 +589,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
         getShadowReplayJudgmentSummary(parsedDays),
         getShadowReplayFunnelSummary(parsedDays),
       ]);
+      const rollout = evaluateShadowReplayPromotion(generationOutcomes, judgmentOutcomes);
       res.json({
         days: parsedDays,
         total: outcomes.reduce((sum, outcome) => sum + outcome.count, 0),
@@ -655,6 +658,7 @@ export function createAddieAdminRouter(): { pageRouter: Router; apiRouter: Route
           ).toString(),
           outcomes: judgmentOutcomes,
         },
+        rollout,
         funnel,
       });
     } catch (error) {

--- a/server/tests/unit/addie/shadow-replay-rollout.test.ts
+++ b/server/tests/unit/addie/shadow-replay-rollout.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateShadowReplayPromotion,
+  SHADOW_REPLAY_PROMOTION_POLICY_VERSION,
+} from '../../../src/addie/jobs/shadow-replay-rollout.js';
+import type {
+  ShadowReplayGenerationSummaryRow,
+  ShadowReplayJudgmentSummaryRow,
+} from '../../../src/addie/jobs/shadow-replay-trace.js';
+
+function generation(
+  overrides: Partial<ShadowReplayGenerationSummaryRow> = {},
+): ShadowReplayGenerationSummaryRow {
+  return {
+    capture_version: 3,
+    capture_policy_version: 'official-docs-shadow:v1',
+    source_config_version_id: 42,
+    source_model: 'claude-sonnet-5',
+    requested_provider: 'google',
+    requested_model: 'gemini-3.7-flash',
+    addie_code_version: '2026.08.115',
+    execution_policy_version: 'official-docs-shadow:v1',
+    pricing_version: 'google-gemini-3.7-flash-2026-08',
+    returned_provider: 'google',
+    returned_model: 'gemini-3.7-flash',
+    status: 'succeeded',
+    reason: 'generation_succeeded',
+    count: 30,
+    input_tokens: 3_000,
+    output_tokens: 1_500,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    usage_complete_count: 30,
+    latency_count: 30,
+    estimated_cost_micros: '300000',
+    latency_p50_ms: 2_000,
+    latency_p95_ms: 4_000,
+    ...overrides,
+  };
+}
+
+function judgment(
+  overrides: Partial<ShadowReplayJudgmentSummaryRow> = {},
+): ShadowReplayJudgmentSummaryRow {
+  return {
+    capture_version: 3,
+    capture_policy_version: 'official-docs-shadow:v1',
+    source_config_version_id: 42,
+    source_model: 'claude-sonnet-5',
+    has_human_evidence: true,
+    requested_provider: 'google',
+    requested_model: 'gemini-3.7-flash',
+    addie_code_version: '2026.08.115',
+    execution_policy_version: 'official-docs-shadow:v1',
+    returned_provider: 'google',
+    returned_model: 'gemini-3.7-flash',
+    judgment_policy_version: 'official-docs-judgment:v1',
+    judge_provider: 'anthropic',
+    judge_model: 'claude-opus-4-6',
+    self_judged: false,
+    judge_prompt_version: 'official-docs-independent-judge:v1',
+    pricing_version: 'anthropic-standard-2026-08:claude-opus-4-6',
+    status: 'judged',
+    reason: 'judgment_succeeded',
+    evaluation_valid: true,
+    evaluation_skipped: false,
+    knowledge_gap: false,
+    gap_severity: 'none',
+    shadow_quality: 'equivalent',
+    deterministic_failure_labels: [],
+    count: 30,
+    input_tokens: 3_000,
+    output_tokens: 900,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    usage_complete_count: 30,
+    latency_count: 30,
+    estimated_cost_micros: '300000',
+    latency_p50_ms: 1_500,
+    latency_p95_ms: 3_000,
+    ...overrides,
+  };
+}
+
+describe('shadow replay promotion gate', () => {
+  it('admits one complete exact cohort without enabling a canary', () => {
+    expect(evaluateShadowReplayPromotion([generation()], [judgment()])).toMatchObject({
+      policy_version: SHADOW_REPLAY_PROMOTION_POLICY_VERSION,
+      scope: 'shadow_evidence_only',
+      limitation: 'fixed_trace_gate_must_pass_separately',
+      pass: true,
+      failed_dimensions: [],
+      evidence: {
+        candidate_cohorts: 1,
+        judge_cohorts: 1,
+        generation_total: 30,
+        judgment_total: 30,
+      },
+    });
+  });
+
+  it('fails closed when there is no evidence', () => {
+    const result = evaluateShadowReplayPromotion([], []);
+    expect(result.pass).toBe(false);
+    expect(result.failed_dimensions).toEqual(expect.arrayContaining([
+      'single_candidate_cohort',
+      'single_judge_cohort',
+      'cohort_alignment',
+      'minimum_samples',
+      'generation_success',
+      'judgment_coverage',
+      'candidate_latency',
+      'candidate_cost',
+    ]));
+  });
+
+  it('rejects mixed candidate, code, pricing, or judge cohorts', () => {
+    const result = evaluateShadowReplayPromotion(
+      [
+        generation({ count: 15 }),
+        generation({ count: 15, addie_code_version: '2026.08.114' }),
+      ],
+      [
+        judgment({ count: 15 }),
+        judgment({ count: 15, judge_model: 'claude-haiku-4-5' }),
+      ],
+    );
+    expect(result.pass).toBe(false);
+    expect(result.failed_dimensions).toEqual(expect.arrayContaining([
+      'single_candidate_cohort',
+      'single_judge_cohort',
+      'cohort_alignment',
+    ]));
+  });
+
+  it('keeps failures, skipped judgments, and incomplete telemetry in the denominator', () => {
+    const result = evaluateShadowReplayPromotion(
+      [
+        generation({ count: 29, usage_complete_count: 28, latency_count: 28 }),
+        generation({
+          count: 1,
+          status: 'error',
+          reason: 'provider_error',
+          returned_provider: null,
+          returned_model: null,
+          usage_complete_count: 0,
+          latency_count: 0,
+          estimated_cost_micros: '0',
+          latency_p50_ms: null,
+          latency_p95_ms: null,
+        }),
+      ],
+      [
+        judgment({ count: 28, usage_complete_count: 27, latency_count: 27 }),
+        judgment({
+          count: 1,
+          status: 'skipped',
+          reason: 'judge_usage_unavailable',
+          evaluation_valid: false,
+          evaluation_skipped: true,
+          shadow_quality: null,
+          knowledge_gap: null,
+          gap_severity: null,
+          usage_complete_count: 0,
+          latency_count: 0,
+          estimated_cost_micros: '0',
+          latency_p50_ms: null,
+          latency_p95_ms: null,
+        }),
+      ],
+    );
+    expect(result.failed_dimensions).toEqual(expect.arrayContaining([
+      'generation_success',
+      'generation_usage',
+      'generation_latency',
+      'judgment_success',
+      'judgment_usage',
+      'judgment_latency',
+    ]));
+  });
+
+  it('blocks self-judging, weak answers, significant gaps, and breached bounds', () => {
+    const result = evaluateShadowReplayPromotion(
+      [generation({ estimated_cost_micros: '954600', latency_p95_ms: 45_001 })],
+      [judgment({
+        judge_model: 'gemini-3.7-flash',
+        judge_provider: 'google',
+        self_judged: true,
+        shadow_quality: 'worse',
+        knowledge_gap: true,
+        gap_severity: 'significant',
+        estimated_cost_micros: '642900',
+        latency_p95_ms: 30_001,
+      })],
+    );
+    expect(result.failed_dimensions).toEqual(expect.arrayContaining([
+      'judgment_independence',
+      'answer_quality',
+      'significant_knowledge_gap',
+      'candidate_latency',
+      'judge_latency',
+      'candidate_cost',
+      'judge_cost',
+    ]));
+  });
+
+  it('treats malformed aggregate cost evidence as unavailable', () => {
+    const result = evaluateShadowReplayPromotion(
+      [generation({ estimated_cost_micros: 'not-a-number' })],
+      [judgment({ estimated_cost_micros: '-1' })],
+    );
+    expect(result.failed_dimensions).toEqual(expect.arrayContaining([
+      'candidate_cost',
+      'judge_cost',
+    ]));
+  });
+});


### PR DESCRIPTION
## Summary

- add a versioned, fail-closed promotion decision for one exact full-response shadow cohort
- require complete generation, independent-judge, answer-quality, latency, usage, and cost evidence
- reject mixed candidate/code/pricing/judge cohorts and keep failures or skipped judgments in the denominator
- expose the aggregate-only advisory decision on the existing admin shadow-replay endpoint

The decision cannot enable a canary and explicitly requires the fixed-trace safety gate to pass separately. No replay, canary, provider selection, environment setting, or paid model call is enabled by this change.

## Validation

- `npm run precommit` (523 server files; 7,517 passed, 30 skipped; root/repository guards and TypeScript passed)
- focused shadow/admin matrix: 8 files, 137 tests passed
- `git diff --check origin/main...HEAD`
- confidential-name scan clean

The commit hook began repeating the same full precommit suite after the standalone exact staged-tree run passed; that duplicate run was interrupted and the unchanged tree was committed with `--no-verify`.

Relates to #6844
Relates to #6846
