### PR TITLE
fix(addie): pin provider across tool continuations

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.115';
+export const CODE_VERSION = '2026.08.116';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/model-providers/model-turn.ts
+++ b/server/src/addie/model-providers/model-turn.ts
@@ -1,6 +1,7 @@
 import type {
   ModelMessage,
   ModelProvider,
+  ModelProviderId,
   ModelProviderToolCallContent,
   ModelProviderToolResultContent,
   ModelRequest,
@@ -175,6 +176,7 @@ export class ModelTurnLoopState {
   private readonly budget: ModelLoopBudget;
   private accumulatedUsage: ModelUsage = { inputTokens: 0, outputTokens: 0 };
   private awaitingResponse = false;
+  private continuationProvider: ModelProviderId | null = null;
 
   constructor(limit: number) {
     this.budget = new ModelLoopBudget(limit);
@@ -194,6 +196,23 @@ export class ModelTurnLoopState {
 
   get usage(): ModelUsage {
     return { ...this.accumulatedUsage };
+  }
+
+  /**
+   * Provider pinned by an accepted response that requires another model turn.
+   * Transport fallback remains possible before the first response is accepted,
+   * but canonical tool/provider continuation state must never cross providers.
+   */
+  get pinnedProvider(): ModelProviderId | null {
+    return this.continuationProvider;
+  }
+
+  assertProviderForInvocation(provider: ModelProviderId): void {
+    if (this.continuationProvider !== null && provider !== this.continuationProvider) {
+      throw new Error(
+        `Model loop continuation is pinned to ${this.continuationProvider}; cannot invoke ${provider}`,
+      );
+    }
   }
 
   startNext(): number {
@@ -230,6 +249,15 @@ export class ModelTurnLoopState {
         }
       : response;
     const turn = inspectModelTurn(acceptedResponse);
+    this.assertProviderForInvocation(acceptedResponse.provider);
+    if (
+      this.continuationProvider === null
+      && (turn.action === 'execute_tools'
+        || turn.action === 'continue'
+        || turn.action === 'continue_provider_tools')
+    ) {
+      this.continuationProvider = acceptedResponse.provider;
+    }
     if (options.countUsage !== false) {
       this.accumulatedUsage = addModelUsage(this.accumulatedUsage, acceptedResponse.usage);
     }
@@ -286,6 +314,7 @@ export class ActiveModelTurn {
   ): Promise<ModelResponse> {
     if (this.accepted) throw new Error('Model turn already accepted a response');
     if (this.invocationInFlight) throw new Error('Model turn provider invocation already in flight');
+    this.loop.assertProviderForInvocation(provider.id);
     this.invocationInFlight = true;
     try {
       return await collectModelResponse(

--- a/server/tests/unit/addie/model-provider-turn.test.ts
+++ b/server/tests/unit/addie/model-provider-turn.test.ts
@@ -4,6 +4,7 @@ import type {
   ModelMessage,
   ModelMessageContent,
   ModelProvider,
+  ModelProviderId,
   ModelRequest,
   ModelResponse,
 } from '../../../src/addie/model-providers/model-provider.js';
@@ -42,9 +43,10 @@ const request: ModelRequest = {
 
 function providerFor(
   respond: ModelProvider['respond'],
+  id: ModelProviderId = 'anthropic',
 ): ModelProvider {
   return {
-    id: 'anthropic',
+    id,
     capabilities: {
       streaming: true,
       structuredOutput: true,
@@ -429,5 +431,56 @@ describe('ModelTurnLoopState', () => {
     expect(attempts).toBe(2);
     await expect(activeTurn.invoke(provider, request)).rejects.toThrow('already accepted');
     expect(() => activeTurn.acceptResponse(terminal)).toThrow('already accepted');
+  });
+
+  it('allows cross-provider fallback before a response is accepted', async () => {
+    const loop = new ModelTurnLoopState(1);
+    const anthropic = providerFor(async function* () {
+      throw new Error('primary unavailable');
+    });
+    const googleResponse = {
+      ...response('stop', [{ type: 'text' as const, text: 'fallback answer' }]),
+      provider: 'google' as const,
+      model: 'fallback-model',
+    };
+    const google = providerFor(async function* () {
+      yield { type: 'response_start', provider: 'google', model: 'fallback-model' };
+      yield { type: 'text_delta', index: 0, text: 'fallback answer' };
+      yield { type: 'response_complete', response: googleResponse };
+    }, 'google');
+    const activeTurn = loop.beginNext();
+
+    await expect(activeTurn.invoke(anthropic, request)).rejects.toThrow('primary unavailable');
+    const invoked = await activeTurn.invoke(google, { ...request, model: 'fallback-model' });
+    activeTurn.acceptResponse(invoked);
+
+    expect(loop.pinnedProvider).toBeNull();
+  });
+
+  it('pins tool continuation before execution and rejects a provider switch', async () => {
+    const loop = new ModelTurnLoopState(2);
+    const toolResponse = response('tool_calls', [{
+      type: 'tool_call',
+      id: 'call-1',
+      name: 'mutate_record',
+      input: {},
+    }]);
+    loop.beginNext().acceptResponse(toolResponse);
+
+    expect(loop.pinnedProvider).toBe('anthropic');
+
+    let googleInvoked = false;
+    const google = providerFor(async function* () {
+      googleInvoked = true;
+    }, 'google');
+    const continuation = loop.beginNext();
+
+    await expect(continuation.invoke(google, { ...request, model: 'fallback-model' }))
+      .rejects.toThrow('continuation is pinned to anthropic; cannot invoke google');
+    expect(googleInvoked).toBe(false);
+
+    const wrongProviderResponse = { ...response('stop'), provider: 'google' as const };
+    expect(() => continuation.acceptResponse(wrongProviderResponse))
+      .toThrow('continuation is pinned to anthropic; cannot invoke google');
   });
 });


### PR DESCRIPTION
## Summary

- keep transport fallback available until a model response is accepted
- pin every tool or provider continuation to the provider that produced the accepted response
- reject cross-provider invocation and direct-response acceptance before continuation work can proceed
- bump Addie CODE_VERSION to 2026.08.116

This closes a provider-neutral runtime safety gap without enabling any alternate provider, canary, environment flag, or paid model call.

## Why

Canonical tool state is provider-specific. Switching providers after accepting a tool-producing response can corrupt continuation state and, after a mutation, risks unsafe replay. The shared model-turn boundary now enforces provider affinity for every continuation while preserving safe pre-acceptance fallback.

## Verification

- root suite: 68 files, 1,056 tests passed
- server unit suite, CI-equivalent four shards: 523 files, 7,519 tests passed, 30 skipped
- provider/runtime focused matrix: 9 files, 244 tests passed
- model turn tests: 31 tests passed
- TypeScript typecheck passed
- Addie tool inventory: 249 tools across 31 sets, current and within budget
- staged diff check and confidential-name/secret-pattern scan passed

The monolithic local server command reached the repository 600-second timeout without reporting a failure; the same suite passed in all four CI-equivalent shards.