### PR TITLE
fix(auth): make canary settings rollback-compatible

### DIFF
--- a/server/src/db/system-settings-db.ts
+++ b/server/src/db/system-settings-db.ts
@@ -4,7 +4,13 @@
  */
 
 import { ORGANIZATION_AUTHORIZATION_BOUNDARY_VALUES } from '../auth/organization-authorization-boundaries.js';
+import { createLogger } from '../logger.js';
 import { query } from './client.js';
+
+const logger = createLogger('system-settings-db');
+let ignoredFutureAuthorizationBoundaryWarningEmitted = false;
+const ORGANIZATION_AUTHORIZATION_BOUNDARY_NAME_PATTERN = /^organization_[a-z0-9]+(?:_[a-z0-9]+)*$/;
+const MAX_ORGANIZATION_AUTHORIZATION_BOUNDARY_NAME_LENGTH = 96;
 
 // ============== Types ==============
 
@@ -160,8 +166,9 @@ const DEFAULT_ORGANIZATION_AUTHORIZATION_ENFORCEMENT: OrganizationAuthorizationE
 /**
  * Read the audited runtime gate for exact-credential organization
  * authorization. Absence is intentionally disabled. Malformed persisted
- * values throw so an environment-staged enforcement process can fail closed
- * instead of silently falling back to legacy authorization.
+ * values throw so an environment-staged enforcement process can fail closed.
+ * Well-formed boundary names introduced by a newer binary are ignored so this
+ * reader remains a safe rollback floor for boundaries it cannot implement.
  */
 export async function getOrganizationAuthorizationEnforcement(): Promise<OrganizationAuthorizationEnforcementSetting> {
   const setting = await getSetting<unknown>(SETTING_KEYS.ORGANIZATION_AUTHORIZATION_ENFORCEMENT);
@@ -181,17 +188,29 @@ export async function getOrganizationAuthorizationEnforcement(): Promise<Organiz
     throw new Error('Invalid organization authorization enforcement setting');
   }
   const enabled = (setting as { enabled: boolean }).enabled;
-  const boundaries = [...new Set(
+  const normalizedBoundaries = [...new Set(
     (setting as { boundaries: string[] }).boundaries.map((value) => value.trim()).filter(Boolean),
   )];
-  const supportedBoundaries = new Set<string>(ORGANIZATION_AUTHORIZATION_BOUNDARY_VALUES);
-  if (
-    boundaries.some((boundary) => !supportedBoundaries.has(boundary)) ||
-    (enabled && boundaries.length === 0)
-  ) {
+  if (enabled && normalizedBoundaries.length === 0) {
     throw new Error('Invalid organization authorization enforcement setting');
   }
-  return { enabled, boundaries };
+  if (normalizedBoundaries.some((boundary) => (
+    boundary.length > MAX_ORGANIZATION_AUTHORIZATION_BOUNDARY_NAME_LENGTH ||
+    !ORGANIZATION_AUTHORIZATION_BOUNDARY_NAME_PATTERN.test(boundary)
+  ))) {
+    throw new Error('Invalid organization authorization enforcement setting');
+  }
+  const supportedBoundaries = new Set<string>(ORGANIZATION_AUTHORIZATION_BOUNDARY_VALUES);
+  const boundaries = normalizedBoundaries.filter((boundary) => supportedBoundaries.has(boundary));
+  const ignoredBoundaryCount = normalizedBoundaries.length - boundaries.length;
+  if (ignoredBoundaryCount > 0 && !ignoredFutureAuthorizationBoundaryWarningEmitted) {
+    ignoredFutureAuthorizationBoundaryWarningEmitted = true;
+    logger.warn(
+      { ignoredBoundaryCount },
+      'Ignored organization authorization boundaries unsupported by this application version',
+    );
+  }
+  return { enabled: enabled && boundaries.length > 0, boundaries };
 }
 
 export async function setOrganizationAuthorizationEnforcement(

--- a/server/tests/unit/organization-authorization-setting-db.test.ts
+++ b/server/tests/unit/organization-authorization-setting-db.test.ts
@@ -1,8 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const queryMock = vi.hoisted(() => vi.fn());
+const warnMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../src/db/client.js", () => ({ query: queryMock }));
+vi.mock("../../src/logger.js", () => ({
+  createLogger: () => ({ warn: warnMock }),
+}));
 
 import {
   getOrganizationAuthorizationEnforcement,
@@ -10,7 +14,10 @@ import {
 } from "../../src/db/system-settings-db.js";
 
 describe("organization authorization system setting", () => {
-  beforeEach(() => queryMock.mockReset());
+  beforeEach(() => {
+    queryMock.mockReset();
+    warnMock.mockReset();
+  });
 
   it("defaults absent configuration off", async () => {
     queryMock.mockResolvedValueOnce({ rows: [] });
@@ -32,13 +39,70 @@ describe("organization authorization system setting", () => {
     });
   });
 
+  it("keeps known enforcement active while ignoring a future boundary", async () => {
+    const persistedSetting = {
+      rows: [{
+        value: {
+          enabled: true,
+          boundaries: [" organization_roles_read ", "organization_future_read", "organization_future_read"],
+        },
+      }],
+    };
+    queryMock.mockResolvedValueOnce(persistedSetting).mockResolvedValueOnce(persistedSetting);
+
+    await expect(getOrganizationAuthorizationEnforcement()).resolves.toEqual({
+      enabled: true,
+      boundaries: ["organization_roles_read"],
+    });
+    await expect(getOrganizationAuthorizationEnforcement()).resolves.toEqual({
+      enabled: true,
+      boundaries: ["organization_roles_read"],
+    });
+    expect(warnMock).toHaveBeenCalledOnce();
+    expect(warnMock).toHaveBeenCalledWith(
+      { ignoredBoundaryCount: 1 },
+      "Ignored organization authorization boundaries unsupported by this application version",
+    );
+    expect(JSON.stringify(warnMock.mock.calls)).not.toContain("organization_future_read");
+  });
+
+  it("disables enforcement when an enabled setting contains only future boundaries", async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [{ value: { enabled: true, boundaries: ["organization_future_read"] } }],
+    });
+
+    await expect(getOrganizationAuthorizationEnforcement()).resolves.toEqual({
+      enabled: false,
+      boundaries: [],
+    });
+  });
+
+  it("filters future boundaries from a disabled setting while retaining known boundaries", async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [{
+        value: {
+          enabled: false,
+          boundaries: ["organization_roles_read", "organization_future_read"],
+        },
+      }],
+    });
+
+    await expect(getOrganizationAuthorizationEnforcement()).resolves.toEqual({
+      enabled: false,
+      boundaries: ["organization_roles_read"],
+    });
+  });
+
   it.each([
     [true],
     [{ enabled: "true", boundaries: [] }],
     [{ enabled: true, boundaries: "organization_roles_read" }],
     [{ enabled: true, boundaries: [42] }],
+    [{ enabled: true, boundaries: ["organization_roles_read", 42] }],
     [{ enabled: true, boundaries: [] }],
-    [{ enabled: true, boundaries: ["unknown_boundary"] }],
+    [{ enabled: true, boundaries: [" ", "\t"] }],
+    [{ enabled: true, boundaries: ["../organization_future_read"] }],
+    [{ enabled: true, boundaries: [`organization_${"a".repeat(97)}`] }],
   ])("rejects malformed persisted configuration %#", async (value) => {
     queryMock.mockResolvedValueOnce({ rows: [{ value }] });
 
@@ -70,6 +134,24 @@ describe("organization authorization system setting", () => {
     await expect(setOrganizationAuthorizationEnforcement({
       enabled: true,
       boundaries: ["unknown_boundary"],
+    })).rejects.toThrow("Invalid organization authorization enforcement setting");
+
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("will not persist disabled configuration outside the fixed boundary allowlist", async () => {
+    await expect(setOrganizationAuthorizationEnforcement({
+      enabled: false,
+      boundaries: ["unknown_boundary"],
+    })).rejects.toThrow("Invalid organization authorization enforcement setting");
+
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])("will not persist mixed known and unknown configuration when enabled=%s", async (enabled) => {
+    await expect(setOrganizationAuthorizationEnforcement({
+      enabled,
+      boundaries: ["organization_roles_read", "organization_future_read"],
     })).rejects.toThrow("Invalid organization authorization enforcement setting");
 
     expect(queryMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- tolerate well-formed authorization boundary names introduced by newer binaries when reading the audited runtime setting
- preserve enforcement for boundaries this binary understands and disable locally when only future boundaries remain
- keep malformed settings fail-closed and all writes strict
- emit one privacy-safe version-skew warning per process

## Why this is separate

This is a behavior-neutral compatibility precursor for the staged #6827 rollout. It must reach full production convergence and become the rollback floor before any newer boundary can be persisted.

## Validation

- 41 focused authorization tests passed
- server TypeScript no-emit passed
- diff check passed
- independent code, security, and test reviews found no blocker

The local repository-wide pre-commit suite hit its existing 600-second hard timeout without reporting a test failure; the full GitHub matrix is authoritative before merge.