### PR TITLE
feat(auth): add default-off organization domains canary

### DIFF
--- a/server/public/admin-settings.html
+++ b/server/public/admin-settings.html
@@ -392,12 +392,20 @@
 
           <div class="setting-row">
             <div class="field">
-              <label for="organizationAuthorizationEnabled">Roles-read boundary</label>
+              <label for="organizationAuthorizationEnabled">Runtime enforcement</label>
               <select id="organizationAuthorizationEnabled">
                 <option value="false">Legacy authorization (off)</option>
                 <option value="true">Exact-credential authorization (on)</option>
               </select>
-              <small>Currently limited to <code>organization_roles_read</code>. Disable here for rollback within five seconds.</small>
+              <label>
+                <input type="checkbox" id="organizationAuthorizationRolesRead">
+                Roles read (<code>organization_roles_read</code>)
+              </label>
+              <label>
+                <input type="checkbox" id="organizationAuthorizationDomainsRead">
+                Domains read (<code>organization_domains_read</code>)
+              </label>
+              <small>Only deployment-staged boundaries can be selected. Disable here for rollback within five seconds.</small>
             </div>
             <button class="btn btn-primary" id="saveOrganizationAuthorizationBtn" onclick="saveOrganizationAuthorizationEnforcement()" disabled>
               Save
@@ -1122,23 +1130,51 @@ loadAuditHistory();
         enabled: false,
         boundaries: [],
       };
-      const boundaryEnabled = setting.enabled === true &&
-        Array.isArray(setting.boundaries) &&
-        setting.boundaries.includes('organization_roles_read');
-      const environmentStaged = currentSettings?.organization_authorization_environment_ceiling?.boundaries
-        ?.includes('organization_roles_read') === true;
+      const boundaryDefinitions = [
+        {
+          value: 'organization_roles_read',
+          label: 'roles read',
+          checkboxId: 'organizationAuthorizationRolesRead',
+        },
+        {
+          value: 'organization_domains_read',
+          label: 'domains read',
+          checkboxId: 'organizationAuthorizationDomainsRead',
+        },
+      ];
+      const configuredBoundaries = new Set(Array.isArray(setting.boundaries) ? setting.boundaries : []);
+      const stagedBoundaries = new Set(
+        currentSettings?.organization_authorization_environment_ceiling?.boundaries ?? [],
+      );
+      const enabledBoundaries = boundaryDefinitions.filter(({ value }) =>
+        setting.enabled === true && configuredBoundaries.has(value)
+      );
+      const activeBoundaries = enabledBoundaries.filter(({ value }) => stagedBoundaries.has(value));
+      const blockedBoundaries = enabledBoundaries.filter(({ value }) => !stagedBoundaries.has(value));
       const el = document.getElementById('currentOrganizationAuthorizationStatus');
       const select = document.getElementById('organizationAuthorizationEnabled');
 
-      el.className = boundaryEnabled && environmentStaged ? 'current-value' : 'current-value not-set';
-      if (boundaryEnabled && environmentStaged) {
-        el.innerHTML = '<strong>Status:</strong> Exact-credential roles read active';
-      } else if (boundaryEnabled) {
-        el.innerHTML = '<strong>Status:</strong> Runtime gate armed, but environment ceiling is off';
+      el.className = activeBoundaries.length > 0
+        ? 'current-value'
+        : 'current-value not-set';
+      if (activeBoundaries.length > 0) {
+        const blockedStatus = blockedBoundaries.length > 0
+          ? `; blocked by environment ceiling: ${blockedBoundaries.map(({ label }) => label).join(', ')}`
+          : '';
+        el.innerHTML = `<strong>Status:</strong> Exact-credential authorization active: ${activeBoundaries.map(({ label }) => label).join(', ')}${blockedStatus}`;
+      } else if (blockedBoundaries.length > 0) {
+        el.innerHTML = `<strong>Status:</strong> Runtime gate armed, but environment ceiling is off for: ${blockedBoundaries.map(({ label }) => label).join(', ')}`;
       } else {
-        el.innerHTML = `<strong>Status:</strong> Legacy roles read (runtime gate off; environment ceiling ${environmentStaged ? 'staged' : 'off'})`;
+        el.innerHTML = `<strong>Status:</strong> Legacy authorization (runtime gate off; ${stagedBoundaries.size} ${stagedBoundaries.size === 1 ? 'boundary' : 'boundaries'} staged)`;
       }
-      select.value = String(boundaryEnabled);
+      select.value = String(setting.enabled === true);
+      for (const { value, checkboxId } of boundaryDefinitions) {
+        const checkbox = document.getElementById(checkboxId);
+        checkbox.checked = configuredBoundaries.has(value);
+        // A configured boundary remains editable after an environment rollback
+        // so an operator can remove it and retain the other active boundaries.
+        checkbox.disabled = !stagedBoundaries.has(value) && !configuredBoundaries.has(value);
+      }
       document.getElementById('saveOrganizationAuthorizationBtn').disabled = false;
     }
 
@@ -1146,6 +1182,17 @@ loadAuditHistory();
       const select = document.getElementById('organizationAuthorizationEnabled');
       const saveBtn = document.getElementById('saveOrganizationAuthorizationBtn');
       const enabled = select.value === 'true';
+      const boundaries = [
+        ['organization_roles_read', 'organizationAuthorizationRolesRead'],
+        ['organization_domains_read', 'organizationAuthorizationDomainsRead'],
+      ]
+        .filter(([, checkboxId]) => document.getElementById(checkboxId).checked)
+        .map(([boundary]) => boundary);
+
+      if (enabled && boundaries.length === 0) {
+        showStatusMessage('Select at least one staged authorization boundary', 'error');
+        return;
+      }
 
       saveBtn.disabled = true;
       saveBtn.textContent = 'Saving...';
@@ -1155,7 +1202,7 @@ loadAuditHistory();
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             enabled,
-            boundaries: ['organization_roles_read'],
+            boundaries,
           }),
         });
         if (!response.ok) {

--- a/server/src/auth/organization-authorization-boundaries.ts
+++ b/server/src/auth/organization-authorization-boundaries.ts
@@ -1,6 +1,7 @@
 /** Fixed rollout boundaries shared by persistence, runtime evaluation, and admin controls. */
 export const ORGANIZATION_AUTHORIZATION_BOUNDARIES = {
   ORGANIZATION_ROLES_READ: 'organization_roles_read',
+  ORGANIZATION_DOMAINS_READ: 'organization_domains_read',
 } as const;
 
 export type OrganizationAuthorizationBoundary =

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -553,13 +553,39 @@ export function createOrganizationsRouter(): Router {
       const user = req.user!;
       const { orgId } = req.params;
 
-      // Verify user is a member of this organization
-      const membership = await resolveUserOrgMembership(workos, user.id, orgId);
-      if (!membership) {
-        return res.status(403).json({
-          error: 'Access denied',
-          message: 'You are not a member of this organization',
-        });
+      const canaryDecision = await evaluateOrganizationAuthorizationCanary({
+        boundary: ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_DOMAINS_READ,
+        principal: user,
+        organizationId: orgId,
+        getWorkos: getAuthorizationEnforcementWorkos,
+      });
+
+      if (canaryDecision.enforced) {
+        recordOrganizationAuthorizationCanaryDecision(
+          ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_DOMAINS_READ,
+          canaryDecision,
+        );
+        if (canaryDecision.status === 'unavailable') {
+          return res.status(503).json({
+            error: 'Authorization temporarily unavailable',
+            message: 'Organization access could not be verified. Please retry.',
+          });
+        }
+        if (canaryDecision.status === 'forbidden') {
+          return res.status(403).json({
+            error: 'Access denied',
+            message: 'You are not a member of this organization',
+          });
+        }
+      } else {
+        // Kill-switch/default path: retain the shipped canonical-user decision.
+        const membership = await resolveUserOrgMembership(workos, user.id, orgId);
+        if (!membership) {
+          return res.status(403).json({
+            error: 'Access denied',
+            message: 'You are not a member of this organization',
+          });
+        }
       }
 
       // Get domains, both auto-provision settings, and any inferred

--- a/server/tests/unit/admin-organization-authorization-setting.test.ts
+++ b/server/tests/unit/admin-organization-authorization-setting.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../src/middleware/auth.js", () => {
 vi.mock("../../src/middleware/organization-authorization-canary.js", () => ({
   ORGANIZATION_AUTHORIZATION_BOUNDARIES: {
     ORGANIZATION_ROLES_READ: "organization_roles_read",
+    ORGANIZATION_DOMAINS_READ: "organization_domains_read",
   },
   isOrganizationAuthorizationBoundaryAllowedByEnvironment: environmentAllowsBoundaryMock,
   invalidateOrganizationAuthorizationRuntimeSettingCache: invalidateCacheMock,
@@ -37,6 +38,16 @@ vi.mock("../../src/middleware/organization-authorization-canary.js", () => ({
 
 vi.mock("../../src/db/system-settings-db.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../src/db/system-settings-db.js")>()),
+  getAllSettings: vi.fn().mockResolvedValue([]),
+  getBillingChannel: vi.fn().mockResolvedValue({ channel_id: null, channel_name: null }),
+  getEscalationChannel: vi.fn().mockResolvedValue({ channel_id: null, channel_name: null }),
+  getAdminChannel: vi.fn().mockResolvedValue({ channel_id: null, channel_name: null }),
+  getProspectChannel: vi.fn().mockResolvedValue({ channel_id: null, channel_name: null }),
+  getProspectTriageEnabled: vi.fn().mockResolvedValue(false),
+  getErrorChannel: vi.fn().mockResolvedValue({ channel_id: null, channel_name: null }),
+  getEditorialChannel: vi.fn().mockResolvedValue({ channel_id: null, channel_name: null }),
+  getAnnouncementChannel: vi.fn().mockResolvedValue({ channel_id: null, channel_name: null }),
+  getS2CanonicalFormatsDeltaRelease: vi.fn().mockResolvedValue({}),
   getOrganizationAuthorizationEnforcement: getSettingMock,
   setOrganizationAuthorizationEnforcement: setSettingMock,
 }));
@@ -91,6 +102,54 @@ describe("organization authorization runtime admin setting", () => {
       enabled: true,
       boundaries: ["organization_roles_read"],
     });
+  });
+
+  it("reports the environment ceiling independently for each supported boundary", async () => {
+    environmentAllowsBoundaryMock.mockImplementation(
+      (boundary: string) => boundary === "organization_domains_read",
+    );
+
+    const response = await request(createApp()).get("/api/admin/settings");
+
+    expect(response.status).toBe(200);
+    expect(response.body.organization_authorization_environment_ceiling).toEqual({
+      boundaries: ["organization_domains_read"],
+    });
+  });
+
+  it("persists independently selected read boundaries", async () => {
+    const response = await request(createApp())
+      .put("/api/admin/settings/organization-authorization-enforcement")
+      .send({
+        enabled: true,
+        boundaries: ["organization_domains_read"],
+      });
+
+    expect(response.status).toBe(200);
+    expect(setSettingMock).toHaveBeenCalledWith(
+      {
+        enabled: true,
+        boundaries: ["organization_domains_read"],
+      },
+      "user_authenticated_admin",
+    );
+  });
+
+  it("rejects a mixed selection when any boundary is outside the environment ceiling", async () => {
+    environmentAllowsBoundaryMock.mockImplementation(
+      (boundary: string) => boundary === "organization_roles_read",
+    );
+
+    const response = await request(createApp())
+      .put("/api/admin/settings/organization-authorization-enforcement")
+      .send({
+        enabled: true,
+        boundaries: ["organization_roles_read", "organization_domains_read"],
+      });
+
+    expect(response.status).toBe(409);
+    expect(setSettingMock).not.toHaveBeenCalled();
+    expect(invalidateCacheMock).not.toHaveBeenCalled();
   });
 
   it("allows an audited runtime rollback without removing the staged boundary", async () => {

--- a/server/tests/unit/admin-settings-organization-authorization-ui.test.ts
+++ b/server/tests/unit/admin-settings-organization-authorization-ui.test.ts
@@ -1,17 +1,192 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { JSDOM } from "jsdom";
+import { describe, expect, it, vi } from "vitest";
 
 const source = readFileSync(
   new URL("../../public/admin-settings.html", import.meta.url),
   "utf8",
 );
 
+function section(start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  if (startIndex < 0 || endIndex < 0) throw new Error(`Missing section: ${start}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function loadControls(currentSettings: Record<string, unknown>) {
+  const dom = new JSDOM(`
+    <div id="currentOrganizationAuthorizationStatus"></div>
+    <select id="organizationAuthorizationEnabled">
+      <option value="false">off</option>
+      <option value="true">on</option>
+    </select>
+    <input type="checkbox" id="organizationAuthorizationRolesRead">
+    <input type="checkbox" id="organizationAuthorizationDomainsRead">
+    <button id="saveOrganizationAuthorizationBtn" disabled>Save</button>
+  `);
+  const fetchMock = vi.fn();
+  const showStatusMessage = vi.fn();
+  const loadAuditHistory = vi.fn();
+  const functions = new Function(
+    "document",
+    "fetch",
+    "showStatusMessage",
+    "loadAuditHistory",
+    "setTimeout",
+    "currentSettings",
+    `${section(
+      "function updateOrganizationAuthorizationDisplay()",
+      "// Status message helpers",
+    )}
+    return {
+      updateOrganizationAuthorizationDisplay,
+      saveOrganizationAuthorizationEnforcement,
+    };`,
+  )(
+    dom.window.document,
+    fetchMock,
+    showStatusMessage,
+    loadAuditHistory,
+    (callback: () => void) => callback(),
+    currentSettings,
+  ) as {
+    updateOrganizationAuthorizationDisplay: () => void;
+    saveOrganizationAuthorizationEnforcement: () => Promise<void>;
+  };
+
+  return {
+    dom,
+    fetchMock,
+    showStatusMessage,
+    loadAuditHistory,
+    ...functions,
+  };
+}
+
 describe("admin organization authorization runtime control", () => {
-  it("loads, renders, and saves the fixed roles-read boundary", () => {
-    expect(source).toContain("updateOrganizationAuthorizationDisplay();");
-    expect(source).toContain("/api/admin/settings/organization-authorization-enforcement");
-    expect(source).toContain("boundaries: ['organization_roles_read']");
-    expect(source).toContain("Disable here for rollback within five seconds.");
-    expect(source).toContain("Runtime gate armed, but environment ceiling is off");
+  it("renders configured boundaries and disables only unavailable additions", () => {
+    const controls = loadControls({
+      organization_authorization_enforcement: {
+        enabled: true,
+        boundaries: ["organization_roles_read"],
+      },
+      organization_authorization_environment_ceiling: {
+        boundaries: ["organization_roles_read"],
+      },
+    });
+
+    controls.updateOrganizationAuthorizationDisplay();
+
+    const document = controls.dom.window.document;
+    expect((document.getElementById("organizationAuthorizationEnabled") as HTMLSelectElement).value)
+      .toBe("true");
+    expect((document.getElementById("organizationAuthorizationRolesRead") as HTMLInputElement).checked)
+      .toBe(true);
+    expect((document.getElementById("organizationAuthorizationRolesRead") as HTMLInputElement).disabled)
+      .toBe(false);
+    expect((document.getElementById("organizationAuthorizationDomainsRead") as HTMLInputElement).checked)
+      .toBe(false);
+    expect((document.getElementById("organizationAuthorizationDomainsRead") as HTMLInputElement).disabled)
+      .toBe(true);
+    expect(document.getElementById("currentOrganizationAuthorizationStatus")?.textContent)
+      .toContain("roles read");
+
+    controls.dom.window.close();
+  });
+
+  it("allows an unstaged configured boundary to be removed during rollback", async () => {
+    const currentSettings = {
+      organization_authorization_enforcement: {
+        enabled: true,
+        boundaries: ["organization_roles_read", "organization_domains_read"],
+      },
+      organization_authorization_environment_ceiling: {
+        boundaries: ["organization_roles_read"],
+      },
+    };
+    const controls = loadControls(currentSettings);
+    controls.updateOrganizationAuthorizationDisplay();
+    const document = controls.dom.window.document;
+    const domains = document.getElementById("organizationAuthorizationDomainsRead") as HTMLInputElement;
+    expect(domains.checked).toBe(true);
+    expect(domains.disabled).toBe(false);
+    expect(document.getElementById("currentOrganizationAuthorizationStatus")?.textContent)
+      .toContain("authorization active: roles read; blocked by environment ceiling: domains read");
+    domains.checked = false;
+
+    controls.fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      organization_authorization_enforcement: {
+        enabled: true,
+        boundaries: ["organization_roles_read"],
+      },
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+
+    await controls.saveOrganizationAuthorizationEnforcement();
+
+    expect(controls.fetchMock).toHaveBeenCalledOnce();
+    const [, init] = controls.fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({
+      enabled: true,
+      boundaries: ["organization_roles_read"],
+    });
+    expect(controls.loadAuditHistory).toHaveBeenCalledOnce();
+
+    controls.dom.window.close();
+  });
+
+  it("saves a domains-only staged selection independently", async () => {
+    const controls = loadControls({
+      organization_authorization_enforcement: {
+        enabled: false,
+        boundaries: [],
+      },
+      organization_authorization_environment_ceiling: {
+        boundaries: ["organization_roles_read", "organization_domains_read"],
+      },
+    });
+    controls.updateOrganizationAuthorizationDisplay();
+    const document = controls.dom.window.document;
+    (document.getElementById("organizationAuthorizationEnabled") as HTMLSelectElement).value = "true";
+    (document.getElementById("organizationAuthorizationDomainsRead") as HTMLInputElement).checked = true;
+
+    controls.fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      organization_authorization_enforcement: {
+        enabled: true,
+        boundaries: ["organization_domains_read"],
+      },
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+
+    await controls.saveOrganizationAuthorizationEnforcement();
+
+    const [, init] = controls.fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({
+      enabled: true,
+      boundaries: ["organization_domains_read"],
+    });
+
+    controls.dom.window.close();
+  });
+
+  it("does not write an enabled setting without a selected boundary", async () => {
+    const controls = loadControls({
+      organization_authorization_enforcement: { enabled: false, boundaries: [] },
+      organization_authorization_environment_ceiling: {
+        boundaries: ["organization_roles_read", "organization_domains_read"],
+      },
+    });
+    controls.updateOrganizationAuthorizationDisplay();
+    (controls.dom.window.document.getElementById("organizationAuthorizationEnabled") as HTMLSelectElement)
+      .value = "true";
+
+    await controls.saveOrganizationAuthorizationEnforcement();
+
+    expect(controls.fetchMock).not.toHaveBeenCalled();
+    expect(controls.showStatusMessage).toHaveBeenCalledWith(
+      "Select at least one staged authorization boundary",
+      "error",
+    );
+
+    controls.dom.window.close();
   });
 });

--- a/server/tests/unit/organization-authorization-canary.test.ts
+++ b/server/tests/unit/organization-authorization-canary.test.ts
@@ -34,6 +34,8 @@ import {
 } from "../../src/middleware/organization-authorization-canary.js";
 
 const BOUNDARY = ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_ROLES_READ;
+const DOMAINS_BOUNDARY =
+  ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_DOMAINS_READ;
 
 describe("organization authorization canary", () => {
   beforeEach(() => {
@@ -159,6 +161,34 @@ describe("organization authorization canary", () => {
     expect(getWorkos).not.toHaveBeenCalled();
     expect(resolveUserOrgAuthorizationMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    [BOUNDARY, DOMAINS_BOUNDARY],
+    [DOMAINS_BOUNDARY, BOUNDARY],
+  ])(
+    "does not enforce %s when runtime enables only %s",
+    async (requestedBoundary, enabledBoundary) => {
+      process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";
+      process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES =
+        `${BOUNDARY},${DOMAINS_BOUNDARY}`;
+      const getWorkos = vi.fn();
+
+      const decision = await evaluateOrganizationAuthorizationCanary({
+        boundary: requestedBoundary,
+        principal: { id: "user_test" },
+        organizationId: "org_test",
+        getWorkos,
+        getRuntimeSetting: vi.fn().mockResolvedValue({
+          enabled: true,
+          boundaries: [enabledBoundary],
+        }),
+      });
+
+      expect(decision).toEqual({ enforced: false });
+      expect(getWorkos).not.toHaveBeenCalled();
+      expect(resolveUserOrgAuthorizationMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("fails closed when the environment is staged but runtime configuration is unavailable", async () => {
     process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";

--- a/server/tests/unit/organization-authorization-setting-db.test.ts
+++ b/server/tests/unit/organization-authorization-setting-db.test.ts
@@ -130,6 +130,27 @@ describe("organization authorization system setting", () => {
     ]);
   });
 
+  it("accepts both supported read boundaries", async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] });
+
+    await setOrganizationAuthorizationEnforcement(
+      {
+        enabled: true,
+        boundaries: ["organization_roles_read", "organization_domains_read"],
+      },
+      "user_authenticated_admin",
+    );
+
+    expect(queryMock.mock.calls[0][1]).toEqual([
+      "organization_authorization_enforcement",
+      JSON.stringify({
+        enabled: true,
+        boundaries: ["organization_roles_read", "organization_domains_read"],
+      }),
+      "user_authenticated_admin",
+    ]);
+  });
+
   it("will not persist enabled configuration outside the fixed boundary allowlist", async () => {
     await expect(setOrganizationAuthorizationEnforcement({
       enabled: true,

--- a/server/tests/unit/organization-domains-canary-route.test.ts
+++ b/server/tests/unit/organization-domains-canary-route.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+
+const {
+  evaluateCanaryMock,
+  recordCanaryDecisionMock,
+  getEnforcementWorkosMock,
+  legacyMembershipMock,
+  poolQueryMock,
+} = vi.hoisted(() => {
+  process.env.WORKOS_API_KEY ||= "sk_test_organization_domains_canary";
+  process.env.WORKOS_CLIENT_ID ||= "client_test_organization_domains_canary";
+  process.env.WORKOS_COOKIE_PASSWORD ||=
+    "test-cookie-password-32chars-min-len-1234";
+  return {
+    evaluateCanaryMock: vi.fn(),
+    recordCanaryDecisionMock: vi.fn(),
+    getEnforcementWorkosMock: vi.fn(() => ({ bounded: true })),
+    legacyMembershipMock: vi.fn(),
+    poolQueryMock: vi.fn(),
+  };
+});
+
+vi.mock("@workos-inc/node", () => ({
+  WorkOS: class {},
+}));
+
+vi.mock("../../src/middleware/auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/middleware/auth.js")>()),
+  requireAuth: (
+    req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction
+  ) => {
+    req.user = {
+      id: "user_canonical",
+      authWorkosUserId: "user_authenticated",
+      email: "linked@example.test",
+      emailVerified: true,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    };
+    next();
+  },
+}));
+
+vi.mock("../../src/auth/workos-client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/auth/workos-client.js")>()),
+  getAuthorizationEnforcementWorkos: getEnforcementWorkosMock,
+}));
+
+vi.mock("../../src/utils/resolve-user-org-membership.js", () => ({
+  resolveUserOrgMembership: legacyMembershipMock,
+}));
+
+vi.mock("../../src/middleware/organization-authorization-canary.js", () => ({
+  ORGANIZATION_AUTHORIZATION_BOUNDARIES: {
+    ORGANIZATION_ROLES_READ: "organization_roles_read",
+    ORGANIZATION_DOMAINS_READ: "organization_domains_read",
+  },
+  evaluateOrganizationAuthorizationCanary: evaluateCanaryMock,
+  recordOrganizationAuthorizationCanaryDecision: recordCanaryDecisionMock,
+}));
+
+vi.mock("../../src/db/client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/db/client.js")>()),
+  getPool: () => ({ query: poolQueryMock }),
+}));
+
+import { createOrganizationsRouter } from "../../src/routes/organizations.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/organizations", createOrganizationsRouter());
+  return app;
+}
+
+describe("GET organization domains authorization canary", () => {
+  beforeEach(() => {
+    evaluateCanaryMock.mockReset().mockResolvedValue({ enforced: false });
+    recordCanaryDecisionMock.mockReset();
+    legacyMembershipMock.mockReset().mockResolvedValue({ role: "member" });
+    poolQueryMock.mockReset().mockImplementation((sql: string) => {
+      if (sql.includes("FROM organization_domains") && sql.includes("SELECT domain")) {
+        return Promise.resolve({
+          rows: [{ domain: "example.test", verified: true, is_primary: true }],
+        });
+      }
+      if (sql.includes("FROM organizations WHERE")) {
+        return Promise.resolve({
+          rows: [{
+            auto_provision_verified_domain: true,
+            auto_provision_brand_hierarchy_children: false,
+            auto_provision_hierarchy_enabled_at: null,
+          }],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+  });
+
+  it("preserves the canonical-user authorization path while disabled", async () => {
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/domains"
+    );
+
+    expect(response.status).toBe(200);
+    expect(legacyMembershipMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "user_canonical",
+      "org_test"
+    );
+    expect(evaluateCanaryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boundary: "organization_domains_read",
+        principal: expect.objectContaining({
+          id: "user_canonical",
+          authWorkosUserId: "user_authenticated",
+        }),
+        organizationId: "org_test",
+        getWorkos: getEnforcementWorkosMock,
+      })
+    );
+    expect(recordCanaryDecisionMock).not.toHaveBeenCalled();
+  });
+
+  it("uses an authorized exact-credential decision without legacy authority", async () => {
+    evaluateCanaryMock.mockResolvedValue({
+      enforced: true,
+      status: "authorized",
+      membership: {
+        organizationId: "org_test",
+        role: "member",
+        source: "workos",
+      },
+    });
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/domains"
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.domains).toEqual([
+      { domain: "example.test", verified: true, is_primary: true },
+    ]);
+    expect(recordCanaryDecisionMock).toHaveBeenCalledWith(
+      "organization_domains_read",
+      expect.objectContaining({ enforced: true, status: "authorized" })
+    );
+    expect(legacyMembershipMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves legacy denial without reading domains while disabled", async () => {
+    legacyMembershipMock.mockResolvedValueOnce(null);
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/domains"
+    );
+
+    expect(response.status).toBe(403);
+    expect(recordCanaryDecisionMock).not.toHaveBeenCalled();
+    expect(poolQueryMock).not.toHaveBeenCalled();
+  });
+
+  it("denies a linked credential even when the canonical credential is a member", async () => {
+    evaluateCanaryMock.mockResolvedValue({ enforced: true, status: "forbidden" });
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/domains"
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Access denied");
+    expect(recordCanaryDecisionMock).toHaveBeenCalledOnce();
+    expect(recordCanaryDecisionMock).toHaveBeenCalledWith(
+      "organization_domains_read",
+      { enforced: true, status: "forbidden" },
+    );
+    expect(legacyMembershipMock).not.toHaveBeenCalled();
+    expect(poolQueryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 before domain reads when authority is unavailable", async () => {
+    evaluateCanaryMock.mockResolvedValue({
+      enforced: true,
+      status: "unavailable",
+      unavailableSources: ["workos"],
+    });
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/domains"
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.body.error).toBe("Authorization temporarily unavailable");
+    expect(recordCanaryDecisionMock).toHaveBeenCalledOnce();
+    expect(recordCanaryDecisionMock).toHaveBeenCalledWith(
+      "organization_domains_read",
+      {
+        enforced: true,
+        status: "unavailable",
+        unavailableSources: ["workos"],
+      },
+    );
+    expect(legacyMembershipMock).not.toHaveBeenCalled();
+    expect(poolQueryMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add `organization_domains_read` as the next exact-credential authorization canary boundary
- enforce it only for the read-only `GET /api/organizations/:orgId/domains` route when both environment and audited runtime gates select it
- preserve the existing legacy path while disabled and emit identifier-free decision telemetry while enforced
- extend the admin control surface for independent roles/domains selection and clear partial-ceiling status
- add route, evaluator, database-setting, API, telemetry, kill-switch, and JSDOM operator-UI coverage

## Rollout constraints

This PR is default-off in production: `fly.toml` continues to stage only `organization_roles_read`, and the audited runtime setting currently remains disabled. It must not merge until compatibility precursor #7045 (`e0deeb71a6`) has fully converged in production and completed a clean settling window. After this code deploys, the environment ceiling and runtime activation will be separate, observable rollout steps.

## Validation

- 60 focused authorization/admin/route tests passed after rebasing onto #7045
- server TypeScript no-emit passed
- diff check passed
- independent code/security/test reviews found the request path safe and identified #7045 as the prerequisite now included in this branch

The local repository-wide pre-commit suite hit its existing 600-second hard timeout without reporting a test failure; the complete GitHub matrix is authoritative before merge.

Part of #6827.