### PR TITLE
chore(auth): stage organization domains canary ceiling

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -40,7 +40,7 @@ primary_region = 'iad'
   # Deployment-time ceiling for the issue #6827 read-only authorization canary.
   # The database runtime gate remains independently disabled until explicitly armed.
   ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true"
-  ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = "organization_roles_read"
+  ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = "organization_roles_read,organization_domains_read"
   # Use pre-cloned repos from Docker build, skip runtime git fetch.
   # Production image has no git binary — unsetting this degrades gracefully
   # (repos skip indexing) but does not crash.


### PR DESCRIPTION
## Summary

- add `organization_domains_read` to the deployment-time authorization ceiling
- retain `organization_roles_read`
- leave the database runtime gate disabled, so this deployment is behavior-neutral

## Rollout safety

This is the configuration-only second stage for #6827. The forward-compatible reader and default-off domains implementation have already converged in production. Runtime activation is a separate audited action after this release converges and completes a clean settling interval.

Rollback before activation is this one-line configuration revert. After activation, the immediate kill switch is the database runtime setting.

## Validation

- one-file/one-line diff
- `git diff --check`
- independent code, security, and test/operational review
