### PR TITLE
chore(release): enter pre mode for 3.2 rc

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,4 +1,4 @@
 {
   "mode": "pre",
-  "tag": "beta"
+  "tag": "rc"
 }


### PR DESCRIPTION
## Summary

Starts the AdCP 3.2 release-candidate cycle by switching Changesets prerelease mode from `beta` to `rc`.

Per the release procedure, this is intentionally a state-only PR. After merge, the release workflow will refresh the Version Packages PR. The next prerelease ordinal is expected to remain monotonic (`3.2.0-rc.10`).

## Verification

- Ran `changeset pre exit`, then `changeset pre enter rc`
- Confirmed `.changeset/pre.json` is the only changed file
- `changeset status` reports a minor bump for `adcontextprotocol`
- Pre-commit suite passed
- `npm run test:release-workflow` passed

Tracks the 3.2 RC gate in #7061.
