### PR TITLE
fix(registry): make support compliance reruns auth-safe

### DIFF
--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -4019,7 +4019,7 @@ registry.registerPath({
   operationId: "refreshAgent",
   summary: "Refresh agent snapshot",
   description:
-    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).\n\n**Compliance re-run:** when the caller owns the agent or is an AAO admin and the capability probe succeeds, the full storyboard suite can run for several minutes on capability-rich agents with a fresh test session, and `agent_storyboard_status` is updated. Owner-triggered runs use `triggered_by: 'owner_test'`; admin-triggered support runs use `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.\n\n**Auth:** owner of the agent, AAO admin, or static `ADMIN_API_KEY`.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
+    "Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).\n\n**Compliance re-run:** when the caller owns the agent or is an AAO admin and the capability probe succeeds, the full storyboard suite can run for several minutes on capability-rich agents with a fresh test session, and `agent_storyboard_status` is updated. Owner-triggered runs use `triggered_by: 'owner_test'`; admin-triggered support runs use `triggered_by: 'manual'`. Cross-owner support runs use the same saved owner credentials as the periodic heartbeat when available. Badge fan-out reissues verification badges off the new run. If the compliance call fails or the verifier cannot authenticate (timeout, missing/rejected credentials, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string and no compliance verdict is persisted.\n\n**Auth:** owner of the agent, AAO admin, or static `ADMIN_API_KEY`.\n\n**Rate limits:** 60 seconds per agent URL, 30 requests per user per hour.",
   tags: ["Agent Compliance"],
   security: [{ bearerAuth: [] }, { oauth2: [] }],
   request: {
@@ -4051,7 +4051,7 @@ registry.registerPath({
             checked_at: z.string(),
             error: z.string().optional(),
             compliance: z.object({
-              ran: z.boolean().openapi({ description: "True if the full storyboard suite ran and agent_storyboard_status was updated. False when ownership couldn't be resolved, the agent reported auth_required, or the compliance call itself failed." }),
+              ran: z.boolean().openapi({ description: "True if the full storyboard suite ran and agent_storyboard_status was updated. False when the verifier could not authenticate or the compliance call itself failed; those inconclusive results are not persisted." }),
               run_id: z.string().optional().openapi({ description: "Compliance run id written by this refresh. Use with /compliance/diagnostics?run_id=... to inspect failing-step wire evidence." }),
               test_session_id: z.string().optional().openapi({ description: "Fresh test session id used for the compliance run. Useful when matching seller-side logs to the refresh." }),
               requested_compliance_target: z.string().optional().openapi({ description: "Requested compliance target before alias resolution, e.g. 3.1, 3.0, 3.1-rc, or 3.1-beta. Present when `ran` is true." }),
@@ -7559,6 +7559,40 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
   }, REFRESH_AGENT_RATE_LIMIT_MS);
   refreshRateLimitCleanupInterval.unref();
 
+  // Match transport/authentication failures, not arbitrary mentions such as
+  // "expected HTTP 401" inside an authentication-conformance assertion.
+  const verifierAuthFailurePattern = /(?:agent returned (?:http )?(?:401|403)\b|request failed (?:with )?(?:http )?(?:status(?: code)? )?(?:401|403)\b|(?:401|403) (?:unauthori[sz]ed|forbidden)\b|authentication required|requires (?:oauth )?authorization|AUTH_(?:MISSING|REQUIRED|INVALID))/i;
+
+  /**
+   * A verifier that lacks usable credentials cannot establish an agent's
+   * conformance. Keep that infrastructure failure out of canonical registry
+   * state even when an SDK version grades the surrounding run as failing or
+   * partial instead of the more precise auth_required status.
+   */
+  function hasVerifierAuthenticationFailure(result: Awaited<ReturnType<typeof comply>>): boolean {
+    if (result.overall_status === 'auth_required') return true;
+
+    if (result.observations.some((observation) =>
+      observation.source?.kind === 'probe' &&
+      (observation.source.code === 'auth-401' || observation.source.code === 'auth-oauth-required')
+    )) return true;
+
+    if (result.failures?.some((failure) =>
+      verifierAuthFailurePattern.test(failure.error ?? '')
+    )) return true;
+
+    return result.tracks.some((track) => track.scenarios.some((scenario) =>
+      scenario.steps?.some((step) =>
+        !step.passed && !step.skipped && verifierAuthFailurePattern.test([
+          step.error,
+          step.details,
+          step.response_preview,
+          ...(step.warnings ?? []),
+        ].filter((value): value is string => typeof value === 'string').join(' '))
+      ) === true
+    ));
+  }
+
   router.post("/registry/agents/:encodedUrl/refresh", ...complianceWriteMiddleware, async (req, res) => {
     try {
       const rawAgentUrl = decodeURIComponent(req.params.encodedUrl);
@@ -7619,17 +7653,19 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
       // Owner sees 502/409 error → has 60s to fix and try again.
       refreshAgentRateLimits.set(agentUrl, now);
 
-      // Resolve saved owner auth (static bearer / basic / OAuth) so the
-      // probe sees the same credentials evaluate_agent_quality uses. The
-      // periodic crawl path also now resolves owner credentials when any
-      // org has registered them (see CrawlerService.resolveProbeAuth); this
-      // route still scopes auth to the caller's own org so an AAO admin
-      // refreshing someone else's agent probes anonymously rather than
-      // accidentally running with the owner's tokens.
+      // Resolve saved owner auth (static bearer / basic / OAuth) so the probe
+      // and compliance suite see the same credentials as the heartbeat. An
+      // owner is scoped to their selected org. A privileged cross-owner
+      // support refresh uses ComplianceDatabase's owner-only lookup: it joins
+      // agent_contexts to the organization that registered this exact agent
+      // URL and never borrows credentials from an unrelated tenant.
       let resolvedAuth: SdkAuth | undefined;
       if (ownerOrgId) {
         const auth = await resolveUserAgentAuth(agentContextDb, ownerOrgId, agentUrl, logger);
         resolvedAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `refresh:${agentUrl}` });
+      } else if (canRunCompliance) {
+        const auth = await complianceDb.resolveOwnerAuth(agentUrl);
+        resolvedAuth = await adaptAuthForSdk(auth, { tokenEndpointLabel: `support-refresh:${agentUrl}` });
       }
 
       let probeResult: Awaited<ReturnType<typeof crawler.refreshSingleAgent>>;
@@ -7712,8 +7748,11 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             response_time_ms: Date.now() - complianceStart,
             success: true,
           });
-          if (complyResult.overall_status === 'auth_required') {
-            complianceSummary = { ran: false, error: 'Agent requires OAuth authorization' };
+          if (hasVerifierAuthenticationFailure(complyResult)) {
+            complianceSummary = {
+              ran: false,
+              error: 'Verifier could not authenticate to the agent; compliance result was not persisted',
+            };
           } else {
             const metadata = await complianceDb.getRegistryMetadata(agentUrl);
             const dbInput = complianceResultToDbInput(

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -43,6 +43,10 @@ const ALL_OWNED_URLS = [
   ownedAgentUrl('canonical-saved-bearer'),
   ownedAgentUrl('badge-fanout'),
   ownedAgentUrl('static-admin'),
+  ownedAgentUrl('static-admin-saved-bearer'),
+  ownedAgentUrl('static-admin-auth-required'),
+  ownedAgentUrl('static-admin-task-auth'),
+  ownedAgentUrl('static-admin-auth-conformance-failure'),
   ownedAgentUrl('applicable-oauth'),
   ownedAgentUrl('selected-org-refresh'),
   ownedAgentUrl('selected-org-challenge'),
@@ -485,6 +489,142 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
       triggered_by: 'manual',
       triggered_org_id: null,
     });
+  });
+
+  it('uses stored owner auth for a cross-owner static-admin compliance rerun', async () => {
+    currentUserId = STATIC_ADMIN_USER_ID;
+    const agentUrl = ownedAgentUrl('static-admin-saved-bearer');
+    const { AgentContextDatabase } = await import('../../src/db/agent-context-db.js');
+    const db = new AgentContextDatabase();
+    const context = await db.create({
+      organization_id: TEST_ORG_ID,
+      agent_url: agentUrl,
+      created_by: OWNER_USER_ID,
+    });
+    const FAKE_BEARER = 'fake-static-admin-bearer-do-not-use-in-prod';
+    await db.saveAuthToken(context.id, FAKE_BEARER, 'bearer');
+
+    try {
+      const res = await request(app).post(url(agentUrl)).send();
+
+      expect(res.status).toBe(200);
+      expect(res.body.compliance.ran).toBe(true);
+      expect(refreshSingleAgentMock).toHaveBeenCalledWith(
+        agentUrl,
+        expect.objectContaining({ auth: { type: 'bearer', token: FAKE_BEARER } }),
+      );
+      expect(complyMock).toHaveBeenCalledWith(
+        agentUrl,
+        expect.objectContaining({ auth: { type: 'bearer', token: FAKE_BEARER } }),
+      );
+    } finally {
+      await pool.query('DELETE FROM agent_contexts WHERE id = $1', [context.id]);
+    }
+  });
+
+  it('does not persist a support run when discovery reports authentication required', async () => {
+    currentUserId = STATIC_ADMIN_USER_ID;
+    const agentUrl = ownedAgentUrl('static-admin-auth-required');
+    complyMock.mockResolvedValue({
+      ...makeComplianceResult(),
+      overall_status: 'auth_required',
+      tracks: [],
+      observations: [{
+        category: 'auth',
+        severity: 'error',
+        message: 'Agent returned 401. Check the verifier token.',
+        source: { kind: 'probe', code: 'auth-401' },
+      }],
+    });
+
+    const res = await request(app).post(url(agentUrl)).send();
+
+    expect(res.status).toBe(200);
+    expect(res.body.compliance).toEqual({
+      ran: false,
+      error: 'Verifier could not authenticate to the agent; compliance result was not persisted',
+    });
+    const runs = await pool.query(
+      'SELECT id FROM agent_compliance_runs WHERE agent_url = $1',
+      [agentUrl],
+    );
+    expect(runs.rowCount).toBe(0);
+  });
+
+  it('does not persist a support run when public discovery masks task-level auth', async () => {
+    currentUserId = STATIC_ADMIN_USER_ID;
+    const agentUrl = ownedAgentUrl('static-admin-task-auth');
+    complyMock.mockResolvedValue({
+      ...makeComplianceResult(),
+      overall_status: 'failing',
+      tracks: [{
+        track: 'media_buy',
+        status: 'fail',
+        duration_ms: 42,
+        scenarios: [{
+          scenario: 'media_buy_seller/capability_discovery',
+          overall_passed: false,
+          steps: [{
+            step: 'Call get_products',
+            task: 'get_products',
+            passed: false,
+            duration_ms: 10,
+            error: 'Agent returned 401 Unauthorized',
+          }],
+        }],
+      }],
+      failures: [{
+        track: 'media_buy',
+        storyboard_id: 'media_buy_seller',
+        step_id: 'get_products',
+        step_title: 'Call get_products',
+        task: 'get_products',
+        error: 'Agent returned 401 Unauthorized',
+        fix_command: 'adcp storyboard run --step get_products',
+      }],
+    });
+
+    const res = await request(app).post(url(agentUrl)).send();
+
+    expect(res.status).toBe(200);
+    expect(res.body.compliance.ran).toBe(false);
+    expect(res.body.compliance.error).toMatch(/Verifier could not authenticate/);
+    const runs = await pool.query(
+      'SELECT id FROM agent_compliance_runs WHERE agent_url = $1',
+      [agentUrl],
+    );
+    expect(runs.rowCount).toBe(0);
+  });
+
+  it('persists a target-agent authentication conformance failure', async () => {
+    currentUserId = STATIC_ADMIN_USER_ID;
+    const agentUrl = ownedAgentUrl('static-admin-auth-conformance-failure');
+    complyMock.mockResolvedValue({
+      ...makeComplianceResult(),
+      overall_status: 'failing',
+      failures: [{
+        track: 'security_transport',
+        storyboard_id: 'security_baseline',
+        step_id: 'reject_unauthenticated_request',
+        step_title: 'Reject unauthenticated request',
+        task: 'get_products',
+        error: 'Expected HTTP 401 but agent returned 200',
+        fix_command: 'adcp storyboard run --step reject_unauthenticated_request',
+      }],
+    });
+
+    const res = await request(app).post(url(agentUrl)).send();
+
+    expect(res.status).toBe(200);
+    expect(res.body.compliance).toMatchObject({
+      ran: true,
+      overall_status: 'failing',
+    });
+    const runs = await pool.query(
+      'SELECT id FROM agent_compliance_runs WHERE agent_url = $1',
+      [agentUrl],
+    );
+    expect(runs.rowCount).toBe(1);
   });
 
   it('non-owner non-admin gets 403', async () => {

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -12129,7 +12129,7 @@ paths:
       description: |-
         Re-probe the agent and update its registry health (online, tools_count, response_time_ms), capability snapshot (inferred type, discovered tools), and compliance verdict (storyboard pass/fail counts). Use after fixing your agent so the registry shows fresh data without waiting for the periodic heartbeat (~1h).
 
-        **Compliance re-run:** when the caller owns the agent or is an AAO admin and the capability probe succeeds, the full storyboard suite can run for several minutes on capability-rich agents with a fresh test session, and `agent_storyboard_status` is updated. Owner-triggered runs use `triggered_by: 'owner_test'`; admin-triggered support runs use `triggered_by: 'manual'`. Badge fan-out reissues verification badges off the new run. If the compliance call fails (timeout, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string.
+        **Compliance re-run:** when the caller owns the agent or is an AAO admin and the capability probe succeeds, the full storyboard suite can run for several minutes on capability-rich agents with a fresh test session, and `agent_storyboard_status` is updated. Owner-triggered runs use `triggered_by: 'owner_test'`; admin-triggered support runs use `triggered_by: 'manual'`. Cross-owner support runs use the same saved owner credentials as the periodic heartbeat when available. Badge fan-out reissues verification badges off the new run. If the compliance call fails or the verifier cannot authenticate (timeout, missing/rejected credentials, OAuth wall, internal error), the capability/health portion still returns successfully — `compliance.ran` is `false` with an `error` string and no compliance verdict is persisted.
 
         **Auth:** owner of the agent, AAO admin, or static `ADMIN_API_KEY`.
 
@@ -12192,7 +12192,7 @@ paths:
                     properties:
                       ran:
                         type: boolean
-                        description: True if the full storyboard suite ran and agent_storyboard_status was updated. False when ownership couldn't be resolved, the agent reported auth_required, or the compliance call itself failed.
+                        description: True if the full storyboard suite ran and agent_storyboard_status was updated. False when the verifier could not authenticate or the compliance call itself failed; those inconclusive results are not persisted.
                       run_id:
                         type: string
                         description: Compliance run id written by this refresh. Use with /compliance/diagnostics?run_id=... to inspect failing-step wire evidence.


### PR DESCRIPTION
## Summary

- reuse the registered owner's stored agent credentials for privileged cross-owner support refreshes
- refuse to persist verifier authentication failures as canonical agent compliance verdicts
- distinguish verifier-inconclusive auth failures from genuine target-agent authentication conformance failures
- document the behavior in the generated Registry OpenAPI surface

Addresses #7070. The production rows named in that issue still need credential-aware restoration after this change is deployed.

## Verification

- `npx vitest run --hookTimeout=30000 server/tests/integration/registry-api-agent-refresh.test.ts` (21/21)
- `npm run typecheck`
- `npm run build:openapi`
- root precommit unit/static suite: 1,056/1,056 passed
- staged full server-unit suite: 7,585 passed, 9 environment-only C2PA native-binary failures on macOS (`c2pa-node` installed without native postinstall); no failures in changed code
- `git diff --check`