### PR TITLE
fix(server): prevent anonymous admin refresh from overwriting authenticated compliance results

### DIFF
--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -7675,6 +7675,19 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         error?: string;
       } = { ran: false };
 
+      // For admin callers without their own org credentials, fall back to
+      // heartbeat-style owner auth so the compliance result reflects the
+      // same credential state the periodic heartbeat uses. Without this,
+      // an admin refresh overwrites a valid credential-aware heartbeat
+      // verdict with an anonymous failure result (#7070).
+      let complianceAuth = resolvedAuth;
+      if (!complianceAuth && canRunCompliance && !ownerOrgId) {
+        const ownerAuth = await complianceDb.resolveOwnerAuth(agentUrl);
+        if (ownerAuth) {
+          complianceAuth = await adaptAuthForSdk(ownerAuth, { tokenEndpointLabel: `admin-refresh:${agentUrl}` });
+        }
+      }
+
       if (canRunCompliance && !probeResult.error && !probeResult.oauth_required) {
         const complianceStart = Date.now();
         try {
@@ -7684,7 +7697,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
             test_session_id: testSessionId,
             timeout_ms: HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
             userAgent: AAO_UA_COMPLIANCE,
-            ...(resolvedAuth && { auth: resolvedAuth }),
+            ...(complianceAuth && { auth: complianceAuth }),
           };
           const seededSupportedVersions = await complianceDb.getRecentSupportedVersions(agentUrl);
           const runTargetSelection = await selectComplianceTargetForAgentSelection(
@@ -7783,7 +7796,13 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         }
       }
 
-      return res.json({ ...probeResult, compliance: complianceSummary });
+      return res.json({
+        ...probeResult,
+        compliance: {
+          ...complianceSummary,
+          auth_available: !!complianceAuth,
+        },
+      });
     } catch (error) {
       logger.error({ err: error, path: req.path }, "Failed to refresh agent");
       res.status(500).json({ error: "Failed to refresh agent" });

--- a/server/tests/integration/external-smoke-check.test.ts
+++ b/server/tests/integration/external-smoke-check.test.ts
@@ -1,0 +1,81 @@
+/**
+ * External-endpoint smoke check for release gate.
+ *
+ * Verifies the hosted verifier can discover, resolve, and classify errors
+ * for a real external agent. Uses the public test agent by default; override
+ * via ADCP_SMOKE_CHECK_URL / ADCP_SMOKE_CHECK_TOKEN.
+ *
+ * Run:
+ *   npx vitest run server/tests/integration/external-smoke-check.test.ts
+ *
+ * Against a custom endpoint:
+ *   ADCP_SMOKE_CHECK_URL=https://example.com/mcp \
+ *   ADCP_SMOKE_CHECK_TOKEN=sk-... \
+ *     npx vitest run server/tests/integration/external-smoke-check.test.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  testCapabilityDiscovery,
+  resolveStoryboardsForCapabilities,
+} from '@adcp/sdk/testing';
+import { PUBLIC_TEST_AGENT } from '../../src/config/test-agent.js';
+import {
+  hostedComplianceTarget,
+  hostedComplianceOptions,
+  withHostedTestOptions,
+} from '../../src/services/hosted-compliance-version.js';
+
+const SMOKE_URL = process.env.ADCP_SMOKE_CHECK_URL || PUBLIC_TEST_AGENT.url;
+const SMOKE_TOKEN = process.env.ADCP_SMOKE_CHECK_TOKEN || PUBLIC_TEST_AGENT.token;
+const complianceTarget = hostedComplianceTarget();
+const complianceOptions = hostedComplianceOptions(complianceTarget);
+
+describe('external endpoint smoke check', () => {
+  it('discovers capabilities from external endpoint', async () => {
+    const result = await testCapabilityDiscovery(SMOKE_URL, withHostedTestOptions({
+      auth: { type: 'bearer', token: SMOKE_TOKEN },
+    }, complianceTarget));
+
+    expect(result.profile).toBeDefined();
+    expect(result.profile!.tools!.length).toBeGreaterThan(0);
+    expect(result.profile!.adcp_supported_versions ?? result.profile!.adcp_version).toBeDefined();
+  }, 30_000);
+
+  it('resolves applicable storyboards for discovered capabilities', async () => {
+    const caps = await testCapabilityDiscovery(SMOKE_URL, withHostedTestOptions({
+      auth: { type: 'bearer', token: SMOKE_TOKEN },
+    }, complianceTarget));
+
+    const profile = caps.profile!;
+    const resolved = resolveStoryboardsForCapabilities({
+      supported_protocols: profile.supported_protocols ?? [],
+      specialisms: profile.specialisms ?? [],
+      major_versions: profile.adcp_major_versions,
+      supported_versions: profile.adcp_supported_versions,
+    }, complianceOptions);
+
+    expect(resolved.storyboards.length).toBeGreaterThan(0);
+    expect(resolved.bundles.length).toBeGreaterThan(0);
+  }, 30_000);
+
+  it('classifies auth-required agents distinctly from discovery failure', async () => {
+    const unauthResult = await testCapabilityDiscovery(SMOKE_URL, withHostedTestOptions({
+      // no auth — anonymous probe
+    }, complianceTarget));
+
+    if (unauthResult.profile) {
+      // Public agent — anon discovery succeeds, no auth error to classify
+      expect(unauthResult.profile.tools).toBeDefined();
+    } else {
+      // Auth-gated agent — steps should show auth failure, not generic crash
+      const failedSteps = unauthResult.steps.filter(s => !s.passed);
+      expect(failedSteps.length).toBeGreaterThan(0);
+      const hasAuthIndicator = failedSteps.some(s =>
+        /auth|401|unauthorized|forbidden/i.test(s.error ?? '') ||
+        /auth|401|unauthorized|forbidden/i.test(s.step_id ?? ''),
+      );
+      expect(hasAuthIndicator).toBe(true);
+    }
+  }, 30_000);
+});

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -47,6 +47,7 @@ const ALL_OWNED_URLS = [
   ownedAgentUrl('selected-org-refresh'),
   ownedAgentUrl('selected-org-challenge'),
   ownedAgentUrl('public-notices'),
+  ownedAgentUrl('admin-auth-fallback'),
 ];
 
 // Toggle which user the auth middleware stamps onto the request. Tests
@@ -725,5 +726,44 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
         membership_org_id: TEST_ORG_ID,
       }),
     ]));
+  });
+
+  // Regression for #7070: admin-refresh must not run comply() anonymously
+  // when the agent owner has stored credentials. The route now falls back
+  // to complianceDb.resolveOwnerAuth (the heartbeat pattern) so the
+  // compliance run uses the owner's saved token.
+  it('admin refresh falls back to stored owner auth for compliance (#7070)', async () => {
+    currentUserId = STATIC_ADMIN_USER_ID;
+    const agentUrl = ownedAgentUrl('admin-auth-fallback');
+
+    const { AgentContextDatabase } = await import('../../src/db/agent-context-db.js');
+    const db = new AgentContextDatabase();
+    const context = await db.create({
+      organization_id: TEST_ORG_ID,
+      agent_url: agentUrl,
+      created_by: OWNER_USER_ID,
+    });
+    const STORED_BEARER = 'stored-owner-bearer-for-admin-fallback';
+    await db.saveAuthToken(context.id, STORED_BEARER, 'bearer');
+
+    complyMock.mockResolvedValueOnce(makeComplianceResult());
+
+    try {
+      const res = await request(app).post(url(agentUrl)).send();
+
+      expect(res.status).toBe(200);
+      expect(res.body.compliance).toMatchObject({
+        ran: true,
+        auth_available: true,
+      });
+      expect(complyMock).toHaveBeenCalledWith(
+        agentUrl,
+        expect.objectContaining({
+          auth: expect.objectContaining({ type: 'bearer', token: STORED_BEARER }),
+        }),
+      );
+    } finally {
+      await pool.query('DELETE FROM agent_contexts WHERE id = $1', [context.id]);
+    }
   });
 });

--- a/server/tests/unit/admin-refresh-auth-safety.test.ts
+++ b/server/tests/unit/admin-refresh-auth-safety.test.ts
@@ -19,7 +19,7 @@
 import { describe, expect, it } from 'vitest';
 
 /**
- * The auth fallback decision from registry-api.ts:7565-7576.
+ * The auth fallback decision from registry-api.ts (search for #7070).
  * Extracted here for testability without the full route setup.
  *
  * The actual code in registry-api.ts:

--- a/server/tests/unit/admin-refresh-auth-safety.test.ts
+++ b/server/tests/unit/admin-refresh-auth-safety.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression tests for #7070: admin-refresh must not overwrite
+ * authenticated compliance results with anonymous failures.
+ *
+ * The refresh endpoint at POST /api/registry/agents/{url}/refresh
+ * now falls back to heartbeat-style owner auth resolution
+ * (`complianceDb.resolveOwnerAuth`) when the caller is an admin
+ * without their own org credentials. This prevents anonymous
+ * comply() results from replacing valid credential-aware heartbeat
+ * verdicts.
+ *
+ * These tests exercise the decision logic that determines which
+ * auth is used for the compliance phase of a refresh. The building
+ * blocks (resolveOwnerAuth, adaptAuthForSdk) have dedicated tests
+ * in compliance-db-resolve-owner-auth.test.ts and
+ * sdk-auth-adapter.test.ts respectively.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The auth fallback decision from registry-api.ts:7565-7576.
+ * Extracted here for testability without the full route setup.
+ *
+ * The actual code in registry-api.ts:
+ *
+ *   let complianceAuth = resolvedAuth;
+ *   if (!complianceAuth && canRunCompliance && !ownerOrgId) {
+ *     const ownerAuth = await complianceDb.resolveOwnerAuth(agentUrl);
+ *     if (ownerAuth) {
+ *       complianceAuth = await adaptAuthForSdk(ownerAuth, ...);
+ *     }
+ *   }
+ */
+interface AuthDecisionInput {
+  resolvedAuth: unknown | undefined;
+  canRunCompliance: boolean;
+  ownerOrgId: string | null;
+  storedOwnerAuth: unknown | undefined;
+}
+
+function shouldFallbackToOwnerAuth(input: AuthDecisionInput): boolean {
+  return !input.resolvedAuth && input.canRunCompliance && !input.ownerOrgId;
+}
+
+function resolveComplianceAuth(input: AuthDecisionInput): unknown | undefined {
+  if (input.resolvedAuth) return input.resolvedAuth;
+  if (shouldFallbackToOwnerAuth(input) && input.storedOwnerAuth) {
+    return input.storedOwnerAuth;
+  }
+  return undefined;
+}
+
+describe('admin refresh compliance auth fallback (#7070)', () => {
+  const ownerAuth = { type: 'bearer', token: 'owner-token' };
+  const callerAuth = { type: 'bearer', token: 'caller-token' };
+
+  it('owner refresh uses caller-resolved auth directly', () => {
+    const auth = resolveComplianceAuth({
+      resolvedAuth: callerAuth,
+      canRunCompliance: true,
+      ownerOrgId: 'org_owner',
+      storedOwnerAuth: ownerAuth,
+    });
+    expect(auth).toBe(callerAuth);
+  });
+
+  it('admin refresh without credentials falls back to stored owner auth', () => {
+    const auth = resolveComplianceAuth({
+      resolvedAuth: undefined,
+      canRunCompliance: true,
+      ownerOrgId: null,
+      storedOwnerAuth: ownerAuth,
+    });
+    expect(auth).toBe(ownerAuth);
+  });
+
+  it('admin refresh for public agent (no stored auth) runs anonymously', () => {
+    const auth = resolveComplianceAuth({
+      resolvedAuth: undefined,
+      canRunCompliance: true,
+      ownerOrgId: null,
+      storedOwnerAuth: undefined,
+    });
+    expect(auth).toBeUndefined();
+  });
+
+  it('non-compliance-eligible caller does not trigger fallback', () => {
+    const auth = resolveComplianceAuth({
+      resolvedAuth: undefined,
+      canRunCompliance: false,
+      ownerOrgId: null,
+      storedOwnerAuth: ownerAuth,
+    });
+    expect(auth).toBeUndefined();
+  });
+
+  it('auth_available flag reflects resolved auth state', () => {
+    expect(!!resolveComplianceAuth({
+      resolvedAuth: undefined,
+      canRunCompliance: true,
+      ownerOrgId: null,
+      storedOwnerAuth: ownerAuth,
+    })).toBe(true);
+
+    expect(!!resolveComplianceAuth({
+      resolvedAuth: undefined,
+      canRunCompliance: true,
+      ownerOrgId: null,
+      storedOwnerAuth: undefined,
+    })).toBe(false);
+
+    expect(!!resolveComplianceAuth({
+      resolvedAuth: callerAuth,
+      canRunCompliance: true,
+      ownerOrgId: 'org_owner',
+      storedOwnerAuth: undefined,
+    })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Admin refresh endpoint (`POST /api/registry/agents/{url}/refresh`) ran `comply()` anonymously for cross-owner admin callers, overwriting valid credential-aware heartbeat verdicts with anonymous `401` failure results
- Now falls back to `complianceDb.resolveOwnerAuth` (the heartbeat pattern from `compliance-heartbeat.ts:93`) when the admin caller has no `ownerOrgId`, so the compliance run uses the same credentials the periodic heartbeat uses
- Adds `auth_available` boolean to the refresh response so dashboards can distinguish auth unavailability from conformance failure
- Public agents (no stored auth) still run compliance anonymously as before

## Test plan

- [x] 5 unit tests in `admin-refresh-auth-safety.test.ts` covering all 4 auth scenarios (owner uses caller auth, admin falls back to stored auth, public agent runs anonymously, non-compliance-eligible skips fallback) + `auth_available` flag
- [x] Integration test in `registry-api-agent-refresh.test.ts` — seeds stored owner auth via `AgentContextDatabase`, runs as static admin, verifies `complyMock` receives stored credentials and response includes `auth_available: true`
- [x] External-endpoint smoke check test (`external-smoke-check.test.ts`) — 3 tests verifying capability discovery, storyboard resolution, and auth-failure classification against the public test agent (overridable via `ADCP_SMOKE_CHECK_URL`/`ADCP_SMOKE_CHECK_TOKEN` for CI)

Fixes #7070
Refs #7061

🤖 Generated with [Claude Code](https://claude.com/claude-code)