### PR TITLE
fix(addie): clarify Luna router boundaries

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.120';
+export const CODE_VERSION = '2026.08.121';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -618,7 +618,12 @@ The user is NOT an admin.
   const explicitlyNamedAddie = mentionsAddie && !thirdPersonAddie;
   const channelNameOverride =
     explicitlyNamedAddie && ctx.source === "channel"
-      ? `\n## Direct Request\nThe user named "Addie" in their message. Treat this as a direct request — respond if you can help, regardless of channel policy.\n`
+      ? `\n## Direct Request\nThe user named "Addie" in their message. Treat this as a direct request — respond if you can help, regardless of channel policy. Direct address does NOT expand Addie's scope: off-topic requests and questions outside Addie's expertise must still be ignored.\n`
+      : "";
+
+  const directMentionGuidance =
+    ctx.source === "mention"
+      ? `\n## Direct Mention Policy\nA mention means the user addressed Addie, but it does NOT automatically require a response or expand Addie's scope. Ignore off-topic requests and questions outside Addie's expertise, even when Addie is named explicitly.\n`
       : "";
 
   // Channel messages require a much higher bar for responding
@@ -653,6 +658,7 @@ ${conditionalRules}
 ${communityChannelGuidance}
 ${channelResponseGuidance}
 ${channelNameOverride}
+${directMentionGuidance}
 
 ## Available Tool Sets
 Select which CATEGORIES of tools will be needed. Each set contains multiple related tools.
@@ -668,7 +674,7 @@ ${
 - Explicit AdCP schema fields, structure, or versioned schema documentation → ["knowledge", "schema_reference"]. This includes "Which AdCP field..." and "Where is the 3.2 schema documentation?" Validating JSON or comparing schema versions → ["schema_reference"]. If schema work is part of validating an implementation, select exactly ["schema_reference", "agent_validation"] and add ["knowledge"] only when separate protocol documentation beyond the schema is requested. Example: "Inspect the schema fields and then validate my implementation against them" → ["schema_reference", "agent_validation"]
 - Explicit requests to search or recap Slack history/channel activity, community discussions, curated resources, recent industry news, supplied web pages, or Slack files → ["community_research"]. Do not add it merely because community opinion could supplement an authoritative answer
 - Questions about the current member's profile, company listing, logo, account, or brand-domain claim → ["member_profile"]
-- Working groups, committee documents, council participation, group posts, or saving a community resource → ["community_groups"]
+- Working group membership or participation, committee documents, council participation, group posts, or saving a community resource → ["community_groups"]
 - Looking for companies/vendors/service providers/implementation partners → ["directory"]
 - Researching or managing brand-registry entries, logos, canonical documents, or reciprocal brand.json assertions → ["brand_registry"], not ["directory"], ["agent_validation"], or ["property_catalog"]
 - Testing or validating an AdCP agent implementation, endpoint, authorization, signing, OAuth, RFP response, or IO execution → ["agent_validation"]
@@ -691,6 +697,7 @@ ${isAAOAdmin
     : '- Refunds, disputes, failed charges, or billing actions for another organization → [] (use the always-available escalation tool)'}
 - Upcoming events, event registrations, "am I registered", event details, register interest, who's coming/attending → ["events"]
 - Scheduling meetings, calendar, covering topics, joining a call, meeting agendas → ["meetings"]
+- When "working group" only identifies which meeting or agenda the user means, select ["meetings"] and do NOT add ["community_groups"]. Add ["community_groups"] only when the user is asking about working group membership, participation, group information, or documents.
 ${isAAOAdmin ? `- Invite someone to an event, create/update events, manage registrations → always select exactly ["events", "admin_events"] so the handler can inspect current event state before using admin mutations
 - Prospect research, pipeline updates, claiming or triaging prospect domains → ["admin_prospects"]
 - Industry feeds, feed proposals, or media contacts → ["admin_feeds"]

--- a/server/tests/unit/addie-router.test.ts
+++ b/server/tests/unit/addie-router.test.ts
@@ -123,6 +123,26 @@ describe('Addie router prompt policy', () => {
     expect(adminPrompt).toContain('→ ["billing"]');
     expect(memberPrompt).toContain('Exact bare acknowledgments');
   });
+
+  it('keeps direct mentions inside Addie\'s domain boundary', () => {
+    const mentionPrompt = buildRoutingPrompt({
+      message: 'Addie, what is the best recipe for soup?',
+      source: 'mention',
+    });
+
+    expect(mentionPrompt).toContain('A mention means the user addressed Addie');
+    expect(mentionPrompt).toContain('Ignore off-topic requests');
+  });
+
+  it('disambiguates working group meetings from working group membership', () => {
+    const prompt = buildRoutingPrompt({
+      message: 'What is on the next working group meeting agenda?',
+      source: 'dm',
+    });
+
+    expect(prompt).toContain('Working group membership or participation');
+    expect(prompt).toContain('select ["meetings"] and do NOT add ["community_groups"]');
+  });
 });
 
 function makeCtx(overrides: Partial<RoutingContext> = {}): RoutingContext {


### PR DESCRIPTION
## Summary

- keep direct mentions inside Addie's existing domain boundary
- disambiguate working-group meeting/agenda requests from group membership and document requests
- add prompt-policy regressions and bump the Addie config version

## Evaluation

A controlled 38-case full-router corpus (3 repetitions, 114 Luna calls) improved from:

- action accuracy: 96.49% to 100%
- exact tool-set selection: 96.15% to 98.72%
- unsafe channel responses: 0 to 0
- invalid tool sets / privilege leaks: 0 to 0

The recurring off-topic mention and working-group agenda failures were eliminated across all returned repetitions. Remaining misses were limited to the soft `requires_depth` classification and one content-document tool-selection miss.

## Verification

- `npx vitest run server/tests/unit/addie-router.test.ts server/tests/unit/addie/provider-router-eval.test.ts` (115 passed, 27 skipped after rebase)
- `npm run typecheck`
- full server unit suite before rebase (486 files, 6,984 passed, 30 skipped)
- PR title validation and diff whitespace checks

No changeset: this updates Addie application routing behavior, not a protocol release surface.
