### PR TITLE
feat(addie): promote Luna to primary router

### DIFF
--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -173,17 +173,8 @@ import {
 } from './thread-utils.js';
 import { getThreadReplies, getSlackUser, getChannelInfo, getChannelHistory } from '../slack/client.js';
 import { AddieRouter, type RoutingContext, type ExecutionPlan, type ConfidenceTier } from './router.js';
-import {
-  loadRouterCanaryMetadata,
-  routeWithRouterCanary,
-} from './router-canary-runtime.js';
-import { selectRouterCanaryCohort } from './router-canary.js';
-import { runRouterShadow, selectRouterShadowCohort } from './router-shadow.js';
 import { ProviderHealthController } from './model-providers/provider-health.js';
-import {
-  OPENAI_ROUTER_MODEL,
-  OpenAIResponsesProvider,
-} from './model-providers/openai-responses-provider.js';
+import { createProductionRouter } from './router-runtime.js';
 import {
   getToolsForSets,
   buildUnavailableSetsHint,
@@ -774,7 +765,6 @@ async function buildCurrentChannelCostOptions(
 
 let addieDb: AddieDatabase | null = null;
 let addieRouter: AddieRouter | null = null;
-let addieLunaRouter: AddieRouter | null = null;
 let threadContextStore: DatabaseThreadContextStore | null = null;
 let initialized = false;
 
@@ -807,23 +797,11 @@ export async function initializeAddieBolt(): Promise<{ app: InstanceType<typeof 
   // Initialize Claude client
   claudeClient = new AddieClaudeClient(anthropicKey, AddieModelConfig.chat, providerHealth);
 
-  // Initialize router (uses Haiku for fast classification)
-  addieRouter = new AddieRouter(anthropicKey, undefined, providerHealth);
-
-  // Construct the strict candidate independently. Selection remains default-off
-  // and fail-closed in router-canary.ts; merely having an API key changes no traffic.
-  addieLunaRouter = openAiKey
-    ? new AddieRouter(
-        openAiKey,
-        new OpenAIResponsesProvider(openAiKey),
-        providerHealth,
-        {
-          model: OPENAI_ROUTER_MODEL,
-          reasoning: { effort: 'none' },
-          strictOutput: true,
-        },
-      )
-    : null;
+  const routerRuntime = createProductionRouter(anthropicKey, openAiKey, providerHealth);
+  addieRouter = routerRuntime.router;
+  if (routerRuntime.primaryProvider !== 'openai') {
+    logger.warn('Addie Bolt: OPENAI_API_KEY missing; using Haiku router fallback only');
+  }
 
   // Initialize database access
   addieDb = new AddieDatabase();
@@ -4820,64 +4798,8 @@ async function handleChannelMessage({
 
     // If no quick match, use the full router AND retrieve SI agents in parallel
     if (!plan) {
-      const canaryCandidate = addieLunaRouter && selectRouterCanaryCohort({
-        channelId,
-        opportunityId: event.ts,
-        // This only avoids a metadata fetch when the independent feature,
-        // evidence, config, allowlist, and sample gates are already closed.
-        // Paid-call admission rechecks live Slack metadata below.
-        channelIsPublic: true,
-        channelIsShared: false,
-      });
-      const shadowCandidate = selectRouterShadowCohort({
-        channelId,
-        opportunityId: event.ts,
-        // Final admission rechecks current Slack metadata inside the detached
-        // observer. These optimistic values only avoid scheduling work when
-        // the independent feature/config/sample gate is already closed.
-        channelIsPublic: true,
-        channelIsShared: false,
-      });
-      const routerPlanPromise = canaryCandidate?.selected && addieLunaRouter
-        ? (async () => {
-            const currentChannel = await loadRouterCanaryMetadata(
-              () => getChannelInfo(channelId, { forceRefresh: true }),
-            );
-            const result = await routeWithRouterCanary({
-              channelId,
-              opportunityId: event.ts,
-              channelIsPublic: currentChannel?.is_private === false,
-              channelIsShared: currentChannel === null
-                || currentChannel.is_shared
-                || currentChannel.is_org_shared
-                || currentChannel.is_pending_ext_shared === true,
-              routingContext: routingCtx,
-            }, {
-              candidateRoute: addieLunaRouter.route.bind(addieLunaRouter),
-              fallbackRoute: addieRouter.route.bind(addieRouter),
-            });
-            return result.plan;
-          })()
-        : addieRouter.route(routingCtx, {
-            ...(shadowCandidate.selected && {
-              observer: async (observation) => {
-                const currentChannel = await getChannelInfo(channelId, { forceRefresh: true })
-                  .catch(() => null);
-                await runRouterShadow({
-                  channelId,
-                  opportunityId: event.ts,
-                  channelIsPublic: currentChannel?.is_private === false,
-                  channelIsShared: currentChannel === null
-                    || currentChannel.is_shared
-                    || currentChannel.is_org_shared
-                    || currentChannel.is_pending_ext_shared === true,
-                  observation,
-                });
-              },
-            }),
-          });
       const [routerPlan, siResult] = await Promise.all([
-        routerPlanPromise,
+        addieRouter.route(routingCtx),
         siRetriever.retrieve(messageText),
       ]);
       plan = routerPlan;

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.121';
+export const CODE_VERSION = '2026.08.122';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -17,7 +17,7 @@
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
-    "server/src/addie/bolt-app.ts": "a8c328f76a8b048a5b8d8ac1abab93c4d4dc27b86457446278a932dab51766f1",
+    "server/src/addie/bolt-app.ts": "60baa3c324eeb2600187b38bdf8dbda46dcade25eb68bf65a2c0a643c67b7a1b",
     "server/src/addie/handler.ts": "cf9d66b7b2700cefd2811d2d9c627ea2683c556e6c3afd36ecc99cac12aa5407",
     "server/src/routes/addie-chat.ts": "da80a42faf005441f4afbf1d003ccb7067dbd4e87b90dae96c0023511806fc08",
     "server/src/routes/tavus.ts": "640e818f0ecd4da6c72f310b7582f7bc1f2c00fd77dbe0dc521f53459e31003f",

--- a/server/src/addie/router-runtime.ts
+++ b/server/src/addie/router-runtime.ts
@@ -1,0 +1,42 @@
+import { AddieRouter } from './router.js';
+import {
+  OPENAI_ROUTER_MODEL,
+  OpenAIResponsesProvider,
+} from './model-providers/openai-responses-provider.js';
+import { ProviderHealthController } from './model-providers/provider-health.js';
+
+export const LUNA_ROUTER_PRIMARY_DEADLINE_MS = 15_000;
+
+export interface ProductionRouterRuntime {
+  router: AddieRouter;
+  primaryProvider: 'openai' | 'anthropic';
+}
+
+/** Builds the production Luna router with an independent Haiku fallback. */
+export function createProductionRouter(
+  anthropicApiKey: string,
+  openAiApiKey: string | undefined,
+  providerHealth: ProviderHealthController = new ProviderHealthController(),
+): ProductionRouterRuntime {
+  const haikuRouter = new AddieRouter(anthropicApiKey, undefined, providerHealth);
+  const normalizedOpenAiKey = openAiApiKey?.trim();
+  if (!normalizedOpenAiKey) {
+    return { router: haikuRouter, primaryProvider: 'anthropic' };
+  }
+
+  return {
+    primaryProvider: 'openai',
+    router: new AddieRouter(
+      normalizedOpenAiKey,
+      new OpenAIResponsesProvider(normalizedOpenAiKey),
+      providerHealth,
+      {
+        model: OPENAI_ROUTER_MODEL,
+        reasoning: { effort: 'none' },
+        strictOutput: true,
+        fallbackRouter: haikuRouter,
+        primaryDeadlineMs: LUNA_ROUTER_PRIMARY_DEADLINE_MS,
+      },
+    ),
+  };
+}

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -57,7 +57,7 @@ import {
  * Execution plan types
  */
 export type ExecutionPlanBase = {
-  /** How the decision was made: 'quick_match' (pattern) or 'llm' (Claude Haiku) */
+  /** How the decision was made: 'quick_match' (pattern) or 'llm' (model router) */
   decision_method: "quick_match" | "llm";
   /** Time spent making the routing decision (ms) */
   latency_ms?: number;
@@ -1116,6 +1116,10 @@ export interface AddieRouterProviderOptions {
   reasoning?: ModelRequest['reasoning'];
   /** Reject malformed, incomplete, or unauthorized plans instead of normalizing them. */
   strictOutput?: boolean;
+  /** Router to invoke when this provider fails or returns invalid strict output. */
+  fallbackRouter?: AddieRouter;
+  /** Hard deadline for this provider before invoking the fallback router. */
+  primaryDeadlineMs?: number;
 }
 
 function queueRouterObserver(
@@ -1137,7 +1141,7 @@ function queueRouterObserver(
 /**
  * Addie Router class
  *
- * Uses Claude Haiku for fast routing decisions
+ * Uses a fast model for routing decisions, with an optional provider fallback.
  */
 export class AddieRouter {
   private readonly provider: ModelProvider;
@@ -1145,6 +1149,8 @@ export class AddieRouter {
   private readonly model: string;
   private readonly reasoning?: ModelRequest['reasoning'];
   private readonly strictOutput: boolean;
+  private readonly fallbackRouter?: AddieRouter;
+  private readonly primaryDeadlineMs?: number;
 
   constructor(
     apiKey: string,
@@ -1159,6 +1165,16 @@ export class AddieRouter {
     this.model = options.model ?? ModelConfig.fast;
     this.reasoning = options.reasoning;
     this.strictOutput = options.strictOutput ?? false;
+    this.fallbackRouter = options.fallbackRouter;
+    if (
+      options.primaryDeadlineMs !== undefined
+      && (!Number.isSafeInteger(options.primaryDeadlineMs)
+        || options.primaryDeadlineMs < 1
+        || options.primaryDeadlineMs > 60_000)
+    ) {
+      throw new RangeError('Invalid router primary deadline');
+    }
+    this.primaryDeadlineMs = options.primaryDeadlineMs;
   }
 
   /**
@@ -1178,18 +1194,42 @@ export class AddieRouter {
     let primaryInvocation: PreparedModelInvocation | null = null;
     let primaryResponse: ModelResponse | null = null;
     let rawResponseText: string | null = null;
+    const deadlineController = this.primaryDeadlineMs === undefined
+      ? null
+      : new AbortController();
+    let primaryTimedOut = false;
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    let callerAbortListener: (() => void) | undefined;
+    if (deadlineController) {
+      if (options.signal?.aborted) {
+        deadlineController.abort(options.signal.reason);
+      } else if (options.signal) {
+        callerAbortListener = () => deadlineController.abort(options.signal?.reason);
+        options.signal.addEventListener('abort', callerAbortListener, { once: true });
+      }
+      deadlineTimer = setTimeout(() => {
+        primaryTimedOut = true;
+        deadlineController.abort(new Error('router_primary_timeout'));
+      }, this.primaryDeadlineMs);
+    }
+    const cleanupPrimaryRequest = () => {
+      if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+      if (callerAbortListener && options.signal) {
+        options.signal.removeEventListener('abort', callerAbortListener);
+      }
+    };
 
     try {
       const availability = this.providerHealth.acquire(this.provider.id, 'router');
       if (!availability.allowed) throw new ProviderCircuitOpenError(availability);
       const response = await collectModelResponse(
         this.provider.respond(canonicalRequest, {
-          // This callback is deliberately assignment-only. Shadow evidence can
-          // never throw before or otherwise interfere with Haiku dispatch.
+          // This callback is deliberately assignment-only. Observability can
+          // never throw before or otherwise interfere with provider dispatch.
           beforeDispatch: (prepared) => {
             primaryInvocation = prepared;
           },
-          signal: options.signal,
+          signal: deadlineController?.signal ?? options.signal,
         }),
         this.provider.id,
       );
@@ -1295,16 +1335,37 @@ export class AddieRouter {
         latencyMs,
       });
 
+      cleanupPrimaryRequest();
       return plan;
     } catch (error) {
+      cleanupPrimaryRequest();
       if (!(error instanceof ProviderCircuitOpenError)) {
         this.providerHealth.recordFailure(this.provider.id, 'router', error);
       }
       const category = classifyRouterError(error);
       logger.error(
-        { category },
+        { category, primaryTimedOut },
         "Router: Failed to generate execution plan",
       );
+      const failureLatencyMs = Date.now() - startTime;
+      if (primaryResponse) {
+        // Strict-output failures still incur provider cost. Track that attempt
+        // separately from the successful fallback call.
+        void trackApiCall({
+          model: this.model,
+          purpose: ApiPurpose.ROUTER,
+          tokens_input: primaryResponse.usage.inputTokens,
+          tokens_output: primaryResponse.usage.outputTokens,
+          latency_ms: failureLatencyMs,
+        });
+      }
+      if (this.fallbackRouter) {
+        logger.warn(
+          { category, primaryTimedOut, primaryProvider: this.provider.id },
+          "Router: Primary failed, invoking fallback provider",
+        );
+        return this.fallbackRouter.route(ctx, options);
+      }
       // On error, retain the pre-split safe read-only knowledge domains.
       const fallbackPlan: ExecutionPlan = {
         action: "respond",
@@ -1312,7 +1373,7 @@ export class AddieRouter {
         confidence: "high",
         reason: "Router error - defaulting to safe knowledge tools",
         decision_method: "llm",
-        latency_ms: Date.now() - startTime,
+        latency_ms: failureLatencyMs,
       };
       queueRouterObserver(options.observer, {
         canonicalRequest,
@@ -1331,7 +1392,7 @@ export class AddieRouter {
         outputTokens: primaryResponse?.usage.outputTokens ?? null,
         cacheReadTokens: primaryResponse?.usage.cacheReadTokens ?? null,
         cacheWriteTokens: primaryResponse?.usage.cacheWriteTokens ?? null,
-        latencyMs: Date.now() - startTime,
+        latencyMs: failureLatencyMs,
       });
       if (options.failureMode === 'throw') throw error;
       return fallbackPlan;

--- a/server/src/addie/services/api-tracker.ts
+++ b/server/src/addie/services/api-tracker.ts
@@ -1,7 +1,7 @@
 /**
  * API Call Tracker
  *
- * Tracks all Anthropic API calls for performance metrics.
+ * Tracks model-provider API calls for performance metrics.
  * This captures both chat messages and background tasks (router, insight extraction, etc.)
  */
 

--- a/server/src/routes/addie-admin.ts
+++ b/server/src/routes/addie-admin.ts
@@ -20,6 +20,7 @@ import {
 import Anthropic from "@anthropic-ai/sdk";
 import { disableAdaptiveThinking, ModelConfig } from "../config/models.js";
 import { AddieRouter, type RoutingContext } from "../addie/router.js";
+import { createProductionRouter } from "../addie/router-runtime.js";
 import { sanitizeInput } from "../addie/security.js";
 import { runSlackHistoryBackfill } from "../addie/jobs/slack-history-backfill.js";
 import { getWorkos } from "../auth/workos-client.js";
@@ -82,11 +83,14 @@ const addieDb = new AddieDatabase();
 let addieRouter: AddieRouter | null = null;
 function getAddieRouter(): AddieRouter {
   if (!addieRouter) {
-    const apiKey = process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) {
+    const anthropicApiKey = process.env.ADDIE_ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY;
+    if (!anthropicApiKey) {
       throw new Error("ANTHROPIC_API_KEY not configured");
     }
-    addieRouter = new AddieRouter(apiKey);
+    addieRouter = createProductionRouter(
+      anthropicApiKey,
+      process.env.OPENAI_API_KEY,
+    ).router;
   }
   return addieRouter;
 }
@@ -1674,7 +1678,7 @@ Be specific and actionable. Focus on patterns that could help improve Addie's be
   // =========================================================================
 
   /**
-   * POST /api/admin/addie/test-router - Test the Haiku router with a simulated message
+   * POST /api/admin/addie/test-router - Test the production router with a simulated message
    *
    * This endpoint simulates a Slack channel message to test the router decision logic
    * and verify router_decision metadata is being logged correctly.

--- a/server/tests/unit/addie-router.test.ts
+++ b/server/tests/unit/addie-router.test.ts
@@ -17,6 +17,7 @@ import type {
   PreparedModelInvocation,
 } from '../../src/addie/model-providers/model-provider.js';
 import { ModelConfig } from '../../src/config/models.js';
+import { trackApiCall } from '../../src/addie/services/api-tracker.js';
 import {
   getToolSetDescriptionsForRouter,
   TOOL_SETS,
@@ -792,6 +793,98 @@ describe('AddieRouter.route', () => {
       tool_sets: ['knowledge'],
       model: 'gpt-5.6-luna',
     });
+  });
+
+  it('uses Haiku after strict Luna output failure and accounts for both calls', async () => {
+    vi.mocked(trackApiCall).mockClear();
+    const lunaProvider = fakeRouterProvider([{ type: 'text', text: 'not-json' }], {
+      providerId: 'openai',
+    });
+    const haikuProvider = fakeRouterProvider([{
+      type: 'text',
+      text: '{"action":"respond","tool_sets":["knowledge"],"confidence":"high","reason":"fallback"}',
+    }]);
+    const haikuRouter = new AddieRouter('unused', haikuProvider);
+    const observer = vi.fn();
+    const subject = new AddieRouter('unused', lunaProvider, undefined, {
+      model: 'gpt-5.6-luna',
+      reasoning: { effort: 'none' },
+      strictOutput: true,
+      fallbackRouter: haikuRouter,
+    });
+
+    await expect(subject.route({ message: 'How does AdCP work?', source: 'dm' }, {
+      observer,
+    })).resolves.toMatchObject({
+      action: 'respond',
+      tool_sets: ['knowledge'],
+      reason: 'fallback',
+      model: ModelConfig.fast,
+    });
+
+    expect(lunaProvider.requests).toHaveLength(1);
+    expect(haikuProvider.requests).toHaveLength(1);
+    expect(trackApiCall).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(trackApiCall).mock.calls.map(([call]) => call.model)).toEqual([
+      'gpt-5.6-luna',
+      ModelConfig.fast,
+    ]);
+    await vi.waitFor(() => expect(observer).toHaveBeenCalledOnce());
+    expect(observer.mock.calls[0][0]).toMatchObject({
+      requestedProvider: 'anthropic',
+      requestedModel: ModelConfig.fast,
+      primaryErrorCategory: null,
+    });
+  });
+
+  it('falls back when the Luna provider exceeds its hard deadline', async () => {
+    let primarySignal: AbortSignal | undefined;
+    const lunaProvider: ModelProvider = {
+      id: 'openai',
+      capabilities: ROUTER_CAPABILITIES,
+      prepare(request: ModelRequest): PreparedModelInvocation {
+        return {
+          provider: 'openai',
+          model: request.model,
+          capabilities: ROUTER_CAPABILITIES,
+          providerRequest: {},
+        };
+      },
+      async *respond(
+        _request: ModelRequest,
+        respondOptions?: ModelRespondOptions,
+      ): AsyncIterable<NormalizedModelEvent> {
+        primarySignal = respondOptions?.signal;
+        await new Promise<never>((_resolve, reject) => {
+          respondOptions?.signal?.addEventListener(
+            'abort',
+            () => reject(respondOptions.signal?.reason),
+            { once: true },
+          );
+        });
+      },
+    };
+    const haikuProvider = fakeRouterProvider([{
+      type: 'text',
+      text: '{"action":"ignore","reason":"fallback"}',
+    }]);
+    const subject = new AddieRouter('unused', lunaProvider, undefined, {
+      model: 'gpt-5.6-luna',
+      strictOutput: true,
+      fallbackRouter: new AddieRouter('unused', haikuProvider),
+      primaryDeadlineMs: 5,
+    });
+
+    await expect(subject.route({ message: 'route me', source: 'channel' }))
+      .resolves.toMatchObject({ action: 'ignore', reason: 'fallback' });
+    expect(primarySignal?.aborted).toBe(true);
+    expect(haikuProvider.requests).toHaveLength(1);
+  });
+
+  it('rejects invalid primary deadlines', () => {
+    expect(() => new AddieRouter('unused', undefined, undefined, {
+      primaryDeadlineMs: 0,
+    })).toThrow('Invalid router primary deadline');
   });
 
   it('forwards an abort signal so a canary boundary can enforce its deadline', async () => {

--- a/server/tests/unit/addie/router-runtime.test.ts
+++ b/server/tests/unit/addie/router-runtime.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LUNA_ROUTER_PRIMARY_DEADLINE_MS,
+  createProductionRouter,
+} from '../../../src/addie/router-runtime.js';
+
+describe('production router runtime', () => {
+  it('selects Luna when the OpenAI key is configured', () => {
+    const runtime = createProductionRouter('anthropic-key', ' openai-key ');
+
+    expect(runtime.primaryProvider).toBe('openai');
+    expect(runtime.router).toBeDefined();
+    expect(LUNA_ROUTER_PRIMARY_DEADLINE_MS).toBe(15_000);
+  });
+
+  it('keeps Haiku available when the OpenAI key is absent', () => {
+    const runtime = createProductionRouter('anthropic-key', undefined);
+
+    expect(runtime.primaryProvider).toBe('anthropic');
+    expect(runtime.router).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- make GPT-5.6 Luna the primary model for all Addie Slack routing paths
- retain Claude Haiku as an independent fallback for provider errors, circuit-open states, timeouts, refusals, truncation, and invalid strict output
- use a 15-second primary deadline and fall back to Haiku-only when `OPENAI_API_KEY` is unavailable
- keep provider-call accounting accurate when a paid Luna attempt falls back

## Evidence
- controlled router eval: 100% action accuracy, 98.72% exact tool selection, and no safety or privilege failures
- `npm run precommit:server-unit` (530 files, 7,634 passed, 30 skipped)
- focused routing/canary suite (150 passed, 27 skipped)
- `npm run typecheck`
- `git diff --check`

## Release
- no changeset: Addie application runtime only; no protocol release surface changed