### PR TITLE
fix(server): add storyboard rotation to manual refresh endpoint

### DIFF
--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -7693,10 +7693,14 @@ export function createRegistryApiRouters(config: RegistryApiConfig): { router: R
         try {
           const testSessionId = `owner-refresh-${Date.now()}-${randomUUID()}`;
           const triggeredBy = ownerOrgId ? 'owner_test' : 'manual';
+          // adcp#6632 — rotate storyboard starting point so budget-limited
+          // refreshes cover different tracks on each run, matching heartbeat.
+          const storyboardStartOffset = await complianceDb.countComplianceRuns(agentUrl);
           const complyOptions = {
             test_session_id: testSessionId,
             timeout_ms: HOSTED_FULL_COMPLIANCE_TIMEOUT_MS,
             userAgent: AAO_UA_COMPLIANCE,
+            storyboard_start_offset: storyboardStartOffset,
             ...(complianceAuth && { auth: complianceAuth }),
           };
           const seededSupportedVersions = await complianceDb.getRecentSupportedVersions(agentUrl);


### PR DESCRIPTION
## Summary

- The heartbeat already rotates the storyboard starting point via `storyboard_start_offset` (merged in #6871), so budget-limited runs cover different tracks each cycle
- The `/api/registry/agents/{encodedUrl}/refresh` endpoint was missing this, so manual refreshes always started from the same storyboard prefix and never reached tail tracks on capability-rich agents
- Adds the same `countComplianceRuns` offset to the refresh handler's comply options

## Context

Observed during #7061 P0 restoration: Elemental TV's manual refresh took 654s (over the 600s budget) and produced a partial result. Without rotation, the same prefix of storyboards gets re-graded on every manual retry while tail tracks are never reached.

Closes #6632 (parity between heartbeat and manual refresh rotation).

## Test plan

- [x] TypeScript compilation clean (zero errors in `registry-api.ts`)
- [x] `admin-refresh-auth-safety.test.ts` — 4/4 pass
- [x] `dashboard-agent-refresh.test.ts` — 7/7 pass
- [x] `compliance-db-run-count.test.ts` — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)