### PR TITLE
fix(server): use constant-time comparison for Luma webhook secret

### DIFF
--- a/server/src/routes/webhooks.ts
+++ b/server/src/routes/webhooks.ts
@@ -56,6 +56,7 @@ import { getThreadService } from '../addie/thread-service.js';
 import { createEscalation } from '../db/escalation-db.js';
 import { Resend } from 'resend';
 import { boundedRawJson, type RawJsonRequest } from '../middleware/bounded-raw-json.js';
+import { constantTimeEqual } from '../utils/constant-time-equal.js';
 
 const logger = createLogger('webhooks');
 
@@ -1221,7 +1222,7 @@ export function createWebhooksRouter(): Router {
       return res.status(503).json({ error: 'Webhook validation not configured' });
     }
     const providedSecret = req.headers['x-luma-signing-secret'] as string | undefined;
-    if (providedSecret !== LUMA_WEBHOOK_SECRET) {
+    if (!providedSecret || !constantTimeEqual(providedSecret, LUMA_WEBHOOK_SECRET)) {
       logger.warn('Luma webhook rejected: invalid signing secret');
       return res.status(401).json({ error: 'Unauthorized' });
     }

--- a/server/tests/unit/webhook-route-security.test.ts
+++ b/server/tests/unit/webhook-route-security.test.ts
@@ -6,30 +6,36 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 const {
   zoomSecret,
   workosSecret,
+  lumaSecret,
   originalZoomSecret,
   originalResendSecret,
   originalWorkosSecret,
   originalWorkosApiKey,
   originalWorkosClientId,
+  originalLumaSecret,
 } = vi.hoisted(() => {
   const originalZoomSecret = process.env.ZOOM_WEBHOOK_SECRET;
   const originalResendSecret = process.env.RESEND_WEBHOOK_SECRET;
   const originalWorkosSecret = process.env.WORKOS_WEBHOOK_SECRET;
   const originalWorkosApiKey = process.env.WORKOS_API_KEY;
   const originalWorkosClientId = process.env.WORKOS_CLIENT_ID;
+  const originalLumaSecret = process.env.LUMA_WEBHOOK_SECRET;
   process.env.ZOOM_WEBHOOK_SECRET = 'zoom-webhook-security-test-secret';
   process.env.WORKOS_WEBHOOK_SECRET = 'workos-webhook-security-test-secret';
   process.env.WORKOS_API_KEY = 'sk_test_security';
   process.env.WORKOS_CLIENT_ID = 'client_security';
+  process.env.LUMA_WEBHOOK_SECRET = 'luma-webhook-security-test-secret';
   delete process.env.RESEND_WEBHOOK_SECRET;
   return {
     zoomSecret: process.env.ZOOM_WEBHOOK_SECRET,
     workosSecret: process.env.WORKOS_WEBHOOK_SECRET,
+    lumaSecret: process.env.LUMA_WEBHOOK_SECRET,
     originalZoomSecret,
     originalResendSecret,
     originalWorkosSecret,
     originalWorkosApiKey,
     originalWorkosClientId,
+    originalLumaSecret,
   };
 });
 
@@ -37,7 +43,19 @@ vi.mock('../../src/addie/error-notifier.js', () => ({
   notifySystemError: vi.fn(),
 }));
 
+// Wrap (not replace) the real implementation so every other test in this file
+// still gets correct accept/reject behavior — this only lets one test below
+// assert that the Luma route *delegates* its secret comparison to the shared
+// constant-time helper, rather than comparing with a plain `!==` (which would
+// produce identical accept/reject outcomes and so wouldn't be caught by a
+// behavior-only test).
+vi.mock('../../src/utils/constant-time-equal.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/utils/constant-time-equal.js')>();
+  return { ...actual, constantTimeEqual: vi.fn(actual.constantTimeEqual) };
+});
+
 import { WEBHOOK_RAW_BODY_LIMIT_BYTES } from '../../src/middleware/bounded-raw-json.js';
+import { constantTimeEqual } from '../../src/utils/constant-time-equal.js';
 import {
   createWebhooksRouter,
   parseCertificationReviewEmailMetadata,
@@ -56,8 +74,26 @@ function workosSignature(rawBody: string, timestamp: string): string {
     .digest('hex');
 }
 
+// Routes that capture their own raw body for signature verification
+// (via `boundedRawJson`) must not have their body stream consumed first —
+// mirror the production skip-list in server/src/http.ts so this app wiring
+// matches what each route actually receives in production.
+const RAW_BODY_ROUTES = new Set([
+  '/api/webhooks/resend-inbound',
+  '/api/webhooks/resend-tracking',
+  '/api/webhooks/workos',
+  '/api/webhooks/zoom',
+]);
+
 function createApp() {
   const app = express();
+  app.use((req, res, next) => {
+    if (RAW_BODY_ROUTES.has(req.path)) {
+      next();
+    } else {
+      express.json()(req, res, next);
+    }
+  });
   app.use('/api/webhooks', createWebhooksRouter());
   app.use('/api/webhooks', createWorkOSWebhooksRouter());
   app.use((err: Error & { status?: number; statusCode?: number }, _req: Request, res: Response, _next: NextFunction) => {
@@ -84,6 +120,8 @@ describe('webhook route security boundaries', () => {
     else process.env.WORKOS_API_KEY = originalWorkosApiKey;
     if (originalWorkosClientId === undefined) delete process.env.WORKOS_CLIENT_ID;
     else process.env.WORKOS_CLIENT_ID = originalWorkosClientId;
+    if (originalLumaSecret === undefined) delete process.env.LUMA_WEBHOOK_SECRET;
+    else process.env.LUMA_WEBHOOK_SECRET = originalLumaSecret;
   });
 
   it('rejects an unsigned Zoom URL-validation challenge instead of exposing an HMAC oracle', async () => {
@@ -191,6 +229,55 @@ describe('webhook route security boundaries', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ ok: true });
+  });
+
+  it('accepts a Luma webhook whose signing secret matches exactly', async () => {
+    const response = await request(app)
+      .post('/api/webhooks/luma')
+      .set('Content-Type', 'application/json')
+      .set('x-luma-signing-secret', lumaSecret)
+      .send(JSON.stringify({ action: 'event.deleted', data: {} }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+
+  it('rejects a Luma webhook with an incorrect signing secret', async () => {
+    const response = await request(app)
+      .post('/api/webhooks/luma')
+      .set('Content-Type', 'application/json')
+      .set('x-luma-signing-secret', `${lumaSecret}-wrong`)
+      .send(JSON.stringify({ action: 'event.deleted', data: {} }));
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('rejects a Luma webhook missing the signing secret header', async () => {
+    const response = await request(app)
+      .post('/api/webhooks/luma')
+      .set('Content-Type', 'application/json')
+      .send(JSON.stringify({ action: 'event.deleted', data: {} }));
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('compares the Luma signing secret via the constant-time helper, not a variable-time ===/!== on the raw strings', async () => {
+    vi.mocked(constantTimeEqual).mockClear();
+
+    const response = await request(app)
+      .post('/api/webhooks/luma')
+      .set('Content-Type', 'application/json')
+      .set('x-luma-signing-secret', lumaSecret)
+      .send(JSON.stringify({ action: 'event.deleted', data: {} }));
+
+    expect(response.status).toBe(200);
+    // The helper must be the thing that actually decided the request was
+    // authorized — a `providedSecret !== LUMA_WEBHOOK_SECRET` implementation
+    // would produce the same 200 above without ever calling this helper,
+    // which is exactly the timing side-channel this guards against.
+    expect(constantTimeEqual).toHaveBeenCalledWith(lumaSecret, lumaSecret);
   });
 
   it.each([


### PR DESCRIPTION
## Problem

`server/src/routes/webhooks.ts`'s Luma webhook handler (`POST /api/webhooks/luma`) authenticates inbound requests by comparing the `x-luma-signing-secret` request header against `process.env.LUMA_WEBHOOK_SECRET` using plain JavaScript `!==`:

```ts
const providedSecret = req.headers['x-luma-signing-secret'] as string | undefined;
if (providedSecret !== LUMA_WEBHOOK_SECRET) {
  ...
  return res.status(401).json({ error: 'Unauthorized' });
}
```

`!==` on strings short-circuits at the first differing byte, which is a textbook timing side-channel for a shared-secret comparison: an attacker who can measure response latency can incrementally recover the secret one byte at a time instead of needing to guess it all at once.

Every other shared-secret comparison in `server/src` already avoids this — `server/src/utils/constant-time-equal.ts` (`constantTimeEqual`, built on `crypto.timingSafeEqual`) or `crypto.timingSafeEqual` directly is used for:

- `ADMIN_API_KEY` in `server/src/middleware/auth.ts` (`constantTimeEqual`, closed as issue #4209 for exactly this class of bug)
- CSRF tokens in `server/src/middleware/csrf.ts`
- Slack signature verification in `server/src/slack/verify.ts`
- Zoom webhook signatures in `server/src/integrations/zoom.ts`
- Tavus webhook signatures in `server/src/routes/tavus.ts`
- Session tokens in `server/src/training-agent/account-handlers.ts` and `server/src/routes/helpers/anonymous-session-capability.ts`

The Luma route was the one holdout doing a variable-time `!==` compare of a static, attacker-supplied shared secret against a server-side secret.

## Verification

- Confirmed the gap is present on current `upstream/main` via `git show HEAD:server/src/routes/webhooks.ts` before making any change.
- `git log --oneline -- server/src/routes/webhooks.ts` and `git blame` show the check was introduced in PR #2019 / #24d9d130c0 and never revisited.
- Checked prior art: issue #4209 ("Use timingSafeEqual for ADMIN_API_KEY comparison") explicitly scoped itself to `auth.ts` only and called out *"Other API key comparisons in the codebase … Audit those separately"* — this Luma comparison is exactly that unaudited case. Issue #4632 later consolidated the `constantTimeEqual` helper this PR reuses.
- Searched `gh issue list` (open + closed) for `luma webhook`, `timing attack`, `webhook signature timing`, `constant time`, and `LUMA_WEBHOOK_SECRET` — no existing issue or PR covers this specific comparison.
- `server/tests/unit/webhook-route-security.test.ts` already exercises Zoom/Resend/WorkOS webhook-auth boundaries in this file but had no coverage of the Luma route at all before this PR.

## Fix

Swap the raw `!==` for the existing `constantTimeEqual` helper, matching the idiomatic pattern already used at every other secret-comparison site in `server/src`:

```ts
const providedSecret = req.headers['x-luma-signing-secret'] as string | undefined;
if (!providedSecret || !constantTimeEqual(providedSecret, LUMA_WEBHOOK_SECRET)) {
  ...
}
```

## Test proof

Added tests to `server/tests/unit/webhook-route-security.test.ts`:
1. Functional coverage of the Luma route's auth boundary (accepts a correct secret, rejects an incorrect one, rejects a missing header) — none of this existed before.
2. A regression test that spies on `constantTimeEqual` (via `vi.mock(..., importOriginal)` wrapping the real implementation) and asserts the route actually calls it with the header value. This is the load-bearing test: a plain `!==` implementation produces *identical* accept/reject HTTP responses to the fixed version, so a behavior-only test cannot catch a regression back to `!==` — only asserting the call site actually delegates to the constant-time helper can.

Reverted the source fix (keeping the new tests) and reran the narrow suite:

```
npx vitest run --config server/vitest.config.ts server/tests/unit/webhook-route-security.test.ts
```
→ 13 passed / **1 failed**: `compares the Luma signing secret via the constant-time helper, not a variable-time ===/!== on the raw strings` (`constantTimeEqual` was never called — 0 calls).

Restored the fix and reran the same command → **14 passed / 0 failed**.

Also ran `npm run typecheck` clean.

## Scope

Single file touched for the fix (`server/src/routes/webhooks.ts`, +2/-1 lines) plus its test file. No schema, docs, or protocol-surface changes — no changeset needed (confirmed via `node scripts/check-changeset-protocol-scope.cjs origin/main` equivalent reasoning: this is server-only application code, not part of the published AdCP protocol package surface).

---

I have read the IPR Policy.