### PR TITLE
fix(registry-sync): apply agent.profile_updated events to the local agent index

### DIFF
--- a/server/src/registry-sync/index.ts
+++ b/server/src/registry-sync/index.ts
@@ -322,6 +322,7 @@ export class RegistrySync extends EventEmitter {
     // from event.created_at) are handled by the caller, not here.
     const patch: Partial<AgentProfile> = {};
     if (typeof payload.name === 'string') patch.name = payload.name;
+    if (typeof payload.type === 'string') patch.agent_type = payload.type;
     if (Array.isArray(payload.channels)) patch.channels = payload.channels as string[];
     if (Array.isArray(payload.property_types)) patch.property_types = payload.property_types as string[];
     if (Array.isArray(payload.markets)) patch.markets = payload.markets as string[];

--- a/server/src/registry-sync/index.ts
+++ b/server/src/registry-sync/index.ts
@@ -201,13 +201,20 @@ export class RegistrySync extends EventEmitter {
         // Unlike agent.discovered's full snapshot, this payload may carry
         // only the fields that changed (see payload.changed_fields in the
         // registry-event schema), so merge onto the existing profile rather
-        // than reconstructing it — mirrors property.updated below.
+        // than reconstructing it. Do NOT spread the raw payload though: per
+        // the schema's agentProfilePayload def, additionalProperties is
+        // true and this event type additionally carries an advisory
+        // changed_fields array — neither is part of AgentProfile, and a
+        // bare spread would leak them into get()/list()/search() results as
+        // if they were real profile fields. Whitelist explicitly instead,
+        // mirroring collectionFromPayload's explicit-construction pattern
+        // below.
         if (this.agents && payload.agent_url) {
           const existing = this.agents.get(payload.agent_url as string);
           if (existing) {
             this.agents.upsert({
               ...existing,
-              ...(payload as Partial<AgentProfile>),
+              ...this.agentProfilePatchFromPayload(payload),
               updated_at: event.created_at.toString(),
             });
           }
@@ -307,6 +314,28 @@ export class RegistrySync extends EventEmitter {
         }
         break;
     }
+  }
+
+  private agentProfilePatchFromPayload(payload: Record<string, unknown>): Partial<AgentProfile> {
+    // Only real AgentProfile fields, explicitly whitelisted — never a raw
+    // spread of `payload`. agent_url (the lookup key) and updated_at (set
+    // from event.created_at) are handled by the caller, not here.
+    const patch: Partial<AgentProfile> = {};
+    if (typeof payload.name === 'string') patch.name = payload.name;
+    if (Array.isArray(payload.channels)) patch.channels = payload.channels as string[];
+    if (Array.isArray(payload.property_types)) patch.property_types = payload.property_types as string[];
+    if (Array.isArray(payload.markets)) patch.markets = payload.markets as string[];
+    if (Array.isArray(payload.categories)) patch.categories = payload.categories as string[];
+    if (Array.isArray(payload.tags)) patch.tags = payload.tags as string[];
+    if (Array.isArray(payload.delivery_types)) patch.delivery_types = payload.delivery_types as string[];
+    if (Array.isArray(payload.format_kinds)) patch.format_kinds = payload.format_kinds as string[];
+    if (typeof payload.property_count === 'number') patch.property_count = payload.property_count;
+    if (typeof payload.publisher_count === 'number') patch.publisher_count = payload.publisher_count;
+    if (typeof payload.has_tmp === 'boolean') patch.has_tmp = payload.has_tmp;
+    if (payload.category_taxonomy === null || typeof payload.category_taxonomy === 'string') {
+      patch.category_taxonomy = payload.category_taxonomy as string | null;
+    }
+    return patch;
   }
 
   private collectionFromPayload(

--- a/server/src/registry-sync/index.ts
+++ b/server/src/registry-sync/index.ts
@@ -197,6 +197,23 @@ export class RegistrySync extends EventEmitter {
         }
         break;
 
+      case 'agent.profile_updated':
+        // Unlike agent.discovered's full snapshot, this payload may carry
+        // only the fields that changed (see payload.changed_fields in the
+        // registry-event schema), so merge onto the existing profile rather
+        // than reconstructing it — mirrors property.updated below.
+        if (this.agents && payload.agent_url) {
+          const existing = this.agents.get(payload.agent_url as string);
+          if (existing) {
+            this.agents.upsert({
+              ...existing,
+              ...(payload as Partial<AgentProfile>),
+              updated_at: event.created_at.toString(),
+            });
+          }
+        }
+        break;
+
       case 'property.created':
         if (this.properties && payload.property_rid) {
           this.properties.upsert({

--- a/server/tests/unit/registry-sync/registry-sync.test.ts
+++ b/server/tests/unit/registry-sync/registry-sync.test.ts
@@ -245,6 +245,53 @@ describe('RegistrySync', () => {
       expect(sync.agents!.get('https://remove-me.example.com')).toBeUndefined();
     });
 
+    it('handles agent.profile_updated event by merging onto the existing profile', () => {
+      // Add agent first, with a full profile.
+      sync.agents!.upsert({
+        agent_url: 'https://update-me.example.com',
+        channels: ['ctv'], property_types: ['video'], markets: ['US'], categories: ['news'],
+        tags: ['premium'], delivery_types: ['guaranteed'], format_kinds: ['video'],
+        property_count: 5, publisher_count: 2, has_tmp: true, category_taxonomy: null,
+        updated_at: '2026-01-01',
+      });
+
+      // The registry sends only the fields that changed (changed_fields is
+      // advisory metadata, not part of AgentProfile) — markets grew to
+      // include CA, everything else is untouched.
+      const event = {
+        event_id: 'e-profile-update', event_type: 'agent.profile_updated', entity_type: 'agent',
+        entity_id: 'https://update-me.example.com',
+        payload: {
+          agent_url: 'https://update-me.example.com',
+          markets: ['US', 'CA'],
+          changed_fields: ['markets'],
+        },
+        actor: 'pipeline:crawler', created_at: new Date('2026-02-01'),
+      };
+
+      (sync as any).applyEvents([event]);
+
+      const updated = sync.agents!.get('https://update-me.example.com');
+      expect(updated?.markets).toEqual(['US', 'CA']);
+      // Fields absent from the partial payload must survive the merge.
+      expect(updated?.channels).toEqual(['ctv']);
+      expect(updated?.property_count).toBe(5);
+      expect(updated?.has_tmp).toBe(true);
+    });
+
+    it('ignores agent.profile_updated for an agent not already in the index', () => {
+      const event = {
+        event_id: 'e-profile-update-unknown', event_type: 'agent.profile_updated', entity_type: 'agent',
+        entity_id: 'https://unknown.example.com',
+        payload: { agent_url: 'https://unknown.example.com', markets: ['US'] },
+        actor: 'pipeline:crawler', created_at: new Date(),
+      };
+
+      (sync as any).applyEvents([event]);
+
+      expect(sync.agents!.get('https://unknown.example.com')).toBeUndefined();
+    });
+
     it('handles property.created event', () => {
       const event = {
         event_id: 'e3', event_type: 'property.created', entity_type: 'property',

--- a/server/tests/unit/registry-sync/registry-sync.test.ts
+++ b/server/tests/unit/registry-sync/registry-sync.test.ts
@@ -303,7 +303,7 @@ describe('RegistrySync', () => {
           agent_url: 'https://whitelist-me.example.com',
           markets: ['US', 'CA'],
           changed_fields: ['markets'],
-          type: 'sales', // schema's agentProfilePayload.type — not an AgentProfile field
+          type: 'sales', // schema field maps to AgentProfile.agent_type
           internal_crawl_note: 'seen on run 42', // arbitrary runtime field a producer could attach
         },
         actor: 'pipeline:crawler', created_at: new Date('2026-02-01'),
@@ -313,12 +313,13 @@ describe('RegistrySync', () => {
 
       const updated = sync.agents!.get('https://whitelist-me.example.com');
       expect(updated?.markets).toEqual(['US', 'CA']);
+      expect(updated?.agent_type).toBe('sales');
       expect(updated).not.toHaveProperty('changed_fields');
       expect(updated).not.toHaveProperty('type');
       expect(updated).not.toHaveProperty('internal_crawl_note');
       expect(Object.keys(updated ?? {}).sort()).toEqual(
         [
-          'agent_url', 'channels', 'property_types', 'markets', 'categories', 'tags',
+          'agent_url', 'agent_type', 'channels', 'property_types', 'markets', 'categories', 'tags',
           'delivery_types', 'format_kinds', 'property_count', 'publisher_count', 'has_tmp',
           'category_taxonomy', 'updated_at',
         ].sort(),

--- a/server/tests/unit/registry-sync/registry-sync.test.ts
+++ b/server/tests/unit/registry-sync/registry-sync.test.ts
@@ -277,6 +277,52 @@ describe('RegistrySync', () => {
       expect(updated?.channels).toEqual(['ctv']);
       expect(updated?.property_count).toBe(5);
       expect(updated?.has_tmp).toBe(true);
+      // changed_fields is advisory event metadata, not part of AgentProfile —
+      // it must not leak into the stored profile.
+      expect(updated).not.toHaveProperty('changed_fields');
+    });
+
+    it('does not leak advisory or unrecognized payload fields into the stored profile', () => {
+      // Add agent first, with a full profile.
+      sync.agents!.upsert({
+        agent_url: 'https://whitelist-me.example.com',
+        channels: ['ctv'], property_types: ['video'], markets: ['US'], categories: ['news'],
+        tags: ['premium'], delivery_types: ['guaranteed'], format_kinds: ['video'],
+        property_count: 5, publisher_count: 2, has_tmp: true, category_taxonomy: null,
+        updated_at: '2026-01-01',
+      });
+
+      // additionalProperties: true on agentProfilePayload means a producer
+      // (or a future one) could legally attach fields that are not part of
+      // AgentProfile at all. get()/list()/search() must never surface these
+      // as if they were real profile data.
+      const event = {
+        event_id: 'e-profile-update-leak', event_type: 'agent.profile_updated', entity_type: 'agent',
+        entity_id: 'https://whitelist-me.example.com',
+        payload: {
+          agent_url: 'https://whitelist-me.example.com',
+          markets: ['US', 'CA'],
+          changed_fields: ['markets'],
+          type: 'sales', // schema's agentProfilePayload.type — not an AgentProfile field
+          internal_crawl_note: 'seen on run 42', // arbitrary runtime field a producer could attach
+        },
+        actor: 'pipeline:crawler', created_at: new Date('2026-02-01'),
+      };
+
+      (sync as any).applyEvents([event]);
+
+      const updated = sync.agents!.get('https://whitelist-me.example.com');
+      expect(updated?.markets).toEqual(['US', 'CA']);
+      expect(updated).not.toHaveProperty('changed_fields');
+      expect(updated).not.toHaveProperty('type');
+      expect(updated).not.toHaveProperty('internal_crawl_note');
+      expect(Object.keys(updated ?? {}).sort()).toEqual(
+        [
+          'agent_url', 'channels', 'property_types', 'markets', 'categories', 'tags',
+          'delivery_types', 'format_kinds', 'property_count', 'publisher_count', 'has_tmp',
+          'category_taxonomy', 'updated_at',
+        ].sort(),
+      );
     });
 
     it('ignores agent.profile_updated for an agent not already in the index', () => {


### PR DESCRIPTION
## Problem

`RegistrySync` (`server/src/registry-sync/index.ts`) is the reference in-memory
client that bootstraps from the registry API and then polls the change feed
to "stay current" (its own docstring). `RegistrySync.applyEvent()` switches
on `event_type` and handles `agent.discovered` / `agent.removed`, but has no
case for `agent.profile_updated` — one of the `event_type` enum values the
`registry-event.json` schema has declared since PR #5054 (merged 2026-05-26)
specifically for "an agent inventory profile changed" (e.g. an agent adds a
market, channel, or format_kind after it was first discovered).

Because the `switch` has no `default` branch and the poller advances its
cursor regardless of whether an event was handled, `agent.profile_updated`
events are silently dropped: the feed cursor moves past them, but the local
`AgentIndex` entry for that agent is never touched. A consumer of
`RegistrySync` (this repo's own `registry-sync-collection-index.test.ts` and
`server/tests/unit/registry-sync/` treat it as a reusable module, and its
class docstring documents `registry.agents.search({ channels: ['ctv'],
markets: ['US'] })` as the intended usage) will keep matching stale
`channels`/`markets`/`format_kinds`/etc. for any already-known agent
indefinitely, until the next full bootstrap (a `cursor_expired` recovery or
process restart).

Confirmed on current `upstream/main` via `git show HEAD` before editing.
`git log -S "agent.profile_updated" -- server/src/registry-sync/index.ts
static/schemas/source/core/registry-event.json` shows the schema gained this
event type in #5054 (2026-05-26), which never touched
`server/src/registry-sync/index.ts`; `RegistrySync` itself predates that PR
(added in #1807) and was never updated to add the new case. No existing
open or closed issue covers this (searched `RegistrySync`,
`agent.profile_updated`, `registry-sync applyEvent`, `agent profile stale`).

## Fix

Added an `agent.profile_updated` case to the `switch` in `applyEvent()`.
Deliberately **not** a copy of `agent.discovered`'s full-snapshot upsert:
per the schema's `changed_fields` field description, an `agent.profile_updated`
payload may legitimately carry only the fields that changed. Reusing
`agent.discovered`'s pattern (`(payload.channels as string[]) ?? []`, etc.)
would silently zero out every field the producer omitted on a partial
update — a subtler regression than doing nothing. Instead the new case
merges the payload onto the existing `AgentIndex` entry, mirroring the exact
pattern the file already uses for `property.updated` immediately below it,
and — matching that same sibling case — is a no-op when the agent isn't
already in the local index (nothing to merge onto).

## Test

Added two tests to `server/tests/unit/registry-sync/registry-sync.test.ts`,
following the file's existing `(sync as any).applyEvents([event])` convention:

1. `handles agent.profile_updated event by merging onto the existing profile`
   — seeds a full agent profile, applies a partial `agent.profile_updated`
   event that only sends `markets`, and asserts the changed field updates
   while untouched fields (`channels`, `property_count`, `has_tmp`) survive.
2. `ignores agent.profile_updated for an agent not already in the index`
   — matches the no-op convention already used for `property.updated`.

**Proof the test is real:** reverted the source change (kept the tests) and
re-ran `npx vitest run --config server/vitest.config.ts
server/tests/unit/registry-sync/registry-sync.test.ts` — 20 passed / 1
failed, with the merge test failing (`expected [ 'US' ] to deeply equal
[ 'US', 'CA' ]`, i.e. the partial update was silently dropped). Restored the
fix and re-ran the same command — 21/21 passed. Ran `npm run typecheck`
(`tsc --project server/tsconfig.json --noEmit`) — clean. Ran
`node scripts/check-changeset-protocol-scope.cjs upstream/main` — this is a
server-code-only change, not protocol-surface-scoped, so no changeset is
required per `.agents/playbook.md`. Final diff is two files, +64 lines (17
in `index.ts`, 47 in the test file), no lines removed.

🤖 Generated with a Claude Code session as part of an ongoing series of
narrowly-scoped, independently-verified fixes to this repository.

---

## Update: addressing @bokelley's review

Both requested changes are addressed, with the second one intentionally
scoped down rather than forced in — see below.

### 1. Whitelist the payload before merge (fixed)

`agentProfilePayload` in `registry-event.json` has `additionalProperties:
true`, and the `agent.profile_updated` branch specifically layers an
advisory `changed_fields` array on top. The original fix's
`{ ...existing, ...(payload as Partial<AgentProfile>) }` spread let both of
those — and any other non-`AgentProfile` key a future producer attaches —
leak straight into the stored profile and back out through
`agents.get()`/`list()`/`search()`.

Replaced the spread with an explicit `agentProfilePatchFromPayload()`
helper that whitelists only real `AgentProfile` fields (`name`, `channels`,
`property_types`, `markets`, `categories`, `tags`, `delivery_types`,
`format_kinds`, `property_count`, `publisher_count`, `has_tmp`,
`category_taxonomy`) before merging — mirroring `collectionFromPayload`'s
existing explicit-construction pattern in the same file (the sibling that
already does this safely), rather than `property.updated`'s spread
immediately below (which has the identical latent leak but is out of scope
for this PR).

Strengthened the existing merge test to assert `changed_fields` doesn't
leak into the stored profile, and added a new test
(`does not leak advisory or unrecognized payload fields into the stored
profile`) that sends `changed_fields` plus an unrelated advisory field and
an unrecognized `type` key (the schema's field name for this concept —
distinct from `AgentProfile`'s `agent_type`, so it's correctly excluded
either way) and asserts the stored profile's key set is *exactly* the
`AgentProfile` fields, nothing else.

Verified: reverted the whitelist change (kept the tests) — both new
assertions fail against the old spread (`changed_fields` present on the
stored object). Restored the fix — 22/22 pass. `npm run typecheck` clean.

### 2. Producer coverage (scoped out, follow-up filed)

I looked at wiring `produceEventsFromDiff` (`server/src/crawler.ts`) up to
actually emit `agent.profile_updated`, and it's not a narrow addition like
point 1 was — genuinely new infrastructure is needed, not a copy of the
`agent.discovered`/`agent.removed` emission pattern:

- The pre-crawl snapshot it diffs against
  (`CrawlerService.snapshotAgentState()`) only captures **domain
  associations** (`Map<string, { domains: Set<string> }>`), built
  specifically for the authorization-granted/revoked diff — it carries no
  profile field values to diff against.
- `AgentInventoryProfilesDatabase` has no bulk "read the previous profile
  for these agent URLs" method today (`getProfile()` is single-agent;
  `search()` is paginated/scored) — one would need to be added, in the same
  single-round-trip spirit as `federatedIndex.getAllAgentDomainPairs()`
  (used in `snapshotAgentState()` specifically to avoid O(N) per-agent
  queries).
- The actual field-level diff needs to be order-independent (several
  `AgentProfile` fields are arrays built fresh from `Set`s each crawl in
  `buildInventoryProfiles()`, e.g. `channels: [...channels]`), so naive
  `!==`/`JSON.stringify` comparison would false-positive on reordering.
  There's already a directly analogous helper to model this on —
  `adagentsChangedFields()` in `server/src/db/publisher-db.ts` (~line 101),
  which normalizes both sides through a sorted-key `stableManifestString`
  before comparing, feeding `publisher.adagents_changed`'s own
  `changed_fields` — but no equivalent exists yet for agent profiles.

That's a new DB read path + a new diff helper + restructuring the
`buildInventoryProfiles` → `produceEventsFromDiff` handoff in the crawl
loop, each of which deserves its own review rather than being folded into
this consumer-side fix. Per your suggested alternative, I'm narrowing this
PR's scope explicitly: **this PR fixes the consumer-side dead code in
`RegistrySync.applyEvent()`; the producer does not yet emit
`agent.profile_updated`, so the tests here exercise `applyEvents()`
directly rather than a real end-to-end crawl-to-consumer path.**

Filed adcontextprotocol/adcp#7095 to track completing the production side,
with the specific suggested scope (bulk previous-profile read, an
`agentProfileChangedFields` helper mirroring `adagentsChangedFields`, the
`produceEventsFromDiff` wiring, and producer-level test coverage in
`server/tests/unit/crawler-format-kind-events.test.ts` or a sibling file).
