### PR TITLE
refactor(addie): share delivery preparation

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -1259,14 +1259,17 @@ export class AddieClaudeClient {
     return fork;
   }
 
-  private prepareFirstNonStreamingInvocation(
+  /** Assemble the shared prompt, tool surface, history, and attachments for either delivery mode. */
+  private prepareFirstInvocation(
     userMessage: string,
     threadContext?: Array<{ user: string; text: string }>,
     requestTools?: RequestTools,
     rulesOverride?: RulesOverride,
     options?: ProcessMessageOptions,
+    delivery: 'non_streaming' | 'streaming' = 'non_streaming',
   ) {
-    const requestWebSearchEnabled = this.webSearchEnabled
+    const requestWebSearchEnabled = delivery === 'non_streaming'
+      && this.webSearchEnabled
       && !isIsolatedExecution(options)
       && options?.disableServerTools !== true;
     const effectiveModel = options?.modelOverride ?? this.model;
@@ -1388,7 +1391,7 @@ export class AddieClaudeClient {
     rulesOverride?: RulesOverride,
     options?: ProcessMessageOptions,
   ): InvocationPreparedSnapshot {
-    const prepared = this.prepareFirstNonStreamingInvocation(
+    const prepared = this.prepareFirstInvocation(
       userMessage,
       threadContext,
       requestTools,
@@ -1512,7 +1515,7 @@ export class AddieClaudeClient {
     let totalLlmMs = 0;
     let totalToolExecutionMs = 0;
 
-    const prepared = this.prepareFirstNonStreamingInvocation(
+    const prepared = this.prepareFirstInvocation(
       userMessage,
       threadContext,
       requestTools,
@@ -2132,38 +2135,33 @@ export class AddieClaudeClient {
       ? await getCurrentConfigVersionId()
       : undefined;
 
-    // Determine effective model (support precision mode override for billing/financial)
-    const effectiveModel = options?.modelOverride ?? this.model;
+    const prepared = this.prepareFirstInvocation(
+      userMessage,
+      threadContext,
+      requestTools,
+      undefined,
+      options,
+      'streaming',
+    );
+    const {
+      effectiveModel,
+      systemBlocks,
+      allHandlers,
+      toolsByName,
+      toolCount,
+      messageTurnsResult,
+      messages,
+      modelMessages,
+      customTools,
+      modelTools,
+    } = prepared;
+    systemPromptMs = prepared.systemPromptMs;
+
     if (options?.modelOverride && options.modelOverride !== this.model) {
       logger.info({ model: effectiveModel, defaultModel: this.model }, 'Addie Stream: Using precision model for billing/financial query');
     }
 
-    // Combine global tools with per-request tools, deduplicating by name (last wins)
-    // Calculate tool count first to inform token budget for conversation history
-    const allowedToolNames = options?.allowedToolNames
-      ? new Set(options.allowedToolNames)
-      : null;
-    const allTools = mergeAddieToolDefinitions(
-      this.tools,
-      requestTools?.tools,
-      options?.allowedToolNames,
-    );
-    const allHandlers = new Map(
-      [...this.toolHandlers, ...(requestTools?.handlers || [])]
-        .filter(([name]) => !allowedToolNames || allowedToolNames.has(name)),
-    );
-
-    // Build the prompt after resolving the exact tool wire surface so domain
-    // guidance and the authoritative catalog cannot advertise omitted tools.
-    const promptStart = Date.now();
-    const systemBlocks = this.buildSystemBlocks(
-      allTools.map(tool => tool.name),
-      options?.selectedToolSetNames,
-      options?.requestContext,
-    );
-    systemPromptMs = Date.now() - promptStart;
-
-    const executeToolCall = createAddieToolExecutor(allTools, allHandlers, {
+    const executeToolCall = createAddieToolExecutor([...toolsByName.values()], allHandlers, {
       executionMode: options?.executionMode ?? 'production',
       policy: options?.toolExecutionPolicy,
       notificationContext: {
@@ -2171,19 +2169,6 @@ export class AddieClaudeClient {
         userDisplayName: options?.userDisplayName,
         threadId: options?.threadId,
       },
-    });
-    const toolCount = allTools.length; // Note: streaming doesn't use web search
-
-    // Build proper message turns from thread context
-    // This sends conversation history as actual user/assistant turns, not flattened text
-    // Token-aware: automatically trims older messages if conversation exceeds limits
-    // Compact old tool results in all conversations to reclaim context
-    const messageTurnsResult = buildMessageTurnsWithMetadata(userMessage, threadContext, {
-      model: effectiveModel,
-      toolCount,
-      maxMessages: options?.maxMessages,
-      compactToolResults: true,
-      currentSpeakerName: options?.currentSpeakerName,
     });
 
     if (messageTurnsResult.wasTrimmed) {
@@ -2196,30 +2181,7 @@ export class AddieClaudeClient {
         },
         'Addie Stream: Trimmed conversation history to fit context limit'
       );
-      // Inject dropped conversation summary so Addie has context from earlier turns
-      if (messageTurnsResult.messagesRemoved > 10) {
-        const summary = messageTurnsResult.droppedMessages
-          ? buildDroppedMessagesSummary(messageTurnsResult.droppedMessages)
-          : null;
-        const contextWarning = summary
-          || `\n\n## Context Warning\n${messageTurnsResult.messagesRemoved} earlier messages were dropped from this conversation to fit the context window. If the user references something you don't recall, let them know and suggest starting a new thread for better accuracy.`;
-        systemBlocks.push({ type: 'text', text: contextWarning });
-      }
     }
-
-    const messages: Anthropic.MessageParam[] = appendInputAttachments(
-      toAnthropicMessages(messageTurnsResult.messages),
-      options?.inputAttachments,
-    );
-    const modelMessages = appendModelInputAttachments(
-      toModelMessages(messageTurnsResult.messages),
-      options?.inputAttachments,
-    );
-
-    // Build tool list once — rebuilt every iteration is wasteful since tools don't change.
-    // Mark the last tool with cache_control so Anthropic caches all tool definitions.
-    const customTools = buildAddieWireTools(allTools) as Anthropic.Tool[];
-    const modelTools = buildModelToolDefinitions(allTools);
     const modelLoop = new ModelTurnLoopState(options?.maxIterations ?? DEFAULT_MAX_ITERATIONS);
     let iteration = 0;
     let lastProviderModel: string | undefined;

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.123';
+export const CODE_VERSION = '2026.08.124';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,7 +12,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "d5b266bfc55f1b8176ef8ccaa81fdc2a5622a007d2028f78eb9835e64fcdfeee",
+    "server/src/addie/claude-client.ts": "00fb7897d05b9286e87e45efa0611bfd612b1dd0a7ab47516b92cb3464f156a1",
     "server/src/addie/prompts.ts": "574444a53fc618878f5e86ab369b738bbfdd3cc42f1688e2b730450647c09f7e",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/tests/unit/addie/claude-client-model-fallback.test.ts
+++ b/server/tests/unit/addie/claude-client-model-fallback.test.ts
@@ -125,7 +125,7 @@ function makeTextStream(text: string) {
   };
 }
 
-describe('Addie sibling-model fallback runtime', () => {
+describe('Addie provider delivery runtime', () => {
   beforeEach(() => {
     mocks.createMessage.mockReset();
     mocks.streamMessage.mockReset();
@@ -293,6 +293,55 @@ describe('Addie sibling-model fallback runtime', () => {
       { type: 'text', text: 'Fallback answer.' },
     ]);
     expect(events.some(event => event.type === 'stream_error')).toBe(false);
+  });
+
+  it('prepares identical canonical inputs for streaming and non-streaming delivery', async () => {
+    mocks.createMessage.mockResolvedValue({
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: 'Prepared answer.' }],
+      usage: { input_tokens: 12, output_tokens: 4 },
+    });
+    mocks.streamMessage.mockReturnValue(makeTextStream('Prepared answer.'));
+
+    const client = new AddieClaudeClient('unused', AddieModelConfig.chat);
+    client.setWebSearchEnabled(false);
+    const threadContext = [
+      { user: 'user', text: 'Earlier question' },
+      { user: 'assistant', text: 'Earlier answer' },
+    ];
+    const options = {
+      uncapped: true,
+      requestContext: 'Account context',
+      currentSpeakerName: 'Casey',
+    } as const;
+
+    await client.processMessage(
+      'Current question',
+      threadContext,
+      githubIssueTools,
+      undefined,
+      options,
+    );
+    for await (const _event of client.processMessageStream(
+      'Current question',
+      threadContext,
+      githubIssueTools,
+      options,
+    )) {
+      // Consume the complete streaming response.
+    }
+
+    const nonStreamingPayload = mocks.createMessage.mock.calls[0]?.[0];
+    const streamingPayload = mocks.streamMessage.mock.calls[0]?.[0];
+    if (!nonStreamingPayload || !streamingPayload) {
+      throw new Error('Expected both delivery modes to dispatch one provider request');
+    }
+    expect(streamingPayload).toEqual(expect.objectContaining({
+      model: nonStreamingPayload.model,
+      system: nonStreamingPayload.system,
+      messages: nonStreamingPayload.messages,
+      tools: nonStreamingPayload.tools,
+    }));
   });
 
   it('does not change models after any streamed delta was received', async () => {


### PR DESCRIPTION
## Summary\n\n- extract one shared preparation path for streaming and non-streaming Addie delivery\n- keep delivery-specific provider web search behavior explicit while sharing model, system, tool, history, and attachment preparation\n- add parity coverage for canonical provider inputs and refresh the Addie runtime inventory/version\n\n## Safety\n\n- no provider selection, canary, environment, or production behavior activation\n- no paid or stochastic model calls\n\n## Verification\n\n- 56 focused runtime tests passed\n- 1,056 root unit tests passed\n- 7,699 server unit tests passed (30 skipped)\n- TypeScript typecheck passed\n- Addie tool inventory/reference checks passed (249 tools, 37 sets)\n- production build passed\n- diff, confidential-name, and credential scans passed\n\nRelated to #6844