### PR TITLE
refactor(addie): share accepted-turn orchestration

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -68,12 +68,13 @@ import {
   type AnthropicMessagesTransport,
 } from './model-providers/anthropic-provider.js';
 import {
-  appendModelTurnContinuation,
   ModelTurnLoopState,
 } from './model-providers/model-turn.js';
 import {
   AddieToolExecutionLedger,
   createAddieToolExecutor,
+  orchestrateAcceptedAddieTurn,
+  type AddieAcceptedTurnDecision,
   type AddieExecutionMode,
   type ToolExecution,
   type ToolExecutionPolicy,
@@ -1762,32 +1763,45 @@ export class AddieClaudeClient {
         logger.warn({ iteration }, 'Addie: Ignoring tool use from text-only recovery');
       }
 
-      // Provider results may accompany a terminal, provider-continuation, or
-      // mixed custom-tool turn. Record them once at the normalized boundary.
-      const providerToolExecutions = executionLedger.recordProviderResults(
-        this.modelProvider,
-        turn.providerToolCalls,
-        turn.providerToolResults,
-        options?.executionMode ?? 'production',
-      );
-      for (const recorded of providerToolExecutions) {
-        logger.debug(
-          {
-            toolName: recorded.execution.tool_name,
-            resultCount: recorded.result.resultCount,
-            parameterKeys: Object.keys(recorded.receipt.parameters).sort(),
-          },
-          'Addie: Provider tool completed',
-        );
+      let turnDecision: AddieAcceptedTurnDecision | undefined;
+      for await (const event of orchestrateAcceptedAddieTurn({
+        turn,
+        provider: this.modelProvider,
+        executionMode: options?.executionMode ?? 'production',
+        messages: modelMessages,
+        ledger: executionLedger,
+        execute: executeToolCall,
+      })) {
+        if (event.type === 'provider_tool') {
+          logger.debug(
+            {
+              toolName: event.recorded.execution.tool_name,
+              resultCount: event.recorded.result.resultCount,
+              parameterKeys: Object.keys(event.recorded.receipt.parameters).sort(),
+            },
+            'Addie: Provider tool completed',
+          );
+        } else if (event.type === 'turn_decision') {
+          turnDecision = event.decision;
+          hasExecutedCustomTool ||= event.decision.hasCustomToolCalls;
+        } else if (event.type === 'start') {
+          logger.debug(
+            {
+              toolName: event.call.name,
+              ...(operationalExecution && { toolInput: event.call.input }),
+            },
+            'Addie: Calling tool',
+          );
+        }
       }
+      if (!turnDecision) throw new Error('Accepted model turn produced no orchestration decision');
 
-      const stopAction = turn.action;
+      const stopAction = turnDecision.action;
 
       if (stopAction === 'continue' || stopAction === 'continue_provider_tools') {
         // Anthropic pause_turn and compaction responses are resumable only
         // when their content is included in the next request. Repeating the
         // unchanged prompt can loop or repeat server-side work.
-        appendModelTurnContinuation(modelMessages, response);
         logger.info(
           { stopReason: response.providerFinishReason, iteration },
           'Addie: Continuing resumable provider turn',
@@ -1796,10 +1810,7 @@ export class AddieClaudeClient {
       }
 
       if (stopAction === 'truncated') {
-        const rawText = turn.textBlocks
-          .map((block) => block.text)
-          .join('\n\n')
-          .trim();
+        const rawText = turnDecision.text.trim();
         const finalized = finalizeAssistantText(userMessage, rawText, toolExecutions, true);
         if (finalized.emptyReason) {
           reportEmptyResponseFallback(finalized.emptyReason, toolsUsed, toolExecutions, options, 'processMessage', effectiveModel, iteration);
@@ -1858,10 +1869,7 @@ export class AddieClaudeClient {
       // Done - no tool use, just text
       if (stopAction === 'complete') {
         // Collect ALL text blocks (web search responses have multiple text blocks)
-        const rawText = turn.textBlocks
-          .map((block) => block.text)
-          .join('\n\n')
-          .trim();
+        const rawText = turnDecision.text.trim();
         // A provider-successful but wholly empty first sample has no visible
         // output or side effect. Production may safely resample it once; eval
         // and replay preserve the original terminal outcome for integrity.
@@ -1959,29 +1967,8 @@ export class AddieClaudeClient {
         };
       }
 
-      // Handle custom tool use. Provider-managed results were recorded above.
-      if (stopAction === 'execute_tools') {
-        const toolResults: ModelToolResultContent[] = [];
-
-        for await (const event of executionLedger.executeCustomCalls(
-          turn.toolCalls,
-          executeToolCall,
-          toolResults,
-        )) {
-          if (event.type === 'start') {
-            hasExecutedCustomTool = true;
-            logger.debug(
-              {
-                toolName: event.call.name,
-                ...(operationalExecution && { toolInput: event.call.input }),
-              },
-              'Addie: Calling tool',
-            );
-          }
-        }
-
-        appendModelTurnContinuation(modelMessages, response, toolResults);
-      }
+      // Custom tool execution and continuation state are owned by the shared
+      // accepted-turn orchestration boundary above.
     }
 
     logger.warn('Addie: Hit max tool iterations');
@@ -2497,34 +2484,66 @@ export class AddieClaudeClient {
           logger.warn({ iteration }, 'Addie Stream: Ignoring tool use from text-only recovery');
         }
 
-        const providerToolExecutions = executionLedger.recordProviderResults(
-          this.modelProvider,
-          turn.providerToolCalls,
-          turn.providerToolResults,
-          options?.executionMode ?? 'production',
-        );
-        for (const recorded of providerToolExecutions) {
-          yield {
-            type: 'tool_start',
-            tool_name: recorded.execution.tool_name,
-            parameters: recorded.execution.parameters,
-          };
-          yield {
-            type: 'tool_end',
-            tool_name: recorded.execution.tool_name,
-            result: recorded.execution.result,
-            is_error: recorded.execution.is_error,
-            normalized_result: recorded.execution.normalized_result,
-          };
-          logger.debug(
-            {
-              toolName: recorded.execution.tool_name,
-              resultCount: recorded.result.resultCount,
-              parameterKeys: Object.keys(recorded.receipt.parameters).sort(),
-            },
-            'Addie Stream: Provider tool completed',
-          );
+        let turnDecision: AddieAcceptedTurnDecision | undefined;
+        for await (const event of orchestrateAcceptedAddieTurn({
+          turn,
+          provider: this.modelProvider,
+          executionMode: options?.executionMode ?? 'production',
+          messages: modelMessages,
+          ledger: executionLedger,
+          execute: executeToolCall,
+        })) {
+          if (event.type === 'provider_tool') {
+            yield {
+              type: 'tool_start',
+              tool_name: event.recorded.execution.tool_name,
+              parameters: event.recorded.execution.parameters,
+            };
+            yield {
+              type: 'tool_end',
+              tool_name: event.recorded.execution.tool_name,
+              result: event.recorded.execution.result,
+              is_error: event.recorded.execution.is_error,
+              normalized_result: event.recorded.execution.normalized_result,
+            };
+            logger.debug(
+              {
+                toolName: event.recorded.execution.tool_name,
+                resultCount: event.recorded.result.resultCount,
+                parameterKeys: Object.keys(event.recorded.receipt.parameters).sort(),
+              },
+              'Addie Stream: Provider tool completed',
+            );
+          } else if (event.type === 'turn_decision') {
+            turnDecision = event.decision;
+            if (event.decision.action === 'execute_tools') {
+              // Preserve accepted text before a tool handler can fail.
+              logicalText += event.decision.text;
+            }
+          } else if (event.type === 'start') {
+            logger.debug(
+              {
+                toolName: event.call.name,
+                ...(operationalExecution && { toolInput: event.call.input }),
+              },
+              'Addie Stream: Calling tool',
+            );
+            yield {
+              type: 'tool_start',
+              tool_name: event.call.name,
+              parameters: this.recordedToolParameters(options, event.call.input),
+            };
+          } else {
+            yield {
+              type: 'tool_end',
+              tool_name: event.call.name,
+              result: event.executed.execution.result,
+              is_error: event.executed.execution.is_error,
+              normalized_result: event.executed.execution.normalized_result,
+            };
+          }
         }
+        if (!turnDecision) throw new Error('Accepted model turn produced no orchestration decision');
 
         // Build the final usage block + charge the user's cost
         // budget (#2790). Both stream terminal paths (end_turn and
@@ -2540,13 +2559,10 @@ export class AddieClaudeClient {
           }
         };
 
-        const stopAction = turn.action;
-        const iterationText = turn.textBlocks
-          .map((block) => block.text)
-          .join('\n\n');
+        const stopAction = turnDecision.action;
+        const iterationText = turnDecision.text;
         if (stopAction === 'continue' || stopAction === 'continue_provider_tools') {
           // Resume from the provider response without exposing interim text.
-          appendModelTurnContinuation(modelMessages, currentResponse);
           logger.info(
             { stopReason: currentResponse.providerFinishReason, iteration },
             'Addie Stream: Continuing resumable provider turn',
@@ -2702,41 +2718,6 @@ export class AddieClaudeClient {
 
         // Handle tool use
         if (stopAction === 'execute_tools') {
-          logicalText += iterationText;
-          const toolResults: ModelToolResultContent[] = [];
-
-          for await (const event of executionLedger.executeCustomCalls(
-            turn.toolCalls,
-            executeToolCall,
-            toolResults,
-          )) {
-            if (event.type === 'start') {
-              logger.debug(
-                {
-                  toolName: event.call.name,
-                  ...(operationalExecution && { toolInput: event.call.input }),
-                },
-                'Addie Stream: Calling tool',
-              );
-              yield {
-                type: 'tool_start',
-                tool_name: event.call.name,
-                parameters: this.recordedToolParameters(options, event.call.input),
-              };
-            } else {
-              yield {
-                type: 'tool_end',
-                tool_name: event.call.name,
-                result: event.executed.execution.result,
-                is_error: event.executed.execution.is_error,
-                normalized_result: event.executed.execution.normalized_result,
-              };
-            }
-          }
-
-          // Continue the conversation with tool results
-          appendModelTurnContinuation(modelMessages, currentResponse, toolResults);
-
           // Add spacing between tool use and subsequent text to prevent run-on text
           if (logicalText.length > 0 && !logicalText.endsWith('\n')) {
             logicalText += '\n\n';

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.124';
+export const CODE_VERSION = '2026.08.125';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,7 +12,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "00fb7897d05b9286e87e45efa0611bfd612b1dd0a7ab47516b92cb3464f156a1",
+    "server/src/addie/claude-client.ts": "2c1e2eff0dac14e7f413de118fd7eaaa62484254d3cc9fd8b9471e8fb9f790ac",
     "server/src/addie/prompts.ts": "574444a53fc618878f5e86ab369b738bbfdd3cc42f1688e2b730450647c09f7e",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/src/addie/model-providers/tool-orchestration.ts
+++ b/server/src/addie/model-providers/tool-orchestration.ts
@@ -18,6 +18,7 @@ import {
 } from '../tool-result-contract.js';
 import type { AddieTool } from '../types.js';
 import type {
+  ModelMessage,
   ModelProvider,
   ModelProviderToolCallContent,
   ModelProviderToolReceipt,
@@ -25,6 +26,11 @@ import type {
   ModelToolCallContent,
   ModelToolResultContent,
 } from './model-provider.js';
+import {
+  appendModelTurnContinuation,
+  type AcceptedModelTurn,
+  type ModelTurnAction,
+} from './model-turn.js';
 
 const logger = createLogger('addie-tool-orchestration');
 const definitionSnapshots = new WeakMap<AddieTool, AddieTool>();
@@ -101,6 +107,26 @@ export interface AddieProviderToolExecution {
   result: ModelProviderToolResultContent;
   receipt: ModelProviderToolReceipt;
   execution: ToolExecution;
+}
+
+export interface AddieAcceptedTurnDecision {
+  action: ModelTurnAction;
+  text: string;
+  hasCustomToolCalls: boolean;
+}
+
+export type AddieAcceptedTurnEvent =
+  | { type: 'provider_tool'; recorded: AddieProviderToolExecution }
+  | AddieToolExecutionEvent
+  | { type: 'turn_decision'; decision: AddieAcceptedTurnDecision };
+
+export interface OrchestrateAcceptedAddieTurnOptions {
+  turn: AcceptedModelTurn;
+  provider: Pick<ModelProvider, 'id' | 'deriveProviderToolReceipt'>;
+  executionMode: AddieExecutionMode;
+  messages: ModelMessage[];
+  ledger: AddieToolExecutionLedger;
+  execute: AddieToolExecutor;
 }
 
 /**
@@ -188,6 +214,59 @@ export class AddieToolExecutionLedger {
     this.completedExecutions.push(event.executed.execution);
     this.pendingCustomSequence = null;
   }
+}
+
+/**
+ * Apply one accepted provider-neutral turn to Addie's shared tool and message
+ * state. Delivery adapters consume the emitted events for logging/UI only;
+ * this boundary owns provider receipts, sequential custom-tool execution, and
+ * the exact assistant/tool-result continuation written to the next request.
+ */
+export async function* orchestrateAcceptedAddieTurn(
+  options: OrchestrateAcceptedAddieTurnOptions,
+): AsyncGenerator<AddieAcceptedTurnEvent> {
+  const {
+    turn,
+    provider,
+    executionMode,
+    messages,
+    ledger,
+    execute,
+  } = options;
+
+  const providerExecutions = ledger.recordProviderResults(
+    provider,
+    turn.providerToolCalls,
+    turn.providerToolResults,
+    executionMode,
+  );
+  for (const recorded of providerExecutions) {
+    yield { type: 'provider_tool', recorded };
+  }
+
+  const decision: AddieAcceptedTurnDecision = Object.freeze({
+    action: turn.action,
+    text: turn.textBlocks.map((block) => block.text).join('\n\n'),
+    hasCustomToolCalls: turn.toolCalls.length > 0,
+  });
+  yield { type: 'turn_decision', decision };
+
+  if (decision.action === 'continue' || decision.action === 'continue_provider_tools') {
+    appendModelTurnContinuation(messages, turn.response);
+    return;
+  }
+
+  if (decision.action !== 'execute_tools') return;
+
+  const toolResults: ModelToolResultContent[] = [];
+  for await (const event of ledger.executeCustomCalls(
+    turn.toolCalls,
+    execute,
+    toolResults,
+  )) {
+    yield event;
+  }
+  appendModelTurnContinuation(messages, turn.response, toolResults);
 }
 
 interface RegisteredTool {

--- a/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
+++ b/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
@@ -1,16 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
+  ModelMessage,
   ModelProvider,
   ModelProviderToolCallContent,
   ModelProviderToolResultContent,
+  ModelResponse,
   ModelToolCallContent,
   ModelToolResultContent,
 } from '../../../src/addie/model-providers/model-provider.js';
+import { ModelTurnLoopState } from '../../../src/addie/model-providers/model-turn.js';
 import {
   AddieToolExecutionLedger,
   BLOCKED_TOOL_RESULT,
   createAddieToolExecutor,
   executeAddieToolCalls,
+  orchestrateAcceptedAddieTurn,
   recordProviderToolResults,
 } from '../../../src/addie/model-providers/tool-orchestration.js';
 import type { AddieTool } from '../../../src/addie/types.js';
@@ -449,5 +453,169 @@ describe('AddieToolExecutionLedger', () => {
     await expect(consume()).rejects.toThrow(
       'Custom-tool completion does not match its start event',
     );
+  });
+});
+
+describe('orchestrateAcceptedAddieTurn', () => {
+  const providerCall: ModelProviderToolCallContent = {
+    type: 'provider_tool_call',
+    provider: 'anthropic',
+    id: 'server_1',
+    name: 'web_search',
+    inputKeys: ['query'],
+  };
+  const providerResult: ModelProviderToolResultContent = {
+    type: 'provider_tool_result',
+    provider: 'anthropic',
+    toolCallId: 'server_1',
+    name: 'web_search',
+    resultCount: 1,
+    isError: false,
+  };
+
+  function accept(response: ModelResponse) {
+    return new ModelTurnLoopState(2).beginNext().acceptResponse(response);
+  }
+
+  it('owns provider receipts, custom-tool dispatch, and continuation ordering', async () => {
+    const customCall = call();
+    const response: ModelResponse = {
+      provider: 'anthropic',
+      model: 'test-model',
+      id: 'response_1',
+      content: [
+        { type: 'text', text: 'Checking both sources.' },
+        providerCall,
+        providerResult,
+        customCall,
+      ],
+      finishReason: 'tool_calls',
+      providerFinishReason: 'tool_use',
+      usage: { inputTokens: 10, outputTokens: 5 },
+    };
+    const messages: ModelMessage[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Look this up.' }] },
+    ];
+    const ledger = new AddieToolExecutionLedger();
+    const execute = vi.fn(async (toolCall: ModelToolCallContent, sequence: number) => ({
+      result: {
+        type: 'tool_result' as const,
+        toolCallId: toolCall.id,
+        toolName: toolCall.name,
+        content: 'custom result',
+      },
+      execution: {
+        tool_name: toolCall.name,
+        parameters: toolCall.input,
+        result: 'custom result',
+        is_error: false,
+        duration_ms: 1,
+        sequence,
+      },
+    }));
+    const events = [];
+
+    for await (const event of orchestrateAcceptedAddieTurn({
+      turn: accept(response),
+      provider: { id: 'anthropic' },
+      executionMode: 'production',
+      messages,
+      ledger,
+      execute,
+    })) {
+      events.push(event);
+    }
+
+    expect(events.map((event) => event.type)).toEqual([
+      'provider_tool',
+      'turn_decision',
+      'start',
+      'end',
+    ]);
+    expect(events[1]).toEqual({
+      type: 'turn_decision',
+      decision: {
+        action: 'execute_tools',
+        text: 'Checking both sources.',
+        hasCustomToolCalls: true,
+      },
+    });
+    expect(execute).toHaveBeenCalledWith(customCall, 2);
+    expect(ledger.toolsUsed).toEqual(['web_search', 'lookup']);
+    expect(ledger.executions.map(({ sequence }) => sequence)).toEqual([1, 2]);
+    expect(messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'Look this up.' }] },
+      { role: 'assistant', content: response.content },
+      {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          toolCallId: 'call_1',
+          toolName: 'lookup',
+          content: 'custom result',
+        }],
+      },
+    ]);
+  });
+
+  it('appends same-provider continuation state without dispatching custom tools', async () => {
+    const response: ModelResponse = {
+      provider: 'anthropic',
+      model: 'test-model',
+      id: 'response_2',
+      content: [
+        { type: 'provider_state', provider: 'anthropic', kind: 'thinking' },
+      ],
+      finishReason: 'continue',
+      providerFinishReason: 'pause_turn',
+      usage: { inputTokens: 4, outputTokens: 2 },
+    };
+    const messages: ModelMessage[] = [];
+    const execute = vi.fn();
+    const events = [];
+
+    for await (const event of orchestrateAcceptedAddieTurn({
+      turn: accept(response),
+      provider: { id: 'anthropic' },
+      executionMode: 'production',
+      messages,
+      ledger: new AddieToolExecutionLedger(),
+      execute,
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([{
+      type: 'turn_decision',
+      decision: { action: 'continue', text: '', hasCustomToolCalls: false },
+    }]);
+    expect(execute).not.toHaveBeenCalled();
+    expect(messages).toEqual([{ role: 'assistant', content: response.content }]);
+  });
+
+  it('does not mutate continuation messages for terminal turns', async () => {
+    const response: ModelResponse = {
+      provider: 'anthropic',
+      model: 'test-model',
+      id: 'response_3',
+      content: [{ type: 'text', text: 'Done.' }],
+      finishReason: 'stop',
+      providerFinishReason: 'end_turn',
+      usage: { inputTokens: 3, outputTokens: 1 },
+    };
+    const messages: ModelMessage[] = [];
+
+    for await (const _event of orchestrateAcceptedAddieTurn({
+      turn: accept(response),
+      provider: { id: 'anthropic' },
+      executionMode: 'production',
+      messages,
+      ledger: new AddieToolExecutionLedger(),
+      execute: vi.fn(),
+    })) {
+      // Consume the shared boundary so its mutation policy is exercised.
+    }
+
+    expect(messages).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary\n\n- add one provider-neutral accepted-turn orchestration boundary for provider receipts, custom-tool execution, and continuation message mutation\n- route streaming and non-streaming Addie delivery through the same neutral lifecycle events while preserving their logging and UI behavior\n- add ordering, continuation, and terminal-mutation invariants; bump the Addie code version and refresh the runtime inventory\n\n## Safety\n\n- tool policy, sequential execution, mutation guards, retry behavior, billing, and persistence boundaries are unchanged\n- no provider selection, canary, environment, or production rollout change\n- no paid or stochastic model calls\n\n## Verification\n\n- 130 focused Claude/provider/tool/replay/stream tests passed\n- 1,056 root unit tests passed\n- 7,707 server unit tests passed (30 skipped)\n- TypeScript typecheck passed\n- Addie inventory/reference checks passed (249 tools, 37 sets)\n- production build passed\n- diff, confidential-name, and credential scans passed\n\nRelated to #6844